### PR TITLE
chore: add changeset for @mnfst/server patch release

### DIFF
--- a/.changeset/warm-planets-think.md
+++ b/.changeset/warm-planets-think.md
@@ -1,2 +1,5 @@
 ---
+"@mnfst/server": patch
 ---
+
+Fix dynamic imports and dependency resolution for local-install mode


### PR DESCRIPTION
## Summary

- Replaces the empty changeset from #768 with a proper `@mnfst/server` patch changeset
- This triggers the release workflow to create a "Version Packages" PR and publish to npm

## Context

PR #768 shipped changes to `@mnfst/server` (fixed dynamic imports, dependency resolution, build scripts) but included an empty changeset, so the npm publish was never triggered.

## Test plan

- [x] `npx changeset status` confirms `@mnfst/server` patch bump detected
- [ ] CI changeset-check job passes
- [ ] After merge, release workflow creates "Version Packages" PR