### PR TITLE
Remove time from x-axis labels on 7-day dashboard charts

### DIFF
--- a/.changeset/fix-dashboard-axis-labels.md
+++ b/.changeset/fix-dashboard-axis-labels.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Remove unnecessary time (HH:MM) from x-axis labels on dashboard charts when using the "Last 7 days" filter

--- a/packages/frontend/src/services/chart-utils.ts
+++ b/packages/frontend/src/services/chart-utils.ts
@@ -98,7 +98,7 @@ export function formatAxisTimestamp(epochSec: number, rangeSeconds: number): str
   if (rangeSeconds <= 86400) return `${hh}:${mm}`;
   const mon = MONTHS[d.getUTCMonth()]!;
   const day = d.getUTCDate();
-  if (rangeSeconds <= 7 * 86400) return `${mon} ${day} ${hh}:${mm}`;
+  if (rangeSeconds <= 7 * 86400) return `${mon} ${day}`;
   return `${mon} ${day}`;
 }
 

--- a/packages/frontend/tests/services/chart-utils-coverage.test.ts
+++ b/packages/frontend/tests/services/chart-utils-coverage.test.ts
@@ -134,10 +134,10 @@ describe("formatAxisTimestamp edge cases", () => {
     expect(result).toBe("00:00");
   });
 
-  it("shows date+time for range just over 86400", () => {
+  it("shows just date for range just over 86400", () => {
     const epoch = Date.UTC(2024, 5, 15, 14, 30) / 1000;
     const result = formatAxisTimestamp(epoch, 86401);
-    expect(result).toBe("Jun 15 14:30");
+    expect(result).toBe("Jun 15");
   });
 
   it("shows just date for range over 7d", () => {

--- a/packages/frontend/tests/services/chart-utils.test.ts
+++ b/packages/frontend/tests/services/chart-utils.test.ts
@@ -20,10 +20,10 @@ describe("formatAxisTimestamp", () => {
     const result = formatAxisTimestamp(epoch, 3600);
     expect(result).toBe("10:30");
   });
-  it("shows date + time for weekly range", () => {
+  it("shows just date for weekly range", () => {
     const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
     const result = formatAxisTimestamp(epoch, 604800);
-    expect(result).toBe("Jan 15 10:30");
+    expect(result).toBe("Jan 15");
   });
   it("shows just date for monthly range", () => {
     const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;


### PR DESCRIPTION
## Summary
This PR removes the unnecessary time component (HH:MM) from x-axis labels on dashboard charts when using the "Last 7 days" filter, improving readability by showing only the date.

## Changes
- Modified `formatAxisTimestamp()` in `chart-utils.ts` to return only the month and day (`${mon} ${day}`) for the 7-day range, instead of including the time component (`${mon} ${day} ${hh}:${mm}`)
- This aligns the 7-day view with the behavior of longer time ranges, which already display only the date without time

## Details
The change simplifies the x-axis labels for the 7-day filter by removing the redundant time information. Since the 7-day range typically shows data points at daily or longer intervals, the time component adds visual clutter without providing meaningful information to users.

https://claude.ai/code/session_018ebs6unBSdtExgPPTxRLgK