### PR TITLE
Fix cost display for sub-cent and negative costs

### DIFF
--- a/.changeset/fix-cost-zero-display.md
+++ b/.changeset/fix-cost-zero-display.md
@@ -1,0 +1,10 @@
+---
+"manifest": patch
+---
+
+Fix cost display showing $0.00 for sub-cent costs and negative costs
+
+- Small positive costs (< $0.01) now display as "< $0.01" instead of misleading "$0.00"
+- Negative costs (from failed pricing lookups) now display as "—" (unknown) instead of "$0.00"
+- Backend aggregation queries (SUM) now exclude negative costs to prevent corrupted totals
+- Added sqlSanitizeCost helper to filter invalid cost data at the query level

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -7,7 +7,7 @@ import { rangeToInterval } from '../../common/utils/range.util';
 import { addTenantFilter, downsample } from './query-helpers';
 import {
   DbDialect, detectDialect, computeCutoff,
-  sqlHourBucket, sqlDateBucket, sqlCastFloat,
+  sqlHourBucket, sqlDateBucket, sqlCastFloat, sqlSanitizeCost,
 } from '../../common/utils/sql-dialect';
 
 @Injectable()
@@ -75,7 +75,7 @@ export class TimeseriesQueriesService {
     const qb = this.turnRepo
       .createQueryBuilder('at')
       .select(hourExpr, 'hour')
-      .addSelect('COALESCE(SUM(at.cost_usd), 0)', 'cost')
+      .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(qb, userId, agentName);
     const rows = await qb.groupBy('hour').orderBy('hour', 'ASC').getRawMany();
@@ -94,7 +94,7 @@ export class TimeseriesQueriesService {
     const qb = this.turnRepo
       .createQueryBuilder('at')
       .select(dateExpr, 'date')
-      .addSelect('COALESCE(SUM(at.cost_usd), 0)', 'cost')
+      .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'cost')
       .where('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(qb, userId, agentName);
     const rows = await qb.groupBy('date').orderBy('date', 'ASC').getRawMany();
@@ -170,7 +170,7 @@ export class TimeseriesQueriesService {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
 
-    const costExpr = sqlCastFloat('at.cost_usd', this.dialect);
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'), this.dialect);
 
     const qb = this.turnRepo
       .createQueryBuilder('at')
@@ -199,7 +199,7 @@ export class TimeseriesQueriesService {
       .createQueryBuilder('at')
       .select("COALESCE(at.model, 'unknown')", 'model')
       .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
-      .addSelect('COALESCE(SUM(at.cost_usd), 0)', 'estimated_cost')
+      .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'estimated_cost')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL')
       .andWhere("at.model != ''");
@@ -226,7 +226,7 @@ export class TimeseriesQueriesService {
       .orderBy('a.created_at', 'DESC')
       .getMany();
 
-    const costExpr = sqlCastFloat('at.cost_usd', this.dialect);
+    const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'), this.dialect);
     const statsQb = this.turnRepo
       .createQueryBuilder('at')
       .select('at.agent_name', 'agent_name')

--- a/packages/backend/src/common/utils/sql-dialect.spec.ts
+++ b/packages/backend/src/common/utils/sql-dialect.spec.ts
@@ -9,6 +9,7 @@ import {
   sqlCastFloat,
   portableSql,
   sqlCastInterval,
+  sqlSanitizeCost,
 } from './sql-dialect';
 
 describe('sql-dialect', () => {
@@ -208,6 +209,18 @@ describe('sql-dialect', () => {
       expect(sqlCastInterval('interval', 'postgres')).toBe(
         'CAST(:interval AS interval)',
       );
+    });
+  });
+
+  describe('sqlSanitizeCost', () => {
+    it('returns a CASE expression that nullifies negative costs', () => {
+      const result = sqlSanitizeCost('at.cost_usd');
+      expect(result).toBe('CASE WHEN at.cost_usd >= 0 THEN at.cost_usd ELSE NULL END');
+    });
+
+    it('works with different column names', () => {
+      const result = sqlSanitizeCost('cost');
+      expect(result).toBe('CASE WHEN cost >= 0 THEN cost ELSE NULL END');
     });
   });
 });

--- a/packages/backend/src/common/utils/sql-dialect.ts
+++ b/packages/backend/src/common/utils/sql-dialect.ts
@@ -66,6 +66,15 @@ export function sqlCastFloat(col: string, dialect: DbDialect): string {
 }
 
 /**
+ * Returns a SQL expression that treats negative costs as NULL.
+ * Negative costs indicate failed pricing lookups and should not be
+ * included in aggregations or displayed as real dollar amounts.
+ */
+export function sqlSanitizeCost(col: string): string {
+  return `CASE WHEN ${col} >= 0 THEN ${col} ELSE NULL END`;
+}
+
+/**
  * Convert Postgres-style $1, $2 placeholders to ? for SQLite.
  * Pass-through for Postgres.
  */

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -232,7 +232,7 @@ const MessageLog: Component = () => {
                           </span>
                         )}
                       </td>
-                      <td style="font-family: var(--font-mono);">
+                      <td style="font-family: var(--font-mono);" title={item.cost != null && item.cost > 0 && item.cost < 0.01 ? `$${item.cost.toFixed(6)}` : undefined}>
                         {item.cost != null ? (formatCost(item.cost) ?? "\u2014") : "\u2014"}
                       </td>
                       <td style="font-family: var(--font-mono);">

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -233,7 +233,7 @@ const MessageLog: Component = () => {
                         )}
                       </td>
                       <td style="font-family: var(--font-mono);">
-                        {item.cost != null ? formatCost(item.cost) : "\u2014"}
+                        {item.cost != null ? (formatCost(item.cost) ?? "\u2014") : "\u2014"}
                       </td>
                       <td style="font-family: var(--font-mono);">
                         {item.total_tokens != null ? formatNumber(item.total_tokens) : "\u2014"}

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -493,7 +493,7 @@ const Overview: Component = () => {
                                 </span>
                               )}
                             </td>
-                            <td style="font-family: var(--font-mono);">
+                            <td style="font-family: var(--font-mono);" title={item.cost != null && item.cost > 0 && item.cost < 0.01 ? `$${item.cost.toFixed(6)}` : undefined}>
                               {item.cost != null
                                 ? (formatCost(item.cost) ?? '\u2014')
                                 : '\u2014'}
@@ -566,7 +566,7 @@ const Overview: Component = () => {
                                 </span>
                               </div>
                             </td>
-                            <td style="font-weight: 600;">
+                            <td style="font-weight: 600;" title={row.estimated_cost > 0 && row.estimated_cost < 0.01 ? `$${row.estimated_cost.toFixed(6)}` : undefined}>
                               {formatCost(row.estimated_cost) ?? '\u2014'}
                             </td>
                           </tr>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -367,7 +367,7 @@ const Overview: Component = () => {
                       <span class="chart-card__label">Cost</span>
                       <div class="chart-card__value-row">
                         <span class="chart-card__value">
-                          {formatCost(d().summary?.cost_today?.value ?? 0)}
+                          {formatCost(d().summary?.cost_today?.value ?? 0) ?? '$0.00'}
                         </span>
                         {trendBadge(d().summary?.cost_today?.trend_pct ?? 0)}
                       </div>
@@ -495,7 +495,7 @@ const Overview: Component = () => {
                             </td>
                             <td style="font-family: var(--font-mono);">
                               {item.cost != null
-                                ? formatCost(item.cost)
+                                ? (formatCost(item.cost) ?? '\u2014')
                                 : '\u2014'}
                             </td>
                             <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
@@ -567,7 +567,7 @@ const Overview: Component = () => {
                               </div>
                             </td>
                             <td style="font-weight: 600;">
-                              {formatCost(row.estimated_cost)}
+                              {formatCost(row.estimated_cost) ?? '\u2014'}
                             </td>
                           </tr>
                         )}

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -219,7 +219,7 @@ const Workspace: Component = () => {
                     <div class="agent-card__stat">
                       <span class="agent-card__stat-label">Cost</span>
                       <span class="agent-card__stat-value">
-                        {formatCost(agent.total_cost)}
+                        {formatCost(agent.total_cost) ?? '$0.00'}
                       </span>
                     </div>
                   </div>

--- a/packages/frontend/src/services/formatters.ts
+++ b/packages/frontend/src/services/formatters.ts
@@ -13,9 +13,13 @@ export function formatNumber(n: number): string {
 
 /**
  * Format a USD cost value (e.g., $6.18, $17.50).
+ * Returns null for negative costs (invalid/unknown pricing).
+ * Returns "< $0.01" for small sub-cent positive costs to avoid misleading "$0.00".
  */
-export function formatCost(n: number): string {
-  return `$${Math.max(0, n).toFixed(2)}`;
+export function formatCost(n: number): string | null {
+  if (n < 0) return null;
+  if (n > 0 && n < 0.01) return "< $0.01";
+  return `$${n.toFixed(2)}`;
 }
 
 /**

--- a/packages/frontend/tests/services/formatters-extra.test.ts
+++ b/packages/frontend/tests/services/formatters-extra.test.ts
@@ -28,8 +28,13 @@ describe("formatCost edge cases", () => {
     expect(formatCost(0)).toBe("$0.00");
   });
 
-  it("formats very small costs", () => {
+  it("formats very small costs above one cent", () => {
     expect(formatCost(0.01)).toBe("$0.01");
+  });
+
+  it("returns '< $0.01' for sub-cent costs", () => {
+    expect(formatCost(0.005)).toBe("< $0.01");
+    expect(formatCost(0.0001)).toBe("< $0.01");
   });
 
   it("formats whole dollar amounts", () => {
@@ -39,6 +44,11 @@ describe("formatCost edge cases", () => {
   it("formats costs with many decimal places (rounds to 2)", () => {
     expect(formatCost(3.456)).toBe("$3.46");
     expect(formatCost(3.454)).toBe("$3.45");
+  });
+
+  it("returns null for negative costs", () => {
+    expect(formatCost(-293)).toBeNull();
+    expect(formatCost(-0.005)).toBeNull();
   });
 });
 

--- a/packages/frontend/tests/services/formatters.test.ts
+++ b/packages/frontend/tests/services/formatters.test.ts
@@ -23,9 +23,19 @@ describe("formatCost", () => {
     expect(formatCost(0)).toBe("$0.00");
     expect(formatCost(17.5)).toBe("$17.50");
   });
-  it("clamps negative costs to $0.00", () => {
-    expect(formatCost(-1527)).toBe("$0.00");
-    expect(formatCost(-0.01)).toBe("$0.00");
+  it("returns null for negative costs (invalid pricing)", () => {
+    expect(formatCost(-1527)).toBeNull();
+    expect(formatCost(-0.01)).toBeNull();
+    expect(formatCost(-9909)).toBeNull();
+  });
+  it("returns '< $0.01' for sub-cent positive costs", () => {
+    expect(formatCost(0.002836)).toBe("< $0.01");
+    expect(formatCost(0.009)).toBe("< $0.01");
+    expect(formatCost(0.001)).toBe("< $0.01");
+  });
+  it("formats costs at or above one cent normally", () => {
+    expect(formatCost(0.01)).toBe("$0.01");
+    expect(formatCost(0.05)).toBe("$0.05");
   });
 });
 


### PR DESCRIPTION
## Summary
This PR fixes cost display and aggregation to properly handle sub-cent costs and negative costs (which indicate failed pricing lookups). Previously, both were misleadingly displayed as "$0.00".

## Key Changes

**Frontend (Display Layer)**
- Modified `formatCost()` to return `null` for negative costs instead of clamping to $0.00
- Added special handling for sub-cent positive costs (0 < cost < $0.01) to display as "< $0.01" instead of "$0.00"
- Updated all cost display locations to handle `null` returns by showing "—" (unknown indicator) or fallback to "$0.00" where appropriate
- Added tooltips showing full precision costs for sub-cent values in tables

**Backend (Data Layer)**
- Created new `sqlSanitizeCost()` helper function that wraps cost columns in a `CASE WHEN col >= 0 THEN col ELSE NULL END` expression
- Applied `sqlSanitizeCost()` to all cost aggregation queries (SUM operations) to exclude negative costs from totals
- This prevents corrupted cost summaries when pricing lookups fail and return negative sentinel values

**Test Coverage**
- Updated existing tests to expect `null` for negative costs instead of "$0.00"
- Added new test cases for sub-cent cost formatting ("< $0.01")
- Added tests for the new `sqlSanitizeCost()` SQL helper function

## Implementation Details
- The fix operates at two levels: query-level filtering (backend) prevents bad data from being aggregated, while display-level handling (frontend) ensures proper user-facing representation
- Negative costs are treated as invalid/unknown pricing data and excluded from calculations rather than being treated as zero
- Sub-cent costs are now visually distinguished from actual zero costs, preventing user confusion about whether a service was free or just very cheap

https://claude.ai/code/session_01Wj649t9fcMhpSYhdjFKF5X