### PR TITLE
fix: make pricing sync resilient and trigger on startup

### DIFF
--- a/.changeset/fix-pricing-sync-resilience.md
+++ b/.changeset/fix-pricing-sync-resilience.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix Model Prices page showing only 31 models: add error handling in OpenRouter sync loop so one bad model doesn't crash the entire sync, trigger sync on startup when data is stale, and always upsert curated seed models on restart

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -93,7 +93,7 @@ describe('DatabaseSeederService', () => {
 
       await service.onModuleInit();
 
-      expect(mockPricingRepo.count).toHaveBeenCalled();
+      expect(mockPricingRepo.upsert).toHaveBeenCalled();
     });
 
     it('should seed demo data when env is development and SEED_DATA is true', async () => {
@@ -303,18 +303,16 @@ describe('DatabaseSeederService', () => {
   });
 
   describe('seedModelPricing', () => {
-    it('should skip seeding when pricing data already exists', async () => {
+    it('should always upsert curated models even when data exists', async () => {
       mockPricingRepo.count.mockResolvedValue(10);
+      mockConfigService.get.mockReturnValue('production');
 
       await service.onModuleInit();
 
-      expect(mockPricingRepo.upsert).not.toHaveBeenCalled();
+      expect(mockPricingRepo.upsert).toHaveBeenCalledTimes(35);
     });
 
     it('should upsert all model pricing entries when table is empty', async () => {
-      mockPricingRepo.count.mockResolvedValue(0);
-
-      // Prevent demo data seeding to isolate pricing test
       mockConfigService.get.mockReturnValue('production');
 
       await service.onModuleInit();

--- a/packages/backend/src/database/database-seeder.service.ts
+++ b/packages/backend/src/database/database-seeder.service.ts
@@ -154,11 +154,8 @@ export class DatabaseSeederService implements OnModuleInit {
   }
 
   private async seedModelPricing() {
-    const count = await this.pricingRepo.count();
-    if (count > 0) return;
-
-    // Prices: [model_id, provider, input_per_token, output_per_token]
-    // Source: official pricing pages (Feb 2026)
+    // Always upsert curated models so new entries are added on every restart
+    // and existing curated models keep correct fallback pricing.
     const models: ReadonlyArray<readonly [string, string, number, number]> = [
       // Anthropic Claude
       ['claude-opus-4-6',            'Anthropic', 0.000015,   0.000075  ],

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -1,7 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { MoreThan, Repository } from 'typeorm';
 import { ModelPricing } from '../entities/model-pricing.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { PricingHistoryService } from './pricing-history.service';
@@ -37,8 +37,10 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
 
 const OPENROUTER_API = 'https://openrouter.ai/api/v1/models';
 
+const FRESHNESS_HOURS = 12;
+
 @Injectable()
-export class PricingSyncService {
+export class PricingSyncService implements OnModuleInit {
   private readonly logger = new Logger(PricingSyncService.name);
 
   constructor(
@@ -48,6 +50,20 @@ export class PricingSyncService {
     private readonly pricingHistory: PricingHistoryService,
     private readonly unresolvedTracker: UnresolvedModelTrackerService,
   ) {}
+
+  async onModuleInit(): Promise<void> {
+    const cutoff = new Date(Date.now() - FRESHNESS_HOURS * 3600_000);
+    const recent = await this.pricingRepo.count({
+      where: { updated_at: MoreThan(cutoff) },
+    });
+    if (recent > 0) {
+      this.logger.log('Pricing data is fresh — skipping startup sync');
+      return;
+    }
+    this.syncPricing().catch((err) => {
+      this.logger.error(`Startup pricing sync failed: ${err}`);
+    });
+  }
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
   async syncPricing(): Promise<number> {
@@ -83,33 +99,49 @@ export class PricingSyncService {
 
   private async syncAllModels(data: OpenRouterModel[]): Promise<number> {
     let updated = 0;
+    let failed = 0;
     const now = new Date(sqlNow());
 
     for (const model of data) {
-      const prompt = Number(model.pricing?.prompt ?? 0);
-      const completion = Number(model.pricing?.completion ?? 0);
-      if (prompt === 0 && completion === 0) continue;
+      try {
+        const prompt = Number(model.pricing?.prompt ?? 0);
+        const completion = Number(model.pricing?.completion ?? 0);
+        if (prompt === 0 && completion === 0) continue;
+        if (!Number.isFinite(prompt) || !Number.isFinite(completion)) {
+          this.logger.warn(`Skipping ${model.id}: non-finite pricing`);
+          failed++;
+          continue;
+        }
 
-      const { canonical, provider } = this.deriveNames(model.id);
-      const existing = await this.pricingRepo.findOneBy({
-        model_name: canonical,
-      });
+        const { canonical, provider } = this.deriveNames(model.id);
+        const existing = await this.pricingRepo.findOneBy({
+          model_name: canonical,
+        });
 
-      const incoming = {
-        model_name: canonical,
-        provider,
-        input_price_per_token: prompt,
-        output_price_per_token: completion,
-      };
+        const incoming = {
+          model_name: canonical,
+          provider,
+          input_price_per_token: prompt,
+          output_price_per_token: completion,
+        };
 
-      await this.pricingHistory.recordChange(existing, incoming, 'sync');
-      await this.pricingRepo.upsert(
-        { ...incoming, updated_at: now },
-        ['model_name'],
-      );
-      updated++;
+        await this.pricingHistory.recordChange(existing, incoming, 'sync');
+        await this.pricingRepo.upsert(
+          { ...incoming, updated_at: now },
+          ['model_name'],
+        );
+        updated++;
+      } catch (err) {
+        failed++;
+        this.logger.warn(
+          `Failed to sync model ${model.id}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
     }
 
+    if (failed > 0) {
+      this.logger.warn(`Pricing sync: ${failed} models failed`);
+    }
     return updated;
   }
 


### PR DESCRIPTION
## Summary

Fixes Model Prices page only showing 31 models (the original seed data) instead of hundreds from OpenRouter.

**Root causes:**
- The OpenRouter sync loop had no error handling — a single bad model (NaN pricing, decimal overflow) would crash the entire sync
- No startup sync trigger — models only populated at the 3 AM cron, so fresh deployments showed nothing until then
- Stale seed data — `seedModelPricing()` skipped when `count > 0`, so new curated models never reached existing databases

**Changes:**
- **Try/catch in sync loop** (`pricing-sync.service.ts`): Each model is wrapped individually so failures are logged and skipped without aborting the sync. Non-finite pricing values are detected upfront.
- **Startup sync** (`pricing-sync.service.ts`): `OnModuleInit` triggers `syncPricing()` when no model has `updated_at` within the last 12 hours, ensuring immediate population after deployment.
- **Always upsert curated models** (`database-seeder.service.ts`): Removed the `if (count > 0) return` guard so the 35 curated models are upserted on every startup.

## Test plan

- [x] All 718 backend unit tests pass
- [x] TypeScript compiles with no errors (backend + frontend)
- [x] Updated seeder tests to reflect new always-upsert behavior
- [ ] Start backend locally and verify sync triggers on startup (check logs for "Starting daily model pricing sync from OpenRouter...")
- [ ] Verify model_pricing table has hundreds of entries after startup
- [ ] Check Model Prices page shows 100+ models