### PR TITLE
Update Manifest UI registry metadata

### DIFF
--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
-  "name": "agentic",
-  "homepage": "https://manifest.build",
+  "name": "Manifest UI",
+  "homepage": "https://ui.manifest.build",
   "items": [
     {
       "name": "contact-form",


### PR DESCRIPTION
Update registry.json to use "Manifest UI" as the name and "https://ui.manifest.build" as the homepage.

