### PR TITLE
Remove outdated better-sqlite3 references

### DIFF
--- a/.changeset/remove-sqlite-refs.md
+++ b/.changeset/remove-sqlite-refs.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Remove outdated better-sqlite3 references and rename sqlitePath config to dbPath

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ coverage/
 .trae/
 .windsurf/
 /backend/
-*.sqlite
-*.sqlite-shm
-*.sqlite-wal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,7 +339,7 @@ To add a new font or icon library:
 - **QueryBuilder API**: Analytics and ingestion services use TypeORM `Repository.createQueryBuilder()` instead of raw SQL. The `addTenantFilter()` helper in `query-helpers.ts` applies multi-tenant WHERE clauses. Only the database seeder and notification cron still use `DataSource.query()` with numbered `$1, $2, ...` placeholders.
 - **PostgreSQL time functions**: `NOW() - CAST(:interval AS interval)`, `to_char(date_trunc('hour', timestamp), ...)`, `timestamp::date`.
 - **Better Auth database**: In cloud mode, uses a `pg.Pool` instance passed directly to `betterAuth({ database: pool })`. In local mode, Better Auth is skipped entirely (`auth = null`) — `LocalAuthGuard` handles auth via loopback IP check, and simple Express handlers serve session data.
-- **Local mode SQLite**: Uses `sql.js` (WASM-based, zero native deps) instead of `better-sqlite3`. TypeORM driver type is `'sqljs'` with `autoSave: true` for file persistence.
+- **Local mode database**: Uses `sql.js` (WASM-based SQLite, zero native deps). TypeORM driver type is `'sqljs'` with `autoSave: true` for file persistence.
 - **PostgreSQL container**: `docker run -d --name postgres_db -e POSTGRES_USER=myuser -e POSTGRES_PASSWORD=mypassword -e POSTGRES_DB=mydatabase -p 5432:5432 postgres:16`
 - **Validation**: Global `ValidationPipe` with `whitelist: true`, `forbidNonWhitelisted: true`. Explicit `@Type()` decorators on numeric DTO fields.
 - **OTLP auth caching**: `OtlpAuthGuard` caches valid API keys in-memory for 5 minutes to avoid repeated DB lookups.

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -644,7 +644,7 @@ describe('AggregationService', () => {
   });
 });
 
-describe('AggregationService (SQLite dialect)', () => {
+describe('AggregationService (sql.js / local mode)', () => {
   let service: AggregationService;
   let mockSelect: jest.Mock;
   let mockAddSelect: jest.Mock;

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -284,7 +284,7 @@ describe('TimeseriesQueriesService', () => {
   });
 });
 
-describe('TimeseriesQueriesService (SQLite dialect)', () => {
+describe('TimeseriesQueriesService (sql.js / local mode)', () => {
   let service: TimeseriesQueriesService;
   let mockSelect: jest.Mock;
   let mockAddSelect: jest.Mock;

--- a/packages/backend/src/auth/auth.instance.spec.ts
+++ b/packages/backend/src/auth/auth.instance.spec.ts
@@ -39,7 +39,7 @@ describe('auth.instance', () => {
       NODE_ENV: 'test',
       BETTER_AUTH_SECRET: 'a]3kF9!xLm2@pQzR7^wYu4&vN6*cE0hT',
     };
-    // Ensure local mode doesn't interfere (SQLite CI job sets MANIFEST_MODE=local)
+    // Ensure local mode doesn't interfere (sql.js CI job sets MANIFEST_MODE=local)
     delete process.env['MANIFEST_MODE'];
   });
 

--- a/packages/backend/src/common/utils/sql-dialect.spec.ts
+++ b/packages/backend/src/common/utils/sql-dialect.spec.ts
@@ -18,10 +18,6 @@ describe('sql-dialect', () => {
       expect(detectDialect('sqljs')).toBe('sqlite');
     });
 
-    it('returns sqlite for better-sqlite3', () => {
-      expect(detectDialect('better-sqlite3')).toBe('sqlite');
-    });
-
     it('returns postgres for postgres', () => {
       expect(detectDialect('postgres')).toBe('postgres');
     });

--- a/packages/backend/src/common/utils/sql-dialect.ts
+++ b/packages/backend/src/common/utils/sql-dialect.ts
@@ -1,7 +1,7 @@
 export type DbDialect = 'postgres' | 'sqlite';
 
 export function detectDialect(dsType: string): DbDialect {
-  return (dsType === 'better-sqlite3' || dsType === 'sqljs') ? 'sqlite' : 'postgres';
+  return dsType === 'sqljs' ? 'sqlite' : 'postgres';
 }
 
 /**

--- a/packages/backend/src/config/app.config.spec.ts
+++ b/packages/backend/src/config/app.config.spec.ts
@@ -42,14 +42,14 @@ describe('appConfig', () => {
   it('sanitizes MANIFEST_DB_PATH with path.resolve', async () => {
     process.env['MANIFEST_DB_PATH'] = './relative/../db.sqlite';
     const config = await loadConfig();
-    expect(config.sqlitePath).not.toContain('..');
-    expect(config.sqlitePath).toMatch(/db\.sqlite$/);
+    expect(config.dbPath).not.toContain('..');
+    expect(config.dbPath).toMatch(/db\.sqlite$/);
   });
 
   it('returns empty string for empty MANIFEST_DB_PATH', async () => {
     delete process.env['MANIFEST_DB_PATH'];
     const config = await loadConfig();
-    expect(config.sqlitePath).toBe('');
+    expect(config.dbPath).toBe('');
   });
 
   it('defaults bindAddress to 127.0.0.1', async () => {

--- a/packages/backend/src/config/app.config.ts
+++ b/packages/backend/src/config/app.config.ts
@@ -1,7 +1,7 @@
 import { registerAs } from '@nestjs/config';
 import { resolve } from 'path';
 
-function sanitizeSqlitePath(raw: string): string {
+function sanitizeDbPath(raw: string): string {
   if (!raw) return '';
   return resolve(raw);
 }
@@ -11,7 +11,7 @@ export const appConfig = registerAs('app', () => ({
   nodeEnv: process.env['NODE_ENV'] ?? 'development',
   databaseUrl: process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/mydatabase',
   manifestMode: process.env['MANIFEST_MODE'] ?? 'cloud',
-  sqlitePath: sanitizeSqlitePath(process.env['MANIFEST_DB_PATH'] ?? ''),
+  dbPath: sanitizeDbPath(process.env['MANIFEST_DB_PATH'] ?? ''),
 
   corsOrigin: process.env['CORS_ORIGIN'] ?? 'http://localhost:3000',
   throttleTtl: Number(process.env['THROTTLE_TTL'] ?? 60000),

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -35,7 +35,7 @@ describe('DatabaseSeederService', () => {
   const originalManifestMode = process.env['MANIFEST_MODE'];
 
   beforeEach(() => {
-    // Ensure local mode doesn't short-circuit onModuleInit (SQLite CI sets MANIFEST_MODE=local)
+    // Ensure local mode doesn't short-circuit onModuleInit (sql.js CI sets MANIFEST_MODE=local)
     delete process.env['MANIFEST_MODE'];
     mockDataSource = { query: jest.fn() };
     mockConfigService = { get: jest.fn() };

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -82,7 +82,7 @@ function buildModeServices() {
       inject: [ConfigService],
       useFactory: (config: ConfigService) => {
         if (isLocalMode) {
-          const dbPath = config.get<string>('app.sqlitePath') || ':memory:';
+          const dbPath = config.get<string>('app.dbPath') || ':memory:';
           return {
             type: 'sqljs' as const,
             location: dbPath === ':memory:' ? undefined : dbPath,

--- a/packages/backend/src/notifications/services/limit-check-local.service.spec.ts
+++ b/packages/backend/src/notifications/services/limit-check-local.service.spec.ts
@@ -6,7 +6,7 @@ import { EmailProviderConfigService } from './email-provider-config.service';
 import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { DataSource } from 'typeorm';
 
-describe('LimitCheckService (SQLite dialect)', () => {
+describe('LimitCheckService (sql.js / local mode)', () => {
   let service: LimitCheckService;
   let mockQuery: jest.Mock;
   let mockGetActiveBlockRules: jest.Mock;
@@ -48,7 +48,7 @@ describe('LimitCheckService (SQLite dialect)', () => {
     ingestSubject.complete();
   });
 
-  it('uses ? placeholders in notification_logs check for SQLite', async () => {
+  it('uses ? placeholders in notification_logs check for sql.js', async () => {
     mockGetActiveBlockRules.mockResolvedValue([{
       id: 'r1', tenant_id: 't1', agent_name: 'a1', user_id: 'u1',
       metric_type: 'tokens', threshold: 100, period: 'day',
@@ -66,7 +66,7 @@ describe('LimitCheckService (SQLite dialect)', () => {
     expect(notifCheck).not.toContain('$1');
   });
 
-  it('uses ? placeholders in user email lookup for SQLite', async () => {
+  it('uses ? placeholders in user email lookup for sql.js', async () => {
     mockGetActiveBlockRules.mockResolvedValue([{
       id: 'r1', tenant_id: 't1', agent_name: 'a1', user_id: 'u1',
       metric_type: 'tokens', threshold: 100, period: 'day',
@@ -86,7 +86,7 @@ describe('LimitCheckService (SQLite dialect)', () => {
     }
   });
 
-  it('still returns LimitExceeded correctly in SQLite mode', async () => {
+  it('still returns LimitExceeded correctly in local mode', async () => {
     mockGetActiveBlockRules.mockResolvedValue([{
       id: 'r1', tenant_id: 't1', agent_name: 'a1', user_id: 'u1',
       metric_type: 'cost', threshold: 5, period: 'month',

--- a/packages/backend/src/notifications/services/notification-cron.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.spec.ts
@@ -337,14 +337,14 @@ describe('NotificationCronService', () => {
   });
 });
 
-describe('NotificationCronService (SQLite dialect)', () => {
+describe('NotificationCronService (sql.js / local mode)', () => {
   let service: NotificationCronService;
   let mockQuery: jest.Mock;
   let mockGetAllActiveRules: jest.Mock;
   let mockGetConsumption: jest.Mock;
   let mockSendThresholdAlert: jest.Mock;
 
-  const sqliteRule = {
+  const localRule = {
     id: 'rule-1',
     tenant_id: 'tenant-1',
     agent_name: 'my-agent',
@@ -385,8 +385,8 @@ describe('NotificationCronService (SQLite dialect)', () => {
     service = module.get(NotificationCronService);
   });
 
-  it('uses ? placeholders in dedup query for sqlite', async () => {
-    mockGetAllActiveRules.mockResolvedValue([sqliteRule]);
+  it('uses ? placeholders in dedup query for sql.js', async () => {
+    mockGetAllActiveRules.mockResolvedValue([localRule]);
     mockQuery.mockResolvedValueOnce([{ 1: 1 }]); // dedup hit
 
     await service.checkThresholds();
@@ -399,8 +399,8 @@ describe('NotificationCronService (SQLite dialect)', () => {
     expect(sql).toContain('notification_logs');
   });
 
-  it('uses ? placeholders in INSERT notification_logs for sqlite', async () => {
-    mockGetAllActiveRules.mockResolvedValue([sqliteRule]);
+  it('uses ? placeholders in INSERT notification_logs for sql.js', async () => {
+    mockGetAllActiveRules.mockResolvedValue([localRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
       .mockResolvedValueOnce([{ email: 'a@b.com' }]) // email
@@ -420,8 +420,8 @@ describe('NotificationCronService (SQLite dialect)', () => {
     expect(params).toHaveLength(9);
   });
 
-  it('uses ? placeholder in user email lookup for sqlite', async () => {
-    mockGetAllActiveRules.mockResolvedValue([sqliteRule]);
+  it('uses ? placeholder in user email lookup for sql.js', async () => {
+    mockGetAllActiveRules.mockResolvedValue([localRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
       .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
@@ -436,8 +436,8 @@ describe('NotificationCronService (SQLite dialect)', () => {
     expect(emailCall[1]).toEqual(['user-1']);
   });
 
-  it('triggers notification correctly on sqlite dialect', async () => {
-    mockGetAllActiveRules.mockResolvedValue([sqliteRule]);
+  it('triggers notification correctly on sql.js dialect', async () => {
+    mockGetAllActiveRules.mockResolvedValue([localRule]);
     mockQuery
       .mockResolvedValueOnce([]) // no dedup
       .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email

--- a/packages/backend/src/notifications/services/notification-rules.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.spec.ts
@@ -396,7 +396,7 @@ describe('NotificationRulesService', () => {
   });
 });
 
-describe('NotificationRulesService (SQLite dialect)', () => {
+describe('NotificationRulesService (sql.js / local mode)', () => {
   let service: NotificationRulesService;
   let mockQuery: jest.Mock;
 
@@ -446,7 +446,7 @@ describe('NotificationRulesService (SQLite dialect)', () => {
     expect(params).toHaveLength(12);
   });
 
-  it('converts is_active boolean to 1/0 for sqlite in updateRule', async () => {
+  it('converts is_active boolean to 1/0 for sql.js in updateRule', async () => {
     mockQuery
       .mockResolvedValueOnce([{ id: 'r1' }]) // verifyOwnership
       .mockResolvedValueOnce(undefined) // UPDATE
@@ -457,11 +457,11 @@ describe('NotificationRulesService (SQLite dialect)', () => {
     const updateCall = mockQuery.mock.calls[1];
     const params = updateCall[1] as unknown[];
 
-    // is_active should be 0 (not false) for SQLite
+    // is_active should be 0 (not false) for sql.js
     expect(params).toContain(0);
   });
 
-  it('converts is_active true to 1 for sqlite in updateRule', async () => {
+  it('converts is_active true to 1 for sql.js in updateRule', async () => {
     mockQuery
       .mockResolvedValueOnce([{ id: 'r1' }]) // verifyOwnership
       .mockResolvedValueOnce(undefined) // UPDATE
@@ -472,11 +472,11 @@ describe('NotificationRulesService (SQLite dialect)', () => {
     const updateCall = mockQuery.mock.calls[1];
     const params = updateCall[1] as unknown[];
 
-    // is_active should be 1 (not true) for SQLite
+    // is_active should be 1 (not true) for sql.js
     expect(params).toContain(1);
   });
 
-  it('uses ? placeholders in UPDATE for sqlite', async () => {
+  it('uses ? placeholders in UPDATE for sql.js', async () => {
     mockQuery
       .mockResolvedValueOnce([{ id: 'r1' }]) // verifyOwnership
       .mockResolvedValueOnce(undefined) // UPDATE
@@ -492,7 +492,7 @@ describe('NotificationRulesService (SQLite dialect)', () => {
     expect(sql).toContain('UPDATE notification_rules');
   });
 
-  it('uses ? placeholders in getConsumption for sqlite', async () => {
+  it('uses ? placeholders in getConsumption for sql.js', async () => {
     mockQuery.mockResolvedValueOnce([{ total: 12345 }]);
 
     await service.getConsumption(
@@ -504,7 +504,7 @@ describe('NotificationRulesService (SQLite dialect)', () => {
     expect((sql.match(/\?/g) ?? []).length).toBe(4);
   });
 
-  it('uses ? placeholder in deleteRule for sqlite', async () => {
+  it('uses ? placeholder in deleteRule for sql.js', async () => {
     mockQuery
       .mockResolvedValueOnce([{ id: 'r1' }]) // verifyOwnership
       .mockResolvedValueOnce(undefined); // DELETE

--- a/packages/backend/test/costs.e2e-spec.ts
+++ b/packages/backend/test/costs.e2e-spec.ts
@@ -15,7 +15,7 @@ beforeAll(async () => {
   const sql = (q: string) => portableSql(q, dialect);
   const now = sqlNow();
 
-  // Seed model pricing so costs can be calculated (use INSERT OR IGNORE for SQLite since helpers.ts already seeds gpt-4o)
+  // Seed model pricing so costs can be calculated (use INSERT OR IGNORE for sql.js since helpers.ts already seeds gpt-4o)
   const insertOrIgnore = dialect === 'sqlite' ? 'INSERT OR IGNORE' : 'INSERT';
   const onConflict = dialect === 'sqlite' ? '' : ' ON CONFLICT (model_name) DO NOTHING';
   await ds.query(
@@ -31,7 +31,7 @@ beforeAll(async () => {
   await app.get(ModelPricingCacheService).reload();
 
   // Seed agent_messages directly (with pre-calculated cost_usd) using the same
-  // timestamp format as sqlNow() so that date comparisons work in both PG & SQLite.
+  // timestamp format as sqlNow() so that date comparisons work in both PG & sql.js.
   const costUsd1 = 5000 * 0.0000025 + 2000 * 0.00001; // 0.0325
   const costUsd2 = 3000 * 0.0000025 + 1000 * 0.00001; // 0.0175
   await ds.query(

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -305,7 +305,7 @@ describe("Limits page", () => {
     });
   });
 
-  it("does not show disabled row for active rules (is_active=1, SQLite)", async () => {
+  it("does not show disabled row for active rules (is_active=1, sql.js local mode)", async () => {
     mockRules = [{
       id: "r1", agent_name: "test-agent", metric_type: "tokens",
       threshold: 50000, period: "day", action: "notify",


### PR DESCRIPTION
## Summary
- Remove `better-sqlite3` from `detectDialect()` — only `sql.js` is used as the SQLite driver
- Rename `sqlitePath` config property to `dbPath` and `sanitizeSqlitePath` to `sanitizeDbPath`
- Rename `limit-check-sqlite.service.spec.ts` → `limit-check-local.service.spec.ts`
- Remove `*.sqlite`, `*.sqlite-shm`, `*.sqlite-wal` from `.gitignore` (WAL-mode artifacts not applicable to sql.js)
- Update test describe blocks and comments from "SQLite" to "sql.js / local mode" across 9 files
- Update CLAUDE.md architecture note to remove `better-sqlite3` mention

## Test plan
- [x] Backend unit tests pass (110 suites, 1643 tests)
- [x] Backend e2e tests pass (15 suites, 86 tests)
- [x] Frontend tests pass (61 suites, 940 tests)
- [x] TypeScript compiles with no errors (backend + frontend)