### PR TITLE
Make getting started block link dynamic based on block categories

### DIFF
--- a/packages/manifest-ui/components/blocks/getting-started.tsx
+++ b/packages/manifest-ui/components/blocks/getting-started.tsx
@@ -1,3 +1,4 @@
+import { blockCategories } from '@/lib/blocks-categories'
 import { ArrowRight, FolderPlus } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
@@ -59,7 +60,11 @@ export function GettingStarted() {
       <section className="space-y-4 pt-4 border-t">
         <h2 className="text-lg font-semibold">Next Step</h2>
         <Link
-          href="/blocks?block=order-confirm"
+          href={
+            blockCategories[0]?.blocks[0]
+              ? `/blocks/${blockCategories[0].id}/${blockCategories[0].blocks[0].id}`
+              : '/blocks'
+          }
           className="inline-flex items-center gap-2 text-primary hover:underline"
         >
           Explore blocks


### PR DESCRIPTION
## Summary

Update the "Getting Started" component to dynamically link to the first available block from the block categories instead of hardcoding a specific block ID. This makes the navigation more flexible and maintainable as block categories change.

## Changes

- Import `blockCategories` from `@/lib/blocks-categories`
- Replace hardcoded `/blocks?block=order-confirm` href with dynamic navigation that:
  - Links to the first block in the first category if available: `/blocks/{categoryId}/{blockId}`
  - Falls back to `/blocks` if no categories or blocks exist
- This ensures the "Explore blocks" link always points to a valid block or the blocks page

## Type of Change

- [x] Refactoring (no functional changes)
- [x] New feature (adds dynamic block navigation)

## Testing

- [ ] Tests pass locally (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)

## Related Issues

<!-- Link any related issues if applicable -->

https://claude.ai/code/session_011LjWtet6SaPfnNd56jxtRM