### PR TITLE
✨ Help texts

### DIFF
--- a/.changeset/wicked-windows-jump.md
+++ b/.changeset/wicked-windows-jump.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+added admin panel input help texts, thanks @ronaldaug

--- a/packages/core/admin/src/app/modules/shared/inputs/currency-input/currency-input.component.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/currency-input/currency-input.component.ts
@@ -16,7 +16,7 @@ import { PropertyManifest } from '@repo/types'
   imports: [NgClass],
   template: ` <label [for]="prop.name">{{ prop.name }}</label>
     <p class="control has-icons-left">
-      <span class="icon is-small is-left">
+      <span class="icon is-left">
         <span class="is-family-sans-serif	">
           {{ symbol }}
         </span>

--- a/packages/core/admin/src/app/modules/shared/inputs/input.component.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/input.component.ts
@@ -188,6 +188,11 @@ import { RichTextInputComponent } from './rich-text-input/rich-text-input.compon
     <ul *ngIf="errors?.length">
       <li *ngFor="let error of errors" class="has-text-danger">{{ error }}</li>
     </ul>
+
+    <!-- Display help text if available -->
+    <p class="help" *ngIf="helpText">
+      {{ helpText }}
+    </p>
   `
 })
 export class InputComponent implements OnChanges {
@@ -198,6 +203,8 @@ export class InputComponent implements OnChanges {
   @Input() errors: string[]
   @Output() valueChanged: EventEmitter<any> = new EventEmitter()
 
+  helpText: string
+
   isError: boolean
   PropType = PropType
 
@@ -207,5 +214,7 @@ export class InputComponent implements OnChanges {
 
   ngOnChanges(): void {
     this.isError = !!this.errors?.length
+
+    this.helpText = this.prop?.helpText || this.relationship?.helpText
   }
 }

--- a/packages/core/admin/src/app/modules/shared/inputs/location-input/location-input.component.ts
+++ b/packages/core/admin/src/app/modules/shared/inputs/location-input/location-input.component.ts
@@ -20,7 +20,7 @@ import { PropertyManifest } from '@repo/types'
         <div class="field">
           <label for="lat-input">Latitude</label>
           <p class="control has-icons-left ">
-            <span class="icon is-small is-left">
+            <span class="icon is-left">
               <i class="icon icon-map-pin"></i>
             </span>
             <input
@@ -40,7 +40,7 @@ import { PropertyManifest } from '@repo/types'
         <div class="field">
           <label for="lng-input">Longitude</label>
           <p class="control has-icons-left ">
-            <span class="icon is-small is-left">
+            <span class="icon is-left">
               <i class="icon icon-map-pin"></i>
             </span>
             <input

--- a/packages/core/json-schema/src/schema/definitions/property-schema.json
+++ b/packages/core/json-schema/src/schema/definitions/property-schema.json
@@ -32,6 +32,10 @@
             "image"
           ]
         },
+        "helpText": {
+          "description": "Optional help text to provide additional guidance for the property in the admin UI.",
+          "type": "string"
+        },
         "validation": {
           "description": "Validation object for the property.",
           "$ref": "./validation-schema.json"

--- a/packages/core/json-schema/src/schema/definitions/relationship-schema.json
+++ b/packages/core/json-schema/src/schema/definitions/relationship-schema.json
@@ -18,6 +18,10 @@
         "eager": {
           "type": "boolean",
           "description": "Whether the relationship should be eager loaded. Otherwise, you need to explicitly request the relation in the client SDK or API.\nDefaults to false."
+        },
+        "helpText": {
+          "description": "Optional help text to provide additional guidance for the relationship in the admin UI.",
+          "type": "string"
         }
       },
       "required": ["entity"],

--- a/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/entity-manifest.service.ts
@@ -358,6 +358,7 @@ export class EntityManifestService {
           {},
         propSchema.validation
       ),
+      helpText: propSchema.helpText || '',
       default: propSchema.default
     }
   }

--- a/packages/core/manifest/src/manifest/services/relationship-manifest.service.ts
+++ b/packages/core/manifest/src/manifest/services/relationship-manifest.service.ts
@@ -37,6 +37,7 @@ export class RelationshipManifestService {
         name: camelize(relationship.name || relationship.entity),
         entity: relationship.entity,
         eager: relationship.eager || false,
+        helpText: relationship.helpText || '',
         type
       }
     } else {
@@ -55,6 +56,7 @@ export class RelationshipManifestService {
         name: pluralize(camelize(relationship.name || relationship.entity)),
         entity: relationship.entity,
         eager: relationship.eager || false,
+        helpText: relationship.helpText || '',
         type,
         owningSide: true,
         inverseSide: pluralize(camelize(entityClassName))

--- a/packages/core/manifest/src/manifest/tests/relationship-manifest.service.spec.ts
+++ b/packages/core/manifest/src/manifest/tests/relationship-manifest.service.spec.ts
@@ -107,7 +107,7 @@ describe('RelationshipManifestService', () => {
     expect(service).toBeDefined()
   })
 
-  it('should transform the relationship schema into a relationship manifest', () => {
+  it('should transform short-syntax many-to-one relationshipSchema into a relationshipManifest', () => {
     const relationship = 'User'
     const type = 'many-to-one'
     const entityClassName = 'Role'
@@ -123,6 +123,73 @@ describe('RelationshipManifestService', () => {
       entity: 'User',
       eager: false,
       type: 'many-to-one'
+    })
+  })
+
+  it('should transform long-syntax many-to-one relationshipSchema into a relationshipManifest', () => {
+    const relationship = {
+      name: 'user',
+      entity: 'User',
+      eager: true,
+      helpText: 'this is the help text',
+      type: 'many-to-one'
+    }
+    const entityClassName = 'Role'
+    const result = service.transformRelationship(
+      relationship,
+      'many-to-one',
+      entityClassName
+    )
+    expect(result).toEqual({
+      name: 'user',
+      entity: 'User',
+      helpText: 'this is the help text',
+      eager: true,
+      type: 'many-to-one'
+    })
+  })
+
+  it('should transform short-syntax many-to-many relationshipSchema into a relationshipManifest', () => {
+    const relationship = 'User'
+    const type = 'many-to-many'
+    const entityClassName = 'Role'
+    const result = service.transformRelationship(
+      relationship,
+      type,
+      entityClassName
+    )
+    expect(result).toEqual({
+      name: 'users',
+      entity: 'User',
+      eager: false,
+      inverseSide: 'roles',
+      type: 'many-to-many',
+      owningSide: true
+    })
+  })
+
+  it('should transform long-syntax many-to-many relationshipSchema into a relationshipManifest', () => {
+    const relationship = {
+      name: 'user',
+      entity: 'User',
+      eager: true,
+      type: 'many-to-many',
+      helpText: 'this is the help text'
+    }
+    const entityClassName = 'Role'
+    const result = service.transformRelationship(
+      relationship,
+      'many-to-many',
+      entityClassName
+    )
+    expect(result).toEqual({
+      name: 'users',
+      entity: 'User',
+      eager: true,
+      inverseSide: 'roles',
+      type: 'many-to-many',
+      helpText: 'this is the help text',
+      owningSide: true
     })
   })
 

--- a/packages/core/types/src/manifests/ManifestSchema.ts
+++ b/packages/core/types/src/manifests/ManifestSchema.ts
@@ -33,6 +33,13 @@ export type PropertySchema =
         | 'location'
         | 'file'
         | 'image'
+      /**
+       * Optional help text to provide additional guidance for the property in the admin UI.
+       */
+      helpText?: string
+      /**
+       * The validation schema for the property. Doc: https://manifest.build/docs/validation
+       */
       validation?: ValidationSchema
       /**
        * The default value of the property. Doc: https://manifest.build/docs/properties#property-params
@@ -70,6 +77,10 @@ export type RelationshipSchema =
        * Defaults to false.
        */
       eager?: boolean
+      /**
+       * Optional help text to provide additional guidance for the relationship in the admin UI.
+       */
+      helpText?: string
     }
   | string
 
@@ -270,7 +281,15 @@ export interface PoliciesSchema {
  * The policies of the entity. Doc: https://manifest.build/docs/policies
  */
 export interface PolicySchema {
-  access: 'public' | 'restricted' | 'forbidden' | 'admin' | '🌐' | '🚫' | '🔒' | '️👨🏻‍💻'
+  access:
+    | 'public'
+    | 'restricted'
+    | 'forbidden'
+    | 'admin'
+    | '🌐'
+    | '🚫'
+    | '🔒'
+    | '️👨🏻‍💻'
   allow?: string | string[]
   /**
    * When set to 'self', restricts access to records owned by the authenticated user (requires belongsTo relationship)
@@ -485,7 +504,15 @@ export interface EndpointSchema {
  * The policies of the entity. Doc: https://manifest.build/docs/policies
  */
 export interface PolicySchema1 {
-  access: 'public' | 'restricted' | 'forbidden' | 'admin' | '🌐' | '🚫' | '🔒' | '️👨🏻‍💻'
+  access:
+    | 'public'
+    | 'restricted'
+    | 'forbidden'
+    | 'admin'
+    | '🌐'
+    | '🚫'
+    | '🔒'
+    | '️👨🏻‍💻'
   allow?: string | string[]
   /**
    * When set to 'self', restricts access to records owned by the authenticated user (requires belongsTo relationship)

--- a/packages/core/types/src/manifests/PropertyManifest.ts
+++ b/packages/core/types/src/manifests/PropertyManifest.ts
@@ -30,6 +30,11 @@ export type PropertyManifest = {
   validation?: ValidationManifest
 
   /**
+   * Optional help text for the property.
+   */
+  helpText?: string
+
+  /**
    * Default value for the property.
    */
   default?: string | number | boolean | Record<string, unknown> | Array<unknown>

--- a/packages/core/types/src/manifests/RelationshipManifest.ts
+++ b/packages/core/types/src/manifests/RelationshipManifest.ts
@@ -22,6 +22,11 @@ export type RelationshipManifest = {
   type: 'many-to-one' | 'many-to-many' | 'one-to-many'
 
   /**
+   * Optional help text to provide additional guidance for the relationship in the admin UI.
+   */
+  helpText?: string
+
+  /**
    * Is this relationship the owning side of the relationship? (only for many-to-many)
    */
   owningSide?: boolean


### PR DESCRIPTION
## Description

Adds help texts for properties and relationships to the Admin UI

Doc PR: https://github.com/mnfst/manifest/pull/449

## How can it be tested?

Go to the admin panel and add helpText in the **properties** and **relationships**. Try with all types to see if layout is correct

```yaml
      - { name: description, type: text, helpText: "The title of the project." }
```

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I created the related [changeset](https://github.com/changesets/changesets) for my changes with `npx changeset`
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [x] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
