### PR TITLE
Add automated categories to registry components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,8 +143,10 @@ A block modification is NOT complete until you have updated:
 |----------|----------------|
 | `registry/<category>/<block>.tsx` | Component code, interfaces, props, default values |
 | `app/blocks/[category]/[block]/page.tsx` | `usageCode`, component preview, block metadata, default data |
-| `registry.json` | Version bump (PATCH/MINOR/MAJOR) |
+| `registry.json` | Version bump (PATCH/MINOR/MAJOR), category field (auto-derived from folder) |
 | `changelog.json` | Changelog entry for the new version |
+
+**Note**: The `category` field in `registry.json` is automatically derived from the folder name (e.g., `registry/form/` → `category: "form"`). When adding a new component, place it in the correct folder and the category will be set automatically.
 
 #### What Lives in `page.tsx`
 
@@ -381,6 +383,43 @@ The changelog is stored in `packages/manifest-ui/changelog.json`:
 - "Bug fixes" (too vague)
 - "Refactored internal state management" (too technical)
 - "Updated dependencies" (not user-facing)
+
+### Category Requirements (CRITICAL)
+
+**Every component MUST have a `category` field in `registry.json`.**
+
+The category is automatically derived from the folder structure:
+- File path: `registry/form/date-time-picker.tsx`
+- Category: `form`
+
+This is enforced by automated tests that will fail if:
+1. A component is missing a `category` field
+2. The `category` doesn't match the folder name in the file path
+
+#### How Categories Work
+
+1. **Folder determines category**: Place your component in `registry/<category>/<component-name>.tsx`
+2. **Category is auto-derived**: The build script extracts the category from the file path
+3. **URL structure matches**: The category appears in URLs as `/blocks/<category>/<component>`
+
+#### Available Categories
+
+| Folder | Category | URL Example |
+|--------|----------|-------------|
+| `registry/blogging/` | `blogging` | `/blocks/blogging/post-card` |
+| `registry/events/` | `events` | `/blocks/events/event-card` |
+| `registry/form/` | `form` | `/blocks/form/contact-form` |
+| `registry/list/` | `list` | `/blocks/list/table` |
+| `registry/messaging/` | `messaging` | `/blocks/messaging/message-bubble` |
+| `registry/miscellaneous/` | `miscellaneous` | `/blocks/miscellaneous/quick-reply` |
+| `registry/payment/` | `payment` | `/blocks/payment/card-form` |
+
+#### Adding a New Category
+
+1. Create a new folder: `registry/<new-category>/`
+2. Add your component: `registry/<new-category>/<component>.tsx`
+3. The category will be automatically derived from the folder name
+4. Update `lib/blocks-categories.ts` to add the category to navigation
 
 ### Events Category Guidelines (CRITICAL)
 

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -9,6 +9,7 @@
       "type": "registry:component",
       "title": "Contact Form",
       "description": "A complete contact form with name fields, phone with country selector, email, message textarea, and file attachment.",
