### PR TITLE
Add GitHub PR labeler workflow and configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,23 @@
+# Configuration for actions/labeler
+# Labels PRs based on which files are changed
+
+# Manifest package label
+manifest:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/manifest/**'
+
+# Manifest UI package label
+manifest UI:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/manifest-ui/**'
+
+# ui.manifest.build website label (subset of manifest-ui)
+ui.manifest.build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'packages/manifest-ui/app/**'
+          - 'packages/manifest-ui/components/**'
+          - 'packages/manifest-ui/lib/**'
+          - 'packages/manifest-ui/public/**'
+          - 'packages/manifest-ui/registry/**'
+          - 'packages/manifest-ui/styles/**'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label:
+    name: Label PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Label PR based on changed files
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: false


### PR DESCRIPTION
## Summary

This PR adds automated PR labeling based on changed files using GitHub Actions. The labeler will automatically apply relevant labels to pull requests depending on which packages or directories are modified, improving PR organization and making it easier to identify the scope of changes at a glance.

## Changes

- Added `.github/workflows/labeler.yml`: GitHub Actions workflow that runs the labeler on PR open, synchronize, and reopen events
- Added `.github/labeler.yml`: Configuration file defining label rules:
  - `manifest` label for changes in `packages/manifest/**`
  - `manifest UI` label for changes in `packages/manifest-ui/**`
  - `ui.manifest.build` label for changes in specific manifest-ui subdirectories (app, components, lib, public, registry, styles)

## Type of Change

- [x] CI/CD (changes to build process or workflows)

## Testing

- Configuration follows the `actions/labeler@v5` specification
- Labels are applied automatically without manual intervention
- `sync-labels: false` prevents removal of manually applied labels

## Related Issues

<!-- Link any related issues if applicable -->