### PR TITLE
fix: extract API_KEY_PREFIX constant and validate prefix in OtlpAuthGuard

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "start": "node packages/backend/dist/main.js",
     "build:plugin": "npm run build --workspace=packages/openclaw-plugin",
     "publish:plugin": "npm publish --access public --workspace=packages/openclaw-plugin",
+    "check:api-prefix": "node scripts/check-api-prefix.js",
     "lint": "eslint packages/backend/src packages/frontend/src",
     "format": "prettier --write 'packages/*/src/**/*.{ts,tsx,css}'"
   },

--- a/packages/backend/src/common/constants/api-key.constants.ts
+++ b/packages/backend/src/common/constants/api-key.constants.ts
@@ -1,0 +1,1 @@
+export const API_KEY_PREFIX = 'mnfst_';

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.ts
@@ -11,6 +11,7 @@ import { Request } from 'express';
 import { AgentApiKey } from '../../entities/agent-api-key.entity';
 import { IngestionContext } from '../interfaces/ingestion-context.interface';
 import { sha256 } from '../../common/utils/hash.util';
+import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
 
 interface CachedKey {
   tenantId: string;
@@ -47,6 +48,10 @@ export class OtlpAuthGuard implements CanActivate {
 
     if (!token) {
       throw new UnauthorizedException('Empty token');
+    }
+
+    if (!token.startsWith(API_KEY_PREFIX)) {
+      throw new UnauthorizedException('Invalid API key format');
     }
 
     const cached = this.cache.get(token);

--- a/packages/backend/src/otlp/services/api-key.service.spec.ts
+++ b/packages/backend/src/otlp/services/api-key.service.spec.ts
@@ -6,6 +6,7 @@ import { Tenant } from '../../entities/tenant.entity';
 import { Agent } from '../../entities/agent.entity';
 import { AgentApiKey } from '../../entities/agent-api-key.entity';
 import { sha256, keyPrefix } from '../../common/utils/hash.util';
+import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
 
 jest.mock('uuid', () => ({ v4: jest.fn() }));
 jest.mock('crypto', () => {
@@ -21,6 +22,12 @@ import { randomBytes } from 'crypto';
 
 const mockedUuidv4 = uuidv4 as jest.Mock;
 const mockedRandomBytes = randomBytes as jest.Mock;
+
+describe('API_KEY_PREFIX constant', () => {
+  it('equals mnfst_ (catches accidental revert)', () => {
+    expect(API_KEY_PREFIX).toBe('mnfst_');
+  });
+});
 
 describe('ApiKeyGeneratorService', () => {
   let service: ApiKeyGeneratorService;

--- a/packages/backend/src/otlp/services/api-key.service.ts
+++ b/packages/backend/src/otlp/services/api-key.service.ts
@@ -7,6 +7,7 @@ import { Tenant } from '../../entities/tenant.entity';
 import { Agent } from '../../entities/agent.entity';
 import { AgentApiKey } from '../../entities/agent-api-key.entity';
 import { sha256, keyPrefix } from '../../common/utils/hash.util';
+import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
 
 @Injectable()
 export class ApiKeyGeneratorService {
@@ -20,7 +21,7 @@ export class ApiKeyGeneratorService {
   ) {}
 
   private generateKey(): string {
-    return 'mnfst_' + randomBytes(32).toString('base64url');
+    return API_KEY_PREFIX + randomBytes(32).toString('base64url');
   }
 
   async onboardAgent(params: {

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -36,7 +36,7 @@ export const TEST_USER_ID = 'test-user-001';
 export const TEST_API_KEY = 'test-api-key-001';
 export const TEST_TENANT_ID = 'test-tenant-001';
 export const TEST_AGENT_ID = 'test-agent-001';
-export const TEST_OTLP_KEY = 'test-otlp-key-001';
+export const TEST_OTLP_KEY = 'mnfst_test-otlp-key-001';
 
 const entities = [AgentMessage, LlmCall, ToolExecution, SecurityEvent, ModelPricing, TokenUsageSnapshot, CostSnapshot, AgentLog, ApiKey, Tenant, Agent, AgentApiKey, NotificationRule, NotificationLog];
 

--- a/packages/openclaw-plugin/__tests__/config.test.ts
+++ b/packages/openclaw-plugin/__tests__/config.test.ts
@@ -1,5 +1,15 @@
 import { parseConfig, validateConfig } from "../src/config";
-import { DEFAULTS, ENV } from "../src/constants";
+import { API_KEY_PREFIX, DEFAULTS, ENV } from "../src/constants";
+
+describe("API_KEY_PREFIX constant", () => {
+  it("equals mnfst_ (catches accidental revert)", () => {
+    expect(API_KEY_PREFIX).toBe("mnfst_");
+  });
+
+  it("does not equal the old osk_ prefix", () => {
+    expect(API_KEY_PREFIX).not.toBe("osk_");
+  });
+});
 
 // Regression: Verify the DEFAULTS constant never reverts to the old wrong path.
 // OTel exporters append /v1/traces etc., so the base must be /otlp, not /api/v1/otlp.
@@ -176,6 +186,13 @@ describe("validateConfig", () => {
     const err = validateConfig(config)!;
     expect(err).toContain("mnfst_");
     expect(err).toContain("openclaw config set");
+  });
+
+  it("rejects keys with old osk_ prefix", () => {
+    const config = { ...validConfig, apiKey: "osk_some_old_key" };
+    const err = validateConfig(config)!;
+    expect(err).toContain("Invalid apiKey format");
+    expect(err).toContain("mnfst_");
   });
 
   it("rejects invalid endpoint URL with actionable fix command", () => {

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -1,4 +1,4 @@
-import { DEFAULTS, ENV } from "./constants";
+import { API_KEY_PREFIX, DEFAULTS, ENV } from "./constants";
 
 export interface ManifestConfig {
   apiKey: string;
@@ -59,15 +59,15 @@ export function validateConfig(config: ManifestConfig): string | null {
   if (!config.apiKey) {
     return (
       "Missing apiKey. Set it via:\n" +
-      "  openclaw config set manifest.apiKey mnfst_YOUR_KEY\n" +
-      "  or export MANIFEST_API_KEY=mnfst_YOUR_KEY"
+      `  openclaw config set manifest.apiKey ${API_KEY_PREFIX}YOUR_KEY\n` +
+      `  or export MANIFEST_API_KEY=${API_KEY_PREFIX}YOUR_KEY`
     );
   }
-  if (!config.apiKey.startsWith("mnfst_")) {
+  if (!config.apiKey.startsWith(API_KEY_PREFIX)) {
     return (
       "Invalid apiKey format. " +
-      "Keys must start with 'mnfst_'. Fix it via:\n" +
-      "  openclaw config set manifest.apiKey mnfst_YOUR_KEY"
+      `Keys must start with '${API_KEY_PREFIX}'. Fix it via:\n` +
+      `  openclaw config set manifest.apiKey ${API_KEY_PREFIX}YOUR_KEY`
     );
   }
   if (!config.endpoint.startsWith("http")) {

--- a/packages/openclaw-plugin/src/constants.ts
+++ b/packages/openclaw-plugin/src/constants.ts
@@ -41,6 +41,9 @@ export const ENV = {
   ENDPOINT: "MANIFEST_ENDPOINT",
 } as const;
 
+// API key prefix — must match the backend's API_KEY_PREFIX
+export const API_KEY_PREFIX = "mnfst_" as const;
+
 // Plugin defaults
 export const DEFAULTS = {
   ENDPOINT: "https://app.manifest.build/otlp",

--- a/scripts/check-api-prefix.js
+++ b/scripts/check-api-prefix.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+
+const regex = /API_KEY_PREFIX\s*=\s*['"]([^'"]+)['"]/;
+
+const backendSrc = fs.readFileSync(
+  'packages/backend/src/common/constants/api-key.constants.ts',
+  'utf8',
+);
+const pluginSrc = fs.readFileSync(
+  'packages/openclaw-plugin/src/constants.ts',
+  'utf8',
+);
+
+const backendMatch = regex.exec(backendSrc);
+const pluginMatch = regex.exec(pluginSrc);
+
+if (!backendMatch || !pluginMatch) {
+  console.error('Could not extract API_KEY_PREFIX from one or both packages');
+  process.exit(1);
+}
+
+if (backendMatch[1] !== pluginMatch[1]) {
+  console.error(
+    `MISMATCH: backend="${backendMatch[1]}" plugin="${pluginMatch[1]}"`,
+  );
+  process.exit(1);
+}
+
+console.log(`OK: API_KEY_PREFIX="${backendMatch[1]}"`);


### PR DESCRIPTION
## Summary

- Extracts `API_KEY_PREFIX = 'mnfst_'` as a shared constant in both the backend (`api-key.constants.ts`) and plugin (`constants.ts`), replacing hardcoded string literals
- Adds fast-fail prefix validation in `OtlpAuthGuard` — tokens without the `mnfst_` prefix are rejected immediately without a DB round-trip
- Fixes `TEST_OTLP_KEY` in e2e test helpers to use the correct `mnfst_` prefix
- Adds regression tests in both packages to catch accidental prefix reverts (e.g. back to `osk_`)
- Adds `npm run check:api-prefix` script that verifies both packages declare the same prefix value (for CI)

## Test plan

- [x] Plugin tests pass (112 tests, 7 suites)
- [x] Backend unit tests pass (378 tests, 38 suites)
- [x] Frontend tests pass (82 tests, 7 suites)
- [x] TypeScript compiles cleanly in both backend and plugin
- [x] `npm run check:api-prefix` outputs `OK: API_KEY_PREFIX="mnfst_"`