### PR TITLE
feat: simplify cloud email notifications, show provider setup in local mode

### DIFF
--- a/.changeset/cloud-email-info.md
+++ b/.changeset/cloud-email-info.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Show cloud email info card on Limits page and move provider setup to local mode only

--- a/packages/frontend/src/components/CloudEmailInfo.tsx
+++ b/packages/frontend/src/components/CloudEmailInfo.tsx
@@ -1,0 +1,24 @@
+import type { Component } from "solid-js";
+
+interface Props {
+  email: string;
+}
+
+const CloudEmailInfo: Component<Props> = (props) => {
+  return (
+    <div class="cloud-email-info">
+      <svg class="cloud-email-info__icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+        <polyline points="22,6 12,13 2,6" />
+      </svg>
+      <div>
+        <div class="cloud-email-info__title">Email alerts</div>
+        <div class="cloud-email-info__desc">
+          Alerts will be sent to <strong>{props.email}</strong>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CloudEmailInfo;

--- a/packages/frontend/src/components/LimitRuleModal.tsx
+++ b/packages/frontend/src/components/LimitRuleModal.tsx
@@ -49,7 +49,7 @@ const LimitRuleModal: Component<Props> = (props) => {
         >
           <h2 class="modal-card__title" id="limit-modal-title">Create rule</h2>
           <p class="modal-card__desc">
-            Set up an alert or hard limit for this agent's usage.
+            Set up an email alert or hard limit for this agent's usage.
           </p>
 
           <label class="modal-card__field-label" style="margin-top: 0;">Rule type</label>
@@ -60,7 +60,7 @@ const LimitRuleModal: Component<Props> = (props) => {
               onClick={() => setAction("notify")}
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.73 21a2 2 0 0 1-3.46 0" /></svg>
-              Alert
+              Email Alert
             </button>
             <button
               class="limit-type-option"

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -2,8 +2,10 @@ import { createSignal, createResource, For, Show, type Component } from "solid-j
 import { useParams } from "@solidjs/router";
 import { Title, Meta } from "@solidjs/meta";
 import { isLocalMode } from "../services/local-mode.js";
+import { authClient } from "../services/auth-client.js";
 import ProviderBanner from "../components/ProviderBanner.js";
 import EmailProviderSetup from "../components/EmailProviderSetup.js";
+import CloudEmailInfo from "../components/CloudEmailInfo.js";
 import LimitRuleModal from "../components/LimitRuleModal.js";
 import { toast } from "../services/toast-store.js";
 import {
@@ -39,6 +41,7 @@ const Limits: Component = () => {
   );
   const [emailProvider, { refetch: refetchProvider }] = createResource(getEmailProvider);
   const [routingStatus] = createResource(getRoutingStatus);
+  const session = authClient.useSession();
   const [showModal, setShowModal] = createSignal(false);
 
   const routingEnabled = () => routingStatus()?.enabled ?? false;
@@ -101,7 +104,7 @@ const Limits: Component = () => {
       <div class="page-header">
         <div>
           <h1>Limits</h1>
-          <span class="breadcrumb">{agentName()} &rsaquo; Alerts &amp; hard limits</span>
+          <span class="breadcrumb">{agentName()} &rsaquo; Email alerts &amp; hard limits</span>
         </div>
         <button class="btn btn--primary btn--sm" onClick={() => setShowModal(true)}>
           + Create rule
@@ -132,6 +135,12 @@ const Limits: Component = () => {
 
       <Show when={!isLocalMode()}>
         <div class="panel" style="margin-bottom: var(--gap-lg);">
+          <CloudEmailInfo email={session().data?.user?.email ?? ""} />
+        </div>
+      </Show>
+
+      <Show when={isLocalMode()}>
+        <div class="panel" style="margin-bottom: var(--gap-lg);">
           <Show
             when={emailProvider()}
             fallback={<EmailProviderSetup onConfigured={refetchProvider} />}
@@ -152,7 +161,7 @@ const Limits: Component = () => {
           fallback={
             <div class="empty-state">
               <div class="empty-state__title">No rules yet</div>
-              <p>Create a rule to get notified or block requests when limits are exceeded.</p>
+              <p>Create a rule to receive email alerts or block requests when thresholds are exceeded.</p>
             </div>
           }
         >
@@ -184,7 +193,7 @@ const Limits: Component = () => {
                         }>
                           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
                         </Show>
-                        {rule.action === "block" ? "Limit" : "Alert"}
+                        {rule.action === "block" ? "Limit" : "Email alert"}
                       </span>
                     </td>
                     <td style="text-transform: capitalize;">{rule.metric_type}</td>

--- a/packages/frontend/src/styles/notifications.css
+++ b/packages/frontend/src/styles/notifications.css
@@ -435,3 +435,33 @@
   justify-content: space-between;
   align-items: center;
 }
+
+/* ── Cloud Email Info Card ──────────────────────── */
+.cloud-email-info {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 20px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+}
+
+.cloud-email-info__icon {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: hsl(var(--success));
+}
+
+.cloud-email-info__title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: hsl(var(--foreground));
+  margin-bottom: 2px;
+}
+
+.cloud-email-info__desc {
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.5;
+}

--- a/packages/frontend/tests/components/CloudEmailInfo.test.tsx
+++ b/packages/frontend/tests/components/CloudEmailInfo.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+import CloudEmailInfo from "../../src/components/CloudEmailInfo";
+
+describe("CloudEmailInfo", () => {
+  it("renders the title", () => {
+    render(() => <CloudEmailInfo email="test@example.com" />);
+    expect(screen.getByText("Email alerts")).toBeDefined();
+  });
+
+  it("displays the user email", () => {
+    const { container } = render(() => <CloudEmailInfo email="user@manifest.build" />);
+    expect(container.textContent).toContain("user@manifest.build");
+  });
+
+  it("renders the mail icon", () => {
+    const { container } = render(() => <CloudEmailInfo email="test@example.com" />);
+    const icon = container.querySelector(".cloud-email-info__icon");
+    expect(icon).not.toBeNull();
+  });
+
+  it("renders the description text", () => {
+    const { container } = render(() => <CloudEmailInfo email="test@example.com" />);
+    expect(container.textContent).toContain("Alerts will be sent to");
+  });
+});

--- a/packages/frontend/tests/components/LimitRuleModal.test.tsx
+++ b/packages/frontend/tests/components/LimitRuleModal.test.tsx
@@ -23,21 +23,21 @@ describe("LimitRuleModal", () => {
       <LimitRuleModal open={true} routingEnabled={true} onClose={mockOnClose} onSave={mockOnSave} />
     ));
     expect(screen.getByRole("dialog")).toBeDefined();
-    expect(screen.getByText("Set up an alert or hard limit for this agent's usage.")).toBeDefined();
+    expect(screen.getByText("Set up an email alert or hard limit for this agent's usage.")).toBeDefined();
   });
 
   it("shows description text", () => {
     render(() => (
       <LimitRuleModal open={true} routingEnabled={true} onClose={mockOnClose} onSave={mockOnSave} />
     ));
-    expect(screen.getByText("Set up an alert or hard limit for this agent's usage.")).toBeDefined();
+    expect(screen.getByText("Set up an email alert or hard limit for this agent's usage.")).toBeDefined();
   });
 
   it("renders Alert and Hard Limit type buttons", () => {
     render(() => (
       <LimitRuleModal open={true} routingEnabled={true} onClose={mockOnClose} onSave={mockOnSave} />
     ));
-    expect(screen.getByText("Alert")).toBeDefined();
+    expect(screen.getByText("Email Alert")).toBeDefined();
     expect(screen.getByText("Hard Limit")).toBeDefined();
   });
 
@@ -46,7 +46,7 @@ describe("LimitRuleModal", () => {
       <LimitRuleModal open={true} routingEnabled={true} onClose={mockOnClose} onSave={mockOnSave} />
     ));
     const alertBtn = container.querySelector(".limit-type-option--active");
-    expect(alertBtn?.textContent).toContain("Alert");
+    expect(alertBtn?.textContent).toContain("Email Alert");
   });
 
   it("allows selecting block action when routing is enabled", () => {
@@ -94,7 +94,7 @@ describe("LimitRuleModal", () => {
     fireEvent.click(buttons[1]); // Hard Limit (disabled)
 
     const active = container.querySelector(".limit-type-option--active");
-    expect(active?.textContent).toContain("Alert"); // still Alert
+    expect(active?.textContent).toContain("Email Alert"); // still Email Alert
   });
 
   it("renders metric select with Tokens and Cost options", () => {

--- a/packages/frontend/tests/pages/Limits-interactions.test.tsx
+++ b/packages/frontend/tests/pages/Limits-interactions.test.tsx
@@ -56,6 +56,18 @@ vi.mock("../../src/components/ProviderBanner.js", () => ({
   ),
 }));
 
+vi.mock("../../src/components/CloudEmailInfo.js", () => ({
+  default: (props: any) => (
+    <div data-testid="cloud-email-info">CloudEmailInfo: {props.email}</div>
+  ),
+}));
+
+vi.mock("../../src/services/auth-client.js", () => ({
+  authClient: {
+    useSession: () => () => ({ data: { user: { email: "user@example.com" } } }),
+  },
+}));
+
 import Limits from "../../src/pages/Limits";
 
 describe("Limits page interactions", () => {
@@ -131,7 +143,7 @@ describe("Limits page interactions", () => {
     const { removeEmailProvider } = await import("../../src/services/api.js");
     const { toast } = await import("../../src/services/toast-store.js");
     mockEmailProvider = { provider: "resend", domain: null, keyPrefix: "re_", is_active: true };
-    mockIsLocalMode = false;
+    mockIsLocalMode = true;
 
     render(() => <Limits />);
 

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -88,6 +88,7 @@ describe("Limits page", () => {
   it("renders breadcrumb with agent name", () => {
     const { container } = render(() => <Limits />);
     expect(container.textContent).toContain("test-agent");
+    expect(container.textContent).toContain("Email alerts & hard limits");
   });
 
   it("renders Create rule button", () => {
@@ -98,6 +99,7 @@ describe("Limits page", () => {
   it("renders empty state when no rules", () => {
     render(() => <Limits />);
     expect(screen.getByText("No rules yet")).toBeDefined();
+    expect(screen.getByText("Create a rule to receive email alerts or block requests when thresholds are exceeded.")).toBeDefined();
   });
 
   it("renders rules table when rules exist", async () => {
@@ -166,6 +168,18 @@ describe("Limits page", () => {
     const { container } = render(() => <Limits />);
     expect(container.querySelector('[data-testid="email-setup"]')).toBeNull();
     expect(container.querySelector('[data-testid="provider-banner"]')).toBeNull();
+  });
+
+  it("hides cloud email info in local mode", () => {
+    mockIsLocalMode = true;
+    const { container } = render(() => <Limits />);
+    expect(container.querySelector('[data-testid="cloud-email-info"]')).toBeNull();
+  });
+
+  it("passes session email to cloud email info", () => {
+    mockIsLocalMode = false;
+    const { container } = render(() => <Limits />);
+    expect(container.textContent).toContain("user@example.com");
   });
 
   it("passes routingEnabled to modal", async () => {

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -58,6 +58,18 @@ vi.mock("../../src/components/ProviderBanner.js", () => ({
   ),
 }));
 
+vi.mock("../../src/components/CloudEmailInfo.js", () => ({
+  default: (props: any) => (
+    <div data-testid="cloud-email-info">CloudEmailInfo: {props.email}</div>
+  ),
+}));
+
+vi.mock("../../src/services/auth-client.js", () => ({
+  authClient: {
+    useSession: () => () => ({ data: { user: { email: "user@example.com" } } }),
+  },
+}));
+
 import Limits from "../../src/pages/Limits";
 
 describe("Limits page", () => {
@@ -105,7 +117,7 @@ describe("Limits page", () => {
     const { container } = render(() => <Limits />);
 
     await vi.waitFor(() => {
-      expect(screen.getByText("Alert")).toBeDefined();
+      expect(screen.getByText("Email alert")).toBeDefined();
       expect(screen.getByText("Limit")).toBeDefined();
       expect(container.querySelectorAll("table tbody tr").length).toBe(2);
     });
@@ -137,14 +149,20 @@ describe("Limits page", () => {
     expect(container.textContent).not.toContain("Enable routing to set hard limits");
   });
 
-  it("shows email provider setup in cloud mode", () => {
+  it("shows cloud email info in cloud mode", () => {
     mockIsLocalMode = false;
+    render(() => <Limits />);
+    expect(screen.getByTestId("cloud-email-info")).toBeDefined();
+  });
+
+  it("shows email provider setup in local mode", () => {
+    mockIsLocalMode = true;
     render(() => <Limits />);
     expect(screen.getByTestId("email-setup")).toBeDefined();
   });
 
-  it("hides email provider section in local mode", () => {
-    mockIsLocalMode = true;
+  it("hides email provider setup in cloud mode", () => {
+    mockIsLocalMode = false;
     const { container } = render(() => <Limits />);
     expect(container.querySelector('[data-testid="email-setup"]')).toBeNull();
     expect(container.querySelector('[data-testid="provider-banner"]')).toBeNull();
@@ -268,9 +286,9 @@ describe("Limits page", () => {
     });
   });
 
-  it("shows provider banner when email provider is configured", async () => {
+  it("shows provider banner when email provider is configured in local mode", async () => {
     mockEmailProvider = { provider: "resend", domain: null, keyPrefix: "re_", is_active: true };
-    mockIsLocalMode = false;
+    mockIsLocalMode = true;
 
     render(() => <Limits />);
 


### PR DESCRIPTION
## Summary
- **Cloud mode**: Replaces the email provider picker (Resend/Mailgun/SendGrid) with a simple "Email alerts" info card showing the user's account email. Cloud users don't need to configure a provider — the platform handles email delivery.
- **Local mode**: Shows the provider setup picker, since local users need to bring their own email provider.
- Updates badge text from "Alert" to "Email alert" and modal description to "email alert" for clarity.
- Updates breadcrumb to "Email alerts & hard limits".

## Test plan
- [x] All 773 frontend tests pass
- [x] TypeScript compiles with no errors
- [x] Manually verified cloud mode — Limits page shows email info card, no provider picker
- [x] Manually verified local mode — Limits page shows provider setup (Resend/Mailgun/SendGrid)
- [x] "Email alert" badge appears in rules table and rule creation modal