### PR TITLE
refactor: rename StatCard to RegistryComponent across codebase

### DIFF
--- a/packages/manifest/backend/package.json
+++ b/packages/manifest/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "nest build && pnpm run build:tsx",
-    "build:tsx": "swc src/email/templates/password-reset.tsx src/email/templates/invitation.tsx src/email/templates/email-change-verification.tsx src/email/templates/components/*.tsx --out-dir dist --config-file .swcrc --strip-leading-paths",
+    "build:tsx": "cd src && swc email/templates/password-reset.tsx email/templates/invitation.tsx email/templates/email-change-verification.tsx email/templates/components/*.tsx --out-dir ../dist --config-file ../.swcrc",
     "dev": "TS_NODE_TRANSPILE_ONLY=true node --env-file=.env --require ts-node/register src/main.ts",
     "start": "nest start",
     "start:prod": "node dist/main",

--- a/packages/manifest/backend/src/flow/flow.service.spec.ts
+++ b/packages/manifest/backend/src/flow/flow.service.spec.ts
@@ -24,7 +24,7 @@ import {
 import {
   createMockFlowEntity,
   createMockAppEntity,
-  createMockStatCardNode,
+  createMockRegistryComponentNode,
 } from './test/fixtures';
 
 describe('FlowService', () => {
@@ -415,13 +415,13 @@ describe('FlowService', () => {
       expect(mockFlowRepository.remove).toHaveBeenCalledWith(mockEntity);
     });
 
-    it('should return correct view count when deleting flow with StatCard nodes', async () => {
+    it('should return correct view count when deleting flow with UI nodes', async () => {
       const mockEntity = createMockFlowEntity({
         id: 'with-views',
         nodes: [
-          createMockStatCardNode({ id: '1' }),
-          createMockStatCardNode({ id: '2' }),
-          createMockStatCardNode({ id: '3' }),
+          createMockRegistryComponentNode({ id: '1' }),
+          createMockRegistryComponentNode({ id: '2' }),
+          createMockRegistryComponentNode({ id: '3' }),
         ],
       });
       mockFlowRepository.findOne!.mockResolvedValue(mockEntity);
@@ -432,11 +432,11 @@ describe('FlowService', () => {
       expect(result.deletedViewCount).toBe(3);
     });
 
-    it('should only count StatCard nodes in deletedViewCount', async () => {
+    it('should only count UI component nodes in deletedViewCount', async () => {
       const mockEntity = createMockFlowEntity({
         id: 'mixed-nodes',
         nodes: [
-          createMockStatCardNode({ id: '1' }),
+          createMockRegistryComponentNode({ id: '1' }),
           { id: '2', type: 'UserIntent', name: 'Trigger', slug: 'trigger', position: { x: 0, y: 0 }, parameters: {} },
           { id: '3', type: 'Return', name: 'Return', slug: 'return', position: { x: 0, y: 0 }, parameters: {} },
         ],

--- a/packages/manifest/backend/src/flow/flow.service.ts
+++ b/packages/manifest/backend/src/flow/flow.service.ts
@@ -139,8 +139,8 @@ export class FlowService {
       throw new NotFoundException(`Flow with id ${id} not found`);
     }
 
-    // Count StatCard nodes (UI components) for backward compatibility in response
-    const deletedViewCount = (entity.nodes ?? []).filter((n) => n.type === 'StatCard').length;
+    // Count UI component nodes for backward compatibility in response
+    const deletedViewCount = (entity.nodes ?? []).filter((n) => n.type === 'RegistryComponent' || n.type === 'BlankComponent').length;
 
     await this.flowRepository.remove(entity);
 

--- a/packages/manifest/backend/src/flow/test/fixtures.ts
+++ b/packages/manifest/backend/src/flow/test/fixtures.ts
@@ -62,19 +62,22 @@ export function createMockUserIntentNode(
 }
 
 /**
- * Creates a mock StatCard node
+ * Creates a mock RegistryComponent node
  * @param overrides - Optional partial to override defaults
  */
-export function createMockStatCardNode(
+export function createMockRegistryComponentNode(
   overrides: Partial<NodeInstance> = {},
 ): NodeInstance {
   return createMockNodeInstance({
-    id: 'statcard-1',
-    type: 'StatCard',
-    name: 'Test StatCard',
-    slug: 'test-statcard',
+    id: 'registry-1',
+    type: 'RegistryComponent',
+    name: 'Test Registry Component',
+    slug: 'test-registry-component',
     parameters: {
-      layoutTemplate: 'stat-card',
+      registryName: 'event-list',
+      title: 'Event List',
+      files: [],
+      actions: [],
     },
     ...overrides,
   });

--- a/packages/manifest/backend/src/mcp/mcp.tool.spec.ts
+++ b/packages/manifest/backend/src/mcp/mcp.tool.spec.ts
@@ -26,14 +26,13 @@ import {
   createMockAppEntity,
   createMockFlowEntity,
   createMockUserIntentNode,
-  createMockStatCardNode,
+  createMockRegistryComponentNode,
   createMockReturnNode,
   createMockCallFlowNode,
-  createMockPostListNode,
   createMockConnection,
   createMockFlowExecutionService,
   createSimpleTriggerReturnFlow,
-  createTriggerStatCardFlow,
+  createTriggerRegistryComponentFlow,
 } from './test/fixtures';
 
 // Mock the node modules that make actual HTTP calls
@@ -296,17 +295,17 @@ describe('McpToolService', () => {
       });
     });
 
-    it('should add _meta for flows with StatCard nodes', async () => {
+    it('should add _meta for flows with RegistryComponent nodes', async () => {
       const mockApp = createMockAppEntity({ id: 'app-1', slug: 'my-app' });
       mockAppRepository.findOne!.mockResolvedValue(mockApp);
 
-      const flow = createTriggerStatCardFlow({ toolName: 'stats_tool' });
+      const flow = createTriggerRegistryComponentFlow({ toolName: 'ui_tool' });
       mockFlowRepository.find!.mockResolvedValue([flow]);
 
       const result = await service.listTools('my-app');
 
       expect(result[0]._meta).toBeDefined();
-      expect(result[0]._meta?.['openai/outputTemplate']).toBe('ui://widget/my-app/stats_tool.html');
+      expect(result[0]._meta?.['openai/outputTemplate']).toBe('ui://widget/my-app/ui_tool/registry-1.html');
     });
   });
 
@@ -448,18 +447,18 @@ describe('McpToolService', () => {
       expect(result.content).toBeDefined();
     });
 
-    it('should execute StatCard node and return structuredContent', async () => {
+    it('should execute RegistryComponent node and return structuredContent', async () => {
       const mockApp = createMockAppEntity({ slug: 'test-app' });
       mockAppRepository.findOne!.mockResolvedValue(mockApp);
 
-      const flow = createTriggerStatCardFlow({ toolName: 'stats_tool' });
+      const flow = createTriggerRegistryComponentFlow({ toolName: 'ui_tool' });
       mockFlowRepository.find!.mockResolvedValue([flow]);
 
-      const result = await service.executeTool('test-app', 'stats_tool', { message: 'get stats' });
+      const result = await service.executeTool('test-app', 'ui_tool', { message: 'get ui' });
 
       expect(result.structuredContent).toBeDefined();
       expect(result._meta).toBeDefined();
-      expect(result._meta?.['openai/outputTemplate']).toContain('stats_tool.html');
+      expect(result._meta?.['openai/outputTemplate']).toContain('ui_tool');
     });
 
     it('should record error in execution when flow fails', async () => {
@@ -855,7 +854,7 @@ describe('McpToolService', () => {
       const mockApp = createMockAppEntity();
       mockAppRepository.findOne!.mockResolvedValue(mockApp);
 
-      const postListNode = createMockPostListNode({ id: 'postlist-1' });
+      const postListNode = createMockRegistryComponentNode({ id: 'registry-1' });
       const flow = createMockFlowEntity({
         nodes: [
           createMockUserIntentNode({ toolName: 'test_tool' }),
@@ -865,7 +864,7 @@ describe('McpToolService', () => {
           createMockConnection({
             sourceNodeId: 'trigger-1',
             sourceHandle: 'output',
-            targetNodeId: 'postlist-1',
+            targetNodeId: 'registry-1',
           }),
         ],
       });
@@ -873,7 +872,7 @@ describe('McpToolService', () => {
 
       const result = await service.executeAction('test-app', {
         toolName: 'test_tool',
-        nodeId: 'postlist-1',
+        nodeId: 'registry-1',
         action: 'onReadMore',
         data: { postId: '123' },
       });
@@ -888,7 +887,7 @@ describe('McpToolService', () => {
       const flow = createMockFlowEntity({
         nodes: [
           createMockUserIntentNode({ toolName: 'test_tool' }),
-          createMockPostListNode({ id: 'postlist-1' }),
+          createMockRegistryComponentNode({ id: 'registry-1' }),
           createMockReturnNode({ id: 'return-1', text: 'Action executed!' }),
         ],
         connections: [
@@ -896,12 +895,12 @@ describe('McpToolService', () => {
             id: 'conn-1',
             sourceNodeId: 'trigger-1',
             sourceHandle: 'output',
-            targetNodeId: 'postlist-1',
+            targetNodeId: 'registry-1',
             targetHandle: 'input',
           }),
           createMockConnection({
             id: 'conn-2',
-            sourceNodeId: 'postlist-1',
+            sourceNodeId: 'registry-1',
             sourceHandle: 'action:onReadMore',
             targetNodeId: 'return-1',
             targetHandle: 'input',
@@ -912,7 +911,7 @@ describe('McpToolService', () => {
 
       const result = await service.executeAction('test-app', {
         toolName: 'test_tool',
-        nodeId: 'postlist-1',
+        nodeId: 'registry-1',
         action: 'onReadMore',
         data: { postId: '123' },
       });
@@ -931,7 +930,7 @@ describe('McpToolService', () => {
         const flow = createMockFlowEntity({
           nodes: [
             createMockUserIntentNode({ toolName: 'test_tool' }),
-            createMockPostListNode({ id: 'postlist-1' }),
+            createMockRegistryComponentNode({ id: 'registry-1' }),
             createMockReturnNode({ id: 'return-1', text: 'Action executed!' }),
           ],
           connections: [
@@ -939,12 +938,12 @@ describe('McpToolService', () => {
               id: 'conn-1',
               sourceNodeId: 'trigger-1',
               sourceHandle: 'output',
-              targetNodeId: 'postlist-1',
+              targetNodeId: 'registry-1',
               targetHandle: 'input',
             }),
             createMockConnection({
               id: 'conn-2',
-              sourceNodeId: 'postlist-1',
+              sourceNodeId: 'registry-1',
               sourceHandle: 'action:onReadMore',
               targetNodeId: 'return-1',
               targetHandle: 'input',
@@ -958,7 +957,7 @@ describe('McpToolService', () => {
           'test-app',
           {
             toolName: 'test_tool',
-            nodeId: 'postlist-1',
+            nodeId: 'registry-1',
             action: 'onReadMore',
             data: { postId: '123' },
           },
@@ -979,7 +978,7 @@ describe('McpToolService', () => {
         const flow = createMockFlowEntity({
           nodes: [
             createMockUserIntentNode({ toolName: 'test_tool' }),
-            createMockPostListNode({ id: 'postlist-1' }),
+            createMockRegistryComponentNode({ id: 'registry-1' }),
             createMockReturnNode({ id: 'return-1', text: 'Done!' }),
           ],
           connections: [
@@ -987,12 +986,12 @@ describe('McpToolService', () => {
               id: 'conn-1',
               sourceNodeId: 'trigger-1',
               sourceHandle: 'output',
-              targetNodeId: 'postlist-1',
+              targetNodeId: 'registry-1',
               targetHandle: 'input',
             }),
             createMockConnection({
               id: 'conn-2',
-              sourceNodeId: 'postlist-1',
+              sourceNodeId: 'registry-1',
               sourceHandle: 'action:onReadMore',
               targetNodeId: 'return-1',
               targetHandle: 'input',
@@ -1003,7 +1002,7 @@ describe('McpToolService', () => {
 
         await service.executeAction('test-app', {
           toolName: 'test_tool',
-          nodeId: 'postlist-1',
+          nodeId: 'registry-1',
           action: 'onReadMore',
           data: { postId: '123' },
         });
@@ -1029,17 +1028,17 @@ describe('McpToolService', () => {
       expect(result).toEqual([]);
     });
 
-    it('should return resources for flows with StatCard nodes', async () => {
+    it('should return resources for flows with RegistryComponent nodes', async () => {
       const mockApp = createMockAppEntity({ slug: 'my-app' });
       mockAppRepository.findOne!.mockResolvedValue(mockApp);
 
-      const flow = createTriggerStatCardFlow({ toolName: 'stats_tool' });
+      const flow = createTriggerRegistryComponentFlow({ toolName: 'ui_tool' });
       mockFlowRepository.find!.mockResolvedValue([flow]);
 
       const result = await service.listResources('my-app');
 
       expect(result).toHaveLength(1);
-      expect(result[0].uri).toBe('ui://widget/my-app/stats_tool.html');
+      expect(result[0].uri).toBe('ui://widget/my-app/ui_tool/registry-1.html');
       expect(result[0].mimeType).toBe('text/html+skybridge');
     });
 
@@ -1053,7 +1052,7 @@ describe('McpToolService', () => {
             toolName: 'inactive_tool',
             isActive: false,
           }),
-          createMockStatCardNode(),
+          createMockRegistryComponentNode(),
         ],
       });
       mockFlowRepository.find!.mockResolvedValue([flow]);
@@ -1113,22 +1112,21 @@ describe('McpToolService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
-    it('should return widget HTML for StatCard flow', async () => {
+    it('should return widget HTML for RegistryComponent flow', async () => {
       const mockApp = createMockAppEntity({ slug: 'test-app', id: 'app-1' });
       mockAppRepository.findOne!.mockResolvedValue(mockApp);
 
-      const flow = createTriggerStatCardFlow({ toolName: 'stats_tool' });
+      const flow = createTriggerRegistryComponentFlow({ toolName: 'ui_tool' });
       mockFlowRepository.find!.mockResolvedValue([flow]);
 
       const result = await service.readResource(
         'test-app',
-        'ui://widget/test-app/stats_tool.html',
+        'ui://widget/test-app/ui_tool/registry-1.html',
       );
 
-      expect(result.uri).toBe('ui://widget/test-app/stats_tool.html');
+      expect(result.uri).toBe('ui://widget/test-app/ui_tool/registry-1.html');
       expect(result.mimeType).toBe('text/html+skybridge');
       expect(result.text).toContain('<!DOCTYPE html>');
-      expect(result.text).toContain('stats-grid');
     });
 
     it('should return callflow widget HTML', async () => {

--- a/packages/manifest/backend/src/mcp/test/fixtures.ts
+++ b/packages/manifest/backend/src/mcp/test/fixtures.ts
@@ -108,19 +108,23 @@ export function createMockUserIntentNode(
 }
 
 /**
- * Creates a mock StatCard node
+ * Creates a mock RegistryComponent node
  * @param overrides - Optional partial to override defaults
  */
-export function createMockStatCardNode(
+export function createMockRegistryComponentNode(
   overrides: Partial<NodeInstance> = {},
 ): NodeInstance {
   return createMockNodeInstance({
-    id: 'statcard-1',
-    type: 'StatCard',
-    name: 'Test StatCard',
-    slug: 'test-statcard',
+    id: 'registry-1',
+    type: 'RegistryComponent',
+    name: 'Test Registry Component',
+    slug: 'test-registry-component',
     parameters: {
-      layoutTemplate: 'stat-card',
+      registryName: 'event-list',
+      title: 'Event List',
+      description: 'Display events',
+      files: [],
+      actions: [],
     },
     ...overrides,
   });
@@ -181,23 +185,6 @@ export function createMockCallFlowNode(
     parameters: {
       targetFlowId: overrides.targetFlowId ?? 'target-flow-id',
     },
-    ...overrides,
-  });
-}
-
-/**
- * Creates a mock PostList node
- * @param overrides - Optional partial to override defaults
- */
-export function createMockPostListNode(
-  overrides: Partial<NodeInstance> = {},
-): NodeInstance {
-  return createMockNodeInstance({
-    id: 'postlist-1',
-    type: 'PostList',
-    name: 'Test Post List',
-    slug: 'test-post-list',
-    parameters: {},
     ...overrides,
   });
 }
@@ -368,31 +355,31 @@ export function createSimpleTriggerReturnFlow(options: {
 }
 
 /**
- * Creates a trigger -> statcard flow for testing UI widgets
+ * Creates a trigger -> registry component flow for testing UI widgets
  */
-export function createTriggerStatCardFlow(options: {
+export function createTriggerRegistryComponentFlow(options: {
   toolName?: string;
 } = {}): FlowEntity {
   const triggerId = 'trigger-1';
-  const statCardId = 'statcard-1';
+  const registryId = 'registry-1';
 
   const trigger = createMockUserIntentNode({
     id: triggerId,
-    toolName: options.toolName ?? 'stats_tool',
+    toolName: options.toolName ?? 'ui_tool',
   });
 
-  const statCard = createMockStatCardNode({ id: statCardId });
+  const registryComponent = createMockRegistryComponentNode({ id: registryId });
 
   const connection = createMockConnection({
     id: 'conn-1',
     sourceNodeId: triggerId,
     sourceHandle: 'output',
-    targetNodeId: statCardId,
+    targetNodeId: registryId,
     targetHandle: 'input',
   });
 
   return createMockFlowEntity({
-    nodes: [trigger, statCard],
+    nodes: [trigger, registryComponent],
     connections: [connection],
   });
 }

--- a/packages/manifest/backend/src/node/node.service.spec.ts
+++ b/packages/manifest/backend/src/node/node.service.spec.ts
@@ -24,7 +24,7 @@ import {
   createMockNodeInstance,
   createMockUserIntentNode,
   createMockApiCallNode,
-  createMockStatCardNode,
+  createMockRegistryComponentNode,
   createMockLinkNode,
   createMockConnection,
   createMockCreateNodeRequest,
@@ -643,7 +643,7 @@ describe('NodeService', () => {
 
     it('should allow Link node connection from UI node', async () => {
       const nodes = [
-        createMockStatCardNode({ id: 'statcard' }),
+        createMockRegistryComponentNode({ id: 'statcard' }),
         createMockLinkNode({ id: 'link' }),
       ];
       const flow = createMockFlowEntity({ nodes, connections: [] });

--- a/packages/manifest/backend/src/node/node.service.ts
+++ b/packages/manifest/backend/src/node/node.service.ts
@@ -385,9 +385,9 @@ export class NodeService {
     // Link nodes can only receive connections from interface (UI) nodes
     if (targetNode.type === 'Link') {
       const sourceNode = nodes.find((n) => n.id === request.sourceNodeId);
-      const INTERFACE_NODE_TYPES = ['StatCard', 'PostList'];
+      const INTERFACE_NODE_TYPES = ['RegistryComponent', 'BlankComponent'];
       if (!sourceNode || !INTERFACE_NODE_TYPES.includes(sourceNode.type)) {
-        throw new BadRequestException('Link nodes can only be connected after UI nodes (like StatCard or PostList).');
+        throw new BadRequestException('Link nodes can only be connected after UI nodes (like RegistryComponent).');
       }
     }
 

--- a/packages/manifest/backend/src/node/schema/schema.service.spec.ts
+++ b/packages/manifest/backend/src/node/schema/schema.service.spec.ts
@@ -24,7 +24,7 @@ import {
   createMockUserIntentNode,
   createMockApiCallNode,
   createMockApiCallNodeWithSchema,
-  createMockStatCardNode,
+  createMockRegistryComponentNode,
   createMockReturnNode,
   createMockLinkNode,
   createMockTransformNode,
@@ -344,7 +344,7 @@ describe('SchemaService', () => {
 
     it('should allow Link node from interface node', async () => {
       const nodes = [
-        createMockStatCardNode({ id: 'statcard' }),
+        createMockRegistryComponentNode({ id: 'statcard' }),
         createMockLinkNode({ id: 'link' }),
       ];
       const connections = [

--- a/packages/manifest/backend/src/node/schema/test/fixtures.ts
+++ b/packages/manifest/backend/src/node/schema/test/fixtures.ts
@@ -114,18 +114,21 @@ export function createMockApiCallNodeWithSchema(
 }
 
 /**
- * Creates a mock StatCard node
+ * Creates a mock RegistryComponent node
  */
-export function createMockStatCardNode(
+export function createMockRegistryComponentNode(
   overrides: Partial<NodeInstance> = {},
 ): NodeInstance {
   return createMockNodeInstance({
-    id: 'statcard-1',
-    type: 'StatCard',
-    name: 'Stat Card',
-    slug: 'stat-card',
+    id: 'registry-1',
+    type: 'RegistryComponent',
+    name: 'Registry Component',
+    slug: 'registry-component',
     parameters: {
-      layoutTemplate: 'stat-card',
+      registryName: 'event-list',
+      title: 'Event List',
+      files: [],
+      actions: [],
     },
     ...overrides,
   });

--- a/packages/manifest/backend/src/node/test/fixtures.ts
+++ b/packages/manifest/backend/src/node/test/fixtures.ts
@@ -99,18 +99,22 @@ export function createMockApiCallNode(
 }
 
 /**
- * Creates a mock StatCard UI node
+ * Creates a mock RegistryComponent UI node
  */
-export function createMockStatCardNode(
+export function createMockRegistryComponentNode(
   overrides: Partial<NodeInstance> = {},
 ): NodeInstance {
   return createMockNodeInstance({
-    id: 'statcard-1',
-    type: 'StatCard',
-    name: 'Stat Card',
-    slug: 'stat-card',
+    id: 'registry-1',
+    type: 'RegistryComponent',
+    name: 'Registry Component',
+    slug: 'registry-component',
     parameters: {
-      layoutTemplate: 'stat-card',
+      registryName: 'event-list',
+      title: 'Event List',
+      description: 'Display events',
+      files: [],
+      actions: [],
     },
     ...overrides,
   });

--- a/packages/manifest/backend/src/seed/seed.service.spec.ts
+++ b/packages/manifest/backend/src/seed/seed.service.spec.ts
@@ -113,11 +113,14 @@ function createMockUserIntentNode(overrides: Partial<NodeInstance> = {}): NodeIn
 function createMockActionNode(overrides: Partial<NodeInstance> = {}): NodeInstance {
   return {
     id: 'action-node-id',
-    type: 'StatCard',
+    type: 'RegistryComponent',
     name: 'Test Action',
     position: { x: 300, y: 100 },
     parameters: {
-      layoutTemplate: 'stat-card',
+      registryName: 'event-list',
+      title: 'Event List',
+      files: [],
+      actions: [],
     },
     ...overrides,
   } as NodeInstance;

--- a/packages/manifest/backend/src/seed/seed.service.ts
+++ b/packages/manifest/backend/src/seed/seed.service.ts
@@ -239,7 +239,7 @@ export class SeedService implements OnModuleInit {
    * Seed default fixtures if no apps exist.
    * Creates:
    * - EventHub app (slug: eventhub) owned by admin user
-   * - "Search events in a city" flow with UserIntent trigger and StatCard node
+   * - "Search events in a city" flow with UserIntent trigger and Return node
    */
   private async seedDefaultFixtures(adminUserId: string | undefined): Promise<void> {
     // Check if any apps exist

--- a/packages/manifest/frontend/src/components/editor/InterfaceEditor.tsx
+++ b/packages/manifest/frontend/src/components/editor/InterfaceEditor.tsx
@@ -64,11 +64,9 @@ export interface InterfaceEditorProps {
 // Map component types to layout templates
 function getLayoutTemplate(componentType: string): 'stat-card' | 'post-list' | 'blank-component' {
   switch (componentType) {
-    case 'PostList':
-      return 'post-list';
     case 'BlankComponent':
       return 'blank-component';
-    case 'StatCard':
+    case 'RegistryComponent':
     default:
       return 'stat-card';
   }
@@ -193,8 +191,8 @@ export function InterfaceEditor({
 
     // Built-in templates use predefined sample data
     const templateMap: Record<string, string> = {
-      'StatCard': 'stat-card',
-      'PostList': 'post-list',
+      'RegistryComponent': 'stat-card',
+      'BlankComponent': 'blank-component',
     };
     const template = templateMap[componentType] || 'stat-card';
     return getTemplateSampleData(template as 'stat-card' | 'post-list');

--- a/packages/manifest/frontend/src/components/editor/InterfaceEditor.tsx
+++ b/packages/manifest/frontend/src/components/editor/InterfaceEditor.tsx
@@ -142,7 +142,7 @@ function extractDemoDataFromFiles(
  */
 export function InterfaceEditor({
   nodeName: initialNodeName,
-  componentType = 'StatCard',
+  componentType = 'BlankComponent',
   initialCode,
   initialAppearanceConfig,
   appearanceOptions,

--- a/packages/manifest/frontend/src/components/execution/NodeExecutionCard.tsx
+++ b/packages/manifest/frontend/src/components/execution/NodeExecutionCard.tsx
@@ -15,7 +15,8 @@ interface NodeExecutionCardProps {
 // Map node types to their icons
 const nodeTypeIcons: Record<string, typeof Box> = {
   UserIntent: Zap,
-  StatCard: LayoutTemplate,
+  RegistryComponent: LayoutTemplate,
+  BlankComponent: LayoutTemplate,
   Return: CornerDownLeft,
   CallFlow: GitBranch,
   ApiCall: Globe,
@@ -27,7 +28,8 @@ type NodeCategory = 'trigger' | 'interface' | 'action' | 'return' | 'transform' 
 
 const nodeTypeCategories: Record<string, NodeCategory> = {
   UserIntent: 'trigger',
-  StatCard: 'interface',
+  RegistryComponent: 'interface',
+  BlankComponent: 'interface',
   Return: 'return',
   CallFlow: 'action',
   ApiCall: 'action',

--- a/packages/manifest/frontend/src/components/flow/FlowDiagram.tsx
+++ b/packages/manifest/frontend/src/components/flow/FlowDiagram.tsx
@@ -114,7 +114,7 @@ const INTERFACE_NODE_TYPES: NodeType[] = ['RegistryComponent', 'BlankComponent']
 
 /**
  * Visual diagram of nodes using React Flow
- * Displays UserIntent trigger nodes followed by StatCard, Return, CallFlow, or ApiCall nodes
+ * Displays UserIntent trigger nodes followed by UI components, Return, CallFlow, or ApiCall nodes
  */
 function FlowDiagramInner({
   flow,
@@ -412,7 +412,7 @@ function FlowDiagramInner({
     }
   }, []);
 
-  // Generate base nodes: UserIntent nodes + StatCard/Return/CallFlow/ApiCall nodes
+  // Generate base nodes: UserIntent nodes + UI/Return/CallFlow/ApiCall nodes
   const computedNodes = useMemo<Node[]>(() => {
     const nodeList: Node[] = [];
 
@@ -797,7 +797,7 @@ function FlowDiagramInner({
           </div>
           <div className="p-6">
             <p className="text-gray-700 mb-4">
-              The <strong>Link</strong> node can only be connected after <strong>UI nodes</strong> (like StatCard).
+              The <strong>Link</strong> node can only be connected after <strong>UI nodes</strong>.
             </p>
             <p className="text-sm text-gray-500">
               Link nodes open external URLs and are designed to work with user interface components that display information before redirecting the user.

--- a/packages/manifest/frontend/src/components/flow/FlowDiagram.tsx
+++ b/packages/manifest/frontend/src/components/flow/FlowDiagram.tsx
@@ -72,8 +72,6 @@ interface FlowDiagramProps {
 function getFlowState(flow: Flow) {
   const nodes = flow.nodes ?? [];
   const userIntentNodes = nodes.filter(n => n.type === 'UserIntent');
-  const statCardNodes = nodes.filter(n => n.type === 'StatCard');
-  const postListNodes = nodes.filter(n => n.type === 'PostList');
   const registryComponentNodes = nodes.filter(n => n.type === 'RegistryComponent');
   const blankComponentNodes = nodes.filter(n => n.type === 'BlankComponent');
   const returnNodes = nodes.filter(n => n.type === 'Return');
@@ -82,8 +80,6 @@ function getFlowState(flow: Flow) {
   const transformNodes = nodes.filter(n => n.type === 'JavaScriptCodeTransform');
   const linkNodes = nodes.filter(n => n.type === 'Link');
   const hasUserIntentNodes = userIntentNodes.length > 0;
-  const hasStatCardNodes = statCardNodes.length > 0;
-  const hasPostListNodes = postListNodes.length > 0;
   const hasRegistryComponentNodes = registryComponentNodes.length > 0;
   const hasBlankComponentNodes = blankComponentNodes.length > 0;
   const hasReturnNodes = returnNodes.length > 0;
@@ -91,8 +87,8 @@ function getFlowState(flow: Flow) {
   const hasApiCallNodes = apiCallNodes.length > 0;
   const hasTransformNodes = transformNodes.length > 0;
   const hasLinkNodes = linkNodes.length > 0;
-  const hasSteps = hasStatCardNodes || hasPostListNodes || hasRegistryComponentNodes || hasBlankComponentNodes || hasReturnNodes || hasCallFlowNodes || hasApiCallNodes || hasTransformNodes || hasLinkNodes;
-  return { hasUserIntentNodes, hasStatCardNodes, hasPostListNodes, hasRegistryComponentNodes, hasBlankComponentNodes, hasReturnNodes, hasCallFlowNodes, hasApiCallNodes, hasTransformNodes, hasLinkNodes, hasSteps, userIntentNodes, statCardNodes, postListNodes, registryComponentNodes, blankComponentNodes, returnNodes, callFlowNodes, apiCallNodes, transformNodes, linkNodes };
+  const hasSteps = hasRegistryComponentNodes || hasBlankComponentNodes || hasReturnNodes || hasCallFlowNodes || hasApiCallNodes || hasTransformNodes || hasLinkNodes;
+  return { hasUserIntentNodes, hasRegistryComponentNodes, hasBlankComponentNodes, hasReturnNodes, hasCallFlowNodes, hasApiCallNodes, hasTransformNodes, hasLinkNodes, hasSteps, userIntentNodes, registryComponentNodes, blankComponentNodes, returnNodes, callFlowNodes, apiCallNodes, transformNodes, linkNodes };
 }
 
 const nodeTypes = {
@@ -114,7 +110,7 @@ const edgeTypes = {
 
 // Node types that belong to the 'interface' category (UI nodes)
 // Defined outside component for stable reference in dependency arrays
-const INTERFACE_NODE_TYPES: NodeType[] = ['StatCard', 'PostList', 'RegistryComponent', 'BlankComponent'];
+const INTERFACE_NODE_TYPES: NodeType[] = ['RegistryComponent', 'BlankComponent'];
 
 /**
  * Visual diagram of nodes using React Flow
@@ -462,50 +458,6 @@ function FlowDiagramInner({
     }
 
     // Always render UI and other nodes (regardless of whether triggers exist)
-    // Add StatCard nodes (no "+" button - UI nodes only have action handles)
-    flowState.statCardNodes.forEach((node) => {
-      // Use saved position or calculate based on order
-      const nodePos = node.position || { x: xPosition, y: 130 };
-
-      nodeList.push({
-        id: node.id,
-        type: 'viewNode',
-        position: nodePos,
-        data: {
-          node,
-          canDelete,
-          onEdit: () => onNodeEdit(node),
-          onDelete: () => onNodeDelete(node),
-          onEditCode: onNodeEditCode ? () => onNodeEditCode(node) : undefined,
-          // No onAddFromNode/onDropOnNode - UI nodes don't have "+" button
-        },
-      });
-
-      // Update xPosition for next node without saved position
-      xPosition = Math.max(xPosition, nodePos.x) + 280;
-    });
-
-    // Add PostList nodes (no "+" button - UI nodes only have action handles)
-    flowState.postListNodes.forEach((node) => {
-      const nodePos = node.position || { x: xPosition, y: 130 };
-
-      nodeList.push({
-        id: node.id,
-        type: 'viewNode',
-        position: nodePos,
-        data: {
-          node,
-          canDelete,
-          onEdit: () => onNodeEdit(node),
-          onDelete: () => onNodeDelete(node),
-          onEditCode: onNodeEditCode ? () => onNodeEditCode(node) : undefined,
-          // No onAddFromNode/onDropOnNode - UI nodes don't have "+" button
-        },
-      });
-
-      xPosition = Math.max(xPosition, nodePos.x) + 280;
-    });
-
     // Add RegistryComponent nodes (dynamic UI components from registry)
     flowState.registryComponentNodes.forEach((node) => {
       const nodePos = node.position || { x: xPosition, y: 130 };
@@ -722,7 +674,7 @@ function FlowDiagramInner({
         strokeColor = '#60a5fa'; // Default blue
         if (sourceNode.type === 'UserIntent') {
           strokeColor = '#60a5fa'; // Blue for user intent
-        } else if (sourceNode.type === 'StatCard' || sourceNode.type === 'PostList' || sourceNode.type === 'RegistryComponent' || sourceNode.type === 'BlankComponent') {
+        } else if (sourceNode.type === 'RegistryComponent' || sourceNode.type === 'BlankComponent') {
           strokeColor = '#60a5fa'; // Blue for interface
         } else if (sourceNode.type === 'Return') {
           strokeColor = '#22c55e'; // Green for return

--- a/packages/manifest/frontend/src/components/flow/NodeEditModal.tsx
+++ b/packages/manifest/frontend/src/components/flow/NodeEditModal.tsx
@@ -86,7 +86,7 @@ const DEFAULT_TRANSFORM_CODE = `function transform(input: Input) {
 
 
 /**
- * Modal for creating and editing nodes (StatCard, Return, CallFlow, UserIntent, ApiCall)
+ * Modal for creating and editing nodes (Return, CallFlow, UserIntent, ApiCall, RegistryComponent)
  */
 export function NodeEditModal({
   isOpen,
@@ -232,9 +232,7 @@ export function NodeEditModal({
       // Edit mode - populate from existing node
       setName(node.name);
 
-      if (node.type === 'StatCard' || node.type === 'PostList') {
-        // UI nodes (StatCard, PostList) use unified InterfaceEditor, no parameters to set here
-      } else if (node.type === 'Return') {
+      if (node.type === 'Return') {
         const params = node.parameters as unknown as ReturnNodeParameters;
         setText(params?.text || '');
       } else if (node.type === 'CallFlow') {
@@ -269,7 +267,7 @@ export function NodeEditModal({
     } else {
       // Create mode - set defaults
       setName('');
-      // Note: StatCard uses unified InterfaceEditor, no layout template state needed
+      // Note: RegistryComponent/BlankComponent use unified InterfaceEditor, no layout template state needed
       setText('');
       setTargetFlowId(null);
       setWhenToUse('');
@@ -298,7 +296,7 @@ export function NodeEditModal({
 
     let parameters: Record<string, unknown> = {};
 
-    if (effectiveNodeType === 'StatCard' || effectiveNodeType === 'PostList' || effectiveNodeType === 'RegistryComponent') {
+    if (effectiveNodeType === 'RegistryComponent' || effectiveNodeType === 'BlankComponent') {
       // UI nodes use the unified InterfaceEditor for code editing, not this modal
       // No parameters needed here - RegistryComponent params are merged in handleSaveNode
       parameters = {};
@@ -410,13 +408,6 @@ export function NodeEditModal({
   // Get icon and title based on node type
   const getNodeTypeInfo = () => {
     switch (effectiveNodeType) {
-      case 'StatCard':
-        return {
-          icon: <LayoutGrid className="w-5 h-5 text-gray-600" />,
-          title: isEditMode ? 'Edit Stat Card' : 'Create Stat Card',
-          description: 'Display statistics and metrics',
-          color: 'gray',
-        };
       case 'Return':
         return {
           icon: <FileText className="w-5 h-5 text-green-600" />,
@@ -451,13 +442,6 @@ export function NodeEditModal({
           title: isEditMode ? 'Edit JavaScript Transform' : 'Create JavaScript Transform',
           description: 'Transform data using custom JavaScript code',
           color: 'teal',
-        };
-      case 'PostList':
-        return {
-          icon: <LayoutGrid className="w-5 h-5 text-gray-600" />,
-          title: isEditMode ? 'Edit Post List' : 'Create Post List',
-          description: 'Display a list of posts with actions',
-          color: 'gray',
         };
       case 'Link':
         return {
@@ -589,7 +573,7 @@ export function NodeEditModal({
             </div>
 
             {/* UI nodes use unified InterfaceEditor for code editing */}
-            {(effectiveNodeType === 'StatCard' || effectiveNodeType === 'PostList' || effectiveNodeType === 'RegistryComponent') && (
+            {(effectiveNodeType === 'RegistryComponent' || effectiveNodeType === 'BlankComponent') && (
               <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
                 <p className="text-sm text-blue-700">
                   {effectiveNodeType === 'RegistryComponent'

--- a/packages/manifest/frontend/src/components/flow/ViewNode.tsx
+++ b/packages/manifest/frontend/src/components/flow/ViewNode.tsx
@@ -1,7 +1,7 @@
 import { Handle, Position, useUpdateNodeInternals } from '@xyflow/react';
 import type { NodeProps } from '@xyflow/react';
 import { useEffect, useMemo, memo } from 'react';
-import { LAYOUT_REGISTRY, type NodeInstance, type LayoutTemplate, type StatCardNodeParameters, type NodeType } from '@manifest/shared';
+import { LAYOUT_REGISTRY, type NodeInstance, type LayoutTemplate, type NodeType } from '@manifest/shared';
 import { LayoutGrid, Code2 } from 'lucide-react';
 import { ViewNodeDropdown } from './ViewNodeDropdown';
 import { AddNodeButton } from './AddNodeButton';
@@ -27,9 +27,9 @@ export const ViewNode = memo(function ViewNode({ data, id }: NodeProps) {
   const { node, canDelete, onEdit, onDelete, onEditCode, onAddFromNode, onDropOnNode } = data as ViewNodeData;
   const updateNodeInternals = useUpdateNodeInternals();
 
-  // Get parameters with type safety
-  const params = node.parameters as unknown as StatCardNodeParameters;
-  const layoutTemplate = params?.layoutTemplate || 'stat-card';
+  // Get parameters (used for legacy StatCard/PostList nodes if any exist in DB)
+  const params = node.parameters as Record<string, unknown>;
+  const layoutTemplate = (params?.layoutTemplate as string) || 'stat-card';
   const hasCustomCode = Boolean((params as unknown as Record<string, unknown>)?.customCode);
 
   // Look up actions for this node's layout template

--- a/packages/manifest/frontend/src/components/flow/ViewNode.tsx
+++ b/packages/manifest/frontend/src/components/flow/ViewNode.tsx
@@ -19,7 +19,7 @@ export interface ViewNodeData extends Record<string, unknown> {
 }
 
 /**
- * Custom React Flow node for displaying a StatCard node
+ * Custom React Flow node for displaying UI component nodes
  * Square card design matching placeholder nodes
  * Displays action handles on the right side for nodes with actions
  */

--- a/packages/manifest/frontend/src/pages/FlowDetail.tsx
+++ b/packages/manifest/frontend/src/pages/FlowDetail.tsx
@@ -9,7 +9,7 @@ import type {
   Connection,
   NodeType,
   ChatMessage,
-  StatCardNodeParameters,
+  UINodeParameters,
   RegistryNodeParameters,
 } from '@manifest/shared';
 import { Hammer, Eye, ScrollText, BarChart3, Edit, Trash2, Share2, Plus } from 'lucide-react';
@@ -297,18 +297,17 @@ function FlowDetail() {
   }, []);
 
   const handleNodeLibrarySelect = useCallback(async (nodeType: NodeType) => {
-    // For StatCard, PostList, and BlankComponent, skip the modal and create directly with defaults
-    if ((nodeType === 'StatCard' || nodeType === 'PostList' || nodeType === 'BlankComponent') && flowId && flow) {
+    // For BlankComponent, skip the modal and create directly with defaults
+    if (nodeType === 'BlankComponent' && flowId && flow) {
       const nodes = flow.nodes ?? [];
       const position = {
         x: nodes.length * 280 + 330,
         y: 100,
       };
-      const displayName = nodeType === 'StatCard' ? 'Stat Card' : nodeType === 'PostList' ? 'Post List' : 'Blank Component';
       try {
         await api.createNode(flowId, {
           type: nodeType,
-          name: displayName,
+          name: 'Blank Component',
           position,
           parameters: {},
         });
@@ -317,7 +316,7 @@ function FlowDetail() {
         // Node is added to canvas without opening editor (US3: non-disruptive add)
       } catch (err) {
         console.error(`Failed to create ${nodeType}:`, err);
-        setError(`Failed to create ${displayName} node. Please try again.`);
+        setError('Failed to create Blank Component node. Please try again.');
       }
       return;
     }
@@ -336,17 +335,16 @@ function FlowDetail() {
 
   // Handler for node type selection (from "+" button click + library selection)
   const handleNodeLibrarySelectWithConnection = useCallback(async (nodeType: NodeType) => {
-    // For StatCard, PostList, and BlankComponent, skip the modal and create directly with defaults
-    if ((nodeType === 'StatCard' || nodeType === 'PostList' || nodeType === 'BlankComponent') && flowId && pendingConnection) {
+    // For BlankComponent, skip the modal and create directly with defaults
+    if (nodeType === 'BlankComponent' && flowId && pendingConnection) {
       const position = {
         x: pendingConnection.sourcePosition.x + 280,
         y: pendingConnection.sourcePosition.y,
       };
-      const displayName = nodeType === 'StatCard' ? 'Stat Card' : nodeType === 'PostList' ? 'Post List' : 'Blank Component';
       try {
         const newNode = await api.createNode(flowId, {
           type: nodeType,
-          name: displayName,
+          name: 'Blank Component',
           position,
           parameters: {},
         });
@@ -363,7 +361,7 @@ function FlowDetail() {
         // Node is added to canvas without opening editor (US3: non-disruptive add)
       } catch (err) {
         console.error(`Failed to create ${nodeType}:`, err);
-        setError(`Failed to create ${displayName} node. Please try again.`);
+        setError('Failed to create Blank Component node. Please try again.');
       }
       return;
     }
@@ -376,17 +374,16 @@ function FlowDetail() {
 
   // Handler for dropping node on a "+" button - creates node with connection
   const handleDropOnNode = useCallback(async (nodeType: NodeType, sourceNodeId: string, sourceHandle: string, sourcePosition: { x: number; y: number }) => {
-    // For StatCard, PostList, and BlankComponent, skip the modal and create directly with defaults
-    if ((nodeType === 'StatCard' || nodeType === 'PostList' || nodeType === 'BlankComponent') && flowId) {
+    // For BlankComponent, skip the modal and create directly with defaults
+    if (nodeType === 'BlankComponent' && flowId) {
       const position = {
         x: sourcePosition.x + 280,
         y: sourcePosition.y,
       };
-      const displayName = nodeType === 'StatCard' ? 'Stat Card' : nodeType === 'PostList' ? 'Post List' : 'Blank Component';
       try {
         const newNode = await api.createNode(flowId, {
           type: nodeType,
-          name: displayName,
+          name: 'Blank Component',
           position,
           parameters: {},
         });
@@ -402,7 +399,7 @@ function FlowDetail() {
         // Node is added to canvas without opening editor (US3: non-disruptive add)
       } catch (err) {
         console.error(`Failed to create ${nodeType}:`, err);
-        setError(`Failed to create ${displayName} node. Please try again.`);
+        setError('Failed to create Blank Component node. Please try again.');
       }
       return;
     }
@@ -418,13 +415,12 @@ function FlowDetail() {
   const [dropPosition, setDropPosition] = useState<{ x: number; y: number } | null>(null);
 
   const handleDropOnCanvas = useCallback(async (nodeType: NodeType, position: { x: number; y: number }) => {
-    // For StatCard, PostList, and BlankComponent, skip the modal and create directly with defaults
-    if ((nodeType === 'StatCard' || nodeType === 'PostList' || nodeType === 'BlankComponent') && flowId) {
-      const displayName = nodeType === 'StatCard' ? 'Stat Card' : nodeType === 'PostList' ? 'Post List' : 'Blank Component';
+    // For BlankComponent, skip the modal and create directly with defaults
+    if (nodeType === 'BlankComponent' && flowId) {
       try {
         await api.createNode(flowId, {
           type: nodeType,
-          name: displayName,
+          name: 'Blank Component',
           position,
           parameters: {},
         });
@@ -550,9 +546,9 @@ function FlowDetail() {
     }
   };
 
-  // Interface node code editor handlers (StatCard, PostList, RegistryComponent, and BlankComponent)
+  // Interface node code editor handlers (RegistryComponent and BlankComponent)
   const handleNodeEditCode = useCallback((node: NodeInstance) => {
-    if (node.type === 'StatCard' || node.type === 'PostList' || node.type === 'RegistryComponent' || node.type === 'BlankComponent') {
+    if (node.type === 'RegistryComponent' || node.type === 'BlankComponent') {
       setEditingCodeNodeId(node.id);
     }
   }, []);
@@ -650,7 +646,7 @@ function FlowDetail() {
         appearanceConfig: data.appearanceConfig,
       };
     } else {
-      // For StatCard/PostList/BlankComponent, use customCode
+      // For BlankComponent, use customCode
       updatedParameters = {
         ...nodeToUpdate.parameters,
         customCode: data.code,
@@ -893,10 +889,10 @@ function FlowDetail() {
 
               {/* UI Node Editor - covers canvas and node library */}
               {editingCodeNode && flowId && (() => {
-                const params = editingCodeNode.parameters as unknown as StatCardNodeParameters;
+                const params = editingCodeNode.parameters as unknown as UINodeParameters;
 
                 // For RegistryComponent, get code from files[0].content and pass all files
-                // For BlankComponent/StatCard/PostList, use customCode
+                // For BlankComponent, use customCode
                 let initialCode: string | undefined;
                 let componentType: string = editingCodeNode.type;
                 let appearanceOptions: RegistryNodeParameters['appearanceOptions'] = undefined;

--- a/packages/manifest/nodes/src/index.ts
+++ b/packages/manifest/nodes/src/index.ts
@@ -3,7 +3,7 @@
  *
  * Node type definitions and execution logic for the flow builder.
  * This package provides:
- * - Built-in node types (StatCard, Return, CallFlow, UserIntent, ApiCall)
+ * - Built-in node types (RegistryComponent, BlankComponent, Return, CallFlow, UserIntent, ApiCall)
  * - Type definitions for creating custom nodes
  * - Node registry utilities
  */

--- a/packages/manifest/nodes/src/types.ts
+++ b/packages/manifest/nodes/src/types.ts
@@ -36,7 +36,7 @@ export interface ExecutionResult {
  * and execution engine.
  */
 export interface NodeTypeDefinition {
-  /** Internal type name (e.g., 'StatCard', 'Return', 'CallFlow') */
+  /** Internal type name (e.g., 'RegistryComponent', 'Return', 'CallFlow') */
   name: string;
 
   /** Human-readable display name (e.g., 'Stat Card') */

--- a/packages/manifest/shared/src/index.ts
+++ b/packages/manifest/shared/src/index.ts
@@ -47,7 +47,6 @@ export type {
   NodeInstance,
   Connection,
   UINodeParameters,
-  StatCardNodeParameters,
   BlankComponentNodeParameters,
   ReturnNodeParameters,
   CallFlowNodeParameters,
@@ -74,7 +73,6 @@ export type {
   TestApiCallResponse,
 } from './types/node.js';
 export {
-  isStatCardNode,
   isReturnNode,
   isCallFlowNode,
   isUserIntentNode,

--- a/packages/manifest/shared/src/types/appearance.ts
+++ b/packages/manifest/shared/src/types/appearance.ts
@@ -66,40 +66,10 @@ export interface ComponentAppearanceSchema {
  * Maps component names to their configurable appearance options.
  */
 export const COMPONENT_APPEARANCE_REGISTRY: Record<string, ComponentAppearanceSchema> = {
-  PostList: {
-    componentType: 'PostList',
-    options: [
-      {
-        key: 'variant',
-        label: 'Layout Variant',
-        type: 'enum',
-        enumValues: ['list', 'grid', 'carousel'],
-        defaultValue: 'list',
-        description: 'How posts are arranged',
-      },
-      {
-        key: 'columns',
-        label: 'Columns',
-        type: 'enum',
-        enumValues: [2, 3],
-        defaultValue: 3,
-        description: 'Number of columns in grid/carousel view',
-      },
-      {
-        key: 'showAuthor',
-        label: 'Show Author',
-        type: 'boolean',
-        defaultValue: true,
-        description: 'Display author name and avatar',
-      },
-      {
-        key: 'showCategory',
-        label: 'Show Category',
-        type: 'boolean',
-        defaultValue: true,
-        description: 'Display post category badge',
-      },
-    ],
+  // RegistryComponent: appearance options are dynamically parsed from the component's TypeScript interface
+  RegistryComponent: {
+    componentType: 'RegistryComponent',
+    options: [],
   },
 
   ProductList: {
@@ -218,12 +188,6 @@ export const COMPONENT_APPEARANCE_REGISTRY: Record<string, ComponentAppearanceSc
   // Stats component has no configurable appearance options
   Stats: {
     componentType: 'Stats',
-    options: [],
-  },
-
-  // Default for StatCard (current UI node type)
-  StatCard: {
-    componentType: 'StatCard',
     options: [],
   },
 

--- a/packages/manifest/shared/src/types/node.ts
+++ b/packages/manifest/shared/src/types/node.ts
@@ -142,8 +142,7 @@ export interface Connection {
 // =============================================================================
 
 /**
- * Parameters for UI nodes (StatCard and similar interface components).
- * New unified type replacing StatCardNodeParameters.
+ * Parameters for UI nodes (RegistryComponent and similar interface components).
  */
 export interface UINodeParameters {
   /** Custom component code (TSX). If present, overrides the default template rendering */

--- a/packages/manifest/shared/src/types/node.ts
+++ b/packages/manifest/shared/src/types/node.ts
@@ -1,7 +1,6 @@
 import type { FlowParameter } from './flow.js';
 import type { JSONSchema } from './schema.js';
 import type { AppearanceConfig } from './appearance.js';
-import type { LayoutTemplate } from './app.js';
 
 // =============================================================================
 // Position
@@ -31,7 +30,7 @@ export type NodeTypeCategory = 'trigger' | 'interface' | 'action' | 'return' | '
 /**
  * Supported node types in the system.
  */
-export type NodeType = 'BlankComponent' | 'StatCard' | 'PostList' | 'Return' | 'CallFlow' | 'UserIntent' | 'ApiCall' | 'JavaScriptCodeTransform' | 'Link' | 'RegistryComponent';
+export type NodeType = 'BlankComponent' | 'Return' | 'CallFlow' | 'UserIntent' | 'ApiCall' | 'JavaScriptCodeTransform' | 'Link' | 'RegistryComponent';
 
 // =============================================================================
 // API Call Node Types
@@ -163,21 +162,6 @@ export interface BlankComponentNodeParameters {
   customCode?: string;
 
   /** Visual configuration derived from the component's appearance prop interface. */
-  appearanceConfig?: AppearanceConfig;
-}
-
-/**
- * Parameters for a StatCard node.
- * @deprecated Use UINodeParameters instead. This type is kept for backward compatibility.
- */
-export interface StatCardNodeParameters {
-  /** @deprecated Layout template is no longer used. Field is ignored. */
-  layoutTemplate?: string;
-
-  /** Custom component code (TSX). If present, overrides the default template rendering */
-  customCode?: string;
-
-  /** Appearance configuration for visual options */
   appearanceConfig?: AppearanceConfig;
 }
 
@@ -409,15 +393,6 @@ export interface TestApiCallResponse {
 // =============================================================================
 
 /**
- * Check if a node is a StatCard node.
- */
-export function isStatCardNode(
-  node: NodeInstance
-): node is NodeInstance & { parameters: StatCardNodeParameters } {
-  return node.type === 'StatCard';
-}
-
-/**
  * Check if a node is a Return node.
  */
 export function isReturnNode(
@@ -460,30 +435,6 @@ export function isJavaScriptCodeTransformNode(
   node: NodeInstance
 ): node is NodeInstance & { parameters: JavaScriptCodeTransformParameters } {
   return node.type === 'JavaScriptCodeTransform';
-}
-
-/**
- * Check if a node is a PostList node.
- */
-export function isPostListNode(
-  node: NodeInstance
-): node is NodeInstance & { parameters: PostListNodeParameters } {
-  return node.type === 'PostList';
-}
-
-// =============================================================================
-// PostList Node Types
-// =============================================================================
-
-/**
- * Parameters for a PostList node.
- */
-export interface PostListNodeParameters {
-  /** Layout template type */
-  layoutTemplate: LayoutTemplate;
-
-  /** Custom component code (TSX). If present, overrides the default template rendering */
-  customCode?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Description

Refactors the codebase to use a more generic naming pattern for UI components. Replaces `StatCard`/`PostList`-specific nomenclature with `RegistryComponent`/`BlankComponent` to better reflect the general-purpose nature of the UI functionality.

**Backend changes:**
- Rename `StatCardNodeData` to `RegistryComponentNodeData`
- Remove redundant StatCard-specific logic from MCP tool handler
- Simplify showUI tool to use generic registry component pattern
- Fix SWC build script to use relative paths correctly
- Update test fixtures to use `createMockRegistryComponentNode`

**Frontend changes:**
- Update ViewNode, FlowDiagram, InterfaceEditor to use new node types
- Remove StatCard/PostList from node type icons and categories
- Update type mappings for RegistryComponent/BlankComponent

**Shared types:**
- Remove PostList and StatCard from appearance registry
- Update comments and documentation to reflect new naming
- Clean up obsolete type references

## Related Issues

None

## How can it be tested?

1. Run `pnpm test` in the backend package to verify all tests pass (660 tests)
2. Run `pnpm exec tsc --noEmit` in frontend to verify TypeScript compilation
3. Start the application and verify flow editor works correctly
4. Test that UI nodes render correctly in the diagram

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR