### PR TITLE
ci: pause release automation until production ready

### DIFF
--- a/.github/workflows/manifest-release.yml
+++ b/.github/workflows/manifest-release.yml
@@ -36,6 +36,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: false # PAUSED: Release automation disabled until production ready
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

Pauses the release automation workflow by adding `if: false` to the release job. This prevents automatic version PRs and Docker Hub deployments until the project is ready for production.

## Related Issues

None

## How can it be tested?

1. Push a commit with a changeset to main
2. Check GitHub Actions - the workflow should show as "skipped"
3. Verify no "Version Packages" PR is created

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR