### PR TITLE
Enhance getting started guide with Tailwind CSS v4 setup

### DIFF
--- a/packages/manifest-ui/components/blocks/getting-started.tsx
+++ b/packages/manifest-ui/components/blocks/getting-started.tsx
@@ -1,5 +1,5 @@
 import { blockCategories } from '@/lib/blocks-categories'
-import { ArrowRight, FolderPlus } from 'lucide-react'
+import { ArrowRight, FolderPlus, Paintbrush, Terminal } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
 
@@ -13,6 +13,124 @@ const CodeBlock = dynamic(
   }
 )
 
+const tailwindCssConfig = `@import "tailwindcss";
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
+
+:root {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.714);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.145 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.145 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.269 0 0);
+  --input: oklch(0.269 0 0);
+  --ring: oklch(0.439 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.269 0 0);
+  --sidebar-ring: oklch(0.439 0 0);
+}
+
+@layer base {
+  * {
+    @apply border-border;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}`
+
 export function GettingStarted() {
   return (
     <div className="max-w-3xl mx-auto space-y-12">
@@ -23,13 +141,15 @@ export function GettingStarted() {
         </p>
       </div>
 
-      {/* Add to Existing Section */}
+      {/* Step 1: Initialize shadcn/ui */}
       <section id="add-to-existing" className="space-y-6 scroll-mt-8">
         <div className="flex items-center gap-3">
           <div className="p-2 rounded-lg bg-primary/10 text-primary">
             <FolderPlus className="h-5 w-5" />
           </div>
-          <h2 className="text-xl font-semibold">Add to existing project</h2>
+          <h2 className="text-xl font-semibold">
+            1. Initialize shadcn/ui
+          </h2>
         </div>
 
         <p className="text-muted-foreground">
@@ -45,15 +165,63 @@ export function GettingStarted() {
           .
         </p>
 
-        <div className="space-y-4">
-          <h3 className="text-md font-semibold">Using a block</h3>
-          <p className="text-sm text-muted-foreground">
-            Simply browse to the block you want to use and run the provided
-            command to add it to your project. For example, to add the Table
-            block:
-          </p>
-          <CodeBlock code="npx shadcn@latest add @manifest/table" />
+        <CodeBlock code="npx shadcn@latest init" />
+      </section>
+
+      {/* Step 2: Configure Tailwind CSS */}
+      <section id="configure-styles" className="space-y-6 scroll-mt-8">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-primary/10 text-primary">
+            <Paintbrush className="h-5 w-5" />
+          </div>
+          <h2 className="text-xl font-semibold">
+            2. Configure Tailwind CSS v4 theme
+          </h2>
         </div>
+
+        <p className="text-muted-foreground">
+          Manifest UI blocks use Tailwind CSS v4 with CSS custom properties for
+          theming. Add the following configuration to your main CSS file
+          (e.g.{' '}
+          <code className="text-sm bg-muted px-1.5 py-0.5 rounded">
+            globals.css
+          </code>{' '}
+          or{' '}
+          <code className="text-sm bg-muted px-1.5 py-0.5 rounded">
+            index.css
+          </code>
+          ).
+        </p>
+
+        <p className="text-sm text-muted-foreground">
+          If you initialized your project with{' '}
+          <code className="bg-muted px-1.5 py-0.5 rounded">
+            npx shadcn@latest init
+          </code>
+          , this may already be configured. If blocks aren&apos;t rendering
+          correctly, verify your CSS includes this setup:
+        </p>
+
+        <div className="max-h-96 overflow-y-auto rounded-lg border">
+          <CodeBlock code={tailwindCssConfig} language="css" />
+        </div>
+      </section>
+
+      {/* Step 3: Add a block */}
+      <section id="add-block" className="space-y-6 scroll-mt-8">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-lg bg-primary/10 text-primary">
+            <Terminal className="h-5 w-5" />
+          </div>
+          <h2 className="text-xl font-semibold">3. Add a block</h2>
+        </div>
+
+        <p className="text-muted-foreground">
+          Browse to the block you want to use and run the provided command to
+          add it to your project. For example, to add the Table block:
+        </p>
+
+        <CodeBlock code="npx shadcn@latest add @manifest/table" />
       </section>
 
       {/* Next Step */}


### PR DESCRIPTION
## Summary

This PR restructures and enhances the getting started guide to provide clearer, step-by-step instructions for users setting up Manifest UI blocks. It adds comprehensive Tailwind CSS v4 configuration guidance with a complete theme setup example, and reorganizes the content into three distinct steps.

## Changes

- Added imports for `Paintbrush` and `Terminal` icons from lucide-react
- Created a `tailwindCssConfig` constant containing a complete Tailwind CSS v4 configuration with:
  - CSS custom properties for all design tokens (colors, radius, etc.)
  - Light and dark theme variants using OKLch color space
  - Base layer styles for consistent border and text rendering
- Restructured the getting started section into three numbered steps:
  1. **Initialize shadcn/ui** - Updated from "Add to existing project" with the init command
  2. **Configure Tailwind CSS v4 theme** - New section with detailed CSS configuration and helpful notes about verification
  3. **Add a block** - Moved from inline content with clearer instructions
- Enhanced visual hierarchy with step numbers and appropriate icons for each section
- Added scrollable code block container for the CSS configuration to handle its length
- Improved explanatory text with code snippets and formatting for better readability

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Testing

- [ ] Tests pass locally (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)

## Related Issues

<!-- Link any related issues if applicable -->

https://claude.ai/code/session_01FtMPEs4hoy7tSzu66vbcPJ