### PR TITLE
chore: remove unused variables and imports

### DIFF
--- a/.changeset/fix-unused-variables.md
+++ b/.changeset/fix-unused-variables.md
@@ -1,5 +1,5 @@
 ---
-'manifest': patch
+"manifest": patch
 ---
 
 Remove unused variables

--- a/.changeset/fix-unused-variables.md
+++ b/.changeset/fix-unused-variables.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Remove unused variables

--- a/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
@@ -7,14 +7,12 @@ describe('AgentAnalyticsService', () => {
   let service: AgentAnalyticsService;
   let mockGetRawOne: jest.Mock;
   let mockGetRawMany: jest.Mock;
-  let qbCallIndex: number;
 
   const scope = { tenantId: 't1', agentId: 'a1' };
 
   beforeEach(async () => {
     mockGetRawOne = jest.fn();
     mockGetRawMany = jest.fn();
-    qbCallIndex = 0;
 
     const mockQb = {
       select: jest.fn().mockReturnThis(),

--- a/packages/backend/src/auth/auth.instance.ts
+++ b/packages/backend/src/auth/auth.instance.ts
@@ -29,7 +29,6 @@ if (!isLocalMode && nodeEnv !== 'test' && (!betterAuthSecret || betterAuthSecret
   throw new Error('BETTER_AUTH_SECRET must be set to a value of at least 32 characters');
 }
 
-import { getLocalAuthSecret } from '../common/constants/local-mode.constants';
 
 function buildTrustedOrigins(): string[] {
   const origins: string[] = [];

--- a/packages/backend/src/auth/local-auth.guard.spec.ts
+++ b/packages/backend/src/auth/local-auth.guard.spec.ts
@@ -7,7 +7,6 @@ jest.mock('../common/constants/local-mode.constants', () => ({
 import { ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { LocalAuthGuard } from './local-auth.guard';
-import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
 import { readLocalNotificationEmail } from '../common/constants/local-mode.constants';
 
 function createMockContext(overrides: {

--- a/packages/backend/src/notifications/services/notification-rules.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.spec.ts
@@ -492,7 +492,7 @@ describe('NotificationRulesService (SQLite dialect)', () => {
 
     await service.deleteRule('user-1', 'r1');
 
-    const deleteCall = mockQuery.mock.calls[2]; // verifyOwnership(2 queries) then DELETE
+    // verifyOwnership(2 queries) then DELETE
     // The DELETE should use ? placeholder
     const allCalls = mockQuery.mock.calls.map((c: unknown[]) => c[0] as string);
     const deleteQuery = allCalls.find((sql) => sql.includes('DELETE'));


### PR DESCRIPTION
This PR cleans up several unused variables and imports across the backend configuration and test files to resolve linter warnings and improve overall code cleanliness. 

**Changes Made:**
- Removed unused `qbCallIndex` variable in [agent-analytics.service.spec.ts](cci:7://file:///c:/Users/Lenovo/manifest/packages/backend/src/analytics/services/agent-analytics.service.spec.ts:0:0-0:0).
- Removed unused `getLocalAuthSecret` import in [auth.instance.ts](cci:7://file:///c:/Users/Lenovo/manifest/packages/backend/src/auth/auth.instance.ts:0:0-0:0).
- Removed unused `IS_PUBLIC_KEY` import in [local-auth.guard.spec.ts](cci:7://file:///c:/Users/Lenovo/manifest/packages/backend/src/auth/local-auth.guard.spec.ts:0:0-0:0).
- Removed unused `deleteCall` assignment in `notification-rules.service.spec.ts`.