### PR TITLE
Fix duplicate payment-success components in registry

### DIFF
--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -169,21 +169,6 @@
       ]
     },
     {
-      "name": "payment-success",
-      "version": "1.0.0",
-      "type": "registry:component",
-      "title": "Payment Success",
-      "description": "Payment success with order details, brand logo, and tracking button.",
-      "dependencies": ["lucide-react"],
-      "registryDependencies": ["button"],
-      "files": [
-        {
-          "path": "registry/payment/payment-success.tsx",
-          "type": "registry:component"
-        }
-      ]
-    },
-    {
       "name": "payment-confirmed",
       "version": "1.0.0",
       "type": "registry:component",


### PR DESCRIPTION
The registry.json had two entries for payment-success component pointing to the same file. Removed the duplicate entry to fix the registry.
