### PR TITLE
fix(manifest-ui): fix sidebar filtering, type hover, and deps tag interaction

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -2876,10 +2876,13 @@ function BlockPageContent() {
                 </span>
               )}
               {depCount !== null && depCount > 0 && (
-                <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1">
+                <button
+                  onClick={() => firstVariantRef.current?.showDepsTab()}
+                  className="px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 inline-flex items-center gap-1 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                >
                   <Package className="w-3 h-3" />
                   {`${depCount} dep${depCount > 1 ? 's' : ''}`}
-                </span>
+                </button>
               )}
             </div>
             <p className="text-muted-foreground">{selectedBlock.description}</p>

--- a/packages/manifest-ui/lib/blocks-categories.ts
+++ b/packages/manifest-ui/lib/blocks-categories.ts
@@ -43,6 +43,9 @@ function buildBlockCategories(): BlockCategory[] {
   const categoryMap = new Map<string, { id: string; name: string }[]>()
 
   for (const item of registry.items) {
+    // Skip non-component items (e.g. shared type definitions)
+    if (item.type !== 'registry:block') continue
+
     // Support both 'categories' array (new format) and 'category' string (old format)
     const categories = item.categories
     if (!categories || categories.length === 0) continue


### PR DESCRIPTION
## Description

Fixes three UI issues on ui.manifest.build:

1. **Sidebar shows non-component items**: The `manifest-types` registry item (type: `registry:lib`) was appearing in the sidebar navigation. Added a filter in `buildBlockCategories()` to skip non-block items.

2. **Type hover not working in Config tab**: Custom types like `ChatMessage` weren't showing hover tooltips because their definitions live in registry dependencies (e.g. `manifest-types`), not in the component's own files. Modified `useSourceCode` to also fetch type definitions from registry dependencies.

3. **Deps tag not clickable**: The "X deps" badge near component titles was a static `<span>`, while the "X actions" badge was a clickable `<button>`. Changed the deps tag to a button that switches the first variant to the Deps tab, matching the actions tag behavior.

## Related Issues

None

## How can it be tested?

1. Visit `/blocks` — verify "Manifest Types" no longer appears in the sidebar
2. Visit `/blocks/messaging/chat-conversation` → click Config tab → hover over `ChatMessage[]` in the Data section — a tooltip showing the type definition should appear
3. Visit `/blocks/events/event-detail` → click the "3 deps" badge near the title — it should switch to the Deps tab

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR