### PR TITLE
feat: import all OpenRouter models with price history and unresolved tracking

### DIFF
--- a/.changeset/model-pricing-improvements.md
+++ b/.changeset/model-pricing-improvements.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": minor
+---
+
+Import all OpenRouter models instead of a curated subset, add price history tracking, unresolved model detection, and a live search/filter UI for the model prices page.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -7,6 +7,8 @@ import { LlmCall } from '../entities/llm-call.entity';
 import { ToolExecution } from '../entities/tool-execution.entity';
 import { SecurityEvent } from '../entities/security-event.entity';
 import { ModelPricing } from '../entities/model-pricing.entity';
+import { ModelPricingHistory } from '../entities/model-pricing-history.entity';
+import { UnresolvedModel } from '../entities/unresolved-model.entity';
 import { TokenUsageSnapshot } from '../entities/token-usage-snapshot.entity';
 import { CostSnapshot } from '../entities/cost-snapshot.entity';
 import { AgentLog } from '../entities/agent-log.entity';
@@ -18,25 +20,30 @@ import { NotificationRule } from '../entities/notification-rule.entity';
 import { NotificationLog } from '../entities/notification-log.entity';
 import { DatabaseSeederService } from './database-seeder.service';
 import { LocalBootstrapService } from './local-bootstrap.service';
-import { PricingSyncService } from './pricing-sync.service';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
 import { HashApiKeys1771500000000 } from './migrations/1771500000000-HashApiKeys';
+import { ModelPricingImprovements1771600000000 } from './migrations/1771600000000-ModelPricingImprovements';
 
 const entities = [
   AgentMessage, LlmCall, ToolExecution, SecurityEvent, ModelPricing,
+  ModelPricingHistory, UnresolvedModel,
   TokenUsageSnapshot, CostSnapshot, AgentLog,
   ApiKey, Tenant, Agent, AgentApiKey,
   NotificationRule, NotificationLog,
 ];
 
