### PR TITLE
fix: sync proxy provider config on cloud mode startup

### DIFF
--- a/.changeset/sync-provider-config.md
+++ b/.changeset/sync-provider-config.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix proxy config desync: call injectProviderConfig in cloud mode so models.providers.manifest stays in sync with the plugin API key on gateway restart

--- a/package-lock.json
+++ b/package-lock.json
@@ -13220,7 +13220,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.11.0",
+      "version": "5.14.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/openclaw-plugin/__tests__/local-mode.test.ts
+++ b/packages/openclaw-plugin/__tests__/local-mode.test.ts
@@ -62,7 +62,7 @@ describe("injectProviderConfig", () => {
   it("writes correct provider config to openclaw.json", () => {
     const api = { config: {} };
 
-    injectProviderConfig(api, "127.0.0.1", 2099, "mnfst_test", mockLogger);
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_test", mockLogger);
 
     expect(writeFileSync).toHaveBeenCalled();
     const writtenData = JSON.parse(
@@ -104,7 +104,7 @@ describe("injectProviderConfig", () => {
     );
 
     const api = { config: {} };
-    injectProviderConfig(api, "127.0.0.1", 2099, "mnfst_new", mockLogger);
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_new", mockLogger);
 
     const writtenData = JSON.parse(
       (writeFileSync as jest.Mock).mock.calls[0][1],
@@ -127,7 +127,7 @@ describe("injectProviderConfig", () => {
     );
 
     const api = { config: {} };
-    injectProviderConfig(api, "127.0.0.1", 2099, "mnfst_test", mockLogger);
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_test", mockLogger);
 
     const writtenData = JSON.parse(
       (writeFileSync as jest.Mock).mock.calls[0][1],
@@ -153,7 +153,7 @@ describe("injectProviderConfig", () => {
     );
 
     const api = { config: {} };
-    injectProviderConfig(api, "127.0.0.1", 2099, "mnfst_test", mockLogger);
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_test", mockLogger);
 
     const writtenData = JSON.parse(
       (writeFileSync as jest.Mock).mock.calls[0][1],
@@ -182,7 +182,7 @@ describe("injectProviderConfig", () => {
     );
 
     const api = { config: {} };
-    injectProviderConfig(api, "127.0.0.1", 3000, "mnfst_new", mockLogger);
+    injectProviderConfig(api, "http://127.0.0.1:3000/v1", "mnfst_new", mockLogger);
 
     const writtenData = JSON.parse(
       (writeFileSync as jest.Mock).mock.calls[0][1],
@@ -196,7 +196,7 @@ describe("injectProviderConfig", () => {
   it("sets runtime config on api.config", () => {
     const api = { config: {} };
 
-    injectProviderConfig(api, "127.0.0.1", 2099, "mnfst_test", mockLogger);
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_test", mockLogger);
 
     expect(api.config).toEqual(
       expect.objectContaining({

--- a/packages/openclaw-plugin/__tests__/register.test.ts
+++ b/packages/openclaw-plugin/__tests__/register.test.ts
@@ -145,7 +145,7 @@ describe("register — dev mode", () => {
     plugin.register(api);
 
     expect(injectProviderConfig).toHaveBeenCalledWith(
-      api, "localhost", 38238, "dev-no-auth", api.logger,
+      api, "http://localhost:38238/v1", "dev-no-auth", api.logger,
     );
     expect(injectAuthProfile).toHaveBeenCalledWith("dev-no-auth", api.logger);
   });
@@ -206,7 +206,7 @@ describe("register — dev mode", () => {
     plugin.register(api);
 
     expect(injectProviderConfig).toHaveBeenCalledWith(
-      api, "dev.example.com", 443, "dev-no-auth", api.logger,
+      api, "https://dev.example.com/v1", "dev-no-auth", api.logger,
     );
   });
 

--- a/packages/openclaw-plugin/src/local-mode.ts
+++ b/packages/openclaw-plugin/src/local-mode.ts
@@ -85,15 +85,16 @@ function atomicWriteJson(path: string, data: unknown): void {
 /**
  * Injects the Manifest provider configuration into OpenClaw's config file
  * and runtime config so that `manifest/auto` is recognized as a valid model.
+ *
+ * `baseUrl` must include the `/v1` path (e.g. `http://127.0.0.1:2099/v1`
+ * or `https://app.manifest.build/v1`).
  */
 export function injectProviderConfig(
   api: any,
-  host: string,
-  port: number,
+  baseUrl: string,
   apiKey: string,
   logger: PluginLogger,
 ): void {
-  const baseUrl = `http://${host}:${port}/v1`;
 
   const providerConfig = {
     baseUrl,
@@ -237,7 +238,7 @@ export function registerLocalMode(
   logger.debug("[manifest] Local mode — starting embedded server...");
 
   // Inject provider config BEFORE routing registration
-  injectProviderConfig(api, host, port, apiKey, logger);
+  injectProviderConfig(api, `http://${host}:${port}/v1`, apiKey, logger);
   injectAuthProfile(apiKey, logger);
 
   // Load the embedded server module


### PR DESCRIPTION
## Summary
- **Root cause**: `injectProviderConfig` was only called in dev/local modes, so `models.providers.manifest` (the proxy config block the gateway reads for routing requests) kept stale values after switching to cloud mode or rotating API keys via `openclaw config set`
- Adds `injectProviderConfig` + `injectAuthProfile` to the cloud mode path in the plugin, so the provider config (baseUrl + apiKey) is synced to both the config file and runtime config on every gateway restart
- Refactors `injectProviderConfig` signature from `(api, host, port, key, logger)` to `(api, baseUrl, key, logger)` to support both `http://` and `https://` URLs
- Updates the setup-manifest-plugin skill script to overwrite the full `models.providers.manifest` block (not just the OTLP endpoint)

## Test plan
- [x] Plugin build passes (`npx tsx build.ts`)
- [x] All 198 plugin tests pass (`npm test --workspace=packages/openclaw-plugin`)
- [x] Setup script dry-run verified for 3 scenarios: dev+port, cloud (no port), cloud+port
- [x] Live test: setup script correctly writes both `plugins.entries.manifest.config` and `models.providers.manifest` with matching API keys
- [x] Gateway starts with correct model (`manifest/auto`) and provider registered
- [x] Proxy routes to `app.manifest.build` (verified via gateway logs)