### PR TITLE
fix: use absolute GitHub URLs for logo in README to fix npm 404

### DIFF
--- a/.changeset/fix-logo-404.md
+++ b/.changeset/fix-logo-404.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix logo 404 on npmjs.com by using absolute GitHub URLs in README

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset=".github/assets/logo-white.svg" />
-    <source media="(prefers-color-scheme: light)" srcset=".github/assets/logo-dark.svg" />
-    <img src=".github/assets/logo-dark.svg" alt="Manifest" height="53" title="Manifest"/>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mnfst/manifest/HEAD/.github/assets/logo-white.svg" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/mnfst/manifest/HEAD/.github/assets/logo-dark.svg" />
+    <img src="https://raw.githubusercontent.com/mnfst/manifest/HEAD/.github/assets/logo-dark.svg" alt="Manifest" height="53" title="Manifest"/>
   </picture>
 </p>
 <p align="center">


### PR DESCRIPTION
The README uses relative paths (.github/assets/logo-dark.svg) for the logo images. This works on GitHub, but the prepublishOnly script copies the README into packages/openclaw-plugin/, causing npm to resolve the paths relative to that subdirectory — resulting in a 404.

Switch to absolute raw.githubusercontent.com URLs so the logo renders correctly on both GitHub and npmjs.com.

https://claude.ai/code/session_01FZjr9XeHTrpWNoCSW7vtVj