### PR TITLE
Fix notification cron: hourly alerts and email retry logic

### DIFF
--- a/.changeset/fix-notification-cron.md
+++ b/.changeset/fix-notification-cron.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Fix notification cron: hourly alerts never triggered because the evaluation window was empty, and failed email sends prevented retries

--- a/package-lock.json
+++ b/package-lock.json
@@ -13027,7 +13027,7 @@
     },
     "packages/manifest-server": {
       "name": "@mnfst/server",
-      "version": "5.2.4",
+      "version": "5.2.10",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",
@@ -13100,8 +13100,11 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.2.4",
+      "version": "5.2.7",
       "license": "MIT",
+      "dependencies": {
+        "@mnfst/server": "^5.2.8"
+      },
       "devDependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",

--- a/packages/backend/src/notifications/services/notification-cron.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.spec.ts
@@ -195,6 +195,46 @@ describe('NotificationCronService', () => {
     expect(result).toBe(1);
   });
 
+  it('triggers notification for hourly period (checks previous hour)', async () => {
+    const hourlyRule = { ...activeRule, id: 'rule-hour', period: 'hour' as const };
+    mockGetAllActiveRules.mockResolvedValue([hourlyRule]);
+    mockQuery
+      .mockResolvedValueOnce([]) // no dedup
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
+    mockGetConsumption.mockResolvedValue(150000);
+
+    const result = await service.checkThresholds();
+    expect(result).toBe(1);
+    expect(mockSendThresholdAlert).toHaveBeenCalled();
+  });
+
+  it('triggers notification for weekly period', async () => {
+    const weeklyRule = { ...activeRule, id: 'rule-week', period: 'week' as const };
+    mockGetAllActiveRules.mockResolvedValue([weeklyRule]);
+    mockQuery
+      .mockResolvedValueOnce([]) // no dedup
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
+    mockGetConsumption.mockResolvedValue(150000);
+
+    const result = await service.checkThresholds();
+    expect(result).toBe(1);
+  });
+
+  it('triggers notification for monthly period', async () => {
+    const monthlyRule = { ...activeRule, id: 'rule-month', period: 'month' as const };
+    mockGetAllActiveRules.mockResolvedValue([monthlyRule]);
+    mockQuery
+      .mockResolvedValueOnce([]) // no dedup
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
+    mockGetConsumption.mockResolvedValue(150000);
+
+    const result = await service.checkThresholds();
+    expect(result).toBe(1);
+  });
+
   it('continues processing remaining rules when one throws', async () => {
     const rule2 = { ...activeRule, id: 'rule-2' };
     mockGetAllActiveRules.mockResolvedValue([activeRule, rule2]);

--- a/packages/backend/src/notifications/services/notification-cron.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.spec.ts
@@ -77,8 +77,8 @@ describe('NotificationCronService', () => {
     mockGetAllActiveRules.mockResolvedValue([activeRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
-      .mockResolvedValueOnce(undefined) // INSERT notification_log
-      .mockResolvedValueOnce([{ email: 'user@test.com' }]); // resolve user email
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // resolve user email
+      .mockResolvedValueOnce(undefined); // INSERT notification_log
     mockGetConsumption.mockResolvedValue(150000);
 
     const result = await service.checkThresholds();
@@ -102,13 +102,29 @@ describe('NotificationCronService', () => {
     mockGetAllActiveRules.mockResolvedValue([activeRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
-      .mockResolvedValueOnce(undefined) // INSERT notification_log
-      .mockResolvedValueOnce([]); // no email
+      .mockResolvedValueOnce([]) // no email
+      .mockResolvedValueOnce(undefined); // INSERT notification_log
     mockGetConsumption.mockResolvedValue(200000);
 
     const result = await service.checkThresholds();
     expect(result).toBe(1);
     expect(mockSendThresholdAlert).not.toHaveBeenCalled();
+  });
+
+  it('does not record log when email send fails (allows retry)', async () => {
+    mockGetAllActiveRules.mockResolvedValue([activeRule]);
+    mockQuery
+      .mockResolvedValueOnce([]) // no dedup
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]); // resolve email
+    mockGetConsumption.mockResolvedValue(200000);
+    mockSendThresholdAlert.mockResolvedValue(false); // email failed
+
+    const result = await service.checkThresholds();
+    expect(result).toBe(0);
+    expect(mockQuery).not.toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO notification_logs'),
+      expect.any(Array),
+    );
   });
 
   it('uses PostgreSQL numbered params ($1, $2) in dedup query', async () => {
@@ -128,13 +144,13 @@ describe('NotificationCronService', () => {
     mockGetAllActiveRules.mockResolvedValue([activeRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
-      .mockResolvedValueOnce(undefined) // INSERT
-      .mockResolvedValueOnce([{ email: 'a@b.com' }]); // email
+      .mockResolvedValueOnce([{ email: 'a@b.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
     mockGetConsumption.mockResolvedValue(200000);
 
     await service.checkThresholds();
 
-    const insertCall = mockQuery.mock.calls[1];
+    const insertCall = mockQuery.mock.calls[2];
     const sql = insertCall[0] as string;
     const params = insertCall[1] as unknown[];
 
@@ -148,13 +164,13 @@ describe('NotificationCronService', () => {
     mockGetAllActiveRules.mockResolvedValue([activeRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
-      .mockResolvedValueOnce(undefined) // INSERT
-      .mockResolvedValueOnce([{ email: 'user@test.com' }]); // email
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
     mockGetConsumption.mockResolvedValue(200000);
 
     await service.checkThresholds();
 
-    const emailCall = mockQuery.mock.calls[2];
+    const emailCall = mockQuery.mock.calls[1];
     const sql = emailCall[0] as string;
     expect(sql).toContain('SELECT email FROM "user" WHERE id = $1');
     expect(emailCall[1]).toEqual(['user-1']);
@@ -167,8 +183,8 @@ describe('NotificationCronService', () => {
     // Rule 1: triggers
     mockQuery
       .mockResolvedValueOnce([]) // no dedup rule-1
-      .mockResolvedValueOnce(undefined) // INSERT rule-1
-      .mockResolvedValueOnce([{ email: 'user@test.com' }]); // email rule-1
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email rule-1
+      .mockResolvedValueOnce(undefined); // INSERT rule-1
     mockGetConsumption.mockResolvedValueOnce(150000); // above 100k
 
     // Rule 2: does not trigger
@@ -189,8 +205,8 @@ describe('NotificationCronService', () => {
     // Rule 2: triggers
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
-      .mockResolvedValueOnce(undefined) // INSERT
-      .mockResolvedValueOnce([{ email: 'user@test.com' }]); // email
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
     mockGetConsumption.mockResolvedValueOnce(200000);
 
     const result = await service.checkThresholds();
@@ -260,13 +276,13 @@ describe('NotificationCronService (SQLite dialect)', () => {
     mockGetAllActiveRules.mockResolvedValue([sqliteRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
-      .mockResolvedValueOnce(undefined) // INSERT
-      .mockResolvedValueOnce([{ email: 'a@b.com' }]); // email
+      .mockResolvedValueOnce([{ email: 'a@b.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
     mockGetConsumption.mockResolvedValue(200000);
 
     await service.checkThresholds();
 
-    const insertCall = mockQuery.mock.calls[1];
+    const insertCall = mockQuery.mock.calls[2];
     const sql = insertCall[0] as string;
     const params = insertCall[1] as unknown[];
 
@@ -281,13 +297,13 @@ describe('NotificationCronService (SQLite dialect)', () => {
     mockGetAllActiveRules.mockResolvedValue([sqliteRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
-      .mockResolvedValueOnce(undefined) // INSERT
-      .mockResolvedValueOnce([{ email: 'user@test.com' }]); // email
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
     mockGetConsumption.mockResolvedValue(200000);
 
     await service.checkThresholds();
 
-    const emailCall = mockQuery.mock.calls[2];
+    const emailCall = mockQuery.mock.calls[1];
     const sql = emailCall[0] as string;
     expect(sql).toContain('SELECT email FROM "user" WHERE id = ?');
     expect(emailCall[1]).toEqual(['user-1']);
@@ -297,8 +313,8 @@ describe('NotificationCronService (SQLite dialect)', () => {
     mockGetAllActiveRules.mockResolvedValue([sqliteRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
-      .mockResolvedValueOnce(undefined) // INSERT
-      .mockResolvedValueOnce([{ email: 'user@test.com' }]); // email
+      .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
+      .mockResolvedValueOnce(undefined); // INSERT
     mockGetConsumption.mockResolvedValue(150000);
 
     const result = await service.checkThresholds();


### PR DESCRIPTION
## Summary
Fixed two critical bugs in the notification cron service that prevented hourly alerts from triggering and blocked retries when email delivery failed.

## Key Changes

- **Fixed hourly period calculation**: Changed the hour boundary calculation from `now.getUTCHours()` to `now.getUTCHours() - 1` to properly evaluate the previous hour's metrics instead of an empty window
- **Implemented email send retry logic**: Moved notification log insertion to occur only after successful email delivery (or when no email exists), allowing failed sends to be retried on the next cron run
- **Improved error handling**: Added warning logs for cases where user email cannot be resolved or email delivery fails
- **Updated return value**: Changed `recordThreshold()` to return the actual send status instead of always returning `true`, enabling proper tracking of successful notifications

## Implementation Details

The notification flow now follows this order:
1. Check for duplicate notifications
2. Resolve user email
3. Send email alert (if email exists)
4. Only record in notification_logs if email was sent successfully OR no email was found
5. Return the actual send status for proper accounting

This ensures that failed email deliveries don't create log entries, allowing the cron job to retry them on subsequent runs without triggering duplicate detection.

https://claude.ai/code/session_016Burqogpf21L8nzuQPu74x