### PR TITLE
Add context-aware Docs link to header

### DIFF
--- a/.changeset/add-doc-link.md
+++ b/.changeset/add-doc-link.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add context-aware Docs link to header

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { A, useNavigate } from "@solidjs/router";
+import { A, useLocation, useNavigate } from "@solidjs/router";
 import { Show, createSignal, onCleanup, onMount, type Component } from "solid-js";
 import { useAgentName } from "../services/routing.js";
 import { authClient } from "../services/auth-client.js";
@@ -10,6 +10,7 @@ const STAR_DISMISSED_KEY = "github-star-dismissed";
 
 const Header: Component = () => {
   const getAgentName = useAgentName();
+  const location = useLocation();
   const [menuOpen, setMenuOpen] = createSignal(false);
   const [starCount, setStarCount] = createSignal<number | null>(null);
   const [starDismissed, setStarDismissed] = createSignal(
@@ -51,6 +52,13 @@ const Header: Component = () => {
     }
     return user()?.name ?? "User";
   };
+  const docsUrl = () => {
+    const p = location.pathname;
+    if (p.includes("/limits")) return "https://manifest.build/docs/set-limits";
+    if (p.includes("/routing")) return "https://manifest.build/docs/routing";
+    return "https://manifest.build/docs/introduction";
+  };
+
   const initials = () => {
     const name = effectiveName();
     return name.charAt(0).toUpperCase();
@@ -94,6 +102,18 @@ const Header: Component = () => {
         </Show>
       </div>
       <div class="header__right">
+        <a
+          href={docsUrl()}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="header__docs-link"
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
+            <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
+          </svg>
+          Docs
+        </a>
         <Show when={!starDismissed()}>
           <div class="header__star-separator" />
           <div class="header__github-star">

--- a/packages/frontend/src/styles/controls.css
+++ b/packages/frontend/src/styles/controls.css
@@ -489,6 +489,32 @@
   background: hsl(var(--accent));
 }
 
+/* ── Docs Link ───────────────────────────────────── */
+.header__docs-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 6px;
+  border: 1px solid hsl(var(--border));
+  background: hsl(var(--card));
+  color: hsl(var(--foreground));
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  font-family: var(--font-family);
+  text-decoration: none;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.header__docs-link:hover {
+  border-color: hsl(var(--ring) / 0.3);
+  background: hsl(var(--muted));
+}
+
 /* ── GitHub Star Button ──────────────────────────── */
 .header__github-star {
   position: relative;


### PR DESCRIPTION
## Summary
- Adds a "Docs" button with a book icon in the header, to the left of GitHub Stars
- Links to page-specific documentation: limits → `/docs/set-limits`, routing → `/docs/routing`, otherwise → `/docs/introduction`

## Test plan
- [ ] Open any page → Docs link points to `/docs/introduction`
- [ ] Navigate to Routing page → Docs link points to `/docs/routing`
- [ ] Navigate to Limits page → Docs link points to `/docs/set-limits`
- [ ] Click Docs → opens in new tab