### PR TITLE
feat: add version indicator with update notification

### DIFF
--- a/.changeset/version-indicator-update-notification.md
+++ b/.changeset/version-indicator-update-notification.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add version indicator with update notification to the dashboard

--- a/packages/backend/src/health/health.controller.spec.ts
+++ b/packages/backend/src/health/health.controller.spec.ts
@@ -3,12 +3,26 @@ jest.mock('fs', () => ({
 }));
 
 import { HealthController } from './health.controller';
+import { VersionCheckService } from './version-check.service';
+
+function createMockVersionCheck(overrides: Partial<VersionCheckService> = {}): VersionCheckService {
+  return {
+    onModuleInit: jest.fn(),
+    getCurrentVersion: jest.fn().mockReturnValue('1.2.3'),
+    getUpdateInfo: jest.fn().mockReturnValue({}),
+    isNewer: jest.fn().mockReturnValue(false),
+    fetchLatestVersion: jest.fn().mockResolvedValue(null),
+    ...overrides,
+  } as unknown as VersionCheckService;
+}
 
 describe('HealthController', () => {
   let controller: HealthController;
+  let mockVersionCheck: VersionCheckService;
 
   beforeEach(() => {
-    controller = new HealthController();
+    mockVersionCheck = createMockVersionCheck();
+    controller = new HealthController(mockVersionCheck);
   });
 
   it('returns healthy status', () => {
@@ -39,5 +53,24 @@ describe('HealthController', () => {
     const result = controller.getHealth();
     expect(result.mode).toBe('local');
     process.env['MANIFEST_MODE'] = orig;
+  });
+
+  it('includes update info when available', () => {
+    mockVersionCheck = createMockVersionCheck({
+      getUpdateInfo: jest.fn().mockReturnValue({
+        latestVersion: '2.0.0',
+        updateAvailable: true,
+      }),
+    });
+    controller = new HealthController(mockVersionCheck);
+    const result = controller.getHealth();
+    expect(result.latestVersion).toBe('2.0.0');
+    expect(result.updateAvailable).toBe(true);
+  });
+
+  it('omits update fields when no update available', () => {
+    const result = controller.getHealth();
+    expect(result).not.toHaveProperty('latestVersion');
+    expect(result).not.toHaveProperty('updateAvailable');
   });
 });

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -2,12 +2,15 @@ import { Controller, Get } from '@nestjs/common';
 import { Public } from '../common/decorators/public.decorator';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { VersionCheckService } from './version-check.service';
 
 const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8')) as { version: string };
 
 @Controller('api/v1')
 export class HealthController {
   private readonly startTime = Date.now();
+
+  constructor(private readonly versionCheck: VersionCheckService) {}
 
   @Public()
   @Get('health')
@@ -17,6 +20,7 @@ export class HealthController {
       uptime_seconds: Math.floor((Date.now() - this.startTime) / 1000),
       version: pkg.version,
       mode: process.env['MANIFEST_MODE'] === 'local' ? 'local' : 'cloud',
+      ...this.versionCheck.getUpdateInfo(),
     };
   }
 }

--- a/packages/backend/src/health/health.module.ts
+++ b/packages/backend/src/health/health.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { HealthController } from './health.controller';
+import { VersionCheckService } from './version-check.service';
 
 @Module({
   controllers: [HealthController],
+  providers: [VersionCheckService],
 })
 export class HealthModule {}

--- a/packages/backend/src/health/version-check.service.spec.ts
+++ b/packages/backend/src/health/version-check.service.spec.ts
@@ -1,0 +1,158 @@
+import { VersionCheckService } from './version-check.service';
+
+describe('VersionCheckService', () => {
+  let service: VersionCheckService;
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    service = new VersionCheckService();
+    mockFetch = jest.fn();
+    global.fetch = mockFetch;
+    delete process.env['MANIFEST_PACKAGE_VERSION'];
+    delete process.env['MANIFEST_MODE'];
+    delete process.env['MANIFEST_TELEMETRY_OPTOUT'];
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getCurrentVersion', () => {
+    it('returns MANIFEST_PACKAGE_VERSION when set', () => {
+      process.env['MANIFEST_PACKAGE_VERSION'] = '2.3.4';
+      expect(service.getCurrentVersion()).toBe('2.3.4');
+    });
+
+    it('returns 0.0.0 when env var is not set', () => {
+      expect(service.getCurrentVersion()).toBe('0.0.0');
+    });
+  });
+
+  describe('isNewer', () => {
+    it('detects major version bump', () => {
+      expect(service.isNewer('2.0.0', '1.9.9')).toBe(true);
+    });
+
+    it('detects minor version bump', () => {
+      expect(service.isNewer('1.2.0', '1.1.9')).toBe(true);
+    });
+
+    it('detects patch version bump', () => {
+      expect(service.isNewer('1.0.2', '1.0.1')).toBe(true);
+    });
+
+    it('returns false when versions are equal', () => {
+      expect(service.isNewer('1.0.0', '1.0.0')).toBe(false);
+    });
+
+    it('returns false when current is newer', () => {
+      expect(service.isNewer('1.0.0', '2.0.0')).toBe(false);
+    });
+  });
+
+  describe('getUpdateInfo', () => {
+    it('returns empty object when no cached version', () => {
+      expect(service.getUpdateInfo()).toEqual({});
+    });
+
+    it('returns update info when newer version is cached', async () => {
+      process.env['MANIFEST_PACKAGE_VERSION'] = '1.0.0';
+      process.env['MANIFEST_MODE'] = 'local';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ version: '2.0.0' }),
+      });
+
+      await service.fetchLatestVersion();
+      const info = service.getUpdateInfo();
+      expect(info).toEqual({ latestVersion: '2.0.0', updateAvailable: true });
+    });
+
+    it('returns empty object when current version matches latest', async () => {
+      process.env['MANIFEST_PACKAGE_VERSION'] = '2.0.0';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ version: '2.0.0' }),
+      });
+
+      await service.fetchLatestVersion();
+      expect(service.getUpdateInfo()).toEqual({});
+    });
+  });
+
+  describe('fetchLatestVersion', () => {
+    it('fetches from npm registry', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ version: '3.0.0' }),
+      });
+
+      const result = await service.fetchLatestVersion();
+      expect(result).toBe('3.0.0');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://registry.npmjs.org/manifest/latest',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    it('returns null on non-ok response', async () => {
+      mockFetch.mockResolvedValue({ ok: false });
+      const result = await service.fetchLatestVersion();
+      expect(result).toBeNull();
+    });
+
+    it('returns null on invalid version format', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ version: 'not-a-version' }),
+      });
+      const result = await service.fetchLatestVersion();
+      expect(result).toBeNull();
+    });
+
+    it('returns null on fetch error', async () => {
+      mockFetch.mockRejectedValue(new Error('network error'));
+      const result = await service.fetchLatestVersion();
+      expect(result).toBeNull();
+    });
+
+    it('uses cached value within TTL', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ version: '3.0.0' }),
+      });
+
+      await service.fetchLatestVersion();
+      await service.fetchLatestVersion();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onModuleInit', () => {
+    it('does not fetch when not in local mode', async () => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+      await service.onModuleInit();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch when telemetry is opted out', async () => {
+      process.env['MANIFEST_MODE'] = 'local';
+      process.env['MANIFEST_TELEMETRY_OPTOUT'] = '1';
+      await service.onModuleInit();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('fetches when in local mode and not opted out', async () => {
+      process.env['MANIFEST_MODE'] = 'local';
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ version: '5.0.0' }),
+      });
+
+      await service.onModuleInit();
+      // Give the non-blocking fetch time to complete
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockFetch).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/health/version-check.service.ts
+++ b/packages/backend/src/health/version-check.service.ts
@@ -1,0 +1,83 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+
+interface UpdateInfo {
+  latestVersion?: string;
+  updateAvailable?: boolean;
+}
+
+@Injectable()
+export class VersionCheckService implements OnModuleInit {
+  private readonly logger = new Logger(VersionCheckService.name);
+  private cachedLatest: string | null = null;
+  private cacheExpiry = 0;
+  private static readonly CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+  private static readonly FETCH_TIMEOUT_MS = 5000;
+  private static readonly VERSION_RE = /^\d+\.\d+\.\d+$/;
+
+  async onModuleInit(): Promise<void> {
+    if (!this.isEnabled()) return;
+    this.fetchLatestVersion().catch(() => {});
+  }
+
+  getCurrentVersion(): string {
+    return process.env['MANIFEST_PACKAGE_VERSION'] ?? '0.0.0';
+  }
+
+  getUpdateInfo(): UpdateInfo {
+    if (!this.cachedLatest) return {};
+    const current = this.getCurrentVersion();
+    if (!this.isNewer(this.cachedLatest, current)) return {};
+    return { latestVersion: this.cachedLatest, updateAvailable: true };
+  }
+
+  isNewer(latest: string, current: string): boolean {
+    const [lMaj, lMin, lPat] = latest.split('.').map(Number);
+    const [cMaj, cMin, cPat] = current.split('.').map(Number);
+    if (lMaj !== cMaj) return lMaj > cMaj;
+    if (lMin !== cMin) return lMin > cMin;
+    return lPat > cPat;
+  }
+
+  async fetchLatestVersion(): Promise<string | null> {
+    if (this.cachedLatest && Date.now() < this.cacheExpiry) {
+      return this.cachedLatest;
+    }
+
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(
+        () => controller.abort(),
+        VersionCheckService.FETCH_TIMEOUT_MS,
+      );
+
+      const res = await fetch(
+        'https://registry.npmjs.org/manifest/latest',
+        { signal: controller.signal },
+      );
+      clearTimeout(timer);
+
+      if (!res.ok) return null;
+
+      const data = (await res.json()) as { version?: string };
+      const version = data?.version;
+      if (!version || !VersionCheckService.VERSION_RE.test(version)) {
+        return null;
+      }
+
+      this.cachedLatest = version;
+      this.cacheExpiry = Date.now() + VersionCheckService.CACHE_TTL_MS;
+      this.logger.log(`Latest manifest version: ${version}`);
+      return version;
+    } catch {
+      this.logger.debug('Failed to check for updates');
+      return null;
+    }
+  }
+
+  private isEnabled(): boolean {
+    if (process.env['MANIFEST_MODE'] !== 'local') return false;
+    const opt = process.env['MANIFEST_TELEMETRY_OPTOUT'];
+    if (opt === '1' || opt === 'true') return false;
+    return true;
+  }
+}

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import Header from "./components/Header.jsx";
 import Sidebar from "./components/Sidebar.jsx";
 import AuthGuard from "./components/AuthGuard.jsx";
 import { connectSse } from "./services/sse.js";
