### PR TITLE
chore: add changeset to publish @mnfst/server

### DIFF
--- a/.changeset/publish-server-package.md
+++ b/.changeset/publish-server-package.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Publish @mnfst/server package


### PR DESCRIPTION
## Summary
- Add changeset for `@mnfst/server` so it gets a version bump and publishes to npm
- The package is at 5.2.0 locally but was never published (PR #751 publish failed, and PR #756 only bumped `manifest`)

## Test plan
- [ ] Merge → release workflow creates "Version Packages" PR bumping `@mnfst/server`
- [ ] Merge version PR → `@mnfst/server` publishes to npm via OIDC