### PR TITLE
Show date alongside time in message timestamps

### DIFF
--- a/.changeset/add-message-dates.md
+++ b/.changeset/add-message-dates.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Show date alongside time in message log and overview tables

--- a/package-lock.json
+++ b/package-lock.json
@@ -13220,7 +13220,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.14.0",
+      "version": "5.15.3",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -173,7 +173,7 @@ const MessageLog: Component = () => {
                 <table class="data-table">
                   <thead>
                     <tr>
-                      <th>Time</th>
+                      <th>Date</th>
                       <th>Message</th>
                       <th>Cost</th>
                       <th>Total Tokens</th>
@@ -205,7 +205,7 @@ const MessageLog: Component = () => {
             <table class="data-table">
               <thead>
                 <tr>
-                  <th>Time</th>
+                  <th>Date</th>
                   <th>Message</th>
                   <th>Cost</th>
                   <th>Total Tokens<InfoTooltip text="Tokens are units of text that AI models process. More tokens = higher cost." /></th>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -306,7 +306,7 @@ const Overview: Component = () => {
                 <table class="data-table">
                   <thead>
                     <tr>
-                      <th>Time</th>
+                      <th>Date</th>
                       <th>Message</th>
                       <th>Cost</th>
                       <th>Model</th>
@@ -468,7 +468,7 @@ const Overview: Component = () => {
                   <table class="data-table">
                     <thead>
                       <tr>
-                        <th>Time</th>
+                        <th>Date</th>
                         <th>Message</th>
                         <th>Cost</th>
                         <th>Model</th>

--- a/packages/frontend/src/services/formatters.ts
+++ b/packages/frontend/src/services/formatters.ts
@@ -27,17 +27,22 @@ export function formatTrend(pct: number): string {
 }
 
 /**
- * Format a timestamp to a short time string (e.g., 09:22:41).
+ * Format a timestamp to a date + time string (e.g., Feb 27, 09:22:41).
  */
 export function formatTime(ts: string): string {
   const normalized = ts.replace(" ", "T");
   const d = new Date(normalized.endsWith("Z") ? normalized : normalized + "Z");
-  return d.toLocaleTimeString("en-US", {
+  const date = d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+  const time = d.toLocaleTimeString("en-US", {
     hour12: false,
     hour: "2-digit",
     minute: "2-digit",
     second: "2-digit",
   });
+  return `${date}, ${time}`;
 }
 
 /**

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -114,7 +114,7 @@ describe("MessageLog", () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Time");
+      expect(container.textContent).toContain("Date");
       expect(container.textContent).toContain("Cost");
       expect(container.textContent).toContain("Total Tokens");
       expect(container.textContent).toContain("Model");

--- a/packages/frontend/tests/services/formatters.test.ts
+++ b/packages/frontend/tests/services/formatters.test.ts
@@ -68,22 +68,22 @@ describe("formatMetricType", () => {
 });
 
 describe("formatTime", () => {
-  it("formats a UTC timestamp", () => {
+  it("formats a UTC timestamp with date and time", () => {
     const result = formatTime("2024-01-15T09:22:41Z");
-    expect(result).toMatch(/\d{2}:\d{2}:\d{2}/);
+    expect(result).toMatch(/\w+ \d+, \d{2}:\d{2}:\d{2}/);
   });
   it("handles space-separated timestamp", () => {
     const result = formatTime("2024-01-15 09:22:41");
-    expect(result).toMatch(/\d{2}:\d{2}:\d{2}/);
+    expect(result).toMatch(/\w+ \d+, \d{2}:\d{2}:\d{2}/);
   });
 });
 
 describe("formatRelativeTime", () => {
-  it("returns time string for today", () => {
+  it("returns date+time string for today", () => {
     const now = new Date();
     const ts = now.toISOString();
     const result = formatRelativeTime(ts);
-    expect(result).toMatch(/\d{2}:\d{2}:\d{2}/);
+    expect(result).toMatch(/\w+ \d+, \d{2}:\d{2}:\d{2}/);
   });
   it("returns Yesterday for yesterday", () => {
     const yesterday = new Date(Date.now() - 86_400_000 - 1000);


### PR DESCRIPTION
## Summary
Updated the timestamp formatting across the application to display both date and time (e.g., "Feb 27, 09:22:41") instead of just the time component. This improves clarity when reviewing message logs and overview tables, especially for messages spanning multiple days.

## Key Changes
- **formatTime() function**: Modified to return a combined date and time string using `toLocaleDateString()` and `toLocaleTimeString()`, formatted as "MMM D, HH:MM:SS"
- **Table headers**: Updated column headers from "Time" to "Date" in MessageLog and Overview pages to reflect the new format
- **Test updates**: Updated regex patterns and test descriptions to match the new date+time format (e.g., `/\w+ \d+, \d{2}:\d{2}:\d{2}/`)
- **Documentation**: Added changeset entry documenting this as a patch-level change

## Implementation Details
- The date portion uses short month format (e.g., "Feb") with numeric day
- Time remains in 24-hour format with 2-digit hours, minutes, and seconds
- Timestamp normalization logic preserved to handle both ISO 8601 and space-separated formats
- All affected test cases updated to validate the new format

https://claude.ai/code/session_01GeEbsAhwfYoPeHWSp1qKmS