### PR TITLE
fix: always tag Docker image as latest and guard semver tags for dev builds

### DIFF
--- a/.github/workflows/manifest-publish.yml
+++ b/.github/workflows/manifest-publish.yml
@@ -85,23 +85,23 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           IMAGE="${{ env.DOCKER_IMAGE }}"
 
-          # Parse semver components
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-
-          # Build tags array
+          # Build tags array — always include the version and latest
           TAGS="${IMAGE}:${VERSION}"
-          TAGS="${TAGS},${IMAGE}:${MAJOR}.${MINOR}"
 
-          # Add major tag only if not v0.x.x
-          if [[ "$MAJOR" != "0" ]]; then
-            TAGS="${TAGS},${IMAGE}:${MAJOR}"
+          # Add semver shorthand tags only for proper versions (not dev-* builds)
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            MAJOR=$(echo "$VERSION" | cut -d. -f1)
+            MINOR=$(echo "$VERSION" | cut -d. -f2)
+            TAGS="${TAGS},${IMAGE}:${MAJOR}.${MINOR}"
+
+            # Add major tag only if not v0.x.x
+            if [[ "$MAJOR" != "0" ]]; then
+              TAGS="${TAGS},${IMAGE}:${MAJOR}"
+            fi
           fi
 
-          # Add latest tag for releases (tag push or workflow_call with version)
-          if [[ "$GITHUB_REF" == refs/tags/v* ]] || [[ -n "${{ inputs.version }}" ]]; then
-            TAGS="${TAGS},${IMAGE}:latest"
-          fi
+          # Always tag the most recent image as latest
+          TAGS="${TAGS},${IMAGE}:latest"
 
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "Generated tags: ${TAGS}"


### PR DESCRIPTION
## Description

The `latest` Docker tag was only applied when the publish workflow was triggered by a git tag push or `workflow_call`. Manual dispatch builds were excluded, meaning the most recent image wasn't tagged as `latest`.

This change:
- Always applies the `latest` tag so the most recently published image is always pullable via `docker pull manifestdotbuild/manifest:latest`
- Guards semver shorthand tags (`major.minor`, `major`) behind a regex check so dev builds (`dev-abc1234`) don't produce malformed tags like `dev-abc1234.`

## Related Issues

None

## How can it be tested?

1. Manually trigger the Docker Publish workflow via `workflow_dispatch`
2. Verify the image is tagged as `dev-<sha>` and `latest` (no trailing-dot tag)
3. Trigger via a version tag push and verify `X.Y.Z`, `X.Y`, `X`, and `latest` tags are all created

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR