### PR TITLE
fix: detect broken better-sqlite3 at install and in CI

### DIFF
--- a/.changeset/better-sqlite3-preflight.md
+++ b/.changeset/better-sqlite3-preflight.md
@@ -1,0 +1,6 @@
+---
+"manifest": patch
+"@mnfst/server": patch
+---
+
+Add postinstall check for better-sqlite3 native module and CI verification step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,11 @@ jobs:
           npm init -y
           npm install ../mnfst-server-*.tgz
 
+      - name: Verify native modules
+        run: |
+          cd "$RUNNER_TEMP/smoke-test"
+          node -e "require('better-sqlite3'); console.log('better-sqlite3 OK')"
+
       - name: Run smoke test
         run: |
           cp packages/manifest-server/smoke-test.cjs "$RUNNER_TEMP/smoke-test/"

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -33,6 +33,7 @@
     "build": "tsx build.ts",
     "dev": "tsx watch build.ts",
     "prepublishOnly": "npm run build",
+    "postinstall": "node -e \"try{require('better-sqlite3')}catch(e){console.warn('\\nWARNING: better-sqlite3 native module not built.\\n  On macOS: xcode-select --install\\n  Then run: npm rebuild better-sqlite3\\n')}\"",
     "typecheck": "tsc --noEmit",
     "test": "jest"
   },


### PR DESCRIPTION
## Summary

Fixes silent failures when `better-sqlite3` native addon fails to compile during plugin installation on macOS (missing Xcode CLI tools, prebuild download timeout, etc.).

- **postinstall check**: The `manifest` plugin now runs a postinstall script that warns immediately if `better-sqlite3` is missing its native addon, instead of failing silently at runtime when the embedded server tries to start.
- **CI verification**: Added an explicit `Verify native modules` step to the `server-smoke` CI job (ubuntu + macOS) so a missing `.node` file is caught with a clear diagnostic before the full smoke test runs.

### Context

After a clean install on macOS, `better-sqlite3` can fail to build its native addon silently (prebuild download fails, node-gyp fails). npm reports success, but the server crashes at runtime with "Could not locate the bindings file" — buried in `~/.openclaw/logs/gateway.err.log` with no user-visible feedback.

The pre-flight check in `@mnfst/server` (already in place) and the improved error handling in the plugin (already in place) catch the issue at runtime. These two additions catch it **earlier**: at install time and in CI.

## Test plan

- [x] `npm test --workspace=packages/openclaw-plugin` — all 125 tests pass
- [ ] CI `server-smoke` job passes on ubuntu-latest and macos-latest
- [ ] Simulate broken addon: rename `better_sqlite3.node` → verify postinstall warning appears on `npm install`