### PR TITLE
fix(manifest-ui): fix non-interactive DateTimePicker and TicketTierSelect previews

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -32,6 +32,7 @@ import {
   demoEvent,
   demoEvents,
   demoEventDetails,
+  demoTicketTiers,
   demoEventConfirmation,
 } from '@/registry/events/demo/data';
 
@@ -1458,6 +1459,7 @@ const categories: Category[] = [
                     image: 'https://images.unsplash.com/photo-1540575467063-178a50c2df87?w=800',
                     currency: 'USD',
                   },
+                  tiers: demoTicketTiers,
                 }}
               />
             ),

--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -12,6 +12,7 @@ import { Suspense, useEffect, useRef, useState } from 'react';
 import { ContactForm } from '@/registry/form/contact-form';
 import { DateTimePicker } from '@/registry/form/date-time-picker';
 import { IssueReportForm } from '@/registry/form/issue-report-form';
+import { demoDateTimePickerData } from '@/registry/form/demo/data';
 
 // Blogging components
 import { PostCardDemo } from '@/components/blocks/post-card-demo';
@@ -1603,10 +1604,10 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <DateTimePicker />,
+            component: <DateTimePicker data={demoDateTimePickerData} />,
             fullscreenComponent: (
               <div className="max-w-[680px] mx-auto">
-                <DateTimePicker />
+                <DateTimePicker data={demoDateTimePickerData} />
               </div>
             ),
             usageCode: `<DateTimePicker

--- a/packages/manifest-ui/lib/preview-components.tsx
+++ b/packages/manifest-ui/lib/preview-components.tsx
@@ -12,6 +12,7 @@ import { ReactNode } from 'react';
 import { ContactForm } from '@/registry/form/contact-form';
 import { DateTimePicker } from '@/registry/form/date-time-picker';
 import { IssueReportForm } from '@/registry/form/issue-report-form';
+import { demoDateTimePickerData } from '@/registry/form/demo/data';
 
 // Payment components
 import { AmountInput } from '@/registry/payment/amount-input';
@@ -122,7 +123,7 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
     category: 'form',
   },
   'date-time-picker': {
-    component: <DateTimePicker />,
+    component: <DateTimePicker data={demoDateTimePickerData} />,
     category: 'form',
   },
   'issue-report-form': {

--- a/packages/manifest-ui/registry/form/demo/data.ts
+++ b/packages/manifest-ui/registry/form/demo/data.ts
@@ -1,4 +1,36 @@
 // Demo data for Form category components
 // This file contains sample data used for component previews and documentation
-// Note: Form components are self-contained and don't require data props to render.
-// This file exists to satisfy the enforcement test that every category has a demo/data.ts.
+
+/**
+ * Generate available dates dynamically so the DateTimePicker preview
+ * always has clickable dates regardless of when it is viewed.
+ */
+function generateAvailableDates(): Date[] {
+  const dates: Date[] = [];
+  const now = new Date();
+  // Walk through current and next month, only keeping weekdays (Mon-Fri)
+  for (let m = 0; m <= 1; m++) {
+    for (let d = 1; d <= 28; d += 2) {
+      const date = new Date(now.getFullYear(), now.getMonth() + m, d);
+      const day = date.getDay();
+      if (day !== 0 && day !== 6) {
+        dates.push(date);
+      }
+    }
+  }
+  return dates;
+}
+
+export const demoDateTimePickerData = {
+  title: 'Select a Date & Time',
+  availableDates: generateAvailableDates(),
+  availableTimeSlots: [
+    '9:00am',
+    '10:00am',
+    '11:30am',
+    '1:00pm',
+    '2:30pm',
+    '4:00pm',
+  ],
+  timezone: 'Eastern Time - US & Canada',
+};


### PR DESCRIPTION
## Description

Fix two component previews that were completely non-interactive due to missing demo data props:

- **DateTimePicker**: Rendered with no props, so `availableDates` defaulted to `[]` and every calendar day was disabled. Added weekday-only dynamically generated dates, time slots, and timezone via centralized `demo/data.ts`.
- **TicketTierSelect**: Rendered with `event` data but no `tiers` array, so the tier list was empty. Added `demoTicketTiers` import from existing centralized demo data.

## Related Issues

None

## How can it be tested?

1. Run `pnpm run dev` in `packages/manifest-ui`
2. Navigate to `/blocks/form/date-time-picker`
   - Verify weekday dates have availability dots and are clickable
   - Click a date — time slots should appear
   - Click a time slot — "Next" button should appear
3. Navigate to `/blocks/events/ticket-tier-select`
   - Verify General Admission and VIP tiers are visible with quantity pickers
   - Increment quantities — order summary should update
   - Click "Check out" — button should be enabled when tickets are selected

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR