### PR TITLE
refactor!: trim invalid actions from UI blocks

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -361,7 +361,6 @@ const categories: Category[] = [
                 appearance={{
                   variant: 'fullwidth',
                   columns: 3,
-                  postsPerPage: 10,
                 }}
               />
             ),
@@ -554,7 +553,6 @@ const categories: Category[] = [
                 appearance={{
                   variant: 'fullwidth',
                   columns: 3,
-                  postsPerPage: 10,
                 }}
               />
             ),
@@ -748,7 +746,6 @@ const categories: Category[] = [
                 appearance={{
                   variant: 'fullwidth',
                   columns: 3,
-                  postsPerPage: 10,
                 }}
               />
             ),
@@ -1314,8 +1311,7 @@ const categories: Category[] = [
   }}
   appearance={{ variant: "grid" }}
   actions={{
-    onEventSelect: (event) => console.log("Event selected:", event.title),
-    onViewMore: () => console.log("View more events")
+    onEventSelect: (event) => console.log("Event selected:", event.title)
   }}
 />`,
           },
@@ -1467,8 +1463,7 @@ const categories: Category[] = [
     ]
   }}
   actions={{
-    onCheckout: (selections, total) => console.log("Checkout:", selections, "Total:", total),
-    onSelectionChange: (selections) => console.log("Selection changed:", selections)
+    onCheckout: (selections, total) => console.log("Checkout:", selections, "Total:", total)
   }}
   appearance={{
     showOrderSummary: true
@@ -1483,7 +1478,7 @@ const categories: Category[] = [
         description: 'Order confirmation with event details, organizer follow, and social sharing.',
         registryName: 'event-confirmation',
         layouts: ['inline', 'fullscreen'],
-        actionCount: 4,
+        actionCount: 3,
         variants: [
           {
             id: 'default',
@@ -1504,7 +1499,6 @@ const categories: Category[] = [
   }}
   actions={{
     onViewTickets: () => console.log("View tickets"),
-    onChangeEmail: () => console.log("Change email"),
     onFollowOrganizer: () => console.log("Follow organizer"),
     onShare: (platform) => console.log("Share on:", platform)
   }}
@@ -1594,7 +1588,6 @@ const categories: Category[] = [
     showTimezone: true
   }}
   actions={{
-    onSelect: (date, time) => console.log("Selected:", { date, time }),
     onNext: (date, time) => console.log("Confirmed:", { date, time })
   }}
 />`,
@@ -1740,8 +1733,7 @@ const categories: Category[] = [
     maxRows: 5
   }}
   actions={{
-    onRefresh: () => console.log("Refreshing..."),
-    onExpand: () => console.log("Expanding...")
+    onRefresh: () => console.log("Refreshing...")
   }}
 />`,
           },
@@ -1760,9 +1752,6 @@ const categories: Category[] = [
             usageCode: `<Table
   data={{ title: "Models", columns: [...], rows: [...] }}
   appearance={{ selectable: "single" }}
-  actions={{
-    onSelectionChange: (selectedRows) => console.log("Selected:", selectedRows)
-  }}
 />`,
           },
           {
@@ -1781,7 +1770,6 @@ const categories: Category[] = [
   data={{ title: "Export Data", columns: [...], rows: [...] }}
   appearance={{ selectable: "multi" }}
   actions={{
-    onSelectionChange: (rows) => console.log("Selected:", rows.length),
     onDownload: (rows) => console.log("Downloading..."),
     onShare: (rows) => console.log("Sharing...")
   }}
@@ -1801,7 +1789,7 @@ const categories: Category[] = [
         description: 'Interactive map with location markers and a draggable carousel of cards',
         registryName: 'map-carousel',
         layouts: ['inline', 'fullscreen', 'pip'],
-        actionCount: 2,
+        actionCount: 1,
         variants: [
           {
             id: 'default',
@@ -1813,7 +1801,6 @@ const categories: Category[] = [
                 appearance={{ displayMode: 'fullscreen' }}
                 actions={{
                   onSelectLocation: (location) => console.log('Selected:', location.name),
-                  onFiltersApply: (filters) => console.log('Filters:', filters),
                 }}
               />
             ),
@@ -1838,9 +1825,7 @@ const categories: Category[] = [
     mapStyle: "voyager"
   }}
   actions={{
-    onSelectLocation: (location) => console.log("Selected:", location.name),
-    onExpand: () => console.log("Expand to fullscreen"),
-    onFiltersApply: (filters) => console.log("Filters applied:", filters)
+    onSelectLocation: (location) => console.log("Selected:", location.name)
   }}
   appearance={{
     displayMode: "inline", // or "fullscreen" for split-screen layout
@@ -2297,7 +2282,7 @@ const categories: Category[] = [
   }}
   appearance={{ multiple: false }}
   actions={{
-    onSelectOption: (option) => console.log("Selected:", option.label)
+    onSubmit: (selected) => console.log("Submitted:", selected)
   }}
 />`,
           },
@@ -2335,7 +2320,7 @@ const categories: Category[] = [
         description: 'Colored tag selector',
         registryName: 'tag-select',
         layouts: ['inline', 'fullscreen', 'pip'],
-        actionCount: 2,
+        actionCount: 1,
         variants: [
           {
             id: 'default',
@@ -2354,7 +2339,6 @@ const categories: Category[] = [
     showValidate: true
   }}
   actions={{
-    onSelectTags: (tagIds) => console.log("Tags:", tagIds),
     onValidate: (tagIds) => console.log("Validated:", tagIds)
   }}
 />`,
@@ -2463,7 +2447,7 @@ const categories: Category[] = [
         description: 'Input for monetary amounts',
         registryName: 'amount-input',
         layouts: ['inline', 'fullscreen', 'pip'],
-        actionCount: 2,
+        actionCount: 1,
         variants: [
           {
             id: 'default',
@@ -2484,7 +2468,6 @@ const categories: Category[] = [
   }}
   control={{ value: 50 }}
   actions={{
-    onChange: (value) => console.log("Amount:", value),
     onConfirm: (value) => console.log("Confirmed:", value)
   }}
 />`,
@@ -2582,7 +2565,7 @@ const categories: Category[] = [
         description: 'LinkedIn post card with image support, engagement stats, and expandable content',
         registryName: 'linkedin-post',
         layouts: ['inline', 'fullscreen', 'pip'],
-        actionCount: 2,
+        actionCount: 0,
         variants: [
           {
             id: 'default',
@@ -2599,8 +2582,6 @@ const categories: Category[] = [
                   topReactions: ['like', 'celebrate', 'love'],
                   comments: '56',
                   reposts: '12',
-                }}
-                actions={{
                   postUrl: 'https://linkedin.com/posts/manifest-123',
                   repostUrl: 'https://linkedin.com/shareArticle?url=...',
                 }}
@@ -2616,9 +2597,7 @@ const categories: Category[] = [
     reactions: "1,234",
     topReactions: ["like", "celebrate", "love"],
     comments: "56",
-    reposts: "12"
-  }}
-  actions={{
+    reposts: "12",
     postUrl: "https://linkedin.com/posts/manifest-123",
     repostUrl: "https://linkedin.com/shareArticle?url=..."
   }}
@@ -2640,8 +2619,6 @@ const categories: Category[] = [
                   topReactions: ['like', 'celebrate', 'insightful'],
                   comments: '124',
                   reposts: '89',
-                }}
-                actions={{
                   postUrl: 'https://linkedin.com/posts/manifest-123',
                   repostUrl: 'https://linkedin.com/shareArticle?url=...',
                 }}
@@ -2658,9 +2635,7 @@ const categories: Category[] = [
     reactions: "2,847",
     topReactions: ["like", "celebrate", "insightful"],
     comments: "124",
-    reposts: "89"
-  }}
-  actions={{
+    reposts: "89",
     postUrl: "https://linkedin.com/posts/manifest-123",
     repostUrl: "https://linkedin.com/shareArticle?url=..."
   }}
@@ -2681,8 +2656,6 @@ const categories: Category[] = [
                   topReactions: ['like', 'insightful', 'celebrate'],
                   comments: '890',
                   reposts: '2.1K',
-                }}
-                actions={{
                   postUrl: 'https://linkedin.com/posts/manifest-123',
                   repostUrl: 'https://linkedin.com/shareArticle?url=...',
                 }}
@@ -2701,9 +2674,7 @@ const categories: Category[] = [
     reactions: "15K",
     topReactions: ["like", "insightful", "celebrate"],
     comments: "890",
-    reposts: "2.1K"
-  }}
-  actions={{
+    reposts: "2.1K",
     postUrl: "https://linkedin.com/posts/manifest-123",
     repostUrl: "https://linkedin.com/shareArticle?url=..."
   }}

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -14,7 +14,8 @@
       "1.0.0": "Initial release with calendar and time slot selection",
       "1.0.1": "Added aria-labels to navigation buttons for better screen reader accessibility",
       "1.0.3": "Added comprehensive JSDoc documentation",
-      "1.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation"
+      "1.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
+      "2.0.0": "BREAKING: Removed onSelect action. Intermediate date/time selection is now internal."
     },
     "issue-report-form": {
       "1.0.0": "Initial release with categories, impact levels and file attachments",
@@ -49,7 +50,8 @@
       "1.0.2": "Added comprehensive JSDoc documentation",
       "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.0.4": "Fixed defensive property access to handle empty objects and null values",
-      "1.0.5": "Additional defensive property access improvements"
+      "1.0.5": "Additional defensive property access improvements",
+      "1.0.6": "Removed onSelectCard action. Card selection is now internal."
     },
     "bank-card-form": {
       "1.0.0": "Initial release with compact inline layout for chat",
@@ -87,13 +89,15 @@
       "2.1.0": "Moved to selection category for better organization",
       "2.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "2.1.2": "Fixed defensive property access to handle empty objects and null values",
-      "2.1.3": "Fixed circular dependency by adding types.ts and demo/data.ts to registry"
+      "2.1.3": "Fixed circular dependency by adding types.ts and demo/data.ts to registry",
+      "3.0.0": "BREAKING: Replaced onSelectOption and onSelectOptions with single onSubmit action. Added confirm button."
     },
     "amount-input": {
       "1.0.0": "Initial release with increment buttons and preset values",
       "1.0.2": "Added comprehensive JSDoc documentation",
       "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-      "1.0.4": "Fixed defensive property access to handle empty objects and null values"
+      "1.0.4": "Fixed defensive property access to handle empty objects and null values",
+      "2.0.0": "BREAKING: Removed onChange action. Value changes are now internal."
     },
     "tag-select": {
       "1.0.0": "Initial release with color variants and multi-select",
@@ -101,7 +105,8 @@
       "1.1.0": "Moved to selection category for better organization",
       "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.1.2": "Fixed defensive property access to handle empty objects and null values",
-      "1.1.3": "Additional defensive property access improvements"
+      "1.1.3": "Additional defensive property access improvements",
+      "2.0.0": "BREAKING: Removed onSelectTags action. Tag toggling is now internal."
     },
     "quick-reply": {
       "1.0.0": "Initial release with quick reply button options",
@@ -143,7 +148,8 @@
       "2.0.2": "Added comprehensive JSDoc documentation",
       "2.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "2.0.4": "Fixed defensive property access to handle empty objects and null values",
-      "2.0.5": "Fixed circular dependency by moving Post interface to types.ts"
+      "2.0.5": "Fixed circular dependency by moving Post interface to types.ts",
+      "2.0.6": "Removed unused OpenAI types side-effect import"
     },
     "post-list": {
       "1.0.0": "Initial release with list, grid and carousel variants",
@@ -155,7 +161,8 @@
       "2.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "2.0.5": "Fixed defensive property access to handle empty objects and null values",
       "2.0.6": "Fixed circular dependency by moving Post interface to types.ts",
-      "2.0.7": "Added bg-card background and margin to list variant for better dark/light mode support"
+      "2.0.7": "Added bg-card background and margin to list variant for better dark/light mode support",
+      "3.0.0": "BREAKING: Removed pagination (onPageChange, postsPerPage, control). Fullwidth variant now renders all posts."
     },
     "post-detail": {
       "1.0.0": "Initial release with cover image, author info and related posts",
@@ -175,7 +182,8 @@
       "2.1.6": "Removed default content - component only renders data explicitly provided by the user",
       "2.1.7": "Added cursor-pointer to expand button for better UX",
       "2.1.8": "Refactored to use HostAPI abstraction for multi-host support",
-      "2.1.9": "Inlined host detection to remove external lib dependency for shadcn distribution"
+      "2.1.9": "Inlined host detection to remove external lib dependency for shadcn distribution",
+      "2.1.10": "Updated post-card dependency with removed OpenAI types import"
     },
     "table": {
       "1.0.0": "Initial release with single and multi-select modes",
@@ -184,7 +192,8 @@
       "1.0.4": "Added comprehensive JSDoc documentation",
       "1.0.5": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.0.6": "Fixed defensive property access to handle empty objects and null values",
-      "1.0.7": "Inlined OpenAI display mode types to remove external lib dependency for shadcn distribution"
+      "1.0.7": "Inlined OpenAI display mode types to remove external lib dependency for shadcn distribution",
+      "2.0.0": "BREAKING: Removed onSelectionChange and onExpand actions. Selection and expand are now internal."
     },
     "message-bubble": {
       "1.0.0": "Initial release with text, image, voice and reaction variants",
@@ -233,7 +242,8 @@
       "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "2.0.0": "BREAKING: Simplified component - removed engagement stats and action buttons, added LinkedIn icon link and optional repost button",
       "2.1.0": "Added image support, engagement stats with reaction icons, expandable content with maxLines prop, and moved repost button to the right",
-      "2.1.1": "Fixed avatar circle visibility - now hides entirely when avatar prop is not provided"
+      "2.1.1": "Fixed avatar circle visibility - now hides entirely when avatar prop is not provided",
+      "3.0.0": "BREAKING: Moved postUrl and repostUrl from actions to data prop"
     },
     "youtube-post": {
       "1.0.0": "Initial release with playable video embed",
@@ -251,7 +261,8 @@
       "1.2.2": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.2.3": "Fixed defensive property access to handle empty objects and null values",
       "1.3.0": "Added display modes (inline/fullscreen) with split-screen layout, filters, and ChatGPT host integration",
-      "1.4.0": "Made filters fully configurable via data prop with custom filter sections and match functions"
+      "1.4.0": "Made filters fully configurable via data prop with custom filter sections and match functions",
+      "2.0.0": "BREAKING: Removed onExpand and onFiltersApply actions. Expand and filter apply are now internal."
     },
     "event-card": {
       "1.0.0": "Initial release with default, compact, horizontal and covered variants. Supports physical, online, and hybrid events with signals and vibe tags.",
@@ -266,7 +277,8 @@
       "5.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "5.0.5": "Fixed defensive property access to handle empty objects and null values",
       "5.0.6": "Added types.ts to registry for proper installation",
-      "5.0.7": "Added demo/data.ts to registry for proper installation via shadcn CLI"
+      "5.0.7": "Added demo/data.ts to registry for proper installation via shadcn CLI",
+      "5.0.8": "Removed unused OpenAI types side-effect import"
     },
     "event-list": {
       "1.0.0": "Initial release with grid, list and carousel layouts. Includes pagination support.",
@@ -285,7 +297,8 @@
       "6.0.5": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "6.0.6": "Fixed defensive property access to handle empty objects and null values",
       "6.0.7": "Added types.ts to registry for proper installation",
-      "6.0.8": "Added demo/data.ts to registry for proper installation via shadcn CLI"
+      "6.0.8": "Added demo/data.ts to registry for proper installation via shadcn CLI",
+      "7.0.0": "BREAKING: Removed onPageChange, onViewMore, onExpand, onFilterClick, onFiltersApply actions. Filters and expand are now internal."
     },
     "event-detail": {
       "1.0.0": "Initial release with image carousel, organizer info, location, policies, FAQs, and ticket purchase.",
@@ -309,12 +322,14 @@
       "2.0.2": "Added comprehensive JSDoc documentation",
       "2.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "3.0.0": "BREAKING: Removed id from TicketTier interface, made name and price optional.",
-      "3.0.1": "Simplified TicketSelection interface by removing tierIndex"
+      "3.0.1": "Simplified TicketSelection interface by removing tierIndex",
+      "4.0.0": "BREAKING: Removed onSelectionChange action. Tier quantity changes are now internal."
     },
     "event-confirmation": {
       "1.0.0": "Initial release with success message, event details, organizer follow, and social sharing",
       "1.0.2": "Added comprehensive JSDoc documentation",
-      "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation"
+      "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
+      "2.0.0": "BREAKING: Removed onChangeEmail action and Change email link"
     },
     "hero": {
       "1.0.0": "Initial release with logos, title, subtitle, CTA buttons, and tech logos footer",

--- a/packages/manifest-ui/components/blocks/post-list-demo.tsx
+++ b/packages/manifest-ui/components/blocks/post-list-demo.tsx
@@ -56,8 +56,7 @@ export function PostListDemo({
               variant: 'fullwidth',
               columns: 3,
               showAuthor: true,
-              showCategory: true,
-              postsPerPage: 10
+              showCategory: true
             }}
           />
         </FullscreenModal>

--- a/packages/manifest-ui/lib/preview-components.tsx
+++ b/packages/manifest-ui/lib/preview-components.tsx
@@ -320,8 +320,6 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
           topReactions: ['like', 'celebrate', 'love'],
           comments: '890',
           reposts: '2.1K',
-        }}
-        actions={{
           postUrl: 'https://linkedin.com/posts/satya',
           repostUrl: 'https://linkedin.com/shareArticle?url=...',
         }}

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -55,12 +55,13 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/date-time-picker.png",
-        "version": "1.0.4",
+        "version": "2.0.0",
         "changelog": {
           "1.0.0": "Initial release with calendar and time slot selection",
           "1.0.1": "Added aria-labels to navigation buttons for better screen reader accessibility",
           "1.0.3": "Added comprehensive JSDoc documentation",
-          "1.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation"
+          "1.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
+          "2.0.0": "BREAKING: Removed onSelect action. Intermediate date/time selection is now internal."
         }
       },
       "dependencies": [
@@ -247,7 +248,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/option-list.png",
-        "version": "2.1.3",
+        "version": "3.0.0",
         "changelog": {
           "1.0.0": "Initial release with single and multiple selection modes",
           "2.0.0": "BREAKING: Removed id from Option interface. Use array index for selection tracking.",
@@ -256,13 +257,16 @@
           "2.1.0": "Moved to selection category for better organization",
           "2.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "2.1.2": "Fixed defensive property access to handle empty objects and null values",
-          "2.1.3": "Fixed circular dependency by adding types.ts and demo/data.ts to registry"
+          "2.1.3": "Fixed circular dependency by adding types.ts and demo/data.ts to registry",
+          "3.0.0": "BREAKING: Replaced onSelectOption and onSelectOptions with single onSubmit action. Added confirm button."
         }
       },
       "dependencies": [
         "lucide-react"
       ],
-      "registryDependencies": [],
+      "registryDependencies": [
+        "button"
+      ],
       "files": [
         {
           "path": "registry/selection/option-list.tsx",
@@ -294,12 +298,13 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/amount-input.png",
-        "version": "1.0.4",
+        "version": "2.0.0",
         "changelog": {
           "1.0.0": "Initial release with increment buttons and preset values",
           "1.0.2": "Added comprehensive JSDoc documentation",
           "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-          "1.0.4": "Fixed defensive property access to handle empty objects and null values"
+          "1.0.4": "Fixed defensive property access to handle empty objects and null values",
+          "2.0.0": "BREAKING: Removed onChange action. Value changes are now internal."
         }
       },
       "dependencies": [
@@ -329,14 +334,15 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/tag-select.png",
-        "version": "1.1.3",
+        "version": "2.0.0",
         "changelog": {
           "1.0.0": "Initial release with color variants and multi-select",
           "1.0.2": "Added comprehensive JSDoc documentation",
           "1.1.0": "Moved to selection category for better organization",
           "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "1.1.2": "Fixed defensive property access to handle empty objects and null values",
-          "1.1.3": "Additional defensive property access improvements"
+          "1.1.3": "Additional defensive property access improvements",
+          "2.0.0": "BREAKING: Removed onSelectTags action. Tag toggling is now internal."
         }
       },
       "dependencies": [
@@ -505,7 +511,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/post-card.png",
-        "version": "2.0.5",
+        "version": "2.0.6",
         "changelog": {
           "1.0.0": "Initial release with default, compact, horizontal and covered variants",
           "2.0.0": "BREAKING: Removed id from Post interface. Use array index for key.",
@@ -513,7 +519,8 @@
           "2.0.2": "Added comprehensive JSDoc documentation",
           "2.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "2.0.4": "Fixed defensive property access to handle empty objects and null values",
-          "2.0.5": "Fixed circular dependency by moving Post interface to types.ts"
+          "2.0.5": "Fixed circular dependency by moving Post interface to types.ts",
+          "2.0.6": "Removed unused OpenAI types side-effect import"
         }
       },
       "dependencies": [
@@ -558,7 +565,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/post-list.png",
-        "version": "2.0.7",
+        "version": "3.0.0",
         "changelog": {
           "1.0.0": "Initial release with list, grid and carousel variants",
           "1.1.0": "Added fullwidth variant with pagination for fullscreen mode",
@@ -569,7 +576,8 @@
           "2.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "2.0.5": "Fixed defensive property access to handle empty objects and null values",
           "2.0.6": "Fixed circular dependency by moving Post interface to types.ts",
-          "2.0.7": "Added bg-card background and margin to list variant for better dark/light mode support"
+          "2.0.7": "Added bg-card background and margin to list variant for better dark/light mode support",
+          "3.0.0": "BREAKING: Removed pagination (onPageChange, postsPerPage, control). Fullwidth variant now renders all posts."
         }
       },
       "dependencies": [
@@ -619,7 +627,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/post-detail.png",
-        "version": "2.1.9",
+        "version": "2.1.10",
         "changelog": {
           "1.0.0": "Initial release with cover image, author info and related posts",
           "2.0.0": "BREAKING: Removed id from Post interface. Use array index for key.",
@@ -638,7 +646,8 @@
           "2.1.6": "Removed default content - component only renders data explicitly provided by the user",
           "2.1.7": "Added cursor-pointer to expand button for better UX",
           "2.1.8": "Refactored to use HostAPI abstraction for multi-host support",
-          "2.1.9": "Inlined host detection to remove external lib dependency for shadcn distribution"
+          "2.1.9": "Inlined host detection to remove external lib dependency for shadcn distribution",
+          "2.1.10": "Updated post-card dependency with removed OpenAI types import"
         }
       },
       "dependencies": [
@@ -684,7 +693,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/table.png",
-        "version": "1.0.7",
+        "version": "2.0.0",
         "changelog": {
           "1.0.0": "Initial release with single and multi-select modes",
           "1.0.1": "Added descriptive alt tags for title images",
@@ -692,7 +701,8 @@
           "1.0.4": "Added comprehensive JSDoc documentation",
           "1.0.5": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "1.0.6": "Fixed defensive property access to handle empty objects and null values",
-          "1.0.7": "Inlined OpenAI display mode types to remove external lib dependency for shadcn distribution"
+          "1.0.7": "Inlined OpenAI display mode types to remove external lib dependency for shadcn distribution",
+          "2.0.0": "BREAKING: Removed onSelectionChange and onExpand actions. Selection and expand are now internal."
         }
       },
       "dependencies": [
@@ -895,7 +905,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/linkedin-post.png",
-        "version": "2.1.1",
+        "version": "3.0.0",
         "changelog": {
           "1.0.0": "Initial release with professional styling",
           "1.0.2": "Added comprehensive JSDoc documentation",
@@ -903,7 +913,8 @@
           "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "2.0.0": "BREAKING: Simplified component - removed engagement stats and action buttons, added LinkedIn icon link and optional repost button",
           "2.1.0": "Added image support, engagement stats with reaction icons, expandable content with maxLines prop, and moved repost button to the right",
-          "2.1.1": "Fixed avatar circle visibility - now hides entirely when avatar prop is not provided"
+          "2.1.1": "Fixed avatar circle visibility - now hides entirely when avatar prop is not provided",
+          "3.0.0": "BREAKING: Moved postUrl and repostUrl from actions to data prop"
         }
       },
       "dependencies": [
@@ -966,7 +977,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/map-carousel.png",
-        "version": "1.4.0",
+        "version": "2.0.0",
         "changelog": {
           "1.0.0": "Initial release with interactive map and location cards",
           "1.1.0": "Made image and price fields optional in Location interface",
@@ -976,7 +987,8 @@
           "1.2.2": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "1.2.3": "Fixed defensive property access to handle empty objects and null values",
           "1.3.0": "Added display modes (inline/fullscreen) with split-screen layout, filters, and ChatGPT host integration",
-          "1.4.0": "Made filters fully configurable via data prop with custom filter sections and match functions"
+          "1.4.0": "Made filters fully configurable via data prop with custom filter sections and match functions",
+          "2.0.0": "BREAKING: Removed onExpand and onFiltersApply actions. Expand and filter apply are now internal."
         }
       },
       "dependencies": [
@@ -1012,7 +1024,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/event-card.png",
-        "version": "5.0.7",
+        "version": "5.0.8",
         "changelog": {
           "1.0.0": "Initial release with default, compact, horizontal and covered variants. Supports physical, online, and hybrid events with signals and vibe tags.",
           "2.0.0": "BREAKING: Simplified Event interface - replaced startDateTime/endDateTime with display-formatted dateTime string, removed image/locationType/onlineUrl, changed ticketTiers to string array",
@@ -1026,7 +1038,8 @@
           "5.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "5.0.5": "Fixed defensive property access to handle empty objects and null values",
           "5.0.6": "Added types.ts to registry for proper installation",
-          "5.0.7": "Added demo/data.ts to registry for proper installation via shadcn CLI"
+          "5.0.7": "Added demo/data.ts to registry for proper installation via shadcn CLI",
+          "5.0.8": "Removed unused OpenAI types side-effect import"
         }
       },
       "dependencies": [
@@ -1066,7 +1079,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/event-list.png",
-        "version": "6.0.8",
+        "version": "7.0.0",
         "changelog": {
           "1.0.0": "Initial release with grid, list and carousel layouts. Includes pagination support.",
           "2.0.0": "BREAKING: Updated to use simplified Event interface with display-formatted dateTime",
@@ -1084,7 +1097,8 @@
           "6.0.5": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "6.0.6": "Fixed defensive property access to handle empty objects and null values",
           "6.0.7": "Added types.ts to registry for proper installation",
-          "6.0.8": "Added demo/data.ts to registry for proper installation via shadcn CLI"
+          "6.0.8": "Added demo/data.ts to registry for proper installation via shadcn CLI",
+          "7.0.0": "BREAKING: Removed onPageChange, onViewMore, onExpand, onFilterClick, onFiltersApply actions. Filters and expand are now internal."
         }
       },
       "dependencies": [
@@ -1190,7 +1204,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/ticket-tier-select.png",
-        "version": "3.0.1",
+        "version": "4.0.0",
         "changelog": {
           "1.0.0": "Initial release with ticket tier cards, quantity controls, price breakdown, and order summary sidebar",
           "1.1.0": "Added optional event image above order summary. Order summary now always visible with fixed width.",
@@ -1198,7 +1212,8 @@
           "2.0.2": "Added comprehensive JSDoc documentation",
           "2.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "3.0.0": "BREAKING: Removed id from TicketTier interface, made name and price optional.",
-          "3.0.1": "Simplified TicketSelection interface by removing tierIndex"
+          "3.0.1": "Simplified TicketSelection interface by removing tierIndex",
+          "4.0.0": "BREAKING: Removed onSelectionChange action. Tier quantity changes are now internal."
         }
       },
       "dependencies": [
@@ -1228,11 +1243,12 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/event-confirmation.png",
-        "version": "1.0.3",
+        "version": "2.0.0",
         "changelog": {
           "1.0.0": "Initial release with success message, event details, organizer follow, and social sharing",
           "1.0.2": "Added comprehensive JSDoc documentation",
-          "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation"
+          "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
+          "2.0.0": "BREAKING: Removed onChangeEmail action and Change email link"
         }
       },
       "dependencies": [

--- a/packages/manifest-ui/registry/blogging/post-list.tsx
+++ b/packages/manifest-ui/registry/blogging/post-list.tsx
@@ -23,8 +23,6 @@ export interface PostListProps {
   actions?: {
     /** Called when the read more button is clicked on a post. */
     onReadMore?: (post: Post) => void
-    /** Called when the page changes (fullwidth variant only). */
-    onPageChange?: (page: number) => void
   }
   appearance?: {
     /**
@@ -47,15 +45,6 @@ export interface PostListProps {
      * @default true
      */
     showCategory?: boolean
-    /**
-     * Number of posts per page (fullwidth variant only).
-     * @default 10
-     */
-    postsPerPage?: number
-  }
-  control?: {
-    /** Controlled current page number for pagination. */
-    currentPage?: number
   }
 }
 
@@ -96,20 +85,14 @@ export interface PostListProps {
  * />
  * ```
  */
-export function PostList({ data, actions, appearance, control }: PostListProps) {
+export function PostList({ data, actions, appearance }: PostListProps) {
   const posts = data?.posts ?? demoPosts
   const onReadMore = actions?.onReadMore
-  const onPageChange = actions?.onPageChange
   const variant = appearance?.variant ?? 'list'
   const columns = appearance?.columns ?? 2
   const showAuthor = appearance?.showAuthor ?? true
   const showCategory = appearance?.showCategory ?? true
-  const postsPerPage = appearance?.postsPerPage ?? 10
-  const controlledPage = control?.currentPage
   const [currentIndex, setCurrentIndex] = useState(0)
-  const [internalPage, setInternalPage] = useState(1)
-
-  const currentPage = controlledPage ?? internalPage
 
   // List variant
   if (variant === 'list') {
@@ -148,20 +131,8 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
     )
   }
 
-  // Fullwidth variant with pagination
+  // Fullwidth variant
   if (variant === 'fullwidth') {
-    const totalPages = Math.ceil(posts.length / postsPerPage)
-    const startIndex = (currentPage - 1) * postsPerPage
-    const endIndex = startIndex + postsPerPage
-    const paginatedPosts = posts.slice(startIndex, endIndex)
-
-    const handlePageChange = (page: number) => {
-      if (page >= 1 && page <= totalPages) {
-        setInternalPage(page)
-        onPageChange?.(page)
-      }
-    }
-
     const getGridColsClass = () => {
       switch (columns) {
         case 2:
@@ -178,7 +149,7 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
     return (
       <div className="space-y-6 p-6">
         <div className={cn('grid gap-6 grid-cols-1', getGridColsClass())}>
-          {paginatedPosts.map((post, index) => (
+          {posts.map((post, index) => (
             <PostCard
               key={index}
               data={{ post }}
@@ -186,52 +157,6 @@ export function PostList({ data, actions, appearance, control }: PostListProps) 
               actions={{ onReadMore }}
             />
           ))}
-        </div>
-
-        {/* Pagination */}
-        {totalPages > 1 && (
-          <div className="flex items-center justify-center gap-2">
-            <Button
-              variant="outline"
-              size="icon"
-              className="h-8 w-8"
-              onClick={() => handlePageChange(currentPage - 1)}
-              disabled={currentPage <= 1}
-              aria-label="Previous page"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-
-            <div className="flex items-center gap-1">
-              {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
-                <Button
-                  key={page}
-                  variant={page === currentPage ? 'default' : 'outline'}
-                  size="icon"
-                  className="h-8 w-8"
-                  onClick={() => handlePageChange(page)}
-                >
-                  {page}
-                </Button>
-              ))}
-            </div>
-
-            <Button
-              variant="outline"
-              size="icon"
-              className="h-8 w-8"
-              onClick={() => handlePageChange(currentPage + 1)}
-              disabled={currentPage >= totalPages}
-              aria-label="Next page"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-          </div>
-        )}
-
-        {/* Page info */}
-        <div className="text-center text-sm text-muted-foreground">
-          Showing {startIndex + 1}-{Math.min(endIndex, posts.length)} of {posts.length} posts
         </div>
       </div>
     )

--- a/packages/manifest-ui/registry/events/event-confirmation.tsx
+++ b/packages/manifest-ui/registry/events/event-confirmation.tsx
@@ -40,8 +40,6 @@ export interface EventConfirmationProps {
   actions?: {
     /** Called when "Take me to my tickets" button is clicked. */
     onViewTickets?: () => void
-    /** Called when "Change" email link is clicked. */
-    onChangeEmail?: () => void
     /** Called when "Follow" organizer button is clicked. */
     onFollowOrganizer?: () => void
     /** Called when a social share button is clicked. */
@@ -95,7 +93,7 @@ export function EventConfirmation({ data, actions }: EventConfirmationProps) {
       image: undefined
     }
   } = data ?? {}
-  const { onViewTickets, onChangeEmail, onFollowOrganizer, onShare } =
+  const { onViewTickets, onFollowOrganizer, onShare } =
     actions ?? {}
 
   return (
@@ -130,14 +128,6 @@ export function EventConfirmation({ data, actions }: EventConfirmationProps) {
               {ticketCount} Ticket sent to
             </p>
             <p className="text-sm">{recipientEmail}</p>
-            {onChangeEmail && (
-              <button
-                onClick={onChangeEmail}
-                className="text-sm text-primary hover:underline"
-              >
-                Change
-              </button>
-            )}
           </div>
 
           {/* Date */}

--- a/packages/manifest-ui/registry/events/event-list.tsx
+++ b/packages/manifest-ui/registry/events/event-list.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { cn } from '@/lib/utils'
-import { ChevronDown, ChevronLeft, ChevronRight, MapPin, Maximize2, SlidersHorizontal, X } from 'lucide-react'
+import { ChevronDown, ChevronLeft, ChevronRight, MapPin, SlidersHorizontal, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ComponentType } from 'react'
 import type { Event } from './types'
@@ -408,16 +408,6 @@ export interface EventListProps {
   actions?: {
     /** Called when an event card is clicked. */
     onEventSelect?: (event: Event) => void
-    /** Called when page changes (for pagination). */
-    onPageChange?: (page: number) => void
-    /** Called when "View more events" button is clicked. */
-    onViewMore?: () => void
-    /** Called when expand/fullscreen button is clicked. */
-    onExpand?: () => void
-    /** Called when the filter button is clicked. */
-    onFilterClick?: () => void
-    /** Called when filters are applied. */
-    onFiltersApply?: (filters: FilterState) => void
   }
   appearance?: {
     /**
@@ -427,12 +417,6 @@ export interface EventListProps {
     variant?: 'list' | 'grid' | 'carousel' | 'fullwidth'
     /** Number of columns for grid layout. */
     columns?: 2 | 3 | 4
-    /** Number of events to show per page. */
-    eventsPerPage?: number
-  }
-  control?: {
-    /** Current page number for pagination. */
-    currentPage?: number
   }
 }
 
@@ -473,10 +457,6 @@ export function EventList({ data, actions, appearance }: EventListProps) {
   const events = data?.events ?? demoEvents
   const title = data?.title
   const onEventSelect = actions?.onEventSelect
-  const onViewMore = actions?.onViewMore
-  const onExpand = actions?.onExpand
-  const onFilterClick = actions?.onFilterClick
-  const onFiltersApply = actions?.onFiltersApply
   const variant = appearance?.variant ?? 'list'
   const [currentIndex, setCurrentIndex] = useState(0)
   const [selectedEventIndex, setSelectedEventIndex] = useState<number | null>(null)
@@ -614,19 +594,8 @@ export function EventList({ data, actions, appearance }: EventListProps) {
     return (
       <div className="space-y-3">
         {title && (
-          <div className="flex items-center justify-between mb-4">
+          <div className="mb-4">
             <h2 className="text-lg font-semibold">{title}</h2>
-            {onExpand && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                onClick={onExpand}
-                aria-label="Expand view"
-              >
-                <Maximize2 className="h-4 w-4" />
-              </Button>
-            )}
           </div>
         )}
         {events.slice(0, 3).map((event, index) => (
@@ -641,24 +610,13 @@ export function EventList({ data, actions, appearance }: EventListProps) {
     )
   }
 
-  // Grid variant (inline mode - show 3 events with images and View More button)
+  // Grid variant (inline mode - show 3 events with images)
   if (variant === 'grid') {
     return (
       <div className="space-y-4">
         {title && (
-          <div className="flex items-center justify-between">
+          <div>
             <h2 className="text-lg font-semibold">{title}</h2>
-            {onExpand && (
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                onClick={onExpand}
-                aria-label="Expand view"
-              >
-                <Maximize2 className="h-4 w-4" />
-              </Button>
-            )}
           </div>
         )}
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
@@ -671,16 +629,6 @@ export function EventList({ data, actions, appearance }: EventListProps) {
             />
           ))}
         </div>
-        {events.length > 3 && (
-          <div className="flex justify-center pt-2">
-            <Button
-              variant="outline"
-              onClick={onViewMore}
-            >
-              View more events
-            </Button>
-          </div>
-        )}
       </div>
     )
   }
@@ -703,21 +651,18 @@ export function EventList({ data, actions, appearance }: EventListProps) {
     }
 
     const handleFilterButtonClick = () => {
-      setFilters(appliedFilters) // Reset to applied filters when opening
+      setFilters(appliedFilters)
       setShowFilters(true)
-      onFilterClick?.()
     }
 
     const handleApplyFilters = () => {
       setAppliedFilters(filters)
       setShowFilters(false)
-      onFiltersApply?.(filters)
     }
 
     const handleResetFilters = () => {
       setFilters(defaultFilters)
       setAppliedFilters(defaultFilters)
-      onFiltersApply?.(defaultFilters)
     }
 
     // Get filtered events
@@ -879,18 +824,8 @@ export function EventList({ data, actions, appearance }: EventListProps) {
   return (
     <div className="relative">
       {title && (
-        <div className="flex items-center justify-between mb-4">
+        <div className="mb-4">
           <h2 className="text-lg font-semibold">{title}</h2>
-          {onExpand && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              onClick={onExpand}
-            >
-              <Maximize2 className="h-4 w-4" />
-            </Button>
-          )}
         </div>
       )}
       <div className="overflow-hidden rounded-lg">

--- a/packages/manifest-ui/registry/events/ticket-tier-select.tsx
+++ b/packages/manifest-ui/registry/events/ticket-tier-select.tsx
@@ -106,8 +106,6 @@ export interface TicketTierSelectProps {
   actions?: {
     /** Called when checkout button is clicked with selections and total. */
     onCheckout?: (selections: TicketSelection[], total: number) => void
-    /** Called when ticket selection changes. */
-    onSelectionChange?: (selections: TicketSelection[]) => void
   }
   appearance?: {
     /**
@@ -163,7 +161,7 @@ export function TicketTierSelect({ data, actions, appearance, control }: TicketT
     tiers = defaultTiers
   } = data ?? {}
   const currency = event.currency ?? 'USD'
-  const { onCheckout, onSelectionChange } = actions ?? {}
+  const { onCheckout } = actions ?? {}
   const { showOrderSummary = true } = appearance ?? {}
 
   const [selections, setSelections] = useState<Record<number, number>>(
@@ -182,10 +180,6 @@ export function TicketTierSelect({ data, actions, appearance, control }: TicketT
       delete newSelections[tierIndex]
     }
     setSelections(newSelections)
-
-    // Notify parent of selection change
-    const selectionsList = getSelectionsList(newSelections)
-    onSelectionChange?.(selectionsList)
   }
 
   const getSelectionsList = (sels: Record<number, number> = selections): TicketSelection[] => {

--- a/packages/manifest-ui/registry/form/date-time-picker.tsx
+++ b/packages/manifest-ui/registry/form/date-time-picker.tsx
@@ -63,8 +63,6 @@ export interface DateTimePickerProps {
     timezone?: string
   }
   actions?: {
-    /** Called when a date and time are selected. */
-    onSelect?: (date: Date, time: string) => void
     /** Called when the user clicks the Next button. */
     onNext?: (date: Date, time: string) => void
   }
@@ -173,7 +171,7 @@ export function DateTimePicker({ data, actions, appearance, control }: DateTimeP
     availableTimeSlots = defaultTimeSlots,
     timezone = 'Eastern Time - US & Canada'
   } = data ?? {}
-  const { onSelect, onNext } = actions ?? {}
+  const { onNext } = actions ?? {}
   const { showTitle = true, showTimezone = true } = appearance ?? {}
   const {
     selectedDate: controlledDate,
@@ -265,7 +263,6 @@ export function DateTimePicker({ data, actions, appearance, control }: DateTimeP
     if (!isDateAvailable(date)) return
     setSelectedDate(date)
     setSelectedTime(null)
-    onSelect?.(date, '')
     // On mobile, switch to time view when date is selected
     setMobileView('time')
   }
@@ -276,9 +273,6 @@ export function DateTimePicker({ data, actions, appearance, control }: DateTimeP
 
   const handleTimeSelect = (time: string) => {
     setSelectedTime(time)
-    if (selectedDate) {
-      onSelect?.(selectedDate, time)
-    }
   }
 
   const handleNext = () => {

--- a/packages/manifest-ui/registry/list/table.tsx
+++ b/packages/manifest-ui/registry/list/table.tsx
@@ -114,8 +114,6 @@ export interface TableProps<T = Record<string, unknown>> {
     totalRows?: number
   }
   actions?: {
-    /** Called when row selection changes with the selected rows. */
-    onSelectionChange?: (selectedRows: T[]) => void
     /** Called when the copy action is triggered with selected rows. */
     onCopy?: (selectedRows: T[]) => void
     /** Called when the download action is triggered with selected rows. */
@@ -124,8 +122,6 @@ export interface TableProps<T = Record<string, unknown>> {
     onShare?: (selectedRows: T[]) => void
     /** Called when the refresh button is clicked. */
     onRefresh?: () => void
-    /** Called when the expand to fullscreen button is clicked. */
-    onExpand?: () => void
   }
   appearance?: {
     /**
@@ -499,12 +495,10 @@ export function Table<T extends Record<string, unknown>>({
     totalRows
   } = dataProps ?? {}
   const {
-    onSelectionChange,
     onCopy,
     onDownload,
     onShare,
-    onRefresh,
-    onExpand
+    onRefresh
   } = actions ?? {}
   const {
     selectable = 'none',
@@ -680,13 +674,11 @@ export function Table<T extends Record<string, unknown>>({
       }
 
       setInternalSelectedRows(newSelected)
-      onSelectionChange?.(sortedData.filter((_, i) => newSelected.has(i)))
     },
     [
       selectable,
       selectedRowsSet,
       sortedData,
-      onSelectionChange,
       isFullscreen,
       currentPage,
       rowsPerPage
@@ -702,8 +694,7 @@ export function Table<T extends Record<string, unknown>>({
       : new Set(visibleData.map((_, i) => i))
 
     setInternalSelectedRows(newSelected)
-    onSelectionChange?.(allSelected ? [] : visibleData)
-  }, [selectable, selectedRowsSet.size, visibleData, onSelectionChange])
+  }, [selectable, selectedRowsSet.size, visibleData])
 
   const getValue = (row: T, accessor: string): unknown => {
     const keys = accessor.split('.')
@@ -733,10 +724,7 @@ export function Table<T extends Record<string, unknown>>({
   }
 
   const handleExpand = () => {
-    if (onExpand) {
-      onExpand()
-    } else if (typeof window !== 'undefined' && window.openai) {
-      // Request fullscreen mode from ChatGPT host
+    if (typeof window !== 'undefined' && window.openai) {
       window.openai.requestDisplayMode({ mode: 'fullscreen' })
     }
   }

--- a/packages/manifest-ui/registry/map/map-carousel.tsx
+++ b/packages/manifest-ui/registry/map/map-carousel.tsx
@@ -195,10 +195,6 @@ export interface MapCarouselProps {
   actions?: {
     /** Called when a user selects a location via marker or card click. */
     onSelectLocation?: (location: Location) => void
-    /** Called when the expand button is clicked (inline mode). */
-    onExpand?: () => void
-    /** Called when filters are applied (fullscreen mode). */
-    onFiltersApply?: (filters: FilterState) => void
   }
   appearance?: {
     /**
@@ -813,7 +809,7 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
   } = data ?? {}
 
   const tileConfig = getTileConfig(mapStyle)
-  const { onSelectLocation, onExpand, onFiltersApply } = actions ?? {}
+  const { onSelectLocation } = actions ?? {}
   const { mapHeight = '504px' } = appearance ?? {}
 
   // Get display mode from host (ChatGPT/MCP) or fall back to appearance prop
@@ -911,11 +907,9 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
 
   // Handle expand button click
   const handleExpand = () => {
-    // Request fullscreen from host if available
     if (typeof window !== 'undefined' && window.openai?.requestDisplayMode) {
       window.openai.requestDisplayMode({ mode: 'fullscreen' })
     }
-    onExpand?.()
   }
 
   // Drag handlers for carousel
@@ -1015,13 +1009,11 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
     const handleApplyFilters = () => {
       setAppliedFilterState(filterState)
       setShowFilters(false)
-      onFiltersApply?.(filterState)
     }
 
     const handleResetFilters = () => {
       setFilterState(emptyFilterState)
       setAppliedFilterState(emptyFilterState)
-      onFiltersApply?.(emptyFilterState)
     }
 
     // Get filtered locations
@@ -1145,19 +1137,17 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
       style={{ height: mapHeight }}
     >
       {/* Expand button in top right */}
-      {onExpand && (
-        <div className="absolute top-3 right-3 z-[1001]">
-          <Button
-            variant="secondary"
-            size="icon"
-            className="h-8 w-8 bg-background/90 backdrop-blur-sm shadow-md"
-            onClick={handleExpand}
-            aria-label="Expand to fullscreen"
-          >
-            <Maximize2 className="h-4 w-4" />
-          </Button>
-        </div>
-      )}
+      <div className="absolute top-3 right-3 z-[1001]">
+        <Button
+          variant="secondary"
+          size="icon"
+          className="h-8 w-8 bg-background/90 backdrop-blur-sm shadow-md"
+          onClick={handleExpand}
+          aria-label="Expand to fullscreen"
+        >
+          <Maximize2 className="h-4 w-4" />
+        </Button>
+      </div>
 
       {/* Map Section - Full size */}
       {leafletComponents ? (

--- a/packages/manifest-ui/registry/payment/amount-input.tsx
+++ b/packages/manifest-ui/registry/payment/amount-input.tsx
@@ -19,8 +19,6 @@ export interface AmountInputProps {
     presets?: number[]
   }
   actions?: {
-    /** Called when the amount changes via buttons, presets, or direct input. */
-    onChange?: (value: number) => void
     /** Called when user confirms the selected amount. */
     onConfirm?: (value: number) => void
   }
@@ -95,7 +93,6 @@ export interface AmountInputProps {
  */
 export function AmountInput({ data, actions, appearance, control }: AmountInputProps) {
   const presets = data?.presets ?? [20, 50, 100, 200]
-  const onChange = actions?.onChange
   const onConfirm = actions?.onConfirm
   const min = appearance?.min ?? 0
   const max = appearance?.max ?? 10000
@@ -120,12 +117,10 @@ export function AmountInput({ data, actions, appearance, control }: AmountInputP
   const handleChange = (newValue: number) => {
     const clamped = Math.max(min, Math.min(max, newValue))
     setAmount(clamped)
-    onChange?.(clamped)
   }
 
   const handlePreset = (preset: number) => {
     setAmount(preset)
-    onChange?.(preset)
   }
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/manifest-ui/registry/payment/saved-cards.tsx
+++ b/packages/manifest-ui/registry/payment/saved-cards.tsx
@@ -50,8 +50,6 @@ export interface SavedCardsProps {
     amount?: number
   }
   actions?: {
-    /** Called when a card is selected from the list. */
-    onSelectCard?: (cardId: string) => void
     /** Called when the user clicks the add new card option. */
     onAddNewCard?: () => void
     /** Called when the user initiates payment with the selected card. */
@@ -123,7 +121,6 @@ const brandColors: Record<string, string> = {
 export function SavedCards({ data, actions, appearance, control }: SavedCardsProps) {
   const cards = data?.cards
   const amount = data?.amount
-  const onSelectCard = actions?.onSelectCard
   const onAddNewCard = actions?.onAddNewCard
   const onPay = actions?.onPay
   const currency = appearance?.currency
@@ -135,7 +132,6 @@ export function SavedCards({ data, actions, appearance, control }: SavedCardsPro
 
   const handleSelect = (cardId: string) => {
     setSelected(cardId)
-    onSelectCard?.(cardId)
   }
 
   const formatCurrency = (value: number) => {

--- a/packages/manifest-ui/registry/selection/option-list.tsx
+++ b/packages/manifest-ui/registry/selection/option-list.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Check } from 'lucide-react'
 import { useState } from 'react'
@@ -25,10 +26,8 @@ export interface OptionListProps {
     options?: Option[]
   }
   actions?: {
-    /** Called when an option is selected in single selection mode. */
-    onSelectOption?: (option: Option) => void
-    /** Called when options are selected in multiple selection mode. */
-    onSelectOptions?: (options: Option[]) => void
+    /** Called when the user confirms their selection. Returns selected option(s). */
+    onSubmit?: (selected: Option[]) => void
   }
   appearance?: {
     /**
@@ -73,8 +72,7 @@ export interface OptionListProps {
  */
 export function OptionList({ data, actions, appearance, control }: OptionListProps) {
   const options = data?.options ?? demoOptions
-  const onSelectOption = actions?.onSelectOption
-  const onSelectOptions = actions?.onSelectOptions
+  const onSubmit = actions?.onSubmit
   const multiple = appearance?.multiple ?? false
   const selectedOptionIndex = control?.selectedOptionIndex
   const selectedOptionIndexes = control?.selectedOptionIndexes ?? []
@@ -91,10 +89,20 @@ export function OptionList({ data, actions, appearance, control }: OptionListPro
         ? currentSelected.filter((i) => i !== index)
         : [...currentSelected, index]
       setSelected(newSelected)
-      onSelectOptions?.(options.filter((_, i) => newSelected.includes(i)))
     } else {
       setSelected(index)
-      onSelectOption?.(option)
+    }
+  }
+
+  const handleSubmit = () => {
+    if (multiple) {
+      const selectedIndexes = selected as number[]
+      onSubmit?.(options.filter((_, i) => selectedIndexes.includes(i)))
+    } else {
+      const selectedIndex = selected as number
+      if (selectedIndex >= 0) {
+        onSubmit?.([options[selectedIndex]])
+      }
     }
   }
 
@@ -105,8 +113,12 @@ export function OptionList({ data, actions, appearance, control }: OptionListPro
     return selected === index
   }
 
+  const hasSelection = multiple
+    ? (selected as number[]).length > 0
+    : (selected as number) >= 0
+
   return (
-    <div className="w-full bg-card rounded-lg p-4">
+    <div className="w-full bg-card rounded-lg p-4 space-y-3">
       <div className="flex flex-wrap gap-2">
         {options.map((option, index) => (
           <button
@@ -141,6 +153,17 @@ export function OptionList({ data, actions, appearance, control }: OptionListPro
           </button>
         ))}
       </div>
+      {onSubmit && (
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={!hasSelection}
+          >
+            Confirm
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/manifest-ui/registry/selection/tag-select.tsx
+++ b/packages/manifest-ui/registry/selection/tag-select.tsx
@@ -32,8 +32,6 @@ export interface TagSelectProps {
     tags?: Tag[]
   }
   actions?: {
-    /** Called when the tag selection changes with the array of selected tag IDs. */
-    onSelectTags?: (tagIds: string[]) => void
     /** Called when the user clicks the validate button with the selected tag IDs. */
     onValidate?: (tagIds: string[]) => void
   }
@@ -117,7 +115,6 @@ const tagClasses = {
  */
 export function TagSelect({ data, actions, appearance, control }: TagSelectProps) {
   const tags = data?.tags ?? defaultTags
-  const onSelectTags = actions?.onSelectTags
   const onValidate = actions?.onValidate
   const mode = appearance?.mode ?? 'multiple'
   const showClear = appearance?.showClear ?? true
@@ -138,12 +135,10 @@ export function TagSelect({ data, actions, appearance, control }: TagSelectProps
     }
 
     setSelected(newSelected)
-    onSelectTags?.(newSelected)
   }
 
   const handleClear = () => {
     setSelected([])
-    onSelectTags?.([])
   }
 
   const handleValidate = () => {

--- a/packages/manifest-ui/registry/social/linkedin-post.tsx
+++ b/packages/manifest-ui/registry/social/linkedin-post.tsx
@@ -36,8 +36,6 @@ export interface LinkedInPostProps {
     comments?: string;
     /** Number of reposts (e.g., "12"). */
     reposts?: string;
-  };
-  actions?: {
     /** URL to the original LinkedIn post. If provided, shows the LinkedIn icon. */
     postUrl?: string;
     /** URL for the repost action. If provided, shows the repost button in footer. */
@@ -336,7 +334,7 @@ const reactionIcons: Record<ReactionType, JSX.Element> = {
  * />
  * ```
  */
-export function LinkedInPost({ data, actions, appearance }: LinkedInPostProps) {
+export function LinkedInPost({ data, appearance }: LinkedInPostProps) {
   const {
     author,
     headline,
@@ -348,9 +346,10 @@ export function LinkedInPost({ data, actions, appearance }: LinkedInPostProps) {
     topReactions,
     comments,
     reposts,
+    postUrl,
+    repostUrl,
   } = data ?? {};
 
-  const { postUrl, repostUrl } = actions ?? {};
   const { maxLines = 3 } = appearance ?? {};
 
   const hasEngagement = reactions || comments || reposts;


### PR DESCRIPTION
## Description

Remove actions from Manifest UI blocks that don't advance the user flow (navigate to another view or return a value). This is a breaking change across 11 components.

**Changes by type:**

- **Removed entirely** (action + UI): `post-list.onPageChange` (pagination), `event-list.onPageChange`/`onViewMore`, `event-confirmation.onChangeEmail`
- **Internalized** (removed from `actions`, kept as internal behavior): expand/collapse, filter toggling, selection changes in `event-list`, `table`, `map-carousel`, `ticket-tier-select`, `date-time-picker`, `amount-input`, `saved-cards`, `tag-select`
- **Moved to `data`**: `linkedin-post.postUrl` and `repostUrl` (were misplaced in `actions`)
- **Simplified**: `option-list` — replaced `onSelectOption`/`onSelectOptions` with single `onSubmit`

All `registry.json` versions bumped (MAJOR for breaking changes), `changelog.json` updated, `page.tsx` usageCode and actionCount synced.

## Related Issues

None

## How can it be tested?

1. Run `pnpm install && cd packages/manifest-ui && pnpm run build` — should compile with no errors
2. Run `pnpm test` — all 1033 tests should pass
3. Run `pnpm run dev` and visually verify each modified block:
   - `/blocks/blogging/post-list` — no pagination controls in fullwidth mode
   - `/blocks/events/event-list` — no "View more" button, filters work internally
   - `/blocks/events/event-confirmation` — no "Change" email link
   - `/blocks/selection/option-list` — has confirm button, fires `onSubmit`
   - `/blocks/social/linkedin-post` — URLs in data prop, no actions

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR