### PR TITLE
Fix duplicate code in create-manifest script

### DIFF
--- a/packages/create-manifest/package.json
+++ b/packages/create-manifest/package.json
@@ -1,13 +1,13 @@
 {
   "name": "create-manifest",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Create a new Manifest project",
   "type": "module",
   "bin": {
     "create-manifest": "./index.js"
   },
   "scripts": {
-    "prepublishOnly": "cp -r ../starter ./starter",
+    "prepublishOnly": "rm -rf ./starter && cp -r ../starter ./starter",
     "postpublish": "rm -rf ./starter"
   },
   "files": [


### PR DESCRIPTION
The prepublishOnly script now removes any existing starter folder before copying. This prevents the cp -r command from creating a nested starter/starter structure when the target directory already exists from a previous failed publish or local development.

Bumps version to 2.0.3.
