### PR TITLE
docs: add README files to manifest subpackages

### DIFF
--- a/.changeset/add-readme-docs.md
+++ b/.changeset/add-readme-docs.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add README documentation to backend, frontend, nodes, and shared packages

--- a/packages/manifest/backend/README.md
+++ b/packages/manifest/backend/README.md
@@ -1,0 +1,26 @@
+# Manifest Backend
+
+NestJS backend API for the Manifest visual builder.
+
+## Overview
+
+This package provides the server-side functionality for Manifest, including:
+
+- REST API endpoints
+- Database management (SQLite, PostgreSQL, MySQL)
+- Authentication and authorization
+- Flow execution engine
+- File storage (local and S3)
+
+## Development
+
+```bash
+# From the monorepo root
+pnpm run dev
+```
+
+The backend runs on port 3847 by default.
+
+## Environment Variables
+
+See `.env.example` for available configuration options.

--- a/packages/manifest/frontend/README.md
+++ b/packages/manifest/frontend/README.md
@@ -1,0 +1,29 @@
+# Manifest Frontend
+
+React-based visual builder interface for creating ChatGPT apps.
+
+## Overview
+
+This package provides the client-side application for Manifest, including:
+
+- Visual flow editor powered by @xyflow/react
+- Node configuration panels
+- Real-time flow execution preview
+- Admin dashboard
+
+## Development
+
+```bash
+# From the monorepo root
+pnpm run dev
+```
+
+The frontend uses Vite and runs on an available port (typically 5176).
+
+## Tech Stack
+
+- React 18
+- TypeScript
+- Vite
+- TailwindCSS
+- shadcn/ui components

--- a/packages/manifest/nodes/README.md
+++ b/packages/manifest/nodes/README.md
@@ -1,0 +1,20 @@
+# Manifest Nodes
+
+Node type definitions for the Manifest flow editor.
+
+## Overview
+
+This package contains the definitions for all available node types in the visual builder:
+
+- Input/Output nodes
+- Logic nodes (conditions, loops)
+- Integration nodes (API calls, webhooks)
+- AI nodes (LLM prompts, embeddings)
+
+## Usage
+
+Nodes are imported by both the backend (for execution) and frontend (for the editor UI).
+
+```typescript
+import { NodeDefinitions } from '@manifest/nodes';
+```

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "manifest",
   "version": "5.0.2",
-  "description": "Flow editor application with NestJS backend and React frontend",
+  "description": "Visual builder to create ChatGPT apps",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mnfst/manifest.git",

--- a/packages/manifest/shared/README.md
+++ b/packages/manifest/shared/README.md
@@ -1,0 +1,26 @@
+# Manifest Shared
+
+Shared types and utilities used across Manifest packages.
+
+## Overview
+
+This package contains code shared between the backend and frontend:
+
+- TypeScript type definitions
+- Validation schemas
+- Utility functions
+- Constants
+
+## Usage
+
+```typescript
+import { FlowDefinition, NodeConfig } from '@manifest/shared';
+```
+
+## Building
+
+This package must be built before running the backend or frontend:
+
+```bash
+pnpm --filter @manifest/shared build
+```


### PR DESCRIPTION
## Description

Add README documentation to the manifest subpackages:
- `packages/manifest/backend/README.md`
- `packages/manifest/frontend/README.md`
- `packages/manifest/nodes/README.md`
- `packages/manifest/shared/README.md`

Also updates the main manifest package description to reflect the product vision.

## Related Issues

None

## How can it be tested?

N/A - documentation changes only

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR