### PR TITLE
fix: increase keyword-trie perf test threshold for CI stability

### DIFF
--- a/.changeset/fix-keyword-trie-test.md
+++ b/.changeset/fix-keyword-trie-test.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix flaky keyword-trie performance test threshold for CI stability

--- a/packages/backend/src/routing/scorer/__tests__/keyword-trie.spec.ts
+++ b/packages/backend/src/routing/scorer/__tests__/keyword-trie.spec.ts
@@ -172,7 +172,7 @@ describe('KeywordTrie', () => {
     expect(trie.scan('can you (prove) this?')).toHaveLength(1);
   });
 
-  it('scans 1000 texts of 500 chars in under 200ms', () => {
+  it('scans 1000 texts of 500 chars in under 500ms', () => {
     const trie = new KeywordTrie([
       { name: 'a', keywords: ['algorithm', 'database', 'architecture'] },
       { name: 'b', keywords: ['prove', 'theorem', 'induction'] },
@@ -189,6 +189,6 @@ describe('KeywordTrie', () => {
       trie.scan(text);
     }
     const elapsed = performance.now() - start;
-    expect(elapsed).toBeLessThan(200);
+    expect(elapsed).toBeLessThan(500);
   });
 });


### PR DESCRIPTION
## Summary
- The `keyword-trie` performance benchmark test was failing intermittently in CI (211ms vs 200ms threshold)
- Increased the threshold from 200ms to 500ms — still catches real regressions while giving CI runners enough headroom

## Test plan
- [x] All 99 backend test suites pass locally (1235 tests)
- [x] `keyword-trie.spec.ts` passes with the updated threshold