### PR TITLE
Fix absurd trend percentages and chart rendering with zero values

### DIFF
--- a/.changeset/fix-chart-zero-values.md
+++ b/.changeset/fix-chart-zero-values.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix absurd trend percentages (e.g. -34497259%) when overview metrics are zero or near-zero. Backend computeTrend() now uses epsilon comparison and clamps output to ±999%. Frontend trendBadge() suppresses badges when the metric value itself is effectively zero. Chart Y-axes no longer collapse when all data points are zero.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13220,7 +13220,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.15.3",
+      "version": "5.15.4",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -19,6 +19,29 @@ describe('computeTrend', () => {
     expect(computeTrend(0, 0)).toBe(0);
   });
 
+  it('returns zero when previous is near-zero (floating-point edge case)', () => {
+    expect(computeTrend(0, 1e-9)).toBe(0);
+    expect(computeTrend(0.001, 1e-9)).toBe(0);
+    expect(computeTrend(1e-9, 1e-9)).toBe(0);
+  });
+
+  it('returns zero when both values are near-zero', () => {
+    expect(computeTrend(1e-8, 1e-7)).toBe(0);
+    expect(computeTrend(0, 0.0000001)).toBe(0);
+  });
+
+  it('clamps extreme positive trends to 999', () => {
+    // current=10000, previous=1 => 999900% => clamped to 999
+    expect(computeTrend(10000, 1)).toBe(999);
+  });
+
+  it('clamps extreme negative trends to -999', () => {
+    // Extreme negative shouldn't go below -999
+    // This case is harder to hit naturally since max drop is -100%,
+    // but testing the clamp boundary
+    expect(computeTrend(0, 100)).toBe(-100);
+  });
+
   it('rounds the result', () => {
     // (200 - 300) / 300 * 100 = -33.333...
     expect(computeTrend(200, 300)).toBe(-33);

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -12,8 +12,18 @@ export function formatTimestamp(d: Date): string {
   return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`;
 }
 
+/**
+ * Compute the percentage change between two values.
+ * Returns 0 when values are too small for a meaningful comparison,
+ * and clamps the result to ±999 to avoid absurd display values
+ * caused by near-zero floating-point denominators.
+ */
 export function computeTrend(current: number, previous: number): number {
-  return previous === 0 ? 0 : Math.round(((current - previous) / previous) * 100);
+  const EPS = 1e-6;
+  if (Math.abs(previous) < EPS) return 0;
+  if (Math.abs(current) < EPS && Math.abs(previous) < EPS) return 0;
+  const pct = Math.round(((current - previous) / previous) * 100);
+  return Math.max(-999, Math.min(999, pct));
 }
 
 export function downsample(data: number[], targetLen: number): number[] {

--- a/packages/frontend/src/components/CostChart.tsx
+++ b/packages/frontend/src/components/CostChart.tsx
@@ -42,7 +42,7 @@ const CostChart: Component<CostChartProps> = (props) => {
         height: 260,
         padding: [16, 16, 0, 0],
         cursor: createCursorSnap(bgColor, c1),
-        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max * 1.15] } },
+        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max > 0 ? max * 1.15 : 1] } },
         axes,
         series: [
           {},

--- a/packages/frontend/src/components/SingleTokenChart.tsx
+++ b/packages/frontend/src/components/SingleTokenChart.tsx
@@ -37,7 +37,7 @@ const SingleTokenChart: Component<SingleTokenChartProps> = (props) => {
         height: 260,
         padding: [16, 16, 0, 0],
         cursor: createCursorSnap(bgColor, color),
-        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max * 1.1] } },
+        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max > 0 ? max * 1.1 : 10] } },
         axes: createBaseAxes(axisColor, gridColor, props.range),
         series: [
           {},

--- a/packages/frontend/src/components/TokenChart.tsx
+++ b/packages/frontend/src/components/TokenChart.tsx
@@ -37,7 +37,7 @@ const TokenChart: Component<TokenChartProps> = (props) => {
         height: 260,
         padding: [16, 16, 0, 0],
         cursor: createCursorSnap(bgColor, inputColor),
-        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max * 1.1] } },
+        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max > 0 ? max * 1.1 : 100] } },
         axes: createBaseAxes(axisColor, gridColor, props.range),
         series: [
           {},

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -112,14 +112,19 @@ const Overview: Component = () => {
     }
   })
 
-  const trendBadge = (pct: number) => {
-    if (pct === 0) return null;
-    const cls = pct > 0 ? 'trend trend--up' : 'trend trend--down'
-    const sign = pct > 0 ? '+' : ''
+  const trendBadge = (pct: number, value?: number) => {
+    if (pct === 0) return null
+    // Don't show trend when the metric value itself is effectively zero
+    if (value !== undefined && Math.abs(value) < 0.005) return null
+    // Clamp absurd percentages (safety net for floating-point edge cases)
+    const clamped = Math.max(-999, Math.min(999, Math.round(pct)))
+    if (clamped === 0) return null
+    const cls = clamped > 0 ? 'trend trend--up' : 'trend trend--down'
+    const sign = clamped > 0 ? '+' : ''
     return (
       <span class={cls}>
         {sign}
-        {pct}%
+        {clamped}%
       </span>
     )
   }
@@ -369,7 +374,7 @@ const Overview: Component = () => {
                         <span class="chart-card__value">
                           {formatCost(d().summary?.cost_today?.value ?? 0)}
                         </span>
-                        {trendBadge(d().summary?.cost_today?.trend_pct ?? 0)}
+                        {trendBadge(d().summary?.cost_today?.trend_pct ?? 0, d().summary?.cost_today?.value ?? 0)}
                       </div>
                     </div>
                     <div
@@ -387,7 +392,7 @@ const Overview: Component = () => {
                         <span class="chart-card__value">
                           {formatNumber(d().summary?.tokens_today?.value ?? 0)}
                         </span>
-                        {trendBadge(d().summary?.tokens_today?.trend_pct ?? 0)}
+                        {trendBadge(d().summary?.tokens_today?.trend_pct ?? 0, d().summary?.tokens_today?.value ?? 0)}
                       </div>
                     </div>
                     <div
@@ -402,7 +407,7 @@ const Overview: Component = () => {
                         <span class="chart-card__value">
                           {d().summary?.messages?.value ?? 0}
                         </span>
-                        {trendBadge(d().summary?.messages?.trend_pct ?? 0)}
+                        {trendBadge(d().summary?.messages?.trend_pct ?? 0, d().summary?.messages?.value ?? 0)}
                       </div>
                     </div>
                   </div>

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -133,6 +133,41 @@ describe("Overview", () => {
     });
   });
 
+  it("hides trend badges when metric values are zero", async () => {
+    const zeroData = {
+      ...overviewData,
+      summary: {
+        ...overviewData.summary,
+        cost_today: { value: 0, trend_pct: -34497259 },
+        tokens_today: { value: 0, trend_pct: 500, sub_values: { input: 0, output: 0 } },
+        messages: { value: 0, trend_pct: -100 },
+      },
+    };
+    mockGetOverview.mockResolvedValue(zeroData);
+    const { container } = render(() => <Overview />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("$0.00");
+      const trends = container.querySelectorAll(".trend");
+      expect(trends.length).toBe(0);
+    });
+  });
+
+  it("clamps absurdly large trend percentages", async () => {
+    const absurdData = {
+      ...overviewData,
+      summary: {
+        ...overviewData.summary,
+        cost_today: { value: 5.0, trend_pct: 5000000 },
+      },
+    };
+    mockGetOverview.mockResolvedValue(absurdData);
+    const { container } = render(() => <Overview />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("+999%");
+      expect(container.textContent).not.toContain("5000000%");
+    });
+  });
+
   it("shows recent messages table", async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);


### PR DESCRIPTION
## Summary
This PR fixes issues with trend percentage calculations and chart rendering when metrics have zero or near-zero values. The changes prevent display of nonsensical percentages (e.g., -34497259%) and ensure charts render properly even when all data points are zero.

## Key Changes

- **Backend trend calculation (`computeTrend`)**: 
  - Added epsilon-based comparison (1e-6) to handle floating-point edge cases where values are effectively zero
  - Implemented clamping to ±999% to prevent absurd percentages from being displayed
  - Added comprehensive documentation and test coverage for edge cases

- **Frontend trend badge display (`trendBadge`)**:
  - Added value parameter to suppress trend badges when the metric value itself is effectively zero (< 0.005)
  - Implemented client-side clamping as a safety net for floating-point edge cases
  - Updated all metric calls (cost, tokens, messages) to pass the metric value to `trendBadge`

- **Chart Y-axis scaling**:
  - Fixed `CostChart`, `SingleTokenChart`, and `TokenChart` to use a minimum Y-axis range when all data points are zero
  - Prevents chart collapse and ensures consistent rendering across all zero-value scenarios

- **Test coverage**:
  - Added tests for zero metric values with trend badges hidden
  - Added tests for absurdly large trend percentages being clamped
  - Added backend tests for floating-point edge cases and clamping behavior

## Implementation Details

The fix uses a two-layer approach:
1. **Backend**: Handles the mathematical edge case at the source with epsilon comparison and clamping
2. **Frontend**: Adds semantic logic to hide trends when the underlying metric is zero, plus defensive clamping

This prevents both the root cause (near-zero denominators in percentage calculations) and the symptom (displaying nonsensical percentages), while maintaining a good user experience with sensible fallback values for charts.

https://claude.ai/code/session_01D7woheABCUuQSiw6qzPyE4