### PR TITLE
fix: fire agent_created telemetry event in local mode

### DIFF
--- a/.changeset/local-mode-agent-telemetry.md
+++ b/.changeset/local-mode-agent-telemetry.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fire agent_created product telemetry event in local mode when a new tenant/agent is created via LocalBootstrapService.

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -9,6 +9,7 @@ import { Agent } from '../entities/agent.entity';
 import { AgentApiKey } from '../entities/agent-api-key.entity';
 import { ModelPricing } from '../entities/model-pricing.entity';
 import { sha256, keyPrefix } from '../common/utils/hash.util';
+import { trackEvent } from '../common/utils/product-telemetry';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { PricingSyncService } from './pricing-sync.service';
 import { LOCAL_USER_ID, LOCAL_EMAIL } from '../common/constants/local-mode.constants';
@@ -67,6 +68,7 @@ export class LocalBootstrapService implements OnModuleInit {
       await this.registerApiKey(apiKey);
     }
 
+    trackEvent('agent_created');
     this.logger.log(`Created tenant/agent for local mode`);
   }
 

--- a/packages/backend/src/otlp/services/api-key.service.spec.ts
+++ b/packages/backend/src/otlp/services/api-key.service.spec.ts
@@ -23,6 +23,7 @@ jest.mock('crypto', () => {
 
 import { v4 as uuidv4 } from 'uuid';
 import { randomBytes } from 'crypto';
+import { trackCloudEvent } from '../../common/utils/product-telemetry';
 
 const mockedUuidv4 = uuidv4 as jest.Mock;
 const mockedRandomBytes = randomBytes as jest.Mock;
@@ -261,6 +262,17 @@ describe('ApiKeyGeneratorService', () => {
         expect.objectContaining({
           description: 'A helpful bot',
         }),
+      );
+    });
+
+    it('fires agent_created telemetry event', async () => {
+      mockTenantFindOne.mockResolvedValue(null);
+
+      const result = await service.onboardAgent(defaultParams);
+
+      expect(trackCloudEvent).toHaveBeenCalledWith(
+        'agent_created',
+        result.tenantId,
       );
     });
 


### PR DESCRIPTION
## Summary

- Fire `trackEvent('agent_created')` in `LocalBootstrapService.ensureTenantAndAgent()` when a new tenant/agent is created, closing the telemetry blind spot in local mode
- Add tests verifying the event fires on fresh bootstrap and does not fire when tenant already exists
- Add test verifying `trackCloudEvent('agent_created', tenantId)` is called in `ApiKeyGeneratorService.onboardAgent()` (cloud mode)

## Test plan

- [x] Backend unit tests pass (718/718)
- [x] TypeScript compiles with no errors
- [ ] CI passes