### PR TITLE
Standardize page meta titles to "Page - Manifest" format

### DIFF
--- a/.changeset/dynamic-meta-titles.md
+++ b/.changeset/dynamic-meta-titles.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Update page meta titles to use "Page - Manifest" format consistently across all pages

--- a/packages/frontend/src/pages/Account.tsx
+++ b/packages/frontend/src/pages/Account.tsx
@@ -47,7 +47,7 @@ const Account: Component = () => {
 
   return (
     <div class="account-modal">
-      <Title>Account Preferences | Manifest</Title>
+      <Title>Account Preferences - Manifest</Title>
       <Meta name="description" content="Manage your profile, workspace, and theme preferences." />
       <div class="account-modal__inner">
         <button class="account-modal__back" onClick={() => navigate(-1)}>

--- a/packages/frontend/src/pages/Help.tsx
+++ b/packages/frontend/src/pages/Help.tsx
@@ -4,7 +4,7 @@ import { Title, Meta } from "@solidjs/meta";
 const Help: Component = () => {
   return (
     <div class="container--sm">
-      <Title>Help & Support | Manifest</Title>
+      <Title>Help & Support - Manifest</Title>
       <Meta name="description" content="Get help with Manifest. Schedule a call or contact support." />
       <div class="page-header">
         <div>

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -98,7 +98,7 @@ const Limits: Component = () => {
 
   return (
     <div class="container--md">
-      <Title>{agentName()} - Limits | Manifest</Title>
+      <Title>{agentName()} Limits - Manifest</Title>
       <Meta name="description" content={`Configure limits and alerts for ${agentName()}.`} />
 
       <div class="page-header">

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -97,7 +97,7 @@ const Login: Component = () => {
 
   return (
     <>
-      <Title>Sign In | Manifest</Title>
+      <Title>Sign In - Manifest</Title>
       <Meta name="description" content="Sign in to Manifest to monitor your AI agents." />
       <Show when={localRedirecting()}>
         <div class="auth-header">

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -65,8 +65,8 @@ const MessageLog: Component = () => {
 
   return (
     <div class="container--full">
-      <Title>{params.agentName} - Messages | Manifest</Title>
-      <Meta name="description" content={`Browse all messages sent and received by ${params.agentName}. Filter by status, model, or cost.`} />
+      <Title>{decodeURIComponent(params.agentName)} Messages - Manifest</Title>
+      <Meta name="description" content={`Browse all messages sent and received by ${decodeURIComponent(params.agentName)}. Filter by status, model, or cost.`} />
       <div class="page-header">
         <div>
           <h1>Messages</h1>

--- a/packages/frontend/src/pages/ModelPrices.tsx
+++ b/packages/frontend/src/pages/ModelPrices.tsx
@@ -140,7 +140,7 @@ const ModelPrices: Component = () => {
 
   return (
     <div class="container--full">
-      <Title>Model Prices | Manifest</Title>
+      <Title>Model Prices - Manifest</Title>
       <Meta name="description" content="Compare per-token pricing across all major LLM providers." />
       <div class="page-header">
         <div>

--- a/packages/frontend/src/pages/NotFound.tsx
+++ b/packages/frontend/src/pages/NotFound.tsx
@@ -5,7 +5,7 @@ import type { Component } from "solid-js";
 const NotFound: Component = () => {
   return (
     <>
-      <Title>404 | Manifest</Title>
+      <Title>Page Not Found - Manifest</Title>
       <div class="not-found">
         <span class="not-found__code">404</span>
         <h1 class="not-found__title">Page not found</h1>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -133,10 +133,10 @@ const Overview: Component = () => {
 
   return (
     <div class="container--md">
-      <Title>{params.agentName} - Overview | Manifest</Title>
+      <Title>{decodeURIComponent(params.agentName)} Overview - Manifest</Title>
       <Meta
         name="description"
-        content={`Monitor ${params.agentName} performance — costs, tokens, and activity.`}
+        content={`Monitor ${decodeURIComponent(params.agentName)} performance — costs, tokens, and activity.`}
       />
       <div class="page-header">
         <div>

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -68,7 +68,7 @@ const Register: Component = () => {
 
   return (
     <>
-      <Title>Sign Up | Manifest</Title>
+      <Title>Sign Up - Manifest</Title>
       <Meta name="description" content="Create a Manifest account to start monitoring your AI agents." />
       <Show when={emailSent()} fallback={
         <>

--- a/packages/frontend/src/pages/ResetPassword.tsx
+++ b/packages/frontend/src/pages/ResetPassword.tsx
@@ -164,7 +164,7 @@ const ResetPassword: Component = () => {
 
   return (
     <>
-      <Title>Reset Password | Manifest</Title>
+      <Title>Reset Password - Manifest</Title>
       <Meta name="description" content="Reset your Manifest account password." />
       <Show when={token()} fallback={<RequestResetForm />}>
         {(t) => <SetNewPasswordForm token={t()} />}

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -136,7 +136,7 @@ const Routing: Component = () => {
 
   return (
     <div class="container--md">
-      <Title>{agentName()} - Routing | Manifest</Title>
+      <Title>{agentName()} Routing - Manifest</Title>
       <Meta name="description" content={`Configure model routing for ${agentName()}.`} />
 
       <div class="page-header routing-page-header">

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -88,7 +88,7 @@ const Settings: Component = () => {
 
   return (
     <div class="container--sm">
-      <Title>{agentName()} - Settings | Manifest</Title>
+      <Title>{agentName()} Settings - Manifest</Title>
       <Meta name="description" content={`Configure settings for ${agentName()}.`} />
       <div class="page-header">
         <div>

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -122,7 +122,7 @@ const Workspace: Component = () => {
 
   return (
     <div class="container--md">
-      <Title>My Agents | Manifest</Title>
+      <Title>My Agents - Manifest</Title>
       <Meta name="description" content="View and manage all your AI agents. Monitor usage, messages, and costs." />
       <div class="page-header">
         <div>


### PR DESCRIPTION
## Summary
This PR standardizes the format of page meta titles across the entire frontend application to follow a consistent "Page Name - Manifest" pattern, replacing the previous mixed formats that used pipes (|) and inconsistent ordering.

## Key Changes
- **Title format standardization**: Updated all page `<Title>` components to use the consistent format of "Page Name - Manifest" instead of "Page Name | Manifest" or "Page Name - Section | Manifest"
- **Specific page updates**:
  - MessageLog: Changed from "{agentName} - Messages | Manifest" to "{agentName} Messages - Manifest"
  - Overview: Changed from "{agentName} - Overview | Manifest" to "{agentName} Overview - Manifest"
  - Account: Changed from "Account Preferences | Manifest" to "Account Preferences - Manifest"
  - Help: Changed from "Help & Support | Manifest" to "Help & Support - Manifest"
  - Limits: Changed from "{agentName} - Limits | Manifest" to "{agentName} Limits - Manifest"
  - Login: Changed from "Sign In | Manifest" to "Sign In - Manifest"
  - ModelPrices: Changed from "Model Prices | Manifest" to "Model Prices - Manifest"
  - NotFound: Changed from "404 | Manifest" to "Page Not Found - Manifest"
  - Register: Changed from "Sign Up | Manifest" to "Sign Up - Manifest"
  - ResetPassword: Changed from "Reset Password | Manifest" to "Reset Password - Manifest"
  - Routing: Changed from "{agentName} - Routing | Manifest" to "{agentName} Routing - Manifest"
  - Settings: Changed from "{agentName} - Settings | Manifest" to "{agentName} Settings - Manifest"
  - Workspace: Changed from "My Agents | Manifest" to "My Agents - Manifest"
- **URL decoding**: Added `decodeURIComponent()` calls in MessageLog and Overview pages to properly handle encoded agent names in page titles and meta descriptions

## Notable Implementation Details
- The change improves SEO consistency and provides a cleaner, more professional appearance in browser tabs and search results
- URL-encoded agent names are now properly decoded for display in titles and descriptions
- All meta descriptions remain unchanged, maintaining their informative content

https://claude.ai/code/session_01DC6eAP1ghkNG5KtiPL5byt