### PR TITLE
fix: SPA deep-page reload returns 404 in local/production mode

### DIFF
--- a/.changeset/fix-spa-deep-reload.md
+++ b/.changeset/fix-spa-deep-reload.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix SPA deep-page reload returning 404 in local/production mode by adding a NotFoundException filter that serves index.html for non-API GET requests

--- a/packages/backend/src/common/filters/spa-fallback.filter.spec.ts
+++ b/packages/backend/src/common/filters/spa-fallback.filter.spec.ts
@@ -1,0 +1,95 @@
+import { NotFoundException } from '@nestjs/common';
+import { SpaFallbackFilter } from './spa-fallback.filter';
+
+// Mock fs.existsSync to control indexPath resolution
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+}));
+
+import { existsSync } from 'fs';
+
+const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+
+function createMockHost(method: string, url: string) {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  const sendFile = jest.fn();
+  const res = { status, json, sendFile };
+  const req = { method, originalUrl: url };
+
+  return {
+    host: {
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => res,
+      }),
+    } as any,
+    req,
+    res,
+  };
+}
+
+describe('SpaFallbackFilter', () => {
+  const exception = new NotFoundException();
+
+  describe('when index.html exists', () => {
+    let filter: SpaFallbackFilter;
+
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+      filter = new SpaFallbackFilter();
+    });
+
+    it('serves index.html for GET to a deep SPA route', () => {
+      const { host, res } = createMockHost('GET', '/agents/foo/routing');
+      filter.catch(exception, host);
+      expect(res.sendFile).toHaveBeenCalledWith(expect.stringContaining('index.html'));
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('returns JSON 404 for GET to /api/ routes', () => {
+      const { host, res } = createMockHost('GET', '/api/v1/nonexistent');
+      filter.catch(exception, host);
+      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns JSON 404 for GET to /otlp/ routes', () => {
+      const { host, res } = createMockHost('GET', '/otlp/v1/unknown');
+      filter.catch(exception, host);
+      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns JSON 404 for GET to /v1/ routes', () => {
+      const { host, res } = createMockHost('GET', '/v1/something');
+      filter.catch(exception, host);
+      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns JSON 404 for non-GET requests', () => {
+      const { host, res } = createMockHost('POST', '/agents/foo');
+      filter.catch(exception, host);
+      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe('when index.html does not exist', () => {
+    let filter: SpaFallbackFilter;
+
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(false);
+      filter = new SpaFallbackFilter();
+    });
+
+    it('returns JSON 404 even for GET to a deep SPA route', () => {
+      const { host, res } = createMockHost('GET', '/agents/foo/routing');
+      filter.catch(exception, host);
+      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+});

--- a/packages/backend/src/common/filters/spa-fallback.filter.ts
+++ b/packages/backend/src/common/filters/spa-fallback.filter.ts
@@ -1,0 +1,43 @@
+import {
+  ExceptionFilter,
+  Catch,
+  NotFoundException,
+  ArgumentsHost,
+} from '@nestjs/common';
+import { Response, Request } from 'express';
+import { join } from 'path';
+import { existsSync } from 'fs';
+
+const API_PREFIXES = ['/api/', '/otlp/', '/v1/'];
+
+@Catch(NotFoundException)
+export class SpaFallbackFilter implements ExceptionFilter {
+  private readonly indexPath: string | null;
+
+  constructor() {
+    const frontendDir =
+      process.env['MANIFEST_FRONTEND_DIR'] ||
+      join(__dirname, '..', '..', '..', '..', 'frontend', 'dist');
+    const candidate = join(frontendDir, 'index.html');
+    this.indexPath = existsSync(candidate) ? candidate : null;
+  }
+
+  catch(exception: NotFoundException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const req = ctx.getRequest<Request>();
+    const res = ctx.getResponse<Response>();
+
+    if (
+      req.method !== 'GET' ||
+      !this.indexPath ||
+      API_PREFIXES.some((p) => req.originalUrl.startsWith(p))
+    ) {
+      const response = exception.getResponse();
+      const status = exception.getStatus();
+      res.status(status).json(response);
+      return;
+    }
+
+    res.sendFile(this.indexPath);
+  }
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -5,6 +5,7 @@ import * as express from 'express';
 import { AppModule } from './app.module';
 import { auth } from './auth/auth.instance';
 import { LOCAL_USER_ID, LOCAL_EMAIL } from './common/constants/local-mode.constants';
+import { SpaFallbackFilter } from './common/filters/spa-fallback.filter';
 
 const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
 
@@ -12,6 +13,7 @@ export async function bootstrap() {
   const logger = new Logger('Bootstrap');
   const app = await NestFactory.create(AppModule, { bodyParser: false });
   app.enableShutdownHooks();
+  app.useGlobalFilters(new SpaFallbackFilter());
 
   app.use(helmet({
     contentSecurityPolicy: {


### PR DESCRIPTION
## Summary

- Add a global `NotFoundException` exception filter (`SpaFallbackFilter`) that serves `index.html` for non-API GET requests when the frontend build exists
- Fixes deep-page reloads (e.g. `/agents/local-agent/routing`) returning NestJS JSON 404 instead of loading the SPA
- API routes (`/api/`, `/otlp/`, `/v1/`) and non-GET requests still return JSON 404 as before
- In dev mode (no frontend build), the filter falls through so Vite handles SPA fallback separately

## Root cause

`@nestjs/serve-static` v5 registers its SPA catch-all route during `onModuleInit()`, but NestJS's internal route resolution catches unmatched requests and throws `NotFoundException` before that Express-level catch-all runs. The root URL `/` works because `express.static()` finds `index.html` directly.

## Test plan

- [x] Unit tests: 6 tests covering all branches (API routes, non-GET, missing index.html, SPA routes)
- [x] Local testing: built frontend + started in local mode, verified deep URLs return 200 and API routes still return proper JSON