### PR TITLE
Proxy GitHub API requests through backend to fix CSP errors

### DIFF
--- a/.changeset/fix-github-star-csp.md
+++ b/.changeset/fix-github-star-csp.md
@@ -1,0 +1,5 @@
+---
+"@mnfst/server": patch
+---
+
+Fix CSP errors from GitHub star button by proxying the GitHub API through a backend endpoint

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { ModelPricesModule } from './model-prices/model-prices.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { CommonModule } from './common/common.module';
 import { SseModule } from './sse/sse.module';
+import { GithubModule } from './github/github.module';
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';
 const sessionGuardClass = isLocalMode ? LocalAuthGuard : SessionGuard;
@@ -56,6 +57,7 @@ const serveStaticImports = existsSync(frontendPath)
     ModelPricesModule,
     NotificationsModule,
     SseModule,
+    GithubModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: sessionGuardClass },

--- a/packages/backend/src/github/github.controller.ts
+++ b/packages/backend/src/github/github.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get } from '@nestjs/common';
+import { Public } from '../common/decorators/public.decorator';
+
+const GITHUB_REPO = 'mnfst/manifest';
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+let cachedStars: number | null = null;
+let cachedAt = 0;
+
+@Controller('api/v1')
+export class GithubController {
+  @Public()
+  @Get('github/stars')
+  async getStars(): Promise<{ stars: number | null }> {
+    if (cachedStars !== null && Date.now() - cachedAt < CACHE_TTL_MS) {
+      return { stars: cachedStars };
+    }
+
+    try {
+      const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}`, {
+        headers: { Accept: 'application/vnd.github.v3+json' },
+      });
+      if (!res.ok) {
+        return { stars: cachedStars };
+      }
+      const data = (await res.json()) as { stargazers_count?: number };
+      if (typeof data.stargazers_count === 'number') {
+        cachedStars = data.stargazers_count;
+        cachedAt = Date.now();
+      }
+    } catch {
+      // Return stale cache or null on failure
+    }
+
+    return { stars: cachedStars };
+  }
+}

--- a/packages/backend/src/github/github.module.ts
+++ b/packages/backend/src/github/github.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { GithubController } from './github.controller';
+
+@Module({
+  controllers: [GithubController],
+})
+export class GithubModule {}

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -20,11 +20,11 @@ const Header: Component = () => {
   onMount(() => {
     checkLocalMode();
     if (!starDismissed()) {
-      fetch(`https://api.github.com/repos/${GITHUB_REPO}`)
+      fetch("/api/v1/github/stars")
         .then((r) => r.json())
         .then((data) => {
-          if (typeof data.stargazers_count === "number") {
-            setStarCount(data.stargazers_count);
+          if (typeof data.stars === "number") {
+            setStarCount(data.stars);
           }
         })
         .catch(() => {});

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -92,7 +92,7 @@ describe("Header", () => {
 describe("Header - GitHub star button", () => {
   it("renders the star button with link to GitHub repo", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: 1234 }))
+      new Response(JSON.stringify({ stars: 1234 }))
     );
     const { container } = render(() => <Header />);
     await vi.waitFor(() => {
@@ -107,7 +107,7 @@ describe("Header - GitHub star button", () => {
 
   it("fetches and displays the star count", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: 5678 }))
+      new Response(JSON.stringify({ stars: 5678 }))
     );
     render(() => <Header />);
     await vi.waitFor(() => {
@@ -117,7 +117,7 @@ describe("Header - GitHub star button", () => {
 
   it("formats large star counts with locale separators", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: 12345 }))
+      new Response(JSON.stringify({ stars: 12345 }))
     );
     render(() => <Header />);
     await vi.waitFor(() => {
@@ -127,7 +127,7 @@ describe("Header - GitHub star button", () => {
 
   it("renders star button without count when API returns non-numeric value", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: "not a number" }))
+      new Response(JSON.stringify({ stars: "not a number" }))
     );
     const { container } = render(() => <Header />);
     await vi.waitFor(() => {
@@ -148,7 +148,7 @@ describe("Header - GitHub star button", () => {
 
   it("shows dismiss button", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: 100 }))
+      new Response(JSON.stringify({ stars: 100 }))
     );
     render(() => <Header />);
     await vi.waitFor(() => {
@@ -158,7 +158,7 @@ describe("Header - GitHub star button", () => {
 
   it("hides star button when dismiss is clicked", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: 100 }))
+      new Response(JSON.stringify({ stars: 100 }))
     );
     const { container } = render(() => <Header />);
     await vi.waitFor(() => {
@@ -170,7 +170,7 @@ describe("Header - GitHub star button", () => {
 
   it("persists dismiss state in sessionStorage", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: 100 }))
+      new Response(JSON.stringify({ stars: 100 }))
     );
     render(() => <Header />);
     await vi.waitFor(() => {
@@ -183,7 +183,7 @@ describe("Header - GitHub star button", () => {
   it("does not render star button if previously dismissed", async () => {
     sessionStorage.setItem("github-star-dismissed", "true");
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: 100 }))
+      new Response(JSON.stringify({ stars: 100 }))
     );
     const { container } = render(() => <Header />);
     expect(container.querySelector(".header__github-star")).toBeNull();
@@ -193,7 +193,7 @@ describe("Header - GitHub star button", () => {
   it("does not fetch star count if dismissed", () => {
     sessionStorage.setItem("github-star-dismissed", "true");
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify({ stargazers_count: 100 }))
+      new Response(JSON.stringify({ stars: 100 }))
     );
     render(() => <Header />);
     expect(fetchSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
This PR fixes Content Security Policy (CSP) errors caused by the frontend directly fetching GitHub star counts by proxying the GitHub API through a new backend endpoint.

## Key Changes
- **New Backend Module**: Created `GithubModule` with `GithubController` that exposes a `/api/v1/github/stars` endpoint
  - Fetches star count from GitHub API (`https://api.github.com/repos/mnfst/manifest`)
  - Implements 10-minute caching to reduce API calls and improve performance
  - Gracefully handles failures by returning stale cache or null
  - Endpoint is marked as `@Public()` to allow unauthenticated access
- **Frontend Update**: Modified `Header.tsx` to call the backend endpoint instead of directly calling GitHub API
  - Changed from `https://api.github.com/repos/${GITHUB_REPO}` to `/api/v1/github/stars`
  - Updated response parsing to use `data.stars` instead of `data.stargazers_count`
- **Module Registration**: Added `GithubModule` to `AppModule` imports

## Implementation Details
- The backend implements simple in-memory caching with a 10-minute TTL to avoid rate limiting and reduce external API calls
- The endpoint returns `{ stars: number | null }` for consistent response format
- Error handling ensures the API gracefully degrades: returns cached value on failure, or null if no cache exists
- The `@Public()` decorator allows the endpoint to be accessed without authentication

https://claude.ai/code/session_01KotXGnQweoqPpQj4Khb55b