### PR TITLE
feat: change default plugin mode from local to cloud

### DIFF
--- a/.changeset/default-cloud-mode.md
+++ b/.changeset/default-cloud-mode.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Change default plugin mode from local to cloud. Cloud mode is now the default when no mode is configured. Set mode to "local" explicitly for the zero-config embedded server.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,11 +144,11 @@ That's it — no API key needed. Telemetry from your agent flows directly to the
 
 #### Plugin Settings
 
-The plugin exposes 5 user-facing settings via `openclaw.plugin.json`. All are optional — local mode works with zero configuration.
+The plugin exposes 5 user-facing settings via `openclaw.plugin.json`. Cloud mode is the default. Set `mode` to `local` for zero-config local mode.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `mode` | `string` | `local` | Controls the plugin's operating mode. `local` starts an embedded NestJS server backed by sql.js. `cloud` exports telemetry to `app.manifest.build`. `dev` connects to a local backend without API key management (uses OTLP loopback bypass). |
+| `mode` | `string` | `cloud` | Controls the plugin's operating mode. `cloud` exports telemetry to `app.manifest.build` (default). `local` starts an embedded NestJS server backed by sql.js. `dev` connects to a local backend without API key management (uses OTLP loopback bypass). |
 | `apiKey` | `string` | env `MANIFEST_API_KEY` | OTLP ingest key (must start with `mnfst_`). Required in cloud mode. Auto-generated and persisted to `~/.openclaw/manifest/config.json` in local mode. Ignored in dev mode. |
 | `endpoint` | `string` | `https://app.manifest.build/otlp` | Base URL for the OTLP exporters. The SDK appends `/v1/traces`, `/v1/metrics`, `/v1/logs` automatically. Only used in cloud and dev modes — local mode overrides this to `http://{host}:{port}/otlp`. |
 | `port` | `number` | `2099` | Bind port for the embedded server (local mode only). Also used for the dashboard URL and the injected OpenAI-compatible provider config. |

--- a/README.md
+++ b/README.md
@@ -51,8 +51,21 @@ Unlike almost all alternatives, everything stays on your machine. No suspicious 
 
 ## Quick Start
 
+### Cloud (default)
+
 ```bash
 openclaw plugins install manifest
+openclaw config set plugins.entries.manifest.config.apiKey "mnfst_YOUR_KEY"
+openclaw gateway restart
+```
+
+Sign up at [app.manifest.build](https://app.manifest.build) to get your API key.
+
+### Local (zero config)
+
+```bash
+openclaw plugins install manifest
+openclaw config set plugins.entries.manifest.config.mode local
 openclaw gateway restart
 ```
 
@@ -77,7 +90,7 @@ Dashboard opens at **http://127.0.0.1:2099**. Telemetry from your agents flows i
 
 ## Privacy
 
-**Your data stays on your machine.** All agent messages, token counts, costs, and telemetry are stored locally. None of this data is ever sent to us or any third party.
+**In local mode, your data stays on your machine.** All agent messages, token counts, costs, and telemetry are stored locally. In cloud mode, only OpenTelemetry metadata (model, tokens, latency) is sent — message content is never collected.
 
 Manifest collects anonymous product analytics (hashed machine ID, OS platform, package version, event names) to help improve the project. No personally identifiable information or agent data is included.
 
@@ -91,20 +104,19 @@ Or add `"telemetryOptOut": true` to `~/.openclaw/manifest/config.json`.
 
 ## Configuration
 
-Local mode works out of the box — all settings are optional.
+Cloud mode is the default. For local mode (zero config), set `mode` to `local`.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `mode` | `string` | `local` | `local` runs an embedded server on your machine. `cloud` sends telemetry to app.manifest.build. `dev` connects to a local backend without API key. |
+| `mode` | `string` | `cloud` | `cloud` sends telemetry to app.manifest.build (default). `local` runs an embedded server on your machine. `dev` connects to a local backend without API key. |
 | `apiKey` | `string` | env `MANIFEST_API_KEY` | Agent API key (must start with `mnfst_`). Required for cloud mode, auto-generated in local mode. |
 | `endpoint` | `string` | `https://app.manifest.build/otlp` | OTLP endpoint URL. Only relevant for cloud and dev modes. |
 | `port` | `number` | `2099` | Port for the embedded dashboard server (local mode only). |
 | `host` | `string` | `127.0.0.1` | Bind address for the embedded server (local mode only). |
 
 ```bash
-# Switch to cloud mode
-openclaw config set plugins.entries.manifest.config.mode cloud
-openclaw config set plugins.entries.manifest.config.apiKey "mnfst_YOUR_KEY"
+# Switch to local mode
+openclaw config set plugins.entries.manifest.config.mode local
 openclaw gateway restart
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13220,7 +13220,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.16.0",
+      "version": "5.16.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -1,13 +1,26 @@
 # Manifest
 
-Cut your AI agent costs by up to 70%. Manifest is an open-source [OpenClaw](https://github.com/open-claw/open-claw) plugin that combines **intelligent LLM routing** with **real-time cost observability** — one install, zero configuration.
+Cut your AI agent costs by up to 70%. Manifest is an open-source [OpenClaw](https://github.com/open-claw/open-claw) plugin that combines **intelligent LLM routing** with **real-time cost observability**.
 
 Instead of sending every request to the most expensive model, Manifest scores each query in under 2ms and routes it to the most cost-effective model that can handle it. Simple lookups go to fast, cheap models. Complex reasoning goes to frontier models. You see exactly where every dollar goes in a local dashboard.
 
 ## Quick start
 
+### Cloud (default)
+
 ```bash
 openclaw plugins install manifest
+openclaw config set plugins.entries.manifest.config.apiKey "mnfst_YOUR_KEY"
+openclaw gateway restart
+```
+
+Sign up at [app.manifest.build](https://app.manifest.build) to get your API key.
+
+### Local (zero config)
+
+```bash
+openclaw plugins install manifest
+openclaw config set plugins.entries.manifest.config.mode local
 openclaw gateway restart
 ```
 
@@ -26,7 +39,7 @@ The entire scoring step adds < 2ms of latency. If the resolve call fails, the re
 
 ### Enable routing
 
-Routing activates automatically in local mode. Point your OpenClaw config to use the `manifest` provider with model `auto`:
+Routing activates automatically when the plugin is enabled. Point your OpenClaw config to use the `manifest` provider with model `auto`:
 
 ```yaml
 # openclaw.config.yaml
@@ -67,21 +80,20 @@ User: "How much have I spent today?"
 
 ## Configuration
 
-Local mode works out of the box with zero configuration. All settings are optional.
+Cloud mode is the default. For local mode (zero config), set `mode` to `local`.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `mode` | string | `local` | `local` runs an embedded server on your machine. `cloud` sends telemetry to app.manifest.build. `dev` connects to a local backend without API key management. |
+| `mode` | string | `cloud` | `cloud` sends telemetry to app.manifest.build (default). `local` runs an embedded server on your machine. `dev` connects to a local backend without API key management. |
 | `apiKey` | string | env `MANIFEST_API_KEY` | Agent API key (must start with `mnfst_`). Required for cloud mode, auto-generated in local mode. |
 | `endpoint` | string | `https://app.manifest.build/otlp` | OTLP endpoint URL. Only relevant for cloud and dev modes. |
 | `port` | number | `2099` | Port for the embedded dashboard server (local mode only). |
 | `host` | string | `127.0.0.1` | Bind address for the embedded server (local mode only). |
 
-### Cloud mode
+### Local mode
 
 ```bash
-openclaw config set plugins.entries.manifest.config.mode cloud
-openclaw config set plugins.entries.manifest.config.apiKey "mnfst_YOUR_KEY"
+openclaw config set plugins.entries.manifest.config.mode local
 openclaw gateway restart
 ```
 

--- a/packages/openclaw-plugin/__tests__/config.test.ts
+++ b/packages/openclaw-plugin/__tests__/config.test.ts
@@ -83,9 +83,9 @@ describe("parseConfig", () => {
     expect(result.endpoint).toBe(DEFAULTS.ENDPOINT);
   });
 
-  it("defaults mode to local", () => {
+  it("defaults mode to cloud", () => {
     const result = parseConfig({ apiKey: "mnfst_abc" });
-    expect(result.mode).toBe("local");
+    expect(result.mode).toBe("cloud");
   });
 
   it("parses explicit mode: cloud", () => {
@@ -111,24 +111,24 @@ describe("parseConfig", () => {
     expect(result.mode).toBe("dev");
   });
 
-  it("falls back to local for unknown mode string", () => {
+  it("falls back to cloud for unknown mode string", () => {
     const result = parseConfig({ mode: "hybrid" });
-    expect(result.mode).toBe("local");
+    expect(result.mode).toBe("cloud");
   });
 
-  it("falls back to local when mode is a non-string value", () => {
+  it("falls back to cloud when mode is a non-string value", () => {
     const result = parseConfig({ mode: 42 });
-    expect(result.mode).toBe("local");
+    expect(result.mode).toBe("cloud");
   });
 
-  it("defaults to local with zero config (empty object)", () => {
+  it("defaults to cloud with zero config (empty object)", () => {
     const result = parseConfig({});
-    expect(result.mode).toBe("local");
+    expect(result.mode).toBe("cloud");
   });
 
-  it("defaults to local with null input", () => {
+  it("defaults to cloud with null input", () => {
     const result = parseConfig(null);
-    expect(result.mode).toBe("local");
+    expect(result.mode).toBe("cloud");
   });
 
   it("preserves mode: cloud through nested config wrapper", () => {

--- a/packages/openclaw-plugin/__tests__/register.test.ts
+++ b/packages/openclaw-plugin/__tests__/register.test.ts
@@ -63,7 +63,7 @@ beforeEach(() => {
 });
 
 describe("register — mode routing", () => {
-  it("delegates to registerLocalMode when mode defaults to local", () => {
+  it("delegates to registerLocalMode when mode is explicitly local", () => {
     (parseConfig as jest.Mock).mockReturnValue({
       mode: "local",
       apiKey: "",
@@ -680,7 +680,7 @@ describe("register — cloud mode missing API key", () => {
     plugin.register(api);
 
     expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("local mode instead (zero config)"),
+      expect.stringContaining("Set mode to local"),
     );
   });
 });

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -12,8 +12,8 @@
       "mode": {
         "type": "string",
         "enum": ["cloud", "local", "dev"],
-        "default": "local",
-        "description": "Run mode: 'local' starts an embedded server (zero config), 'cloud' sends to app.manifest.build, 'dev' connects to a dev server without API key"
+        "default": "cloud",
+        "description": "Run mode: 'cloud' sends telemetry to app.manifest.build (default), 'local' starts an embedded server (zero config), 'dev' connects to a dev server without API key"
       },
       "apiKey": {
         "type": "string",
@@ -39,7 +39,7 @@
   "uiHints": {
     "mode": {
       "label": "Mode",
-      "description": "Choose 'local' for a self-contained server with sql.js (default), or 'cloud' to send data to app.manifest.build"
+      "description": "Choose 'cloud' to send data to app.manifest.build (default), or 'local' for a self-contained server with sql.js"
     },
     "apiKey": {
       "label": "API Key",

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -25,11 +25,11 @@ export function parseConfig(raw: unknown): ManifestConfig {
   }
 
   const mode =
-    obj.mode === "cloud"
-      ? "cloud" as const
+    obj.mode === "local"
+      ? "local" as const
       : obj.mode === "dev"
         ? "dev" as const
-        : "local" as const;
+        : "cloud" as const;
 
   const apiKey =
     typeof obj.apiKey === "string" && obj.apiKey.length > 0

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -39,7 +39,9 @@ module.exports = {
           "[manifest] Cloud mode requires an API key:\n" +
             "  openclaw config set plugins.entries.manifest.config.apiKey mnfst_YOUR_KEY\n" +
             "  openclaw gateway restart\n\n" +
-            "Tip: Remove the mode setting to use local mode instead (zero config).",
+            "Tip: Set mode to local for a zero-config embedded server:\n" +
+            "  openclaw config set plugins.entries.manifest.config.mode local\n" +
+            "  openclaw gateway restart",
         );
       } else {
         logger.error(`[manifest] Configuration error:\n${error}`);

--- a/packages/openclaw-plugin/src/product-telemetry.ts
+++ b/packages/openclaw-plugin/src/product-telemetry.ts
@@ -26,7 +26,7 @@ export function trackPluginEvent(
       os_version: release(),
       node_version: process.versions.node,
       package_version: config.packageVersion,
-      mode: process.env['MANIFEST_MODE'] ?? 'local',
+      mode: process.env['MANIFEST_MODE'] ?? 'cloud',
       ...properties,
     },
     timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- **Default mode is now `cloud`** instead of `local` when no mode is configured
- Users who want local mode can explicitly set `mode` to `local` — it remains fully supported as a zero-config alternative
- Updated tip message for missing API key to show actionable `openclaw config set` command for switching to local mode
- Updated plugin schema, telemetry fallback, tests, and documentation (root README, plugin README, CONTRIBUTING.md)

## Test plan

- [x] Plugin tests pass (239 passed, 11 suites)
- [x] Backend tests pass (1637 passed, 110 suites)
- [x] Frontend tests pass (854 passed, 58 suites)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual: install plugin with no config → should log cloud-mode missing API key message with tip about local mode
- [ ] Manual: set mode to local → should start embedded server at :2099