### PR TITLE
Add weekStartsOn option to DateTimePicker component

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -1624,7 +1624,8 @@ const categories: Category[] = [
   }}
   appearance={{
     showTitle: true,
-    showTimezone: true
+    showTimezone: true,
+    weekStartsOn: "sunday" // "sunday" | "monday" | "saturday"
   }}
   actions={{
     onNext: (date, time) => console.log("Confirmed:", { date, time })

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -21,7 +21,8 @@
       "2.0.0": "BREAKING: Removed onSelect action. Intermediate date/time selection is now internal.",
       "2.0.1": "Removed default content data - component only renders explicitly provided data",
       "2.0.2": "Fixed missing popover dependency for shadcn CLI installation",
-      "2.0.3": "Replaced hardcoded UTC offsets with IANA timezone identifiers for correct DST handling"
+      "2.0.3": "Replaced hardcoded UTC offsets with IANA timezone identifiers for correct DST handling",
+      "2.1.0": "Added weekStartsOn appearance option to configure first day of the week (Sunday, Monday, or Saturday)"
     },
     "issue-report-form": {
       "1.0.0": "Initial release with categories, impact levels and file attachments",

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -63,7 +63,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/date-time-picker.png",
-        "version": "2.0.3",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with calendar and time slot selection",
           "1.0.1": "Added aria-labels to navigation buttons for better screen reader accessibility",
@@ -72,7 +72,8 @@
           "2.0.0": "BREAKING: Removed onSelect action. Intermediate date/time selection is now internal.",
           "2.0.1": "Removed default content data - component only renders explicitly provided data",
           "2.0.2": "Fixed missing popover dependency for shadcn CLI installation",
-          "2.0.3": "Replaced hardcoded UTC offsets with IANA timezone identifiers for correct DST handling"
+          "2.0.3": "Replaced hardcoded UTC offsets with IANA timezone identifiers for correct DST handling",
+          "2.1.0": "Added weekStartsOn appearance option to configure first day of the week (Sunday, Monday, or Saturday)"
         }
       },
       "dependencies": [


### PR DESCRIPTION
## Summary

Added a new `weekStartsOn` appearance option to the DateTimePicker component that allows users to configure which day of the week the calendar should start with. This supports three common week start conventions: Sunday (US/Canada/Japan), Monday (ISO 8601/Europe), and Saturday (Middle East).

## Changes

- Added `weekStartsOn` property to the `DateTimePickerProps` appearance interface with support for 'sunday' | 'monday' | 'saturday'
- Implemented `WEEK_START_OFFSETS` mapping and `getOrderedDays()` utility function to dynamically reorder day headers based on the selected week start
- Updated calendar day calculation logic to correctly compute leading days from the previous month based on the configured week start offset
- Updated day headers rendering to use the dynamically ordered days array
- Updated component version from 2.0.3 to 2.1.0 in both changelog.json and registry.json
- Added comprehensive JSDoc documentation explaining the three week start options and their regional usage

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Testing

- Component maintains backward compatibility with default 'sunday' week start
- Calendar grid correctly adjusts leading days from previous month for all three week start options
- Day headers display in correct order for each configuration

## Related Issues

<!-- Link any related issues if applicable -->

https://claude.ai/code/session_01GEzALHv1p4jAQss7WHNF6D