+      "category": "form",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button", "input", "label", "select"],
       "files": [
@@ -24,6 +25,7 @@
       "type": "registry:component",
       "title": "Date & Time Picker",
       "description": "A Calendly-style date and time picker with calendar, available time slots, and timezone display.",
+      "category": "form",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -39,6 +41,7 @@
       "type": "registry:component",
       "title": "Issue Report Form",
       "description": "A compact issue reporting form for team members with categories, impact/urgency levels, and file attachments.",
+      "category": "form",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button", "input", "label", "select"],
       "files": [
@@ -54,6 +57,7 @@
       "type": "registry:component",
       "title": "Card Form",
       "description": "A credit card payment form with card number, expiry date, CVV, and cardholder name fields.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["card", "input", "label", "button"],
       "files": [
@@ -69,6 +73,7 @@
       "type": "registry:component",
       "title": "Pay Confirm",
       "description": "A payment confirmation block displaying amount, card details, and confirm/cancel actions.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["card", "button", "separator"],
       "files": [
@@ -84,6 +89,7 @@
       "type": "registry:component",
       "title": "Order Summary",
       "description": "An order summary block displaying items, subtotal, shipping, tax, discounts, and total.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["card", "badge", "separator"],
       "files": [
@@ -99,6 +105,7 @@
       "type": "registry:component",
       "title": "Saved Cards",
       "description": "A card selector for choosing a saved payment method with support for multiple card brands.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["card", "button"],
       "files": [
@@ -114,6 +121,7 @@
       "type": "registry:component",
       "title": "Payment Success",
       "description": "A payment confirmation screen showing order details, delivery info, and tracking options.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["card", "button", "separator"],
       "files": [
@@ -129,6 +137,7 @@
       "type": "registry:component",
       "title": "Bank Card Form",
       "description": "Compact bank card payment form with inline layout for chat interfaces.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -144,6 +153,7 @@
       "type": "registry:component",
       "title": "Payment Methods",
       "description": "Payment method selector with card brands (Visa, Mastercard, CB, Amex) and Apple Pay.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -159,6 +169,7 @@
       "type": "registry:component",
       "title": "Order Confirm",
       "description": "Order confirmation with product image, delivery info, and confirm action.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -174,6 +185,7 @@
       "type": "registry:component",
       "title": "Payment Confirmed",
       "description": "Payment confirmation card with product image, price, delivery info, and tracking button.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -189,6 +201,7 @@
       "type": "registry:component",
       "title": "Product List",
       "description": "Product list with list, grid, carousel, and picker variants.",
+      "category": "list",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -204,6 +217,7 @@
       "type": "registry:component",
       "title": "Option List",
       "description": "Tag-style option selector with single or multiple selection modes.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": [],
       "files": [
@@ -219,6 +233,7 @@
       "type": "registry:component",
       "title": "Amount Input",
       "description": "Amount input with increment/decrement buttons and preset values.",
+      "category": "payment",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -234,6 +249,7 @@
       "type": "registry:component",
       "title": "Tag Select",
       "description": "Colored tag selector with single or multiple selection and color variants.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -249,6 +265,7 @@
       "type": "registry:component",
       "title": "Quick Reply",
       "description": "Quick reply buttons for common chat responses.",
+      "category": "miscellaneous",
       "dependencies": [],
       "registryDependencies": [],
       "files": [
@@ -264,6 +281,7 @@
       "type": "registry:component",
       "title": "Progress Steps",
       "description": "Progress indicator with horizontal or vertical layout and step statuses.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": [],
       "files": [
@@ -279,6 +297,7 @@
       "type": "registry:component",
       "title": "Status Badge",
       "description": "Status badge with multiple states (success, pending, processing, error, shipped, delivered).",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": [],
       "files": [
@@ -294,6 +313,7 @@
       "type": "registry:component",
       "title": "Stats",
       "description": "Scrollable stat cards with values, trends, and change indicators.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": [],
       "files": [
@@ -309,6 +329,7 @@
       "type": "registry:component",
       "title": "Skeleton Loaders",
       "description": "Skeleton placeholder components with pulse animation for loading states.",
+      "category": "miscellaneous",
       "dependencies": [],
       "registryDependencies": [],
       "files": [
@@ -324,6 +345,7 @@
       "type": "registry:component",
       "title": "Post Card",
       "description": "Post card with image, title, excerpt, author info and read more button. Supports default, compact, horizontal, and covered variants. Includes post-detail for fullscreen view.",
+      "category": "blogging",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -343,6 +365,7 @@
       "type": "registry:component",
       "title": "Post List",
       "description": "Post list with list, grid, carousel, and fullwidth variants. Fullwidth mode shows paginated posts.",
+      "category": "blogging",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -366,6 +389,7 @@
       "type": "registry:component",
       "title": "Post Detail",
       "description": "Full post view with cover image, author info, content, tags and related posts section.",
+      "category": "blogging",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -385,6 +409,7 @@
       "type": "registry:component",
       "title": "Table",
       "description": "Data table with optional single or multi-select modes for chat interfaces.",
+      "category": "list",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button", "checkbox", "popover", "select", "input"],
       "files": [
@@ -400,6 +425,7 @@
       "type": "registry:component",
       "title": "Message Bubble",
       "description": "Chat message bubbles with text, image, voice, and reaction variants.",
+      "category": "messaging",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["dropdown-menu"],
       "files": [
@@ -415,6 +441,7 @@
       "type": "registry:component",
       "title": "Chat Conversation",
       "description": "Full chat conversation component with multiple message types.",
+      "category": "messaging",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["dropdown-menu"],
       "files": [
@@ -434,6 +461,7 @@
       "type": "registry:component",
       "title": "X Post",
       "description": "X (Twitter) post card with engagement metrics.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": [],
       "files": [
@@ -449,6 +477,7 @@
       "type": "registry:component",
       "title": "Instagram Post",
       "description": "Instagram post card with image and engagement.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["dropdown-menu"],
       "files": [
@@ -464,6 +493,7 @@
       "type": "registry:component",
       "title": "LinkedIn Post",
       "description": "LinkedIn post card with professional styling.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["dropdown-menu"],
       "files": [
@@ -479,6 +509,7 @@
       "type": "registry:component",
       "title": "YouTube Post",
       "description": "YouTube video card with playable embed.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["dropdown-menu"],
       "files": [
@@ -494,6 +525,7 @@
       "type": "registry:component",
       "title": "Map Carousel",
       "description": "Interactive map with location markers and a draggable carousel of cards.",
+      "category": "miscellaneous",
       "dependencies": ["lucide-react", "leaflet", "react-leaflet"],
       "registryDependencies": [],
       "files": [
@@ -509,6 +541,7 @@
       "type": "registry:component",
       "title": "Event Card",
       "description": "Display event information with multiple layouts. Supports events with images, signals, vibe tags, and display-formatted date/time. Entire card is clickable.",
+      "category": "events",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -528,6 +561,7 @@
       "type": "registry:component",
       "title": "Event List",
       "description": "Display events in grid, list, or carousel layouts. Fullscreen mode shows interactive split-screen map with Leaflet and animated filter panel.",
+      "category": "events",
       "dependencies": ["lucide-react", "react-leaflet", "leaflet"],
       "registryDependencies": ["button", "checkbox", "https://ui.manifest.build/r/event-card.json"],
       "files": [
@@ -547,6 +581,7 @@
       "type": "registry:component",
       "title": "Event Detail",
       "description": "Full event detail view with organizer info, interactive map, policies, and ticket purchase. Fullwidth mode only.",
+      "category": "events",
       "dependencies": ["lucide-react", "react-leaflet", "leaflet"],
       "registryDependencies": ["button"],
       "files": [
@@ -566,6 +601,7 @@
       "type": "registry:component",
       "title": "Ticket Tier Select",
       "description": "Ticket tier selection with quantity controls and order summary. Shows price breakdown with fees.",
+      "category": "events",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [
@@ -581,6 +617,7 @@
       "type": "registry:component",
       "title": "Event Checkout",
       "description": "Event checkout form with billing info, payment method selection, and order summary. Includes countdown timer.",
+      "category": "events",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button", "checkbox"],
       "files": [
@@ -596,6 +633,7 @@
       "type": "registry:component",
       "title": "Event Confirmation",
       "description": "Order confirmation with event details, ticket delivery info, organizer follow, and social sharing.",
+      "category": "events",
       "dependencies": ["lucide-react"],
       "registryDependencies": ["button"],
       "files": [


### PR DESCRIPTION
- Add `category` field to all components in registry.json, derived from the folder structure (e.g., registry/form/ → category: "form")
- Update inject-versions.mjs script to auto-populate and validate categories during build
- Add category validation tests to ensure all components have categories matching their file paths
- Update CLAUDE.md documentation with category requirements and guidelines

Categories are now automatically derived from the component's folder location, making it automated for new components.
