### PR TITLE
fix(manifest): fix demo data loading for UI component nodes

### DIFF
--- a/.changeset/fix-demo-data-loading.md
+++ b/.changeset/fix-demo-data-loading.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix demo data loading for UI component nodes: correct GitHub raw URLs, filter library entries from component list, and extract component-specific demo data shapes

--- a/packages/manifest/frontend/src/components/editor/InterfaceEditor.tsx
+++ b/packages/manifest/frontend/src/components/editor/InterfaceEditor.tsx
@@ -83,7 +83,7 @@ function extractDemoDataFromFiles(
   if (!siblingFiles) return null;
 
   // Find the demo/data file
-  const demoFile = siblingFiles.find(f => f.path.includes('/demo/data'));
+  const demoFile = siblingFiles.find(f => f.path.includes('/demo/'));
   if (!demoFile) return null;
 
   try {

--- a/packages/manifest/frontend/src/components/editor/InterfaceEditor.tsx
+++ b/packages/manifest/frontend/src/components/editor/InterfaceEditor.tsx
@@ -6,7 +6,9 @@
  * Enables live preview updates when adjusting appearance or demo data.
  */
 import { useState, useCallback, useEffect, useMemo } from 'react';
+import React from 'react';
 import { X, Save, Code, Eye, Palette, Database } from 'lucide-react';
+import { transform } from 'sucrase';
 import { CodeEditor } from './CodeEditor';
 import { ComponentPreview } from './ComponentPreview';
 import { AppearanceTab } from './AppearanceTab';
@@ -71,6 +73,69 @@ function getLayoutTemplate(componentType: string): 'stat-card' | 'post-list' | '
 }
 
 /**
+ * Extract the component-specific demo data by parsing the component source
+ * to find which demo export it uses as fallback (the `data ?? <expr>` pattern),
+ * then compiling the demo file and evaluating that expression.
+ */
+function extractComponentDemoData(
+  files: Array<{ path: string; content: string }>
+): Record<string, unknown> | undefined {
+  const mainFile = files.find(f => f.path.endsWith('.tsx') && !f.path.includes('/demo/'));
+  if (!mainFile) return undefined;
+
+  const demoFile = files.find(f => f.path.includes('/demo/'));
+  if (!demoFile) return undefined;
+
+  // Find the `data ?? <expression>` pattern in the component source
+  const fallbackMatch = mainFile.content.match(/=\s*data\s*\?\?\s*([^\n;]+)/);
+  if (!fallbackMatch) return undefined;
+  const fallbackExpr = fallbackMatch[1].trim();
+
+  try {
+    const processedCode = demoFile.content
+      .replace(/['"]use client['"]\s*;?/g, '')
+      .replace(/['"]use server['"]\s*;?/g, '');
+
+    const result = transform(processedCode, {
+      transforms: ['jsx', 'typescript', 'imports'],
+      jsxRuntime: 'classic',
+      jsxPragma: 'React.createElement',
+      jsxFragmentPragma: 'React.Fragment',
+    });
+
+    const moduleCode = `
+      var exports = {};
+      var module = { exports: exports };
+      ${result.code}
+      return exports;
+    `;
+
+    const mockRequire = () => ({});
+    const factory = new Function('React', 'require', moduleCode);
+    const rawExports = factory(React, mockRequire) as Record<string, unknown>;
+
+    // Filter internal keys, keep only demo exports
+    const demoExports: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rawExports)) {
+      if (key !== '__esModule' && key !== 'default') {
+        demoExports[key] = value;
+      }
+    }
+
+    // Evaluate the fallback expression with demo exports in scope
+    const paramNames = Object.keys(demoExports);
+    const paramValues = Object.values(demoExports);
+    const evalFn = new Function(...paramNames, `return (${fallbackExpr})`);
+    const value = evalFn(...paramValues);
+
+    return value && typeof value === 'object' ? value as Record<string, unknown> : undefined;
+  } catch (err) {
+    console.warn('Failed to extract component demo data:', err);
+    return undefined;
+  }
+}
+
+/**
  * Full-screen editor for customizing UI node configuration.
  * Split-panel layout: Preview/Code (75%) | Appearance/Demo Data (25%)
  */
@@ -115,11 +180,10 @@ export function InterfaceEditor({
 
   // Calculate initial demo data
   const initialDemoData = useMemo(() => {
-    // Registry components import their own demo data and handle fallback
-    // via the `data ?? demoData` pattern in their source code.
-    // Pass undefined so the component's built-in fallback kicks in.
-    if (siblingFiles && siblingFiles.length > 0) {
-      return undefined;
+    // Registry components: extract the component-specific demo data
+    // by evaluating the component's `data ?? <expr>` fallback expression
+    if (files && files.length > 1) {
+      return extractComponentDemoData(files);
     }
 
     // Built-in templates use predefined sample data
@@ -129,7 +193,7 @@ export function InterfaceEditor({
     };
     const template = templateMap[componentType] || 'stat-card';
     return getTemplateSampleData(template as 'stat-card' | 'post-list');
-  }, [componentType, siblingFiles]);
+  }, [componentType, files]);
 
   // Editor state - unified for all tabs
   const [name, setName] = useState(initialNodeName);

--- a/packages/manifest/frontend/src/components/editor/__tests__/extractComponentDemoData.test.ts
+++ b/packages/manifest/frontend/src/components/editor/__tests__/extractComponentDemoData.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from 'vitest';
+import { extractComponentDemoData } from '../extractComponentDemoData';
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+/** Build a minimal files array with a component and demo file. */
+function makeFiles(
+  componentCode: string,
+  demoCode: string,
+  componentPath = 'registry/social/linkedin-post.tsx',
+  demoPath = 'registry/social/demo/social.ts',
+): Array<{ path: string; content: string }> {
+  return [
+    { path: componentPath, content: componentCode },
+    { path: demoPath, content: demoCode },
+  ];
+}
+
+// ─── Demo file fixtures ─────────────────────────────────────────
+
+const SIMPLE_DEMO = `
+export const demoLinkedInPost = {
+  author: 'Manifest',
+  headline: 'Open Source',
+  content: 'Hello world',
+};
+
+export const demoXPost = {
+  author: 'X User',
+  username: 'xuser',
+};
+`;
+
+const OBJECT_WRAP_DEMO = `
+export const demoPost = {
+  title: 'Getting Started',
+  excerpt: 'Learn how to build...',
+};
+
+export const demoPosts = [
+  { title: 'Post 1' },
+  { title: 'Post 2' },
+];
+`;
+
+const ARRAY_DEMO = `
+export const demoTextMessages = [
+  { content: 'Hello', avatarFallback: 'A' },
+  { content: 'World', avatarFallback: 'B' },
+];
+`;
+
+const MULTI_KEY_DEMO = `
+export const demoMapLocations = [
+  { lat: 40.7, lng: -74.0, title: 'NYC' },
+];
+export const demoMapCenter = { lat: 40.7, lng: -74.0 };
+export const demoMapZoom = 12;
+`;
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+describe('extractComponentDemoData', () => {
+  describe('simple variable fallback (e.g., LinkedInPost)', () => {
+    it('returns the correct export value for `data ?? demoLinkedInPost`', () => {
+      const component = `
+        import { demoLinkedInPost } from './demo/social';
+        export function LinkedInPost({ data }: Props) {
+          const resolved = data ?? demoLinkedInPost;
+          return null;
+        }
+      `;
+      const result = extractComponentDemoData(makeFiles(component, SIMPLE_DEMO));
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('author', 'Manifest');
+      expect(result).toHaveProperty('headline', 'Open Source');
+      expect(result).toHaveProperty('content', 'Hello world');
+    });
+
+    it('returns only the referenced export, not all exports', () => {
+      const component = `
+        import { demoLinkedInPost } from './demo/social';
+        export function LinkedInPost({ data }: Props) {
+          const resolved = data ?? demoLinkedInPost;
+          return null;
+        }
+      `;
+      const result = extractComponentDemoData(makeFiles(component, SIMPLE_DEMO));
+
+      // Should NOT contain fields from demoXPost
+      expect(result).not.toHaveProperty('username');
+    });
+  });
+
+  describe('object literal fallback (e.g., PostCard)', () => {
+    it('returns wrapped object for `data ?? { post: demoPost }`', () => {
+      const component = `
+        import { demoPost } from './demo/blogging';
+        export function PostCard({ data }: Props) {
+          const resolved = data ?? { post: demoPost }
+          return null;
+        }
+      `;
+      const files = makeFiles(
+        component,
+        OBJECT_WRAP_DEMO,
+        'registry/blogging/post-card.tsx',
+        'registry/blogging/demo/blogging.ts',
+      );
+      const result = extractComponentDemoData(files);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('post');
+      expect((result as { post: { title: string } }).post.title).toBe('Getting Started');
+    });
+
+    it('returns wrapped array for `data ?? { posts: demoPosts }`', () => {
+      const component = `
+        import { demoPosts } from './demo/blogging';
+        export function PostList({ data }: Props) {
+          const resolved = data ?? { posts: demoPosts }
+          return null;
+        }
+      `;
+      const files = makeFiles(
+        component,
+        OBJECT_WRAP_DEMO,
+        'registry/blogging/post-list.tsx',
+        'registry/blogging/demo/blogging.ts',
+      );
+      const result = extractComponentDemoData(files);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('posts');
+      expect(Array.isArray((result as { posts: unknown[] }).posts)).toBe(true);
+      expect((result as { posts: Array<{ title: string }> }).posts).toHaveLength(2);
+    });
+  });
+
+  describe('array access fallback (e.g., MessageBubble)', () => {
+    it('returns the first element for `data ?? demoTextMessages[0]`', () => {
+      const component = `
+        import { demoTextMessages } from './demo/messaging';
+        export function MessageBubble({ data }: Props) {
+          const resolved = data ?? demoTextMessages[0]
+          return null;
+        }
+      `;
+      const files = makeFiles(
+        component,
+        ARRAY_DEMO,
+        'registry/messaging/message-bubble.tsx',
+        'registry/messaging/demo/messaging.ts',
+      );
+      const result = extractComponentDemoData(files);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('content', 'Hello');
+      expect(result).toHaveProperty('avatarFallback', 'A');
+    });
+  });
+
+  describe('multi-key object fallback (e.g., MapCarousel)', () => {
+    it('returns object with multiple demo exports', () => {
+      const component = `
+        import { demoMapLocations, demoMapCenter, demoMapZoom } from './demo/map';
+        export function MapCarousel({ data }: Props) {
+          const resolvedData = data ?? { locations: demoMapLocations, center: demoMapCenter, zoom: demoMapZoom }
+          return null;
+        }
+      `;
+      const files = makeFiles(
+        component,
+        MULTI_KEY_DEMO,
+        'registry/map/map-carousel.tsx',
+        'registry/map/demo/map.ts',
+      );
+      const result = extractComponentDemoData(files);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('locations');
+      expect(result).toHaveProperty('center');
+      // zoom is a number primitive — filtered out by typeof check
+      expect(Array.isArray((result as { locations: unknown[] }).locations)).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns undefined when no files provided', () => {
+      expect(extractComponentDemoData([])).toBeUndefined();
+    });
+
+    it('returns undefined when no .tsx component file exists', () => {
+      const files = [
+        { path: 'registry/social/demo/social.ts', content: SIMPLE_DEMO },
+      ];
+      expect(extractComponentDemoData(files)).toBeUndefined();
+    });
+
+    it('returns undefined when no demo file exists', () => {
+      const component = `
+        export function MyComponent({ data }: Props) {
+          const resolved = data ?? {};
+          return null;
+        }
+      `;
+      const files = [
+        { path: 'registry/misc/my-component.tsx', content: component },
+      ];
+      expect(extractComponentDemoData(files)).toBeUndefined();
+    });
+
+    it('returns undefined when component has no data ?? pattern', () => {
+      const component = `
+        export function MyComponent({ title }: Props) {
+          return null;
+        }
+      `;
+      const files = makeFiles(component, SIMPLE_DEMO);
+      expect(extractComponentDemoData(files)).toBeUndefined();
+    });
+
+    it('handles demo files with TypeScript type imports', () => {
+      const demoWithTypes = `
+        import type { Post } from '../types';
+        export const demoPost: Post = {
+          title: 'Typed Post',
+          excerpt: 'With type annotation',
+        };
+      `;
+      const component = `
+        import { demoPost } from './demo/blogging';
+        export function PostCard({ data }: Props) {
+          const resolved = data ?? { post: demoPost }
+          return null;
+        }
+      `;
+      const files = makeFiles(
+        component,
+        demoWithTypes,
+        'registry/blogging/post-card.tsx',
+        'registry/blogging/demo/blogging.ts',
+      );
+      const result = extractComponentDemoData(files);
+
+      expect(result).toBeDefined();
+      expect((result as { post: { title: string } }).post.title).toBe('Typed Post');
+    });
+
+    it('handles demo files with "use client" directive', () => {
+      const demoWithDirective = `
+        'use client';
+        export const demoHero = { title: 'Hello' };
+      `;
+      const component = `
+        import { demoHero } from './demo/misc';
+        export function Hero({ data }: Props) {
+          const resolved = data ?? demoHero;
+          return null;
+        }
+      `;
+      const files = makeFiles(
+        component,
+        demoWithDirective,
+        'registry/misc/hero.tsx',
+        'registry/misc/demo/misc.ts',
+      );
+      const result = extractComponentDemoData(files);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('title', 'Hello');
+    });
+
+    it('handles demo files with TypeScript `as` type assertions', () => {
+      const demoWithAssertion = `
+        export const demoLinkedInPost = {
+          author: 'Test',
+          reactions: ['like', 'love'] as ('like' | 'love')[],
+        };
+      `;
+      const component = `
+        import { demoLinkedInPost } from './demo/social';
+        export function LinkedInPost({ data }: Props) {
+          const resolved = data ?? demoLinkedInPost;
+          return null;
+        }
+      `;
+      const files = makeFiles(component, demoWithAssertion);
+      const result = extractComponentDemoData(files);
+
+      expect(result).toBeDefined();
+      expect(result).toHaveProperty('author', 'Test');
+      expect(result).toHaveProperty('reactions');
+      expect(Array.isArray((result as { reactions: string[] }).reactions)).toBe(true);
+    });
+  });
+});

--- a/packages/manifest/frontend/src/components/editor/extractComponentDemoData.ts
+++ b/packages/manifest/frontend/src/components/editor/extractComponentDemoData.ts
@@ -1,0 +1,69 @@
+/**
+ * Extracts component-specific demo data by parsing the component's
+ * `data ?? <expr>` fallback and evaluating it against compiled demo exports.
+ */
+import React from 'react';
+import { transform } from 'sucrase';
+
+/**
+ * Extract the component-specific demo data by parsing the component source
+ * to find which demo export it uses as fallback (the `data ?? <expr>` pattern),
+ * then compiling the demo file and evaluating that expression.
+ */
+export function extractComponentDemoData(
+  files: Array<{ path: string; content: string }>
+): Record<string, unknown> | undefined {
+  const mainFile = files.find(f => f.path.endsWith('.tsx') && !f.path.includes('/demo/'));
+  if (!mainFile) return undefined;
+
+  const demoFile = files.find(f => f.path.includes('/demo/'));
+  if (!demoFile) return undefined;
+
+  // Find the `data ?? <expression>` pattern in the component source
+  const fallbackMatch = mainFile.content.match(/=\s*data\s*\?\?\s*([^\n;]+)/);
+  if (!fallbackMatch) return undefined;
+  const fallbackExpr = fallbackMatch[1].trim();
+
+  try {
+    const processedCode = demoFile.content
+      .replace(/['"]use client['"]\s*;?/g, '')
+      .replace(/['"]use server['"]\s*;?/g, '');
+
+    const result = transform(processedCode, {
+      transforms: ['jsx', 'typescript', 'imports'],
+      jsxRuntime: 'classic',
+      jsxPragma: 'React.createElement',
+      jsxFragmentPragma: 'React.Fragment',
+    });
+
+    const moduleCode = `
+      var exports = {};
+      var module = { exports: exports };
+      ${result.code}
+      return exports;
+    `;
+
+    const mockRequire = () => ({});
+    const factory = new Function('React', 'require', moduleCode);
+    const rawExports = factory(React, mockRequire) as Record<string, unknown>;
+
+    // Filter internal keys, keep only demo exports
+    const demoExports: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rawExports)) {
+      if (key !== '__esModule' && key !== 'default') {
+        demoExports[key] = value;
+      }
+    }
+
+    // Evaluate the fallback expression with demo exports in scope
+    const paramNames = Object.keys(demoExports);
+    const paramValues = Object.values(demoExports);
+    const evalFn = new Function(...paramNames, `return (${fallbackExpr})`);
+    const value = evalFn(...paramValues);
+
+    return value && typeof value === 'object' ? value as Record<string, unknown> : undefined;
+  } catch (err) {
+    console.warn('Failed to extract component demo data:', err);
+    return undefined;
+  }
+}

--- a/packages/manifest/frontend/src/services/registry.ts
+++ b/packages/manifest/frontend/src/services/registry.ts
@@ -107,7 +107,7 @@ async function fetchDemoData(category: string): Promise<string | null> {
     return cached.content;
   }
 
-  const url = `${GITHUB_RAW_BASE}/registry/${category}/demo/data.ts`;
+  const url = `${GITHUB_RAW_BASE}/registry/${category}/demo/${category}.ts`;
   try {
     const response = await fetch(url);
     if (!response.ok) return null;
@@ -157,7 +157,7 @@ export async function fetchComponentDetail(name: string): Promise<ComponentDetai
       detail.files = [
         ...(detail.files || []),
         {
-          path: `registry/${category}/demo/data.ts`,
+          path: `registry/${category}/demo/${category}.ts`,
           type: 'registry:demo',
           content: demoDataContent,
         },

--- a/packages/manifest/frontend/src/services/registry.ts
+++ b/packages/manifest/frontend/src/services/registry.ts
@@ -132,7 +132,8 @@ export async function fetchRegistry(): Promise<RegistryItem[]> {
   }
 
   const data: RegistryResponse = await response.json();
-  return data.items;
+  // Filter out library/utility entries (e.g., manifest-types) that aren't user-facing components
+  return data.items.filter(item => item.type === 'registry:block');
 }
 
 /**


### PR DESCRIPTION
## Description

Fixes multiple issues with demo data loading in the UI Component editor:

1. **Wrong demo data URL**: Demo data files were fetched from `/demo/data.ts` but actual files are named `/demo/{category}.ts` (e.g., `blogging.ts`, `events.ts`), causing 404s for all component previews.

2. **Library entries in component list**: `manifest-types` (a `registry:lib` item) appeared in the UI component selector alongside actual components. Fixed by filtering `fetchRegistry()` to only return `registry:block` items.

3. **Wrong demo data shape for most components**: The previous `extractDemoDataFromFiles` function flattened ALL exports from the category demo file into one object, which only worked for PostCard by coincidence. Components like LinkedInPost, Hero, etc. got incorrect data shapes. Fixed with a new `extractComponentDemoData` function that parses each component's specific `data ?? <expr>` fallback pattern and evaluates only that expression.

## Related Issues

None

## How can it be tested?

1. Start the dev server with `pnpm dev`
2. Open the flow editor and add a UI Component node (e.g., Post Card, LinkedIn Post, Hero)
3. Open the node editor — verify the Preview tab shows the component with demo data
4. Switch to the Demo Data tab — verify it shows the correct JSON data (not `{}`)
5. Edit the JSON in the Demo Data tab and verify the preview updates live
6. Verify "Manifest Types" no longer appears in the UI component library list

## Check list before submitting

- [x] This PR is wrote in a clear language and correctly labeled
- [x] I have performed a self-review of my code (no debugs, no commented code, good naming, etc.)
- [x] I wrote the relative tests
- [ ] I created a PR for the [documentation](https://github.com/mnfst/docs) if necessary and attached the link to this PR