### PR TITLE
fix: unify analytics funnel distinct IDs across modes

### DIFF
--- a/.changeset/fix-analytics-funnel.md
+++ b/.changeset/fix-analytics-funnel.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix broken product analytics funnel by unifying distinct IDs across funnel steps. Local mode now uses machine_id consistently, cloud mode uses SHA256(user.id). Suppress plugin analytics in dev mode. Add file-based dedup for local first_telemetry_received.

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -11,6 +11,7 @@ import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
 import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
 import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
 import { readLocalApiKey } from '../../common/constants/local-mode.constants';
+import { trackCloudEvent } from '../../common/utils/product-telemetry';
 
 @Controller('api/v1')
 export class AgentsController {
@@ -36,6 +37,7 @@ export class AgentsController {
       agentName: body.name,
       email: user.email,
     });
+    trackCloudEvent('agent_created', user.id, { agent_name: body.name });
     return { agent: { id: result.agentId, name: body.name }, apiKey: result.apiKey };
   }
 

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -25,6 +25,11 @@ jest.mock('../model-prices/model-pricing-cache.service', () => ({
   ModelPricingCacheService: jest.fn(),
 }));
 
+// Mock product telemetry
+jest.mock('../common/utils/product-telemetry', () => ({
+  trackEvent: jest.fn(),
+}));
+
 // Mock entity imports
 jest.mock('../entities/tenant.entity', () => ({ Tenant: jest.fn() }));
 jest.mock('../entities/agent.entity', () => ({ Agent: jest.fn() }));
@@ -32,6 +37,7 @@ jest.mock('../entities/agent-api-key.entity', () => ({ AgentApiKey: jest.fn() })
 jest.mock('../entities/model-pricing.entity', () => ({ ModelPricing: jest.fn() }));
 
 import { LocalBootstrapService } from './local-bootstrap.service';
+import { trackEvent } from '../common/utils/product-telemetry';
 
 function makeMockRepo() {
   return {
@@ -51,6 +57,7 @@ describe('LocalBootstrapService', () => {
   let mockPricingSync: { syncPricing: jest.Mock };
 
   beforeEach(() => {
+    (trackEvent as jest.Mock).mockClear();
     mockTenantRepo = makeMockRepo();
     mockAgentRepo = makeMockRepo();
     mockAgentKeyRepo = makeMockRepo();
@@ -102,6 +109,20 @@ describe('LocalBootstrapService', () => {
 
       expect(mockTenantRepo.insert).not.toHaveBeenCalled();
       expect(mockAgentRepo.insert).not.toHaveBeenCalled();
+    });
+
+    it('calls trackEvent agent_created during first bootstrap', async () => {
+      await service.onModuleInit();
+
+      expect(trackEvent).toHaveBeenCalledWith('agent_created', { agent_name: 'local-agent' });
+    });
+
+    it('does NOT call trackEvent when tenant already exists', async () => {
+      mockTenantRepo.count.mockResolvedValue(1);
+
+      await service.onModuleInit();
+
+      expect(trackEvent).not.toHaveBeenCalled();
     });
 
     it('skips model pricing seed when models already exist', async () => {

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -18,6 +18,7 @@ import {
   LOCAL_AGENT_ID,
   LOCAL_AGENT_NAME,
 } from '../common/constants/local-mode.constants';
+import { trackEvent } from '../common/utils/product-telemetry';
 
 @Injectable()
 export class LocalBootstrapService implements OnModuleInit {
@@ -63,6 +64,7 @@ export class LocalBootstrapService implements OnModuleInit {
       is_active: true,
       tenant_id: LOCAL_TENANT_ID,
     });
+    trackEvent('agent_created', { agent_name: LOCAL_AGENT_NAME });
 
     const apiKey = this.readApiKeyFromConfig();
     if (apiKey) {

--- a/packages/backend/src/otlp/otlp.controller.spec.ts
+++ b/packages/backend/src/otlp/otlp.controller.spec.ts
@@ -6,9 +6,19 @@ import { MetricIngestService } from './services/metric-ingest.service';
 import { LogIngestService } from './services/log-ingest.service';
 import { OtlpAuthGuard } from './guards/otlp-auth.guard';
 import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
+import { trackEvent, trackCloudEvent } from '../common/utils/product-telemetry';
+import { existsSync } from 'fs';
 
 jest.mock('../common/utils/product-telemetry', () => ({
+  trackEvent: jest.fn(),
   trackCloudEvent: jest.fn(),
+}));
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn().mockReturnValue(false),
+  writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
 }));
 
 describe('OtlpController', () => {
@@ -108,6 +118,62 @@ describe('OtlpController', () => {
       const result = await controller.ingestLogs(makeReq('application/json', {}, undefined));
 
       expect(result.partialSuccess).toEqual({ rejectedLogRecords: 0 });
+    });
+  });
+
+  describe('trackFirstTelemetry', () => {
+    const origMode = process.env['MANIFEST_MODE'];
+
+    beforeEach(() => {
+      (trackEvent as jest.Mock).mockClear();
+      (trackCloudEvent as jest.Mock).mockClear();
+      (existsSync as jest.Mock).mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      if (origMode === undefined) delete process.env['MANIFEST_MODE'];
+      else process.env['MANIFEST_MODE'] = origMode;
+    });
+
+    it('calls trackCloudEvent in cloud mode', async () => {
+      delete process.env['MANIFEST_MODE'];
+      await controller.ingestTraces(makeReq('application/json', {}, undefined));
+
+      expect(trackCloudEvent).toHaveBeenCalledWith(
+        'first_telemetry_received',
+        'test-tenant',
+        { agent_id_hash: 'test-age' },
+      );
+      expect(trackEvent).not.toHaveBeenCalled();
+    });
+
+    it('calls trackEvent in local mode', async () => {
+      process.env['MANIFEST_MODE'] = 'local';
+      (existsSync as jest.Mock).mockReturnValue(false);
+      await controller.ingestTraces(makeReq('application/json', {}, undefined));
+
+      expect(trackEvent).toHaveBeenCalledWith(
+        'first_telemetry_received',
+        { agent_id_hash: 'test-age' },
+      );
+      expect(trackCloudEvent).not.toHaveBeenCalled();
+    });
+
+    it('skips tracking in local mode when marker file exists', async () => {
+      process.env['MANIFEST_MODE'] = 'local';
+      (existsSync as jest.Mock).mockReturnValue(true);
+      await controller.ingestTraces(makeReq('application/json', {}, undefined));
+
+      expect(trackEvent).not.toHaveBeenCalled();
+      expect(trackCloudEvent).not.toHaveBeenCalled();
+    });
+
+    it('deduplicates by agentId in cloud mode', async () => {
+      delete process.env['MANIFEST_MODE'];
+      await controller.ingestTraces(makeReq('application/json', {}, undefined));
+      await controller.ingestTraces(makeReq('application/json', {}, undefined));
+
+      expect(trackCloudEvent).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/backend/src/otlp/otlp.controller.ts
+++ b/packages/backend/src/otlp/otlp.controller.ts
@@ -1,5 +1,8 @@
 import { Controller, Post, Req, UseGuards, HttpCode, Logger } from '@nestjs/common';
 import { Request } from 'express';
+import { existsSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
 import { Public } from '../common/decorators/public.decorator';
 import { OtlpAuthGuard } from './guards/otlp-auth.guard';
 import { OtlpDecoderService } from './services/otlp-decoder.service';
@@ -8,7 +11,7 @@ import { MetricIngestService } from './services/metric-ingest.service';
 import { LogIngestService } from './services/log-ingest.service';
 import { IngestionContext } from './interfaces/ingestion-context.interface';
 import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
-import { trackCloudEvent } from '../common/utils/product-telemetry';
+import { trackEvent, trackCloudEvent } from '../common/utils/product-telemetry';
 
 interface RawBodyRequest extends Request {
   rawBody?: Buffer;
@@ -73,10 +76,22 @@ export class OtlpController {
   }
 
   private trackFirstTelemetry(ctx: IngestionContext): void {
-    if (this.seenAgents.has(ctx.agentId)) return;
-    this.seenAgents.add(ctx.agentId);
-    trackCloudEvent('first_telemetry_received', ctx.tenantId, {
-      agent_id_hash: ctx.agentId.slice(0, 8),
-    });
+    const isLocal = process.env['MANIFEST_MODE'] === 'local';
+    if (isLocal) {
+      const markerDir = join(homedir(), '.openclaw', 'manifest');
+      const markerPath = join(markerDir, '.first_telemetry_sent');
+      if (existsSync(markerPath)) return;
+      trackEvent('first_telemetry_received', {
+        agent_id_hash: ctx.agentId.slice(0, 8),
+      });
+      mkdirSync(markerDir, { recursive: true });
+      writeFileSync(markerPath, new Date().toISOString(), { mode: 0o600 });
+    } else {
+      if (this.seenAgents.has(ctx.agentId)) return;
+      this.seenAgents.add(ctx.agentId);
+      trackCloudEvent('first_telemetry_received', ctx.tenantId, {
+        agent_id_hash: ctx.agentId.slice(0, 8),
+      });
+    }
   }
 }

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -14,7 +14,6 @@ import { toast } from "../services/toast-store.js";
 import { formatNumber, formatCost } from "../services/formatters.js";
 import Sparkline from "../components/Sparkline.jsx";
 import { checkLocalMode } from "../services/local-mode.js";
-import { trackEvent } from "../services/analytics.js";
 
 interface Agent {
   agent_name: string;
@@ -40,7 +39,6 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
     if (!agentName) return;
     try {
       const result = await createAgent(agentName);
-      trackEvent("agent_created", { agent_name: agentName });
       toast.success(`Agent "${agentName}" connected`);
       props.onClose();
       setName("");

--- a/packages/openclaw-plugin/__tests__/register.test.ts
+++ b/packages/openclaw-plugin/__tests__/register.test.ts
@@ -129,6 +129,16 @@ describe("register — dev mode", () => {
     host: "127.0.0.1",
   };
 
+  it("does NOT call trackPluginEvent in dev mode", () => {
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(trackPluginEvent).not.toHaveBeenCalled();
+  });
+
   it("does NOT delegate to registerLocalMode", () => {
     (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -21,8 +21,10 @@ module.exports = {
     };
 
     const config: ManifestConfig = parseConfig(api.pluginConfig);
-    trackPluginEvent("plugin_registered");
-    trackPluginEvent("plugin_mode_selected", { mode: config.mode });
+    if (config.mode !== "dev") {
+      trackPluginEvent("plugin_registered");
+      trackPluginEvent("plugin_mode_selected", { mode: config.mode });
+    }
 
     if (config.mode === "local") {
       registerLocalMode(api, config, logger);


### PR DESCRIPTION
## Summary

Fixes the broken PostHog funnel (Install → Create Agent → First Data) where each step used a different identity, making PostHog unable to link them into one user journey.

**Root causes fixed:**
- Each funnel step used a different distinct_id (machine_id vs anon_id vs hashed tenant)
- All local users collapsed into 1 person (same `LOCAL_TENANT_ID` hash)
- `agent_created` never fired in local mode (auto-redirected past Workspace)
- Dev mode polluted analytics with plugin events
- In-memory dedup reset on restart

**Changes:**
- Suppress `trackPluginEvent` in dev mode (plugin `index.ts`)
- Move `agent_created` from frontend (`Workspace.tsx`) to backend (`AgentsController` for cloud, `LocalBootstrapService` for local)
- Fix `first_telemetry_received`: local mode uses `trackEvent` (machine_id), cloud uses `trackCloudEvent` (hashed user.id)
- Add file-based dedup (`~/.openclaw/manifest/.first_telemetry_sent`) for local mode to survive restarts

**Resulting funnels:**
- **Local mode** — all events keyed by `machine_id`: `server_started` → `agent_created` → `first_telemetry_received`
- **Cloud mode** — all events keyed by `SHA256(user.id)`: `agent_created` → `first_telemetry_received`

## Test plan

- [x] Backend unit tests pass (102 suites, 1341 tests)
- [x] Backend e2e tests pass (14 suites, 80 tests)
- [x] Frontend tests pass (52 suites, 711 tests)
- [x] Plugin tests pass (10 suites, 182 tests)
- [x] TypeScript compiles cleanly (backend + frontend)
- [x] New tests: cloud/local mode branching, file-based dedup, dev mode suppression, agent_created tracking assertions