### PR TITLE
Fix table preview not displaying data by passing demo columns and rows

### DIFF
--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -40,7 +40,15 @@ import {
 import { TableDemo } from '@/components/blocks/table-demo';
 import { ProductList } from '@/registry/list/product-list';
 import { Table } from '@/registry/list/table';
-import { demoProducts } from '@/registry/list/demo/data';
+import {
+  demoProducts,
+  demoApiUsageColumns,
+  demoApiUsageRows,
+  demoModelsColumns,
+  demoModelsRows,
+  demoExportColumns,
+  demoExportRows,
+} from '@/registry/list/demo/data';
 
 // Payment components
 import { AmountInput } from '@/registry/payment/amount-input';
@@ -1750,9 +1758,9 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <TableDemo data={{ title: 'API Usage' }} />,
+            component: <TableDemo data={{ title: 'API Usage', columns: demoApiUsageColumns, rows: demoApiUsageRows }} />,
             fullscreenComponent: (
-              <Table data={{ title: 'API Usage' }} appearance={{ displayMode: 'fullscreen' }} />
+              <Table data={{ title: 'API Usage', columns: demoApiUsageColumns, rows: demoApiUsageRows }} appearance={{ displayMode: 'fullscreen' }} />
             ),
             usageCode: `<Table
   data={{
@@ -1780,11 +1788,11 @@ const categories: Category[] = [
             id: 'single-select',
             name: 'Single Select',
             component: (
-              <TableDemo data={{ title: 'Models' }} appearance={{ selectable: 'single' }} />
+              <TableDemo data={{ title: 'Models', columns: demoModelsColumns, rows: demoModelsRows }} appearance={{ selectable: 'single' }} />
             ),
             fullscreenComponent: (
               <Table
-                data={{ title: 'Models' }}
+                data={{ title: 'Models', columns: demoModelsColumns, rows: demoModelsRows }}
                 appearance={{ selectable: 'single', displayMode: 'fullscreen' }}
               />
             ),
@@ -1797,11 +1805,11 @@ const categories: Category[] = [
             id: 'multi-select',
             name: 'Multi Select',
             component: (
-              <TableDemo data={{ title: 'Export Data' }} appearance={{ selectable: 'multi' }} />
+              <TableDemo data={{ title: 'Export Data', columns: demoExportColumns, rows: demoExportRows }} appearance={{ selectable: 'multi' }} />
             ),
             fullscreenComponent: (
               <Table
-                data={{ title: 'Export Data' }}
+                data={{ title: 'Export Data', columns: demoExportColumns, rows: demoExportRows }}
                 appearance={{ selectable: 'multi', displayMode: 'fullscreen' }}
               />
             ),

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -225,7 +225,8 @@
       "2.0.1": "Removed default content data - component only renders explicitly provided data",
       "2.0.2": "Removed unused checkbox from registry dependencies",
       "2.0.3": "Migrated from OpenAI Apps SDK to MCP Apps protocol for host communication",
-      "2.0.4": "Removed stale sortedData from handleRowSelect dependency array"
+      "2.0.4": "Removed stale sortedData from handleRowSelect dependency array",
+      "2.0.5": "Fixed table preview not displaying data by passing demo columns and rows"
     },
     "message-bubble": {
       "1.0.0": "Initial release with text, image, voice and reaction variants",

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -709,7 +709,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/table.png",
-        "version": "2.0.4",
+        "version": "2.0.5",
         "changelog": {
           "1.0.0": "Initial release with single and multi-select modes",
           "1.0.1": "Added descriptive alt tags for title images",
@@ -722,7 +722,8 @@
           "2.0.1": "Removed default content data - component only renders explicitly provided data",
           "2.0.2": "Removed unused checkbox from registry dependencies",
           "2.0.3": "Migrated from OpenAI Apps SDK to MCP Apps protocol for host communication",
-          "2.0.4": "Removed stale sortedData from handleRowSelect dependency array"
+          "2.0.4": "Removed stale sortedData from handleRowSelect dependency array",
+          "2.0.5": "Fixed table preview not displaying data by passing demo columns and rows"
         }
       },
       "dependencies": [

--- a/packages/manifest-ui/registry/list/demo/data.ts
+++ b/packages/manifest-ui/registry/list/demo/data.ts
@@ -71,3 +71,44 @@ export const demoTableRows = [
   { name: 'Jane Smith', email: 'jane@example.com', status: 'Pending' },
   { name: 'Bob Johnson', email: 'bob@example.com', status: 'Active' },
 ]
+
+// Table variant: API Usage (default)
+export const demoApiUsageColumns = [
+  { header: 'Model', accessor: 'model', sortable: true },
+  { header: 'Total Tokens', accessor: 'totalTokens', sortable: true, align: 'right' as const },
+]
+
+export const demoApiUsageRows = [
+  { model: 'gpt-5', totalTokens: 2267482 },
+  { model: 'claude-3.5-sonnet', totalTokens: 647528 },
+  { model: 'gemini-pro', totalTokens: 428190 },
+  { model: 'llama-3', totalTokens: 312475 },
+]
+
+// Table variant: Models (single select)
+export const demoModelsColumns = [
+  { header: 'Model', accessor: 'model', sortable: true },
+  { header: 'Provider', accessor: 'provider', sortable: true },
+  { header: 'Context Window', accessor: 'contextWindow', sortable: true, align: 'right' as const },
+]
+
+export const demoModelsRows = [
+  { model: 'GPT-5', provider: 'OpenAI', contextWindow: '128K' },
+  { model: 'Claude 3.5 Sonnet', provider: 'Anthropic', contextWindow: '200K' },
+  { model: 'Gemini Pro', provider: 'Google', contextWindow: '1M' },
+  { model: 'Llama 3', provider: 'Meta', contextWindow: '128K' },
+]
+
+// Table variant: Export Data (multi select)
+export const demoExportColumns = [
+  { header: 'Date', accessor: 'date', sortable: true },
+  { header: 'Event', accessor: 'event', sortable: true },
+  { header: 'Users', accessor: 'users', sortable: true, align: 'right' as const },
+]
+
+export const demoExportRows = [
+  { date: '2025-01-15', event: 'Page View', users: 1243 },
+  { date: '2025-01-15', event: 'Sign Up', users: 87 },
+  { date: '2025-01-14', event: 'Page View', users: 1105 },
+  { date: '2025-01-14', event: 'Purchase', users: 42 },
+]


### PR DESCRIPTION
## Summary

Fixed an issue where table component previews in the block showcase were not displaying any data. The table components were being rendered without the necessary `columns` and `rows` data props, resulting in empty table displays.

## Changes

- Added imports for demo data exports (`demoApiUsageColumns`, `demoApiUsageRows`, `demoModelsColumns`, `demoModelsRows`, `demoExportColumns`, `demoExportRows`) from the demo data file
- Updated three table preview variants to pass the appropriate demo data:
  - **API Usage (default)**: Added `demoApiUsageColumns` and `demoApiUsageRows` with model and token usage data
  - **Models (single select)**: Added `demoModelsColumns` and `demoModelsRows` with model provider and context window information
  - **Export Data (multi select)**: Added `demoExportColumns` and `demoExportRows` with event tracking data
- Updated both `TableDemo` and `Table` component instances in the block showcase to include the data props
- Created new demo data exports in `registry/list/demo/data.ts` for each table variant
- Bumped table component version from 2.0.4 to 2.0.5
- Updated changelog entries in both `changelog.json` and `registry.json`

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- Visual verification that table previews now display the appropriate demo data
- Verified that both preview and fullscreen variants render correctly with the provided data
- Confirmed that sorting and selection features work with the populated data

## Related Issues

Fixes table preview rendering issue where no data was visible in the block showcase.

https://claude.ai/code/session_019pBU9Tkk316BvpBP96kjJP