### PR TITLE
fix(manifest-ui): fix TypeScript errors when installing registry components

### DIFF
--- a/packages/manifest-ui/__tests__/shared-types-coverage.test.ts
+++ b/packages/manifest-ui/__tests__/shared-types-coverage.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Shared Types Coverage Test
+ *
+ * Validates that every named import from './types' or '../types' in registry
+ * files actually exists as an export in registry/shared-types.ts.
+ *
+ * This prevents the scenario where a component imports a type that exists in
+ * a local types.ts file but is missing from the shared types file that gets
+ * installed as components/ui/types.ts via the manifest-types registry item.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { join, resolve, relative } from 'path'
+import { describe, it, expect } from 'vitest'
+
+const ROOT_PATH = resolve(__dirname, '..')
+const REGISTRY_PATH = resolve(ROOT_PATH, 'registry')
+const SHARED_TYPES_PATH = resolve(REGISTRY_PATH, 'shared-types.ts')
+
+/**
+ * Get all exported names from shared-types.ts
+ */
+function getSharedTypeExports(): Set<string> {
+  const content = readFileSync(SHARED_TYPES_PATH, 'utf-8')
+  const exports = new Set<string>()
+
+  // Match: export interface Name
+  // Match: export type Name
+  // Match: export enum Name
+  // Match: export const Name
+  // Match: export function Name
+  const exportRegex = /^export\s+(?:interface|type|enum|const|function)\s+(\w+)/gm
+  let match: RegExpExecArray | null
+  while ((match = exportRegex.exec(content)) !== null) {
+    exports.add(match[1])
+  }
+
+  return exports
+}
+
+/**
+ * Extract named imports from types paths in a file
+ */
+function extractTypesImports(
+  filePath: string
+): { names: string[]; line: number; importPath: string }[] {
+  const content = readFileSync(filePath, 'utf-8')
+  const lines = content.split('\n')
+  const results: { names: string[]; line: number; importPath: string }[] = []
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    // Match imports from ./types or ../types (with optional type keyword)
+    const match = line.match(
+      /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"](\.\.\?\/types|\.\/types)['"]/
+    )
+    if (!match) continue
+
+    const namesStr = match[1]
+    const importPath = match[2]
+    const names = namesStr
+      .split(',')
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0)
+      // Handle `type X` inside import { type X, Y }
+      .map((n) => n.replace(/^type\s+/, ''))
+
+    results.push({ names, line: i + 1, importPath })
+  }
+
+  return results
+}
+
+/**
+ * Get all .ts/.tsx files recursively in a directory
+ */
+function getAllFiles(dir: string): string[] {
+  const files: string[] = []
+  const entries = readdirSync(dir)
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry)
+    const stat = statSync(fullPath)
+
+    if (stat.isDirectory()) {
+      files.push(...getAllFiles(fullPath))
+    } else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+describe('Shared Types Coverage', () => {
+  const sharedExports = getSharedTypeExports()
+  const allFiles = getAllFiles(REGISTRY_PATH).filter(
+    (f) => !f.endsWith('shared-types.ts')
+  )
+
+  it('should have exports in shared-types.ts', () => {
+    expect(sharedExports.size).toBeGreaterThan(0)
+  })
+
+  for (const absPath of allFiles) {
+    const relPath = relative(ROOT_PATH, absPath)
+    const imports = extractTypesImports(absPath)
+
+    if (imports.length === 0) continue
+
+    it(`${relPath} — all types imports exist in shared-types.ts`, () => {
+      const errors: string[] = []
+
+      for (const imp of imports) {
+        for (const name of imp.names) {
+          if (!sharedExports.has(name)) {
+            errors.push(
+              `"${name}" is imported from '${imp.importPath}' at line ${imp.line} but is not exported from shared-types.ts`
+            )
+          }
+        }
+      }
+
+      if (errors.length > 0) {
+        throw new Error(
+          `File "${relPath}" imports types not found in shared-types.ts:\n\n` +
+            errors.map((e) => `  ${e}`).join('\n') +
+            '\n\n' +
+            'When a component is installed via shadcn CLI, imports from ./types or ../types\n' +
+            'resolve to components/ui/types.ts (shared-types.ts). Every named import must\n' +
+            'be exported from registry/shared-types.ts.'
+        )
+      }
+
+      expect(errors).toHaveLength(0)
+    })
+  }
+})

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -433,7 +433,12 @@
       "2.1.1": "Reduced logo image height for better visual balance",
       "2.1.2": "Removed default content data - component only renders explicitly provided data",
       "2.1.3": "Replaced key={index} with stable content-based keys for tech logos",
-      "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
+      "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided",
+      "2.2.1": "Fixed import type for verbatimModuleSyntax compatibility"
+    },
+    "manifest-types": {
+      "1.0.0": "Initial shared type definitions for Manifest UI components",
+      "1.0.1": "Added missing OrderItem export for payment components"
     }
   }
 }

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -361,7 +361,8 @@
         "lucide-react"
       ],
       "registryDependencies": [
-        "button"
+        "button",
+        "https://ui.manifest.build/r/manifest-types.json"
       ],
       "files": [
         {
@@ -1441,7 +1442,7 @@
       ],
       "meta": {
         "preview": "https://ui.manifest.build/previews/hero.png",
-        "version": "2.2.0",
+        "version": "2.2.1",
         "changelog": {
           "1.0.0": "Initial release with logos, title, subtitle, CTA buttons, and tech logos footer",
           "1.1.0": "Added card wrapper, text logo support, improved light/dark mode compatibility",
@@ -1451,7 +1452,8 @@
           "2.1.1": "Reduced logo image height for better visual balance",
           "2.1.2": "Removed default content data - component only renders explicitly provided data",
           "2.1.3": "Replaced key={index} with stable content-based keys for tech logos",
-          "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
+          "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided",
+          "2.2.1": "Fixed import type for verbatimModuleSyntax compatibility"
         }
       },
       "dependencies": [

--- a/packages/manifest-ui/registry/miscellaneous/hero.tsx
+++ b/packages/manifest-ui/registry/miscellaneous/hero.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { demoHeroDefault } from './demo/miscellaneous';
 
 /**

--- a/packages/manifest-ui/registry/shared-types.ts
+++ b/packages/manifest-ui/registry/shared-types.ts
@@ -311,3 +311,19 @@ export interface EventDetails extends Omit<Event, 'dateTime'> {
   relatedEvents?: Event[]
   relatedTags?: string[] // "Los Angeles Events", "California Nightlife"
 }
+
+// ---------------------------------------------------------------------------
+// Payment
+// ---------------------------------------------------------------------------
+
+/**
+ * Represents an item in an order.
+ * @interface OrderItem
+ */
+export interface OrderItem {
+  id: string
+  name?: string
+  quantity?: number
+  price?: number
+  image?: string
+}


### PR DESCRIPTION
## Description

Fixes two TypeScript errors that occur when components are installed into a real project via `shadcn add`:

1. **Missing `OrderItem` type** — `demo/payment.ts` imports `OrderItem` from `../types`, which resolves to `components/ui/types.ts` (shared-types.ts) at install time. The type was missing from shared-types.ts.
2. **Non-type-only `ReactNode` import** — `hero.tsx` uses `import { ReactNode }` which breaks under `verbatimModuleSyntax`.

Also adds `manifest-types` to `amount-input`'s `registryDependencies` (was missing — its demo file imports from `../types`), and introduces a new test to prevent this class of bug from recurring.

## Related Issues

None

## How can it be tested?

1. Run `pnpm test` in `packages/manifest-ui/` — all 1308 tests pass
2. Run `pnpm lint` in `packages/manifest-ui/` — 0 errors
3. Run `pnpm run registry:build` — builds successfully
4. Install `amount-input` or `order-confirm` via `shadcn add` into a project with `verbatimModuleSyntax` enabled — no TS errors

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR