### PR TITLE
feat: add event ticket flow components

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -1303,27 +1303,31 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <TicketTierSelect />,
+            component: <TicketTierSelect data={{ event: { title: "Player Play Date", date: "Fri, Feb 06 · 2:00 pm", image: "https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=800", currency: "USD" } }} />,
             usageCode: `<TicketTierSelect
   data={{
-    eventTitle: "Player Play Date",
-    eventDate: "Fri, Feb 06 · 2:00 pm",
+    event: {
+      title: "Player Play Date",
+      date: "Fri, Feb 06 · 2:00 pm",
+      image: "https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=800",
+      currency: "USD"
+    },
     tiers: [
       {
         id: "early-bird",
         name: "Early Bird",
         description: "Limited availability - best price!",
         price: 45,
-        originalPrice: 65,
+        fee: 5.50,
         available: 12,
-        maxPerOrder: 4,
-        benefits: ["Priority entry", "Free drink"]
+        maxPerOrder: 4
       },
       {
         id: "general",
         name: "General Admission",
         description: "Standard entry to the event",
         price: 65,
+        fee: 7.25,
         available: 250,
         maxPerOrder: 8
       },
@@ -1332,12 +1336,11 @@ const categories: Category[] = [
         name: "VIP Access",
         description: "Premium experience with exclusive perks",
         price: 150,
+        fee: 12.00,
         available: 20,
-        maxPerOrder: 2,
-        benefits: ["Skip the line", "VIP lounge access", "Complimentary drinks", "Meet & greet"]
+        maxPerOrder: 2
       }
-    ],
-    currency: "USD"
+    ]
   }}
   actions={{
     onCheckout: (selections, total) => console.log("Checkout:", selections, "Total:", total),
@@ -1362,33 +1365,38 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <EventCheckout />,
+            component: <EventCheckout data={{ event: { title: "Player Play Date", date: "Fri, Feb 06 · 2:00 pm", image: "https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=800", price: "$25.05", currency: "USD" } }} actions={{ onBack: () => {}, onPlaceOrder: () => {} }} />,
             usageCode: `<EventCheckout
   data={{
-    eventTitle: "Player Play Date",
-    eventDate: "Fri, Feb 06 · 2:00 pm",
-    eventPrice: "$25.05",
-    orderItems: [
-      { name: "General Admission", quantity: 2, price: 21.75 },
-      { name: "VIP Upgrade", quantity: 1, price: 35.00 }
-    ],
-    fees: 8.50,
-    delivery: 0,
-    deliveryMethod: "3 x eTicket",
+    event: {
+      title: "Player Play Date",
+      date: "Fri, Feb 06 · 2:00 pm",
+      image: "https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=800",
+      price: "$25.05",
+      currency: "USD"
+    },
+    order: {
+      items: [
+        { name: "General Admission", quantity: 2, price: 21.75 },
+        { name: "VIP Upgrade", quantity: 1, price: 35.00 }
+      ],
+      fees: 8.50,
+      delivery: 0,
+      deliveryMethod: "3 x eTicket"
+    },
     paymentMethods: [
       { id: "card", name: "Credit or debit card", icon: "card" },
       { id: "paypal", name: "PayPal", icon: "paypal" },
       { id: "google", name: "Google Pay", icon: "google" }
-    ],
-    currency: "USD",
-    timerMinutes: 20
+    ]
   }}
   actions={{
     onBack: () => console.log("Navigate back"),
-    onPlaceOrder: (formData) => console.log("Order placed:", formData)
+    onPlaceOrder: () => console.log("Order placed")
   }}
   appearance={{
     showTimer: true,
+    timerMinutes: 20,
     showEventCard: true
   }}
 />`

--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -19,8 +19,11 @@ import { PostList } from '@/registry/blogging/post-list'
 
 // Events components
 import { EventCard } from '@/registry/events/event-card'
+import { EventCheckout } from '@/registry/events/event-checkout'
+import { EventConfirmation } from '@/registry/events/event-confirmation'
 import { EventDetail } from '@/registry/events/event-detail'
 import { EventList } from '@/registry/events/event-list'
+import { TicketTierSelect } from '@/registry/events/ticket-tier-select'
 
 // List components
 import { TableDemo } from '@/components/blocks/table-demo'
@@ -1283,6 +1286,146 @@ const categories: Category[] = [
   appearance={{ variant: "carousel" }}
   actions={{
     onEventSelect: (event) => console.log("Event selected:", event.title)
+  }}
+/>`
+          }
+        ]
+      },
+      {
+        id: 'ticket-tier-select',
+        name: 'Ticket Tier Select',
+        description:
+          'Select ticket tiers with quantity controls and order summary.',
+        registryName: 'ticket-tier-select',
+        layouts: ['inline'],
+        actionCount: 2,
+        variants: [
+          {
+            id: 'default',
+            name: 'Default',
+            component: <TicketTierSelect />,
+            usageCode: `<TicketTierSelect
+  data={{
+    eventTitle: "Player Play Date",
+    eventDate: "Fri, Feb 06 · 2:00 pm",
+    tiers: [
+      {
+        id: "early-bird",
+        name: "Early Bird",
+        description: "Limited availability - best price!",
+        price: 45,
+        originalPrice: 65,
+        available: 12,
+        maxPerOrder: 4,
+        benefits: ["Priority entry", "Free drink"]
+      },
+      {
+        id: "general",
+        name: "General Admission",
+        description: "Standard entry to the event",
+        price: 65,
+        available: 250,
+        maxPerOrder: 8
+      },
+      {
+        id: "vip",
+        name: "VIP Access",
+        description: "Premium experience with exclusive perks",
+        price: 150,
+        available: 20,
+        maxPerOrder: 2,
+        benefits: ["Skip the line", "VIP lounge access", "Complimentary drinks", "Meet & greet"]
+      }
+    ],
+    currency: "USD"
+  }}
+  actions={{
+    onCheckout: (selections, total) => console.log("Checkout:", selections, "Total:", total),
+    onSelectionChange: (selections) => console.log("Selection changed:", selections)
+  }}
+  appearance={{
+    showOrderSummary: true
+  }}
+/>`
+          }
+        ]
+      },
+      {
+        id: 'event-checkout',
+        name: 'Event Checkout',
+        description:
+          'Checkout form with billing information, payment methods, and order summary.',
+        registryName: 'event-checkout',
+        layouts: ['inline', 'fullscreen'],
+        actionCount: 2,
+        variants: [
+          {
+            id: 'default',
+            name: 'Default',
+            component: <EventCheckout />,
+            usageCode: `<EventCheckout
+  data={{
+    eventTitle: "Player Play Date",
+    eventDate: "Fri, Feb 06 · 2:00 pm",
+    eventPrice: "$25.05",
+    orderItems: [
+      { name: "General Admission", quantity: 2, price: 21.75 },
+      { name: "VIP Upgrade", quantity: 1, price: 35.00 }
+    ],
+    fees: 8.50,
+    delivery: 0,
+    deliveryMethod: "3 x eTicket",
+    paymentMethods: [
+      { id: "card", name: "Credit or debit card", icon: "card" },
+      { id: "paypal", name: "PayPal", icon: "paypal" },
+      { id: "google", name: "Google Pay", icon: "google" }
+    ],
+    currency: "USD",
+    timerMinutes: 20
+  }}
+  actions={{
+    onBack: () => console.log("Navigate back"),
+    onPlaceOrder: (formData) => console.log("Order placed:", formData)
+  }}
+  appearance={{
+    showTimer: true,
+    showEventCard: true
+  }}
+/>`
+          }
+        ]
+      },
+      {
+        id: 'event-confirmation',
+        name: 'Event Confirmation',
+        description:
+          'Order confirmation with event details, organizer follow, and social sharing.',
+        registryName: 'event-confirmation',
+        layouts: ['inline', 'fullscreen'],
+        actionCount: 4,
+        variants: [
+          {
+            id: 'default',
+            name: 'Default',
+            component: <EventConfirmation />,
+            usageCode: `<EventConfirmation
+  data={{
+    orderNumber: "#14040333743",
+    eventTitle: "Cavity Free SF Children's Oral Health Strategic Plan Launch",
+    ticketCount: 2,
+    recipientEmail: "john@example.com",
+    eventDate: "Thursday, February 19 · 9am - 12pm PST",
+    eventLocation: "San Francisco, CA",
+    organizer: {
+      name: "CavityFree SF",
+      image: "https://i.pravatar.cc/80?u=cavityfree"
+    }
+  }}
+  actions={{
+    onViewTickets: () => console.log("View tickets"),
+    onChangeEmail: () => console.log("Change email"),
+    onFollowOrganizer: () => console.log("Follow organizer"),
+    onShare: (platform) => console.log("Share on:", platform)
   }}
 />`
           }

--- a/packages/manifest-ui/app/blocks/page.tsx
+++ b/packages/manifest-ui/app/blocks/page.tsx
@@ -37,8 +37,11 @@ const categories: Category[] = [
     name: 'Events',
     blocks: [
       { id: 'event-card', name: 'Event Card' },
+      { id: 'event-list', name: 'Event List' },
       { id: 'event-detail', name: 'Event Detail' },
-      { id: 'event-list', name: 'Event List' }
+      { id: 'ticket-tier-select', name: 'Ticket Tier Select' },
+      { id: 'event-checkout', name: 'Event Checkout' },
+      { id: 'event-confirmation', name: 'Event Confirmation' }
     ]
   },
   {

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -138,6 +138,15 @@
       "2.0.0": "BREAKING: Updated to use simplified Event interface with display-formatted dateTime and string ticketTiers",
       "2.1.0": "Moved Get Tickets CTA from sticky bottom to end of content for fullscreen mode.",
       "2.2.0": "Changed CTA buttons and map tooltip from orange to dark theme colors"
+    },
+    "ticket-tier-select": {
+      "1.0.0": "Initial release with ticket tier cards, quantity controls, price breakdown, and order summary sidebar"
+    },
+    "event-checkout": {
+      "1.0.0": "Initial release with billing form, payment methods, countdown timer, and order summary"
+    },
+    "event-confirmation": {
+      "1.0.0": "Initial release with success message, event details, organizer follow, and social sharing"
     }
   }
 }

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -140,10 +140,14 @@
       "2.2.0": "Changed CTA buttons and map tooltip from orange to dark theme colors"
     },
     "ticket-tier-select": {
-      "1.0.0": "Initial release with ticket tier cards, quantity controls, price breakdown, and order summary sidebar"
+      "1.0.0": "Initial release with ticket tier cards, quantity controls, price breakdown, and order summary sidebar",
+      "1.1.0": "Added optional event image above order summary. Order summary now always visible with fixed width.",
+      "2.0.0": "BREAKING: Refactored to use nested event object (event.title, event.date, event.image, event.currency) instead of flat props"
     },
     "event-checkout": {
-      "1.0.0": "Initial release with billing form, payment methods, countdown timer, and order summary"
+      "1.0.0": "Initial release with billing form, payment methods, countdown timer, and order summary",
+      "1.1.0": "Added event image display above order summary on right side",
+      "2.0.0": "BREAKING: Refactored to use nested event and order objects. Simplified onPlaceOrder to () => void. Moved timerMinutes to appearance."
     },
     "event-confirmation": {
       "1.0.0": "Initial release with success message, event details, organizer follow, and social sharing"

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -577,7 +577,7 @@
     },
     {
       "name": "ticket-tier-select",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "type": "registry:component",
       "title": "Ticket Tier Select",
       "description": "Ticket tier selection with quantity controls and order summary. Shows price breakdown with fees.",
@@ -592,7 +592,7 @@
     },
     {
       "name": "event-checkout",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "type": "registry:component",
       "title": "Event Checkout",
       "description": "Event checkout form with billing info, payment method selection, and order summary. Includes countdown timer.",

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -574,6 +574,51 @@
           "type": "registry:lib"
         }
       ]
+    },
+    {
+      "name": "ticket-tier-select",
+      "version": "1.0.0",
+      "type": "registry:component",
+      "title": "Ticket Tier Select",
+      "description": "Ticket tier selection with quantity controls and order summary. Shows price breakdown with fees.",
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button"],
+      "files": [
+        {
+          "path": "registry/events/ticket-tier-select.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "event-checkout",
+      "version": "1.0.0",
+      "type": "registry:component",
+      "title": "Event Checkout",
+      "description": "Event checkout form with billing info, payment method selection, and order summary. Includes countdown timer.",
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button", "checkbox"],
+      "files": [
+        {
+          "path": "registry/events/event-checkout.tsx",
+          "type": "registry:component"
+        }
+      ]
+    },
+    {
+      "name": "event-confirmation",
+      "version": "1.0.0",
+      "type": "registry:component",
+      "title": "Event Confirmation",
+      "description": "Order confirmation with event details, ticket delivery info, organizer follow, and social sharing.",
+      "dependencies": ["lucide-react"],
+      "registryDependencies": ["button"],
+      "files": [
+        {
+          "path": "registry/events/event-confirmation.tsx",
+          "type": "registry:component"
+        }
+      ]
     }
   ]
 }

--- a/packages/manifest-ui/registry/events/event-checkout.tsx
+++ b/packages/manifest-ui/registry/events/event-checkout.tsx
@@ -3,8 +3,8 @@
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { cn } from '@/lib/utils'
-import { ChevronLeft, CreditCard, Info, Timer } from 'lucide-react'
-import { useState, useEffect } from 'react'
+import { ArrowLeft, CreditCard, Info, Timer } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 // Format currency
 function formatCurrency(amount: number, currency: string = 'USD'): string {
@@ -21,6 +21,13 @@ export interface OrderItem {
   price: number
 }
 
+export interface CheckoutOrder {
+  items: OrderItem[]
+  fees?: number
+  delivery?: number
+  deliveryMethod?: string
+}
+
 export interface PaymentMethod {
   id: string
   name: string
@@ -33,64 +40,67 @@ const defaultPaymentMethods: PaymentMethod[] = [
   { id: 'google', name: 'Google Pay', icon: 'google' }
 ]
 
-const defaultOrderItems: OrderItem[] = [
-  { name: 'General Admission', quantity: 1, price: 21.75 }
-]
+const defaultOrder: CheckoutOrder = {
+  items: [{ name: 'General Admission', quantity: 1, price: 21.75 }],
+  fees: 3.30,
+  delivery: 0,
+  deliveryMethod: '1 x eTicket'
+}
+
+export interface CheckoutEvent {
+  title: string
+  date: string
+  image?: string
+  price?: string
+  currency?: string
+}
+
+const defaultEvent: CheckoutEvent = {
+  title: 'Player Play Date',
+  date: 'Fri, Feb 06 · 2:00 pm',
+  price: '$25.05',
+  currency: 'USD'
+}
 
 export interface EventCheckoutProps {
   data?: {
-    eventTitle?: string
-    eventDate?: string
-    eventImage?: string
-    eventPrice?: string
-    orderItems?: OrderItem[]
-    fees?: number
-    delivery?: number
-    deliveryMethod?: string
+    event?: CheckoutEvent
+    order?: CheckoutOrder
     paymentMethods?: PaymentMethod[]
-    currency?: string
-    timerMinutes?: number
   }
   actions?: {
     onBack?: () => void
-    onPlaceOrder?: (formData: {
-      firstName: string
-      lastName: string
-      email: string
-      paymentMethod: string
-      marketingOptIn: boolean
-      eventUpdates: boolean
-    }) => void
+    onPlaceOrder?: () => void
   }
   appearance?: {
     showTimer?: boolean
+    timerMinutes?: number
     showEventCard?: boolean
   }
 }
 
-export function EventCheckout({ data, actions, appearance }: EventCheckoutProps) {
+export function EventCheckout({
+  data,
+  actions,
+  appearance
+}: EventCheckoutProps) {
   const {
-    eventTitle = 'Player Play Date',
-    eventDate = 'Fri, Feb 06 · 2:00 pm',
-    eventImage,
-    eventPrice = '$25.05',
-    orderItems = defaultOrderItems,
-    fees = 3.30,
-    delivery = 0,
-    deliveryMethod = '1 x eTicket',
-    paymentMethods = defaultPaymentMethods,
-    currency = 'USD',
-    timerMinutes = 20
+    event = defaultEvent,
+    order = defaultOrder,
+    paymentMethods = defaultPaymentMethods
   } = data ?? {}
+  const currency = event.currency ?? 'USD'
   const { onBack, onPlaceOrder } = actions ?? {}
-  const { showTimer = true, showEventCard = true } = appearance ?? {}
+  const { showTimer = true, timerMinutes = 20, showEventCard = true } = appearance ?? {}
 
   // Form state
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
   const [email, setEmail] = useState('')
   const [confirmEmail, setConfirmEmail] = useState('')
-  const [selectedPayment, setSelectedPayment] = useState(paymentMethods[0]?.id || 'card')
+  const [selectedPayment, setSelectedPayment] = useState(
+    paymentMethods[0]?.id || 'card'
+  )
   const [marketingOptIn, setMarketingOptIn] = useState(true)
   const [eventUpdates, setEventUpdates] = useState(false)
 
@@ -100,7 +110,7 @@ export function EventCheckout({ data, actions, appearance }: EventCheckoutProps)
   useEffect(() => {
     if (!showTimer) return
     const interval = setInterval(() => {
-      setTimeLeft(prev => Math.max(0, prev - 1))
+      setTimeLeft((prev) => Math.max(0, prev - 1))
     }, 1000)
     return () => clearInterval(interval)
   }, [showTimer])
@@ -112,22 +122,19 @@ export function EventCheckout({ data, actions, appearance }: EventCheckoutProps)
   }
 
   // Calculate totals
-  const subtotal = orderItems.reduce((sum, item) => sum + item.price * item.quantity, 0)
-  const total = subtotal + fees + delivery
+  const subtotal = order.items.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  )
+  const total = subtotal + (order.fees ?? 0) + (order.delivery ?? 0)
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    onPlaceOrder?.({
-      firstName,
-      lastName,
-      email,
-      paymentMethod: selectedPayment,
-      marketingOptIn,
-      eventUpdates
-    })
+    onPlaceOrder?.()
   }
 
-  const isFormValid = firstName && lastName && email && confirmEmail && email === confirmEmail
+  const isFormValid =
+    firstName && lastName && email && confirmEmail && email === confirmEmail
 
   const PaymentIcon = ({ type }: { type?: string }) => {
     switch (type) {
@@ -157,221 +164,245 @@ export function EventCheckout({ data, actions, appearance }: EventCheckoutProps)
   }
 
   return (
-    <div className="flex flex-col lg:flex-row gap-6">
-      {/* Left side - Checkout form */}
-      <div className="flex-1">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-6">
-          {onBack && (
-            <button
-              onClick={onBack}
-              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-          )}
-          <h2 className="text-xl font-semibold flex-1 text-center">Checkout</h2>
-          {showTimer && (
-            <div className="flex items-center gap-1 text-sm text-muted-foreground">
-              <Timer className="h-4 w-4" />
-              Time left {formatTime(timeLeft)}
-            </div>
-          )}
-        </div>
-
-        {/* Event card */}
-        {showEventCard && (
-          <div className="rounded-lg border p-4 mb-6">
-            <div className="flex items-center gap-4">
-              {eventImage && (
-                <img
-                  src={eventImage}
-                  alt={eventTitle}
-                  className="h-12 w-12 rounded object-cover"
-                />
-              )}
-              <div>
-                <h3 className="font-medium">{eventTitle}</h3>
-                <p className="text-sm text-muted-foreground">{eventDate}</p>
-                <p className="text-sm text-muted-foreground">{eventPrice}</p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit}>
-          {/* Billing information */}
-          <div className="mb-6">
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold">Billing information</h3>
-              <span className="text-sm text-muted-foreground">
-                <span className="text-destructive">*</span> Required
-              </span>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4 mb-4">
-              <div>
-                <input
-                  type="text"
-                  placeholder="First name"
-                  value={firstName}
-                  onChange={(e) => setFirstName(e.target.value)}
-                  className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                  required
-                />
-              </div>
-              <div>
-                <input
-                  type="text"
-                  placeholder="Last name"
-                  value={lastName}
-                  onChange={(e) => setLastName(e.target.value)}
-                  className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                  required
-                />
-              </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4 mb-4">
-              <div>
-                <input
-                  type="email"
-                  placeholder="Email address"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                  required
-                />
-              </div>
-              <div>
-                <input
-                  type="email"
-                  placeholder="Confirm email"
-                  value={confirmEmail}
-                  onChange={(e) => setConfirmEmail(e.target.value)}
-                  className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-                  required
-                />
-              </div>
-            </div>
-
-            {/* Marketing checkboxes */}
-            <div className="space-y-3">
-              <label className="flex items-start gap-3 cursor-pointer">
-                <Checkbox
-                  checked={marketingOptIn}
-                  onCheckedChange={(checked) => setMarketingOptIn(checked as boolean)}
-                  className="mt-0.5"
-                />
-                <span className="text-sm">
-                  Keep me updated on more events and news from this event organizer.
-                </span>
-              </label>
-              <label className="flex items-start gap-3 cursor-pointer">
-                <Checkbox
-                  checked={eventUpdates}
-                  onCheckedChange={(checked) => setEventUpdates(checked as boolean)}
-                  className="mt-0.5"
-                />
-                <span className="text-sm">
-                  Send me emails about the best events happening nearby or online.
-                </span>
-              </label>
-            </div>
-          </div>
-
-          {/* Payment methods */}
-          <div className="mb-6">
-            <h3 className="text-lg font-semibold mb-4">Pay with</h3>
-            <div className="space-y-3">
-              {paymentMethods.map((method) => (
-                <label
-                  key={method.id}
-                  className={cn(
-                    'flex items-center gap-3 rounded-lg border p-4 cursor-pointer transition-colors',
-                    selectedPayment === method.id && 'border-primary ring-1 ring-primary'
-                  )}
-                >
-                  <input
-                    type="radio"
-                    name="payment"
-                    value={method.id}
-                    checked={selectedPayment === method.id}
-                    onChange={() => setSelectedPayment(method.id)}
-                    className="sr-only"
-                  />
-                  <PaymentIcon type={method.icon} />
-                  <span className="font-medium">{method.name}</span>
-                </label>
-              ))}
-            </div>
-          </div>
-
-          {/* Terms and submit */}
-          <div>
-            <p className="text-sm text-muted-foreground mb-4">
-              By selecting Place Order, I agree to the{' '}
-              <a href="#" className="text-primary hover:underline">
-                Terms of Service
-              </a>
-            </p>
-            <Button
-              type="submit"
-              className="w-full sm:w-auto"
-              size="lg"
-              disabled={!isFormValid}
-            >
-              Place Order
-            </Button>
-          </div>
-        </form>
-      </div>
-
-      {/* Right side - Order summary */}
-      <div className="w-full lg:w-80 shrink-0">
-        <div className="rounded-lg border bg-card p-4">
-          <h3 className="font-semibold mb-4">Order summary</h3>
-
-          {/* Line items */}
-          <div className="space-y-2">
-            {orderItems.map((item, index) => (
-              <div key={index} className="flex justify-between text-sm">
-                <span>{item.quantity} x {item.name}</span>
-                <span>{formatCurrency(item.price * item.quantity, currency)}</span>
-              </div>
-            ))}
-          </div>
-
-          {/* Totals */}
-          <div className="mt-4 pt-4 border-t space-y-2">
-            <div className="flex justify-between text-sm">
-              <span>Subtotal</span>
-              <span>{formatCurrency(subtotal, currency)}</span>
-            </div>
-            <div className="flex justify-between text-sm">
-              <span className="flex items-center gap-1">
-                Fees
-                <Info className="h-3 w-3 text-muted-foreground" />
-              </span>
-              <span>{formatCurrency(fees, currency)}</span>
-            </div>
-            {delivery !== undefined && (
-              <div className="flex justify-between text-sm">
-                <div>
-                  <span>Delivery</span>
-                  {deliveryMethod && (
-                    <p className="text-xs text-muted-foreground">{deliveryMethod}</p>
-                  )}
-                </div>
-                <span>{formatCurrency(delivery, currency)}</span>
+    <div className="rounded-xl border bg-card p-6">
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Left side - Checkout form */}
+        <div className="flex-1">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-6">
+            {onBack && (
+              <button
+                onClick={onBack}
+                className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground cursor-pointer"
+              >
+                <ArrowLeft className="h-4 w-4" />
+              </button>
+            )}
+            <h2 className="text-xl font-semibold flex-1">Checkout</h2>
+            {showTimer && (
+              <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                <Timer className="h-4 w-4" />
+                Time left {formatTime(timeLeft)}
               </div>
             )}
           </div>
 
-          <div className="mt-4 pt-4 border-t">
-            <div className="flex justify-between font-semibold">
-              <span>Total</span>
-              <span>{formatCurrency(total, currency)}</span>
+          {/* Event card */}
+          {showEventCard && (
+            <div className="rounded-lg border p-4 mb-6">
+              <div className="flex items-center gap-4">
+                {event.image && (
+                  <img
+                    src={event.image}
+                    alt={event.title}
+                    className="h-12 w-12 rounded object-cover"
+                  />
+                )}
+                <div>
+                  <h3 className="font-medium">{event.title}</h3>
+                  <p className="text-sm text-muted-foreground">{event.date}</p>
+                  <p className="text-sm text-muted-foreground">{event.price}</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            {/* Billing information */}
+            <div className="mb-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold">Billing information</h3>
+                <span className="text-sm text-muted-foreground">
+                  <span className="text-destructive">*</span> Required
+                </span>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4 mb-4">
+                <div>
+                  <input
+                    type="text"
+                    placeholder="First name"
+                    value={firstName}
+                    onChange={(e) => setFirstName(e.target.value)}
+                    className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                    required
+                  />
+                </div>
+                <div>
+                  <input
+                    type="text"
+                    placeholder="Last name"
+                    value={lastName}
+                    onChange={(e) => setLastName(e.target.value)}
+                    className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4 mb-4">
+                <div>
+                  <input
+                    type="email"
+                    placeholder="Email address"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                    required
+                  />
+                </div>
+                <div>
+                  <input
+                    type="email"
+                    placeholder="Confirm email"
+                    value={confirmEmail}
+                    onChange={(e) => setConfirmEmail(e.target.value)}
+                    className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                    required
+                  />
+                </div>
+              </div>
+
+              {/* Marketing checkboxes */}
+              <div className="space-y-3">
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <Checkbox
+                    checked={marketingOptIn}
+                    onCheckedChange={(checked) =>
+                      setMarketingOptIn(checked as boolean)
+                    }
+                    className="mt-0.5"
+                  />
+                  <span className="text-sm">
+                    Keep me updated on more events and news from this event
+                    organizer.
+                  </span>
+                </label>
+                <label className="flex items-start gap-3 cursor-pointer">
+                  <Checkbox
+                    checked={eventUpdates}
+                    onCheckedChange={(checked) =>
+                      setEventUpdates(checked as boolean)
+                    }
+                    className="mt-0.5"
+                  />
+                  <span className="text-sm">
+                    Send me emails about the best events happening nearby or
+                    online.
+                  </span>
+                </label>
+              </div>
+            </div>
+
+            {/* Payment methods */}
+            <div className="mb-6">
+              <h3 className="text-lg font-semibold mb-4">Pay with</h3>
+              <div className="space-y-3">
+                {paymentMethods.map((method) => (
+                  <label
+                    key={method.id}
+                    className={cn(
+                      'flex items-center gap-3 rounded-lg border p-4 cursor-pointer transition-colors',
+                      selectedPayment === method.id &&
+                        'border-primary ring-1 ring-primary'
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="payment"
+                      value={method.id}
+                      checked={selectedPayment === method.id}
+                      onChange={() => setSelectedPayment(method.id)}
+                      className="sr-only"
+                    />
+                    <PaymentIcon type={method.icon} />
+                    <span className="font-medium">{method.name}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* Terms and submit */}
+            <div>
+              <p className="text-sm text-muted-foreground mb-4">
+                By selecting Place Order, I agree to the{' '}
+                <a href="#" className="text-primary hover:underline">
+                  Terms of Service
+                </a>
+              </p>
+              <Button
+                type="submit"
+                className="w-full sm:w-auto"
+                size="lg"
+                disabled={!isFormValid}
+              >
+                Place Order
+              </Button>
+            </div>
+          </form>
+        </div>
+
+        {/* Right side - Order summary */}
+        <div className="w-full lg:w-80 shrink-0">
+          {/* Event image */}
+          {event.image && (
+            <img
+              src={event.image}
+              alt={event.title}
+              className="w-full h-40 object-cover rounded-lg mb-4"
+            />
+          )}
+
+          <div className="rounded-lg border bg-muted/30 p-4">
+            <h3 className="font-semibold mb-4">Order summary</h3>
+
+            {/* Line items */}
+            <div className="space-y-2">
+              {order.items.map((item, index) => (
+                <div key={index} className="flex justify-between text-sm">
+                  <span>
+                    {item.quantity} x {item.name}
+                  </span>
+                  <span>
+                    {formatCurrency(item.price * item.quantity, currency)}
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {/* Totals */}
+            <div className="mt-4 pt-4 border-t space-y-2">
+              <div className="flex justify-between text-sm">
+                <span>Subtotal</span>
+                <span>{formatCurrency(subtotal, currency)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="flex items-center gap-1">
+                  Fees
+                  <Info className="h-3 w-3 text-muted-foreground" />
+                </span>
+                <span>{formatCurrency(order.fees ?? 0, currency)}</span>
+              </div>
+              {order.delivery !== undefined && (
+                <div className="flex justify-between text-sm">
+                  <div>
+                    <span>Delivery</span>
+                    {order.deliveryMethod && (
+                      <p className="text-xs text-muted-foreground">
+                        {order.deliveryMethod}
+                      </p>
+                    )}
+                  </div>
+                  <span>{formatCurrency(order.delivery, currency)}</span>
+                </div>
+              )}
+            </div>
+
+            <div className="mt-4 pt-4 border-t">
+              <div className="flex justify-between font-semibold">
+                <span>Total</span>
+                <span>{formatCurrency(total, currency)}</span>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/manifest-ui/registry/events/event-checkout.tsx
+++ b/packages/manifest-ui/registry/events/event-checkout.tsx
@@ -1,0 +1,381 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { cn } from '@/lib/utils'
+import { ChevronLeft, CreditCard, Info, Timer } from 'lucide-react'
+import { useState, useEffect } from 'react'
+
+// Format currency
+function formatCurrency(amount: number, currency: string = 'USD'): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2
+  }).format(amount)
+}
+
+export interface OrderItem {
+  name: string
+  quantity: number
+  price: number
+}
+
+export interface PaymentMethod {
+  id: string
+  name: string
+  icon?: 'card' | 'paypal' | 'google' | 'apple'
+}
+
+const defaultPaymentMethods: PaymentMethod[] = [
+  { id: 'card', name: 'Credit or debit card', icon: 'card' },
+  { id: 'paypal', name: 'PayPal', icon: 'paypal' },
+  { id: 'google', name: 'Google Pay', icon: 'google' }
+]
+
+const defaultOrderItems: OrderItem[] = [
+  { name: 'General Admission', quantity: 1, price: 21.75 }
+]
+
+export interface EventCheckoutProps {
+  data?: {
+    eventTitle?: string
+    eventDate?: string
+    eventImage?: string
+    eventPrice?: string
+    orderItems?: OrderItem[]
+    fees?: number
+    delivery?: number
+    deliveryMethod?: string
+    paymentMethods?: PaymentMethod[]
+    currency?: string
+    timerMinutes?: number
+  }
+  actions?: {
+    onBack?: () => void
+    onPlaceOrder?: (formData: {
+      firstName: string
+      lastName: string
+      email: string
+      paymentMethod: string
+      marketingOptIn: boolean
+      eventUpdates: boolean
+    }) => void
+  }
+  appearance?: {
+    showTimer?: boolean
+    showEventCard?: boolean
+  }
+}
+
+export function EventCheckout({ data, actions, appearance }: EventCheckoutProps) {
+  const {
+    eventTitle = 'Player Play Date',
+    eventDate = 'Fri, Feb 06 · 2:00 pm',
+    eventImage,
+    eventPrice = '$25.05',
+    orderItems = defaultOrderItems,
+    fees = 3.30,
+    delivery = 0,
+    deliveryMethod = '1 x eTicket',
+    paymentMethods = defaultPaymentMethods,
+    currency = 'USD',
+    timerMinutes = 20
+  } = data ?? {}
+  const { onBack, onPlaceOrder } = actions ?? {}
+  const { showTimer = true, showEventCard = true } = appearance ?? {}
+
+  // Form state
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [email, setEmail] = useState('')
+  const [confirmEmail, setConfirmEmail] = useState('')
+  const [selectedPayment, setSelectedPayment] = useState(paymentMethods[0]?.id || 'card')
+  const [marketingOptIn, setMarketingOptIn] = useState(true)
+  const [eventUpdates, setEventUpdates] = useState(false)
+
+  // Timer state
+  const [timeLeft, setTimeLeft] = useState(timerMinutes * 60)
+
+  useEffect(() => {
+    if (!showTimer) return
+    const interval = setInterval(() => {
+      setTimeLeft(prev => Math.max(0, prev - 1))
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [showTimer])
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60)
+    const secs = seconds % 60
+    return `${mins}:${secs.toString().padStart(2, '0')}`
+  }
+
+  // Calculate totals
+  const subtotal = orderItems.reduce((sum, item) => sum + item.price * item.quantity, 0)
+  const total = subtotal + fees + delivery
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onPlaceOrder?.({
+      firstName,
+      lastName,
+      email,
+      paymentMethod: selectedPayment,
+      marketingOptIn,
+      eventUpdates
+    })
+  }
+
+  const isFormValid = firstName && lastName && email && confirmEmail && email === confirmEmail
+
+  const PaymentIcon = ({ type }: { type?: string }) => {
+    switch (type) {
+      case 'card':
+        return <CreditCard className="h-5 w-5 text-muted-foreground" />
+      case 'paypal':
+        return (
+          <div className="h-5 w-5 rounded bg-[#003087] flex items-center justify-center">
+            <span className="text-white text-[10px] font-bold">P</span>
+          </div>
+        )
+      case 'google':
+        return (
+          <div className="h-5 w-5 rounded border flex items-center justify-center">
+            <span className="text-[10px] font-medium">G</span>
+          </div>
+        )
+      case 'apple':
+        return (
+          <div className="h-5 w-5 rounded bg-black flex items-center justify-center">
+            <span className="text-white text-[10px] font-bold">A</span>
+          </div>
+        )
+      default:
+        return <CreditCard className="h-5 w-5 text-muted-foreground" />
+    }
+  }
+
+  return (
+    <div className="flex flex-col lg:flex-row gap-6">
+      {/* Left side - Checkout form */}
+      <div className="flex-1">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          {onBack && (
+            <button
+              onClick={onBack}
+              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+          )}
+          <h2 className="text-xl font-semibold flex-1 text-center">Checkout</h2>
+          {showTimer && (
+            <div className="flex items-center gap-1 text-sm text-muted-foreground">
+              <Timer className="h-4 w-4" />
+              Time left {formatTime(timeLeft)}
+            </div>
+          )}
+        </div>
+
+        {/* Event card */}
+        {showEventCard && (
+          <div className="rounded-lg border p-4 mb-6">
+            <div className="flex items-center gap-4">
+              {eventImage && (
+                <img
+                  src={eventImage}
+                  alt={eventTitle}
+                  className="h-12 w-12 rounded object-cover"
+                />
+              )}
+              <div>
+                <h3 className="font-medium">{eventTitle}</h3>
+                <p className="text-sm text-muted-foreground">{eventDate}</p>
+                <p className="text-sm text-muted-foreground">{eventPrice}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          {/* Billing information */}
+          <div className="mb-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold">Billing information</h3>
+              <span className="text-sm text-muted-foreground">
+                <span className="text-destructive">*</span> Required
+              </span>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4 mb-4">
+              <div>
+                <input
+                  type="text"
+                  placeholder="First name"
+                  value={firstName}
+                  onChange={(e) => setFirstName(e.target.value)}
+                  className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  required
+                />
+              </div>
+              <div>
+                <input
+                  type="text"
+                  placeholder="Last name"
+                  value={lastName}
+                  onChange={(e) => setLastName(e.target.value)}
+                  className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-4 mb-4">
+              <div>
+                <input
+                  type="email"
+                  placeholder="Email address"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  required
+                />
+              </div>
+              <div>
+                <input
+                  type="email"
+                  placeholder="Confirm email"
+                  value={confirmEmail}
+                  onChange={(e) => setConfirmEmail(e.target.value)}
+                  className="w-full rounded-lg border bg-background px-4 py-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                  required
+                />
+              </div>
+            </div>
+
+            {/* Marketing checkboxes */}
+            <div className="space-y-3">
+              <label className="flex items-start gap-3 cursor-pointer">
+                <Checkbox
+                  checked={marketingOptIn}
+                  onCheckedChange={(checked) => setMarketingOptIn(checked as boolean)}
+                  className="mt-0.5"
+                />
+                <span className="text-sm">
+                  Keep me updated on more events and news from this event organizer.
+                </span>
+              </label>
+              <label className="flex items-start gap-3 cursor-pointer">
+                <Checkbox
+                  checked={eventUpdates}
+                  onCheckedChange={(checked) => setEventUpdates(checked as boolean)}
+                  className="mt-0.5"
+                />
+                <span className="text-sm">
+                  Send me emails about the best events happening nearby or online.
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* Payment methods */}
+          <div className="mb-6">
+            <h3 className="text-lg font-semibold mb-4">Pay with</h3>
+            <div className="space-y-3">
+              {paymentMethods.map((method) => (
+                <label
+                  key={method.id}
+                  className={cn(
+                    'flex items-center gap-3 rounded-lg border p-4 cursor-pointer transition-colors',
+                    selectedPayment === method.id && 'border-primary ring-1 ring-primary'
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="payment"
+                    value={method.id}
+                    checked={selectedPayment === method.id}
+                    onChange={() => setSelectedPayment(method.id)}
+                    className="sr-only"
+                  />
+                  <PaymentIcon type={method.icon} />
+                  <span className="font-medium">{method.name}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Terms and submit */}
+          <div>
+            <p className="text-sm text-muted-foreground mb-4">
+              By selecting Place Order, I agree to the{' '}
+              <a href="#" className="text-primary hover:underline">
+                Terms of Service
+              </a>
+            </p>
+            <Button
+              type="submit"
+              className="w-full sm:w-auto"
+              size="lg"
+              disabled={!isFormValid}
+            >
+              Place Order
+            </Button>
+          </div>
+        </form>
+      </div>
+
+      {/* Right side - Order summary */}
+      <div className="w-full lg:w-80 shrink-0">
+        <div className="rounded-lg border bg-card p-4">
+          <h3 className="font-semibold mb-4">Order summary</h3>
+
+          {/* Line items */}
+          <div className="space-y-2">
+            {orderItems.map((item, index) => (
+              <div key={index} className="flex justify-between text-sm">
+                <span>{item.quantity} x {item.name}</span>
+                <span>{formatCurrency(item.price * item.quantity, currency)}</span>
+              </div>
+            ))}
+          </div>
+
+          {/* Totals */}
+          <div className="mt-4 pt-4 border-t space-y-2">
+            <div className="flex justify-between text-sm">
+              <span>Subtotal</span>
+              <span>{formatCurrency(subtotal, currency)}</span>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span className="flex items-center gap-1">
+                Fees
+                <Info className="h-3 w-3 text-muted-foreground" />
+              </span>
+              <span>{formatCurrency(fees, currency)}</span>
+            </div>
+            {delivery !== undefined && (
+              <div className="flex justify-between text-sm">
+                <div>
+                  <span>Delivery</span>
+                  {deliveryMethod && (
+                    <p className="text-xs text-muted-foreground">{deliveryMethod}</p>
+                  )}
+                </div>
+                <span>{formatCurrency(delivery, currency)}</span>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-4 pt-4 border-t">
+            <div className="flex justify-between font-semibold">
+              <span>Total</span>
+              <span>{formatCurrency(total, currency)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/manifest-ui/registry/events/event-confirmation.tsx
+++ b/packages/manifest-ui/registry/events/event-confirmation.tsx
@@ -1,7 +1,13 @@
 'use client'
 
 import { Button } from '@/components/ui/button'
-import { CheckCircle, Facebook, Twitter, Mail, MessageCircle } from 'lucide-react'
+import {
+  CheckCircle,
+  Facebook,
+  Mail,
+  MessageCircle,
+  Twitter
+} from 'lucide-react'
 
 export interface EventConfirmationProps {
   data?: {
@@ -37,10 +43,11 @@ export function EventConfirmation({ data, actions }: EventConfirmationProps) {
       image: undefined
     }
   } = data ?? {}
-  const { onViewTickets, onChangeEmail, onFollowOrganizer, onShare } = actions ?? {}
+  const { onViewTickets, onChangeEmail, onFollowOrganizer, onShare } =
+    actions ?? {}
 
   return (
-    <div className="max-w-2xl mx-auto">
+    <div className="rounded-xl border bg-card p-6 ">
       {/* Success header */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-8">
         <div className="flex items-center gap-3">
@@ -122,7 +129,9 @@ export function EventConfirmation({ data, actions }: EventConfirmationProps) {
                   Don't miss out on events from
                 </p>
                 <p className="font-semibold">{organizer.name}</p>
-                <p className="text-xs text-muted-foreground">Created this event</p>
+                <p className="text-xs text-muted-foreground">
+                  Created this event
+                </p>
               </div>
             </div>
             <Button variant="outline" onClick={onFollowOrganizer}>

--- a/packages/manifest-ui/registry/events/event-confirmation.tsx
+++ b/packages/manifest-ui/registry/events/event-confirmation.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { CheckCircle, Facebook, Twitter, Mail, MessageCircle } from 'lucide-react'
+
+export interface EventConfirmationProps {
+  data?: {
+    orderNumber?: string
+    eventTitle?: string
+    ticketCount?: number
+    recipientEmail?: string
+    eventDate?: string
+    eventLocation?: string
+    organizer?: {
+      name: string
+      image?: string
+    }
+  }
+  actions?: {
+    onViewTickets?: () => void
+    onChangeEmail?: () => void
+    onFollowOrganizer?: () => void
+    onShare?: (platform: 'facebook' | 'twitter' | 'messenger' | 'email') => void
+  }
+}
+
+export function EventConfirmation({ data, actions }: EventConfirmationProps) {
+  const {
+    orderNumber = '#14040333743',
+    eventTitle = "Cavity Free SF Children's Oral Health Strategic Plan Launch",
+    ticketCount = 1,
+    recipientEmail = 'user@example.com',
+    eventDate = 'Thursday, February 19 · 9am - 12pm PST',
+    eventLocation = 'San Francisco, CA',
+    organizer = {
+      name: 'CavityFree SF',
+      image: undefined
+    }
+  } = data ?? {}
+  const { onViewTickets, onChangeEmail, onFollowOrganizer, onShare } = actions ?? {}
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      {/* Success header */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-8">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100">
+            <CheckCircle className="h-6 w-6 text-green-600" />
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold">Thanks for your order!</h1>
+            <p className="text-sm text-muted-foreground">{orderNumber}</p>
+          </div>
+        </div>
+        <Button onClick={onViewTickets} size="lg">
+          Take me to my tickets
+        </Button>
+      </div>
+
+      {/* Event details */}
+      <div className="mb-8">
+        <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-2">
+          You're going to
+        </p>
+        <h2 className="text-2xl font-bold leading-tight mb-6">{eventTitle}</h2>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+          {/* Ticket sent to */}
+          <div>
+            <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-1">
+              {ticketCount} Ticket sent to
+            </p>
+            <p className="text-sm">{recipientEmail}</p>
+            {onChangeEmail && (
+              <button
+                onClick={onChangeEmail}
+                className="text-sm text-primary hover:underline"
+              >
+                Change
+              </button>
+            )}
+          </div>
+
+          {/* Date */}
+          <div>
+            <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-1">
+              Date
+            </p>
+            <p className="text-sm">{eventDate}</p>
+          </div>
+
+          {/* Location */}
+          <div>
+            <p className="text-xs font-semibold tracking-wider text-muted-foreground uppercase mb-1">
+              Location
+            </p>
+            <p className="text-sm">{eventLocation}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Organizer follow section */}
+      {organizer && (
+        <div className="rounded-lg border bg-muted/30 p-4 mb-8">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              {organizer.image ? (
+                <img
+                  src={organizer.image}
+                  alt={organizer.name}
+                  className="h-12 w-12 rounded-full object-cover"
+                />
+              ) : (
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-orange-100">
+                  <span className="text-lg font-semibold text-orange-600">
+                    {organizer.name.charAt(0)}
+                  </span>
+                </div>
+              )}
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Don't miss out on events from
+                </p>
+                <p className="font-semibold">{organizer.name}</p>
+                <p className="text-xs text-muted-foreground">Created this event</p>
+              </div>
+            </div>
+            <Button variant="outline" onClick={onFollowOrganizer}>
+              Follow
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Social sharing */}
+      <div className="flex items-center gap-4">
+        <button
+          onClick={() => onShare?.('facebook')}
+          className="flex h-10 w-10 items-center justify-center rounded-full border hover:bg-muted transition-colors"
+          aria-label="Share on Facebook"
+        >
+          <Facebook className="h-5 w-5" />
+        </button>
+        <button
+          onClick={() => onShare?.('messenger')}
+          className="flex h-10 w-10 items-center justify-center rounded-full border hover:bg-muted transition-colors"
+          aria-label="Share on Messenger"
+        >
+          <MessageCircle className="h-5 w-5" />
+        </button>
+        <button
+          onClick={() => onShare?.('twitter')}
+          className="flex h-10 w-10 items-center justify-center rounded-full border hover:bg-muted transition-colors"
+          aria-label="Share on Twitter"
+        >
+          <Twitter className="h-5 w-5" />
+        </button>
+        <button
+          onClick={() => onShare?.('email')}
+          className="flex h-10 w-10 items-center justify-center rounded-full border hover:bg-muted transition-colors"
+          aria-label="Share via Email"
+        >
+          <Mail className="h-5 w-5" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/manifest-ui/registry/events/ticket-tier-select.tsx
+++ b/packages/manifest-ui/registry/events/ticket-tier-select.tsx
@@ -1,0 +1,274 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { Minus, Plus, Info } from 'lucide-react'
+import { useState } from 'react'
+
+// Format number with commas (consistent across server/client)
+function formatNumber(num: number): string {
+  return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+}
+
+// Format currency
+function formatCurrency(amount: number, currency: string = 'USD'): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2
+  }).format(amount)
+}
+
+export interface TicketTier {
+  id: string
+  name: string
+  price: number
+  fee: number
+  available: number
+  salesEndDate?: string
+  description?: string
+  maxPerOrder?: number
+}
+
+export interface TicketSelection {
+  tierId: string
+  tierName: string
+  quantity: number
+  price: number
+  fee: number
+}
+
+const defaultTiers: TicketTier[] = [
+  {
+    id: 'general',
+    name: 'General Admission',
+    price: 21.75,
+    fee: 3.30,
+    available: 100,
+    salesEndDate: 'Feb 6, 2026',
+    maxPerOrder: 10
+  },
+  {
+    id: 'vip',
+    name: 'VIP',
+    price: 35.85,
+    fee: 4.25,
+    available: 50,
+    salesEndDate: 'Feb 6, 2026',
+    description: 'VIP tickets include entrance into Player Play Date for one person/ticket and a customized Player Play Date tote bag.',
+    maxPerOrder: 5
+  }
+]
+
+export interface TicketTierSelectProps {
+  data?: {
+    eventTitle?: string
+    eventDate?: string
+    tiers?: TicketTier[]
+    currency?: string
+  }
+  actions?: {
+    onCheckout?: (selections: TicketSelection[], total: number) => void
+    onSelectionChange?: (selections: TicketSelection[]) => void
+  }
+  appearance?: {
+    showOrderSummary?: boolean
+  }
+  control?: {
+    selections?: Record<string, number>
+  }
+}
+
+export function TicketTierSelect({ data, actions, appearance, control }: TicketTierSelectProps) {
+  const {
+    eventTitle = 'Player Play Date',
+    eventDate = 'Friday, February 6 · 2 - 5pm PST',
+    tiers = defaultTiers,
+    currency = 'USD'
+  } = data ?? {}
+  const { onCheckout, onSelectionChange } = actions ?? {}
+  const { showOrderSummary = true } = appearance ?? {}
+
+  const [selections, setSelections] = useState<Record<string, number>>(
+    control?.selections ?? {}
+  )
+
+  const updateQuantity = (tierId: string, delta: number) => {
+    const tier = tiers.find(t => t.id === tierId)
+    if (!tier) return
+
+    const currentQty = selections[tierId] || 0
+    const newQty = Math.max(0, Math.min(currentQty + delta, tier.maxPerOrder ?? 10, tier.available))
+
+    const newSelections = { ...selections, [tierId]: newQty }
+    if (newQty === 0) {
+      delete newSelections[tierId]
+    }
+    setSelections(newSelections)
+
+    // Notify parent of selection change
+    const selectionsList = getSelectionsList(newSelections)
+    onSelectionChange?.(selectionsList)
+  }
+
+  const getSelectionsList = (sels: Record<string, number> = selections): TicketSelection[] => {
+    return Object.entries(sels)
+      .filter(([_, qty]) => qty > 0)
+      .map(([tierId, qty]) => {
+        const tier = tiers.find(t => t.id === tierId)!
+        return {
+          tierId,
+          tierName: tier.name,
+          quantity: qty,
+          price: tier.price,
+          fee: tier.fee
+        }
+      })
+  }
+
+  const selectionsList = getSelectionsList()
+  const hasSelections = selectionsList.length > 0
+
+  const subtotal = selectionsList.reduce((sum, s) => sum + s.price * s.quantity, 0)
+  const totalFees = selectionsList.reduce((sum, s) => sum + s.fee * s.quantity, 0)
+  const total = subtotal + totalFees
+
+  const handleCheckout = () => {
+    onCheckout?.(selectionsList, total)
+  }
+
+  return (
+    <div className="flex flex-col lg:flex-row gap-6">
+      {/* Left side - Tier selection */}
+      <div className="flex-1">
+        {/* Header */}
+        <div className="text-center mb-6">
+          <h2 className="text-xl font-semibold">{eventTitle}</h2>
+          <p className="text-sm text-muted-foreground mt-1">{eventDate}</p>
+        </div>
+
+        {/* Tiers */}
+        <div className="space-y-4">
+          {tiers.map((tier) => {
+            const qty = selections[tier.id] || 0
+            const isSelected = qty > 0
+            const totalPrice = tier.price + tier.fee
+
+            return (
+              <div
+                key={tier.id}
+                className={cn(
+                  'rounded-lg border p-4 transition-colors',
+                  isSelected && 'border-primary ring-1 ring-primary'
+                )}
+              >
+                {/* Tier header */}
+                <div className="flex items-center justify-between">
+                  <h3 className="font-medium">{tier.name}</h3>
+                  <div className="flex items-center gap-3">
+                    <Button
+                      variant="outline"
+                      size="icon"
+                      className={cn(
+                        'h-8 w-8 rounded-full',
+                        qty === 0 && 'opacity-50'
+                      )}
+                      onClick={() => updateQuantity(tier.id, -1)}
+                      disabled={qty === 0}
+                    >
+                      <Minus className="h-4 w-4" />
+                    </Button>
+                    <span className="w-6 text-center font-medium">{qty}</span>
+                    <Button
+                      size="icon"
+                      className="h-8 w-8 rounded-full"
+                      onClick={() => updateQuantity(tier.id, 1)}
+                      disabled={qty >= (tier.maxPerOrder ?? 10) || qty >= tier.available}
+                    >
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+
+                {/* Price info */}
+                <div className="mt-3">
+                  <div className="flex items-baseline gap-2">
+                    <span className="font-semibold">{formatCurrency(totalPrice, currency)}</span>
+                    <span className="text-sm text-muted-foreground">
+                      incl. {formatCurrency(tier.fee, currency)} Fee
+                    </span>
+                  </div>
+                  {tier.salesEndDate && (
+                    <p className="text-sm text-muted-foreground mt-1">
+                      Sales end on {tier.salesEndDate}
+                    </p>
+                  )}
+                </div>
+
+                {/* Description */}
+                {tier.description && (
+                  <p className="text-sm text-muted-foreground mt-3">
+                    {tier.description}
+                  </p>
+                )}
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Checkout button */}
+        <div className="mt-6">
+          <Button
+            className="w-full"
+            size="lg"
+            onClick={handleCheckout}
+            disabled={!hasSelections}
+          >
+            Check out
+          </Button>
+        </div>
+      </div>
+
+      {/* Right side - Order summary */}
+      {showOrderSummary && hasSelections && (
+        <div className="w-full lg:w-80 shrink-0">
+          <div className="rounded-lg border bg-card p-4">
+            <h3 className="font-semibold mb-4">Order summary</h3>
+
+            {/* Line items */}
+            <div className="space-y-2">
+              {selectionsList.map((selection) => (
+                <div key={selection.tierId} className="flex justify-between text-sm">
+                  <span>{selection.quantity} x {selection.tierName}</span>
+                  <span>{formatCurrency(selection.price * selection.quantity, currency)}</span>
+                </div>
+              ))}
+            </div>
+
+            {/* Totals */}
+            <div className="mt-4 pt-4 border-t space-y-2">
+              <div className="flex justify-between text-sm">
+                <span>Subtotal</span>
+                <span>{formatCurrency(subtotal, currency)}</span>
+              </div>
+              <div className="flex justify-between text-sm">
+                <span className="flex items-center gap-1">
+                  Fees
+                  <Info className="h-3 w-3 text-muted-foreground" />
+                </span>
+                <span>{formatCurrency(totalFees, currency)}</span>
+              </div>
+            </div>
+
+            <div className="mt-4 pt-4 border-t">
+              <div className="flex justify-between font-semibold">
+                <span>Total</span>
+                <span>{formatCurrency(total, currency)}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/manifest-ui/registry/events/ticket-tier-select.tsx
+++ b/packages/manifest-ui/registry/events/ticket-tier-select.tsx
@@ -60,12 +60,23 @@ const defaultTiers: TicketTier[] = [
   }
 ]
 
+export interface TicketTierEvent {
+  title: string
+  date: string
+  image?: string
+  currency?: string
+}
+
+const defaultEvent: TicketTierEvent = {
+  title: 'Player Play Date',
+  date: 'Friday, February 6 · 2 - 5pm PST',
+  currency: 'USD'
+}
+
 export interface TicketTierSelectProps {
   data?: {
-    eventTitle?: string
-    eventDate?: string
+    event?: TicketTierEvent
     tiers?: TicketTier[]
-    currency?: string
   }
   actions?: {
     onCheckout?: (selections: TicketSelection[], total: number) => void
@@ -81,11 +92,10 @@ export interface TicketTierSelectProps {
 
 export function TicketTierSelect({ data, actions, appearance, control }: TicketTierSelectProps) {
   const {
-    eventTitle = 'Player Play Date',
-    eventDate = 'Friday, February 6 · 2 - 5pm PST',
-    tiers = defaultTiers,
-    currency = 'USD'
+    event = defaultEvent,
+    tiers = defaultTiers
   } = data ?? {}
+  const currency = event.currency ?? 'USD'
   const { onCheckout, onSelectionChange } = actions ?? {}
   const { showOrderSummary = true } = appearance ?? {}
 
@@ -138,13 +148,14 @@ export function TicketTierSelect({ data, actions, appearance, control }: TicketT
   }
 
   return (
-    <div className="flex flex-col lg:flex-row gap-6">
-      {/* Left side - Tier selection */}
-      <div className="flex-1">
+    <div className="rounded-xl border bg-card p-6">
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Left side - Tier selection */}
+        <div className="flex-1">
         {/* Header */}
         <div className="text-center mb-6">
-          <h2 className="text-xl font-semibold">{eventTitle}</h2>
-          <p className="text-sm text-muted-foreground mt-1">{eventDate}</p>
+          <h2 className="text-xl font-semibold">{event.title}</h2>
+          <p className="text-sm text-muted-foreground mt-1">{event.date}</p>
         </div>
 
         {/* Tiers */}
@@ -229,46 +240,62 @@ export function TicketTierSelect({ data, actions, appearance, control }: TicketT
         </div>
       </div>
 
-      {/* Right side - Order summary */}
-      {showOrderSummary && hasSelections && (
-        <div className="w-full lg:w-80 shrink-0">
-          <div className="rounded-lg border bg-card p-4">
-            <h3 className="font-semibold mb-4">Order summary</h3>
+        {/* Right side - Order summary */}
+        {showOrderSummary && (
+          <div className="w-full lg:w-80 shrink-0">
+            {/* Event image */}
+            {event.image && (
+              <img
+                src={event.image}
+                alt={event.title}
+                className="w-full h-40 object-cover rounded-lg mb-4"
+              />
+            )}
 
-            {/* Line items */}
-            <div className="space-y-2">
-              {selectionsList.map((selection) => (
-                <div key={selection.tierId} className="flex justify-between text-sm">
-                  <span>{selection.quantity} x {selection.tierName}</span>
-                  <span>{formatCurrency(selection.price * selection.quantity, currency)}</span>
-                </div>
-              ))}
-            </div>
+            <div className="rounded-lg border bg-muted/30 p-4">
+              <h3 className="font-semibold mb-4">Order summary</h3>
 
-            {/* Totals */}
-            <div className="mt-4 pt-4 border-t space-y-2">
-              <div className="flex justify-between text-sm">
-                <span>Subtotal</span>
-                <span>{formatCurrency(subtotal, currency)}</span>
-              </div>
-              <div className="flex justify-between text-sm">
-                <span className="flex items-center gap-1">
-                  Fees
-                  <Info className="h-3 w-3 text-muted-foreground" />
-                </span>
-                <span>{formatCurrency(totalFees, currency)}</span>
-              </div>
-            </div>
+              {hasSelections ? (
+                <>
+                  {/* Line items */}
+                  <div className="space-y-2">
+                    {selectionsList.map((selection) => (
+                      <div key={selection.tierId} className="flex justify-between text-sm">
+                        <span>{selection.quantity} x {selection.tierName}</span>
+                        <span>{formatCurrency(selection.price * selection.quantity, currency)}</span>
+                      </div>
+                    ))}
+                  </div>
 
-            <div className="mt-4 pt-4 border-t">
-              <div className="flex justify-between font-semibold">
-                <span>Total</span>
-                <span>{formatCurrency(total, currency)}</span>
-              </div>
+                  {/* Totals */}
+                  <div className="mt-4 pt-4 border-t space-y-2">
+                    <div className="flex justify-between text-sm">
+                      <span>Subtotal</span>
+                      <span>{formatCurrency(subtotal, currency)}</span>
+                    </div>
+                    <div className="flex justify-between text-sm">
+                      <span className="flex items-center gap-1">
+                        Fees
+                        <Info className="h-3 w-3 text-muted-foreground" />
+                      </span>
+                      <span>{formatCurrency(totalFees, currency)}</span>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 pt-4 border-t">
+                    <div className="flex justify-between font-semibold">
+                      <span>Total</span>
+                      <span>{formatCurrency(total, currency)}</span>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">No tickets selected</p>
+              )}
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Description

Add three new event components to complete the ticket purchase flow:
- **TicketTierSelect**: Select ticket tiers with quantity controls and order summary sidebar
- **EventCheckout**: Checkout form with billing information, payment methods, countdown timer, and order summary
- **EventConfirmation**: Order confirmation page with event details, organizer follow, and social sharing

## Related Issues

None

## How can it be tested?

1. Run `pnpm run dev` from root
2. Navigate to http://localhost:3001/blocks
3. Click on "Events" category in sidebar
4. Test each new block:
   - Ticket Tier Select - adjust quantities, view order summary
   - Event Checkout - fill billing form, select payment method
   - Event Confirmation - view confirmation with sharing options

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR