### PR TITLE
Add dual Y-axis to token chart and seed demo messages

### DIFF
--- a/.changeset/chart-double-scale.md
+++ b/.changeset/chart-double-scale.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add dual Y-axis to token chart and seed demo agent messages

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -30,6 +30,7 @@ describe('DatabaseSeederService', () => {
   let mockApiKeyRepo: ReturnType<typeof makeMockRepo>;
   let mockPricingRepo: ReturnType<typeof makeMockRepo>;
   let mockSecurityRepo: ReturnType<typeof makeMockRepo>;
+  let mockMessageRepo: ReturnType<typeof makeMockRepo>;
   let mockPricingCache: { reload: jest.Mock };
   const originalSeedData = process.env['SEED_DATA'];
   const originalManifestMode = process.env['MANIFEST_MODE'];
@@ -45,6 +46,7 @@ describe('DatabaseSeederService', () => {
     mockApiKeyRepo = makeMockRepo();
     mockPricingRepo = makeMockRepo();
     mockSecurityRepo = makeMockRepo();
+    mockMessageRepo = makeMockRepo();
     mockPricingCache = { reload: jest.fn().mockResolvedValue(undefined) };
 
     service = new DatabaseSeederService(
@@ -56,6 +58,7 @@ describe('DatabaseSeederService', () => {
       mockApiKeyRepo as never,
       mockPricingRepo as never,
       mockSecurityRepo as never,
+      mockMessageRepo as never,
       mockPricingCache as never,
     );
 

--- a/packages/backend/src/database/database-seeder.service.ts
+++ b/packages/backend/src/database/database-seeder.service.ts
@@ -9,8 +9,10 @@ import { AgentApiKey } from '../entities/agent-api-key.entity';
 import { ApiKey } from '../entities/api-key.entity';
 import { ModelPricing } from '../entities/model-pricing.entity';
 import { SecurityEvent } from '../entities/security-event.entity';
+import { AgentMessage } from '../entities/agent-message.entity';
 import { sha256, keyPrefix } from '../common/utils/hash.util';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
+import { seedAgentMessages } from './seed-messages';
 
 const SEED_API_KEY = 'dev-api-key-manifest-001';
 const SEED_OTLP_KEY = 'mnfst_dev-otlp-key-001';
@@ -30,6 +32,7 @@ export class DatabaseSeederService implements OnModuleInit {
     @InjectRepository(ApiKey) private readonly apiKeyRepo: Repository<ApiKey>,
     @InjectRepository(ModelPricing) private readonly pricingRepo: Repository<ModelPricing>,
     @InjectRepository(SecurityEvent) private readonly securityRepo: Repository<SecurityEvent>,
+    @InjectRepository(AgentMessage) private readonly messageRepo: Repository<AgentMessage>,
     private readonly pricingCache: ModelPricingCacheService,
   ) {}
 
@@ -47,6 +50,7 @@ export class DatabaseSeederService implements OnModuleInit {
       await this.seedApiKey();
       await this.seedTenantAndAgent();
       await this.seedSecurityEvents();
+      await this.seedAgentMessages();
       this.logger.log('Seeded demo data (dev/test only, SEED_DATA=true)');
     }
   }
@@ -313,5 +317,11 @@ export class DatabaseSeederService implements OnModuleInit {
         user_id: userId,
       });
     }
+  }
+
+  private async seedAgentMessages() {
+    const userId = await this.getAdminUserId();
+    if (!userId) return;
+    await seedAgentMessages(this.messageRepo, userId, this.logger);
   }
 }

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -105,7 +105,7 @@ function buildModeServices() {
         };
       },
     }),
