### PR TITLE
fix: resolve better-sqlite3 version conflict for local mode on macOS

### DIFF
--- a/.changeset/fix-local-mode-sqlite.md
+++ b/.changeset/fix-local-mode-sqlite.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Fix better-sqlite3 version conflict causing silent failures on macOS and improve error messages for native module issues

--- a/package-lock.json
+++ b/package-lock.json
@@ -12699,7 +12699,7 @@
         "@react-email/components": "^1.0.7",
         "@react-email/render": "^2.0.4",
         "better-auth": "^1.4.18",
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": ">=11.0.0",
         "cache-manager": "^7.2.8",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
@@ -13027,7 +13027,7 @@
     },
     "packages/manifest-server": {
       "name": "@mnfst/server",
-      "version": "5.2.4",
+      "version": "5.3.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",
@@ -13042,7 +13042,7 @@
         "@react-email/components": "^1.0.7",
         "@react-email/render": "^2.0.4",
         "better-auth": "^1.4.18",
-        "better-sqlite3": "^11.0.0",
+        "better-sqlite3": ">=11.0.0",
         "cache-manager": "^7.2.8",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
@@ -13057,8 +13057,11 @@
         "uuid": "^11.0.0"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.0",
+        "jest": "^29.7.0",
         "manifest-backend": "*",
-        "manifest-frontend": "*"
+        "manifest-frontend": "*",
+        "ts-jest": "^29.2.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -13100,8 +13103,11 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.2.4",
+      "version": "5.2.11",
       "license": "MIT",
+      "dependencies": {
+        "@mnfst/server": "^5.2.11"
+      },
       "devDependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,7 +40,7 @@
     "react-dom": "^19.2.4",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.0",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": ">=11.0.0",
     "typeorm": "^0.3.0",
     "uuid": "^11.0.0"
   },

--- a/packages/manifest-server/jest.config.js
+++ b/packages/manifest-server/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.spec.ts"],
+};

--- a/packages/manifest-server/package.json
+++ b/packages/manifest-server/package.json
@@ -35,7 +35,8 @@
   },
   "scripts": {
     "build": "node scripts/copy-assets.js && tsc",
-    "prebuild": "rm -rf dist public"
+    "prebuild": "rm -rf dist public",
+    "test": "jest"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^3.1.0",
@@ -50,7 +51,7 @@
     "@react-email/components": "^1.0.7",
     "@react-email/render": "^2.0.4",
     "better-auth": "^1.4.18",
-    "better-sqlite3": "^11.0.0",
+    "better-sqlite3": ">=11.0.0",
     "cache-manager": "^7.2.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
@@ -65,8 +66,11 @@
     "uuid": "^11.0.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "jest": "^29.7.0",
     "manifest-backend": "*",
-    "manifest-frontend": "*"
+    "manifest-frontend": "*",
+    "ts-jest": "^29.2.0"
   },
   "files": [
     "dist",

--- a/packages/manifest-server/src/index.spec.ts
+++ b/packages/manifest-server/src/index.spec.ts
@@ -1,0 +1,76 @@
+import { join } from 'path';
+
+// Save original env and modules
+const originalEnv = { ...process.env };
+
+// Mock fs.existsSync
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+}));
+
+// We need to control require() calls inside start(), so we use a manual approach
+const mockRequire = jest.fn();
+
+beforeEach(() => {
+  jest.resetModules();
+  process.env = { ...originalEnv };
+  jest.restoreAllMocks();
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('start() pre-flight checks', () => {
+  it('throws when backend dist does not exist', async () => {
+    const fs = require('fs');
+    fs.existsSync.mockReturnValue(false);
+
+    const { start } = require('./index');
+
+    await expect(start({ quiet: true })).rejects.toThrow('Backend not found');
+    await expect(start({ quiet: true })).rejects.toThrow('corrupt');
+  });
+
+  it('throws with actionable message when better-sqlite3 fails to load', async () => {
+    const fs = require('fs');
+    // First call: backend dist exists; second call: whatever else
+    fs.existsSync.mockReturnValue(true);
+
+    // Mock require to fail for better-sqlite3
+    jest.mock('better-sqlite3', () => {
+      throw new Error('Could not locate the bindings file');
+    });
+
+    const { start } = require('./index');
+
+    await expect(start({ quiet: true })).rejects.toThrow(
+      'better-sqlite3 native module failed to load',
+    );
+    await expect(start({ quiet: true })).rejects.toThrow('xcode-select --install');
+    await expect(start({ quiet: true })).rejects.toThrow('npm rebuild better-sqlite3');
+  });
+
+  it('sets environment variables before importing backend', async () => {
+    const fs = require('fs');
+    fs.existsSync.mockReturnValue(true);
+
+    // Mock better-sqlite3 to succeed
+    jest.mock('better-sqlite3', () => ({}));
+
+    const { start } = require('./index');
+
+    // The start function will fail when trying to import the backend,
+    // but we can verify env vars were set
+    try {
+      await start({ port: 3000, host: '0.0.0.0', quiet: true });
+    } catch {
+      // Expected to fail when importing backend
+    }
+
+    expect(process.env['MANIFEST_MODE']).toBe('local');
+    expect(process.env['MANIFEST_EMBEDDED']).toBe('1');
+    expect(process.env['PORT']).toBe('3000');
+    expect(process.env['BIND_ADDRESS']).toBe('0.0.0.0');
+  });
+});

--- a/packages/manifest-server/src/index.ts
+++ b/packages/manifest-server/src/index.ts
@@ -40,6 +40,19 @@ export async function start(options: StartOptions = {}): Promise<unknown> {
     );
   }
 
+  // Pre-flight: verify better-sqlite3 native addon loads
+  try {
+    require('better-sqlite3');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `better-sqlite3 native module failed to load: ${msg}\n` +
+      '  On macOS, install Xcode Command Line Tools: xcode-select --install\n' +
+      '  Then rebuild: npm rebuild better-sqlite3\n' +
+      '  Or reinstall the plugin: openclaw plugins install manifest',
+    );
+  }
+
   // Generate a random persistent secret for local mode
   if (!process.env['BETTER_AUTH_SECRET']) {
     const constants = require(`${BACKEND_DIR}/common/constants/local-mode.constants`);

--- a/packages/openclaw-plugin/__mocks__/@mnfst/server.js
+++ b/packages/openclaw-plugin/__mocks__/@mnfst/server.js
@@ -1,0 +1,5 @@
+// Default mock for @mnfst/server — overridden per test via jest.doMock
+module.exports = {
+  start: jest.fn().mockResolvedValue({}),
+  version: "0.0.0-mock",
+};

--- a/packages/openclaw-plugin/__tests__/local-mode.test.ts
+++ b/packages/openclaw-plugin/__tests__/local-mode.test.ts
@@ -1,0 +1,236 @@
+import { registerLocalMode } from "../src/local-mode";
+import { ManifestConfig } from "../src/config";
+import { PluginLogger } from "../src/telemetry";
+
+// Mock all dependencies that local-mode.ts imports
+jest.mock("fs", () => ({
+  readFileSync: jest.fn(() => JSON.stringify({ apiKey: "mnfst_test_key" })),
+  writeFileSync: jest.fn(),
+  existsSync: jest.fn(() => true),
+  mkdirSync: jest.fn(),
+}));
+
+jest.mock("../src/telemetry", () => ({
+  PluginLogger: jest.fn(),
+  initTelemetry: jest.fn(() => ({
+    tracer: {},
+    meter: {},
+  })),
+  shutdownTelemetry: jest.fn(),
+}));
+
+jest.mock("../src/hooks", () => ({
+  registerHooks: jest.fn(),
+  initMetrics: jest.fn(),
+}));
+
+jest.mock("../src/tools", () => ({
+  registerTools: jest.fn(),
+}));
+
+function makeLogger(): PluginLogger {
+  return {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as PluginLogger;
+}
+
+function makeApi() {
+  return {
+    registerService: jest.fn(),
+    registerTool: jest.fn(),
+  };
+}
+
+function makeConfig(overrides: Partial<ManifestConfig> = {}): ManifestConfig {
+  return {
+    mode: "local",
+    apiKey: "mnfst_test",
+    endpoint: "http://127.0.0.1:2099/otlp",
+    serviceName: "test",
+    captureContent: false,
+    metricsIntervalMs: 30000,
+    port: 2099,
+    host: "127.0.0.1",
+    ...overrides,
+  };
+}
+
+describe("registerLocalMode", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("logs error with reinstall instructions when @mnfst/server is not installed", () => {
+    // Re-require with @mnfst/server failing to load
+    jest.mock("@mnfst/server", () => {
+      throw new Error("Cannot find module '@mnfst/server'");
+    });
+
+    // Need to re-require local-mode since jest.mock is hoisted
+    jest.isolateModules(() => {
+      const { registerLocalMode: register } = require("../src/local-mode");
+      const logger = makeLogger();
+      const api = makeApi();
+      register(api, makeConfig(), logger);
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("@mnfst/server is not installed"),
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("openclaw plugins install manifest"),
+      );
+      expect(api.registerService).not.toHaveBeenCalled();
+    });
+  });
+
+  it("registers a service when @mnfst/server loads successfully", () => {
+    jest.mock("@mnfst/server", () => ({
+      start: jest.fn().mockResolvedValue({}),
+      version: "1.0.0",
+    }));
+
+    jest.isolateModules(() => {
+      const { registerLocalMode: register } = require("../src/local-mode");
+      const logger = makeLogger();
+      const api = makeApi();
+      register(api, makeConfig(), logger);
+
+      expect(api.registerService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "manifest-local",
+          start: expect.any(Function),
+          stop: expect.any(Function),
+        }),
+      );
+    });
+  });
+
+  it("logs EADDRINUSE error with port change instructions", async () => {
+    const mockStart = jest.fn().mockRejectedValue(new Error("listen EADDRINUSE: address already in use"));
+    jest.mock("@mnfst/server", () => ({
+      start: mockStart,
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { registerLocalMode: register } = require("../src/local-mode");
+      const logger = makeLogger();
+      const api = makeApi();
+      register(api, makeConfig({ port: 2099 }), logger);
+
+      const service = api.registerService.mock.calls[0][0];
+      await service.start();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Port 2099 is already in use"),
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("openclaw config set"),
+      );
+    });
+  });
+
+  it("logs native module error with build tools instructions", async () => {
+    const mockStart = jest.fn().mockRejectedValue(
+      new Error("Could not load better-sqlite3 bindings"),
+    );
+    jest.mock("@mnfst/server", () => ({
+      start: mockStart,
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { registerLocalMode: register } = require("../src/local-mode");
+      const logger = makeLogger();
+      const api = makeApi();
+      register(api, makeConfig(), logger);
+
+      const service = api.registerService.mock.calls[0][0];
+      await service.start();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("SQLite native module failed to load"),
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("xcode-select --install"),
+      );
+    });
+  });
+
+  it("logs permission error with path hints", async () => {
+    const mockStart = jest.fn().mockRejectedValue(
+      new Error("EACCES: permission denied, open '/home/.openclaw/manifest/manifest.db'"),
+    );
+    jest.mock("@mnfst/server", () => ({
+      start: mockStart,
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { registerLocalMode: register } = require("../src/local-mode");
+      const logger = makeLogger();
+      const api = makeApi();
+      register(api, makeConfig(), logger);
+
+      const service = api.registerService.mock.calls[0][0];
+      await service.start();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Permission denied"),
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Check permissions on"),
+      );
+    });
+  });
+
+  it("logs generic error with reinstall instructions", async () => {
+    const mockStart = jest.fn().mockRejectedValue(
+      new Error("Something unexpected happened"),
+    );
+    jest.mock("@mnfst/server", () => ({
+      start: mockStart,
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { registerLocalMode: register } = require("../src/local-mode");
+      const logger = makeLogger();
+      const api = makeApi();
+      register(api, makeConfig(), logger);
+
+      const service = api.registerService.mock.calls[0][0];
+      await service.start();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to start local server"),
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("Try reinstalling"),
+      );
+    });
+  });
+
+  it("logs success messages when server starts", async () => {
+    const mockStart = jest.fn().mockResolvedValue({});
+    jest.mock("@mnfst/server", () => ({
+      start: mockStart,
+    }));
+
+    await jest.isolateModulesAsync(async () => {
+      const { registerLocalMode: register } = require("../src/local-mode");
+      const logger = makeLogger();
+      const api = makeApi();
+      register(api, makeConfig({ port: 2099, host: "127.0.0.1" }), logger);
+
+      const service = api.registerService.mock.calls[0][0];
+      await service.start();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Local server running on http://127.0.0.1:2099"),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Dashboard: http://127.0.0.1:2099"),
+      );
+    });
+  });
+});

--- a/packages/openclaw-plugin/jest.config.js
+++ b/packages/openclaw-plugin/jest.config.js
@@ -4,4 +4,7 @@ module.exports = {
   testEnvironment: "node",
   roots: ["<rootDir>/__tests__"],
   testMatch: ["**/*.test.ts"],
+  moduleNameMapper: {
+    "^@mnfst/server$": "<rootDir>/__mocks__/@mnfst/server.js",
+  },
 };

--- a/packages/openclaw-plugin/src/local-mode.ts
+++ b/packages/openclaw-plugin/src/local-mode.ts
@@ -117,8 +117,29 @@ export function registerLocalMode(
               `  Change it with: openclaw config set plugins.entries.manifest.config.port ${port + 1}\n` +
               `  Then restart the gateway.`,
           );
+        } else if (
+          msg.includes("better-sqlite3") ||
+          msg.includes("bindings") ||
+          msg.includes("native module")
+        ) {
+          logger.error(
+            `[manifest] SQLite native module failed to load: ${msg}\n` +
+              `  On macOS, install build tools: xcode-select --install\n` +
+              `  Then reinstall: openclaw plugins install manifest\n` +
+              `  Then restart: openclaw gateway restart`,
+          );
+        } else if (msg.includes("EACCES") || msg.includes("permission denied")) {
+          logger.error(
+            `[manifest] Permission denied: ${msg}\n` +
+              `  Check permissions on: ${dbPath}\n` +
+              `  Or delete and recreate: rm -rf ~/.openclaw/manifest && openclaw gateway restart`,
+          );
         } else {
-          logger.error(`[manifest] Failed to start local server: ${msg}`);
+          logger.error(
+            `[manifest] Failed to start local server: ${msg}\n` +
+              `  Try reinstalling: openclaw plugins install manifest\n` +
+              `  Then restart: openclaw gateway restart`,
+          );
         }
       }
     },


### PR DESCRIPTION
## Summary

- **Widen `better-sqlite3` version range** from `^11.0.0` to `>=11.0.0` in both `packages/backend` and `packages/manifest-server`, allowing npm to dedupe with whatever version `better-auth` resolves (v12.x). This prevents a nested native module that fails to compile silently on macOS.
- **Add pre-flight check** in `@mnfst/server` `start()` that verifies `better-sqlite3` loads before attempting to boot the backend. Throws an actionable error with platform-specific hints (xcode-select, npm rebuild, reinstall).
- **Improve error messages** in the plugin's `local-mode.ts` catch block with pattern matching for native module failures, permission errors, and a better generic fallback — all with step-by-step remediation commands.
- **Add tests** for both the server pre-flight checks (3 tests) and the plugin error handling paths (7 tests).

## Test plan

- [x] `npm test -w manifest-backend` — 641 tests pass
- [x] `npx jest` in `packages/openclaw-plugin` — 107 tests pass (7 new)
- [x] `npx jest` in `packages/manifest-server` — 3 tests pass (all new)
- [x] `npx tsc --noEmit -p packages/manifest-server/tsconfig.json` — compiles clean
- [x] `npx changeset status --since=origin/main` — valid `@mnfst/server` patch changeset