### PR TITLE
Add precise ALT tags to all images

### DIFF
--- a/packages/agentic-ui-toolkit/registry.json
+++ b/packages/agentic-ui-toolkit/registry.json
@@ -396,7 +396,7 @@
     },
     {
       "name": "table",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "registry:component",
       "title": "Table",
       "description": "Data table with optional single or multi-select modes for chat interfaces.",
@@ -411,7 +411,7 @@
     },
     {
       "name": "message-bubble",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "type": "registry:component",
       "title": "Message Bubble",
       "description": "Chat message bubbles with text, image, voice, and reaction variants.",
@@ -460,7 +460,7 @@
     },
     {
       "name": "instagram-post",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "registry:component",
       "title": "Instagram Post",
       "description": "Instagram post card with image and engagement.",
@@ -490,7 +490,7 @@
     },
     {
       "name": "youtube-post",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "type": "registry:component",
       "title": "YouTube Post",
       "description": "YouTube video card with playable embed.",

--- a/packages/agentic-ui-toolkit/registry.json
+++ b/packages/agentic-ui-toolkit/registry.json
@@ -426,7 +426,7 @@
     },
     {
       "name": "chat-conversation",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "type": "registry:component",
       "title": "Chat Conversation",
       "description": "Full chat conversation component with multiple message types.",

--- a/packages/agentic-ui-toolkit/registry/list/table.tsx
+++ b/packages/agentic-ui-toolkit/registry/list/table.tsx
@@ -253,7 +253,7 @@ function TableHeader({
         {titleImage && (
           <img
             src={titleImage}
-            alt=""
+            alt={title ? `${title} icon` : "Table icon"}
             className="h-5 w-5 rounded object-cover"
           />
         )}
@@ -645,7 +645,7 @@ export function Table<T extends Record<string, unknown>>({
             {titleImage && (
               <img
                 src={titleImage}
-                alt=""
+                alt={title ? `${title} icon` : "Table icon"}
                 className="h-5 w-5 rounded object-cover"
               />
             )}

--- a/packages/agentic-ui-toolkit/registry/messaging/message-bubble.tsx
+++ b/packages/agentic-ui-toolkit/registry/messaging/message-bubble.tsx
@@ -115,7 +115,7 @@ export function ImageMessageBubble({ data, appearance, control }: ImageMessageBu
         >
           <img
             src={image}
-            alt="Shared image"
+            alt={caption || "Shared image in chat"}
             className="w-full max-w-[280px] h-auto object-cover"
           />
           {caption && (

--- a/packages/agentic-ui-toolkit/registry/miscellaneous/instagram-post.tsx
+++ b/packages/agentic-ui-toolkit/registry/miscellaneous/instagram-post.tsx
@@ -87,7 +87,7 @@ export function InstagramPost({ data }: InstagramPostProps) {
         </DropdownMenu>
       </div>
       <div className="aspect-square bg-muted">
-        <img src={image} alt="Post" className="w-full h-full object-cover" />
+        <img src={image} alt={`Instagram post by ${author}`} className="w-full h-full object-cover" />
       </div>
       <div className="p-3 space-y-2">
         <div className="flex items-center justify-between">

--- a/packages/agentic-ui-toolkit/registry/miscellaneous/youtube-post.tsx
+++ b/packages/agentic-ui-toolkit/registry/miscellaneous/youtube-post.tsx
@@ -66,7 +66,7 @@ export function YouTubePost({ data }: YouTubePostProps) {
           />
         ) : (
           <>
-            <img src={thumbnail} alt="Video" className="w-full h-full object-cover" />
+            <img src={thumbnail} alt={`Video thumbnail: ${title}`} className="w-full h-full object-cover" />
 
             {/* YouTube play button overlay */}
             <button

--- a/packages/starter/web/src/components/table.tsx
+++ b/packages/starter/web/src/components/table.tsx
@@ -253,7 +253,7 @@ function TableHeader({
         {titleImage && (
           <img
             src={titleImage}
-            alt=""
+            alt={title ? `${title} icon` : "Table icon"}
             className="h-5 w-5 rounded object-cover"
           />
         )}
@@ -645,7 +645,7 @@ export function Table<T extends Record<string, unknown>>({
             {titleImage && (
               <img
                 src={titleImage}
-                alt=""
+                alt={title ? `${title} icon` : "Table icon"}
                 className="h-5 w-5 rounded object-cover"
               />
             )}


### PR DESCRIPTION
- Add contextual alt tags to table title images using title prop
- Improve instagram-post alt to include author name
- Improve youtube-post alt to include video title
- Improve message-bubble image alt to use caption when available
- Bump versions: table, instagram-post, youtube-post to 1.0.1
- Bump message-bubble to 1.0.2