-    TypeOrmModule.forFeature([Tenant, Agent, AgentApiKey, ApiKey, ModelPricing, SecurityEvent]),
+    TypeOrmModule.forFeature([Tenant, Agent, AgentApiKey, AgentMessage, ApiKey, ModelPricing, SecurityEvent]),
     ModelPricesModule,
   ],
   providers: buildModeServices(),

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -34,6 +34,7 @@ jest.mock('../common/utils/product-telemetry', () => ({
 jest.mock('../entities/tenant.entity', () => ({ Tenant: jest.fn() }));
 jest.mock('../entities/agent.entity', () => ({ Agent: jest.fn() }));
 jest.mock('../entities/agent-api-key.entity', () => ({ AgentApiKey: jest.fn() }));
+jest.mock('../entities/agent-message.entity', () => ({ AgentMessage: jest.fn() }));
 jest.mock('../entities/model-pricing.entity', () => ({ ModelPricing: jest.fn() }));
 
 import { LocalBootstrapService } from './local-bootstrap.service';
@@ -52,6 +53,7 @@ describe('LocalBootstrapService', () => {
   let mockTenantRepo: ReturnType<typeof makeMockRepo>;
   let mockAgentRepo: ReturnType<typeof makeMockRepo>;
   let mockAgentKeyRepo: ReturnType<typeof makeMockRepo>;
+  let mockMessageRepo: ReturnType<typeof makeMockRepo>;
   let mockPricingRepo: ReturnType<typeof makeMockRepo>;
   let mockPricingCache: { reload: jest.Mock };
   let mockPricingSync: { syncPricing: jest.Mock };
@@ -61,6 +63,7 @@ describe('LocalBootstrapService', () => {
     mockTenantRepo = makeMockRepo();
     mockAgentRepo = makeMockRepo();
     mockAgentKeyRepo = makeMockRepo();
+    mockMessageRepo = makeMockRepo();
     mockPricingRepo = makeMockRepo();
     mockPricingCache = { reload: jest.fn().mockResolvedValue(undefined) };
     mockPricingSync = { syncPricing: jest.fn().mockResolvedValue(undefined) };
@@ -69,6 +72,7 @@ describe('LocalBootstrapService', () => {
       mockTenantRepo as never,
       mockAgentRepo as never,
       mockAgentKeyRepo as never,
+      mockMessageRepo as never,
       mockPricingRepo as never,
       mockPricingCache as never,
       mockPricingSync as never,

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -7,6 +7,7 @@ import { homedir } from 'os';
 import { Tenant } from '../entities/tenant.entity';
 import { Agent } from '../entities/agent.entity';
 import { AgentApiKey } from '../entities/agent-api-key.entity';
+import { AgentMessage } from '../entities/agent-message.entity';
 import { ModelPricing } from '../entities/model-pricing.entity';
 import { sha256, keyPrefix } from '../common/utils/hash.util';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
@@ -19,6 +20,7 @@ import {
   LOCAL_AGENT_NAME,
 } from '../common/constants/local-mode.constants';
 import { trackEvent } from '../common/utils/product-telemetry';
+import { seedAgentMessages } from './seed-messages';
 
 @Injectable()
 export class LocalBootstrapService implements OnModuleInit {
@@ -28,6 +30,7 @@ export class LocalBootstrapService implements OnModuleInit {
     @InjectRepository(Tenant) private readonly tenantRepo: Repository<Tenant>,
     @InjectRepository(Agent) private readonly agentRepo: Repository<Agent>,
     @InjectRepository(AgentApiKey) private readonly agentKeyRepo: Repository<AgentApiKey>,
+    @InjectRepository(AgentMessage) private readonly messageRepo: Repository<AgentMessage>,
     @InjectRepository(ModelPricing) private readonly pricingRepo: Repository<ModelPricing>,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly pricingSync: PricingSyncService,
@@ -37,6 +40,11 @@ export class LocalBootstrapService implements OnModuleInit {
     await this.seedModelPricing();
     await this.pricingCache.reload();
     await this.ensureTenantAndAgent();
+    await seedAgentMessages(this.messageRepo, LOCAL_USER_ID, this.logger, {
+      tenantId: LOCAL_TENANT_ID,
+      agentId: LOCAL_AGENT_ID,
+      agentName: LOCAL_AGENT_NAME,
+    });
     this.logger.log('Local mode bootstrap complete');
 
     // Fetch fresh prices from OpenRouter in the background

--- a/packages/backend/src/database/seed-messages.spec.ts
+++ b/packages/backend/src/database/seed-messages.spec.ts
@@ -1,0 +1,390 @@
+import { Logger } from '@nestjs/common';
+import { seedAgentMessages } from './seed-messages';
+
+function makeMockRepo() {
+  return {
+    count: jest.fn().mockResolvedValue(0),
+    insert: jest.fn().mockResolvedValue({}),
+  };
+}
+
+function makeMockLogger(): Logger & { log: jest.Mock } {
+  return { log: jest.fn() } as unknown as Logger & { log: jest.Mock };
+}
+
+/** Collects all messages passed to repo.insert across batched calls. */
+function collectInsertedMessages(
+  mockRepo: ReturnType<typeof makeMockRepo>,
+): Array<Record<string, unknown>> {
+  const messages: Array<Record<string, unknown>> = [];
+  for (const call of mockRepo.insert.mock.calls) {
+    const batch = call[0] as Array<Record<string, unknown>>;
+    messages.push(...batch);
+  }
+  return messages;
+}
+
+describe('seedAgentMessages', () => {
+  let mockRepo: ReturnType<typeof makeMockRepo>;
+  let logger: Logger & { log: jest.Mock };
+
+  beforeEach(() => {
+    mockRepo = makeMockRepo();
+    logger = makeMockLogger();
+    jest.clearAllMocks();
+  });
+
+  describe('early exit when messages exist', () => {
+    it('should skip seeding when message count > 0', async () => {
+      mockRepo.count.mockResolvedValue(10);
+
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+
+      expect(mockRepo.count).toHaveBeenCalledTimes(1);
+      expect(mockRepo.insert).not.toHaveBeenCalled();
+      expect(logger.log).not.toHaveBeenCalled();
+    });
+
+    it('should check the message count before proceeding', async () => {
+      mockRepo.count.mockResolvedValue(1);
+
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+
+      expect(mockRepo.count).toHaveBeenCalled();
+      expect(mockRepo.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('seeding when table is empty', () => {
+    it('should insert messages when count is 0', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+
+      expect(mockRepo.insert).toHaveBeenCalled();
+    });
+
+    it('should log the total number of seeded messages', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+
+      expect(logger.log).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith(
+        expect.stringMatching(/^Seeded \d+ agent messages$/),
+      );
+    });
+
+    it('should generate approximately 695 messages over 7 days', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+
+      const messages = collectInsertedMessages(mockRepo);
+      // The exact count depends on the PRNG and the current time's UTC hours,
+      // but 168 hours with ~4 msgs/hour should yield several hundred messages.
+      expect(messages.length).toBeGreaterThan(200);
+      expect(messages.length).toBeLessThan(1500);
+    });
+  });
+
+  describe('context parameter', () => {
+    it('should use default context when not provided', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+
+      const messages = collectInsertedMessages(mockRepo);
+      expect(messages.length).toBeGreaterThan(0);
+      for (const msg of messages) {
+        expect(msg.tenant_id).toBe('seed-tenant-001');
+        expect(msg.agent_id).toBe('seed-agent-001');
+        expect(msg.agent_name).toBe('demo-agent');
+      }
+    });
+
+    it('should use custom context when provided', async () => {
+      const customCtx = {
+        tenantId: 'custom-tenant',
+        agentId: 'custom-agent-id',
+        agentName: 'my-agent',
+      };
+
+      await seedAgentMessages(
+        mockRepo as never,
+        'user-2',
+        logger,
+        customCtx,
+      );
+
+      const messages = collectInsertedMessages(mockRepo);
+      expect(messages.length).toBeGreaterThan(0);
+      for (const msg of messages) {
+        expect(msg.tenant_id).toBe('custom-tenant');
+        expect(msg.agent_id).toBe('custom-agent-id');
+        expect(msg.agent_name).toBe('my-agent');
+      }
+    });
+
+    it('should attach the provided userId to all messages', async () => {
+      await seedAgentMessages(mockRepo as never, 'test-user-42', logger);
+
+      const messages = collectInsertedMessages(mockRepo);
+      for (const msg of messages) {
+        expect(msg.user_id).toBe('test-user-42');
+      }
+    });
+  });
+
+  describe('determinism', () => {
+    it('should produce identical messages on repeated runs', async () => {
+      // Run 1
+      const repo1 = makeMockRepo();
+      await seedAgentMessages(repo1 as never, 'user-1', logger);
+      const msgs1 = collectInsertedMessages(repo1);
+
+      // Run 2
+      const repo2 = makeMockRepo();
+      await seedAgentMessages(repo2 as never, 'user-1', logger);
+      const msgs2 = collectInsertedMessages(repo2);
+
+      expect(msgs1.length).toBe(msgs2.length);
+      for (let i = 0; i < msgs1.length; i++) {
+        expect(msgs1[i].id).toBe(msgs2[i].id);
+        expect(msgs1[i].model).toBe(msgs2[i].model);
+        expect(msgs1[i].input_tokens).toBe(msgs2[i].input_tokens);
+        expect(msgs1[i].output_tokens).toBe(msgs2[i].output_tokens);
+        expect(msgs1[i].cost_usd).toBe(msgs2[i].cost_usd);
+        expect(msgs1[i].status).toBe(msgs2[i].status);
+        expect(msgs1[i].session_key).toBe(msgs2[i].session_key);
+      }
+    });
+  });
+
+  describe('message field validation', () => {
+    let messages: Array<Record<string, unknown>>;
+
+    beforeEach(async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      messages = collectInsertedMessages(mockRepo);
+    });
+
+    it('should generate unique sequential ids', () => {
+      const ids = messages.map((m) => m.id as string);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+
+      // IDs should follow the seed-msg-NNNN pattern
+      for (const id of ids) {
+        expect(id).toMatch(/^seed-msg-\d{4}$/);
+      }
+    });
+
+    it('should set valid ISO timestamps on all messages', () => {
+      for (const msg of messages) {
+        const ts = msg.timestamp as string;
+        expect(ts).toBeDefined();
+        const parsed = new Date(ts);
+        expect(parsed.getTime()).not.toBeNaN();
+      }
+    });
+
+    it('should generate timestamps within the last 7 days', () => {
+      const now = Date.now();
+      const sevenDaysAgo = now - 7 * 24 * 3600000;
+      // The random offset within each hour can push timestamps up to ~58 min
+      // past the hourBase, so timestamps from hour 0 (now) can be ~1 hour
+      // into the future. Use a generous margin.
+      const margin = 3600000;
+
+      for (const msg of messages) {
+        const ts = new Date(msg.timestamp as string).getTime();
+        expect(ts).toBeGreaterThanOrEqual(sevenDaysAgo - margin);
+        expect(ts).toBeLessThanOrEqual(now + margin);
+      }
+    });
+
+    it('should assign a model from the predefined list', () => {
+      const validModels = new Set([
+        'claude-sonnet-4-5-20250929',
+        'gpt-4o',
+        'claude-haiku-4-5-20251001',
+        'gemini-2.5-flash',
+      ]);
+
+      for (const msg of messages) {
+        expect(validModels.has(msg.model as string)).toBe(true);
+      }
+    });
+
+    it('should span multiple models (not all the same)', () => {
+      const models = new Set(messages.map((m) => m.model as string));
+      expect(models.size).toBe(4);
+    });
+
+    it('should have positive input_tokens and output_tokens', () => {
+      for (const msg of messages) {
+        expect(msg.input_tokens).toBeGreaterThan(0);
+        expect(msg.output_tokens).toBeGreaterThan(0);
+      }
+    });
+
+    it('should have input_tokens larger than output_tokens for the vast majority', () => {
+      // The source ranges overlap slightly at the edges:
+      // input: 800..14800, output: 60..1260. Most messages will have
+      // input >> output, but a few edge cases can be close or inverted.
+      let inputLargerCount = 0;
+      for (const msg of messages) {
+        if ((msg.input_tokens as number) > (msg.output_tokens as number)) {
+          inputLargerCount++;
+        }
+      }
+      expect(inputLargerCount / messages.length).toBeGreaterThan(0.95);
+    });
+
+    it('should have non-negative cache_read_tokens', () => {
+      for (const msg of messages) {
+        expect(msg.cache_read_tokens).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('should set cache_creation_tokens to 0', () => {
+      for (const msg of messages) {
+        expect(msg.cache_creation_tokens).toBe(0);
+      }
+    });
+
+    it('should have positive duration_ms within expected range', () => {
+      for (const msg of messages) {
+        const dur = msg.duration_ms as number;
+        expect(dur).toBeGreaterThanOrEqual(200);
+        expect(dur).toBeLessThan(5000);
+      }
+    });
+
+    it('should assign session keys in the format sess-NNN', () => {
+      for (const msg of messages) {
+        expect(msg.session_key).toMatch(/^sess-\d{3}$/);
+      }
+    });
+  });
+
+  describe('cost calculation', () => {
+    it('should calculate cost_usd as input * 0.000003 + output * 0.000015', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+
+      for (const msg of messages) {
+        const input = msg.input_tokens as number;
+        const output = msg.output_tokens as number;
+        const expectedCost = input * 0.000003 + output * 0.000015;
+        expect(msg.cost_usd).toBeCloseTo(expectedCost, 10);
+      }
+    });
+
+    it('should produce positive cost for every message', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+
+      for (const msg of messages) {
+        expect(msg.cost_usd as number).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('status distribution', () => {
+    it('should set most messages to status ok', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+
+      const okCount = messages.filter((m) => m.status === 'ok').length;
+      const errorCount = messages.filter((m) => m.status === 'error').length;
+
+      // The vast majority should be 'ok' (threshold > 0.95 means ~5% error)
+      expect(okCount).toBeGreaterThan(errorCount);
+      expect(okCount / messages.length).toBeGreaterThan(0.8);
+    });
+
+    it('should include some error messages', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+
+      const errorMsgs = messages.filter((m) => m.status === 'error');
+      expect(errorMsgs.length).toBeGreaterThan(0);
+    });
+
+    it('should set error_message only on error status messages', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+
+      for (const msg of messages) {
+        if (msg.status === 'error') {
+          expect(msg.error_message).toBe('Rate limit exceeded');
+        } else {
+          expect(msg.error_message).toBeNull();
+        }
+      }
+    });
+
+    it('should only contain ok and error statuses', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+
+      for (const msg of messages) {
+        expect(['ok', 'error']).toContain(msg.status);
+      }
+    });
+  });
+
+  describe('batch insertion', () => {
+    it('should insert in batches of 100', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+      const totalCalls = mockRepo.insert.mock.calls.length;
+
+      // All batches except possibly the last should have exactly 100
+      for (let i = 0; i < totalCalls - 1; i++) {
+        const batch = mockRepo.insert.mock.calls[i][0] as unknown[];
+        expect(batch).toHaveLength(100);
+      }
+
+      // Last batch should have the remainder
+      const lastBatch = mockRepo.insert.mock.calls[totalCalls - 1][0] as unknown[];
+      expect(lastBatch.length).toBeGreaterThan(0);
+      expect(lastBatch.length).toBeLessThanOrEqual(100);
+
+      // Total messages across all batches should match
+      let total = 0;
+      for (const call of mockRepo.insert.mock.calls) {
+        total += (call[0] as unknown[]).length;
+      }
+      expect(total).toBe(messages.length);
+    });
+
+    it('should call insert the correct number of times for the data size', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+      const expectedCalls = Math.ceil(messages.length / 100);
+      expect(mockRepo.insert).toHaveBeenCalledTimes(expectedCalls);
+    });
+  });
+
+  describe('day/night pattern', () => {
+    it('should generate fewer messages during night hours (0-7 UTC)', async () => {
+      await seedAgentMessages(mockRepo as never, 'user-1', logger);
+      const messages = collectInsertedMessages(mockRepo);
+
+      let nightCount = 0;
+      let dayCount = 0;
+
+      for (const msg of messages) {
+        const hour = new Date(msg.timestamp as string).getUTCHours();
+        // Messages within an hour window can spill into adjacent hours
+        // due to the random offset, so use a conservative range
+        if (hour >= 1 && hour <= 6) {
+          nightCount++;
+        } else if (hour >= 9 && hour <= 21) {
+          dayCount++;
+        }
+      }
+
+      // Day hours (9-21 = 13 hours) should have more messages per hour
+      // than night hours (1-6 = 6 hours). Compare normalized rates.
+      const nightRate = nightCount / 6;
+      const dayRate = dayCount / 13;
+      expect(dayRate).toBeGreaterThan(nightRate);
+    });
+  });
+});

--- a/packages/backend/src/database/seed-messages.ts
+++ b/packages/backend/src/database/seed-messages.ts
@@ -1,0 +1,76 @@
+import { Repository } from 'typeorm';
+import { Logger } from '@nestjs/common';
+import { AgentMessage } from '../entities/agent-message.entity';
+
+interface SeedContext {
+  tenantId: string;
+  agentId: string;
+  agentName: string;
+}
+
+/** Deterministic pseudo-random for reproducible seed data */
+function seededRandom(seed: number): number {
+  const x = Math.sin(seed * 9301 + 49297) * 233280;
+  return x - Math.floor(x);
+}
+
+export async function seedAgentMessages(
+  messageRepo: Repository<AgentMessage>,
+  userId: string,
+  logger: Logger,
+  ctx: SeedContext = { tenantId: 'seed-tenant-001', agentId: 'seed-agent-001', agentName: 'demo-agent' },
+): Promise<void> {
+  const count = await messageRepo.count();
+  if (count > 0) return;
+
+  const models = ['claude-sonnet-4-5-20250929', 'gpt-4o', 'claude-haiku-4-5-20251001', 'gemini-2.5-flash'];
+  const now = Date.now();
+  const messages: Array<Partial<AgentMessage>> = [];
+  let idx = 0;
+
+  // Generate ~4-8 messages per hour over the last 7 days (168 hours)
+  for (let h = 168; h >= 0; h--) {
+    const hourBase = now - h * 3600000;
+    // Fewer messages at night (hours 0-7 UTC), more during work hours
+    const utcHour = new Date(hourBase).getUTCHours();
+    const msgCount = utcHour >= 8 && utcHour <= 22
+      ? 4 + Math.floor(seededRandom(h) * 5)
+      : Math.floor(seededRandom(h + 500) * 3);
+
+    for (let m = 0; m < msgCount; m++) {
+      idx++;
+      const model = models[idx % models.length]!;
+      const ts = new Date(hourBase + Math.floor(seededRandom(idx) * 3500000)).toISOString();
+
+      // Input tokens 5-25x larger than output (realistic for LLM usage)
+      const inputBase = 800 + Math.floor(seededRandom(idx * 3) * 14000);
+      const outputBase = 60 + Math.floor(seededRandom(idx * 7) * 1200);
+      const cacheRead = Math.floor(seededRandom(idx * 11) * inputBase * 0.4);
+
+      messages.push({
+        id: `seed-msg-${String(idx).padStart(4, '0')}`,
+        tenant_id: ctx.tenantId,
+        agent_id: ctx.agentId,
+        user_id: userId,
+        agent_name: ctx.agentName,
+        timestamp: ts,
+        model,
+        input_tokens: inputBase,
+        output_tokens: outputBase,
+        cache_read_tokens: cacheRead,
+        cache_creation_tokens: 0,
+        cost_usd: inputBase * 0.000003 + outputBase * 0.000015,
+        duration_ms: 200 + Math.floor(seededRandom(idx * 13) * 4800),
+        status: seededRandom(idx * 17) > 0.95 ? 'error' : 'ok',
+        error_message: seededRandom(idx * 17) > 0.95 ? 'Rate limit exceeded' : null,
+        session_key: `sess-${String((idx % 40) + 1).padStart(3, '0')}`,
+      });
+    }
+  }
+
+  // Bulk insert in batches of 100
+  for (let i = 0; i < messages.length; i += 100) {
+    await messageRepo.insert(messages.slice(i, i + 100));
+  }
+  logger.log(`Seeded ${messages.length} agent messages`);
+}

--- a/packages/frontend/src/components/TokenChart.tsx
+++ b/packages/frontend/src/components/TokenChart.tsx
@@ -34,21 +34,42 @@ const TokenChart: Component<TokenChartProps> = (props) => {
       const gridColor = getHslA("--foreground", 0.05);
       const bgColor = getHsl("--card");
 
+      const yRange = (_u: uPlot, _min: number, max: number): [number, number] => [0, max > 0 ? max * 1.1 : 100];
+
       return new uPlot({
         width: w,
         height: 260,
-        padding: [16, 16, 0, 0],
+        padding: [16, 0, 0, 0],
         cursor: createCursorSnap(bgColor, inputColor),
-        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max > 0 ? max * 1.1 : 100] } },
+        scales: {
+          x: { time: true, range: timeScaleRange },
+          y: { auto: true, range: yRange },
+          y2: { auto: true, range: yRange },
+        },
         axes: (() => {
           const a = createBaseAxes(axisColor, gridColor, props.range);
-          a[1] = { ...a[1]!, values: (u: uPlot, vals: number[]) => vals.map((v) => formatLegendTokens(u, v)) };
+          a[1] = {
+            ...a[1]!,
+            stroke: inputColor,
+            values: (u: uPlot, vals: number[]) => vals.map((v) => formatLegendTokens(u, v)),
+          };
+          a.push({
+            scale: "y2",
+            side: 1,
+            stroke: outputColor,
+            grid: { show: false },
+            ticks: { show: false },
+            font: '11px "Inter"',
+            size: 54,
+            gap: 8,
+            values: (u: uPlot, vals: number[]) => vals.map((v) => formatLegendTokens(u, v)),
+          });
           return a;
         })(),
         series: [
           { value: formatLegendTimestamp },
-          { label: "Sent to AI", stroke: inputColor, width: 2.5, fill: makeGradientFillFromVar("--bar-input", 0.25), value: formatLegendTokens },
-          { label: "Received from AI", stroke: outputColor, width: 2, fill: makeGradientFillFromVar("--bar-output", 0.15), value: formatLegendTokens },
+          { label: "Sent to AI", scale: "y", stroke: inputColor, width: 2.5, fill: makeGradientFillFromVar("--bar-input", 0.25), value: formatLegendTokens },
+          { label: "Received from AI", scale: "y2", stroke: outputColor, width: 2, fill: makeGradientFillFromVar("--bar-output", 0.15), value: formatLegendTokens },
         ],
       }, [
         parseTimestamps(props.data),

--- a/packages/frontend/tests/components/TokenChart.test.tsx
+++ b/packages/frontend/tests/components/TokenChart.test.tsx
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@solidjs/testing-library";
+
+let capturedOpts: any = null;
+let capturedData: any = null;
+let capturedLifecycleOpts: any = null;
+
+vi.mock("uplot", () => {
+  return {
+    default: class MockUPlot {
+      constructor(opts: any, data: any, _el: any) {
+        capturedOpts = opts;
+        capturedData = data;
+      }
+      destroy = vi.fn();
+    },
+  };
+});
+
+vi.mock("../../src/services/theme.js", () => ({
+  getHsl: (name: string) => `hsl(var(${name}))`,
+  getHslA: (name: string, alpha: number) => `hsla(var(${name}), ${alpha})`,
+}));
+
+vi.mock("../../src/services/chart-utils.js", () => ({
+  makeGradientFillFromVar: (cssVar: string, alpha: number) =>
+    `gradient(${cssVar}, ${alpha})`,
+  useChartLifecycle: (opts: any) => {
+    capturedLifecycleOpts = opts;
+  },
+  createCursorSnap: (bg: string, point: string) => ({
+    show: true,
+    bg,
+    point,
+  }),
+  createBaseAxes: (axisColor: string, gridColor: string, _range?: string) => [
+    {
+      stroke: axisColor,
+      grid: { stroke: gridColor, width: 1 },
+      ticks: { stroke: gridColor, width: 1 },
+      font: '11px "Inter"',
+      gap: 8,
+    },
+    {
+      stroke: axisColor,
+      grid: { stroke: gridColor, width: 1 },
+      ticks: { show: false },
+      font: '11px "Inter"',
+      size: 54,
+      gap: 8,
+    },
+  ],
+  parseTimestamps: (data: any[]) => data.map((_: any, i: number) => 1000 + i),
+  timeScaleRange: vi.fn(),
+  formatLegendTimestamp: vi.fn(),
+  formatLegendTokens: vi.fn(),
+}));
+
+import TokenChart from "../../src/components/TokenChart";
+
+const sampleData = [
+  { hour: "2026-02-18 10:00:00", input_tokens: 1000, output_tokens: 500 },
+  { hour: "2026-02-18 11:00:00", input_tokens: 2000, output_tokens: 800 },
+  { hour: "2026-02-18 12:00:00", input_tokens: 1500, output_tokens: 1200 },
+];
+
+function renderAndBuild(data = sampleData, range?: string) {
+  capturedOpts = null;
+  capturedData = null;
+  capturedLifecycleOpts = null;
+
+  render(() => <TokenChart data={data} range={range} />);
+
+  // The mock useChartLifecycle captured the options including buildChart.
+  // The component's `el` ref is set after render, but clientWidth is 0 in jsdom.
+  // Stub clientWidth on the element so buildChart proceeds past the width guard.
+  const el = capturedLifecycleOpts.el();
+  Object.defineProperty(el, "clientWidth", { value: 800, configurable: true });
+
+  capturedLifecycleOpts.buildChart();
+}
+
+describe("TokenChart", () => {
+  beforeEach(() => {
+    capturedOpts = null;
+    capturedData = null;
+    capturedLifecycleOpts = null;
+  });
+
+  describe("rendering", () => {
+    it("should render a container div element", () => {
+      const { container } = render(() => <TokenChart data={sampleData} />);
+      const div = container.querySelector("div");
+      expect(div).not.toBeNull();
+    });
+
+    it("should set min-height of 260px on the container", () => {
+      const { container } = render(() => <TokenChart data={sampleData} />);
+      const div = container.querySelector("div");
+      expect(div?.style.minHeight).toBe("260px");
+    });
+
+    it("should set width to 100% on the container", () => {
+      const { container } = render(() => <TokenChart data={sampleData} />);
+      const div = container.querySelector("div");
+      expect(div?.style.width).toBe("100%");
+    });
+  });
+
+  describe("scales configuration", () => {
+    it("should define an x scale with time enabled", () => {
+      renderAndBuild();
+      expect(capturedOpts).not.toBeNull();
+      expect(capturedOpts.scales.x).toBeDefined();
+      expect(capturedOpts.scales.x.time).toBe(true);
+    });
+
+    it("should define a y scale for input tokens (left axis)", () => {
+      renderAndBuild();
+      expect(capturedOpts.scales.y).toBeDefined();
+      expect(capturedOpts.scales.y.auto).toBe(true);
+    });
+
+    it("should define a y2 scale for output tokens (right axis)", () => {
+      renderAndBuild();
+      expect(capturedOpts.scales.y2).toBeDefined();
+      expect(capturedOpts.scales.y2.auto).toBe(true);
+    });
+
+    it("should have three scales total (x, y, y2)", () => {
+      renderAndBuild();
+      const scaleKeys = Object.keys(capturedOpts.scales);
+      expect(scaleKeys).toContain("x");
+      expect(scaleKeys).toContain("y");
+      expect(scaleKeys).toContain("y2");
+      expect(scaleKeys).toHaveLength(3);
+    });
+
+    it("should use a yRange function that pads max by 10%", () => {
+      renderAndBuild();
+      const yRange = capturedOpts.scales.y.range;
+      const [min, max] = yRange(null, 0, 1000);
+      expect(min).toBe(0);
+      expect(max).toBe(1100);
+    });
+
+    it("should return [0, 100] when max is 0", () => {
+      renderAndBuild();
+      const yRange = capturedOpts.scales.y.range;
+      const [min, max] = yRange(null, 0, 0);
+      expect(min).toBe(0);
+      expect(max).toBe(100);
+    });
+
+    it("should use the same yRange logic for y and y2 scales", () => {
+      renderAndBuild();
+      const yRange = capturedOpts.scales.y.range;
+      const y2Range = capturedOpts.scales.y2.range;
+      expect(yRange(null, 0, 500)).toEqual(y2Range(null, 0, 500));
+    });
+  });
+
+  describe("axes configuration", () => {
+    it("should define three axes (x, left y, right y2)", () => {
+      renderAndBuild();
+      expect(capturedOpts.axes).toHaveLength(3);
+    });
+
+    it("should color the left y-axis with inputColor (--bar-input)", () => {
+      renderAndBuild();
+      const leftYAxis = capturedOpts.axes[1];
+      expect(leftYAxis.stroke).toBe("hsl(var(--bar-input))");
+    });
+
+    it("should color the right y2-axis with outputColor (--bar-output)", () => {
+      renderAndBuild();
+      const rightYAxis = capturedOpts.axes[2];
+      expect(rightYAxis.stroke).toBe("hsl(var(--bar-output))");
+    });
+
+    it("should assign right y2-axis to scale y2", () => {
+      renderAndBuild();
+      const rightYAxis = capturedOpts.axes[2];
+      expect(rightYAxis.scale).toBe("y2");
+    });
+
+    it("should place right y2-axis on side 1 (right side)", () => {
+      renderAndBuild();
+      const rightYAxis = capturedOpts.axes[2];
+      expect(rightYAxis.side).toBe(1);
+    });
+
+    it("should disable grid lines on the right y2-axis", () => {
+      renderAndBuild();
+      const rightYAxis = capturedOpts.axes[2];
+      expect(rightYAxis.grid).toEqual({ show: false });
+    });
+
+    it("should disable ticks on the right y2-axis", () => {
+      renderAndBuild();
+      const rightYAxis = capturedOpts.axes[2];
+      expect(rightYAxis.ticks).toEqual({ show: false });
+    });
+
+    it("should set font on the right y2-axis", () => {
+      renderAndBuild();
+      const rightYAxis = capturedOpts.axes[2];
+      expect(rightYAxis.font).toBe('11px "Inter"');
+    });
+
+    it("should set size and gap on the right y2-axis", () => {
+      renderAndBuild();
+      const rightYAxis = capturedOpts.axes[2];
+      expect(rightYAxis.size).toBe(54);
+      expect(rightYAxis.gap).toBe(8);
+    });
+
+    it("should have a values formatter on the left y-axis", () => {
+      renderAndBuild();
+      const leftYAxis = capturedOpts.axes[1];
+      expect(typeof leftYAxis.values).toBe("function");
+    });
+
+    it("should have a values formatter on the right y2-axis", () => {
+      renderAndBuild();
+      const rightYAxis = capturedOpts.axes[2];
+      expect(typeof rightYAxis.values).toBe("function");
+    });
+  });
+
+  describe("series configuration", () => {
+    it("should define three series (timestamp, input, output)", () => {
+      renderAndBuild();
+      expect(capturedOpts.series).toHaveLength(3);
+    });
+
+    it("should assign the input series label as 'Sent to AI'", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[1].label).toBe("Sent to AI");
+    });
+
+    it("should assign the output series label as 'Received from AI'", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[2].label).toBe("Received from AI");
+    });
+
+    it("should assign input series to scale y (left axis)", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[1].scale).toBe("y");
+    });
+
+    it("should assign output series to scale y2 (right axis)", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[2].scale).toBe("y2");
+    });
+
+    it("should color input series stroke with inputColor", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[1].stroke).toBe("hsl(var(--bar-input))");
+    });
+
+    it("should color output series stroke with outputColor", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[2].stroke).toBe("hsl(var(--bar-output))");
+    });
+
+    it("should set input series line width to 2.5", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[1].width).toBe(2.5);
+    });
+
+    it("should set output series line width to 2", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[2].width).toBe(2);
+    });
+
+    it("should use gradient fill for input series from --bar-input", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[1].fill).toBe("gradient(--bar-input, 0.25)");
+    });
+
+    it("should use gradient fill for output series from --bar-output", () => {
+      renderAndBuild();
+      expect(capturedOpts.series[2].fill).toBe("gradient(--bar-output, 0.15)");
+    });
+  });
+
+  describe("layout configuration", () => {
+    it("should set chart height to 260", () => {
+      renderAndBuild();
+      expect(capturedOpts.height).toBe(260);
+    });
+
+    it("should set right padding to 0 for the dual-axis layout", () => {
+      renderAndBuild();
+      expect(capturedOpts.padding[1]).toBe(0);
+    });
+
+    it("should set top padding to 16", () => {
+      renderAndBuild();
+      expect(capturedOpts.padding[0]).toBe(16);
+    });
+
+    it("should set the full padding array to [16, 0, 0, 0]", () => {
+      renderAndBuild();
+      expect(capturedOpts.padding).toEqual([16, 0, 0, 0]);
+    });
+
+    it("should set chart width from the container element", () => {
+      renderAndBuild();
+      expect(capturedOpts.width).toBe(800);
+    });
+  });
+
+  describe("data mapping", () => {
+    it("should pass input_tokens as the second data series", () => {
+      renderAndBuild();
+      expect(capturedData[1]).toEqual([1000, 2000, 1500]);
+    });
+
+    it("should pass output_tokens as the third data series", () => {
+      renderAndBuild();
+      expect(capturedData[2]).toEqual([500, 800, 1200]);
+    });
+
+    it("should pass timestamps as the first data series", () => {
+      renderAndBuild();
+      expect(capturedData[0]).toEqual([1000, 1001, 1002]);
+    });
+
+    it("should pass three data arrays total", () => {
+      renderAndBuild();
+      expect(capturedData).toHaveLength(3);
+    });
+  });
+
+  describe("buildChart guard clauses", () => {
+    it("should return null when el has zero width", () => {
+      render(() => <TokenChart data={sampleData} />);
+      // el.clientWidth defaults to 0 in jsdom, do not stub it
+      const result = capturedLifecycleOpts.buildChart();
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Dual Y-axis on token chart**: Input tokens use the left Y-axis, output tokens use the right Y-axis, each independently scaled. Both axes are color-coded to match their series. This prevents the smaller series (output) from being visually flattened when input tokens are much larger.
- **Seed demo agent messages**: Adds ~695 deterministic messages over 7 days with realistic token distributions (input 5-25x larger than output) to both cloud and local mode bootstrapping, so the dashboard has data on first run.

## Test plan
- [x] Frontend tests pass (989 tests including 42 new TokenChart tests)
- [x] Backend tests pass (1654 tests including 29 new seed-messages tests)
- [x] TypeScript compiles cleanly in both frontend and backend
- [x] Manual verification: started local server, confirmed dual Y-axes render with seed data
- [x] Changeset included for `manifest` (minor)