### PR TITLE
Update demo payment data product name to Air Force 1

### DIFF
--- a/packages/manifest-ui/registry/payment/demo/data.ts
+++ b/packages/manifest-ui/registry/payment/demo/data.ts
@@ -22,7 +22,7 @@ export const demoOrderData = {
 
 // OrderConfirm component data
 export const demoOrderConfirm = {
-  productName: 'Premium Headphones',
+  productName: "Air Force 1 '07",
   productImage: 'https://ui.manifest.build/demo/shoe-1.png',
   price: 299,
   deliveryDate: 'Jan 20, 2024',
@@ -33,7 +33,7 @@ export const demoAmountPresets = [10, 25, 50, 100]
 
 // PaymentConfirmed component data
 export const demoPaymentConfirmed = {
-  productName: 'Premium Headphones',
+  productName: "Air Force 1 '07",
   productImage: 'https://ui.manifest.build/demo/shoe-1.png',
   price: 299,
   deliveryDate: 'Jan 20, 2024',


### PR DESCRIPTION
## Summary

Update demo product names in the payment UI registry from "Premium Headphones" to "Air Force 1 '07" to better align with the shoe product image being used in the demo data.

## Changes

- Updated `demoOrderConfirm.productName` from "Premium Headphones" to "Air Force 1 '07"
- Updated `demoPaymentConfirmed.productName` from "Premium Headphones" to "Air Force 1 '07"

These changes ensure consistency between the product name and the product image (`shoe-1.png`) used in the payment UI demo components.

## Type of Change

- [x] Refactoring (no functional changes)

## Testing

- [x] Tests pass locally (`pnpm test`)
- [x] Lint passes (`pnpm lint`)

## Related Issues

<!-- Link any related issues if applicable -->

https://claude.ai/code/session_01AeWdAw7eM2wESwHGTG3FKc