### PR TITLE
fix(manifest-ui): fix broken demo data across social, map, and blogging

### DIFF
--- a/packages/manifest-ui/registry/blogging/demo/data.ts
+++ b/packages/manifest-ui/registry/blogging/demo/data.ts
@@ -8,7 +8,7 @@ export const demoPost: Post = {
   title: 'Getting Started with Agentic UI Components',
   excerpt:
     'Learn how to build conversational interfaces with our comprehensive component library designed for AI-powered applications.',
-  coverImage: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=800',
+  coverImage: 'https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=800',
   author: {
     name: 'Sarah Chen',
     avatar: 'https://i.pravatar.cc/150?u=sarah',
@@ -37,7 +37,7 @@ export const demoRelatedPosts: Post[] = [
     title: 'Designing for Conversational Interfaces',
     excerpt:
       'Best practices for creating intuitive UI components that work within chat environments.',
-    coverImage: 'https://images.unsplash.com/photo-1559028012-481c04fa702d?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=800',
     author: { name: 'Alex Rivera', avatar: 'https://i.pravatar.cc/150?u=alex' },
     publishedAt: '2024-01-12',
     readTime: '8 min read',
@@ -48,7 +48,7 @@ export const demoRelatedPosts: Post[] = [
   {
     title: 'MCP Integration Patterns',
     excerpt: 'How to leverage Model Context Protocol for seamless backend communication.',
-    coverImage: 'https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=800',
     author: { name: 'Jordan Kim', avatar: 'https://i.pravatar.cc/150?u=jordan' },
     publishedAt: '2024-01-10',
     readTime: '12 min read',
@@ -74,7 +74,7 @@ export const demoPosts: Post[] = [
     title: 'Getting Started with Agentic UI Components',
     excerpt:
       'Learn how to build conversational interfaces with our comprehensive component library designed for AI-powered applications.',
-    coverImage: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=800',
     author: {
       name: 'Sarah Chen',
       avatar: 'https://i.pravatar.cc/150?u=sarah',
@@ -88,7 +88,7 @@ export const demoPosts: Post[] = [
     title: 'Designing for Conversational Interfaces with Manifest UI',
     excerpt:
       'Best practices for creating intuitive UI components that work within chat environments.',
-    coverImage: 'https://images.unsplash.com/photo-1559028012-481c04fa702d?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=800',
     author: {
       name: 'Alex Rivera',
       avatar: 'https://i.pravatar.cc/150?u=alex',
@@ -102,7 +102,7 @@ export const demoPosts: Post[] = [
     title: 'MCP Integration Patterns',
     excerpt:
       'How to leverage Model Context Protocol for seamless backend communication in your agentic applications.',
-    coverImage: 'https://images.unsplash.com/photo-1558494949-ef010cbdcc31?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=800',
     author: {
       name: 'Jordan Kim',
       avatar: 'https://i.pravatar.cc/150?u=jordan',
@@ -116,7 +116,7 @@ export const demoPosts: Post[] = [
     title: 'Building Payment Flows in Chat',
     excerpt:
       'A complete guide to implementing secure, user-friendly payment experiences within conversational interfaces.',
-    coverImage: 'https://images.unsplash.com/photo-1556742049-0cfed4f6a45d?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1472214103451-9374bd1c798e?w=800',
     author: {
       name: 'Morgan Lee',
       avatar: 'https://i.pravatar.cc/150?u=morgan',
@@ -130,7 +130,7 @@ export const demoPosts: Post[] = [
     title: 'Real-time Collaboration in AI Apps',
     excerpt:
       'Implementing WebSocket connections and real-time updates for collaborative agentic experiences.',
-    coverImage: 'https://images.unsplash.com/photo-1552664730-d307ca884978?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800',
     author: {
       name: 'Casey Taylor',
       avatar: 'https://i.pravatar.cc/150?u=casey',
@@ -144,7 +144,7 @@ export const demoPosts: Post[] = [
     title: 'Accessibility in Chat Interfaces',
     excerpt:
       'Making your conversational UI accessible to all users with screen readers and keyboard navigation.',
-    coverImage: 'https://images.unsplash.com/photo-1573164713988-8665fc963095?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1507525428034-b723cf961d3e?w=800',
     author: {
       name: 'Jamie Park',
       avatar: 'https://i.pravatar.cc/150?u=jamie',
@@ -158,7 +158,7 @@ export const demoPosts: Post[] = [
     title: 'State Management for Complex Workflows',
     excerpt:
       'Managing complex multi-step workflows in agentic applications using modern state patterns.',
-    coverImage: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1501785888041-af3ef285b470?w=800',
     author: {
       name: 'Drew Martinez',
       avatar: 'https://i.pravatar.cc/150?u=drew',
@@ -171,7 +171,7 @@ export const demoPosts: Post[] = [
   {
     title: 'Testing Conversational Components',
     excerpt: 'Strategies for unit testing and integration testing of chat-based UI components.',
-    coverImage: 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1433086966358-54859d0ed716?w=800',
     author: {
       name: 'Riley Johnson',
       avatar: 'https://i.pravatar.cc/150?u=riley',
@@ -184,7 +184,7 @@ export const demoPosts: Post[] = [
   {
     title: 'Theming and Dark Mode Support',
     excerpt: 'Implementing flexible theming systems with dark mode for agentic UI components.',
-    coverImage: 'https://images.unsplash.com/photo-1555066931-4365d14bab8c?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1475924156734-496f6cac6ec1?w=800',
     author: {
       name: 'Avery Williams',
       avatar: 'https://i.pravatar.cc/150?u=avery',
@@ -197,7 +197,7 @@ export const demoPosts: Post[] = [
   {
     title: 'Performance Optimization Techniques',
     excerpt: 'Optimizing render performance and reducing bundle size in chat applications.',
-    coverImage: 'https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1518173946687-a2e8a36af77a?w=800',
     author: {
       name: 'Quinn Anderson',
       avatar: 'https://i.pravatar.cc/150?u=quinn',
@@ -211,7 +211,7 @@ export const demoPosts: Post[] = [
     title: 'Error Handling and Recovery',
     excerpt:
       'Graceful error handling patterns and user-friendly recovery flows in conversational UIs.',
-    coverImage: 'https://images.unsplash.com/photo-1504639725590-34d0984388bd?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1509316975850-ff9c5deb0cd9?w=800',
     author: {
       name: 'Sage Thompson',
       avatar: 'https://i.pravatar.cc/150?u=sage',
@@ -224,7 +224,7 @@ export const demoPosts: Post[] = [
   {
     title: 'Internationalization Best Practices',
     excerpt: 'Making your agentic UI components work across languages and locales.',
-    coverImage: 'https://images.unsplash.com/photo-1526304640581-d334cdbbf45e?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1426604966848-d7adac402bff?w=800',
     author: {
       name: 'Blake Garcia',
       avatar: 'https://i.pravatar.cc/150?u=blake',
@@ -237,7 +237,7 @@ export const demoPosts: Post[] = [
   {
     title: 'Mobile-First Chat Design',
     excerpt: 'Designing conversational interfaces that work beautifully on mobile devices.',
-    coverImage: 'https://images.unsplash.com/photo-1512941937669-90a1b58e7e9c?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=800',
     author: {
       name: 'Charlie Brown',
       avatar: 'https://i.pravatar.cc/150?u=charlie',
@@ -250,7 +250,7 @@ export const demoPosts: Post[] = [
   {
     title: 'Analytics and User Insights',
     excerpt: 'Tracking user interactions and deriving insights from conversational UI usage.',
-    coverImage: 'https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?w=800',
     author: {
       name: 'Sydney Chen',
       avatar: 'https://i.pravatar.cc/150?u=sydney',
@@ -263,7 +263,7 @@ export const demoPosts: Post[] = [
   {
     title: 'Building Reusable Component Libraries',
     excerpt: 'Creating a scalable component library for agentic UIs that teams can share.',
-    coverImage: 'https://images.unsplash.com/photo-1558655146-d09347e92766?w=800',
+    coverImage: 'https://images.unsplash.com/photo-1465056836900-8f1e940f2114?w=800',
     author: {
       name: 'Taylor Swift',
       avatar: 'https://i.pravatar.cc/150?u=taylor',

--- a/packages/manifest-ui/registry/map/demo/data.ts
+++ b/packages/manifest-ui/registry/map/demo/data.ts
@@ -4,22 +4,22 @@
 export const demoMapLocations = [
   {
     id: '1',
-    name: 'Coffee Shop',
-    coordinates: [40.7128, -74.006] as [number, number],
-    description: 'Best coffee in town',
+    name: 'Blue Bottle Coffee',
+    coordinates: [37.7823, -122.4075] as [number, number],
+    description: 'Specialty coffee roaster',
   },
   {
     id: '2',
-    name: 'Book Store',
-    coordinates: [40.7138, -74.008] as [number, number],
-    description: 'Rare books collection',
+    name: 'City Lights Bookstore',
+    coordinates: [37.7976, -122.4064] as [number, number],
+    description: 'Iconic independent bookstore',
   },
   {
     id: '3',
-    name: 'Park',
-    coordinates: [40.7148, -74.004] as [number, number],
-    description: 'Beautiful city park',
+    name: 'Dolores Park',
+    coordinates: [37.7596, -122.4269] as [number, number],
+    description: 'Popular city park with skyline views',
   },
 ]
 
-export const demoMapCenter: [number, number] = [40.7128, -74.006]
+export const demoMapCenter: [number, number] = [37.7749, -122.4194]

--- a/packages/manifest-ui/registry/social/demo/data.ts
+++ b/packages/manifest-ui/registry/social/demo/data.ts
@@ -2,48 +2,48 @@
 // This file contains sample data used for component previews and documentation
 
 export const demoXPost = {
-  author: 'Elon Musk',
-  username: 'elonmusk',
-  avatar: 'https://i.pravatar.cc/150?u=elon',
+  author: 'Manifest',
+  username: 'manifest_ui',
+  avatar: 'M',
   verified: true,
-  content: 'The future of AI is here!',
+  content: 'Just shipped a new batch of agentic UI components. Build conversational interfaces faster than ever.',
   time: '2h',
-  likes: '42K',
-  retweets: '8.5K',
-  replies: '3.2K',
+  likes: '1.2K',
+  retweets: '234',
+  replies: '56',
   views: '45.2K',
 }
 
 export const demoInstagramPost = {
-  author: 'National Geographic',
-  avatar: 'https://i.pravatar.cc/150?u=natgeo',
+  author: 'manifest.ui',
+  avatar: 'M',
   verified: true,
   image:
     'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800',
-  caption: 'Nature at its finest',
-  likes: '125K',
+  caption: 'Building the future of agentic UIs, one component at a time.',
+  likes: '2,847',
   time: '2h',
 }
 
 export const demoLinkedInPost = {
-  author: 'Satya Nadella',
-  headline: 'CEO at Microsoft',
-  avatar: 'S',
-  content: 'Excited to announce our latest AI innovations...',
+  author: 'Manifest',
+  headline: 'Manifest UI | Open Source',
+  avatar: 'M',
+  content: 'Excited to announce our latest milestone! We\'ve just crossed 10,000 developers using Manifest to build agentic UIs.',
   time: '1d',
-  reactions: '15K',
+  reactions: '1,234',
   topReactions: ['like', 'celebrate', 'love'] as ('like' | 'celebrate' | 'support' | 'love' | 'insightful' | 'funny')[],
-  comments: '890',
-  reposts: '2.1K',
-  postUrl: 'https://linkedin.com/posts/satya',
+  comments: '56',
+  reposts: '12',
+  postUrl: 'https://linkedin.com/posts/manifest-123',
   repostUrl: 'https://linkedin.com/shareArticle?url=...',
 }
 
 export const demoYouTubePost = {
-  channel: 'TechTalks',
-  avatar: 'https://i.pravatar.cc/150?u=techtalks',
-  title: 'Building the Future of AI',
-  views: '1.2M',
+  channel: 'Manifest',
+  avatar: 'M',
+  title: 'Building Agentic UIs with Manifest',
+  views: '12K',
   time: '3 days ago',
   thumbnail:
     'https://images.unsplash.com/photo-1677442136019-21780ecad995?w=800',


### PR DESCRIPTION
## Description

Fixes several demo data issues on ui.manifest.build:

- **Social cards**: Avatar fields contained full URLs (`https://i.pravatar.cc/...`) but components render avatars as text inside colored circles (not `<img>` tags), causing broken displays. Replaced with single-letter fallbacks (`'M'`). Also replaced real-person references (Elon Musk, Satya Nadella, National Geographic) with generic Manifest branding.
- **Map carousel**: Changed coordinates from NYC to San Francisco with real SF landmarks (Blue Bottle Coffee, City Lights Bookstore, Dolores Park) to match the "Hotels in San Francisco" title already used in `usageCode`.
- **Blogging images**: Replaced tech/stock cover images with nature photography (mountains, forests, beaches, waterfalls, meadows) across all 17 cover image URLs.

## Related Issues

None

## How can it be tested?

1. Run `pnpm dev` in `packages/manifest-ui`
2. Check `/blocks/social/x-post` — should show "Manifest" with "M" letter avatar (no broken URL text)
3. Check `/blocks/social/instagram-post` — should show "manifest.ui" with "M" avatar
4. Check `/blocks/social/linkedin-post` — should show "Manifest" with "M" avatar
5. Check `/blocks/social/youtube-post` — should show "Manifest" with "M" avatar
6. Check `/blocks/map/map-carousel` — map should center on San Francisco
7. Check `/blocks/blogging/post-card` and `/blocks/blogging/post-list` — cover images should be nature photos

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR