### PR TITLE
Highlight Action paragraph on page load

### DIFF
--- a/packages/agentic-ui-toolkit/app/globals.css
+++ b/packages/agentic-ui-toolkit/app/globals.css
@@ -194,4 +194,32 @@
     overflow: visible;
     max-height: none;
   }
+
+  /* Stack Overflow-style highlight animation for linked sections */
+  @keyframes highlight-fade {
+    0% {
+      background-color: oklch(0.905 0.166 84.429);
+    }
+    100% {
+      background-color: transparent;
+    }
+  }
+
+  .animate-highlight {
+    animation: highlight-fade 2.5s ease-out forwards;
+  }
+
+  /* Dark mode highlight color - slightly muted amber */
+  .dark .animate-highlight {
+    animation: highlight-fade-dark 2.5s ease-out forwards;
+  }
+
+  @keyframes highlight-fade-dark {
+    0% {
+      background-color: oklch(0.45 0.12 84.429);
+    }
+    100% {
+      background-color: transparent;
+    }
+  }
 }

--- a/packages/agentic-ui-toolkit/components/blocks/configuration-viewer.tsx
+++ b/packages/agentic-ui-toolkit/components/blocks/configuration-viewer.tsx
@@ -572,12 +572,14 @@ interface ConfigurationViewerProps {
   sourceCode: string | null
   relatedSourceFiles?: string[]
   loading?: boolean
+  highlightCategory?: ConfigCategory['name'] | null
 }
 
 export function ConfigurationViewer({
   sourceCode,
   relatedSourceFiles = [],
-  loading
+  loading,
+  highlightCategory
 }: ConfigurationViewerProps) {
   const { categories, typeDefinitions } = useMemo(() => {
     if (!sourceCode) return { categories: [], typeDefinitions: new Map() }
@@ -644,7 +646,14 @@ export function ConfigurationViewer({
 
       <div className="grid gap-4">
         {categories.map((category) => (
-          <div key={category.name} id={`config-${category.name}`} className="rounded-lg border bg-card p-4">
+          <div
+            key={category.name}
+            id={`config-${category.name}`}
+            className={cn(
+              'rounded-lg border bg-card p-4',
+              highlightCategory === category.name && 'animate-highlight'
+            )}
+          >
             {/* Category header */}
             <div className="flex items-center gap-3 mb-3">
               <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-muted-foreground">

--- a/packages/agentic-ui-toolkit/components/blocks/variant-section.tsx
+++ b/packages/agentic-ui-toolkit/components/blocks/variant-section.tsx
@@ -134,12 +134,15 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
 }, ref) {
   const [viewMode, setViewMode] = useState<ViewMode>('inline')
   const [isFullscreenOpen, setIsFullscreenOpen] = useState(false)
+  const [highlightCategory, setHighlightCategory] = useState<'data' | 'actions' | 'appearance' | 'control' | null>(null)
   const sourceCode = useSourceCode(registryName)
 
   // Expose imperative methods to parent components
   useImperativeHandle(ref, () => ({
     showActionsConfig: () => {
       setViewMode('config')
+      // Trigger the highlight animation
+      setHighlightCategory('actions')
       // Wait for the config view to render, then scroll to actions
       setTimeout(() => {
         const actionsElement = document.getElementById('config-actions')
@@ -147,6 +150,10 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
           actionsElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
         }
       }, 100)
+      // Clear the highlight after the animation completes (2.5s)
+      setTimeout(() => {
+        setHighlightCategory(null)
+      }, 2600)
     }
   }), [])
 
@@ -154,6 +161,7 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
   useEffect(() => {
     setViewMode('inline')
     setIsFullscreenOpen(false)
+    setHighlightCategory(null)
   }, [registryName])
 
   const hasFullwidth = layouts.includes('fullscreen')
@@ -263,6 +271,7 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
             sourceCode={sourceCode.code}
             relatedSourceFiles={sourceCode.relatedFiles}
             loading={sourceCode.loading}
+            highlightCategory={highlightCategory}
           />
         )}
 


### PR DESCRIPTION
… Actions section

When clicking the action count badge, the Actions section now highlights with a yellow fade-out animation (similar to Stack Overflow) to help users locate the scrolled-to content.

