### PR TITLE
Fix missing version numbers in JSON components

### DIFF
--- a/packages/agentic-ui-toolkit/components/blocks/install-command-inline.tsx
+++ b/packages/agentic-ui-toolkit/components/blocks/install-command-inline.tsx
@@ -35,10 +35,12 @@ const packageManagers: {
 
 interface InstallCommandInlineProps {
   componentName: string
+  version?: string | null
 }
 
 export function InstallCommandInline({
-  componentName
+  componentName,
+  version
 }: InstallCommandInlineProps) {
   const [selectedPm, setSelectedPm] = useState<PackageManager>('npx')
   const [copied, setCopied] = useState(false)
@@ -57,6 +59,13 @@ export function InstallCommandInline({
 
   return (
     <div className="flex items-center gap-2">
+      {/* Version badge */}
+      {version && (
+        <span className="px-2 py-1 text-xs font-mono bg-muted text-muted-foreground rounded-md">
+          v{version}
+        </span>
+      )}
+
       {/* Package manager select */}
       <div className="relative">
         <select

--- a/packages/agentic-ui-toolkit/components/blocks/variant-section.tsx
+++ b/packages/agentic-ui-toolkit/components/blocks/variant-section.tsx
@@ -28,12 +28,14 @@ interface VariantSectionProps {
 
 interface SourceCodeState {
   code: string | null
+  version: string | null
   loading: boolean
   error: string | null
 }
 
 function useSourceCode(registryName: string): SourceCodeState {
   const [code, setCode] = useState<string | null>(null)
+  const [version, setVersion] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
@@ -50,6 +52,7 @@ function useSourceCode(registryName: string): SourceCodeState {
         const content = data.files?.[0]?.content
         if (content) {
           setCode(content)
+          setVersion(data.version || null)
         } else {
           setError('No source code available')
         }
@@ -62,7 +65,7 @@ function useSourceCode(registryName: string): SourceCodeState {
     fetchCode()
   }, [registryName])
 
-  return { code, loading, error }
+  return { code, version, loading, error }
 }
 
 function CodeViewer({ sourceCode }: { sourceCode: SourceCodeState }) {
@@ -202,7 +205,7 @@ export function VariantSection({
           </button>
         </div>
 
-        <InstallCommandInline componentName={registryName} />
+        <InstallCommandInline componentName={registryName} version={sourceCode.version} />
       </div>
 
       {/* Content based on view mode */}

--- a/packages/agentic-ui-toolkit/package.json
+++ b/packages/agentic-ui-toolkit/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "registry:build": "shadcn build"
+    "registry:build": "shadcn build && node scripts/inject-versions.mjs"
   },
   "dependencies": {
     "@openai/apps-sdk-ui": "^0.2.1",

--- a/packages/agentic-ui-toolkit/scripts/inject-versions.mjs
+++ b/packages/agentic-ui-toolkit/scripts/inject-versions.mjs
@@ -1,0 +1,63 @@
+/**
+ * Post-build script to inject version numbers into generated registry JSON files.
+ *
+ * The shadcn build command doesn't include version fields in the output,
+ * so this script reads versions from registry.json and adds them to each
+ * component's JSON file in public/r/.
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const rootDir = join(__dirname, '..')
+
+const registryPath = join(rootDir, 'registry.json')
+const outputDir = join(rootDir, 'public', 'r')
+
+// Read the source registry
+const registry = JSON.parse(readFileSync(registryPath, 'utf-8'))
+
+let updated = 0
+let skipped = 0
+
+for (const item of registry.items) {
+  const { name, version } = item
+
+  if (!version) {
+    console.log(`⚠ Skipping ${name}: no version defined`)
+    skipped++
+    continue
+  }
+
+  const outputPath = join(outputDir, `${name}.json`)
+
+  if (!existsSync(outputPath)) {
+    console.log(`⚠ Skipping ${name}: output file not found`)
+    skipped++
+    continue
+  }
+
+  // Read the generated JSON
+  const outputJson = JSON.parse(readFileSync(outputPath, 'utf-8'))
+
+  // Add version field after name
+  const updatedJson = {
+    $schema: outputJson.$schema,
+    name: outputJson.name,
+    version: version,
+    ...Object.fromEntries(
+      Object.entries(outputJson).filter(([key]) => !['$schema', 'name'].includes(key))
+    )
+  }
+
+  // Write back
+  writeFileSync(outputPath, JSON.stringify(updatedJson, null, 2))
+  updated++
+}
+
+console.log(`✓ Injected versions into ${updated} component(s)`)
+if (skipped > 0) {
+  console.log(`⚠ Skipped ${skipped} component(s)`)
+}


### PR DESCRIPTION
The version data was stored in registry.json but not being displayed in the UI. This fix:
- Updates useSourceCode hook to extract version from the fetched JSON data
- Passes version to InstallCommandInline component
- Displays version as a badge (e.g., "v1.0.0") next to the install command

## Description

## Related Issues

## How can it be tested?

## Check list before submitting

- [ ] This PR is wrote in a clear language and correctly labeled
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
