### PR TITLE
Fix issue 569 and update version documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,10 +240,37 @@ When adding a block to `app/blocks/page.tsx`, follow this pattern:
 }
 ```
 
+### Version Bump Requirements (CRITICAL)
+
+**Every modification to a block's source files MUST include a version bump in `registry.json`.**
+
+This is enforced by automated tests that will fail if:
+1. You modified any file in `registry/**/*.tsx`
+2. But did NOT update the corresponding component's `version` in `registry.json`
+
+#### Semantic Versioning Guide
+
+| Change Type | Version Bump | Examples |
+|-------------|--------------|----------|
+| **PATCH** | `1.0.0` → `1.0.1` | Bug fixes, styling fixes, refactoring without API changes |
+| **MINOR** | `1.0.0` → `1.1.0` | New features, new optional props, new variants |
+| **MAJOR** | `1.0.0` → `2.0.0` | Breaking changes: removing/renaming props, changing behavior |
+
+#### Example
+
+```json
+// Before modifying message-bubble.tsx
+{ "name": "message-bubble", "version": "1.0.0", ... }
+
+// After bug fix - bump PATCH
+{ "name": "message-bubble", "version": "1.0.1", ... }
+```
+
 ### Checklist for Block Changes
 
 Before submitting a PR with block changes:
 
+- [ ] **Version bumped in `registry.json`** (REQUIRED - tests will fail otherwise)
 - [ ] Component implements the standard props pattern (`data`, `actions`, `appearance`, `control`)
 - [ ] Block is registered in `registry.json` with correct dependencies
 - [ ] Block demo added to `app/blocks/page.tsx` with ALL variants

--- a/packages/agentic-ui-toolkit/CLAUDE.md
+++ b/packages/agentic-ui-toolkit/CLAUDE.md
@@ -118,6 +118,15 @@ Run `pnpm test` to verify version changes are valid. Tests will fail if:
 - A component file was modified but version wasn't bumped
 - Version format is invalid (must be `X.Y.Z` where X, Y, Z are non-negative integers)
 
+### IMPORTANT: Always Bump Versions
+
+**This is enforced by automated tests.** The test suite (`__tests__/version-bump.test.ts`) compares your changes against the base branch and will **fail the build** if:
+
+1. You modified any file in `registry/**/*.tsx`
+2. But did NOT update the corresponding component's `version` in `registry.json`
+
+This ensures that all component changes are properly versioned for consumers of the registry.
+
 ## Analytics Tracking (Vercel)
 
 **IMPORTANT**: When adding or updating blocks, maintain Vercel Analytics tracking for user interactions.

--- a/packages/agentic-ui-toolkit/__tests__/version-bump.test.ts
+++ b/packages/agentic-ui-toolkit/__tests__/version-bump.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Version Bump Enforcement Tests
+ *
+ * These tests ensure that when a block/component file is modified,
+ * its version in registry.json must also be updated.
+ *
+ * This prevents the situation where changes are made to a component
+ * without incrementing its version number.
+ */
+
+import { execSync } from 'child_process'
+import { readFileSync, existsSync } from 'fs'
+import { resolve, relative } from 'path'
+import { describe, it, expect } from 'vitest'
+
+const REGISTRY_DIR = resolve(__dirname, '..', 'registry')
+const REGISTRY_JSON_PATH = resolve(__dirname, '..', 'registry.json')
+
+interface RegistryItem {
+  name: string
+  version: string
+  files: Array<{ path: string }>
+}
+
+interface Registry {
+  items: RegistryItem[]
+}
+
+/**
+ * Get the list of files changed in the current branch compared to base
+ */
+function getChangedFiles(baseBranch = 'main'): string[] {
+  try {
+    // Try to get files changed compared to main/master
+    const result = execSync(
+      `git diff --name-only ${baseBranch}...HEAD 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo ""`,
+      { encoding: 'utf-8', cwd: resolve(__dirname, '..') }
+    )
+    return result
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Get the previous version of registry.json from git
+ */
+function getPreviousRegistry(baseBranch = 'main'): Registry | null {
+  try {
+    const content = execSync(
+      `git show ${baseBranch}:packages/agentic-ui-toolkit/registry.json 2>/dev/null || git show HEAD~1:packages/agentic-ui-toolkit/registry.json 2>/dev/null`,
+      { encoding: 'utf-8', cwd: resolve(__dirname, '../../..') }
+    )
+    return JSON.parse(content)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Load the current registry.json
+ */
+function loadCurrentRegistry(): Registry {
+  const content = readFileSync(REGISTRY_JSON_PATH, 'utf-8')
+  return JSON.parse(content)
+}
+
+/**
+ * Build a map of component name to version
+ */
+function buildVersionMap(registry: Registry): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const item of registry.items) {
+    map.set(item.name, item.version)
+  }
+  return map
+}
+
+/**
+ * Build a map of file path to component name
+ */
+function buildFileToComponentMap(registry: Registry): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const item of registry.items) {
+    for (const file of item.files) {
+      // Normalize path - registry files are relative to packages/agentic-ui-toolkit
+      map.set(file.path, item.name)
+    }
+  }
+  return map
+}
+
+describe('Version Bump Enforcement', () => {
+  const currentRegistry = loadCurrentRegistry()
+  const previousRegistry = getPreviousRegistry()
+  const changedFiles = getChangedFiles()
+
+  // Skip tests if we can't determine previous state (e.g., initial commit)
+  const canCompare = previousRegistry !== null
+
+  it('should be able to load current registry', () => {
+    expect(currentRegistry).toBeDefined()
+    expect(currentRegistry.items).toBeDefined()
+    expect(Array.isArray(currentRegistry.items)).toBe(true)
+  })
+
+  describe('Modified components must have version bumps', () => {
+    if (!canCompare) {
+      it.skip('skipped - no previous registry to compare against', () => {})
+      return
+    }
+
+    const currentVersions = buildVersionMap(currentRegistry)
+    const previousVersions = buildVersionMap(previousRegistry!)
+    const fileToComponent = buildFileToComponentMap(currentRegistry)
+
+    // Filter changed files to only registry component files
+    const changedComponentFiles = changedFiles.filter(
+      (file) =>
+        file.startsWith('packages/agentic-ui-toolkit/registry/') &&
+        file.endsWith('.tsx')
+    )
+
+    // Get unique component names that have changes
+    const modifiedComponents = new Set<string>()
+    for (const file of changedComponentFiles) {
+      // Extract relative path from packages/agentic-ui-toolkit/
+      const relativePath = file.replace('packages/agentic-ui-toolkit/', '')
+      const componentName = fileToComponent.get(relativePath)
+      if (componentName) {
+        modifiedComponents.add(componentName)
+      }
+    }
+
+    if (modifiedComponents.size === 0) {
+      it('no component files were modified', () => {
+        expect(modifiedComponents.size).toBe(0)
+      })
+      return
+    }
+
+    // Test each modified component
+    for (const componentName of modifiedComponents) {
+      it(`"${componentName}" was modified and should have version bump`, () => {
+        const previousVersion = previousVersions.get(componentName)
+        const currentVersion = currentVersions.get(componentName)
+
+        // New components don't need version comparison
+        if (!previousVersion) {
+          expect(currentVersion).toBeDefined()
+          return
+        }
+
+        expect(currentVersion).toBeDefined()
+
+        // Parse versions
+        const [prevMajor, prevMinor, prevPatch] = previousVersion
+          .split('.')
+          .map(Number)
+        const [currMajor, currMinor, currPatch] = currentVersion!
+          .split('.')
+          .map(Number)
+
+        const previousTotal = prevMajor * 10000 + prevMinor * 100 + prevPatch
+        const currentTotal = currMajor * 10000 + currMinor * 100 + currPatch
+
+        const versionBumped = currentTotal > previousTotal
+
+        if (!versionBumped) {
+          throw new Error(
+            `Component "${componentName}" was modified but version was not bumped!\n` +
+              `  Previous version: ${previousVersion}\n` +
+              `  Current version: ${currentVersion}\n` +
+              `  Modified files: ${changedComponentFiles
+                .filter((f) => {
+                  const rel = f.replace('packages/agentic-ui-toolkit/', '')
+                  return fileToComponent.get(rel) === componentName
+                })
+                .join(', ')}\n\n` +
+              `Please bump the version in registry.json for this component.\n` +
+              `Use semantic versioning:\n` +
+              `  - PATCH (x.y.Z): Bug fixes, minor improvements\n` +
+              `  - MINOR (x.Y.z): New features, backward-compatible changes\n` +
+              `  - MAJOR (X.y.z): Breaking changes`
+          )
+        }
+
+        expect(versionBumped).toBe(true)
+      })
+    }
+  })
+
+  describe('Summary of changes', () => {
+    it('should report what components would need version bumps', () => {
+      if (!canCompare) {
+        console.log('No previous registry to compare against')
+        return
+      }
+
+      const fileToComponent = buildFileToComponentMap(currentRegistry)
+      const changedComponentFiles = changedFiles.filter(
+        (file) =>
+          file.startsWith('packages/agentic-ui-toolkit/registry/') &&
+          file.endsWith('.tsx')
+      )
+
+      if (changedComponentFiles.length > 0) {
+        console.log('\n=== Changed Component Files ===')
+        for (const file of changedComponentFiles) {
+          const relativePath = file.replace('packages/agentic-ui-toolkit/', '')
+          const componentName = fileToComponent.get(relativePath) || 'unknown'
+          console.log(`  ${file} (component: ${componentName})`)
+        }
+      }
+
+      expect(true).toBe(true)
+    })
+  })
+})
+
+/**
+ * Export utility for use in pre-commit hooks
+ */
+export function checkVersionBumps(): { valid: boolean; errors: string[] } {
+  const errors: string[] = []
+
+  try {
+    const currentRegistry = loadCurrentRegistry()
+    const previousRegistry = getPreviousRegistry()
+
+    if (!previousRegistry) {
+      return { valid: true, errors: [] }
+    }
+
+    const currentVersions = buildVersionMap(currentRegistry)
+    const previousVersions = buildVersionMap(previousRegistry)
+    const fileToComponent = buildFileToComponentMap(currentRegistry)
+    const changedFiles = getChangedFiles()
+
+    const changedComponentFiles = changedFiles.filter(
+      (file) =>
+        file.startsWith('packages/agentic-ui-toolkit/registry/') &&
+        file.endsWith('.tsx')
+    )
+
+    for (const file of changedComponentFiles) {
+      const relativePath = file.replace('packages/agentic-ui-toolkit/', '')
+      const componentName = fileToComponent.get(relativePath)
+
+      if (!componentName) continue
+
+      const previousVersion = previousVersions.get(componentName)
+      const currentVersion = currentVersions.get(componentName)
+
+      if (!previousVersion || !currentVersion) continue
+
+      const [prevMajor, prevMinor, prevPatch] = previousVersion
+        .split('.')
+        .map(Number)
+      const [currMajor, currMinor, currPatch] = currentVersion
+        .split('.')
+        .map(Number)
+
+      const previousTotal = prevMajor * 10000 + prevMinor * 100 + prevPatch
+      const currentTotal = currMajor * 10000 + currMinor * 100 + currPatch
+
+      if (currentTotal <= previousTotal) {
+        errors.push(
+          `${componentName}: modified but version not bumped (${previousVersion} -> ${currentVersion})`
+        )
+      }
+    }
+
+    return { valid: errors.length === 0, errors }
+  } catch (error) {
+    return { valid: true, errors: [] } // Don't block on errors
+  }
+}

--- a/packages/agentic-ui-toolkit/registry.json
+++ b/packages/agentic-ui-toolkit/registry.json
@@ -411,7 +411,7 @@
     },
     {
       "name": "message-bubble",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "registry:component",
       "title": "Message Bubble",
       "description": "Chat message bubbles with text, image, voice, and reaction variants.",
@@ -426,7 +426,7 @@
     },
     {
       "name": "chat-conversation",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "registry:component",
       "title": "Chat Conversation",
       "description": "Full chat conversation component with multiple message types.",


### PR DESCRIPTION
Add automated tests that fail when a block's source files are modified without bumping its version in registry.json. This prevents regressions like the message-bubble change in PR #568 that didn't include a version update.

Changes:
- Add __tests__/version-bump.test.ts to detect file changes without version bumps
- Update CLAUDE.md files with explicit version bump requirements
- Bump message-bubble and chat-conversation to 1.0.1 (retroactive fix)

Closes #569


