### PR TITLE
Fix event-list component installation error

### DIFF
--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -131,7 +131,8 @@
       "4.0.0": "BREAKING: Added fullwidth variant with split-screen map layout. Updated to 15 events. Added coordinates to Event type.",
       "5.0.0": "BREAKING: Fullwidth is no longer a variant - use fullscreenComponent instead. Map now uses real Leaflet.",
       "5.1.0": "Added animated filter panel with Category, Date, Neighborhood, Price, and Format filters. Filters apply to both list and map markers.",
-      "5.2.0": "Added expand button next to title in list and carousel variants with onExpand action"
+      "5.2.0": "Added expand button next to title in list and carousel variants with onExpand action",
+      "5.2.1": "Fixed event-card dependency resolution for shadcn CLI installation"
     },
     "event-detail": {
       "1.0.0": "Initial release with image carousel, organizer info, location, policies, FAQs, and ticket purchase.",

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -539,12 +539,12 @@
     },
     {
       "name": "event-list",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "type": "registry:component",
       "title": "Event List",
       "description": "Display events in grid, list, or carousel layouts. Fullscreen mode shows interactive split-screen map with Leaflet and animated filter panel.",
       "dependencies": ["lucide-react", "react-leaflet", "leaflet"],
-      "registryDependencies": ["button", "checkbox", "event-card"],
+      "registryDependencies": ["button", "checkbox", "https://ui.manifest.build/r/event-card.json"],
       "files": [
         {
           "path": "registry/events/event-list.tsx",


### PR DESCRIPTION
The event-card dependency was referenced as a plain string, causing shadcn CLI to look for it in the default registry (ui.shadcn.com) instead of the Manifest registry (ui.manifest.build). Using the full URL ensures correct dependency resolution.
