### PR TITLE
Fix routing CTA banner flicker on Limits page

### DIFF
--- a/.changeset/fix-limits-cta-flicker.md
+++ b/.changeset/fix-limits-cta-flicker.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix routing CTA banner flicker on Limits page by waiting for routing status to load before rendering

--- a/package-lock.json
+++ b/package-lock.json
@@ -13220,7 +13220,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.15.3",
+      "version": "5.15.4",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -121,7 +121,7 @@ const Limits: Component = () => {
         </div>
       </Show>
 
-      <Show when={!routingEnabled() && !isLocalMode()}>
+      <Show when={routingStatus() && !routingEnabled() && !isLocalMode()}>
         <div class="limits-routing-cta">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="10" /><line x1="12" y1="16" x2="12" y2="12" /><line x1="12" y1="8" x2="12.01" y2="8" />

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -125,12 +125,15 @@ describe("Limits page", () => {
     });
   });
 
-  it("shows routing CTA banner when routing disabled in cloud mode", () => {
+  it("shows routing CTA banner when routing disabled in cloud mode", async () => {
     mockRoutingStatus = { enabled: false };
     mockIsLocalMode = false;
 
     const { container } = render(() => <Limits />);
-    expect(container.textContent).toContain("Enable routing to set hard limits");
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Enable routing to set hard limits");
+    });
   });
 
   it("hides routing CTA banner when routing enabled", async () => {


### PR DESCRIPTION
## Summary
Fixed a visual flicker issue on the Limits page where the routing CTA banner would briefly appear before the routing status had finished loading.

## Changes
- **Limits.tsx**: Added a check for `routingStatus()` in the `Show` condition to ensure the routing status has loaded before rendering the CTA banner. This prevents the banner from appearing prematurely when `routingEnabled()` is still in an indeterminate state.
- **Limits.test.tsx**: Updated the test to use `async/await` and `vi.waitFor()` to properly wait for the routing status to load before asserting on the banner text, making the test more reliable and aligned with the actual component behavior.
- **Changeset**: Added a patch-level changeset documenting the fix.

## Implementation Details
The root cause was that the banner would render as soon as `!routingEnabled()` evaluated to true, even before the routing status had been fetched. By adding the `routingStatus()` check, we ensure the component waits for the status to be available before showing the banner, eliminating the flicker effect.

https://claude.ai/code/session_01Bj5vPQAVnQKVSaQMKg5kWT