### PR TITLE
fix(ci): read version from correct package.json

### DIFF
--- a/.github/workflows/manifest-release.yml
+++ b/.github/workflows/manifest-release.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           # Check if there was a version bump by looking at the commit
           if git log -1 --pretty=%B | grep -q "chore: version packages"; then
-            VERSION=$(node -p "require('./packages/manifest/backend/package.json').version")
+            VERSION=$(node -p "require('./packages/manifest/package.json').version")
             echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Description

Fixes the Docker Hub publish workflow failing with `fatal: tag 'v1.0.0' already exists`.

The release workflow was reading the version from `packages/manifest/backend/package.json` (which has stale version `1.0.0`) instead of `packages/manifest/package.json` (which has the correct version `5.0.2` bumped by changesets).

| File | Version |
|------|---------|
| `packages/manifest/package.json` | 5.0.2 ✅ (correct) |
| `packages/manifest/backend/package.json` | 1.0.0 ❌ (stale) |

## Related Issues

None

## How can it be tested?

1. Merge this PR
2. Re-run the release workflow
3. It should create tag `v5.0.2` and publish Docker image with that version

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR