### PR TITLE
fix: use success color for cloud badge, set Codecov branch to main

### DIFF
--- a/.changeset/cloud-badge-color.md
+++ b/.changeset/cloud-badge-color.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: use success color for cloud mode badge in header

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+codecov:
+  branch: main
 coverage:
   status:
     project:

--- a/packages/frontend/src/styles/controls.css
+++ b/packages/frontend/src/styles/controls.css
@@ -351,8 +351,8 @@
   letter-spacing: 0.05em;
   padding: 2px 7px;
   border-radius: var(--radius);
-  background: hsl(var(--chart-4) / 0.15);
-  color: hsl(var(--chart-4));
+  background: hsl(var(--success) / 0.15);
+  color: hsl(var(--success));
   line-height: 1.4;
   user-select: none;
 }


### PR DESCRIPTION
## Summary
- Change the header cloud mode badge color from red (`--chart-4`) to the theme success color (`--success`) so it reads as a positive status indicator
- Configure Codecov to use `main` as the default branch instead of `master`, which was preventing report updates

## Test plan
- [ ] Verify cloud badge in header shows green/teal instead of red
- [ ] Confirm Codecov starts processing reports against `main` after merge