### PR TITLE
fix(ci): skip changeset check for Version Packages PR

### DIFF
--- a/.github/workflows/manifest-ci.yml
+++ b/.github/workflows/manifest-ci.yml
@@ -20,7 +20,8 @@ jobs:
   changeset-check:
     name: Changeset Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # Skip for Version Packages PR (created by changesets action)
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Description

Fixes the CI failure on Version Packages PRs created by the changesets action.

The Version Packages PR consumes changeset files and updates CHANGELOG.md/package.json. The changeset check was incorrectly failing because it detected changes in `packages/manifest/**` but found no changeset files (they were already consumed by the version bump).

This fix skips the changeset check when the PR branch is `changeset-release/main`.

## Related Issues

Fixes CI failure on PR #654

## How can it be tested?

1. Merge this PR
2. The Version Packages PR (#654) should pass CI after re-running the workflow

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR