### PR TITLE
Remove unused component properties from widgets

### DIFF
--- a/packages/manifest-ui/app/page.tsx
+++ b/packages/manifest-ui/app/page.tsx
@@ -82,7 +82,6 @@ function TechCrunchLogo({ className }: { className?: string }) {
 
 const techCrunchArticles = [
   {
-    id: '1',
     title: 'The accelerator is on the floor for autonomous vehicles',
     excerpt:
       'Major automakers are ramping up investments in self-driving technology as regulatory frameworks become clearer.',
@@ -97,7 +96,6 @@ const techCrunchArticles = [
     category: 'Transportation'
   },
   {
-    id: '2',
     title: 'X deactivates European Commission ad account after €120M fine',
     excerpt:
       "The social media platform has suspended the EU institution's advertising capabilities following the recent penalty.",
@@ -112,7 +110,6 @@ const techCrunchArticles = [
     category: 'Social'
   },
   {
-    id: '3',
     title: 'Coinbase starts onboarding users again in India',
     excerpt:
       'The crypto exchange plans to introduce fiat on-ramp capabilities in the region by next year.',
@@ -127,7 +124,6 @@ const techCrunchArticles = [
 
 const audioProducts: Product[] = [
   {
-    id: '1',
     name: 'Iyo Pro',
     description: 'Premium Earbuds',
     price: 299,
@@ -138,7 +134,6 @@ const audioProducts: Product[] = [
     inStock: true
   },
   {
-    id: '2',
     name: 'Iyo Air',
     description: 'Wireless Earbuds',
     price: 149,
@@ -149,7 +144,6 @@ const audioProducts: Product[] = [
     inStock: true
   },
   {
-    id: '3',
     name: 'Iyo Studio',
     description: 'Over-Ear Headphones',
     price: 349,
@@ -161,7 +155,6 @@ const audioProducts: Product[] = [
     inStock: true
   },
   {
-    id: '4',
     name: 'Iyo Sport',
     description: 'Active Earbuds',
     price: 199,
@@ -171,7 +164,6 @@ const audioProducts: Product[] = [
     inStock: true
   },
   {
-    id: '5',
     name: 'Iyo Mini',
     description: 'Compact Earbuds',
     price: 99,
@@ -183,7 +175,6 @@ const audioProducts: Product[] = [
     inStock: true
   },
   {
-    id: '6',
     name: 'Iyo Max',
     description: 'Premium Headphones',
     price: 449,
@@ -195,7 +186,6 @@ const audioProducts: Product[] = [
 ]
 
 const featuredArticle = {
-  id: '0',
   title: 'The accelerator is on the floor for autonomous vehicles',
   excerpt:
     'Major automakers are ramping up investments in self-driving technology as regulatory frameworks become clearer and consumer acceptance grows.',
@@ -217,12 +207,10 @@ const useCases = [
     label: 'Product selection',
     messages: [
       {
-        id: '1',
         role: 'user' as const,
         content: "I'm looking for premium wireless earbuds"
       },
       {
-        id: '2',
         role: 'assistant' as const,
         content: 'Here are our best-selling audio products:',
         component: <ProductList data={{ products: audioProducts }} appearance={{ variant: "carousel" }} />,
@@ -232,12 +220,10 @@ const useCases = [
           'Browse through our selection and let me know which one catches your eye. Each model offers different features to match your lifestyle.'
       },
       {
-        id: '3',
         role: 'user' as const,
         content: "I'll take the Iyo Pro"
       },
       {
-        id: '4',
         role: 'assistant' as const,
         content: "Excellent choice! Here's your order summary:",
         component: <OrderConfirm />,
@@ -252,12 +238,10 @@ const useCases = [
     label: 'Payment workflow',
     messages: [
       {
-        id: '1',
         role: 'user' as const,
         content: "I'd like to complete my purchase"
       },
       {
-        id: '2',
         role: 'assistant' as const,
         content: 'Please select your payment method:',
         component: <PaymentMethods />,
@@ -266,12 +250,10 @@ const useCases = [
           'Your payment information is secured with end-to-end encryption. Select your preferred method to continue.'
       },
       {
-        id: '3',
         role: 'user' as const,
         content: 'Using my Visa card'
       },
       {
-        id: '4',
         role: 'assistant' as const,
         content: 'Payment successful!',
         component: <PaymentConfirmed />,
@@ -286,12 +268,10 @@ const useCases = [
     label: 'Tech news',
     messages: [
       {
-        id: '1',
         role: 'user' as const,
         content: "What's happening in tech today?"
       },
       {
-        id: '2',
         role: 'assistant' as const,
         content: "Here's the top story from TechCrunch:",
         component: <PostCard data={{ post: featuredArticle }} appearance={{ variant: "covered" }} />,
@@ -303,12 +283,10 @@ const useCases = [
           'This article is getting a lot of attention. Would you like to see more tech news?'
       },
       {
-        id: '3',
         role: 'user' as const,
         content: 'Yes, show me more articles'
       },
       {
-        id: '4',
         role: 'assistant' as const,
         content: 'Here are more trending stories:',
         component: <PostList data={{ posts: techCrunchArticles }} appearance={{ variant: "list" }} />,

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -41,10 +41,12 @@
       "1.0.0": "Initial release with product image and tracking button"
     },
     "product-list": {
-      "1.0.0": "Initial release with list, grid, carousel and picker variants"
+      "1.0.0": "Initial release with list, grid, carousel and picker variants",
+      "2.0.0": "BREAKING: Removed id from Product interface. Use array index for selection tracking."
     },
     "option-list": {
-      "1.0.0": "Initial release with single and multiple selection modes"
+      "1.0.0": "Initial release with single and multiple selection modes",
+      "2.0.0": "BREAKING: Removed id from Option interface. Use array index for selection tracking."
     },
     "amount-input": {
       "1.0.0": "Initial release with increment buttons and preset values"
@@ -54,7 +56,8 @@
     },
     "quick-reply": {
       "1.0.0": "Initial release with quick reply button options",
-      "2.0.0": "BREAKING: Removed unused value prop from QuickReply interface"
+      "2.0.0": "BREAKING: Removed unused value prop from QuickReply interface",
+      "3.0.0": "BREAKING: Removed id from QuickReply interface. Use array index for key."
     },
     "progress-steps": {
       "1.0.0": "Initial release with horizontal and vertical layouts"
@@ -69,14 +72,17 @@
       "1.0.0": "Initial release with pulse animation placeholders"
     },
     "post-card": {
-      "1.0.0": "Initial release with default, compact, horizontal and covered variants"
+      "1.0.0": "Initial release with default, compact, horizontal and covered variants",
+      "2.0.0": "BREAKING: Removed id from Post interface. Use array index for key."
     },
     "post-list": {
       "1.0.0": "Initial release with list, grid and carousel variants",
-      "1.1.0": "Added fullwidth variant with pagination for fullscreen mode"
+      "1.1.0": "Added fullwidth variant with pagination for fullscreen mode",
+      "2.0.0": "BREAKING: Removed id from Post interface. Use array index for key."
     },
     "post-detail": {
-      "1.0.0": "Initial release with cover image, author info and related posts"
+      "1.0.0": "Initial release with cover image, author info and related posts",
+      "2.0.0": "BREAKING: Removed id from Post interface. Use array index for key."
     },
     "table": {
       "1.0.0": "Initial release with single and multi-select modes",
@@ -97,7 +103,8 @@
       "1.0.3": "Added default value 'text' for message type",
       "1.1.0": "Added avatarUrl prop for image avatars with letter fallback",
       "2.0.0": "BREAKING: Renamed avatar prop to avatarFallback for clarity",
-      "3.0.0": "BREAKING: Removed caption prop, use content for image captions"
+      "3.0.0": "BREAKING: Removed caption prop, use content for image captions",
+      "4.0.0": "BREAKING: Removed id from ChatMessage interface. Use array index for key."
     },
     "x-post": {
       "1.0.0": "Initial release with engagement metrics display"
@@ -122,7 +129,8 @@
       "2.0.0": "BREAKING: Simplified Event interface - replaced startDateTime/endDateTime with display-formatted dateTime string, removed image/locationType/onlineUrl, changed ticketTiers to string array",
       "3.0.0": "Added image support to Event type and default variant for displaying cover images.",
       "4.0.0": "BREAKING: Removed View button from all variants. Entire card is now clickable.",
-      "4.1.0": "Added image display to horizontal (list) and compact (carousel) variants"
+      "4.1.0": "Added image display to horizontal (list) and compact (carousel) variants",
+      "5.0.0": "BREAKING: Removed id from Event interface. Use array index for key."
     },
     "event-list": {
       "1.0.0": "Initial release with grid, list and carousel layouts. Includes pagination support.",
@@ -132,13 +140,15 @@
       "5.0.0": "BREAKING: Fullwidth is no longer a variant - use fullscreenComponent instead. Map now uses real Leaflet.",
       "5.1.0": "Added animated filter panel with Category, Date, Neighborhood, Price, and Format filters. Filters apply to both list and map markers.",
       "5.2.0": "Added expand button next to title in list and carousel variants with onExpand action",
-      "5.2.1": "Fixed event-card dependency resolution for shadcn CLI installation"
+      "5.2.1": "Fixed event-card dependency resolution for shadcn CLI installation",
+      "6.0.0": "BREAKING: Removed id from Event interface. Use array index for selection and key."
     },
     "event-detail": {
       "1.0.0": "Initial release with image carousel, organizer info, location, policies, FAQs, and ticket purchase.",
       "2.0.0": "BREAKING: Updated to use simplified Event interface with display-formatted dateTime and string ticketTiers",
       "2.1.0": "Moved Get Tickets CTA from sticky bottom to end of content for fullscreen mode.",
-      "2.2.0": "Changed CTA buttons and map tooltip from orange to dark theme colors"
+      "2.2.0": "Changed CTA buttons and map tooltip from orange to dark theme colors",
+      "3.0.0": "BREAKING: Removed id from EventDetails, Organizer, and tier interfaces. Use array index for key."
     },
     "ticket-tier-select": {
       "1.0.0": "Initial release with ticket tier cards, quantity controls, price breakdown, and order summary sidebar",

--- a/packages/manifest-ui/components/chat/chat-demo.tsx
+++ b/packages/manifest-ui/components/chat/chat-demo.tsx
@@ -4,7 +4,6 @@ import { cn } from '@/lib/utils'
 import { Send, Copy, ThumbsUp, ThumbsDown, RotateCcw } from 'lucide-react'
 
 interface Message {
-  id: string
   role: 'user' | 'assistant'
   content?: string
   component?: React.ReactNode
@@ -79,10 +78,10 @@ export function ChatDemo({ messages, className, variant = 'chatgpt' }: ChatDemoP
             ? 'max-w-[calc(100vw-16px)] sm:max-w-[768px]'
             : 'max-w-[calc(100vw-16px)] sm:max-w-[720px]'
         )}>
-          {messages.map((message) => {
+          {messages.map((message, index) => {
             return (
               <div
-                key={message.id}
+                key={index}
                 className={cn(
                   'flex flex-col',
                   message.role === 'user' ? 'items-end' : 'items-start'

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -200,7 +200,7 @@
     },
     {
       "name": "product-list",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "type": "registry:component",
       "title": "Product List",
       "description": "Product list with list, grid, carousel, and picker variants.",
@@ -215,7 +215,7 @@
     },
     {
       "name": "option-list",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "type": "registry:component",
       "title": "Option List",
       "description": "Tag-style option selector with single or multiple selection modes.",
@@ -260,7 +260,7 @@
     },
     {
       "name": "quick-reply",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "type": "registry:component",
       "title": "Quick Reply",
       "description": "Quick reply buttons for common chat responses.",
@@ -335,7 +335,7 @@
     },
     {
       "name": "post-card",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "type": "registry:component",
       "title": "Post Card",
       "description": "Post card with image, title, excerpt, author info and read more button. Supports default, compact, horizontal, and covered variants. Includes post-detail for fullscreen view.",
@@ -354,7 +354,7 @@
     },
     {
       "name": "post-list",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "type": "registry:component",
       "title": "Post List",
       "description": "Post list with list, grid, carousel, and fullwidth variants. Fullwidth mode shows paginated posts.",
@@ -377,7 +377,7 @@
     },
     {
       "name": "post-detail",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "type": "registry:component",
       "title": "Post Detail",
       "description": "Full post view with cover image, author info, content, tags and related posts section.",
@@ -426,7 +426,7 @@
     },
     {
       "name": "chat-conversation",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "type": "registry:component",
       "title": "Chat Conversation",
       "description": "Full chat conversation component with multiple message types.",
@@ -520,7 +520,7 @@
     },
     {
       "name": "event-card",
-      "version": "4.1.0",
+      "version": "5.0.0",
       "type": "registry:component",
       "title": "Event Card",
       "description": "Display event information with multiple layouts. Supports events with images, signals, vibe tags, and display-formatted date/time. Entire card is clickable.",
@@ -539,7 +539,7 @@
     },
     {
       "name": "event-list",
-      "version": "5.2.1",
+      "version": "6.0.0",
       "type": "registry:component",
       "title": "Event List",
       "description": "Display events in grid, list, or carousel layouts. Fullscreen mode shows interactive split-screen map with Leaflet and animated filter panel.",
@@ -558,7 +558,7 @@
     },
     {
       "name": "event-detail",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "type": "registry:component",
       "title": "Event Detail",
       "description": "Full event detail view with organizer info, interactive map, policies, and ticket purchase. Fullwidth mode only.",

--- a/packages/manifest-ui/registry/blogging/post-card.tsx
+++ b/packages/manifest-ui/registry/blogging/post-card.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/ui/button'
 import '@/lib/openai-types' // Side effect: extends Window interface
 
 export interface Post {
-  id: string
   title: string
   excerpt: string
   coverImage?: string
@@ -22,7 +21,6 @@ export interface Post {
 }
 
 const defaultPost: Post = {
-  id: '1',
   title: 'Getting Started with Agentic UI Components',
   excerpt:
     'Learn how to build conversational interfaces with our comprehensive component library designed for AI-powered applications.',

--- a/packages/manifest-ui/registry/blogging/post-detail.tsx
+++ b/packages/manifest-ui/registry/blogging/post-detail.tsx
@@ -66,7 +66,6 @@ function TagList({
 }
 
 const defaultPost: Post = {
-  id: '1',
   title: 'Getting Started with Agentic UI Components',
   excerpt:
     'Learn how to build conversational interfaces with our comprehensive component library designed for AI-powered applications.',
@@ -95,7 +94,6 @@ const defaultContent = `
 
 const defaultRelatedPosts: Post[] = [
   {
-    id: '2',
     title: 'Designing for Conversational Interfaces',
     excerpt:
       'Best practices for creating intuitive UI components that work within chat environments.',
@@ -112,7 +110,6 @@ const defaultRelatedPosts: Post[] = [
     url: 'https://example.com/posts/designing-conversational-interfaces'
   },
   {
-    id: '3',
     title: 'MCP Integration Patterns',
     excerpt:
       'How to leverage Model Context Protocol for seamless backend communication in your agentic applications.',
@@ -129,7 +126,6 @@ const defaultRelatedPosts: Post[] = [
     url: 'https://example.com/posts/mcp-integration-patterns'
   },
   {
-    id: '4',
     title: 'Building Payment Flows in Chat',
     excerpt:
       'A complete guide to implementing secure, user-friendly payment experiences within conversational interfaces.',
@@ -328,9 +324,9 @@ export function PostDetail({ data, actions, appearance }: PostDetailProps) {
           <div className="mt-16 border-t pt-10">
             <h3 className="mb-6 text-lg font-semibold">Related Posts</h3>
             <div className="space-y-4">
-              {relatedPosts.map((related) => (
+              {relatedPosts.map((related, index) => (
                 <a
-                  key={related.id}
+                  key={index}
                   href={related.url || '#'}
                   target="_blank"
                   rel="noopener noreferrer"

--- a/packages/manifest-ui/registry/blogging/post-list.tsx
+++ b/packages/manifest-ui/registry/blogging/post-list.tsx
@@ -8,7 +8,6 @@ import { Post, PostCard } from './post-card'
 
 const defaultPosts: Post[] = [
   {
-    id: '1',
     title: 'Getting Started with Agentic UI Components',
     excerpt:
       'Learn how to build conversational interfaces with our comprehensive component library designed for AI-powered applications.',
@@ -24,7 +23,6 @@ const defaultPosts: Post[] = [
     category: 'Tutorial'
   },
   {
-    id: '2',
     title: 'Designing for Conversational Interfaces',
     excerpt:
       'Best practices for creating intuitive UI components that work within chat environments.',
@@ -40,7 +38,6 @@ const defaultPosts: Post[] = [
     category: 'Design'
   },
   {
-    id: '3',
     title: 'MCP Integration Patterns',
     excerpt:
       'How to leverage Model Context Protocol for seamless backend communication in your agentic applications.',
@@ -56,7 +53,6 @@ const defaultPosts: Post[] = [
     category: 'Development'
   },
   {
-    id: '4',
     title: 'Building Payment Flows in Chat',
     excerpt:
       'A complete guide to implementing secure, user-friendly payment experiences within conversational interfaces.',
@@ -72,7 +68,6 @@ const defaultPosts: Post[] = [
     category: 'Tutorial'
   },
   {
-    id: '5',
     title: 'Real-time Collaboration in AI Apps',
     excerpt:
       'Implementing WebSocket connections and real-time updates for collaborative agentic experiences.',
@@ -88,7 +83,6 @@ const defaultPosts: Post[] = [
     category: 'Development'
   },
   {
-    id: '6',
     title: 'Accessibility in Chat Interfaces',
     excerpt:
       'Making your conversational UI accessible to all users with screen readers and keyboard navigation.',
@@ -104,7 +98,6 @@ const defaultPosts: Post[] = [
     category: 'Design'
   },
   {
-    id: '7',
     title: 'State Management for Complex Workflows',
     excerpt:
       'Managing complex multi-step workflows in agentic applications using modern state patterns.',
@@ -120,7 +113,6 @@ const defaultPosts: Post[] = [
     category: 'Development'
   },
   {
-    id: '8',
     title: 'Testing Conversational Components',
     excerpt:
       'Strategies for unit testing and integration testing of chat-based UI components.',
@@ -136,7 +128,6 @@ const defaultPosts: Post[] = [
     category: 'Development'
   },
   {
-    id: '9',
     title: 'Theming and Dark Mode Support',
     excerpt:
       'Implementing flexible theming systems with dark mode for agentic UI components.',
@@ -152,7 +143,6 @@ const defaultPosts: Post[] = [
     category: 'Design'
   },
   {
-    id: '10',
     title: 'Performance Optimization Techniques',
     excerpt:
       'Optimizing render performance and reducing bundle size in chat applications.',
@@ -168,7 +158,6 @@ const defaultPosts: Post[] = [
     category: 'Development'
   },
   {
-    id: '11',
     title: 'Error Handling and Recovery',
     excerpt:
       'Graceful error handling patterns and user-friendly recovery flows in conversational UIs.',
@@ -184,7 +173,6 @@ const defaultPosts: Post[] = [
     category: 'Development'
   },
   {
-    id: '12',
     title: 'Internationalization Best Practices',
     excerpt:
       'Making your agentic UI components work across languages and locales.',
@@ -200,7 +188,6 @@ const defaultPosts: Post[] = [
     category: 'Design'
   },
   {
-    id: '13',
     title: 'Mobile-First Chat Design',
     excerpt:
       'Designing conversational interfaces that work beautifully on mobile devices.',
@@ -216,7 +203,6 @@ const defaultPosts: Post[] = [
     category: 'Design'
   },
   {
-    id: '14',
     title: 'Analytics and User Insights',
     excerpt:
       'Tracking user interactions and deriving insights from conversational UI usage.',
@@ -232,7 +218,6 @@ const defaultPosts: Post[] = [
     category: 'Tutorial'
   },
   {
-    id: '15',
     title: 'Building Reusable Component Libraries',
     excerpt:
       'Creating a scalable component library for agentic UIs that teams can share.',
@@ -283,9 +268,9 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
   if (variant === 'list') {
     return (
       <div className="space-y-3">
-        {posts.slice(0, 3).map((post) => (
+        {posts.slice(0, 3).map((post, index) => (
           <PostCard
-            key={post.id}
+            key={index}
             data={{ post }}
             appearance={{ variant: "horizontal", showAuthor, showCategory }}
             actions={{ onReadMore }}
@@ -304,9 +289,9 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
           columns === 2 ? 'sm:grid-cols-2' : 'sm:grid-cols-3'
         )}
       >
-        {posts.slice(0, 4).map((post) => (
+        {posts.slice(0, 4).map((post, index) => (
           <PostCard
-            key={post.id}
+            key={index}
             data={{ post }}
             appearance={{ variant: "compact", showImage: false, showAuthor, showCategory }}
             actions={{ onReadMore }}
@@ -346,9 +331,9 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
     return (
       <div className="space-y-6 p-6">
         <div className={cn('grid gap-6 grid-cols-1', getGridColsClass())}>
-          {paginatedPosts.map((post) => (
+          {paginatedPosts.map((post, index) => (
             <PostCard
-              key={post.id}
+              key={index}
               data={{ post }}
               appearance={{ variant: "default", showAuthor, showCategory }}
               actions={{ onReadMore }}
@@ -429,8 +414,8 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
           className="flex transition-transform duration-300 ease-out md:hidden"
           style={{ transform: `translateX(-${currentIndex * 100}%)` }}
         >
-          {posts.map((post) => (
-            <div key={post.id} className="w-full shrink-0 px-0.5">
+          {posts.map((post, index) => (
+            <div key={index} className="w-full shrink-0 px-0.5">
               <PostCard
                 data={{ post }}
                 appearance={{ variant: "compact", showAuthor, showCategory }}
@@ -445,8 +430,8 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
           className="hidden md:flex lg:hidden transition-transform duration-300 ease-out"
           style={{ transform: `translateX(-${currentIndex * 50}%)` }}
         >
-          {posts.map((post) => (
-            <div key={post.id} className="w-1/2 shrink-0 px-1.5">
+          {posts.map((post, index) => (
+            <div key={index} className="w-1/2 shrink-0 px-1.5">
               <PostCard
                 data={{ post }}
                 appearance={{ variant: "compact", showAuthor, showCategory }}
@@ -461,8 +446,8 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
           className="hidden lg:flex transition-transform duration-300 ease-out"
           style={{ transform: `translateX(-${currentIndex * (100 / 3)}%)` }}
         >
-          {posts.map((post) => (
-            <div key={post.id} className="w-1/3 shrink-0 px-1.5">
+          {posts.map((post, index) => (
+            <div key={index} className="w-1/3 shrink-0 px-1.5">
               <PostCard
                 data={{ post }}
                 appearance={{ variant: "compact", showAuthor, showCategory }}

--- a/packages/manifest-ui/registry/events/event-card.tsx
+++ b/packages/manifest-ui/registry/events/event-card.tsx
@@ -19,7 +19,6 @@ import type { Event, EventSignal } from './types'
 import '@/lib/openai-types'
 
 const defaultEvent: Event = {
-  id: 'evt-1',
   title: 'NEON Vol. 9',
   category: 'Music',
   venue: 'Echoplex',

--- a/packages/manifest-ui/registry/events/event-detail.tsx
+++ b/packages/manifest-ui/registry/events/event-detail.tsx
@@ -97,7 +97,6 @@ function formatNumber(num: number): string {
 }
 
 const defaultEvent: EventDetails = {
-  id: '1',
   title: 'Sunglasses at Night: Underground Techno',
   category: 'Nightlife',
   venue: 'The White Rabbit',
@@ -122,7 +121,6 @@ const defaultEvent: EventDetails = {
     { name: 'Sam', avatar: 'https://i.pravatar.cc/40?u=sam' }
   ],
   organizer: {
-    id: '1',
     name: 'Midnight Lovers',
     image: 'https://i.pravatar.cc/80?u=midnight',
     rating: 4.5,
@@ -141,8 +139,8 @@ const defaultEvent: EventDetails = {
     coordinates: { lat: 29.7604, lng: -95.3698 }
   },
   tiers: [
-    { id: '1', name: 'General Admission', price: 15, available: 50 },
-    { id: '2', name: 'VIP Access', price: 30, available: 20, benefits: ['Skip the line', 'Exclusive lounge'] }
+    { name: 'General Admission', price: 15, available: 50 },
+    { name: 'VIP Access', price: 30, available: 20, benefits: ['Skip the line', 'Exclusive lounge'] }
   ],
   goodToKnow: {
     duration: '2 hours',

--- a/packages/manifest-ui/registry/events/event-list.tsx
+++ b/packages/manifest-ui/registry/events/event-list.tsx
@@ -38,12 +38,12 @@ function MapPlaceholder() {
 // Inner map component that uses Leaflet hooks for event markers
 function EventMapMarkers({
   events,
-  selectedId,
+  selectedIndex,
   onSelectEvent
 }: {
   events: Event[]
-  selectedId: string | null
-  onSelectEvent: (event: Event) => void
+  selectedIndex: number | null
+  onSelectEvent: (event: Event, index: number) => void
 }) {
   const [L, setL] = useState<typeof import('leaflet') | null>(null)
 
@@ -79,9 +79,9 @@ function EventMapMarkers({
 
   return (
     <>
-      {events.map((event) => {
+      {events.map((event, index) => {
         if (!event.coordinates) return null
-        const isSelected = selectedId === event.id
+        const isSelected = selectedIndex === index
 
         const icon = L.divIcon({
           className: '',
@@ -98,12 +98,12 @@ function EventMapMarkers({
 
         return (
           <Marker
-            key={event.id}
+            key={index}
             position={[event.coordinates.lat, event.coordinates.lng]}
             icon={icon}
             zIndexOffset={isSelected ? 1000 : 0}
             eventHandlers={{
-              click: () => onSelectEvent(event)
+              click: () => onSelectEvent(event, index)
             }}
           />
         )
@@ -114,7 +114,6 @@ function EventMapMarkers({
 
 const defaultEvents: Event[] = [
   {
-    id: 'evt-1',
     title: 'NEON Vol. 9',
     category: 'Music',
     venue: 'Echoplex',
@@ -131,7 +130,7 @@ const defaultEvents: Event[] = [
     ageRestriction: '21+'
   },
   {
-    id: 'evt-2',
+    
     title: 'The Midnight Show',
     category: 'Comedy',
     venue: 'The Comedy Underground',
@@ -148,7 +147,7 @@ const defaultEvents: Event[] = [
     discount: 'TONIGHT ONLY - 40% OFF'
   },
   {
-    id: 'evt-3',
+    
     title: 'Salsa Sundays @ Echo Park',
     category: 'Classes',
     venue: 'Echo Park Lake',
@@ -164,7 +163,7 @@ const defaultEvents: Event[] = [
     reviewCount: 8764
   },
   {
-    id: 'evt-4',
+    
     title: 'Dawn Flow: Griffith Park',
     category: 'Classes',
     venue: 'Griffith Park',
@@ -180,7 +179,7 @@ const defaultEvents: Event[] = [
     discount: 'FREE - First 50 Only'
   },
   {
-    id: 'evt-5',
+    
     title: 'Lakers vs Celtics',
     category: 'Sports',
     venue: 'Crypto.com Arena',
@@ -196,7 +195,7 @@ const defaultEvents: Event[] = [
     reviewCount: 2341
   },
   {
-    id: 'evt-6',
+    
     title: 'Smorgasburg LA: Sunday Market',
     category: 'Food & Drink',
     venue: 'ROW DTLA',
@@ -211,7 +210,7 @@ const defaultEvents: Event[] = [
     reviewCount: 5632
   },
   {
-    id: 'evt-7',
+    
     title: 'LACMA After Hours',
     category: 'Arts',
     venue: 'LACMA',
@@ -228,7 +227,7 @@ const defaultEvents: Event[] = [
     discount: 'MEMBER PRICE'
   },
   {
-    id: 'evt-8',
+    
     title: 'Blue Note Under Stars',
     category: 'Music',
     venue: 'Hollywood Bowl',
@@ -244,7 +243,7 @@ const defaultEvents: Event[] = [
     reviewCount: 12453
   },
   {
-    id: 'evt-9',
+    
     title: 'Meraki: Seth Troxler',
     category: 'Nightlife',
     venue: 'Sound Nightclub',
@@ -261,7 +260,7 @@ const defaultEvents: Event[] = [
     ageRestriction: '21+'
   },
   {
-    id: 'evt-10',
+    
     title: 'Whitney Cummings + Friends',
     category: 'Comedy',
     venue: 'The Laugh Factory',
@@ -277,7 +276,7 @@ const defaultEvents: Event[] = [
     ageRestriction: '18+'
   },
   {
-    id: 'evt-11',
+    
     title: 'Venice Beach Drum Circle',
     category: 'Music',
     venue: 'Venice Beach Boardwalk',
@@ -293,7 +292,7 @@ const defaultEvents: Event[] = [
     reviewCount: 2145
   },
   {
-    id: 'evt-12',
+    
     title: 'Rooftop Cinema: Blade Runner',
     category: 'Film',
     venue: 'Rooftop Cinema Club',
@@ -308,7 +307,7 @@ const defaultEvents: Event[] = [
     reviewCount: 892
   },
   {
-    id: 'evt-13',
+    
     title: 'Dodgers vs Giants',
     category: 'Sports',
     venue: 'Dodger Stadium',
@@ -324,7 +323,7 @@ const defaultEvents: Event[] = [
     reviewCount: 15678
   },
   {
-    id: 'evt-14',
+    
     title: 'Natural Wine Fair',
     category: 'Food & Drink',
     venue: 'Grand Central Market',
@@ -341,7 +340,7 @@ const defaultEvents: Event[] = [
     ageRestriction: '21+'
   },
   {
-    id: 'evt-15',
+    
     title: 'Meditation in the Gardens',
     category: 'Wellness',
     venue: 'The Getty Center',
@@ -604,7 +603,7 @@ export function EventList({ data, actions, appearance }: EventListProps) {
   const { onEventSelect, onViewMore, onExpand, onFilterClick, onFiltersApply } = actions ?? {}
   const { variant = 'list' } = appearance ?? {}
   const [currentIndex, setCurrentIndex] = useState(0)
-  const [selectedEventId, setSelectedEventId] = useState<string | null>(null)
+  const [selectedEventIndex, setSelectedEventIndex] = useState<number | null>(null)
   const [isMounted, setIsMounted] = useState(false)
 
   // Filter state for fullwidth variant
@@ -614,11 +613,11 @@ export function EventList({ data, actions, appearance }: EventListProps) {
 
   // Refs for fullwidth variant scroll functionality
   const listContainerRef = useRef<HTMLDivElement>(null)
-  const eventItemRefs = useRef<Map<string, HTMLDivElement>>(new Map())
+  const eventItemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
 
   // Scroll to event in list when selected from map
-  const scrollToEvent = useCallback((eventId: string) => {
-    const eventElement = eventItemRefs.current.get(eventId)
+  const scrollToEvent = useCallback((eventIndex: number) => {
+    const eventElement = eventItemRefs.current.get(eventIndex)
     if (eventElement && listContainerRef.current) {
       const container = listContainerRef.current
       const elementTop = eventElement.offsetTop
@@ -754,9 +753,9 @@ export function EventList({ data, actions, appearance }: EventListProps) {
             )}
           </div>
         )}
-        {events.slice(0, 3).map((event) => (
+        {events.slice(0, 3).map((event, index) => (
           <EventCard
-            key={event.id}
+            key={index}
             data={{ event }}
             appearance={{ variant: 'horizontal' }}
             actions={{ onClick: onEventSelect }}
@@ -786,9 +785,9 @@ export function EventList({ data, actions, appearance }: EventListProps) {
           </div>
         )}
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-          {events.slice(0, 3).map((event) => (
+          {events.slice(0, 3).map((event, index) => (
             <EventCard
-              key={event.id}
+              key={index}
               data={{ event }}
               appearance={{ variant: 'default' }}
               actions={{ onClick: onEventSelect }}
@@ -811,18 +810,18 @@ export function EventList({ data, actions, appearance }: EventListProps) {
 
   // Fullwidth variant with split-screen layout (list on left, map on right)
   if (variant === 'fullwidth') {
-    const handleEventHover = (eventId: string | null) => {
-      setSelectedEventId(eventId)
+    const handleEventHover = (eventIndex: number | null) => {
+      setSelectedEventIndex(eventIndex)
     }
 
-    const handleEventClick = (event: Event) => {
-      setSelectedEventId(event.id)
+    const handleEventClick = (event: Event, index: number) => {
+      setSelectedEventIndex(index)
       onEventSelect?.(event)
     }
 
-    const handleMapMarkerClick = (event: Event) => {
-      setSelectedEventId(event.id)
-      scrollToEvent(event.id)
+    const handleMapMarkerClick = (event: Event, index: number) => {
+      setSelectedEventIndex(index)
+      scrollToEvent(index)
       onEventSelect?.(event)
     }
 
@@ -891,19 +890,19 @@ export function EventList({ data, actions, appearance }: EventListProps) {
                 </Button>
               </div>
             ) : (
-              filteredEvents.map((event) => (
+              filteredEvents.map((event, index) => (
                 <div
-                  key={event.id}
+                  key={index}
                   ref={(el) => {
-                    if (el) eventItemRefs.current.set(event.id, el)
+                    if (el) eventItemRefs.current.set(index, el)
                   }}
                   className={cn(
                     'border-b transition-colors cursor-pointer',
-                    selectedEventId === event.id && 'bg-accent'
+                    selectedEventIndex === index && 'bg-accent'
                   )}
-                  onMouseEnter={() => handleEventHover(event.id)}
+                  onMouseEnter={() => handleEventHover(index)}
                   onMouseLeave={() => handleEventHover(null)}
-                  onClick={() => handleEventClick(event)}
+                  onClick={() => handleEventClick(event, index)}
                 >
                   <div className="flex gap-3 p-3">
                     {/* Thumbnail */}
@@ -961,7 +960,7 @@ export function EventList({ data, actions, appearance }: EventListProps) {
               />
               <EventMapMarkers
                 events={filteredEvents}
-                selectedId={selectedEventId}
+                selectedIndex={selectedEventIndex}
                 onSelectEvent={handleMapMarkerClick}
               />
             </MapContainer>
@@ -1014,8 +1013,8 @@ export function EventList({ data, actions, appearance }: EventListProps) {
           className="flex transition-transform duration-300 ease-out md:hidden"
           style={{ transform: `translateX(-${currentIndex * 100}%)` }}
         >
-          {events.map((event) => (
-            <div key={event.id} className="w-full shrink-0 px-0.5">
+          {events.map((event, index) => (
+            <div key={index} className="w-full shrink-0 px-0.5">
               <EventCard
                 data={{ event }}
                 appearance={{ variant: 'compact' }}
@@ -1030,8 +1029,8 @@ export function EventList({ data, actions, appearance }: EventListProps) {
           className="hidden md:flex lg:hidden transition-transform duration-300 ease-out"
           style={{ transform: `translateX(-${currentIndex * 50}%)` }}
         >
-          {events.map((event) => (
-            <div key={event.id} className="w-1/2 shrink-0 px-1.5">
+          {events.map((event, index) => (
+            <div key={index} className="w-1/2 shrink-0 px-1.5">
               <EventCard
                 data={{ event }}
                 appearance={{ variant: 'compact' }}
@@ -1046,8 +1045,8 @@ export function EventList({ data, actions, appearance }: EventListProps) {
           className="hidden lg:flex transition-transform duration-300 ease-out"
           style={{ transform: `translateX(-${currentIndex * (100 / 3)}%)` }}
         >
-          {events.map((event) => (
-            <div key={event.id} className="w-1/3 shrink-0 px-1.5">
+          {events.map((event, index) => (
+            <div key={index} className="w-1/3 shrink-0 px-1.5">
               <EventCard
                 data={{ event }}
                 appearance={{ variant: 'compact' }}

--- a/packages/manifest-ui/registry/events/types.ts
+++ b/packages/manifest-ui/registry/events/types.ts
@@ -47,7 +47,6 @@ export type VibeTag =
   | 'Wellness'
 
 export interface Event {
-  id: string
   title: string
   category: string // "Music", "Comedy", "Classes", "Nightlife", "Sports", "Food & Drink", "Arts", "Film", "Networking", "Festivals", "Wellness", "Social", "Games", "Gallery"
   venue: string
@@ -72,7 +71,6 @@ export interface Event {
 }
 
 export interface Organizer {
-  id: string
   name: string
   image?: string
   rating: number
@@ -86,12 +84,11 @@ export interface Organizer {
 }
 
 export interface TicketSelection {
-  tierId: string
+  tierIndex: number
   quantity: number
 }
 
 export interface EventBooking {
-  id: string
   event: Event
   tickets: { tierName: string; quantity: number; price: number }[]
   total: number
@@ -122,7 +119,6 @@ export interface EventDetails extends Omit<Event, 'dateTime'> {
   friendsGoing?: { name: string; avatar?: string }[]
   highlights?: string[] // "2 hours", "In person"
   tiers?: {
-    id: string
     name: string
     price: number
     available: number

--- a/packages/manifest-ui/registry/list/product-list.tsx
+++ b/packages/manifest-ui/registry/list/product-list.tsx
@@ -18,7 +18,6 @@ import { useCallback, useState } from 'react'
  */
 
 export interface Product {
-  id: string
   name: string
   description?: string
   price: number
@@ -44,13 +43,12 @@ export interface ProductListProps {
     buttonLabel?: string
   }
   control?: {
-    selectedProductId?: string
+    selectedProductIndex?: number
   }
 }
 
 const defaultProducts: Product[] = [
   {
-    id: '1',
     name: "Air Force 1 '07",
     description: 'Nike',
     price: 119,
@@ -60,7 +58,6 @@ const defaultProducts: Product[] = [
     inStock: true
   },
   {
-    id: '2',
     name: 'Air Max 90',
     description: 'Nike',
     price: 140,
@@ -69,7 +66,6 @@ const defaultProducts: Product[] = [
     inStock: true
   },
   {
-    id: '3',
     name: 'Air Max Plus',
     description: 'Nike',
     price: 170,
@@ -80,7 +76,6 @@ const defaultProducts: Product[] = [
     inStock: true
   },
   {
-    id: '4',
     name: 'Dunk Low',
     description: 'Nike',
     price: 115,
@@ -89,7 +84,6 @@ const defaultProducts: Product[] = [
     inStock: true
   },
   {
-    id: '5',
     name: 'Jordan 1 Low',
     description: 'Nike',
     price: 135,
@@ -98,7 +92,6 @@ const defaultProducts: Product[] = [
     inStock: true
   },
   {
-    id: '6',
     name: 'Blazer Mid',
     description: 'Nike',
     price: 105,
@@ -186,18 +179,18 @@ function ListVariant({
   formatCurrency
 }: {
   products: Product[]
-  selected: string | undefined
-  onSelect: (product: Product) => void
+  selected: number | undefined
+  onSelect: (product: Product, index: number) => void
   formatCurrency: (value: number) => string
 }) {
   return (
     <div className="w-full space-y-2 p-1 sm:p-0">
-      {products.slice(0, 4).map((product) => (
+      {products.slice(0, 4).map((product, index) => (
         <ProductHorizontalCard
-          key={product.id}
+          key={index}
           product={product}
-          selected={selected === product.id}
-          onSelect={() => onSelect(product)}
+          selected={selected === index}
+          onSelect={() => onSelect(product, index)}
           formatCurrency={formatCurrency}
         />
       ))}
@@ -214,8 +207,8 @@ function GridVariant({
   columns
 }: {
   products: Product[]
-  selected: string | undefined
-  onSelect: (product: Product) => void
+  selected: number | undefined
+  onSelect: (product: Product, index: number) => void
   formatCurrency: (value: number) => string
   columns: 3 | 4
 }) {
@@ -229,14 +222,14 @@ function GridVariant({
           columns === 4 ? 'sm:grid-cols-4' : 'sm:grid-cols-3'
         )}
       >
-        {displayProducts.map((product) => (
+        {displayProducts.map((product, index) => (
           <button
-            key={product.id}
-            onClick={() => onSelect(product)}
+            key={index}
+            onClick={() => onSelect(product, index)}
             disabled={!product.inStock}
             className={cn(
               'rounded-[12px] border text-left transition-all overflow-hidden cursor-pointer',
-              selected === product.id
+              selected === index
                 ? 'bg-card border-foreground ring-1 ring-foreground'
                 : 'bg-card border-border hover:border-foreground/50',
               !product.inStock && 'opacity-50 !cursor-not-allowed'
@@ -313,8 +306,8 @@ function CarouselVariant({
   formatCurrency
 }: {
   products: Product[]
-  selected: string | undefined
-  onSelect: (product: Product) => void
+  selected: number | undefined
+  onSelect: (product: Product, index: number) => void
   formatCurrency: (value: number) => string
 }) {
   const [currentIndex, setCurrentIndex] = useState(0)
@@ -331,15 +324,15 @@ function CarouselVariant({
   }
 
   // Horizontal card for mobile/tablet
-  const HorizontalCard = ({ product }: { product: Product }) => (
+  const HorizontalCard = ({ product, index }: { product: Product; index: number }) => (
     <button
       type="button"
-      onClick={() => onSelect(product)}
+      onClick={() => onSelect(product, index)}
       disabled={!product.inStock}
       className={cn(
         'w-full rounded-[12px] border text-left cursor-pointer',
         'flex items-center gap-3 p-2',
-        selected === product.id
+        selected === index
           ? 'bg-card border-foreground shadow-[0_0_0_1px] shadow-foreground'
           : 'bg-card border-border hover:border-foreground/50',
         !product.inStock && 'opacity-50 !cursor-not-allowed'
@@ -419,7 +412,7 @@ function CarouselVariant({
           key={currentIndex}
           className="w-full animate-in fade-in slide-in-from-right-4 duration-300"
         >
-          {mobileProduct && <HorizontalCard product={mobileProduct} />}
+          {mobileProduct && <HorizontalCard product={mobileProduct} index={currentIndex} />}
         </div>
         <Dots
           count={products.length}
@@ -434,9 +427,10 @@ function CarouselVariant({
           key={Math.min(currentIndex, tabletMaxIndex)}
           className="grid grid-cols-2 gap-2 animate-in fade-in slide-in-from-right-4 duration-300"
         >
-          {tabletProducts.map((product) => (
-            <HorizontalCard key={product.id} product={product} />
-          ))}
+          {tabletProducts.map((product, i) => {
+            const productIndex = Math.min(currentIndex, tabletMaxIndex) + i
+            return <HorizontalCard key={productIndex} product={product} index={productIndex} />
+          })}
         </div>
         <Dots
           count={tabletMaxIndex + 1}
@@ -484,15 +478,15 @@ function CarouselVariant({
                 className="flex gap-3 transition-transform duration-300 ease-out px-1"
                 style={{ transform: `translateX(-${desktopTransform}px)` }}
               >
-                {products.map((product) => (
+                {products.map((product, index) => (
                   <button
                     type="button"
-                    key={product.id}
-                    onClick={() => onSelect(product)}
+                    key={index}
+                    onClick={() => onSelect(product, index)}
                     disabled={!product.inStock}
                     className={cn(
                       'flex-shrink-0 w-40 rounded-[12px] border text-left cursor-pointer',
-                      selected === product.id
+                      selected === index
                         ? 'bg-card border-foreground ring-1 ring-foreground'
                         : 'bg-card border-border hover:border-foreground/50',
                       !product.inStock && 'opacity-50 !cursor-not-allowed'
@@ -555,60 +549,64 @@ function PickerVariant({
   onAddToCart?: (products: Product[]) => void
   buttonLabel?: string
 }) {
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [selectedIndexes, setSelectedIndexes] = useState<Set<number>>(new Set())
 
-  const handleSelect = useCallback((product: Product) => {
+  const handleSelect = useCallback((index: number, product: Product) => {
     if (!product.inStock) return
 
-    setSelectedIds((prev) => {
+    setSelectedIndexes((prev) => {
       const newSet = new Set(prev)
-      if (newSet.has(product.id)) {
-        newSet.delete(product.id)
+      if (newSet.has(index)) {
+        newSet.delete(index)
       } else {
-        newSet.add(product.id)
+        newSet.add(index)
       }
       return newSet
     })
   }, [])
 
   const handleSelectAll = useCallback(() => {
-    const availableProducts = products.filter((p) => p.inStock)
-    const allSelected = availableProducts.every((p) => selectedIds.has(p.id))
+    const availableIndexes = products
+      .map((p, i) => (p.inStock ? i : -1))
+      .filter((i) => i !== -1)
+    const allSelected = availableIndexes.every((i) => selectedIndexes.has(i))
 
     if (allSelected) {
-      setSelectedIds(new Set())
+      setSelectedIndexes(new Set())
     } else {
-      setSelectedIds(new Set(availableProducts.map((p) => p.id)))
+      setSelectedIndexes(new Set(availableIndexes))
     }
-  }, [products, selectedIds])
+  }, [products, selectedIndexes])
 
   const handleAddToCart = useCallback(() => {
-    const selectedProducts = products.filter((p) => selectedIds.has(p.id))
+    const selectedProducts = products.filter((_, i) => selectedIndexes.has(i))
     onAddToCart?.(selectedProducts)
-  }, [products, selectedIds, onAddToCart])
+  }, [products, selectedIndexes, onAddToCart])
 
-  const availableProducts = products.filter((p) => p.inStock)
+  const availableIndexes = products
+    .map((p, i) => (p.inStock ? i : -1))
+    .filter((i) => i !== -1)
   const allSelected =
-    availableProducts.length > 0 &&
-    availableProducts.every((p) => selectedIds.has(p.id))
+    availableIndexes.length > 0 &&
+    availableIndexes.every((i) => selectedIndexes.has(i))
 
   const totalPrice = products
-    .filter((p) => selectedIds.has(p.id))
+    .filter((_, i) => selectedIndexes.has(i))
     .reduce((sum, p) => sum + p.price, 0)
 
   return (
     <div className="w-full space-y-3 rounded-md sm:rounded-lg p-4 sm:p-0">
       {/* Mobile: Card view */}
       <div className="sm:hidden space-y-2 px-0.5">
-        {products.map((product) => (
+        {products.map((product, index) => (
           <button
-            key={product.id}
+            key={index}
             type="button"
-            onClick={() => handleSelect(product)}
+            onClick={() => handleSelect(index, product)}
             disabled={!product.inStock}
             className={cn(
               'w-full flex items-center gap-3 rounded-md sm:rounded-lg border bg-card p-2 text-left transition-all cursor-pointer',
-              selectedIds.has(product.id)
+              selectedIndexes.has(index)
                 ? 'border-foreground ring-1 ring-foreground'
                 : 'border-border hover:border-foreground/30',
               !product.inStock && 'opacity-50 !cursor-not-allowed'
@@ -618,12 +616,12 @@ function PickerVariant({
             <div
               className={cn(
                 'flex h-4 w-4 flex-shrink-0 items-center justify-center rounded border transition-colors',
-                selectedIds.has(product.id)
+                selectedIndexes.has(index)
                   ? 'bg-foreground border-foreground text-background'
                   : 'border-border'
               )}
             >
-              {selectedIds.has(product.id) && <Check className="h-3 w-3" />}
+              {selectedIndexes.has(index) && <Check className="h-3 w-3" />}
             </div>
 
             {/* Image */}
@@ -691,10 +689,10 @@ function PickerVariant({
             </tr>
           </thead>
           <tbody>
-            {products.map((product) => (
+            {products.map((product, index) => (
               <tr
-                key={product.id}
-                onClick={() => handleSelect(product)}
+                key={index}
+                onClick={() => handleSelect(index, product)}
                 className={cn(
                   'border-b border-border last:border-0 transition-colors',
                   product.inStock
@@ -706,12 +704,12 @@ function PickerVariant({
                   <div
                     className={cn(
                       'flex h-4 w-4 items-center justify-center rounded border transition-colors',
-                      selectedIds.has(product.id)
+                      selectedIndexes.has(index)
                         ? 'bg-foreground border-foreground text-background'
                         : 'border-border'
                     )}
                   >
-                    {selectedIds.has(product.id) && (
+                    {selectedIndexes.has(index) && (
                       <Check className="h-3 w-3" />
                     )}
                   </div>
@@ -759,9 +757,9 @@ function PickerVariant({
       {/* Add to cart button */}
       <div className="flex items-center justify-between gap-4 p-3 border-t-1">
         <div className="text-xs sm:text-sm text-muted-foreground">
-          {selectedIds.size > 0 ? (
+          {selectedIndexes.size > 0 ? (
             <span>
-              {selectedIds.size} item{selectedIds.size !== 1 ? 's' : ''}{' '}
+              {selectedIndexes.size} item{selectedIndexes.size !== 1 ? 's' : ''}{' '}
               selected
               {' · '}
               <span className="font-medium text-foreground">
@@ -774,7 +772,7 @@ function PickerVariant({
         </div>
         <Button
           onClick={handleAddToCart}
-          disabled={selectedIds.size === 0}
+          disabled={selectedIndexes.size === 0}
           size="sm"
         >
           <ShoppingCart className="h-4 w-4 mr-1.5" />
@@ -789,8 +787,8 @@ export function ProductList({ data, actions, appearance, control }: ProductListP
   const { products = defaultProducts } = data ?? {}
   const { onSelectProduct, onAddToCart } = actions ?? {}
   const { variant = 'list', currency = 'EUR', columns = 4, buttonLabel } = appearance ?? {}
-  const { selectedProductId } = control ?? {}
-  const [selected, setSelected] = useState<string | undefined>(selectedProductId)
+  const { selectedProductIndex } = control ?? {}
+  const [selected, setSelected] = useState<number | undefined>(selectedProductIndex)
 
   const formatCurrency = (value: number) => {
     return new Intl.NumberFormat('en-US', {
@@ -800,8 +798,8 @@ export function ProductList({ data, actions, appearance, control }: ProductListP
     }).format(value)
   }
 
-  const handleSelect = (product: Product) => {
-    setSelected(product.id)
+  const handleSelect = (product: Product, index: number) => {
+    setSelected(index)
     onSelectProduct?.(product)
   }
 

--- a/packages/manifest-ui/registry/messaging/chat-conversation.tsx
+++ b/packages/manifest-ui/registry/messaging/chat-conversation.tsx
@@ -4,7 +4,6 @@ import { ImageMessageBubble, MessageBubble } from './message-bubble'
 
 // Chat Conversation (multiple messages)
 export interface ChatMessage {
-  id: string
   type?: 'text' | 'image'
   content: string
   image?: string
@@ -24,7 +23,6 @@ export interface ChatConversationProps {
 
 const defaultMessages: ChatMessage[] = [
   {
-    id: '1',
     type: 'text',
     content: 'Hey! Check out this new feature we just shipped 🚀',
     author: 'Sarah',
@@ -33,7 +31,6 @@ const defaultMessages: ChatMessage[] = [
     isOwn: false
   },
   {
-    id: '2',
     type: 'text',
     content: 'Oh wow, that looks amazing! How long did it take to build?',
     author: 'You',
@@ -43,7 +40,6 @@ const defaultMessages: ChatMessage[] = [
     status: 'read'
   },
   {
-    id: '3',
     type: 'image',
     content: "Here's a preview of the dashboard",
     image:
@@ -54,7 +50,6 @@ const defaultMessages: ChatMessage[] = [
     isOwn: false
   },
   {
-    id: '4',
     type: 'text',
     content: 'This is incredible! The UI is so clean 👏',
     author: 'You',
@@ -69,11 +64,11 @@ export function ChatConversation({ data }: ChatConversationProps) {
   const { messages = defaultMessages } = data ?? {}
   return (
     <div className="rounded-xl bg-card p-4 space-y-4">
-      {messages.map((message) => {
+      {messages.map((message, index) => {
         const messageType = message.type ?? 'text'
         return messageType === 'image' ? (
           <ImageMessageBubble
-            key={message.id}
+            key={index}
             data={{
               image: message.image!,
               content: message.content,
@@ -87,7 +82,7 @@ export function ChatConversation({ data }: ChatConversationProps) {
           />
         ) : (
           <MessageBubble
-            key={message.id}
+            key={index}
             data={{
               content: message.content,
               avatarFallback: message.avatarFallback,

--- a/packages/manifest-ui/registry/miscellaneous/option-list.tsx
+++ b/packages/manifest-ui/registry/miscellaneous/option-list.tsx
@@ -13,7 +13,6 @@ import { useState } from 'react'
  */
 
 export interface Option {
-  id: string
   label: string
   description?: string
   icon?: React.ReactNode
@@ -32,60 +31,60 @@ export interface OptionListProps {
     multiple?: boolean
   }
   control?: {
-    selectedOptionId?: string
-    selectedOptionIds?: string[]
+    selectedOptionIndex?: number
+    selectedOptionIndexes?: number[]
   }
 }
 
 const defaultOptions: Option[] = [
-  { id: '1', label: 'Standard shipping', description: '3-5 business days' },
-  { id: '2', label: 'Express shipping', description: '1-2 business days' },
-  { id: '3', label: 'Store pickup', description: 'Available in 2h' }
+  { label: 'Standard shipping', description: '3-5 business days' },
+  { label: 'Express shipping', description: '1-2 business days' },
+  { label: 'Store pickup', description: 'Available in 2h' }
 ]
 
 export function OptionList({ data, actions, appearance, control }: OptionListProps) {
   const { options = defaultOptions } = data ?? {}
   const { onSelectOption, onSelectOptions } = actions ?? {}
   const { multiple = false } = appearance ?? {}
-  const { selectedOptionId, selectedOptionIds = [] } = control ?? {}
-  const [selected, setSelected] = useState<string | string[]>(
-    multiple ? selectedOptionIds : selectedOptionId || ''
+  const { selectedOptionIndex, selectedOptionIndexes = [] } = control ?? {}
+  const [selected, setSelected] = useState<number | number[]>(
+    multiple ? selectedOptionIndexes : selectedOptionIndex ?? -1
   )
 
-  const handleSelect = (option: Option) => {
+  const handleSelect = (option: Option, index: number) => {
     if (option.disabled) return
 
     if (multiple) {
-      const currentSelected = selected as string[]
-      const newSelected = currentSelected.includes(option.id)
-        ? currentSelected.filter((id) => id !== option.id)
-        : [...currentSelected, option.id]
+      const currentSelected = selected as number[]
+      const newSelected = currentSelected.includes(index)
+        ? currentSelected.filter((i) => i !== index)
+        : [...currentSelected, index]
       setSelected(newSelected)
-      onSelectOptions?.(options.filter((o) => newSelected.includes(o.id)))
+      onSelectOptions?.(options.filter((_, i) => newSelected.includes(i)))
     } else {
-      setSelected(option.id)
+      setSelected(index)
       onSelectOption?.(option)
     }
   }
 
-  const isSelected = (id: string) => {
+  const isSelected = (index: number) => {
     if (multiple) {
-      return (selected as string[]).includes(id)
+      return (selected as number[]).includes(index)
     }
-    return selected === id
+    return selected === index
   }
 
   return (
     <div className="w-full bg-card rounded-lg p-4">
       <div className="flex flex-wrap gap-2">
-        {options.map((option) => (
+        {options.map((option, index) => (
           <button
-            key={option.id}
-            onClick={() => handleSelect(option)}
+            key={index}
+            onClick={() => handleSelect(option, index)}
             disabled={option.disabled}
             className={cn(
               'inline-flex items-center gap-1.5 sm:gap-2 rounded-full border px-2.5 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm transition-colors cursor-pointer',
-              isSelected(option.id)
+              isSelected(index)
                 ? 'border-foreground bg-foreground text-background'
                 : 'border-border bg-background hover:bg-muted',
               option.disabled && 'opacity-50 !cursor-not-allowed'
@@ -97,7 +96,7 @@ export function OptionList({ data, actions, appearance, control }: OptionListPro
               <span
                 className={cn(
                   'text-[10px] sm:text-xs',
-                  isSelected(option.id)
+                  isSelected(index)
                     ? 'text-background/70'
                     : 'text-muted-foreground'
                 )}
@@ -105,7 +104,7 @@ export function OptionList({ data, actions, appearance, control }: OptionListPro
                 · {option.description}
               </span>
             )}
-            {isSelected(option.id) && multiple && (
+            {isSelected(index) && multiple && (
               <Check className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
             )}
           </button>

--- a/packages/manifest-ui/registry/miscellaneous/quick-reply.tsx
+++ b/packages/manifest-ui/registry/miscellaneous/quick-reply.tsx
@@ -10,7 +10,6 @@ import { cn } from '@/lib/utils'
  */
 
 export interface QuickReply {
-  id: string
   label: string
   icon?: React.ReactNode
 }
@@ -25,10 +24,10 @@ export interface QuickReplyProps {
 }
 
 const defaultReplies: QuickReply[] = [
-  { id: '1', label: 'Yes, confirm' },
-  { id: '2', label: 'No thanks' },
-  { id: '3', label: 'I have a question' },
-  { id: '4', label: 'View details' }
+  { label: 'Yes, confirm' },
+  { label: 'No thanks' },
+  { label: 'I have a question' },
+  { label: 'View details' }
 ]
 
 export function QuickReply({ data, actions }: QuickReplyProps) {
@@ -37,9 +36,9 @@ export function QuickReply({ data, actions }: QuickReplyProps) {
   return (
     <div className="w-full bg-card rounded-lg p-4">
       <div className="flex flex-wrap gap-2">
-        {replies.map((reply) => (
+        {replies.map((reply, index) => (
           <button
-            key={reply.id}
+            key={index}
             onClick={() => onSelectReply?.(reply)}
             className={cn(
               'inline-flex items-center gap-1 sm:gap-1.5 rounded-full border border-border bg-background px-2.5 sm:px-3 py-1 sm:py-1.5 text-xs sm:text-sm text-foreground transition-colors cursor-pointer',


### PR DESCRIPTION
BREAKING CHANGE: Removed id from Product, Post, Event, EventDetails, ChatMessage, QuickReply, and Option interfaces. Components now use array index for React keys and selection tracking.

Components affected:
- product-list: selectedProductId → selectedProductIndex
- option-list: selectedOptionId → selectedOptionIndex
- chat-conversation, post-card, post-list, post-detail
- event-card, event-list, event-detail
- quick-reply

Related to #564 (but does not fix it entierly)
