### PR TITLE
feat(manifest): add JSON request body support to API Call Node

### DIFF
--- a/.changeset/api-call-request-body.md
+++ b/.changeset/api-call-request-body.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add JSON request body support to API Call Node with type-preserving template variables and relaxed JSON linting

--- a/packages/manifest/backend/src/node/schema/utils/template-resolver.utils.ts
+++ b/packages/manifest/backend/src/node/schema/utils/template-resolver.utils.ts
@@ -1,6 +1,25 @@
 import { sanitizeMockValue } from './value-sanitizer.utils';
 
 /**
+ * Navigates a dot-separated path on an object to retrieve a nested value.
+ * Returns undefined if any segment is missing.
+ */
+function resolvePathValue(
+  root: unknown,
+  parts: string[]
+): unknown {
+  let value = root;
+  for (let i = 1; i < parts.length && value != null; i++) {
+    if (typeof value === 'object' && value !== null) {
+      value = (value as Record<string, unknown>)[parts[i]];
+    } else {
+      return undefined;
+    }
+  }
+  return value;
+}
+
+/**
  * Resolve template variables in a string using mock values.
  * Returns the resolved string and list of unresolved variable names.
  * All mock values are sanitized to prevent SSRF through URL injection.
@@ -41,4 +60,71 @@ export function resolveTemplateVariables(
   });
 
   return { resolved, unresolvedVars };
+}
+
+/**
+ * Determines whether a regex match position is inside a JSON string
+ * (between unescaped double quotes).
+ */
+function isInsideJsonString(text: string, matchStart: number): boolean {
+  let insideString = false;
+  for (let i = 0; i < matchStart; i++) {
+    if (text[i] === '"' && (i === 0 || text[i - 1] !== '\\')) {
+      insideString = !insideString;
+    }
+  }
+  return insideString;
+}
+
+/**
+ * Resolves template variables in a JSON body string with type preservation.
+ *
+ * - Bare template variables (outside quotes) resolve to their JSON-serialized type
+ *   (number, boolean, object, array, string, null).
+ * - String-embedded template variables (inside quotes) resolve via string interpolation.
+ *
+ * @param body - Raw body string with {{ }} template variables
+ * @param mockValues - Key-value map of node outputs for resolution
+ * @returns Object with resolved body string and array of unresolved variable names
+ */
+export function resolveBodyTemplateVariables(
+  body: string,
+  mockValues?: Record<string, unknown>
+): { resolved: string; unresolvedVars: string[] } {
+  const unresolvedVars: string[] = [];
+  const pattern = /\{\{([^{}]+)\}\}/g;
+
+  // Process replacements in reverse order to preserve indices
+  const matches = [...body.matchAll(pattern)];
+  let result = body;
+
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const match = matches[i];
+    const varPath = match[1].trim();
+    const parts = varPath.split('.');
+    const rootKey = parts[0];
+    const matchStart = match.index!;
+    const matchEnd = matchStart + match[0].length;
+
+    if (!mockValues || !(rootKey in mockValues)) {
+      unresolvedVars.push(varPath);
+      continue;
+    }
+
+    const value = resolvePathValue(mockValues[rootKey], parts);
+
+    if (value === undefined) {
+      unresolvedVars.push(varPath);
+      continue;
+    }
+
+    const inString = isInsideJsonString(body, matchStart);
+    const replacement = inString
+      ? String(value ?? '')
+      : JSON.stringify(value ?? null);
+
+    result = result.slice(0, matchStart) + replacement + result.slice(matchEnd);
+  }
+
+  return { resolved: result, unresolvedVars };
 }

--- a/packages/manifest/frontend/src/components/common/JSONEditor.tsx
+++ b/packages/manifest/frontend/src/components/common/JSONEditor.tsx
@@ -3,6 +3,7 @@ import CodeMirror from '@uiw/react-codemirror';
 import { json, jsonParseLinter } from '@codemirror/lang-json';
 import { linter } from '@codemirror/lint';
 import { EditorView } from '@codemirror/view';
+import { createRelaxedJsonLinter } from '@/lib/relaxed-json-linter';
 
 interface JSONEditorProps {
   /** The JSON value as a string */
@@ -15,6 +16,8 @@ interface JSONEditorProps {
   height?: string;
   /** Whether the editor is disabled */
   disabled?: boolean;
+  /** Use relaxed linting that tolerates {{ }} template variables (default: false) */
+  relaxedLinting?: boolean;
 }
 
 /**
@@ -62,6 +65,7 @@ export function JSONEditor({
   placeholder = '{"example": "data"}',
   height = '150px',
   disabled = false,
+  relaxedLinting = false,
 }: JSONEditorProps) {
   const handleChange = useCallback(
     (newValue: string) => {
@@ -77,9 +81,9 @@ export function JSONEditor({
     () => [
       json(),
       customTheme,
-      linter(jsonParseLinter()),
+      linter(relaxedLinting ? createRelaxedJsonLinter() : jsonParseLinter()),
     ],
-    []
+    [relaxedLinting]
   );
 
   return (

--- a/packages/manifest/frontend/src/components/flow/NodeEditModal.tsx
+++ b/packages/manifest/frontend/src/components/flow/NodeEditModal.tsx
@@ -138,6 +138,7 @@ export function NodeEditModal({
   const [apiMethod, setApiMethod] = useState<HttpMethod>('GET');
   const [apiUrl, setApiUrl] = useState('');
   const [apiHeaders, setApiHeaders] = useState<HeaderEntry[]>([]);
+  const [apiBody, setApiBody] = useState('');
   const [apiTimeout, setApiTimeout] = useState(30000);
   const [apiResolvedOutputSchema, setApiResolvedOutputSchema] = useState<JSONSchema | null>(null);
 
@@ -251,6 +252,7 @@ export function NodeEditModal({
         setApiMethod(params?.method || 'GET');
         setApiUrl(params?.url || '');
         setApiHeaders(params?.headers || []);
+        setApiBody(params?.body || '');
         setApiTimeout(params?.timeout || 30000);
         setApiResolvedOutputSchema(params?.resolvedOutputSchema || null);
         resetApiTest();
@@ -280,6 +282,7 @@ export function NodeEditModal({
       setApiMethod('GET');
       setApiUrl('');
       setApiHeaders([]);
+      setApiBody('');
       setApiTimeout(30000);
       setApiResolvedOutputSchema(null);
       setTransformCode(DEFAULT_TRANSFORM_CODE);
@@ -320,6 +323,7 @@ export function NodeEditModal({
         method: apiMethod,
         url: apiUrl,
         headers: apiHeaders,
+        body: apiBody,
         timeout: apiTimeout,
         inputMappings: [],
         resolvedOutputSchema: finalApiOutputSchema,
@@ -979,6 +983,26 @@ export function NodeEditModal({
                   )}
                 </div>
 
+                {/* Request Body editor - only for methods that support bodies */}
+                {apiMethod !== 'GET' && (
+                  <div>
+                    <Label className="block text-sm font-medium text-gray-700 mb-1">
+                      Request Body (JSON)
+                    </Label>
+                    <JSONEditor
+                      value={apiBody}
+                      onChange={setApiBody}
+                      placeholder={'{\n  "key": "value"\n}'}
+                      height="200px"
+                      disabled={isLoading}
+                      relaxedLinting
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                      Use {'{{ nodeSlug.path }}'} for dynamic values. Bare variables preserve their type (number, boolean, etc.).
+                    </p>
+                  </div>
+                )}
+
                 {/* Timeout input */}
                 <div>
                   <Label htmlFor="api-timeout" className="block text-sm font-medium text-gray-700 mb-1">
