### PR TITLE
Fix Docker Hub image publishing workflow

### DIFF
--- a/.github/workflows/manifest-publish.yml
+++ b/.github/workflows/manifest-publish.yml
@@ -4,11 +4,12 @@
 # Builds and publishes Docker images to Docker Hub.
 #
 # Triggers:
-#   - Push of version tags (v1.0.0, v1.2.3, etc.) - created by release workflow
+#   - Called by release workflow (workflow_call) after version bump
+#   - Push of version tags (v1.0.0, v1.2.3, etc.) - backup trigger
 #   - Manual trigger via workflow_dispatch
 #
 # Versioning Strategy:
-#   On version tag (v1.2.3):
+#   On version (1.2.3):
 #     - 1.2.3, 1.2, 1, latest
 #
 # Required Secrets:
@@ -18,8 +19,8 @@
 # Release Flow:
 #   1. PR with changeset merged to main
 #   2. Release workflow creates "Version Packages" PR
-#   3. Version PR merged creates GitHub release + tag
-#   4. This workflow triggers on the tag to publish Docker image
+#   3. Version PR merged → release workflow creates tag + calls this workflow
+#   4. Docker image is built and pushed to Docker Hub
 # ============================================================================
 
 name: Docker Publish
@@ -31,6 +32,12 @@ on:
   push:
     tags: ['v*.*.*']
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish (without v prefix)'
+        required: true
+        type: string
 
 env:
   DOCKER_IMAGE: manifestdotbuild/manifest
@@ -59,8 +66,10 @@ jobs:
           BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
           SHORT_SHA="${GITHUB_SHA::7}"
 
-          # Extract version from tag or use sha for manual dispatch
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+          # Extract version from: workflow_call input > tag > sha for manual dispatch
+          if [[ -n "${{ inputs.version }}" ]]; then
+            VERSION="${{ inputs.version }}"
+          elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
             VERSION="dev-${SHORT_SHA}"
@@ -70,19 +79,32 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
-      - name: Generate Docker metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.DOCKER_IMAGE }}
-          tags: |
-            # Semver tags: 1.2.3, 1.2, 1, latest (only on version tags)
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            # Manual dispatch tag
-            type=raw,value=dev-${{ steps.version.outputs.short_sha }},enable=${{ github.event_name == 'workflow_dispatch' }}
+      - name: Generate Docker tags
+        id: tags
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          IMAGE="${{ env.DOCKER_IMAGE }}"
+
+          # Parse semver components
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+
+          # Build tags array
+          TAGS="${IMAGE}:${VERSION}"
+          TAGS="${TAGS},${IMAGE}:${MAJOR}.${MINOR}"
+
+          # Add major tag only if not v0.x.x
+          if [[ "$MAJOR" != "0" ]]; then
+            TAGS="${TAGS},${IMAGE}:${MAJOR}"
+          fi
+
+          # Add latest tag for releases (tag push or workflow_call with version)
+          if [[ "$GITHUB_REF" == refs/tags/v* ]] || [[ -n "${{ inputs.version }}" ]]; then
+            TAGS="${TAGS},${IMAGE}:latest"
+          fi
+
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "Generated tags: ${TAGS}"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -91,8 +113,14 @@ jobs:
           file: docker/manifest/Dockerfile
           push: true
           platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.created=${{ steps.version.outputs.build_date }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.source=https://github.com/mnfst/manifest
+            org.opencontainers.image.title=Manifest
+            org.opencontainers.image.description=The simplest BaaS for AI-generated full-stack apps
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -105,7 +133,7 @@ jobs:
         run: |
           echo "## Docker Image Published" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "### Release: ${GITHUB_REF#refs/tags/}" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Release: v${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "| Property | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|----------|-------|" >> "$GITHUB_STEP_SUMMARY"
@@ -117,7 +145,7 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Tags" >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.tags.outputs.tags }}" | tr ',' '\n' >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Pull Command" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,3 +92,19 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    outputs:
+      should_release: ${{ steps.version.outputs.should_release }}
+      version: ${{ steps.version.outputs.version }}
+
+  # Publish Docker image after release
+  # This is called directly instead of relying on tag push events
+  # because GITHUB_TOKEN pushes don't trigger other workflows
+  docker-publish:
+    name: Docker Publish
+    needs: release
+    if: needs.release.outputs.should_release == 'true'
+    uses: ./.github/workflows/manifest-publish.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
The Docker publish workflow wasn't triggering because GITHUB_TOKEN pushes don't create new workflow runs (GitHub security measure).

Changes:
- Add workflow_call trigger to manifest-publish.yml with version input
- Update release.yml to call docker-publish directly after tagging
- Replace docker/metadata-action with custom tag generation script
- Add explicit OCI labels to the Docker build step

The release workflow now explicitly calls the Docker publish workflow after creating the version tag, ensuring Docker images are published.
