### PR TITLE
fix(ci): use secret instead of variable for APP_ID

### DIFF
--- a/.github/workflows/manifest-release.yml
+++ b/.github/workflows/manifest-release.yml
@@ -11,9 +11,8 @@
 # Uses a GitHub App token so the version PR triggers CI workflows.
 #
 # Required secrets:
-#   - APP_PRIVATE_KEY: GitHub App private key
-# Required variables:
 #   - APP_ID: GitHub App ID
+#   - APP_PRIVATE_KEY: GitHub App private key
 # ============================================================================
 
 name: Manifest Release
@@ -48,7 +47,7 @@ jobs:
         uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Setup pnpm


### PR DESCRIPTION
## Description

Fixes the release workflow failing with "Input required and not supplied: app-id" error.

The `APP_ID` was configured as a repository secret but the workflow was referencing it via `vars.APP_ID` (variables) instead of `secrets.APP_ID` (secrets).

## Related Issues

None

## How can it be tested?

1. Merge this PR to main
2. The release workflow should now successfully generate the GitHub App token
3. Verify the workflow proceeds past the "Generate GitHub App token" step

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR