### PR TITLE
chore: rebrand log prefix to [Manifest] and improve test coverage

### DIFF
--- a/.changeset/improve-test-coverage.md
+++ b/.changeset/improve-test-coverage.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Rebrand log prefix from [Nest] to [Manifest] and improve test coverage across backend and frontend

--- a/packages/backend/src/entities/email-provider-config.entity.spec.ts
+++ b/packages/backend/src/entities/email-provider-config.entity.spec.ts
@@ -1,0 +1,56 @@
+import { EmailProviderConfig } from './email-provider-config.entity';
+
+describe('EmailProviderConfig entity', () => {
+  it('creates an instance with all fields', () => {
+    const config = new EmailProviderConfig();
+    config.id = 'epc-1';
+    config.user_id = 'user-1';
+    config.provider = 'mailgun';
+    config.api_key_encrypted = 'enc-abc123';
+    config.domain = 'mg.example.com';
+    config.notification_email = 'alerts@example.com';
+    config.is_active = true;
+    config.created_at = '2025-01-01T00:00:00Z';
+    config.updated_at = '2025-01-02T00:00:00Z';
+
+    expect(config.id).toBe('epc-1');
+    expect(config.user_id).toBe('user-1');
+    expect(config.provider).toBe('mailgun');
+    expect(config.api_key_encrypted).toBe('enc-abc123');
+    expect(config.domain).toBe('mg.example.com');
+    expect(config.notification_email).toBe('alerts@example.com');
+    expect(config.is_active).toBe(true);
+    expect(config.created_at).toBe('2025-01-01T00:00:00Z');
+    expect(config.updated_at).toBe('2025-01-02T00:00:00Z');
+  });
+
+  it('allows nullable fields to be null', () => {
+    const config = new EmailProviderConfig();
+    config.id = 'epc-2';
+    config.user_id = 'user-2';
+    config.provider = 'resend';
+    config.api_key_encrypted = 'enc-xyz';
+    config.domain = null;
+    config.notification_email = null;
+    config.is_active = true;
+    config.created_at = '2025-06-01T00:00:00Z';
+    config.updated_at = '2025-06-01T00:00:00Z';
+
+    expect(config.domain).toBeNull();
+    expect(config.notification_email).toBeNull();
+  });
+
+  it('supports all provider values', () => {
+    const config = new EmailProviderConfig();
+    for (const provider of ['resend', 'mailgun', 'sendgrid']) {
+      config.provider = provider;
+      expect(config.provider).toBe(provider);
+    }
+  });
+
+  it('allows is_active to be set to false', () => {
+    const config = new EmailProviderConfig();
+    config.is_active = false;
+    expect(config.is_active).toBe(false);
+  });
+});

--- a/packages/backend/src/github/github.controller.spec.ts
+++ b/packages/backend/src/github/github.controller.spec.ts
@@ -1,0 +1,174 @@
+const fetchMock = jest.fn();
+(global as unknown as Record<string, unknown>).fetch = fetchMock;
+
+describe('GithubController', () => {
+  let controller: InstanceType<
+    typeof import('./github.controller').GithubController
+  >;
+
+  /** Re-imports the module with fresh module-level cache variables. */
+  async function freshImport() {
+    const mod = await import('./github.controller');
+    return new mod.GithubController();
+  }
+
+  beforeEach(async () => {
+    jest.resetModules();
+    fetchMock.mockReset();
+    controller = await freshImport();
+  });
+
+  // ── Happy path ────────────────────────────────────────────────
+
+  it('should fetch stars from GitHub API on first call', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 42 }),
+    });
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: 42 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.github.com/repos/mnfst/manifest',
+      { headers: { Accept: 'application/vnd.github.v3+json' } },
+    );
+  });
+
+  it('should return cached stars within TTL without fetching', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 100 }),
+    });
+
+    // First call populates the cache
+    await controller.getStars();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second call should use the cache
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: 100 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should re-fetch after cache TTL expires', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 50 }),
+    });
+
+    await controller.getStars();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Advance time past the 10-minute TTL
+    const realDateNow = Date.now;
+    Date.now = () => realDateNow() + 11 * 60 * 1000;
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 75 }),
+    });
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: 75 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    Date.now = realDateNow;
+  });
+
+  // ── Error handling ────────────────────────────────────────────
+
+  it('should return null when API fails on first call', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: null });
+  });
+
+  it('should return stale cache when API fails after previous success', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 200 }),
+    });
+    await controller.getStars();
+
+    // Expire the cache
+    const realDateNow = Date.now;
+    Date.now = () => realDateNow() + 11 * 60 * 1000;
+
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: 200 });
+
+    Date.now = realDateNow;
+  });
+
+  it('should return null when fetch throws on first call', async () => {
+    fetchMock.mockRejectedValue(new Error('network error'));
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: null });
+  });
+
+  it('should return stale cache when fetch throws after previous success', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 300 }),
+    });
+    await controller.getStars();
+
+    // Expire the cache
+    const realDateNow = Date.now;
+    Date.now = () => realDateNow() + 11 * 60 * 1000;
+
+    fetchMock.mockRejectedValue(new Error('timeout'));
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: 300 });
+
+    Date.now = realDateNow;
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────
+
+  it('should not update cache when stargazers_count is missing', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ some_other_field: 'abc' }),
+    });
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: null });
+  });
+
+  it('should not update cache when stargazers_count is not a number', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 'not-a-number' }),
+    });
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: null });
+  });
+
+  it('should update cache when stargazers_count is zero', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ stargazers_count: 0 }),
+    });
+
+    const result = await controller.getStars();
+
+    expect(result).toEqual({ stars: 0 });
+  });
+});

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { Logger, ValidationPipe } from '@nestjs/common';
+import { ConsoleLogger, Logger, ValidationPipe } from '@nestjs/common';
 import helmet from 'helmet';
 import * as express from 'express';
 import { AppModule } from './app.module';
@@ -11,7 +11,10 @@ const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
 
 export async function bootstrap() {
   const logger = new Logger('Bootstrap');
-  const app = await NestFactory.create(AppModule, { bodyParser: false });
+  const app = await NestFactory.create(AppModule, {
+    bodyParser: false,
+    logger: new ConsoleLogger({ prefix: 'Manifest' }),
+  });
   app.enableShutdownHooks();
   app.useGlobalFilters(new SpaFallbackFilter());
 

--- a/packages/backend/src/notifications/dto/set-email-provider.dto.spec.ts
+++ b/packages/backend/src/notifications/dto/set-email-provider.dto.spec.ts
@@ -1,0 +1,412 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { SetEmailProviderDto, TestEmailProviderDto } from './set-email-provider.dto';
+
+describe('SetEmailProviderDto', () => {
+  function create(data: Record<string, unknown>): SetEmailProviderDto {
+    return plainToInstance(SetEmailProviderDto, data);
+  }
+
+  describe('provider', () => {
+    it('should accept resend', async () => {
+      const dto = create({ provider: 'resend' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should accept mailgun with domain', async () => {
+      const dto = create({ provider: 'mailgun', domain: 'mg.example.com' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should accept sendgrid', async () => {
+      const dto = create({ provider: 'sendgrid' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject an invalid provider', async () => {
+      const dto = create({ provider: 'smtp' });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      const providerError = errors.find((e) => e.property === 'provider');
+      expect(providerError).toBeDefined();
+    });
+
+    it('should reject missing provider', async () => {
+      const dto = create({});
+      const errors = await validate(dto);
+      const providerError = errors.find((e) => e.property === 'provider');
+      expect(providerError).toBeDefined();
+    });
+
+    it('should reject non-string provider', async () => {
+      const dto = create({ provider: 123 });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('apiKey', () => {
+    it('should accept when omitted', async () => {
+      const dto = create({ provider: 'resend' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should accept a valid api key', async () => {
+      const dto = create({ provider: 'resend', apiKey: 'my-secret-key-12345' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject an api key shorter than 8 characters', async () => {
+      const dto = create({ provider: 'resend', apiKey: 'short' });
+      const errors = await validate(dto);
+      const apiKeyError = errors.find((e) => e.property === 'apiKey');
+      expect(apiKeyError).toBeDefined();
+    });
+
+    it('should trim the api key via Transform', () => {
+      const dto = create({ provider: 'resend', apiKey: '  my-secret-key  ' });
+      expect(dto.apiKey).toBe('my-secret-key');
+    });
+
+    it('should pass through non-string apiKey without trimming', () => {
+      const dto = create({ provider: 'resend', apiKey: 12345678 });
+      expect(dto.apiKey).toBe(12345678);
+    });
+  });
+
+  describe('domain', () => {
+    it('should be required when provider is mailgun', async () => {
+      const dto = create({ provider: 'mailgun' });
+      const errors = await validate(dto);
+      const domainError = errors.find((e) => e.property === 'domain');
+      expect(domainError).toBeDefined();
+    });
+
+    it('should accept a valid domain for mailgun', async () => {
+      const dto = create({ provider: 'mailgun', domain: 'mg.example.com' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should not be required for resend', async () => {
+      const dto = create({ provider: 'resend' });
+      const errors = await validate(dto);
+      const domainError = errors.find((e) => e.property === 'domain');
+      expect(domainError).toBeUndefined();
+    });
+
+    it('should not be required for sendgrid', async () => {
+      const dto = create({ provider: 'sendgrid' });
+      const errors = await validate(dto);
+      const domainError = errors.find((e) => e.property === 'domain');
+      expect(domainError).toBeUndefined();
+    });
+
+    it('should trim and lowercase the domain via Transform', () => {
+      const dto = create({ provider: 'mailgun', domain: '  MG.Example.COM  ' });
+      expect(dto.domain).toBe('mg.example.com');
+    });
+
+    it('should pass through non-string domain without transforming', () => {
+      const dto = create({ provider: 'mailgun', domain: 999 });
+      expect(dto.domain).toBe(999);
+    });
+
+    it('should reject empty string domain for mailgun', async () => {
+      const dto = create({ provider: 'mailgun', domain: '' });
+      const errors = await validate(dto);
+      const domainError = errors.find((e) => e.property === 'domain');
+      expect(domainError).toBeDefined();
+    });
+  });
+
+  describe('notificationEmail', () => {
+    it('should accept when omitted', async () => {
+      const dto = create({ provider: 'resend' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should accept a valid email', async () => {
+      const dto = create({
+        provider: 'resend',
+        notificationEmail: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject an invalid email', async () => {
+      const dto = create({
+        provider: 'resend',
+        notificationEmail: 'not-an-email',
+      });
+      const errors = await validate(dto);
+      const emailError = errors.find(
+        (e) => e.property === 'notificationEmail',
+      );
+      expect(emailError).toBeDefined();
+    });
+
+    it('should trim and lowercase the email via Transform', () => {
+      const dto = create({
+        provider: 'resend',
+        notificationEmail: '  User@Example.COM  ',
+      });
+      expect(dto.notificationEmail).toBe('user@example.com');
+    });
+
+    it('should pass through non-string notificationEmail without transforming', () => {
+      const dto = create({ provider: 'resend', notificationEmail: 42 });
+      expect(dto.notificationEmail).toBe(42);
+    });
+  });
+
+  describe('full valid payloads', () => {
+    it('should validate with all fields populated', async () => {
+      const dto = create({
+        provider: 'mailgun',
+        apiKey: 'a-long-enough-key',
+        domain: 'mg.example.com',
+        notificationEmail: 'alerts@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should validate with only required fields for resend', async () => {
+      const dto = create({ provider: 'resend' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});
+
+describe('TestEmailProviderDto', () => {
+  function create(data: Record<string, unknown>): TestEmailProviderDto {
+    return plainToInstance(TestEmailProviderDto, data);
+  }
+
+  describe('provider', () => {
+    it('should accept resend', async () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: 'valid-api-key-123',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should accept mailgun with domain', async () => {
+      const dto = create({
+        provider: 'mailgun',
+        apiKey: 'valid-api-key-123',
+        domain: 'mg.example.com',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should accept sendgrid', async () => {
+      const dto = create({
+        provider: 'sendgrid',
+        apiKey: 'valid-api-key-123',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should reject an invalid provider', async () => {
+      const dto = create({
+        provider: 'postmark',
+        apiKey: 'valid-api-key-123',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      const providerError = errors.find((e) => e.property === 'provider');
+      expect(providerError).toBeDefined();
+    });
+
+    it('should reject missing provider', async () => {
+      const dto = create({
+        apiKey: 'valid-api-key-123',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      const providerError = errors.find((e) => e.property === 'provider');
+      expect(providerError).toBeDefined();
+    });
+  });
+
+  describe('apiKey', () => {
+    it('should reject missing apiKey', async () => {
+      const dto = create({
+        provider: 'resend',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      const apiKeyError = errors.find((e) => e.property === 'apiKey');
+      expect(apiKeyError).toBeDefined();
+    });
+
+    it('should reject apiKey shorter than 8 characters', async () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: 'short',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      const apiKeyError = errors.find((e) => e.property === 'apiKey');
+      expect(apiKeyError).toBeDefined();
+    });
+
+    it('should accept a valid apiKey', async () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: 'long-enough-key',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should trim the apiKey via Transform', () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: '  my-secret-key  ',
+        to: 'user@example.com',
+      });
+      expect(dto.apiKey).toBe('my-secret-key');
+    });
+
+    it('should pass through non-string apiKey without trimming', () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: 12345678,
+        to: 'user@example.com',
+      });
+      expect(dto.apiKey).toBe(12345678);
+    });
+  });
+
+  describe('domain', () => {
+    it('should be required when provider is mailgun', async () => {
+      const dto = create({
+        provider: 'mailgun',
+        apiKey: 'valid-api-key-123',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      const domainError = errors.find((e) => e.property === 'domain');
+      expect(domainError).toBeDefined();
+    });
+
+    it('should not be required for resend', async () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: 'valid-api-key-123',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      const domainError = errors.find((e) => e.property === 'domain');
+      expect(domainError).toBeUndefined();
+    });
+
+    it('should not be required for sendgrid', async () => {
+      const dto = create({
+        provider: 'sendgrid',
+        apiKey: 'valid-api-key-123',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      const domainError = errors.find((e) => e.property === 'domain');
+      expect(domainError).toBeUndefined();
+    });
+
+    it('should trim and lowercase the domain via Transform', () => {
+      const dto = create({
+        provider: 'mailgun',
+        apiKey: 'valid-api-key-123',
+        domain: '  MG.Example.COM  ',
+        to: 'user@example.com',
+      });
+      expect(dto.domain).toBe('mg.example.com');
+    });
+
+    it('should pass through non-string domain without transforming', () => {
+      const dto = create({
+        provider: 'mailgun',
+        apiKey: 'valid-api-key-123',
+        domain: 999,
+        to: 'user@example.com',
+      });
+      expect(dto.domain).toBe(999);
+    });
+
+    it('should reject empty string domain for mailgun', async () => {
+      const dto = create({
+        provider: 'mailgun',
+        apiKey: 'valid-api-key-123',
+        domain: '',
+        to: 'user@example.com',
+      });
+      const errors = await validate(dto);
+      const domainError = errors.find((e) => e.property === 'domain');
+      expect(domainError).toBeDefined();
+    });
+  });
+
+  describe('to', () => {
+    it('should reject missing to', async () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: 'valid-api-key-123',
+      });
+      const errors = await validate(dto);
+      const toError = errors.find((e) => e.property === 'to');
+      expect(toError).toBeDefined();
+    });
+
+    it('should accept a valid to string', async () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: 'valid-api-key-123',
+        to: 'test@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('full valid payloads', () => {
+    it('should validate with all fields for mailgun', async () => {
+      const dto = create({
+        provider: 'mailgun',
+        apiKey: 'a-long-enough-key',
+        domain: 'mg.example.com',
+        to: 'recipient@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should validate with minimum fields for sendgrid', async () => {
+      const dto = create({
+        provider: 'sendgrid',
+        apiKey: 'a-long-enough-key',
+        to: 'recipient@example.com',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -321,4 +321,815 @@ describe('TraceIngestService', () => {
     const result = await service.ingest({ resourceSpans: undefined as never }, testCtx);
     expect(result.accepted).toBe(0);
   });
+
+  it('skips root_request spans without inserting anything', async () => {
+    const span = makeSpan({
+      spanId: 'span-root',
+      name: 'openclaw.request',
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    const result = await service.ingest(request, testCtx);
+    expect(result.accepted).toBe(1);
+    expect(mockTurnInsert).not.toHaveBeenCalled();
+    expect(mockLlmInsert).not.toHaveBeenCalled();
+    expect(mockToolInsert).not.toHaveBeenCalled();
+  });
+
+  it('classifies spans with manifest.* prefix as agent_message', async () => {
+    const span = makeSpan({
+      name: 'manifest.something.custom',
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
+    expect(mockLlmInsert).not.toHaveBeenCalled();
+    expect(mockToolInsert).not.toHaveBeenCalled();
+  });
+
+  it('handles missing scopeSpans gracefully', async () => {
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: undefined as never,
+      }],
+    };
+
+    const result = await service.ingest(request, testCtx);
+    expect(result.accepted).toBe(0);
+  });
+
+  it('handles missing spans array within scopeSpans gracefully', async () => {
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: undefined as never,
+        }],
+      }],
+    };
+
+    const result = await service.ingest(request, testCtx);
+    expect(result.accepted).toBe(0);
+  });
+
+  it('sets error_message to null when status code is not 2', async () => {
+    const span = makeSpan({
+      status: { code: 1, message: 'should be ignored' },
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ok',
+        error_message: null,
+      }),
+    );
+  });
+
+  it('sets null messageId when llm_call parent is not an agent_message', async () => {
+    const rootSpan = makeSpan({
+      spanId: 'span-root',
+      name: 'openclaw.request',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm',
+      parentSpanId: 'span-root',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'anthropic' } },
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-opus-4-6' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [rootSpan, llmSpan] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockLlmInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ turn_id: null }),
+    );
+  });
+
+  it('sets null llmCallId when tool parent is not an llm_call', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-parent',
+      name: 'openclaw.agent.turn',
+    });
+
+    const toolSpan = makeSpan({
+      spanId: 'span-tool',
+      parentSpanId: 'span-parent',
+      attributes: [
+        { key: 'tool.name', value: { stringValue: 'bash' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [parentSpan, toolSpan] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockToolInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ llm_call_id: null }),
+    );
+  });
+
+  it('uses tool.name from resource attributes for tool_execution classification', async () => {
+    const request = {
+      resourceSpans: [{
+        resource: {
+          attributes: [
+            { key: 'tool.name', value: { stringValue: 'resource-tool' } },
+          ],
+        },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [makeSpan({
+            spanId: 'span-t',
+            name: 'span-level-name',
+            attributes: [],
+          })],
+        }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockToolInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ tool_name: 'resource-tool' }),
+    );
+  });
+
+  it('sets error_message on tool_execution spans with error status', async () => {
+    const toolSpan = makeSpan({
+      spanId: 'span-tool-err',
+      status: { code: 2, message: 'tool failed' },
+      attributes: [
+        { key: 'tool.name', value: { stringValue: 'broken_tool' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [toolSpan] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockToolInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        error_message: 'tool failed',
+      }),
+    );
+  });
+
+  it('sets null error_message on tool_execution spans with ok status', async () => {
+    const toolSpan = makeSpan({
+      spanId: 'span-tool-ok',
+      status: { code: 0 },
+      attributes: [
+        { key: 'tool.name', value: { stringValue: 'good_tool' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [toolSpan] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockToolInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ok',
+        error_message: null,
+      }),
+    );
+  });
+
+  it('does not accumulate to message when llm_call parent is not agent_message', async () => {
+    const rootSpan = makeSpan({
+      spanId: 'span-root',
+      name: 'openclaw.request',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm',
+      parentSpanId: 'span-root',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'openai' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [rootSpan, llmSpan] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    // Since the parent is root_request (not agent_message), accumulateToMessage returns early
+    // No rollup query should be executed
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('skips rollup when accumulated tokens are both zero', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-msg',
+      name: 'openclaw.agent.turn',
+    });
+
+    // llm_call with no token attributes (defaults to 0)
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-no-tokens',
+      parentSpanId: 'span-msg',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'openai' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [parentSpan, llmSpan] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    // Both input and output tokens are 0, so rollup should be skipped
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('computes cost in rollup when pricing is available', async () => {
+    mockPricingGetByModel.mockReturnValue({
+      input_price_per_token: 0.01,
+      output_price_per_token: 0.03,
+    });
+
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-cost',
+      name: 'openclaw.agent.turn',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-cost',
+      parentSpanId: 'span-msg-cost',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'anthropic' } },
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-opus-4-6' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 200 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 100 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan],
+        }],
+      }],
+    };
+
+    const repoInstance = (service as any).turnRepo;
+    const mockQb = repoInstance.createQueryBuilder();
+
+    await service.ingest(request, testCtx);
+
+    expect(mockExecute).toHaveBeenCalled();
+    // cost_usd should be 200 * 0.01 + 100 * 0.03 = 5.0
+    expect(mockQb.set).toHaveBeenCalledWith(
+      expect.objectContaining({ cost_usd: expect.closeTo(5.0, 4) }),
+    );
+  });
+
+  it('sets null cost in rollup when no pricing is available', async () => {
+    mockPricingGetByModel.mockReturnValue(undefined);
+
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-nocost',
+      name: 'openclaw.agent.turn',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-nocost',
+      parentSpanId: 'span-msg-nocost',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'openai' } },
+        { key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 50 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 25 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan],
+        }],
+      }],
+    };
+
+    const repoInstance = (service as any).turnRepo;
+    const mockQb = repoInstance.createQueryBuilder();
+
+    await service.ingest(request, testCtx);
+
+    expect(mockExecute).toHaveBeenCalled();
+    expect(mockQb.set).toHaveBeenCalledWith(
+      expect.objectContaining({ cost_usd: null }),
+    );
+  });
+
+  it('returns null cost when model has no tokens', async () => {
+    const span = makeSpan({
+      attributes: [
+        { key: 'gen_ai.response.model', value: { stringValue: 'gpt-4o' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ cost_usd: null }),
+    );
+  });
+
+  it('returns null cost when no model attribute is present', async () => {
+    const span = makeSpan({
+      attributes: [
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ cost_usd: null }),
+    );
+  });
+
+  it('returns null cost when model exists but pricing is not found', async () => {
+    mockPricingGetByModel.mockReturnValue(undefined);
+
+    const span = makeSpan({
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'unknown-model' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ cost_usd: null }),
+    );
+  });
+
+  it('uses gen_ai.response.model as fallback when gen_ai.request.model is absent', async () => {
+    mockPricingGetByModel.mockReturnValue({
+      input_price_per_token: 0.001,
+      output_price_per_token: 0.002,
+    });
+
+    const span = makeSpan({
+      attributes: [
+        { key: 'gen_ai.response.model', value: { stringValue: 'claude-3-haiku' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 10 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 5 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockPricingGetByModel).toHaveBeenCalledWith('claude-3-haiku');
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-3-haiku',
+        cost_usd: expect.closeTo(0.02, 4),
+      }),
+    );
+  });
+
+  it('uses fallback model from gen_ai.response.model in accumulation', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-resp',
+      name: 'openclaw.agent.turn',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-resp',
+      parentSpanId: 'span-msg-resp',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'openai' } },
+        { key: 'gen_ai.response.model', value: { stringValue: 'gpt-4o-2024' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 30 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 15 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan],
+        }],
+      }],
+    };
+
+    const repoInstance = (service as any).turnRepo;
+    const mockQb = repoInstance.createQueryBuilder();
+
+    await service.ingest(request, testCtx);
+
+    expect(mockQb.setParameter).toHaveBeenCalledWith('model', 'gpt-4o-2024');
+  });
+
+  it('accumulates cache tokens from llm_call children', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-cache',
+      name: 'openclaw.agent.turn',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-cache',
+      parentSpanId: 'span-msg-cache',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'anthropic' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 200 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.cache_read_input_tokens', value: { intValue: 50 } },
+        { key: 'gen_ai.usage.cache_creation_input_tokens', value: { intValue: 25 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan],
+        }],
+      }],
+    };
+
+    const repoInstance = (service as any).turnRepo;
+    const mockQb = repoInstance.createQueryBuilder();
+
+    await service.ingest(request, testCtx);
+
+    expect(mockQb.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cache_read_tokens: 50,
+        cache_creation_tokens: 25,
+      }),
+    );
+  });
+
+  it('defaults token attributes to 0 when absent in accumulation', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-noattrs',
+      name: 'openclaw.agent.turn',
+    });
+
+    // llm_call with only gen_ai.system but no token attributes
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-noattrs',
+      parentSpanId: 'span-msg-noattrs',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'openai' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 10 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 5 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan],
+        }],
+      }],
+    };
+
+    const repoInstance = (service as any).turnRepo;
+    const mockQb = repoInstance.createQueryBuilder();
+
+    await service.ingest(request, testCtx);
+
+    // cache tokens should default to 0
+    expect(mockQb.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+      }),
+    );
+  });
+
+  it('does not accumulate when llm_call has no parent in spanMap', async () => {
+    const llmSpan = makeSpan({
+      spanId: 'span-orphan-llm',
+      parentSpanId: 'span-nonexistent',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'openai' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [llmSpan] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockLlmInsert).toHaveBeenCalledTimes(1);
+    // No accumulation should happen, so no rollup query
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('uses ctx.agentName when agent.name attribute is absent', async () => {
+    const span = makeSpan();
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ agent_name: 'test-agent' }),
+    );
+  });
+
+  it('sets null cost in rollup when model is null in aggregates', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-nomodel',
+      name: 'openclaw.agent.turn',
+    });
+
+    // llm_call with tokens but no model attribute
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-nomodel',
+      parentSpanId: 'span-msg-nomodel',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'openai' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 50 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 25 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan],
+        }],
+      }],
+    };
+
+    const repoInstance = (service as any).turnRepo;
+    const mockQb = repoInstance.createQueryBuilder();
+
+    await service.ingest(request, testCtx);
+
+    // model is null so cost should be null
+    expect(mockQb.set).toHaveBeenCalledWith(
+      expect.objectContaining({ cost_usd: null }),
+    );
+  });
+
+  it('persists llm_call cache tokens from span attributes', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-parent-ct',
+      name: 'openclaw.agent.turn',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-ct',
+      parentSpanId: 'span-parent-ct',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'anthropic' } },
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-opus-4-6' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+        { key: 'gen_ai.usage.cache_read_input_tokens', value: { intValue: 30 } },
+        { key: 'gen_ai.usage.cache_creation_input_tokens', value: { intValue: 20 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan],
+        }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockLlmInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cache_read_tokens: 30,
+        cache_creation_tokens: 20,
+      }),
+    );
+  });
+
+  it('sets null error_message when error status has no message field', async () => {
+    const span = makeSpan({
+      status: { code: 2 },
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        error_message: null,
+      }),
+    );
+  });
+
+  it('sets llmCallId when tool parent is an llm_call', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-parent',
+      name: 'openclaw.agent.turn',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-parent',
+      parentSpanId: 'span-msg-parent',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'anthropic' } },
+      ],
+    });
+
+    const toolSpan = makeSpan({
+      spanId: 'span-tool-child',
+      parentSpanId: 'span-llm-parent',
+      attributes: [
+        { key: 'tool.name', value: { stringValue: 'file_read' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan, toolSpan],
+        }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockToolInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        llm_call_id: expect.any(String),
+        tool_name: 'file_read',
+      }),
+    );
+    // Verify llm_call_id is not null (it should be the uuid of the llm span entry)
+    const insertArg = mockToolInsert.mock.calls[0][0];
+    expect(insertArg.llm_call_id).not.toBeNull();
+  });
+
+  it('sets null error_message on tool_execution with error status and no message', async () => {
+    const toolSpan = makeSpan({
+      spanId: 'span-tool-err-nomsg',
+      status: { code: 2 },
+      attributes: [
+        { key: 'tool.name', value: { stringValue: 'bad_tool' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{ scope: { name: 'test' }, spans: [toolSpan] }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockToolInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        error_message: null,
+      }),
+    );
+  });
+
+  it('defaults llm_call cache tokens to 0 when attributes are absent', async () => {
+    const parentSpan = makeSpan({
+      spanId: 'span-parent-nct',
+      name: 'openclaw.agent.turn',
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-nct',
+      parentSpanId: 'span-parent-nct',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'anthropic' } },
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-opus-4-6' } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { name: 'test' },
+          spans: [parentSpan, llmSpan],
+        }],
+      }],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockLlmInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+      }),
+    );
+  });
 });

--- a/packages/frontend/tests/services/analytics.test.ts
+++ b/packages/frontend/tests/services/analytics.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+let mockTelemetryOptOut = false;
+
+vi.mock("../../src/services/local-mode.js", () => ({
+  telemetryOptOut: () => mockTelemetryOptOut,
+}));
+
+const mockFetch = vi.fn();
+const mockLocalStorage: Record<string, string> = {};
+
+beforeEach(() => {
+  mockTelemetryOptOut = false;
+  mockFetch.mockResolvedValue({});
+  vi.stubGlobal("fetch", mockFetch);
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn((key: string) => mockLocalStorage[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      mockLocalStorage[key] = value;
+    }),
+  });
+  vi.stubGlobal("crypto", {
+    getRandomValues: vi.fn((arr: Uint8Array) => {
+      for (let i = 0; i < arr.length; i++) {
+        arr[i] = i;
+      }
+      return arr;
+    }),
+  });
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-15T12:00:00.000Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  mockFetch.mockReset();
+  Object.keys(mockLocalStorage).forEach((k) => delete mockLocalStorage[k]);
+});
+
+describe("trackEvent", () => {
+  it("should not call fetch when telemetry is opted out", async () => {
+    mockTelemetryOptOut = true;
+    const { trackEvent } = await import("../../src/services/analytics.js");
+
+    trackEvent("page_view");
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(localStorage.getItem).not.toHaveBeenCalled();
+  });
+
+  it("should send event to PostHog when telemetry is not opted out", async () => {
+    const { trackEvent } = await import("../../src/services/analytics.js");
+
+    trackEvent("page_view");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://eu.i.posthog.com/capture");
+    expect(options.method).toBe("POST");
+    expect(options.headers).toEqual({ "Content-Type": "application/json" });
+
+    const body = JSON.parse(options.body);
+    expect(body.api_key).toBe("phc_g5pLOu5bBRjhVJBwAsx0eCzJFWq0cri2TyVLQLxf045");
+    expect(body.event).toBe("page_view");
+    expect(body.properties.source).toBe("frontend");
+    expect(body.timestamp).toBe("2026-01-15T12:00:00.000Z");
+  });
+
+  it("should include custom properties merged with defaults", async () => {
+    const { trackEvent } = await import("../../src/services/analytics.js");
+
+    trackEvent("button_click", { button: "submit", page: "settings" });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.properties.button).toBe("submit");
+    expect(body.properties.page).toBe("settings");
+    expect(body.properties.source).toBe("frontend");
+    expect(body.properties.distinct_id).toBeDefined();
+  });
+
+  it("should work without optional properties argument", async () => {
+    const { trackEvent } = await import("../../src/services/analytics.js");
+
+    trackEvent("simple_event");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.event).toBe("simple_event");
+    expect(body.properties.source).toBe("frontend");
+    expect(body.properties.distinct_id).toBeDefined();
+  });
+
+  it("should silently swallow fetch errors", async () => {
+    mockFetch.mockRejectedValue(new Error("Network error"));
+    const { trackEvent } = await import("../../src/services/analytics.js");
+
+    // Should not throw
+    expect(() => trackEvent("test_event")).not.toThrow();
+  });
+});
+
+describe("getAnonymousId (via trackEvent)", () => {
+  it("should generate a new ID and store it when none exists", async () => {
+    const { trackEvent } = await import("../../src/services/analytics.js");
+
+    trackEvent("test_event");
+
+    expect(localStorage.getItem).toHaveBeenCalledWith("mnfst_anon_id");
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "mnfst_anon_id",
+      expect.any(String),
+    );
+
+    // Verify the generated ID is a 32-char hex string based on our mock
+    const storedId = (localStorage.setItem as ReturnType<typeof vi.fn>).mock
+      .calls[0][1] as string;
+    expect(storedId).toMatch(/^[0-9a-f]{32}$/);
+    // With our mock (bytes 0-15), the expected hex is:
+    expect(storedId).toBe("000102030405060708090a0b0c0d0e0f");
+  });
+
+  it("should reuse existing ID from localStorage", async () => {
+    mockLocalStorage["mnfst_anon_id"] = "existing-anon-id-abc123";
+    const { trackEvent } = await import("../../src/services/analytics.js");
+
+    trackEvent("test_event");
+
+    expect(localStorage.getItem).toHaveBeenCalledWith("mnfst_anon_id");
+    expect(localStorage.setItem).not.toHaveBeenCalled();
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.properties.distinct_id).toBe("existing-anon-id-abc123");
+  });
+
+  it("should use the generated ID as distinct_id in the payload", async () => {
+    const { trackEvent } = await import("../../src/services/analytics.js");
+
+    trackEvent("test_event");
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.properties.distinct_id).toBe(
+      "000102030405060708090a0b0c0d0e0f",
+    );
+  });
+});

--- a/packages/frontend/tests/services/chart-utils.test.ts
+++ b/packages/frontend/tests/services/chart-utils.test.ts
@@ -1,5 +1,46 @@
-import { describe, it, expect } from "vitest";
-import { rangeToSeconds, formatAxisTimestamp, parseTimestamps, timeScaleRange } from "../../src/services/chart-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// --- Capture SolidJS lifecycle callbacks ---
+let mountCb: (() => void) | null = null;
+let cleanupCb: (() => void) | null = null;
+let effectCb: (() => void) | null = null;
+
+vi.mock("solid-js", () => ({
+  onMount: (cb: () => void) => { mountCb = cb; },
+  onCleanup: (cb: () => void) => { cleanupCb = cb; },
+  createEffect: (cb: () => void) => { effectCb = cb; },
+  on: (_dep: unknown, cb: () => void) => cb,
+}));
+
+vi.mock("../../src/services/theme.js", () => ({
+  getHslA: (cssVar: string, alpha: number) => `hsla(var(${cssVar}), ${alpha})`,
+}));
+
+import {
+  makeGradientFill,
+  makeGradientFillFromVar,
+  createCursorSnap,
+  createBaseAxes,
+  rangeToSeconds,
+  formatAxisTimestamp,
+  parseTimestamps,
+  timeScaleRange,
+  useChartLifecycle,
+} from "../../src/services/chart-utils";
+
+beforeEach(() => {
+  mountCb = null;
+  cleanupCb = null;
+  effectCb = null;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ---------- rangeToSeconds ----------
 
 describe("rangeToSeconds", () => {
   it("returns correct seconds for known ranges", () => {
@@ -9,28 +50,69 @@ describe("rangeToSeconds", () => {
     expect(rangeToSeconds("7d")).toBe(604800);
     expect(rangeToSeconds("30d")).toBe(2592000);
   });
+
   it("defaults to 86400 for unknown range", () => {
     expect(rangeToSeconds("unknown")).toBe(86400);
   });
+
+  it("defaults to 86400 for empty string", () => {
+    expect(rangeToSeconds("")).toBe(86400);
+  });
 });
 
+// ---------- formatAxisTimestamp ----------
+
 describe("formatAxisTimestamp", () => {
-  it("shows HH:MM for short ranges", () => {
+  it("shows HH:MM for range <= 86400 (1h range)", () => {
     const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
-    const result = formatAxisTimestamp(epoch, 3600);
-    expect(result).toBe("10:30");
+    expect(formatAxisTimestamp(epoch, 3600)).toBe("10:30");
   });
-  it("shows just date for weekly range", () => {
-    const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
-    const result = formatAxisTimestamp(epoch, 604800);
-    expect(result).toBe("Jan 15");
+
+  it("shows HH:MM for range exactly 86400", () => {
+    const epoch = Date.UTC(2024, 5, 15, 0, 0) / 1000;
+    expect(formatAxisTimestamp(epoch, 86400)).toBe("00:00");
   });
-  it("shows just date for monthly range", () => {
+
+  it("shows Mon Day for range > 86400 and <= 7*86400 (weekly)", () => {
     const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
-    const result = formatAxisTimestamp(epoch, 2592000);
-    expect(result).toBe("Jan 15");
+    expect(formatAxisTimestamp(epoch, 604800)).toBe("Jan 15");
+  });
+
+  it("shows Mon Day for range just over 86400", () => {
+    const epoch = Date.UTC(2024, 5, 15, 14, 30) / 1000;
+    expect(formatAxisTimestamp(epoch, 86401)).toBe("Jun 15");
+  });
+
+  it("shows Mon Day for range > 7*86400 (monthly)", () => {
+    const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
+    expect(formatAxisTimestamp(epoch, 2592000)).toBe("Jan 15");
+  });
+
+  it("shows Mon Day for 30-day range", () => {
+    const epoch = Date.UTC(2024, 11, 25, 8, 0) / 1000;
+    expect(formatAxisTimestamp(epoch, 30 * 86400)).toBe("Dec 25");
+  });
+
+  it("pads single-digit hours and minutes", () => {
+    const epoch = Date.UTC(2024, 0, 1, 5, 3) / 1000;
+    expect(formatAxisTimestamp(epoch, 3600)).toBe("05:03");
+  });
+
+  it("handles midnight correctly", () => {
+    const epoch = Date.UTC(2024, 0, 1, 0, 0) / 1000;
+    expect(formatAxisTimestamp(epoch, 3600)).toBe("00:00");
+  });
+
+  it("uses all months correctly", () => {
+    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+    for (let m = 0; m < 12; m++) {
+      const epoch = Date.UTC(2024, m, 10) / 1000;
+      expect(formatAxisTimestamp(epoch, 604800)).toBe(`${months[m]} 10`);
+    }
   });
 });
+
+// ---------- parseTimestamps ----------
 
 describe("parseTimestamps", () => {
   it("parses hour-based timestamps", () => {
@@ -38,24 +120,559 @@ describe("parseTimestamps", () => {
     const result = parseTimestamps(data);
     expect(result).toHaveLength(1);
     expect(typeof result[0]).toBe("number");
+    expect(result[0]).toBeGreaterThan(0);
   });
+
   it("parses date-based timestamps", () => {
     const data = [{ date: "2024-01-15" }];
     const result = parseTimestamps(data);
     expect(result).toHaveLength(1);
     expect(typeof result[0]).toBe("number");
   });
+
+  it("returns empty array for empty input", () => {
+    expect(parseTimestamps([])).toHaveLength(0);
+  });
+
+  it("produces epoch seconds, not milliseconds", () => {
+    const data = [{ hour: "2026-02-16T00:00:00" }];
+    const result = parseTimestamps(data);
+    expect(result[0]).toBeLessThan(2_000_000_000);
+    expect(result[0]).toBeGreaterThan(1_000_000_000);
+  });
+
+  it("produces correct sequential hour differences", () => {
+    const data = [
+      { hour: "2024-01-15 10:00" },
+      { hour: "2024-01-15 11:00" },
+    ];
+    const result = parseTimestamps(data);
+    expect(result[1]! - result[0]!).toBe(3600);
+  });
+
+  it("produces correct sequential day differences", () => {
+    const data = [{ date: "2024-01-15" }, { date: "2024-01-16" }];
+    const result = parseTimestamps(data);
+    expect(result[1]! - result[0]!).toBe(86400);
+  });
+
+  it("prefers hour over date when both present", () => {
+    const data = [{ hour: "2024-01-15 10:00", date: "2024-01-20" }];
+    const result = parseTimestamps(data);
+    // hour is checked first via (d.hour ?? d.date)
+    const expected = Date.UTC(2024, 0, 15, 10, 0) / 1000;
+    expect(result[0]).toBe(expected);
+  });
+
+  it("handles entries with extra record fields", () => {
+    const data = [
+      { hour: "2024-01-15 09:00", input_tokens: 100, output_tokens: 50 },
+    ];
+    const result = parseTimestamps(data);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeGreaterThan(0);
+  });
+
+  it("falls back to empty string when neither hour nor date is present", () => {
+    const data = [{ someOtherField: "value" } as any];
+    const result = parseTimestamps(data);
+    expect(result).toHaveLength(1);
+    // new Date("Z") is Invalid Date, getTime() returns NaN, NaN/1000 = NaN
+    expect(Number.isNaN(result[0])).toBe(true);
+  });
 });
+
+// ---------- timeScaleRange ----------
 
 describe("timeScaleRange", () => {
   it("expands small ranges to minimum 6 hours", () => {
     const [min, max] = timeScaleRange(null as any, 100, 200);
-    const span = max - min;
-    expect(span).toBe(6 * 3600);
+    expect(max - min).toBe(6 * 3600);
   });
-  it("keeps range when span is larger than minimum", () => {
+
+  it("centers the expanded range around the midpoint", () => {
+    const [min, max] = timeScaleRange(null as any, 1000, 2000);
+    const mid = (1000 + 2000) / 2;
+    expect(min).toBe(mid - 10800);
+    expect(max).toBe(mid + 10800);
+  });
+
+  it("keeps range when span equals MIN_SPAN exactly", () => {
+    const [min, max] = timeScaleRange(null as any, 0, 21600);
+    expect(min).toBe(0);
+    expect(max).toBe(21600);
+  });
+
+  it("keeps range when span is larger than MIN_SPAN", () => {
     const [min, max] = timeScaleRange(null as any, 0, 100000);
     expect(min).toBe(0);
     expect(max).toBe(100000);
+  });
+
+  it("handles zero-width range", () => {
+    const [min, max] = timeScaleRange(null as any, 5000, 5000);
+    expect(max - min).toBe(6 * 3600);
+    expect((min + max) / 2).toBe(5000);
+  });
+});
+
+// ---------- makeGradientFill ----------
+
+describe("makeGradientFill", () => {
+  it("returns a function", () => {
+    const fill = makeGradientFill("red", "blue");
+    expect(typeof fill).toBe("function");
+  });
+
+  it("returns topColor when bbox.top is NaN", () => {
+    const fill = makeGradientFill("red", "blue") as Function;
+    const result = fill({ bbox: { top: NaN, height: 100 }, ctx: {} });
+    expect(result).toBe("red");
+  });
+
+  it("returns topColor when bbox.height is NaN", () => {
+    const fill = makeGradientFill("red", "blue") as Function;
+    const result = fill({ bbox: { top: 10, height: NaN }, ctx: {} });
+    expect(result).toBe("red");
+  });
+
+  it("returns topColor when bbox.height is 0", () => {
+    const fill = makeGradientFill("red", "blue") as Function;
+    const result = fill({ bbox: { top: 0, height: 0 }, ctx: {} });
+    expect(result).toBe("red");
+  });
+
+  it("returns topColor when bbox.top is Infinity", () => {
+    const fill = makeGradientFill("red", "blue") as Function;
+    const result = fill({ bbox: { top: Infinity, height: 100 }, ctx: {} });
+    expect(result).toBe("red");
+  });
+
+  it("returns topColor when bbox.height is -Infinity", () => {
+    const fill = makeGradientFill("red", "blue") as Function;
+    const result = fill({ bbox: { top: 10, height: -Infinity }, ctx: {} });
+    expect(result).toBe("red");
+  });
+
+  it("creates gradient when bbox is valid", () => {
+    const fill = makeGradientFill("red", "blue") as Function;
+    const mockGradient = { addColorStop: vi.fn() };
+    const mockU = {
+      bbox: { top: 10, height: 200 },
+      ctx: { createLinearGradient: vi.fn().mockReturnValue(mockGradient) },
+    };
+    const result = fill(mockU);
+    expect(mockU.ctx.createLinearGradient).toHaveBeenCalledWith(0, 10, 0, 210);
+    expect(mockGradient.addColorStop).toHaveBeenCalledWith(0, "red");
+    expect(mockGradient.addColorStop).toHaveBeenCalledWith(1, "blue");
+    expect(result).toBe(mockGradient);
+  });
+});
+
+// ---------- makeGradientFillFromVar ----------
+
+describe("makeGradientFillFromVar", () => {
+  it("returns a function that delegates to makeGradientFill with theme colors", () => {
+    const fill = makeGradientFillFromVar("--chart-1", 0.3);
+    expect(typeof fill).toBe("function");
+  });
+
+  it("creates gradient using getHslA-derived top color and transparent bottom", () => {
+    const fill = makeGradientFillFromVar("--chart-1", 0.5) as Function;
+    const mockGradient = { addColorStop: vi.fn() };
+    const mockU = {
+      bbox: { top: 0, height: 100 },
+      ctx: { createLinearGradient: vi.fn().mockReturnValue(mockGradient) },
+    };
+    fill(mockU);
+    expect(mockGradient.addColorStop).toHaveBeenCalledWith(
+      0,
+      "hsla(var(--chart-1), 0.5)",
+    );
+    expect(mockGradient.addColorStop).toHaveBeenCalledWith(1, "transparent");
+  });
+});
+
+// ---------- createCursorSnap ----------
+
+describe("createCursorSnap", () => {
+  it("returns cursor config with correct properties", () => {
+    const cursor = createCursorSnap("#fff", "#0f0");
+    expect(cursor.show).toBe(true);
+    expect(cursor.x).toBe(true);
+    expect(cursor.y).toBe(false);
+    expect(cursor.drag).toEqual({ x: false, y: false });
+    expect(cursor.points?.show).toBe(true);
+    expect(cursor.points?.size).toBe(8);
+    expect(cursor.points?.fill).toBe("#0f0");
+    expect(cursor.points?.stroke).toBe("#fff");
+    expect(cursor.points?.width).toBe(2);
+  });
+
+  it("move snaps to nearest data point when idx is valid", () => {
+    const cursor = createCursorSnap("#fff", "#0f0");
+    const mockU = {
+      posToIdx: vi.fn().mockReturnValue(2),
+      data: [[100, 200, 300]],
+      valToPos: vi.fn().mockReturnValue(150),
+    };
+    const result = (cursor.move as Function)(mockU, 100, 50);
+    expect(mockU.posToIdx).toHaveBeenCalledWith(100);
+    expect(mockU.valToPos).toHaveBeenCalledWith(300, "x");
+    expect(result).toEqual([150, 50]);
+  });
+
+  it("move returns original left when posToIdx returns null", () => {
+    const cursor = createCursorSnap("#fff", "#0f0");
+    const mockU = {
+      posToIdx: vi.fn().mockReturnValue(null),
+      data: [[]],
+      valToPos: vi.fn(),
+    };
+    const result = (cursor.move as Function)(mockU, 100, 50);
+    expect(result[0]).toBe(100);
+    expect(result[1]).toBe(50);
+  });
+
+  it("move returns original left when data at idx is null", () => {
+    const cursor = createCursorSnap("#fff", "#0f0");
+    const mockU = {
+      posToIdx: vi.fn().mockReturnValue(5),
+      data: [[100, 200, 300]], // idx 5 is out of bounds => undefined
+      valToPos: vi.fn(),
+    };
+    const result = (cursor.move as Function)(mockU, 77, 33);
+    expect(result[0]).toBe(77);
+    expect(result[1]).toBe(33);
+  });
+
+  it("move returns original left when data[0] is undefined", () => {
+    const cursor = createCursorSnap("#fff", "#0f0");
+    const mockU = {
+      posToIdx: vi.fn().mockReturnValue(0),
+      data: [],
+      valToPos: vi.fn(),
+    };
+    const result = (cursor.move as Function)(mockU, 42, 10);
+    expect(result[0]).toBe(42);
+    expect(result[1]).toBe(10);
+  });
+});
+
+// ---------- createBaseAxes ----------
+
+describe("createBaseAxes", () => {
+  it("returns array of 2 axes", () => {
+    const axes = createBaseAxes("#aaa", "#eee");
+    expect(axes).toHaveLength(2);
+  });
+
+  it("x-axis has correct stroke and grid", () => {
+    const axes = createBaseAxes("#aaa", "#eee");
+    expect(axes[0].stroke).toBe("#aaa");
+    expect(axes[0].grid?.stroke).toBe("#eee");
+    expect(axes[0].grid?.width).toBe(1);
+    expect(axes[0].ticks?.stroke).toBe("#eee");
+    expect(axes[0].font).toBe('11px "Inter"');
+    expect(axes[0].gap).toBe(8);
+  });
+
+  it("y-axis has ticks hidden and correct sizing", () => {
+    const axes = createBaseAxes("#aaa", "#eee");
+    expect(axes[1].stroke).toBe("#aaa");
+    expect(axes[1].ticks?.show).toBe(false);
+    expect(axes[1].font).toBe('11px "Inter"');
+    expect(axes[1].size).toBe(54);
+    expect(axes[1].gap).toBe(8);
+  });
+
+  it("x-axis values formatter uses provided range", () => {
+    const axes = createBaseAxes("#aaa", "#eee", "24h");
+    const mockU = { scales: { x: {} } } as any;
+    const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
+    const formatted = (axes[0].values as Function)(mockU, [epoch]);
+    expect(formatted[0]).toBe("10:30");
+  });
+
+  it("x-axis values formatter uses u.scales.x when no range provided", () => {
+    const axes = createBaseAxes("#aaa", "#eee");
+    const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
+    const mockU = { scales: { x: { min: epoch - 3600, max: epoch } } } as any;
+    const formatted = (axes[0].values as Function)(mockU, [epoch]);
+    expect(formatted[0]).toBe("10:30");
+  });
+
+  it("x-axis values formatter falls back to vals array when scales.x has no min/max", () => {
+    const axes = createBaseAxes("#aaa", "#eee");
+    const epoch1 = Date.UTC(2024, 0, 15, 10, 0) / 1000;
+    const epoch2 = Date.UTC(2024, 0, 15, 11, 0) / 1000;
+    const mockU = { scales: { x: {} } } as any;
+    const formatted = (axes[0].values as Function)(mockU, [epoch1, epoch2]);
+    // span = epoch2 - epoch1 = 3600 (short range), so HH:MM format
+    expect(formatted[0]).toBe("10:00");
+    expect(formatted[1]).toBe("11:00");
+  });
+
+  it("x-axis values formatter handles missing scales.x entirely", () => {
+    const axes = createBaseAxes("#aaa", "#eee");
+    const epoch1 = Date.UTC(2024, 0, 15, 10, 0) / 1000;
+    const epoch2 = Date.UTC(2024, 0, 15, 11, 0) / 1000;
+    const mockU = { scales: {} } as any;
+    const formatted = (axes[0].values as Function)(mockU, [epoch1, epoch2]);
+    // scales.x is undefined, so uses nullish coalescing chain to vals
+    expect(formatted[0]).toBe("10:00");
+    expect(formatted[1]).toBe("11:00");
+  });
+
+  it("x-axis values formatter handles empty vals array", () => {
+    const axes = createBaseAxes("#aaa", "#eee");
+    const mockU = { scales: { x: {} } } as any;
+    const formatted = (axes[0].values as Function)(mockU, []);
+    expect(formatted).toEqual([]);
+  });
+
+  it("x-axis values formatter with 7d range shows date format", () => {
+    const axes = createBaseAxes("#aaa", "#eee", "7d");
+    const epoch = Date.UTC(2024, 0, 15, 10, 30) / 1000;
+    const mockU = { scales: {} } as any;
+    const formatted = (axes[0].values as Function)(mockU, [epoch]);
+    expect(formatted[0]).toBe("Jan 15");
+  });
+});
+
+// ---------- useChartLifecycle ----------
+
+describe("useChartLifecycle", () => {
+  let mockEl: HTMLDivElement;
+  let mockObserve: ReturnType<typeof vi.fn>;
+  let mockDisconnect: ReturnType<typeof vi.fn>;
+  let resizeCallback: ((entries: unknown[]) => void) | null;
+
+  beforeEach(() => {
+    mockEl = { clientWidth: 800 } as HTMLDivElement;
+    mockObserve = vi.fn();
+    mockDisconnect = vi.fn();
+    resizeCallback = null;
+
+    vi.stubGlobal("ResizeObserver", class {
+      constructor(cb: (entries: unknown[]) => void) {
+        resizeCallback = cb;
+      }
+      observe = mockObserve;
+      disconnect = mockDisconnect;
+      unobserve = vi.fn();
+    });
+  });
+
+  function setupLifecycle(dataValues: unknown[] | undefined, buildChart: () => any) {
+    useChartLifecycle({
+      el: () => mockEl,
+      data: () => dataValues,
+      buildChart,
+    });
+  }
+
+  it("registers onMount, onCleanup, and createEffect callbacks", () => {
+    setupLifecycle([1, 2, 3], () => null);
+    expect(mountCb).toBeTruthy();
+    expect(cleanupCb).toBeTruthy();
+    expect(effectCb).toBeTruthy();
+  });
+
+  it("onMount does nothing when data is empty", () => {
+    setupLifecycle([], () => null);
+    mountCb!();
+    expect(mockObserve).not.toHaveBeenCalled();
+  });
+
+  it("onMount does nothing when data is undefined", () => {
+    setupLifecycle(undefined, () => null);
+    mountCb!();
+    expect(mockObserve).not.toHaveBeenCalled();
+  });
+
+  it("onMount creates ResizeObserver and observes element when data has items", () => {
+    setupLifecycle([1, 2], () => null);
+    mountCb!();
+    expect(mockObserve).toHaveBeenCalledWith(mockEl);
+  });
+
+  it("onMount schedules tryCreate via setTimeout(50)", () => {
+    const buildChart = vi.fn().mockReturnValue({ destroy: vi.fn() });
+    setupLifecycle([1, 2], buildChart);
+    mountCb!();
+    expect(buildChart).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(50);
+    expect(buildChart).toHaveBeenCalledTimes(1);
+  });
+
+  it("tryCreate does not call buildChart if chart already exists", () => {
+    const mockChart = { destroy: vi.fn(), setSize: vi.fn() };
+    const buildChart = vi.fn().mockReturnValue(mockChart);
+    setupLifecycle([1, 2], buildChart);
+    mountCb!();
+
+    // First call via setTimeout creates the chart
+    vi.advanceTimersByTime(50);
+    expect(buildChart).toHaveBeenCalledTimes(1);
+
+    // Trigger ResizeObserver -- chart already exists, should call setSize
+    resizeCallback!([]);
+    expect(buildChart).toHaveBeenCalledTimes(1); // not called again
+    expect(mockChart.setSize).toHaveBeenCalledWith({
+      width: 800,
+      height: 260,
+    });
+  });
+
+  it("ResizeObserver callback calls tryCreate when chart is null", () => {
+    const buildChart = vi.fn().mockReturnValue(null);
+    setupLifecycle([1, 2], buildChart);
+    mountCb!();
+
+    // Trigger resize before setTimeout fires; chart is null
+    resizeCallback!([]);
+    expect(buildChart).toHaveBeenCalledTimes(1);
+  });
+
+  it("ResizeObserver callback resizes existing chart", () => {
+    const mockChart = { destroy: vi.fn(), setSize: vi.fn() };
+    const buildChart = vi.fn().mockReturnValue(mockChart);
+    setupLifecycle([1, 2], buildChart);
+    mountCb!();
+    vi.advanceTimersByTime(50);
+
+    (mockEl as any).clientWidth = 1200;
+    resizeCallback!([]);
+    expect(mockChart.setSize).toHaveBeenCalledWith({
+      width: 1200,
+      height: 260,
+    });
+  });
+
+  it("tryCreate does not assign chart when buildChart returns null", () => {
+    const buildChart = vi.fn().mockReturnValue(null);
+    setupLifecycle([1, 2], buildChart);
+    mountCb!();
+    vi.advanceTimersByTime(50);
+
+    // Chart is still null, so resize should try to create again
+    resizeCallback!([]);
+    expect(buildChart).toHaveBeenCalledTimes(2);
+  });
+
+  it("effect destroys existing chart and schedules tryCreate when data changes with items", () => {
+    const mockChart = { destroy: vi.fn(), setSize: vi.fn() };
+    const buildChart = vi.fn().mockReturnValue(mockChart);
+    let currentData: unknown[] | undefined = [1, 2];
+    useChartLifecycle({
+      el: () => mockEl,
+      data: () => currentData,
+      buildChart,
+    });
+
+    // Mount and create the chart
+    mountCb!();
+    vi.advanceTimersByTime(50);
+    expect(buildChart).toHaveBeenCalledTimes(1);
+
+    // Simulate data change via effect
+    currentData = [3, 4, 5];
+    effectCb!();
+    expect(mockChart.destroy).toHaveBeenCalledTimes(1);
+
+    // New chart should be scheduled via setTimeout(0)
+    vi.advanceTimersByTime(0);
+    expect(buildChart).toHaveBeenCalledTimes(2);
+  });
+
+  it("effect does not schedule tryCreate when data becomes empty", () => {
+    const mockChart = { destroy: vi.fn(), setSize: vi.fn() };
+    const buildChart = vi.fn().mockReturnValue(mockChart);
+    let currentData: unknown[] | undefined = [1, 2];
+    useChartLifecycle({
+      el: () => mockEl,
+      data: () => currentData,
+      buildChart,
+    });
+
+    mountCb!();
+    vi.advanceTimersByTime(50);
+
+    currentData = [];
+    effectCb!();
+    expect(mockChart.destroy).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(100);
+    // buildChart should not be called again for empty data
+    expect(buildChart).toHaveBeenCalledTimes(1);
+  });
+
+  it("effect handles case when chart is already null", () => {
+    const buildChart = vi.fn().mockReturnValue(null);
+    let currentData: unknown[] | undefined = [1, 2];
+    useChartLifecycle({
+      el: () => mockEl,
+      data: () => currentData,
+      buildChart,
+    });
+
+    mountCb!();
+    vi.advanceTimersByTime(50);
+    // buildChart returned null, so chart is null
+
+    currentData = [3, 4];
+    effectCb!();
+    // Should not throw; just schedules tryCreate
+    vi.advanceTimersByTime(0);
+    expect(buildChart).toHaveBeenCalledTimes(2);
+  });
+
+  it("effect does not schedule tryCreate when data becomes undefined", () => {
+    const buildChart = vi.fn().mockReturnValue(null);
+    let currentData: unknown[] | undefined = [1];
+    useChartLifecycle({
+      el: () => mockEl,
+      data: () => currentData,
+      buildChart,
+    });
+
+    mountCb!();
+    vi.advanceTimersByTime(50);
+
+    currentData = undefined;
+    effectCb!();
+    vi.advanceTimersByTime(100);
+    expect(buildChart).toHaveBeenCalledTimes(1);
+  });
+
+  it("onCleanup disconnects ResizeObserver and destroys chart", () => {
+    const mockChart = { destroy: vi.fn(), setSize: vi.fn() };
+    const buildChart = vi.fn().mockReturnValue(mockChart);
+    setupLifecycle([1, 2], buildChart);
+    mountCb!();
+    vi.advanceTimersByTime(50);
+
+    cleanupCb!();
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    expect(mockChart.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("onCleanup works safely when no chart or observer exists", () => {
+    setupLifecycle([], () => null);
+    // No mount was called effectively (data empty), so ro is null
+    expect(() => cleanupCb!()).not.toThrow();
+  });
+
+  it("onCleanup works when chart was never built", () => {
+    const buildChart = vi.fn().mockReturnValue(null);
+    setupLifecycle([1, 2], buildChart);
+    mountCb!();
+    vi.advanceTimersByTime(50);
+    // chart is null (buildChart returned null)
+
+    cleanupCb!();
+    expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    // No error thrown
   });
 });

--- a/packages/frontend/tests/services/display-name.test.ts
+++ b/packages/frontend/tests/services/display-name.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Track signal states created by our mock
+const signalStates: { value: unknown }[] = [];
+
+vi.mock("solid-js", () => ({
+  createSignal: (init: unknown) => {
+    const state = { value: init };
+    signalStates.push(state);
+    return [() => state.value, (v: unknown) => { state.value = v; }];
+  },
+}));
+
+describe("display-name", () => {
+  let getItemSpy: ReturnType<typeof vi.fn>;
+  let setItemSpy: ReturnType<typeof vi.fn>;
+  let removeItemSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    signalStates.length = 0;
+
+    getItemSpy = vi.fn().mockReturnValue(null);
+    setItemSpy = vi.fn();
+    removeItemSpy = vi.fn();
+
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: getItemSpy,
+        setItem: setItemSpy,
+        removeItem: removeItemSpy,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("initializes signal with empty string when localStorage has no value", async () => {
+    getItemSpy.mockReturnValue(null);
+
+    const { displayName } = await import("../../src/services/display-name.js");
+
+    expect(getItemSpy).toHaveBeenCalledWith("manifest-display-name");
+    expect(displayName()).toBe("");
+  });
+
+  it("initializes signal with stored value from localStorage", async () => {
+    getItemSpy.mockReturnValue("Alice");
+
+    const { displayName } = await import("../../src/services/display-name.js");
+
+    expect(displayName()).toBe("Alice");
+  });
+
+  it("displayName returns current signal value", async () => {
+    getItemSpy.mockReturnValue("Bob");
+
+    const { displayName } = await import("../../src/services/display-name.js");
+
+    expect(displayName()).toBe("Bob");
+  });
+
+  it("setDisplayName stores trimmed value in localStorage when non-empty", async () => {
+    const { setDisplayName } = await import("../../src/services/display-name.js");
+
+    setDisplayName("Charlie");
+
+    expect(setItemSpy).toHaveBeenCalledWith("manifest-display-name", "Charlie");
+    expect(removeItemSpy).not.toHaveBeenCalled();
+  });
+
+  it("setDisplayName trims whitespace before storing", async () => {
+    const { displayName, setDisplayName } = await import("../../src/services/display-name.js");
+
+    setDisplayName("  Dana  ");
+
+    expect(setItemSpy).toHaveBeenCalledWith("manifest-display-name", "Dana");
+    expect(displayName()).toBe("Dana");
+  });
+
+  it("setDisplayName removes from localStorage when value is empty after trim", async () => {
+    const { displayName, setDisplayName } = await import("../../src/services/display-name.js");
+
+    setDisplayName("");
+
+    expect(removeItemSpy).toHaveBeenCalledWith("manifest-display-name");
+    expect(setItemSpy).not.toHaveBeenCalled();
+    expect(displayName()).toBe("");
+  });
+
+  it("setDisplayName removes from localStorage when value is only whitespace", async () => {
+    const { displayName, setDisplayName } = await import("../../src/services/display-name.js");
+
+    setDisplayName("   ");
+
+    expect(removeItemSpy).toHaveBeenCalledWith("manifest-display-name");
+    expect(setItemSpy).not.toHaveBeenCalled();
+    expect(displayName()).toBe("");
+  });
+
+  it("setDisplayName updates signal so displayName reflects new value", async () => {
+    const { displayName, setDisplayName } = await import("../../src/services/display-name.js");
+
+    expect(displayName()).toBe("");
+
+    setDisplayName("Eve");
+    expect(displayName()).toBe("Eve");
+
+    setDisplayName("Frank");
+    expect(displayName()).toBe("Frank");
+  });
+
+  it("setDisplayName clears signal when given empty string after prior value", async () => {
+    getItemSpy.mockReturnValue("Grace");
+
+    const { displayName, setDisplayName } = await import("../../src/services/display-name.js");
+
+    expect(displayName()).toBe("Grace");
+
+    setDisplayName("");
+    expect(displayName()).toBe("");
+    expect(removeItemSpy).toHaveBeenCalledWith("manifest-display-name");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `[Nest]` logger prefix with `[Manifest]` in production logs via `ConsoleLogger({ prefix: 'Manifest' })`
- Add ~200 new unit tests across 9 files with the lowest code coverage
- Coverage improvements:
  - `github.controller.ts`: 0% → 100%
  - `email-provider-config.entity.ts`: 0% → 100%
  - `analytics.ts`: 0% → 100%
  - `set-email-provider.dto.ts`: 0% → 100%
  - `display-name.ts`: 52.94% → 100%
  - `auth.instance.ts`: 63.46% → ~97.5%
  - `chart-utils.ts`: 72.72% → 100%
  - `trace-ingest.service.ts`: 76.64% → ~97%
  - `aggregation.service.ts`: 80.17% → 100%

## Test plan
- [x] All 1628 backend tests pass
- [x] All 848 frontend tests pass
- [x] TypeScript compiles cleanly