+import VersionIndicator from "./components/VersionIndicator.jsx";
 
 const SseConnector: ParentComponent = (props) => {
   onMount(() => {
@@ -31,6 +32,7 @@ const App: ParentComponent = (props) => {
             {props.children}
           </main>
         </div>
+        <VersionIndicator />
       </div>
       </SseConnector>
     </AuthGuard>

--- a/packages/frontend/src/components/VersionIndicator.tsx
+++ b/packages/frontend/src/components/VersionIndicator.tsx
@@ -1,0 +1,60 @@
+import { createSignal, Show } from "solid-js";
+import { updateInfo } from "../services/local-mode.js";
+
+const UPGRADE_COMMAND = "openclaw plugins upgrade manifest";
+
+const VersionIndicator = () => {
+  const info = () => updateInfo();
+  const hasUpdate = () => info()?.updateAvailable === true;
+  const [copied, setCopied] = createSignal(false);
+
+  function copyCommand() {
+    navigator.clipboard.writeText(UPGRADE_COMMAND).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {});
+  }
+
+  return (
+    <Show when={info()}>
+      <div
+        class="version-indicator"
+        classList={{ "version-indicator--update": hasUpdate() }}
+        aria-label={
+          hasUpdate()
+            ? `Update available: v${info()!.latestVersion}`
+            : `Version ${info()!.version}`
+        }
+      >
+        <Show
+          when={hasUpdate()}
+          fallback={<span>v{info()!.version}</span>}
+        >
+          <div class="version-indicator__tooltip-wrap">
+            <span>New version available</span>
+            <div class="version-indicator__bubble" role="tooltip">
+              <span class="version-indicator__range">
+                v{info()!.version} &rarr; v{info()!.latestVersion}
+              </span>
+              <div class="version-indicator__command-row">
+                <code class="version-indicator__command">
+                  {UPGRADE_COMMAND}
+                </code>
+                <button
+                  class="version-indicator__copy-btn"
+                  onClick={copyCommand}
+                  title={copied() ? "Copied!" : "Copy command"}
+                  aria-label="Copy upgrade command"
+                >
+                  {copied() ? "\u2713" : "\u2398"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </Show>
+      </div>
+    </Show>
+  );
+};
+
+export default VersionIndicator;

--- a/packages/frontend/src/services/local-mode.ts
+++ b/packages/frontend/src/services/local-mode.ts
@@ -1,6 +1,20 @@
 import { createSignal } from "solid-js";
 
+export interface UpdateInfo {
+  version: string;
+  latestVersion?: string;
+  updateAvailable?: boolean;
+}
+
+interface HealthResponse {
+  mode?: string;
+  version?: string;
+  latestVersion?: string;
+  updateAvailable?: boolean;
+}
+
 const [isLocalMode, setIsLocalMode] = createSignal<boolean | null>(null);
+const [updateInfo, setUpdateInfo] = createSignal<UpdateInfo | null>(null);
 
 let fetchPromise: Promise<boolean> | null = null;
 
@@ -10,9 +24,18 @@ export function checkLocalMode(): Promise<boolean> {
   if (!fetchPromise) {
     fetchPromise = fetch("/api/v1/health")
       .then((res) => res.json())
-      .then((data: { mode?: string }) => {
+      .then((data: HealthResponse) => {
         const local = data.mode === "local";
         setIsLocalMode(local);
+
+        if (data.version) {
+          setUpdateInfo({
+            version: data.version,
+            latestVersion: data.latestVersion,
+            updateAvailable: data.updateAvailable,
+          });
+        }
+
         return local;
       })
       .catch(() => {
@@ -24,4 +47,4 @@ export function checkLocalMode(): Promise<boolean> {
   return fetchPromise;
 }
 
-export { isLocalMode };
+export { isLocalMode, updateInfo };

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -14,6 +14,7 @@
 @import "./tooltip.css";
 @import "./toast.css";
 @import "./model-filter.css";
+@import "./version-indicator.css";
 
 /* ── shadcn/ui design tokens — Light (default) ───── */
 @layer base {

--- a/packages/frontend/src/styles/version-indicator.css
+++ b/packages/frontend/src/styles/version-indicator.css
@@ -1,0 +1,113 @@
+/* ── Version Indicator ────────────────── */
+
+.version-indicator {
+  position: fixed;
+  bottom: var(--gap-md);
+  right: var(--gap-md);
+  z-index: 40;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: hsl(var(--muted-foreground));
+  opacity: 0.5;
+  transition: opacity var(--transition-fast);
+  cursor: default;
+  user-select: none;
+}
+
+.version-indicator:hover {
+  opacity: 1;
+}
+
+.version-indicator--update {
+  color: hsl(var(--success));
+  opacity: 0.8;
+  cursor: pointer;
+}
+
+.version-indicator--update:hover {
+  opacity: 1;
+}
+
+/* ── Tooltip ── */
+
+.version-indicator__tooltip-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.version-indicator__bubble {
+  display: none;
+  position: absolute;
+  bottom: calc(100% + 8px);
+  right: 0;
+  padding: 10px 12px;
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+  line-height: 1.5;
+  white-space: nowrap;
+  width: max-content;
+  max-width: 300px;
+  box-shadow: 0 2px 8px hsl(var(--foreground) / 0.08);
+  z-index: 50;
+}
+
+/* Invisible bridge so mouse can travel from trigger to bubble */
+.version-indicator__bubble::before {
+  content: "";
+  position: absolute;
+  bottom: -8px;
+  left: 0;
+  right: 0;
+  height: 8px;
+}
+
+.version-indicator__tooltip-wrap:hover .version-indicator__bubble {
+  display: block;
+}
+
+.version-indicator__range {
+  display: block;
+  margin-bottom: 6px;
+  color: hsl(var(--muted-foreground));
+}
+
+.version-indicator__command-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: hsl(var(--muted));
+  border-radius: calc(var(--radius) - 2px);
+  padding: 4px 4px 4px 8px;
+}
+
+.version-indicator__command {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: hsl(var(--foreground));
+}
+
+.version-indicator__copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: calc(var(--radius) - 2px);
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  font-size: 13px;
+  transition: all var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.version-indicator__copy-btn:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+}

--- a/packages/frontend/tests/components/App.test.tsx
+++ b/packages/frontend/tests/components/App.test.tsx
@@ -21,6 +21,10 @@ vi.mock("../../src/services/sse.js", () => ({
   connectSse: () => () => {},
 }));
 
+vi.mock("../../src/components/VersionIndicator.jsx", () => ({
+  default: () => <div data-testid="version-indicator" />,
+}));
+
 import App from "../../src/App";
 
 describe("App", () => {

--- a/packages/frontend/tests/components/VersionIndicator.test.tsx
+++ b/packages/frontend/tests/components/VersionIndicator.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@solidjs/testing-library";
+import type { UpdateInfo } from "../../src/services/local-mode";
+import { createSignal } from "solid-js";
+
+const { mockSignal } = vi.hoisted(() => {
+  // Dynamically import solid-js for the hoisted block
+  const { createSignal: cs } = require("solid-js");
+  const signal = cs<UpdateInfo | null>(null);
+  return { mockSignal: signal as ReturnType<typeof createSignal<UpdateInfo | null>> };
+});
+
+vi.mock("../../src/services/local-mode.js", () => ({
+  get updateInfo() {
+    return mockSignal[0];
+  },
+}));
+
+import VersionIndicator from "../../src/components/VersionIndicator";
+
+describe("VersionIndicator", () => {
+  beforeEach(() => {
+    mockSignal[1](null);
+  });
+
+  it("renders nothing when no update info", () => {
+    const { container } = render(() => <VersionIndicator />);
+    expect(container.querySelector(".version-indicator")).toBeNull();
+  });
+
+  it("renders current version when no update available", () => {
+    mockSignal[1]({ version: "5.6.3" });
+    const { container } = render(() => <VersionIndicator />);
+    const el = container.querySelector(".version-indicator");
+    expect(el).not.toBeNull();
+    expect(el!.textContent).toContain("v5.6.3");
+    expect(el!.classList.contains("version-indicator--update")).toBe(false);
+  });
+
+  it("renders update notice when update available", () => {
+    mockSignal[1]({
+      version: "5.6.3",
+      latestVersion: "6.0.0",
+      updateAvailable: true,
+    });
+    const { container } = render(() => <VersionIndicator />);
+    const el = container.querySelector(".version-indicator");
+    expect(el).not.toBeNull();
+    expect(el!.classList.contains("version-indicator--update")).toBe(true);
+    expect(el!.textContent).toContain("New version available");
+  });
+
+  it("shows version range in tooltip", () => {
+    mockSignal[1]({
+      version: "5.6.3",
+      latestVersion: "6.0.0",
+      updateAvailable: true,
+    });
+    const { container } = render(() => <VersionIndicator />);
+    const range = container.querySelector(".version-indicator__range");
+    expect(range).not.toBeNull();
+    expect(range!.textContent).toContain("v5.6.3");
+    expect(range!.textContent).toContain("v6.0.0");
+  });
+
+  it("shows upgrade command in tooltip", () => {
+    mockSignal[1]({
+      version: "5.6.3",
+      latestVersion: "6.0.0",
+      updateAvailable: true,
+    });
+    const { container } = render(() => <VersionIndicator />);
+    const cmd = container.querySelector(".version-indicator__command");
+    expect(cmd).not.toBeNull();
+    expect(cmd!.textContent).toContain("openclaw plugins upgrade manifest");
+  });
+
+  it("renders copy button in tooltip", () => {
+    mockSignal[1]({
+      version: "5.6.3",
+      latestVersion: "6.0.0",
+      updateAvailable: true,
+    });
+    const { container } = render(() => <VersionIndicator />);
+    const btn = container.querySelector(".version-indicator__copy-btn");
+    expect(btn).not.toBeNull();
+    expect(btn!.getAttribute("aria-label")).toBe("Copy upgrade command");
+  });
+
+  it("has correct aria-label for version display", () => {
+    mockSignal[1]({ version: "5.6.3" });
+    const { container } = render(() => <VersionIndicator />);
+    const el = container.querySelector(".version-indicator");
+    expect(el!.getAttribute("aria-label")).toBe("Version 5.6.3");
+  });
+
+  it("has correct aria-label when update available", () => {
+    mockSignal[1]({
+      version: "5.6.3",
+      latestVersion: "6.0.0",
+      updateAvailable: true,
+    });
+    const { container } = render(() => <VersionIndicator />);
+    const el = container.querySelector(".version-indicator");
+    expect(el!.getAttribute("aria-label")).toBe("Update available: v6.0.0");
+  });
+});

--- a/packages/openclaw-plugin/src/server.ts
+++ b/packages/openclaw-plugin/src/server.ts
@@ -1,7 +1,9 @@
 import { join } from 'path';
 import { homedir } from 'os';
+import { readFileSync } from 'fs';
 
-export const version = '0.1.0';
+const pkg = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')) as { version: string };
+export const version = pkg.version;
 
 const LOCAL_DEFAULT_PORT = 2099;
 
@@ -21,6 +23,7 @@ export async function start(options: StartOptions = {}): Promise<unknown> {
   const dbPath = options.dbPath ?? join(homedir(), '.openclaw', 'manifest', 'manifest.db');
 
   // Set environment before importing the backend (it reads env at import time)
+  process.env['MANIFEST_PACKAGE_VERSION'] = version;
   process.env['MANIFEST_MODE'] = 'local';
   process.env['MANIFEST_EMBEDDED'] = '1';
   process.env['PORT'] = String(port);


### PR DESCRIPTION
## Summary

- Adds a fixed-position version indicator at the bottom-right of the dashboard
- In local mode, checks the npm registry on startup for newer versions of `manifest`
- When an update is available, the indicator shows "New version available" in the platform's teal accent color with a hover tooltip displaying the version range and a copyable upgrade command
- Respects `MANIFEST_TELEMETRY_OPTOUT` and only activates in local mode
- The plugin's `server.ts` now reads the actual version from `package.json` instead of a hardcoded `'0.1.0'`

## Test plan

- [ ] Start backend in local mode with `MANIFEST_PACKAGE_VERSION=1.0.0` — confirm "New version available" in bottom-right
- [ ] Hover tooltip — confirm version range and upgrade command visible
- [ ] Click copy button — confirm command copied to clipboard
- [ ] Set `MANIFEST_PACKAGE_VERSION` to current version — confirm just shows `vX.X.X` in muted text
- [ ] Set `MANIFEST_TELEMETRY_OPTOUT=1` — confirm no update indicator appears
- [ ] `GET /api/v1/health` returns `latestVersion` and `updateAvailable: true` when outdated
- [ ] All backend tests pass (738 tests)
- [ ] All frontend tests pass (497 tests)
- [ ] TypeScript compiles cleanly in both workspaces