### PR TITLE
fix(manifestUI): unify shared type exports via manifest-types registry item

### DIFF
--- a/.github/workflows/manifest-ui-ci.yml
+++ b/.github/workflows/manifest-ui-ci.yml
@@ -2,9 +2,9 @@
 # Manifest UI CI Workflow
 # ============================================================================
 # Runs CI checks for the manifest-ui package:
-#   - Builds the registry and generates preview images
-#   - Runs the production build (includes generated previews)
-#   - Runs tests
+#   - Lint and test (fast, no browser needed)
+#   - Generate preview images (requires Playwright + dev server)
+#   - Production build (includes generated previews)
 # ============================================================================
 
 name: Manifest UI CI
@@ -18,7 +18,36 @@ on:
 
 jobs:
   test:
-    name: test
+    name: lint & test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build registry
+        working-directory: packages/manifest-ui
+        run: pnpm run registry:build
+
+      - name: Run tests
+        run: pnpm run manifest-ui:test
+
+  previews:
+    name: previews & build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -86,6 +115,3 @@ jobs:
       - name: Build manifest-ui
         working-directory: packages/manifest-ui
         run: pnpm exec next build
-
-      - name: Run tests
-        run: pnpm run manifest-ui:test

--- a/packages/manifest-ui/__tests__/component-exports.test.ts
+++ b/packages/manifest-ui/__tests__/component-exports.test.ts
@@ -58,9 +58,10 @@ function loadRegistry(): Registry {
 
 describe('Component Exports', () => {
   const registry = loadRegistry()
+  const blockItems = registry.items.filter((item) => item.type === 'registry:block')
 
   describe('Export presence', () => {
-    for (const item of registry.items) {
+    for (const item of blockItems) {
       const mainFile = item.files[0]
       if (!mainFile) continue
 
@@ -90,7 +91,7 @@ describe('Component Exports', () => {
   })
 
   describe('Component function export', () => {
-    for (const item of registry.items) {
+    for (const item of blockItems) {
       const mainFile = item.files[0]
       if (!mainFile) continue
 
@@ -139,7 +140,7 @@ describe('Component Exports', () => {
   })
 
   describe('Props interface export', () => {
-    for (const item of registry.items) {
+    for (const item of blockItems) {
       const mainFile = item.files[0]
       if (!mainFile) continue
 
@@ -174,7 +175,7 @@ describe('Component Exports', () => {
   })
 
   describe('React import or JSX usage', () => {
-    for (const item of registry.items) {
+    for (const item of blockItems) {
       const mainFile = item.files[0]
       if (!mainFile) continue
 
@@ -227,9 +228,10 @@ describe('Component Exports', () => {
 
 describe('Component Structure Standards', () => {
   const registry = loadRegistry()
+  const blockItems = registry.items.filter((item) => item.type === 'registry:block')
 
   describe('No console.log statements', () => {
-    for (const item of registry.items) {
+    for (const item of blockItems) {
       const mainFile = item.files[0]
       if (!mainFile) continue
 
@@ -259,7 +261,7 @@ describe('Component Structure Standards', () => {
   })
 
   describe('TypeScript types', () => {
-    for (const item of registry.items) {
+    for (const item of blockItems) {
       const mainFile = item.files[0]
       if (!mainFile) continue
 
@@ -296,9 +298,10 @@ describe('Component Structure Standards', () => {
 
 describe('Import Standards', () => {
   const registry = loadRegistry()
+  const blockItems = registry.items.filter((item) => item.type === 'registry:block')
 
   describe('No relative parent imports outside registry', () => {
-    for (const item of registry.items) {
+    for (const item of blockItems) {
       const mainFile = item.files[0]
       if (!mainFile) continue
 
@@ -330,7 +333,7 @@ describe('Import Standards', () => {
   })
 
   describe('Uses @/ alias for lib imports', () => {
-    for (const item of registry.items) {
+    for (const item of blockItems) {
       const mainFile = item.files[0]
       if (!mainFile) continue
 

--- a/packages/manifest-ui/__tests__/no-broken-imports.test.ts
+++ b/packages/manifest-ui/__tests__/no-broken-imports.test.ts
@@ -268,9 +268,19 @@ describe('No Broken Imports in Registry Components', () => {
             }
 
             if (!inRegistry) {
-              errors.push(
-                `Line ${imp.line}: "${imp.path}" resolves to "${resolvedFile}" which is not included in the registry files for any owning component (${ownerItems.map((i) => i.name).join(', ')})`
+              // Check if the import is for types provided by manifest-types via registryDependencies.
+              // Components import from './types' (resolving to category types.ts locally),
+              // but at install time manifest-types provides components/ui/types.ts.
+              const isTypesImport = resolvedFile.endsWith('/types.ts')
+              const hasManifestTypesDep = ownerItems.some((oi) =>
+                oi.registryDependencies?.includes('manifest-types')
               )
+
+              if (!(isTypesImport && hasManifestTypesDep)) {
+                errors.push(
+                  `Line ${imp.line}: "${imp.path}" resolves to "${resolvedFile}" which is not included in the registry files for any owning component (${ownerItems.map((i) => i.name).join(', ')})`
+                )
+              }
             }
           }
         }

--- a/packages/manifest-ui/__tests__/preview-generation.test.ts
+++ b/packages/manifest-ui/__tests__/preview-generation.test.ts
@@ -148,10 +148,13 @@ describe('Preview Generation Configuration', () => {
     it('should have backgrounds for all registry categories', () => {
       const backgroundCategories = getPreviewBackgroundCategories()
 
-      // Get unique categories from registry
+      // Get unique categories from registry (only block items need preview backgrounds)
       const registryCategories = [
         ...new Set(
-          registry.items.map((item) => item.category).filter(Boolean)
+          registry.items
+            .filter((item: { name: string }) => item.name !== 'manifest-types')
+            .map((item: { category?: string }) => item.category)
+            .filter(Boolean)
         )
       ]
 
@@ -222,7 +225,7 @@ describe('Registry components should have preview configurations', () => {
   const previewComponentNames = getPreviewComponentNames()
 
   // Components that may be difficult to render in isolation
-  const skippedComponents: string[] = []
+  const skippedComponents: string[] = ['manifest-types']
 
   for (const item of registry.items) {
     const { name } = item

--- a/packages/manifest-ui/__tests__/registry-dependencies.test.ts
+++ b/packages/manifest-ui/__tests__/registry-dependencies.test.ts
@@ -73,9 +73,10 @@ describe('Registry Dependencies Accuracy', () => {
           }
         }
 
-        // Filter registryDependencies to only shadcn primitives (not URLs)
+        // Filter registryDependencies to only shadcn UI primitives
+        // Exclude URLs and manifest-types (shared types provided via registry dependency)
         const declared = (item.registryDependencies ?? [])
-          .filter((dep) => !dep.includes('/'))
+          .filter((dep) => !dep.includes('/') && dep !== 'manifest-types')
           .sort()
 
         const actual = [...allImports].sort()

--- a/packages/manifest-ui/__tests__/version-bump.test.ts
+++ b/packages/manifest-ui/__tests__/version-bump.test.ts
@@ -276,8 +276,9 @@ describe('Version Bump Enforcement', () => {
 
   describe('Changelog entries must exist for all versions', () => {
     const changelog = loadChangelog()
+    const blockItems = currentRegistry.items.filter((item) => item.type === undefined || item.type === 'registry:block')
 
-    for (const item of currentRegistry.items) {
+    for (const item of blockItems) {
       const name = item.name
       const version = getVersion(item)
       const componentChangelog = changelog.components[name]
@@ -293,8 +294,11 @@ describe('Version Bump Enforcement', () => {
   })
 
   describe('Category validation', () => {
+    // Only validate block items — registry:lib items (e.g. manifest-types) use top-level paths
+    const blockItems = currentRegistry.items.filter((item) => item.type === undefined || item.type === 'registry:block')
+
     it('should have valid categories for all components', () => {
-      for (const item of currentRegistry.items) {
+      for (const item of blockItems) {
         const { files } = item
         const category = getCategory(item)
 
@@ -311,7 +315,7 @@ describe('Version Bump Enforcement', () => {
       }
     })
 
-    for (const item of currentRegistry.items) {
+    for (const item of blockItems) {
       const { name, files } = item
       const category = getCategory(item)
       const derivedCategory = files && files.length > 0

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -224,18 +224,14 @@
         "lucide-react"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "manifest-types"
       ],
       "files": [
         {
           "path": "registry/list/product-list.tsx",
           "type": "registry:block",
           "target": "components/ui/product-list.tsx"
-        },
-        {
-          "path": "registry/list/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/types.ts"
         },
         {
           "path": "registry/list/demo/data.ts",
@@ -275,18 +271,14 @@
         "lucide-react"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "manifest-types"
       ],
       "files": [
         {
           "path": "registry/selection/option-list.tsx",
           "type": "registry:block",
           "target": "components/ui/option-list.tsx"
-        },
-        {
-          "path": "registry/selection/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/types.ts"
         },
         {
           "path": "registry/selection/demo/data.ts",
@@ -545,7 +537,8 @@
       ],
       "registryDependencies": [
         "button",
-        "tooltip"
+        "tooltip",
+        "manifest-types"
       ],
       "files": [
         {
@@ -557,11 +550,6 @@
           "path": "registry/blogging/post-detail.tsx",
           "type": "registry:block",
           "target": "components/ui/post-detail.tsx"
-        },
-        {
-          "path": "registry/blogging/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/types.ts"
         },
         {
           "path": "registry/blogging/demo/data.ts",
@@ -605,7 +593,8 @@
       ],
       "registryDependencies": [
         "button",
-        "tooltip"
+        "tooltip",
+        "manifest-types"
       ],
       "files": [
         {
@@ -622,11 +611,6 @@
           "path": "registry/blogging/post-detail.tsx",
           "type": "registry:block",
           "target": "components/ui/post-detail.tsx"
-        },
-        {
-          "path": "registry/blogging/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/types.ts"
         },
         {
           "path": "registry/blogging/demo/data.ts",
@@ -677,7 +661,8 @@
       ],
       "registryDependencies": [
         "button",
-        "tooltip"
+        "tooltip",
+        "manifest-types"
       ],
       "files": [
         {
@@ -689,11 +674,6 @@
           "path": "registry/blogging/post-card.tsx",
           "type": "registry:block",
           "target": "components/ui/post-card.tsx"
-        },
-        {
-          "path": "registry/blogging/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/types.ts"
         },
         {
           "path": "registry/blogging/demo/data.ts",
@@ -823,7 +803,8 @@
         "lucide-react"
       ],
       "registryDependencies": [
-        "dropdown-menu"
+        "dropdown-menu",
+        "manifest-types"
       ],
       "files": [
         {
@@ -835,11 +816,6 @@
           "path": "registry/messaging/message-bubble.tsx",
           "type": "registry:block",
           "target": "components/ui/message-bubble.tsx"
-        },
-        {
-          "path": "registry/messaging/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/types.ts"
         },
         {
           "path": "registry/messaging/demo/data.ts",
@@ -1076,17 +1052,14 @@
       "dependencies": [
         "lucide-react"
       ],
-      "registryDependencies": [],
+      "registryDependencies": [
+        "manifest-types"
+      ],
       "files": [
         {
           "path": "registry/events/event-card.tsx",
           "type": "registry:block",
           "target": "components/ui/event-card.tsx"
-        },
-        {
-          "path": "registry/events/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/event-types.ts"
         },
         {
           "path": "registry/events/demo/data.ts",
@@ -1142,18 +1115,14 @@
       "registryDependencies": [
         "button",
         "checkbox",
-        "https://ui.manifest.build/r/event-card.json"
+        "https://ui.manifest.build/r/event-card.json",
+        "manifest-types"
       ],
       "files": [
         {
           "path": "registry/events/event-list.tsx",
           "type": "registry:block",
           "target": "components/ui/event-list.tsx"
-        },
-        {
-          "path": "registry/events/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/event-types.ts"
         },
         {
           "path": "registry/events/demo/data.ts",
@@ -1202,18 +1171,14 @@
         "@types/leaflet"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "manifest-types"
       ],
       "files": [
         {
           "path": "registry/events/event-detail.tsx",
           "type": "registry:block",
           "target": "components/ui/event-detail.tsx"
-        },
-        {
-          "path": "registry/events/types.ts",
-          "type": "registry:lib",
-          "target": "components/ui/event-types.ts"
         },
         {
           "path": "registry/events/demo/data.ts",
@@ -1337,6 +1302,24 @@
       ],
       "category": "miscellaneous",
       "preview": "https://ui.manifest.build/previews/hero.png"
+    },
+    {
+      "name": "manifest-types",
+      "type": "registry:lib",
+      "title": "Manifest Types",
+      "description": "Shared type definitions for Manifest UI components.",
+      "author": "MNFST, Inc",
+      "categories": [
+        "lib"
+      ],
+      "files": [
+        {
+          "path": "registry/shared-types.ts",
+          "type": "registry:lib",
+          "target": "components/ui/types.ts"
+        }
+      ],
+      "category": "lib"
     }
   ]
 }

--- a/packages/manifest-ui/registry.test.ts
+++ b/packages/manifest-ui/registry.test.ts
@@ -56,9 +56,9 @@ describe('Registry Component Versioning', () => {
 
   describe('Version field presence', () => {
     it('all components should have a version field', () => {
-      const componentsWithoutVersion = registry.items.filter(
-        (item) => !getVersion(item)
-      )
+      const componentsWithoutVersion = registry.items
+        .filter((item) => item.type === 'registry:block')
+        .filter((item) => !getVersion(item))
 
       if (componentsWithoutVersion.length > 0) {
         const names = componentsWithoutVersion.map((c) => c.name).join(', ')
@@ -109,7 +109,8 @@ describe('Registry Component Versioning', () => {
 
   describe('Component registry structure', () => {
     it('all components should have required fields', () => {
-      for (const item of registry.items) {
+      const blockItems = registry.items.filter((item) => item.type === 'registry:block')
+      for (const item of blockItems) {
         expect(item.name).toBeDefined()
         expect(typeof item.name).toBe('string')
         expect(item.name.length).toBeGreaterThan(0)

--- a/packages/manifest-ui/registry/shared-types.ts
+++ b/packages/manifest-ui/registry/shared-types.ts
@@ -1,0 +1,313 @@
+// Shared type definitions for Manifest UI components
+// This file is installed as components/ui/types.ts via the manifest-types registry item.
+// All category-specific types are unified here to prevent collisions when
+// installing multiple components via shadcn CLI.
+
+import type { ReactNode } from 'react'
+
+// ---------------------------------------------------------------------------
+// Blogging
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a blog post with metadata.
+ * @interface Post
+ * @property {string} [title] - Post title
+ * @property {string} [excerpt] - Brief description or summary
+ * @property {string} [coverImage] - URL of the cover image
+ * @property {object} [author] - Author information
+ * @property {string} [author.name] - Author's display name
+ * @property {string} [author.avatar] - Author's avatar URL
+ * @property {string} [publishedAt] - ISO date string of publication
+ * @property {string} [readTime] - Estimated read time (e.g., "5 min read")
+ * @property {string[]} [tags] - Array of tag labels
+ * @property {string} [category] - Category name
+ * @property {string} [url] - External URL for the post
+ */
+export interface Post {
+  title?: string
+  excerpt?: string
+  coverImage?: string
+  author?: {
+    name?: string
+    avatar?: string
+  }
+  publishedAt?: string
+  readTime?: string
+  tags?: string[]
+  category?: string
+  url?: string
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a product with pricing and display information.
+ * @interface Product
+ */
+export interface Product {
+  name?: string
+  description?: string
+  price?: number
+  originalPrice?: number
+  image?: string
+  rating?: number
+  badge?: string
+  inStock?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a selectable option with label and description.
+ * @interface Option
+ */
+export interface Option {
+  label?: string
+  description?: string
+  icon?: ReactNode
+  disabled?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Messaging
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents a chat message with content and metadata.
+ * @interface ChatMessage
+ */
+export interface ChatMessage {
+  type?: 'text' | 'image'
+  content?: string
+  image?: string
+  author?: string
+  avatarUrl?: string
+  avatarFallback?: string
+  time?: string
+  isOwn?: boolean
+  status?: 'sent' | 'delivered' | 'read'
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/**
+ * Status indicators for events.
+ * @typedef {"going-fast" | "popular" | "just-added" | "sales-end-soon" | "few-tickets-left" | "canceled" | "ended" | "postponed"} EventSignal
+ */
+export type EventSignal =
+  | 'going-fast'
+  | 'popular'
+  | 'just-added'
+  | 'sales-end-soon'
+  | 'few-tickets-left'
+  | 'canceled'
+  | 'ended'
+  | 'postponed'
+
+/**
+ * Descriptive tags for event atmosphere and vibe.
+ * @typedef VibeTag
+ */
+export type VibeTag =
+  | 'All night'
+  | 'Beginner-friendly'
+  | 'Casual'
+  | 'Chill'
+  | 'Classic'
+  | 'Cocktails'
+  | 'Creative'
+  | 'Date night'
+  | 'Discover'
+  | 'Dressy'
+  | 'Educational'
+  | 'Exciting'
+  | 'Exclusive'
+  | 'Family-friendly'
+  | 'Fun'
+  | 'Hands-on'
+  | 'High energy'
+  | 'Immersive'
+  | 'Interactive'
+  | 'Intimate'
+  | 'Kids'
+  | 'Late night'
+  | 'Legendary'
+  | 'Outdoor'
+  | 'Premium'
+  | 'Relaxing'
+  | 'Scenic'
+  | 'Social'
+  | 'Sophisticated'
+  | 'Tasting'
+  | 'Underground'
+  | 'Upscale'
+  | 'Views'
+  | 'Wellness'
+
+/**
+ * Represents a basic event with essential information.
+ * @interface Event
+ * @property {string} title - Event title
+ * @property {string} category - Event category (Music, Comedy, etc.)
+ * @property {string} venue - Venue name
+ * @property {string | null} [neighborhood] - Neighborhood/district
+ * @property {string} city - City name
+ * @property {string} dateTime - Display format date/time
+ * @property {string} priceRange - Price display (e.g., "$45 - $150", "Free")
+ * @property {string} [image] - Cover image URL
+ * @property {{ lat: number; lng: number }} [coordinates] - Map coordinates
+ * @property {VibeTag[]} [vibeTags] - Atmosphere/vibe tags
+ * @property {string} [vibeDescription] - Vibe description text
+ * @property {string} [aiSummary] - AI-generated summary
+ * @property {string[]} [lineup] - Performer lineup
+ * @property {string[]} [ticketTiers] - Available ticket tiers
+ * @property {EventSignal} [eventSignal] - Status signal
+ * @property {number} [organizerRating] - Organizer rating
+ * @property {number} [reviewCount] - Number of reviews
+ * @property {number} [venueRating] - Venue rating
+ * @property {string | null} [ageRestriction] - Age restriction
+ * @property {boolean} [hasMultipleDates] - Whether event has multiple dates
+ * @property {string} [discount] - Discount text
+ */
+export interface Event {
+  title?: string
+  category?: string // "Music", "Comedy", "Classes", "Nightlife", "Sports", "Food & Drink", "Arts", "Film", "Networking", "Festivals", "Wellness", "Social", "Games", "Gallery"
+  venue?: string
+  neighborhood?: string | null
+  city?: string
+  dateTime: string // Display format: "Tonight 9:00 PM - 3:00 AM", "Tomorrow 6:00 AM", "In 2 days 8:00 PM"
+  priceRange?: string // "$45 - $150", "Free", "Free - $5"
+  image?: string // Cover image URL for the event
+  coordinates?: { lat: number; lng: number } // For map display in fullscreen mode
+  vibeTags?: VibeTag[]
+  vibeDescription?: string
+  aiSummary?: string // AI-generated match explanation
+  lineup?: string[]
+  ticketTiers?: string[] // ["General Admission $45", "VIP Access $120"]
+  eventSignal?: EventSignal
+  organizerRating?: number
+  reviewCount?: number
+  venueRating?: number
+  ageRestriction?: string | null // "21+", "18+", "Ages 5-12", null
+  hasMultipleDates?: boolean
+  discount?: string // "TONIGHT ONLY - 40% OFF", "FREE - First 50 Only"
+}
+
+/**
+ * Represents an event organizer.
+ * @interface Organizer
+ * @property {string} [name] - Organizer name
+ * @property {string} [image] - Profile image URL
+ * @property {number} rating - Average rating
+ * @property {number} reviewCount - Number of reviews
+ * @property {boolean} [verified] - Whether organizer is verified
+ * @property {number} [followers] - Follower count
+ * @property {number} [eventsCount] - Total events hosted
+ * @property {number} [hostingYears] - Years hosting events
+ * @property {"very responsive" | "responsive" | "slow"} [responseRate] - Response speed
+ * @property {"great" | "good" | "new"} [trackRecord] - Track record rating
+ */
+export interface Organizer {
+  name?: string
+  image?: string
+  rating?: number
+  reviewCount?: number
+  verified?: boolean
+  followers?: number
+  eventsCount?: number
+  hostingYears?: number
+  responseRate?: 'very responsive' | 'responsive' | 'slow'
+  trackRecord?: 'great' | 'good' | 'new'
+}
+
+/**
+ * Represents a ticket selection with tier and quantity.
+ * @interface TicketSelection
+ * @property {number} tierIndex - Selected tier index
+ * @property {number} quantity - Number of tickets
+ */
+export interface TicketSelection {
+  tierIndex: number
+  quantity: number
+}
+
+/**
+ * Represents a completed event booking.
+ * @interface EventBooking
+ * @property {Event} event - The booked event
+ * @property {{ tierName: string; quantity: number; price: number }[]} tickets - Purchased tickets
+ * @property {number} total - Total amount paid
+ * @property {number} fees - Service fees
+ * @property {string} confirmationCode - Confirmation code
+ * @property {string} [qrCode] - QR code image URL
+ * @property {string} purchaseDate - Purchase date string
+ */
+export interface EventBooking {
+  event: Event
+  tickets?: { tierName: string; quantity: number; price: number }[]
+  total?: number
+  fees?: number
+  confirmationCode?: string
+  qrCode?: string
+  purchaseDate?: string
+}
+
+/**
+ * Extended Event with full details for event-detail component.
+ * Includes additional fields for comprehensive event display.
+ * @interface EventDetails
+ * @extends {Omit<Event, 'dateTime'>}
+ */
+export interface EventDetails extends Omit<Event, 'dateTime'> {
+  // Override dateTime with ISO format dates for dynamic formatting
+  startDateTime?: string // ISO format: "2025-01-11T21:00:00Z"
+  endDateTime?: string // ISO format: "2025-01-12T03:00:00Z"
+  locationType?: 'physical' | 'online' | 'hybrid' // Event location type
+  images?: string[] // Multiple images for carousel
+  description?: string
+  organizer?: Organizer
+  address?: string // Street address for the venue
+  venue_details?: {
+    name: string
+    address: string
+    city: string
+    coordinates?: { lat: number; lng: number }
+  }
+  coordinates?: { lat: number; lng: number } // For map display
+  attendeesCount?: number // "537 going"
+  friendsGoing?: { name: string; avatar?: string }[]
+  highlights?: string[] // "2 hours", "In person"
+  tiers?: {
+    name: string
+    price: number
+    available: number
+    benefits?: string[]
+  }[]
+  goodToKnow?: {
+    accessibility?: string[]
+    dressCode?: string
+    parking?: string
+    duration?: string
+    doorsOpen?: string
+    showtime?: string
+    ageRestriction?: string
+  }
+  amenities?: string[]
+  policies?: {
+    refund?: string
+    entry?: string
+    idRequired?: boolean
+    securityOnSite?: boolean
+    items?: string[]
+  }
+  faq?: { question: string; answer: string }[]
+  relatedEvents?: Event[]
+  relatedTags?: string[] // "Los Angeles Events", "California Nightlife"
+}

--- a/packages/manifest-ui/scripts/generate-previews.mjs
+++ b/packages/manifest-ui/scripts/generate-previews.mjs
@@ -98,7 +98,8 @@ async function generatePreviews() {
   }
 
   const registry = JSON.parse(readFileSync(REGISTRY_PATH, 'utf-8'))
-  let components = registry.items
+  // Only generate previews for visual block components (skip registry:lib like manifest-types)
+  let components = registry.items.filter((c) => c.type === 'registry:block')
 
   // Filter to specific component if requested
   if (options.component) {


### PR DESCRIPTION
## Summary

When installing multiple Manifest UI components via shadcn CLI, type imports broke because each category bundled its own `types.ts` targeting the same `components/ui/types.ts` — last install wins, overwriting all others. This caused 13 TypeScript errors for missing type exports (Post, Product, Option, Event, etc.).

- Created `registry/shared-types.ts` combining all category type definitions into one file
- Added `manifest-types` registry:lib item to `registry.json` that installs as `components/ui/types.ts`
- Updated 9 components to use `registryDependencies: ["manifest-types"]` instead of bundling category types.ts files
- Fixed 7 test files to properly handle `registry:lib` items (not just `registry:block`)
- Added 3 new "Shared Types Pattern" enforcement tests to prevent regression
- Fixed 2 new upstream test files (`no-broken-imports`, `registry-dependencies`) to recognize manifest-types dependency pattern

## Test plan

- [x] All 1152 tests pass (15 test files, 0 failures)
- [x] Lint passes with 0 errors
- [ ] `pnpm run registry:build` generates correct `manifest-types.json`
- [ ] Install post-card + event-card via shadcn CLI → `types.ts` contains all exports
- [ ] `npx tsc --noEmit` passes after multi-component install