### PR TITLE
fix: skip agent guard 404 redirect for newly created agents

### DIFF
--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from "@solidjs/router";
+import { useParams, useNavigate, useLocation } from "@solidjs/router";
 import { createResource, createEffect, Show, type ParentComponent } from "solid-js";
 import ErrorState from "./ErrorState.jsx";
 import { getAgents } from "../services/api.js";
@@ -14,9 +14,11 @@ interface AgentsData {
 const AgentGuard: ParentComponent = (props) => {
   const params = useParams<{ agentName: string }>();
   const navigate = useNavigate();
+  const location = useLocation<{ newAgent?: boolean }>();
   const [data, { refetch }] = createResource(() => getAgents() as Promise<AgentsData>);
 
   createEffect(() => {
+    if (location.state?.newAgent) return;
     const list = data()?.agents;
     if (!list) return;
     const exists = list.some(


### PR DESCRIPTION
## Summary
- Fix race condition where creating a new agent sometimes redirects to a 404 page
- `AgentGuard` now checks the `newAgent` navigation state flag (already passed by `Workspace.tsx`) and skips the existence check for freshly created agents

## Test plan
- [ ] Create a new agent via the "Connect Agent" modal
- [ ] Verify you land on the agent's overview page (not 404)
- [ ] Verify navigating to a non-existent agent URL still shows 404