### PR TITLE
fix: add repository url to @mnfst/server for provenance

### DIFF
--- a/.changeset/fix-server-repository.md
+++ b/.changeset/fix-server-repository.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Add repository field for npm provenance validation

--- a/packages/manifest-server/package.json
+++ b/packages/manifest-server/package.json
@@ -15,6 +15,10 @@
     "dist",
     "public"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mnfst/manifest"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Add `repository` field to `@mnfst/server` package.json
- npm provenance validation requires `repository.url` to match the GitHub repo in the sigstore bundle
- Without it: `E422 - package.json: "repository.url" is "", expected to match "https://github.com/mnfst/manifest"`

## Test plan
- [ ] Merge → version PR bumps `@mnfst/server` → merge version PR → publishes to npm