### PR TITLE
fix: harden Docker image with semver dev tags and CVE remediation

### DIFF
--- a/.github/workflows/manifest-publish.yml
+++ b/.github/workflows/manifest-publish.yml
@@ -72,7 +72,8 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
           else
-            VERSION="dev-${SHORT_SHA}"
+            PKG_VERSION=$(jq -r '.version' packages/manifest/package.json)
+            VERSION="${PKG_VERSION}-dev.${SHORT_SHA}"
           fi
 
           echo "build_date=${BUILD_DATE}" >> "$GITHUB_OUTPUT"
@@ -89,7 +90,7 @@ jobs:
           TAGS="${IMAGE}:${VERSION}"
 
           # Add semver shorthand tags only for proper versions (not dev-* builds)
-          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             MAJOR=$(echo "$VERSION" | cut -d. -f1)
             MINOR=$(echo "$VERSION" | cut -d. -f2)
             TAGS="${TAGS},${IMAGE}:${MAJOR}.${MINOR}"


### PR DESCRIPTION
## Description

Two improvements to the Docker publish workflow and image security:

1. **Semver dev tags**: Dev builds now produce tags like `5.0.5-dev.d94835a` instead of `dev-d94835a` by reading the version from `package.json`. Anchored the semver regex with `$` so dev tags don't overwrite stable shorthand tags (`5.0`, `5`).

2. **CVE remediation**: Pinned the base image to `node:22.22.0-alpine3.22` and updated vulnerable dependencies to address 91 Docker Scout vulnerabilities across Critical, High, and Medium severities.

### Changes

| File | Change |
|------|--------|
| `.github/workflows/manifest-publish.yml` | Read version from `package.json` for dev tags; anchor semver regex with `$` |
| `docker/manifest/Dockerfile` | Pin base image `node:22-alpine` → `node:22.22.0-alpine3.22` |
| `package.json` | Add `lodash>=4.17.23` and `glob>=10.5.0` overrides; bump pnpm to 10.28.0 |
| `packages/manifest/backend/package.json` | Bump `@nestjs/common`, `core`, `platform-express`, `testing` to `^10.4.16` |
| `pnpm-lock.yaml` | Lockfile regenerated |

### CVEs addressed

| CVE | Severity | Package | Fix |
|-----|----------|---------|-----|
| CVE-2024-24790 | 9.8 Critical | golang/stdlib | Base image pin |
| GHSA-7h2j-956f-4vf2 | 9.2 Critical | brace-expansion | Base image pin + existing override |
| CVE-2025-22871 | 9.1 Critical | golang/stdlib | Base image pin |
| CVE-2025-64756 | 7.5 High | glob | pnpm override `>=10.5.0` |
| CVE-2025-13465 | 6.9 Medium | lodash | pnpm override `>=4.17.23` |
| CVE-2024-29409 | 5.5 Medium | @nestjs/common | Bump to `^10.4.16` |
| 40+ golang/stdlib CVEs | High/Medium | golang/stdlib | Base image pin |
| 3 npm/tar CVEs | High | tar | Base image pin + existing override |
| 5 pnpm CVEs | Medium | pnpm | Bump to 10.28.0 |

## Related Issues

None

## How can it be tested?

1. Build the Docker image locally: `docker build -f docker/manifest/Dockerfile .`
2. Run Docker Scout against the new image to verify reduced CVE count
3. Trigger a `workflow_dispatch` run and verify dev tag format is `<version>-dev.<sha>`
4. Trigger a release via `workflow_call` and verify shorthand tags are still generated

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR