### PR TITLE
fix: resolve react-leaflet Invalid hook call errors

### DIFF
--- a/packages/manifest-ui/registry/events/event-list.tsx
+++ b/packages/manifest-ui/registry/events/event-list.tsx
@@ -4,84 +4,22 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { cn } from '@/lib/utils'
 import { ChevronDown, ChevronLeft, ChevronRight, SlidersHorizontal, X } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import type { ComponentType } from 'react'
+import { Suspense, useCallback, useRef, useState } from 'react'
 import type { Event } from './types'
 import { EventCard } from './event-card'
-import { useReactLeaflet, injectLeafletCSS, MapPlaceholder } from './shared'
-import type { LeafletMarkerAttrs } from './shared'
+import { LazyLeafletMap, MapPlaceholder } from './shared'
 
-// Inner map component that uses Leaflet hooks for event markers
-function EventMapMarkers({
-  events,
-  selectedIndex,
-  onSelectEvent,
-  MarkerComponent
-}: {
-  events: Event[]
-  selectedIndex: number | null
-  onSelectEvent: (event: Event, index: number) => void
-  MarkerComponent: ComponentType<LeafletMarkerAttrs>
-}) {
-  const [L, setL] = useState<typeof import('leaflet') | null>(null)
-
-  useEffect(() => {
-    // Import Leaflet CSS and library on client side
-    import('leaflet').then((leaflet) => {
-      setL(leaflet.default)
-    })
-    const cleanup = injectLeafletCSS()
-    return cleanup
-  }, [])
-
-  if (!L) return null
-
-  // SVG pin marker - teardrop shape like Google Maps
-  const createPinSvg = (isSelected: boolean) => {
-    const color = '#374151' // slate-700
-    const ringColor = isSelected ? '#9ca3af' : 'transparent' // gray-400 ring when selected
-    return `
-      <svg width="32" height="42" viewBox="0 0 32 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-        ${isSelected ? `<circle cx="16" cy="16" r="14" fill="none" stroke="${ringColor}" stroke-width="3"/>` : ''}
-        <path d="M16 0C7.163 0 0 7.163 0 16c0 12 16 26 16 26s16-14 16-26c0-8.837-7.163-16-16-16z" fill="${color}"/>
-        <circle cx="16" cy="16" r="6" fill="white"/>
-      </svg>
-    `
-  }
-
-  return (
-    <>
-      {events.map((event, index) => {
-        if (!event.coordinates) return null
-        const isSelected = selectedIndex === index
-
-        const icon = L.divIcon({
-          className: '',
-          html: `<div style="
-            position: absolute;
-            left: 50%;
-            top: 100%;
-            transform: translate(-50%, -100%);
-            z-index: ${isSelected ? '1000' : '1'};
-          ">${createPinSvg(isSelected)}</div>`,
-          iconSize: [32, 42],
-          iconAnchor: [16, 42]
-        })
-
-        return (
-          <MarkerComponent
-            key={index}
-            position={[event.coordinates.lat, event.coordinates.lng]}
-            icon={icon}
-            zIndexOffset={isSelected ? 1000 : 0}
-            eventHandlers={{
-              click: () => onSelectEvent(event, index)
-            }}
-          />
-        )
-      })}
-    </>
-  )
+// SVG pin marker - teardrop shape like Google Maps
+function createPinSvg(isSelected: boolean) {
+  const color = '#374151' // slate-700
+  const ringColor = isSelected ? '#9ca3af' : 'transparent' // gray-400 ring when selected
+  return `
+    <svg width="32" height="42" viewBox="0 0 32 42" fill="none" xmlns="http://www.w3.org/2000/svg">
+      ${isSelected ? `<circle cx="16" cy="16" r="14" fill="none" stroke="${ringColor}" stroke-width="3"/>` : ''}
+      <path d="M16 0C7.163 0 0 7.163 0 16c0 12 16 26 16 26s16-14 16-26c0-8.837-7.163-16-16-16z" fill="${color}"/>
+      <circle cx="16" cy="16" r="6" fill="white"/>
+    </svg>
+  `
 }
 
 // Filter options
@@ -381,9 +319,6 @@ export function EventList({ data, actions, appearance }: EventListProps) {
   const variant = appearance?.variant ?? 'list'
   const [currentIndex, setCurrentIndex] = useState(0)
   const [selectedEventIndex, setSelectedEventIndex] = useState<number | null>(null)
-
-  // Lazy load react-leaflet components (React-only, no Next.js dependency)
-  const leafletComponents = useReactLeaflet()
 
   // Filter state for fullwidth variant
   const [showFilters, setShowFilters] = useState(false)
@@ -697,28 +632,43 @@ export function EventList({ data, actions, appearance }: EventListProps) {
 
         {/* Right Panel - Map */}
         <div className="hidden md:flex flex-1 relative">
-          {leafletComponents ? (
-            <leafletComponents.MapContainer
-              center={[34.0522, -118.2437]} // Los Angeles center
+          <Suspense fallback={<MapPlaceholder />}>
+            <LazyLeafletMap
+              center={[34.0522, -118.2437]}
               zoom={12}
-              style={{ height: '100%', width: '100%' }}
-              zoomControl={true}
-              scrollWheelZoom={true}
-            >
-              <leafletComponents.TileLayer
-                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
-                url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
-              />
-              <EventMapMarkers
-                events={filteredEvents}
-                selectedIndex={selectedEventIndex}
-                onSelectEvent={handleMapMarkerClick}
-                MarkerComponent={leafletComponents.Marker}
-              />
-            </leafletComponents.MapContainer>
-          ) : (
-            <MapPlaceholder />
-          )}
+              renderMarkers={({ Marker, L }) => (
+                <>
+                  {filteredEvents.map((event, index) => {
+                    if (!event.coordinates) return null
+                    const isSelected = selectedEventIndex === index
+                    const icon = L.divIcon({
+                      className: '',
+                      html: `<div style="
+                        position: absolute;
+                        left: 50%;
+                        top: 100%;
+                        transform: translate(-50%, -100%);
+                        z-index: ${isSelected ? '1000' : '1'};
+                      ">${createPinSvg(isSelected)}</div>`,
+                      iconSize: [32, 42],
+                      iconAnchor: [16, 42]
+                    })
+                    return (
+                      <Marker
+                        key={index}
+                        position={[event.coordinates.lat, event.coordinates.lng]}
+                        icon={icon}
+                        zIndexOffset={isSelected ? 1000 : 0}
+                        eventHandlers={{
+                          click: () => handleMapMarkerClick(event, index)
+                        }}
+                      />
+                    )
+                  })}
+                </>
+              )}
+            />
+          </Suspense>
         </div>
       </div>
     )

--- a/packages/manifest-ui/registry/map/map-carousel.tsx
+++ b/packages/manifest-ui/registry/map/map-carousel.tsx
@@ -4,56 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { cn } from '@/lib/utils'
 import { ChevronDown, MapPin, Maximize2, SlidersHorizontal, X } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import type { ComponentType } from 'react'
-
-// Internal types for react-leaflet component attributes (not exported component props)
-type LeafletMarkerAttrs = {
-  position: [number, number]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  icon?: any
-  zIndexOffset?: number
-  eventHandlers?: {
-    click?: () => void
-  }
-}
-
-// Lazy-loaded react-leaflet components (React-only, no Next.js dependency)
-// Using any to avoid type mismatches between react-leaflet versions and @types/react
-interface ReactLeafletComponents {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  MapContainer: ComponentType<any>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TileLayer: ComponentType<any>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Marker: ComponentType<any>
-}
-
-/**
- * Hook to lazy load react-leaflet components on client-side only.
- * This avoids SSR issues with Leaflet without requiring Next.js dynamic imports.
- */
-function useReactLeaflet(): ReactLeafletComponents | null {
-  const [components, setComponents] = useState<ReactLeafletComponents | null>(null)
-
-  useEffect(() => {
-    let mounted = true
-    import('react-leaflet').then((mod) => {
-      if (mounted) {
-        setComponents({
-          MapContainer: mod.MapContainer,
-          TileLayer: mod.TileLayer,
-          Marker: mod.Marker,
-        })
-      }
-    })
-    return () => {
-      mounted = false
-    }
-  }, [])
-
-  return components
-}
+import { lazy, Suspense, useCallback, useRef, useState } from 'react'
 
 /**
  * Represents a location/hotel to display on the map.
@@ -507,83 +458,96 @@ function MapPlaceholder({ height }: { height?: string }) {
   )
 }
 
-// Inner map component that uses Leaflet hooks
-function MapWithMarkers({
-  locations,
-  selectedIndex,
-  onSelectLocation,
-  MarkerComponent
-}: {
+// Lazy-loaded map component using React.lazy to ensure proper React dispatcher
+// This avoids Invalid hook call errors caused by dynamic import module boundaries
+interface LeafletMapConfig {
+  center: [number, number]
+  zoom: number
+  tileConfig: { url: string; attribution: string }
   locations: Location[]
   selectedIndex: number | null
   onSelectLocation: (location: Location, index: number) => void
-  MarkerComponent: ComponentType<LeafletMarkerAttrs>
-}) {
-  const [L, setL] = useState<typeof import('leaflet') | null>(null)
-
-  useEffect(() => {
-    // Import Leaflet CSS and library on client side
-    import('leaflet').then((leaflet) => {
-      setL(leaflet.default)
-    })
-    // Inject Leaflet CSS with deduplication
-    const LEAFLET_CSS_ID = 'leaflet-css-1.9.4'
-    if (!document.getElementById(LEAFLET_CSS_ID)) {
-      const link = document.createElement('link')
-      link.id = LEAFLET_CSS_ID
-      link.rel = 'stylesheet'
-      link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'
-      document.head.appendChild(link)
-    }
-  }, [])
-
-  if (!L) return null
-
-  return (
-    <>
-      {locations.map((location, index) => {
-        const isSelected = selectedIndex === index
-        const icon = L.divIcon({
-          className: '',
-          html: `<div style="
-            position: absolute;
-            left: 50%;
-            top: 50%;
-            transform: translate(-50%, -50%);
-            display: inline-block;
-            padding: 4px 8px;
-            border-radius: 8px;
-            font-size: 12px;
-            font-weight: 600;
-            font-family: system-ui, -apple-system, sans-serif;
-            white-space: nowrap;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.15), 0 1px 3px rgba(0,0,0,0.1);
-            z-index: ${isSelected ? '1000' : '1'};
-            ${
-              isSelected
-                ? 'background-color: #18181b; color: white;'
-                : 'background-color: white; color: #18181b;'
-            }
-          ">${location.price !== undefined ? `$${location.price}` : location.name ?? 'Location'}</div>`,
-          iconSize: [60, 24],
-          iconAnchor: [30, 12]
-        })
-
-        return (
-          <MarkerComponent
-            key={index}
-            position={location.coordinates}
-            icon={icon}
-            zIndexOffset={isSelected ? 1000 : 0}
-            eventHandlers={{
-              click: () => onSelectLocation(location, index)
-            }}
-          />
-        )
-      })}
-    </>
-  )
+  style?: React.CSSProperties
 }
+
+const LeafletMap = lazy(async () => {
+  // Guard against SSR - react-leaflet/leaflet require window
+  if (typeof window === 'undefined') {
+    return { default: () => null }
+  }
+
+  const { MapContainer, TileLayer, Marker } = await import('react-leaflet')
+  const L = (await import('leaflet')).default
+
+  // Inject Leaflet CSS with deduplication
+  const LEAFLET_CSS_ID = 'leaflet-css-1.9.4'
+  if (typeof document !== 'undefined' && !document.getElementById(LEAFLET_CSS_ID)) {
+    const link = document.createElement('link')
+    link.id = LEAFLET_CSS_ID
+    link.rel = 'stylesheet'
+    link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'
+    document.head.appendChild(link)
+  }
+
+  function LeafletMapComponent(props: LeafletMapConfig) {
+    return (
+      <MapContainer
+        center={props.center}
+        zoom={props.zoom}
+        style={props.style ?? { height: '100%', width: '100%' }}
+        zoomControl={true}
+        scrollWheelZoom={true}
+      >
+        <TileLayer
+          attribution={props.tileConfig.attribution}
+          url={props.tileConfig.url}
+        />
+        {props.locations.map((location, index) => {
+          const isSelected = props.selectedIndex === index
+          const icon = L.divIcon({
+            className: '',
+            html: `<div style="
+              position: absolute;
+              left: 50%;
+              top: 50%;
+              transform: translate(-50%, -50%);
+              display: inline-block;
+              padding: 4px 8px;
+              border-radius: 8px;
+              font-size: 12px;
+              font-weight: 600;
+              font-family: system-ui, -apple-system, sans-serif;
+              white-space: nowrap;
+              box-shadow: 0 2px 8px rgba(0,0,0,0.15), 0 1px 3px rgba(0,0,0,0.1);
+              z-index: ${isSelected ? '1000' : '1'};
+              ${
+                isSelected
+                  ? 'background-color: #18181b; color: white;'
+                  : 'background-color: white; color: #18181b;'
+              }
+            ">${location.price !== undefined ? `$${location.price}` : location.name ?? 'Location'}</div>`,
+            iconSize: [60, 24],
+            iconAnchor: [30, 12]
+          })
+
+          return (
+            <Marker
+              key={index}
+              position={location.coordinates}
+              icon={icon}
+              zIndexOffset={isSelected ? 1000 : 0}
+              eventHandlers={{
+                click: () => props.onSelectLocation(location, index)
+              }}
+            />
+          )
+        })}
+      </MapContainer>
+    )
+  }
+
+  return { default: LeafletMapComponent }
+})
 
 /**
  * Gets the tile configuration for a given map style.
@@ -703,9 +667,6 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
   // Refs for fullscreen scroll functionality
   const listContainerRef = useRef<HTMLDivElement>(null)
   const locationItemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
-
-  // Lazy load react-leaflet components (React-only, no Next.js dependency)
-  const leafletComponents = useReactLeaflet()
 
   // Filter locations based on applied filters using dynamic matchFn
   const filterLocations = useCallback((locationsToFilter: Location[], filtersToApply: FilterState): Location[] => {
@@ -967,28 +928,16 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
 
         {/* Right Panel - Map */}
         <div className="flex flex-1 min-w-0 relative">
-          {leafletComponents ? (
-            <leafletComponents.MapContainer
+          <Suspense fallback={<MapPlaceholder />}>
+            <LeafletMap
               center={center}
               zoom={zoom}
-              style={{ height: '100%', width: '100%' }}
-              zoomControl={true}
-              scrollWheelZoom={true}
-            >
-              <leafletComponents.TileLayer
-                attribution={tileConfig.attribution}
-                url={tileConfig.url}
-              />
-              <MapWithMarkers
-                locations={filteredLocations}
-                selectedIndex={selectedIndex}
-                onSelectLocation={handleMapMarkerClick}
-                MarkerComponent={leafletComponents.Marker}
-              />
-            </leafletComponents.MapContainer>
-          ) : (
-            <MapPlaceholder />
-          )}
+              tileConfig={tileConfig}
+              locations={filteredLocations}
+              selectedIndex={selectedIndex}
+              onSelectLocation={handleMapMarkerClick}
+            />
+          </Suspense>
         </div>
       </div>
     )
@@ -1014,28 +963,16 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
       </div>
 
       {/* Map Section - Full size */}
-      {leafletComponents ? (
-        <leafletComponents.MapContainer
+      <Suspense fallback={<MapPlaceholder height={mapHeight} />}>
+        <LeafletMap
           center={center}
           zoom={zoom}
-          style={{ height: '100%', width: '100%' }}
-          zoomControl={true}
-          scrollWheelZoom={true}
-        >
-          <leafletComponents.TileLayer
-            attribution={tileConfig.attribution}
-            url={tileConfig.url}
-          />
-          <MapWithMarkers
-            locations={locations}
-            selectedIndex={selectedIndex}
-            onSelectLocation={handleSelectLocation}
-            MarkerComponent={leafletComponents.Marker}
-          />
-        </leafletComponents.MapContainer>
-      ) : (
-        <MapPlaceholder height={mapHeight} />
-      )}
+          tileConfig={tileConfig}
+          locations={locations}
+          selectedIndex={selectedIndex}
+          onSelectLocation={handleSelectLocation}
+        />
+      </Suspense>
 
       {/* Carousel Section - Overlay at bottom */}
       <div className="absolute bottom-0 left-0 right-0 z-[1000]">


### PR DESCRIPTION
## Description

Fixes Invalid hook call errors on all components using react-leaflet (map-carousel, event-list, event-detail) in Next.js 16 with Turbopack.

The root cause was using `useEffect` + `import('react-leaflet')` + `useState` to lazy-load react-leaflet components. This pattern causes Turbopack to create a separate module boundary where React's hook dispatcher isn't properly connected, so when MapContainer/TileLayer/Marker try to call `useState` internally, they get null.

The fix replaces this with `React.lazy` + `Suspense`, which properly integrates dynamically-loaded components into React's rendering pipeline.

Changes:
- `map-carousel.tsx`: Replace `useReactLeaflet` hook and `MapWithMarkers` with lazy-loaded `LeafletMap` component
- `events/shared.tsx`: Replace `useReactLeaflet` with `LazyLeafletMap` using render prop pattern for custom markers
- `event-detail.tsx`: Inline `VenueMapMarker` into `renderMarkers` callback
- `event-list.tsx`: Inline `EventMapMarkers` into `renderMarkers` callback
- SSR guard (`typeof window`) in lazy factories prevents server-side errors

Net reduction: -174 lines (248 added, 422 removed).

## Related Issues

Follows up on #708 and #710

## How can it be tested?

1. Run `pnpm run dev` in `packages/manifest-ui`
2. Navigate to `http://localhost:3001/blocks/map/map-carousel`
3. Verify the map loads without "Invalid hook call" errors in the browser console
4. Navigate to `http://localhost:3001/blocks/events/event-list` and `event-detail`
5. Verify maps load correctly on those pages too
6. Check server terminal — no `ReferenceError: window is not defined`

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR