### PR TITLE
Fix post list fullwidth mode pagination

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -15,6 +15,7 @@ import { IssueReportForm } from '@/registry/form/issue-report-form'
 import { PostCardDemo } from '@/components/blocks/post-card-demo'
 import { PostListDemo } from '@/components/blocks/post-list-demo'
 import { PostDetail } from '@/registry/blogging/post-detail'
+import { PostList } from '@/registry/blogging/post-list'
 
 // List components
 import { TableDemo } from '@/components/blocks/table-demo'
@@ -262,7 +263,7 @@ const categories: Category[] = [
             id: 'list',
             name: 'List',
             component: <PostListDemo appearance={{ variant: 'list' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            fullscreenComponent: <PostList appearance={{ variant: 'fullwidth', columns: 3, postsPerPage: 10 }} />,
             usageCode: `<PostList
   data={{
     posts: [
@@ -293,7 +294,7 @@ const categories: Category[] = [
             id: 'grid',
             name: 'Grid',
             component: <PostListDemo appearance={{ variant: 'grid' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            fullscreenComponent: <PostList appearance={{ variant: 'fullwidth', columns: 3, postsPerPage: 10 }} />,
             usageCode: `<PostList
   data={{ posts: [...] }}
   appearance={{
@@ -311,7 +312,7 @@ const categories: Category[] = [
             id: 'carousel',
             name: 'Carousel',
             component: <PostListDemo appearance={{ variant: 'carousel' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            fullscreenComponent: <PostList appearance={{ variant: 'fullwidth', columns: 3, postsPerPage: 10 }} />,
             usageCode: `<PostList
   data={{ posts: [...] }}
   appearance={{

--- a/packages/manifest-ui/app/blocks/page.tsx
+++ b/packages/manifest-ui/app/blocks/page.tsx
@@ -15,6 +15,7 @@ import { IssueReportForm } from '@/registry/form/issue-report-form'
 import { PostCardDemo } from '@/components/blocks/post-card-demo'
 import { PostListDemo } from '@/components/blocks/post-list-demo'
 import { PostDetail } from '@/registry/blogging/post-detail'
+import { PostList } from '@/registry/blogging/post-list'
 
 // List components
 import { TableDemo } from '@/components/blocks/table-demo'
@@ -261,7 +262,7 @@ const categories: Category[] = [
             id: 'list',
             name: 'List',
             component: <PostListDemo appearance={{ variant: 'list' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            fullscreenComponent: <PostList appearance={{ variant: 'fullwidth', columns: 3, postsPerPage: 10 }} />,
             usageCode: `<PostList
   data={{
     posts: [
@@ -314,7 +315,7 @@ const categories: Category[] = [
             id: 'grid',
             name: 'Grid',
             component: <PostListDemo appearance={{ variant: 'grid' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            fullscreenComponent: <PostList appearance={{ variant: 'fullwidth', columns: 3, postsPerPage: 10 }} />,
             usageCode: `<PostList
   data={{
     posts: [
@@ -371,7 +372,7 @@ const categories: Category[] = [
             id: 'carousel',
             name: 'Carousel',
             component: <PostListDemo appearance={{ variant: 'carousel' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            fullscreenComponent: <PostList appearance={{ variant: 'fullwidth', columns: 3, postsPerPage: 10 }} />,
             usageCode: `<PostList
   data={{
     posts: [

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -69,7 +69,8 @@
       "1.0.0": "Initial release with default, compact, horizontal and covered variants"
     },
     "post-list": {
-      "1.0.0": "Initial release with list, grid and carousel variants"
+      "1.0.0": "Initial release with list, grid and carousel variants",
+      "1.1.0": "Added fullwidth variant with pagination for fullscreen mode"
     },
     "post-detail": {
       "1.0.0": "Initial release with cover image, author info and related posts"

--- a/packages/manifest-ui/components/blocks/post-list-demo.tsx
+++ b/packages/manifest-ui/components/blocks/post-list-demo.tsx
@@ -2,8 +2,6 @@
 
 import { FullscreenModal } from '@/components/layout/fullscreen-modal'
 import { HostAPIProvider, DisplayMode } from '@/lib/host-api'
-import { Post } from '@/registry/blogging/post-card'
-import { PostDetail } from '@/registry/blogging/post-detail'
 import { PostList, PostListProps } from '@/registry/blogging/post-list'
 import { useState, useCallback } from 'react'
 
@@ -25,7 +23,6 @@ export function PostListDemo({
   appearance
 }: PostListDemoProps) {
   const [displayMode, setDisplayMode] = useState<DisplayMode>('inline')
-  const [selectedPost, setSelectedPost] = useState<Post | null>(null)
 
   const handleDisplayModeRequest = useCallback((mode: DisplayMode) => {
     setDisplayMode(mode)
@@ -44,19 +41,24 @@ export function PostListDemo({
         />
       )}
 
-      {/* Fullscreen mode - show selected post detail */}
-      {displayMode === 'fullscreen' && selectedPost && (
+      {/* Fullscreen mode - show fullwidth post list with pagination */}
+      {displayMode === 'fullscreen' && (
         <FullscreenModal
           appName={appName}
           appUrl={appUrl}
           onClose={() => {
             setDisplayMode('inline')
-            setSelectedPost(null)
           }}
         >
-          <PostDetail
-            data={{ post: selectedPost }}
-            appearance={{ displayMode: 'fullscreen' }}
+          <PostList
+            data={data}
+            appearance={{
+              variant: 'fullwidth',
+              columns: 3,
+              showAuthor: true,
+              showCategory: true,
+              postsPerPage: 10
+            }}
           />
         </FullscreenModal>
       )}

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -354,10 +354,10 @@
     },
     {
       "name": "post-list",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "registry:component",
       "title": "Post List",
-      "description": "Post list with list, grid, and carousel variants. Includes post-detail for fullscreen view.",
+      "description": "Post list with list, grid, carousel, and fullwidth variants. Fullwidth mode shows paginated posts.",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [

--- a/packages/manifest-ui/registry/blogging/post-list.tsx
+++ b/packages/manifest-ui/registry/blogging/post-list.tsx
@@ -70,6 +70,182 @@ const defaultPosts: Post[] = [
     readTime: '10 min read',
     tags: ['Payments', 'Security'],
     category: 'Tutorial'
+  },
+  {
+    id: '5',
+    title: 'Real-time Collaboration in AI Apps',
+    excerpt:
+      'Implementing WebSocket connections and real-time updates for collaborative agentic experiences.',
+    coverImage:
+      'https://images.unsplash.com/photo-1552664730-d307ca884978?w=800',
+    author: {
+      name: 'Casey Taylor',
+      avatar: 'https://i.pravatar.cc/150?u=casey'
+    },
+    publishedAt: '2024-01-06',
+    readTime: '15 min read',
+    tags: ['WebSocket', 'Real-time', 'Collaboration'],
+    category: 'Development'
+  },
+  {
+    id: '6',
+    title: 'Accessibility in Chat Interfaces',
+    excerpt:
+      'Making your conversational UI accessible to all users with screen readers and keyboard navigation.',
+    coverImage:
+      'https://images.unsplash.com/photo-1573164713988-8665fc963095?w=800',
+    author: {
+      name: 'Jamie Park',
+      avatar: 'https://i.pravatar.cc/150?u=jamie'
+    },
+    publishedAt: '2024-01-04',
+    readTime: '9 min read',
+    tags: ['Accessibility', 'A11y', 'UX'],
+    category: 'Design'
+  },
+  {
+    id: '7',
+    title: 'State Management for Complex Workflows',
+    excerpt:
+      'Managing complex multi-step workflows in agentic applications using modern state patterns.',
+    coverImage:
+      'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=800',
+    author: {
+      name: 'Drew Martinez',
+      avatar: 'https://i.pravatar.cc/150?u=drew'
+    },
+    publishedAt: '2024-01-02',
+    readTime: '11 min read',
+    tags: ['State', 'Workflow', 'Architecture'],
+    category: 'Development'
+  },
+  {
+    id: '8',
+    title: 'Testing Conversational Components',
+    excerpt:
+      'Strategies for unit testing and integration testing of chat-based UI components.',
+    coverImage:
+      'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=800',
+    author: {
+      name: 'Riley Johnson',
+      avatar: 'https://i.pravatar.cc/150?u=riley'
+    },
+    publishedAt: '2023-12-30',
+    readTime: '8 min read',
+    tags: ['Testing', 'Quality', 'CI/CD'],
+    category: 'Development'
+  },
+  {
+    id: '9',
+    title: 'Theming and Dark Mode Support',
+    excerpt:
+      'Implementing flexible theming systems with dark mode for agentic UI components.',
+    coverImage:
+      'https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=800',
+    author: {
+      name: 'Avery Williams',
+      avatar: 'https://i.pravatar.cc/150?u=avery'
+    },
+    publishedAt: '2023-12-28',
+    readTime: '7 min read',
+    tags: ['Theming', 'Dark Mode', 'CSS'],
+    category: 'Design'
+  },
+  {
+    id: '10',
+    title: 'Performance Optimization Techniques',
+    excerpt:
+      'Optimizing render performance and reducing bundle size in chat applications.',
+    coverImage:
+      'https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=800',
+    author: {
+      name: 'Quinn Anderson',
+      avatar: 'https://i.pravatar.cc/150?u=quinn'
+    },
+    publishedAt: '2023-12-25',
+    readTime: '13 min read',
+    tags: ['Performance', 'Optimization', 'React'],
+    category: 'Development'
+  },
+  {
+    id: '11',
+    title: 'Error Handling and Recovery',
+    excerpt:
+      'Graceful error handling patterns and user-friendly recovery flows in conversational UIs.',
+    coverImage:
+      'https://images.unsplash.com/photo-1504639725590-34d0984388bd?w=800',
+    author: {
+      name: 'Sage Thompson',
+      avatar: 'https://i.pravatar.cc/150?u=sage'
+    },
+    publishedAt: '2023-12-22',
+    readTime: '10 min read',
+    tags: ['Error Handling', 'UX', 'Resilience'],
+    category: 'Development'
+  },
+  {
+    id: '12',
+    title: 'Internationalization Best Practices',
+    excerpt:
+      'Making your agentic UI components work across languages and locales.',
+    coverImage:
+      'https://images.unsplash.com/photo-1526304640581-d334cdbbf45e?w=800',
+    author: {
+      name: 'Blake Garcia',
+      avatar: 'https://i.pravatar.cc/150?u=blake'
+    },
+    publishedAt: '2023-12-20',
+    readTime: '9 min read',
+    tags: ['i18n', 'Localization', 'Global'],
+    category: 'Design'
+  },
+  {
+    id: '13',
+    title: 'Mobile-First Chat Design',
+    excerpt:
+      'Designing conversational interfaces that work beautifully on mobile devices.',
+    coverImage:
+      'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=800',
+    author: {
+      name: 'Charlie Brown',
+      avatar: 'https://i.pravatar.cc/150?u=charlie'
+    },
+    publishedAt: '2023-12-18',
+    readTime: '8 min read',
+    tags: ['Mobile', 'Responsive', 'Design'],
+    category: 'Design'
+  },
+  {
+    id: '14',
+    title: 'Analytics and User Insights',
+    excerpt:
+      'Tracking user interactions and deriving insights from conversational UI usage.',
+    coverImage:
+      'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=800',
+    author: {
+      name: 'Sydney Chen',
+      avatar: 'https://i.pravatar.cc/150?u=sydney'
+    },
+    publishedAt: '2023-12-15',
+    readTime: '11 min read',
+    tags: ['Analytics', 'Insights', 'Data'],
+    category: 'Tutorial'
+  },
+  {
+    id: '15',
+    title: 'Building Reusable Component Libraries',
+    excerpt:
+      'Creating a scalable component library for agentic UIs that teams can share.',
+    coverImage:
+      'https://images.unsplash.com/photo-1558655146-d09347e92766?w=800',
+    author: {
+      name: 'Taylor Swift',
+      avatar: 'https://i.pravatar.cc/150?u=taylor'
+    },
+    publishedAt: '2023-12-12',
+    readTime: '14 min read',
+    tags: ['Components', 'Library', 'Scalability'],
+    category: 'Development'
   }
 ]
 
@@ -79,20 +255,29 @@ export interface PostListProps {
   }
   actions?: {
     onReadMore?: (post: Post) => void
+    onPageChange?: (page: number) => void
   }
   appearance?: {
-    variant?: 'list' | 'grid' | 'carousel'
-    columns?: 2 | 3
+    variant?: 'list' | 'grid' | 'carousel' | 'fullwidth'
+    columns?: 2 | 3 | 4
     showAuthor?: boolean
     showCategory?: boolean
+    postsPerPage?: number
+  }
+  control?: {
+    currentPage?: number
   }
 }
 
-export function PostList({ data, actions, appearance }: PostListProps) {
+export function PostList({ data, actions, appearance, control }: PostListProps) {
   const { posts = defaultPosts } = data ?? {}
-  const { onReadMore } = actions ?? {}
-  const { variant = 'list', columns = 2, showAuthor = true, showCategory = true } = appearance ?? {}
+  const { onReadMore, onPageChange } = actions ?? {}
+  const { variant = 'list', columns = 2, showAuthor = true, showCategory = true, postsPerPage = 10 } = appearance ?? {}
+  const { currentPage: controlledPage } = control ?? {}
   const [currentIndex, setCurrentIndex] = useState(0)
+  const [internalPage, setInternalPage] = useState(1)
+
+  const currentPage = controlledPage ?? internalPage
 
   // List variant
   if (variant === 'list') {
@@ -127,6 +312,93 @@ export function PostList({ data, actions, appearance }: PostListProps) {
             actions={{ onReadMore }}
           />
         ))}
+      </div>
+    )
+  }
+
+  // Fullwidth variant with pagination
+  if (variant === 'fullwidth') {
+    const totalPages = Math.ceil(posts.length / postsPerPage)
+    const startIndex = (currentPage - 1) * postsPerPage
+    const endIndex = startIndex + postsPerPage
+    const paginatedPosts = posts.slice(startIndex, endIndex)
+
+    const handlePageChange = (page: number) => {
+      if (page >= 1 && page <= totalPages) {
+        setInternalPage(page)
+        onPageChange?.(page)
+      }
+    }
+
+    const getGridColsClass = () => {
+      switch (columns) {
+        case 2:
+          return 'sm:grid-cols-2'
+        case 3:
+          return 'sm:grid-cols-2 lg:grid-cols-3'
+        case 4:
+          return 'sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+        default:
+          return 'sm:grid-cols-2'
+      }
+    }
+
+    return (
+      <div className="space-y-6">
+        <div className={cn('grid gap-6 grid-cols-1', getGridColsClass())}>
+          {paginatedPosts.map((post) => (
+            <PostCard
+              key={post.id}
+              data={{ post }}
+              appearance={{ variant: "default", showAuthor, showCategory }}
+              actions={{ onReadMore }}
+            />
+          ))}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage <= 1}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+
+            <div className="flex items-center gap-1">
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+                <Button
+                  key={page}
+                  variant={page === currentPage ? 'default' : 'outline'}
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => handlePageChange(page)}
+                >
+                  {page}
+                </Button>
+              ))}
+            </div>
+
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage >= totalPages}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+
+        {/* Page info */}
+        <div className="text-center text-sm text-muted-foreground">
+          Showing {startIndex + 1}-{Math.min(endIndex, posts.length)} of {posts.length} posts
+        </div>
       </div>
     )
   }

--- a/packages/manifest-ui/registry/blogging/post-list.tsx
+++ b/packages/manifest-ui/registry/blogging/post-list.tsx
@@ -295,7 +295,7 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
     )
   }
 
-  // Grid variant
+  // Grid variant (inline mode - show only 4 posts)
   if (variant === 'grid') {
     return (
       <div
@@ -304,7 +304,7 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
           columns === 2 ? 'sm:grid-cols-2' : 'sm:grid-cols-3'
         )}
       >
-        {posts.map((post) => (
+        {posts.slice(0, 4).map((post) => (
           <PostCard
             key={post.id}
             data={{ post }}

--- a/packages/manifest-ui/registry/blogging/post-list.tsx
+++ b/packages/manifest-ui/registry/blogging/post-list.tsx
@@ -344,7 +344,7 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
     }
 
     return (
-      <div className="space-y-6">
+      <div className="space-y-6 p-6">
         <div className={cn('grid gap-6 grid-cols-1', getGridColsClass())}>
           {paginatedPosts.map((post) => (
             <PostCard


### PR DESCRIPTION
Previously, fullscreen mode for the post-list component incorrectly showed a post detail instead of a list. This change adds a new fullwidth variant that displays 15 posts with pagination (10 per page), which is now used in fullscreen mode.

Changes:
- Added fullwidth variant to PostList with pagination support
- Updated PostListDemo to use fullwidth PostList in fullscreen
- Fixed blocks page fullscreenComponent references
- Bumped version to 1.1.0

## Description

## Related Issues

## How can it be tested?

## Check list before submitting

- [ ] This PR is wrote in a clear language and correctly labeled
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
