### PR TITLE
fix(ci): add workflow_dispatch to Docker publish workflow

### DIFF
--- a/.github/workflows/manifest-publish.yml
+++ b/.github/workflows/manifest-publish.yml
@@ -6,6 +6,7 @@
 # Triggers:
 #   - Push to main branch (development builds)
 #   - Push of version tags (v1.0.0, v1.2.3, etc.)
+#   - Manual trigger via workflow_dispatch
 #
 # Versioning Strategy:
 #   On version tag (v1.2.3):
@@ -36,6 +37,7 @@ on:
     tags: ['v*.*.*']
     paths:
       - 'packages/manifest/**'
+  workflow_dispatch:
 
 env:
   DOCKER_IMAGE: manifestdotbuild/manifest


### PR DESCRIPTION
## Description

Add `workflow_dispatch` trigger to the Docker publish workflow. This allows manual triggering of the workflow, which is needed when workflow-only changes are merged that don't touch `packages/manifest/**` but still need to trigger a new publish.

## Related Issues

None

## How can it be tested?

1. Merge this PR
2. Go to Actions > Docker Publish > Run workflow
3. Verify the workflow can be manually triggered

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR