### PR TITLE
Add data config documentation to stats card

### DIFF
--- a/packages/agentic-ui-toolkit/registry/miscellaneous/stat-card.tsx
+++ b/packages/agentic-ui-toolkit/registry/miscellaneous/stat-card.tsx
@@ -3,7 +3,7 @@
 import { TrendingUp, TrendingDown, Minus } from "lucide-react"
 import { cn } from "@/lib/utils"
 
-export interface StatCardProps {
+export interface StatCard {
   label: string
   value: string | number
   change?: number
@@ -14,11 +14,11 @@ export interface StatCardProps {
 
 export interface StatsProps {
   data?: {
-    stats?: StatCardProps[]
+    stats?: StatCard[]
   }
 }
 
-const defaultStats: StatCardProps[] = [
+const defaultStats: StatCard[] = [
   { label: "Sales", value: "$12,543", change: 12.5, trend: "up" },
   { label: "Orders", value: "342", change: -3.2, trend: "down" },
   { label: "Customers", value: "1,205", change: 0, trend: "neutral" },


### PR DESCRIPTION
The configuration viewer parses Props interfaces to generate documentation. StatCardProps was being matched before StatsProps because it appeared first in the file, causing "No configuration schema detected" to be shown.

Renaming to StatCard follows the pattern used by other components (Product, Step, Tag, etc.) and allows StatsProps to be correctly parsed.

## Description

## Related Issues

## How can it be tested?

## Check list before submitting

- [ ] This PR is wrote in a clear language and correctly labeled
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
