### PR TITLE
fix: improve local mode first-visit UX

### DIFF
--- a/.changeset/smooth-local-ux.md
+++ b/.changeset/smooth-local-ux.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Improve local mode first-visit UX: skip redundant setup modal for local-agent, print dashboard URL from @mnfst/server, and show contextual verify step in local mode

--- a/packages/frontend/src/components/SetupModal.tsx
+++ b/packages/frontend/src/components/SetupModal.tsx
@@ -118,7 +118,7 @@ const SetupModal: Component<{ open: boolean; agentName: string; apiKey?: string 
               />
             </Show>
             <Show when={step() === 2}>
-              <SetupStepVerify />
+              <SetupStepVerify isLocal={isLocal()} />
             </Show>
           </Show>
 

--- a/packages/frontend/src/components/SetupStepVerify.tsx
+++ b/packages/frontend/src/components/SetupStepVerify.tsx
@@ -1,42 +1,53 @@
-import { type Component } from "solid-js";
+import { Show, type Component } from "solid-js";
 import { CopyButton } from "./SetupStepInstall.jsx";
 
 const RESTART_CMD = "openclaw gateway restart";
 
-const SetupStepVerify: Component<{ stepNumber?: number }> = (props) => {
+const SetupStepVerify: Component<{ stepNumber?: number; isLocal?: boolean }> = (props) => {
   return (
     <div>
-      <h3 style="margin: 0 0 4px; font-size: var(--font-size-base); font-weight: 600;">
-        {props.stepNumber ? `${props.stepNumber}. ` : ''}Activate the plugin
-      </h3>
-      <p style="margin: 0 0 16px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-        Restart OpenClaw to activate the plugin:
-      </p>
+      <Show when={props.isLocal} fallback={
+        <>
+          <h3 style="margin: 0 0 4px; font-size: var(--font-size-base); font-weight: 600;">
+            {props.stepNumber ? `${props.stepNumber}. ` : ''}Activate the plugin
+          </h3>
+          <p style="margin: 0 0 16px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
+            Restart OpenClaw to activate the plugin:
+          </p>
 
-      <div class="modal-terminal">
-        <div class="modal-terminal__header">
-          <div class="modal-terminal__dots">
-            <span class="modal-terminal__dot modal-terminal__dot--red" />
-            <span class="modal-terminal__dot modal-terminal__dot--yellow" />
-            <span class="modal-terminal__dot modal-terminal__dot--green" />
+          <div class="modal-terminal">
+            <div class="modal-terminal__header">
+              <div class="modal-terminal__dots">
+                <span class="modal-terminal__dot modal-terminal__dot--red" />
+                <span class="modal-terminal__dot modal-terminal__dot--yellow" />
+                <span class="modal-terminal__dot modal-terminal__dot--green" />
+              </div>
+              <div class="modal-terminal__tabs">
+                <span class="modal-terminal__tab modal-terminal__tab--active">Terminal</span>
+              </div>
+            </div>
+            <div class="modal-terminal__body">
+              <CopyButton text={RESTART_CMD} />
+              <div class="modal-terminal__line modal-terminal__line--comment"># Restart OpenClaw to activate the plugin</div>
+              <div>
+                <span class="modal-terminal__prompt">$</span>
+                <span class="modal-terminal__code">{RESTART_CMD}</span>
+              </div>
+            </div>
           </div>
-          <div class="modal-terminal__tabs">
-            <span class="modal-terminal__tab modal-terminal__tab--active">Terminal</span>
-          </div>
-        </div>
-        <div class="modal-terminal__body">
-          <CopyButton text={RESTART_CMD} />
-          <div class="modal-terminal__line modal-terminal__line--comment"># Restart OpenClaw to activate the plugin</div>
-          <div>
-            <span class="modal-terminal__prompt">$</span>
-            <span class="modal-terminal__code">{RESTART_CMD}</span>
-          </div>
-        </div>
-      </div>
 
-      <p style="margin: 16px 0 0; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-        Once restarted, send a message to your agent. Activity will appear on the dashboard a few seconds after the agent responds.
-      </p>
+          <p style="margin: 16px 0 0; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
+            Once restarted, send a message to your agent. Activity will appear on the dashboard a few seconds after the agent responds.
+          </p>
+        </>
+      }>
+        <h3 style="margin: 0 0 4px; font-size: var(--font-size-base); font-weight: 600;">
+          {props.stepNumber ? `${props.stepNumber}. ` : ''}Start chatting
+        </h3>
+        <p style="margin: 0; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
+          Your agent is ready to receive telemetry. Send a message to your agent and activity will appear on the dashboard within a few seconds.
+        </p>
+      </Show>
     </div>
   );
 };

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -6,6 +6,7 @@ import { getMessages } from "../services/api.js";
 import { formatNumber, formatCost, formatTime, formatStatus } from "../services/formatters.js";
 import Select from "../components/Select.jsx";
 import InfoTooltip from "../components/InfoTooltip.jsx";
+import { isLocalMode } from "../services/local-mode.js";
 import { pingCount } from "../services/sse.js";
 import SetupModal from "../components/SetupModal.jsx";
 import "../styles/overview.css";
@@ -37,7 +38,8 @@ const MessageLog: Component = () => {
   const [costMax, setCostMax] = createSignal("");
   const [setupOpen, setSetupOpen] = createSignal(false);
   const [setupCompleted] = createSignal(
-    !!localStorage.getItem(`setup_completed_${params.agentName}`)
+    !!localStorage.getItem(`setup_completed_${params.agentName}`) ||
+    (isLocalMode() === true && params.agentName === 'local-agent')
   );
   const [data, { refetch }] = createResource(
     () => ({ status: statusFilter(), model: modelFilter(), costMin: costMin(), costMax: costMax(), agentName: params.agentName, _ping: pingCount() }),

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -22,6 +22,7 @@ import {
   formatStatus,
   formatTime,
 } from '../services/formatters.js'
+import { isLocalMode } from '../services/local-mode.js'
 import { pingCount } from '../services/sse.js'
 import '../styles/overview.css'
 
@@ -97,6 +98,11 @@ const Overview: Component = () => {
   }
 
   createEffect(() => {
+    if (isLocalMode() === true && params.agentName === 'local-agent') {
+      localStorage.setItem(`setup_completed_${params.agentName}`, '1')
+      setSetupCompleted(true)
+      return
+    }
     if (isNewAgent() && !setupCompleted() && !localStorage.getItem(`setup_dismissed_${params.agentName}`)) {
       setSetupOpen(true)
     }

--- a/packages/frontend/tests/components/SetupStepVerify.test.tsx
+++ b/packages/frontend/tests/components/SetupStepVerify.test.tsx
@@ -42,4 +42,53 @@ describe("SetupStepVerify", () => {
     const { container } = render(() => <SetupStepVerify stepNumber={3} />);
     expect(container.textContent).toContain("3. Activate the plugin");
   });
+
+  describe("when isLocal is true", () => {
+    it("should render Start chatting heading", () => {
+      render(() => <SetupStepVerify isLocal={true} />);
+      expect(screen.getByText("Start chatting")).toBeDefined();
+    });
+
+    it("should not render Activate the plugin heading", () => {
+      const { container } = render(() => <SetupStepVerify isLocal={true} />);
+      expect(container.textContent).not.toContain("Activate the plugin");
+    });
+
+    it("should not show terminal UI", () => {
+      const { container } = render(() => <SetupStepVerify isLocal={true} />);
+      expect(container.querySelector(".modal-terminal")).toBeNull();
+    });
+
+    it("should not show restart command", () => {
+      const { container } = render(() => <SetupStepVerify isLocal={true} />);
+      expect(container.textContent).not.toContain("openclaw gateway restart");
+    });
+
+    it("should show telemetry ready message", () => {
+      const { container } = render(() => <SetupStepVerify isLocal={true} />);
+      expect(container.textContent).toContain("ready to receive telemetry");
+    });
+
+    it("should show step number with Start chatting heading", () => {
+      const { container } = render(() => <SetupStepVerify isLocal={true} stepNumber={2} />);
+      expect(container.textContent).toContain("2. Start chatting");
+    });
+  });
+
+  describe("when isLocal is false", () => {
+    it("should render Activate the plugin heading", () => {
+      render(() => <SetupStepVerify isLocal={false} />);
+      expect(screen.getByText("Activate the plugin")).toBeDefined();
+    });
+
+    it("should show terminal UI", () => {
+      const { container } = render(() => <SetupStepVerify isLocal={false} />);
+      expect(container.querySelector(".modal-terminal")).not.toBeNull();
+    });
+
+    it("should show restart command", () => {
+      const { container } = render(() => <SetupStepVerify isLocal={false} />);
+      expect(container.textContent).toContain("openclaw gateway restart");
+    });
+  });
 });

--- a/packages/manifest-server/src/index.ts
+++ b/packages/manifest-server/src/index.ts
@@ -13,6 +13,7 @@ interface StartOptions {
   port?: number;
   host?: string;
   dbPath?: string;
+  quiet?: boolean;
 }
 
 export async function start(options: StartOptions = {}): Promise<unknown> {
@@ -37,6 +38,10 @@ export async function start(options: StartOptions = {}): Promise<unknown> {
 
   const backendMain = await import(`${BACKEND_DIR}/main`);
   const app = await backendMain.bootstrap();
+
+  if (!options.quiet) {
+    console.log(`Manifest dashboard ready: http://${host}:${port}`);
+  }
 
   const { trackEvent } = require(`${BACKEND_DIR}/common/utils/product-telemetry`);
   trackEvent('server_started', { package_version: version });

--- a/packages/openclaw-plugin/src/local-mode.ts
+++ b/packages/openclaw-plugin/src/local-mode.ts
@@ -97,7 +97,7 @@ export function registerLocalMode(
     id: "manifest-local",
     start: async () => {
       try {
-        await serverModule.start({ port, host, dbPath });
+        await serverModule.start({ port, host, dbPath, quiet: true });
         logger.info(`[manifest] Local server running on http://${host}:${port}`);
         logger.info(`[manifest]   Dashboard: http://${host}:${port}`);
         logger.info(`[manifest]   DB: ${dbPath}`);


### PR DESCRIPTION
## Summary

- **Skip redundant setup modal** for `local-agent` in local mode — auto-marks setup as completed so users land directly on the "waiting for data" banner instead of a confusing wizard with 3 green checkmarks
- **Print dashboard URL** from `@mnfst/server` (`Manifest dashboard ready: http://host:port`) so direct consumers know where the dashboard is; suppressed via `quiet: true` from the plugin which already prints its own messages
- **Local-mode-aware Verify step** — shows "Start chatting" with relevant instructions instead of "Restart OpenClaw" which is irrelevant in local mode

## Test plan

- [x] Frontend tests pass (418/418)
- [x] Backend tests pass (577/577)
- [x] TypeScript compiles with no errors (frontend + backend)
- [ ] Manual: kill manifest, remove `~/.openclaw/manifest/`, restart gateway, open `http://127.0.0.1:2099` — should land on waiting banner with no setup modal
- [ ] Manual: cloud mode setup modal still opens for new agents created via "Connect Agent"