### PR TITLE
fix(plugin): align OpenClaw plugin API with official docs

### DIFF
--- a/.changeset/plugin-api-compliance.md
+++ b/.changeset/plugin-api-compliance.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Align OpenClaw plugin API with official docs: migrate hooks to registerHook with metadata, rename tool handler to execute with content return format, add optional flag to tools, change provider name to label, add /manifest slash command, and update plugin manifest metadata.

--- a/packages/openclaw-plugin/__tests__/command.test.ts
+++ b/packages/openclaw-plugin/__tests__/command.test.ts
@@ -1,0 +1,138 @@
+import { registerCommand } from "../src/command";
+import { verifyConnection } from "../src/verify";
+import { ManifestConfig } from "../src/config";
+
+jest.mock("../src/verify", () => ({
+  verifyConnection: jest.fn(),
+}));
+const mockVerify = verifyConnection as jest.MockedFunction<typeof verifyConnection>;
+
+const mockLogger = {
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+};
+
+const config: ManifestConfig = {
+  mode: "dev",
+  apiKey: "",
+  endpoint: "http://localhost:38238/otlp",
+  port: 2099,
+  host: "127.0.0.1",
+};
+
+describe("registerCommand", () => {
+  it("registers /manifest command when registerCommand is available", () => {
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    expect(api.registerCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "manifest",
+        description: expect.any(String),
+        execute: expect.any(Function),
+      }),
+    );
+  });
+
+  it("skips gracefully when registerCommand is not available", () => {
+    const api = {};
+    registerCommand(api, config, mockLogger);
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("not available"),
+    );
+  });
+
+  it("returns status text on successful verify", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: true,
+      authValid: true,
+      agentName: "test-agent",
+      error: null,
+    });
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result).toContain("Mode: dev");
+    expect(result).toContain("Endpoint reachable: yes");
+    expect(result).toContain("Auth valid: yes");
+    expect(result).toContain("Agent: test-agent");
+    expect(result).not.toContain("Error:");
+  });
+
+  it("includes error in status text when verify reports one", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: false,
+      authValid: false,
+      agentName: null,
+      error: "Cannot reach endpoint: ECONNREFUSED",
+    });
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result).toContain("Endpoint reachable: no");
+    expect(result).toContain("Error: Cannot reach endpoint: ECONNREFUSED");
+  });
+
+  it("returns error message when verify throws", async () => {
+    mockVerify.mockRejectedValueOnce(new Error("network down"));
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result).toContain("Manifest status check failed: network down");
+  });
+
+  it("returns stringified error when verify throws a non-Error value", async () => {
+    mockVerify.mockRejectedValueOnce("string-error");
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result).toContain("Manifest status check failed: string-error");
+  });
+
+  it("omits agent line when agentName is null", async () => {
+    mockVerify.mockResolvedValueOnce({
+      endpointReachable: true,
+      authValid: true,
+      agentName: null,
+      error: null,
+    });
+
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    const cmd = api.registerCommand.mock.calls[0][0];
+    const result = await cmd.execute();
+
+    expect(result).toContain("Mode: dev");
+    expect(result).toContain("Endpoint reachable: yes");
+    expect(result).not.toContain("Agent:");
+  });
+
+  it("logs debug message after registering the command", () => {
+    const api = { registerCommand: jest.fn() };
+    registerCommand(api, config, mockLogger);
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      "[manifest] Registered /manifest command",
+    );
+  });
+});

--- a/packages/openclaw-plugin/__tests__/register.test.ts
+++ b/packages/openclaw-plugin/__tests__/register.test.ts
@@ -24,6 +24,9 @@ jest.mock("../src/local-mode", () => ({
 jest.mock("../src/routing", () => ({
   registerRouting: jest.fn(),
 }));
+jest.mock("../src/command", () => ({
+  registerCommand: jest.fn(),
+}));
 jest.mock("../src/product-telemetry", () => ({
   trackPluginEvent: jest.fn(),
 }));
@@ -34,6 +37,7 @@ import { initTelemetry, shutdownTelemetry } from "../src/telemetry";
 import { registerHooks, initMetrics } from "../src/hooks";
 import { registerRouting } from "../src/routing";
 import { registerTools } from "../src/tools";
+import { registerCommand } from "../src/command";
 import { verifyConnection } from "../src/verify";
 import { trackPluginEvent } from "../src/product-telemetry";
 
@@ -290,6 +294,356 @@ describe("register — dev mode", () => {
     expect(api.logger.error).toHaveBeenCalledWith(
       expect.stringContaining("Invalid endpoint URL"),
     );
+  });
+});
+
+describe("register — cloud mode full path", () => {
+  const cloudConfig = {
+    mode: "cloud" as const,
+    apiKey: "mnfst_abc",
+    endpoint: "https://app.manifest.build/otlp",
+    port: 2099,
+    host: "127.0.0.1",
+  };
+
+  it("initializes telemetry, hooks, routing, tools, and command in cloud mode", () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(initTelemetry).toHaveBeenCalledWith(cloudConfig, api.logger);
+    expect(initMetrics).toHaveBeenCalled();
+    expect(registerHooks).toHaveBeenCalledWith(api, expect.anything(), cloudConfig, api.logger);
+    expect(registerRouting).toHaveBeenCalledWith(api, cloudConfig, api.logger);
+    expect(registerTools).toHaveBeenCalledWith(api, cloudConfig, api.logger);
+    expect(registerCommand).toHaveBeenCalledWith(api, cloudConfig, api.logger);
+  });
+
+  it("calls injectProviderConfig and injectAuthProfile in cloud mode", () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(injectProviderConfig).toHaveBeenCalledWith(
+      api, "https://app.manifest.build/v1", "mnfst_abc", api.logger,
+    );
+    expect(injectAuthProfile).toHaveBeenCalledWith("mnfst_abc", api.logger);
+  });
+
+  it("registers manifest-telemetry service in cloud mode", () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(api.registerService).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "manifest-telemetry" }),
+    );
+  });
+
+  it("cloud service start invokes verifyConnection and logs success", async () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+    (verifyConnection as jest.Mock).mockResolvedValue({
+      error: null,
+      agentName: "cloud-agent",
+    });
+
+    const api = makeApi();
+    plugin.register(api);
+
+    const serviceCall = api.registerService.mock.calls[0][0];
+    serviceCall.start();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(verifyConnection).toHaveBeenCalledWith(cloudConfig);
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("Connection verified"),
+    );
+  });
+
+  it("cloud service start logs warning on verify error", async () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+    (verifyConnection as jest.Mock).mockResolvedValue({
+      error: "Cannot reach endpoint",
+      agentName: null,
+    });
+
+    const api = makeApi();
+    plugin.register(api);
+
+    const serviceCall = api.registerService.mock.calls[0][0];
+    serviceCall.start();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Connection check failed"),
+    );
+  });
+
+  it("cloud service start handles verify rejection silently", async () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+    (verifyConnection as jest.Mock).mockRejectedValue(new Error("boom"));
+
+    const api = makeApi();
+    plugin.register(api);
+
+    const serviceCall = api.registerService.mock.calls[0][0];
+    serviceCall.start();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Should not throw
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("Observability pipeline active"),
+    );
+  });
+
+  it("cloud service stop shuts down telemetry", async () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    const serviceCall = api.registerService.mock.calls[0][0];
+    await serviceCall.stop();
+
+    expect(shutdownTelemetry).toHaveBeenCalledWith(api.logger);
+  });
+
+  it("skips registerTools when registerTool is not a function", () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    delete (api as any).registerTool;
+    plugin.register(api);
+
+    expect(registerTools).not.toHaveBeenCalled();
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("Agent tools not available"),
+    );
+  });
+});
+
+describe("register — fallback logger", () => {
+  it("uses console-based logger when api.logger is not provided", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      mode: "local",
+      apiKey: "",
+      endpoint: "",
+      port: 2099,
+      host: "127.0.0.1",
+    });
+
+    const api = {
+      pluginConfig: {},
+      config: { plugins: { entries: {} } },
+      registerService: jest.fn(),
+      registerTool: jest.fn(),
+    };
+    // No logger property
+
+    plugin.register(api);
+
+    // Should not throw and registerLocalMode should be called
+    expect(registerLocalMode).toHaveBeenCalled();
+  });
+
+  it("fallback logger.info delegates to console.log", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      mode: "local",
+      apiKey: "",
+      endpoint: "",
+      port: 2099,
+      host: "127.0.0.1",
+    });
+
+    let capturedLogger: any;
+    (registerLocalMode as jest.Mock).mockImplementation((_api, _config, logger) => {
+      capturedLogger = logger;
+    });
+
+    const api = {
+      pluginConfig: {},
+      config: { plugins: { entries: {} } },
+      registerService: jest.fn(),
+      registerTool: jest.fn(),
+    };
+
+    plugin.register(api);
+
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    capturedLogger.info("test info");
+    expect(consoleSpy).toHaveBeenCalledWith("test info");
+    consoleSpy.mockRestore();
+  });
+
+  it("fallback logger.error delegates to console.error", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      mode: "local",
+      apiKey: "",
+      endpoint: "",
+      port: 2099,
+      host: "127.0.0.1",
+    });
+
+    let capturedLogger: any;
+    (registerLocalMode as jest.Mock).mockImplementation((_api, _config, logger) => {
+      capturedLogger = logger;
+    });
+
+    const api = {
+      pluginConfig: {},
+      config: { plugins: { entries: {} } },
+      registerService: jest.fn(),
+      registerTool: jest.fn(),
+    };
+
+    plugin.register(api);
+
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    capturedLogger.error("test error");
+    expect(consoleSpy).toHaveBeenCalledWith("test error");
+    consoleSpy.mockRestore();
+  });
+
+  it("fallback logger.warn delegates to console.warn", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      mode: "local",
+      apiKey: "",
+      endpoint: "",
+      port: 2099,
+      host: "127.0.0.1",
+    });
+
+    let capturedLogger: any;
+    (registerLocalMode as jest.Mock).mockImplementation((_api, _config, logger) => {
+      capturedLogger = logger;
+    });
+
+    const api = {
+      pluginConfig: {},
+      config: { plugins: { entries: {} } },
+      registerService: jest.fn(),
+      registerTool: jest.fn(),
+    };
+
+    plugin.register(api);
+
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    capturedLogger.warn("test warn");
+    expect(consoleSpy).toHaveBeenCalledWith("test warn");
+    consoleSpy.mockRestore();
+  });
+
+  it("fallback logger.debug is a no-op", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      mode: "local",
+      apiKey: "",
+      endpoint: "",
+      port: 2099,
+      host: "127.0.0.1",
+    });
+
+    let capturedLogger: any;
+    (registerLocalMode as jest.Mock).mockImplementation((_api, _config, logger) => {
+      capturedLogger = logger;
+    });
+
+    const api = {
+      pluginConfig: {},
+      config: { plugins: { entries: {} } },
+      registerService: jest.fn(),
+      registerTool: jest.fn(),
+    };
+
+    plugin.register(api);
+
+    // Should not throw
+    capturedLogger.debug("test debug");
+  });
+});
+
+describe("register — diagnostics-otel conflict", () => {
+  it("aborts registration when diagnostics-otel is enabled", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      mode: "cloud",
+      apiKey: "mnfst_abc",
+      endpoint: "https://app.manifest.build/otlp",
+      port: 2099,
+      host: "127.0.0.1",
+    });
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = {
+      pluginConfig: {},
+      config: {
+        plugins: {
+          entries: {
+            "diagnostics-otel": { enabled: true },
+          },
+        },
+      },
+      logger: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+      },
+      registerService: jest.fn(),
+      registerTool: jest.fn(),
+    };
+
+    plugin.register(api);
+
+    expect(api.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("diagnostics-otel"),
+    );
+    expect(initTelemetry).not.toHaveBeenCalled();
+  });
+});
+
+describe("register — registerCommand wiring", () => {
+  it("calls registerCommand in dev mode", () => {
+    const devConfig = {
+      mode: "dev" as const,
+      apiKey: "",
+      endpoint: "http://localhost:38238/otlp",
+      port: 2099,
+      host: "127.0.0.1",
+    };
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(registerCommand).toHaveBeenCalledWith(api, devConfig, api.logger);
+  });
+
+  it("calls registerCommand in cloud mode", () => {
+    const cloudConfig = {
+      mode: "cloud" as const,
+      apiKey: "mnfst_abc",
+      endpoint: "https://app.manifest.build/otlp",
+      port: 2099,
+      host: "127.0.0.1",
+    };
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(registerCommand).toHaveBeenCalledWith(api, cloudConfig, api.logger);
   });
 });
 

--- a/packages/openclaw-plugin/__tests__/routing.test.ts
+++ b/packages/openclaw-plugin/__tests__/routing.test.ts
@@ -240,6 +240,7 @@ describe("registerRouting", () => {
     expect(api.registerProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "manifest",
+        label: "Manifest Router",
         models: ["auto"],
       }),
     );

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "manifest",
+  "kind": "observability",
   "name": "Manifest — Agent Observability",
-  "version": "5.0.0",
   "description": "Traces, metrics, and cost tracking for your OpenClaw agent. Zero-config local dashboard included.",
   "author": "MNFST Inc.",
   "homepage": "https://manifest.build",

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -45,6 +45,8 @@
   "keywords": [
     "openclaw",
     "openclaw-plugin",
+    "openclaw-extension",
+    "openclaw-observability",
     "clawdbot",
     "moltbot",
     "manifest",

--- a/packages/openclaw-plugin/src/command.ts
+++ b/packages/openclaw-plugin/src/command.ts
@@ -1,0 +1,42 @@
+import { ManifestConfig } from "./config";
+import { PluginLogger } from "./telemetry";
+import { verifyConnection } from "./verify";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function registerCommand(
+  api: any,
+  config: ManifestConfig,
+  logger: PluginLogger,
+): void {
+  if (typeof api.registerCommand !== "function") {
+    logger.debug("[manifest] registerCommand not available, skipping /manifest command");
+    return;
+  }
+
+  api.registerCommand({
+    name: "manifest",
+    description: "Show Manifest plugin status and connection info",
+    async execute() {
+      try {
+        const check = await verifyConnection(config);
+        const lines = [
+          `Mode: ${config.mode}`,
+          `Endpoint reachable: ${check.endpointReachable ? "yes" : "no"}`,
+          `Auth valid: ${check.authValid ? "yes" : "no"}`,
+        ];
+        if (check.agentName) {
+          lines.push(`Agent: ${check.agentName}`);
+        }
+        if (check.error) {
+          lines.push(`Error: ${check.error}`);
+        }
+        return lines.join("\n");
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return `Manifest status check failed: ${msg}`;
+      }
+    },
+  });
+
+  logger.debug("[manifest] Registered /manifest command");
+}

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -3,6 +3,7 @@ import { initTelemetry, shutdownTelemetry, PluginLogger } from "./telemetry";
 import { registerHooks, initMetrics } from "./hooks";
 import { registerRouting } from "./routing";
 import { registerTools } from "./tools";
+import { registerCommand } from "./command";
 import { verifyConnection } from "./verify";
 import { registerLocalMode, injectProviderConfig, injectAuthProfile } from "./local-mode";
 import { trackPluginEvent } from "./product-telemetry";
@@ -79,6 +80,7 @@ module.exports = {
       if (typeof api.registerTool === "function") {
         registerTools(api, config, logger);
       }
+      registerCommand(api, config, logger);
 
       logger.info(`[manifest]   Dashboard: ${baseOrigin}`);
 
@@ -125,6 +127,7 @@ module.exports = {
         "[manifest] Agent tools not available in this OpenClaw version",
       );
     }
+    registerCommand(api, config, logger);
 
     api.registerService({
       id: "manifest-telemetry",

--- a/packages/openclaw-plugin/src/local-mode.ts
+++ b/packages/openclaw-plugin/src/local-mode.ts
@@ -16,6 +16,7 @@ import { initTelemetry, shutdownTelemetry } from "./telemetry";
 import { registerHooks, initMetrics } from "./hooks";
 import { registerRouting } from "./routing";
 import { registerTools } from "./tools";
+import { registerCommand } from "./command";
 import { API_KEY_PREFIX } from "./constants";
 
 const CONFIG_DIR = join(homedir(), ".openclaw", "manifest");
@@ -81,6 +82,10 @@ function atomicWriteJson(path: string, data: unknown): void {
   writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
   renameSync(tmp, path);
 }
+
+// TODO: Replace direct file mutation with api.config persistent API
+// when OpenClaw documents a write-through config mechanism.
+// See: https://docs.openclaw.ai/tools/plugin#configuration
 
 /**
  * Injects the Manifest provider configuration into OpenClaw's config file
@@ -271,6 +276,7 @@ export function registerLocalMode(
   if (typeof api.registerTool === "function") {
     registerTools(api, localConfig, logger);
   }
+  registerCommand(api, localConfig, logger);
 
   logger.info(`[manifest] 🦚 View your Manifest Dashboard -> http://${host}:${port}`);
 

--- a/packages/openclaw-plugin/src/routing.ts
+++ b/packages/openclaw-plugin/src/routing.ts
@@ -165,7 +165,7 @@ export function registerRouting(
   try {
     api.registerProvider({
       id: "manifest",
-      name: "Manifest Router",
+      label: "Manifest Router",
       api: "openai-completions",
       baseUrl,
       apiKey: config.apiKey,


### PR DESCRIPTION
## Summary

Brings the Manifest OpenClaw plugin to full compliance with the [official plugin API docs](https://docs.openclaw.ai/tools/plugin):

- **Hooks**: Migrate all 4 `api.on()` calls to `api.registerHook()` with metadata (name + description), making hooks visible in `openclaw hooks list` diagnostics
- **Tools**: Rename `handler` to `execute(_id, params)`, change return format to `{ content: [{ type: "text", text }] }`, add `{ optional: true }` flag to all 3 tool registrations
- **Provider**: Change `name` to `label` in `registerProvider()` call
- **Slash command**: New `/manifest` command via `api.registerCommand()` — shows mode, endpoint status, auth status, and agent name
- **Plugin manifest**: Remove hardcoded `version` (derived from package.json), add `"kind": "observability"` for slot exclusivity
- **Keywords**: Add `openclaw-extension` and `openclaw-observability` to package.json

## Test plan

- [x] Plugin tests pass (242 tests, 11 suites)
- [x] Backend tests pass (1631 tests, 110 suites)
- [x] Frontend tests pass (848 tests, 58 suites)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Plugin builds successfully (`npx tsx build.ts`)
- [ ] Manual: install built plugin in OpenClaw, verify `openclaw hooks list` shows manifest hooks
- [ ] Manual: verify `/manifest` command returns status