### PR TITLE
fix(manifest): unify password minimum length to 8 characters

### DIFF
--- a/.changeset/fix-password-validation.md
+++ b/.changeset/fix-password-validation.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fixed password validation mismatch where signup form showed 4-character minimum but backend required 12 characters

--- a/packages/manifest/backend/src/auth/auth.ts
+++ b/packages/manifest/backend/src/auth/auth.ts
@@ -41,7 +41,7 @@ export const auth = betterAuth({
 
   emailAndPassword: {
     enabled: true,
-    minPasswordLength: 12, // SECURITY: Strong password requirement
+    minPasswordLength: 8, // Password minimum requirement
     requireEmailVerification: false, // Enable in production with email provider
     // Note: better-auth doesn't support complexity rules natively
     // Consider adding custom validation in signup flow if needed

--- a/packages/manifest/frontend/src/components/auth/SignupForm.tsx
+++ b/packages/manifest/frontend/src/components/auth/SignupForm.tsx
@@ -35,8 +35,8 @@ export function SignupForm({ onSuccess }: SignupFormProps) {
       return;
     }
 
-    if (password.length < 4) {
-      setError('Password must be at least 4 characters');
+    if (password.length < 8) {
+      setError('Password must be at least 8 characters');
       setIsLoading(false);
       return;
     }
@@ -131,8 +131,8 @@ export function SignupForm({ onSuccess }: SignupFormProps) {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
-          minLength={4}
-          placeholder="At least 4 characters"
+          minLength={8}
+          placeholder="At least 8 characters"
         />
       </div>
 

--- a/packages/manifest/shared/src/types/auth.ts
+++ b/packages/manifest/shared/src/types/auth.ts
@@ -5,7 +5,7 @@
 /**
  * Default admin user credentials for development/POC.
  * Used by seed service and can be pre-filled on login page.
- * SECURITY: Password meets 12-character minimum requirement.
+ * SECURITY: Password meets 8-character minimum requirement.
  */
 export const DEFAULT_ADMIN_USER = {
   email: 'admin@example.com',


### PR DESCRIPTION
## Description

The signup form UI displayed "At least 4 characters" but the backend (`better-auth`) required 12 characters minimum, causing confusing "password too short" errors when users entered passwords between 4-11 characters.

This PR unifies all password validation to 8 characters minimum across the entire codebase.

## Related Issues

None

## How can it be tested?

1. Start the development servers
2. Navigate to the signup page
3. Verify the password field shows "At least 8 characters" placeholder
4. Try signing up with a 7-character password - should show validation error
5. Sign up with an 8+ character password - should succeed

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR