### PR TITLE
fix: use NPM_TOKEN for release workflow authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
       - uses: changesets/action@v1
@@ -27,4 +28,6 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Add `registry-url` and `NPM_TOKEN`/`NODE_AUTH_TOKEN` secrets for npm authentication
- Keep `id-token: write` and `NPM_CONFIG_PROVENANCE` for provenance signing
- `changesets/action@v1` detects OIDC but does not properly pass the token to npm — both with and without `registry-url` fail (`ENEEDAUTH` / `E404`)

## Before merging
Create an npm **Granular Access Token** with publish permissions for `manifest` and `@mnfst/server`, then add it as `NPM_TOKEN` in **Settings > Secrets and variables > Actions**.

## Test plan
- [ ] Add `NPM_TOKEN` secret to the repo
- [ ] Merge → release workflow publishes `manifest@5.2.1` and `@mnfst/server@5.2.2` to npm