### PR TITLE
fix: remove registry-url to allow npm OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
       - uses: changesets/action@v1


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `setup-node` in the release workflow
- `setup-node` with `registry-url` creates `.npmrc` with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` — since `NODE_AUTH_TOKEN` isn't set, npm uses the empty token instead of falling through to OIDC authentication
- Without `registry-url`, npm defaults to `registry.npmjs.org` and uses the OIDC token natively for trusted publishing

## Context
PR #755 added `registry-url` thinking it was needed for OIDC, but it actually blocks it. The release run showed OIDC was detected correctly but npm still failed with "Access token expired or revoked" because the empty `.npmrc` token took precedence.

## Test plan
- [ ] Merge → release workflow publishes `manifest@5.2.1` and `@mnfst/server@5.2.0` via OIDC