### PR TITLE
Enforce component naming convention: rename Stats to StatCard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,28 @@ Always check that staged files do not include:
 - Any `settings.local.json` files
 - Claude settings or command files (unless they are speckit-related)
 
+## Component Naming Convention (CRITICAL)
+
+**All component names MUST be consistent across registry name, display title, and React export.**
+
+The relationship between the three names must follow this deterministic mapping:
+
+| Layer | Format | Example |
+|-------|--------|---------|
+| Registry `name` in `registry.json` | kebab-case | `stat-card` |
+| Display `title` in `registry.json` | Title Case | `Stat Card` |
+| React component export | PascalCase of registry name | `StatCard` |
+| Props interface export | PascalCase + `Props` | `StatCardProps` |
+
+**The React component name MUST be the PascalCase version of the registry `name`.** No abbreviations, no synonyms, no creative alternatives.
+
+**Known exceptions** for brand-specific casing (tracked in `NAMING_VARIATIONS` in tests):
+- `linkedin-post` → `LinkedInPost` (brand casing)
+- `youtube-post` → `YouTubePost` (brand casing)
+- `x-post` → `XPost` (single-letter brand)
+
+When creating a new component, verify: registry name → PascalCase → component export → props interface all align.
+
 ## Block Development Guidelines
 
 **CRITICAL**: When adding or editing a block, you MUST update ALL related code across the codebase.

--- a/packages/manifest-ui/CLAUDE.md
+++ b/packages/manifest-ui/CLAUDE.md
@@ -58,6 +58,63 @@ Uses shadcn style with:
 4. Run `pnpm run registry:build` to generate the distributable JSON
 5. Import in `app/page.tsx` to preview
 
+## Component Naming Convention (CRITICAL)
+
+**All component names MUST be consistent across registry name, display title, and React export.** This is enforced by tests (`__tests__/component-exports.test.ts`).
+
+### The Rule
+
+The relationship between the three names must follow this deterministic mapping:
+
+| Layer | Format | Example |
+|-------|--------|---------|
+| Registry `name` | kebab-case | `stat-card` |
+| Display `title` | Title Case | `Stat Card` |
+| React component export | PascalCase | `StatCard` |
+| Props interface export | PascalCase + `Props` | `StatCardProps` |
+
+**The React component name MUST be the PascalCase version of the registry `name`.** No abbreviations, no synonyms, no creative alternatives.
+
+### Known Exceptions
+
+Some components have brand-specific casing that cannot follow simple kebab-to-PascalCase conversion. These are tracked in the `NAMING_VARIATIONS` map in `__tests__/component-exports.test.ts`:
+
+| Registry Name | Component Export | Reason |
+|---|---|---|
+| `linkedin-post` | `LinkedInPost` | Brand name "LinkedIn" has internal capital |
+| `youtube-post` | `YouTubePost` | Brand name "YouTube" has internal capital |
+| `x-post` | `XPost` | Single-letter brand name |
+
+### Examples
+
+```typescript
+// ✅ CORRECT - Registry name "contact-form" → component "ContactForm"
+export interface ContactFormProps { ... }
+export function ContactForm(props: ContactFormProps) { ... }
+
+// ✅ CORRECT - Registry name "map-carousel" → component "MapCarousel"
+export interface MapCarouselProps { ... }
+export function MapCarousel(props: MapCarouselProps) { ... }
+
+// ❌ WRONG - Registry name "stat-card" but component "Stats" (inconsistent)
+export interface StatsProps { ... }
+export function Stats(props: StatsProps) { ... }
+
+// ✅ FIXED - Registry name "stat-card" → component "StatCard"
+export interface StatCardProps { ... }
+export function StatCard(props: StatCardProps) { ... }
+```
+
+### Checklist for New Components
+
+Before creating a component:
+
+1. Choose the kebab-case registry name (e.g., `my-component`)
+2. The display title is the Title Case version (e.g., `My Component`)
+3. The component export MUST be the PascalCase version (e.g., `MyComponent`)
+4. The props interface MUST be `{ComponentName}Props` (e.g., `MyComponentProps`)
+5. If the name contains a brand with non-standard casing, add it to `NAMING_VARIATIONS`
+
 ## Component Props Interface Convention
 
 **IMPORTANT**: All registry block components MUST follow this Props interface naming and documentation convention. Tests enforce these rules (`__tests__/props-jsdoc.test.ts`, `__tests__/component-exports.test.ts`).

--- a/packages/manifest-ui/__tests__/component-exports.test.ts
+++ b/packages/manifest-ui/__tests__/component-exports.test.ts
@@ -46,7 +46,6 @@ const NAMING_VARIATIONS: Record<string, string> = {
   'linkedin-post': 'LinkedInPost',
   'youtube-post': 'YouTubePost',
   'x-post': 'XPost',
-  'stat-card': 'Stats',
 }
 
 /**

--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -101,7 +101,7 @@ import { demoProgressSteps } from '@/registry/status/demo/status';
 
 // Miscellaneous components
 import { Hero } from '@/registry/miscellaneous/hero';
-import { Stats } from '@/registry/miscellaneous/stat-card';
+import { StatCard } from '@/registry/miscellaneous/stat-card';
 import {
   demoStats,
   demoHeroDefault,
@@ -2134,8 +2134,8 @@ const categories: Category[] = [
           {
             id: 'default',
             name: 'Default',
-            component: <Stats data={{ stats: demoStats }} />,
-            usageCode: `<Stats
+            component: <StatCard data={{ stats: demoStats }} />,
+            usageCode: `<StatCard
   data={{
     stats: [
       { label: "Sales", value: "$12,543", change: 12.5, trend: "up" },

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -171,7 +171,8 @@
       "1.0.4": "Fixed defensive property access to handle empty objects and null values",
       "1.0.5": "Additional defensive property access improvements",
       "1.0.6": "Removed default content data - component only renders explicitly provided data",
-      "1.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
+      "1.1.0": "Added demo data defaults - component renders demo content when no data prop is provided",
+      "2.0.0": "BREAKING: Renamed component export from Stats to StatCard and StatsProps to StatCardProps for naming consistency"
     },
     "post-card": {
       "1.0.0": "Initial release with default, compact, horizontal and covered variants",

--- a/packages/manifest-ui/lib/preview-components.tsx
+++ b/packages/manifest-ui/lib/preview-components.tsx
@@ -53,7 +53,7 @@ import {
 
 // Miscellaneous components
 import { Hero } from '@/registry/miscellaneous/hero';
-import { Stats } from '@/registry/miscellaneous/stat-card';
+import { StatCard } from '@/registry/miscellaneous/stat-card';
 import {
   demoStats,
   demoHeroDefault,
@@ -189,7 +189,7 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
 
   // Miscellaneous components
   'stat-card': {
-    component: <Stats data={{ stats: demoStats }} />,
+    component: <StatCard data={{ stats: demoStats }} />,
     category: 'miscellaneous',
   },
   'hero': {

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -537,7 +537,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/stat-card.png",
-        "version": "1.1.0",
+        "version": "2.0.0",
         "changelog": {
           "1.0.0": "Initial release with scrollable stat cards and trends",
           "1.0.2": "Added comprehensive JSDoc documentation",
@@ -545,7 +545,8 @@
           "1.0.4": "Fixed defensive property access to handle empty objects and null values",
           "1.0.5": "Additional defensive property access improvements",
           "1.0.6": "Removed default content data - component only renders explicitly provided data",
-          "1.1.0": "Added demo data defaults - component renders demo content when no data prop is provided"
+          "1.1.0": "Added demo data defaults - component renders demo content when no data prop is provided",
+          "2.0.0": "BREAKING: Renamed component export from Stats to StatCard and StatsProps to StatCardProps for naming consistency"
         }
       },
       "dependencies": [

--- a/packages/manifest-ui/registry/miscellaneous/stat-card.tsx
+++ b/packages/manifest-ui/registry/miscellaneous/stat-card.tsx
@@ -25,13 +25,13 @@ export interface StatCard {
 
 /**
  * ═══════════════════════════════════════════════════════════════════════════
- * StatsProps
+ * StatCardProps
  * ═══════════════════════════════════════════════════════════════════════════
  *
- * Props for the Stats component, which displays a grid of statistic cards
+ * Props for the StatCard component, which displays a grid of statistic cards
  * with values, trend indicators, and optional icons.
  */
-export interface StatsProps {
+export interface StatCardProps {
   data?: {
     /** Array of stat cards to display in the grid. */
     stats?: StatCard[]
@@ -53,7 +53,7 @@ export interface StatsProps {
  * @component
  * @example
  * ```tsx
- * <Stats
+ * <StatCard
  *   data={{
  *     stats: [
  *       { label: "Revenue", value: "$12,543", change: 12.5, trend: "up" },
@@ -64,8 +64,8 @@ export interface StatsProps {
  * />
  * ```
  */
-export function Stats({ data }: StatsProps) {
-  const resolved: NonNullable<StatsProps['data']> = data ?? { stats: demoStats }
+export function StatCard({ data }: StatCardProps) {
+  const resolved: NonNullable<StatCardProps['data']> = data ?? { stats: demoStats }
   const stats = resolved.stats ?? []
   const getTrendIcon = (trend?: "up" | "down" | "neutral") => {
     switch (trend) {


### PR DESCRIPTION
## Summary

This PR enforces the component naming convention by renaming the `Stats` component to `StatCard` to match its registry name. The component export name must be the PascalCase version of the kebab-case registry name (`stat-card` → `StatCard`), with no exceptions or creative alternatives.

## Changes

- **Documentation**: Added comprehensive "Component Naming Convention (CRITICAL)" section to both root `CLAUDE.md` and `packages/manifest-ui/CLAUDE.md` with:
  - Deterministic mapping table (registry name → display title → React export → props interface)
  - Known exceptions for brand-specific casing (LinkedIn, YouTube, X)
  - Checklist for creating new components
  - Code examples of correct and incorrect naming

- **Component Rename**: 
  - Renamed `Stats` component export to `StatCard` in `registry/miscellaneous/stat-card.tsx`
  - Renamed `StatsProps` interface to `StatCardProps`
  - Updated all JSDoc comments to reference `StatCard`
  - Updated component usage in `app/blocks/[category]/[block]/page.tsx`
  - Updated component usage in `lib/preview-components.tsx`

- **Test Updates**:
  - Removed `'stat-card': 'Stats'` from `NAMING_VARIATIONS` in `__tests__/component-exports.test.ts` (no longer an exception)

- **Version & Changelog**:
  - Bumped `stat-card` version from `1.1.0` to `2.0.0` in `registry.json`
  - Added breaking change entry to changelog: "BREAKING: Renamed component export from Stats to StatCard and StatsProps to StatCardProps for naming consistency"
  - Updated `changelog.json` with same breaking change note

## Type of Change

- [x] Breaking change (component export renamed from `Stats` to `StatCard`)
- [x] Refactoring (enforcing naming consistency)
- [x] Documentation update (added naming convention guidelines)

## Testing

- [x] Tests pass locally (`pnpm test`) - component-exports test now passes with corrected naming
- [x] Lint passes (`pnpm lint`)
- All imports and usages updated to use new `StatCard` name

## Related Issues

Enforces the critical component naming convention documented in CLAUDE.md to prevent future naming inconsistencies.

https://claude.ai/code/session_01KLitoSKhxcxieNaNWd5njf