### PR TITLE
fix(plugin): restore backwards-compatible gateway API

### DIFF
--- a/.changeset/fix-plugin-gateway-compat.md
+++ b/.changeset/fix-plugin-gateway-compat.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix plugin hooks not firing on current gateways by using api.on() instead of api.registerHook(), add backwards-compatible handler/execute and name/label fields for tools and provider registration

--- a/packages/openclaw-plugin/__tests__/hooks.test.ts
+++ b/packages/openclaw-plugin/__tests__/hooks.test.ts
@@ -163,6 +163,22 @@ describe("registerHooks", () => {
     expect(api.on).toHaveBeenCalledWith("agent_end", expect.any(Function));
   });
 
+  it("falls back to registerHook when api.on is not available", () => {
+    const fallbackApi = {
+      handlers: new Map<string, (event: unknown) => void>(),
+      registerHook: jest.fn((event: string, handler: (event: unknown) => void) => {
+        fallbackApi.handlers.set(event, handler);
+      }),
+    };
+    const fbTracer = createMockTracer();
+    const fbMeter = createMockMeter();
+    initMetrics(fbMeter as any);
+    registerHooks(fallbackApi as any, fbTracer as any, config, mockLogger);
+
+    expect(fallbackApi.registerHook).toHaveBeenCalledWith("message_received", expect.any(Function));
+    expect(fallbackApi.registerHook).toHaveBeenCalledWith("agent_end", expect.any(Function));
+  });
+
   it("logs that hooks are registered", () => {
     expect(mockLogger.debug).toHaveBeenCalledWith(
       "[manifest] All hooks registered",

--- a/packages/openclaw-plugin/__tests__/hooks.test.ts
+++ b/packages/openclaw-plugin/__tests__/hooks.test.ts
@@ -53,12 +53,12 @@ function createMockMeter() {
   };
 }
 
-// --- Mock API (hook registry) ---
+// --- Mock API (event emitter) ---
 function createMockApi() {
   const handlers = new Map<string, (event: unknown) => void>();
   return {
     handlers,
-    registerHook: jest.fn((event: string, handler: (event: unknown) => void, _metadata?: unknown) => {
+    on: jest.fn((event: string, handler: (event: unknown) => void) => {
       handlers.set(event, handler);
     }),
     emit(event: string, data: unknown) {
@@ -156,23 +156,11 @@ describe("registerHooks", () => {
     registerHooks(api, tracer as any, config, mockLogger);
   });
 
-  it("registers all four event handlers with metadata", () => {
-    expect(api.registerHook).toHaveBeenCalledWith(
-      "message_received", expect.any(Function),
-      expect.objectContaining({ name: "manifest.message-received" }),
-    );
-    expect(api.registerHook).toHaveBeenCalledWith(
-      "before_agent_start", expect.any(Function),
-      expect.objectContaining({ name: "manifest.agent-turn-start" }),
-    );
-    expect(api.registerHook).toHaveBeenCalledWith(
-      "tool_result_persist", expect.any(Function),
-      expect.objectContaining({ name: "manifest.tool-result" }),
-    );
-    expect(api.registerHook).toHaveBeenCalledWith(
-      "agent_end", expect.any(Function),
-      expect.objectContaining({ name: "manifest.agent-end" }),
-    );
+  it("registers all four event handlers", () => {
+    expect(api.on).toHaveBeenCalledWith("message_received", expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith("before_agent_start", expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith("tool_result_persist", expect.any(Function));
+    expect(api.on).toHaveBeenCalledWith("agent_end", expect.any(Function));
   });
 
   it("logs that hooks are registered", () => {

--- a/packages/openclaw-plugin/src/command.ts
+++ b/packages/openclaw-plugin/src/command.ts
@@ -13,29 +13,32 @@ export function registerCommand(
     return;
   }
 
+  const commandHandler = async () => {
+    try {
+      const check = await verifyConnection(config);
+      const lines = [
+        `Mode: ${config.mode}`,
+        `Endpoint reachable: ${check.endpointReachable ? "yes" : "no"}`,
+        `Auth valid: ${check.authValid ? "yes" : "no"}`,
+      ];
+      if (check.agentName) {
+        lines.push(`Agent: ${check.agentName}`);
+      }
+      if (check.error) {
+        lines.push(`Error: ${check.error}`);
+      }
+      return lines.join("\n");
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return `Manifest status check failed: ${msg}`;
+    }
+  };
+
   api.registerCommand({
     name: "manifest",
     description: "Show Manifest plugin status and connection info",
-    async execute() {
-      try {
-        const check = await verifyConnection(config);
-        const lines = [
-          `Mode: ${config.mode}`,
-          `Endpoint reachable: ${check.endpointReachable ? "yes" : "no"}`,
-          `Auth valid: ${check.authValid ? "yes" : "no"}`,
-        ];
-        if (check.agentName) {
-          lines.push(`Agent: ${check.agentName}`);
-        }
-        if (check.error) {
-          lines.push(`Error: ${check.error}`);
-        }
-        return lines.join("\n");
-      } catch (err: unknown) {
-        const msg = err instanceof Error ? err.message : String(err);
-        return `Manifest status check failed: ${msg}`;
-      }
-    },
+    handler: commandHandler,
+    execute: commandHandler,
   });
 
   logger.debug("[manifest] Registered /manifest command");

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -66,6 +66,21 @@ export function initMetrics(meter: Meter): void {
 }
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Register an event handler using the best available gateway API.
+ * Current gateways (v2026.2.x) dispatch via api.on(); newer versions
+ * may use api.registerHook() with metadata. Try api.on() first since
+ * it's confirmed to work, fall back to registerHook() for forward compat.
+ */
+function hookOn(api: any, event: string, handler: (...args: any[]) => any): void {
+  if (typeof api.on === "function") {
+    api.on(event, handler);
+  } else if (typeof api.registerHook === "function") {
+    api.registerHook(event, handler);
+  }
+}
+
 export function registerHooks(
   api: any,
   tracer: Tracer,
@@ -74,7 +89,7 @@ export function registerHooks(
 ): void {
   // --- message_received ---
   // Creates the root span for the entire request lifecycle.
-  api.registerHook("message_received", (event: any) => {
+  hookOn(api, "message_received", (event: any) => {
     const sessionKey =
       event.sessionKey || event.session?.key || `agent:${event.agent || "main"}:main`;
     const channel = event.channel || "unknown";
@@ -90,14 +105,11 @@ export function registerHooks(
     activeSpans.set(sessionKey, { root: rootSpan });
     messagesReceived.add(1, { [ATTRS.CHANNEL]: channel });
     logger.debug(`[manifest] Root span started for session=${sessionKey}`);
-  }, {
-    name: "manifest.message-received",
-    description: "Creates root OTLP span for the request lifecycle",
   });
 
   // --- before_agent_start ---
   // Creates a child span under the root for the agent turn.
-  api.registerHook("before_agent_start", (event: any) => {
+  hookOn(api, "before_agent_start", (event: any) => {
     const sessionKey =
       event.sessionKey ||
       event.session?.key ||
@@ -130,14 +142,11 @@ export function registerHooks(
     logger.debug(
       `[manifest] Agent turn started: agent=${agentName}, session=${sessionKey}`,
     );
-  }, {
-    name: "manifest.agent-turn-start",
-    description: "Creates a child span for the agent turn",
   });
 
   // --- tool_result_persist ---
   // Records tool metrics and creates a child span.
-  api.registerHook("tool_result_persist", (event: any) => {
+  hookOn(api, "tool_result_persist", (event: any) => {
     const toolName = event.toolName || event.tool || "unknown";
     const durationMs = event.durationMs || 0;
     const success = event.error == null;
@@ -172,16 +181,13 @@ export function registerHooks(
 
     toolCalls.add(1, { [ATTRS.TOOL_NAME]: toolName });
     toolDuration.record(durationMs, { [ATTRS.TOOL_NAME]: toolName });
-  }, {
-    name: "manifest.tool-result",
-    description: "Records tool metrics and creates a tool span",
   });
 
   // --- agent_end ---
   // Records LLM metrics and closes all spans.
   // Event shape: { messages: Message[], success: boolean, durationMs: number }
   // Usage data lives on each assistant message, not at the top level.
-  api.registerHook("agent_end", async (event: any) => {
+  hookOn(api, "agent_end", async (event: any) => {
     const sessionKey =
       event.sessionKey ||
       event.session?.key ||
@@ -283,9 +289,6 @@ export function registerHooks(
       `[manifest] agent_end tokens: in=${inputTokens}, out=${outputTokens}, cache=${cacheReadTokens}`,
     );
     logger.debug(`[manifest] Trace completed for session=${sessionKey}`);
-  }, {
-    name: "manifest.agent-end",
-    description: "Records LLM metrics, resolves routing, and closes all spans",
   });
 
   logger.debug("[manifest] All hooks registered");

--- a/packages/openclaw-plugin/src/routing.ts
+++ b/packages/openclaw-plugin/src/routing.ts
@@ -165,6 +165,7 @@ export function registerRouting(
   try {
     api.registerProvider({
       id: "manifest",
+      name: "Manifest Router",
       label: "Manifest Router",
       api: "openai-completions",
       baseUrl,


### PR DESCRIPTION
## Summary

- Fix OTLP telemetry hooks not firing on current gateways (v2026.2.x) after PR #910 migrated from `api.on()` to `api.registerHook()`
- Add `hookOn()` helper that tries `api.on()` first (works now), falls back to `api.registerHook()` (forward compat)
- Add `name` alongside `label` in `registerProvider()` for backwards compat
- Add `handler` alongside `execute` in `registerTool()` and `registerCommand()` for older gateways
- Add `toLegacy()` converter for tool results (`{ result?, error? }` format for old gateways)

## Root cause

PR #910 changed all 4 hook registrations from `api.on("event", handler)` to `api.registerHook("event", handler, { metadata })`. While `registerHook()` exists on the gateway API and registration succeeds (logs show "4 registered hooks"), the gateway v2026.2.x only **dispatches** events to `api.on()` handlers — so hooks silently stopped firing, breaking all telemetry.

## Test plan

- [x] Plugin tests: 242 passed
- [x] Backend unit tests: 1637 passed
- [x] Backend e2e tests: 85 passed
- [x] Frontend tests: 854 passed
- [x] TypeScript compilation: clean
- [ ] Install plugin, configure cloud mode, send a message, verify telemetry appears on dashboard