### PR TITLE
feat: add Deps tab to block detail pages

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -2,7 +2,8 @@
 
 import { blockCategories } from '@/lib/blocks-categories';
 import { cn } from '@/lib/utils';
-import { ChevronRight, Github, Zap } from 'lucide-react';
+import { useExternalDepCount } from '@/components/blocks/dependency-viewer';
+import { ChevronRight, Github, Package, Zap } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { Suspense, useEffect, useRef, useState } from 'react';
@@ -2796,6 +2797,7 @@ function BlockPageContent() {
 
   // Find the category from blockCategories for sidebar and related blocks
   const sidebarCategory = blockCategories.find((c) => c.id === categorySlug);
+  const depCount = useExternalDepCount(selectedBlock?.registryName ?? '');
 
   // Ref for the first variant section
   const firstVariantRef = useRef<VariantSectionHandle>(null);
@@ -2910,6 +2912,12 @@ function BlockPageContent() {
                 <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1">
                   <Zap className="w-3 h-3" />
                   read only
+                </span>
+              )}
+              {depCount !== null && depCount > 0 && (
+                <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1">
+                  <Package className="w-3 h-3" />
+                  {`${depCount} dep${depCount > 1 ? 's' : ''}`}
                 </span>
               )}
             </div>

--- a/packages/manifest-ui/components/blocks/dependency-viewer.tsx
+++ b/packages/manifest-ui/components/blocks/dependency-viewer.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react'
+
+const FILTERED_DEPS = new Set(['lucide-react'])
+
+export function useExternalDepCount(registryName: string): number | null {
+  const [count, setCount] = useState<number | null>(null)
+
+  useEffect(() => {
+    async function fetchDeps() {
+      if (!registryName) return
+      try {
+        const res = await fetch(`/r/${registryName}.json`)
+        if (!res.ok) return
+        const data = await res.json()
+        const deps = (data.dependencies || []) as string[]
+        const devDeps = (data.devDependencies || []) as string[]
+        const total = deps.filter(d => !FILTERED_DEPS.has(d)).length +
+          devDeps.filter(d => !FILTERED_DEPS.has(d)).length
+        setCount(total)
+      } catch {
+        // ignore
+      }
+    }
+    fetchDeps()
+  }, [registryName])
+
+  return count
+}
+
+interface DependencyViewerProps {
+  dependencies: string[]
+  devDependencies: string[]
+  loading: boolean
+}
+
+function NpmLink({ pkg }: { pkg: string }) {
+  return (
+    <a
+      href={`https://www.npmjs.com/package/${pkg}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-muted text-sm font-mono hover:bg-muted/80 hover:text-foreground transition-colors"
+    >
+      <svg
+        className="h-3.5 w-3.5 shrink-0"
+        viewBox="0 0 256 256"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-label="npm"
+      >
+        <rect fill="#C12127" width="256" height="256" rx="8" />
+        <path fill="#fff" d="M48 48h160v160h-32V80h-48v128H48z" />
+      </svg>
+      {pkg}
+    </a>
+  )
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div className="h-4 bg-muted rounded w-48" />
+      <div className="flex flex-wrap gap-2">
+        <div className="h-8 bg-muted rounded w-28" />
+        <div className="h-8 bg-muted rounded w-32" />
+      </div>
+    </div>
+  )
+}
+
+export function hasExternalDeps(
+  dependencies: string[],
+  devDependencies: string[]
+): boolean {
+  return dependencies.some(d => !FILTERED_DEPS.has(d)) ||
+    devDependencies.some(d => !FILTERED_DEPS.has(d))
+}
+
+export function DependencyViewer({
+  dependencies,
+  devDependencies,
+  loading
+}: DependencyViewerProps) {
+  if (loading) {
+    return <LoadingSkeleton />
+  }
+
+  const filteredDeps = dependencies.filter(d => !FILTERED_DEPS.has(d))
+  const filteredDevDeps = devDependencies.filter(d => !FILTERED_DEPS.has(d))
+
+  return (
+    <div className="space-y-5">
+      <p className="text-sm text-muted-foreground">
+        Installing this component will also install the following packages:
+      </p>
+
+      {filteredDeps.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+            Packages
+          </h4>
+          <div className="flex flex-wrap gap-2">
+            {filteredDeps.map(dep => (
+              <NpmLink key={dep} pkg={dep} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {filteredDevDeps.length > 0 && (
+        <div className="space-y-2">
+          <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+            Dev Packages
+          </h4>
+          <div className="flex flex-wrap gap-2">
+            {filteredDevDeps.map(dep => (
+              <NpmLink key={dep} pkg={dep} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Add a **Deps tab** to block detail pages that shows external npm dependencies for registry components. The tab appears alongside Config and Code, but only for components that have non-trivial external dependencies (lucide-react is filtered out).

Features:
- **Deps tab** with npm package links (including npm logo) grouped by Packages and Dev Packages
- **"X deps" badge** next to the actions badge in the block header
- Tab and badge only appear when external deps exist (e.g., map-carousel, event-list, event-detail)
- Introductory sentence: "Installing this component will also install the following packages:"
- Fix: changelog popover z-index now renders above Leaflet map components

## Related Issues

None

## How can it be tested?

1. Navigate to `/blocks/map/map-carousel` — should show "3 deps" badge and Deps tab with leaflet, react-leaflet, @types/leaflet
2. Navigate to `/blocks/events/event-list` — should show Deps tab with same leaflet deps
3. Navigate to any non-map block (e.g., `/blocks/form/contact-form`) — should NOT show Deps tab or badge
4. Click the version changelog popover on map-carousel — should render above the map

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR