### PR TITLE
feat: add initialValues prop to ContactForm

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -951,18 +951,24 @@ const categories: Category[] = [
             component: <ContactForm />,
             usageCode: `<ContactForm
   data={{
-    title: "Contact Us",
+    title: "Contact us",
     subtitle: "Fill out the form below and we'll get back to you as soon as possible.",
-    submitLabel: "Send Message"
+    submitLabel: "Send message",
+    initialValues: {
+      firstName: "John",
+      lastName: "Doe",
+      countryId: "us",
+      countryCode: "+1",
+      phoneNumber: "(555) 123-4567",
+      email: "john.doe@example.com",
+      message: "I'm interested in learning more about your services."
+    }
   }}
   appearance={{
     showTitle: true
   }}
   actions={{
-    onSubmit: (data) => console.log("Form submitted:", data)
-  }}
-  control={{
-    isLoading: false
+    onSubmit: (formData) => console.log(formData)
   }}
 />`
           }

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -3,7 +3,8 @@
   "components": {
     "contact-form": {
       "1.0.0": "Initial release with name, phone, email, message and file attachment fields",
-      "1.1.0": "Made phone, email, and message fields optional with defaults"
+      "1.1.0": "Made phone, email, and message fields optional with defaults",
+      "1.2.0": "Added initialValues prop to pre-fill form fields"
     },
     "date-time-picker": {
       "1.0.0": "Initial release with calendar and time slot selection"

--- a/packages/manifest-ui/components/blocks/configuration-viewer.tsx
+++ b/packages/manifest-ui/components/blocks/configuration-viewer.tsx
@@ -93,6 +93,12 @@ function extractTypeName(type: string): string | null {
     return simpleMatch[1]
   }
 
+  // Handle generic types like "Partial<ContactFormData>" or "Array<Item>"
+  const genericMatch = type.match(/^\w+<(\w+)>$/)
+  if (genericMatch && isCustomType(genericMatch[1])) {
+    return genericMatch[1]
+  }
+
   // Handle nested object types like "{ emoji: string; count: number }[]"
   // These are inline types, not custom types
   if (type.includes('{')) {

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -5,7 +5,7 @@
   "items": [
     {
       "name": "contact-form",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "type": "registry:component",
       "title": "Contact Form",
       "description": "A complete contact form with name fields, phone with country selector, email, message textarea, and file attachment.",

--- a/packages/starter/web/src/components/contact-form.tsx
+++ b/packages/starter/web/src/components/contact-form.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'

--- a/packages/starter/web/src/widgets/canvas.tsx
+++ b/packages/starter/web/src/widgets/canvas.tsx
@@ -1,4 +1,4 @@
-import { IssueReportForm } from '../components/issue-report-form'
+import { ContactForm } from '@/components/contact-form'
 import React from 'react'
 import { mountWidget } from 'skybridge/web'
 import '../index.css'
@@ -10,7 +10,29 @@ import '../index.css'
 const MyWidget: React.FC = () => {
   return (
     <div>
-      <IssueReportForm />
+      <ContactForm
+        data={{
+          title: 'Contact us',
+          subtitle:
+            "Fill out the form below and we'll get back to you as soon as possible.",
+          submitLabel: 'Send message',
+          initialValues: {
+            firstName: 'John',
+            lastName: 'Doe',
+            countryId: 'us',
+            countryCode: '+1',
+            phoneNumber: '(555) 123-4567',
+            email: 'john.doe@example.com',
+            message: "I'm interested in learning more about your services."
+          }
+        }}
+        appearance={{
+          showTitle: true
+        }}
+        actions={{
+          onSubmit: (formData) => console.log(formData)
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Description

Adds the ability to pre-fill ContactForm fields with initial values, making it easier for developers to demonstrate the form with sample data.

Changes:
- Added `initialValues` prop to `ContactFormProps.data` accepting `Partial<ContactFormData>`
- Form fields now initialize with provided values instead of empty strings
- Updated usageCode to show pre-filled form with realistic demo data
- Fixed configuration-viewer to highlight generic types like `Partial<T>` (now hoverable with type definition)

## Related Issues

None

## How can it be tested?

1. Run `pnpm run dev`
2. Navigate to http://localhost:3001/blocks/form/contact-form
3. Verify the form shows pre-filled values in the preview
4. In the Config tab, hover over `Partial<ContactFormData>` - it should be underlined and show the type definition on hover

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR