### PR TITLE
Fix browser tab title by moving to @solidjs/meta Title component</title>
<body>
## Summary
Fixed an issue where the browser tab title was stuck on "Manifest" by removing the static `<title>` tag from index.html and using @solidjs/meta's `Title` component as the sole title manager.

## Changes
- Removed the static `<title>Manifest

### DIFF
--- a/.changeset/fix-meta-title-browser-tab.md
+++ b/.changeset/fix-meta-title-browser-tab.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix browser tab title stuck on "Manifest" by removing static `<title>` from index.html and using @solidjs/meta's Title component as the sole title manager

--- a/package-lock.json
+++ b/package-lock.json
@@ -13220,7 +13220,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.15.4",
+      "version": "5.16.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
     <link href="/fonts/boxicons/boxicons-duotone.min.css" rel="stylesheet" />
-    <title>Manifest</title>
     <meta
       name="description"
       content="Open Source platform to monitor and control OpenClaw costs and performance."

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -1,7 +1,7 @@
 /* @refresh reload */
 import { render } from "solid-js/web";
 import { Router, Route } from "@solidjs/router";
-import { MetaProvider } from "@solidjs/meta";
+import { MetaProvider, Title } from "@solidjs/meta";
 import App from "./App.jsx";
 import AuthLayout from "./layouts/AuthLayout.jsx";
 import Workspace from "./pages/Workspace.jsx";
@@ -39,6 +39,7 @@ if (!root) {
 render(
   () => (
     <MetaProvider>
+      <Title>Manifest</Title>
       <ToastContainer />
       <Router>
         <Route path="/" component={App}>


### PR DESCRIPTION
## Summary
Fixed an issue where the browser tab title was stuck on "Manifest" by removing the static `<title>` tag from index.html and using @solidjs/meta's `Title` component as the sole title manager.

## Changes
- Removed the static `<title>Manifest</title>` from `packages/frontend/index.html`
- Added import of `Title` component from `@solidjs/meta` in `packages/frontend/src/index.tsx`
- Added `<Title>Manifest</Title>` component at the root level within the `MetaProvider` in the render function

## Implementation Details
This change consolidates title management to use Solid.js's meta library exclusively. By removing the static HTML title and using the `Title` component from @solidjs/meta, the title can now be properly managed and updated dynamically throughout the application lifecycle, preventing it from becoming stuck on the initial value.

https://claude.ai/code/session_01TFTgQryYTjc4Z7f2317VUq