### PR TITLE
fix(manifest-ui): replace react-leaflet with vanilla leaflet to fix Invalid hook call

### DIFF
--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -331,7 +331,8 @@
       "2.0.3": "Fixed Leaflet CSS injection deduplication and hardcoded date display",
       "2.0.4": "Adjusted demo map zoom level to show more of the San Francisco bay area",
       "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided",
-      "2.1.1": "Fixed react-leaflet Invalid hook call errors by using React.lazy instead of useEffect dynamic imports"
+      "2.1.1": "Fixed react-leaflet Invalid hook call errors by using React.lazy instead of useEffect dynamic imports",
+      "2.1.2": "Fixed Invalid hook call errors by replacing react-leaflet with vanilla leaflet API"
     },
     "event-card": {
       "1.0.0": "Initial release with default, compact, horizontal and covered variants. Supports physical, online, and hybrid events with signals and vibe tags.",

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -1085,7 +1085,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/map-carousel.png",
-        "version": "2.1.1",
+        "version": "2.1.2",
         "changelog": {
           "1.0.0": "Initial release with interactive map and location cards",
           "1.1.0": "Made image and price fields optional in Location interface",
@@ -1102,13 +1102,13 @@
           "2.0.3": "Fixed Leaflet CSS injection deduplication and hardcoded date display",
           "2.0.4": "Adjusted demo map zoom level to show more of the San Francisco bay area",
           "2.1.0": "Added demo data defaults - component renders demo content when no data prop is provided",
-          "2.1.1": "Fixed react-leaflet Invalid hook call errors by using React.lazy instead of useEffect dynamic imports"
+          "2.1.1": "Fixed react-leaflet Invalid hook call errors by using React.lazy instead of useEffect dynamic imports",
+          "2.1.2": "Fixed Invalid hook call errors by replacing react-leaflet with vanilla leaflet API"
         }
       },
       "dependencies": [
         "lucide-react",
-        "leaflet",
-        "react-leaflet"
+        "leaflet"
       ],
       "devDependencies": [
         "@types/leaflet"


### PR DESCRIPTION
## Description

Replace `react-leaflet` with vanilla `leaflet` API in the `map-carousel` component to fix "Invalid hook call" errors that occur when consumers install the component in their own apps.

**Root cause:** `react-leaflet` uses React hooks internally. When bundlers (especially Vite) create two separate copies of React — one for the consumer app and one resolved by `react-leaflet` — the hooks fail with "Invalid hook call" because they run against a React instance with no active component rendering.

**Fix:** Use the `leaflet` JS API directly via `useRef`/`useEffect` instead of `react-leaflet`'s React wrapper components. Since `leaflet` is a plain JavaScript library with zero React dependency, the dual-React problem is eliminated entirely.

## Related Issues

None

## How can it be tested?

1. Install the `map-carousel` component in a Vite-based React app via `npx shadcn@latest add`
2. Render `<MapCarousel />` with location data
3. Verify the map renders without "Invalid hook call" errors
4. Verify markers appear and are clickable
5. Verify the carousel cards sync with marker selection
6. Test both inline and fullscreen display modes

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR