### PR TITLE
Fix search query

### DIFF
--- a/.changeset/mean-hornets-give.md
+++ b/.changeset/mean-hornets-give.md
@@ -1,0 +1,5 @@
+---
+'@mnfst/sdk': patch
+---
+
+fix where function acts strangely when using search query that contains where operator, thanks @davidhidvegi

--- a/packages/core/common/src/base-classes/BaseSdk.ts
+++ b/packages/core/common/src/base-classes/BaseSdk.ts
@@ -59,8 +59,9 @@ export class BaseSDK {
       )
     }
 
+    const spacedOperator = ` ${whereOperator} `
     const [propName, propValue] = whereClause
-      .split(whereOperator)
+      .split(spacedOperator)
       .map((str) => str.trim())
 
     const suffix: string = whereOperatorKeySuffix[whereOperator]


### PR DESCRIPTION
## Description

Fixes an SDK issue where using a where query that contains a where operator ("in", "like"...) returns all items instead of filtering:

```js
const dogs = await manifest.from('dogs').where('name like %likein%').find()
```
## Related Issues

- Closes #470 

