### PR TITLE
feat: add PiP and Fullwidth layouts to all blocks

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { ChevronRight, Link as LinkIcon, Zap } from 'lucide-react'
+import { ChevronRight, Zap } from 'lucide-react'
 import Link from 'next/link'
-import { useParams, usePathname } from 'next/navigation'
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { Suspense, useEffect, useRef, useState } from 'react'
 
 // Form components
 import { ContactForm } from '@/registry/form/contact-form'
@@ -1274,44 +1274,6 @@ const categories: Category[] = [
   }
 ]
 
-// Copy link button component
-function CopyLinkButton({ anchor, className }: { anchor?: string; className?: string }) {
-  const [copied, setCopied] = useState(false)
-  const pathname = usePathname()
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-      }
-    }
-  }, [])
-
-  const handleCopy = useCallback(() => {
-    const url = `${window.location.origin}${pathname}${anchor ? `#${anchor}` : ''}`
-    navigator.clipboard.writeText(url)
-    setCopied(true)
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-    }
-    timeoutRef.current = setTimeout(() => setCopied(false), 2000)
-  }, [pathname, anchor])
-
-  return (
-    <button
-      onClick={handleCopy}
-      className={cn(
-        'opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-muted',
-        className
-      )}
-      title={copied ? 'Copied!' : 'Copy link'}
-    >
-      <LinkIcon className={cn('h-4 w-4', copied ? 'text-green-500' : 'text-muted-foreground')} />
-    </button>
-  )
-}
-
 function BlockPageContent() {
   const params = useParams()
   const categorySlug = params.category as string
@@ -1434,7 +1396,6 @@ function BlockPageContent() {
             {/* Block Title */}
             <div className="flex items-center gap-3 mb-1">
               <h1 className="text-2xl font-bold">{selectedBlock.name}</h1>
-              <CopyLinkButton />
               {selectedBlock.actionCount > 0 ? (
                 <button
                   onClick={() => firstVariantRef.current?.showActionsConfig()}
@@ -1458,10 +1419,6 @@ function BlockPageContent() {
           {/* All Variants */}
           {selectedBlock.variants.map((variant, index) => (
             <div key={variant.id} id={variant.id} className="scroll-mt-20">
-              <div className="group flex items-center gap-2 mb-3">
-                <h2 className="text-lg font-bold">{variant.name}</h2>
-                <CopyLinkButton anchor={variant.id} />
-              </div>
               <VariantSection
                 ref={index === 0 ? firstVariantRef : undefined}
                 name={variant.name}
@@ -1470,7 +1427,6 @@ function BlockPageContent() {
                 registryName={selectedBlock.registryName}
                 usageCode={variant.usageCode}
                 layouts={selectedBlock.layouts}
-                hideTitle
               />
             </div>
           ))}

--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -97,7 +97,7 @@ const categories: Category[] = [
         description:
           'Display blog posts with various layouts and styles. Click "Read" to see fullscreen mode.',
         registryName: 'post-card',
-        layouts: ['inline', 'fullscreen'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -255,7 +255,7 @@ const categories: Category[] = [
         name: 'Post List',
         description: 'Display multiple posts in various layouts',
         registryName: 'post-list',
-        layouts: ['inline', 'fullscreen'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -337,13 +337,14 @@ const categories: Category[] = [
         name: 'Contact Form',
         description: 'A complete contact form with name fields, phone number with country selector, email, message textarea, and file attachment.',
         registryName: 'contact-form',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <ContactForm />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><ContactForm /></div>,
             usageCode: `<ContactForm
   data={{
     title: "Contact Us",
@@ -368,13 +369,14 @@ const categories: Category[] = [
         name: 'Date & Time Picker',
         description: 'A Calendly-style date and time picker. Select a date to reveal available time slots, then select a time to show the Next button.',
         registryName: 'date-time-picker',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <DateTimePicker />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><DateTimePicker /></div>,
             usageCode: `<DateTimePicker
   data={{
     title: "Select a Date & Time",
@@ -402,13 +404,14 @@ const categories: Category[] = [
         name: 'Issue Report Form',
         description: 'A compact issue reporting form for team members with categories, subcategories, impact/urgency levels, and file attachments.',
         registryName: 'issue-report-form',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <IssueReportForm />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><IssueReportForm /></div>,
             usageCode: `<IssueReportForm
   data={{
     title: "Report an Issue",
@@ -441,7 +444,7 @@ const categories: Category[] = [
         name: 'Product List',
         description: 'Display products in various layouts',
         registryName: 'product-list',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 2,
         variants: [
           {
@@ -503,7 +506,7 @@ const categories: Category[] = [
         description:
           'Data table with header, footer, expand to fullscreen, and optional selection',
         registryName: 'table',
-        layouts: ['inline', 'fullscreen'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 6,
         variants: [
           {
@@ -596,7 +599,7 @@ const categories: Category[] = [
         description:
           'Interactive map with location markers and a draggable carousel of cards',
         registryName: 'map-carousel',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -636,7 +639,7 @@ const categories: Category[] = [
         name: 'Message Bubble',
         description: 'Chat message bubbles',
         registryName: 'chat-conversation',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -779,7 +782,7 @@ const categories: Category[] = [
         name: 'Chat Conversation',
         description: 'Full chat conversation view',
         registryName: 'chat-conversation',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -822,7 +825,7 @@ const categories: Category[] = [
         name: 'Option List',
         description: 'Tag-style option selector',
         registryName: 'option-list',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -849,7 +852,7 @@ const categories: Category[] = [
         name: 'Progress Steps',
         description: 'Step-by-step progress indicator',
         registryName: 'progress-steps',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -874,7 +877,7 @@ const categories: Category[] = [
         name: 'Quick Reply',
         description: 'Quick reply buttons for chat',
         registryName: 'quick-reply',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -900,7 +903,7 @@ const categories: Category[] = [
         name: 'Stats Cards',
         description: 'Display statistics and metrics',
         registryName: 'stats',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -923,7 +926,7 @@ const categories: Category[] = [
         name: 'Status Badge',
         description: 'Various status indicators',
         registryName: 'status-badge',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -951,7 +954,7 @@ const categories: Category[] = [
         name: 'Tag Select',
         description: 'Colored tag selector',
         registryName: 'tag-select',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 2,
         variants: [
           {
@@ -989,13 +992,14 @@ const categories: Category[] = [
         name: 'Order Confirmation',
         description: 'Display order summary before payment',
         registryName: 'order-confirm',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <OrderConfirm />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><OrderConfirm /></div>,
             usageCode: `<OrderConfirm
   data={{
     productName: "MacBook Pro 14-inch",
@@ -1015,13 +1019,14 @@ const categories: Category[] = [
         name: 'Payment Methods',
         description: 'Select payment method',
         registryName: 'payment-methods',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 3,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <PaymentMethods />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><PaymentMethods /></div>,
             usageCode: `<PaymentMethods
   data={{
     methods: [
@@ -1046,13 +1051,14 @@ const categories: Category[] = [
         name: 'Bank Card Form',
         description: 'Credit card input form',
         registryName: 'bank-card-form',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <BankCardForm />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><BankCardForm /></div>,
             usageCode: `<BankCardForm
   data={{ amount: 149.99 }}
   appearance={{ currency: "USD", submitLabel: "Pay $149.99" }}
@@ -1068,13 +1074,14 @@ const categories: Category[] = [
         name: 'Amount Input',
         description: 'Input for monetary amounts',
         registryName: 'amount-input',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 2,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <AmountInput />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><AmountInput /></div>,
             usageCode: `<AmountInput
   data={{ presets: [20, 50, 100, 200] }}
   appearance={{
@@ -1097,13 +1104,14 @@ const categories: Category[] = [
         name: 'Payment Success',
         description: 'Success confirmation after payment',
         registryName: 'payment-success',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <PaymentSuccess />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><PaymentSuccess /></div>,
             usageCode: `<PaymentSuccess
   data={{
     orderId: "ORD-2024-7842",
@@ -1123,13 +1131,14 @@ const categories: Category[] = [
         name: 'Payment Confirmation',
         description: 'Detailed payment confirmation',
         registryName: 'payment-confirmed',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <PaymentConfirmed />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><PaymentConfirmed /></div>,
             usageCode: `<PaymentConfirmed
   data={{
     orderId: "ORD-2024-7842",
@@ -1156,7 +1165,7 @@ const categories: Category[] = [
         name: 'Instagram Post',
         description: 'Instagram post card',
         registryName: 'instagram-post',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1182,7 +1191,7 @@ const categories: Category[] = [
         name: 'LinkedIn Post',
         description: 'LinkedIn post card',
         registryName: 'linkedin-post',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1209,7 +1218,7 @@ const categories: Category[] = [
         name: 'X Post',
         description: 'X (Twitter) post card',
         registryName: 'x-post',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1238,7 +1247,7 @@ const categories: Category[] = [
         name: 'YouTube Post',
         description: 'YouTube video card',
         registryName: 'youtube-post',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {

--- a/packages/manifest-ui/app/blocks/page.tsx
+++ b/packages/manifest-ui/app/blocks/page.tsx
@@ -96,7 +96,7 @@ const categories: Category[] = [
         description:
           'Display blog posts with various layouts and styles. Click "Read" to see fullscreen mode.',
         registryName: 'post-card',
-        layouts: ['inline', 'fullscreen'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -254,7 +254,7 @@ const categories: Category[] = [
         name: 'Post List',
         description: 'Display multiple posts in various layouts',
         registryName: 'post-list',
-        layouts: ['inline', 'fullscreen'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -432,13 +432,14 @@ const categories: Category[] = [
         name: 'Contact Form',
         description: 'A complete contact form with name fields, phone number with country selector, email, message textarea, and file attachment.',
         registryName: 'contact-form',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <ContactForm />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><ContactForm /></div>,
             usageCode: `<ContactForm
   data={{
     title: "Contact Us",
@@ -469,13 +470,14 @@ const categories: Category[] = [
         name: 'Date & Time Picker',
         description: 'A Calendly-style date and time picker. Select a date to reveal available time slots, then select a time to show the Next button.',
         registryName: 'date-time-picker',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <DateTimePicker />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><DateTimePicker /></div>,
             usageCode: `<DateTimePicker
   data={{
     title: "Select a Date & Time",
@@ -521,13 +523,14 @@ const categories: Category[] = [
         name: 'Issue Report Form',
         description: 'A compact issue reporting form for team members with categories, subcategories, impact/urgency levels, and file attachments. Collapsible sections keep it chat-friendly.',
         registryName: 'issue-report-form',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <IssueReportForm />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><IssueReportForm /></div>,
             usageCode: `<IssueReportForm
   data={{
     title: "Report an Issue",
@@ -592,7 +595,7 @@ const categories: Category[] = [
         name: 'Product List',
         description: 'Display products in various layouts',
         registryName: 'product-list',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 2,
         variants: [
           {
@@ -657,7 +660,7 @@ const categories: Category[] = [
         description:
           'Data table with header, footer, expand to fullscreen, and optional selection',
         registryName: 'table',
-        layouts: ['inline', 'fullscreen'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 6,
         variants: [
           {
@@ -803,7 +806,7 @@ const categories: Category[] = [
         description:
           'Interactive map with location markers and a draggable carousel of cards',
         registryName: 'map-carousel',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -873,7 +876,7 @@ const categories: Category[] = [
         name: 'Message Bubble',
         description: 'Chat message bubbles',
         registryName: 'chat-conversation',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1034,7 +1037,7 @@ const categories: Category[] = [
         name: 'Chat Conversation',
         description: 'Full chat conversation view',
         registryName: 'chat-conversation',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1091,7 +1094,7 @@ const categories: Category[] = [
         name: 'Option List',
         description: 'Tag-style option selector',
         registryName: 'option-list',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -1119,7 +1122,7 @@ const categories: Category[] = [
         name: 'Progress Steps',
         description: 'Step-by-step progress indicator',
         registryName: 'progress-steps',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1144,7 +1147,7 @@ const categories: Category[] = [
         name: 'Quick Reply',
         description: 'Quick reply buttons for chat',
         registryName: 'quick-reply',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
@@ -1172,7 +1175,7 @@ const categories: Category[] = [
         name: 'Stats Cards',
         description: 'Display statistics and metrics',
         registryName: 'stats',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1196,7 +1199,7 @@ const categories: Category[] = [
         name: 'Status Badge',
         description: 'Various status indicators',
         registryName: 'status-badge',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1253,7 +1256,7 @@ const categories: Category[] = [
         name: 'Tag Select',
         description: 'Colored tag selector',
         registryName: 'tag-select',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 2,
         variants: [
           {
@@ -1296,13 +1299,14 @@ const categories: Category[] = [
         name: 'Order Confirmation',
         description: 'Display order summary before payment',
         registryName: 'order-confirm',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <OrderConfirm />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><OrderConfirm /></div>,
             usageCode: `<OrderConfirm
   data={{
     productName: "MacBook Pro 14-inch",
@@ -1326,13 +1330,14 @@ const categories: Category[] = [
         name: 'Payment Methods',
         description: 'Select payment method',
         registryName: 'payment-methods',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 3,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <PaymentMethods />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><PaymentMethods /></div>,
             usageCode: `<PaymentMethods
   data={{
     methods: [
@@ -1357,13 +1362,14 @@ const categories: Category[] = [
         name: 'Bank Card Form',
         description: 'Credit card input form',
         registryName: 'bank-card-form',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <BankCardForm />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><BankCardForm /></div>,
             usageCode: `<BankCardForm
   data={{ amount: 149.99 }}
   appearance={{ currency: "USD", submitLabel: "Pay $149.99" }}
@@ -1379,13 +1385,14 @@ const categories: Category[] = [
         name: 'Amount Input',
         description: 'Input for monetary amounts',
         registryName: 'amount-input',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 2,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <AmountInput />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><AmountInput /></div>,
             usageCode: `<AmountInput
   data={{ presets: [20, 50, 100, 200] }}
   appearance={{
@@ -1409,13 +1416,14 @@ const categories: Category[] = [
         name: 'Payment Success',
         description: 'Success confirmation after payment',
         registryName: 'payment-success',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <PaymentSuccess />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><PaymentSuccess /></div>,
             usageCode: `<PaymentSuccess
   data={{
     orderId: "ORD-2024-7842",
@@ -1435,13 +1443,14 @@ const categories: Category[] = [
         name: 'Payment Confirmation',
         description: 'Detailed payment confirmation',
         registryName: 'payment-confirmed',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 1,
         variants: [
           {
             id: 'default',
             name: 'Default',
             component: <PaymentConfirmed />,
+            fullscreenComponent: <div className="max-w-[680px] mx-auto"><PaymentConfirmed /></div>,
             usageCode: `<PaymentConfirmed
   data={{
     orderId: "ORD-2024-7842",
@@ -1468,7 +1477,7 @@ const categories: Category[] = [
         name: 'Instagram Post',
         description: 'Instagram post card',
         registryName: 'instagram-post',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1494,7 +1503,7 @@ const categories: Category[] = [
         name: 'LinkedIn Post',
         description: 'LinkedIn post card',
         registryName: 'linkedin-post',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1521,7 +1530,7 @@ const categories: Category[] = [
         name: 'X Post',
         description: 'X (Twitter) post card',
         registryName: 'x-post',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {
@@ -1550,7 +1559,7 @@ const categories: Category[] = [
         name: 'YouTube Post',
         description: 'YouTube video card',
         registryName: 'youtube-post',
-        layouts: ['inline'],
+        layouts: ['inline', 'fullscreen', 'pip'],
         actionCount: 0,
         variants: [
           {

--- a/packages/manifest-ui/components/blocks/variant-section.tsx
+++ b/packages/manifest-ui/components/blocks/variant-section.tsx
@@ -4,6 +4,7 @@ import dynamic from 'next/dynamic'
 import { InstallCommandInline } from '@/components/blocks/install-command-inline'
 import { ConfigurationViewer } from '@/components/blocks/configuration-viewer'
 import { FullscreenModal } from '@/components/layout/fullscreen-modal'
+import { PipModal } from '@/components/layout/pip-modal'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Maximize2, MessageSquare, PictureInPicture2, Settings2 } from 'lucide-react'
@@ -136,6 +137,7 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
 }, ref) {
   const [viewMode, setViewMode] = useState<ViewMode>('inline')
   const [isFullscreenOpen, setIsFullscreenOpen] = useState(false)
+  const [isPipOpen, setIsPipOpen] = useState(false)
   const [highlightCategory, setHighlightCategory] = useState<'data' | 'actions' | 'appearance' | 'control' | null>(null)
   const sourceCode = useSourceCode(registryName)
   const timeoutRefs = useRef<NodeJS.Timeout[]>([])
@@ -178,6 +180,7 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
   useEffect(() => {
     setViewMode('inline')
     setIsFullscreenOpen(false)
+    setIsPipOpen(false)
     setHighlightCategory(null)
   }, [registryName])
 
@@ -286,7 +289,14 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
 
         {viewMode === 'pip' && (
           <div className="flex items-center justify-center min-h-[300px] bg-muted/30 rounded-lg border border-dashed">
-            <p className="text-muted-foreground text-sm">PiP mode coming soon</p>
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={() => setIsPipOpen(true)}
+              className="px-8"
+            >
+              Open PiP
+            </Button>
           </div>
         )}
 
@@ -323,6 +333,16 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
         >
           {fullscreenComponent || component}
         </FullscreenModal>
+      )}
+
+      {/* PiP Modal */}
+      {isPipOpen && (
+        <PipModal
+          appName={name}
+          onClose={() => setIsPipOpen(false)}
+        >
+          {component}
+        </PipModal>
       )}
     </div>
   )

--- a/packages/manifest-ui/components/layout/fullscreen-modal.tsx
+++ b/packages/manifest-ui/components/layout/fullscreen-modal.tsx
@@ -60,8 +60,10 @@ export function FullscreenModal({
         )}
       </header>
 
-      {/* Content - component fills this space at 100% */}
-      <div className="flex-1 overflow-auto overscroll-contain">{children}</div>
+      {/* Content - full width/height white background with centered content */}
+      <div className="flex-1 overflow-auto overscroll-contain bg-white dark:bg-zinc-950 flex justify-center p-8">
+        {children}
+      </div>
     </div>
   )
 }

--- a/packages/manifest-ui/components/layout/pip-modal.tsx
+++ b/packages/manifest-ui/components/layout/pip-modal.tsx
@@ -7,6 +7,8 @@ export interface PipModalProps {
   children: ReactNode
   appName: string
   onClose?: () => void
+  /** Position and width to match the inline content */
+  position?: { left: number; width: number }
 }
 
 /**
@@ -21,37 +23,27 @@ export interface PipModalProps {
  * Our components should NOT render this directly - they call requestDisplayMode('pip')
  * and the host wraps them in their own PiP container.
  */
-export function PipModal({ children, appName, onClose }: PipModalProps) {
+export function PipModal({ children, onClose, position }: PipModalProps) {
   return (
     <>
-      {/* Backdrop - subtle overlay */}
+      {/* PiP Window - just the component with shadow and close button */}
       <div
-        className="fixed inset-0 z-40 bg-black/20 backdrop-blur-[2px]"
-        onClick={onClose}
-      />
+        className="fixed top-20 z-50"
+        style={position ? { left: position.left, width: position.width } : { right: 16, width: 'min(400px, calc(100vw - 2rem))' }}
+      >
+        {/* Close button - top left, floating over content */}
+        <button
+          onClick={onClose}
+          className="absolute -top-3 -left-3 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black text-white shadow-lg hover:bg-black/80 transition-colors cursor-pointer"
+          aria-label="Close PiP"
+        >
+          <X className="h-4 w-4" />
+        </button>
 
-      {/* PiP Window - fixed floating container */}
-      <div className="fixed top-20 right-4 md:right-8 z-50 w-[min(400px,calc(100vw-2rem))] max-h-[calc(100vh-8rem)] flex flex-col bg-background rounded-xl shadow-2xl border overflow-hidden animate-in slide-in-from-top-2 fade-in duration-200">
-        {/* Header */}
-        <header className="flex h-11 shrink-0 items-center justify-between border-b px-3 bg-muted/30">
-          <span className="text-sm font-medium truncate">{appName}</span>
-
-          <button
-            onClick={onClose}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
-            aria-label="Close PiP"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </header>
-
-        {/* Content */}
-        <div className="flex-1 overflow-auto overscroll-contain p-4">
+        {/* Content - just the component with rounded corners and shadow */}
+        <div className="rounded-2xl overflow-hidden shadow-lg">
           {children}
         </div>
-
-        {/* Footer indicator */}
-        <div className="h-1 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 opacity-50" />
       </div>
     </>
   )

--- a/packages/manifest-ui/components/layout/pip-modal.tsx
+++ b/packages/manifest-ui/components/layout/pip-modal.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { X } from 'lucide-react'
+import { ReactNode } from 'react'
+
+export interface PipModalProps {
+  children: ReactNode
+  appName: string
+  onClose?: () => void
+}
+
+/**
+ * Picture-in-Picture modal that simulates ChatGPT's PiP container.
+ *
+ * A persistent floating window optimized for ongoing or live sessions.
+ * PiP remains visible while the conversation continues and stays fixed
+ * to the top of the viewport on scroll.
+ *
+ * IMPORTANT: This is for PREVIEW mode only on our website.
+ * In real ChatGPT environments, the HOST controls the PiP container.
+ * Our components should NOT render this directly - they call requestDisplayMode('pip')
+ * and the host wraps them in their own PiP container.
+ */
+export function PipModal({ children, appName, onClose }: PipModalProps) {
+  return (
+    <>
+      {/* Backdrop - subtle overlay */}
+      <div
+        className="fixed inset-0 z-40 bg-black/20 backdrop-blur-[2px]"
+        onClick={onClose}
+      />
+
+      {/* PiP Window - fixed floating container */}
+      <div className="fixed top-20 right-4 md:right-8 z-50 w-[min(400px,calc(100vw-2rem))] max-h-[calc(100vh-8rem)] flex flex-col bg-background rounded-xl shadow-2xl border overflow-hidden animate-in slide-in-from-top-2 fade-in duration-200">
+        {/* Header */}
+        <header className="flex h-11 shrink-0 items-center justify-between border-b px-3 bg-muted/30">
+          <span className="text-sm font-medium truncate">{appName}</span>
+
+          <button
+            onClick={onClose}
+            className="flex h-7 w-7 items-center justify-center rounded-md text-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
+            aria-label="Close PiP"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto overscroll-contain p-4">
+          {children}
+        </div>
+
+        {/* Footer indicator */}
+        <div className="h-1 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500 opacity-50" />
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Description

Add Picture-in-Picture (PiP) and Fullwidth layout modes to all 27 blocks in the registry. This enables users to preview components in different display modes:
- **Inline**: Default view within the page
- **PiP**: Fixed floating window that follows scroll, matching inline position/width
- **Fullwidth**: Fullscreen modal view

Also adds max-width (680px) centered styling for Forms and Payment blocks in fullwidth mode, and updates button labels for clarity.

## Related Issues

None

## How can it be tested?

1. Navigate to http://localhost:3001/blocks
2. Select any block from the sidebar
3. Click the PiP button (picture-in-picture icon) and click "Open in Picture-in-Picture"
   - Verify the component appears fixed at the top and follows scroll
   - Verify the close button (X) works
4. Click the Fullwidth button (maximize icon) and click "Open in Full width"
   - Verify the fullscreen modal opens with muted background
   - For Forms/Payment blocks, verify max-width is applied and centered
5. Test on different blocks to ensure all have PiP and Fullwidth available

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR