### PR TITLE
fix: resolve Docker CORS rejection and missing workspace dependencies

### DIFF
--- a/.changeset/fix-docker-cors.md
+++ b/.changeset/fix-docker-cors.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix CORS rejection for localhost origins when running in Docker with port mapping

--- a/docker/manifest/Dockerfile
+++ b/docker/manifest/Dockerfile
@@ -42,6 +42,7 @@ COPY packages/manifest/shared/package.json ./packages/manifest/shared/
 COPY packages/manifest/nodes/package.json ./packages/manifest/nodes/
 COPY packages/manifest/backend/package.json ./packages/manifest/backend/
 COPY packages/manifest/frontend/package.json ./packages/manifest/frontend/
+COPY packages/manifest/package.json ./packages/manifest/
 
 # Install dependencies with frozen lockfile
 RUN pnpm install --frozen-lockfile
@@ -104,21 +105,21 @@ RUN addgroup -g 1001 -S nodejs && \
 # Install pnpm in production stage
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-# Copy package files (for runtime metadata and tooling)
-# Note: frontend package.json is intentionally not copied here. The frontend is
-# built as static assets in /packages/manifest/frontend/dist and has no Node runtime
-# dependencies in the production image.
+# Copy package files for workspace resolution and runtime metadata.
+# All workspace members declared in pnpm-workspace.yaml must be present
+# so that `pnpm prune --prod` can resolve the full workspace graph.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/manifest/shared/package.json ./packages/manifest/shared/
 COPY packages/manifest/nodes/package.json ./packages/manifest/nodes/
 COPY packages/manifest/backend/package.json ./packages/manifest/backend/
+COPY packages/manifest/package.json ./packages/manifest/
+COPY packages/manifest/frontend/package.json ./packages/manifest/frontend/
 
-# Copy node_modules from deps stage and prune devDependencies for production
+# Copy the pnpm virtual store from deps stage, then install production-only
+# dependencies. This re-creates the per-workspace symlinks that COPY loses,
+# and avoids re-downloading packages already present in .pnpm.
 COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/packages/manifest/shared/node_modules ./packages/manifest/shared/node_modules
-COPY --from=deps /app/packages/manifest/nodes/node_modules ./packages/manifest/nodes/node_modules
-COPY --from=deps /app/packages/manifest/backend/node_modules ./packages/manifest/backend/node_modules
-RUN CI=true HUSKY=0 pnpm prune --prod --ignore-scripts
+RUN CI=true HUSKY=0 pnpm install --prod --frozen-lockfile --ignore-scripts
 
 # Copy built artifacts from build stage
 COPY --chown=appuser:nodejs --from=build /app/packages/manifest/shared/dist ./packages/manifest/shared/dist

--- a/docker/manifest/docker-compose.yml
+++ b/docker/manifest/docker-compose.yml
@@ -25,6 +25,9 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3001
+      # Auth secret (required in production)
+      # Set via .env file or environment variable
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-}
       # OpenAI API key (required for AI functionality)
       # Set via .env file or environment variable
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}

--- a/packages/manifest/backend/src/main.ts
+++ b/packages/manifest/backend/src/main.ts
@@ -87,9 +87,11 @@ async function bootstrap() {
       // Allow requests with no origin (same-origin, mobile apps, curl)
       if (!origin) return callback(null, true);
 
-      // Development: allow localhost on any port
-      if (process.env.NODE_ENV !== 'production') {
-        if (origin.match(/^http:\/\/localhost:\d+$/)) {
+      // Allow localhost on any port in development
+      // Also allow in production when no explicit ALLOWED_ORIGINS is set
+      // (self-hosted Docker with port mapping, e.g. -p 3847:3001)
+      if (origin.match(/^http:\/\/localhost:\d+$/)) {
+        if (process.env.NODE_ENV !== 'production' || allowedOrigins.length === 0) {
           return callback(null, true);
         }
       }


### PR DESCRIPTION
## Description

Fix production Docker image build and runtime issues:

1. **Missing workspace dependencies**: Include all workspace `package.json` files (including `packages/manifest/` and `packages/manifest/frontend/`) needed for pnpm workspace resolution. Switch from `pnpm prune --prod` to `pnpm install --prod --frozen-lockfile` to properly re-create workspace symlinks.

2. **CORS rejection on localhost**: When running Docker with port mapping (e.g. `-p 3847:3001`), the browser sends `Origin: http://localhost:3847` but the backend rejected it because the localhost CORS bypass was only enabled in development. Now localhost origins are also allowed in production when no explicit `ALLOWED_ORIGINS` env var is configured.

3. **Missing `BETTER_AUTH_SECRET` passthrough**: Add the env var to `docker-compose.yml` so it gets forwarded to the container.

## Related Issues

None

## How can it be tested?

1. Build and run: `BETTER_AUTH_SECRET=$(openssl rand -base64 32) docker compose -f docker/manifest/docker-compose.yml up --build`
2. Verify frontend loads at `http://localhost:3001`
3. Verify API responds: `curl -I -H "Origin: http://localhost:3001" http://localhost:3001/api/apps` — should include `Access-Control-Allow-Origin` header
4. Verify mapped port CORS: `curl -I -H "Origin: http://localhost:3847" http://localhost:3001/api/apps` — should also include CORS header (no rejection)

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR