### PR TITLE
Fix block variant header layout alignment

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { cn } from '@/lib/utils'
+import { CopyLinkButton } from '@/components/blocks/copy-link-button'
 import { ChevronRight, Zap } from 'lucide-react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
@@ -2411,7 +2412,7 @@ function BlockPageContent() {
             />
 
             {/* Block Title */}
-            <div className="flex items-center gap-3 mb-1">
+            <div className="group flex items-center gap-3 mb-1">
               <h1 className="text-2xl font-bold">{selectedBlock.name}</h1>
               <CopyLinkButton />
               {selectedBlock.actionCount > 0 ? (

--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { cn } from '@/lib/utils'
-import { ChevronRight, Link as LinkIcon, Zap } from 'lucide-react'
+import { ChevronRight, Zap } from 'lucide-react'
 import Link from 'next/link'
-import { useParams, usePathname } from 'next/navigation'
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { Suspense, useEffect, useRef, useState } from 'react'
 
 // Form components
 import { ContactForm } from '@/registry/form/contact-form'
@@ -2289,55 +2289,6 @@ const categories: Category[] = [
   }
 ]
 
-// Copy link button component
-function CopyLinkButton({
-  anchor,
-  className
-}: {
-  anchor?: string
-  className?: string
-}) {
-  const [copied, setCopied] = useState(false)
-  const pathname = usePathname()
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current)
-      }
-    }
-  }, [])
-
-  const handleCopy = useCallback(() => {
-    const url = `${window.location.origin}${pathname}${anchor ? `#${anchor}` : ''}`
-    navigator.clipboard.writeText(url)
-    setCopied(true)
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-    }
-    timeoutRef.current = setTimeout(() => setCopied(false), 2000)
-  }, [pathname, anchor])
-
-  return (
-    <button
-      onClick={handleCopy}
-      className={cn(
-        'opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-muted',
-        className
-      )}
-      title={copied ? 'Copied!' : 'Copy link'}
-    >
-      <LinkIcon
-        className={cn(
-          'h-4 w-4',
-          copied ? 'text-green-500' : 'text-muted-foreground'
-        )}
-      />
-    </button>
-  )
-}
-
 function BlockPageContent() {
   const params = useParams()
   const categorySlug = params.category as string
@@ -2484,10 +2435,6 @@ function BlockPageContent() {
           {/* All Variants */}
           {selectedBlock.variants.map((variant, index) => (
             <div key={variant.id} id={variant.id} className="scroll-mt-20">
-              <div className="group flex items-center gap-2 mb-3">
-                <h2 className="text-lg font-bold">{variant.name}</h2>
-                <CopyLinkButton anchor={variant.id} />
-              </div>
               <VariantSection
                 ref={index === 0 ? firstVariantRef : undefined}
                 name={variant.name}
@@ -2496,7 +2443,7 @@ function BlockPageContent() {
                 registryName={selectedBlock.registryName}
                 usageCode={variant.usageCode}
                 layouts={selectedBlock.layouts}
-                hideTitle
+                variantId={variant.id}
               />
             </div>
           ))}

--- a/packages/manifest-ui/components/blocks/copy-link-button.tsx
+++ b/packages/manifest-ui/components/blocks/copy-link-button.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { LinkIcon } from 'lucide-react'
+import { usePathname } from 'next/navigation'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
+
+export function CopyLinkButton({
+  anchor,
+  className
+}: {
+  anchor?: string
+  className?: string
+}) {
+  const [copied, setCopied] = useState(false)
+  const pathname = usePathname()
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleCopy = useCallback(() => {
+    const url = `${window.location.origin}${pathname}${anchor ? `#${anchor}` : ''}`
+    navigator.clipboard.writeText(url)
+    setCopied(true)
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+    timeoutRef.current = setTimeout(() => setCopied(false), 2000)
+  }, [pathname, anchor])
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={cn(
+        'opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-muted',
+        className
+      )}
+      title={copied ? 'Copied!' : 'Copy link'}
+    >
+      <LinkIcon
+        className={cn(
+          'h-4 w-4',
+          copied ? 'text-green-500' : 'text-muted-foreground'
+        )}
+      />
+    </button>
+  )
+}

--- a/packages/manifest-ui/components/blocks/variant-section.tsx
+++ b/packages/manifest-ui/components/blocks/variant-section.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import dynamic from 'next/dynamic'
+import { CopyLinkButton } from '@/components/blocks/copy-link-button'
 import { InstallCommandInline } from '@/components/blocks/install-command-inline'
 import { ConfigurationViewer } from '@/components/blocks/configuration-viewer'
 import { FullscreenModal } from '@/components/layout/fullscreen-modal'
@@ -25,6 +26,7 @@ interface VariantSectionProps {
   usageCode?: string
   layouts?: LayoutMode[]
   hideTitle?: boolean
+  variantId?: string
 }
 
 export interface VariantSectionHandle {
@@ -132,7 +134,8 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
   registryName,
   usageCode,
   layouts = ['inline'],
-  hideTitle = false
+  hideTitle = false,
+  variantId
 }, ref) {
   // Determine default view mode based on available layouts
   const getDefaultViewMode = (): ViewMode => {
@@ -194,23 +197,22 @@ export const VariantSection = forwardRef<VariantSectionHandle, VariantSectionPro
 
   return (
     <div className="space-y-3">
-      {/* Row 1: Title + Version (mobile) / Title + Version + Install command (desktop) */}
-      {!hideTitle && (
-        <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-2 lg:gap-4">
-          <div className="flex items-center gap-2">
-            <h2 className="text-lg font-bold">{name}</h2>
-            {sourceCode.version && (
-              <span className="text-xs text-muted-foreground">V{sourceCode.version}</span>
-            )}
-          </div>
-          <InstallCommandInline componentName={registryName} />
+      {/* Header: Title + Version + CopyLinkButton (left) | Install command (right) */}
+      {/* On mobile, install command wraps below */}
+      <div className="group flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {!hideTitle && (
+            <>
+              <h2 className="text-lg font-bold">{name}</h2>
+              {sourceCode.version && (
+                <span className="text-xs text-muted-foreground">V{sourceCode.version}</span>
+              )}
+              {variantId && <CopyLinkButton anchor={variantId} />}
+            </>
+          )}
         </div>
-      )}
-      {hideTitle && (
-        <div className="flex justify-end">
-          <InstallCommandInline componentName={registryName} />
-        </div>
-      )}
+        <InstallCommandInline componentName={registryName} />
+      </div>
 
       {/* Row 2 (desktop) / Row 3 (mobile): Mode buttons */}
       <div className="flex items-center gap-1.5">


### PR DESCRIPTION
- Move CopyLinkButton to shared component for reuse
- Consolidate block variant header into VariantSection component
- Title + version + link button on left, npx command on right
- Use flex-wrap to move npx command below title on mobile to prevent overflow
- Clean up unused imports from page.tsx

## Description

## Related Issues

## How can it be tested?

## Check list before submitting

- [ ] This PR is wrote in a clear language and correctly labeled
- [ ] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR
