### PR TITLE
fix(manifest-ui): add resolved demo data pattern to remaining components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,8 @@ return post?.title && <h1>{post.title}</h1>;
 - Default data creates confusion about required vs optional fields
 - Demo data belongs in `demo/data.ts`, not in the component
 
+**Note:** While components don't use *inline* hardcoded defaults, they DO import centralized demo data and use `data ?? demoData` so that `<Component />` renders meaningful content. See `packages/manifest-ui/CLAUDE.md` for the full "Component Demo Data Initialization" pattern.
+
 ### Centralized Demo Data Pattern (CRITICAL)
 
 All demo data MUST live in `registry/<category>/demo/data.ts`:

--- a/packages/manifest-ui/CLAUDE.md
+++ b/packages/manifest-ui/CLAUDE.md
@@ -257,6 +257,36 @@ export function PostDetail({ data }: PostDetailProps) {
 3. **Defaults are OK for appearance/behavior** props (e.g., `variant ?? 'default'`)
 4. **Demo data lives separately** in `demo/data.ts` files (see below)
 
+## Component Demo Data Initialization (CRITICAL)
+
+**IMPORTANT**: Every component with a `data?` prop MUST import centralized demo data and use the `resolved` fallback pattern. This ensures components render meaningful content when called without arguments (`<Component />`).
+
+### Implementation Pattern
+
+```typescript
+import { demoMyComponentData } from './demo/<category>'
+
+export function MyComponent({ data, actions, appearance }: MyComponentProps) {
+  const resolved: NonNullable<MyComponentProps['data']> = data ?? demoMyComponentData
+  const title = resolved.title
+  const items = resolved.items ?? []
+  // ...
+}
+```
+
+### Key Rules
+
+1. **Import from `./demo/<category>`** — demo data is centralized per category
+2. **Use `data ?? demoData`** — fallback to demo data when no data prop is provided
+3. **Type as `NonNullable<Props['data']>`** — ensures type safety on the resolved object
+4. **Enforced by tests** — `__tests__/component-init-demo-data.test.ts` validates this for all registered blocks
+
+### Why This Matters
+
+- Components rendered without arguments in MCP Jam must show demo content
+- Users can still override with explicit `data` prop (demo data is only the fallback)
+- This is NOT the same as hardcoded inline defaults — demo data is centralized and importable
+
 ## Centralized Demo Data
 
 **IMPORTANT**: Demo data for component previews MUST be centralized in dedicated files, not duplicated across preview components and page files.

--- a/packages/manifest-ui/__tests__/component-init-demo-data.test.ts
+++ b/packages/manifest-ui/__tests__/component-init-demo-data.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Component Demo Data Initialization Test
+ *
+ * Ensures every registered block with a `data?` prop uses the `resolved`
+ * initialization pattern:
+ *   const resolved: NonNullable<Props['data']> = data ?? demoData
+ *
+ * This guarantees components render meaningful content when called without
+ * arguments (e.g. `<Component />`), which is required for MCP Jam previews
+ * and zero-config usage.
+ *
+ * Components without a `data?` prop (e.g. utility libs, types-only files)
+ * are excluded automatically.
+ */
+
+import { readFileSync } from 'fs'
+import { resolve, relative } from 'path'
+import { describe, it, expect } from 'vitest'
+
+const ROOT_PATH = resolve(__dirname, '..')
+
+interface RegistryFile {
+  path: string
+  type: string
+  target: string
+}
+
+interface RegistryItem {
+  name: string
+  type: string
+  files: RegistryFile[]
+}
+
+/**
+ * Read registry.json and return only `registry:block` items
+ * (excluding libs, types, and shared utilities).
+ */
+function getRegisteredBlocks(): RegistryItem[] {
+  const registryJson = JSON.parse(
+    readFileSync(resolve(ROOT_PATH, 'registry.json'), 'utf-8')
+  )
+  return registryJson.items.filter(
+    (item: RegistryItem) => item.type === 'registry:block'
+  )
+}
+
+/**
+ * Find the main .tsx block file for a registry item.
+ * The main file is the first `registry:block` typed file.
+ */
+function getMainBlockFile(item: RegistryItem): string | null {
+  const blockFile = item.files.find((f) => f.type === 'registry:block')
+  return blockFile ? blockFile.path : null
+}
+
+/**
+ * Check if a component file has a `data?` prop in its Props interface.
+ */
+function hasDataProp(content: string): boolean {
+  // Match interfaces with data?: { ... } pattern
+  return /interface\s+\w+Props\s*\{[^}]*\bdata\?:/s.test(content)
+}
+
+/**
+ * Extract the category from a registry file path.
+ * e.g. "registry/form/contact-form.tsx" -> "form"
+ */
+function getCategoryFromPath(filePath: string): string | null {
+  const match = filePath.match(/^registry\/([^/]+)\//)
+  return match ? match[1] : null
+}
+
+describe('Component Demo Data Initialization', () => {
+  const blocks = getRegisteredBlocks()
+
+  it('should find registered blocks to check', () => {
+    expect(blocks.length).toBeGreaterThan(0)
+  })
+
+  for (const block of blocks) {
+    const mainFile = getMainBlockFile(block)
+    if (!mainFile) continue
+
+    const absPath = resolve(ROOT_PATH, mainFile)
+    let content: string
+    try {
+      content = readFileSync(absPath, 'utf-8')
+    } catch {
+      continue
+    }
+
+    // Skip components without a data? prop
+    if (!hasDataProp(content)) continue
+
+    const category = getCategoryFromPath(mainFile)
+    const relPath = relative(ROOT_PATH, absPath)
+
+    describe(`${block.name} (${relPath})`, () => {
+      it('must import demo data from ./demo/<category>', () => {
+        const importPattern = new RegExp(
+          `from\\s+['"]\\./demo/${category}['"]`
+        )
+        expect(content).toMatch(importPattern)
+      })
+
+      it('must use data ?? demo fallback pattern', () => {
+        // Match: data ?? demo<Something> or data ?? { ... demo<Something> }
+        const fallbackPattern = /=\s*data\s*\?\?\s*(?:demo\w+|\{[^}]*demo\w+)/
+        expect(content).toMatch(fallbackPattern)
+      })
+    })
+  }
+})

--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -12,7 +12,6 @@ import { Suspense, useEffect, useRef, useState } from 'react';
 import { ContactForm } from '@/registry/form/contact-form';
 import { DateTimePicker } from '@/registry/form/date-time-picker';
 import { IssueReportForm } from '@/registry/form/issue-report-form';
-import { demoDateTimePickerData } from '@/registry/form/demo/form';
 
 // Blogging components
 import { PostCardDemo } from '@/components/blocks/post-card-demo';
@@ -56,7 +55,6 @@ import { OrderConfirm } from '@/registry/payment/order-confirm';
 import { PaymentConfirmed } from '@/registry/payment/payment-confirmed';
 import {
   demoOrderConfirm,
-  demoAmountPresets,
   demoPaymentConfirmed,
 } from '@/registry/payment/demo/payment';
 
@@ -1614,10 +1612,10 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <DateTimePicker data={demoDateTimePickerData} />,
+            component: <DateTimePicker />,
             fullscreenComponent: (
               <div className="max-w-[680px] mx-auto">
-                <DateTimePicker data={demoDateTimePickerData} />
+                <DateTimePicker />
               </div>
             ),
             usageCode: `<DateTimePicker
@@ -2455,10 +2453,10 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <AmountInput data={{ presets: demoAmountPresets }} />,
+            component: <AmountInput />,
             fullscreenComponent: (
               <div className="max-w-[680px] mx-auto">
-                <AmountInput data={{ presets: demoAmountPresets }} />
+                <AmountInput />
               </div>
             ),
             usageCode: `<AmountInput

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -11,7 +11,8 @@
       "1.2.5": "Fixed defensive property access to handle empty objects and null values",
       "1.2.6": "Removed default content data - component only renders explicitly provided data",
       "1.2.7": "Fixed missing popover dependency for shadcn CLI installation",
-      "1.2.8": "Extracted country data to separate countries.ts file"
+      "1.2.8": "Extracted country data to separate countries.ts file",
+      "1.2.9": "Show demo data when rendered without props"
     },
     "date-time-picker": {
       "1.0.0": "Initial release with calendar and time slot selection",
@@ -22,7 +23,8 @@
       "2.0.1": "Removed default content data - component only renders explicitly provided data",
       "2.0.2": "Fixed missing popover dependency for shadcn CLI installation",
       "2.0.3": "Replaced hardcoded UTC offsets with IANA timezone identifiers for correct DST handling",
-      "2.1.0": "Added weekStartsOn appearance option to configure first day of the week (Sunday, Monday, or Saturday)"
+      "2.1.0": "Added weekStartsOn appearance option to configure first day of the week (Sunday, Monday, or Saturday)",
+      "2.1.1": "Show demo data when rendered without props"
     },
     "issue-report-form": {
       "1.0.0": "Initial release with categories, impact levels and file attachments",
@@ -30,7 +32,8 @@
       "1.0.3": "Added comprehensive JSDoc documentation",
       "1.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
       "1.0.5": "Fixed defensive property access to handle empty objects and null values",
-      "1.0.6": "Removed default content data - component only renders explicitly provided data"
+      "1.0.6": "Removed default content data - component only renders explicitly provided data",
+      "1.0.7": "Show demo data when rendered without props"
     },
     "card-form": {
       "1.0.0": "Initial release with card number, expiry, CVV and name fields",
@@ -118,7 +121,8 @@
       "1.0.4": "Fixed defensive property access to handle empty objects and null values",
       "2.0.0": "BREAKING: Removed onChange action. Value changes are now internal.",
       "2.0.1": "Removed default content data - component only renders explicitly provided data",
-      "2.0.2": "Fixed stale controlled state sync and memoized currency symbol computation"
+      "2.0.2": "Fixed stale controlled state sync and memoized currency symbol computation",
+      "2.0.3": "Show demo data when rendered without props"
     },
     "tag-select": {
       "1.0.0": "Initial release with color variants and multi-select",
@@ -254,7 +258,8 @@
       "3.0.1": "Added aria-labels to reaction buttons and voice message controls for accessibility",
       "3.0.3": "Added comprehensive JSDoc documentation",
       "3.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-      "3.0.5": "Removed default content data - component only renders explicitly provided data"
+      "3.0.5": "Removed default content data - component only renders explicitly provided data",
+      "3.0.6": "Show demo data when rendered without props"
     },
     "chat-conversation": {
       "1.0.0": "Initial release with multiple message types",

--- a/packages/manifest-ui/lib/preview-components.tsx
+++ b/packages/manifest-ui/lib/preview-components.tsx
@@ -12,15 +12,12 @@ import { ReactNode } from 'react';
 import { ContactForm } from '@/registry/form/contact-form';
 import { DateTimePicker } from '@/registry/form/date-time-picker';
 import { IssueReportForm } from '@/registry/form/issue-report-form';
-import { demoDateTimePickerData } from '@/registry/form/demo/form';
-
 // Payment components
 import { AmountInput } from '@/registry/payment/amount-input';
 import { OrderConfirm } from '@/registry/payment/order-confirm';
 import { PaymentConfirmed } from '@/registry/payment/payment-confirmed';
 import {
   demoOrderConfirm,
-  demoAmountPresets,
   demoPaymentConfirmed,
 } from '@/registry/payment/demo/payment';
 
@@ -124,7 +121,7 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
     category: 'form',
   },
   'date-time-picker': {
-    component: <DateTimePicker data={demoDateTimePickerData} />,
+    component: <DateTimePicker />,
     category: 'form',
   },
   'issue-report-form': {
@@ -142,7 +139,7 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
     category: 'payment',
   },
   'amount-input': {
-    component: <AmountInput data={{ presets: demoAmountPresets }} />,
+    component: <AmountInput />,
     category: 'payment',
   },
 

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -14,7 +14,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/contact-form.png",
-        "version": "1.2.8",
+        "version": "1.2.9",
         "changelog": {
           "1.0.0": "Initial release with name, phone, email, message and file attachment fields",
           "1.1.0": "Made phone, email, and message fields optional with defaults",
@@ -25,7 +25,8 @@
           "1.2.5": "Fixed defensive property access to handle empty objects and null values",
           "1.2.6": "Removed default content data - component only renders explicitly provided data",
           "1.2.7": "Fixed missing popover dependency for shadcn CLI installation",
-          "1.2.8": "Extracted country data to separate countries.ts file"
+          "1.2.8": "Extracted country data to separate countries.ts file",
+          "1.2.9": "Show demo data when rendered without props"
         }
       },
       "dependencies": [
@@ -47,6 +48,11 @@
           "path": "registry/form/countries.ts",
           "type": "registry:lib",
           "target": "components/ui/countries.ts"
+        },
+        {
+          "path": "registry/form/demo/form.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/form.ts"
         }
       ],
       "category": "form",
@@ -63,7 +69,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/date-time-picker.png",
-        "version": "2.1.0",
+        "version": "2.1.1",
         "changelog": {
           "1.0.0": "Initial release with calendar and time slot selection",
           "1.0.1": "Added aria-labels to navigation buttons for better screen reader accessibility",
@@ -73,7 +79,8 @@
           "2.0.1": "Removed default content data - component only renders explicitly provided data",
           "2.0.2": "Fixed missing popover dependency for shadcn CLI installation",
           "2.0.3": "Replaced hardcoded UTC offsets with IANA timezone identifiers for correct DST handling",
-          "2.1.0": "Added weekStartsOn appearance option to configure first day of the week (Sunday, Monday, or Saturday)"
+          "2.1.0": "Added weekStartsOn appearance option to configure first day of the week (Sunday, Monday, or Saturday)",
+          "2.1.1": "Show demo data when rendered without props"
         }
       },
       "dependencies": [
@@ -88,6 +95,11 @@
           "path": "registry/form/date-time-picker.tsx",
           "type": "registry:block",
           "target": "components/ui/date-time-picker.tsx"
+        },
+        {
+          "path": "registry/form/demo/form.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/form.ts"
         }
       ],
       "category": "form",
@@ -104,14 +116,15 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/issue-report-form.png",
-        "version": "1.0.6",
+        "version": "1.0.7",
         "changelog": {
           "1.0.0": "Initial release with categories, impact levels and file attachments",
           "1.0.1": "Added aria-label to file removal button for screen reader accessibility",
           "1.0.3": "Added comprehensive JSDoc documentation",
           "1.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
           "1.0.5": "Fixed defensive property access to handle empty objects and null values",
-          "1.0.6": "Removed default content data - component only renders explicitly provided data"
+          "1.0.6": "Removed default content data - component only renders explicitly provided data",
+          "1.0.7": "Show demo data when rendered without props"
         }
       },
       "dependencies": [
@@ -128,6 +141,11 @@
           "path": "registry/form/issue-report-form.tsx",
           "type": "registry:block",
           "target": "components/ui/issue-report-form.tsx"
+        },
+        {
+          "path": "registry/form/demo/form.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/form.ts"
         }
       ],
       "category": "form",
@@ -327,7 +345,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/amount-input.png",
-        "version": "2.0.2",
+        "version": "2.0.3",
         "changelog": {
           "1.0.0": "Initial release with increment buttons and preset values",
           "1.0.2": "Added comprehensive JSDoc documentation",
@@ -335,7 +353,8 @@
           "1.0.4": "Fixed defensive property access to handle empty objects and null values",
           "2.0.0": "BREAKING: Removed onChange action. Value changes are now internal.",
           "2.0.1": "Removed default content data - component only renders explicitly provided data",
-          "2.0.2": "Fixed stale controlled state sync and memoized currency symbol computation"
+          "2.0.2": "Fixed stale controlled state sync and memoized currency symbol computation",
+          "2.0.3": "Show demo data when rendered without props"
         }
       },
       "dependencies": [
@@ -349,6 +368,11 @@
           "path": "registry/payment/amount-input.tsx",
           "type": "registry:block",
           "target": "components/ui/amount-input.tsx"
+        },
+        {
+          "path": "registry/payment/demo/payment.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/payment.ts"
         }
       ],
       "category": "payment",
@@ -814,7 +838,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/message-bubble.png",
-        "version": "3.0.5",
+        "version": "3.0.6",
         "changelog": {
           "1.0.0": "Initial release with text, image, voice and reaction variants",
           "1.0.1": "Added better image captions for accessibility",
@@ -825,7 +849,8 @@
           "3.0.1": "Added aria-labels to reaction buttons and voice message controls for accessibility",
           "3.0.3": "Added comprehensive JSDoc documentation",
           "3.0.4": "Updated Props interface with decorative header and sub-parameter JSDoc documentation",
-          "3.0.5": "Removed default content data - component only renders explicitly provided data"
+          "3.0.5": "Removed default content data - component only renders explicitly provided data",
+          "3.0.6": "Show demo data when rendered without props"
         }
       },
       "dependencies": [
@@ -839,6 +864,11 @@
           "path": "registry/messaging/message-bubble.tsx",
           "type": "registry:block",
           "target": "components/ui/message-bubble.tsx"
+        },
+        {
+          "path": "registry/messaging/demo/messaging.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/messaging.ts"
         }
       ],
       "category": "messaging",

--- a/packages/manifest-ui/registry/form/contact-form.tsx
+++ b/packages/manifest-ui/registry/form/contact-form.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/lib/utils';
 import { ChevronDown, Paperclip, Search, Send, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { countries } from './countries';
+import { demoContactFormData } from './demo/form';
 
 /**
  * Data structure representing the contact form submission.
@@ -103,10 +104,11 @@ export interface ContactFormProps {
  * ```
  */
 export function ContactForm({ data, actions, appearance, control }: ContactFormProps) {
-  const title = data?.title
-  const subtitle = data?.subtitle
-  const submitLabel = data?.submitLabel ?? 'Submit'
-  const initialValues = data?.initialValues
+  const resolved: NonNullable<ContactFormProps['data']> = data ?? demoContactFormData
+  const title = resolved.title
+  const subtitle = resolved.subtitle
+  const submitLabel = resolved.submitLabel ?? 'Submit'
+  const initialValues = resolved.initialValues
   const { onSubmit } = actions ?? {};
   const { showTitle = true } = appearance ?? {};
   const { isLoading = false } = control ?? {};

--- a/packages/manifest-ui/registry/form/date-time-picker.tsx
+++ b/packages/manifest-ui/registry/form/date-time-picker.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/popover'
 import { ArrowLeft, ChevronLeft, ChevronRight, Globe, Search } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { demoDateTimePickerData } from './demo/form'
 
 /** Timezone configuration using IANA timezone identifiers for correct DST handling */
 const timezones = [
@@ -162,10 +163,11 @@ const isSameDay = (date1: Date, date2: Date) => {
  * ```
  */
 export function DateTimePicker({ data, actions, appearance, control }: DateTimePickerProps) {
-  const title = data?.title
-  const availableDates = data?.availableDates ?? []
-  const availableTimeSlots = data?.availableTimeSlots ?? []
-  const timezone = data?.timezone
+  const resolved: NonNullable<DateTimePickerProps['data']> = data ?? demoDateTimePickerData
+  const title = resolved.title
+  const availableDates = resolved.availableDates ?? []
+  const availableTimeSlots = resolved.availableTimeSlots ?? []
+  const timezone = resolved.timezone
   const { onNext } = actions ?? {}
   const { showTitle = true, showTimezone = true, weekStartsOn = 'sunday' } = appearance ?? {}
   const orderedDays = getOrderedDays(weekStartsOn)

--- a/packages/manifest-ui/registry/form/demo/form.ts
+++ b/packages/manifest-ui/registry/form/demo/form.ts
@@ -21,6 +21,49 @@ function generateAvailableDates(): Date[] {
   return dates;
 }
 
+export const demoContactFormData = {
+  title: 'Get in Touch',
+  subtitle: "We'd love to hear from you. Fill out the form below.",
+  submitLabel: 'Send Message',
+}
+
+export const demoIssueReportFormData = {
+  title: 'Report an Issue',
+  teams: ['Engineering', 'Product', 'Design', 'Marketing', 'Operations'],
+  locations: ['New York - HQ', 'San Francisco', 'London', 'Remote'],
+  categories: {
+    Software: ['Business App', 'Email', 'VPN', 'Browser', 'OS'],
+    Hardware: ['Computer', 'Monitor', 'Keyboard', 'Mouse', 'Printer'],
+    Network: ['Wi-Fi', 'Ethernet', 'VPN Access'],
+    Access: ['Account', 'Permissions', 'Password Reset'],
+  } as Record<string, string[]>,
+  impacts: [
+    { value: 'critical', label: 'Critical - Work stopped' },
+    { value: 'high', label: 'High - Major feature broken' },
+    { value: 'medium', label: 'Medium - Workaround available' },
+    { value: 'low', label: 'Low - Minor inconvenience' },
+  ],
+  urgencies: [
+    { value: 'immediate', label: 'Immediate' },
+    { value: 'today', label: 'Today' },
+    { value: 'this-week', label: 'This week' },
+    { value: 'no-rush', label: 'No rush' },
+  ],
+  frequencies: [
+    { value: 'constant', label: 'Constant' },
+    { value: 'frequent', label: 'Frequent' },
+    { value: 'occasional', label: 'Occasional' },
+    { value: 'once', label: 'Happened once' },
+  ],
+  attemptedActions: [
+    'Restarted the application',
+    'Cleared browser cache',
+    'Restarted computer',
+    'Checked internet connection',
+    'Contacted a colleague',
+  ],
+}
+
 export const demoDateTimePickerData = {
   title: 'Select a Date & Time',
   availableDates: generateAvailableDates(),

--- a/packages/manifest-ui/registry/form/issue-report-form.tsx
+++ b/packages/manifest-ui/registry/form/issue-report-form.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue
 } from '@/components/ui/select'
 import { cn } from '@/lib/utils'
+import { demoIssueReportFormData } from './demo/form'
 import { ChevronDown, ChevronUp, Paperclip, Send, X } from 'lucide-react'
 import { useRef, useState } from 'react'
 
@@ -139,14 +140,15 @@ export function IssueReportForm({
   actions,
   appearance
 }: IssueReportFormProps) {
-  const title = data?.title
-  const teams = data?.teams ?? []
-  const locations = data?.locations ?? []
-  const categories = data?.categories ?? {}
-  const impacts = data?.impacts ?? []
-  const urgencies = data?.urgencies ?? []
-  const frequencies = data?.frequencies ?? []
-  const attemptedActions = data?.attemptedActions ?? []
+  const resolved: NonNullable<IssueReportFormProps['data']> = data ?? demoIssueReportFormData
+  const title = resolved.title
+  const teams = resolved.teams ?? []
+  const locations = resolved.locations ?? []
+  const categories = resolved.categories ?? {}
+  const impacts = resolved.impacts ?? []
+  const urgencies = resolved.urgencies ?? []
+  const frequencies = resolved.frequencies ?? []
+  const attemptedActions = resolved.attemptedActions ?? []
   const { onSubmit } = actions ?? {}
   const { showTitle = true } = appearance ?? {}
 

--- a/packages/manifest-ui/registry/messaging/message-bubble.tsx
+++ b/packages/manifest-ui/registry/messaging/message-bubble.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
+import { demoTextMessages, demoImageMessages, demoReactionMessage, demoVoiceMessage } from './demo/messaging'
 import { Check, CheckCheck, Smile } from 'lucide-react'
 import { useRef, useState } from 'react'
 
@@ -112,10 +113,11 @@ export function MessageBubble({
   appearance,
   control
 }: MessageBubbleProps) {
-  const content = data?.content
-  const avatarFallback = data?.avatarFallback
-  const avatarUrl = data?.avatarUrl
-  const time = data?.time
+  const resolved: NonNullable<MessageBubbleProps['data']> = data ?? demoTextMessages[0]
+  const content = resolved.content
+  const avatarFallback = resolved.avatarFallback
+  const avatarUrl = resolved.avatarUrl
+  const time = resolved.time
   const { isOwn = false } = appearance ?? {}
   const { status } = control ?? {}
   return (
@@ -218,11 +220,12 @@ export function ImageMessageBubble({
   appearance,
   control
 }: ImageMessageBubbleProps) {
-  const image = data?.image
-  const content = data?.content
-  const avatarFallback = data?.avatarFallback
-  const avatarUrl = data?.avatarUrl
-  const time = data?.time
+  const resolved: NonNullable<ImageMessageBubbleProps['data']> = data ?? demoImageMessages[0]
+  const image = resolved.image
+  const content = resolved.content
+  const avatarFallback = resolved.avatarFallback
+  const avatarUrl = resolved.avatarUrl
+  const time = resolved.time
   const { isOwn = false } = appearance ?? {}
   const { status } = control ?? {}
   return (
@@ -358,11 +361,12 @@ export function MessageWithReactions({
   actions,
   appearance
 }: MessageWithReactionsProps) {
-  const content = data?.content
-  const avatarFallback = data?.avatarFallback
-  const avatarUrl = data?.avatarUrl
-  const time = data?.time
-  const initialReactions = data?.reactions ?? []
+  const resolved: NonNullable<MessageWithReactionsProps['data']> = data ?? demoReactionMessage
+  const content = resolved.content
+  const avatarFallback = resolved.avatarFallback
+  const avatarUrl = resolved.avatarUrl
+  const time = resolved.time
+  const initialReactions = resolved.reactions ?? []
   const { onReact } = actions ?? {}
   const { isOwn = false } = appearance ?? {}
   const [reactions, setReactions] = useState(initialReactions)
@@ -564,11 +568,12 @@ export function VoiceMessageBubble({
   appearance,
   control
 }: VoiceMessageBubbleProps) {
-  const duration = data?.duration
-  const avatarFallback = data?.avatarFallback
-  const avatarUrl = data?.avatarUrl
-  const time = data?.time
-  const audioSrc = data?.audioSrc
+  const resolved: NonNullable<VoiceMessageBubbleProps['data']> = data ?? demoVoiceMessage
+  const duration = resolved.duration
+  const avatarFallback = resolved.avatarFallback
+  const avatarUrl = resolved.avatarUrl
+  const time = resolved.time
+  const audioSrc = resolved.audioSrc
   const { isOwn = false } = appearance ?? {}
   const { status } = control ?? {}
   const [isPlaying, setIsPlaying] = useState(false)

--- a/packages/manifest-ui/registry/payment/amount-input.tsx
+++ b/packages/manifest-ui/registry/payment/amount-input.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useMemo } from "react"
 import { Button } from "@/components/ui/button"
 import { Minus, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { demoAmountPresets } from "./demo/payment"
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
@@ -92,7 +93,8 @@ export interface AmountInputProps {
  * ```
  */
 export function AmountInput({ data, actions, appearance, control }: AmountInputProps) {
-  const presets = data?.presets ?? []
+  const resolved: NonNullable<AmountInputProps['data']> = data ?? { presets: demoAmountPresets }
+  const presets = resolved.presets ?? []
   const onConfirm = actions?.onConfirm
   const min = appearance?.min ?? 0
   const max = appearance?.max ?? 10000


### PR DESCRIPTION
## Description

Applies the `data ?? demoData` initialization pattern to components that were still missing it, ensuring they render meaningful content when called without arguments (`<Component />`). This is required for MCP Jam previews and zero-config usage.

**Components updated:**
- `contact-form`, `date-time-picker`, `issue-report-form` (form category)
- `message-bubble`, `ImageMessageBubble`, `MessageWithReactions`, `VoiceMessageBubble` (messaging category)
- `amount-input` (payment category)

**Other changes:**
- Created centralized demo data file `registry/form/demo/form.ts`
- Removed explicit data props from `preview-components.tsx` for self-initializing components
- Updated `registry.json` with version bumps and demo file references
- Added changelog entries for all bumped components
- Added new test `component-init-demo-data.test.ts` that enforces the pattern across all registered blocks with a `data?` prop

## Related Issues

None

## How can it be tested?

1. Run `pnpm install && pnpm run dev` in `packages/manifest-ui/`
2. Visit each updated component's block page and verify it renders with demo data when no props are passed
3. Run `pnpm test` — all 1295 tests pass (17 test files), including the new `component-init-demo-data.test.ts`
4. Run `pnpm lint` — no errors

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR