### PR TITLE
Fix tier label alignment in message tables

### DIFF
--- a/.changeset/fix-tier-label-alignment.md
+++ b/.changeset/fix-tier-label-alignment.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix tier label alignment in message tables to display inline with model name

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -250,8 +250,8 @@ const MessageLog: Component = () => {
                             <span title={inferProviderName(item.model)} style="display: inline-flex; flex-shrink: 0;">{providerIcon(inferProviderFromModel(item.model)!, 14)}</span>
                           )}
                           {item.model ?? "\u2014"}
+                          {item.routing_tier && <span class={`tier-badge tier-badge--${item.routing_tier}`}>{item.routing_tier}</span>}
                         </span>
-                        {item.routing_tier && <span class={`tier-badge tier-badge--${item.routing_tier}`}>{item.routing_tier}</span>}
                       </td>
                       <td>
                         <span class={`status-badge status-badge--${item.status}`}>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -504,8 +504,8 @@ const Overview: Component = () => {
                                   <span title={inferProviderName(item.model)} style="display: inline-flex; flex-shrink: 0;">{providerIcon(inferProviderFromModel(item.model)!, 14)}</span>
                                 )}
                                 {item.model ?? '\u2014'}
+                                {item.routing_tier && <span class={`tier-badge tier-badge--${item.routing_tier}`}>{item.routing_tier}</span>}
                               </span>
-                              {item.routing_tier && <span class={`tier-badge tier-badge--${item.routing_tier}`}>{item.routing_tier}</span>}
                             </td>
                             <td style="font-family: var(--font-mono);">
                               {item.total_tokens != null

--- a/packages/frontend/src/styles/data.css
+++ b/packages/frontend/src/styles/data.css
@@ -98,7 +98,6 @@
   padding: 1px 6px;
   border-radius: var(--radius-sm);
   font-weight: 500;
-  margin-left: 6px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }


### PR DESCRIPTION
## Summary
Fixed the alignment of tier labels in message tables by moving them inline with the model name instead of displaying them on a separate line.

## Key Changes
- Moved tier badge elements inside the parent `<span>` that contains the model name and provider icon in both `MessageLog.tsx` and `Overview.tsx`
- Removed the `margin-left: 6px;` CSS rule from `.tier-badge` class since the badge is now inline with other content
- The tier badge now displays as part of the same text flow as the model name rather than as a separate block element

## Implementation Details
The tier badge was previously positioned outside the span containing the model name, causing it to wrap to a new line. By moving it inside the span (after the model name text), it now displays inline with proper spacing inherited from the parent container's layout. The left margin was removed from the CSS since the inline positioning handles spacing naturally through the flex layout of the parent span.

https://claude.ai/code/session_01MRG21W4ysnUJnd1xgU1aJX