### PR TITLE
Fix PostHog funnel distinct_id mismatch in cloud mode

### DIFF
--- a/.changeset/fix-posthog-funnel-distinct-id.md
+++ b/.changeset/fix-posthog-funnel-distinct-id.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix PostHog funnel distinct_id mismatch in cloud mode by emitting plugin_registered from backend with hashed user ID, and pass explicit mode to plugin telemetry events

--- a/package-lock.json
+++ b/package-lock.json
@@ -14131,7 +14131,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.18.0",
+      "version": "5.19.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/backend/src/otlp/otlp.controller.spec.ts
+++ b/packages/backend/src/otlp/otlp.controller.spec.ts
@@ -62,7 +62,12 @@ describe('OtlpController', () => {
       headers: { 'content-type': contentType },
       body,
       rawBody,
-      ingestionContext: { tenantId: 'test-tenant', agentId: 'test-agent', agentName: 'test-agent', userId: 'test-user' },
+      ingestionContext: {
+        tenantId: 'test-tenant',
+        agentId: 'test-agent',
+        agentName: 'test-agent',
+        userId: 'test-user',
+      },
     } as never;
   }
 
@@ -139,11 +144,12 @@ describe('OtlpController', () => {
       delete process.env['MANIFEST_MODE'];
       await controller.ingestTraces(makeReq('application/json', {}, undefined));
 
-      expect(trackCloudEvent).toHaveBeenCalledWith(
-        'first_telemetry_received',
-        'test-user',
-        { agent_id_hash: 'test-age' },
-      );
+      expect(trackCloudEvent).toHaveBeenCalledWith('plugin_registered', 'test-user', {
+        source: 'backend',
+      });
+      expect(trackCloudEvent).toHaveBeenCalledWith('first_telemetry_received', 'test-user', {
+        agent_id_hash: 'test-age',
+      });
       expect(trackEvent).not.toHaveBeenCalled();
     });
 
@@ -152,10 +158,9 @@ describe('OtlpController', () => {
       (existsSync as jest.Mock).mockReturnValue(false);
       await controller.ingestTraces(makeReq('application/json', {}, undefined));
 
-      expect(trackEvent).toHaveBeenCalledWith(
-        'first_telemetry_received',
-        { agent_id_hash: 'test-age' },
-      );
+      expect(trackEvent).toHaveBeenCalledWith('first_telemetry_received', {
+        agent_id_hash: 'test-age',
+      });
       expect(trackCloudEvent).not.toHaveBeenCalled();
     });
 
@@ -173,7 +178,111 @@ describe('OtlpController', () => {
       await controller.ingestTraces(makeReq('application/json', {}, undefined));
       await controller.ingestTraces(makeReq('application/json', {}, undefined));
 
-      expect(trackCloudEvent).toHaveBeenCalledTimes(1);
+      // 2 calls on first ingest (plugin_registered + first_telemetry_received), 0 on second
+      expect(trackCloudEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it('emits plugin_registered with source backend via metrics ingestion', async () => {
+      delete process.env['MANIFEST_MODE'];
+      await controller.ingestMetrics(makeReq('application/json', {}, undefined));
+
+      expect(trackCloudEvent).toHaveBeenCalledWith('plugin_registered', 'test-user', {
+        source: 'backend',
+      });
+      expect(trackCloudEvent).toHaveBeenCalledWith('first_telemetry_received', 'test-user', {
+        agent_id_hash: 'test-age',
+      });
+    });
+
+    it('emits plugin_registered with source backend via logs ingestion', async () => {
+      delete process.env['MANIFEST_MODE'];
+      await controller.ingestLogs(makeReq('application/json', {}, undefined));
+
+      expect(trackCloudEvent).toHaveBeenCalledWith('plugin_registered', 'test-user', {
+        source: 'backend',
+      });
+      expect(trackCloudEvent).toHaveBeenCalledWith('first_telemetry_received', 'test-user', {
+        agent_id_hash: 'test-age',
+      });
+    });
+
+    it('deduplicates across different ingestion methods for the same agent', async () => {
+      delete process.env['MANIFEST_MODE'];
+      await controller.ingestTraces(makeReq('application/json', {}, undefined));
+      await controller.ingestMetrics(makeReq('application/json', {}, undefined));
+      await controller.ingestLogs(makeReq('application/json', {}, undefined));
+
+      // Only the first call (traces) should trigger events
+      expect(trackCloudEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it('tracks separately for different agentIds in cloud mode', async () => {
+      delete process.env['MANIFEST_MODE'];
+
+      const reqAgent1 = {
+        headers: { 'content-type': 'application/json' },
+        body: {},
+        rawBody: undefined,
+        ingestionContext: {
+          tenantId: 'tenant-1',
+          agentId: 'agent-1',
+          agentName: 'agent-1',
+          userId: 'user-1',
+        },
+      } as never;
+
+      const reqAgent2 = {
+        headers: { 'content-type': 'application/json' },
+        body: {},
+        rawBody: undefined,
+        ingestionContext: {
+          tenantId: 'tenant-1',
+          agentId: 'agent-2',
+          agentName: 'agent-2',
+          userId: 'user-1',
+        },
+      } as never;
+
+      await controller.ingestTraces(reqAgent1);
+      await controller.ingestTraces(reqAgent2);
+
+      // 2 events per agent = 4 total
+      expect(trackCloudEvent).toHaveBeenCalledTimes(4);
+    });
+
+    it('uses userId as the distinct_id key for trackCloudEvent', async () => {
+      delete process.env['MANIFEST_MODE'];
+
+      const req = {
+        headers: { 'content-type': 'application/json' },
+        body: {},
+        rawBody: undefined,
+        ingestionContext: {
+          tenantId: 'my-tenant',
+          agentId: 'my-agent',
+          agentName: 'my-agent',
+          userId: 'user-abc-123',
+        },
+      } as never;
+
+      await controller.ingestTraces(req);
+
+      expect(trackCloudEvent).toHaveBeenCalledWith('plugin_registered', 'user-abc-123', {
+        source: 'backend',
+      });
+      expect(trackCloudEvent).toHaveBeenCalledWith('first_telemetry_received', 'user-abc-123', {
+        agent_id_hash: 'my-agent',
+      });
+    });
+
+    it('does not emit events when no data is accepted', async () => {
+      delete process.env['MANIFEST_MODE'];
+      mockTraceIngest.ingest.mockResolvedValue({ accepted: 0 });
+
+      await controller.ingestTraces(makeReq('application/json', {}, undefined));
+
+      expect(trackCloudEvent).not.toHaveBeenCalled();
+      expect(trackEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/otlp/otlp.controller.ts
+++ b/packages/backend/src/otlp/otlp.controller.ts
@@ -89,6 +89,9 @@ export class OtlpController {
     } else {
       if (this.seenAgents.has(ctx.agentId)) return;
       this.seenAgents.add(ctx.agentId);
+      trackCloudEvent('plugin_registered', ctx.userId, {
+        source: 'backend',
+      });
       trackCloudEvent('first_telemetry_received', ctx.userId, {
         agent_id_hash: ctx.agentId.slice(0, 8),
       });

--- a/packages/openclaw-plugin/__tests__/product-telemetry.test.ts
+++ b/packages/openclaw-plugin/__tests__/product-telemetry.test.ts
@@ -1,0 +1,199 @@
+jest.mock("../src/telemetry-config", () => ({
+  getTelemetryConfig: jest.fn(),
+}));
+
+import { trackPluginEvent } from "../src/product-telemetry";
+import { getTelemetryConfig } from "../src/telemetry-config";
+
+const mockGetTelemetryConfig = getTelemetryConfig as jest.Mock;
+
+describe("trackPluginEvent", () => {
+  const origMode = process.env["MANIFEST_MODE"];
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env["MANIFEST_MODE"];
+    fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({} as Response);
+    mockGetTelemetryConfig.mockReturnValue({
+      optedOut: false,
+      packageVersion: "1.2.3",
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    if (origMode === undefined) delete process.env["MANIFEST_MODE"];
+    else process.env["MANIFEST_MODE"] = origMode;
+  });
+
+  describe("opt-out behavior", () => {
+    it("should not call fetch when telemetry is opted out", () => {
+      mockGetTelemetryConfig.mockReturnValue({
+        optedOut: true,
+        packageVersion: "1.2.3",
+      });
+
+      trackPluginEvent("some_event");
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should return immediately when opted out without building payload", () => {
+      mockGetTelemetryConfig.mockReturnValue({
+        optedOut: true,
+        packageVersion: "1.2.3",
+      });
+
+      trackPluginEvent("some_event", { extra: "data" }, "local");
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mode parameter resolution", () => {
+    it("should use explicit mode parameter when provided", () => {
+      trackPluginEvent("plugin_registered", undefined, "local");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.mode).toBe("local");
+    });
+
+    it("should fall back to MANIFEST_MODE env var when mode parameter is undefined", () => {
+      process.env["MANIFEST_MODE"] = "local";
+
+      trackPluginEvent("plugin_registered");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.mode).toBe("local");
+    });
+
+    it("should default to 'cloud' when neither mode param nor env var is set", () => {
+      delete process.env["MANIFEST_MODE"];
+
+      trackPluginEvent("plugin_registered");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.mode).toBe("cloud");
+    });
+
+    it("should prefer explicit mode parameter over MANIFEST_MODE env var", () => {
+      process.env["MANIFEST_MODE"] = "cloud";
+
+      trackPluginEvent("plugin_registered", undefined, "local");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.mode).toBe("local");
+    });
+  });
+
+  describe("PostHog payload structure", () => {
+    it("should POST to the correct PostHog capture endpoint", () => {
+      trackPluginEvent("test_event");
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "https://eu.i.posthog.com/capture",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    });
+
+    it("should include the PostHog API key in the payload", () => {
+      trackPluginEvent("test_event");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.api_key).toBe("phc_g5pLOu5bBRjhVJBwAsx0eCzJFWq0cri2TyVLQLxf045");
+    });
+
+    it("should include event name in the payload", () => {
+      trackPluginEvent("plugin_registered");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.event).toBe("plugin_registered");
+    });
+
+    it("should include a timestamp in ISO format", () => {
+      trackPluginEvent("test_event");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.timestamp).toBeDefined();
+      expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+    });
+
+    it("should include distinct_id derived from machine identity", () => {
+      trackPluginEvent("test_event");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.distinct_id).toBeDefined();
+      expect(typeof body.properties.distinct_id).toBe("string");
+      expect(body.properties.distinct_id.length).toBe(16);
+    });
+
+    it("should produce a stable distinct_id across calls", () => {
+      trackPluginEvent("event_1");
+      trackPluginEvent("event_2");
+
+      const body1 = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      const body2 = JSON.parse(fetchSpy.mock.calls[1][1].body);
+      expect(body1.properties.distinct_id).toBe(body2.properties.distinct_id);
+    });
+
+    it("should include os, os_version, and node_version in properties", () => {
+      trackPluginEvent("test_event");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.os).toBeDefined();
+      expect(body.properties.os_version).toBeDefined();
+      expect(body.properties.node_version).toBe(process.versions.node);
+    });
+
+    it("should include package_version from telemetry config", () => {
+      mockGetTelemetryConfig.mockReturnValue({
+        optedOut: false,
+        packageVersion: "5.19.0",
+      });
+
+      trackPluginEvent("test_event");
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.package_version).toBe("5.19.0");
+    });
+  });
+
+  describe("custom properties", () => {
+    it("should merge additional properties into the payload", () => {
+      trackPluginEvent("plugin_mode_selected", { mode: "local" });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.mode).toBe("local");
+    });
+
+    it("should allow custom properties to override base properties", () => {
+      trackPluginEvent("test_event", { distinct_id: "custom-id" });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.properties.distinct_id).toBe("custom-id");
+    });
+
+    it("should work with no custom properties", () => {
+      trackPluginEvent("plugin_registered");
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.event).toBe("plugin_registered");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should silently swallow fetch errors", () => {
+      fetchSpy.mockRejectedValue(new Error("Network error"));
+
+      expect(() => trackPluginEvent("test_event")).not.toThrow();
+    });
+  });
+});

--- a/packages/openclaw-plugin/__tests__/register.test.ts
+++ b/packages/openclaw-plugin/__tests__/register.test.ts
@@ -106,9 +106,45 @@ describe("register — mode routing", () => {
     const api = makeApi();
     plugin.register(api);
 
+    expect(trackPluginEvent).toHaveBeenCalledWith("plugin_registered", undefined, "local");
     expect(trackPluginEvent).toHaveBeenCalledWith("plugin_mode_selected", {
       mode: "local",
+    }, "local");
+  });
+
+  it("passes config.mode as third argument to trackPluginEvent in cloud mode", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      mode: "cloud",
+      apiKey: "mnfst_abc",
+      endpoint: "https://app.manifest.build/otlp",
+      port: 2099,
+      host: "127.0.0.1",
     });
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(trackPluginEvent).toHaveBeenCalledWith("plugin_registered", undefined, "cloud");
+    expect(trackPluginEvent).toHaveBeenCalledWith("plugin_mode_selected", {
+      mode: "cloud",
+    }, "cloud");
+  });
+
+  it("calls trackPluginEvent exactly twice for non-dev modes", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      mode: "cloud",
+      apiKey: "mnfst_abc",
+      endpoint: "https://app.manifest.build/otlp",
+      port: 2099,
+      host: "127.0.0.1",
+    });
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(trackPluginEvent).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1,17 +1,17 @@
-import { parseConfig, validateConfig, ManifestConfig } from "./config";
-import { initTelemetry, shutdownTelemetry, PluginLogger } from "./telemetry";
-import { registerHooks, initMetrics } from "./hooks";
-import { registerRouting } from "./routing";
-import { registerTools } from "./tools";
-import { registerCommand } from "./command";
-import { verifyConnection } from "./verify";
-import { registerLocalMode, injectProviderConfig, injectAuthProfile } from "./local-mode";
-import { trackPluginEvent } from "./product-telemetry";
+import { parseConfig, validateConfig, ManifestConfig } from './config';
+import { initTelemetry, shutdownTelemetry, PluginLogger } from './telemetry';
+import { registerHooks, initMetrics } from './hooks';
+import { registerRouting } from './routing';
+import { registerTools } from './tools';
+import { registerCommand } from './command';
+import { verifyConnection } from './verify';
+import { registerLocalMode, injectProviderConfig, injectAuthProfile } from './local-mode';
+import { trackPluginEvent } from './product-telemetry';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 module.exports = {
-  id: "manifest",
-  name: "Manifest — Agent Observability",
+  id: 'manifest',
+  name: 'Manifest — Agent Observability',
 
   register(api: any) {
     const logger: PluginLogger = api.logger || {
@@ -22,26 +22,26 @@ module.exports = {
     };
 
     const config: ManifestConfig = parseConfig(api.pluginConfig);
-    if (config.mode !== "dev") {
-      trackPluginEvent("plugin_registered");
-      trackPluginEvent("plugin_mode_selected", { mode: config.mode });
+    if (config.mode !== 'dev') {
+      trackPluginEvent('plugin_registered', undefined, config.mode);
+      trackPluginEvent('plugin_mode_selected', { mode: config.mode }, config.mode);
     }
 
-    if (config.mode === "local") {
+    if (config.mode === 'local') {
       registerLocalMode(api, config, logger);
       return;
     }
 
     const error = validateConfig(config);
     if (error) {
-      if (config.mode === "cloud" && !config.apiKey) {
+      if (config.mode === 'cloud' && !config.apiKey) {
         logger.info(
-          "[manifest] Cloud mode requires an API key:\n" +
-            "  openclaw config set plugins.entries.manifest.config.apiKey mnfst_YOUR_KEY\n" +
-            "  openclaw gateway restart\n\n" +
-            "Tip: Set mode to local for a zero-config embedded server:\n" +
-            "  openclaw config set plugins.entries.manifest.config.mode local\n" +
-            "  openclaw gateway restart",
+          '[manifest] Cloud mode requires an API key:\n' +
+            '  openclaw config set plugins.entries.manifest.config.apiKey mnfst_YOUR_KEY\n' +
+            '  openclaw gateway restart\n\n' +
+            'Tip: Set mode to local for a zero-config embedded server:\n' +
+            '  openclaw config set plugins.entries.manifest.config.mode local\n' +
+            '  openclaw gateway restart',
         );
       } else {
         logger.error(`[manifest] Configuration error:\n${error}`);
@@ -51,26 +51,26 @@ module.exports = {
 
     // Detect built-in diagnostics-otel conflict
     const entries = api.config?.plugins?.entries || {};
-    if (entries["diagnostics-otel"]?.enabled) {
+    if (entries['diagnostics-otel']?.enabled) {
       logger.error(
         "[manifest] ERROR: Built-in 'diagnostics-otel' is also enabled. " +
-          "This causes duplicate OTel registration errors. " +
-          "Disable it now:\n" +
-          "  openclaw plugins disable diagnostics-otel\n" +
-          "Then restart the gateway.",
+          'This causes duplicate OTel registration errors. ' +
+          'Disable it now:\n' +
+          '  openclaw plugins disable diagnostics-otel\n' +
+          'Then restart the gateway.',
       );
       return;
     }
 
     // Derive the base origin from the OTLP endpoint (strip /otlp suffix).
     // Used by both dev and cloud modes to build the provider baseUrl.
-    const baseOrigin = config.endpoint.replace(/\/otlp(\/v1)?\/?$/, "");
+    const baseOrigin = config.endpoint.replace(/\/otlp(\/v1)?\/?$/, '');
 
     // Dev mode: connect to an external server without API key
-    if (config.mode === "dev") {
-      logger.info("[manifest] Dev mode — connecting to external server...");
+    if (config.mode === 'dev') {
+      logger.info('[manifest] Dev mode — connecting to external server...');
 
-      const devPlaceholderKey = "dev-no-auth";
+      const devPlaceholderKey = 'dev-no-auth';
       injectProviderConfig(api, `${baseOrigin}/v1`, devPlaceholderKey, logger);
       injectAuthProfile(devPlaceholderKey, logger);
 
@@ -79,7 +79,7 @@ module.exports = {
       registerHooks(api, tracer, config, logger);
       registerRouting(api, config, logger);
 
-      if (typeof api.registerTool === "function") {
+      if (typeof api.registerTool === 'function') {
         registerTools(api, config, logger);
       }
       registerCommand(api, config, logger);
@@ -87,19 +87,21 @@ module.exports = {
       logger.info(`[manifest]   Dashboard: ${baseOrigin}`);
 
       api.registerService({
-        id: "manifest-dev",
+        id: 'manifest-dev',
         start: () => {
-          logger.info("[manifest] Dev mode pipeline active");
+          logger.info('[manifest] Dev mode pipeline active');
           logger.info(`[manifest]   Endpoint=${config.endpoint}`);
 
-          verifyConnection(config).then((check) => {
-            if (check.error) {
-              logger.warn?.(`[manifest] Connection check failed: ${check.error}`);
-              return;
-            }
-            const agent = check.agentName ? ` (agent: ${check.agentName})` : "";
-            logger.info(`[manifest] Connection verified${agent}`);
-          }).catch(() => {});
+          verifyConnection(config)
+            .then((check) => {
+              if (check.error) {
+                logger.warn?.(`[manifest] Connection check failed: ${check.error}`);
+                return;
+              }
+              const agent = check.agentName ? ` (agent: ${check.agentName})` : '';
+              logger.info(`[manifest] Connection verified${agent}`);
+            })
+            .catch(() => {});
         },
         stop: async () => {
           await shutdownTelemetry(logger);
@@ -110,7 +112,7 @@ module.exports = {
     }
 
     // Cloud mode
-    logger.info("[manifest] Initializing observability pipeline...");
+    logger.info('[manifest] Initializing observability pipeline...');
 
     // Sync the provider config file so the gateway uses the correct
     // baseUrl and apiKey for proxy requests after restarts.
@@ -122,32 +124,32 @@ module.exports = {
     registerHooks(api, tracer, config, logger);
     registerRouting(api, config, logger);
 
-    if (typeof api.registerTool === "function") {
+    if (typeof api.registerTool === 'function') {
       registerTools(api, config, logger);
     } else {
-      logger.info(
-        "[manifest] Agent tools not available in this OpenClaw version",
-      );
+      logger.info('[manifest] Agent tools not available in this OpenClaw version');
     }
     registerCommand(api, config, logger);
 
     api.registerService({
-      id: "manifest-telemetry",
+      id: 'manifest-telemetry',
       start: () => {
-        logger.info("[manifest] Observability pipeline active");
+        logger.info('[manifest] Observability pipeline active');
         logger.info(`[manifest]   Endpoint=${config.endpoint}`);
 
         // Non-blocking connection verify after startup
-        verifyConnection(config).then((check) => {
-          if (check.error) {
-            logger.warn?.(`[manifest] Connection check failed: ${check.error}`);
-            return;
-          }
-          const agent = check.agentName ? ` (agent: ${check.agentName})` : "";
-          logger.info(`[manifest] Connection verified${agent}`);
-        }).catch(() => {
-          // Swallow — startup should never fail on verify
-        });
+        verifyConnection(config)
+          .then((check) => {
+            if (check.error) {
+              logger.warn?.(`[manifest] Connection check failed: ${check.error}`);
+              return;
+            }
+            const agent = check.agentName ? ` (agent: ${check.agentName})` : '';
+            logger.info(`[manifest] Connection verified${agent}`);
+          })
+          .catch(() => {
+            // Swallow — startup should never fail on verify
+          });
       },
       stop: async () => {
         await shutdownTelemetry(logger);

--- a/packages/openclaw-plugin/src/product-telemetry.ts
+++ b/packages/openclaw-plugin/src/product-telemetry.ts
@@ -1,18 +1,19 @@
-import { createHash } from "crypto";
-import { hostname, platform, arch, release } from "os";
-import { getTelemetryConfig } from "./telemetry-config";
+import { createHash } from 'crypto';
+import { hostname, platform, arch, release } from 'os';
+import { getTelemetryConfig } from './telemetry-config';
 
-const POSTHOG_HOST = "https://eu.i.posthog.com";
-const POSTHOG_API_KEY = "phc_g5pLOu5bBRjhVJBwAsx0eCzJFWq0cri2TyVLQLxf045";
+const POSTHOG_HOST = 'https://eu.i.posthog.com';
+const POSTHOG_API_KEY = 'phc_g5pLOu5bBRjhVJBwAsx0eCzJFWq0cri2TyVLQLxf045';
 
 function getMachineId(): string {
   const raw = `${hostname()}-${platform()}-${arch()}`;
-  return createHash("sha256").update(raw).digest("hex").slice(0, 16);
+  return createHash('sha256').update(raw).digest('hex').slice(0, 16);
 }
 
 export function trackPluginEvent(
   event: string,
   properties?: Record<string, unknown>,
+  mode?: string,
 ): void {
   const config = getTelemetryConfig();
   if (config.optedOut) return;
@@ -26,15 +27,15 @@ export function trackPluginEvent(
       os_version: release(),
       node_version: process.versions.node,
       package_version: config.packageVersion,
-      mode: process.env['MANIFEST_MODE'] ?? 'cloud',
+      mode: mode ?? process.env['MANIFEST_MODE'] ?? 'cloud',
       ...properties,
     },
     timestamp: new Date().toISOString(),
   };
 
   fetch(`${POSTHOG_HOST}/capture`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   }).catch(() => {});
 }


### PR DESCRIPTION
## Summary

- Emit backend-side `plugin_registered` event using `trackCloudEvent` with hashed `user.id` when a cloud user's plugin first connects via OTLP. This ensures all three funnel events (`plugin_registered`, `agent_created`, `first_telemetry_received`) share the same `distinct_id` for cloud users.
- Fix the plugin's `mode` property by passing `config.mode` explicitly to `trackPluginEvent` instead of reading `MANIFEST_MODE` env var (which may not be set at registration time).
- Add comprehensive test coverage for `trackPluginEvent` (new test file) and expand OTLP controller tests for the new behavior.

## Context

The PostHog funnel "Install → Create Agent → First Data" showed 0% conversion in cloud mode because each funnel step used a different `distinct_id`:
- `plugin_registered` → machine ID (`sha256(hostname-platform-arch)`)
- `agent_created` → hashed tenant (`sha256(user.id)`)
- `first_telemetry_received` → hashed tenant (`sha256(user.id)`)

## Test plan

- [x] Backend unit tests pass (1757 tests)
- [x] Backend e2e tests pass (86 tests)
- [x] Plugin tests pass (259 tests)
- [x] Frontend tests pass (997 tests)
- [x] TypeScript compilation clean (backend + plugin)
- [ ] Verify in PostHog that cloud mode funnel now shows conversions after deploy