### PR TITLE
Create public changelog for component versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,11 +266,53 @@ This is enforced by automated tests that will fail if:
 { "name": "message-bubble", "version": "1.0.1", ... }
 ```
 
+### Changelog Requirements (CRITICAL)
+
+**Every version MUST have a corresponding changelog entry in `changelog.json`.**
+
+This is enforced by automated tests that will fail if:
+1. A component has a version in `registry.json`
+2. But does NOT have a changelog entry for that version in `changelog.json`
+
+#### Changelog File Structure
+
+The changelog is stored in `packages/agentic-ui-toolkit/changelog.json`:
+
+```json
+{
+  "components": {
+    "component-name": {
+      "1.0.0": "Initial release with core features",
+      "1.0.1": "Fixed a display issue on mobile devices",
+      "1.1.0": "Added new compact variant"
+    }
+  }
+}
+```
+
+#### Changelog Entry Guidelines
+
+1. **Keep it simple** - One sentence, non-technical if possible
+2. **Focus on user impact** - What changed from the user's perspective
+3. **Be specific** - Avoid vague descriptions like "bug fixes"
+
+**Good examples:**
+- "Initial release with text, image, and voice message support"
+- "Fixed images not loading on slow connections"
+- "Added dark mode support"
+- "Improved accessibility with better screen reader support"
+
+**Bad examples:**
+- "Bug fixes" (too vague)
+- "Refactored internal state management" (too technical)
+- "Updated dependencies" (not user-facing)
+
 ### Checklist for Block Changes
 
 Before submitting a PR with block changes:
 
 - [ ] **Version bumped in `registry.json`** (REQUIRED - tests will fail otherwise)
+- [ ] **Changelog entry added in `changelog.json`** (REQUIRED - tests will fail otherwise)
 - [ ] Component implements the standard props pattern (`data`, `actions`, `appearance`, `control`)
 - [ ] Block is registered in `registry.json` with correct dependencies
 - [ ] Block demo added to `app/blocks/page.tsx` with ALL variants

--- a/packages/agentic-ui-toolkit/changelog.json
+++ b/packages/agentic-ui-toolkit/changelog.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "./changelog.schema.json",
+  "components": {
+    "contact-form": {
+      "1.0.0": "Initial release with name, phone, email, message and file attachment fields"
+    },
+    "date-time-picker": {
+      "1.0.0": "Initial release with calendar and time slot selection"
+    },
+    "issue-report-form": {
+      "1.0.0": "Initial release with categories, impact levels and file attachments"
+    },
+    "card-form": {
+      "1.0.0": "Initial release with card number, expiry, CVV and name fields"
+    },
+    "pay-confirm": {
+      "1.0.0": "Initial release with amount display and confirm actions",
+      "1.0.1": "Updated to show a more realistic default amount"
+    },
+    "order-summary": {
+      "1.0.0": "Initial release with items, subtotal, shipping, tax and discounts"
+    },
+    "saved-cards": {
+      "1.0.0": "Initial release with support for multiple card brands"
+    },
+    "payment-success": {
+      "1.0.0": "Initial release with order details and tracking options"
+    },
+    "bank-card-form": {
+      "1.0.0": "Initial release with compact inline layout for chat"
+    },
+    "payment-methods": {
+      "1.0.0": "Initial release with card brands and Apple Pay support"
+    },
+    "order-confirm": {
+      "1.0.0": "Initial release with product image and delivery info"
+    },
+    "payment-confirmed": {
+      "1.0.0": "Initial release with product image and tracking button"
+    },
+    "product-list": {
+      "1.0.0": "Initial release with list, grid, carousel and picker variants"
+    },
+    "option-list": {
+      "1.0.0": "Initial release with single and multiple selection modes"
+    },
+    "amount-input": {
+      "1.0.0": "Initial release with increment buttons and preset values"
+    },
+    "tag-select": {
+      "1.0.0": "Initial release with color variants and multi-select"
+    },
+    "quick-reply": {
+      "1.0.0": "Initial release with quick reply button options"
+    },
+    "progress-steps": {
+      "1.0.0": "Initial release with horizontal and vertical layouts"
+    },
+    "status-badge": {
+      "1.0.0": "Initial release with multiple status states"
+    },
+    "stats": {
+      "1.0.0": "Initial release with scrollable stat cards and trends"
+    },
+    "skeleton": {
+      "1.0.0": "Initial release with pulse animation placeholders"
+    },
+    "post-card": {
+      "1.0.0": "Initial release with default, compact, horizontal and covered variants"
+    },
+    "post-list": {
+      "1.0.0": "Initial release with list, grid and carousel variants"
+    },
+    "post-detail": {
+      "1.0.0": "Initial release with cover image, author info and related posts"
+    },
+    "table": {
+      "1.0.0": "Initial release with single and multi-select modes",
+      "1.0.1": "Added descriptive alt tags for title images"
+    },
+    "message-bubble": {
+      "1.0.0": "Initial release with text, image, voice and reaction variants",
+      "1.0.1": "Added better image captions for accessibility",
+      "1.0.2": "Improved alt text to use caption when available"
+    },
+    "chat-conversation": {
+      "1.0.0": "Initial release with multiple message types",
+      "1.0.1": "Updated to use improved message bubble styling",
+      "1.0.2": "Synced with message-bubble alt tag improvements"
+    },
+    "x-post": {
+      "1.0.0": "Initial release with engagement metrics display"
+    },
+    "instagram-post": {
+      "1.0.0": "Initial release with image and engagement display",
+      "1.0.1": "Improved alt text to include author name"
+    },
+    "linkedin-post": {
+      "1.0.0": "Initial release with professional styling"
+    },
+    "youtube-post": {
+      "1.0.0": "Initial release with playable video embed",
+      "1.0.1": "Improved alt text to include video title"
+    },
+    "map-carousel": {
+      "1.0.0": "Initial release with interactive map and location cards"
+    }
+  }
+}


### PR DESCRIPTION
- Create changelog.json to store version history for all components
- Add "view changelog" link on hover over version number in UI
- Open popover with complete changelog when clicked
- Update inject-versions script to include changelog data in builds
- Add tests to enforce changelog entries for every version
- Update CLAUDE.md with changelog requirements and guidelines
