### PR TITLE
feat: add PostHog analytics for routing adoption

### DIFF
--- a/.changeset/routing-analytics.md
+++ b/.changeset/routing-analytics.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add PostHog analytics for routing adoption tracking

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -40,7 +40,7 @@ export class RoutingService {
     userId: string,
     provider: string,
     apiKey?: string,
-  ): Promise<UserProvider> {
+  ): Promise<{ provider: UserProvider; isNew: boolean }> {
     const apiKeyEncrypted = apiKey
       ? encrypt(apiKey, getEncryptionSecret())
       : null;
@@ -57,7 +57,7 @@ export class RoutingService {
       existing.updated_at = new Date().toISOString();
       await this.providerRepo.save(existing);
       await this.autoAssign.recalculate(userId);
-      return existing;
+      return { provider: existing, isNew: false };
     }
 
     const record: UserProvider = Object.assign(new UserProvider(), {
@@ -72,7 +72,7 @@ export class RoutingService {
 
     await this.providerRepo.insert(record);
     await this.autoAssign.recalculate(userId);
-    return record;
+    return { provider: record, isNew: true };
   }
 
   async removeProvider(


### PR DESCRIPTION
## Summary

- Track `routing_provider_connected` event when a user connects a **new** provider (not on reconnect/reactivation)
- Track `routing_first_proxy_request` event on first proxy request per user per process lifetime (same pattern as `first_telemetry_received` in OtlpController)
- Change `upsertProvider()` return type to `{ provider: UserProvider; isNew: boolean }` so the controller can distinguish new vs existing connections
- Both events use `trackCloudEvent()` which hashes the userId for privacy

## Test plan

- [x] Unit tests for `routing.service.spec.ts` — verify `isNew` flag on new vs existing providers, return shape contract, timestamps
- [x] Unit tests for `routing.controller.spec.ts` — verify event fires on new provider, skipped on existing, correct properties passed
- [x] Unit tests for `proxy.controller.spec.ts` — verify first request fires event, second doesn't, different users tracked independently, provider errors still track, proxyService errors don't track
- [x] Full backend test suite passes (1238 tests)