### PR TITLE
chore(ci): remove orphaned changeset for ignored package

### DIFF
--- a/.changeset/fix-sidebar-links.md
+++ b/.changeset/fix-sidebar-links.md
@@ -1,5 +1,0 @@
----
-"manifest-ui": patch
----
-
-Fix sidebar navigation consistency on block detail pages by using dynamic blockCategories from registry instead of hardcoded array


### PR DESCRIPTION
## Description

Removes the orphaned changeset file `fix-sidebar-links.md` that was causing the release workflow to fail.

The `manifest-ui` package was added to the changeset ignore list in PR #639, but the existing changeset file was not removed. This caused the release workflow to fail with "No commits between main and changeset-release/main" because changesets ignored the version bump but still tried to create a PR.

## Related Issues

Fixes the failed workflow run: https://github.com/mnfst/manifest/actions/runs/21236238358/job/61104782396

## How can it be tested?

1. Merge this PR
2. The release workflow should run successfully (or skip gracefully if no changesets exist)

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR

---
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>