### PR TITLE
Replace Jawg with Leaflet-only map styling

### DIFF
--- a/packages/agentic-ui-toolkit/app/blocks/page.tsx
+++ b/packages/agentic-ui-toolkit/app/blocks/page.tsx
@@ -806,7 +806,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <MapCarousel data={{ mapStyle: 'jawg-lagoon', jawgAccessToken: '22bVROs6auuCAJ3QALhiCdA2wbAj4w0KPtPmNr5Eq5Hbpi2ug7foYlemD85sIi9Q' }} />,
+            component: <MapCarousel />,
             usageCode: `<MapCarousel
   data={{
     locations: [
@@ -843,7 +843,13 @@ const categories: Category[] = [
     ],
     center: [37.7899, -122.4034],
     zoom: 14,
-    mapStyle: "positron" // "positron" | "dark-matter" | "voyager"
+    // Available styles (no API key required):
+    // "voyager" - Colorful, detailed, Apple Maps-like (default)
+    // "voyager-smooth" - Same as voyager with labels under roads
+    // "positron" - Light, minimal, clean
+    // "dark-matter" - Dark theme
+    // "openstreetmap" - Standard OSM
+    mapStyle: "voyager"
   }}
   appearance={{ mapHeight: "504px" }}
   actions={{

--- a/packages/agentic-ui-toolkit/registry/miscellaneous/map-carousel.tsx
+++ b/packages/agentic-ui-toolkit/registry/miscellaneous/map-carousel.tsx
@@ -33,7 +33,12 @@ export interface Location {
   link?: string
 }
 
-export type MapStyle = 'positron' | 'dark-matter' | 'voyager' | 'jawg-lagoon' | 'jawg-dark' | 'jawg-streets'
+export type MapStyle =
+  | 'voyager'
+  | 'voyager-smooth'
+  | 'positron'
+  | 'dark-matter'
+  | 'openstreetmap'
 
 export interface MapCarouselProps {
   data?: {
@@ -41,7 +46,6 @@ export interface MapCarouselProps {
     center?: [number, number]
     zoom?: number
     mapStyle?: MapStyle
-    jawgAccessToken?: string
   }
   actions?: {
     onSelectLocation?: (location: Location) => void
@@ -312,31 +316,37 @@ function MapWithMarkers({
   )
 }
 
-const getTileConfig = (style: MapStyle, jawgToken?: string) => {
-  const configs = {
-    'positron': {
-      url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+const getTileConfig = (style: MapStyle) => {
+  const configs: Record<MapStyle, { url: string; attribution: string }> = {
+    // Voyager - Colorful, detailed, Apple Maps-like (recommended default)
+    voyager: {
+      url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
     },
+    // Voyager with labels under roads - cleaner look
+    'voyager-smooth': {
+      url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png',
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+    },
+    // Positron - Light, minimal, clean
+    positron: {
+      url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+    },
+    // Dark Matter - Dark theme
     'dark-matter': {
       url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
     },
-    'voyager': {
-      url: 'https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png',
-      attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
-    },
-    'jawg-lagoon': {
-      url: `https://tile.jawg.io/jawg-lagoon/{z}/{x}/{y}{r}.png?access-token=${jawgToken}`,
-      attribution: '<a href="https://jawg.io" target="_blank">&copy; Jawg</a> | <a href="https://www.openstreetmap.org/copyright">&copy; OpenStreetMap</a>'
-    },
-    'jawg-dark': {
-      url: `https://tile.jawg.io/jawg-dark/{z}/{x}/{y}{r}.png?access-token=${jawgToken}`,
-      attribution: '<a href="https://jawg.io" target="_blank">&copy; Jawg</a> | <a href="https://www.openstreetmap.org/copyright">&copy; OpenStreetMap</a>'
-    },
-    'jawg-streets': {
-      url: `https://tile.jawg.io/jawg-streets/{z}/{x}/{y}{r}.png?access-token=${jawgToken}`,
-      attribution: '<a href="https://jawg.io" target="_blank">&copy; Jawg</a> | <a href="https://www.openstreetmap.org/copyright">&copy; OpenStreetMap</a>'
+    // OpenStreetMap - Standard, detailed
+    openstreetmap: {
+      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
     }
   }
   return configs[style]
@@ -347,11 +357,10 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
     locations = defaultLocations,
     center = [37.7899, -122.4034], // San Francisco
     zoom = 14,
-    mapStyle = 'positron',
-    jawgAccessToken
+    mapStyle = 'voyager'
   } = data ?? {}
 
-  const tileConfig = getTileConfig(mapStyle, jawgAccessToken)
+  const tileConfig = getTileConfig(mapStyle)
   const { onSelectLocation } = actions ?? {}
   const { mapHeight = '504px' } = appearance ?? {}
 


### PR DESCRIPTION
Remove the requirement for a Jawg access token by using only free tile providers. The new default style is "voyager" which provides a colorful, detailed, Apple Maps-like appearance without any API keys.

Available map styles:
- voyager: Colorful, detailed (default)
- voyager-smooth: Same with labels under roads
- positron: Light, minimal, clean
- dark-matter: Dark theme
- openstreetmap: Standard OSM

## Description

## Related Issues

## How can it be tested?

## Check list before submitting

- [ ] This PR is wrote in a clear language and correctly labeled
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
