### PR TITLE
feat(manifest-ui): add chart-block component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -848,3 +848,10 @@ SEO requirements are enforced by tests in `__tests__/seo.test.ts`. Run `pnpm tes
 - Always include descriptive `alt` attributes
 - Use Next.js `Image` component when possible for optimization
 - Keep OG images under 100KB
+
+## Active Technologies
+- TypeScript 5.x, React 19, Next.js 15 + Recharts (new), shadcn/ui chart primitives (new), lucide-react (existing) (001-chart-component)
+- N/A (client-side component only) (001-chart-component)
+
+## Recent Changes
+- 001-chart-component: Added TypeScript 5.x, React 19, Next.js 15 + Recharts (new), shadcn/ui chart primitives (new), lucide-react (existing)

--- a/packages/manifest-ui/__tests__/component-exports.test.ts
+++ b/packages/manifest-ui/__tests__/component-exports.test.ts
@@ -47,6 +47,7 @@ const NAMING_VARIATIONS: Record<string, string> = {
   'youtube-post': 'YouTubePost',
   'x-post': 'XPost',
   'stat-card': 'Stats',
+  'chart-block': 'Chart',
 }
 
 /**

--- a/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
+++ b/packages/manifest-ui/app/blocks/[category]/[block]/page.tsx
@@ -90,6 +90,15 @@ import {
   demoYouTubePost,
 } from '@/registry/social/demo/social';
 
+// Charts components
+import { Chart } from '@/registry/charts/chart';
+import {
+  demoAreaChart,
+  demoBarChart,
+  demoLineChart,
+  demoPieChart,
+} from '@/registry/charts/demo/charts';
+
 // Map components
 import { MapCarousel } from '@/registry/map/map-carousel';
 import { demoMapLocations, demoMapCenter, demoMapZoom } from '@/registry/map/demo/map';
@@ -1065,6 +1074,163 @@ const categories: Category[] = [
             },
           ];
         })(),
+      },
+    ],
+  },
+  {
+    id: 'charts',
+    name: 'Charts',
+    blocks: [
+      {
+        id: 'chart-block',
+        name: 'Chart',
+        description:
+          'Data visualization chart component supporting area, bar, line, pie, radar, and radial chart types.',
+        registryName: 'chart-block',
+        layouts: ['inline', 'fullscreen', 'pip'],
+        actionCount: 0,
+        variants: [
+          {
+            id: 'single-chart',
+            name: 'Single Chart',
+            component: <Chart data={{ charts: [demoAreaChart] }} />,
+            usageCode: `<Chart
+  data={{
+    charts: [
+      {
+        title: "Monthly Revenue",
+        bigNumber: "$45,231",
+        description: "Total revenue over the last 6 months",
+        type: "area",
+        dataKey: "month",
+        data: [
+          { month: "Jan", revenue: 4000 },
+          { month: "Feb", revenue: 3000 },
+          { month: "Mar", revenue: 5000 },
+          { month: "Apr", revenue: 4500 },
+          { month: "May", revenue: 6000 },
+          { month: "Jun", revenue: 5500 }
+        ],
+        config: {
+          revenue: { label: "Revenue", color: "#ec4899" }
+        }
+      }
+    ]
+  }}
+/>`,
+          },
+          {
+            id: 'multiple-charts',
+            name: 'Multiple Charts',
+            component: (
+              <Chart data={{ charts: [demoAreaChart, demoBarChart, demoPieChart] }} />
+            ),
+            fullscreenComponent: (
+              <Chart
+                data={{ charts: [demoAreaChart, demoBarChart, demoPieChart] }}
+                appearance={{ displayMode: 'fullscreen' }}
+              />
+            ),
+            usageCode: `<Chart
+  data={{
+    charts: [
+      {
+        title: "Monthly Revenue",
+        bigNumber: "$45,231",
+        description: "Total revenue over the last 6 months",
+        type: "area",
+        dataKey: "month",
+        data: [
+          { month: "Jan", revenue: 4000 },
+          { month: "Feb", revenue: 3000 },
+          { month: "Mar", revenue: 5000 },
+          { month: "Apr", revenue: 4500 },
+          { month: "May", revenue: 6000 },
+          { month: "Jun", revenue: 5500 }
+        ],
+        config: {
+          revenue: { label: "Revenue", color: "#ec4899" }
+        }
+      },
+      {
+        title: "Browser Usage",
+        bigNumber: "1,247",
+        description: "Visitor count by browser this month",
+        type: "bar",
+        dataKey: "browser",
+        data: [
+          { browser: "Chrome", visitors: 275 },
+          { browser: "Safari", visitors: 200 },
+          { browser: "Firefox", visitors: 187 },
+          { browser: "Edge", visitors: 173 }
+        ],
+        config: {
+          visitors: { label: "Visitors", color: "#a855f7" }
+        }
+      },
+      {
+        title: "Market Share",
+        description: "Distribution by product category",
+        type: "pie",
+        dataKey: "category",
+        data: [
+          { category: "Electronics", sales: 450 },
+          { category: "Clothing", sales: 300 },
+          { category: "Food", sales: 250 },
+          { category: "Books", sales: 150 }
+        ],
+        config: {
+          electronics: { label: "Electronics", color: "#ec4899" },
+          clothing: { label: "Clothing", color: "#a855f7" },
+          food: { label: "Food", color: "#06b6d4" },
+          books: { label: "Books", color: "#10b981" }
+        }
+      }
+    ]
+  }}
+/>`,
+          },
+          {
+            id: 'multi-series',
+            name: 'Multi-Series',
+            component: (
+              <Chart
+                data={{
+                  charts: [
+                    { ...demoLineChart, showLegend: true, stacked: false },
+                  ],
+                }}
+              />
+            ),
+            usageCode: `<Chart
+  data={{
+    charts: [
+      {
+        title: "Page Views",
+        bigNumber: "12,540",
+        description: "Desktop vs mobile traffic",
+        type: "line",
+        dataKey: "month",
+        data: [
+          { month: "Jan", desktop: 186, mobile: 80 },
+          { month: "Feb", desktop: 305, mobile: 200 },
+          { month: "Mar", desktop: 237, mobile: 120 },
+          { month: "Apr", desktop: 273, mobile: 190 },
+          { month: "May", desktop: 209, mobile: 130 },
+          { month: "Jun", desktop: 314, mobile: 140 }
+        ],
+        config: {
+          desktop: { label: "Desktop", color: "#ec4899" },
+          mobile: { label: "Mobile", color: "#06b6d4" }
+        },
+        showLegend: true,
+        stacked: false
+      }
+    ]
+  }}
+/>`,
+          },
+        ],
       },
     ],
   },

--- a/packages/manifest-ui/changelog.json
+++ b/packages/manifest-ui/changelog.json
@@ -429,6 +429,9 @@
       "2.1.2": "Removed default content data - component only renders explicitly provided data",
       "2.1.3": "Replaced key={index} with stable content-based keys for tech logos",
       "2.2.0": "Added demo data defaults - component renders demo content when no data prop is provided"
+    },
+    "chart-block": {
+      "1.0.0": "Initial release with area, bar, line, pie, radar, and radial chart types"
     }
   }
 }

--- a/packages/manifest-ui/components/ui/card.tsx
+++ b/packages/manifest-ui/components/ui/card.tsx
@@ -2,83 +2,91 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-/*
- * Card Component - ChatGPT UI Guidelines Compliant
- * - Consistent 8px border radius (rounded-lg)
- * - No nested scrolling - cards auto-fit content
- * - System grid spacing for cards, collections
- * - Maintain visual hierarchy: headline, supporting text, CTA
- */
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground",
-      className
-    )}
-    {...props}
-  />
-))
-Card.displayName = "Card"
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-4", className)}
-    {...props}
-  />
-))
-CardHeader.displayName = "CardHeader"
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
 
-const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("font-semibold leading-tight", className)}
-    {...props}
-  />
-))
-CardTitle.displayName = "CardTitle"
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
 
-const CardDescription = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-CardDescription.displayName = "CardDescription"
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-4 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-4 pt-0", className)}
-    {...props}
-  />
-))
-CardFooter.displayName = "CardFooter"
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/packages/manifest-ui/components/ui/chart.tsx
+++ b/packages/manifest-ui/components/ui/chart.tsx
@@ -1,0 +1,379 @@
+"use client"
+
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"]
+}) {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+  const containerRef = React.useRef<HTMLDivElement>(null)
+  const [size, setSize] = React.useState({ width: 0, height: 0 })
+
+  React.useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+
+    const measure = () => {
+      setSize({ width: el.clientWidth, height: el.clientHeight })
+    }
+    measure()
+
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        ref={containerRef}
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        {size.width > 0 && size.height > 0 && (
+          React.isValidElement(children)
+            ? React.cloneElement(children as React.ReactElement<{ width?: number; height?: number }>, {
+                width: size.width,
+                height: size.height,
+              })
+            : children
+        )}
+      </div>
+    </ChartContext.Provider>
+  )
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean
+    hideIndicator?: boolean
+    indicator?: "line" | "dot" | "dashed"
+    nameKey?: string
+    labelKey?: string
+  }) {
+  const { config } = useChart()
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null
+    }
+
+    const [item] = payload
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`
+    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      )
+    }
+
+    if (!value) {
+      return null
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ])
+
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot"
+
+  return (
+    <div
+      className={cn(
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color || item.payload.fill || item.color
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="text-foreground font-mono font-medium tabular-nums">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+      </div>
+    </div>
+  )
+}
+
+const ChartLegend = RechartsPrimitive.Legend
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> &
+  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    hideIcon?: boolean
+    nameKey?: string
+  }) {
+  const { config } = useChart()
+
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload
+        .filter((item) => item.type !== "none")
+        .map((item) => {
+          const key = `${nameKey || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/packages/manifest-ui/lib/blocks-categories.ts
+++ b/packages/manifest-ui/lib/blocks-categories.ts
@@ -11,6 +11,7 @@ export interface BlockCategory {
 // Map category IDs to display names
 const categoryDisplayNames: Record<string, string> = {
   blogging: 'Blogging',
+  charts: 'Charts',
   events: 'Events',
   form: 'Forms',
   list: 'Lists & Tables',
@@ -26,6 +27,7 @@ const categoryDisplayNames: Record<string, string> = {
 // Define the order of categories in the sidebar
 const categoryOrder = [
   'blogging',
+  'charts',
   'events',
   'form',
   'list',

--- a/packages/manifest-ui/lib/preview-backgrounds.ts
+++ b/packages/manifest-ui/lib/preview-backgrounds.ts
@@ -49,6 +49,10 @@ export const categoryBackgrounds: Record<string, PreviewBackground> = {
     gradient: 'linear-gradient(135deg, #1DA1F2 0%, #0D8BD9 100%)',
     className: 'from-sky-500 to-sky-600'
   },
+  charts: {
+    gradient: 'linear-gradient(135deg, #6366F1 0%, #8B5CF6 100%)',
+    className: 'from-indigo-500 to-violet-500'
+  },
   map: {
     gradient: 'linear-gradient(135deg, #059669 0%, #047857 100%)',
     className: 'from-emerald-600 to-emerald-700'

--- a/packages/manifest-ui/lib/preview-components.tsx
+++ b/packages/manifest-ui/lib/preview-components.tsx
@@ -94,6 +94,10 @@ import { ChatConversation } from '@/registry/messaging/chat-conversation';
 import { MessageBubble } from '@/registry/messaging/message-bubble';
 import { demoMessages } from '@/registry/messaging/demo/messaging';
 
+// Charts components
+import { Chart } from '@/registry/charts/chart';
+import { demoCharts } from '@/registry/charts/demo/charts';
+
 // Events components
 import { EventCard } from '@/registry/events/event-card';
 import { EventConfirmation } from '@/registry/events/event-confirmation';
@@ -256,6 +260,12 @@ export const previewComponents: Record<string, PreviewComponentConfig> = {
   'chat-conversation': {
     component: <ChatConversation data={{ messages: demoMessages }} />,
     category: 'messaging',
+  },
+
+  // Charts components
+  'chart-block': {
+    component: <Chart data={{ charts: demoCharts.slice(0, 3) }} />,
+    category: 'charts',
   },
 
   // Events components

--- a/packages/manifest-ui/package.json
+++ b/packages/manifest-ui/package.json
@@ -34,6 +34,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-leaflet": "^5.0.0",
+    "recharts": "2.15.4",
     "shadcn": "^3.0.0",
     "shiki": "^3.19.0",
     "simplex-noise": "^4.0.3",

--- a/packages/manifest-ui/registry.json
+++ b/packages/manifest-ui/registry.json
@@ -1498,6 +1498,46 @@
         }
       ],
       "category": "lib"
+    },
+    {
+      "name": "chart-block",
+      "type": "registry:block",
+      "title": "Chart",
+      "description": "A read-only data visualization component that renders one or more chart cards with support for area, bar, line, pie, radar, and radial chart types.",
+      "author": "MNFST, Inc",
+      "categories": [
+        "charts"
+      ],
+      "meta": {
+        "preview": "https://ui.manifest.build/previews/chart-block.png",
+        "version": "1.0.0",
+        "changelog": {
+          "1.0.0": "Initial release with area, bar, line, pie, radar, and radial chart types"
+        }
+      },
+      "dependencies": [
+        "recharts",
+        "lucide-react"
+      ],
+      "registryDependencies": [
+        "card",
+        "chart",
+        "manifest-types"
+      ],
+      "files": [
+        {
+          "path": "registry/charts/chart.tsx",
+          "type": "registry:block",
+          "target": "components/ui/chart-block.tsx"
+        },
+        {
+          "path": "registry/charts/demo/charts.ts",
+          "type": "registry:lib",
+          "target": "components/ui/demo/charts.ts"
+        }
+      ],
+      "category": "charts",
+      "preview": "https://ui.manifest.build/previews/chart-block.png"
     }
   ]
 }

--- a/packages/manifest-ui/registry/charts/chart.tsx
+++ b/packages/manifest-ui/registry/charts/chart.tsx
@@ -1,0 +1,330 @@
+'use client'
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  PolarAngleAxis,
+  PolarGrid,
+  Radar,
+  RadarChart,
+  RadialBar,
+  RadialBarChart,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig as ShadcnChartConfig,
+} from '@/components/ui/chart'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Loader2 } from 'lucide-react'
+import type { ChartDefinition } from './types'
+import { demoCharts } from './demo/charts'
+/**
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ChartProps
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * Props for the Chart component.
+ * A read-only data visualization component that renders one or more chart
+ * cards. Each chart definition produces a full-width card with a title,
+ * optional description, optional big number, and the chart visualization.
+ */
+export interface ChartProps {
+  data?: {
+    /** Array of chart definitions. Each entry renders a separate card. */
+    charts?: ChartDefinition[]
+  }
+  appearance?: {
+    /**
+     * Display mode for the component.
+     * @default "inline"
+     */
+    displayMode?: 'inline' | 'pip' | 'fullscreen'
+  }
+  control?: {
+    /**
+     * Whether the component is in loading state.
+     * @default false
+     */
+    loading?: boolean
+  }
+}
+
+function toShadcnConfig(config?: ChartDefinition['config']): ShadcnChartConfig {
+  if (!config) return {}
+  const result: ShadcnChartConfig = {}
+  for (const [key, entry] of Object.entries(config)) {
+    result[key] = { label: entry.label ?? key, color: entry.color ?? '' }
+  }
+  return result
+}
+
+function ChartCardHeader({ chart }: { chart: ChartDefinition }) {
+  return (
+    <CardHeader className="pb-2">
+      <div className="flex items-center justify-between">
+        {chart.title && (
+          <h3 className="text-sm font-medium leading-none tracking-tight">
+            {chart.title}
+          </h3>
+        )}
+        {chart.bigNumber && (
+          <span className="text-2xl font-bold tabular-nums">
+            {chart.bigNumber}
+          </span>
+        )}
+      </div>
+      {chart.description && (
+        <p className="text-xs text-muted-foreground">{chart.description}</p>
+      )}
+    </CardHeader>
+  )
+}
+
+interface ChartDimensions {
+  width?: number
+  height?: number
+}
+
+function CartesianChartContent({ chart, width, height }: { chart: ChartDefinition } & ChartDimensions) {
+  const configKeys = Object.keys(chart.config ?? {})
+  const showGrid = chart.showGrid !== false
+  const showXAxis = chart.showXAxis !== false
+  const showYAxis = chart.showYAxis !== false
+  const type = chart.type ?? 'line'
+
+  const sharedProps = {
+    data: chart.data,
+    accessibilityLayer: true,
+    ...(width ? { width } : {}),
+    ...(height ? { height } : {}),
+  }
+
+  const renderSeries = () =>
+    configKeys.map((key) => {
+      const stackId = chart.stacked ? 'stack' : undefined
+      const color = `var(--color-${key})`
+
+      if (type === 'area') {
+        return (
+          <Area
+            key={key}
+            dataKey={key}
+            type="natural"
+            fill={color}
+            fillOpacity={0.4}
+            stroke={color}
+            stackId={stackId}
+          />
+        )
+      }
+      if (type === 'bar') {
+        return (
+          <Bar
+            key={key}
+            dataKey={key}
+            fill={color}
+            radius={[4, 4, 0, 0]}
+            stackId={stackId}
+          />
+        )
+      }
+      return (
+        <Line
+          key={key}
+          dataKey={key}
+          type="natural"
+          stroke={color}
+          strokeWidth={2}
+          dot={false}
+        />
+      )
+    })
+
+  const ChartComponent =
+    type === 'area' ? AreaChart : type === 'bar' ? BarChart : LineChart
+
+  return (
+    <ChartComponent {...sharedProps}>
+      {showGrid && <CartesianGrid vertical={false} />}
+      {showXAxis && (
+        <XAxis
+          dataKey={chart.dataKey}
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+        />
+      )}
+      {showYAxis && (
+        <YAxis tickLine={false} axisLine={false} tickMargin={8} />
+      )}
+      {chart.showTooltip !== false && (
+        <ChartTooltip content={<ChartTooltipContent />} />
+      )}
+      {chart.showLegend && (
+        <ChartLegend content={<ChartLegendContent />} />
+      )}
+      {renderSeries()}
+    </ChartComponent>
+  )
+}
+
+function PieChartContent({ chart, width, height }: { chart: ChartDefinition } & ChartDimensions) {
+  const nameKey = chart.dataKey ?? 'name'
+
+  // Find the numeric value field (not the category/name field)
+  const firstPoint = chart.data?.[0]
+  const valueKey = firstPoint
+    ? Object.keys(firstPoint).find(
+        (k) => k !== nameKey && typeof firstPoint[k] === 'number'
+      ) ?? 'value'
+    : 'value'
+
+  // Add fill colors so each slice gets its config color
+  const dataWithFills = (chart.data ?? []).map((point) => {
+    if (point.fill) return point
+    const name = String(point[nameKey] ?? '').toLowerCase()
+    return { ...point, fill: `var(--color-${name})` }
+  })
+
+  const innerRadius = height && height < 200 ? Math.max(10, height * 0.15) : 60
+
+  return (
+    <PieChart accessibilityLayer width={width} height={height}>
+      <Pie
+        data={dataWithFills}
+        dataKey={valueKey}
+        nameKey={nameKey}
+        innerRadius={innerRadius}
+        strokeWidth={5}
+      />
+      {chart.showTooltip !== false && (
+        <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+      )}
+      {chart.showLegend && (
+        <ChartLegend content={<ChartLegendContent nameKey={nameKey} />} />
+      )}
+    </PieChart>
+  )
+}
+
+function RadarChartContent({ chart, width, height }: { chart: ChartDefinition } & ChartDimensions) {
+  const configKeys = Object.keys(chart.config ?? {})
+
+  return (
+    <RadarChart data={chart.data} accessibilityLayer width={width} height={height}>
+      <PolarGrid />
+      <PolarAngleAxis dataKey={chart.dataKey} />
+      {configKeys.map((key) => (
+        <Radar
+          key={key}
+          dataKey={key}
+          fill={`var(--color-${key})`}
+          fillOpacity={0.6}
+          dot={{ r: 4, fillOpacity: 1 }}
+        />
+      ))}
+      {chart.showTooltip !== false && (
+        <ChartTooltip content={<ChartTooltipContent />} />
+      )}
+      {chart.showLegend && (
+        <ChartLegend content={<ChartLegendContent />} />
+      )}
+    </RadarChart>
+  )
+}
+
+function RadialChartContent({ chart, width, height }: { chart: ChartDefinition } & ChartDimensions) {
+  return (
+    <RadialBarChart
+      data={chart.data}
+      innerRadius={30}
+      outerRadius={110}
+      accessibilityLayer
+      width={width}
+      height={height}
+    >
+      <RadialBar dataKey="value" background />
+      {chart.showTooltip !== false && (
+        <ChartTooltip content={<ChartTooltipContent hideLabel nameKey="name" />} />
+      )}
+      {chart.showLegend && (
+        <ChartLegend content={<ChartLegendContent nameKey="name" />} />
+      )}
+    </RadialBarChart>
+  )
+}
+
+function ChartVisualization({ chart, width, height }: { chart: ChartDefinition } & ChartDimensions) {
+  const type = chart.type ?? 'line'
+
+  if (type === 'pie') return <PieChartContent chart={chart} width={width} height={height} />
+  if (type === 'radar') return <RadarChartContent chart={chart} width={width} height={height} />
+  if (type === 'radial') return <RadialChartContent chart={chart} width={width} height={height} />
+  return <CartesianChartContent chart={chart} width={width} height={height} />
+}
+
+/** Chart renders one or more chart cards from an array of chart definitions. */
+export function Chart({ data, appearance, control }: ChartProps) {
+  const resolved = data ?? { charts: demoCharts }
+  const charts = resolved.charts
+  const displayMode = appearance?.displayMode ?? 'inline'
+
+  if (control?.loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!charts?.length) return null
+
+  const isMulti = charts.length > 1
+  const chartHeight =
+    displayMode === 'fullscreen'
+      ? 'h-[350px]'
+      : isMulti
+        ? 'h-[120px]'
+        : 'h-[250px]'
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      {charts.map((chart, index) => {
+        const config = toShadcnConfig(chart.config)
+        const hasData = chart.data && chart.data.length > 0
+
+        return (
+          <Card key={`${chart.title ?? ''}-${index}`}>
+            <ChartCardHeader chart={chart} />
+            <CardContent className="px-2 pb-4 pt-0 sm:px-6">
+              {hasData ? (
+                <ChartContainer config={config} className={`w-full ${chartHeight} aspect-auto`}>
+                  <ChartVisualization chart={chart} />
+                </ChartContainer>
+              ) : (
+                <div className={`flex items-center justify-center ${chartHeight} aspect-auto text-muted-foreground text-sm`}>
+                  No data available
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}
+
+export type { ChartDefinition, ChartConfig } from './types'

--- a/packages/manifest-ui/registry/charts/demo/charts.ts
+++ b/packages/manifest-ui/registry/charts/demo/charts.ts
@@ -1,0 +1,126 @@
+import type { ChartDefinition } from '../types'
+
+export const demoAreaChart: ChartDefinition = {
+  title: 'Monthly Revenue',
+  bigNumber: '$45,231',
+  description: 'Total revenue over the last 6 months',
+  type: 'area',
+  dataKey: 'month',
+  data: [
+    { month: 'Jan', revenue: 4000 },
+    { month: 'Feb', revenue: 3000 },
+    { month: 'Mar', revenue: 5000 },
+    { month: 'Apr', revenue: 4500 },
+    { month: 'May', revenue: 6000 },
+    { month: 'Jun', revenue: 5500 },
+  ],
+  config: {
+    revenue: { label: 'Revenue', color: '#ec4899' },
+  },
+}
+
+export const demoBarChart: ChartDefinition = {
+  title: 'Browser Usage',
+  bigNumber: '1,247',
+  description: 'Visitor count by browser this month',
+  type: 'bar',
+  dataKey: 'browser',
+  data: [
+    { browser: 'Chrome', visitors: 275 },
+    { browser: 'Safari', visitors: 200 },
+    { browser: 'Firefox', visitors: 187 },
+    { browser: 'Edge', visitors: 173 },
+    { browser: 'Opera', visitors: 90 },
+  ],
+  config: {
+    visitors: { label: 'Visitors', color: '#a855f7' },
+  },
+}
+
+export const demoLineChart: ChartDefinition = {
+  title: 'Page Views',
+  bigNumber: '12,540',
+  description: 'Desktop vs mobile traffic',
+  type: 'line',
+  dataKey: 'month',
+  data: [
+    { month: 'Jan', desktop: 186, mobile: 80 },
+    { month: 'Feb', desktop: 305, mobile: 200 },
+    { month: 'Mar', desktop: 237, mobile: 120 },
+    { month: 'Apr', desktop: 273, mobile: 190 },
+    { month: 'May', desktop: 209, mobile: 130 },
+    { month: 'Jun', desktop: 314, mobile: 140 },
+  ],
+  config: {
+    desktop: { label: 'Desktop', color: '#ec4899' },
+    mobile: { label: 'Mobile', color: '#06b6d4' },
+  },
+  showLegend: true,
+}
+
+export const demoPieChart: ChartDefinition = {
+  title: 'Market Share',
+  description: 'Distribution by product category',
+  type: 'pie',
+  dataKey: 'category',
+  data: [
+    { category: 'Electronics', sales: 450 },
+    { category: 'Clothing', sales: 300 },
+    { category: 'Food', sales: 250 },
+    { category: 'Books', sales: 150 },
+    { category: 'Sports', sales: 100 },
+  ],
+  config: {
+    electronics: { label: 'Electronics', color: '#ec4899' },
+    clothing: { label: 'Clothing', color: '#a855f7' },
+    food: { label: 'Food', color: '#06b6d4' },
+    books: { label: 'Books', color: '#10b981' },
+    sports: { label: 'Sports', color: '#f59e0b' },
+  },
+}
+
+export const demoRadarChart: ChartDefinition = {
+  title: 'Skill Assessment',
+  description: 'Team capabilities across key areas',
+  type: 'radar',
+  dataKey: 'skill',
+  data: [
+    { skill: 'Frontend', level: 85 },
+    { skill: 'Backend', level: 90 },
+    { skill: 'Design', level: 70 },
+    { skill: 'DevOps', level: 75 },
+    { skill: 'Testing', level: 80 },
+    { skill: 'Security', level: 65 },
+  ],
+  config: {
+    level: { label: 'Skill Level', color: '#d946ef' },
+  },
+}
+
+export const demoRadialChart: ChartDefinition = {
+  title: 'Completion Rate',
+  bigNumber: '78%',
+  description: 'Tasks completed this quarter',
+  type: 'radial',
+  dataKey: 'name',
+  data: [
+    { name: 'Completed', value: 78, fill: '#ec4899' },
+    { name: 'In Progress', value: 15, fill: '#a855f7' },
+    { name: 'Pending', value: 7, fill: '#06b6d4' },
+  ],
+  config: {
+    completed: { label: 'Completed', color: '#ec4899' },
+    inProgress: { label: 'In Progress', color: '#a855f7' },
+    pending: { label: 'Pending', color: '#06b6d4' },
+  },
+}
+
+/** All demo charts for preview (one per chart type). */
+export const demoCharts: ChartDefinition[] = [
+  demoAreaChart,
+  demoBarChart,
+  demoLineChart,
+  demoPieChart,
+  demoRadarChart,
+  demoRadialChart,
+]

--- a/packages/manifest-ui/registry/charts/types.ts
+++ b/packages/manifest-ui/registry/charts/types.ts
@@ -1,0 +1,70 @@
+/** Supported chart visualization types. */
+export type ChartType = 'area' | 'bar' | 'line' | 'pie' | 'radar' | 'radial'
+
+/** Display properties for a single data series. */
+export interface ChartConfigEntry {
+  /** Human-readable label for tooltips and legends. */
+  label?: string
+  /** CSS color value: CSS variable, hex, HSL, or oklch. */
+  color?: string
+}
+
+/**
+ * Maps data keys to their display configuration.
+ * Each key corresponds to a numeric property in the data points.
+ */
+export type ChartConfig = Record<string, ChartConfigEntry>
+
+/**
+ * A single data record. One key represents the category axis (e.g., "month"),
+ * other keys represent numeric data series values.
+ */
+export type DataPoint = Record<string, string | number>
+
+/** Defines a single chart card with all its data and configuration. */
+export interface ChartDefinition {
+  /** Title displayed at the top-left of the card. */
+  title?: string
+  /** Optional description displayed below the title row. */
+  description?: string
+  /** Optional KPI metric displayed at the top-right, same row as title. */
+  bigNumber?: string
+  /** The chart visualization type. */
+  type?: ChartType
+  /** Data property for the category axis. Required for area, bar, line. */
+  dataKey?: string
+  /** Array of data points for the chart. */
+  data?: DataPoint[]
+  /** Maps data keys to labels and colors. */
+  config?: ChartConfig
+  /**
+   * Show background grid lines.
+   * @default true
+   */
+  showGrid?: boolean
+  /**
+   * Show X-axis (Cartesian types only).
+   * @default true
+   */
+  showXAxis?: boolean
+  /**
+   * Show Y-axis (Cartesian types only).
+   * @default true
+   */
+  showYAxis?: boolean
+  /**
+   * Show chart legend.
+   * @default false
+   */
+  showLegend?: boolean
+  /**
+   * Show tooltip on hover.
+   * @default true
+   */
+  showTooltip?: boolean
+  /**
+   * Stack data series (area and bar types only).
+   * @default false
+   */
+  stacked?: boolean
+}

--- a/packages/manifest-ui/registry/shared-types.ts
+++ b/packages/manifest-ui/registry/shared-types.ts
@@ -311,3 +311,78 @@ export interface EventDetails extends Omit<Event, 'dateTime'> {
   relatedEvents?: Event[]
   relatedTags?: string[] // "Los Angeles Events", "California Nightlife"
 }
+
+// ---------------------------------------------------------------------------
+// Charts
+// ---------------------------------------------------------------------------
+
+/** Supported chart visualization types. */
+export type ChartType = 'area' | 'bar' | 'line' | 'pie' | 'radar' | 'radial'
+
+/** Display properties for a single data series. */
+export interface ChartConfigEntry {
+  /** Human-readable label for tooltips and legends. */
+  label?: string
+  /** CSS color value: CSS variable, hex, HSL, or oklch. */
+  color?: string
+}
+
+/**
+ * Maps data keys to their display configuration.
+ * Each key corresponds to a numeric property in the data points.
+ */
+export type ChartConfig = Record<string, ChartConfigEntry>
+
+/**
+ * A single data record. One key represents the category axis (e.g., "month"),
+ * other keys represent numeric data series values.
+ */
+export type DataPoint = Record<string, string | number>
+
+/** Defines a single chart card with all its data and configuration. */
+export interface ChartDefinition {
+  /** Title displayed at the top-left of the card. */
+  title?: string
+  /** Optional description displayed below the title row. */
+  description?: string
+  /** Optional KPI metric displayed at the top-right, same row as title. */
+  bigNumber?: string
+  /** The chart visualization type. */
+  type?: ChartType
+  /** Data property for the category axis. Required for area, bar, line. */
+  dataKey?: string
+  /** Array of data points for the chart. */
+  data?: DataPoint[]
+  /** Maps data keys to labels and colors. */
+  config?: ChartConfig
+  /**
+   * Show background grid lines.
+   * @default true
+   */
+  showGrid?: boolean
+  /**
+   * Show X-axis (Cartesian types only).
+   * @default true
+   */
+  showXAxis?: boolean
+  /**
+   * Show Y-axis (Cartesian types only).
+   * @default true
+   */
+  showYAxis?: boolean
+  /**
+   * Show chart legend.
+   * @default false
+   */
+  showLegend?: boolean
+  /**
+   * Show tooltip on hover.
+   * @default true
+   */
+  showTooltip?: boolean
+  /**
+   * Stack data series (area and bar types only).
+   * @default false
+   */
+  stacked?: boolean
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       react-leaflet:
         specifier: ^5.0.0
         version: 5.0.0(leaflet@1.9.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      recharts:
+        specifier: 2.15.4
+        version: 2.15.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       shadcn:
         specifier: ^3.0.0
         version: 3.6.2(@cfworker/json-schema@4.1.1)(@types/node@20.19.27)(hono@4.11.3)(typescript@5.9.3)
@@ -240,13 +243,13 @@ importers:
         version: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@thallesp/nestjs-better-auth':
         specifier: ^2.2.0
-        version: 2.2.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/graphql@13.2.3(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.12.0)(reflect-metadata@0.2.2)(ts-morph@26.0.0))(@nestjs/websockets@11.1.12)(better-auth@1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(express@5.2.1)(graphql@16.12.0)(typescript@5.9.3)
+        version: 2.2.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/graphql@13.2.3(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.12.0)(reflect-metadata@0.2.2)(ts-morph@26.0.0))(@nestjs/websockets@11.1.12)(better-auth@1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(express@5.2.1)(graphql@16.12.0)(typescript@5.9.3)
       bcrypt:
         specifier: ^5.1.1
         version: 5.1.1(encoding@0.1.13)
       better-auth:
         specifier: ^1.4.10
-        version: 1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       better-sqlite3:
         specifier: ^11.7.0
         version: 11.10.0
@@ -13594,12 +13597,12 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@thallesp/nestjs-better-auth@2.2.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/graphql@13.2.3(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.12.0)(reflect-metadata@0.2.2)(ts-morph@26.0.0))(@nestjs/websockets@11.1.12)(better-auth@1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(express@5.2.1)(graphql@16.12.0)(typescript@5.9.3)':
+  '@thallesp/nestjs-better-auth@2.2.2(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(@nestjs/graphql@13.2.3(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.12.0)(reflect-metadata@0.2.2)(ts-morph@26.0.0))(@nestjs/websockets@11.1.12)(better-auth@1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)))(express@5.2.1)(graphql@16.12.0)(typescript@5.9.3)':
     dependencies:
       '@nestjs/common': 10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@10.4.22)(@nestjs/websockets@11.1.12)(encoding@0.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/graphql': 13.2.3(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@10.4.22)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.12.0)(reflect-metadata@0.2.2)(ts-morph@26.0.0)
-      better-auth: 1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      better-auth: 1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       express: 5.2.1
       graphql: 16.12.0
       typescript: 5.9.3
@@ -14742,7 +14745,7 @@ snapshots:
       - encoding
       - supports-color
 
-  better-auth@1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+  better-auth@1.4.15(better-sqlite3@11.10.0)(next@16.1.5(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vitest@4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@better-auth/core': 1.4.15(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.5))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0)
       '@better-auth/telemetry': 1.4.15(@better-auth/core@1.4.15(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.5))(jose@6.1.3)(kysely@0.28.10)(nanostores@1.1.0))
@@ -14750,7 +14753,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.1.8(zod@3.25.76)
+      better-call: 1.1.8(zod@4.3.5)
       defu: 6.1.4
       jose: 6.1.3
       kysely: 0.28.10
@@ -14758,7 +14761,7 @@ snapshots:
       zod: 4.3.5
     optionalDependencies:
       better-sqlite3: 11.10.0
-      next: 16.1.5(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next: 16.1.5(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       vitest: 4.0.16(@types/node@22.19.7)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(msw@2.12.7(@types/node@22.19.7)(typescript@5.9.3))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -14771,7 +14774,7 @@ snapshots:
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.1.8(zod@4.3.5)
+      better-call: 1.1.8(zod@3.25.76)
       defu: 6.1.4
       jose: 6.1.3
       kysely: 0.28.10
@@ -18306,32 +18309,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.5(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 16.1.5
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.9.13
-      caniuse-lite: 1.0.30001763
-      postcss: 8.4.31
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.1.5
-      '@next/swc-darwin-x64': 16.1.5
-      '@next/swc-linux-arm64-gnu': 16.1.5
-      '@next/swc-linux-arm64-musl': 16.1.5
-      '@next/swc-linux-x64-gnu': 16.1.5
-      '@next/swc-linux-x64-musl': 16.1.5
-      '@next/swc-win32-arm64-msvc': 16.1.5
-      '@next/swc-win32-x64-msvc': 16.1.5
-      '@playwright/test': 1.57.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    optional: true
-
   node-abi@3.86.0:
     dependencies:
       semver: 7.7.3
@@ -19003,6 +18980,14 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
+  react-smooth@4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-transition-group: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
   react-style-singleton@2.2.3(@types/react@18.3.17)(react@18.3.1):
     dependencies:
       get-nonce: 1.0.1
@@ -19036,6 +19021,15 @@ snapshots:
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-transition-state@2.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -19092,6 +19086,19 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-is: 18.3.1
       react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
+
+  recharts@2.15.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2


### PR DESCRIPTION
## Description

Add a new `chart-block` registry component that supports 6 chart types: area, bar, line, pie, radar, and radial. Built with Recharts and shadcn/ui chart primitives.

Key implementation details:
- Replaced Recharts' broken `ResponsiveContainer` (incompatible with React 19) with a custom `ResizeObserver`-based sizing wrapper in `components/ui/chart.tsx`
- Dynamic `innerRadius` scaling for pie charts in compact display modes
- Chart type definitions added to `shared-types.ts` for Config tab hover tooltips
- Three variants: Single Chart, Multiple Charts (dashboard), and Multi-Series

## Related Issues

None

## How can it be tested?

1. Run `pnpm run dev` in the `packages/manifest-ui` directory
2. Navigate to http://localhost:3001/blocks/charts/chart-block
3. Verify "Single Chart" variant shows an area chart with pink fill
4. Verify "Multiple Charts" variant shows 3 compact cards (area, bar, pie)
5. Verify "Multi-Series" variant shows a dual-line chart with legend
6. Hover `ChartDefinition[]` in the Config tab to see the full type tooltip
7. Run `pnpm test` — all 1263 tests pass

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR