### PR TITLE
fix: add realistic default amount to pay-confirm component

### DIFF
--- a/packages/agentic-ui-toolkit/registry.json
+++ b/packages/agentic-ui-toolkit/registry.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "pay-confirm",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "registry:component",
       "title": "Pay Confirm",
       "description": "A payment confirmation block displaying amount, card details, and confirm/cancel actions.",

--- a/packages/agentic-ui-toolkit/registry/payment/pay-confirm.tsx
+++ b/packages/agentic-ui-toolkit/registry/payment/pay-confirm.tsx
@@ -39,7 +39,7 @@ export interface PayConfirmProps {
 }
 
 export function PayConfirm({ data, actions, appearance, control }: PayConfirmProps) {
-  const { amount = 0, cardLast4 = "4242", cardBrand = "Visa" } = data ?? {}
+  const { amount = 99.99, cardLast4 = "4242", cardBrand = "Visa" } = data ?? {}
   const { onConfirm, onCancel } = actions ?? {}
   const { currency = "USD" } = appearance ?? {}
   const { isLoading = false } = control ?? {}


### PR DESCRIPTION
The pay-confirm component had a default amount of 0, which would display "$0.00" when rendered without data. Changed the default to $99.99 to provide better preview experience.

Bumped version to 1.0.1.

## Description

## Related Issues

## How can it be tested?

## Check list before submitting

- [ ] This PR is wrote in a clear language and correctly labeled
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
