### PR TITLE
Add SEO breadcrumb navigation with schema

### DIFF
--- a/packages/agentic-ui-toolkit/app/blocks/[category]/[block]/page.tsx
+++ b/packages/agentic-ui-toolkit/app/blocks/[category]/[block]/page.tsx
@@ -54,6 +54,9 @@ import { YouTubePost } from '@/registry/miscellaneous/youtube-post'
 // UI components
 import { VariantSection, VariantSectionHandle } from '@/components/blocks/variant-section'
 
+// SEO components
+import { Breadcrumb } from '@/components/seo/breadcrumb'
+
 // Types for the new structure
 interface BlockVariant {
   id: string
@@ -1391,8 +1394,17 @@ function BlockPageContent() {
       {/* Main content */}
       <div className="w-full md:w-[calc(100vw-226px)] p-4 md:p-8 bg-muted/50">
         <div className="max-w-3xl mx-auto space-y-12">
+          {/* Breadcrumb Navigation */}
+          <Breadcrumb
+            items={[
+              { name: 'Blocks', href: '/blocks' },
+              { name: selectedCategory?.name || categorySlug },
+              { name: selectedBlock.name }
+            ]}
+          />
+
           {/* Block Title */}
-          <div className="group" id={selectedBlock.id}>
+          <div className="group -mt-8" id={selectedBlock.id}>
             <div className="flex items-center gap-3 mb-1">
               <h1 className="text-2xl font-bold">{selectedBlock.name}</h1>
               <CopyLinkButton />

--- a/packages/agentic-ui-toolkit/app/blocks/[category]/[block]/page.tsx
+++ b/packages/agentic-ui-toolkit/app/blocks/[category]/[block]/page.tsx
@@ -1394,17 +1394,18 @@ function BlockPageContent() {
       {/* Main content */}
       <div className="w-full md:w-[calc(100vw-226px)] p-4 md:p-8 bg-muted/50">
         <div className="max-w-3xl mx-auto space-y-12">
-          {/* Breadcrumb Navigation */}
-          <Breadcrumb
-            items={[
-              { name: 'Blocks', href: '/blocks' },
-              { name: selectedCategory?.name || categorySlug },
-              { name: selectedBlock.name }
-            ]}
-          />
+          {/* Block Header with Breadcrumb */}
+          <div id={selectedBlock.id}>
+            {/* Breadcrumb Navigation */}
+            <Breadcrumb
+              items={[
+                { name: 'Blocks', href: '/blocks' },
+                { name: selectedCategory?.name || categorySlug },
+                { name: selectedBlock.name }
+              ]}
+            />
 
-          {/* Block Title */}
-          <div className="group -mt-8" id={selectedBlock.id}>
+            {/* Block Title */}
             <div className="flex items-center gap-3 mb-1">
               <h1 className="text-2xl font-bold">{selectedBlock.name}</h1>
               <CopyLinkButton />

--- a/packages/agentic-ui-toolkit/app/blocks/page.tsx
+++ b/packages/agentic-ui-toolkit/app/blocks/page.tsx
@@ -55,6 +55,9 @@ import { YouTubePost } from '@/registry/miscellaneous/youtube-post'
 import { GettingStarted } from '@/components/blocks/getting-started'
 import { VariantSection, VariantSectionHandle } from '@/components/blocks/variant-section'
 
+// SEO components
+import { Breadcrumb } from '@/components/seo/breadcrumb'
+
 // Types for the new structure
 interface BlockVariant {
   id: string
@@ -1590,9 +1593,12 @@ function BlocksContent() {
     )
   }
 
-  // Find the selected block group
-  const selectedBlock = blockId
-    ? categories.flatMap((c) => c.blocks).find((b) => b.id === blockId)
+  // Find the selected block group and its category
+  const selectedCategory = blockId
+    ? categories.find((c) => c.blocks.some((b) => b.id === blockId))
+    : null
+  const selectedBlock = selectedCategory
+    ? selectedCategory.blocks.find((b) => b.id === blockId)
     : null
 
   // Ref for the first variant section to enable scrolling to actions config
@@ -1655,8 +1661,17 @@ function BlocksContent() {
       <div className="w-full md:w-[calc(100vw-226px)] p-4 md:p-8 bg-muted/50">
         {selectedBlock ? (
           <div className="max-w-3xl mx-auto space-y-12">
+            {/* Breadcrumb Navigation */}
+            <Breadcrumb
+              items={[
+                { name: 'Blocks', href: '/blocks' },
+                { name: selectedCategory?.name || '' },
+                { name: selectedBlock.name }
+              ]}
+            />
+
             {/* Block Title */}
-            <div>
+            <div className="-mt-8">
               <div className="flex items-center gap-3 mb-1">
                 <h1 className="text-2xl font-bold">{selectedBlock.name}</h1>
                 {selectedBlock.actionCount > 0 ? (
@@ -1694,7 +1709,15 @@ function BlocksContent() {
             ))}
           </div>
         ) : (
-          <GettingStarted />
+          <div className="max-w-3xl mx-auto">
+            {/* Breadcrumb Navigation */}
+            <Breadcrumb
+              items={[
+                { name: 'Blocks' }
+              ]}
+            />
+            <GettingStarted />
+          </div>
         )}
       </div>
     </div>

--- a/packages/agentic-ui-toolkit/app/blocks/page.tsx
+++ b/packages/agentic-ui-toolkit/app/blocks/page.tsx
@@ -1661,17 +1661,18 @@ function BlocksContent() {
       <div className="w-full md:w-[calc(100vw-226px)] p-4 md:p-8 bg-muted/50">
         {selectedBlock ? (
           <div className="max-w-3xl mx-auto space-y-12">
-            {/* Breadcrumb Navigation */}
-            <Breadcrumb
-              items={[
-                { name: 'Blocks', href: '/blocks' },
-                { name: selectedCategory?.name || '' },
-                { name: selectedBlock.name }
-              ]}
-            />
+            {/* Block Header with Breadcrumb */}
+            <div>
+              {/* Breadcrumb Navigation */}
+              <Breadcrumb
+                items={[
+                  { name: 'Blocks', href: '/blocks' },
+                  { name: selectedCategory?.name || '' },
+                  { name: selectedBlock.name }
+                ]}
+              />
 
-            {/* Block Title */}
-            <div className="-mt-8">
+              {/* Block Title */}
               <div className="flex items-center gap-3 mb-1">
                 <h1 className="text-2xl font-bold">{selectedBlock.name}</h1>
                 {selectedBlock.actionCount > 0 ? (

--- a/packages/agentic-ui-toolkit/components/seo/breadcrumb.tsx
+++ b/packages/agentic-ui-toolkit/components/seo/breadcrumb.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import Link from 'next/link'
+import { ChevronRight, Home } from 'lucide-react'
+
+export interface BreadcrumbItem {
+  name: string
+  href?: string
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[]
+  baseUrl?: string
+}
+
+/**
+ * SEO-friendly Breadcrumb component with JSON-LD structured data
+ * Automatically generates BreadcrumbList schema for search engines
+ */
+export function Breadcrumb({ items, baseUrl = 'https://ui.manifest.build' }: BreadcrumbProps) {
+  // Build full items array including Home
+  const fullItems: BreadcrumbItem[] = [
+    { name: 'Home', href: '/' },
+    ...items
+  ]
+
+  // Generate JSON-LD structured data
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: fullItems.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      // Last item doesn't need an item URL (it's the current page)
+      ...(item.href && index < fullItems.length - 1
+        ? { item: `${baseUrl}${item.href}` }
+        : item.href
+          ? { item: `${baseUrl}${item.href}` }
+          : {})
+    }))
+  }
+
+  return (
+    <>
+      {/* JSON-LD Structured Data */}
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      {/* Visual Breadcrumb Navigation */}
+      <nav aria-label="Breadcrumb" className="mb-4">
+        <ol className="flex items-center gap-1 text-sm text-muted-foreground">
+          {fullItems.map((item, index) => (
+            <li key={index} className="flex items-center gap-1">
+              {index > 0 && (
+                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/50" />
+              )}
+              {item.href && index < fullItems.length - 1 ? (
+                <Link
+                  href={item.href}
+                  className="flex items-center gap-1 hover:text-foreground transition-colors"
+                >
+                  {index === 0 && <Home className="h-3.5 w-3.5" />}
+                  <span>{item.name}</span>
+                </Link>
+              ) : (
+                <span className="flex items-center gap-1 text-foreground font-medium">
+                  {index === 0 && <Home className="h-3.5 w-3.5" />}
+                  <span>{item.name}</span>
+                </span>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+    </>
+  )
+}
+
+/**
+ * Helper function to generate breadcrumb items for block pages
+ * Use this for automatic breadcrumb generation based on category and block
+ */
+export function generateBlockBreadcrumbs(
+  categoryId?: string,
+  categoryName?: string,
+  blockName?: string
+): BreadcrumbItem[] {
+  const items: BreadcrumbItem[] = [
+    { name: 'Blocks', href: '/blocks' }
+  ]
+
+  if (categoryId && categoryName) {
+    // Category is not linkable since we don't have category-only pages
+    // But we include it in the trail for context
+    items.push({ name: categoryName })
+  }
+
+  if (blockName) {
+    // Block name is the current page (no href needed)
+    // Replace the category item to include the block
+    if (categoryId && categoryName) {
+      items.pop() // Remove category without href
+      items.push({ name: categoryName }) // Re-add category (could link to /blocks with filter in future)
+    }
+    items.push({ name: blockName })
+  }
+
+  return items
+}


### PR DESCRIPTION
Add automatic breadcrumb navigation for blocks pages with:
- Visual breadcrumb trail (Home > Blocks > Category > Block)
- JSON-LD BreadcrumbList structured data for SEO
- Reusable Breadcrumb component in components/seo/
- Works automatically for all existing and new blocks
