### PR TITLE
Make action count clickable on payment success

### DIFF
--- a/packages/agentic-ui-toolkit/app/blocks/page.tsx
+++ b/packages/agentic-ui-toolkit/app/blocks/page.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 import { ChevronRight, Zap } from 'lucide-react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { Suspense, useState } from 'react'
+import { Suspense, useRef, useState } from 'react'
 
 // Form components
 import { ContactForm } from '@/registry/form/contact-form'
@@ -53,7 +53,7 @@ import { YouTubePost } from '@/registry/miscellaneous/youtube-post'
 
 // UI components
 import { GettingStarted } from '@/components/blocks/getting-started'
-import { VariantSection } from '@/components/blocks/variant-section'
+import { VariantSection, VariantSectionHandle } from '@/components/blocks/variant-section'
 
 // Types for the new structure
 interface BlockVariant {
@@ -1589,6 +1589,9 @@ function BlocksContent() {
     ? categories.flatMap((c) => c.blocks).find((b) => b.id === blockId)
     : null
 
+  // Ref for the first variant section to enable scrolling to actions config
+  const firstVariantRef = useRef<VariantSectionHandle>(null)
+
   return (
     <div className="flex min-h-[calc(100vh-3.5rem)] bg-card">
       {/* Sidebar */}
@@ -1650,12 +1653,20 @@ function BlocksContent() {
             <div>
               <div className="flex items-center gap-3 mb-1">
                 <h1 className="text-2xl font-bold">{selectedBlock.name}</h1>
-                <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1">
-                  <Zap className="w-3 h-3" />
-                  {selectedBlock.actionCount > 0
-                    ? `${selectedBlock.actionCount} action${selectedBlock.actionCount > 1 ? 's' : ''}`
-                    : 'read only'}
-                </span>
+                {selectedBlock.actionCount > 0 ? (
+                  <button
+                    onClick={() => firstVariantRef.current?.showActionsConfig()}
+                    className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                  >
+                    <Zap className="w-3 h-3" />
+                    {`${selectedBlock.actionCount} action${selectedBlock.actionCount > 1 ? 's' : ''}`}
+                  </button>
+                ) : (
+                  <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1">
+                    <Zap className="w-3 h-3" />
+                    read only
+                  </span>
+                )}
               </div>
               <p className="text-muted-foreground">
                 {selectedBlock.description}
@@ -1663,9 +1674,10 @@ function BlocksContent() {
             </div>
 
             {/* All Variants */}
-            {selectedBlock.variants.map((variant) => (
+            {selectedBlock.variants.map((variant, index) => (
               <VariantSection
                 key={variant.id}
+                ref={index === 0 ? firstVariantRef : undefined}
                 name={variant.name}
                 component={variant.component}
                 fullscreenComponent={variant.fullscreenComponent}

--- a/packages/agentic-ui-toolkit/components/blocks/configuration-viewer.tsx
+++ b/packages/agentic-ui-toolkit/components/blocks/configuration-viewer.tsx
@@ -644,7 +644,7 @@ export function ConfigurationViewer({
 
       <div className="grid gap-4">
         {categories.map((category) => (
-          <div key={category.name} className="rounded-lg border bg-card p-4">
+          <div key={category.name} id={`config-${category.name}`} className="rounded-lg border bg-card p-4">
             {/* Category header */}
             <div className="flex items-center gap-3 mb-3">
               <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-muted-foreground">

--- a/packages/agentic-ui-toolkit/components/blocks/variant-section.tsx
+++ b/packages/agentic-ui-toolkit/components/blocks/variant-section.tsx
@@ -7,7 +7,7 @@ import { FullscreenModal } from '@/components/layout/fullscreen-modal'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Maximize2, MessageSquare, PictureInPicture2, Settings2 } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useState } from 'react'
 
 const CodeBlock = dynamic(() => import('./code-block').then(m => m.CodeBlock), {
   ssr: false,
@@ -24,6 +24,10 @@ interface VariantSectionProps {
   registryName: string
   usageCode?: string
   layouts?: LayoutMode[]
+}
+
+export interface VariantSectionHandle {
+  showActionsConfig: () => void
 }
 
 interface SourceCodeState {
@@ -120,17 +124,31 @@ function FullwidthPlaceholder({ onOpen }: { onOpen: () => void }) {
   )
 }
 
-export function VariantSection({
+export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionProps>(function VariantSection({
   name,
   component,
   fullscreenComponent,
   registryName,
   usageCode,
   layouts = ['inline']
-}: VariantSectionProps) {
+}, ref) {
   const [viewMode, setViewMode] = useState<ViewMode>('inline')
   const [isFullscreenOpen, setIsFullscreenOpen] = useState(false)
   const sourceCode = useSourceCode(registryName)
+
+  // Expose imperative methods to parent components
+  useImperativeHandle(ref, () => ({
+    showActionsConfig: () => {
+      setViewMode('config')
+      // Wait for the config view to render, then scroll to actions
+      setTimeout(() => {
+        const actionsElement = document.getElementById('config-actions')
+        if (actionsElement) {
+          actionsElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
+        }
+      }, 100)
+    }
+  }), [])
 
   // Reset view mode to inline when navigating to a different component
   useEffect(() => {
@@ -275,4 +293,4 @@ export function VariantSection({
       )}
     </div>
   )
-}
+})


### PR DESCRIPTION
When a block has actions, clicking the action count badge now:
- Switches to the Config tab
- Scrolls smoothly to the Actions section

This improves discoverability of action callbacks for developers.

## Description

## Related Issues

## How can it be tested?

## Check list before submitting

- [ ] This PR is wrote in a clear language and correctly labeled
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