-const migrations = [InitialSchema1771464895790, HashApiKeys1771500000000];
+const migrations = [
+  InitialSchema1771464895790,
+  HashApiKeys1771500000000,
+  ModelPricingImprovements1771600000000,
+];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';
 
 function buildModeServices() {
   const seeder = isLocalMode ? LocalBootstrapService : DatabaseSeederService;
-  return [seeder, PricingSyncService];
+  return [seeder];
 }
 
 @Module({

--- a/packages/backend/src/database/migrations/1771600000000-ModelPricingImprovements.ts
+++ b/packages/backend/src/database/migrations/1771600000000-ModelPricingImprovements.ts
@@ -1,0 +1,78 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ModelPricingImprovements1771600000000
+  implements MigrationInterface
+{
+  name = 'ModelPricingImprovements1771600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.createModelPricingHistoryTable(queryRunner);
+    await this.createUnresolvedModelsTable(queryRunner);
+    await this.convertUpdatedAtToTimestamp(queryRunner);
+  }
+
+  private async createModelPricingHistoryTable(
+    queryRunner: QueryRunner,
+  ): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "model_pricing_history" (
+        "id" character varying NOT NULL,
+        "model_name" character varying NOT NULL,
+        "input_price_per_token" numeric(12,10) NOT NULL,
+        "output_price_per_token" numeric(12,10) NOT NULL,
+        "provider" character varying NOT NULL DEFAULT '',
+        "effective_from" TIMESTAMP NOT NULL,
+        "effective_until" TIMESTAMP,
+        "change_source" character varying NOT NULL DEFAULT 'sync',
+        CONSTRAINT "PK_model_pricing_history" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_mph_model_name" ON "model_pricing_history" ("model_name")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_mph_model_effective" ON "model_pricing_history" ("model_name", "effective_from")`,
+    );
+  }
+
+  private async createUnresolvedModelsTable(
+    queryRunner: QueryRunner,
+  ): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "unresolved_models" (
+        "model_name" character varying NOT NULL,
+        "first_seen" TIMESTAMP NOT NULL,
+        "last_seen" TIMESTAMP NOT NULL,
+        "occurrence_count" integer NOT NULL DEFAULT 1,
+        "resolved" boolean NOT NULL DEFAULT false,
+        "resolved_to" character varying,
+        "resolved_at" TIMESTAMP,
+        CONSTRAINT "PK_unresolved_models" PRIMARY KEY ("model_name")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_unresolved_resolved" ON "unresolved_models" ("resolved")`,
+    );
+  }
+
+  private async convertUpdatedAtToTimestamp(
+    queryRunner: QueryRunner,
+  ): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "model_pricing"
+      ALTER COLUMN "updated_at" TYPE TIMESTAMP
+      USING "updated_at"::timestamp
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "model_pricing" ALTER COLUMN "updated_at" TYPE character varying`,
+    );
+    await queryRunner.query(`DROP INDEX "IDX_unresolved_resolved"`);
+    await queryRunner.query(`DROP TABLE "unresolved_models"`);
+    await queryRunner.query(`DROP INDEX "IDX_mph_model_effective"`);
+    await queryRunner.query(`DROP INDEX "IDX_mph_model_name"`);
+    await queryRunner.query(`DROP TABLE "model_pricing_history"`);
+  }
+}

--- a/packages/backend/src/database/pricing-history.service.spec.ts
+++ b/packages/backend/src/database/pricing-history.service.spec.ts
@@ -1,0 +1,194 @@
+import { PricingHistoryService } from './pricing-history.service';
+import { ModelPricing } from '../entities/model-pricing.entity';
+
+describe('PricingHistoryService', () => {
+  let service: PricingHistoryService;
+  let mockRepo: {
+    create: jest.Mock;
+    save: jest.Mock;
+    update: jest.Mock;
+    find: jest.Mock;
+  };
+
+  beforeEach(() => {
+    mockRepo = {
+      create: jest.fn((data) => ({ ...data })),
+      save: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    service = new PricingHistoryService(mockRepo as never);
+  });
+
+  describe('recordChange', () => {
+    const incoming = {
+      model_name: 'gpt-4o',
+      input_price_per_token: 0.000003,
+      output_price_per_token: 0.000012,
+      provider: 'OpenAI',
+    };
+
+    it('should insert history for a new model', async () => {
+      const changed = await service.recordChange(null, incoming, 'sync');
+
+      expect(changed).toBe(true);
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model_name: 'gpt-4o',
+          input_price_per_token: 0.000003,
+          output_price_per_token: 0.000012,
+          provider: 'OpenAI',
+          change_source: 'sync',
+          effective_until: null,
+        }),
+      );
+      expect(mockRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return false when prices have not changed', async () => {
+      const existing = {
+        model_name: 'gpt-4o',
+        input_price_per_token: 0.000003,
+        output_price_per_token: 0.000012,
+      } as ModelPricing;
+
+      const changed = await service.recordChange(existing, incoming, 'sync');
+
+      expect(changed).toBe(false);
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should record change when input price differs', async () => {
+      const existing = {
+        model_name: 'gpt-4o',
+        input_price_per_token: 0.000002,
+        output_price_per_token: 0.000012,
+      } as ModelPricing;
+
+      const changed = await service.recordChange(existing, incoming, 'sync');
+
+      expect(changed).toBe(true);
+      expect(mockRepo.update).toHaveBeenCalledTimes(1);
+      expect(mockRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should record change when output price differs', async () => {
+      const existing = {
+        model_name: 'gpt-4o',
+        input_price_per_token: 0.000003,
+        output_price_per_token: 0.000010,
+      } as ModelPricing;
+
+      const changed = await service.recordChange(existing, incoming, 'sync');
+
+      expect(changed).toBe(true);
+    });
+
+    it('should close the old history entry on price change', async () => {
+      const existing = {
+        model_name: 'gpt-4o',
+        input_price_per_token: 0.000001,
+        output_price_per_token: 0.000005,
+      } as ModelPricing;
+
+      await service.recordChange(existing, incoming, 'sync');
+
+      expect(mockRepo.update).toHaveBeenCalledWith(
+        expect.objectContaining({ model_name: 'gpt-4o' }),
+        expect.objectContaining({ effective_until: expect.any(Date) }),
+      );
+    });
+
+    it('should handle string-typed decimal values from DB', async () => {
+      const existing = {
+        model_name: 'gpt-4o',
+        input_price_per_token: '0.0000030000' as unknown as number,
+        output_price_per_token: '0.0000120000' as unknown as number,
+      } as ModelPricing;
+
+      const changed = await service.recordChange(existing, incoming, 'sync');
+      expect(changed).toBe(false);
+    });
+
+    it('should record change when both input and output price differ', async () => {
+      const existing = {
+        model_name: 'gpt-4o',
+        input_price_per_token: 0.000001,
+        output_price_per_token: 0.000005,
+      } as ModelPricing;
+
+      const changed = await service.recordChange(existing, incoming, 'sync');
+
+      expect(changed).toBe(true);
+      expect(mockRepo.update).toHaveBeenCalledTimes(1);
+      expect(mockRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should generate a UUID id for history entries', async () => {
+      const changed = await service.recordChange(null, incoming, 'sync');
+
+      expect(changed).toBe(true);
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+
+    it('should pass the change_source through to the history entry', async () => {
+      await service.recordChange(null, incoming, 'manual');
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ change_source: 'manual' }),
+      );
+    });
+
+    it('should close the previous entry with IsNull filter', async () => {
+      const existing = {
+        model_name: 'gpt-4o',
+        input_price_per_token: 0.000001,
+        output_price_per_token: 0.000005,
+      } as ModelPricing;
+
+      await service.recordChange(existing, incoming, 'sync');
+
+      const updateFilter = mockRepo.update.mock.calls[0][0];
+      expect(updateFilter.model_name).toBe('gpt-4o');
+      // The IsNull() TypeORM FindOperator should be present
+      expect(updateFilter.effective_until).toBeDefined();
+      expect(updateFilter.effective_until._type).toBe('isNull');
+    });
+
+    it('should set effective_from as a Date on new entries', async () => {
+      await service.recordChange(null, incoming, 'sync');
+
+      const created = mockRepo.create.mock.calls[0][0];
+      expect(created.effective_from).toBeInstanceOf(Date);
+      expect(created.effective_until).toBeNull();
+    });
+  });
+
+  describe('getHistory', () => {
+    it('should return history records ordered by effective_from DESC', async () => {
+      const records = [
+        { id: '2', model_name: 'gpt-4o', effective_from: new Date('2025-02-01') },
+        { id: '1', model_name: 'gpt-4o', effective_from: new Date('2025-01-01') },
+      ];
+      mockRepo.find.mockResolvedValue(records);
+
+      const result = await service.getHistory('gpt-4o');
+
+      expect(result).toEqual(records);
+      expect(mockRepo.find).toHaveBeenCalledWith({
+        where: { model_name: 'gpt-4o' },
+        order: { effective_from: 'DESC' },
+      });
+    });
+
+    it('should return empty array for unknown model', async () => {
+      mockRepo.find.mockResolvedValue([]);
+
+      const result = await service.getHistory('unknown');
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/backend/src/database/pricing-history.service.ts
+++ b/packages/backend/src/database/pricing-history.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { randomUUID } from 'crypto';
+import { ModelPricingHistory } from '../entities/model-pricing-history.entity';
+import { ModelPricing } from '../entities/model-pricing.entity';
+import { sqlNow } from '../common/utils/sql-dialect';
+
+interface IncomingPricing {
+  model_name: string;
+  input_price_per_token: number;
+  output_price_per_token: number;
+  provider: string;
+}
+
+@Injectable()
+export class PricingHistoryService {
+  constructor(
+    @InjectRepository(ModelPricingHistory)
+    private readonly historyRepo: Repository<ModelPricingHistory>,
+  ) {}
+
+  async recordChange(
+    existing: ModelPricing | null,
+    incoming: IncomingPricing,
+    source: string,
+  ): Promise<boolean> {
+    const now = new Date(sqlNow());
+
+    if (!existing) {
+      await this.insertHistoryEntry(incoming, now, source);
+      return true;
+    }
+
+    if (!this.hasPriceChanged(existing, incoming)) {
+      return false;
+    }
+
+    await this.closeCurrentEntry(existing.model_name, now);
+    await this.insertHistoryEntry(incoming, now, source);
+    return true;
+  }
+
+  private hasPriceChanged(
+    existing: ModelPricing,
+    incoming: IncomingPricing,
+  ): boolean {
+    const oldInput = Number(existing.input_price_per_token);
+    const oldOutput = Number(existing.output_price_per_token);
+    return (
+      oldInput !== incoming.input_price_per_token ||
+      oldOutput !== incoming.output_price_per_token
+    );
+  }
+
+  private async closeCurrentEntry(
+    modelName: string,
+    until: Date,
+  ): Promise<void> {
+    await this.historyRepo.update(
+      { model_name: modelName, effective_until: IsNull() },
+      { effective_until: until },
+    );
+  }
+
+  private async insertHistoryEntry(
+    incoming: IncomingPricing,
+    effectiveFrom: Date,
+    source: string,
+  ): Promise<void> {
+    const entry = this.historyRepo.create({
+      id: randomUUID(),
+      model_name: incoming.model_name,
+      input_price_per_token: incoming.input_price_per_token,
+      output_price_per_token: incoming.output_price_per_token,
+      provider: incoming.provider,
+      effective_from: effectiveFrom,
+      effective_until: null,
+      change_source: source,
+    });
+    await this.historyRepo.save(entry);
+  }
+
+  async getHistory(modelName: string): Promise<ModelPricingHistory[]> {
+    return this.historyRepo.find({
+      where: { model_name: modelName },
+      order: { effective_from: 'DESC' },
+    });
+  }
+}

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -1,10 +1,21 @@
 import { PricingSyncService } from './pricing-sync.service';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
+import { PricingHistoryService } from './pricing-history.service';
+import { UnresolvedModelTrackerService } from '../model-prices/unresolved-model-tracker.service';
 
 const mockUpsert = jest.fn();
-const mockRepo = { upsert: mockUpsert } as never;
+const mockFindOneBy = jest.fn().mockResolvedValue(null);
+const mockRepo = { upsert: mockUpsert, findOneBy: mockFindOneBy } as never;
 const mockReload = jest.fn().mockResolvedValue(undefined);
 const mockPricingCache = { reload: mockReload } as unknown as ModelPricingCacheService;
+const mockRecordChange = jest.fn().mockResolvedValue(false);
+const mockPricingHistory = { recordChange: mockRecordChange } as unknown as PricingHistoryService;
+const mockGetUnresolved = jest.fn().mockResolvedValue([]);
+const mockMarkResolved = jest.fn().mockResolvedValue(undefined);
+const mockUnresolvedTracker = {
+  getUnresolved: mockGetUnresolved,
+  markResolved: mockMarkResolved,
+} as unknown as UnresolvedModelTrackerService;
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
@@ -13,11 +24,19 @@ describe('PricingSyncService', () => {
   let service: PricingSyncService;
 
   beforeEach(() => {
-    service = new PricingSyncService(mockRepo, mockPricingCache);
+    service = new PricingSyncService(
+      mockRepo,
+      mockPricingCache,
+      mockPricingHistory,
+      mockUnresolvedTracker,
+    );
     jest.clearAllMocks();
+    mockFindOneBy.mockResolvedValue(null);
+    mockRecordChange.mockResolvedValue(false);
+    mockGetUnresolved.mockResolvedValue([]);
   });
 
-  it('updates known models from OpenRouter response', async () => {
+  it('updates all models with pricing from OpenRouter', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -30,25 +49,33 @@ describe('PricingSyncService', () => {
     });
 
     const updated = await service.syncPricing();
-    expect(updated).toBe(2);
+
+    expect(updated).toBe(3);
     expect(mockReload).toHaveBeenCalledTimes(1);
-    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    expect(mockUpsert).toHaveBeenCalledTimes(3);
     expect(mockUpsert).toHaveBeenCalledWith(
-      {
-        model_name: 'claude-opus-4-6',
+      expect.objectContaining({
+        model_name: 'claude-opus-4',
         provider: 'Anthropic',
         input_price_per_token: 0.000015,
         output_price_per_token: 0.000075,
-      },
+      }),
       ['model_name'],
     );
     expect(mockUpsert).toHaveBeenCalledWith(
-      {
+      expect.objectContaining({
         model_name: 'gpt-4o',
         provider: 'OpenAI',
         input_price_per_token: 0.0000025,
         output_price_per_token: 0.00001,
-      },
+      }),
+      ['model_name'],
+    );
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model_name: 'unknown-model',
+        provider: 'Some',
+      }),
       ['model_name'],
     );
   });
@@ -106,72 +133,297 @@ describe('PricingSyncService', () => {
     expect(updated).toBe(0);
   });
 
-  it('updates Zhipu models from OpenRouter response', async () => {
+  it('does not call reload when zero models are updated', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'zhipuai/glm-4-plus', pricing: { prompt: '0.0000005', completion: '0.0000005' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0', completion: '0' } }],
+      }),
+    });
+
+    await service.syncPricing();
+    expect(mockReload).not.toHaveBeenCalled();
+  });
+
+  it('handles missing data field in response body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const updated = await service.syncPricing();
+    expect(updated).toBe(0);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('handles models with only prompt pricing', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025' } }],
       }),
     });
 
     const updated = await service.syncPricing();
     expect(updated).toBe(1);
     expect(mockUpsert).toHaveBeenCalledWith(
-      {
-        model_name: 'glm-4-plus',
-        provider: 'Zhipu',
-        input_price_per_token: 0.0000005,
-        output_price_per_token: 0.0000005,
-      },
+      expect.objectContaining({
+        input_price_per_token: 0.0000025,
+        output_price_per_token: 0,
+      }),
       ['model_name'],
     );
   });
 
-  it('updates Amazon Nova models from OpenRouter response', async () => {
+  it('handles models with only completion pricing', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'amazon/nova-pro', pricing: { prompt: '0.0000008', completion: '0.0000032' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { completion: '0.00001' } }],
       }),
     });
 
     const updated = await service.syncPricing();
     expect(updated).toBe(1);
     expect(mockUpsert).toHaveBeenCalledWith(
-      {
-        model_name: 'nova-pro',
-        provider: 'Amazon',
-        input_price_per_token: 0.0000008,
-        output_price_per_token: 0.0000032,
-      },
+      expect.objectContaining({
+        input_price_per_token: 0,
+        output_price_per_token: 0.00001,
+      }),
       ['model_name'],
     );
   });
 
-  it('updates Qwen 3 models from OpenRouter response', async () => {
+  it('passes existing model to recordChange when found in DB', async () => {
+    const existingModel = {
+      model_name: 'gpt-4o',
+      input_price_per_token: 0.000002,
+      output_price_per_token: 0.00001,
+      provider: 'OpenAI',
+    };
+    mockFindOneBy.mockResolvedValue(existingModel);
+
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
         data: [
-          { id: 'qwen/qwen3-235b-a22b', pricing: { prompt: '0.0000003', completion: '0.0000012' } },
+          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
         ],
       }),
     });
 
-    const updated = await service.syncPricing();
-    expect(updated).toBe(1);
+    await service.syncPricing();
+
+    expect(mockRecordChange).toHaveBeenCalledWith(
+      existingModel,
+      expect.objectContaining({ model_name: 'gpt-4o' }),
+      'sync',
+    );
+  });
+
+  it('records price history for each model', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
+        ],
+      }),
+    });
+
+    await service.syncPricing();
+
+    expect(mockRecordChange).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        model_name: 'gpt-4o',
+        input_price_per_token: 0.0000025,
+        output_price_per_token: 0.00001,
+      }),
+      'sync',
+    );
+  });
+
+  it('includes updated_at in upsert', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
+        ],
+      }),
+    });
+
+    await service.syncPricing();
+
     expect(mockUpsert).toHaveBeenCalledWith(
-      {
-        model_name: 'qwen3-235b-a22b',
-        provider: 'Alibaba',
-        input_price_per_token: 0.0000003,
-        output_price_per_token: 0.0000012,
-      },
+      expect.objectContaining({ updated_at: expect.any(Date) }),
       ['model_name'],
     );
+  });
+
+  describe('deriveNames', () => {
+    it('derives canonical name and known provider', () => {
+      expect(service.deriveNames('anthropic/claude-opus-4')).toEqual({
+        canonical: 'claude-opus-4',
+        provider: 'Anthropic',
+      });
+    });
+
+    it('derives canonical name for unknown provider', () => {
+      expect(service.deriveNames('newprovider/some-model')).toEqual({
+        canonical: 'some-model',
+        provider: 'Newprovider',
+      });
+    });
+
+    it('handles IDs without slash', () => {
+      expect(service.deriveNames('standalone-model')).toEqual({
+        canonical: 'standalone-model',
+        provider: 'Unknown',
+      });
+    });
+
+    it('maps meta-llama to Meta', () => {
+      expect(service.deriveNames('meta-llama/llama-4-scout').provider).toBe('Meta');
+    });
+
+    it('maps qwen to Alibaba', () => {
+      expect(service.deriveNames('qwen/qwen3-235b-a22b').provider).toBe('Alibaba');
+    });
+
+    it('maps xai to xAI', () => {
+      expect(service.deriveNames('xai/grok-3').provider).toBe('xAI');
+    });
+
+    it('maps google to Google', () => {
+      expect(service.deriveNames('google/gemini-2.0-flash').provider).toBe('Google');
+    });
+
+    it('maps deepseek to DeepSeek', () => {
+      expect(service.deriveNames('deepseek/deepseek-v3').provider).toBe('DeepSeek');
+    });
+
+    it('maps mistralai to Mistral', () => {
+      expect(service.deriveNames('mistralai/mistral-large').provider).toBe('Mistral');
+    });
+
+    it('maps cohere to Cohere', () => {
+      expect(service.deriveNames('cohere/command-r-plus').provider).toBe('Cohere');
+    });
+
+    it('maps amazon to Amazon', () => {
+      expect(service.deriveNames('amazon/nova-pro').provider).toBe('Amazon');
+    });
+
+    it('maps moonshotai to Moonshot', () => {
+      expect(service.deriveNames('moonshotai/moonshot-v1').provider).toBe('Moonshot');
+    });
+
+    it('maps zhipuai to Zhipu', () => {
+      expect(service.deriveNames('zhipuai/glm-4-plus').provider).toBe('Zhipu');
+    });
+
+    it('handles multi-segment canonical names after slash', () => {
+      expect(service.deriveNames('openai/gpt-4o-mini-2024-07-18')).toEqual({
+        canonical: 'gpt-4o-mini-2024-07-18',
+        provider: 'OpenAI',
+      });
+    });
+  });
+
+  describe('auto-resolve unresolved models', () => {
+    it('resolves models that match synced names', async () => {
+      mockGetUnresolved.mockResolvedValue([
+        { model_name: 'gpt-4o', resolved: false },
+      ]);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
+          ],
+        }),
+      });
+
+      await service.syncPricing();
+
+      expect(mockMarkResolved).toHaveBeenCalledWith('gpt-4o', 'gpt-4o');
+    });
+
+    it('resolves prefixed model names', async () => {
+      mockGetUnresolved.mockResolvedValue([
+        { model_name: 'openai/gpt-4o', resolved: false },
+      ]);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
+          ],
+        }),
+      });
+
+      await service.syncPricing();
+
+      expect(mockMarkResolved).toHaveBeenCalledWith('openai/gpt-4o', 'gpt-4o');
+    });
+
+    it('resolves date-suffixed model names', async () => {
+      mockGetUnresolved.mockResolvedValue([
+        { model_name: 'gpt-4o-2025-01-15', resolved: false },
+      ]);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
+          ],
+        }),
+      });
+
+      await service.syncPricing();
+
+      expect(mockMarkResolved).toHaveBeenCalledWith('gpt-4o-2025-01-15', 'gpt-4o');
+    });
+
+    it('skips resolution when no unresolved models exist', async () => {
+      mockGetUnresolved.mockResolvedValue([]);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
+          ],
+        }),
+      });
+
+      await service.syncPricing();
+
+      expect(mockMarkResolved).not.toHaveBeenCalled();
+    });
+
+    it('does not resolve models with no match', async () => {
+      mockGetUnresolved.mockResolvedValue([
+        { model_name: 'totally-fake', resolved: false },
+      ]);
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
+          ],
+        }),
+      });
+
+      await service.syncPricing();
+
+      expect(mockMarkResolved).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -4,6 +4,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ModelPricing } from '../entities/model-pricing.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
+import { PricingHistoryService } from './pricing-history.service';
+import { UnresolvedModelTrackerService } from '../model-prices/unresolved-model-tracker.service';
+import { sqlNow } from '../common/utils/sql-dialect';
 
 interface OpenRouterModel {
   id: string;
@@ -17,59 +20,19 @@ interface OpenRouterResponse {
   data: OpenRouterModel[];
 }
 
-interface ModelMapping {
-  canonical: string;
-  provider: string;
-}
-
-// Map OpenRouter model IDs to our canonical model names + provider
-const MODEL_MAP: Record<string, ModelMapping> = {
-  // Anthropic
-  'anthropic/claude-opus-4': { canonical: 'claude-opus-4-6', provider: 'Anthropic' },
-  'anthropic/claude-sonnet-4': { canonical: 'claude-sonnet-4-20250514', provider: 'Anthropic' },
-  'anthropic/claude-sonnet-4.5': { canonical: 'claude-sonnet-4-5-20250929', provider: 'Anthropic' },
-  'anthropic/claude-haiku-4.5': { canonical: 'claude-haiku-4-5-20251001', provider: 'Anthropic' },
-  // OpenAI GPT
-  'openai/gpt-4o': { canonical: 'gpt-4o', provider: 'OpenAI' },
-  'openai/gpt-4o-mini': { canonical: 'gpt-4o-mini', provider: 'OpenAI' },
-  'openai/gpt-4.1': { canonical: 'gpt-4.1', provider: 'OpenAI' },
-  'openai/gpt-4.1-mini': { canonical: 'gpt-4.1-mini', provider: 'OpenAI' },
-  'openai/gpt-4.1-nano': { canonical: 'gpt-4.1-nano', provider: 'OpenAI' },
-  // OpenAI reasoning
-  'openai/o3': { canonical: 'o3', provider: 'OpenAI' },
-  'openai/o3-mini': { canonical: 'o3-mini', provider: 'OpenAI' },
-  'openai/o4-mini': { canonical: 'o4-mini', provider: 'OpenAI' },
-  // OpenAI GPT-5.3
-  'openai/gpt-5.3': { canonical: 'gpt-5.3', provider: 'OpenAI' },
-  'openai/gpt-5.3-codex': { canonical: 'gpt-5.3-codex', provider: 'OpenAI' },
-  'openai/gpt-5.3-mini': { canonical: 'gpt-5.3-mini', provider: 'OpenAI' },
-  // Google Gemini
-  'google/gemini-2.5-pro': { canonical: 'gemini-2.5-pro', provider: 'Google' },
-  'google/gemini-2.5-flash': { canonical: 'gemini-2.5-flash', provider: 'Google' },
-  'google/gemini-2.5-flash-lite': { canonical: 'gemini-2.5-flash-lite', provider: 'Google' },
-  'google/gemini-2.0-flash': { canonical: 'gemini-2.0-flash', provider: 'Google' },
-  // DeepSeek
-  'deepseek/deepseek-chat-v3-0324': { canonical: 'deepseek-v3', provider: 'DeepSeek' },
-  'deepseek/deepseek-r1': { canonical: 'deepseek-r1', provider: 'DeepSeek' },
-  // Moonshot (Kimi)
-  'moonshotai/kimi-k2': { canonical: 'kimi-k2', provider: 'Moonshot' },
-  // Alibaba (Qwen)
-  'qwen/qwen-2.5-72b-instruct': { canonical: 'qwen-2.5-72b-instruct', provider: 'Alibaba' },
-  'qwen/qwq-32b': { canonical: 'qwq-32b', provider: 'Alibaba' },
-  'qwen/qwen-2.5-coder-32b-instruct': { canonical: 'qwen-2.5-coder-32b-instruct', provider: 'Alibaba' },
-  'qwen/qwen3-235b-a22b': { canonical: 'qwen3-235b-a22b', provider: 'Alibaba' },
-  'qwen/qwen3-32b': { canonical: 'qwen3-32b', provider: 'Alibaba' },
-  // Mistral
-  'mistralai/mistral-large': { canonical: 'mistral-large', provider: 'Mistral' },
-  'mistralai/mistral-small': { canonical: 'mistral-small', provider: 'Mistral' },
-  'mistralai/codestral': { canonical: 'codestral', provider: 'Mistral' },
-  // Zhipu (GLM)
-  'zhipuai/glm-4-plus': { canonical: 'glm-4-plus', provider: 'Zhipu' },
-  'zhipuai/glm-4-flash': { canonical: 'glm-4-flash', provider: 'Zhipu' },
-  // Amazon Nova
-  'amazon/nova-pro': { canonical: 'nova-pro', provider: 'Amazon' },
-  'amazon/nova-lite': { canonical: 'nova-lite', provider: 'Amazon' },
-  'amazon/nova-micro': { canonical: 'nova-micro', provider: 'Amazon' },
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  google: 'Google',
+  deepseek: 'DeepSeek',
+  mistralai: 'Mistral',
+  moonshotai: 'Moonshot',
+  qwen: 'Alibaba',
+  zhipuai: 'Zhipu',
+  amazon: 'Amazon',
+  'meta-llama': 'Meta',
+  cohere: 'Cohere',
+  xai: 'xAI',
 };
 
 const OPENROUTER_API = 'https://openrouter.ai/api/v1/models';
@@ -82,51 +45,134 @@ export class PricingSyncService {
     @InjectRepository(ModelPricing)
     private readonly pricingRepo: Repository<ModelPricing>,
     private readonly pricingCache: ModelPricingCacheService,
+    private readonly pricingHistory: PricingHistoryService,
+    private readonly unresolvedTracker: UnresolvedModelTrackerService,
   ) {}
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
   async syncPricing(): Promise<number> {
     this.logger.log('Starting daily model pricing sync from OpenRouter...');
 
-    let data: OpenRouterModel[];
-    try {
-      const res = await fetch(OPENROUTER_API);
-      if (!res.ok) {
-        this.logger.error(`OpenRouter API returned ${res.status}`);
-        return 0;
-      }
-      const body = (await res.json()) as OpenRouterResponse;
-      data = body.data ?? [];
-    } catch (err) {
-      this.logger.error(`Failed to fetch OpenRouter models: ${err}`);
-      return 0;
-    }
+    const data = await this.fetchOpenRouterModels();
+    if (!data) return 0;
 
-    let updated = 0;
-    for (const model of data) {
-      const mapping = MODEL_MAP[model.id];
-      if (!mapping) continue;
-
-      const prompt = Number(model.pricing?.prompt ?? 0);
-      const completion = Number(model.pricing?.completion ?? 0);
-      if (prompt === 0 && completion === 0) continue;
-
-      await this.pricingRepo.upsert(
-        {
-          model_name: mapping.canonical,
-          provider: mapping.provider,
-          input_price_per_token: prompt,
-          output_price_per_token: completion,
-        },
-        ['model_name'],
-      );
-      updated++;
-    }
+    const updated = await this.syncAllModels(data);
+    await this.resolveUnresolvedModels(data);
 
     this.logger.log(`Pricing sync complete: ${updated} models updated`);
     if (updated > 0) {
       await this.pricingCache.reload();
     }
     return updated;
+  }
+
+  private async fetchOpenRouterModels(): Promise<OpenRouterModel[] | null> {
+    try {
+      const res = await fetch(OPENROUTER_API);
+      if (!res.ok) {
+        this.logger.error(`OpenRouter API returned ${res.status}`);
+        return null;
+      }
+      const body = (await res.json()) as OpenRouterResponse;
+      return body.data ?? [];
+    } catch (err) {
+      this.logger.error(`Failed to fetch OpenRouter models: ${err}`);
+      return null;
+    }
+  }
+
+  private async syncAllModels(data: OpenRouterModel[]): Promise<number> {
+    let updated = 0;
+    const now = new Date(sqlNow());
+
+    for (const model of data) {
+      const prompt = Number(model.pricing?.prompt ?? 0);
+      const completion = Number(model.pricing?.completion ?? 0);
+      if (prompt === 0 && completion === 0) continue;
+
+      const { canonical, provider } = this.deriveNames(model.id);
+      const existing = await this.pricingRepo.findOneBy({
+        model_name: canonical,
+      });
+
+      const incoming = {
+        model_name: canonical,
+        provider,
+        input_price_per_token: prompt,
+        output_price_per_token: completion,
+      };
+
+      await this.pricingHistory.recordChange(existing, incoming, 'sync');
+      await this.pricingRepo.upsert(
+        { ...incoming, updated_at: now },
+        ['model_name'],
+      );
+      updated++;
+    }
+
+    return updated;
+  }
+
+  deriveNames(openRouterId: string): {
+    canonical: string;
+    provider: string;
+  } {
+    const slashIndex = openRouterId.indexOf('/');
+    if (slashIndex === -1) {
+      return { canonical: openRouterId, provider: 'Unknown' };
+    }
+
+    const prefix = openRouterId.substring(0, slashIndex);
+    const canonical = openRouterId.substring(slashIndex + 1);
+    const provider = PROVIDER_DISPLAY_NAMES[prefix] ?? this.titleCase(prefix);
+
+    return { canonical, provider };
+  }
+
+  private titleCase(str: string): string {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
+
+  private async resolveUnresolvedModels(
+    data: OpenRouterModel[],
+  ): Promise<void> {
+    const unresolved = await this.unresolvedTracker.getUnresolved();
+    if (unresolved.length === 0) return;
+
+    const knownNames = new Set<string>();
+    for (const model of data) {
+      const { canonical } = this.deriveNames(model.id);
+      knownNames.add(canonical);
+    }
+
+    for (const entry of unresolved) {
+      const resolvedName = this.tryResolve(entry.model_name, knownNames);
+      if (resolvedName) {
+        await this.unresolvedTracker.markResolved(
+          entry.model_name,
+          resolvedName,
+        );
+      }
+    }
+  }
+
+  private tryResolve(
+    modelName: string,
+    knownNames: Set<string>,
+  ): string | null {
+    if (knownNames.has(modelName)) return modelName;
+
+    const stripped = this.stripPrefix(modelName);
+    if (knownNames.has(stripped)) return stripped;
+
+    const noDate = stripped.replace(/-\d{4}-\d{2}-\d{2}$/, '');
+    if (noDate !== stripped && knownNames.has(noDate)) return noDate;
+
+    return null;
+  }
+
+  private stripPrefix(name: string): string {
+    const slashIndex = name.indexOf('/');
+    return slashIndex === -1 ? name : name.substring(slashIndex + 1);
   }
 }

--- a/packages/backend/src/entities/model-pricing-history.entity.ts
+++ b/packages/backend/src/entities/model-pricing-history.entity.ts
@@ -1,9 +1,13 @@
-import { Entity, Column, PrimaryColumn } from 'typeorm';
+import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType } from '../common/utils/sql-dialect';
 
-@Entity('model_pricing')
-export class ModelPricing {
+@Entity('model_pricing_history')
+@Index('IDX_mph_model_effective', ['model_name', 'effective_from'])
+export class ModelPricingHistory {
   @PrimaryColumn('varchar')
+  id!: string;
+
+  @Column('varchar')
   model_name!: string;
 
   @Column('decimal', { precision: 12, scale: 10 })
@@ -15,6 +19,12 @@ export class ModelPricing {
   @Column('varchar', { default: '' })
   provider!: string;
 
+  @Column(timestampType())
+  effective_from!: Date;
+
   @Column(timestampType(), { nullable: true })
-  updated_at!: Date | null;
+  effective_until!: Date | null;
+
+  @Column('varchar', { default: 'sync' })
+  change_source!: string;
 }

--- a/packages/backend/src/entities/unresolved-model.entity.ts
+++ b/packages/backend/src/entities/unresolved-model.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import { timestampType } from '../common/utils/sql-dialect';
+
+@Entity('unresolved_models')
+export class UnresolvedModel {
+  @PrimaryColumn('varchar')
+  model_name!: string;
+
+  @Column(timestampType())
+  first_seen!: Date;
+
+  @Column(timestampType())
+  last_seen!: Date;
+
+  @Column('integer', { default: 1 })
+  occurrence_count!: number;
+
+  @Index('IDX_unresolved_resolved')
+  @Column('boolean', { default: false })
+  resolved!: boolean;
+
+  @Column('varchar', { nullable: true })
+  resolved_to!: string | null;
+
+  @Column(timestampType(), { nullable: true })
+  resolved_at!: Date | null;
+}

--- a/packages/backend/src/model-prices/model-prices.controller.spec.ts
+++ b/packages/backend/src/model-prices/model-prices.controller.spec.ts
@@ -6,7 +6,12 @@ describe('ModelPricesController', () => {
   let mockService: jest.Mocked<ModelPricesService>;
 
   beforeEach(() => {
-    mockService = { getAll: jest.fn() } as unknown as jest.Mocked<ModelPricesService>;
+    mockService = {
+      getAll: jest.fn(),
+      triggerSync: jest.fn(),
+      getUnresolved: jest.fn(),
+      getHistory: jest.fn(),
+    } as unknown as jest.Mocked<ModelPricesService>;
     controller = new ModelPricesController(mockService);
   });
 
@@ -18,5 +23,35 @@ describe('ModelPricesController', () => {
 
     expect(result).toBe(expected);
     expect(mockService.getAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates to service.triggerSync()', async () => {
+    const expected = { updated: 100 };
+    mockService.triggerSync.mockResolvedValue(expected);
+
+    const result = await controller.triggerSync();
+
+    expect(result).toEqual(expected);
+    expect(mockService.triggerSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates to service.getUnresolved()', async () => {
+    const expected = [{ model_name: 'unknown', occurrence_count: 5 }];
+    mockService.getUnresolved.mockResolvedValue(expected as never);
+
+    const result = await controller.getUnresolved();
+
+    expect(result).toEqual(expected);
+    expect(mockService.getUnresolved).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates to service.getHistory()', async () => {
+    const expected = [{ model_name: 'gpt-4o', input_price_per_million: 2.5 }];
+    mockService.getHistory.mockResolvedValue(expected as never);
+
+    const result = await controller.getHistory('gpt-4o');
+
+    expect(result).toEqual(expected);
+    expect(mockService.getHistory).toHaveBeenCalledWith('gpt-4o');
   });
 });

--- a/packages/backend/src/model-prices/model-prices.controller.ts
+++ b/packages/backend/src/model-prices/model-prices.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, UseInterceptors } from '@nestjs/common';
+import { Controller, Get, Param, Post, UseInterceptors } from '@nestjs/common';
 import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
 import { ModelPricesService } from './model-prices.service';
 import { MODEL_PRICES_CACHE_TTL_MS } from '../common/constants/cache.constants';
@@ -12,5 +12,20 @@ export class ModelPricesController {
   @CacheTTL(MODEL_PRICES_CACHE_TTL_MS)
   async getModelPrices() {
     return this.modelPricesService.getAll();
+  }
+
+  @Post('model-prices/sync')
+  async triggerSync() {
+    return this.modelPricesService.triggerSync();
+  }
+
+  @Get('model-prices/unresolved')
+  async getUnresolved() {
+    return this.modelPricesService.getUnresolved();
+  }
+
+  @Get('model-prices/:modelName/history')
+  async getHistory(@Param('modelName') modelName: string) {
+    return this.modelPricesService.getHistory(modelName);
   }
 }

--- a/packages/backend/src/model-prices/model-prices.module.ts
+++ b/packages/backend/src/model-prices/model-prices.module.ts
@@ -1,14 +1,32 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ModelPricing } from '../entities/model-pricing.entity';
+import { ModelPricingHistory } from '../entities/model-pricing-history.entity';
+import { UnresolvedModel } from '../entities/unresolved-model.entity';
 import { ModelPricesController } from './model-prices.controller';
 import { ModelPricesService } from './model-prices.service';
 import { ModelPricingCacheService } from './model-pricing-cache.service';
+import { UnresolvedModelTrackerService } from './unresolved-model-tracker.service';
+import { PricingHistoryService } from '../database/pricing-history.service';
+import { PricingSyncService } from '../database/pricing-sync.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ModelPricing])],
+  imports: [
+    TypeOrmModule.forFeature([ModelPricing, ModelPricingHistory, UnresolvedModel]),
+  ],
   controllers: [ModelPricesController],
-  providers: [ModelPricesService, ModelPricingCacheService],
-  exports: [ModelPricingCacheService],
+  providers: [
+    ModelPricesService,
+    ModelPricingCacheService,
+    UnresolvedModelTrackerService,
+    PricingHistoryService,
+    PricingSyncService,
+  ],
+  exports: [
+    ModelPricingCacheService,
+    UnresolvedModelTrackerService,
+    PricingHistoryService,
+    PricingSyncService,
+  ],
 })
 export class ModelPricesModule {}

--- a/packages/backend/src/model-prices/model-prices.service.spec.ts
+++ b/packages/backend/src/model-prices/model-prices.service.spec.ts
@@ -1,13 +1,28 @@
 import { ModelPricesService } from './model-prices.service';
 import { DataSource } from 'typeorm';
+import { UnresolvedModelTrackerService } from './unresolved-model-tracker.service';
+import { PricingHistoryService } from '../database/pricing-history.service';
+import { PricingSyncService } from '../database/pricing-sync.service';
 
 describe('ModelPricesService', () => {
   let service: ModelPricesService;
   let mockDs: jest.Mocked<DataSource>;
+  let mockTracker: jest.Mocked<UnresolvedModelTrackerService>;
+  let mockHistory: jest.Mocked<PricingHistoryService>;
+  let mockSync: jest.Mocked<PricingSyncService>;
 
   beforeEach(() => {
     mockDs = { query: jest.fn() } as unknown as jest.Mocked<DataSource>;
-    service = new ModelPricesService(mockDs);
+    mockTracker = {
+      getUnresolved: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<UnresolvedModelTrackerService>;
+    mockHistory = {
+      getHistory: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<PricingHistoryService>;
+    mockSync = {
+      syncPricing: jest.fn().mockResolvedValue(0),
+    } as unknown as jest.Mocked<PricingSyncService>;
+    service = new ModelPricesService(mockDs, mockTracker, mockHistory, mockSync);
   });
 
   it('returns mapped models and lastSyncedAt', async () => {
@@ -38,6 +53,31 @@ describe('ModelPricesService', () => {
     expect(result.lastSyncedAt).toBeNull();
   });
 
+  it('returns multiple models correctly', async () => {
+    mockDs.query
+      .mockResolvedValueOnce([
+        { model_name: 'gpt-4o', provider: 'OpenAI', input_price_per_token: 0.0000025, output_price_per_token: 0.00001, updated_at: '2025-01-01' },
+        { model_name: 'claude-opus-4', provider: 'Anthropic', input_price_per_token: 0.000015, output_price_per_token: 0.000075, updated_at: '2025-01-01' },
+      ])
+      .mockResolvedValueOnce([{ last_synced: '2025-01-01' }]);
+
+    const result = await service.getAll();
+
+    expect(result.models).toHaveLength(2);
+    expect(result.models[0]).toEqual({
+      model_name: 'gpt-4o',
+      provider: 'OpenAI',
+      input_price_per_million: 2.5,
+      output_price_per_million: 10,
+    });
+    expect(result.models[1]).toEqual({
+      model_name: 'claude-opus-4',
+      provider: 'Anthropic',
+      input_price_per_million: 15,
+      output_price_per_million: 75,
+    });
+  });
+
   it('handles empty model list', async () => {
     mockDs.query
       .mockResolvedValueOnce([])
@@ -47,5 +87,129 @@ describe('ModelPricesService', () => {
 
     expect(result.models).toEqual([]);
     expect(result.lastSyncedAt).toBeNull();
+  });
+
+  describe('triggerSync', () => {
+    it('delegates to pricing sync service and returns count', async () => {
+      mockSync.syncPricing.mockResolvedValue(150);
+      const result = await service.triggerSync();
+      expect(result).toEqual({ updated: 150 });
+      expect(mockSync.syncPricing).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getUnresolved', () => {
+    it('delegates to tracker service', async () => {
+      const entries = [{ model_name: 'unknown', occurrence_count: 10 }];
+      mockTracker.getUnresolved.mockResolvedValue(entries as never);
+
+      const result = await service.getUnresolved();
+      expect(result).toEqual(entries);
+    });
+  });
+
+  describe('getHistory', () => {
+    it('converts prices to per-million format', async () => {
+      mockHistory.getHistory.mockResolvedValue([
+        {
+          id: '1',
+          model_name: 'gpt-4o',
+          input_price_per_token: 0.0000025 as never,
+          output_price_per_token: 0.00001 as never,
+          provider: 'OpenAI',
+          effective_from: new Date('2025-01-01'),
+          effective_until: null,
+          change_source: 'sync',
+        },
+      ]);
+
+      const result = await service.getHistory('gpt-4o');
+
+      expect(result[0].input_price_per_million).toBeCloseTo(2.5);
+      expect(result[0].output_price_per_million).toBeCloseTo(10);
+    });
+
+    it('preserves all original fields alongside computed ones', async () => {
+      const effectiveFrom = new Date('2025-01-01');
+      const effectiveUntil = new Date('2025-06-01');
+      mockHistory.getHistory.mockResolvedValue([
+        {
+          id: 'uuid-123',
+          model_name: 'gpt-4o',
+          input_price_per_token: 0.000003 as never,
+          output_price_per_token: 0.000012 as never,
+          provider: 'OpenAI',
+          effective_from: effectiveFrom,
+          effective_until: effectiveUntil,
+          change_source: 'manual',
+        },
+      ]);
+
+      const result = await service.getHistory('gpt-4o');
+
+      expect(result[0].id).toBe('uuid-123');
+      expect(result[0].model_name).toBe('gpt-4o');
+      expect(result[0].provider).toBe('OpenAI');
+      expect(result[0].effective_from).toBe(effectiveFrom);
+      expect(result[0].effective_until).toBe(effectiveUntil);
+      expect(result[0].change_source).toBe('manual');
+    });
+
+    it('handles string-typed decimal values from DB', async () => {
+      mockHistory.getHistory.mockResolvedValue([
+        {
+          id: '1',
+          model_name: 'gpt-4o',
+          input_price_per_token: '0.0000025000' as never,
+          output_price_per_token: '0.0000100000' as never,
+          provider: 'OpenAI',
+          effective_from: new Date('2025-01-01'),
+          effective_until: null,
+          change_source: 'sync',
+        },
+      ]);
+
+      const result = await service.getHistory('gpt-4o');
+
+      expect(result[0].input_price_per_million).toBeCloseTo(2.5);
+      expect(result[0].output_price_per_million).toBeCloseTo(10);
+    });
+
+    it('converts multiple history records', async () => {
+      mockHistory.getHistory.mockResolvedValue([
+        {
+          id: '2',
+          model_name: 'gpt-4o',
+          input_price_per_token: 0.000005 as never,
+          output_price_per_token: 0.000015 as never,
+          provider: 'OpenAI',
+          effective_from: new Date('2025-06-01'),
+          effective_until: null,
+          change_source: 'sync',
+        },
+        {
+          id: '1',
+          model_name: 'gpt-4o',
+          input_price_per_token: 0.0000025 as never,
+          output_price_per_token: 0.00001 as never,
+          provider: 'OpenAI',
+          effective_from: new Date('2025-01-01'),
+          effective_until: new Date('2025-06-01'),
+          change_source: 'sync',
+        },
+      ]);
+
+      const result = await service.getHistory('gpt-4o');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].input_price_per_million).toBeCloseTo(5);
+      expect(result[1].input_price_per_million).toBeCloseTo(2.5);
+    });
+
+    it('returns empty array for unknown model', async () => {
+      mockHistory.getHistory.mockResolvedValue([]);
+      const result = await service.getHistory('unknown');
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/packages/backend/src/model-prices/unresolved-model-tracker.service.spec.ts
+++ b/packages/backend/src/model-prices/unresolved-model-tracker.service.spec.ts
@@ -1,0 +1,196 @@
+import { UnresolvedModelTrackerService } from './unresolved-model-tracker.service';
+import { UnresolvedModel } from '../entities/unresolved-model.entity';
+
+describe('UnresolvedModelTrackerService', () => {
+  let service: UnresolvedModelTrackerService;
+  let mockRepo: {
+    findOneBy: jest.Mock;
+    find: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+    update: jest.Mock;
+  };
+
+  beforeEach(() => {
+    mockRepo = {
+      findOneBy: jest.fn(),
+      find: jest.fn().mockResolvedValue([]),
+      create: jest.fn((data) => ({ ...data }) as UnresolvedModel),
+      save: jest.fn().mockResolvedValue(undefined),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    service = new UnresolvedModelTrackerService(mockRepo as never);
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
+  describe('track', () => {
+    it('should accumulate counts for the same model', async () => {
+      service.track('unknown-model');
+      service.track('unknown-model');
+      service.track('unknown-model');
+
+      mockRepo.findOneBy.mockResolvedValue(null);
+      await service.flush();
+
+      expect(mockRepo.save).toHaveBeenCalledTimes(1);
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ occurrence_count: 3 }),
+      );
+    });
+
+    it('should track multiple distinct models', async () => {
+      service.track('model-a');
+      service.track('model-b');
+
+      mockRepo.findOneBy.mockResolvedValue(null);
+      await service.flush();
+
+      expect(mockRepo.save).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('flush', () => {
+    it('should do nothing when no pending entries', async () => {
+      await service.flush();
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should insert new entries for unseen models', async () => {
+      service.track('new-model');
+      mockRepo.findOneBy.mockResolvedValue(null);
+
+      await service.flush();
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model_name: 'new-model',
+          occurrence_count: 1,
+          resolved: false,
+        }),
+      );
+      expect(mockRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should update existing entries by incrementing count', async () => {
+      const existing = {
+        model_name: 'known-unresolved',
+        occurrence_count: 5,
+        last_seen: new Date('2024-01-01'),
+      } as UnresolvedModel;
+
+      service.track('known-unresolved');
+      service.track('known-unresolved');
+      mockRepo.findOneBy.mockResolvedValue(existing);
+
+      await service.flush();
+
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ occurrence_count: 7 }),
+      );
+    });
+
+    it('should set first_seen and last_seen as Date objects for new entries', async () => {
+      service.track('brand-new-model');
+      mockRepo.findOneBy.mockResolvedValue(null);
+
+      await service.flush();
+
+      const createArg = mockRepo.create.mock.calls[0][0];
+      expect(createArg.first_seen).toBeInstanceOf(Date);
+      expect(createArg.last_seen).toBeInstanceOf(Date);
+    });
+
+    it('should update last_seen as Date on existing entries', async () => {
+      const existing = {
+        model_name: 'old-model',
+        occurrence_count: 3,
+        last_seen: new Date('2024-01-01'),
+      } as UnresolvedModel;
+
+      service.track('old-model');
+      mockRepo.findOneBy.mockResolvedValue(existing);
+
+      await service.flush();
+
+      expect(existing.last_seen).toBeInstanceOf(Date);
+      expect(existing.last_seen.getTime()).toBeGreaterThan(
+        new Date('2024-01-01').getTime(),
+      );
+    });
+
+    it('should clear pending entries after flush', async () => {
+      service.track('some-model');
+      mockRepo.findOneBy.mockResolvedValue(null);
+
+      await service.flush();
+      jest.clearAllMocks();
+
+      await service.flush();
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getUnresolved', () => {
+    it('should return unresolved entries ordered by count', async () => {
+      const entries = [
+        { model_name: 'b', occurrence_count: 10 },
+        { model_name: 'a', occurrence_count: 5 },
+      ];
+      mockRepo.find.mockResolvedValue(entries);
+
+      const result = await service.getUnresolved();
+
+      expect(result).toEqual(entries);
+      expect(mockRepo.find).toHaveBeenCalledWith({
+        where: { resolved: false },
+        order: { occurrence_count: 'DESC' },
+      });
+    });
+  });
+
+  describe('markResolved', () => {
+    it('should mark an entry as resolved', async () => {
+      await service.markResolved('unknown-model', 'gpt-4o');
+
+      expect(mockRepo.update).toHaveBeenCalledWith(
+        { model_name: 'unknown-model' },
+        expect.objectContaining({
+          resolved: true,
+          resolved_to: 'gpt-4o',
+        }),
+      );
+    });
+
+    it('should set resolved_at to a valid date', async () => {
+      await service.markResolved('unknown-model', 'gpt-4o');
+
+      const updateCall = mockRepo.update.mock.calls[0];
+      expect(updateCall[1].resolved_at).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('should clean up the interval timer', () => {
+      service.onModuleDestroy();
+      // No error thrown means the timer was cleared successfully
+    });
+
+    it('should be safe to call twice', () => {
+      service.onModuleDestroy();
+      service.onModuleDestroy();
+      // No error thrown means idempotent cleanup works
+    });
+  });
+
+  describe('flush error handling', () => {
+    it('should propagate errors from upsertEntry', async () => {
+      service.track('fail-model');
+      mockRepo.findOneBy.mockRejectedValue(new Error('DB down'));
+
+      await expect(service.flush()).rejects.toThrow('DB down');
+    });
+  });
+});

--- a/packages/backend/src/model-prices/unresolved-model-tracker.service.ts
+++ b/packages/backend/src/model-prices/unresolved-model-tracker.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UnresolvedModel } from '../entities/unresolved-model.entity';
+import { sqlNow } from '../common/utils/sql-dialect';
+
+const FLUSH_INTERVAL_MS = 60_000;
+
+@Injectable()
+export class UnresolvedModelTrackerService implements OnModuleDestroy {
+  private readonly logger = new Logger(UnresolvedModelTrackerService.name);
+  private readonly pending = new Map<string, number>();
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(
+    @InjectRepository(UnresolvedModel)
+    private readonly unresolvedRepo: Repository<UnresolvedModel>,
+  ) {
+    this.flushTimer = setInterval(() => {
+      this.flush().catch((err) => {
+        this.logger.error(`Flush failed: ${err}`);
+      });
+    }, FLUSH_INTERVAL_MS);
+  }
+
+  onModuleDestroy(): void {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  track(modelName: string): void {
+    const current = this.pending.get(modelName) ?? 0;
+    this.pending.set(modelName, current + 1);
+  }
+
+  async flush(): Promise<void> {
+    if (this.pending.size === 0) return;
+
+    const entries = [...this.pending.entries()];
+    this.pending.clear();
+
+    const now = sqlNow();
+    for (const [modelName, count] of entries) {
+      await this.upsertEntry(modelName, count, now);
+    }
+
+    this.logger.debug(`Flushed ${entries.length} unresolved model entries`);
+  }
+
+  private async upsertEntry(
+    modelName: string,
+    count: number,
+    now: string,
+  ): Promise<void> {
+    const existing = await this.unresolvedRepo.findOneBy({
+      model_name: modelName,
+    });
+
+    if (existing) {
+      existing.occurrence_count += count;
+      existing.last_seen = new Date(now);
+      await this.unresolvedRepo.save(existing);
+    } else {
+      const entry = this.unresolvedRepo.create({
+        model_name: modelName,
+        first_seen: new Date(now),
+        last_seen: new Date(now),
+        occurrence_count: count,
+        resolved: false,
+      });
+      await this.unresolvedRepo.save(entry);
+    }
+  }
+
+  async getUnresolved(): Promise<UnresolvedModel[]> {
+    return this.unresolvedRepo.find({
+      where: { resolved: false },
+      order: { occurrence_count: 'DESC' },
+    });
+  }
+
+  async markResolved(
+    modelName: string,
+    resolvedTo: string,
+  ): Promise<void> {
+    await this.unresolvedRepo.update(
+      { model_name: modelName },
+      {
+        resolved: true,
+        resolved_to: resolvedTo,
+        resolved_at: new Date(sqlNow()),
+      },
+    );
+  }
+}

--- a/packages/frontend/src/components/ModelPricesFilterBar.tsx
+++ b/packages/frontend/src/components/ModelPricesFilterBar.tsx
@@ -1,0 +1,104 @@
+import { For, Show, type Component } from "solid-js";
+
+interface ModelPricesFilterBarProps {
+  search: string;
+  onSearchChange: (value: string) => void;
+  providers: string[];
+  selectedProviders: Set<string>;
+  onToggleProvider: (provider: string) => void;
+  onClearFilters: () => void;
+  totalCount: number;
+  filteredCount: number;
+}
+
+const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
+  const hasActiveFilters = () => props.search.trim() !== "" || props.selectedProviders.size > 0;
+
+  return (
+    <div class="model-filter">
+      <div class="model-filter__row">
+        <div class="model-filter__search-wrapper">
+          <svg
+            class="model-filter__search-icon"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          <input
+            type="text"
+            class="model-filter__search"
+            placeholder="Search models..."
+            value={props.search}
+            onInput={(e) => props.onSearchChange(e.currentTarget.value)}
+            aria-label="Search models by name"
+          />
+          <Show when={props.search.length > 0}>
+            <button
+              class="model-filter__clear-input"
+              onClick={() => props.onSearchChange("")}
+              aria-label="Clear search"
+              type="button"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            </button>
+          </Show>
+        </div>
+        <div class="model-filter__summary">
+          <Show when={hasActiveFilters()} fallback={
+            <span>{props.totalCount} models</span>
+          }>
+            <span>{props.filteredCount} of {props.totalCount} models</span>
+            <button
+              class="model-filter__clear-all"
+              onClick={props.onClearFilters}
+              type="button"
+            >
+              Clear filters
+            </button>
+          </Show>
+        </div>
+      </div>
+      <Show when={props.providers.length > 1}>
+        <div class="model-filter__chips" role="group" aria-label="Filter by provider">
+          <For each={props.providers}>
+            {(provider) => (
+              <button
+                class="model-filter__chip"
+                classList={{ "model-filter__chip--active": props.selectedProviders.has(provider) }}
+                onClick={() => props.onToggleProvider(provider)}
+                type="button"
+                aria-pressed={props.selectedProviders.has(provider)}
+              >
+                {provider}
+              </button>
+            )}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default ModelPricesFilterBar;

--- a/packages/frontend/src/styles/model-filter.css
+++ b/packages/frontend/src/styles/model-filter.css
@@ -1,0 +1,174 @@
+/* ── Model Prices Filter ─────────────────────────── */
+.model-filter {
+  margin-bottom: var(--gap-lg);
+}
+
+.model-filter__row {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-md);
+}
+
+.model-filter__search-wrapper {
+  position: relative;
+  flex: 1;
+  max-width: 320px;
+}
+
+.model-filter__search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: hsl(var(--muted-foreground));
+  pointer-events: none;
+}
+
+.model-filter__search {
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 2rem 0 2rem;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.model-filter__search::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+
+.model-filter__search:focus-visible {
+  outline: none;
+  border-color: hsl(var(--ring));
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+}
+
+.model-filter__clear-input {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.model-filter__clear-input:hover {
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
+}
+
+.model-filter__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--gap-sm);
+  font-size: var(--font-size-sm);
+  color: hsl(var(--muted-foreground));
+  white-space: nowrap;
+  margin-left: auto;
+}
+
+.model-filter__clear-all {
+  background: none;
+  border: none;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family);
+  color: hsl(var(--ring));
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  transition: color var(--transition-fast);
+}
+
+.model-filter__clear-all:hover {
+  color: hsl(var(--foreground));
+}
+
+.model-filter__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: var(--gap-sm);
+}
+
+.model-filter__chip {
+  display: inline-flex;
+  align-items: center;
+  height: 1.75rem;
+  padding: 0 12px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 9999px;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-xs);
+  font-family: var(--font-family);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  user-select: none;
+}
+
+.model-filter__chip:hover {
+  border-color: hsl(var(--foreground) / 0.3);
+  color: hsl(var(--foreground));
+}
+
+.model-filter__chip--active {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border-color: hsl(var(--primary));
+}
+
+.model-filter__chip--active:hover {
+  background: hsl(var(--primary) / 0.9);
+  border-color: hsl(var(--primary) / 0.9);
+  color: hsl(var(--primary-foreground));
+}
+
+.model-filter__empty {
+  text-align: center;
+  padding: var(--gap-2xl) var(--gap-lg);
+}
+
+.model-filter__empty-title {
+  font-size: var(--font-size-base);
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  margin-bottom: var(--gap-xs);
+}
+
+.model-filter__empty-hint {
+  font-size: var(--font-size-sm);
+  color: hsl(var(--muted-foreground));
+  margin-bottom: var(--gap-md);
+}
+
+@media (max-width: 640px) {
+  .model-filter__row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .model-filter__search-wrapper {
+    max-width: 100%;
+  }
+
+  .model-filter__summary {
+    margin-left: 0;
+  }
+}

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -13,6 +13,7 @@
 @import "./notifications.css";
 @import "./tooltip.css";
 @import "./toast.css";
+@import "./model-filter.css";
 
 /* ── shadcn/ui design tokens — Light (default) ───── */
 @layer base {


### PR DESCRIPTION
## Summary

- **Import all OpenRouter models** — Removed the hardcoded `MODEL_MAP` (28 models). The sync now imports every model with pricing from OpenRouter (~300+ models), deriving canonical names and provider labels from the model ID.
- **Price history tracking** — New `model_pricing_history` table records price changes on each sync. API endpoint `GET /api/v1/model-prices/:modelName/history` exposes the history.
- **Unresolved model detection** — New `unresolved_models` table tracks model names from telemetry that don't match any known pricing entry. Batched in-memory tracker flushes every 60s. API endpoint `GET /api/v1/model-prices/unresolved` surfaces them. Auto-resolution attempted on each sync.
- **Manual sync trigger** — New `POST /api/v1/model-prices/sync` endpoint to trigger an OpenRouter sync on demand.
- **Frontend filtering** — Added live search bar and provider filter chips to the Model Prices page for quickly finding models among hundreds of entries.

## Test plan

- [x] All 641 unit tests pass (`npm test --workspace=packages/backend`)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Server starts with migration running successfully
- [x] Manual sync imports 300+ models from OpenRouter
- [x] New API endpoints return correct data (`/unresolved`, `/:modelName/history`, `/sync`)
- [x] Frontend search and provider chips filter models correctly
- [x] Changeset included for `@mnfst/server` (minor)