@@ -1107,7 +1131,7 @@ export function NodeEditModal({
 
                 {/* Template References Display - shows input requirements from {{ }} variables */}
                 <TemplateReferencesDisplay
-                  values={[apiUrl, ...apiHeaders.map(h => h.value)]}
+                  values={[apiUrl, ...apiHeaders.map(h => h.value), apiBody]}
                   upstreamNodes={upstreamNodes}
                   isConnected={upstreamNodes.length > 0}
                 />

--- a/packages/manifest/frontend/src/lib/relaxed-json-linter.ts
+++ b/packages/manifest/frontend/src/lib/relaxed-json-linter.ts
@@ -1,0 +1,118 @@
+import type { Diagnostic } from '@codemirror/lint';
+import type { EditorView } from '@codemirror/view';
+
+/** Matches {{ ... }} template variables (non-greedy, no nested braces) */
+const TEMPLATE_PATTERN = /\{\{[^{}]+\}\}/g;
+
+/**
+ * Determines if a template match at a given index is inside a JSON string
+ * (between unescaped double quotes).
+ */
+function isInsideString(text: string, matchStart: number): boolean {
+  let insideString = false;
+  for (let i = 0; i < matchStart; i++) {
+    if (text[i] === '"' && (i === 0 || text[i - 1] !== '\\')) {
+      insideString = !insideString;
+    }
+  }
+  return insideString;
+}
+
+/**
+ * Builds a position-offset map for translating error positions from
+ * preprocessed text back to the original text.
+ */
+function buildOffsetMap(
+  replacements: Array<{ start: number; end: number; replacementLength: number }>
+): (preprocessedPos: number) => number {
+  return (preprocessedPos: number) => {
+    let cumulativeShift = 0;
+    for (const r of replacements) {
+      const preprocessedStart = r.start - cumulativeShift;
+      const preprocessedEnd = preprocessedStart + r.replacementLength;
+
+      if (preprocessedPos <= preprocessedStart) break;
+      if (preprocessedPos >= preprocessedEnd) {
+        cumulativeShift += (r.end - r.start) - r.replacementLength;
+      }
+    }
+    return preprocessedPos + cumulativeShift;
+  };
+}
+
+/**
+ * Creates a CodeMirror linter that validates JSON while tolerating {{ }}
+ * template variable placeholders.
+ *
+ * Pre-processes text by replacing:
+ * - Bare {{ }} (outside quotes) with `null`
+ * - In-string {{ }} (inside quotes) with empty string
+ *
+ * Then runs JSON.parse() and maps errors back to original positions.
+ */
+export function createRelaxedJsonLinter(): (view: EditorView) => Diagnostic[] {
+  return (view: EditorView): Diagnostic[] => {
+    const text = view.state.doc.toString();
+
+    if (!text.trim()) return [];
+
+    const replacements: Array<{ start: number; end: number; replacementLength: number }> = [];
+    let preprocessed = text;
+    let offset = 0;
+
+    // Collect all template matches and replace them
+    const matches = [...text.matchAll(TEMPLATE_PATTERN)];
+    for (const match of matches) {
+      const originalStart = match.index!;
+      const originalEnd = originalStart + match[0].length;
+      const adjustedStart = originalStart - offset;
+
+      const inString = isInsideString(text, originalStart);
+      const replacement = inString ? '' : 'null';
+
+      preprocessed =
+        preprocessed.slice(0, adjustedStart) +
+        replacement +
+        preprocessed.slice(adjustedStart + match[0].length);
+
+      replacements.push({
+        start: originalStart,
+        end: originalEnd,
+        replacementLength: replacement.length,
+      });
+
+      offset += match[0].length - replacement.length;
+    }
+
+    // Try to parse the preprocessed JSON
+    try {
+      JSON.parse(preprocessed);
+      return [];
+    } catch (e) {
+      if (!(e instanceof SyntaxError)) return [];
+
+      // Extract position from the error message
+      const posMatch = e.message.match(/position\s+(\d+)/i);
+      let from = 0;
+      if (posMatch) {
+        const preprocessedPos = parseInt(posMatch[1], 10);
+        const toOriginal = buildOffsetMap(replacements);
+        from = toOriginal(preprocessedPos);
+      }
+
+      // Clamp to document bounds
+      const docLength = view.state.doc.length;
+      from = Math.min(from, docLength);
+      const to = Math.min(from + 1, docLength);
+
+      return [
+        {
+          from,
+          to,
+          severity: 'error',
+          message: e.message,
+        },
+      ];
+    }
+  };
+}

--- a/packages/manifest/shared/src/types/node.ts
+++ b/packages/manifest/shared/src/types/node.ts
@@ -76,6 +76,8 @@ export interface ApiCallNodeParameters {
   url: string;
   /** HTTP headers as key-value pairs */
   headers: HeaderEntry[];
+  /** Raw JSON request body (may contain {{}} template variables). Only sent for POST/PUT/PATCH/DELETE. */
+  body?: string;
   /** Request timeout in milliseconds (default: 30000) */
   timeout: number;
   /** Mappings from upstream node outputs (for dynamic values) */


### PR DESCRIPTION
## Description

Add a `body` field to the API Call Node that allows users to send JSON request bodies with POST, PUT, PATCH, and DELETE methods. Template variables (`{{ nodeSlug.path }}`) are fully supported with type-preserving resolution:

- **Bare variables** (outside JSON strings) resolve to their native type (number, boolean, object, array, null)
- **In-string variables** (inside JSON strings) resolve via string interpolation

The body editor uses CodeMirror with a custom relaxed JSON linter that tolerates `{{ }}` placeholders while still validating the surrounding JSON structure. Content-Type is auto-set to `application/json` when a body is present and no Content-Type header is explicitly configured.

### Changes across the stack:

| Layer | File | Change |
|-------|------|--------|
| Shared types | `shared/src/types/node.ts` | Added optional `body` field to `ApiCallNodeParameters` |
| Node runtime | `nodes/src/nodes/action/ApiCallNode.ts` | Added `resolveBodyTemplate()` with type-aware resolution + `addContentTypeIfMissing()` |
| Backend service | `backend/src/node/schema/schema.service.ts` | Added body template resolution and Content-Type auto-detection for test execution |
| Backend utils | `backend/src/node/schema/utils/template-resolver.utils.ts` | Added `resolveBodyTemplateVariables()` and `resolvePathValue()` helper |
| Frontend editor | `frontend/src/components/flow/NodeEditModal.tsx` | Added body editor UI (hidden for GET), wired state + save + template refs |
| Frontend component | `frontend/src/components/common/JSONEditor.tsx` | Added `relaxedLinting` prop for template-tolerant mode |
| Frontend linter | `frontend/src/lib/relaxed-json-linter.ts` | New CodeMirror linter that replaces `{{ }}` before JSON.parse validation |

## Related Issues

None

## How can it be tested?

1. Start the dev server with `pnpm run dev`
2. Open the flow editor and add an API Call node
3. Set method to POST — the "Request Body (JSON)" editor should appear
4. Enter JSON with template variables, e.g. `{"name": "{{ userNode.name }}", "age": {{ userNode.age }}}`
5. Verify the relaxed linter does NOT show errors for `{{ }}` placeholders but DOES catch real JSON syntax errors
6. Switch method to GET — the body editor should disappear
7. Connect upstream nodes and run a test — verify the body is sent with resolved values and correct types
8. Verify Content-Type: application/json is auto-added when body is present

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [ ] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR