### PR TITLE
docs(changeset): fixed whitescreen on reload admin panel deep pages, …

### DIFF
--- a/.changeset/tame-cameras-beg.md
+++ b/.changeset/tame-cameras-beg.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+fixed whitescreen on reload admin panel deep pages, thanks Emilien


### PR DESCRIPTION
Description
This PR fixes an admin panel bug where the screen goes white after reloading the page if on deep pages.

Related Issues
Issue was done from Discord member https://discordapp.com/channels/1089907785178812499/1414531967206035466

