### PR TITLE
feat: allow spaces in agent names (display name + slug)

### DIFF
--- a/.changeset/agent-display-name.md
+++ b/.changeset/agent-display-name.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Allow spaces in agent names by adding a display_name column. User input like "My Cool Agent" is auto-slugified to "my-cool-agent" for URLs and internal references, while the original name is stored as display_name and shown in the UI.

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -272,6 +272,7 @@ export class TimeseriesQueriesService {
       const stats = statsMap.get(name);
       return {
         agent_name: name,
+        display_name: a.display_name ?? name,
         message_count: Number(stats?.['message_count'] ?? 0),
         last_active: String(stats?.['last_active'] ?? a.created_at ?? ''),
         total_cost: Number(stats?.['total_cost'] ?? 0),

--- a/packages/backend/src/common/dto/create-agent.dto.spec.ts
+++ b/packages/backend/src/common/dto/create-agent.dto.spec.ts
@@ -5,7 +5,7 @@ import { CreateAgentDto } from './create-agent.dto';
 
 describe('CreateAgentDto', () => {
   it('accepts valid agent names', async () => {
-    for (const name of ['my-agent', 'agent_1', 'TestBot', 'a']) {
+    for (const name of ['my-agent', 'agent_1', 'TestBot', 'a', 'My Cool Agent']) {
       const dto = plainToInstance(CreateAgentDto, { name });
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
@@ -24,10 +24,10 @@ describe('CreateAgentDto', () => {
     expect(errors.length).toBeGreaterThan(0);
   });
 
-  it('rejects names with spaces', async () => {
+  it('accepts names with spaces', async () => {
     const dto = plainToInstance(CreateAgentDto, { name: 'has spaces' });
     const errors = await validate(dto);
-    expect(errors.length).toBeGreaterThan(0);
+    expect(errors).toHaveLength(0);
   });
 
   it('rejects names with special characters', async () => {

--- a/packages/backend/src/common/dto/create-agent.dto.ts
+++ b/packages/backend/src/common/dto/create-agent.dto.ts
@@ -5,6 +5,6 @@ export class CreateAgentDto {
   @IsNotEmpty()
   @MinLength(1)
   @MaxLength(100)
-  @Matches(/^[a-zA-Z0-9_-]+$/, { message: 'Agent name must contain only letters, numbers, dashes, and underscores' })
+  @Matches(/^[a-zA-Z0-9 _-]+$/, { message: 'Agent name must contain only letters, numbers, spaces, dashes, and underscores' })
   name!: string;
 }

--- a/packages/backend/src/common/dto/rename-agent.dto.spec.ts
+++ b/packages/backend/src/common/dto/rename-agent.dto.spec.ts
@@ -5,7 +5,7 @@ import { RenameAgentDto } from './rename-agent.dto';
 
 describe('RenameAgentDto', () => {
   it('accepts valid agent names', async () => {
-    for (const name of ['my-agent', 'agent_1', 'TestBot', 'a']) {
+    for (const name of ['my-agent', 'agent_1', 'TestBot', 'a', 'My Cool Agent']) {
       const dto = plainToInstance(RenameAgentDto, { name });
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
@@ -24,10 +24,10 @@ describe('RenameAgentDto', () => {
     expect(errors.length).toBeGreaterThan(0);
   });
 
-  it('rejects names with spaces', async () => {
+  it('accepts names with spaces', async () => {
     const dto = plainToInstance(RenameAgentDto, { name: 'has spaces' });
     const errors = await validate(dto);
-    expect(errors.length).toBeGreaterThan(0);
+    expect(errors).toHaveLength(0);
   });
 
   it('rejects names with special characters', async () => {

--- a/packages/backend/src/common/dto/rename-agent.dto.ts
+++ b/packages/backend/src/common/dto/rename-agent.dto.ts
@@ -5,6 +5,6 @@ export class RenameAgentDto {
   @IsNotEmpty()
   @MinLength(1)
   @MaxLength(100)
-  @Matches(/^[a-zA-Z0-9_-]+$/, { message: 'Agent name must contain only letters, numbers, dashes, and underscores' })
+  @Matches(/^[a-zA-Z0-9 _-]+$/, { message: 'Agent name must contain only letters, numbers, spaces, dashes, and underscores' })
   name!: string;
 }

--- a/packages/backend/src/common/utils/slugify.spec.ts
+++ b/packages/backend/src/common/utils/slugify.spec.ts
@@ -1,0 +1,59 @@
+import { slugify } from './slugify';
+
+describe('slugify', () => {
+  it('converts spaces to hyphens', () => {
+    expect(slugify('My Cool Agent')).toBe('my-cool-agent');
+  });
+
+  it('converts underscores to hyphens', () => {
+    expect(slugify('my_cool_agent')).toBe('my-cool-agent');
+  });
+
+  it('lowercases input', () => {
+    expect(slugify('TestBot')).toBe('testbot');
+  });
+
+  it('removes special characters', () => {
+    expect(slugify('agent@home!')).toBe('agenthome');
+  });
+
+  it('collapses consecutive hyphens', () => {
+    expect(slugify('my---cool---agent')).toBe('my-cool-agent');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(slugify('--my-agent--')).toBe('my-agent');
+  });
+
+  it('handles mixed spaces and underscores', () => {
+    expect(slugify('My Cool_Agent')).toBe('my-cool-agent');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(slugify('')).toBe('');
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(slugify('   ')).toBe('');
+  });
+
+  it('returns empty string for special-chars-only input', () => {
+    expect(slugify('!@#$%')).toBe('');
+  });
+
+  it('preserves already-valid slugs', () => {
+    expect(slugify('my-agent')).toBe('my-agent');
+  });
+
+  it('handles single word', () => {
+    expect(slugify('agent')).toBe('agent');
+  });
+
+  it('handles numbers', () => {
+    expect(slugify('Agent 42')).toBe('agent-42');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(slugify('  My Agent  ')).toBe('my-agent');
+  });
+});

--- a/packages/backend/src/common/utils/slugify.ts
+++ b/packages/backend/src/common/utils/slugify.ts
@@ -1,0 +1,15 @@
+/**
+ * Converts a human-readable name into a URL-safe slug.
+ *
+ * trim → lowercase → spaces/underscores to hyphens → remove invalid chars
+ * → collapse consecutive hyphens → strip leading/trailing hyphens.
+ */
+export function slugify(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -38,6 +38,7 @@ import { MakeApiKeyNullable1772000000000 } from './migrations/1772000000000-Make
 import { AddRoutingTier1772100000000 } from './migrations/1772100000000-AddRoutingTier';
 import { AddLimitAction1772200000000 } from './migrations/1772200000000-AddLimitAction';
 import { AddRoutingReason1772300000000 } from './migrations/1772300000000-AddRoutingReason';
+import { AddAgentDisplayName1772400000000 } from './migrations/1772400000000-AddAgentDisplayName';
 
 const entities = [
   AgentMessage, LlmCall, ToolExecution, SecurityEvent, ModelPricing,
@@ -64,6 +65,7 @@ const migrations = [
   AddRoutingTier1772100000000,
   AddLimitAction1772200000000,
   AddRoutingReason1772300000000,
+  AddAgentDisplayName1772400000000,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';

--- a/packages/backend/src/database/migrations/1772400000000-AddAgentDisplayName.ts
+++ b/packages/backend/src/database/migrations/1772400000000-AddAgentDisplayName.ts
@@ -1,0 +1,11 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAgentDisplayName1772400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE agents ADD COLUMN display_name varchar`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE agents DROP COLUMN display_name`);
+  }
+}

--- a/packages/backend/src/entities/agent.entity.ts
+++ b/packages/backend/src/entities/agent.entity.ts
@@ -21,6 +21,9 @@ export class Agent {
   name!: string;
 
   @Column('varchar', { nullable: true })
+  display_name!: string | null;
+
+  @Column('varchar', { nullable: true })
   description!: string | null;
 
   @Column('boolean', { default: true })

--- a/packages/backend/src/otlp/services/api-key.service.spec.ts
+++ b/packages/backend/src/otlp/services/api-key.service.spec.ts
@@ -245,6 +245,33 @@ describe('ApiKeyGeneratorService', () => {
       );
     });
 
+    it('should default display_name to null when omitted', async () => {
+      mockTenantFindOne.mockResolvedValue(null);
+
+      await service.onboardAgent(defaultParams);
+
+      expect(mockAgentInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          display_name: null,
+        }),
+      );
+    });
+
+    it('should store displayName when provided', async () => {
+      mockTenantFindOne.mockResolvedValue(null);
+
+      await service.onboardAgent({
+        ...defaultParams,
+        displayName: 'My Cool Agent',
+      });
+
+      expect(mockAgentInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          display_name: 'My Cool Agent',
+        }),
+      );
+    });
+
     it('should pass agent description when provided', async () => {
       mockTenantFindOne.mockResolvedValue(null);
 

--- a/packages/backend/src/otlp/services/api-key.service.ts
+++ b/packages/backend/src/otlp/services/api-key.service.ts
@@ -30,6 +30,7 @@ export class ApiKeyGeneratorService {
     organizationName?: string;
     email?: string;
     agentDescription?: string;
+    displayName?: string;
   }): Promise<{ tenantId: string; agentId: string; apiKey: string }> {
     const existing = await this.tenantRepo.findOne({
       where: { name: params.tenantName },
@@ -53,6 +54,7 @@ export class ApiKeyGeneratorService {
     await this.agentRepo.insert({
       id: agentId,
       name: params.agentName,
+      display_name: params.displayName ?? null,
       description: params.agentDescription ?? null,
       is_active: true,
       tenant_id: tenantId,

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -137,8 +137,8 @@ export async function createTestApp(): Promise<INestApplication> {
     [TEST_TENANT_ID, TEST_USER_ID, 'Test Org', now, now],
   );
   await ds.query(
-    sql(`INSERT INTO agents (id, name, description, is_active, tenant_id, created_at, updated_at) VALUES ($1,$2,$3,true,$4,$5,$6)`),
-    [TEST_AGENT_ID, 'test-agent', 'Test agent', TEST_TENANT_ID, now, now],
+    sql(`INSERT INTO agents (id, name, display_name, description, is_active, tenant_id, created_at, updated_at) VALUES ($1,$2,$3,$4,true,$5,$6,$7)`),
+    [TEST_AGENT_ID, 'test-agent', 'Test Agent', 'Test agent', TEST_TENANT_ID, now, now],
   );
   await ds.query(
     sql(`INSERT INTO agent_api_keys (id, key, key_hash, key_prefix, label, tenant_id, agent_id, is_active, created_at) VALUES ($1, NULL, $2, $3, $4, $5, $6, true, $7)`),

--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -7,6 +7,7 @@ import { isLocalMode, checkLocalMode } from "../services/local-mode.js";
 
 interface Agent {
   agent_name: string;
+  display_name?: string;
 }
 
 interface AgentsData {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -56,8 +56,9 @@ const Settings: Component = () => {
 
     setSaving(true);
     try {
-      await renameAgent(agentName(), newName);
-      navigate(`/agents/${encodeURIComponent(newName)}/settings`, { replace: true, state: { newAgent: true } });
+      const result = await renameAgent(agentName(), newName);
+      const slug = result?.name ?? newName;
+      navigate(`/agents/${encodeURIComponent(slug)}/settings`, { replace: true, state: { newAgent: true } });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch {

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -17,6 +17,7 @@ import { checkLocalMode } from "../services/local-mode.js";
 
 interface Agent {
   agent_name: string;
+  display_name?: string;
   message_count: number;
   last_active: string;
   total_cost: number;
@@ -42,7 +43,8 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
       toast.success(`Agent "${agentName}" connected`);
       props.onClose();
       setName("");
-      const url = `/agents/${encodeURIComponent(agentName)}`;
+      const slug = result?.agent?.name ?? agentName;
+      const url = `/agents/${encodeURIComponent(slug)}`;
       navigate(url, { state: { newAgent: true, newApiKey: result?.apiKey } });
     } catch {
       // error toast already shown by fetchMutate
@@ -85,7 +87,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
             ref={(el) => requestAnimationFrame(() => el.focus())}
             class="modal-card__input"
             type="text"
-            placeholder="e.g. Clawdy"
+            placeholder="e.g. My Cool Agent"
             value={name()}
             onInput={(e) => setName(e.currentTarget.value)}
             onKeyDown={handleKeyDown}
@@ -199,7 +201,7 @@ const Workspace: Component = () => {
                   class="agent-card"
                 >
                   <div class="agent-card__top">
-                    <span class="agent-card__name">{agent.agent_name}</span>
+                    <span class="agent-card__name">{agent.display_name ?? agent.agent_name}</span>
                   </div>
                   <div class="agent-card__stats">
                     <div class="agent-card__stat">

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -45,10 +45,10 @@ describe("Workspace", () => {
     mockCheckLocalMode = vi.fn().mockResolvedValue(false);
     mockGetAgents.mockResolvedValue({
       agents: [
-        { agent_name: "demo-agent", message_count: 42, last_active: "2024-01-01", total_cost: 5.5, total_tokens: 15000, sparkline: [1, 2, 3] },
+        { agent_name: "demo-agent", display_name: "Demo Agent", message_count: 42, last_active: "2024-01-01", total_cost: 5.5, total_tokens: 15000, sparkline: [1, 2, 3] },
       ],
     });
-    mockCreateAgent.mockResolvedValue({ apiKey: "test-key" });
+    mockCreateAgent.mockResolvedValue({ agent: { name: "new-agent", display_name: "new-agent" }, apiKey: "test-key" });
   });
 
   it("renders My Agents heading", async () => {
@@ -62,10 +62,10 @@ describe("Workspace", () => {
     expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders agent cards when data loads", async () => {
+  it("renders agent cards with display name when data loads", async () => {
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("demo-agent");
+      expect(container.textContent).toContain("Demo Agent");
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `display_name` column to agents table via database migration
- Add `slugify()` utility that converts user input like "My Cool Agent" → `my-cool-agent`
- Controller slugifies on create/rename, rejects empty slugs with 400
- DTOs now accept spaces in agent names (`/^[a-zA-Z0-9 _-]+$/`)
- API returns both `name` (slug) and `display_name` in responses
- Frontend shows `display_name` in agent cards, navigates using slug from response
- Rename short-circuits when only display_name changes (same slug)
- Existing agents unaffected: `display_name` is nullable, UI falls back to slug

## Test plan

- [x] Backend unit tests pass (107 suites, 1510 tests)
- [x] Backend e2e tests pass (15 suites, 85 tests)
- [x] Frontend tests pass (55 suites, 768 tests)
- [ ] Manual: create agent with spaces → verify slug in URL, display name in UI
- [ ] Manual: rename agent with spaces → verify slug changes, display name updates
- [ ] Manual: existing agents without display_name show slug as fallback