### PR TITLE
fix(auth): use 12-character password for default admin user

### DIFF
--- a/packages/manifest/shared/src/types/auth.ts
+++ b/packages/manifest/shared/src/types/auth.ts
@@ -9,7 +9,7 @@
  */
 export const DEFAULT_ADMIN_USER = {
   email: 'admin@example.com',
-  password: 'changeme123',
+  password: 'changeme1234',
   firstName: 'Admin',
   lastName: 'User',
   name: 'Admin User',


### PR DESCRIPTION
## Description

Fixed the default admin user password to meet the 12-character minimum requirement. The previous password `changeme123` was only 11 characters, causing the seed service to fail when creating the admin user with Better Auth.

## Related Issues

None

## How can it be tested?

1. Delete the existing database: `rm packages/manifest/backend/data/app.db`
2. Start the backend: `pnpm dev` from `packages/manifest/backend`
3. Verify in logs: "Created admin user: admin@example.com" (no "Password too short" error)
4. Login at frontend with `admin@example.com` / `changeme1234`

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR