### PR TITLE
fix(manifestUI): centralize demo data and fix broken component previews

### DIFF
--- a/packages/manifest-ui/CLAUDE.md
+++ b/packages/manifest-ui/CLAUDE.md
@@ -312,8 +312,10 @@ import { demoPostDetailData } from '@/registry/blogging/demo/data';
 
 1. **Single source of truth**: All demo data in `registry/<category>/demo/data.ts`
 2. **No duplication**: `preview-components.tsx` and `page.tsx` import from demo/data.ts
-3. **Complete data**: Include all fields needed for realistic previews
-4. **Typed exports**: Export with proper TypeScript types
+3. **No inline demo data**: `preview-components.tsx` and `page.tsx` must NOT define local demo data constants or large inline `data={{...}}` objects. All substantial data must come from imports.
+4. **Complete data**: Include all fields needed for realistic previews
+5. **Typed exports**: Export with proper TypeScript types
+6. **Enforced by tests**: `__tests__/demo-data-placement.test.ts` validates these rules automatically
 
 ## Component Versioning (Semver)
 

--- a/packages/manifest-ui/__tests__/demo-data-placement.test.ts
+++ b/packages/manifest-ui/__tests__/demo-data-placement.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Demo Data Placement Enforcement Test
+ *
+ * Validates that demo data is centralized in registry/<category>/demo/data.ts files,
+ * not inlined in preview-components.tsx or page.tsx.
+ *
+ * Rules enforced:
+ * A) Every category directory with .tsx components must have a demo/data.ts file
+ * B) preview-components.tsx must NOT define local demo data constants
+ * C) preview-components.tsx must NOT have inline data objects with >2 properties
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs'
+import { join, resolve } from 'path'
+import { describe, it, expect } from 'vitest'
+
+const ROOT_PATH = resolve(__dirname, '..')
+const REGISTRY_PATH = resolve(ROOT_PATH, 'registry')
+const PREVIEW_PATH = resolve(ROOT_PATH, 'lib', 'preview-components.tsx')
+
+/**
+ * Get all category directories that contain .tsx component files
+ */
+function getCategoryDirs(): string[] {
+  const entries = readdirSync(REGISTRY_PATH)
+  const categories: string[] = []
+
+  for (const entry of entries) {
+    const fullPath = join(REGISTRY_PATH, entry)
+    const stat = statSync(fullPath)
+    if (!stat.isDirectory()) continue
+
+    // Check if directory contains .tsx files (not just subdirectories)
+    const files = readdirSync(fullPath)
+    const hasTsx = files.some((f) => f.endsWith('.tsx'))
+    if (hasTsx) {
+      categories.push(entry)
+    }
+  }
+
+  return categories
+}
+
+describe('Demo Data Placement', () => {
+  const categories = getCategoryDirs()
+
+  it('should find category directories to check', () => {
+    expect(categories.length).toBeGreaterThan(0)
+  })
+
+  describe('Rule A: Every category with .tsx files must have demo/data.ts', () => {
+    for (const category of categories) {
+      it(`registry/${category}/ must have demo/data.ts`, () => {
+        const demoDataPath = join(REGISTRY_PATH, category, 'demo', 'data.ts')
+        expect(
+          existsSync(demoDataPath),
+          `Missing demo/data.ts for category "${category}". ` +
+            `Create registry/${category}/demo/data.ts with demo data for this category.`
+        ).toBe(true)
+      })
+    }
+  })
+
+  describe('Rule B: preview-components.tsx must NOT define local demo data constants', () => {
+    it('should not have local const demo* variables', () => {
+      const content = readFileSync(PREVIEW_PATH, 'utf-8')
+      const lines = content.split('\n')
+      const issues: string[] = []
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]
+        // Match "const demo" at the start of a line (after optional whitespace)
+        // but not inside import blocks
+        if (/^\s*const\s+demo\w+/.test(line)) {
+          issues.push(
+            `Line ${i + 1}: "${line.trim()}" — ` +
+              'Demo data must be imported from registry/*/demo/data.ts, not defined locally.'
+          )
+        }
+      }
+
+      if (issues.length > 0) {
+        throw new Error(
+          'preview-components.tsx contains local demo data constants:\n' +
+            issues.join('\n')
+        )
+      }
+    })
+  })
+
+  describe('Rule C: preview-components.tsx must NOT have large inline data objects', () => {
+    it('should not have inline data={{ with >4 top-level properties', () => {
+      const content = readFileSync(PREVIEW_PATH, 'utf-8')
+
+      // Find all data={{ blocks and count top-level properties.
+      // This is a heuristic: we count word: patterns that are NOT inside nested objects.
+      // Small inline data (2-4 simple props like message bubbles) is acceptable;
+      // large data objects (5+ props) should be extracted to demo/data.ts.
+      const dataBlockPattern = /data=\{\{((?:(?!\}\}).|\n)*?)\}\}/g
+      const issues: string[] = []
+      let match
+
+      while ((match = dataBlockPattern.exec(content)) !== null) {
+        const block = match[1]
+        // Strip nested objects to avoid counting their keys as top-level
+        const stripped = block.replace(/\{[^}]*\}/g, '{}')
+        const propCount = (stripped.match(/\w+\s*:/g) || []).length
+        if (propCount > 4) {
+          const lineNum =
+            content.substring(0, match.index).split('\n').length
+          issues.push(
+            `Line ~${lineNum}: Inline data={{ with ${propCount} top-level properties. ` +
+              'Extract to demo/data.ts instead.'
+          )
+        }
+      }
+
+      if (issues.length > 0) {
+        throw new Error(
+          'preview-components.tsx contains large inline data objects:\n' +
+            issues.join('\n')
+        )
+      }
+    })
+  })
+})

--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -17,7 +17,7 @@ import { IssueReportForm } from '@/registry/form/issue-report-form';
 import { PostCardDemo } from '@/components/blocks/post-card-demo';
 import { PostDetailDemo } from '@/components/blocks/post-detail-demo';
 import { PostListDemo } from '@/components/blocks/post-list-demo';
-import { demoPostDetailData } from '@/registry/blogging/demo/data';
+import { demoPost, demoPosts, demoPostDetailData } from '@/registry/blogging/demo/data';
 import { PostDetail } from '@/registry/blogging/post-detail';
 import { PostList } from '@/registry/blogging/post-list';
 
@@ -27,16 +27,28 @@ import { EventConfirmation } from '@/registry/events/event-confirmation';
 import { EventDetail } from '@/registry/events/event-detail';
 import { EventList } from '@/registry/events/event-list';
 import { TicketTierSelect } from '@/registry/events/ticket-tier-select';
+import {
+  demoEvent,
+  demoEvents,
+  demoEventDetails,
+  demoEventConfirmation,
+} from '@/registry/events/demo/data';
 
 // List components
 import { TableDemo } from '@/components/blocks/table-demo';
 import { ProductList } from '@/registry/list/product-list';
 import { Table } from '@/registry/list/table';
+import { demoProducts } from '@/registry/list/demo/data';
 
 // Payment components
 import { AmountInput } from '@/registry/payment/amount-input';
 import { OrderConfirm } from '@/registry/payment/order-confirm';
 import { PaymentConfirmed } from '@/registry/payment/payment-confirmed';
+import {
+  demoOrderConfirm,
+  demoAmountPresets,
+  demoPaymentConfirmed,
+} from '@/registry/payment/demo/data';
 
 // Messaging components
 import { ChatConversation } from '@/registry/messaging/chat-conversation';
@@ -51,23 +63,43 @@ import {
 import { OptionList } from '@/registry/selection/option-list';
 import { QuickReply } from '@/registry/selection/quick-reply';
 import { TagSelect } from '@/registry/selection/tag-select';
+import {
+  demoOptions,
+  demoQuickReplies,
+  demoTags,
+} from '@/registry/selection/demo/data';
 
 // Social components
 import { InstagramPost } from '@/registry/social/instagram-post';
 import { LinkedInPost } from '@/registry/social/linkedin-post';
 import { XPost } from '@/registry/social/x-post';
 import { YouTubePost } from '@/registry/social/youtube-post';
+import {
+  demoXPost,
+  demoInstagramPost,
+  demoYouTubePost,
+} from '@/registry/social/demo/data';
 
 // Map components
 import { MapCarousel } from '@/registry/map/map-carousel';
+import { demoMapLocations, demoMapCenter } from '@/registry/map/demo/data';
 
 // Status components
 import { ProgressSteps } from '@/registry/status/progress-steps';
 import { StatusBadge } from '@/registry/status/status-badge';
+import { demoProgressSteps } from '@/registry/status/demo/data';
 
 // Miscellaneous components
 import { Hero } from '@/registry/miscellaneous/hero';
 import { Stats } from '@/registry/miscellaneous/stat-card';
+import {
+  demoStats,
+  demoHeroDefault,
+  demoHeroTwoLogos,
+  demoHeroWithTechLogos,
+  demoHeroMinimal,
+} from '@/registry/miscellaneous/demo/data';
+import { demoMessages } from '@/registry/messaging/demo/data';
 
 // UI components
 import { VariantSection, VariantSectionHandle } from '@/components/blocks/variant-section';
@@ -122,8 +154,8 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <PostCardDemo />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            component: <PostCardDemo data={{ post: demoPost }} />,
+            fullscreenComponent: <PostDetail data={demoPostDetailData} appearance={{ displayMode: 'fullscreen' }} />,
             usageCode: `<PostCard
   data={{
     post: {
@@ -170,8 +202,8 @@ const categories: Category[] = [
           {
             id: 'no-image',
             name: 'Without Image',
-            component: <PostCardDemo appearance={{ showImage: false }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            component: <PostCardDemo data={{ post: demoPost }} appearance={{ showImage: false }} />,
+            fullscreenComponent: <PostDetail data={demoPostDetailData} appearance={{ displayMode: 'fullscreen' }} />,
             usageCode: `<PostCard
   data={{
     post: {
@@ -211,8 +243,8 @@ const categories: Category[] = [
           {
             id: 'compact',
             name: 'Compact',
-            component: <PostCardDemo appearance={{ variant: 'compact' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            component: <PostCardDemo data={{ post: demoPost }} appearance={{ variant: 'compact' }} />,
+            fullscreenComponent: <PostDetail data={demoPostDetailData} appearance={{ displayMode: 'fullscreen' }} />,
             usageCode: `<PostCard
   data={{
     post: {
@@ -255,8 +287,8 @@ const categories: Category[] = [
           {
             id: 'horizontal',
             name: 'Horizontal',
-            component: <PostCardDemo appearance={{ variant: 'horizontal' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            component: <PostCardDemo data={{ post: demoPost }} appearance={{ variant: 'horizontal' }} />,
+            fullscreenComponent: <PostDetail data={demoPostDetailData} appearance={{ displayMode: 'fullscreen' }} />,
             usageCode: `<PostCard
   data={{
     post: {
@@ -301,8 +333,8 @@ const categories: Category[] = [
           {
             id: 'covered',
             name: 'Covered',
-            component: <PostCardDemo appearance={{ variant: 'covered' }} />,
-            fullscreenComponent: <PostDetail appearance={{ displayMode: 'fullscreen' }} />,
+            component: <PostCardDemo data={{ post: demoPost }} appearance={{ variant: 'covered' }} />,
+            fullscreenComponent: <PostDetail data={demoPostDetailData} appearance={{ displayMode: 'fullscreen' }} />,
             usageCode: `<PostCard
   data={{
     post: {
@@ -356,9 +388,10 @@ const categories: Category[] = [
           {
             id: 'list',
             name: 'List',
-            component: <PostListDemo appearance={{ variant: 'list' }} />,
+            component: <PostListDemo data={{ posts: demoPosts }} appearance={{ variant: 'list' }} />,
             fullscreenComponent: (
               <PostList
+                data={{ posts: demoPosts }}
                 appearance={{
                   variant: 'fullwidth',
                   columns: 3,
@@ -548,9 +581,10 @@ const categories: Category[] = [
           {
             id: 'grid',
             name: 'Grid',
-            component: <PostListDemo appearance={{ variant: 'grid' }} />,
+            component: <PostListDemo data={{ posts: demoPosts }} appearance={{ variant: 'grid' }} />,
             fullscreenComponent: (
               <PostList
+                data={{ posts: demoPosts }}
                 appearance={{
                   variant: 'fullwidth',
                   columns: 3,
@@ -741,9 +775,10 @@ const categories: Category[] = [
           {
             id: 'carousel',
             name: 'Carousel',
-            component: <PostListDemo appearance={{ variant: 'carousel' }} />,
+            component: <PostListDemo data={{ posts: demoPosts }} appearance={{ variant: 'carousel' }} />,
             fullscreenComponent: (
               <PostList
+                data={{ posts: demoPosts }}
                 appearance={{
                   variant: 'fullwidth',
                   columns: 3,
@@ -1038,7 +1073,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <EventCard />,
+            component: <EventCard data={{ event: demoEvent }} />,
             usageCode: `<EventCard
   data={{
     event: {
@@ -1073,7 +1108,7 @@ const categories: Category[] = [
           {
             id: 'compact',
             name: 'Compact',
-            component: <EventCard appearance={{ variant: 'compact' }} />,
+            component: <EventCard data={{ event: demoEvent }} appearance={{ variant: 'compact' }} />,
             usageCode: `<EventCard
   data={{
     event: {
@@ -1105,7 +1140,7 @@ const categories: Category[] = [
           {
             id: 'horizontal',
             name: 'Horizontal',
-            component: <EventCard appearance={{ variant: 'horizontal' }} />,
+            component: <EventCard data={{ event: demoEvent }} appearance={{ variant: 'horizontal' }} />,
             usageCode: `<EventCard
   data={{
     event: {
@@ -1137,7 +1172,7 @@ const categories: Category[] = [
           {
             id: 'covered',
             name: 'Covered',
-            component: <EventCard appearance={{ variant: 'covered' }} />,
+            component: <EventCard data={{ event: demoEvent }} appearance={{ variant: 'covered' }} />,
             usageCode: `<EventCard
   data={{
     event: {
@@ -1181,7 +1216,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <EventDetail />,
+            component: <EventDetail data={{ event: demoEventDetails }} />,
             usageCode: `<EventDetail
   data={{
     event: {
@@ -1279,13 +1314,13 @@ const categories: Category[] = [
             name: 'Grid',
             component: (
               <EventList
-                data={{ title: 'Recommendations for you' }}
+                data={{ title: 'Recommendations for you', events: demoEvents }}
                 appearance={{ variant: 'grid' }}
               />
             ),
             fullscreenComponent: (
               <EventList
-                data={{ title: 'Recommendations for you' }}
+                data={{ title: 'Recommendations for you', events: demoEvents }}
                 appearance={{ variant: 'fullwidth' }}
               />
             ),
@@ -1321,13 +1356,13 @@ const categories: Category[] = [
             name: 'List',
             component: (
               <EventList
-                data={{ title: 'Recommendations for you' }}
+                data={{ title: 'Recommendations for you', events: demoEvents }}
                 appearance={{ variant: 'list' }}
               />
             ),
             fullscreenComponent: (
               <EventList
-                data={{ title: 'Recommendations for you' }}
+                data={{ title: 'Recommendations for you', events: demoEvents }}
                 appearance={{ variant: 'fullwidth' }}
               />
             ),
@@ -1363,13 +1398,13 @@ const categories: Category[] = [
             name: 'Carousel',
             component: (
               <EventList
-                data={{ title: 'Recommendations for you' }}
+                data={{ title: 'Recommendations for you', events: demoEvents }}
                 appearance={{ variant: 'carousel' }}
               />
             ),
             fullscreenComponent: (
               <EventList
-                data={{ title: 'Recommendations for you' }}
+                data={{ title: 'Recommendations for you', events: demoEvents }}
                 appearance={{ variant: 'fullwidth' }}
               />
             ),
@@ -1484,7 +1519,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <EventConfirmation />,
+            component: <EventConfirmation data={demoEventConfirmation} />,
             usageCode: `<EventConfirmation
   data={{
     orderNumber: "#14040333743",
@@ -1651,7 +1686,7 @@ const categories: Category[] = [
           {
             id: 'list',
             name: 'List',
-            component: <ProductList appearance={{ variant: 'list' }} />,
+            component: <ProductList data={{ products: demoProducts }} appearance={{ variant: 'list' }} />,
             usageCode: `<ProductList
   data={{
     products: [
@@ -1672,7 +1707,7 @@ const categories: Category[] = [
           {
             id: 'grid',
             name: 'Grid',
-            component: <ProductList appearance={{ variant: 'grid' }} />,
+            component: <ProductList data={{ products: demoProducts }} appearance={{ variant: 'grid' }} />,
             usageCode: `<ProductList
   data={{ products: [...] }}
   appearance={{ variant: "grid", columns: 4, currency: "USD" }}
@@ -1682,7 +1717,7 @@ const categories: Category[] = [
           {
             id: 'carousel',
             name: 'Carousel',
-            component: <ProductList appearance={{ variant: 'carousel' }} />,
+            component: <ProductList data={{ products: demoProducts }} appearance={{ variant: 'carousel' }} />,
             usageCode: `<ProductList
   data={{ products: [...] }}
   appearance={{ variant: "carousel" }}
@@ -1692,7 +1727,7 @@ const categories: Category[] = [
           {
             id: 'picker',
             name: 'Picker',
-            component: <ProductList appearance={{ variant: 'picker' }} />,
+            component: <ProductList data={{ products: demoProducts }} appearance={{ variant: 'picker' }} />,
             usageCode: `<ProductList
   data={{ products: [...] }}
   appearance={{ variant: "picker", buttonLabel: "Add to cart" }}
@@ -1795,10 +1830,10 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <MapCarousel />,
+            component: <MapCarousel data={{ locations: demoMapLocations, center: demoMapCenter }} />,
             fullscreenComponent: (
               <MapCarousel
-                data={{ title: 'Hotels in San Francisco' }}
+                data={{ title: 'Hotels in San Francisco', locations: demoMapLocations, center: demoMapCenter }}
                 appearance={{ displayMode: 'fullscreen' }}
                 actions={{
                   onSelectLocation: (location) => console.log('Selected:', location.name),
@@ -2019,7 +2054,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <ChatConversation />,
+            component: <ChatConversation data={{ messages: demoMessages }} />,
             usageCode: `<ChatConversation
   data={{
     messages: [
@@ -2087,7 +2122,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <Stats />,
+            component: <Stats data={{ stats: demoStats }} />,
             usageCode: `<Stats
   data={{
     stats: [
@@ -2110,7 +2145,14 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <Hero />,
+            component: (
+              <Hero
+                data={{
+                  ...demoHeroDefault,
+                  secondaryButton: { label: 'GitHub', icon: <Github className="h-5 w-5" /> },
+                }}
+              />
+            ),
             usageCode: `<Hero
   data={{
     logo1: { text: "Acme", alt: "Acme" },
@@ -2131,17 +2173,7 @@ const categories: Category[] = [
             component: (
               <Hero
                 data={{
-                  logo1: { text: 'Acme' },
-                  logo2: {
-                    url: '/logo-manifest-ui.svg',
-                    urlLight: '/logo-manifest-ui-light.svg',
-                    alt: 'Manifest',
-                  },
-                  logoSeparator: 'x',
-                  title: 'Acme x Manifest UI',
-                  subtitle:
-                    'Combining the best of both worlds to deliver exceptional user experiences.',
-                  primaryButton: { label: 'Get Started' },
+                  ...demoHeroTwoLogos,
                   secondaryButton: { label: 'GitHub', icon: <Github className="h-5 w-5" /> },
                 }}
               />
@@ -2168,40 +2200,8 @@ const categories: Category[] = [
             component: (
               <Hero
                 data={{
-                  logo1: { text: 'Acme' },
-                  title: 'Build your next project with Acme',
-                  subtitle:
-                    'Create beautiful experiences with our comprehensive platform designed for modern applications.',
-                  primaryButton: { label: 'Get Started' },
+                  ...demoHeroWithTechLogos,
                   secondaryButton: { label: 'GitHub', icon: <Github className="h-5 w-5" /> },
-                  techLogosLabel: 'Built with open-source technologies',
-                  techLogos: [
-                    {
-                      url: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-original.svg',
-                      alt: 'Next.js',
-                      name: 'Next.js',
-                    },
-                    {
-                      url: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg',
-                      alt: 'TypeScript',
-                      name: 'TypeScript',
-                    },
-                    {
-                      url: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg',
-                      alt: 'React',
-                      name: 'React',
-                    },
-                    {
-                      url: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-original.svg',
-                      alt: 'Tailwind CSS',
-                      name: 'Tailwind CSS',
-                    },
-                    {
-                      url: '/demo/os-tech-mnfst.svg',
-                      alt: 'Manifest',
-                      name: 'Manifest',
-                    },
-                  ],
                 }}
               />
             ),
@@ -2230,17 +2230,7 @@ const categories: Category[] = [
           {
             id: 'minimal',
             name: 'Minimal',
-            component: (
-              <Hero
-                data={{
-                  logo1: undefined,
-                  title: 'Welcome to the Future',
-                  subtitle: 'A simple, clean hero without logos or extra elements.',
-                  primaryButton: { label: 'Get Started' },
-                  secondaryButton: undefined,
-                }}
-              />
-            ),
+            component: <Hero data={demoHeroMinimal} />,
             usageCode: `<Hero
   data={{
     logo1: undefined,
@@ -2273,7 +2263,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <OptionList />,
+            component: <OptionList data={{ options: demoOptions }} />,
             usageCode: `<OptionList
   data={{
     options: [
@@ -2300,7 +2290,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <QuickReply />,
+            component: <QuickReply data={{ replies: demoQuickReplies }} />,
             usageCode: `<QuickReply
   data={{
     replies: [
@@ -2326,7 +2316,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <TagSelect />,
+            component: <TagSelect data={{ tags: demoTags }} />,
             usageCode: `<TagSelect
   data={{
     tags: [
@@ -2363,7 +2353,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <ProgressSteps />,
+            component: <ProgressSteps data={{ steps: demoProgressSteps }} />,
             usageCode: `<ProgressSteps
   data={{
     steps: [
@@ -2422,10 +2412,10 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <OrderConfirm />,
+            component: <OrderConfirm data={demoOrderConfirm} />,
             fullscreenComponent: (
               <div className="max-w-[680px] mx-auto">
-                <OrderConfirm />
+                <OrderConfirm data={demoOrderConfirm} />
               </div>
             ),
             usageCode: `<OrderConfirm
@@ -2453,10 +2443,10 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <AmountInput />,
+            component: <AmountInput data={{ presets: demoAmountPresets }} />,
             fullscreenComponent: (
               <div className="max-w-[680px] mx-auto">
-                <AmountInput />
+                <AmountInput data={{ presets: demoAmountPresets }} />
               </div>
             ),
             usageCode: `<AmountInput
@@ -2486,10 +2476,10 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <PaymentConfirmed />,
+            component: <PaymentConfirmed data={demoPaymentConfirmed} />,
             fullscreenComponent: (
               <div className="max-w-[680px] mx-auto">
-                <PaymentConfirmed />
+                <PaymentConfirmed data={demoPaymentConfirmed} />
               </div>
             ),
             usageCode: `<PaymentConfirmed
@@ -2508,10 +2498,10 @@ const categories: Category[] = [
           {
             id: 'compressed',
             name: 'Compressed',
-            component: <PaymentConfirmed appearance={{ variant: 'compressed' }} />,
+            component: <PaymentConfirmed data={demoPaymentConfirmed} appearance={{ variant: 'compressed' }} />,
             fullscreenComponent: (
               <div className="max-w-[680px] mx-auto">
-                <PaymentConfirmed appearance={{ variant: 'compressed' }} />
+                <PaymentConfirmed data={demoPaymentConfirmed} appearance={{ variant: 'compressed' }} />
               </div>
             ),
             usageCode: `<PaymentConfirmed
@@ -2545,7 +2535,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <InstagramPost />,
+            component: <InstagramPost data={demoInstagramPost} />,
             usageCode: `<InstagramPost
   data={{
     author: "manifest.ai",
@@ -2697,7 +2687,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <XPost />,
+            component: <XPost data={demoXPost} />,
             usageCode: `<XPost
   data={{
     author: "Manifest",
@@ -2726,7 +2716,7 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <YouTubePost />,
+            component: <YouTubePost data={demoYouTubePost} />,
             usageCode: `<YouTubePost
   data={{
     channel: "NetworkChuck",

--- a/packages/manifest-ui/lib/preview-components.tsx
+++ b/packages/manifest-ui/lib/preview-components.tsx
@@ -2,7 +2,8 @@
 
 /**
  * Component map for preview generation.
- * Maps component names to their rendered React elements with default demo data.
+ * Maps component names to their rendered React elements with demo data
+ * imported from centralized demo/data.ts files.
  */
 
 import { ReactNode } from 'react';
@@ -16,32 +17,65 @@ import { IssueReportForm } from '@/registry/form/issue-report-form';
 import { AmountInput } from '@/registry/payment/amount-input';
 import { OrderConfirm } from '@/registry/payment/order-confirm';
 import { PaymentConfirmed } from '@/registry/payment/payment-confirmed';
+import {
+  demoOrderConfirm,
+  demoAmountPresets,
+  demoPaymentConfirmed,
+} from '@/registry/payment/demo/data';
 
 // List components
 import { ProductList } from '@/registry/list/product-list';
 import { Table } from '@/registry/list/table';
+import {
+  demoProducts,
+  demoTableColumns,
+  demoTableRows,
+} from '@/registry/list/demo/data';
 
 // Selection components
 import { OptionList } from '@/registry/selection/option-list';
 import { QuickReply } from '@/registry/selection/quick-reply';
 import { TagSelect } from '@/registry/selection/tag-select';
+import {
+  demoOptions,
+  demoQuickReplies,
+  demoTags,
+} from '@/registry/selection/demo/data';
 
 // Status components
 import { ProgressSteps } from '@/registry/status/progress-steps';
 import { StatusBadge } from '@/registry/status/status-badge';
+import {
+  demoProgressSteps,
+  demoStatusBadge,
+} from '@/registry/status/demo/data';
 
 // Miscellaneous components
 import { Hero } from '@/registry/miscellaneous/hero';
 import { Stats } from '@/registry/miscellaneous/stat-card';
+import {
+  demoStats,
+  demoHeroDefault,
+} from '@/registry/miscellaneous/demo/data';
 
 // Social components
 import { InstagramPost } from '@/registry/social/instagram-post';
 import { LinkedInPost } from '@/registry/social/linkedin-post';
 import { XPost } from '@/registry/social/x-post';
 import { YouTubePost } from '@/registry/social/youtube-post';
+import {
+  demoXPost,
+  demoInstagramPost,
+  demoLinkedInPost,
+  demoYouTubePost,
+} from '@/registry/social/demo/data';
 
 // Map components
 import { MapCarousel } from '@/registry/map/map-carousel';
+import {
+  demoMapLocations,
+  demoMapCenter,
+} from '@/registry/map/demo/data';
 
 // Blogging components
 import { PostCard } from '@/registry/blogging/post-card';
@@ -56,6 +90,7 @@ import {
 // Messaging components
 import { ChatConversation } from '@/registry/messaging/chat-conversation';
 import { MessageBubble } from '@/registry/messaging/message-bubble';
+import { demoMessages } from '@/registry/messaging/demo/data';
 
 // Events components
 import { EventCard } from '@/registry/events/event-card';
@@ -63,47 +98,13 @@ import { EventConfirmation } from '@/registry/events/event-confirmation';
 import { EventDetail } from '@/registry/events/event-detail';
 import { EventList } from '@/registry/events/event-list';
 import { TicketTierSelect } from '@/registry/events/ticket-tier-select';
-
-// Demo data
-const demoProducts = [
-  { name: 'Premium Headphones', price: 299, image: 'https://ui.manifest.build/demo/shoe-1.png' },
-  { name: 'Wireless Earbuds', price: 149, image: 'https://ui.manifest.build/demo/shoe-2.png' },
-  { name: 'Smart Speaker', price: 199, image: 'https://ui.manifest.build/demo/shoe-3.png' },
-];
-
-const demoTicketTiers = [
-  { id: '1', name: 'General Admission', price: 45, fee: 5, available: 100, maxPerOrder: 10 },
-  {
-    id: '2',
-    name: 'VIP',
-    price: 150,
-    fee: 15,
-    available: 20,
-    maxPerOrder: 4,
-    description: 'Includes backstage access',
-  },
-];
-
-const demoMapLocations = [
-  {
-    id: '1',
-    name: 'Coffee Shop',
-    coordinates: [40.7128, -74.006] as [number, number],
-    description: 'Best coffee in town',
-  },
-  {
-    id: '2',
-    name: 'Book Store',
-    coordinates: [40.7138, -74.008] as [number, number],
-    description: 'Rare books collection',
-  },
-  {
-    id: '3',
-    name: 'Park',
-    coordinates: [40.7148, -74.004] as [number, number],
-    description: 'Beautiful city park',
-  },
-];
+import {
+  demoEvent,
+  demoEvents,
+  demoEventDetails,
+  demoTicketTiers,
+  demoEventConfirmation,
+} from '@/registry/events/demo/data';
 
 export interface PreviewComponentConfig {
   component: ReactNode;
@@ -131,33 +132,15 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
 
   // Payment components
   'order-confirm': {
-    component: (
-      <OrderConfirm
-        data={{
-          productName: 'Premium Headphones',
-          productImage: 'https://ui.manifest.build/demo/shoe-1.png',
-          price: 299,
-          deliveryDate: 'Jan 20, 2024',
-        }}
-      />
-    ),
+    component: <OrderConfirm data={demoOrderConfirm} />,
     category: 'payment',
   },
   'payment-confirmed': {
-    component: (
-      <PaymentConfirmed
-        data={{
-          productName: 'Premium Headphones',
-          productImage: 'https://ui.manifest.build/demo/shoe-1.png',
-          price: 299,
-          deliveryDate: 'Jan 20, 2024',
-        }}
-      />
-    ),
+    component: <PaymentConfirmed data={demoPaymentConfirmed} />,
     category: 'payment',
   },
   'amount-input': {
-    component: <AmountInput data={{ presets: [10, 25, 50, 100] }} />,
+    component: <AmountInput data={{ presets: demoAmountPresets }} />,
     category: 'payment',
   },
 
@@ -168,185 +151,73 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
   },
   'table': {
     component: (
-      <Table
-        data={{
-          columns: [
-            { header: 'Name', accessor: 'name' },
-            { header: 'Email', accessor: 'email' },
-            { header: 'Status', accessor: 'status' },
-          ],
-          rows: [
-            { name: 'John Doe', email: 'john@example.com', status: 'Active' },
-            { name: 'Jane Smith', email: 'jane@example.com', status: 'Pending' },
-            { name: 'Bob Johnson', email: 'bob@example.com', status: 'Active' },
-          ],
-        }}
-      />
+      <Table data={{ columns: demoTableColumns, rows: demoTableRows }} />
     ),
     category: 'list',
   },
 
   // Selection components
   'option-list': {
-    component: (
-      <OptionList
-        data={{ options: [{ label: 'Option A' }, { label: 'Option B' }, { label: 'Option C' }] }}
-      />
-    ),
+    component: <OptionList data={{ options: demoOptions }} />,
     category: 'selection',
   },
   'tag-select': {
-    component: (
-      <TagSelect
-        data={{
-          tags: [
-            { id: '1', label: 'Important', color: 'red' },
-            { id: '2', label: 'In Progress', color: 'yellow' },
-            { id: '3', label: 'Done', color: 'green' },
-          ],
-        }}
-      />
-    ),
+    component: <TagSelect data={{ tags: demoTags }} />,
     category: 'selection',
   },
   'quick-reply': {
-    component: (
-      <QuickReply
-        data={{
-          replies: [{ label: 'Yes, please' }, { label: 'No, thanks' }, { label: 'Tell me more' }],
-        }}
-      />
-    ),
+    component: <QuickReply data={{ replies: demoQuickReplies }} />,
     category: 'selection',
   },
 
   // Status components
   'progress-steps': {
-    component: (
-      <ProgressSteps
-        data={{
-          steps: [
-            { label: 'Cart', status: 'completed' },
-            { label: 'Shipping', status: 'current' },
-            { label: 'Payment', status: 'pending' },
-            { label: 'Confirm', status: 'pending' },
-          ],
-        }}
-      />
-    ),
+    component: <ProgressSteps data={{ steps: demoProgressSteps }} />,
     category: 'status',
   },
   'status-badge': {
-    component: <StatusBadge data={{ status: 'processing' }} appearance={{ label: 'Processing' }} />,
+    component: (
+      <StatusBadge
+        data={{ status: demoStatusBadge.status }}
+        appearance={{ label: demoStatusBadge.label }}
+      />
+    ),
     category: 'status',
   },
 
   // Miscellaneous components
   'stats': {
-    component: (
-      <Stats
-        data={{
-          stats: [
-            { label: 'Revenue', value: '$12,345', change: 12.5 },
-            { label: 'Orders', value: '1,234', change: -3.2 },
-            { label: 'Customers', value: '567', change: 8.1 },
-          ],
-        }}
-      />
-    ),
+    component: <Stats data={{ stats: demoStats }} />,
     category: 'miscellaneous',
   },
   'hero': {
-    component: (
-      <Hero
-        data={{
-          logo1: { text: 'Acme', alt: 'Acme' },
-          title: 'Build beautiful chat experiences with Manifest UI',
-          subtitle:
-            'Create beautiful chat experiences with our comprehensive component library designed for agentic applications.',
-          primaryButton: { label: 'Get Started' },
-          secondaryButton: { label: 'GitHub' },
-        }}
-      />
-    ),
+    component: <Hero data={demoHeroDefault} />,
     category: 'miscellaneous',
   },
 
   // Social components
   'x-post': {
-    component: (
-      <XPost
-        data={{
-          author: 'Elon Musk',
-          username: 'elonmusk',
-          avatar: 'https://i.pravatar.cc/150?u=elon',
-          verified: true,
-          content: 'The future of AI is here!',
-          time: '2h',
-          likes: '42K',
-          retweets: '8.5K',
-          replies: '3.2K',
-        }}
-      />
-    ),
+    component: <XPost data={demoXPost} />,
     category: 'social',
   },
   'instagram-post': {
-    component: (
-      <InstagramPost
-        data={{
-          author: 'National Geographic',
-          avatar: 'https://i.pravatar.cc/150?u=natgeo',
-          verified: true,
-          image: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800',
-          caption: 'Nature at its finest',
-          likes: '125K',
-          time: '2h',
-        }}
-      />
-    ),
+    component: <InstagramPost data={demoInstagramPost} />,
     category: 'social',
   },
   'linkedin-post': {
-    component: (
-      <LinkedInPost
-        data={{
-          author: 'Satya Nadella',
-          headline: 'CEO at Microsoft',
-          avatar: 'S',
-          content: 'Excited to announce our latest AI innovations...',
-          time: '1d',
-          reactions: '15K',
-          topReactions: ['like', 'celebrate', 'love'],
-          comments: '890',
-          reposts: '2.1K',
-          postUrl: 'https://linkedin.com/posts/satya',
-          repostUrl: 'https://linkedin.com/shareArticle?url=...',
-        }}
-      />
-    ),
+    component: <LinkedInPost data={demoLinkedInPost} />,
     category: 'social',
   },
   'youtube-post': {
-    component: (
-      <YouTubePost
-        data={{
-          channel: 'TechTalks',
-          avatar: 'https://i.pravatar.cc/150?u=techtalks',
-          title: 'Building the Future of AI',
-          views: '1.2M',
-          time: '3 days ago',
-          thumbnail: 'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=800',
-          duration: '15:42',
-        }}
-      />
-    ),
+    component: <YouTubePost data={demoYouTubePost} />,
     category: 'social',
   },
 
   // Map components
   'map-carousel': {
-    component: <MapCarousel data={{ locations: demoMapLocations, center: [40.7128, -74.006] }} />,
+    component: (
+      <MapCarousel data={{ locations: demoMapLocations, center: demoMapCenter }} />
+    ),
     category: 'map',
   },
 
@@ -381,106 +252,23 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
     category: 'messaging',
   },
   'chat-conversation': {
-    component: (
-      <ChatConversation
-        data={{
-          messages: [
-            { content: 'Hello! How can I help you today?', isOwn: false, time: '10:00 AM' },
-            { content: 'I need help with my order', isOwn: true, time: '10:01 AM' },
-            {
-              content: 'Of course! Could you please provide your order number?',
-              isOwn: false,
-              time: '10:01 AM',
-            },
-          ],
-        }}
-      />
-    ),
+    component: <ChatConversation data={{ messages: demoMessages }} />,
     category: 'messaging',
   },
 
   // Events components
   'event-card': {
-    component: (
-      <EventCard
-        data={{
-          event: {
-            title: 'Summer Music Festival',
-            category: 'Music',
-            venue: 'Central Park',
-            city: 'New York',
-            dateTime: new Date(Date.now() + 86400000 * 7).toISOString(),
-            priceRange: '$45 - $150',
-            image: 'https://images.unsplash.com/photo-1459749411175-04bf5292ceea?w=800',
-            vibeTags: ['High energy', 'Outdoor', 'Social'],
-            eventSignal: 'popular',
-          },
-        }}
-      />
-    ),
+    component: <EventCard data={{ event: demoEvent }} />,
     category: 'events',
   },
   'event-list': {
     component: (
-      <EventList
-        data={{
-          events: [
-            {
-              title: 'Summer Music Festival',
-              category: 'Music',
-              venue: 'Central Park',
-              city: 'New York',
-              dateTime: new Date(Date.now() + 86400000 * 7).toISOString(),
-              priceRange: '$45 - $150',
-              image: 'https://images.unsplash.com/photo-1459749411175-04bf5292ceea?w=800',
-            },
-            {
-              title: 'Jazz Night',
-              category: 'Music',
-              venue: 'Blue Note',
-              city: 'New York',
-              dateTime: new Date(Date.now() + 86400000 * 14).toISOString(),
-              priceRange: '$30 - $80',
-            },
-            {
-              title: 'Comedy Show',
-              category: 'Comedy',
-              venue: 'Comedy Cellar',
-              city: 'New York',
-              dateTime: new Date(Date.now() + 86400000 * 3).toISOString(),
-              priceRange: '$25 - $50',
-            },
-          ],
-        }}
-        appearance={{ variant: 'grid' }}
-      />
+      <EventList data={{ events: demoEvents }} appearance={{ variant: 'grid' }} />
     ),
     category: 'events',
   },
   'event-detail': {
-    component: (
-      <EventDetail
-        data={{
-          event: {
-            title: 'Summer Music Festival',
-            category: 'Music',
-            venue: 'Central Park',
-            city: 'New York',
-            startDateTime: new Date(Date.now() + 86400000 * 7).toISOString(),
-            priceRange: '$45 - $150',
-            image: 'https://images.unsplash.com/photo-1459749411175-04bf5292ceea?w=800',
-            description: 'Join us for an amazing summer music festival!',
-            organizer: {
-              name: 'Live Events Co',
-              image: 'https://i.pravatar.cc/150?u=live',
-              rating: 4.8,
-              reviewCount: 120,
-              verified: true,
-            },
-          },
-        }}
-      />
-    ),
+    component: <EventDetail data={{ event: demoEventDetails }} />,
     category: 'events',
   },
   'ticket-tier-select': {
@@ -495,18 +283,7 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
     category: 'events',
   },
   'event-confirmation': {
-    component: (
-      <EventConfirmation
-        data={{
-          orderNumber: 'EVT-12345',
-          eventTitle: 'Summer Music Festival',
-          ticketCount: 2,
-          recipientEmail: 'customer@example.com',
-          eventDate: 'Jan 20, 2024',
-          eventLocation: 'Central Park, New York',
-        }}
-      />
-    ),
+    component: <EventConfirmation data={demoEventConfirmation} />,
     category: 'events',
   },
 };

--- a/packages/manifest-ui/registry/events/demo/data.ts
+++ b/packages/manifest-ui/registry/events/demo/data.ts
@@ -354,3 +354,34 @@ export const demoEventDetails: EventDetails = {
   ],
   relatedTags: ['Houston Events', 'Texas Nightlife', 'Techno Parties']
 }
+
+// Ticket tiers for TicketTierSelect
+export const demoTicketTiers = [
+  {
+    id: '1',
+    name: 'General Admission',
+    price: 45,
+    fee: 5,
+    available: 100,
+    maxPerOrder: 10,
+  },
+  {
+    id: '2',
+    name: 'VIP',
+    price: 150,
+    fee: 15,
+    available: 20,
+    maxPerOrder: 4,
+    description: 'Includes backstage access',
+  },
+]
+
+// Event confirmation data
+export const demoEventConfirmation = {
+  orderNumber: 'EVT-12345',
+  eventTitle: 'Summer Music Festival',
+  ticketCount: 2,
+  recipientEmail: 'customer@example.com',
+  eventDate: 'Jan 20, 2024',
+  eventLocation: 'Central Park, New York',
+}

--- a/packages/manifest-ui/registry/form/demo/data.ts
+++ b/packages/manifest-ui/registry/form/demo/data.ts
@@ -1,0 +1,4 @@
+// Demo data for Form category components
+// This file contains sample data used for component previews and documentation
+// Note: Form components are self-contained and don't require data props to render.
+// This file exists to satisfy the enforcement test that every category has a demo/data.ts.

--- a/packages/manifest-ui/registry/list/demo/data.ts
+++ b/packages/manifest-ui/registry/list/demo/data.ts
@@ -55,5 +55,19 @@ export const demoProducts: Product[] = [
     image: 'https://ui.manifest.build/demo/shoe-2.png',
     rating: 4.5,
     inStock: true
-  }
+  },
+]
+
+// Table columns
+export const demoTableColumns = [
+  { header: 'Name', accessor: 'name' },
+  { header: 'Email', accessor: 'email' },
+  { header: 'Status', accessor: 'status' },
+]
+
+// Table rows
+export const demoTableRows = [
+  { name: 'John Doe', email: 'john@example.com', status: 'Active' },
+  { name: 'Jane Smith', email: 'jane@example.com', status: 'Pending' },
+  { name: 'Bob Johnson', email: 'bob@example.com', status: 'Active' },
 ]

--- a/packages/manifest-ui/registry/map/demo/data.ts
+++ b/packages/manifest-ui/registry/map/demo/data.ts
@@ -1,0 +1,25 @@
+// Demo data for Map category components
+// This file contains sample data used for component previews and documentation
+
+export const demoMapLocations = [
+  {
+    id: '1',
+    name: 'Coffee Shop',
+    coordinates: [40.7128, -74.006] as [number, number],
+    description: 'Best coffee in town',
+  },
+  {
+    id: '2',
+    name: 'Book Store',
+    coordinates: [40.7138, -74.008] as [number, number],
+    description: 'Rare books collection',
+  },
+  {
+    id: '3',
+    name: 'Park',
+    coordinates: [40.7148, -74.004] as [number, number],
+    description: 'Beautiful city park',
+  },
+]
+
+export const demoMapCenter: [number, number] = [40.7128, -74.006]

--- a/packages/manifest-ui/registry/messaging/demo/data.ts
+++ b/packages/manifest-ui/registry/messaging/demo/data.ts
@@ -42,3 +42,59 @@ export const demoMessages: ChatMessage[] = [
     status: 'delivered'
   }
 ]
+
+// Text message bubble data
+export const demoTextMessages = [
+  {
+    content: 'Hey! How are you doing today?',
+    avatarUrl: 'https://i.pravatar.cc/150?u=sarah',
+    avatarFallback: 'S',
+    time: 'Dec 8, 10:30 AM',
+  },
+  {
+    content: "I'm doing great, thanks for asking!",
+    avatarFallback: 'Y',
+    time: 'Dec 8, 10:31 AM',
+    isOwn: true,
+    status: 'read' as const,
+  },
+]
+
+// Image message bubble data
+export const demoImageMessages = [
+  {
+    image:
+      'https://images.unsplash.com/photo-1682687220742-aba13b6e50ba?w=400&h=300&fit=crop',
+    content: 'Check out this view!',
+    avatarUrl: 'https://i.pravatar.cc/150?u=alex',
+    avatarFallback: 'A',
+    time: 'Dec 8, 2:45 PM',
+  },
+  {
+    image:
+      'https://images.unsplash.com/photo-1618477388954-7852f32655ec?w=400&h=300&fit=crop',
+    time: 'Dec 8, 2:46 PM',
+    isOwn: true,
+    status: 'delivered' as const,
+  },
+]
+
+// Voice message bubble data
+export const demoVoiceMessage = {
+  duration: '0:42',
+  avatarUrl: 'https://i.pravatar.cc/150?u=mickael',
+  avatarFallback: 'M',
+  time: 'Dec 8, 3:15 PM',
+}
+
+// Reaction message data
+export const demoReactionMessage = {
+  content: 'We just hit 10,000 users!',
+  avatarFallback: 'T',
+  time: 'Dec 8, 4:20 PM',
+  reactions: [
+    { emoji: '🎉', count: 5 },
+    { emoji: '❤️', count: 3 },
+    { emoji: '👏', count: 2 },
+  ],
+}

--- a/packages/manifest-ui/registry/miscellaneous/demo/data.ts
+++ b/packages/manifest-ui/registry/miscellaneous/demo/data.ts
@@ -1,0 +1,77 @@
+// Demo data for Miscellaneous category components
+// This file contains sample data used for component previews and documentation
+
+export const demoStats = [
+  { label: 'Revenue', value: '$12,345', change: 12.5 },
+  { label: 'Orders', value: '1,234', change: -3.2 },
+  { label: 'Customers', value: '567', change: 8.1 },
+]
+
+export const demoHeroDefault = {
+  logo1: { text: 'Acme', alt: 'Acme' },
+  title: 'Build beautiful chat experiences with Manifest UI',
+  subtitle:
+    'Create beautiful chat experiences with our comprehensive component library designed for agentic applications.',
+  primaryButton: { label: 'Get Started' },
+  secondaryButton: { label: 'GitHub' },
+}
+
+export const demoHeroTwoLogos = {
+  logo1: { text: 'Acme' },
+  logo2: {
+    url: '/logo-manifest-ui.svg',
+    urlLight: '/logo-manifest-ui-light.svg',
+    alt: 'Manifest',
+  },
+  logoSeparator: 'x',
+  title: 'Acme x Manifest UI',
+  subtitle:
+    'Combining the best of both worlds to deliver exceptional user experiences.',
+  primaryButton: { label: 'Get Started' },
+  secondaryButton: { label: 'GitHub' },
+}
+
+export const demoHeroWithTechLogos = {
+  logo1: { text: 'Acme' },
+  title: 'Build your next project with Acme',
+  subtitle:
+    'Create beautiful experiences with our comprehensive platform designed for modern applications.',
+  primaryButton: { label: 'Get Started' },
+  secondaryButton: { label: 'GitHub' },
+  techLogosLabel: 'Built with open-source technologies',
+  techLogos: [
+    {
+      url: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nextjs/nextjs-original.svg',
+      alt: 'Next.js',
+      name: 'Next.js',
+    },
+    {
+      url: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/typescript/typescript-original.svg',
+      alt: 'TypeScript',
+      name: 'TypeScript',
+    },
+    {
+      url: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg',
+      alt: 'React',
+      name: 'React',
+    },
+    {
+      url: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-original.svg',
+      alt: 'Tailwind CSS',
+      name: 'Tailwind CSS',
+    },
+    {
+      url: 'https://ui.manifest.build/demo/os-tech-mnfst.svg',
+      alt: 'Manifest',
+      name: 'Manifest',
+    },
+  ],
+}
+
+export const demoHeroMinimal = {
+  logo1: undefined,
+  title: 'Welcome to the Future',
+  subtitle: 'A simple, clean hero without logos or extra elements.',
+  primaryButton: { label: 'Get Started' },
+  secondaryButton: undefined,
+}

--- a/packages/manifest-ui/registry/payment/demo/data.ts
+++ b/packages/manifest-ui/registry/payment/demo/data.ts
@@ -17,5 +17,24 @@ export const demoOrderData = {
   tax: 21.58,
   discount: 25.0,
   discountCode: 'SAVE10',
-  total: 266.54
+  total: 266.54,
+}
+
+// OrderConfirm component data
+export const demoOrderConfirm = {
+  productName: 'Premium Headphones',
+  productImage: 'https://ui.manifest.build/demo/shoe-1.png',
+  price: 299,
+  deliveryDate: 'Jan 20, 2024',
+}
+
+// AmountInput presets
+export const demoAmountPresets = [10, 25, 50, 100]
+
+// PaymentConfirmed component data
+export const demoPaymentConfirmed = {
+  productName: 'Premium Headphones',
+  productImage: 'https://ui.manifest.build/demo/shoe-1.png',
+  price: 299,
+  deliveryDate: 'Jan 20, 2024',
 }

--- a/packages/manifest-ui/registry/selection/demo/data.ts
+++ b/packages/manifest-ui/registry/selection/demo/data.ts
@@ -7,5 +7,19 @@ import type { Option } from '../types'
 export const demoOptions: Option[] = [
   { label: 'Standard shipping', description: '3-5 business days' },
   { label: 'Express shipping', description: '1-2 business days' },
-  { label: 'Store pickup', description: 'Available in 2h' }
+  { label: 'Store pickup', description: 'Available in 2h' },
+]
+
+// Quick reply options
+export const demoQuickReplies = [
+  { label: 'Yes, please' },
+  { label: 'No, thanks' },
+  { label: 'Tell me more' },
+]
+
+// Tag select options
+export const demoTags: { id: string; label: string; color: 'red' | 'yellow' | 'green' }[] = [
+  { id: '1', label: 'Important', color: 'red' },
+  { id: '2', label: 'In Progress', color: 'yellow' },
+  { id: '3', label: 'Done', color: 'green' },
 ]

--- a/packages/manifest-ui/registry/social/demo/data.ts
+++ b/packages/manifest-ui/registry/social/demo/data.ts
@@ -1,0 +1,51 @@
+// Demo data for Social category components
+// This file contains sample data used for component previews and documentation
+
+export const demoXPost = {
+  author: 'Elon Musk',
+  username: 'elonmusk',
+  avatar: 'https://i.pravatar.cc/150?u=elon',
+  verified: true,
+  content: 'The future of AI is here!',
+  time: '2h',
+  likes: '42K',
+  retweets: '8.5K',
+  replies: '3.2K',
+  views: '45.2K',
+}
+
+export const demoInstagramPost = {
+  author: 'National Geographic',
+  avatar: 'https://i.pravatar.cc/150?u=natgeo',
+  verified: true,
+  image:
+    'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800',
+  caption: 'Nature at its finest',
+  likes: '125K',
+  time: '2h',
+}
+
+export const demoLinkedInPost = {
+  author: 'Satya Nadella',
+  headline: 'CEO at Microsoft',
+  avatar: 'S',
+  content: 'Excited to announce our latest AI innovations...',
+  time: '1d',
+  reactions: '15K',
+  topReactions: ['like', 'celebrate', 'love'] as ('like' | 'celebrate' | 'support' | 'love' | 'insightful' | 'funny')[],
+  comments: '890',
+  reposts: '2.1K',
+  postUrl: 'https://linkedin.com/posts/satya',
+  repostUrl: 'https://linkedin.com/shareArticle?url=...',
+}
+
+export const demoYouTubePost = {
+  channel: 'TechTalks',
+  avatar: 'https://i.pravatar.cc/150?u=techtalks',
+  title: 'Building the Future of AI',
+  views: '1.2M',
+  time: '3 days ago',
+  thumbnail:
+    'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=800',
+  duration: '15:42',
+}

--- a/packages/manifest-ui/registry/status/demo/data.ts
+++ b/packages/manifest-ui/registry/status/demo/data.ts
@@ -1,0 +1,14 @@
+// Demo data for Status category components
+// This file contains sample data used for component previews and documentation
+
+export const demoProgressSteps = [
+  { label: 'Cart', status: 'completed' as const },
+  { label: 'Shipping', status: 'current' as const },
+  { label: 'Payment', status: 'pending' as const },
+  { label: 'Confirm', status: 'pending' as const },
+]
+
+export const demoStatusBadge = {
+  status: 'processing' as const,
+  label: 'Processing',
+}


### PR DESCRIPTION
## Description

Components were returning `null` after the default data removal (commit 3224a07b) because `page.tsx` and `preview-components.tsx` were never updated to pass demo data. This PR centralizes all demo data in `registry/<category>/demo/data.ts` files and fixes all component previews.

**Changes:**
- Create `demo/data.ts` for 5 new categories: social, miscellaneous, status, map, form
- Extend existing `demo/data.ts` for 5 categories: events, messaging, selection, payment, list
- Refactor `preview-components.tsx` to import all data from `demo/data.ts` (520→297 lines)
- Fix ~30 component previews in `page.tsx` to receive demo data props
- Add enforcement test (`demo-data-placement.test.ts`) with 3 rules:
  - Every category with `.tsx` files must have `demo/data.ts`
  - No local `const demo*` in `preview-components.tsx`
  - No large inline `data={{...}}` objects (>4 top-level properties)

## Related Issues

None

## How can it be tested?

1. Run `pnpm run dev` in `packages/manifest-ui`
2. Browse to `/blocks/blogging/post-card` — verify preview renders with data
3. Check other categories: events, payment, messaging, social, miscellaneous
4. Run `pnpm test` — all 1181 tests pass including new demo-data-placement test
5. Run `pnpm run build` — no TypeScript errors

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR