### PR TITLE
feat(manifest-ui): add demo data defaults to all components

### DIFF
--- a/packages/manifest-ui/__tests__/no-default-data.test.ts
+++ b/packages/manifest-ui/__tests__/no-default-data.test.ts
@@ -1,11 +1,11 @@
 /**
  * No Default Data Enforcement Test
  *
- * Validates that component files do NOT contain hardcoded default data.
- * Components should only render data explicitly provided by the user.
+ * Validates that component files do NOT contain hardcoded inline default data.
+ * Components may import from demo/data and use as ?? fallback (this is the
+ * intended demo data strategy for shadcn distribution).
  *
  * Rules enforced:
- * A) Components must not import from ./demo/data and use the import as a ?? fallback
  * B) Components must not destructure data props with inline string/object defaults
  * C) Components must not use ?? with string literals for content data props
  *
@@ -80,41 +80,6 @@ describe('No Default Data in Components', () => {
 
   it('should find component files to check', () => {
     expect(componentFiles.length).toBeGreaterThan(0)
-  })
-
-  describe('Rule A: No demo data imports used as ?? fallbacks', () => {
-    for (const absPath of componentFiles) {
-      const relPath = relative(ROOT_PATH, absPath)
-
-      it(`${relPath}`, () => {
-        const content = readFileSync(absPath, 'utf-8')
-
-        const importMatch = content.match(
-          /import\s+\{([^}]+)\}\s+from\s+['"]\.\/demo\/data['"]/
-        )
-        if (!importMatch) return
-
-        const importNames = importMatch[1]
-          .split(',')
-          .map((s) => s.trim())
-          .filter(Boolean)
-
-        const issues: string[] = []
-        for (const name of importNames) {
-          const fallbackPattern = new RegExp(`\\?\\?\\s*${name}\\b`)
-          if (fallbackPattern.test(content)) {
-            issues.push(
-              `Uses "${name}" from demo/data as a ?? fallback. ` +
-                'Demo data should only be used in page.tsx and preview files.'
-            )
-          }
-        }
-
-        if (issues.length > 0) {
-          throw new Error(issues.join('\n'))
-        }
-      })
-    }
   })
 
   describe('Rule B: No inline content defaults in data destructuring', () => {

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -72,7 +72,8 @@
       "1.0.0": "Initial release with product image and delivery info",
       "1.0.2": "Added comprehensive JSDoc documentation",
       "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-      "1.0.4": "Removed default content data - component only renders explicitly provided data"
+      "1.0.4": "Removed default content data - component only renders explicitly provided data",
+      "1.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "payment-confirmed": {
       "1.0.0": "Initial release with product image and tracking button",
@@ -80,7 +81,8 @@
       "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "2.0.0": "Added compressed variant, merged payment-success into this component",
       "2.0.1": "Removed default content data - component only renders explicitly provided data",
-      "2.0.2": "Fixed missing alt fallback on product image in compressed desktop variant"
+      "2.0.2": "Fixed missing alt fallback on product image in compressed desktop variant",
+      "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "product-list": {
       "1.0.0": "Initial release with list, grid, carousel and picker variants",
@@ -91,7 +93,8 @@
       "2.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "2.0.5": "Fixed defensive property access to handle empty objects and null values",
       "2.0.6": "Fixed circular dependency by adding types.ts and demo/data.ts to registry",
-      "2.0.7": "Removed default content data - component only renders explicitly provided data"
+      "2.0.7": "Removed default content data - component only renders explicitly provided data",
+      "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "option-list": {
       "1.0.0": "Initial release with single and multiple selection modes",
@@ -105,7 +108,8 @@
       "3.0.0": "BREAKING: Replaced onSelectOption and onSelectOptions with single onSubmit action. Added confirm button.",
       "3.0.1": "Removed default content data - component only renders explicitly provided data",
       "3.0.2": "Fixed stale controlled state and improved list item keys",
-      "3.0.3": "Fixed infinite re-render loop when control prop is not provided"
+      "3.0.3": "Fixed infinite re-render loop when control prop is not provided",
+      "3.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "amount-input": {
       "1.0.0": "Initial release with increment buttons and preset values",
@@ -126,7 +130,8 @@
       "2.0.0": "BREAKING: Removed onSelectTags action. Tag toggling is now internal.",
       "2.0.1": "Removed default content data - component only renders explicitly provided data",
       "2.0.2": "Fixed stale controlled state sync for selectedTagIds",
-      "2.0.3": "Fixed infinite re-render loop when control prop is not provided"
+      "2.0.3": "Fixed infinite re-render loop when control prop is not provided",
+      "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "quick-reply": {
       "1.0.0": "Initial release with quick reply button options",
@@ -137,7 +142,8 @@
       "3.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "3.1.2": "Fixed defensive property access to handle empty objects and null values",
       "3.1.3": "Additional defensive property access improvements",
-      "3.1.4": "Removed default content data - component only renders explicitly provided data"
+      "3.1.4": "Removed default content data - component only renders explicitly provided data",
+      "3.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "progress-steps": {
       "1.0.0": "Initial release with horizontal and vertical layouts",
@@ -147,14 +153,16 @@
       "1.1.2": "Fixed defensive property access to handle empty objects and null values",
       "1.1.3": "Additional defensive property access improvements",
       "2.0.0": "BREAKING: Removed id from Step interface, use array index for key",
-      "2.0.1": "Removed default content data - component only renders explicitly provided data"
+      "2.0.1": "Removed default content data - component only renders explicitly provided data",
+      "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "status-badge": {
       "1.0.0": "Initial release with multiple status states",
       "1.0.2": "Added comprehensive JSDoc documentation",
       "1.1.0": "Moved to status category for better organization",
       "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-      "1.1.2": "Fixed defensive property access to handle empty objects and null values"
+      "1.1.2": "Fixed defensive property access to handle empty objects and null values",
+      "1.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "stat-card": {
       "1.0.0": "Initial release with scrollable stat cards and trends",
@@ -162,7 +170,8 @@
       "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.0.4": "Fixed defensive property access to handle empty objects and null values",
       "1.0.5": "Additional defensive property access improvements",
-      "1.0.6": "Removed default content data - component only renders explicitly provided data"
+      "1.0.6": "Removed default content data - component only renders explicitly provided data",
+      "1.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "post-card": {
       "1.0.0": "Initial release with default, compact, horizontal and covered variants",
@@ -174,7 +183,8 @@
       "2.0.5": "Fixed circular dependency by moving Post interface to types.ts",
       "2.0.6": "Removed unused OpenAI types side-effect import",
       "2.0.7": "Removed default content data - component only renders explicitly provided data",
-      "2.0.8": "Fixed missing tooltip dependency for shadcn CLI installation"
+      "2.0.8": "Fixed missing tooltip dependency for shadcn CLI installation",
+      "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "post-list": {
       "1.0.0": "Initial release with list, grid and carousel variants",
@@ -190,7 +200,8 @@
       "3.0.0": "BREAKING: Removed pagination (onPageChange, postsPerPage, control). Fullwidth variant now renders all posts.",
       "3.0.1": "Removed default content data - component only renders explicitly provided data",
       "3.0.2": "Fixed missing tooltip dependency for shadcn CLI installation",
-      "3.0.3": "Replaced key={index} with stable content-based keys"
+      "3.0.3": "Replaced key={index} with stable content-based keys",
+      "3.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "post-detail": {
       "1.0.0": "Initial release with cover image, author info and related posts",
@@ -214,7 +225,8 @@
       "2.1.10": "Updated post-card dependency with removed OpenAI types import",
       "2.1.11": "Removed default content data - component only renders explicitly provided data",
       "2.1.12": "Migrated from OpenAI Apps SDK to MCP Apps protocol for host communication",
-      "2.1.13": "Added XSS sanitization for HTML content and replaced key={index} with stable keys"
+      "2.1.13": "Added XSS sanitization for HTML content and replaced key={index} with stable keys",
+      "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "table": {
       "1.0.0": "Initial release with single and multi-select modes",
@@ -229,7 +241,8 @@
       "2.0.2": "Removed unused checkbox from registry dependencies",
       "2.0.3": "Migrated from OpenAI Apps SDK to MCP Apps protocol for host communication",
       "2.0.4": "Removed stale sortedData from handleRowSelect dependency array",
-      "2.0.5": "Fixed table preview not displaying data by passing demo columns and rows"
+      "2.0.5": "Fixed table preview not displaying data by passing demo columns and rows",
+      "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "message-bubble": {
       "1.0.0": "Initial release with text, image, voice and reaction variants",
@@ -259,7 +272,8 @@
       "4.0.5": "Fixed defensive property access to handle empty objects and null values",
       "4.0.6": "Fixed circular dependency by adding types.ts and demo/data.ts to registry",
       "4.0.7": "Removed default content data - component only renders explicitly provided data",
-      "4.0.8": "Replaced key={index} with content-based keys for message list"
+      "4.0.8": "Replaced key={index} with content-based keys for message list",
+      "4.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "x-post": {
       "1.0.0": "Initial release with engagement metrics display",
@@ -267,7 +281,8 @@
       "1.1.0": "Moved to social category for better organization",
       "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.1.2": "Removed default content data - component only renders explicitly provided data",
-      "1.1.3": "Added aria-labels to icon-only action buttons for accessibility"
+      "1.1.3": "Added aria-labels to icon-only action buttons for accessibility",
+      "1.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "instagram-post": {
       "1.0.0": "Initial release with image and engagement display",
@@ -276,7 +291,8 @@
       "1.1.0": "Moved to social category for better organization",
       "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.1.2": "Removed default content data - component only renders explicitly provided data",
-      "1.1.3": "Added aria-labels to icon-only action buttons for accessibility"
+      "1.1.3": "Added aria-labels to icon-only action buttons for accessibility",
+      "1.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "linkedin-post": {
       "1.0.0": "Initial release with professional styling",
@@ -287,7 +303,8 @@
       "2.1.0": "Added image support, engagement stats with reaction icons, expandable content with maxLines prop, and moved repost button to the right",
       "2.1.1": "Fixed avatar circle visibility - now hides entirely when avatar prop is not provided",
       "3.0.0": "BREAKING: Moved postUrl and repostUrl from actions to data prop",
-      "3.0.1": "Fixed JSX namespace deprecation and removed dynamic Tailwind class"
+      "3.0.1": "Fixed JSX namespace deprecation and removed dynamic Tailwind class",
+      "3.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "youtube-post": {
       "1.0.0": "Initial release with playable video embed",
@@ -295,7 +312,8 @@
       "1.0.3": "Added comprehensive JSDoc documentation",
       "1.1.0": "Moved to social category for better organization",
       "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-      "1.1.2": "Removed default content data - component only renders explicitly provided data"
+      "1.1.2": "Removed default content data - component only renders explicitly provided data",
+      "1.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "map-carousel": {
       "1.0.0": "Initial release with interactive map and location cards",
@@ -311,7 +329,8 @@
       "2.0.1": "Removed default content data - component only renders explicitly provided data",
       "2.0.2": "Migrated from OpenAI Apps SDK to MCP Apps protocol for host communication",
       "2.0.3": "Fixed Leaflet CSS injection deduplication and hardcoded date display",
-      "2.0.4": "Adjusted demo map zoom level to show more of the San Francisco bay area"
+      "2.0.4": "Adjusted demo map zoom level to show more of the San Francisco bay area",
+      "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "event-card": {
       "1.0.0": "Initial release with default, compact, horizontal and covered variants. Supports physical, online, and hybrid events with signals and vibe tags.",
@@ -329,7 +348,8 @@
       "5.0.7": "Added demo/data.ts to registry for proper installation via shadcn CLI",
       "5.0.8": "Removed unused OpenAI types side-effect import",
       "5.0.9": "Removed default content data - component only renders explicitly provided data",
-      "5.0.10": "Removed unused button from registry dependencies"
+      "5.0.10": "Removed unused button from registry dependencies",
+      "5.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "event-list": {
       "1.0.0": "Initial release with grid, list and carousel layouts. Includes pagination support.",
@@ -351,7 +371,8 @@
       "6.0.8": "Added demo/data.ts to registry for proper installation via shadcn CLI",
       "7.0.0": "BREAKING: Removed onPageChange, onViewMore, onExpand, onFilterClick, onFiltersApply actions. Filters and expand are now internal.",
       "7.0.1": "Removed default content data - component only renders explicitly provided data",
-      "7.0.2": "Extracted shared map utilities to shared.tsx and fixed Leaflet CSS deduplication"
+      "7.0.2": "Extracted shared map utilities to shared.tsx and fixed Leaflet CSS deduplication",
+      "7.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "event-detail": {
       "1.0.0": "Initial release with image carousel, organizer info, location, policies, FAQs, and ticket purchase.",
@@ -368,7 +389,8 @@
       "3.0.7": "Added types.ts to registry for proper installation",
       "3.0.8": "Added demo/data.ts to registry for proper installation via shadcn CLI",
       "3.0.9": "Removed default content data - component only renders explicitly provided data",
-      "3.0.10": "Extracted shared map utilities to shared.tsx and fixed Leaflet CSS deduplication"
+      "3.0.10": "Extracted shared map utilities to shared.tsx and fixed Leaflet CSS deduplication",
+      "3.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "ticket-tier-select": {
       "1.0.0": "Initial release with ticket tier cards, quantity controls, price breakdown, and order summary sidebar",
@@ -379,14 +401,16 @@
       "3.0.0": "BREAKING: Removed id from TicketTier interface, made name and price optional.",
       "3.0.1": "Simplified TicketSelection interface by removing tierIndex",
       "4.0.0": "BREAKING: Removed onSelectionChange action. Tier quantity changes are now internal.",
-      "4.0.1": "Removed default content data - component only renders explicitly provided data"
+      "4.0.1": "Removed default content data - component only renders explicitly provided data",
+      "4.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "event-confirmation": {
       "1.0.0": "Initial release with success message, event details, organizer follow, and social sharing",
       "1.0.2": "Added comprehensive JSDoc documentation",
       "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "2.0.0": "BREAKING: Removed onChangeEmail action and Change email link",
-      "2.0.1": "Removed default content data - component only renders explicitly provided data"
+      "2.0.1": "Removed default content data - component only renders explicitly provided data",
+      "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     },
     "event-shared": {
       "1.0.0": "Extracted shared map utilities and signal badges from event-list and event-detail"
@@ -399,7 +423,8 @@
       "2.1.0": "Added urlLight prop for dark mode logo variant support",
       "2.1.1": "Reduced logo image height for better visual balance",
       "2.1.2": "Removed default content data - component only renders explicitly provided data",
-      "2.1.3": "Replaced key={index} with stable content-based keys for tech logos"
+      "2.1.3": "Replaced key={index} with stable content-based keys for tech logos",
+      "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
     }
   }
 }

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -144,25 +144,32 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/order-confirm.png",
-        "version": "1.0.4",
+        "version": "1.1.0",
         "changelog": {
           "1.0.0": "Initial release with product image and delivery info",
           "1.0.2": "Added comprehensive JSDoc documentation",
           "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-          "1.0.4": "Removed default content data - component only renders explicitly provided data"
+          "1.0.4": "Removed default content data - component only renders explicitly provided data",
+          "1.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
         "lucide-react"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "https://ui.manifest.build/r/manifest-types.json"
       ],
       "files": [
         {
           "path": "registry/payment/order-confirm.tsx",
           "type": "registry:block",
           "target": "components/ui/order-confirm.tsx"
+        },
+        {
+          "path": "registry/payment/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "payment",
@@ -179,27 +186,34 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/payment-confirmed.png",
-        "version": "2.0.2",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with product image and tracking button",
           "1.0.2": "Added comprehensive JSDoc documentation",
           "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "2.0.0": "Added compressed variant, merged payment-success into this component",
           "2.0.1": "Removed default content data - component only renders explicitly provided data",
-          "2.0.2": "Fixed missing alt fallback on product image in compressed desktop variant"
+          "2.0.2": "Fixed missing alt fallback on product image in compressed desktop variant",
+          "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
         "lucide-react"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "https://ui.manifest.build/r/manifest-types.json"
       ],
       "files": [
         {
           "path": "registry/payment/payment-confirmed.tsx",
           "type": "registry:block",
           "target": "components/ui/payment-confirmed.tsx"
+        },
+        {
+          "path": "registry/payment/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "payment",
@@ -216,7 +230,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/product-list.png",
-        "version": "2.0.7",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with list, grid, carousel and picker variants",
           "2.0.0": "BREAKING: Removed id from Product interface. Use array index for selection tracking.",
@@ -226,7 +240,8 @@
           "2.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "2.0.5": "Fixed defensive property access to handle empty objects and null values",
           "2.0.6": "Fixed circular dependency by adding types.ts and demo/data.ts to registry",
-          "2.0.7": "Removed default content data - component only renders explicitly provided data"
+          "2.0.7": "Removed default content data - component only renders explicitly provided data",
+          "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -262,7 +277,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/option-list.png",
-        "version": "3.0.3",
+        "version": "3.1.0",
         "changelog": {
           "1.0.0": "Initial release with single and multiple selection modes",
           "2.0.0": "BREAKING: Removed id from Option interface. Use array index for selection tracking.",
@@ -275,7 +290,8 @@
           "3.0.0": "BREAKING: Replaced onSelectOption and onSelectOptions with single onSubmit action. Added confirm button.",
           "3.0.1": "Removed default content data - component only renders explicitly provided data",
           "3.0.2": "Fixed stale controlled state and improved list item keys",
-          "3.0.3": "Fixed infinite re-render loop when control prop is not provided"
+          "3.0.3": "Fixed infinite re-render loop when control prop is not provided",
+          "3.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -349,7 +365,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/tag-select.png",
-        "version": "2.0.3",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with color variants and multi-select",
           "1.0.2": "Added comprehensive JSDoc documentation",
@@ -360,7 +376,8 @@
           "2.0.0": "BREAKING: Removed onSelectTags action. Tag toggling is now internal.",
           "2.0.1": "Removed default content data - component only renders explicitly provided data",
           "2.0.2": "Fixed stale controlled state sync for selectedTagIds",
-          "2.0.3": "Fixed infinite re-render loop when control prop is not provided"
+          "2.0.3": "Fixed infinite re-render loop when control prop is not provided",
+          "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -374,6 +391,11 @@
           "path": "registry/selection/tag-select.tsx",
           "type": "registry:block",
           "target": "components/ui/tag-select.tsx"
+        },
+        {
+          "path": "registry/selection/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "selection",
@@ -390,7 +412,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/quick-reply.png",
-        "version": "3.1.4",
+        "version": "3.2.0",
         "changelog": {
           "1.0.0": "Initial release with quick reply button options",
           "2.0.0": "BREAKING: Removed unused value prop from QuickReply interface",
@@ -400,7 +422,8 @@
           "3.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "3.1.2": "Fixed defensive property access to handle empty objects and null values",
           "3.1.3": "Additional defensive property access improvements",
-          "3.1.4": "Removed default content data - component only renders explicitly provided data"
+          "3.1.4": "Removed default content data - component only renders explicitly provided data",
+          "3.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [],
@@ -410,6 +433,11 @@
           "path": "registry/selection/quick-reply.tsx",
           "type": "registry:block",
           "target": "components/ui/quick-reply.tsx"
+        },
+        {
+          "path": "registry/selection/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "selection",
@@ -426,7 +454,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/progress-steps.png",
-        "version": "2.0.1",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with horizontal and vertical layouts",
           "1.0.2": "Added comprehensive JSDoc documentation",
@@ -435,7 +463,8 @@
           "1.1.2": "Fixed defensive property access to handle empty objects and null values",
           "1.1.3": "Additional defensive property access improvements",
           "2.0.0": "BREAKING: Removed id from Step interface, use array index for key",
-          "2.0.1": "Removed default content data - component only renders explicitly provided data"
+          "2.0.1": "Removed default content data - component only renders explicitly provided data",
+          "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -447,6 +476,11 @@
           "path": "registry/status/progress-steps.tsx",
           "type": "registry:block",
           "target": "components/ui/progress-steps.tsx"
+        },
+        {
+          "path": "registry/status/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "status",
@@ -463,13 +497,14 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/status-badge.png",
-        "version": "1.1.2",
+        "version": "1.2.0",
         "changelog": {
           "1.0.0": "Initial release with multiple status states",
           "1.0.2": "Added comprehensive JSDoc documentation",
           "1.1.0": "Moved to status category for better organization",
           "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-          "1.1.2": "Fixed defensive property access to handle empty objects and null values"
+          "1.1.2": "Fixed defensive property access to handle empty objects and null values",
+          "1.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -481,6 +516,11 @@
           "path": "registry/status/status-badge.tsx",
           "type": "registry:block",
           "target": "components/ui/status-badge.tsx"
+        },
+        {
+          "path": "registry/status/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "status",
@@ -497,14 +537,15 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/stat-card.png",
-        "version": "1.0.6",
+        "version": "1.1.0",
         "changelog": {
           "1.0.0": "Initial release with scrollable stat cards and trends",
           "1.0.2": "Added comprehensive JSDoc documentation",
           "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "1.0.4": "Fixed defensive property access to handle empty objects and null values",
           "1.0.5": "Additional defensive property access improvements",
-          "1.0.6": "Removed default content data - component only renders explicitly provided data"
+          "1.0.6": "Removed default content data - component only renders explicitly provided data",
+          "1.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -516,6 +557,11 @@
           "path": "registry/miscellaneous/stat-card.tsx",
           "type": "registry:block",
           "target": "components/ui/stat-card.tsx"
+        },
+        {
+          "path": "registry/miscellaneous/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "miscellaneous",
@@ -532,7 +578,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/post-card.png",
-        "version": "2.0.8",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with default, compact, horizontal and covered variants",
           "2.0.0": "BREAKING: Removed id from Post interface. Use array index for key.",
@@ -543,7 +589,8 @@
           "2.0.5": "Fixed circular dependency by moving Post interface to types.ts",
           "2.0.6": "Removed unused OpenAI types side-effect import",
           "2.0.7": "Removed default content data - component only renders explicitly provided data",
-          "2.0.8": "Fixed missing tooltip dependency for shadcn CLI installation"
+          "2.0.8": "Fixed missing tooltip dependency for shadcn CLI installation",
+          "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -585,7 +632,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/post-list.png",
-        "version": "3.0.3",
+        "version": "3.1.0",
         "changelog": {
           "1.0.0": "Initial release with list, grid and carousel variants",
           "1.1.0": "Added fullwidth variant with pagination for fullscreen mode",
@@ -600,7 +647,8 @@
           "3.0.0": "BREAKING: Removed pagination (onPageChange, postsPerPage, control). Fullwidth variant now renders all posts.",
           "3.0.1": "Removed default content data - component only renders explicitly provided data",
           "3.0.2": "Fixed missing tooltip dependency for shadcn CLI installation",
-          "3.0.3": "Replaced key={index} with stable content-based keys"
+          "3.0.3": "Replaced key={index} with stable content-based keys",
+          "3.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -647,7 +695,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/post-detail.png",
-        "version": "2.1.13",
+        "version": "2.2.0",
         "changelog": {
           "1.0.0": "Initial release with cover image, author info and related posts",
           "2.0.0": "BREAKING: Removed id from Post interface. Use array index for key.",
@@ -670,7 +718,8 @@
           "2.1.10": "Updated post-card dependency with removed OpenAI types import",
           "2.1.11": "Removed default content data - component only renders explicitly provided data",
           "2.1.12": "Migrated from OpenAI Apps SDK to MCP Apps protocol for host communication",
-          "2.1.13": "Added XSS sanitization for HTML content and replaced key={index} with stable keys"
+          "2.1.13": "Added XSS sanitization for HTML content and replaced key={index} with stable keys",
+          "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -712,7 +761,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/table.png",
-        "version": "2.0.5",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with single and multi-select modes",
           "1.0.1": "Added descriptive alt tags for title images",
@@ -726,7 +775,8 @@
           "2.0.2": "Removed unused checkbox from registry dependencies",
           "2.0.3": "Migrated from OpenAI Apps SDK to MCP Apps protocol for host communication",
           "2.0.4": "Removed stale sortedData from handleRowSelect dependency array",
-          "2.0.5": "Fixed table preview not displaying data by passing demo columns and rows"
+          "2.0.5": "Fixed table preview not displaying data by passing demo columns and rows",
+          "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -743,6 +793,11 @@
           "path": "registry/list/table.tsx",
           "type": "registry:block",
           "target": "components/ui/table.tsx"
+        },
+        {
+          "path": "registry/list/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "list",
@@ -800,7 +855,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/chat-conversation.png",
-        "version": "4.0.8",
+        "version": "4.1.0",
         "changelog": {
           "1.0.0": "Initial release with multiple message types",
           "1.0.1": "Updated to use improved message bubble styling",
@@ -817,7 +872,8 @@
           "4.0.5": "Fixed defensive property access to handle empty objects and null values",
           "4.0.6": "Fixed circular dependency by adding types.ts and demo/data.ts to registry",
           "4.0.7": "Removed default content data - component only renders explicitly provided data",
-          "4.0.8": "Replaced key={index} with content-based keys for message list"
+          "4.0.8": "Replaced key={index} with content-based keys for message list",
+          "4.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -858,14 +914,15 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/x-post.png",
-        "version": "1.1.3",
+        "version": "1.2.0",
         "changelog": {
           "1.0.0": "Initial release with engagement metrics display",
           "1.0.2": "Added comprehensive JSDoc documentation",
           "1.1.0": "Moved to social category for better organization",
           "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "1.1.2": "Removed default content data - component only renders explicitly provided data",
-          "1.1.3": "Added aria-labels to icon-only action buttons for accessibility"
+          "1.1.3": "Added aria-labels to icon-only action buttons for accessibility",
+          "1.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -877,6 +934,11 @@
           "path": "registry/social/x-post.tsx",
           "type": "registry:block",
           "target": "components/ui/x-post.tsx"
+        },
+        {
+          "path": "registry/social/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "social",
@@ -893,7 +955,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/instagram-post.png",
-        "version": "1.1.3",
+        "version": "1.2.0",
         "changelog": {
           "1.0.0": "Initial release with image and engagement display",
           "1.0.1": "Improved alt text to include author name",
@@ -901,7 +963,8 @@
           "1.1.0": "Moved to social category for better organization",
           "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "1.1.2": "Removed default content data - component only renders explicitly provided data",
-          "1.1.3": "Added aria-labels to icon-only action buttons for accessibility"
+          "1.1.3": "Added aria-labels to icon-only action buttons for accessibility",
+          "1.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -915,6 +978,11 @@
           "path": "registry/social/instagram-post.tsx",
           "type": "registry:block",
           "target": "components/ui/instagram-post.tsx"
+        },
+        {
+          "path": "registry/social/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "social",
@@ -931,7 +999,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/linkedin-post.png",
-        "version": "3.0.1",
+        "version": "3.1.0",
         "changelog": {
           "1.0.0": "Initial release with professional styling",
           "1.0.2": "Added comprehensive JSDoc documentation",
@@ -941,7 +1009,8 @@
           "2.1.0": "Added image support, engagement stats with reaction icons, expandable content with maxLines prop, and moved repost button to the right",
           "2.1.1": "Fixed avatar circle visibility - now hides entirely when avatar prop is not provided",
           "3.0.0": "BREAKING: Moved postUrl and repostUrl from actions to data prop",
-          "3.0.1": "Fixed JSX namespace deprecation and removed dynamic Tailwind class"
+          "3.0.1": "Fixed JSX namespace deprecation and removed dynamic Tailwind class",
+          "3.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -952,6 +1021,11 @@
           "path": "registry/social/linkedin-post.tsx",
           "type": "registry:block",
           "target": "components/ui/linkedin-post.tsx"
+        },
+        {
+          "path": "registry/social/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "social",
@@ -968,14 +1042,15 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/youtube-post.png",
-        "version": "1.1.2",
+        "version": "1.2.0",
         "changelog": {
           "1.0.0": "Initial release with playable video embed",
           "1.0.1": "Improved alt text to include video title",
           "1.0.3": "Added comprehensive JSDoc documentation",
           "1.1.0": "Moved to social category for better organization",
           "1.1.1": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-          "1.1.2": "Removed default content data - component only renders explicitly provided data"
+          "1.1.2": "Removed default content data - component only renders explicitly provided data",
+          "1.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -989,6 +1064,11 @@
           "path": "registry/social/youtube-post.tsx",
           "type": "registry:block",
           "target": "components/ui/youtube-post.tsx"
+        },
+        {
+          "path": "registry/social/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "social",
@@ -1005,7 +1085,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/map-carousel.png",
-        "version": "2.0.4",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with interactive map and location cards",
           "1.1.0": "Made image and price fields optional in Location interface",
@@ -1020,7 +1100,8 @@
           "2.0.1": "Removed default content data - component only renders explicitly provided data",
           "2.0.2": "Migrated from OpenAI Apps SDK to MCP Apps protocol for host communication",
           "2.0.3": "Fixed Leaflet CSS injection deduplication and hardcoded date display",
-          "2.0.4": "Adjusted demo map zoom level to show more of the San Francisco bay area"
+          "2.0.4": "Adjusted demo map zoom level to show more of the San Francisco bay area",
+          "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -1040,6 +1121,11 @@
           "path": "registry/map/map-carousel.tsx",
           "type": "registry:block",
           "target": "components/ui/map-carousel.tsx"
+        },
+        {
+          "path": "registry/map/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "map",
@@ -1056,7 +1142,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/event-card.png",
-        "version": "5.0.10",
+        "version": "5.1.0",
         "changelog": {
           "1.0.0": "Initial release with default, compact, horizontal and covered variants. Supports physical, online, and hybrid events with signals and vibe tags.",
           "2.0.0": "BREAKING: Simplified Event interface - replaced startDateTime/endDateTime with display-formatted dateTime string, removed image/locationType/onlineUrl, changed ticketTiers to string array",
@@ -1073,7 +1159,8 @@
           "5.0.7": "Added demo/data.ts to registry for proper installation via shadcn CLI",
           "5.0.8": "Removed unused OpenAI types side-effect import",
           "5.0.9": "Removed default content data - component only renders explicitly provided data",
-          "5.0.10": "Removed unused button from registry dependencies"
+          "5.0.10": "Removed unused button from registry dependencies",
+          "5.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -1108,7 +1195,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/event-list.png",
-        "version": "7.0.2",
+        "version": "7.1.0",
         "changelog": {
           "1.0.0": "Initial release with grid, list and carousel layouts. Includes pagination support.",
           "2.0.0": "BREAKING: Updated to use simplified Event interface with display-formatted dateTime",
@@ -1129,7 +1216,8 @@
           "6.0.8": "Added demo/data.ts to registry for proper installation via shadcn CLI",
           "7.0.0": "BREAKING: Removed onPageChange, onViewMore, onExpand, onFilterClick, onFiltersApply actions. Filters and expand are now internal.",
           "7.0.1": "Removed default content data - component only renders explicitly provided data",
-          "7.0.2": "Extracted shared map utilities to shared.tsx and fixed Leaflet CSS deduplication"
+          "7.0.2": "Extracted shared map utilities to shared.tsx and fixed Leaflet CSS deduplication",
+          "7.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -1173,7 +1261,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/event-detail.png",
-        "version": "3.0.10",
+        "version": "3.1.0",
         "changelog": {
           "1.0.0": "Initial release with image carousel, organizer info, location, policies, FAQs, and ticket purchase.",
           "2.0.0": "BREAKING: Updated to use simplified Event interface with display-formatted dateTime and string ticketTiers",
@@ -1189,7 +1277,8 @@
           "3.0.7": "Added types.ts to registry for proper installation",
           "3.0.8": "Added demo/data.ts to registry for proper installation via shadcn CLI",
           "3.0.9": "Removed default content data - component only renders explicitly provided data",
-          "3.0.10": "Extracted shared map utilities to shared.tsx and fixed Leaflet CSS deduplication"
+          "3.0.10": "Extracted shared map utilities to shared.tsx and fixed Leaflet CSS deduplication",
+          "3.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -1231,7 +1320,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/ticket-tier-select.png",
-        "version": "4.0.1",
+        "version": "4.1.0",
         "changelog": {
           "1.0.0": "Initial release with ticket tier cards, quantity controls, price breakdown, and order summary sidebar",
           "1.1.0": "Added optional event image above order summary. Order summary now always visible with fixed width.",
@@ -1241,7 +1330,8 @@
           "3.0.0": "BREAKING: Removed id from TicketTier interface, made name and price optional.",
           "3.0.1": "Simplified TicketSelection interface by removing tierIndex",
           "4.0.0": "BREAKING: Removed onSelectionChange action. Tier quantity changes are now internal.",
-          "4.0.1": "Removed default content data - component only renders explicitly provided data"
+          "4.0.1": "Removed default content data - component only renders explicitly provided data",
+          "4.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -1255,6 +1345,11 @@
           "path": "registry/events/ticket-tier-select.tsx",
           "type": "registry:block",
           "target": "components/ui/ticket-tier-select.tsx"
+        },
+        {
+          "path": "registry/events/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "events",
@@ -1271,13 +1366,14 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/event-confirmation.png",
-        "version": "2.0.1",
+        "version": "2.1.0",
         "changelog": {
           "1.0.0": "Initial release with success message, event details, organizer follow, and social sharing",
           "1.0.2": "Added comprehensive JSDoc documentation",
           "1.0.3": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "2.0.0": "BREAKING: Removed onChangeEmail action and Change email link",
-          "2.0.1": "Removed default content data - component only renders explicitly provided data"
+          "2.0.1": "Removed default content data - component only renders explicitly provided data",
+          "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -1291,6 +1387,11 @@
           "path": "registry/events/event-confirmation.tsx",
           "type": "registry:block",
           "target": "components/ui/event-confirmation.tsx"
+        },
+        {
+          "path": "registry/events/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "events",
@@ -1307,7 +1408,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/hero.png",
-        "version": "2.1.3",
+        "version": "2.2.0",
         "changelog": {
           "1.0.0": "Initial release with logos, title, subtitle, CTA buttons, and tech logos footer",
           "1.1.0": "Added card wrapper, text logo support, improved light/dark mode compatibility",
@@ -1316,7 +1417,8 @@
           "2.1.0": "Added urlLight prop for dark mode logo variant support",
           "2.1.1": "Reduced logo image height for better visual balance",
           "2.1.2": "Removed default content data - component only renders explicitly provided data",
-          "2.1.3": "Replaced key={index} with stable content-based keys for tech logos"
+          "2.1.3": "Replaced key={index} with stable content-based keys for tech logos",
+          "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
         }
       },
       "dependencies": [
@@ -1330,6 +1432,11 @@
           "path": "registry/miscellaneous/hero.tsx",
           "type": "registry:block",
           "target": "components/ui/hero.tsx"
+        },
+        {
+          "path": "registry/miscellaneous/demo/data.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/data.ts"
         }
       ],
       "category": "miscellaneous",

--- a/packages/manifest-ui/registry/blogging/post-card.tsx
+++ b/packages/manifest-ui/registry/blogging/post-card.tsx
@@ -7,6 +7,8 @@ import type { Post } from './types'
 // Re-export for backward compatibility
 export type { Post } from './types'
 
+import { demoPost } from './demo/data'
+
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -89,7 +91,8 @@ export interface PostCardProps {
  * ```
  */
 export function PostCard({ data, actions, appearance }: PostCardProps) {
-  const post = data?.post
+  const resolved: NonNullable<PostCardProps['data']> = data ?? { post: demoPost }
+  const post = resolved.post
   if (!post) {
     return null
   }

--- a/packages/manifest-ui/registry/blogging/post-detail.tsx
+++ b/packages/manifest-ui/registry/blogging/post-detail.tsx
@@ -5,6 +5,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Calendar, Clock, ExternalLink, Maximize2 } from 'lucide-react';
 import { useMemo } from 'react';
 import type { Post } from './types';
