### PR TITLE
Replace autofocus attribute with requestAnimationFrame focus

### DIFF
--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -80,13 +80,13 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
 
           <label class="modal-card__field-label">Agent name</label>
           <input
+            ref={(el) => requestAnimationFrame(() => el.focus())}
             class="modal-card__input"
             type="text"
             placeholder="e.g. Clawdy"
             value={name()}
             onInput={(e) => setName(e.currentTarget.value)}
             onKeyDown={handleKeyDown}
-            autofocus
           />
 
           <div class="modal-card__footer">


### PR DESCRIPTION
## Summary
Replaced the HTML `autofocus` attribute with a programmatic focus approach using `requestAnimationFrame` in the AddAgentModal component.

## Key Changes
- Removed the `autofocus` attribute from the agent name input field
- Added a ref callback that uses `requestAnimationFrame` to focus the input element after the next animation frame

## Implementation Details
This change improves focus handling by deferring the focus operation to the next animation frame, which can be more reliable in certain scenarios (e.g., when the modal is being rendered or when there are competing focus operations). The `requestAnimationFrame` approach ensures the DOM is fully painted before attempting to focus, potentially providing better UX and avoiding focus-related race conditions.

https://claude.ai/code/session_017RgxhKztkL6mqihfTYJwN8