### PR TITLE
fix: change event-shared install target to match import paths

### DIFF
--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -1365,7 +1365,7 @@
         {
           "path": "registry/events/shared.tsx",
           "type": "registry:lib",
-          "target": "components/ui/event-shared.tsx"
+          "target": "components/ui/shared.tsx"
         }
       ],
       "category": "events"


### PR DESCRIPTION
## Description

Fixes a broken install for `event-list` and `event-detail` components. Both import from `./shared`, but the `event-shared` registry item was installing the file as `event-shared.tsx`. Changed the target from `components/ui/event-shared.tsx` to `components/ui/shared.tsx` so the import paths resolve correctly after installation via `npx shadcn@latest add`.

## Related Issues

None

## How can it be tested?

1. Run `pnpm test` in `packages/manifest-ui` — all tests pass
2. After deploying, verify install works:
   ```bash
   mkdir /tmp/test && cd /tmp/test
   npx shadcn@latest init
   npx shadcn@latest add https://ui.manifest.build/r/event-list.json --yes
   npx tsc --noEmit
   ```
3. Confirm `shared.tsx` is created alongside `event-list.tsx` in `components/ui/`

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR