### PR TITLE
fix: correct registryDependencies for shadcn CLI installation

### DIFF
--- a/packages/manifest-ui/__tests__/registry-dependencies.test.ts
+++ b/packages/manifest-ui/__tests__/registry-dependencies.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Registry Dependencies Accuracy Tests
+ *
+ * Ensures that registryDependencies in registry.json exactly match
+ * the actual @/components/ui/* imports in each component's source files.
+ *
+ * - Missing deps break `npx shadcn@latest add` installation
+ * - Extra deps bloat the install with unused packages
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const ROOT_DIR = resolve(__dirname, '..')
+const REGISTRY_JSON_PATH = resolve(ROOT_DIR, 'registry.json')
+
+interface RegistryFile {
+  path: string
+  type: string
+}
+
+interface RegistryItem {
+  name: string
+  registryDependencies?: string[]
+  files: RegistryFile[]
+}
+
+interface Registry {
+  items: RegistryItem[]
+}
+
+/**
+ * Extract all @/components/ui/<name> imports from a TypeScript file.
+ * Handles both single-line and multi-line import statements.
+ */
+function extractUiImports(filePath: string): string[] {
+  const content = readFileSync(filePath, 'utf-8')
+  const imports = new Set<string>()
+
+  // Match: from '@/components/ui/<name>' or from "@/components/ui/<name>"
+  const regex = /from\s+['"]@\/components\/ui\/([^'"]+)['"]/g
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(content)) !== null) {
+    imports.add(match[1])
+  }
+
+  return [...imports].sort()
+}
+
+function loadRegistry(): Registry {
+  const content = readFileSync(REGISTRY_JSON_PATH, 'utf-8')
+  return JSON.parse(content) as Registry
+}
+
+describe('Registry Dependencies Accuracy', () => {
+  const registry = loadRegistry()
+
+  for (const item of registry.items) {
+    describe(`${item.name}`, () => {
+      it('should declare exactly the shadcn UI primitives it imports', () => {
+        // Collect all @/components/ui/* imports from all .tsx files
+        const allImports = new Set<string>()
+
+        for (const file of item.files) {
+          if (!file.path.endsWith('.tsx')) continue
+
+          const fullPath = resolve(ROOT_DIR, file.path)
+          const imports = extractUiImports(fullPath)
+          for (const imp of imports) {
+            allImports.add(imp)
+          }
+        }
+
+        // Filter registryDependencies to only shadcn primitives (not URLs)
+        const declared = (item.registryDependencies ?? [])
+          .filter((dep) => !dep.includes('/'))
+          .sort()
+
+        const actual = [...allImports].sort()
+
+        const missing = actual.filter((imp) => !declared.includes(imp))
+        const extra = declared.filter((dep) => !actual.includes(dep))
+
+        if (missing.length > 0) {
+          throw new Error(
+            `Component "${item.name}" imports ${missing.map((m) => `"${m}"`).join(', ')} ` +
+              `from @/components/ui/ but they are NOT in registryDependencies. ` +
+              `This breaks \`npx shadcn@latest add\` installation.`
+          )
+        }
+
+        if (extra.length > 0) {
+          throw new Error(
+            `Component "${item.name}" declares ${extra.map((e) => `"${e}"`).join(', ')} ` +
+              `in registryDependencies but does NOT import them. ` +
+              `Remove unused dependencies to avoid bloating installations.`
+          )
+        }
+
+        expect(actual).toEqual(declared)
+      })
+    })
+  }
+})

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -9,7 +9,8 @@
       "1.2.3": "Added comprehensive JSDoc documentation",
       "1.2.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.2.5": "Fixed defensive property access to handle empty objects and null values",
-      "1.2.6": "Removed default content data - component only renders explicitly provided data"
+      "1.2.6": "Removed default content data - component only renders explicitly provided data",
+      "1.2.7": "Fixed missing popover dependency for shadcn CLI installation"
     },
     "date-time-picker": {
       "1.0.0": "Initial release with calendar and time slot selection",
@@ -17,7 +18,8 @@
       "1.0.3": "Added comprehensive JSDoc documentation",
       "1.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "2.0.0": "BREAKING: Removed onSelect action. Intermediate date/time selection is now internal.",
-      "2.0.1": "Removed default content data - component only renders explicitly provided data"
+      "2.0.1": "Removed default content data - component only renders explicitly provided data",
+      "2.0.2": "Fixed missing popover dependency for shadcn CLI installation"
     },
     "issue-report-form": {
       "1.0.0": "Initial release with categories, impact levels and file attachments",
@@ -162,7 +164,8 @@
       "2.0.4": "Fixed defensive property access to handle empty objects and null values",
       "2.0.5": "Fixed circular dependency by moving Post interface to types.ts",
       "2.0.6": "Removed unused OpenAI types side-effect import",
-      "2.0.7": "Removed default content data - component only renders explicitly provided data"
+      "2.0.7": "Removed default content data - component only renders explicitly provided data",
+      "2.0.8": "Fixed missing tooltip dependency for shadcn CLI installation"
     },
     "post-list": {
       "1.0.0": "Initial release with list, grid and carousel variants",
@@ -176,7 +179,8 @@
       "2.0.6": "Fixed circular dependency by moving Post interface to types.ts",
       "2.0.7": "Added bg-card background and margin to list variant for better dark/light mode support",
       "3.0.0": "BREAKING: Removed pagination (onPageChange, postsPerPage, control). Fullwidth variant now renders all posts.",
-      "3.0.1": "Removed default content data - component only renders explicitly provided data"
+      "3.0.1": "Removed default content data - component only renders explicitly provided data",
+      "3.0.2": "Fixed missing tooltip dependency for shadcn CLI installation"
     },
     "post-detail": {
       "1.0.0": "Initial release with cover image, author info and related posts",
@@ -209,7 +213,8 @@
       "1.0.6": "Fixed defensive property access to handle empty objects and null values",
       "1.0.7": "Inlined OpenAI display mode types to remove external lib dependency for shadcn distribution",
       "2.0.0": "BREAKING: Removed onSelectionChange and onExpand actions. Selection and expand are now internal.",
-      "2.0.1": "Removed default content data - component only renders explicitly provided data"
+      "2.0.1": "Removed default content data - component only renders explicitly provided data",
+      "2.0.2": "Removed unused checkbox from registry dependencies"
     },
     "message-bubble": {
       "1.0.0": "Initial release with text, image, voice and reaction variants",
@@ -301,7 +306,8 @@
       "5.0.6": "Added types.ts to registry for proper installation",
       "5.0.7": "Added demo/data.ts to registry for proper installation via shadcn CLI",
       "5.0.8": "Removed unused OpenAI types side-effect import",
-      "5.0.9": "Removed default content data - component only renders explicitly provided data"
+      "5.0.9": "Removed default content data - component only renders explicitly provided data",
+      "5.0.10": "Removed unused button from registry dependencies"
     },
     "event-list": {
       "1.0.0": "Initial release with grid, list and carousel layouts. Includes pagination support.",

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -14,7 +14,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/contact-form.png",
-        "version": "1.2.6",
+        "version": "1.2.7",
         "changelog": {
           "1.0.0": "Initial release with name, phone, email, message and file attachment fields",
           "1.1.0": "Made phone, email, and message fields optional with defaults",
@@ -23,7 +23,8 @@
           "1.2.3": "Added comprehensive JSDoc documentation",
           "1.2.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "1.2.5": "Fixed defensive property access to handle empty objects and null values",
-          "1.2.6": "Removed default content data - component only renders explicitly provided data"
+          "1.2.6": "Removed default content data - component only renders explicitly provided data",
+          "1.2.7": "Fixed missing popover dependency for shadcn CLI installation"
         }
       },
       "dependencies": [
@@ -33,7 +34,7 @@
         "button",
         "input",
         "label",
-        "select"
+        "popover"
       ],
       "files": [
         {
@@ -56,21 +57,23 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/date-time-picker.png",
-        "version": "2.0.1",
+        "version": "2.0.2",
         "changelog": {
           "1.0.0": "Initial release with calendar and time slot selection",
           "1.0.1": "Added aria-labels to navigation buttons for better screen reader accessibility",
           "1.0.3": "Added comprehensive JSDoc documentation",
           "1.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "2.0.0": "BREAKING: Removed onSelect action. Intermediate date/time selection is now internal.",
-          "2.0.1": "Removed default content data - component only renders explicitly provided data"
+          "2.0.1": "Removed default content data - component only renders explicitly provided data",
+          "2.0.2": "Fixed missing popover dependency for shadcn CLI installation"
         }
       },
       "dependencies": [
         "lucide-react"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "popover"
       ],
       "files": [
         {
@@ -523,7 +526,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/post-card.png",
-        "version": "2.0.7",
+        "version": "2.0.8",
         "changelog": {
           "1.0.0": "Initial release with default, compact, horizontal and covered variants",
           "2.0.0": "BREAKING: Removed id from Post interface. Use array index for key.",
@@ -533,14 +536,16 @@
           "2.0.4": "Fixed defensive property access to handle empty objects and null values",
           "2.0.5": "Fixed circular dependency by moving Post interface to types.ts",
           "2.0.6": "Removed unused OpenAI types side-effect import",
-          "2.0.7": "Removed default content data - component only renders explicitly provided data"
+          "2.0.7": "Removed default content data - component only renders explicitly provided data",
+          "2.0.8": "Fixed missing tooltip dependency for shadcn CLI installation"
         }
       },
       "dependencies": [
         "lucide-react"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "tooltip"
       ],
       "files": [
         {
@@ -578,7 +583,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/post-list.png",
-        "version": "3.0.1",
+        "version": "3.0.2",
         "changelog": {
           "1.0.0": "Initial release with list, grid and carousel variants",
           "1.1.0": "Added fullwidth variant with pagination for fullscreen mode",
@@ -591,14 +596,16 @@
           "2.0.6": "Fixed circular dependency by moving Post interface to types.ts",
           "2.0.7": "Added bg-card background and margin to list variant for better dark/light mode support",
           "3.0.0": "BREAKING: Removed pagination (onPageChange, postsPerPage, control). Fullwidth variant now renders all posts.",
-          "3.0.1": "Removed default content data - component only renders explicitly provided data"
+          "3.0.1": "Removed default content data - component only renders explicitly provided data",
+          "3.0.2": "Fixed missing tooltip dependency for shadcn CLI installation"
         }
       },
       "dependencies": [
         "lucide-react"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "tooltip"
       ],
       "files": [
         {
@@ -708,7 +715,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/table.png",
-        "version": "2.0.1",
+        "version": "2.0.2",
         "changelog": {
           "1.0.0": "Initial release with single and multi-select modes",
           "1.0.1": "Added descriptive alt tags for title images",
@@ -718,7 +725,8 @@
           "1.0.6": "Fixed defensive property access to handle empty objects and null values",
           "1.0.7": "Inlined OpenAI display mode types to remove external lib dependency for shadcn distribution",
           "2.0.0": "BREAKING: Removed onSelectionChange and onExpand actions. Selection and expand are now internal.",
-          "2.0.1": "Removed default content data - component only renders explicitly provided data"
+          "2.0.1": "Removed default content data - component only renders explicitly provided data",
+          "2.0.2": "Removed unused checkbox from registry dependencies"
         }
       },
       "dependencies": [
@@ -726,7 +734,6 @@
       ],
       "registryDependencies": [
         "button",
-        "checkbox",
         "popover",
         "select",
         "input"
@@ -1046,7 +1053,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/event-card.png",
-        "version": "5.0.9",
+        "version": "5.0.10",
         "changelog": {
           "1.0.0": "Initial release with default, compact, horizontal and covered variants. Supports physical, online, and hybrid events with signals and vibe tags.",
           "2.0.0": "BREAKING: Simplified Event interface - replaced startDateTime/endDateTime with display-formatted dateTime string, removed image/locationType/onlineUrl, changed ticketTiers to string array",
@@ -1062,15 +1069,14 @@
           "5.0.6": "Added types.ts to registry for proper installation",
           "5.0.7": "Added demo/data.ts to registry for proper installation via shadcn CLI",
           "5.0.8": "Removed unused OpenAI types side-effect import",
-          "5.0.9": "Removed default content data - component only renders explicitly provided data"
+          "5.0.9": "Removed default content data - component only renders explicitly provided data",
+          "5.0.10": "Removed unused button from registry dependencies"
         }
       },
       "dependencies": [
         "lucide-react"
       ],
-      "registryDependencies": [
-        "button"
-      ],
+      "registryDependencies": [],
       "files": [
         {
           "path": "registry/events/event-card.tsx",


### PR DESCRIPTION
## Description

Fix incorrect `registryDependencies` in `registry.json` that cause broken or bloated installations via `npx shadcn@latest add`:

**Missing dependencies (broke installation):**
- `contact-form`: declared `select` but actually imports `popover`
- `date-time-picker`: missing `popover`
- `post-card`: missing `tooltip` (from bundled `post-detail.tsx`)
- `post-list`: missing `tooltip` (from bundled `post-detail.tsx`)

**Extra dependencies (bloated installation):**
- `table`: declared `checkbox` but doesn't import it
- `event-card`: declared `button` but doesn't import any UI primitives

Also adds a new automated test (`registry-dependencies.test.ts`) that scans every component's source files for `@/components/ui/*` imports and verifies they exactly match declared `registryDependencies`. This prevents future regressions.

## Related Issues

None

## How can it be tested?

1. Run `pnpm test` in `packages/manifest-ui/` — all 1179 tests pass
2. Run `pnpm build` — build succeeds
3. Try `npx shadcn@latest add https://ui.manifest.build/r/contact-form.json` — should install `popover` instead of `select`
4. To verify the test catches issues: temporarily remove a dep from `registryDependencies` and run `pnpm test` — the new test will fail

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR