### PR TITLE
Fix infinite re-render loops in option-list and tag-select

### DIFF
--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -103,7 +103,8 @@
       "2.1.3": "Fixed circular dependency by adding types.ts and demo/data.ts to registry",
       "3.0.0": "BREAKING: Replaced onSelectOption and onSelectOptions with single onSubmit action. Added confirm button.",
       "3.0.1": "Removed default content data - component only renders explicitly provided data",
-      "3.0.2": "Fixed stale controlled state and improved list item keys"
+      "3.0.2": "Fixed stale controlled state and improved list item keys",
+      "3.0.3": "Fixed infinite re-render loop when control prop is not provided"
     },
     "amount-input": {
       "1.0.0": "Initial release with increment buttons and preset values",
@@ -123,7 +124,8 @@
       "1.1.3": "Additional defensive property access improvements",
       "2.0.0": "BREAKING: Removed onSelectTags action. Tag toggling is now internal.",
       "2.0.1": "Removed default content data - component only renders explicitly provided data",
-      "2.0.2": "Fixed stale controlled state sync for selectedTagIds"
+      "2.0.2": "Fixed stale controlled state sync for selectedTagIds",
+      "2.0.3": "Fixed infinite re-render loop when control prop is not provided"
     },
     "quick-reply": {
       "1.0.0": "Initial release with quick reply button options",

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -261,7 +261,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/option-list.png",
-        "version": "3.0.2",
+        "version": "3.0.3",
         "changelog": {
           "1.0.0": "Initial release with single and multiple selection modes",
           "2.0.0": "BREAKING: Removed id from Option interface. Use array index for selection tracking.",
@@ -273,7 +273,8 @@
           "2.1.3": "Fixed circular dependency by adding types.ts and demo/data.ts to registry",
           "3.0.0": "BREAKING: Replaced onSelectOption and onSelectOptions with single onSubmit action. Added confirm button.",
           "3.0.1": "Removed default content data - component only renders explicitly provided data",
-          "3.0.2": "Fixed stale controlled state and improved list item keys"
+          "3.0.2": "Fixed stale controlled state and improved list item keys",
+          "3.0.3": "Fixed infinite re-render loop when control prop is not provided"
         }
       },
       "dependencies": [
@@ -347,7 +348,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/tag-select.png",
-        "version": "2.0.2",
+        "version": "2.0.3",
         "changelog": {
           "1.0.0": "Initial release with color variants and multi-select",
           "1.0.2": "Added comprehensive JSDoc documentation",
@@ -357,7 +358,8 @@
           "1.1.3": "Additional defensive property access improvements",
           "2.0.0": "BREAKING: Removed onSelectTags action. Tag toggling is now internal.",
           "2.0.1": "Removed default content data - component only renders explicitly provided data",
-          "2.0.2": "Fixed stale controlled state sync for selectedTagIds"
+          "2.0.2": "Fixed stale controlled state sync for selectedTagIds",
+          "2.0.3": "Fixed infinite re-render loop when control prop is not provided"
         }
       },
       "dependencies": [

--- a/packages/manifest-ui/registry/selection/option-list.tsx
+++ b/packages/manifest-ui/registry/selection/option-list.tsx
@@ -74,15 +74,15 @@ export function OptionList({ data, actions, appearance, control }: OptionListPro
   const onSubmit = actions?.onSubmit
   const multiple = appearance?.multiple ?? false
   const selectedOptionIndex = control?.selectedOptionIndex
-  const selectedOptionIndexes = control?.selectedOptionIndexes ?? []
+  const selectedOptionIndexes = control?.selectedOptionIndexes
   const [selected, setSelected] = useState<number | number[]>(
-    multiple ? selectedOptionIndexes : selectedOptionIndex ?? -1
+    multiple ? (selectedOptionIndexes ?? []) : selectedOptionIndex ?? -1
   )
 
   // Sync internal state when controlled props change
   useEffect(() => {
     if (multiple) {
-      setSelected(selectedOptionIndexes)
+      setSelected(selectedOptionIndexes ?? [])
     } else if (selectedOptionIndex !== undefined) {
       setSelected(selectedOptionIndex)
     }

--- a/packages/manifest-ui/registry/selection/tag-select.tsx
+++ b/packages/manifest-ui/registry/selection/tag-select.tsx
@@ -112,12 +112,12 @@ export function TagSelect({ data, actions, appearance, control }: TagSelectProps
   const showClear = appearance?.showClear ?? true
   const showValidate = appearance?.showValidate ?? true
   const validateLabel = appearance?.validateLabel ?? 'Validate selection'
-  const selectedTagIds = control?.selectedTagIds ?? []
-  const [selected, setSelected] = useState<string[]>(selectedTagIds)
+  const selectedTagIds = control?.selectedTagIds
+  const [selected, setSelected] = useState<string[]>(selectedTagIds ?? [])
 
   // Sync internal state when controlled prop changes
   useEffect(() => {
-    setSelected(selectedTagIds)
+    setSelected(selectedTagIds ?? [])
   }, [selectedTagIds])
 
   const handleToggle = (tagId: string) => {


### PR DESCRIPTION
## Summary

Fixed infinite re-render loops in the `option-list` and `tag-select` components that occurred when the `control` prop was not provided. The issue was caused by using default values (`??`) in the dependency arrays of `useEffect` hooks, which created new array references on every render.

## Changes

- **option-list.tsx**: Changed `selectedOptionIndexes` to use optional chaining without a default value in the variable declaration, then apply the default only when needed in `useState` and `useEffect`
- **tag-select.tsx**: Applied the same pattern to `selectedTagIds` to prevent creating new array references on each render
- **changelog.json & registry.json**: Added version 3.0.3 entries for both components documenting the fix

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Testing

- [x] Tests pass locally (`pnpm test`)
- [x] Lint passes (`pnpm lint`)

## Related Issues

Fixes infinite re-render loops when `control` prop is undefined in option-list and tag-select components.

https://claude.ai/code/session_01QEeBN9qMyVqWaSYGUYxZ3M