### PR TITLE
fix: resolve actual model name in cloud mode telemetry

### DIFF
--- a/.changeset/resolve-cloud-model.md
+++ b/.changeset/resolve-cloud-model.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix cloud mode telemetry recording model as "auto" instead of the actual model name by removing the cloud mode exclusion from routing resolution in agent_end hook

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -198,7 +198,7 @@ export function registerHooks(
     let routingTier: string | null = null;
     let routingReason: string | null = null;
 
-    if (finalModel === "auto" && config.mode !== "cloud") {
+    if (finalModel === "auto") {
       const resolved = await resolveRouting(config, messages, sessionKey, logger);
       if (resolved) {
         finalModel = resolved.model;


### PR DESCRIPTION
## Summary

- Remove the `config.mode !== "cloud"` guard from the `agent_end` hook's routing resolution, so `resolveRouting()` runs for all modes when the model is `"auto"`
- Fixes cloud mode OTLP telemetry recording model as `"auto"` instead of the actual model name (e.g. `gpt-4o`), which broke dashboard display, cost calculations, and provider attribution
- Updates the corresponding test to assert routing **is** resolved in cloud mode

## Test plan

- [x] Plugin tests pass (198/198)
- [x] Backend unit tests pass (1490/1490)
- [x] Backend e2e tests pass (85/85)
- [x] Frontend tests pass (768/768)
- [x] TypeScript compiles with no errors (backend + frontend)
- [ ] Manual: connect in cloud mode, send a message, verify dashboard shows actual model name instead of "auto"