### PR TITLE
fix: remove private workspace packages from plugin devDependencies

### DIFF
--- a/.changeset/fix-plugin-npm-install.md
+++ b/.changeset/fix-plugin-npm-install.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: remove private workspace packages from devDependencies to fix standalone npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -13127,7 +13127,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.3.4",
+      "version": "5.6.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",
@@ -13167,8 +13167,6 @@
         "@types/jest": "^29.5.0",
         "esbuild": "^0.25.0",
         "jest": "^29.7.0",
-        "manifest-backend": "*",
-        "manifest-frontend": "*",
         "ts-jest": "^29.2.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0"

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -101,8 +101,6 @@
     "typescript": "^5.7.0",
     "@types/jest": "^29.5.0",
     "jest": "^29.7.0",
-    "ts-jest": "^29.2.0",
-    "manifest-backend": "*",
-    "manifest-frontend": "*"
+    "ts-jest": "^29.2.0"
   }
 }


### PR DESCRIPTION
## Summary

- Removes `manifest-backend` and `manifest-frontend` from the openclaw-plugin's `devDependencies`
- These are private workspace packages (never published to npm) that cause a 404 when the plugin is installed standalone via `openclaw plugins install manifest`
- The build script already references these packages by filesystem path, not by package name, so the entries served no purpose

## Root cause

npm resolves `devDependencies` even with `--omit dev` to build the full dependency tree. Since `manifest-backend` and `manifest-frontend` don't exist on the npm registry, resolution fails with:

```
404 Not Found - GET https://registry.npmjs.org/manifest-backend - Not found
```

## Test plan

- [x] `npm install` updates lockfile cleanly
- [x] All 150 plugin tests pass
- [x] TypeScript compiles with no errors
- [x] Packed tarball installs successfully with `npm install --omit dev --ignore-scripts`