+import { demoPostDetailData } from './demo/data';
 
 // DOM-based allowlist HTML sanitizer for post content
 const ALLOWED_TAGS = new Set([
@@ -192,10 +193,11 @@ export interface PostDetailProps {
  * ```
  */
 export function PostDetail({ data, actions, appearance }: PostDetailProps) {
-  const post = data?.post;
-  const rawContent = data?.content;
+  const resolved: NonNullable<PostDetailProps['data']> = data ?? demoPostDetailData;
+  const post = resolved.post;
+  const rawContent = resolved.content;
   const content = useMemo(() => rawContent ? sanitizeHtml(rawContent) : undefined, [rawContent]);
-  const relatedPosts = data?.relatedPosts ?? [];
+  const relatedPosts = resolved.relatedPosts ?? [];
   const onReadMore = actions?.onReadMore;
   const showCover = appearance?.showCover ?? true;
   const showAuthor = appearance?.showAuthor ?? true;

--- a/packages/manifest-ui/registry/blogging/post-list.tsx
+++ b/packages/manifest-ui/registry/blogging/post-list.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useState } from 'react'
 import type { Post } from './types'
 import { PostCard } from './post-card'
+import { demoPosts } from './demo/data'
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -85,7 +86,8 @@ export interface PostListProps {
  * ```
  */
 export function PostList({ data, actions, appearance }: PostListProps) {
-  const posts = data?.posts ?? []
+  const resolved: NonNullable<PostListProps['data']> = data ?? { posts: demoPosts }
+  const posts = resolved.posts ?? []
   const onReadMore = actions?.onReadMore
   const variant = appearance?.variant ?? 'list'
   const columns = appearance?.columns ?? 2

--- a/packages/manifest-ui/registry/events/demo/data.ts
+++ b/packages/manifest-ui/registry/events/demo/data.ts
@@ -384,4 +384,7 @@ export const demoEventConfirmation = {
   recipientEmail: 'customer@example.com',
   eventDate: 'Jan 20, 2024',
   eventLocation: 'Central Park, New York',
+  organizer: {
+    name: 'Live Nation',
+  },
 }

--- a/packages/manifest-ui/registry/events/event-card.tsx
+++ b/packages/manifest-ui/registry/events/event-card.tsx
@@ -14,6 +14,7 @@ import {
   XCircle
 } from 'lucide-react'
 import type { Event, EventSignal } from './types'
+import { demoEvent } from './demo/data'
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -150,7 +151,8 @@ function formatNumber(num: number): string {
  * ```
  */
 export function EventCard({ data, actions, appearance }: EventCardProps) {
-  const event = data?.event
+  const resolved: NonNullable<EventCardProps['data']> = data ?? { event: demoEvent }
+  const event = resolved.event
   const onClick = actions?.onClick
   const variant = appearance?.variant ?? 'default'
   const showSignal = appearance?.showSignal ?? true

--- a/packages/manifest-ui/registry/events/event-confirmation.tsx
+++ b/packages/manifest-ui/registry/events/event-confirmation.tsx
@@ -8,6 +8,7 @@ import {
   MessageCircle,
   Twitter
 } from 'lucide-react'
+import { demoEventConfirmation } from './demo/data'
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -81,13 +82,14 @@ export interface EventConfirmationProps {
  * ```
  */
 export function EventConfirmation({ data, actions }: EventConfirmationProps) {
-  const orderNumber = data?.orderNumber
-  const eventTitle = data?.eventTitle
-  const ticketCount = data?.ticketCount
-  const recipientEmail = data?.recipientEmail
-  const eventDate = data?.eventDate
-  const eventLocation = data?.eventLocation
-  const organizer = data?.organizer
+  const resolved: NonNullable<EventConfirmationProps['data']> = data ?? demoEventConfirmation
+  const orderNumber = resolved?.orderNumber
+  const eventTitle = resolved?.eventTitle
+  const ticketCount = resolved?.ticketCount
+  const recipientEmail = resolved?.recipientEmail
+  const eventDate = resolved?.eventDate
+  const eventLocation = resolved?.eventLocation
+  const organizer = resolved?.organizer
   const { onViewTickets, onFollowOrganizer, onShare } =
     actions ?? {}
 

--- a/packages/manifest-ui/registry/events/event-detail.tsx
+++ b/packages/manifest-ui/registry/events/event-detail.tsx
@@ -29,6 +29,7 @@ import {
   EventSignalBadge
 } from './shared'
 import type { LeafletMarkerAttrs } from './shared'
+import { demoEventDetails } from './demo/data'
 
 // Format date for display
 function formatEventDateTime(startDateTime: string, endDateTime?: string): string {
@@ -167,7 +168,8 @@ export interface EventDetailProps {
 }
 
 export function EventDetail({ data, actions, appearance }: EventDetailProps) {
-  const event = data?.event
+  const resolved: NonNullable<EventDetailProps['data']> = data ?? { event: demoEventDetails }
+  const event = resolved.event
   const onGetTickets = actions?.onGetTickets
   const onShare = actions?.onShare
   const onSave = actions?.onSave

--- a/packages/manifest-ui/registry/events/event-list.tsx
+++ b/packages/manifest-ui/registry/events/event-list.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ComponentType } from 'react'
 import type { Event } from './types'
 import { EventCard } from './event-card'
+import { demoEvents } from './demo/data'
 import { useReactLeaflet, injectLeafletCSS, MapPlaceholder } from './shared'
 import type { LeafletMarkerAttrs } from './shared'
 
@@ -375,8 +376,9 @@ export interface EventListProps {
  * ```
  */
 export function EventList({ data, actions, appearance }: EventListProps) {
-  const events = data?.events ?? []
-  const title = data?.title
+  const resolved: NonNullable<EventListProps['data']> = data ?? { events: demoEvents }
+  const events = resolved.events ?? []
+  const title = resolved.title
   const onEventSelect = actions?.onEventSelect
   const variant = appearance?.variant ?? 'list'
   const [currentIndex, setCurrentIndex] = useState(0)

--- a/packages/manifest-ui/registry/events/ticket-tier-select.tsx
+++ b/packages/manifest-ui/registry/events/ticket-tier-select.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Minus, Plus, Info } from 'lucide-react'
 import { useState } from 'react'
+import { demoTicketTiers } from './demo/data'
 
 /**
  * Formats a currency amount.
@@ -130,8 +131,9 @@ export interface TicketTierSelectProps {
  * ```
  */
 export function TicketTierSelect({ data, actions, appearance, control }: TicketTierSelectProps) {
-  const event = data?.event
-  const tiers = data?.tiers ?? []
+  const resolved: NonNullable<TicketTierSelectProps['data']> = data ?? { tiers: demoTicketTiers }
+  const event = resolved.event
+  const tiers = resolved.tiers ?? []
   const currency = event?.currency ?? 'USD'
   const { onCheckout } = actions ?? {}
   const { showOrderSummary = true } = appearance ?? {}

--- a/packages/manifest-ui/registry/list/product-list.tsx
+++ b/packages/manifest-ui/registry/list/product-list.tsx
@@ -10,6 +10,8 @@ import type { Product } from './types'
 // Re-export for backward compatibility
 export type { Product } from './types'
 
+import { demoProducts } from './demo/data'
+
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -795,7 +797,8 @@ function PickerVariant({
  * ```
  */
 export function ProductList({ data, actions, appearance, control }: ProductListProps) {
-  const products = data?.products ?? []
+  const resolved: NonNullable<ProductListProps['data']> = data ?? { products: demoProducts }
+  const products = resolved.products ?? []
   const onSelectProduct = actions?.onSelectProduct
   const onAddToCart = actions?.onAddToCart
   const variant = appearance?.variant ?? 'list'

--- a/packages/manifest-ui/registry/list/table.tsx
+++ b/packages/manifest-ui/registry/list/table.tsx
@@ -15,6 +15,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
+import { demoTableColumns, demoTableRows } from './demo/data'
 import {
   ArrowDownAZ,
   ArrowUpAZ,
@@ -377,6 +378,7 @@ export function Table<T extends Record<string, unknown>>({
   appearance,
   control
 }: TableProps<T>) {
+  const resolvedData: NonNullable<TableProps<T>['data']> = dataProps ?? { columns: demoTableColumns as unknown as TableColumn<T>[], rows: demoTableRows as unknown as T[] }
   const {
     columns = [] as unknown as TableColumn<T>[],
     rows: tableData = [] as unknown as T[],
@@ -384,7 +386,7 @@ export function Table<T extends Record<string, unknown>>({
     titleImage,
     lastUpdated,
     totalRows
-  } = dataProps ?? {}
+  } = resolvedData
   const {
     onCopy,
     onDownload,

--- a/packages/manifest-ui/registry/map/map-carousel.tsx
+++ b/packages/manifest-ui/registry/map/map-carousel.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/lib/utils'
 import { ChevronDown, MapPin, Maximize2, SlidersHorizontal, X } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ComponentType } from 'react'
+import { demoMapLocations, demoMapCenter, demoMapZoom } from './demo/data'
 
 // Internal types for react-leaflet component attributes (not exported component props)
 type LeafletMarkerAttrs = {
@@ -671,6 +672,7 @@ const getTileConfig = (style: MapStyle) => {
  * ```
  */
 export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
+  const resolvedData: NonNullable<MapCarouselProps['data']> = data ?? { locations: demoMapLocations, center: demoMapCenter, zoom: demoMapZoom }
   const {
     locations = [],
     center = [37.7899, -122.4034], // San Francisco
@@ -678,7 +680,7 @@ export function MapCarousel({ data, actions, appearance }: MapCarouselProps) {
     mapStyle = 'voyager',
     title,
     filters: filterConfigs = []
-  } = data ?? {}
+  } = resolvedData
 
   const tileConfig = getTileConfig(mapStyle)
   const { onSelectLocation } = actions ?? {}

--- a/packages/manifest-ui/registry/messaging/chat-conversation.tsx
+++ b/packages/manifest-ui/registry/messaging/chat-conversation.tsx
@@ -7,6 +7,8 @@ import type { ChatMessage } from './types'
 // Re-export for backward compatibility
 export type { ChatMessage } from './types'
 
+import { demoMessages } from './demo/data'
+
 /**
  * ═══════════════════════════════════════════════════════════════════════════
  * ChatConversationProps
@@ -47,7 +49,8 @@ export interface ChatConversationProps {
  * ```
  */
 export function ChatConversation({ data }: ChatConversationProps) {
-  const messages = data?.messages
+  const resolved: NonNullable<ChatConversationProps['data']> = data ?? { messages: demoMessages }
+  const messages = resolved.messages
 
   if (!messages || messages.length === 0) {
     return <div className="rounded-xl bg-card p-4" />

--- a/packages/manifest-ui/registry/miscellaneous/hero.tsx
+++ b/packages/manifest-ui/registry/miscellaneous/hero.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button';
 import { ReactNode } from 'react';
+import { demoHeroDefault } from './demo/data';
 
 /**
  * Represents a logo in the hero section.
@@ -155,15 +156,16 @@ function LogoDisplay({ logo }: { logo: HeroLogo }) {
  * ```
  */
 export function Hero({ data, actions }: HeroProps) {
-  const logo1 = data?.logo1;
-  const logo2 = data?.logo2;
-  const logoSeparator = data?.logoSeparator ?? 'x';
-  const title = data?.title;
-  const subtitle = data?.subtitle;
-  const primaryButton = data?.primaryButton;
-  const secondaryButton = data?.secondaryButton;
-  const techLogosLabel = data?.techLogosLabel;
-  const techLogos = data?.techLogos;
+  const resolved: NonNullable<HeroProps['data']> = data ?? demoHeroDefault;
+  const logo1 = resolved?.logo1;
+  const logo2 = resolved?.logo2;
+  const logoSeparator = resolved?.logoSeparator ?? 'x';
+  const title = resolved?.title;
+  const subtitle = resolved?.subtitle;
+  const primaryButton = resolved?.primaryButton;
+  const secondaryButton = resolved?.secondaryButton;
+  const techLogosLabel = resolved?.techLogosLabel;
+  const techLogos = resolved?.techLogos;
 
   const hasLogo1 = logo1?.url || logo1?.text;
   const hasLogo2 = logo2?.url || logo2?.text;

--- a/packages/manifest-ui/registry/miscellaneous/stat-card.tsx
+++ b/packages/manifest-ui/registry/miscellaneous/stat-card.tsx
@@ -2,6 +2,7 @@
 
 import { TrendingUp, TrendingDown, Minus } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { demoStats } from './demo/data'
 
 /**
  * Represents a single statistic card with trend data.
@@ -64,7 +65,8 @@ export interface StatsProps {
  * ```
  */
 export function Stats({ data }: StatsProps) {
-  const stats = data?.stats ?? []
+  const resolved: NonNullable<StatsProps['data']> = data ?? { stats: demoStats }
+  const stats = resolved.stats ?? []
   const getTrendIcon = (trend?: "up" | "down" | "neutral") => {
     switch (trend) {
       case "up":

--- a/packages/manifest-ui/registry/payment/order-confirm.tsx
+++ b/packages/manifest-ui/registry/payment/order-confirm.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button'
 import { ArrowRight, Calendar, MapPin } from 'lucide-react'
+import { demoOrderConfirm } from './demo/data'
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -91,14 +92,15 @@ export interface OrderConfirmProps {
  * ```
  */
 export function OrderConfirm({ data, actions, appearance, control }: OrderConfirmProps) {
-  const productName = data?.productName
-  const productVariant = data?.productVariant
-  const productImage = data?.productImage
-  const quantity = data?.quantity ?? 1
-  const price = data?.price
-  const deliveryDate = data?.deliveryDate
-  const deliveryAddress = data?.deliveryAddress
-  const freeShipping = data?.freeShipping ?? true
+  const resolved: NonNullable<OrderConfirmProps['data']> = data ?? demoOrderConfirm
+  const productName = resolved?.productName
+  const productVariant = resolved?.productVariant
+  const productImage = resolved?.productImage
+  const quantity = resolved?.quantity ?? 1
+  const price = resolved?.price
+  const deliveryDate = resolved?.deliveryDate
+  const deliveryAddress = resolved?.deliveryAddress
+  const freeShipping = resolved?.freeShipping ?? true
   const { onConfirm } = actions ?? {}
   const { currency = 'USD' } = appearance ?? {}
   const { isLoading = false } = control ?? {}

--- a/packages/manifest-ui/registry/payment/payment-confirmed.tsx
+++ b/packages/manifest-ui/registry/payment/payment-confirmed.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button'
 import { Check, ExternalLink } from 'lucide-react'
+import { demoPaymentConfirmed } from './demo/data'
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -76,12 +77,13 @@ export interface PaymentConfirmedProps {
  * ```
  */
 export function PaymentConfirmed({ data, actions, appearance }: PaymentConfirmedProps) {
-  const orderId = data?.orderId
-  const productName = data?.productName
-  const productDescription = data?.productDescription
-  const productImage = data?.productImage
-  const price = data?.price
-  const deliveryDate = data?.deliveryDate
+  const resolved: NonNullable<PaymentConfirmedProps['data']> = data ?? demoPaymentConfirmed
+  const orderId = resolved?.orderId
+  const productName = resolved?.productName
+  const productDescription = resolved?.productDescription
+  const productImage = resolved?.productImage
+  const price = resolved?.price
+  const deliveryDate = resolved?.deliveryDate
   const { onTrackOrder } = actions ?? {}
   const { variant = 'default', currency = 'EUR' } = appearance ?? {}
 

--- a/packages/manifest-ui/registry/selection/option-list.tsx
+++ b/packages/manifest-ui/registry/selection/option-list.tsx
@@ -10,6 +10,8 @@ import type { Option } from './types'
 // Re-export for backward compatibility
 export type { Option } from './types'
 
+import { demoOptions } from './demo/data'
+
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -70,7 +72,8 @@ export interface OptionListProps {
  * ```
  */
 export function OptionList({ data, actions, appearance, control }: OptionListProps) {
-  const options = data?.options ?? []
+  const resolved: NonNullable<OptionListProps['data']> = data ?? { options: demoOptions }
+  const options = resolved.options ?? []
   const onSubmit = actions?.onSubmit
   const multiple = appearance?.multiple ?? false
   const selectedOptionIndex = control?.selectedOptionIndex

--- a/packages/manifest-ui/registry/selection/quick-reply.tsx
+++ b/packages/manifest-ui/registry/selection/quick-reply.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { cn } from '@/lib/utils'
+import { demoQuickReplies } from './demo/data'
 
 /**
  * Represents a quick reply option.
@@ -62,7 +63,8 @@ export interface QuickReplyProps {
  * ```
  */
 export function QuickReply({ data, actions }: QuickReplyProps) {
-  const replies = data?.replies ?? []
+  const resolved: NonNullable<QuickReplyProps['data']> = data ?? { replies: demoQuickReplies }
+  const replies = resolved.replies ?? []
   const onSelectReply = actions?.onSelectReply
   return (
     <div className="w-full bg-card rounded-lg p-4">

--- a/packages/manifest-ui/registry/selection/tag-select.tsx
+++ b/packages/manifest-ui/registry/selection/tag-select.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { Check, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { demoTags } from './demo/data'
 
 /**
  * Represents an individual tag option.
@@ -106,7 +107,8 @@ const tagClasses = {
  * ```
  */
 export function TagSelect({ data, actions, appearance, control }: TagSelectProps) {
-  const tags = data?.tags ?? []
+  const resolved: NonNullable<TagSelectProps['data']> = data ?? { tags: demoTags }
+  const tags = resolved.tags ?? []
   const onValidate = actions?.onValidate
   const mode = appearance?.mode ?? 'multiple'
   const showClear = appearance?.showClear ?? true

--- a/packages/manifest-ui/registry/social/instagram-post.tsx
+++ b/packages/manifest-ui/registry/social/instagram-post.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Heart, MessageCircle, Send, Bookmark, MoreHorizontal, Flag, UserMinus, Link, Code } from "lucide-react"
+import { demoInstagramPost } from './demo/data'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -65,13 +66,14 @@ export interface InstagramPostProps {
  * ```
  */
 export function InstagramPost({ data }: InstagramPostProps) {
-  const author = data?.author
-  const avatar = data?.avatar
-  const image = data?.image
-  const likes = data?.likes
-  const caption = data?.caption
-  const time = data?.time
-  const verified = data?.verified
+  const resolved: NonNullable<InstagramPostProps['data']> = data ?? demoInstagramPost
+  const author = resolved?.author
+  const avatar = resolved?.avatar
+  const image = resolved?.image
+  const likes = resolved?.likes
+  const caption = resolved?.caption
+  const time = resolved?.time
+  const verified = resolved?.verified
 
   if (!author && !image && !caption) {
     return null

--- a/packages/manifest-ui/registry/social/linkedin-post.tsx
+++ b/packages/manifest-ui/registry/social/linkedin-post.tsx
@@ -3,6 +3,7 @@
 import { Repeat2 } from 'lucide-react';
 import type { JSX } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
+import { demoLinkedInPost } from './demo/data';
 
 /** Reaction type for LinkedIn posts */
 type ReactionType = 'like' | 'celebrate' | 'support' | 'love' | 'insightful' | 'funny';
@@ -336,6 +337,7 @@ const reactionIcons: Record<ReactionType, JSX.Element> = {
  * ```
  */
 export function LinkedInPost({ data, appearance }: LinkedInPostProps) {
+  const resolved: NonNullable<LinkedInPostProps['data']> = data ?? demoLinkedInPost;
   const {
     author,
     headline,
@@ -349,7 +351,7 @@ export function LinkedInPost({ data, appearance }: LinkedInPostProps) {
     reposts,
     postUrl,
     repostUrl,
-  } = data ?? {};
+  } = resolved;
 
   const { maxLines = 3 } = appearance ?? {};
 

--- a/packages/manifest-ui/registry/social/x-post.tsx
+++ b/packages/manifest-ui/registry/social/x-post.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Heart, MessageCircle, Repeat2, Share, Bookmark } from "lucide-react"
+import { demoXPost } from './demo/data'
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -66,16 +67,17 @@ export interface XPostProps {
  * ```
  */
 export function XPost({ data }: XPostProps) {
-  const author = data?.author
-  const username = data?.username
-  const avatar = data?.avatar
-  const content = data?.content
-  const time = data?.time
-  const likes = data?.likes
-  const retweets = data?.retweets
-  const replies = data?.replies
-  const views = data?.views
-  const verified = data?.verified
+  const resolved: NonNullable<XPostProps['data']> = data ?? demoXPost
+  const author = resolved?.author
+  const username = resolved?.username
+  const avatar = resolved?.avatar
+  const content = resolved?.content
+  const time = resolved?.time
+  const likes = resolved?.likes
+  const retweets = resolved?.retweets
+  const replies = resolved?.replies
+  const views = resolved?.views
+  const verified = resolved?.verified
 
   if (!author && !content) {
     return null

--- a/packages/manifest-ui/registry/social/youtube-post.tsx
+++ b/packages/manifest-ui/registry/social/youtube-post.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import { Bookmark, MoreHorizontal, Share, EyeOff, Flag } from "lucide-react"
+import { demoYouTubePost } from './demo/data'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -75,15 +76,16 @@ export interface YouTubePostProps {
  * ```
  */
 export function YouTubePost({ data }: YouTubePostProps) {
-  const channel = data?.channel
-  const avatar = data?.avatar
-  const title = data?.title
-  const views = data?.views
-  const time = data?.time
-  const duration = data?.duration
-  const thumbnail = data?.thumbnail
-  const verified = data?.verified
-  const videoId = data?.videoId
+  const resolved: NonNullable<YouTubePostProps['data']> = data ?? demoYouTubePost
+  const channel = resolved?.channel
+  const avatar = resolved?.avatar
+  const title = resolved?.title
+  const views = resolved?.views
+  const time = resolved?.time
+  const duration = resolved?.duration
+  const thumbnail = resolved?.thumbnail
+  const verified = resolved?.verified
+  const videoId = resolved?.videoId
 
   const [isPlaying, setIsPlaying] = useState(false)
 

--- a/packages/manifest-ui/registry/status/progress-steps.tsx
+++ b/packages/manifest-ui/registry/status/progress-steps.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@/lib/utils'
 import { Check } from 'lucide-react'
+import { demoProgressSteps } from './demo/data'
 
 /**
  * Represents an individual step in the progress tracker.
@@ -56,7 +57,8 @@ export interface ProgressStepsProps {
  * ```
  */
 export function ProgressSteps({ data }: ProgressStepsProps) {
-  const steps = data?.steps ?? []
+  const resolved: NonNullable<ProgressStepsProps['data']> = data ?? { steps: demoProgressSteps }
+  const steps = resolved.steps ?? []
   return (
     <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-2 bg-card rounded-lg p-4">
       {steps.map((step, index) => {

--- a/packages/manifest-ui/registry/status/status-badge.tsx
+++ b/packages/manifest-ui/registry/status/status-badge.tsx
@@ -9,6 +9,7 @@ import {
   Truck,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { demoStatusBadge } from './demo/data'
 
 /**
  * Available status types for the badge.
@@ -132,7 +133,8 @@ const iconSizes = {
  * ```
  */
 export function StatusBadge({ data, appearance }: StatusBadgeProps) {
-  const status = data?.status ?? "pending"
+  const resolved: NonNullable<StatusBadgeProps['data']> = data ?? demoStatusBadge
+  const status = resolved?.status ?? "pending"
   const label = appearance?.label
   const showIcon = appearance?.showIcon ?? true
   const size = appearance?.size ?? "md"


### PR DESCRIPTION
## Description

Components now render demo data when used with no data prop (`<Component />`), providing immediate visual feedback after installation via `npx shadcn@latest add`. When any data prop is passed, only user-provided data is rendered (all-or-nothing nullish coalescing pattern).

**25 components updated** across all categories:
- Blogging: post-card, post-list, post-detail
- Events: event-card, event-list, event-detail, ticket-tier-select, event-confirmation
- List: product-list, table
- Map: map-carousel
- Messaging: chat-conversation
- Miscellaneous: hero, stat-card
- Payment: order-confirm, payment-confirmed
- Selection: option-list, quick-reply, tag-select
- Social: x-post, instagram-post, linkedin-post, youtube-post
- Status: progress-steps, status-badge

**Pattern used**: `const resolved = data ?? demoX` at component top level — demo data from `demo/data.ts` is used only when `data` is `undefined`/`null`.

**Additional changes**:
- Removed Rule A from `no-default-data.test.ts` (demo data `??` fallbacks are now the intended pattern)
- Added `manifest-types` registryDependency for order-confirm and payment-confirmed
- MINOR version bumps and changelog entries for all 25 components
- Added `demo/data.ts` to registry files arrays for components that were missing it

## Related Issues

None

## How can it be tested?

1. Run `pnpm test` in `packages/manifest-ui/` — all 1215 tests pass
2. Verify a component like `<PostCard />` renders demo data with no props
3. Verify `<PostCard data={{ post: customPost }} />` renders only the custom data (no demo data mixed in)

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR