### PR TITLE
Fix INVALID_ORIGIN error by auto-adding BETTER_AUTH_URL to trusted origins

### DIFF
--- a/.changeset/fix-auth-origin-error.md
+++ b/.changeset/fix-auth-origin-error.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix INVALID_ORIGIN error by automatically adding BETTER_AUTH_URL to trusted origins

--- a/packages/manifest/backend/src/auth/auth.ts
+++ b/packages/manifest/backend/src/auth/auth.ts
@@ -9,6 +9,12 @@ import Database from 'better-sqlite3';
 function getTrustedOrigins(): string[] {
   const origins: string[] = [];
 
+  // Add BETTER_AUTH_URL to trusted origins (the app's own URL should always be trusted)
+  if (process.env.BETTER_AUTH_URL) {
+    // Remove trailing slash if present for consistency
+    origins.push(process.env.BETTER_AUTH_URL.replace(/\/$/, ''));
+  }
+
   // Add origins from ALLOWED_ORIGINS env var
   if (process.env.ALLOWED_ORIGINS) {
     origins.push(...process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim()));


### PR DESCRIPTION
## Summary

This PR fixes the `INVALID_ORIGIN` error that occurs during authentication by automatically adding the `BETTER_AUTH_URL` environment variable to the list of trusted origins. The application's own URL should always be trusted for authentication to work properly.

## Changes

- Modified `getTrustedOrigins()` function in `packages/manifest/backend/src/auth/auth.ts` to automatically include `BETTER_AUTH_URL` as a trusted origin
- Added logic to normalize the URL by removing trailing slashes for consistency
- The `BETTER_AUTH_URL` is now added before other allowed origins from the `ALLOWED_ORIGINS` environment variable

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [ ] Tests pass locally (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)

## Related Issues

Fixes the `INVALID_ORIGIN` error that users encounter during authentication flows.