### PR TITLE
fix: clean up plugin install — remove broken deps, surface dashboard URL

### DIFF
--- a/packages/openclaw-plugin/__tests__/hooks.test.ts
+++ b/packages/openclaw-plugin/__tests__/hooks.test.ts
@@ -144,7 +144,7 @@ describe("registerHooks", () => {
   });
 
   it("logs that hooks are registered", () => {
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       "[manifest] All hooks registered",
     );
   });

--- a/packages/openclaw-plugin/__tests__/telemetry.test.ts
+++ b/packages/openclaw-plugin/__tests__/telemetry.test.ts
@@ -172,10 +172,10 @@ describe("initTelemetry", () => {
   it("logs trace and metrics exporter endpoints", () => {
     initTelemetry(config, mockLogger);
 
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining("Trace exporter ->"),
     );
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining("Metrics exporter ->"),
     );
   });

--- a/packages/openclaw-plugin/__tests__/tools.test.ts
+++ b/packages/openclaw-plugin/__tests__/tools.test.ts
@@ -49,7 +49,7 @@ describe("registerTools", () => {
   });
 
   it("logs registered tool names", () => {
-    expect(mockLogger.info).toHaveBeenCalledWith(
+    expect(mockLogger.debug).toHaveBeenCalledWith(
       expect.stringContaining("manifest_usage"),
     );
   });

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -227,5 +227,5 @@ export function registerHooks(
     logger.debug(`[manifest] Trace completed for session=${sessionKey}`);
   });
 
-  logger.info("[manifest] All hooks registered");
+  logger.debug("[manifest] All hooks registered");
 }

--- a/packages/openclaw-plugin/src/local-mode.ts
+++ b/packages/openclaw-plugin/src/local-mode.ts
@@ -233,7 +233,7 @@ export function registerLocalMode(
   const apiKey = loadOrGenerateApiKey();
   const dbPath = join(CONFIG_DIR, "manifest.db");
 
-  logger.info("[manifest] Local mode — starting embedded server...");
+  logger.debug("[manifest] Local mode — starting embedded server...");
 
   // Inject provider config BEFORE routing registration
   injectProviderConfig(api, host, port, apiKey, logger);
@@ -270,6 +270,8 @@ export function registerLocalMode(
   if (typeof api.registerTool === "function") {
     registerTools(api, localConfig, logger);
   }
+
+  logger.info(`[manifest] 🦚 View your Manifest Dashboard -> http://${host}:${port}`);
 
   api.registerService({
     id: "manifest-local",

--- a/packages/openclaw-plugin/src/telemetry.ts
+++ b/packages/openclaw-plugin/src/telemetry.ts
@@ -53,7 +53,7 @@ export function initTelemetry(
     ],
   });
   tracerProvider.register();
-  logger.info(`[manifest] Trace exporter -> ${config.endpoint}/v1/traces`);
+  logger.debug(`[manifest] Trace exporter -> ${config.endpoint}/v1/traces`);
 
   // Metrics exporter
   const metricExporter = new OTLPMetricExporter({
@@ -71,7 +71,7 @@ export function initTelemetry(
     ],
   });
   metrics.setGlobalMeterProvider(meterProvider);
-  logger.info(
+  logger.debug(
     `[manifest] Metrics exporter -> ${config.endpoint}/v1/metrics ` +
       `(interval=${config.metricsIntervalMs}ms)`,
   );

--- a/packages/openclaw-plugin/src/tools.ts
+++ b/packages/openclaw-plugin/src/tools.ts
@@ -106,7 +106,7 @@ export function registerTools(
     },
   });
 
-  logger.info(
+  logger.debug(
     "[manifest] Registered agent tools: manifest_usage, manifest_costs, manifest_health",
   );
 }


### PR DESCRIPTION
## Summary

- Remove private workspace packages (`manifest-backend`, `manifest-frontend`) from the plugin's `devDependencies` so that standalone `npm install manifest` no longer fails with unresolvable dependency errors.
- Downgrade noisy telemetry/hook/tool registration log messages from `info` to `debug` level so the install output is clean.
- Add a single `info`-level message showing the Manifest Dashboard URL — the one thing users actually care about during install.

**Before:**
```
[manifest] Local mode — starting embedded server...
[manifest] Trace exporter -> http://127.0.0.1:2099/otlp/v1/traces
[manifest] Metrics exporter -> http://127.0.0.1:2099/otlp/v1/metrics (interval=10000ms)
[manifest] All hooks registered
[manifest] Registered agent tools: manifest_usage, manifest_costs, manifest_health
```

**After:**
```
[manifest] 🦚 View your Manifest Dashboard -> http://127.0.0.1:2099
```

## Test plan

- [x] Plugin builds cleanly (`npx tsx build.ts`)
- [x] Backend unit tests pass (718/718)
- [x] Frontend tests pass (465/465)
- [ ] Install plugin via `openclaw plugins install manifest` — confirm clean output with dashboard URL
- [ ] Restart gateway — confirm server startup logs still appear from the service `start()` callback