### PR TITLE
feat: per-agent routing configuration

### DIFF
--- a/.changeset/per-agent-routing.md
+++ b/.changeset/per-agent-routing.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Make routing configuration per-agent instead of per-user. Each agent now has its own independent set of provider connections (with encrypted API keys) and tier-to-model assignments. Dashboard routing API endpoints include the agent name in the URL path. Existing user-level routing configuration is automatically migrated to all agents under each user.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -39,6 +39,7 @@ import { AddRoutingTier1772100000000 } from './migrations/1772100000000-AddRouti
 import { AddLimitAction1772200000000 } from './migrations/1772200000000-AddLimitAction';
 import { AddRoutingReason1772300000000 } from './migrations/1772300000000-AddRoutingReason';
 import { AddAgentDisplayName1772400000000 } from './migrations/1772400000000-AddAgentDisplayName';
+import { PerAgentRouting1772500000000 } from './migrations/1772500000000-PerAgentRouting';
 
 const entities = [
   AgentMessage,
@@ -82,6 +83,7 @@ const migrations = [
   AddLimitAction1772200000000,
   AddRoutingReason1772300000000,
   AddAgentDisplayName1772400000000,
+  PerAgentRouting1772500000000,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';
@@ -129,6 +131,8 @@ function buildModeServices() {
       ApiKey,
       ModelPricing,
       SecurityEvent,
+      UserProvider,
+      TierAssignment,
     ]),
     ModelPricesModule,
   ],

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -1,6 +1,7 @@
 // Mock typeorm to avoid path-scurry native dependency issue
 jest.mock('typeorm', () => ({
   Repository: jest.fn(),
+  IsNull: jest.fn().mockReturnValue({ _type: 'isNull' }),
 }));
 
 jest.mock('@nestjs/typeorm', () => ({
@@ -36,6 +37,8 @@ jest.mock('../entities/agent.entity', () => ({ Agent: jest.fn() }));
 jest.mock('../entities/agent-api-key.entity', () => ({ AgentApiKey: jest.fn() }));
 jest.mock('../entities/agent-message.entity', () => ({ AgentMessage: jest.fn() }));
 jest.mock('../entities/model-pricing.entity', () => ({ ModelPricing: jest.fn() }));
+jest.mock('../entities/user-provider.entity', () => ({ UserProvider: jest.fn() }));
+jest.mock('../entities/tier-assignment.entity', () => ({ TierAssignment: jest.fn() }));
 
 import { LocalBootstrapService } from './local-bootstrap.service';
 import { trackEvent } from '../common/utils/product-telemetry';
@@ -45,6 +48,8 @@ function makeMockRepo() {
     count: jest.fn().mockResolvedValue(0),
     insert: jest.fn().mockResolvedValue({}),
     upsert: jest.fn().mockResolvedValue({}),
+    find: jest.fn().mockResolvedValue([]),
+    save: jest.fn().mockResolvedValue({}),
   };
 }
 
@@ -55,6 +60,8 @@ describe('LocalBootstrapService', () => {
   let mockAgentKeyRepo: ReturnType<typeof makeMockRepo>;
   let mockMessageRepo: ReturnType<typeof makeMockRepo>;
   let mockPricingRepo: ReturnType<typeof makeMockRepo>;
+  let mockProviderRepo: ReturnType<typeof makeMockRepo>;
+  let mockTierRepo: ReturnType<typeof makeMockRepo>;
   let mockPricingCache: { reload: jest.Mock };
   let mockPricingSync: { syncPricing: jest.Mock };
 
@@ -65,6 +72,8 @@ describe('LocalBootstrapService', () => {
     mockAgentKeyRepo = makeMockRepo();
     mockMessageRepo = makeMockRepo();
     mockPricingRepo = makeMockRepo();
+    mockProviderRepo = makeMockRepo();
+    mockTierRepo = makeMockRepo();
     mockPricingCache = { reload: jest.fn().mockResolvedValue(undefined) };
     mockPricingSync = { syncPricing: jest.fn().mockResolvedValue(undefined) };
 
@@ -74,6 +83,8 @@ describe('LocalBootstrapService', () => {
       mockAgentKeyRepo as never,
       mockMessageRepo as never,
       mockPricingRepo as never,
+      mockProviderRepo as never,
+      mockTierRepo as never,
       mockPricingCache as never,
       mockPricingSync as never,
     );
@@ -191,6 +202,62 @@ describe('LocalBootstrapService', () => {
       mockPricingSync.syncPricing.mockRejectedValue(new Error('network error'));
 
       await expect(service.onModuleInit()).resolves.not.toThrow();
+    });
+  });
+
+  describe('fixupRoutingAgentIds', () => {
+    it('updates orphaned provider rows to LOCAL_AGENT_ID', async () => {
+      const orphanedProvider = { id: 'p1', provider: 'openai', agent_id: null };
+      mockProviderRepo.find.mockResolvedValue([orphanedProvider]);
+      mockTierRepo.find.mockResolvedValue([]);
+
+      await service.onModuleInit();
+
+      expect(mockProviderRepo.find).toHaveBeenCalledWith({
+        where: { agent_id: expect.anything() },
+      });
+      expect(orphanedProvider.agent_id).toBe('local-agent-001');
+      expect(mockProviderRepo.save).toHaveBeenCalledWith(orphanedProvider);
+    });
+
+    it('updates orphaned tier rows to LOCAL_AGENT_ID', async () => {
+      const orphanedTier = { id: 't1', tier: 'simple', agent_id: null };
+      mockProviderRepo.find.mockResolvedValue([]);
+      mockTierRepo.find.mockResolvedValue([orphanedTier]);
+
+      await service.onModuleInit();
+
+      expect(mockTierRepo.find).toHaveBeenCalledWith({
+        where: { agent_id: expect.anything() },
+      });
+      expect(orphanedTier.agent_id).toBe('local-agent-001');
+      expect(mockTierRepo.save).toHaveBeenCalledWith(orphanedTier);
+    });
+
+    it('updates both orphaned providers and tiers', async () => {
+      const provider1 = { id: 'p1', provider: 'openai', agent_id: null };
+      const provider2 = { id: 'p2', provider: 'anthropic', agent_id: null };
+      const tier1 = { id: 't1', tier: 'simple', agent_id: null };
+      mockProviderRepo.find.mockResolvedValue([provider1, provider2]);
+      mockTierRepo.find.mockResolvedValue([tier1]);
+
+      await service.onModuleInit();
+
+      expect(provider1.agent_id).toBe('local-agent-001');
+      expect(provider2.agent_id).toBe('local-agent-001');
+      expect(tier1.agent_id).toBe('local-agent-001');
+      expect(mockProviderRepo.save).toHaveBeenCalledTimes(2);
+      expect(mockTierRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when no orphaned rows exist', async () => {
+      mockProviderRepo.find.mockResolvedValue([]);
+      mockTierRepo.find.mockResolvedValue([]);
+
+      await service.onModuleInit();
+
+      expect(mockProviderRepo.save).not.toHaveBeenCalled();
+      expect(mockTierRepo.save).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -9,6 +9,8 @@ import { Agent } from '../entities/agent.entity';
 import { AgentApiKey } from '../entities/agent-api-key.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { ModelPricing } from '../entities/model-pricing.entity';
+import { UserProvider } from '../entities/user-provider.entity';
+import { TierAssignment } from '../entities/tier-assignment.entity';
 import { hashKey, keyPrefix } from '../common/utils/hash.util';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { PricingSyncService } from './pricing-sync.service';
@@ -32,6 +34,8 @@ export class LocalBootstrapService implements OnModuleInit {
     @InjectRepository(AgentApiKey) private readonly agentKeyRepo: Repository<AgentApiKey>,
     @InjectRepository(AgentMessage) private readonly messageRepo: Repository<AgentMessage>,
     @InjectRepository(ModelPricing) private readonly pricingRepo: Repository<ModelPricing>,
+    @InjectRepository(UserProvider) private readonly providerRepo: Repository<UserProvider>,
+    @InjectRepository(TierAssignment) private readonly tierRepo: Repository<TierAssignment>,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly pricingSync: PricingSyncService,
   ) {}
@@ -40,6 +44,7 @@ export class LocalBootstrapService implements OnModuleInit {
     await this.seedModelPricing();
     await this.pricingCache.reload();
     await this.ensureTenantAndAgent();
+    await this.fixupRoutingAgentIds();
     await seedAgentMessages(this.messageRepo, LOCAL_USER_ID, this.logger, {
       tenantId: LOCAL_TENANT_ID,
       agentId: LOCAL_AGENT_ID,
@@ -108,6 +113,33 @@ export class LocalBootstrapService implements OnModuleInit {
       agent_id: LOCAL_AGENT_ID,
       is_active: true,
     });
+  }
+
+  private async fixupRoutingAgentIds() {
+    // Fix routing rows missing agent_id (from pre-migration SQLite DBs).
+    // SQLite uses synchronize:true so the column is added automatically but
+    // existing rows will have NULL agent_id.
+    const orphanedProviders = await this.providerRepo.find({
+      where: { agent_id: IsNull() as unknown as string },
+    });
+    for (const row of orphanedProviders) {
+      row.agent_id = LOCAL_AGENT_ID;
+      await this.providerRepo.save(row);
+    }
+
+    const orphanedTiers = await this.tierRepo.find({
+      where: { agent_id: IsNull() as unknown as string },
+    });
+    for (const row of orphanedTiers) {
+      row.agent_id = LOCAL_AGENT_ID;
+      await this.tierRepo.save(row);
+    }
+
+    if (orphanedProviders.length > 0 || orphanedTiers.length > 0) {
+      this.logger.log(
+        `Fixed ${orphanedProviders.length} provider(s) and ${orphanedTiers.length} tier(s) with missing agent_id`,
+      );
+    }
   }
 
   private async seedModelPricing() {

--- a/packages/backend/src/database/migrations/1772500000000-PerAgentRouting.ts
+++ b/packages/backend/src/database/migrations/1772500000000-PerAgentRouting.ts
@@ -1,0 +1,103 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PerAgentRouting1772500000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1. Add nullable agent_id column to both tables
+    await queryRunner.query(`ALTER TABLE "user_providers" ADD COLUMN "agent_id" varchar`);
+    await queryRunner.query(`ALTER TABLE "tier_assignments" ADD COLUMN "agent_id" varchar`);
+
+    // 2. Data migration: copy each row for every agent under the user's tenant
+    // user_providers: for each existing row, insert a copy per agent
+    await queryRunner.query(`
+      INSERT INTO "user_providers" ("id", "user_id", "agent_id", "provider", "api_key_encrypted", "is_active", "connected_at", "updated_at")
+      SELECT
+        gen_random_uuid()::varchar,
+        up."user_id",
+        a."id",
+        up."provider",
+        up."api_key_encrypted",
+        up."is_active",
+        up."connected_at",
+        up."updated_at"
+      FROM "user_providers" up
+      JOIN "tenants" t ON t."name" = up."user_id"
+      JOIN "agents" a ON a."tenant_id" = t."id"
+      WHERE up."agent_id" IS NULL
+    `);
+
+    // tier_assignments: for each existing row, insert a copy per agent
+    await queryRunner.query(`
+      INSERT INTO "tier_assignments" ("id", "user_id", "agent_id", "tier", "override_model", "auto_assigned_model", "updated_at")
+      SELECT
+        gen_random_uuid()::varchar,
+        ta."user_id",
+        a."id",
+        ta."tier",
+        ta."override_model",
+        ta."auto_assigned_model",
+        ta."updated_at"
+      FROM "tier_assignments" ta
+      JOIN "tenants" t ON t."name" = ta."user_id"
+      JOIN "agents" a ON a."tenant_id" = t."id"
+      WHERE ta."agent_id" IS NULL
+    `);
+
+    // 3. Delete original rows (where agent_id IS NULL)
+    await queryRunner.query(`DELETE FROM "user_providers" WHERE "agent_id" IS NULL`);
+    await queryRunner.query(`DELETE FROM "tier_assignments" WHERE "agent_id" IS NULL`);
+
+    // 4. Set agent_id to NOT NULL
+    await queryRunner.query(`ALTER TABLE "user_providers" ALTER COLUMN "agent_id" SET NOT NULL`);
+    await queryRunner.query(`ALTER TABLE "tier_assignments" ALTER COLUMN "agent_id" SET NOT NULL`);
+
+    // 5. Drop old unique indexes
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_user_providers_user_provider"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_tier_assignments_user_tier"`);
+
+    // 6. Create new unique indexes on (agent_id, provider) and (agent_id, tier)
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_user_providers_agent_provider"
+        ON "user_providers" ("agent_id", "provider")
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_tier_assignments_agent_tier"
+        ON "tier_assignments" ("agent_id", "tier")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop new indexes
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_user_providers_agent_provider"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_tier_assignments_agent_tier"`);
+
+    // Deduplicate rows before restoring unique indexes on (user_id, provider/tier).
+    // After fan-out, multiple rows share the same user_id+provider/tier (one per agent).
+    // Keep the row with the smallest id per (user_id, provider) / (user_id, tier).
+    await queryRunner.query(`
+      DELETE FROM "user_providers"
+      WHERE "id" NOT IN (
+        SELECT MIN("id") FROM "user_providers" GROUP BY "user_id", "provider"
+      )
+    `);
+    await queryRunner.query(`
+      DELETE FROM "tier_assignments"
+      WHERE "id" NOT IN (
+        SELECT MIN("id") FROM "tier_assignments" GROUP BY "user_id", "tier"
+      )
+    `);
+
+    // Restore old indexes
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_user_providers_user_provider"
+        ON "user_providers" ("user_id", "provider")
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_tier_assignments_user_tier"
+        ON "tier_assignments" ("user_id", "tier")
+    `);
+
+    // Drop agent_id columns
+    await queryRunner.query(`ALTER TABLE "user_providers" DROP COLUMN "agent_id"`);
+    await queryRunner.query(`ALTER TABLE "tier_assignments" DROP COLUMN "agent_id"`);
+  }
+}

--- a/packages/backend/src/entities/tier-assignment.entity.ts
+++ b/packages/backend/src/entities/tier-assignment.entity.ts
@@ -2,13 +2,16 @@ import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType, timestampDefault } from '../common/utils/sql-dialect';
 
 @Entity('tier_assignments')
-@Index(['user_id', 'tier'], { unique: true })
+@Index(['agent_id', 'tier'], { unique: true })
 export class TierAssignment {
   @PrimaryColumn('varchar')
   id!: string;
 
   @Column('varchar')
   user_id!: string;
+
+  @Column('varchar')
+  agent_id!: string;
 
   @Column('varchar')
   tier!: string;

--- a/packages/backend/src/entities/user-provider.entity.ts
+++ b/packages/backend/src/entities/user-provider.entity.ts
@@ -2,13 +2,16 @@ import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType, timestampDefault } from '../common/utils/sql-dialect';
 
 @Entity('user_providers')
-@Index(['user_id', 'provider'], { unique: true })
+@Index(['agent_id', 'provider'], { unique: true })
 export class UserProvider {
   @PrimaryColumn('varchar')
   id!: string;
 
   @Column('varchar')
   user_id!: string;
+
+  @Column('varchar')
+  agent_id!: string;
 
   @Column('varchar')
   provider!: string;

--- a/packages/backend/src/routing/dto/routing.dto.spec.ts
+++ b/packages/backend/src/routing/dto/routing.dto.spec.ts
@@ -1,0 +1,72 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { AgentNameParamDto } from './routing.dto';
+
+function toDto(data: Record<string, unknown>): AgentNameParamDto {
+  return plainToInstance(AgentNameParamDto, data);
+}
+
+describe('AgentNameParamDto', () => {
+  it('should pass with alphanumeric name', async () => {
+    const dto = toDto({ agentName: 'myagent123' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass with hyphens', async () => {
+    const dto = toDto({ agentName: 'my-agent' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass with underscores', async () => {
+    const dto = toDto({ agentName: 'my_agent' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass with mixed valid characters', async () => {
+    const dto = toDto({ agentName: 'Agent-01_test' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should pass with single character', async () => {
+    const dto = toDto({ agentName: 'a' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject empty string', async () => {
+    const dto = toDto({ agentName: '' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('should reject name with spaces', async () => {
+    const dto = toDto({ agentName: 'my agent' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('should reject name with special characters', async () => {
+    for (const name of ['agent@home', 'agent!', 'agent.name', 'agent/path', 'agent$']) {
+      const dto = toDto({ agentName: name });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('should reject missing agentName', async () => {
+    const dto = toDto({});
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('should reject non-string agentName', async () => {
+    const dto = toDto({ agentName: 123 });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/backend/src/routing/dto/routing.dto.ts
+++ b/packages/backend/src/routing/dto/routing.dto.ts
@@ -1,6 +1,13 @@
-import { IsString, IsIn, IsNotEmpty, IsOptional } from 'class-validator';
+import { IsString, IsIn, IsNotEmpty, IsOptional, Matches } from 'class-validator';
 
 const VALID_TIERS = ['simple', 'standard', 'complex', 'reasoning'] as const;
+
+export class AgentNameParamDto {
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[a-zA-Z0-9_-]+$/, { message: 'Invalid agent name' })
+  agentName!: string;
+}
 
 export class TierParamDto {
   @IsIn(VALID_TIERS)

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -16,9 +16,13 @@ function mockResponse(): {
   const headers: Record<string, string> = {};
   let statusCode = 200;
   const res: Record<string, jest.Mock | boolean | number> = {
-    setHeader: jest.fn((k: string, v: string) => { headers[k] = v; }),
+    setHeader: jest.fn((k: string, v: string) => {
+      headers[k] = v;
+    }),
     flushHeaders: jest.fn(),
-    write: jest.fn((chunk: string) => { written.push(chunk); }),
+    write: jest.fn((chunk: string) => {
+      written.push(chunk);
+    }),
     end: jest.fn(),
     send: jest.fn(),
     json: jest.fn(),
@@ -29,10 +33,21 @@ function mockResponse(): {
     on: jest.fn(),
     writableEnded: false,
   };
-  return { res, written, headers, get statusCode() { return statusCode; } };
+  return {
+    res,
+    written,
+    headers,
+    get statusCode() {
+      return statusCode;
+    },
+  };
 }
 
-function mockRequest(body: Record<string, unknown>, userId = 'user-1', headers: Record<string, string> = {}) {
+function mockRequest(
+  body: Record<string, unknown>,
+  userId = 'user-1',
+  headers: Record<string, string> = {},
+) {
   return {
     ingestionContext: {
       userId,
@@ -93,7 +108,13 @@ describe('ProxyController', () => {
 
     proxyService.proxyRequest.mockResolvedValue({
       forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
-      meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9, reason: 'scored' },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
     });
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -121,7 +142,13 @@ describe('ProxyController', () => {
 
     proxyService.proxyRequest.mockResolvedValue({
       forward: { response: mockProviderResp, isGoogle: true, isAnthropic: false },
-      meta: { tier: 'standard', model: 'gemini-2.0-flash', provider: 'Google', confidence: 0.8, reason: 'scored' },
+      meta: {
+        tier: 'standard',
+        model: 'gemini-2.0-flash',
+        provider: 'Google',
+        confidence: 0.8,
+        reason: 'scored',
+      },
     });
     providerClient.convertGoogleResponse.mockReturnValue(convertedBody);
 
@@ -152,7 +179,13 @@ describe('ProxyController', () => {
 
     proxyService.proxyRequest.mockResolvedValue({
       forward: { response: mockProviderResp, isGoogle: false, isAnthropic: true },
-      meta: { tier: 'complex', model: 'claude-sonnet-4-20250514', provider: 'Anthropic', confidence: 0.9, reason: 'scored' },
+      meta: {
+        tier: 'complex',
+        model: 'claude-sonnet-4-20250514',
+        provider: 'Anthropic',
+        confidence: 0.9,
+        reason: 'scored',
+      },
     });
     providerClient.convertAnthropicResponse.mockReturnValue(convertedBody);
 
@@ -177,7 +210,13 @@ describe('ProxyController', () => {
 
     proxyService.proxyRequest.mockResolvedValue({
       forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
-      meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+      meta: {
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        reason: 'scored',
+      },
     });
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
@@ -221,7 +260,10 @@ describe('ProxyController', () => {
 
   it('should record rate_limited agent_message on 429', async () => {
     proxyService.proxyRequest.mockRejectedValue(
-      new HttpException({ error: { message: 'Limit exceeded: tokens usage (52,000) exceeds 50,000 per day' } }, 429),
+      new HttpException(
+        { error: { message: 'Limit exceeded: tokens usage (52,000) exceeds 50,000 per day' } },
+        429,
+      ),
     );
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -262,9 +304,7 @@ describe('ProxyController', () => {
   });
 
   it('should not record agent_message on 400 errors from catch block', async () => {
-    proxyService.proxyRequest.mockRejectedValue(
-      new HttpException('Bad request', 400),
-    );
+    proxyService.proxyRequest.mockRejectedValue(new HttpException('Bad request', 400));
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
     const { res } = mockResponse();
@@ -296,9 +336,16 @@ describe('ProxyController', () => {
     proxyService.proxyRequest.mockResolvedValue({
       forward: {
         response: new Response(JSON.stringify(responseBody), { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       },
-      meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9, reason: 'scored' },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
     });
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -308,6 +355,7 @@ describe('ProxyController', () => {
     await controller.chatCompletions(req as never, res as never);
 
     expect(proxyService.proxyRequest).toHaveBeenCalledWith(
+      'agent-1',
       'user-1',
       req.body,
       'my-session',
@@ -321,9 +369,16 @@ describe('ProxyController', () => {
     proxyService.proxyRequest.mockResolvedValue({
       forward: {
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       },
-      meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9, reason: 'scored' },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
     });
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -332,6 +387,7 @@ describe('ProxyController', () => {
     await controller.chatCompletions(req as never, res as never);
 
     expect(proxyService.proxyRequest).toHaveBeenCalledWith(
+      'agent-1',
       'user-1',
       req.body,
       'default',
@@ -344,7 +400,11 @@ describe('ProxyController', () => {
   describe('rate limiting', () => {
     it('should call checkLimit and acquireSlot before proxying', async () => {
       proxyService.proxyRequest.mockResolvedValue({
-        forward: { response: new Response('{}', { status: 200 }), isGoogle: false, isAnthropic: false },
+        forward: {
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+        },
         meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9 },
       });
 
@@ -439,7 +499,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
@@ -471,7 +537,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
@@ -498,7 +570,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
-        meta: { tier: 'complex', model: 'claude-opus-4', provider: 'Anthropic', confidence: 0.9, reason: 'scored' },
+        meta: {
+          tier: 'complex',
+          model: 'claude-opus-4',
+          provider: 'Anthropic',
+          confidence: 0.9,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
@@ -517,14 +595,21 @@ describe('ProxyController', () => {
     });
 
     it('should apply 429 cooldown for provider responses', async () => {
-      const makeResp = () => new Response('{"error":"rate limit"}', {
-        status: 429,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      const makeResp = () =>
+        new Response('{"error":"rate limit"}', {
+          status: 429,
+          headers: { 'Content-Type': 'application/json' },
+        });
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: makeResp(), isGoogle: false, isAnthropic: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req1 = mockRequest({ messages: [{ role: 'user', content: 'a' }] });
@@ -534,7 +619,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: makeResp(), isGoogle: false, isAnthropic: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req2 = mockRequest({ messages: [{ role: 'user', content: 'b' }] });
@@ -555,14 +646,18 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
-      const req = mockRequest(
-        { messages: [{ role: 'user', content: 'test' }] },
-        'user-1',
-        { traceparent: '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01' },
-      );
+      const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] }, 'user-1', {
+        traceparent: '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01',
+      });
       const { res } = mockResponse();
 
       await controller.chatCompletions(req as never, res as never);
@@ -585,7 +680,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
@@ -610,7 +711,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
@@ -630,7 +737,11 @@ describe('ProxyController', () => {
   describe('client disconnect', () => {
     it('should register close listener on response', async () => {
       proxyService.proxyRequest.mockResolvedValue({
-        forward: { response: new Response('{}', { status: 200 }), isGoogle: false, isAnthropic: false },
+        forward: {
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+        },
         meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9 },
       });
 
@@ -644,7 +755,11 @@ describe('ProxyController', () => {
 
     it('should pass AbortSignal to proxyService', async () => {
       proxyService.proxyRequest.mockResolvedValue({
-        forward: { response: new Response('{}', { status: 200 }), isGoogle: false, isAnthropic: false },
+        forward: {
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+        },
         meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9 },
       });
 
@@ -653,7 +768,7 @@ describe('ProxyController', () => {
 
       await controller.chatCompletions(req as never, res as never);
 
-      const signal = proxyService.proxyRequest.mock.calls[0][5];
+      const signal = proxyService.proxyRequest.mock.calls[0][6];
       expect(signal).toBeInstanceOf(AbortSignal);
       expect(signal.aborted).toBe(false);
     });
@@ -732,9 +847,16 @@ describe('ProxyController', () => {
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
           response: new Response(JSON.stringify(responseBody), { status: 200 }),
-          isGoogle: false, isAnthropic: false,
+          isGoogle: false,
+          isAnthropic: false,
         },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.9,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -753,9 +875,16 @@ describe('ProxyController', () => {
       const makeProxyResult = () => ({
         forward: {
           response: new Response('{}', { status: 200 }),
-          isGoogle: false, isAnthropic: false,
+          isGoogle: false,
+          isAnthropic: false,
         },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.9,
+          reason: 'scored',
+        },
       });
 
       proxyService.proxyRequest.mockResolvedValue(makeProxyResult());
@@ -776,9 +905,16 @@ describe('ProxyController', () => {
       const makeProxyResult = () => ({
         forward: {
           response: new Response('{}', { status: 200 }),
-          isGoogle: false, isAnthropic: false,
+          isGoogle: false,
+          isAnthropic: false,
         },
-        meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9, reason: 'scored' },
+        meta: {
+          tier: 'simple',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.9,
+          reason: 'scored',
+        },
       });
 
       proxyService.proxyRequest.mockResolvedValue(makeProxyResult());
@@ -813,7 +949,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
-        meta: { tier: 'complex', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.7, reason: 'scored' },
+        meta: {
+          tier: 'complex',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.7,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -829,9 +971,7 @@ describe('ProxyController', () => {
     });
 
     it('should not fire event when proxyService throws before tracking', async () => {
-      proxyService.proxyRequest.mockRejectedValue(
-        new Error('No model available'),
-      );
+      proxyService.proxyRequest.mockRejectedValue(new Error('No model available'));
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
       const { res } = mockResponse();
@@ -855,9 +995,16 @@ describe('ProxyController', () => {
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
           response: new Response('{}', { status: 200 }),
-          isGoogle: false, isAnthropic: false,
+          isGoogle: false,
+          isAnthropic: false,
         },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.9,
+          reason: 'scored',
+        },
       });
 
       const req2 = mockRequest({ messages: [{ role: 'user', content: 'retry' }] });
@@ -877,9 +1024,16 @@ describe('ProxyController', () => {
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
           response: new Response('{}', { status: 200 }),
-          isGoogle: false, isAnthropic: false,
+          isGoogle: false,
+          isAnthropic: false,
         },
-        meta: { tier: 'simple', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9, reason: 'scored' },
+        meta: {
+          tier: 'simple',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.9,
+          reason: 'scored',
+        },
       });
 
       const req1 = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -893,7 +1047,13 @@ describe('ProxyController', () => {
       const errorResp = new Response('{"error":"rate limit"}', { status: 429 });
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: errorResp, isGoogle: false, isAnthropic: false },
-        meta: { tier: 'complex', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'complex',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req2 = mockRequest({ messages: [{ role: 'user', content: 'hi again' }] });
@@ -907,7 +1067,8 @@ describe('ProxyController', () => {
       proxyService.proxyRequest.mockResolvedValue({
         forward: {
           response: new Response('{}', { status: 200 }),
-          isGoogle: false, isAnthropic: false,
+          isGoogle: false,
+          isAnthropic: false,
         },
         meta: {
           tier: 'reasoning',
@@ -939,9 +1100,7 @@ describe('ProxyController', () => {
 
   describe('error handling edge cases', () => {
     it('should mask error message for 500+ status codes', async () => {
-      proxyService.proxyRequest.mockRejectedValue(
-        new Error('Sensitive internal error details'),
-      );
+      proxyService.proxyRequest.mockRejectedValue(new Error('Sensitive internal error details'));
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
       const { res } = mockResponse();
@@ -1015,7 +1174,11 @@ describe('ProxyController', () => {
       });
 
       proxyService.proxyRequest.mockResolvedValue({
-        forward: { response: new Response(failingStream, { status: 200 }), isGoogle: false, isAnthropic: false },
+        forward: {
+          response: new Response(failingStream, { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+        },
         meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8 },
       });
 
@@ -1039,7 +1202,11 @@ describe('ProxyController', () => {
       });
 
       proxyService.proxyRequest.mockResolvedValue({
-        forward: { response: new Response(failingStream, { status: 200 }), isGoogle: false, isAnthropic: false },
+        forward: {
+          response: new Response(failingStream, { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+        },
         meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8 },
       });
 
@@ -1072,9 +1239,7 @@ describe('ProxyController', () => {
     it('should handle messageRepo.insert failure gracefully', async () => {
       mockMessageRepo.insert.mockRejectedValue(new Error('DB connection failed'));
 
-      proxyService.proxyRequest.mockRejectedValue(
-        new HttpException('Rate limit exceeded', 429),
-      );
+      proxyService.proxyRequest.mockRejectedValue(new HttpException('Rate limit exceeded', 429));
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
       const { res } = mockResponse();
@@ -1150,17 +1315,15 @@ describe('ProxyController', () => {
       const makeProxyResult = () => ({
         forward: {
           response: new Response('{}', { status: 200 }),
-          isGoogle: false, isAnthropic: false,
+          isGoogle: false,
+          isAnthropic: false,
         },
         meta: { tier: 'simple' as const, model: 'gpt-4o', provider: 'OpenAI', confidence: 0.9 },
       });
 
       // This request fills the Set to exactly 10K
       proxyService.proxyRequest.mockResolvedValue(makeProxyResult());
-      const req1 = mockRequest(
-        { messages: [{ role: 'user', content: 'hi' }] },
-        'user-9999',
-      );
+      const req1 = mockRequest({ messages: [{ role: 'user', content: 'hi' }] }, 'user-9999');
       const { res: res1 } = mockResponse();
       await controller.chatCompletions(req1 as never, res1 as never);
 
@@ -1168,10 +1331,7 @@ describe('ProxyController', () => {
 
       // Next request should evict the oldest entry
       proxyService.proxyRequest.mockResolvedValue(makeProxyResult());
-      const req2 = mockRequest(
-        { messages: [{ role: 'user', content: 'hi' }] },
-        'user-10000',
-      );
+      const req2 = mockRequest({ messages: [{ role: 'user', content: 'hi' }] }, 'user-10000');
       const { res: res2 } = mockResponse();
       await controller.chatCompletions(req2 as never, res2 as never);
 
@@ -1208,7 +1368,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({
@@ -1231,7 +1397,13 @@ describe('ProxyController', () => {
 
       proxyService.proxyRequest.mockResolvedValue({
         forward: { response: mockProviderResp, isGoogle: true, isAnthropic: false },
-        meta: { tier: 'standard', model: 'gemini-2.0-flash', provider: 'Google', confidence: 0.8, reason: 'scored' },
+        meta: {
+          tier: 'standard',
+          model: 'gemini-2.0-flash',
+          provider: 'Google',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       providerClient.convertGoogleStreamChunk.mockReturnValue(
@@ -1260,8 +1432,18 @@ describe('ProxyController', () => {
       });
 
       proxyService.proxyRequest.mockResolvedValue({
-        forward: { response: new Response(failingStream, { status: 200 }), isGoogle: false, isAnthropic: false },
-        meta: { tier: 'standard', model: 'gpt-4o', provider: 'OpenAI', confidence: 0.8, reason: 'scored' },
+        forward: {
+          response: new Response(failingStream, { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+        },
+        meta: {
+          tier: 'standard',
+          model: 'gpt-4o',
+          provider: 'OpenAI',
+          confidence: 0.8,
+          reason: 'scored',
+        },
       });
 
       const req = mockRequest({

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -53,14 +53,14 @@ describe('ProxyService', () => {
   };
 
   it('throws BadRequestException when messages are missing', async () => {
-    await expect(
-      service.proxyRequest('user-1', {}, 'default'),
-    ).rejects.toThrow(BadRequestException);
+    await expect(service.proxyRequest('agent-1', 'user-1', {}, 'default')).rejects.toThrow(
+      BadRequestException,
+    );
   });
 
   it('throws BadRequestException when messages array is empty', async () => {
     await expect(
-      service.proxyRequest('user-1', { messages: [] }, 'default'),
+      service.proxyRequest('agent-1', 'user-1', { messages: [] }, 'default'),
     ).rejects.toThrow(BadRequestException);
   });
 
@@ -74,9 +74,9 @@ describe('ProxyService', () => {
       reason: 'ambiguous',
     });
 
-    await expect(
-      service.proxyRequest('user-1', body, 'default'),
-    ).rejects.toThrow('No model available');
+    await expect(service.proxyRequest('agent-1', 'user-1', body, 'default')).rejects.toThrow(
+      'No model available',
+    );
   });
 
   it('throws when no API key found for provider', async () => {
@@ -90,9 +90,9 @@ describe('ProxyService', () => {
     });
     routingService.getProviderApiKey.mockResolvedValue(null);
 
-    await expect(
-      service.proxyRequest('user-1', body, 'default'),
-    ).rejects.toThrow('No API key found');
+    await expect(service.proxyRequest('agent-1', 'user-1', body, 'default')).rejects.toThrow(
+      'No API key found',
+    );
   });
 
   it('resolves, forwards, and records momentum on success', async () => {
@@ -109,10 +109,11 @@ describe('ProxyService', () => {
     const mockResponse = new Response('{}', { status: 200 });
     providerClient.forward.mockResolvedValue({
       response: mockResponse,
-      isGoogle: false, isAnthropic: false,
+      isGoogle: false,
+      isAnthropic: false,
     });
 
-    const result = await service.proxyRequest('user-1', body, 'sess-1');
+    const result = await service.proxyRequest('agent-1', 'user-1', body, 'sess-1');
 
     expect(result.meta).toEqual({
       tier: 'standard',
@@ -153,13 +154,14 @@ describe('ProxyService', () => {
     routingService.getProviderApiKey.mockResolvedValue('sk-ant');
     providerClient.forward.mockResolvedValue({
       response: new Response('{}', { status: 200 }),
-      isGoogle: false, isAnthropic: false,
+      isGoogle: false,
+      isAnthropic: false,
     });
 
-    await service.proxyRequest('user-1', body, 'sess-1');
+    await service.proxyRequest('agent-1', 'user-1', body, 'sess-1');
 
     expect(resolveService.resolve).toHaveBeenCalledWith(
-      'user-1',
+      'agent-1',
       body.messages,
       undefined,
       undefined,
@@ -180,7 +182,8 @@ describe('ProxyService', () => {
     routingService.getProviderApiKey.mockResolvedValue('sk-test');
     providerClient.forward.mockResolvedValue({
       response: new Response('{}', { status: 200 }),
-      isGoogle: false, isAnthropic: false,
+      isGoogle: false,
+      isAnthropic: false,
     });
 
     const bodyWithTools = {
@@ -190,11 +193,11 @@ describe('ProxyService', () => {
       stream: false,
     };
 
-    await service.proxyRequest('user-1', bodyWithTools, 'default');
+    await service.proxyRequest('agent-1', 'user-1', bodyWithTools, 'default');
 
     // Resolver should receive undefined for tools and tool_choice
     expect(resolveService.resolve).toHaveBeenCalledWith(
-      'user-1',
+      'agent-1',
       expect.any(Array),
       undefined,
       undefined,
@@ -226,11 +229,20 @@ describe('ProxyService', () => {
     routingService.getProviderApiKey.mockResolvedValue('sk-test');
     providerClient.forward.mockResolvedValue({
       response: new Response('{}', { status: 200 }),
-      isGoogle: false, isAnthropic: false,
+      isGoogle: false,
+      isAnthropic: false,
     });
 
     const abortController = new AbortController();
-    await service.proxyRequest('user-1', body, 'default', undefined, undefined, abortController.signal);
+    await service.proxyRequest(
+      'agent-1',
+      'user-1',
+      body,
+      'default',
+      undefined,
+      undefined,
+      abortController.signal,
+    );
 
     expect(providerClient.forward).toHaveBeenCalledWith(
       'OpenAI',
@@ -249,8 +261,7 @@ describe('ProxyService', () => {
         { role: 'system', content: 'You are a helpful assistant.' },
         {
           role: 'user',
-          content:
-            'Check tasks and reply HEARTBEAT_OK if nothing needs attention.',
+          content: 'Check tasks and reply HEARTBEAT_OK if nothing needs attention.',
         },
       ],
       stream: false,
@@ -268,12 +279,13 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
 
-      const result = await service.proxyRequest('user-1', heartbeatBody, 'sess-1');
+      const result = await service.proxyRequest('agent-1', 'user-1', heartbeatBody, 'sess-1');
 
-      expect(resolveService.resolveForTier).toHaveBeenCalledWith('user-1', 'simple');
+      expect(resolveService.resolveForTier).toHaveBeenCalledWith('agent-1', 'simple');
       expect(resolveService.resolve).not.toHaveBeenCalled();
       expect(result.meta.tier).toBe('simple');
       expect(result.meta.model).toBe('gpt-4o-mini');
@@ -291,10 +303,11 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
 
-      await service.proxyRequest('user-1', heartbeatBody, 'sess-1');
+      await service.proxyRequest('agent-1', 'user-1', heartbeatBody, 'sess-1');
 
       expect(providerClient.forward).toHaveBeenCalledWith(
         'OpenAI',
@@ -332,12 +345,13 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
 
-      const result = await service.proxyRequest('user-1', buriedHeartbeatBody, 'sess-1');
+      const result = await service.proxyRequest('agent-1', 'user-1', buriedHeartbeatBody, 'sess-1');
 
-      expect(resolveService.resolveForTier).toHaveBeenCalledWith('user-1', 'simple');
+      expect(resolveService.resolveForTier).toHaveBeenCalledWith('agent-1', 'simple');
       expect(resolveService.resolve).not.toHaveBeenCalled();
       expect(result.meta.tier).toBe('simple');
       expect(result.meta.reason).toBe('heartbeat');
@@ -350,7 +364,10 @@ describe('ProxyService', () => {
           {
             role: 'user',
             content: [
-              { type: 'text', text: 'Check tasks and reply HEARTBEAT_OK if nothing needs attention.' },
+              {
+                type: 'text',
+                text: 'Check tasks and reply HEARTBEAT_OK if nothing needs attention.',
+              },
             ],
           },
         ],
@@ -368,12 +385,13 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
 
-      const result = await service.proxyRequest('user-1', arrayContentBody, 'sess-1');
+      const result = await service.proxyRequest('agent-1', 'user-1', arrayContentBody, 'sess-1');
 
-      expect(resolveService.resolveForTier).toHaveBeenCalledWith('user-1', 'simple');
+      expect(resolveService.resolveForTier).toHaveBeenCalledWith('agent-1', 'simple');
       expect(result.meta.tier).toBe('simple');
       expect(result.meta.reason).toBe('heartbeat');
     });
@@ -390,10 +408,11 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
 
-      await service.proxyRequest('user-1', body, 'default');
+      await service.proxyRequest('agent-1', 'user-1', body, 'default');
 
       expect(resolveService.resolve).toHaveBeenCalled();
     });
@@ -412,7 +431,8 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
     };
 
@@ -428,7 +448,7 @@ describe('ProxyService', () => {
         stream: false,
       };
 
-      await service.proxyRequest('user-1', bodyWithSystem, 'default');
+      await service.proxyRequest('agent-1', 'user-1', bodyWithSystem, 'default');
 
       // Scorer should only receive the user message (system/developer stripped)
       const scoredMessages = resolveService.resolve.mock.calls[0][1];
@@ -446,7 +466,7 @@ describe('ProxyService', () => {
         stream: false,
       };
 
-      await service.proxyRequest('user-1', bodyWithSystem, 'default');
+      await service.proxyRequest('agent-1', 'user-1', bodyWithSystem, 'default');
 
       // Provider should get the FULL body including system messages
       expect(providerClient.forward).toHaveBeenCalledWith(
@@ -472,7 +492,7 @@ describe('ProxyService', () => {
         })),
       ];
 
-      await service.proxyRequest('user-1', { messages, stream: false }, 'default');
+      await service.proxyRequest('agent-1', 'user-1', { messages, stream: false }, 'default');
 
       const scoredMessages = resolveService.resolve.mock.calls[0][1];
       expect(scoredMessages).toHaveLength(10);
@@ -495,7 +515,8 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
     };
 
@@ -509,11 +530,11 @@ describe('ProxyService', () => {
       });
 
       await expect(
-        service.proxyRequest('user-1', body, 'default', 'tenant-1', 'my-agent'),
+        service.proxyRequest('agent-1', 'user-1', body, 'default', 'tenant-1', 'my-agent'),
       ).rejects.toThrow(HttpException);
 
       try {
-        await service.proxyRequest('user-1', body, 'default', 'tenant-1', 'my-agent');
+        await service.proxyRequest('agent-1', 'user-1', body, 'default', 'tenant-1', 'my-agent');
       } catch (err) {
         expect((err as HttpException).getStatus()).toBe(429);
         const response = (err as HttpException).getResponse() as Record<string, unknown>;
@@ -526,7 +547,7 @@ describe('ProxyService', () => {
     it('does not check limits when tenantId/agentName are not provided', async () => {
       setupSuccessMocks();
 
-      await service.proxyRequest('user-1', body, 'default');
+      await service.proxyRequest('agent-1', 'user-1', body, 'default');
 
       expect(limitCheck.checkLimits).not.toHaveBeenCalled();
     });
@@ -534,7 +555,7 @@ describe('ProxyService', () => {
     it('does not check limits when only tenantId is provided without agentName', async () => {
       setupSuccessMocks();
 
-      await service.proxyRequest('user-1', body, 'default', 'tenant-1');
+      await service.proxyRequest('agent-1', 'user-1', body, 'default', 'tenant-1');
 
       expect(limitCheck.checkLimits).not.toHaveBeenCalled();
     });
@@ -542,7 +563,7 @@ describe('ProxyService', () => {
     it('does not check limits when only agentName is provided without tenantId', async () => {
       setupSuccessMocks();
 
-      await service.proxyRequest('user-1', body, 'default', undefined, 'my-agent');
+      await service.proxyRequest('agent-1', 'user-1', body, 'default', undefined, 'my-agent');
 
       expect(limitCheck.checkLimits).not.toHaveBeenCalled();
     });
@@ -551,7 +572,14 @@ describe('ProxyService', () => {
       setupSuccessMocks();
       limitCheck.checkLimits.mockResolvedValue(null);
 
-      const result = await service.proxyRequest('user-1', body, 'default', 'tenant-1', 'my-agent');
+      const result = await service.proxyRequest(
+        'agent-1',
+        'user-1',
+        body,
+        'default',
+        'tenant-1',
+        'my-agent',
+      );
 
       expect(limitCheck.checkLimits).toHaveBeenCalledWith('tenant-1', 'my-agent');
       expect(result.meta.model).toBe('gpt-4o');
@@ -567,7 +595,7 @@ describe('ProxyService', () => {
       });
 
       try {
-        await service.proxyRequest('user-1', body, 'default', 'tenant-1', 'my-agent');
+        await service.proxyRequest('agent-1', 'user-1', body, 'default', 'tenant-1', 'my-agent');
         fail('Expected HttpException');
       } catch (err) {
         const response = (err as HttpException).getResponse() as Record<string, unknown>;
@@ -588,7 +616,7 @@ describe('ProxyService', () => {
       });
 
       try {
-        await service.proxyRequest('user-1', body, 'default', 'tenant-1', 'my-agent');
+        await service.proxyRequest('agent-1', 'user-1', body, 'default', 'tenant-1', 'my-agent');
         fail('Expected HttpException');
       } catch (err) {
         const response = (err as HttpException).getResponse() as Record<string, unknown>;
@@ -614,7 +642,8 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
 
       const bodyWithMaxTokens = {
@@ -623,10 +652,10 @@ describe('ProxyService', () => {
         stream: false,
       };
 
-      await service.proxyRequest('user-1', bodyWithMaxTokens, 'default');
+      await service.proxyRequest('agent-1', 'user-1', bodyWithMaxTokens, 'default');
 
       expect(resolveService.resolve).toHaveBeenCalledWith(
-        'user-1',
+        'agent-1',
         expect.any(Array),
         undefined,
         undefined,
@@ -649,7 +678,8 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
 
       const bodyWithOnlySystem = {
@@ -660,7 +690,7 @@ describe('ProxyService', () => {
         stream: false,
       };
 
-      await service.proxyRequest('user-1', bodyWithOnlySystem, 'default');
+      await service.proxyRequest('agent-1', 'user-1', bodyWithOnlySystem, 'default');
 
       // Scorer receives empty array after filtering
       const scoredMessages = resolveService.resolve.mock.calls[0][1];
@@ -693,10 +723,11 @@ describe('ProxyService', () => {
       routingService.getProviderApiKey.mockResolvedValue('');
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
-        isGoogle: false, isAnthropic: false,
+        isGoogle: false,
+        isAnthropic: false,
       });
 
-      const result = await service.proxyRequest('user-1', body, 'default');
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
 
       expect(result.meta.provider).toBe('Ollama');
       expect(providerClient.forward).toHaveBeenCalledWith(

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -1,12 +1,4 @@
-import {
-  Controller,
-  Post,
-  Req,
-  Res,
-  UseGuards,
-  Logger,
-  HttpException,
-} from '@nestjs/common';
+import { Controller, Post, Req, Res, UseGuards, Logger, HttpException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Request, Response as ExpressResponse } from 'express';
@@ -48,7 +40,7 @@ export class ProxyController {
     @Req() req: Request & { ingestionContext: IngestionContext },
     @Res() res: ExpressResponse,
   ): Promise<void> {
-    const { userId, tenantId, agentName } = req.ingestionContext;
+    const { userId, agentId, tenantId, agentName } = req.ingestionContext;
     const body = req.body as Record<string, unknown>;
     const sessionKey = (req.headers['x-session-key'] as string) || 'default';
     const traceId = this.extractTraceId(req);
@@ -64,6 +56,7 @@ export class ProxyController {
       this.rateLimiter.acquireSlot(userId);
       slotAcquired = true;
       const { forward, meta } = await this.proxyService.proxyRequest(
+        agentId,
         userId,
         body,
         sessionKey,
@@ -95,9 +88,7 @@ export class ProxyController {
           meta.model,
           meta.tier,
           traceId,
-        ).catch((e) =>
-          this.logger.warn(`Failed to record provider error: ${e}`),
-        );
+        ).catch((e) => this.logger.warn(`Failed to record provider error: ${e}`));
 
         res.status(errorStatus);
         for (const [k, v] of Object.entries(metaHeaders)) res.setHeader(k, v);
@@ -112,10 +103,8 @@ export class ProxyController {
         headersSent = true;
 
         if (forward.isGoogle) {
-          await pipeStream(
-            providerResponse.body,
-            res,
-            (chunk) => this.providerClient.convertGoogleStreamChunk(chunk, meta.model),
+          await pipeStream(providerResponse.body, res, (chunk) =>
+            this.providerClient.convertGoogleStreamChunk(chunk, meta.model),
           );
         } else if (forward.isAnthropic) {
           await pipeStream(
@@ -130,10 +119,10 @@ export class ProxyController {
         let responseBody: unknown;
 
         if (forward.isGoogle) {
-          const googleData = await providerResponse.json() as Record<string, unknown>;
+          const googleData = (await providerResponse.json()) as Record<string, unknown>;
           responseBody = this.providerClient.convertGoogleResponse(googleData, meta.model);
         } else if (forward.isAnthropic) {
-          const anthropicData = await providerResponse.json() as Record<string, unknown>;
+          const anthropicData = (await providerResponse.json()) as Record<string, unknown>;
           responseBody = this.providerClient.convertAnthropicResponse(anthropicData, meta.model);
         } else {
           responseBody = await providerResponse.json();
@@ -154,10 +143,14 @@ export class ProxyController {
       this.logger.error(`Proxy error: ${message}`);
 
       if (status === 429 || status === 403 || status >= 500) {
-        this.recordProviderError(req.ingestionContext, status, message, undefined, undefined, traceId).catch(
-          (e) =>
-            this.logger.warn(`Failed to record provider error: ${e}`),
-        );
+        this.recordProviderError(
+          req.ingestionContext,
+          status,
+          message,
+          undefined,
+          undefined,
+          traceId,
+        ).catch((e) => this.logger.warn(`Failed to record provider error: ${e}`));
       }
 
       if (headersSent) {
@@ -191,8 +184,7 @@ export class ProxyController {
 
       if (this.rateLimitCooldown.size > this.MAX_COOLDOWN_ENTRIES) {
         for (const [k, v] of this.rateLimitCooldown) {
-          if (now - v >= this.RATE_LIMIT_COOLDOWN_MS)
-            this.rateLimitCooldown.delete(k);
+          if (now - v >= this.RATE_LIMIT_COOLDOWN_MS) this.rateLimitCooldown.delete(k);
         }
       }
     }

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -41,6 +41,7 @@ export class ProxyService {
   ) {}
 
   async proxyRequest(
+    agentId: string,
     userId: string,
     body: Record<string, unknown>,
     sessionKey: string,
@@ -56,19 +57,24 @@ export class ProxyService {
     if (tenantId && agentName) {
       const exceeded = await this.limitCheck.checkLimits(tenantId, agentName);
       if (exceeded) {
-        const fmt = exceeded.metricType === 'cost'
-          ? `$${exceeded.actual.toFixed(2)}`
-          : exceeded.actual.toLocaleString();
-        const threshFmt = exceeded.metricType === 'cost'
-          ? `$${exceeded.threshold.toFixed(2)}`
-          : exceeded.threshold.toLocaleString();
-        throw new HttpException({
-          error: {
-            message: `Limit exceeded: ${exceeded.metricType} usage (${fmt}) exceeds ${threshFmt} per ${exceeded.period}`,
-            type: 'rate_limit_exceeded',
-            code: 'limit_exceeded',
+        const fmt =
+          exceeded.metricType === 'cost'
+            ? `$${exceeded.actual.toFixed(2)}`
+            : exceeded.actual.toLocaleString();
+        const threshFmt =
+          exceeded.metricType === 'cost'
+            ? `$${exceeded.threshold.toFixed(2)}`
+            : exceeded.threshold.toLocaleString();
+        throw new HttpException(
+          {
+            error: {
+              message: `Limit exceeded: ${exceeded.metricType} usage (${fmt}) exceeds ${threshFmt} per ${exceeded.period}`,
+              type: 'rate_limit_exceeded',
+              code: 'limit_exceeded',
+            },
           },
-        }, 429);
+          429,
+        );
       }
     }
 
@@ -103,9 +109,9 @@ export class ProxyService {
     // tool presence always inflates scores since gateways send tools
     // with every request regardless of user intent)
     const resolved = isHeartbeat
-      ? await this.resolveService.resolveForTier(userId, 'simple')
+      ? await this.resolveService.resolveForTier(agentId, 'simple')
       : await this.resolveService.resolve(
-          userId,
+          agentId,
           scoringMessages,
           undefined,
           undefined,
@@ -115,9 +121,9 @@ export class ProxyService {
 
     if (!resolved.model || !resolved.provider) {
       this.logger.warn(
-        `No model available for user=${userId}: ` +
-        `tier=${resolved.tier} model=${resolved.model} provider=${resolved.provider} ` +
-        `confidence=${resolved.confidence} reason=${resolved.reason}`,
+        `No model available for agent=${agentId}: ` +
+          `tier=${resolved.tier} model=${resolved.model} provider=${resolved.provider} ` +
+          `confidence=${resolved.confidence} reason=${resolved.reason}`,
       );
       throw new BadRequestException(
         'No model available. Connect a provider in the Manifest dashboard.',
@@ -125,10 +131,7 @@ export class ProxyService {
     }
 
     // Get the provider's API key
-    const apiKey = await this.routingService.getProviderApiKey(
-      userId,
-      resolved.provider,
-    );
+    const apiKey = await this.routingService.getProviderApiKey(agentId, resolved.provider);
     if (apiKey === null) {
       throw new BadRequestException(
         `No API key found for provider: ${resolved.provider}. Re-connect the provider with an API key.`,

--- a/packages/backend/src/routing/resolve.controller.spec.ts
+++ b/packages/backend/src/routing/resolve.controller.spec.ts
@@ -19,12 +19,10 @@ describe('ResolveController', () => {
     mockResolveService = {
       resolve: jest.fn().mockResolvedValue(mockResponse),
     };
-    controller = new ResolveController(
-      mockResolveService as unknown as ResolveService,
-    );
+    controller = new ResolveController(mockResolveService as unknown as ResolveService);
   });
 
-  it('should pass userId from ingestionContext to service', async () => {
+  it('should pass agentId from ingestionContext to service', async () => {
     const req = {
       ingestionContext: {
         userId: 'user-42',
@@ -34,13 +32,10 @@ describe('ResolveController', () => {
       },
     } as never;
 
-    await controller.resolve(
-      { messages: [{ role: 'user', content: 'hi' }] } as never,
-      req,
-    );
+    await controller.resolve({ messages: [{ role: 'user', content: 'hi' }] } as never, req);
 
     expect(mockResolveService.resolve).toHaveBeenCalledWith(
-      'user-42',
+      'a1',
       [{ role: 'user', content: 'hi' }],
       undefined,
       undefined,
@@ -64,7 +59,7 @@ describe('ResolveController', () => {
     await controller.resolve(body as never, req);
 
     expect(mockResolveService.resolve).toHaveBeenCalledWith(
-      'user-1',
+      'a',
       body.messages,
       body.tools,
       'auto',

--- a/packages/backend/src/routing/resolve.controller.ts
+++ b/packages/backend/src/routing/resolve.controller.ts
@@ -19,9 +19,9 @@ export class ResolveController {
     @Body() body: ResolveRequestDto,
     @Req() req: Request & { ingestionContext: IngestionContext },
   ): Promise<ResolveResponse> {
-    const { userId } = req.ingestionContext;
+    const { agentId } = req.ingestionContext;
     return this.resolveService.resolve(
-      userId,
+      agentId,
       body.messages as { role: string; content?: unknown; [k: string]: unknown }[],
       body.tools,
       body.tool_choice,

--- a/packages/backend/src/routing/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve.service.spec.ts
@@ -31,10 +31,7 @@ describe('ResolveService', () => {
     mockRoutingService.getEffectiveModel.mockResolvedValue('gpt-4o-mini');
     mockPricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' });
 
-    const result = await service.resolve(
-      'user-1',
-      [{ role: 'user', content: 'hello' }],
-    );
+    const result = await service.resolve('agent-1', [{ role: 'user', content: 'hello' }]);
 
     expect(result.tier).toBe('simple');
     expect(result.model).toBe('gpt-4o-mini');
@@ -45,10 +42,7 @@ describe('ResolveService', () => {
   it('should return null model when no effective model available', async () => {
     mockRoutingService.getEffectiveModel.mockResolvedValue(null);
 
-    const result = await service.resolve(
-      'user-1',
-      [{ role: 'user', content: 'hello' }],
-    );
+    const result = await service.resolve('agent-1', [{ role: 'user', content: 'hello' }]);
 
     expect(result.tier).toBe('simple');
     expect(result.model).toBeNull();
@@ -58,10 +52,7 @@ describe('ResolveService', () => {
   it('should return null model when no tier assignment found', async () => {
     mockRoutingService.getTiers.mockResolvedValue([]);
 
-    const result = await service.resolve(
-      'user-1',
-      [{ role: 'user', content: 'hello' }],
-    );
+    const result = await service.resolve('agent-1', [{ role: 'user', content: 'hello' }]);
 
     expect(result.model).toBeNull();
     expect(result.provider).toBeNull();
@@ -82,7 +73,7 @@ describe('ResolveService', () => {
       },
     ];
 
-    const result = await service.resolve('user-1', messages);
+    const result = await service.resolve('agent-1', messages);
 
     expect(['complex', 'standard', 'reasoning']).toContain(result.tier);
     expect(result.model).toBe('claude-sonnet-4');
@@ -93,7 +84,7 @@ describe('ResolveService', () => {
     mockPricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' });
 
     const result = await service.resolve(
-      'user-1',
+      'agent-1',
       [{ role: 'user', content: 'continue' }],
       undefined,
       undefined,
@@ -109,10 +100,7 @@ describe('ResolveService', () => {
     mockRoutingService.getEffectiveModel.mockResolvedValue('unknown-model');
     mockPricingCache.getByModel.mockReturnValue(undefined);
 
-    const result = await service.resolve(
-      'user-1',
-      [{ role: 'user', content: 'hello' }],
-    );
+    const result = await service.resolve('agent-1', [{ role: 'user', content: 'hello' }]);
 
     expect(result.model).toBe('unknown-model');
     expect(result.provider).toBeNull();
@@ -123,7 +111,7 @@ describe('ResolveService', () => {
       mockRoutingService.getEffectiveModel.mockResolvedValue('gpt-4o-mini');
       mockPricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' });
 
-      const result = await service.resolveForTier('user-1', 'simple');
+      const result = await service.resolveForTier('agent-1', 'simple');
 
       expect(result.tier).toBe('simple');
       expect(result.model).toBe('gpt-4o-mini');
@@ -136,7 +124,7 @@ describe('ResolveService', () => {
     it('should return null model when tier has no assignment', async () => {
       mockRoutingService.getTiers.mockResolvedValue([]);
 
-      const result = await service.resolveForTier('user-1', 'simple');
+      const result = await service.resolveForTier('agent-1', 'simple');
 
       expect(result.tier).toBe('simple');
       expect(result.model).toBeNull();
@@ -147,7 +135,7 @@ describe('ResolveService', () => {
     it('should return null model when effective model is null', async () => {
       mockRoutingService.getEffectiveModel.mockResolvedValue(null);
 
-      const result = await service.resolveForTier('user-1', 'simple');
+      const result = await service.resolveForTier('agent-1', 'simple');
 
       expect(result.tier).toBe('simple');
       expect(result.model).toBeNull();
@@ -160,7 +148,7 @@ describe('ResolveService', () => {
     mockPricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' });
 
     const result = await service.resolve(
-      'user-1',
+      'agent-1',
       [{ role: 'user', content: 'hi' }],
       [{ name: 'search' }],
       'auto',

--- a/packages/backend/src/routing/resolve.service.ts
+++ b/packages/backend/src/routing/resolve.service.ts
@@ -15,7 +15,7 @@ export class ResolveService {
   ) {}
 
   async resolve(
-    userId: string,
+    agentId: string,
     messages: ScorerInput['messages'],
     tools?: ScorerInput['tools'],
     toolChoice?: unknown,
@@ -28,13 +28,13 @@ export class ResolveService {
 
     const result = scoreRequest(input, undefined, momentum);
 
-    const tiers = await this.routingService.getTiers(userId);
+    const tiers = await this.routingService.getTiers(agentId);
     const assignment = tiers.find((t) => t.tier === result.tier);
 
     if (!assignment) {
       this.logger.warn(
-        `No tier assignment found for user=${userId} tier=${result.tier} ` +
-        `(available tiers: ${tiers.map((t) => t.tier).join(', ') || 'none'})`,
+        `No tier assignment found for agent=${agentId} tier=${result.tier} ` +
+          `(available tiers: ${tiers.map((t) => t.tier).join(', ') || 'none'})`,
       );
       return {
         tier: result.tier,
@@ -46,12 +46,12 @@ export class ResolveService {
       };
     }
 
-    const model = await this.routingService.getEffectiveModel(userId, assignment);
+    const model = await this.routingService.getEffectiveModel(agentId, assignment);
 
     if (!model) {
       this.logger.warn(
-        `getEffectiveModel returned null for user=${userId} tier=${result.tier} ` +
-        `override=${assignment.override_model} auto=${assignment.auto_assigned_model}`,
+        `getEffectiveModel returned null for agent=${agentId} tier=${result.tier} ` +
+          `override=${assignment.override_model} auto=${assignment.auto_assigned_model}`,
       );
       return {
         tier: result.tier,
@@ -67,8 +67,8 @@ export class ResolveService {
 
     if (!pricing) {
       this.logger.warn(
-        `Pricing cache miss for model=${model} (user=${userId} tier=${result.tier}). ` +
-        `Provider will be null.`,
+        `Pricing cache miss for model=${model} (agent=${agentId} tier=${result.tier}). ` +
+          `Provider will be null.`,
       );
     }
 
@@ -82,15 +82,15 @@ export class ResolveService {
     };
   }
 
-  async resolveForTier(userId: string, tier: Tier): Promise<ResolveResponse> {
-    const tiers = await this.routingService.getTiers(userId);
+  async resolveForTier(agentId: string, tier: Tier): Promise<ResolveResponse> {
+    const tiers = await this.routingService.getTiers(agentId);
     const assignment = tiers.find((t) => t.tier === tier);
 
     if (!assignment) {
       return { tier, model: null, provider: null, confidence: 1, score: 0, reason: 'heartbeat' };
     }
 
-    const model = await this.routingService.getEffectiveModel(userId, assignment);
+    const model = await this.routingService.getEffectiveModel(agentId, assignment);
     const pricing = model ? this.pricingCache.getByModel(model) : null;
 
     return {

--- a/packages/backend/src/routing/routing.controller.spec.ts
+++ b/packages/backend/src/routing/routing.controller.spec.ts
@@ -1,3 +1,4 @@
+import { NotFoundException } from '@nestjs/common';
 import { RoutingController } from './routing.controller';
 import { RoutingService } from './routing.service';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
@@ -10,12 +11,16 @@ jest.mock('../common/utils/product-telemetry', () => ({
 }));
 
 const mockUser = { id: 'user-1' } as never;
+const mockAgentName = { agentName: 'test-agent' } as never;
+const TEST_AGENT_ID = 'agent-001';
 
 describe('RoutingController', () => {
   let controller: RoutingController;
   let mockRoutingService: Record<string, jest.Mock>;
   let mockPricingCache: Record<string, jest.Mock>;
   let mockOllamaSync: Record<string, jest.Mock>;
+  let mockAgentRepo: Record<string, jest.Mock>;
+  let mockTenantRepo: Record<string, jest.Mock>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -36,11 +41,19 @@ describe('RoutingController', () => {
     mockOllamaSync = {
       sync: jest.fn().mockResolvedValue({ count: 0 }),
     };
+    mockTenantRepo = {
+      findOne: jest.fn().mockResolvedValue({ id: 'tenant-001', name: 'user-1' }),
+    };
+    mockAgentRepo = {
+      findOne: jest.fn().mockResolvedValue({ id: TEST_AGENT_ID, name: 'test-agent' }),
+    };
 
     controller = new RoutingController(
       mockRoutingService as unknown as RoutingService,
       mockPricingCache as unknown as ModelPricingCacheService,
       mockOllamaSync as unknown as OllamaSyncService,
+      mockAgentRepo as never,
+      mockTenantRepo as never,
     );
   });
 
@@ -52,7 +65,7 @@ describe('RoutingController', () => {
         { id: 'p1', provider: 'openai', is_active: true },
       ]);
 
-      const result = await controller.getStatus(mockUser);
+      const result = await controller.getStatus(mockUser, mockAgentName);
       expect(result).toEqual({ enabled: true });
     });
 
@@ -61,14 +74,14 @@ describe('RoutingController', () => {
         { id: 'p1', provider: 'openai', is_active: false },
       ]);
 
-      const result = await controller.getStatus(mockUser);
+      const result = await controller.getStatus(mockUser, mockAgentName);
       expect(result).toEqual({ enabled: false });
     });
 
     it('returns enabled false when no providers exist', async () => {
       mockRoutingService.getProviders.mockResolvedValue([]);
 
-      const result = await controller.getStatus(mockUser);
+      const result = await controller.getStatus(mockUser, mockAgentName);
       expect(result).toEqual({ enabled: false });
     });
 
@@ -78,7 +91,7 @@ describe('RoutingController', () => {
         { id: 'p2', provider: 'anthropic', is_active: true },
       ]);
 
-      const result = await controller.getStatus(mockUser);
+      const result = await controller.getStatus(mockUser, mockAgentName);
       expect(result).toEqual({ enabled: true });
     });
   });
@@ -88,34 +101,54 @@ describe('RoutingController', () => {
   describe('getProviders', () => {
     it('should return mapped provider list', async () => {
       mockRoutingService.getProviders.mockResolvedValue([
-        { id: 'p1', provider: 'openai', is_active: true, connected_at: '2025-01-01', api_key_encrypted: 'enc' },
+        {
+          id: 'p1',
+          provider: 'openai',
+          is_active: true,
+          connected_at: '2025-01-01',
+          api_key_encrypted: 'enc',
+        },
       ]);
       mockRoutingService.getKeyPrefix.mockReturnValue('sk-proj-');
 
-      const result = await controller.getProviders(mockUser);
+      const result = await controller.getProviders(mockUser, mockAgentName);
 
-      expect(mockRoutingService.getProviders).toHaveBeenCalledWith('user-1');
+      expect(mockRoutingService.getProviders).toHaveBeenCalledWith(TEST_AGENT_ID);
       expect(result).toEqual([
-        { id: 'p1', provider: 'openai', is_active: true, has_api_key: true, key_prefix: 'sk-proj-', connected_at: '2025-01-01' },
+        {
+          id: 'p1',
+          provider: 'openai',
+          is_active: true,
+          has_api_key: true,
+          key_prefix: 'sk-proj-',
+          connected_at: '2025-01-01',
+        },
       ]);
     });
 
     it('should strip internal fields from response', async () => {
       mockRoutingService.getProviders.mockResolvedValue([
-        { id: 'p1', provider: 'openai', is_active: true, connected_at: '2025-01-01', api_key_encrypted: 'secret', user_id: 'u1' },
+        {
+          id: 'p1',
+          provider: 'openai',
+          is_active: true,
+          connected_at: '2025-01-01',
+          api_key_encrypted: 'secret',
+          agent_id: 'a1',
+        },
       ]);
       mockRoutingService.getKeyPrefix.mockReturnValue('sk-proj-');
 
-      const result = await controller.getProviders(mockUser);
+      const result = await controller.getProviders(mockUser, mockAgentName);
 
       expect(result[0]).not.toHaveProperty('api_key_encrypted');
-      expect(result[0]).not.toHaveProperty('user_id');
+      expect(result[0]).not.toHaveProperty('agent_id');
       expect(result[0]).toHaveProperty('has_api_key', true);
       expect(result[0]).toHaveProperty('key_prefix', 'sk-proj-');
     });
 
     it('should return empty array when no providers', async () => {
-      const result = await controller.getProviders(mockUser);
+      const result = await controller.getProviders(mockUser, mockAgentName);
       expect(result).toEqual([]);
     });
   });
@@ -129,12 +162,17 @@ describe('RoutingController', () => {
         isNew: true,
       });
 
-      const result = await controller.upsertProvider(mockUser, {
+      const result = await controller.upsertProvider(mockUser, mockAgentName, {
         provider: 'anthropic',
         apiKey: 'sk-ant-test',
       });
 
-      expect(mockRoutingService.upsertProvider).toHaveBeenCalledWith('user-1', 'anthropic', 'sk-ant-test');
+      expect(mockRoutingService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'user-1',
+        'anthropic',
+        'sk-ant-test',
+      );
       expect(result).toEqual({ id: 'p1', provider: 'anthropic', is_active: true });
     });
 
@@ -144,11 +182,16 @@ describe('RoutingController', () => {
         isNew: false,
       });
 
-      const result = await controller.upsertProvider(mockUser, {
+      const result = await controller.upsertProvider(mockUser, mockAgentName, {
         provider: 'openai',
       });
 
-      expect(mockRoutingService.upsertProvider).toHaveBeenCalledWith('user-1', 'openai', undefined);
+      expect(mockRoutingService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'user-1',
+        'openai',
+        undefined,
+      );
       expect(result).toEqual({ id: 'p1', provider: 'openai', is_active: true });
     });
 
@@ -158,7 +201,10 @@ describe('RoutingController', () => {
         isNew: true,
       });
 
-      await controller.upsertProvider(mockUser, { provider: 'openai', apiKey: 'sk-test' });
+      await controller.upsertProvider(mockUser, mockAgentName, {
+        provider: 'openai',
+        apiKey: 'sk-test',
+      });
 
       expect(telemetry.trackCloudEvent).toHaveBeenCalledWith(
         'routing_provider_connected',
@@ -173,42 +219,12 @@ describe('RoutingController', () => {
         isNew: false,
       });
 
-      await controller.upsertProvider(mockUser, { provider: 'openai', apiKey: 'sk-test' });
+      await controller.upsertProvider(mockUser, mockAgentName, {
+        provider: 'openai',
+        apiKey: 'sk-test',
+      });
 
       expect(telemetry.trackCloudEvent).not.toHaveBeenCalled();
-    });
-
-    it('should fire event for new provider even without apiKey', async () => {
-      mockRoutingService.upsertProvider.mockResolvedValue({
-        provider: { id: 'p1', provider: 'anthropic', is_active: true },
-        isNew: true,
-      });
-
-      await controller.upsertProvider(mockUser, { provider: 'anthropic' });
-
-      expect(telemetry.trackCloudEvent).toHaveBeenCalledWith(
-        'routing_provider_connected',
-        'user-1',
-        { provider: 'anthropic' },
-      );
-    });
-
-    it('should pass body.provider to trackCloudEvent, not result.provider', async () => {
-      // Simulate a case where the body provider name differs in casing
-      // from the stored result provider name
-      mockRoutingService.upsertProvider.mockResolvedValue({
-        provider: { id: 'p1', provider: 'OpenAI', is_active: true },
-        isNew: true,
-      });
-
-      await controller.upsertProvider(mockUser, { provider: 'openai', apiKey: 'sk-test' });
-
-      // The event should use body.provider ('openai'), not result.provider ('OpenAI')
-      expect(telemetry.trackCloudEvent).toHaveBeenCalledWith(
-        'routing_provider_connected',
-        'user-1',
-        { provider: 'openai' },
-      );
     });
 
     it('should not expose api_key_encrypted in response', async () => {
@@ -218,39 +234,21 @@ describe('RoutingController', () => {
           provider: 'openai',
           is_active: true,
           api_key_encrypted: 'secret-encrypted-value',
-          user_id: 'user-1',
+          agent_id: 'a1',
           connected_at: '2025-01-01',
           updated_at: '2025-01-01',
         },
         isNew: true,
       });
 
-      const result = await controller.upsertProvider(mockUser, {
+      const result = await controller.upsertProvider(mockUser, mockAgentName, {
         provider: 'openai',
         apiKey: 'sk-test',
       });
 
       expect(result).toEqual({ id: 'p1', provider: 'openai', is_active: true });
       expect(result).not.toHaveProperty('api_key_encrypted');
-      expect(result).not.toHaveProperty('user_id');
-      expect(result).not.toHaveProperty('connected_at');
-      expect(result).not.toHaveProperty('updated_at');
-    });
-
-    it('should pass user.id to trackCloudEvent as tenantId', async () => {
-      const customUser = { id: 'custom-user-id-123' } as never;
-      mockRoutingService.upsertProvider.mockResolvedValue({
-        provider: { id: 'p1', provider: 'openai', is_active: true },
-        isNew: true,
-      });
-
-      await controller.upsertProvider(customUser, { provider: 'openai' });
-
-      expect(telemetry.trackCloudEvent).toHaveBeenCalledWith(
-        'routing_provider_connected',
-        'custom-user-id-123',
-        { provider: 'openai' },
-      );
+      expect(result).not.toHaveProperty('agent_id');
     });
   });
 
@@ -258,9 +256,9 @@ describe('RoutingController', () => {
 
   describe('deactivateAllProviders', () => {
     it('should return ok after deactivating all', async () => {
-      const result = await controller.deactivateAllProviders(mockUser);
+      const result = await controller.deactivateAllProviders(mockUser, mockAgentName);
 
-      expect(mockRoutingService.deactivateAllProviders).toHaveBeenCalledWith('user-1');
+      expect(mockRoutingService.deactivateAllProviders).toHaveBeenCalledWith(TEST_AGENT_ID);
       expect(result).toEqual({ ok: true });
     });
   });
@@ -271,16 +269,16 @@ describe('RoutingController', () => {
     it('should return ok with notification count', async () => {
       mockRoutingService.removeProvider.mockResolvedValue({ notifications: 3 });
 
-      const result = await controller.removeProvider(mockUser, { provider: 'openai' });
+      const result = await controller.removeProvider(mockUser, 'test-agent', 'openai');
 
-      expect(mockRoutingService.removeProvider).toHaveBeenCalledWith('user-1', 'openai');
+      expect(mockRoutingService.removeProvider).toHaveBeenCalledWith(TEST_AGENT_ID, 'openai');
       expect(result).toEqual({ ok: true, notifications: 3 });
     });
 
     it('should return zero notifications when none cleared', async () => {
       mockRoutingService.removeProvider.mockResolvedValue({ notifications: 0 });
 
-      const result = await controller.removeProvider(mockUser, { provider: 'deepseek' });
+      const result = await controller.removeProvider(mockUser, 'test-agent', 'deepseek');
       expect(result).toEqual({ ok: true, notifications: 0 });
     });
   });
@@ -289,14 +287,12 @@ describe('RoutingController', () => {
 
   describe('getTiers', () => {
     it('should delegate to service', async () => {
-      const tiers = [
-        { tier: 'simple', override_model: null, auto_assigned_model: 'gpt-4o' },
-      ];
+      const tiers = [{ tier: 'simple', override_model: null, auto_assigned_model: 'gpt-4o' }];
       mockRoutingService.getTiers.mockResolvedValue(tiers);
 
-      const result = await controller.getTiers(mockUser);
+      const result = await controller.getTiers(mockUser, mockAgentName);
 
-      expect(mockRoutingService.getTiers).toHaveBeenCalledWith('user-1');
+      expect(mockRoutingService.getTiers).toHaveBeenCalledWith(TEST_AGENT_ID, 'user-1');
       expect(result).toBe(tiers);
     });
   });
@@ -308,13 +304,16 @@ describe('RoutingController', () => {
       const updated = { tier: 'complex', override_model: 'claude-opus-4-6' };
       mockRoutingService.setOverride.mockResolvedValue(updated);
 
-      const result = await controller.setOverride(
-        mockUser,
-        { tier: 'complex' },
-        { model: 'claude-opus-4-6' },
-      );
+      const result = await controller.setOverride(mockUser, 'test-agent', 'complex', {
+        model: 'claude-opus-4-6',
+      });
 
-      expect(mockRoutingService.setOverride).toHaveBeenCalledWith('user-1', 'complex', 'claude-opus-4-6');
+      expect(mockRoutingService.setOverride).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'user-1',
+        'complex',
+        'claude-opus-4-6',
+      );
       expect(result).toBe(updated);
     });
   });
@@ -323,9 +322,9 @@ describe('RoutingController', () => {
 
   describe('clearOverride', () => {
     it('should return ok after clearing', async () => {
-      const result = await controller.clearOverride(mockUser, { tier: 'simple' });
+      const result = await controller.clearOverride(mockUser, 'test-agent', 'simple');
 
-      expect(mockRoutingService.clearOverride).toHaveBeenCalledWith('user-1', 'simple');
+      expect(mockRoutingService.clearOverride).toHaveBeenCalledWith(TEST_AGENT_ID, 'simple');
       expect(result).toEqual({ ok: true });
     });
   });
@@ -334,9 +333,9 @@ describe('RoutingController', () => {
 
   describe('resetAllOverrides', () => {
     it('should return ok after resetting', async () => {
-      const result = await controller.resetAllOverrides(mockUser);
+      const result = await controller.resetAllOverrides(mockUser, mockAgentName);
 
-      expect(mockRoutingService.resetAllOverrides).toHaveBeenCalledWith('user-1');
+      expect(mockRoutingService.resetAllOverrides).toHaveBeenCalledWith(TEST_AGENT_ID);
       expect(result).toEqual({ ok: true });
     });
   });
@@ -360,7 +359,7 @@ describe('RoutingController', () => {
         isNew: true,
       });
 
-      await controller.upsertProvider(mockUser, { provider: 'ollama' });
+      await controller.upsertProvider(mockUser, mockAgentName, { provider: 'ollama' });
 
       expect(mockOllamaSync.sync).toHaveBeenCalled();
       expect(mockRoutingService.upsertProvider).toHaveBeenCalled();
@@ -394,47 +393,41 @@ describe('RoutingController', () => {
         makePricing({ model_name: 'claude-opus-4-6', provider: 'Anthropic' }),
       ]);
 
-      const result = await controller.getAvailableModels(mockUser);
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
 
       expect(result).toHaveLength(1);
       expect(result[0].model_name).toBe('gpt-4o');
     });
 
     it('should expand provider aliases (gemini ↔ google)', async () => {
-      mockRoutingService.getProviders.mockResolvedValue([
-        { provider: 'gemini', is_active: true },
-      ]);
+      mockRoutingService.getProviders.mockResolvedValue([{ provider: 'gemini', is_active: true }]);
       mockPricingCache.getAll.mockReturnValue([
         makePricing({ model_name: 'gemini-2.5-pro', provider: 'Google' }),
       ]);
 
-      const result = await controller.getAvailableModels(mockUser);
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
 
       expect(result).toHaveLength(1);
       expect(result[0].model_name).toBe('gemini-2.5-pro');
     });
 
     it('should return empty array when no active providers', async () => {
-      mockRoutingService.getProviders.mockResolvedValue([
-        { provider: 'openai', is_active: false },
-      ]);
+      mockRoutingService.getProviders.mockResolvedValue([{ provider: 'openai', is_active: false }]);
       mockPricingCache.getAll.mockReturnValue([
         makePricing({ model_name: 'gpt-4o', provider: 'OpenAI' }),
       ]);
 
-      const result = await controller.getAvailableModels(mockUser);
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
       expect(result).toEqual([]);
     });
 
     it('should return only whitelisted fields', async () => {
-      mockRoutingService.getProviders.mockResolvedValue([
-        { provider: 'openai', is_active: true },
-      ]);
+      mockRoutingService.getProviders.mockResolvedValue([{ provider: 'openai', is_active: true }]);
       mockPricingCache.getAll.mockReturnValue([
         makePricing({ model_name: 'gpt-4o', provider: 'OpenAI' }),
       ]);
 
-      const result = await controller.getAvailableModels(mockUser);
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
 
       expect(Object.keys(result[0]).sort()).toEqual([
         'capability_code',
@@ -459,10 +452,80 @@ describe('RoutingController', () => {
         makePricing({ model_name: 'claude-opus-4-6', provider: 'Anthropic' }),
       ]);
 
-      const result = await controller.getAvailableModels(mockUser);
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
 
       expect(result).toHaveLength(2);
       expect(result.map((m) => m.model_name).sort()).toEqual(['gpt-4o', 'grok-3']);
+    });
+  });
+
+  /* ── resolveAgent (tested through public endpoints) ── */
+
+  describe('resolveAgent', () => {
+    it('should throw NotFoundException when tenant is not found', async () => {
+      mockTenantRepo.findOne.mockResolvedValue(null);
+
+      await expect(controller.getStatus(mockUser, mockAgentName)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockTenantRepo.findOne).toHaveBeenCalledWith({
+        where: { name: 'user-1' },
+      });
+      expect(mockAgentRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when agent is not found', async () => {
+      mockTenantRepo.findOne.mockResolvedValue({ id: 'tenant-001', name: 'user-1' });
+      mockAgentRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        controller.getProviders(mockUser, { agentName: 'nonexistent' } as never),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockAgentRepo.findOne).toHaveBeenCalledWith({
+        where: { tenant_id: 'tenant-001', name: 'nonexistent' },
+      });
+    });
+
+    it('should resolve agent and pass its id to service methods', async () => {
+      mockTenantRepo.findOne.mockResolvedValue({ id: 'tenant-002', name: 'user-1' });
+      mockAgentRepo.findOne.mockResolvedValue({ id: 'agent-xyz', name: 'my-agent' });
+      mockRoutingService.getProviders.mockResolvedValue([]);
+
+      await controller.getStatus(mockUser, { agentName: 'my-agent' } as never);
+
+      expect(mockTenantRepo.findOne).toHaveBeenCalledWith({
+        where: { name: 'user-1' },
+      });
+      expect(mockAgentRepo.findOne).toHaveBeenCalledWith({
+        where: { tenant_id: 'tenant-002', name: 'my-agent' },
+      });
+      expect(mockRoutingService.getProviders).toHaveBeenCalledWith('agent-xyz');
+    });
+
+    it('should propagate NotFoundException through upsertProvider', async () => {
+      mockTenantRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        controller.upsertProvider(mockUser, mockAgentName, {
+          provider: 'openai',
+          apiKey: 'sk-test',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should propagate NotFoundException through removeProvider', async () => {
+      mockTenantRepo.findOne.mockResolvedValue({ id: 'tenant-001', name: 'user-1' });
+      mockAgentRepo.findOne.mockResolvedValue(null);
+
+      await expect(controller.removeProvider(mockUser, 'missing-agent', 'openai')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should propagate NotFoundException through getTiers', async () => {
+      mockTenantRepo.findOne.mockResolvedValue(null);
+
+      await expect(controller.getTiers(mockUser, mockAgentName)).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/packages/backend/src/routing/routing.controller.ts
+++ b/packages/backend/src/routing/routing.controller.ts
@@ -1,25 +1,16 @@
-import {
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Param,
-  Post,
-  Put,
-} from '@nestjs/common';
+import { Body, Controller, Delete, Get, NotFoundException, Param, Post, Put } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
+import { Agent } from '../entities/agent.entity';
+import { Tenant } from '../entities/tenant.entity';
 import { RoutingService } from './routing.service';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { expandProviderNames } from './provider-aliases';
 import { trackCloudEvent } from '../common/utils/product-telemetry';
-import {
-  TierParamDto,
-  ProviderParamDto,
-  ConnectProviderDto,
-  SetOverrideDto,
-} from './dto/routing.dto';
+import { AgentNameParamDto, ConnectProviderDto, SetOverrideDto } from './dto/routing.dto';
 
 @Controller('api/v1/routing')
 export class RoutingController {
@@ -27,22 +18,38 @@ export class RoutingController {
     private readonly routingService: RoutingService,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly ollamaSync: OllamaSyncService,
+    @InjectRepository(Agent)
+    private readonly agentRepo: Repository<Agent>,
+    @InjectRepository(Tenant)
+    private readonly tenantRepo: Repository<Tenant>,
   ) {}
+
+  private async resolveAgent(userId: string, agentName: string): Promise<Agent> {
+    const tenant = await this.tenantRepo.findOne({ where: { name: userId } });
+    if (!tenant) throw new NotFoundException(`Tenant not found`);
+    const agent = await this.agentRepo.findOne({
+      where: { tenant_id: tenant.id, name: agentName },
+    });
+    if (!agent) throw new NotFoundException(`Agent "${agentName}" not found`);
+    return agent;
+  }
 
   /* ── Status ── */
 
-  @Get('status')
-  async getStatus(@CurrentUser() user: AuthUser) {
-    const providers = await this.routingService.getProviders(user.id);
+  @Get(':agentName/status')
+  async getStatus(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
+    const agent = await this.resolveAgent(user.id, params.agentName);
+    const providers = await this.routingService.getProviders(agent.id);
     const enabled = providers.some((p) => p.is_active);
     return { enabled };
   }
 
   /* ── Providers ── */
 
-  @Get('providers')
-  async getProviders(@CurrentUser() user: AuthUser) {
-    const providers = await this.routingService.getProviders(user.id);
+  @Get(':agentName/providers')
+  async getProviders(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
+    const agent = await this.resolveAgent(user.id, params.agentName);
+    const providers = await this.routingService.getProviders(agent.id);
     return providers.map((p) => ({
       id: p.id,
       provider: p.provider,
@@ -53,22 +60,25 @@ export class RoutingController {
     }));
   }
 
-  @Post('providers')
+  @Post(':agentName/providers')
   async upsertProvider(
     @CurrentUser() user: AuthUser,
+    @Param() params: AgentNameParamDto,
     @Body() body: ConnectProviderDto,
   ) {
+    const agent = await this.resolveAgent(user.id, params.agentName);
+
     // Sync Ollama models before connecting so tier assignment has data
     if (body.provider.toLowerCase() === 'ollama') {
       await this.ollamaSync.sync();
     }
 
-    const { provider: result, isNew } =
-      await this.routingService.upsertProvider(
-        user.id,
-        body.provider,
-        body.apiKey,
-      );
+    const { provider: result, isNew } = await this.routingService.upsertProvider(
+      agent.id,
+      user.id,
+      body.provider,
+      body.apiKey,
+    );
 
     if (isNew) {
       trackCloudEvent('routing_provider_connected', user.id, {
@@ -83,21 +93,21 @@ export class RoutingController {
     };
   }
 
-  @Post('providers/deactivate-all')
-  async deactivateAllProviders(@CurrentUser() user: AuthUser) {
-    await this.routingService.deactivateAllProviders(user.id);
+  @Post(':agentName/providers/deactivate-all')
+  async deactivateAllProviders(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
+    const agent = await this.resolveAgent(user.id, params.agentName);
+    await this.routingService.deactivateAllProviders(agent.id);
     return { ok: true };
   }
 
-  @Delete('providers/:provider')
+  @Delete(':agentName/providers/:provider')
   async removeProvider(
     @CurrentUser() user: AuthUser,
-    @Param() params: ProviderParamDto,
+    @Param('agentName') agentName: string,
+    @Param('provider') provider: string,
   ) {
-    const { notifications } = await this.routingService.removeProvider(
-      user.id,
-      params.provider,
-    );
+    const agent = await this.resolveAgent(user.id, agentName);
+    const { notifications } = await this.routingService.removeProvider(agent.id, provider);
     return { ok: true, notifications };
   }
 
@@ -110,40 +120,47 @@ export class RoutingController {
 
   /* ── Tiers ── */
 
-  @Get('tiers')
-  async getTiers(@CurrentUser() user: AuthUser) {
-    return this.routingService.getTiers(user.id);
+  @Get(':agentName/tiers')
+  async getTiers(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
+    const agent = await this.resolveAgent(user.id, params.agentName);
+    return this.routingService.getTiers(agent.id, user.id);
   }
 
-  @Put('tiers/:tier')
+  @Put(':agentName/tiers/:tier')
   async setOverride(
     @CurrentUser() user: AuthUser,
-    @Param() params: TierParamDto,
+    @Param('agentName') agentName: string,
+    @Param('tier') tier: string,
     @Body() body: SetOverrideDto,
   ) {
-    return this.routingService.setOverride(user.id, params.tier, body.model);
+    const agent = await this.resolveAgent(user.id, agentName);
+    return this.routingService.setOverride(agent.id, user.id, tier, body.model);
   }
 
-  @Delete('tiers/:tier')
+  @Delete(':agentName/tiers/:tier')
   async clearOverride(
     @CurrentUser() user: AuthUser,
-    @Param() params: TierParamDto,
+    @Param('agentName') agentName: string,
+    @Param('tier') tier: string,
   ) {
-    await this.routingService.clearOverride(user.id, params.tier);
+    const agent = await this.resolveAgent(user.id, agentName);
+    await this.routingService.clearOverride(agent.id, tier);
     return { ok: true };
   }
 
-  @Post('tiers/reset-all')
-  async resetAllOverrides(@CurrentUser() user: AuthUser) {
-    await this.routingService.resetAllOverrides(user.id);
+  @Post(':agentName/tiers/reset-all')
+  async resetAllOverrides(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
+    const agent = await this.resolveAgent(user.id, params.agentName);
+    await this.routingService.resetAllOverrides(agent.id);
     return { ok: true };
   }
 
   /* ── Available models ── */
 
-  @Get('available-models')
-  async getAvailableModels(@CurrentUser() user: AuthUser) {
-    const providers = await this.routingService.getProviders(user.id);
+  @Get(':agentName/available-models')
+  async getAvailableModels(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
+    const agent = await this.resolveAgent(user.id, params.agentName);
+    const providers = await this.routingService.getProviders(agent.id);
     const activeProviders = expandProviderNames(
       providers.filter((p) => p.is_active).map((p) => p.provider),
     );

--- a/packages/backend/src/routing/routing.module.ts
+++ b/packages/backend/src/routing/routing.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserProvider } from '../entities/user-provider.entity';
 import { TierAssignment } from '../entities/tier-assignment.entity';
+import { Agent } from '../entities/agent.entity';
+import { Tenant } from '../entities/tenant.entity';
 import { AgentApiKey } from '../entities/agent-api-key.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { ModelPricing } from '../entities/model-pricing.entity';
@@ -22,7 +24,15 @@ import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([UserProvider, TierAssignment, AgentApiKey, AgentMessage, ModelPricing]),
+    TypeOrmModule.forFeature([
+      UserProvider,
+      TierAssignment,
+      Agent,
+      Tenant,
+      AgentApiKey,
+      AgentMessage,
+      ModelPricing,
+    ]),
     ModelPricesModule,
     NotificationsModule,
   ],

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -42,11 +42,11 @@ describe('RoutingService', () => {
   describe('getTiers (lazy init)', () => {
     it('should return existing rows when they exist', async () => {
       const rows = [
-        { user_id: 'u1', tier: 'simple', override_model: null, auto_assigned_model: 'gpt-4o' },
+        { agent_id: 'a1', tier: 'simple', override_model: null, auto_assigned_model: 'gpt-4o' },
       ];
       mockTierRepo.find.mockResolvedValue(rows);
 
-      const result = await service.getTiers('u1');
+      const result = await service.getTiers('a1');
       expect(result).toBe(rows);
       expect(mockTierRepo.insert).not.toHaveBeenCalled();
     });
@@ -56,7 +56,7 @@ describe('RoutingService', () => {
       mockTierRepo.find.mockResolvedValueOnce([]);
       mockProviderRepo.find.mockResolvedValue([]);
 
-      const result = await service.getTiers('u1');
+      const result = await service.getTiers('a1');
 
       expect(mockTierRepo.insert).toHaveBeenCalledTimes(4);
       const tiers = mockTierRepo.insert.mock.calls.map(
@@ -66,31 +66,30 @@ describe('RoutingService', () => {
       expect(result).toHaveLength(4);
     });
 
-    it('should recalculate and re-fetch when user has active providers', async () => {
+    it('should recalculate and re-fetch when agent has active providers', async () => {
       mockTierRepo.find
         .mockResolvedValueOnce([]) // initial: no rows
-        .mockResolvedValueOnce([  // after recalculate
+        .mockResolvedValueOnce([
+          // after recalculate
           { tier: 'simple', auto_assigned_model: 'gpt-4o' },
           { tier: 'standard', auto_assigned_model: 'gpt-4o' },
           { tier: 'complex', auto_assigned_model: 'gpt-4o' },
           { tier: 'reasoning', auto_assigned_model: 'gpt-4o' },
         ]);
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'openai', is_active: true },
-      ]);
+      mockProviderRepo.find.mockResolvedValue([{ provider: 'openai', is_active: true }]);
 
-      const result = await service.getTiers('u1');
+      const result = await service.getTiers('a1');
 
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
       expect(result).toHaveLength(4);
       expect(result[0].auto_assigned_model).toBe('gpt-4o');
     });
 
-    it('should not recalculate when user has no active providers', async () => {
+    it('should not recalculate when agent has no active providers', async () => {
       mockTierRepo.find.mockResolvedValueOnce([]);
       mockProviderRepo.find.mockResolvedValue([]);
 
-      await service.getTiers('u1');
+      await service.getTiers('a1');
 
       expect(mockAutoAssign.recalculate).not.toHaveBeenCalled();
     });
@@ -106,11 +105,9 @@ describe('RoutingService', () => {
       mockPricingCache.getByModel.mockReturnValue({
         provider: 'Anthropic',
       } as ModelPricing);
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'anthropic', is_active: true },
-      ]);
+      mockProviderRepo.find.mockResolvedValue([{ provider: 'anthropic', is_active: true }]);
 
-      const result = await service.getEffectiveModel('u1', assignment);
+      const result = await service.getEffectiveModel('a1', assignment);
       expect(result).toBe('claude-opus-4-6');
     });
 
@@ -124,11 +121,9 @@ describe('RoutingService', () => {
         provider: 'OpenAI',
       } as ModelPricing);
       // DB stores "OpenAI" with different case than pricing lowercase
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'OpenAI', is_active: true },
-      ]);
+      mockProviderRepo.find.mockResolvedValue([{ provider: 'OpenAI', is_active: true }]);
 
-      const result = await service.getEffectiveModel('u1', assignment);
+      const result = await service.getEffectiveModel('a1', assignment);
       expect(result).toBe('gpt-4o-mini');
     });
 
@@ -143,7 +138,7 @@ describe('RoutingService', () => {
       } as ModelPricing);
       mockProviderRepo.find.mockResolvedValue([]); // no active providers
 
-      const result = await service.getEffectiveModel('u1', assignment);
+      const result = await service.getEffectiveModel('a1', assignment);
       expect(result).toBe('gpt-4o');
     });
 
@@ -155,7 +150,7 @@ describe('RoutingService', () => {
 
       mockPricingCache.getByModel.mockReturnValue(undefined);
 
-      const result = await service.getEffectiveModel('u1', assignment);
+      const result = await service.getEffectiveModel('a1', assignment);
       expect(result).toBe('gpt-4o');
     });
 
@@ -165,7 +160,7 @@ describe('RoutingService', () => {
         auto_assigned_model: 'gpt-4o',
       } as TierAssignment;
 
-      const result = await service.getEffectiveModel('u1', assignment);
+      const result = await service.getEffectiveModel('a1', assignment);
       expect(result).toBe('gpt-4o');
     });
 
@@ -175,7 +170,7 @@ describe('RoutingService', () => {
         auto_assigned_model: null,
       } as TierAssignment;
 
-      const result = await service.getEffectiveModel('u1', assignment);
+      const result = await service.getEffectiveModel('a1', assignment);
       expect(result).toBeNull();
     });
   });
@@ -183,23 +178,23 @@ describe('RoutingService', () => {
   /* ── getProviders ── */
 
   describe('getProviders', () => {
-    it('should return all providers for a user', async () => {
+    it('should return all providers for an agent', async () => {
       const providers = [
-        { id: 'p1', user_id: 'u1', provider: 'openai', is_active: true },
-        { id: 'p2', user_id: 'u1', provider: 'anthropic', is_active: false },
+        { id: 'p1', agent_id: 'a1', provider: 'openai', is_active: true },
+        { id: 'p2', agent_id: 'a1', provider: 'anthropic', is_active: false },
       ];
       mockProviderRepo.find.mockResolvedValue(providers);
 
-      const result = await service.getProviders('u1');
+      const result = await service.getProviders('a1');
 
-      expect(mockProviderRepo.find).toHaveBeenCalledWith({ where: { user_id: 'u1' } });
+      expect(mockProviderRepo.find).toHaveBeenCalledWith({ where: { agent_id: 'a1' } });
       expect(result).toBe(providers);
     });
 
-    it('should return empty array when user has no providers', async () => {
+    it('should return empty array when agent has no providers', async () => {
       mockProviderRepo.find.mockResolvedValue([]);
 
-      const result = await service.getProviders('u1');
+      const result = await service.getProviders('a1');
       expect(result).toEqual([]);
     });
   });
@@ -210,10 +205,11 @@ describe('RoutingService', () => {
     it('should create a new provider when none exists (with apiKey)', async () => {
       mockProviderRepo.findOne.mockResolvedValue(null);
 
-      const result = await service.upsertProvider('u1', 'openai', 'enc-key');
+      const result = await service.upsertProvider('a1', 'u1', 'openai', 'enc-key');
 
       expect(mockProviderRepo.insert).toHaveBeenCalledWith(
         expect.objectContaining({
+          agent_id: 'a1',
           user_id: 'u1',
           provider: 'openai',
           is_active: true,
@@ -222,7 +218,7 @@ describe('RoutingService', () => {
       const inserted = mockProviderRepo.insert.mock.calls[0][0];
       expect(inserted.api_key_encrypted).not.toBe('enc-key');
       expect(inserted.api_key_encrypted).toContain(':');
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
       expect(result.provider.provider).toBe('openai');
       expect(result.provider.is_active).toBe(true);
       expect(result.isNew).toBe(true);
@@ -231,11 +227,11 @@ describe('RoutingService', () => {
     it('should create a new provider without apiKey (null encrypted)', async () => {
       mockProviderRepo.findOne.mockResolvedValue(null);
 
-      const result = await service.upsertProvider('u1', 'openai');
+      const result = await service.upsertProvider('a1', 'u1', 'openai');
 
       const inserted = mockProviderRepo.insert.mock.calls[0][0];
       expect(inserted.api_key_encrypted).toBeNull();
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
       expect(result.provider.provider).toBe('openai');
       expect(result.provider.is_active).toBe(true);
       expect(result.isNew).toBe(true);
@@ -245,13 +241,14 @@ describe('RoutingService', () => {
       const existing = Object.assign(new UserProvider(), {
         id: 'p1',
         user_id: 'u1',
+        agent_id: 'a1',
         provider: 'openai',
         api_key_encrypted: 'old-key',
         is_active: false,
       });
       mockProviderRepo.findOne.mockResolvedValue(existing);
 
-      const result = await service.upsertProvider('u1', 'openai', 'new-key');
+      const result = await service.upsertProvider('a1', 'u1', 'openai', 'new-key');
 
       expect(mockProviderRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -262,7 +259,7 @@ describe('RoutingService', () => {
       expect(saved.api_key_encrypted).not.toBe('new-key');
       expect(saved.api_key_encrypted).toContain(':');
       expect(mockProviderRepo.insert).not.toHaveBeenCalled();
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
       expect(result.provider.api_key_encrypted).toContain(':');
       expect(result.provider.is_active).toBe(true);
       expect(result.isNew).toBe(false);
@@ -272,24 +269,25 @@ describe('RoutingService', () => {
       const existing = Object.assign(new UserProvider(), {
         id: 'p1',
         user_id: 'u1',
+        agent_id: 'a1',
         provider: 'openai',
         api_key_encrypted: 'old-encrypted',
         is_active: false,
       });
       mockProviderRepo.findOne.mockResolvedValue(existing);
 
-      const result = await service.upsertProvider('u1', 'openai');
+      const result = await service.upsertProvider('a1', 'u1', 'openai');
 
       expect(result.provider.is_active).toBe(true);
       expect(result.provider.api_key_encrypted).toBe('old-encrypted');
       expect(result.isNew).toBe(false);
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
     });
 
     it('should return object with exactly provider and isNew keys', async () => {
       mockProviderRepo.findOne.mockResolvedValue(null);
 
-      const result = await service.upsertProvider('u1', 'openai', 'key');
+      const result = await service.upsertProvider('a1', 'u1', 'openai', 'key');
 
       expect(Object.keys(result).sort()).toEqual(['isNew', 'provider']);
       expect(result.provider).toBeDefined();
@@ -300,7 +298,7 @@ describe('RoutingService', () => {
       mockProviderRepo.findOne.mockResolvedValue(null);
 
       const before = new Date().toISOString();
-      const result = await service.upsertProvider('u1', 'openai', 'key');
+      const result = await service.upsertProvider('a1', 'u1', 'openai', 'key');
       const after = new Date().toISOString();
 
       const inserted = mockProviderRepo.insert.mock.calls[0][0];
@@ -318,6 +316,7 @@ describe('RoutingService', () => {
       const existing = Object.assign(new UserProvider(), {
         id: 'p1',
         user_id: 'u1',
+        agent_id: 'a1',
         provider: 'openai',
         api_key_encrypted: 'old-encrypted',
         is_active: false,
@@ -327,7 +326,7 @@ describe('RoutingService', () => {
       mockProviderRepo.findOne.mockResolvedValue(existing);
 
       const before = new Date().toISOString();
-      await service.upsertProvider('u1', 'openai', 'new-key');
+      await service.upsertProvider('a1', 'u1', 'openai', 'new-key');
 
       const saved = mockProviderRepo.save.mock.calls[0][0];
       expect(saved.connected_at).toBe(originalConnectedAt);
@@ -337,15 +336,13 @@ describe('RoutingService', () => {
     it('should generate a UUID id for new provider', async () => {
       mockProviderRepo.findOne.mockResolvedValue(null);
 
-      await service.upsertProvider('u1', 'openai', 'key');
+      await service.upsertProvider('a1', 'u1', 'openai', 'key');
 
       const inserted = mockProviderRepo.insert.mock.calls[0][0];
       expect(inserted.id).toBeDefined();
       expect(typeof inserted.id).toBe('string');
       // UUID v4 format: 8-4-4-4-12
-      expect(inserted.id).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
-      );
+      expect(inserted.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     });
   });
 
@@ -355,47 +352,44 @@ describe('RoutingService', () => {
     it('should throw NotFoundException when provider does not exist', async () => {
       mockProviderRepo.findOne.mockResolvedValue(null);
 
-      await expect(service.removeProvider('u1', 'nonexistent')).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(service.removeProvider('a1', 'nonexistent')).rejects.toThrow(NotFoundException);
     });
 
     it('should deactivate provider and recalculate', async () => {
       const existing = Object.assign(new UserProvider(), {
         id: 'p1',
-        user_id: 'u1',
+        agent_id: 'a1',
         provider: 'openai',
         is_active: true,
       });
       mockProviderRepo.findOne.mockResolvedValue(existing);
       mockTierRepo.find.mockResolvedValue([]); // no overrides
 
-      const result = await service.removeProvider('u1', 'openai');
+      const result = await service.removeProvider('a1', 'openai');
 
       expect(existing.is_active).toBe(false);
       expect(mockProviderRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({ is_active: false }),
       );
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
       expect(result.notifications).toEqual([]);
     });
 
     it('should invalidate overrides belonging to the removed provider', async () => {
       const existing = Object.assign(new UserProvider(), {
         id: 'p1',
-        user_id: 'u1',
+        agent_id: 'a1',
         provider: 'openai',
         is_active: true,
       });
       mockProviderRepo.findOne.mockResolvedValue(existing);
 
       const override = Object.assign(new TierAssignment(), {
-        user_id: 'u1',
+        agent_id: 'a1',
         tier: 'complex',
         override_model: 'gpt-4o',
       });
-      mockTierRepo.find
-        .mockResolvedValueOnce([override]); // overrides query
+      mockTierRepo.find.mockResolvedValueOnce([override]); // overrides query
       mockTierRepo.findOne.mockResolvedValue({
         auto_assigned_model: 'claude-opus-4-6',
       });
@@ -404,7 +398,7 @@ describe('RoutingService', () => {
         provider: 'OpenAI',
       } as ModelPricing);
 
-      const result = await service.removeProvider('u1', 'openai');
+      const result = await service.removeProvider('a1', 'openai');
 
       expect(override.override_model).toBeNull();
       expect(mockTierRepo.save).toHaveBeenCalledWith(
@@ -419,14 +413,14 @@ describe('RoutingService', () => {
     it('should build notification without fallback model when auto is null', async () => {
       const existing = Object.assign(new UserProvider(), {
         id: 'p1',
-        user_id: 'u1',
+        agent_id: 'a1',
         provider: 'openai',
         is_active: true,
       });
       mockProviderRepo.findOne.mockResolvedValue(existing);
 
       const override = Object.assign(new TierAssignment(), {
-        user_id: 'u1',
+        agent_id: 'a1',
         tier: 'simple',
         override_model: 'gpt-4o',
       });
@@ -436,7 +430,7 @@ describe('RoutingService', () => {
       });
       mockPricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' } as ModelPricing);
 
-      const result = await service.removeProvider('u1', 'openai');
+      const result = await service.removeProvider('a1', 'openai');
 
       expect(result.notifications[0]).toContain('automatic mode.');
       expect(result.notifications[0]).not.toContain('(');
@@ -445,14 +439,14 @@ describe('RoutingService', () => {
     it('should not invalidate overrides from other providers', async () => {
       const existing = Object.assign(new UserProvider(), {
         id: 'p1',
-        user_id: 'u1',
+        agent_id: 'a1',
         provider: 'openai',
         is_active: true,
       });
       mockProviderRepo.findOne.mockResolvedValue(existing);
 
       const override = Object.assign(new TierAssignment(), {
-        user_id: 'u1',
+        agent_id: 'a1',
         tier: 'complex',
         override_model: 'claude-opus-4-6',
       });
@@ -461,7 +455,7 @@ describe('RoutingService', () => {
         provider: 'Anthropic',
       } as ModelPricing);
 
-      const result = await service.removeProvider('u1', 'openai');
+      const result = await service.removeProvider('a1', 'openai');
 
       expect(override.override_model).toBe('claude-opus-4-6'); // not cleared
       expect(result.notifications).toEqual([]);
@@ -474,13 +468,13 @@ describe('RoutingService', () => {
     it('should update existing tier row', async () => {
       const existing = Object.assign(new TierAssignment(), {
         id: 't1',
-        user_id: 'u1',
+        agent_id: 'a1',
         tier: 'complex',
         override_model: null,
       });
       mockTierRepo.findOne.mockResolvedValue(existing);
 
-      const result = await service.setOverride('u1', 'complex', 'claude-opus-4-6');
+      const result = await service.setOverride('a1', 'u1', 'complex', 'claude-opus-4-6');
 
       expect(existing.override_model).toBe('claude-opus-4-6');
       expect(mockTierRepo.save).toHaveBeenCalledWith(
@@ -492,10 +486,11 @@ describe('RoutingService', () => {
     it('should create new tier row when none exists', async () => {
       mockTierRepo.findOne.mockResolvedValue(null);
 
-      const result = await service.setOverride('u1', 'reasoning', 'o1-pro');
+      const result = await service.setOverride('a1', 'u1', 'reasoning', 'o1-pro');
 
       expect(mockTierRepo.insert).toHaveBeenCalledWith(
         expect.objectContaining({
+          agent_id: 'a1',
           user_id: 'u1',
           tier: 'reasoning',
           override_model: 'o1-pro',
@@ -512,13 +507,13 @@ describe('RoutingService', () => {
     it('should clear override on existing tier', async () => {
       const existing = Object.assign(new TierAssignment(), {
         id: 't1',
-        user_id: 'u1',
+        agent_id: 'a1',
         tier: 'simple',
         override_model: 'gpt-4o',
       });
       mockTierRepo.findOne.mockResolvedValue(existing);
 
-      await service.clearOverride('u1', 'simple');
+      await service.clearOverride('a1', 'simple');
 
       expect(existing.override_model).toBeNull();
       expect(mockTierRepo.save).toHaveBeenCalledWith(
@@ -529,7 +524,7 @@ describe('RoutingService', () => {
     it('should be a no-op when tier does not exist', async () => {
       mockTierRepo.findOne.mockResolvedValue(null);
 
-      await service.clearOverride('u1', 'nonexistent');
+      await service.clearOverride('a1', 'nonexistent');
 
       expect(mockTierRepo.save).not.toHaveBeenCalled();
     });
@@ -538,11 +533,11 @@ describe('RoutingService', () => {
   /* ── resetAllOverrides ── */
 
   describe('resetAllOverrides', () => {
-    it('should update all tiers for the user', async () => {
-      await service.resetAllOverrides('u1');
+    it('should update all tiers for the agent', async () => {
+      await service.resetAllOverrides('a1');
 
       expect(mockTierRepo.update).toHaveBeenCalledWith(
-        { user_id: 'u1' },
+        { agent_id: 'a1' },
         expect.objectContaining({ override_model: null }),
       );
     });
@@ -552,17 +547,17 @@ describe('RoutingService', () => {
 
   describe('deactivateAllProviders', () => {
     it('should deactivate all providers, clear overrides, and recalculate', async () => {
-      await service.deactivateAllProviders('u1');
+      await service.deactivateAllProviders('a1');
 
       expect(mockProviderRepo.update).toHaveBeenCalledWith(
-        { user_id: 'u1' },
+        { agent_id: 'a1' },
         expect.objectContaining({ is_active: false }),
       );
       expect(mockTierRepo.update).toHaveBeenCalledWith(
-        { user_id: 'u1' },
+        { agent_id: 'a1' },
         expect.objectContaining({ override_model: null }),
       );
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
     });
   });
 
@@ -584,14 +579,14 @@ describe('RoutingService', () => {
       expect(mockAutoAssign.recalculate).not.toHaveBeenCalled();
     });
 
-    it('should clear overrides and recalculate for affected users', async () => {
+    it('should clear overrides and recalculate for affected agents', async () => {
       const tier1 = Object.assign(new TierAssignment(), {
-        user_id: 'u1',
+        agent_id: 'a1',
         tier: 'complex',
         override_model: 'old-model',
       });
       const tier2 = Object.assign(new TierAssignment(), {
-        user_id: 'u2',
+        agent_id: 'a2',
         tier: 'simple',
         override_model: 'old-model',
       });
@@ -602,18 +597,18 @@ describe('RoutingService', () => {
       expect(tier1.override_model).toBeNull();
       expect(tier2.override_model).toBeNull();
       expect(mockTierRepo.save).toHaveBeenCalledTimes(2);
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u2');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a2');
     });
 
-    it('should recalculate each user only once', async () => {
+    it('should recalculate each agent only once', async () => {
       const tier1 = Object.assign(new TierAssignment(), {
-        user_id: 'u1',
+        agent_id: 'a1',
         tier: 'complex',
         override_model: 'model-a',
       });
       const tier2 = Object.assign(new TierAssignment(), {
-        user_id: 'u1',
+        agent_id: 'a1',
         tier: 'simple',
         override_model: 'model-b',
       });
@@ -621,9 +616,9 @@ describe('RoutingService', () => {
 
       await service.invalidateOverridesForRemovedModels(['model-a', 'model-b']);
 
-      // Same user — should only recalculate once
+      // Same agent — should only recalculate once
       expect(mockAutoAssign.recalculate).toHaveBeenCalledTimes(1);
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('u1');
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
     });
   });
 
@@ -641,9 +636,7 @@ describe('RoutingService', () => {
     });
 
     it('should return first 8 chars of decrypted key', async () => {
-      const { encrypt, getEncryptionSecret } = await import(
-        '../common/utils/crypto.util'
-      );
+      const { encrypt, getEncryptionSecret } = await import('../common/utils/crypto.util');
       const secret = getEncryptionSecret();
       const encrypted = encrypt('sk-abcdefghijklmnop', secret);
 
@@ -652,9 +645,7 @@ describe('RoutingService', () => {
     });
 
     it('should return custom length prefix', async () => {
-      const { encrypt, getEncryptionSecret } = await import(
-        '../common/utils/crypto.util'
-      );
+      const { encrypt, getEncryptionSecret } = await import('../common/utils/crypto.util');
       const secret = getEncryptionSecret();
       const encrypted = encrypt('sk-abcdefghijklmnop', secret);
 
@@ -663,16 +654,11 @@ describe('RoutingService', () => {
     });
 
     it('should return null and log warning when decrypt throws', () => {
-      const warnSpy = jest.spyOn(
-        (service as any).logger,
-        'warn',
-      );
+      const warnSpy = jest.spyOn((service as any).logger, 'warn');
 
       const result = service.getKeyPrefix('invalid:encrypted:data');
       expect(result).toBeNull();
-      expect(warnSpy).toHaveBeenCalledWith(
-        'Failed to decrypt API key for prefix extraction',
-      );
+      expect(warnSpy).toHaveBeenCalledWith('Failed to decrypt API key for prefix extraction');
     });
   });
 
@@ -686,56 +672,56 @@ describe('RoutingService', () => {
 
       mockProviderRepo.find.mockResolvedValue([
         {
-          user_id: 'u1',
+          agent_id: 'a1',
           provider: 'openai',
           is_active: true,
           api_key_encrypted: encrypted,
         },
       ]);
 
-      const result = await service.getProviderApiKey('u1', 'openai');
+      const result = await service.getProviderApiKey('a1', 'openai');
       expect(result).toBe('sk-test-key');
     });
 
     it('should return null when no active provider matches', async () => {
       mockProviderRepo.find.mockResolvedValue([
         {
-          user_id: 'u1',
+          agent_id: 'a1',
           provider: 'anthropic',
           is_active: true,
           api_key_encrypted: 'enc',
         },
       ]);
 
-      const result = await service.getProviderApiKey('u1', 'openai');
+      const result = await service.getProviderApiKey('a1', 'openai');
       expect(result).toBeNull();
     });
 
     it('should return null when match has no encrypted key', async () => {
       mockProviderRepo.find.mockResolvedValue([
         {
-          user_id: 'u1',
+          agent_id: 'a1',
           provider: 'openai',
           is_active: true,
           api_key_encrypted: null,
         },
       ]);
 
-      const result = await service.getProviderApiKey('u1', 'openai');
+      const result = await service.getProviderApiKey('a1', 'openai');
       expect(result).toBeNull();
     });
 
     it('should return null when decryption fails', async () => {
       mockProviderRepo.find.mockResolvedValue([
         {
-          user_id: 'u1',
+          agent_id: 'a1',
           provider: 'openai',
           is_active: true,
           api_key_encrypted: 'invalid:encrypted:data:format',
         },
       ]);
 
-      const result = await service.getProviderApiKey('u1', 'openai');
+      const result = await service.getProviderApiKey('a1', 'openai');
       expect(result).toBeNull();
     });
 
@@ -746,32 +732,32 @@ describe('RoutingService', () => {
 
       mockProviderRepo.find.mockResolvedValue([
         {
-          user_id: 'u1',
+          agent_id: 'a1',
           provider: 'gemini',
           is_active: true,
           api_key_encrypted: encrypted,
         },
       ]);
 
-      const result = await service.getProviderApiKey('u1', 'google');
+      const result = await service.getProviderApiKey('a1', 'google');
       expect(result).toBe('AIza-test');
     });
 
     it('should return null when no records exist', async () => {
       mockProviderRepo.find.mockResolvedValue([]);
 
-      const result = await service.getProviderApiKey('u1', 'openai');
+      const result = await service.getProviderApiKey('a1', 'openai');
       expect(result).toBeNull();
     });
 
     it('should return empty string for Ollama provider without DB lookup', async () => {
-      const result = await service.getProviderApiKey('u1', 'Ollama');
+      const result = await service.getProviderApiKey('a1', 'Ollama');
       expect(result).toBe('');
       expect(mockProviderRepo.find).not.toHaveBeenCalled();
     });
 
     it('should return empty string for ollama in any case', async () => {
-      const result = await service.getProviderApiKey('u1', 'OLLAMA');
+      const result = await service.getProviderApiKey('a1', 'OLLAMA');
       expect(result).toBe('');
       expect(mockProviderRepo.find).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -32,21 +32,20 @@ export class RoutingService {
 
   /* ── Providers ── */
 
-  async getProviders(userId: string): Promise<UserProvider[]> {
-    return this.providerRepo.find({ where: { user_id: userId } });
+  async getProviders(agentId: string): Promise<UserProvider[]> {
+    return this.providerRepo.find({ where: { agent_id: agentId } });
   }
 
   async upsertProvider(
+    agentId: string,
     userId: string,
     provider: string,
     apiKey?: string,
   ): Promise<{ provider: UserProvider; isNew: boolean }> {
-    const apiKeyEncrypted = apiKey
-      ? encrypt(apiKey, getEncryptionSecret())
-      : null;
+    const apiKeyEncrypted = apiKey ? encrypt(apiKey, getEncryptionSecret()) : null;
 
     const existing = await this.providerRepo.findOne({
-      where: { user_id: userId, provider },
+      where: { agent_id: agentId, provider },
     });
 
     if (existing) {
@@ -56,13 +55,14 @@ export class RoutingService {
       existing.is_active = true;
       existing.updated_at = new Date().toISOString();
       await this.providerRepo.save(existing);
-      await this.autoAssign.recalculate(userId);
+      await this.autoAssign.recalculate(agentId);
       return { provider: existing, isNew: false };
     }
 
     const record: UserProvider = Object.assign(new UserProvider(), {
       id: randomUUID(),
       user_id: userId,
+      agent_id: agentId,
       provider,
       api_key_encrypted: apiKeyEncrypted,
       is_active: true,
@@ -71,22 +71,19 @@ export class RoutingService {
     });
 
     await this.providerRepo.insert(record);
-    await this.autoAssign.recalculate(userId);
+    await this.autoAssign.recalculate(agentId);
     return { provider: record, isNew: true };
   }
 
-  async removeProvider(
-    userId: string,
-    provider: string,
-  ): Promise<{ notifications: string[] }> {
+  async removeProvider(agentId: string, provider: string): Promise<{ notifications: string[] }> {
     const existing = await this.providerRepo.findOne({
-      where: { user_id: userId, provider },
+      where: { agent_id: agentId, provider },
     });
     if (!existing) throw new NotFoundException('Provider not found');
 
     // Find overrides that belong to this provider
     const overrides = await this.tierRepo.find({
-      where: { user_id: userId, override_model: Not(IsNull()) },
+      where: { agent_id: agentId, override_model: Not(IsNull()) },
     });
 
     const invalidated: { tier: string; modelName: string }[] = [];
@@ -104,13 +101,13 @@ export class RoutingService {
     existing.is_active = false;
     existing.updated_at = new Date().toISOString();
     await this.providerRepo.save(existing);
-    await this.autoAssign.recalculate(userId);
+    await this.autoAssign.recalculate(agentId);
 
     // Build notification messages
     const notifications: string[] = [];
     for (const { tier, modelName } of invalidated) {
       const updated = await this.tierRepo.findOne({
-        where: { user_id: userId, tier },
+        where: { agent_id: agentId, tier },
       });
       const newModel = updated?.auto_assigned_model ?? null;
       const tierLabel = TIER_LABELS[tier] ?? tier;
@@ -123,23 +120,21 @@ export class RoutingService {
     return { notifications };
   }
 
-  async deactivateAllProviders(userId: string): Promise<void> {
+  async deactivateAllProviders(agentId: string): Promise<void> {
     await this.providerRepo.update(
-      { user_id: userId },
+      { agent_id: agentId },
       { is_active: false, updated_at: new Date().toISOString() },
     );
     await this.tierRepo.update(
-      { user_id: userId },
+      { agent_id: agentId },
       { override_model: null, updated_at: new Date().toISOString() },
     );
-    await this.autoAssign.recalculate(userId);
+    await this.autoAssign.recalculate(agentId);
   }
 
   /* ── Override invalidation (for pricing sync) ── */
 
-  async invalidateOverridesForRemovedModels(
-    removedModels: string[],
-  ): Promise<void> {
+  async invalidateOverridesForRemovedModels(removedModels: string[]): Promise<void> {
     if (removedModels.length === 0) return;
 
     const affected = await this.tierRepo.find({
@@ -148,30 +143,30 @@ export class RoutingService {
 
     if (affected.length === 0) return;
 
-    const userIds = new Set<string>();
+    const agentIds = new Set<string>();
     for (const tier of affected) {
       this.logger.warn(
-        `Clearing override ${tier.override_model} for user ${tier.user_id} tier ${tier.tier} (model removed)`,
+        `Clearing override ${tier.override_model} for agent ${tier.agent_id} tier ${tier.tier} (model removed)`,
       );
       tier.override_model = null;
       tier.updated_at = new Date().toISOString();
       await this.tierRepo.save(tier);
-      userIds.add(tier.user_id);
+      agentIds.add(tier.agent_id);
     }
 
-    for (const userId of userIds) {
-      await this.autoAssign.recalculate(userId);
+    for (const agentId of agentIds) {
+      await this.autoAssign.recalculate(agentId);
     }
 
     this.logger.log(
-      `Invalidated ${affected.length} overrides for ${userIds.size} users (removed models: ${removedModels.join(', ')})`,
+      `Invalidated ${affected.length} overrides for ${agentIds.size} agents (removed models: ${removedModels.join(', ')})`,
     );
   }
 
   /* ── Tier Assignments ── */
 
-  async getTiers(userId: string): Promise<TierAssignment[]> {
-    const rows = await this.tierRepo.find({ where: { user_id: userId } });
+  async getTiers(agentId: string, userId?: string): Promise<TierAssignment[]> {
+    const rows = await this.tierRepo.find({ where: { agent_id: agentId } });
 
     if (rows.length === 0) {
       // Lazy init: create the 4 tier rows
@@ -179,7 +174,8 @@ export class RoutingService {
       for (const tier of TIERS) {
         const record = Object.assign(new TierAssignment(), {
           id: randomUUID(),
-          user_id: userId,
+          user_id: userId ?? '',
+          agent_id: agentId,
           tier,
           override_model: null,
           auto_assigned_model: null,
@@ -188,13 +184,13 @@ export class RoutingService {
         created.push(record);
       }
 
-      // If user has active providers, recalculate immediately
+      // If agent has active providers, recalculate immediately
       const providers = await this.providerRepo.find({
-        where: { user_id: userId, is_active: true },
+        where: { agent_id: agentId, is_active: true },
       });
       if (providers.length > 0) {
-        await this.autoAssign.recalculate(userId);
-        return this.tierRepo.find({ where: { user_id: userId } });
+        await this.autoAssign.recalculate(agentId);
+        return this.tierRepo.find({ where: { agent_id: agentId } });
       }
 
       return created;
@@ -204,12 +200,13 @@ export class RoutingService {
   }
 
   async setOverride(
+    agentId: string,
     userId: string,
     tier: string,
     model: string,
   ): Promise<TierAssignment> {
     const existing = await this.tierRepo.findOne({
-      where: { user_id: userId, tier },
+      where: { agent_id: agentId, tier },
     });
 
     if (existing) {
@@ -222,6 +219,7 @@ export class RoutingService {
     const record: TierAssignment = Object.assign(new TierAssignment(), {
       id: randomUUID(),
       user_id: userId,
+      agent_id: agentId,
       tier,
       override_model: model,
       auto_assigned_model: null,
@@ -231,9 +229,9 @@ export class RoutingService {
     return record;
   }
 
-  async clearOverride(userId: string, tier: string): Promise<void> {
+  async clearOverride(agentId: string, tier: string): Promise<void> {
     const existing = await this.tierRepo.findOne({
-      where: { user_id: userId, tier },
+      where: { agent_id: agentId, tier },
     });
     if (!existing) return;
 
@@ -242,25 +240,22 @@ export class RoutingService {
     await this.tierRepo.save(existing);
   }
 
-  async resetAllOverrides(userId: string): Promise<void> {
+  async resetAllOverrides(agentId: string): Promise<void> {
     await this.tierRepo.update(
-      { user_id: userId },
+      { agent_id: agentId },
       { override_model: null, updated_at: new Date().toISOString() },
     );
   }
 
   /* ── Provider API key retrieval ── */
 
-  async getProviderApiKey(
-    userId: string,
-    provider: string,
-  ): Promise<string | null> {
+  async getProviderApiKey(agentId: string, provider: string): Promise<string | null> {
     // Ollama runs locally — no API key needed
     if (provider.toLowerCase() === 'ollama') return '';
 
     const names = expandProviderNames([provider]);
     const records = await this.providerRepo.find({
-      where: { user_id: userId, is_active: true },
+      where: { agent_id: agentId, is_active: true },
     });
 
     const match = records.find((r) => names.has(r.provider.toLowerCase()));
@@ -289,35 +284,26 @@ export class RoutingService {
 
   /* ── Runtime helper ── */
 
-  async getEffectiveModel(
-    userId: string,
-    assignment: TierAssignment,
-  ): Promise<string | null> {
+  async getEffectiveModel(agentId: string, assignment: TierAssignment): Promise<string | null> {
     if (assignment.override_model !== null) {
-      // Belt-and-suspenders: verify the provider is still connected.
-      // Use the same case-insensitive matching as getProviderApiKey —
-      // the DB may store "OpenAI" while pricing has "openai" or vice-versa.
       const pricing = this.pricingCache.getByModel(assignment.override_model);
       if (pricing) {
         const names = expandProviderNames([pricing.provider]);
         const records = await this.providerRepo.find({
-          where: { user_id: userId, is_active: true },
+          where: { agent_id: agentId, is_active: true },
         });
         const match = records.find((r) => names.has(r.provider.toLowerCase()));
         if (match) return assignment.override_model;
       }
-      // Provider disconnected or model unknown — fall through to auto
       this.logger.warn(
         `Override ${assignment.override_model} falling through to auto ` +
-        `for user=${userId} tier=${assignment.tier} ` +
-        `(auto=${assignment.auto_assigned_model})`,
+          `for agent=${agentId} tier=${assignment.tier} ` +
+          `(auto=${assignment.auto_assigned_model})`,
       );
     }
 
     if (assignment.auto_assigned_model === null) {
-      this.logger.warn(
-        `auto_assigned_model is null for user=${userId} tier=${assignment.tier}`,
-      );
+      this.logger.warn(`auto_assigned_model is null for agent=${agentId} tier=${assignment.tier}`);
     }
 
     return assignment.auto_assigned_model;

--- a/packages/backend/src/routing/tier-auto-assign.service.spec.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.spec.ts
@@ -53,22 +53,46 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should pick free models (e.g. local Ollama)', () => {
-      const free = makeModel({ model_name: 'free', input_price_per_token: 0, output_price_per_token: 0 });
+      const free = makeModel({
+        model_name: 'free',
+        input_price_per_token: 0,
+        output_price_per_token: 0,
+      });
       expect(service.pickBest([free], 'simple')!.model_name).toBe('free');
     });
 
     // ── SIMPLE: cheapest wins ──
 
     it('simple: should pick cheapest model', () => {
-      const cheap = makeModel({ model_name: 'cheap', input_price_per_token: 0.000001, output_price_per_token: 0.000002, quality_score: 1 });
-      const expensive = makeModel({ model_name: 'expensive', input_price_per_token: 0.00001, output_price_per_token: 0.00003, quality_score: 5 });
+      const cheap = makeModel({
+        model_name: 'cheap',
+        input_price_per_token: 0.000001,
+        output_price_per_token: 0.000002,
+        quality_score: 1,
+      });
+      const expensive = makeModel({
+        model_name: 'expensive',
+        input_price_per_token: 0.00001,
+        output_price_per_token: 0.00003,
+        quality_score: 5,
+      });
 
       expect(service.pickBest([cheap, expensive], 'simple')!.model_name).toBe('cheap');
     });
 
     it('simple: quality does not matter', () => {
-      const lowQ = makeModel({ model_name: 'low-q', input_price_per_token: 0.0000001, output_price_per_token: 0.0000004, quality_score: 1 });
-      const highQ = makeModel({ model_name: 'high-q', input_price_per_token: 0.0000002, output_price_per_token: 0.0000008, quality_score: 5 });
+      const lowQ = makeModel({
+        model_name: 'low-q',
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        quality_score: 1,
+      });
+      const highQ = makeModel({
+        model_name: 'high-q',
+        input_price_per_token: 0.0000002,
+        output_price_per_token: 0.0000008,
+        quality_score: 5,
+      });
 
       expect(service.pickBest([lowQ, highQ], 'simple')!.model_name).toBe('low-q');
     });
@@ -76,15 +100,35 @@ describe('TierAutoAssignService', () => {
     // ── STANDARD: cheapest among quality >= 2 ──
 
     it('standard: should exclude quality 1 models', () => {
-      const ultraCheap = makeModel({ model_name: 'ultra-cheap', input_price_per_token: 0.0000001, output_price_per_token: 0.0000004, quality_score: 1 });
-      const decent = makeModel({ model_name: 'decent', input_price_per_token: 0.000001, output_price_per_token: 0.000002, quality_score: 2 });
+      const ultraCheap = makeModel({
+        model_name: 'ultra-cheap',
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        quality_score: 1,
+      });
+      const decent = makeModel({
+        model_name: 'decent',
+        input_price_per_token: 0.000001,
+        output_price_per_token: 0.000002,
+        quality_score: 2,
+      });
 
       expect(service.pickBest([ultraCheap, decent], 'standard')!.model_name).toBe('decent');
     });
 
     it('standard: should fallback to cheapest if all are quality 1', () => {
-      const a = makeModel({ model_name: 'a', input_price_per_token: 0.0000001, output_price_per_token: 0.0000004, quality_score: 1 });
-      const b = makeModel({ model_name: 'b', input_price_per_token: 0.0000002, output_price_per_token: 0.0000008, quality_score: 1 });
+      const a = makeModel({
+        model_name: 'a',
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        quality_score: 1,
+      });
+      const b = makeModel({
+        model_name: 'b',
+        input_price_per_token: 0.0000002,
+        output_price_per_token: 0.0000008,
+        quality_score: 1,
+      });
 
       expect(service.pickBest([a, b], 'standard')!.model_name).toBe('a');
     });
@@ -92,15 +136,35 @@ describe('TierAutoAssignService', () => {
     // ── COMPLEX: best quality, price as tiebreaker ──
 
     it('complex: should pick highest quality regardless of price', () => {
-      const cheap = makeModel({ model_name: 'cheap', input_price_per_token: 0.0000001, output_price_per_token: 0.0000004, quality_score: 1 });
-      const expensive = makeModel({ model_name: 'expensive', input_price_per_token: 0.000015, output_price_per_token: 0.000075, quality_score: 5 });
+      const cheap = makeModel({
+        model_name: 'cheap',
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        quality_score: 1,
+      });
+      const expensive = makeModel({
+        model_name: 'expensive',
+        input_price_per_token: 0.000015,
+        output_price_per_token: 0.000075,
+        quality_score: 5,
+      });
 
       expect(service.pickBest([cheap, expensive], 'complex')!.model_name).toBe('expensive');
     });
 
     it('complex: should use price as tiebreaker at same quality', () => {
-      const cheapQ4 = makeModel({ model_name: 'cheap-q4', input_price_per_token: 0.000003, output_price_per_token: 0.000015, quality_score: 4 });
-      const expensiveQ4 = makeModel({ model_name: 'expensive-q4', input_price_per_token: 0.000015, output_price_per_token: 0.000075, quality_score: 4 });
+      const cheapQ4 = makeModel({
+        model_name: 'cheap-q4',
+        input_price_per_token: 0.000003,
+        output_price_per_token: 0.000015,
+        quality_score: 4,
+      });
+      const expensiveQ4 = makeModel({
+        model_name: 'expensive-q4',
+        input_price_per_token: 0.000015,
+        output_price_per_token: 0.000075,
+        quality_score: 4,
+      });
 
       expect(service.pickBest([expensiveQ4, cheapQ4], 'complex')!.model_name).toBe('cheap-q4');
     });
@@ -108,22 +172,58 @@ describe('TierAutoAssignService', () => {
     // ── REASONING: best quality among reasoning models ──
 
     it('reasoning: should pick best reasoning model over cheaper non-reasoning', () => {
-      const cheap = makeModel({ model_name: 'cheap', input_price_per_token: 0.0000001, output_price_per_token: 0.0000004, quality_score: 2, capability_reasoning: false });
-      const reasoning = makeModel({ model_name: 'reasoning', input_price_per_token: 0.000015, output_price_per_token: 0.000075, quality_score: 5, capability_reasoning: true });
+      const cheap = makeModel({
+        model_name: 'cheap',
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        quality_score: 2,
+        capability_reasoning: false,
+      });
+      const reasoning = makeModel({
+        model_name: 'reasoning',
+        input_price_per_token: 0.000015,
+        output_price_per_token: 0.000075,
+        quality_score: 5,
+        capability_reasoning: true,
+      });
 
       expect(service.pickBest([cheap, reasoning], 'reasoning')!.model_name).toBe('reasoning');
     });
 
     it('reasoning: should fallback to complex logic when no reasoning models', () => {
-      const lowQ = makeModel({ model_name: 'low-q', input_price_per_token: 0.0000001, output_price_per_token: 0.0000004, quality_score: 1, capability_reasoning: false });
-      const highQ = makeModel({ model_name: 'high-q', input_price_per_token: 0.000015, output_price_per_token: 0.000075, quality_score: 5, capability_reasoning: false });
+      const lowQ = makeModel({
+        model_name: 'low-q',
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        quality_score: 1,
+        capability_reasoning: false,
+      });
+      const highQ = makeModel({
+        model_name: 'high-q',
+        input_price_per_token: 0.000015,
+        output_price_per_token: 0.000075,
+        quality_score: 5,
+        capability_reasoning: false,
+      });
 
       expect(service.pickBest([lowQ, highQ], 'reasoning')!.model_name).toBe('high-q');
     });
 
     it('reasoning: should pick cheapest reasoning model at same quality', () => {
-      const cheapR = makeModel({ model_name: 'cheap-r', input_price_per_token: 0.000003, output_price_per_token: 0.000015, quality_score: 4, capability_reasoning: true });
-      const expensiveR = makeModel({ model_name: 'expensive-r', input_price_per_token: 0.000015, output_price_per_token: 0.000075, quality_score: 4, capability_reasoning: true });
+      const cheapR = makeModel({
+        model_name: 'cheap-r',
+        input_price_per_token: 0.000003,
+        output_price_per_token: 0.000015,
+        quality_score: 4,
+        capability_reasoning: true,
+      });
+      const expensiveR = makeModel({
+        model_name: 'expensive-r',
+        input_price_per_token: 0.000015,
+        output_price_per_token: 0.000075,
+        quality_score: 4,
+        capability_reasoning: true,
+      });
 
       expect(service.pickBest([expensiveR, cheapR], 'reasoning')!.model_name).toBe('cheap-r');
     });
@@ -131,9 +231,30 @@ describe('TierAutoAssignService', () => {
     // ── Real-world: single provider with multiple tiers ──
 
     it('should assign different models per tier (Gemini-like catalog)', () => {
-      const flashLite = makeModel({ model_name: 'gemini-2.5-flash-lite', provider: 'Google', input_price_per_token: 0.0000001, output_price_per_token: 0.0000004, quality_score: 1 });
-      const flash = makeModel({ model_name: 'gemini-2.5-flash', provider: 'Google', input_price_per_token: 0.00000015, output_price_per_token: 0.0000006, quality_score: 2, capability_code: true });
-      const pro = makeModel({ model_name: 'gemini-2.5-pro', provider: 'Google', input_price_per_token: 0.00000125, output_price_per_token: 0.00001, quality_score: 5, capability_reasoning: true, capability_code: true });
+      const flashLite = makeModel({
+        model_name: 'gemini-2.5-flash-lite',
+        provider: 'Google',
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        quality_score: 1,
+      });
+      const flash = makeModel({
+        model_name: 'gemini-2.5-flash',
+        provider: 'Google',
+        input_price_per_token: 0.00000015,
+        output_price_per_token: 0.0000006,
+        quality_score: 2,
+        capability_code: true,
+      });
+      const pro = makeModel({
+        model_name: 'gemini-2.5-pro',
+        provider: 'Google',
+        input_price_per_token: 0.00000125,
+        output_price_per_token: 0.00001,
+        quality_score: 5,
+        capability_reasoning: true,
+        capability_code: true,
+      });
 
       const models = [flashLite, flash, pro];
 
@@ -144,10 +265,39 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should assign different models per tier (multi-provider catalog)', () => {
-      const nano = makeModel({ model_name: 'gpt-4.1-nano', provider: 'OpenAI', input_price_per_token: 0.0000001, output_price_per_token: 0.0000003, quality_score: 1 });
-      const deepseekV3 = makeModel({ model_name: 'deepseek-v3', provider: 'DeepSeek', input_price_per_token: 0.00000014, output_price_per_token: 0.00000028, quality_score: 2, capability_code: true });
-      const opus = makeModel({ model_name: 'claude-opus-4', provider: 'Anthropic', input_price_per_token: 0.000015, output_price_per_token: 0.000075, quality_score: 5, capability_reasoning: true, capability_code: true });
-      const sonnet = makeModel({ model_name: 'claude-sonnet-4', provider: 'Anthropic', input_price_per_token: 0.000003, output_price_per_token: 0.000015, quality_score: 4, capability_reasoning: true, capability_code: true });
+      const nano = makeModel({
+        model_name: 'gpt-4.1-nano',
+        provider: 'OpenAI',
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000003,
+        quality_score: 1,
+      });
+      const deepseekV3 = makeModel({
+        model_name: 'deepseek-v3',
+        provider: 'DeepSeek',
+        input_price_per_token: 0.00000014,
+        output_price_per_token: 0.00000028,
+        quality_score: 2,
+        capability_code: true,
+      });
+      const opus = makeModel({
+        model_name: 'claude-opus-4',
+        provider: 'Anthropic',
+        input_price_per_token: 0.000015,
+        output_price_per_token: 0.000075,
+        quality_score: 5,
+        capability_reasoning: true,
+        capability_code: true,
+      });
+      const sonnet = makeModel({
+        model_name: 'claude-sonnet-4',
+        provider: 'Anthropic',
+        input_price_per_token: 0.000003,
+        output_price_per_token: 0.000015,
+        quality_score: 4,
+        capability_reasoning: true,
+        capability_code: true,
+      });
 
       const models = [nano, deepseekV3, opus, sonnet];
 
@@ -164,7 +314,7 @@ describe('TierAutoAssignService', () => {
       const model = makeModel({ model_name: 'gpt-4o', provider: 'OpenAI' });
       mockPricingCache.getAll.mockReturnValue([model]);
 
-      await service.recalculate('user-1');
+      await service.recalculate('agent-1');
 
       expect(mockTierRepo.insert).toHaveBeenCalledTimes(4);
       for (const call of mockTierRepo.insert.mock.calls) {
@@ -176,7 +326,7 @@ describe('TierAutoAssignService', () => {
       mockProviderRepo.find.mockResolvedValue([]);
       mockPricingCache.getAll.mockReturnValue([]);
 
-      await service.recalculate('user-1');
+      await service.recalculate('agent-1');
 
       expect(mockTierRepo.insert).toHaveBeenCalledTimes(4);
       for (const call of mockTierRepo.insert.mock.calls) {
@@ -186,15 +336,20 @@ describe('TierAutoAssignService', () => {
 
     it('should preserve manual overrides during recalculation', async () => {
       const existingTier = {
-        id: 'tier-1', user_id: 'user-1', tier: 'complex',
-        override_model: 'claude-opus-4-6', auto_assigned_model: 'gpt-4o',
+        id: 'tier-1',
+        agent_id: 'agent-1',
+        tier: 'complex',
+        override_model: 'claude-opus-4-6',
+        auto_assigned_model: 'gpt-4o',
         updated_at: '2024-01-01',
       };
       mockTierRepo.findOne.mockResolvedValueOnce(existingTier);
       mockProviderRepo.find.mockResolvedValue([{ provider: 'openai', is_active: true }]);
-      mockPricingCache.getAll.mockReturnValue([makeModel({ model_name: 'gpt-4o', provider: 'OpenAI' })]);
+      mockPricingCache.getAll.mockReturnValue([
+        makeModel({ model_name: 'gpt-4o', provider: 'OpenAI' }),
+      ]);
 
-      await service.recalculate('user-1');
+      await service.recalculate('agent-1');
 
       expect(mockTierRepo.save).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/packages/backend/src/routing/tier-auto-assign.service.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.ts
@@ -26,23 +26,19 @@ export class TierAutoAssignService {
     private readonly tierRepo: Repository<TierAssignment>,
   ) {}
 
-  async recalculate(userId: string): Promise<void> {
+  async recalculate(agentId: string): Promise<void> {
     const providers = await this.providerRepo.find({
-      where: { user_id: userId, is_active: true },
+      where: { agent_id: agentId, is_active: true },
     });
-    const activeProviders = expandProviderNames(
-      providers.map((p) => p.provider),
-    );
+    const activeProviders = expandProviderNames(providers.map((p) => p.provider));
 
     const allModels = this.pricingCache.getAll();
-    const available = allModels.filter((m) =>
-      activeProviders.has(m.provider.toLowerCase()),
-    );
+    const available = allModels.filter((m) => activeProviders.has(m.provider.toLowerCase()));
 
     for (const tier of TIERS) {
       const best = this.pickBest(available, tier);
       const existing = await this.tierRepo.findOne({
-        where: { user_id: userId, tier },
+        where: { agent_id: agentId, tier },
       });
 
       if (existing) {
@@ -52,7 +48,8 @@ export class TierAutoAssignService {
       } else {
         await this.tierRepo.insert({
           id: randomUUID(),
-          user_id: userId,
+          user_id: '',
+          agent_id: agentId,
           tier,
           override_model: null,
           auto_assigned_model: best?.model_name ?? null,
@@ -60,7 +57,7 @@ export class TierAutoAssignService {
       }
     }
 
-    this.logger.log(`Recalculated tier assignments for user ${userId}`);
+    this.logger.log(`Recalculated tier assignments for agent ${agentId}`);
   }
 
   /**
@@ -81,9 +78,7 @@ export class TierAutoAssignService {
     const quality = (m: ModelPricing) => m.quality_score ?? 3;
 
     // Sort by price ascending (cheapest first, including free local models)
-    const byPrice = [...models].sort(
-      (a, b) => totalPrice(a) - totalPrice(b),
-    );
+    const byPrice = [...models].sort((a, b) => totalPrice(a) - totalPrice(b));
 
     if (byPrice.length === 0) return null;
 
@@ -105,28 +100,20 @@ export class TierAutoAssignService {
 
       case 'complex': {
         // Best quality first, then cheapest as tiebreaker
-        const byQuality = [...byPrice].sort(
-          (a, b) => quality(b) - quality(a),
-        );
+        const byQuality = [...byPrice].sort((a, b) => quality(b) - quality(a));
         picked = byQuality[0];
         break;
       }
 
       case 'reasoning': {
         // Among reasoning-capable: best quality, then cheapest
-        const reasoningModels = byPrice.filter(
-          (m) => m.capability_reasoning,
-        );
+        const reasoningModels = byPrice.filter((m) => m.capability_reasoning);
         if (reasoningModels.length > 0) {
-          const byQuality = [...reasoningModels].sort(
-            (a, b) => quality(b) - quality(a),
-          );
+          const byQuality = [...reasoningModels].sort((a, b) => quality(b) - quality(a));
           picked = byQuality[0];
         } else {
           // Fallback to COMPLEX logic
-          const byQuality = [...byPrice].sort(
-            (a, b) => quality(b) - quality(a),
-          );
+          const byQuality = [...byPrice].sort((a, b) => quality(b) - quality(a));
           picked = byQuality[0];
         }
         break;

--- a/packages/backend/test/limits.e2e-spec.ts
+++ b/packages/backend/test/limits.e2e-spec.ts
@@ -117,7 +117,7 @@ describe('Limits API', () => {
 
   it('GET /api/v1/routing/status returns routing status', async () => {
     const res = await request(app.getHttpServer())
-      .get('/api/v1/routing/status')
+      .get('/api/v1/routing/test-agent/status')
       .set('x-api-key', TEST_API_KEY)
       .expect(200);
 

--- a/packages/backend/test/proxy.e2e-spec.ts
+++ b/packages/backend/test/proxy.e2e-spec.ts
@@ -31,7 +31,7 @@ beforeAll(async () => {
 
   // Connect OpenAI provider with a fake API key via API
   await request(app.getHttpServer())
-    .post('/api/v1/routing/providers')
+    .post('/api/v1/routing/test-agent/providers')
     .set('x-api-key', TEST_API_KEY)
     .send({ provider: 'openai', apiKey: 'sk-fake-test-key' })
     .expect(201);

--- a/packages/backend/test/routing-flow.e2e-spec.ts
+++ b/packages/backend/test/routing-flow.e2e-spec.ts
@@ -83,10 +83,10 @@ describe('Routing disabled → null model (OpenClaw uses Gemini default)', () =>
 
 describe('Routing enabled → scorer routes by query complexity', () => {
   beforeAll(async () => {
-    await auth(api().post('/api/v1/routing/providers'))
+    await auth(api().post('/api/v1/routing/test-agent/providers'))
       .send({ provider: 'openai' })
       .expect(201);
-    await auth(api().post('/api/v1/routing/providers'))
+    await auth(api().post('/api/v1/routing/test-agent/providers'))
       .send({ provider: 'anthropic' })
       .expect(201);
   });
@@ -210,7 +210,7 @@ describe('Routing enabled → scorer routes by query complexity', () => {
 
 describe('Routing disabled after deactivation → falls back to null', () => {
   it('deactivating all providers removes model assignments', async () => {
-    await auth(api().post('/api/v1/routing/providers/deactivate-all'))
+    await auth(api().post('/api/v1/routing/test-agent/providers/deactivate-all'))
       .expect(201);
 
     const res = await bearer(api().post('/api/v1/routing/resolve'))
@@ -224,7 +224,7 @@ describe('Routing disabled after deactivation → falls back to null', () => {
   });
 
   it('re-enabling providers restores model routing', async () => {
-    await auth(api().post('/api/v1/routing/providers'))
+    await auth(api().post('/api/v1/routing/test-agent/providers'))
       .send({ provider: 'openai' })
       .expect(201);
 

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -1,11 +1,12 @@
-import { createSignal, For, Show, type Component } from "solid-js";
-import { PROVIDERS, validateApiKey } from "../services/providers.js";
-import { providerIcon } from "./ProviderIcon.js";
-import { connectProvider, disconnectProvider, type RoutingProvider } from "../services/api.js";
-import { toast } from "../services/toast-store.js";
-import { isLocalMode } from "../services/local-mode.js";
+import { createSignal, For, Show, type Component } from 'solid-js';
+import { PROVIDERS, validateApiKey } from '../services/providers.js';
+import { providerIcon } from './ProviderIcon.js';
+import { connectProvider, disconnectProvider, type RoutingProvider } from '../services/api.js';
+import { toast } from '../services/toast-store.js';
+import { isLocalMode } from '../services/local-mode.js';
 
 interface Props {
+  agentName: string;
   providers: RoutingProvider[];
   onClose: () => void;
   onUpdate: () => void;
@@ -14,13 +15,12 @@ interface Props {
 const ProviderSelectModal: Component<Props> = (props) => {
   const [selectedProvider, setSelectedProvider] = createSignal<string | null>(null);
   const [busy, setBusy] = createSignal(false);
-  const [keyInput, setKeyInput] = createSignal("");
+  const [keyInput, setKeyInput] = createSignal('');
   const [editing, setEditing] = createSignal(false);
   const [validationError, setValidationError] = createSignal<string | null>(null);
-  const [direction, setDirection] = createSignal<"forward" | "back" | null>(null);
+  const [direction, setDirection] = createSignal<'forward' | 'back' | null>(null);
 
-  const getProviderData = (provId: string) =>
-    props.providers.find((p) => p.provider === provId);
+  const getProviderData = (provId: string) => props.providers.find((p) => p.provider === provId);
 
   const isConnected = (provId: string): boolean => {
     const p = getProviderData(provId);
@@ -35,22 +35,22 @@ const ProviderSelectModal: Component<Props> = (props) => {
 
   const getKeyPrefixDisplay = (provId: string): string => {
     const p = getProviderData(provId);
-    if (p?.key_prefix) return `${p.key_prefix}${"•".repeat(8)}`;
-    return "••••••••••••";
+    if (p?.key_prefix) return `${p.key_prefix}${'•'.repeat(8)}`;
+    return '••••••••••••';
   };
 
   const openDetail = (provId: string) => {
-    setDirection("forward");
+    setDirection('forward');
     setSelectedProvider(provId);
-    setKeyInput("");
+    setKeyInput('');
     setEditing(false);
     setValidationError(null);
   };
 
   const goBack = () => {
-    setDirection("back");
+    setDirection('back');
     setSelectedProvider(null);
-    setKeyInput("");
+    setKeyInput('');
     setEditing(false);
     setValidationError(null);
   };
@@ -69,7 +69,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
 
     setBusy(true);
     try {
-      await connectProvider({
+      await connectProvider(props.agentName, {
         provider: provId,
         apiKey: isOllama ? undefined : keyInput().trim(),
       });
@@ -93,7 +93,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
 
     setBusy(true);
     try {
-      await connectProvider({
+      await connectProvider(props.agentName, {
         provider: provId,
         apiKey: keyInput().trim(),
       });
@@ -110,7 +110,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
   const handleDisconnect = async (provId: string) => {
     setBusy(true);
     try {
-      const result = await disconnectProvider(provId);
+      const result = await disconnectProvider(props.agentName, provId);
       if (result?.notifications?.length) {
         for (const msg of result.notifications) {
           toast.error(msg);
@@ -128,8 +128,12 @@ const ProviderSelectModal: Component<Props> = (props) => {
   return (
     <div
       class="modal-overlay"
-      onClick={(e) => { if (e.target === e.currentTarget) props.onClose(); }}
-      onKeyDown={(e) => { if (e.key === "Escape") props.onClose(); }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) props.onClose();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') props.onClose();
+      }}
     >
       <div
         class="modal-card"
@@ -142,237 +146,300 @@ const ProviderSelectModal: Component<Props> = (props) => {
         <Show when={selectedProvider() === null}>
           <div
             class="provider-modal__view"
-            classList={{ "provider-modal__view--from-left": direction() === "back" }}
+            classList={{ 'provider-modal__view--from-left': direction() === 'back' }}
           >
-          <div class="routing-modal__header">
-            <div>
-              <div class="routing-modal__title" id="provider-modal-title">Connect providers</div>
-              <div class="routing-modal__subtitle">
-                Add your API keys to enable routing through each provider
+            <div class="routing-modal__header">
+              <div>
+                <div class="routing-modal__title" id="provider-modal-title">
+                  Connect providers
+                </div>
+                <div class="routing-modal__subtitle">
+                  Add your API keys to enable routing through each provider
+                </div>
               </div>
+              <button class="modal__close" onClick={props.onClose} aria-label="Close">
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M18 6 6 18" />
+                  <path d="m6 6 12 12" />
+                </svg>
+              </button>
             </div>
-            <button class="modal__close" onClick={props.onClose} aria-label="Close">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M18 6 6 18" /><path d="m6 6 12 12" />
-              </svg>
-            </button>
-          </div>
 
-          <div class="provider-modal__list">
-            <For each={isLocalMode() ? PROVIDERS : [...PROVIDERS].sort((a, b) => (a.localOnly ? 1 : 0) - (b.localOnly ? 1 : 0))}>
-              {(prov) => {
-                const connected = () => isConnected(prov.id) || isNoKeyConnected(prov.id);
-                const disabled = () => !!prov.localOnly && !isLocalMode();
+            <div class="provider-modal__list">
+              <For
+                each={
+                  isLocalMode()
+                    ? PROVIDERS
+                    : [...PROVIDERS].sort((a, b) => (a.localOnly ? 1 : 0) - (b.localOnly ? 1 : 0))
+                }
+              >
+                {(prov) => {
+                  const connected = () => isConnected(prov.id) || isNoKeyConnected(prov.id);
+                  const disabled = () => !!prov.localOnly && !isLocalMode();
 
-                return (
-                  <button
-                    class="provider-toggle"
-                    disabled={disabled()}
-                    onClick={() => !disabled() && openDetail(prov.id)}
-                  >
-                    <span class="provider-toggle__icon">
-                      {providerIcon(prov.id, 20) ?? (
-                        <span
-                          class="provider-card__logo-letter"
-                          style={{ background: prov.color }}
-                        >
-                          {prov.initial}
-                        </span>
-                      )}
-                    </span>
-                    <span class="provider-toggle__info">
-                      <span class="provider-toggle__name">{prov.name}</span>
-                      <Show when={disabled()}>
-                        <span class="provider-toggle__local-only">Only available on Manifest Local</span>
-                      </Show>
-                    </span>
-                    <Show when={!disabled()}>
-                      <span
-                        class="provider-toggle__switch"
-                        classList={{ "provider-toggle__switch--on": connected() }}
-                      >
-                        <span class="provider-toggle__switch-thumb" />
+                  return (
+                    <button
+                      class="provider-toggle"
+                      disabled={disabled()}
+                      onClick={() => !disabled() && openDetail(prov.id)}
+                    >
+                      <span class="provider-toggle__icon">
+                        {providerIcon(prov.id, 20) ?? (
+                          <span
+                            class="provider-card__logo-letter"
+                            style={{ background: prov.color }}
+                          >
+                            {prov.initial}
+                          </span>
+                        )}
                       </span>
-                    </Show>
-                  </button>
-                );
-              }}
-            </For>
-          </div>
+                      <span class="provider-toggle__info">
+                        <span class="provider-toggle__name">{prov.name}</span>
+                        <Show when={disabled()}>
+                          <span class="provider-toggle__local-only">
+                            Only available on Manifest Local
+                          </span>
+                        </Show>
+                      </span>
+                      <Show when={!disabled()}>
+                        <span
+                          class="provider-toggle__switch"
+                          classList={{ 'provider-toggle__switch--on': connected() }}
+                        >
+                          <span class="provider-toggle__switch-thumb" />
+                        </span>
+                      </Show>
+                    </button>
+                  );
+                }}
+              </For>
+            </div>
 
-          <div class="provider-modal__footer">
-            <button class="btn btn--primary" onClick={props.onClose}>Done</button>
-          </div>
+            <div class="provider-modal__footer">
+              <button class="btn btn--primary" onClick={props.onClose}>
+                Done
+              </button>
+            </div>
           </div>
         </Show>
 
         {/* ── Detail View ── */}
         <Show when={selectedProvider() !== null}>
           <div class="provider-modal__view provider-modal__view--from-right">
-          {(() => {
-            const provId = selectedProvider()!;
-            const provDef = PROVIDERS.find((p) => p.id === provId)!;
-            const connected = () => isConnected(provId) || isNoKeyConnected(provId);
-            const isOllama = provDef.noKeyRequired;
+            {(() => {
+              const provId = selectedProvider()!;
+              const provDef = PROVIDERS.find((p) => p.id === provId)!;
+              const connected = () => isConnected(provId) || isNoKeyConnected(provId);
+              const isOllama = provDef.noKeyRequired;
 
-            return (
-              <div class="provider-detail">
-                {/* Back arrow */}
-                <button class="provider-detail__back" onClick={goBack} aria-label="Back to providers">
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <path d="m15 18-6-6 6-6" />
-                  </svg>
-                </button>
+              return (
+                <div class="provider-detail">
+                  {/* Back arrow */}
+                  <button
+                    class="provider-detail__back"
+                    onClick={goBack}
+                    aria-label="Back to providers"
+                  >
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
+                    >
+                      <path d="m15 18-6-6 6-6" />
+                    </svg>
+                  </button>
 
-                {/* Title */}
-                <div class="routing-modal__header" style="border: none; padding: 0; margin-bottom: 20px;">
-                  <div>
-                    <div class="routing-modal__title">Connect providers</div>
-                    <div class="routing-modal__subtitle">
-                      Add your API keys to enable routing through each provider
+                  {/* Title */}
+                  <div
+                    class="routing-modal__header"
+                    style="border: none; padding: 0; margin-bottom: 20px;"
+                  >
+                    <div>
+                      <div class="routing-modal__title">Connect providers</div>
+                      <div class="routing-modal__subtitle">
+                        Add your API keys to enable routing through each provider
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                {/* Provider row */}
-                <div class="provider-detail__header">
-                  <span class="provider-detail__icon">
-                    {providerIcon(provId, 28) ?? (
-                      <span
-                        class="provider-card__logo-letter"
-                        style={{ background: provDef.color, width: "32px", height: "32px", "font-size": "13px" }}
-                      >
-                        {provDef.initial}
-                      </span>
-                    )}
-                  </span>
-                  <div class="provider-detail__title-group">
-                    <div class="provider-detail__name">{provDef.name}</div>
-                  </div>
-                </div>
-
-                {/* Ollama (no key) */}
-                <Show when={isOllama}>
-                  <div class="provider-detail__field">
-                    <span class="provider-detail__no-key">No API key required for local models</span>
-                  </div>
-                  <Show when={!connected()}>
-                    <button
-                      class="btn btn--primary provider-detail__action"
-                      disabled={busy()}
-                      onClick={() => handleConnect(provId)}
-                    >
-                      Connect
-                    </button>
-                  </Show>
-                  <Show when={connected()}>
-                    <button
-                      class="btn btn--outline provider-detail__action provider-detail__disconnect"
-                      disabled={busy()}
-                      onClick={() => handleDisconnect(provId)}
-                    >
-                      Disconnect
-                    </button>
-                  </Show>
-                </Show>
-
-                {/* Non-Ollama: not yet connected */}
-                <Show when={!isOllama && !connected()}>
-                  <div class="provider-detail__field">
-                    <label class="provider-detail__label">API Key</label>
-                    <input
-                      class="provider-detail__input"
-                      classList={{ "provider-detail__input--error": !!validationError() }}
-                      type="password"
-                      placeholder={provDef.keyPlaceholder}
-                      aria-label={`${provDef.name} API key`}
-                      value={keyInput()}
-                      onInput={(e) => {
-                        setKeyInput(e.currentTarget.value);
-                        setValidationError(null);
-                      }}
-                      onKeyDown={(e) => { if (e.key === "Enter") handleConnect(provId); }}
-                    />
-                    <Show when={validationError()}>
-                      <div class="provider-detail__error">{validationError()}</div>
-                    </Show>
-                  </div>
-                  <button
-                    class="btn btn--primary provider-detail__action"
-                    disabled={busy() || !keyInput().trim()}
-                    onClick={() => handleConnect(provId)}
-                  >
-                    Connect
-                  </button>
-                </Show>
-
-                {/* Non-Ollama: already connected */}
-                <Show when={!isOllama && connected()}>
-                  <div class="provider-detail__field">
-                    <label class="provider-detail__label">API Key</label>
-                    <Show when={!editing()}>
-                      <div class="provider-detail__key-row">
-                        <input
-                          class="provider-detail__input provider-detail__input--disabled"
-                          type="text"
-                          value={getKeyPrefixDisplay(provId)}
-                          disabled
-                          aria-label="Current API key (masked)"
-                        />
-                        <button
-                          class="btn btn--outline btn--sm"
-                          onClick={() => {
-                            setEditing(true);
-                            setKeyInput("");
-                            setValidationError(null);
+                  {/* Provider row */}
+                  <div class="provider-detail__header">
+                    <span class="provider-detail__icon">
+                      {providerIcon(provId, 28) ?? (
+                        <span
+                          class="provider-card__logo-letter"
+                          style={{
+                            background: provDef.color,
+                            width: '32px',
+                            height: '32px',
+                            'font-size': '13px',
                           }}
                         >
-                          Change
-                        </button>
-                        <button
-                          class="provider-detail__disconnect-icon"
-                          disabled={busy()}
-                          onClick={() => handleDisconnect(provId)}
-                          aria-label="Disconnect provider"
-                          title="Disconnect"
-                        >
-                          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                            <path d="M3 6h18" /><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" /><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
-                          </svg>
-                        </button>
-                      </div>
+                          {provDef.initial}
+                        </span>
+                      )}
+                    </span>
+                    <div class="provider-detail__title-group">
+                      <div class="provider-detail__name">{provDef.name}</div>
+                    </div>
+                  </div>
+
+                  {/* Ollama (no key) */}
+                  <Show when={isOllama}>
+                    <div class="provider-detail__field">
+                      <span class="provider-detail__no-key">
+                        No API key required for local models
+                      </span>
+                    </div>
+                    <Show when={!connected()}>
+                      <button
+                        class="btn btn--primary provider-detail__action"
+                        disabled={busy()}
+                        onClick={() => handleConnect(provId)}
+                      >
+                        Connect
+                      </button>
                     </Show>
-                    <Show when={editing()}>
+                    <Show when={connected()}>
+                      <button
+                        class="btn btn--outline provider-detail__action provider-detail__disconnect"
+                        disabled={busy()}
+                        onClick={() => handleDisconnect(provId)}
+                      >
+                        Disconnect
+                      </button>
+                    </Show>
+                  </Show>
+
+                  {/* Non-Ollama: not yet connected */}
+                  <Show when={!isOllama && !connected()}>
+                    <div class="provider-detail__field">
+                      <label class="provider-detail__label">API Key</label>
                       <input
                         class="provider-detail__input"
-                        classList={{ "provider-detail__input--error": !!validationError() }}
+                        classList={{ 'provider-detail__input--error': !!validationError() }}
                         type="password"
                         placeholder={provDef.keyPlaceholder}
-                        aria-label={`New ${provDef.name} API key`}
+                        aria-label={`${provDef.name} API key`}
                         value={keyInput()}
                         onInput={(e) => {
                           setKeyInput(e.currentTarget.value);
                           setValidationError(null);
                         }}
-                        onKeyDown={(e) => { if (e.key === "Enter") handleUpdateKey(provId); }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') handleConnect(provId);
+                        }}
                       />
                       <Show when={validationError()}>
                         <div class="provider-detail__error">{validationError()}</div>
                       </Show>
-                      <button
-                        class="btn btn--primary provider-detail__action"
-                        disabled={busy() || !keyInput().trim()}
-                        onClick={() => handleUpdateKey(provId)}
-                        style="margin-top: 12px;"
-                      >
-                        Save
-                      </button>
-                    </Show>
-                  </div>
-                </Show>
-              </div>
-            );
-          })()}
+                    </div>
+                    <button
+                      class="btn btn--primary provider-detail__action"
+                      disabled={busy() || !keyInput().trim()}
+                      onClick={() => handleConnect(provId)}
+                    >
+                      Connect
+                    </button>
+                  </Show>
+
+                  {/* Non-Ollama: already connected */}
+                  <Show when={!isOllama && connected()}>
+                    <div class="provider-detail__field">
+                      <label class="provider-detail__label">API Key</label>
+                      <Show when={!editing()}>
+                        <div class="provider-detail__key-row">
+                          <input
+                            class="provider-detail__input provider-detail__input--disabled"
+                            type="text"
+                            value={getKeyPrefixDisplay(provId)}
+                            disabled
+                            aria-label="Current API key (masked)"
+                          />
+                          <button
+                            class="btn btn--outline btn--sm"
+                            onClick={() => {
+                              setEditing(true);
+                              setKeyInput('');
+                              setValidationError(null);
+                            }}
+                          >
+                            Change
+                          </button>
+                          <button
+                            class="provider-detail__disconnect-icon"
+                            disabled={busy()}
+                            onClick={() => handleDisconnect(provId)}
+                            aria-label="Disconnect provider"
+                            title="Disconnect"
+                          >
+                            <svg
+                              width="16"
+                              height="16"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              aria-hidden="true"
+                            >
+                              <path d="M3 6h18" />
+                              <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                              <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                            </svg>
+                          </button>
+                        </div>
+                      </Show>
+                      <Show when={editing()}>
+                        <input
+                          class="provider-detail__input"
+                          classList={{ 'provider-detail__input--error': !!validationError() }}
+                          type="password"
+                          placeholder={provDef.keyPlaceholder}
+                          aria-label={`New ${provDef.name} API key`}
+                          value={keyInput()}
+                          onInput={(e) => {
+                            setKeyInput(e.currentTarget.value);
+                            setValidationError(null);
+                          }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleUpdateKey(provId);
+                          }}
+                        />
+                        <Show when={validationError()}>
+                          <div class="provider-detail__error">{validationError()}</div>
+                        </Show>
+                        <button
+                          class="btn btn--primary provider-detail__action"
+                          disabled={busy() || !keyInput().trim()}
+                          onClick={() => handleUpdateKey(provId)}
+                          style="margin-top: 12px;"
+                        >
+                          Save
+                        </button>
+                      </Show>
+                    </div>
+                  </Show>
+                </div>
+              );
+            })()}
           </div>
         </Show>
       </div>

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -1,18 +1,18 @@
-import { createSignal, createResource, For, Show, onCleanup, type Component } from "solid-js";
-import { useParams } from "@solidjs/router";
-import { Title, Meta } from "@solidjs/meta";
-import { Portal } from "solid-js/web";
-import { isLocalMode } from "../services/local-mode.js";
-import { authClient } from "../services/auth-client.js";
-import ProviderBanner from "../components/ProviderBanner.js";
-import EmailProviderSetup from "../components/EmailProviderSetup.js";
-import CloudEmailInfo from "../components/CloudEmailInfo.js";
-import LimitRuleModal from "../components/LimitRuleModal.js";
-import type { LimitRuleData } from "../components/LimitRuleModal.js";
-import EmailProviderModal from "../components/EmailProviderModal.js";
-import LimitIcon from "../components/LimitIcon.js";
-import AlertIcon from "../components/AlertIcon.js";
-import { toast } from "../services/toast-store.js";
+import { createSignal, createResource, For, Show, onCleanup, type Component } from 'solid-js';
+import { useParams } from '@solidjs/router';
+import { Title, Meta } from '@solidjs/meta';
+import { Portal } from 'solid-js/web';
+import { isLocalMode } from '../services/local-mode.js';
+import { authClient } from '../services/auth-client.js';
+import ProviderBanner from '../components/ProviderBanner.js';
+import EmailProviderSetup from '../components/EmailProviderSetup.js';
+import CloudEmailInfo from '../components/CloudEmailInfo.js';
+import LimitRuleModal from '../components/LimitRuleModal.js';
+import type { LimitRuleData } from '../components/LimitRuleModal.js';
+import EmailProviderModal from '../components/EmailProviderModal.js';
+import LimitIcon from '../components/LimitIcon.js';
+import AlertIcon from '../components/AlertIcon.js';
+import { toast } from '../services/toast-store.js';
 import {
   getNotificationRules,
   createNotificationRule,
@@ -22,18 +22,18 @@ import {
   removeEmailProvider,
   getRoutingStatus,
   type NotificationRule,
-} from "../services/api.js";
+} from '../services/api.js';
 
 function formatThreshold(rule: NotificationRule): string {
-  if (rule.metric_type === "cost") return `$${Number(rule.threshold).toFixed(2)}`;
+  if (rule.metric_type === 'cost') return `$${Number(rule.threshold).toFixed(2)}`;
   return Number(rule.threshold).toLocaleString();
 }
 
 const PERIOD_LABELS: Record<string, string> = {
-  hour: "Per hour",
-  day: "Per day",
-  week: "Per week",
-  month: "Per month",
+  hour: 'Per hour',
+  day: 'Per day',
+  week: 'Per week',
+  month: 'Per month',
 };
 
 const Limits: Component = () => {
@@ -45,7 +45,7 @@ const Limits: Component = () => {
     (name) => getNotificationRules(name),
   );
   const [emailProvider, { refetch: refetchProvider }] = createResource(getEmailProvider);
-  const [routingStatus] = createResource(getRoutingStatus);
+  const [routingStatus] = createResource(() => agentName(), getRoutingStatus);
   const session = authClient.useSession();
   const [showModal, setShowModal] = createSignal(false);
   const [showEditProvider, setShowEditProvider] = createSignal(false);
@@ -71,11 +71,11 @@ const Limits: Component = () => {
       const rect = btn.getBoundingClientRect();
       setMenuPos({ top: rect.bottom + 4, left: rect.right });
       setOpenMenuId(ruleId);
-      setTimeout(() => document.addEventListener("click", handleDocClick, { once: true }), 0);
+      setTimeout(() => document.addEventListener('click', handleDocClick, { once: true }), 0);
     }
   };
 
-  onCleanup(() => document.removeEventListener("click", handleDocClick));
+  onCleanup(() => document.removeEventListener('click', handleDocClick));
 
   const handleEdit = (rule: NotificationRule) => {
     closeMenu();
@@ -88,10 +88,10 @@ const Limits: Component = () => {
     try {
       if (editing) {
         await updateNotificationRule(editing.id, { ...data });
-        toast.success("Rule updated");
+        toast.success('Rule updated');
       } else {
         await createNotificationRule({ agent_name: agentName(), ...data });
-        toast.success("Rule created");
+        toast.success('Rule created');
       }
       await refetchRules();
       setShowModal(false);
@@ -113,7 +113,7 @@ const Limits: Component = () => {
     try {
       await deleteNotificationRule(target.id);
       await refetchRules();
-      toast.success("Rule deleted");
+      toast.success('Rule deleted');
     } catch {
       // error toast from fetchMutate
     }
@@ -124,7 +124,7 @@ const Limits: Component = () => {
   const hasEmailRules = () => {
     const r = rules();
     if (!r) return false;
-    return r.some((rule) => rule.action === "notify" || rule.action === "both");
+    return r.some((rule) => rule.action === 'notify' || rule.action === 'both');
   };
 
   const handleRemoveProvider = async () => {
@@ -132,23 +132,28 @@ const Limits: Component = () => {
       await removeEmailProvider();
       await refetchProvider();
       setShowRemoveProvider(false);
-      toast.success("Email provider removed");
+      toast.success('Email provider removed');
     } catch {
       // error toast from fetchMutate
     }
   };
 
   const isActive = (rule: NotificationRule) =>
-    typeof rule.is_active === "number" ? !!rule.is_active : rule.is_active;
+    typeof rule.is_active === 'number' ? !!rule.is_active : rule.is_active;
 
   const blockRulesExceeded = () => {
     const r = rules();
     if (!r) return false;
-    return r.some((rule) => (rule.action === "block" || rule.action === "both") && isActive(rule) && Number(rule.trigger_count) > 0);
+    return r.some(
+      (rule) =>
+        (rule.action === 'block' || rule.action === 'both') &&
+        isActive(rule) &&
+        Number(rule.trigger_count) > 0,
+    );
   };
 
-  const hasEmailAction = (action: string) => action === "notify" || action === "both";
-  const hasBlockAction = (action: string) => action === "block" || action === "both";
+  const hasEmailAction = (action: string) => action === 'notify' || action === 'both';
+  const hasBlockAction = (action: string) => action === 'block' || action === 'both';
 
   return (
     <div class="container--sm">
@@ -158,38 +163,74 @@ const Limits: Component = () => {
       <div class="page-header">
         <div>
           <h1>Limits</h1>
-          <span class="breadcrumb">{agentName()} &rsaquo; Get notified or block requests when token or cost thresholds are exceeded</span>
+          <span class="breadcrumb">
+            {agentName()} &rsaquo; Get notified or block requests when token or cost thresholds are
+            exceeded
+          </span>
         </div>
-        <button class="btn btn--primary btn--sm" onClick={() => { setEditRule(null); setShowModal(true); }}>
+        <button
+          class="btn btn--primary btn--sm"
+          onClick={() => {
+            setEditRule(null);
+            setShowModal(true);
+          }}
+        >
           + Create rule
         </button>
       </div>
 
       <Show when={blockRulesExceeded()}>
         <div class="limits-warning-banner">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
             <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-            <line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
           </svg>
-          <span>One or more hard limits have been triggered &mdash; new proxy requests for this agent will be blocked until the usage resets in the next period.</span>
+          <span>
+            One or more hard limits have been triggered &mdash; new proxy requests for this agent
+            will be blocked until the usage resets in the next period.
+          </span>
         </div>
       </Show>
 
       <Show when={routingStatus() && !routingEnabled() && !isLocalMode()}>
         <div class="limits-routing-cta">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="12" cy="12" r="10" /><line x1="12" y1="16" x2="12" y2="12" /><line x1="12" y1="8" x2="12.01" y2="8" />
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="16" x2="12" y2="12" />
+            <line x1="12" y1="8" x2="12.01" y2="8" />
           </svg>
           <div>
             <strong>Enable routing to set hard limits</strong>
-            <p>Hard limits automatically block proxy requests when usage exceeds a threshold. Email alerts work without routing &mdash; only hard limits require it.</p>
+            <p>
+              Hard limits automatically block proxy requests when usage exceeds a threshold. Email
+              alerts work without routing &mdash; only hard limits require it.
+            </p>
           </div>
         </div>
       </Show>
 
       <Show when={!isLocalMode()}>
         <div style="margin-bottom: var(--gap-lg);">
-          <CloudEmailInfo email={session().data?.user?.email ?? ""} />
+          <CloudEmailInfo email={session().data?.user?.email ?? ''} />
         </div>
       </Show>
 
@@ -215,7 +256,10 @@ const Limits: Component = () => {
           fallback={
             <div class="empty-state">
               <div class="empty-state__title">No rules yet</div>
-              <p>Set up email alerts to get notified when usage spikes, or create hard limits to automatically block requests that exceed your budget.</p>
+              <p>
+                Set up email alerts to get notified when usage spikes, or create hard limits to
+                automatically block requests that exceed your budget.
+              </p>
             </div>
           }
         >
@@ -231,24 +275,34 @@ const Limits: Component = () => {
             <tbody>
               <For each={rules()}>
                 {(rule) => (
-                  <tr classList={{ "notif-table__row--disabled": !isActive(rule) }}>
+                  <tr classList={{ 'notif-table__row--disabled': !isActive(rule) }}>
                     <td>
                       <div class="limit-type-icons">
-                        <Show when={hasEmailAction(rule.action ?? "notify")}>
+                        <Show when={hasEmailAction(rule.action ?? 'notify')}>
                           <span class="limit-type-icon" title="Email Alert">
                             <AlertIcon size={14} />
                           </span>
                         </Show>
-                        <Show when={hasBlockAction(rule.action ?? "notify")}>
+                        <Show when={hasBlockAction(rule.action ?? 'notify')}>
                           <span class="limit-type-icon" title="Hard Limit">
                             <LimitIcon size={14} />
                           </span>
                         </Show>
-                        <Show when={hasEmailAction(rule.action ?? "notify") && !hasProvider()}>
+                        <Show when={hasEmailAction(rule.action ?? 'notify') && !hasProvider()}>
                           <span class="limit-warn-tag">
-                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <svg
+                              width="12"
+                              height="12"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                            >
                               <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-                              <line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+                              <line x1="12" y1="9" x2="12" y2="13" />
+                              <line x1="12" y1="17" x2="12.01" y2="17" />
                             </svg>
                             No provider
                           </span>
@@ -256,9 +310,10 @@ const Limits: Component = () => {
                       </div>
                     </td>
                     <td>
-                      <span class="notif-table__mono">{formatThreshold(rule)}</span>
-                      {" "}
-                      <span class="notif-table__period">{(PERIOD_LABELS[rule.period] ?? rule.period).toLowerCase()}</span>
+                      <span class="notif-table__mono">{formatThreshold(rule)}</span>{' '}
+                      <span class="notif-table__period">
+                        {(PERIOD_LABELS[rule.period] ?? rule.period).toLowerCase()}
+                      </span>
                     </td>
                     <td class="notif-table__mono">{rule.trigger_count ?? 0}</td>
                     <td>
@@ -293,14 +348,46 @@ const Limits: Component = () => {
             return (
               <div
                 class="rule-menu__dropdown"
-                style={{ position: "fixed", top: `${menuPos().top}px`, left: `${menuPos().left}px`, transform: "translateX(-100%)" }}
+                style={{
+                  position: 'fixed',
+                  top: `${menuPos().top}px`,
+                  left: `${menuPos().left}px`,
+                  transform: 'translateX(-100%)',
+                }}
               >
                 <button class="rule-menu__item" onClick={() => handleEdit(rule)}>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                  </svg>
                   Edit
                 </button>
-                <button class="rule-menu__item rule-menu__item--danger" onClick={() => openDeleteConfirm(rule)}>
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6" /><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" /></svg>
+                <button
+                  class="rule-menu__item rule-menu__item--danger"
+                  onClick={() => openDeleteConfirm(rule)}
+                >
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <polyline points="3 6 5 6 21 6" />
+                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                  </svg>
                   Delete
                 </button>
               </div>
@@ -312,7 +399,13 @@ const Limits: Component = () => {
       {/* Delete confirmation modal */}
       <Portal>
         <Show when={deleteTarget()}>
-          <div class="modal-overlay" onClick={() => { setDeleteTarget(null); setDeleteConfirmed(false); }}>
+          <div
+            class="modal-overlay"
+            onClick={() => {
+              setDeleteTarget(null);
+              setDeleteConfirmed(false);
+            }}
+          >
             <div
               class="modal-card"
               role="dialog"
@@ -322,8 +415,12 @@ const Limits: Component = () => {
             >
               <h2 class="modal-card__title">Delete rule</h2>
               <p class="modal-card__desc">
-                This will permanently delete the <span style="font-weight: 600;">{deleteTarget()!.metric_type === "tokens" ? "token" : "cost"}</span> rule
-                ({formatThreshold(deleteTarget()!)} {PERIOD_LABELS[deleteTarget()!.period]?.toLowerCase() ?? deleteTarget()!.period}).
+                This will permanently delete the{' '}
+                <span style="font-weight: 600;">
+                  {deleteTarget()!.metric_type === 'tokens' ? 'token' : 'cost'}
+                </span>{' '}
+                rule ({formatThreshold(deleteTarget()!)}{' '}
+                {PERIOD_LABELS[deleteTarget()!.period]?.toLowerCase() ?? deleteTarget()!.period}).
                 This action cannot be undone.
               </p>
 
@@ -337,7 +434,13 @@ const Limits: Component = () => {
               </label>
 
               <div class="confirm-modal__footer">
-                <button class="btn btn--ghost" onClick={() => { setDeleteTarget(null); setDeleteConfirmed(false); }}>
+                <button
+                  class="btn btn--ghost"
+                  onClick={() => {
+                    setDeleteTarget(null);
+                    setDeleteConfirmed(false);
+                  }}
+                >
                   Cancel
                 </button>
                 <button
@@ -368,7 +471,8 @@ const Limits: Component = () => {
               <p class="modal-card__desc">
                 This will disconnect your email provider.
                 <Show when={hasEmailRules()}>
-                  {" "}Email alerts won't be sent until you set up a new one.
+                  {' '}
+                  Email alerts won't be sent until you set up a new one.
                 </Show>
               </p>
 
@@ -376,10 +480,7 @@ const Limits: Component = () => {
                 <button class="btn btn--ghost" onClick={() => setShowRemoveProvider(false)}>
                   Cancel
                 </button>
-                <button
-                  class="btn btn--danger"
-                  onClick={handleRemoveProvider}
-                >
+                <button class="btn btn--danger" onClick={handleRemoveProvider}>
                   Remove
                 </button>
               </div>
@@ -390,20 +491,27 @@ const Limits: Component = () => {
 
       <LimitRuleModal
         open={showModal()}
-        onClose={() => { setShowModal(false); setEditRule(null); }}
+        onClose={() => {
+          setShowModal(false);
+          setEditRule(null);
+        }}
         onSave={handleSave}
         hasProvider={hasProvider()}
-        editData={editRule() ? {
-          metric_type: editRule()!.metric_type,
-          threshold: Number(editRule()!.threshold),
-          period: editRule()!.period,
-          action: editRule()!.action ?? "notify",
-        } : null}
+        editData={
+          editRule()
+            ? {
+                metric_type: editRule()!.metric_type,
+                threshold: Number(editRule()!.threshold),
+                period: editRule()!.period,
+                action: editRule()!.action ?? 'notify',
+              }
+            : null
+        }
       />
 
       <EmailProviderModal
         open={showEditProvider()}
-        initialProvider={emailProvider()?.provider ?? "resend"}
+        initialProvider={emailProvider()?.provider ?? 'resend'}
         editMode={true}
         existingKeyPrefix={emailProvider()?.keyPrefix ?? null}
         existingDomain={emailProvider()?.domain ?? null}

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -1,13 +1,13 @@
-import { createSignal, createResource, For, Show, type Component } from "solid-js";
-import { useParams } from "@solidjs/router";
-import { Title, Meta } from "@solidjs/meta";
-import { STAGES, PROVIDERS, getModelLabel } from "../services/providers.js";
-import { providerIcon } from "../components/ProviderIcon.js";
-import ProviderSelectModal from "../components/ProviderSelectModal.js";
-import RoutingInstructionModal from "../components/RoutingInstructionModal.js";
-import ModelPickerModal from "../components/ModelPickerModal.js";
-import { toast } from "../services/toast-store.js";
-import { pricePerM, resolveProviderId } from "../services/routing-utils.js";
+import { createSignal, createResource, For, Show, type Component } from 'solid-js';
+import { useParams } from '@solidjs/router';
+import { Title, Meta } from '@solidjs/meta';
+import { STAGES, PROVIDERS, getModelLabel } from '../services/providers.js';
+import { providerIcon } from '../components/ProviderIcon.js';
+import ProviderSelectModal from '../components/ProviderSelectModal.js';
+import RoutingInstructionModal from '../components/RoutingInstructionModal.js';
+import ModelPickerModal from '../components/ModelPickerModal.js';
+import { toast } from '../services/toast-store.js';
+import { pricePerM, resolveProviderId } from '../services/routing-utils.js';
 import {
   getTierAssignments,
   getAvailableModels,
@@ -18,14 +18,22 @@ import {
   resetAllTiers,
   type TierAssignment,
   type AvailableModel,
-} from "../services/api.js";
+} from '../services/api.js';
 
 function providerIdForModel(model: string, apiModels: AvailableModel[]): string | undefined {
-  const m = apiModels.find((x) => x.model_name === model)
-    ?? apiModels.find((x) => x.model_name.startsWith(model + "-"));
+  const m =
+    apiModels.find((x) => x.model_name === model) ??
+    apiModels.find((x) => x.model_name.startsWith(model + '-'));
   if (m) return resolveProviderId(m.provider);
   for (const prov of PROVIDERS) {
-    if (prov.models.some((pm) => pm.value === model || model.startsWith(pm.value + "-") || pm.value.startsWith(model + "-"))) {
+    if (
+      prov.models.some(
+        (pm) =>
+          pm.value === model ||
+          model.startsWith(pm.value + '-') ||
+          pm.value.startsWith(model + '-'),
+      )
+    ) {
       return prov.id;
     }
   }
@@ -36,20 +44,27 @@ const Routing: Component = () => {
   const params = useParams<{ agentName: string }>();
   const agentName = () => decodeURIComponent(params.agentName);
 
-  const [tiers, { refetch: refetchTiers }] = createResource(getTierAssignments);
-  const [models, { refetch: refetchModels }] = createResource(getAvailableModels);
-  const [connectedProviders, { refetch: refetchProviders }] = createResource(getProviders);
+  const [tiers, { refetch: refetchTiers }] = createResource(() => agentName(), getTierAssignments);
+  const [models, { refetch: refetchModels }] = createResource(
+    () => agentName(),
+    getAvailableModels,
+  );
+  const [connectedProviders, { refetch: refetchProviders }] = createResource(
+    () => agentName(),
+    getProviders,
+  );
   const [dropdownTier, setDropdownTier] = createSignal<string | null>(null);
   const [showProviderModal, setShowProviderModal] = createSignal(false);
   const [disabling, setDisabling] = createSignal(false);
   const [confirmDisable, setConfirmDisable] = createSignal(false);
-  const [instructionModal, setInstructionModal] = createSignal<"enable" | "disable" | null>(null);
+  const [instructionModal, setInstructionModal] = createSignal<'enable' | 'disable' | null>(null);
 
-  const isEnabled = () =>
-    connectedProviders()?.some((p) => p.is_active) ?? false;
+  const isEnabled = () => connectedProviders()?.some((p) => p.is_active) ?? false;
 
   const activeProviderIds = () =>
-    connectedProviders()?.filter((p) => p.is_active).map((p) => p.provider) ?? [];
+    connectedProviders()
+      ?.filter((p) => p.is_active)
+      .map((p) => p.provider) ?? [];
 
   const getTier = (tierId: string): TierAssignment | undefined =>
     tiers()?.find((t) => t.tier === tierId);
@@ -59,8 +74,10 @@ const Routing: Component = () => {
 
   const modelInfo = (modelName: string): AvailableModel | undefined => {
     const all = models() ?? [];
-    return all.find((m) => m.model_name === modelName)
-      ?? all.find((m) => m.model_name.startsWith(modelName + "-"));
+    return (
+      all.find((m) => m.model_name === modelName) ??
+      all.find((m) => m.model_name.startsWith(modelName + '-'))
+    );
   };
 
   const labelFor = (modelName: string): string => {
@@ -74,16 +91,16 @@ const Routing: Component = () => {
 
   const priceLabel = (modelName: string): string => {
     const info = modelInfo(modelName);
-    if (!info) return "";
+    if (!info) return '';
     return `${pricePerM(info.input_price_per_token)} in · ${pricePerM(info.output_price_per_token)} out per 1M`;
   };
 
   const handleOverride = async (tierId: string, modelName: string) => {
     setDropdownTier(null);
     try {
-      await overrideTier(tierId, modelName);
+      await overrideTier(agentName(), tierId, modelName);
       await refetchTiers();
-      toast.success("Routing updated");
+      toast.success('Routing updated');
     } catch {
       // error toast from fetchMutate
     }
@@ -91,9 +108,9 @@ const Routing: Component = () => {
 
   const handleReset = async (tierId: string) => {
     try {
-      await resetTier(tierId);
+      await resetTier(agentName(), tierId);
       await refetchTiers();
-      toast.success("Reset to auto");
+      toast.success('Reset to auto');
     } catch {
       // error toast from fetchMutate
     }
@@ -101,9 +118,9 @@ const Routing: Component = () => {
 
   const handleResetAll = async () => {
     try {
-      await resetAllTiers();
+      await resetAllTiers(agentName());
       await refetchTiers();
-      toast.success("All tiers reset to auto");
+      toast.success('All tiers reset to auto');
     } catch {
       // error toast from fetchMutate
     }
@@ -114,9 +131,9 @@ const Routing: Component = () => {
   const handleDisable = async () => {
     setDisabling(true);
     try {
-      await deactivateAllProviders();
+      await deactivateAllProviders(agentName());
       await Promise.all([refetchProviders(), refetchTiers(), refetchModels()]);
-      setInstructionModal("disable");
+      setInstructionModal('disable');
     } catch {
       // error toast from fetchMutate
     } finally {
@@ -128,7 +145,7 @@ const Routing: Component = () => {
     const wasEnabled = isEnabled();
     await Promise.all([refetchProviders(), refetchTiers(), refetchModels()]);
     if (!wasEnabled && isEnabled()) {
-      setInstructionModal("enable");
+      setInstructionModal('enable');
     }
   };
 
@@ -142,7 +159,9 @@ const Routing: Component = () => {
       <div class="page-header routing-page-header">
         <div>
           <h1>Routing</h1>
-          <span class="breadcrumb">{agentName()} &rsaquo; Route requests to different models based on complexity</span>
+          <span class="breadcrumb">
+            {agentName()} &rsaquo; Route requests to different models based on complexity
+          </span>
         </div>
         <Show when={isEnabled()}>
           <button class="btn btn--primary btn--sm" onClick={() => setShowProviderModal(true)}>
@@ -151,24 +170,40 @@ const Routing: Component = () => {
         </Show>
       </div>
 
-      <Show when={!tiers.loading && !connectedProviders.loading} fallback={
-        <div class="panel" style="padding: var(--gap-xl);">
-          <div class="skeleton skeleton--rect" style="width: 100%; height: 200px;" />
-        </div>
-      }>
+      <Show
+        when={!tiers.loading && !connectedProviders.loading}
+        fallback={
+          <div class="panel" style="padding: var(--gap-xl);">
+            <div class="skeleton skeleton--rect" style="width: 100%; height: 200px;" />
+          </div>
+        }
+      >
         <Show
           when={isEnabled()}
           fallback={
             <div class="routing-enable-card">
               <div class="routing-enable-card__icon">
-                <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                  <path d="M12 2L2 7l10 5 10-5-10-5z" /><path d="M2 17l10 5 10-5" /><path d="M2 12l10 5 10-5" />
+                <svg
+                  width="32"
+                  height="32"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M12 2L2 7l10 5 10-5-10-5z" />
+                  <path d="M2 17l10 5 10-5" />
+                  <path d="M2 12l10 5 10-5" />
                 </svg>
               </div>
               <h2 class="routing-enable-card__title">Smart model routing</h2>
               <p class="routing-enable-card__desc">
-                Route each request to the best model for its complexity level &mdash; use cheaper models for simple tasks
-                and more capable models for complex ones. Connect your LLM providers and Manifest handles the rest.
+                Route each request to the best model for its complexity level &mdash; use cheaper
+                models for simple tasks and more capable models for complex ones. Connect your LLM
+                providers and Manifest handles the rest.
               </p>
               <button class="btn btn--primary" onClick={handleEnable}>
                 Enable Routing
@@ -190,7 +225,7 @@ const Routing: Component = () => {
               </For>
             </span>
             <span class="routing-providers-info__label">
-              {activeProviderIds().length} provider{activeProviderIds().length !== 1 ? "s" : ""}
+              {activeProviderIds().length} provider{activeProviderIds().length !== 1 ? 's' : ''}
             </span>
           </div>
 
@@ -198,8 +233,12 @@ const Routing: Component = () => {
             <For each={STAGES}>
               {(stage) => {
                 const tier = () => getTier(stage.id);
-                const eff = () => { const t = tier(); return t ? effectiveModel(t) : null; };
-                const isManual = () => tier()?.override_model !== null && tier()?.override_model !== undefined;
+                const eff = () => {
+                  const t = tier();
+                  return t ? effectiveModel(t) : null;
+                };
+                const isManual = () =>
+                  tier()?.override_model !== null && tier()?.override_model !== undefined;
 
                 return (
                   <div class="routing-card">
@@ -208,32 +247,64 @@ const Routing: Component = () => {
                       <span class="routing-card__desc">{stage.desc}</span>
                     </div>
                     <div class="routing-card__body">
-                      <Show when={eff()} fallback={
-                        <div class="routing-card__empty">
-                          <span class="routing-card__empty-text">No model available</span>
-                          <button class="routing-card__empty-link" onClick={() => setDropdownTier(stage.id)}>Select model</button>
-                        </div>
-                      }>
-                        {(modelName) => (<>
-                          <div class="routing-card__override">
-                            {(() => {
-                              const provId = providerIdForModel(modelName(), models() ?? []);
-                              return (<Show when={provId}>{(pid) => (<span class="routing-card__override-icon">{providerIcon(pid(), 16)}</span>)}</Show>);
-                            })()}
-                            <span class="routing-card__main">{labelFor(modelName())}</span>
-                            <Show when={!isManual()}><span class="routing-card__auto-tag">auto</span></Show>
+                      <Show
+                        when={eff()}
+                        fallback={
+                          <div class="routing-card__empty">
+                            <span class="routing-card__empty-text">No model available</span>
+                            <button
+                              class="routing-card__empty-link"
+                              onClick={() => setDropdownTier(stage.id)}
+                            >
+                              Select model
+                            </button>
                           </div>
-                          <span class="routing-card__sub">{priceLabel(modelName())}</span>
-                        </>)}
+                        }
+                      >
+                        {(modelName) => (
+                          <>
+                            <div class="routing-card__override">
+                              {(() => {
+                                const provId = providerIdForModel(modelName(), models() ?? []);
+                                return (
+                                  <Show when={provId}>
+                                    {(pid) => (
+                                      <span class="routing-card__override-icon">
+                                        {providerIcon(pid(), 16)}
+                                      </span>
+                                    )}
+                                  </Show>
+                                );
+                              })()}
+                              <span class="routing-card__main">{labelFor(modelName())}</span>
+                              <Show when={!isManual()}>
+                                <span class="routing-card__auto-tag">auto</span>
+                              </Show>
+                            </div>
+                            <span class="routing-card__sub">{priceLabel(modelName())}</span>
+                          </>
+                        )}
                       </Show>
                     </div>
                     <Show when={eff()}>
                       <div class="routing-card__actions">
-                        <Show when={isManual()} fallback={
-                          <button class="routing-action" onClick={() => setDropdownTier(stage.id)}>Override</button>
-                        }>
-                          <button class="routing-action" onClick={() => setDropdownTier(stage.id)}>Edit</button>
-                          <button class="routing-action" onClick={() => handleReset(stage.id)}>Reset</button>
+                        <Show
+                          when={isManual()}
+                          fallback={
+                            <button
+                              class="routing-action"
+                              onClick={() => setDropdownTier(stage.id)}
+                            >
+                              Override
+                            </button>
+                          }
+                        >
+                          <button class="routing-action" onClick={() => setDropdownTier(stage.id)}>
+                            Edit
+                          </button>
+                          <button class="routing-action" onClick={() => handleReset(stage.id)}>
+                            Reset
+                          </button>
                         </Show>
                       </div>
                     </Show>
@@ -244,16 +315,27 @@ const Routing: Component = () => {
           </div>
 
           <div class="routing-footer">
-            <button class="routing-disable-btn" onClick={() => setConfirmDisable(true)} disabled={disabling()}>
-              {disabling() ? "Disabling..." : "Disable Routing"}
+            <button
+              class="routing-disable-btn"
+              onClick={() => setConfirmDisable(true)}
+              disabled={disabling()}
+            >
+              {disabling() ? 'Disabling...' : 'Disable Routing'}
             </button>
             <Show when={hasOverrides()}>
-              <button class="btn btn--outline" style="font-size: var(--font-size-sm);" onClick={handleResetAll}>
+              <button
+                class="btn btn--outline"
+                style="font-size: var(--font-size-sm);"
+                onClick={handleResetAll}
+              >
                 Reset all to auto
               </button>
             </Show>
             <div style="flex: 1;" />
-            <button class="routing-footer__instructions" onClick={() => setInstructionModal("enable")}>
+            <button
+              class="routing-footer__instructions"
+              onClick={() => setInstructionModal('enable')}
+            >
               Setup instructions
             </button>
           </div>
@@ -274,6 +356,7 @@ const Routing: Component = () => {
 
       <Show when={showProviderModal()}>
         <ProviderSelectModal
+          agentName={agentName()}
           providers={connectedProviders() ?? []}
           onClose={() => setShowProviderModal(false)}
           onUpdate={handleProviderUpdate}
@@ -282,22 +365,28 @@ const Routing: Component = () => {
 
       <RoutingInstructionModal
         open={instructionModal() !== null}
-        mode={instructionModal() ?? "enable"}
+        mode={instructionModal() ?? 'enable'}
         onClose={() => setInstructionModal(null)}
       />
 
       <Show when={confirmDisable()}>
         <div
           class="modal-overlay"
-          onClick={(e) => { if (e.target === e.currentTarget) setConfirmDisable(false); }}
-          onKeyDown={(e) => { if (e.key === "Escape") setConfirmDisable(false); }}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setConfirmDisable(false);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setConfirmDisable(false);
+          }}
         >
           <div class="modal-card" style="max-width: 420px;">
             <h2 style="margin: 0 0 12px; font-size: var(--font-size-lg); font-weight: 600;">
               Disable routing?
             </h2>
             <p style="margin: 0 0 20px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-              All provider API keys and tier-to-model assignments will be permanently removed. If you re-enable routing later, you will need to reconnect your providers and reconfigure each tier.
+              All provider API keys and tier-to-model assignments will be permanently removed. If
+              you re-enable routing later, you will need to reconnect your providers and reconfigure
+              each tier.
             </p>
             <div style="display: flex; justify-content: flex-end; gap: 8px;">
               <button class="btn btn--outline" onClick={() => setConfirmDisable(false)}>
@@ -311,7 +400,7 @@ const Routing: Component = () => {
                   await handleDisable();
                 }}
               >
-                {disabling() ? "Disabling..." : "Disable"}
+                {disabling() ? 'Disabling...' : 'Disable'}
               </button>
             </div>
           </div>

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -1,6 +1,6 @@
-import { toast } from "./toast-store.js";
+import { toast } from './toast-store.js';
 
-const BASE_URL = "/api/v1";
+const BASE_URL = '/api/v1';
 
 async function fetchJson<T>(path: string, params?: Record<string, string | undefined>): Promise<T> {
   const url = new URL(`${BASE_URL}${path}`, window.location.origin);
@@ -10,16 +10,16 @@ async function fetchJson<T>(path: string, params?: Record<string, string | undef
     }
   }
 
-  const res = await fetch(url.toString(), { credentials: "include" });
+  const res = await fetch(url.toString(), { credentials: 'include' });
   if (res.status === 401) {
     // Session expired or user logged out — silently redirect to login
-    if (window.location.pathname !== "/login") {
-      window.location.href = "/login";
+    if (window.location.pathname !== '/login') {
+      window.location.href = '/login';
     }
     return new Promise<T>(() => {}); // hang forever, page is redirecting
   }
   if (!res.ok) {
-    const body = await res.text().catch(() => "");
+    const body = await res.text().catch(() => '');
     throw new Error(body || `API error: ${res.status} ${res.statusText}`);
   }
   return res.json() as Promise<T>;
@@ -28,8 +28,8 @@ async function fetchJson<T>(path: string, params?: Record<string, string | undef
 async function parseErrorMessage(res: Response): Promise<string> {
   try {
     const body = await res.json();
-    if (typeof body.message === "string") return body.message;
-    if (Array.isArray(body.message)) return body.message.join(", ");
+    if (typeof body.message === 'string') return body.message;
+    if (Array.isArray(body.message)) return body.message.join(', ');
   } catch {
     // not JSON — fall through
   }
@@ -37,7 +37,7 @@ async function parseErrorMessage(res: Response): Promise<string> {
 }
 
 async function fetchMutate<T = void>(url: string, options: RequestInit): Promise<T> {
-  const res = await fetch(url, { credentials: "include", ...options });
+  const res = await fetch(url, { credentials: 'include', ...options });
   if (!res.ok) {
     const message = await parseErrorMessage(res);
     toast.error(message);
@@ -49,90 +49,103 @@ async function fetchMutate<T = void>(url: string, options: RequestInit): Promise
 }
 
 export function getAgents() {
-  return fetchJson("/agents");
+  return fetchJson('/agents');
 }
 
-export function getOverview(range = "24h", agentName?: string) {
-  return fetchJson("/overview", { range, ...(agentName ? { agent_name: agentName } : {}) });
+export function getOverview(range = '24h', agentName?: string) {
+  return fetchJson('/overview', { range, ...(agentName ? { agent_name: agentName } : {}) });
 }
 
-export function getTokens(range = "24h", agentName?: string) {
-  return fetchJson("/tokens", { range, ...(agentName ? { agent_name: agentName } : {}) });
+export function getTokens(range = '24h', agentName?: string) {
+  return fetchJson('/tokens', { range, ...(agentName ? { agent_name: agentName } : {}) });
 }
 
-export function getCosts(range = "24h", agentName?: string) {
-  return fetchJson("/costs", { range, ...(agentName ? { agent_name: agentName } : {}) });
+export function getCosts(range = '24h', agentName?: string) {
+  return fetchJson('/costs', { range, ...(agentName ? { agent_name: agentName } : {}) });
 }
 
-export function getMessages(params: {
-  range?: string;
-  status?: string;
-  service_type?: string;
-  cursor?: string;
-  limit?: string;
-  agent_name?: string;
-} = {}) {
-  return fetchJson("/messages", params);
+export function getMessages(
+  params: {
+    range?: string;
+    status?: string;
+    service_type?: string;
+    cursor?: string;
+    limit?: string;
+    agent_name?: string;
+  } = {},
+) {
+  return fetchJson('/messages', params);
 }
 
-export function getSecurity(range = "24h") {
-  return fetchJson("/security", { range });
+export function getSecurity(range = '24h') {
+  return fetchJson('/security', { range });
 }
 
 export function getHealth() {
-  return fetchJson("/health");
+  return fetchJson('/health');
 }
 
 export function getAgentKey(agentName: string) {
-  return fetchJson<{ keyPrefix: string; apiKey?: string; pluginEndpoint?: string }>(`/agents/${encodeURIComponent(agentName)}/key`);
+  return fetchJson<{ keyPrefix: string; apiKey?: string; pluginEndpoint?: string }>(
+    `/agents/${encodeURIComponent(agentName)}/key`,
+  );
 }
 
 export function rotateAgentKey(agentName: string) {
-  return fetchMutate<{ apiKey: string }>(`${BASE_URL}/agents/${encodeURIComponent(agentName)}/rotate-key`, {
-    method: "POST",
-  });
+  return fetchMutate<{ apiKey: string }>(
+    `${BASE_URL}/agents/${encodeURIComponent(agentName)}/rotate-key`,
+    {
+      method: 'POST',
+    },
+  );
 }
 
 export function renameAgent(currentName: string, newName: string) {
-  return fetchMutate<{ renamed: boolean; name: string }>(`${BASE_URL}/agents/${encodeURIComponent(currentName)}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name: newName }),
-  });
+  return fetchMutate<{ renamed: boolean; name: string }>(
+    `${BASE_URL}/agents/${encodeURIComponent(currentName)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName }),
+    },
+  );
 }
 
 export function deleteAgent(agentName: string) {
   return fetchMutate(`${BASE_URL}/agents/${encodeURIComponent(agentName)}`, {
-    method: "DELETE",
+    method: 'DELETE',
   });
 }
 
 export function getModelPrices() {
-  return fetchJson("/model-prices");
+  return fetchJson('/model-prices');
 }
 
 export function createAgent(name: string) {
-  return fetchMutate<{ agent: { id: string; name: string }; apiKey: string }>(`${BASE_URL}/agents`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name }),
-  });
+  return fetchMutate<{ agent: { id: string; name: string }; apiKey: string }>(
+    `${BASE_URL}/agents`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    },
+  );
 }
 
 export interface NotificationRule {
   id: string;
   agent_name: string;
-  metric_type: "tokens" | "cost";
+  metric_type: 'tokens' | 'cost';
   threshold: number;
-  period: "hour" | "day" | "week" | "month";
-  action: "notify" | "block" | "both";
+  period: 'hour' | 'day' | 'week' | 'month';
+  action: 'notify' | 'block' | 'both';
   is_active: boolean | number;
   trigger_count: number;
   created_at: string;
 }
 
 export function getNotificationRules(agentName: string) {
-  return fetchJson<NotificationRule[]>("/notifications", { agent_name: agentName });
+  return fetchJson<NotificationRule[]>('/notifications', { agent_name: agentName });
 }
 
 export function createNotificationRule(data: {
@@ -143,23 +156,23 @@ export function createNotificationRule(data: {
   action?: string;
 }) {
   return fetchMutate(`${BASE_URL}/notifications`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
 }
 
 export function updateNotificationRule(id: string, data: Record<string, unknown>) {
   return fetchMutate(`${BASE_URL}/notifications/${encodeURIComponent(id)}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
 }
 
 export function deleteNotificationRule(id: string) {
   return fetchMutate(`${BASE_URL}/notifications/${encodeURIComponent(id)}`, {
-    method: "DELETE",
+    method: 'DELETE',
   });
 }
 
@@ -172,49 +185,67 @@ export interface EmailProviderConfig {
 }
 
 export async function getEmailProvider(): Promise<EmailProviderConfig | null> {
-  const data = await fetchJson<EmailProviderConfig & { configured?: boolean }>("/notifications/email-provider");
+  const data = await fetchJson<EmailProviderConfig & { configured?: boolean }>(
+    '/notifications/email-provider',
+  );
   if ('configured' in data && data.configured === false) return null;
   return data;
 }
 
-export function setEmailProvider(data: { provider: string; apiKey?: string; domain?: string; notificationEmail?: string }) {
+export function setEmailProvider(data: {
+  provider: string;
+  apiKey?: string;
+  domain?: string;
+  notificationEmail?: string;
+}) {
   return fetchMutate(`${BASE_URL}/notifications/email-provider`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
 }
 
 export function removeEmailProvider() {
   return fetchMutate(`${BASE_URL}/notifications/email-provider`, {
-    method: "DELETE",
+    method: 'DELETE',
   });
 }
 
-export function testEmailProvider(data: { provider: string; apiKey: string; domain?: string; to: string }) {
-  return fetchMutate<{ success: boolean; error?: string }>(`${BASE_URL}/notifications/email-provider/test`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-  });
+export function testEmailProvider(data: {
+  provider: string;
+  apiKey: string;
+  domain?: string;
+  to: string;
+}) {
+  return fetchMutate<{ success: boolean; error?: string }>(
+    `${BASE_URL}/notifications/email-provider/test`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    },
+  );
 }
 
 export function testSavedEmailProvider(to: string) {
-  return fetchMutate<{ success: boolean; error?: string }>(`${BASE_URL}/notifications/email-provider/test-saved`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ to }),
-  });
+  return fetchMutate<{ success: boolean; error?: string }>(
+    `${BASE_URL}/notifications/email-provider/test-saved`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ to }),
+    },
+  );
 }
 
 export function getNotificationEmailForProvider() {
-  return fetchJson<{ email: string | null }>("/notifications/notification-email");
+  return fetchJson<{ email: string | null }>('/notifications/notification-email');
 }
 
 export function saveNotificationEmailForProvider(email: string) {
   return fetchMutate<{ saved: boolean }>(`${BASE_URL}/notifications/notification-email`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email }),
   });
 }
@@ -229,45 +260,53 @@ export interface EmailConfig {
 }
 
 export function getEmailConfig() {
-  return fetchJson<EmailConfig>("/email-config");
+  return fetchJson<EmailConfig>('/email-config');
 }
 
-export function saveEmailConfig(data: { provider: string; apiKey: string; domain?: string; fromEmail?: string }) {
+export function saveEmailConfig(data: {
+  provider: string;
+  apiKey: string;
+  domain?: string;
+  fromEmail?: string;
+}) {
   return fetchMutate(`${BASE_URL}/email-config`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),
   });
 }
 
-export function testEmailConfig(data: { provider: string; apiKey: string; domain?: string; fromEmail?: string }, toEmail: string) {
+export function testEmailConfig(
+  data: { provider: string; apiKey: string; domain?: string; fromEmail?: string },
+  toEmail: string,
+) {
   return fetchMutate<{ success: boolean; error?: string }>(`${BASE_URL}/email-config/test`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ...data, toEmail }),
   });
 }
 
 export function clearEmailConfig() {
-  return fetchMutate(`${BASE_URL}/email-config`, { method: "DELETE" });
+  return fetchMutate(`${BASE_URL}/email-config`, { method: 'DELETE' });
 }
 
 export function getNotificationEmail() {
-  return fetchJson<{ email: string | null; isDefault: boolean }>("/notification-email");
+  return fetchJson<{ email: string | null; isDefault: boolean }>('/notification-email');
 }
 
 export function saveNotificationEmail(email: string) {
   return fetchMutate(`${BASE_URL}/notification-email`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ email }),
   });
 }
 
 /* -- Routing: Status -- */
 
-export function getRoutingStatus() {
-  return fetchJson<{ enabled: boolean }>("/routing/status");
+export function getRoutingStatus(agentName: string) {
+  return fetchJson<{ enabled: boolean }>(`/routing/${encodeURIComponent(agentName)}/status`);
 }
 
 /* -- Routing: Providers -- */
@@ -281,32 +320,32 @@ export interface RoutingProvider {
   connected_at: string;
 }
 
-export function getProviders() {
-  return fetchJson<RoutingProvider[]>("/routing/providers");
+export function getProviders(agentName: string) {
+  return fetchJson<RoutingProvider[]>(`/routing/${encodeURIComponent(agentName)}/providers`);
 }
 
-export function connectProvider(data: { provider: string; apiKey?: string }) {
+export function connectProvider(agentName: string, data: { provider: string; apiKey?: string }) {
   return fetchMutate<{ id: string; provider: string; is_active: boolean }>(
-    `${BASE_URL}/routing/providers`,
+    `${BASE_URL}/routing/${encodeURIComponent(agentName)}/providers`,
     {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
     },
   );
 }
 
-export function deactivateAllProviders() {
+export function deactivateAllProviders(agentName: string) {
   return fetchMutate<{ ok: boolean }>(
-    `${BASE_URL}/routing/providers/deactivate-all`,
-    { method: "POST" },
+    `${BASE_URL}/routing/${encodeURIComponent(agentName)}/providers/deactivate-all`,
+    { method: 'POST' },
   );
 }
 
-export function disconnectProvider(provider: string) {
+export function disconnectProvider(agentName: string, provider: string) {
   return fetchMutate<{ ok: boolean; notifications: string[] }>(
-    `${BASE_URL}/routing/providers/${encodeURIComponent(provider)}`,
-    { method: "DELETE" },
+    `${BASE_URL}/routing/${encodeURIComponent(agentName)}/providers/${encodeURIComponent(provider)}`,
+    { method: 'DELETE' },
   );
 }
 
@@ -314,37 +353,40 @@ export function disconnectProvider(provider: string) {
 
 export interface TierAssignment {
   id: string;
-  user_id: string;
+  agent_id: string;
   tier: string;
   override_model: string | null;
   auto_assigned_model: string | null;
   updated_at: string;
 }
 
-export function getTierAssignments() {
-  return fetchJson<TierAssignment[]>("/routing/tiers");
+export function getTierAssignments(agentName: string) {
+  return fetchJson<TierAssignment[]>(`/routing/${encodeURIComponent(agentName)}/tiers`);
 }
 
-export function overrideTier(tier: string, model: string) {
+export function overrideTier(agentName: string, tier: string, model: string) {
   return fetchMutate<TierAssignment>(
-    `${BASE_URL}/routing/tiers/${encodeURIComponent(tier)}`,
+    `${BASE_URL}/routing/${encodeURIComponent(agentName)}/tiers/${encodeURIComponent(tier)}`,
     {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ model }),
     },
   );
 }
 
-export function resetTier(tier: string) {
-  return fetchMutate(`${BASE_URL}/routing/tiers/${encodeURIComponent(tier)}`, {
-    method: "DELETE",
-  });
+export function resetTier(agentName: string, tier: string) {
+  return fetchMutate(
+    `${BASE_URL}/routing/${encodeURIComponent(agentName)}/tiers/${encodeURIComponent(tier)}`,
+    {
+      method: 'DELETE',
+    },
+  );
 }
 
-export function resetAllTiers() {
-  return fetchMutate(`${BASE_URL}/routing/tiers/reset-all`, {
-    method: "POST",
+export function resetAllTiers(agentName: string) {
+  return fetchMutate(`${BASE_URL}/routing/${encodeURIComponent(agentName)}/tiers/reset-all`, {
+    method: 'POST',
   });
 }
 
@@ -361,6 +403,6 @@ export interface AvailableModel {
   quality_score: number;
 }
 
-export function getAvailableModels() {
-  return fetchJson<AvailableModel[]>("/routing/available-models");
+export function getAvailableModels(agentName: string) {
+  return fetchJson<AvailableModel[]>(`/routing/${encodeURIComponent(agentName)}/available-models`);
 }

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -62,21 +62,21 @@ describe("ProviderSelectModal", () => {
 
   it("renders modal with title", () => {
     render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     expect(screen.getByText("Connect providers")).toBeDefined();
   });
 
   it("renders subtitle description", () => {
     render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     expect(screen.getByText("Add your API keys to enable routing through each provider")).toBeDefined();
   });
 
   it("renders all provider names from the PROVIDERS list", () => {
     render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     expect(screen.getByText("OpenAI")).toBeDefined();
     expect(screen.getByText("Anthropic")).toBeDefined();
@@ -91,6 +91,7 @@ describe("ProviderSelectModal", () => {
         providers={[connectedProvider]}
         onClose={onClose}
         onUpdate={onUpdate}
+        agentName="test-agent"
       />
     ));
     const onSwitches = container.querySelectorAll(".provider-toggle__switch--on");
@@ -99,7 +100,7 @@ describe("ProviderSelectModal", () => {
 
   it("shows toggle switch in 'off' state for disconnected providers", () => {
     const { container } = render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     const allSwitches = container.querySelectorAll(".provider-toggle__switch");
     const onSwitches = container.querySelectorAll(".provider-toggle__switch--on");
@@ -109,7 +110,7 @@ describe("ProviderSelectModal", () => {
 
   it("calls onClose when Done button is clicked", () => {
     render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     fireEvent.click(screen.getByText("Done"));
     expect(onClose).toHaveBeenCalledOnce();
@@ -117,7 +118,7 @@ describe("ProviderSelectModal", () => {
 
   it("calls onClose when close button is clicked", () => {
     render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     fireEvent.click(screen.getByLabelText("Close"));
     expect(onClose).toHaveBeenCalledOnce();
@@ -125,7 +126,7 @@ describe("ProviderSelectModal", () => {
 
   it("calls onClose when clicking overlay background", () => {
     const { container } = render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     const overlay = container.querySelector(".modal-overlay")!;
     fireEvent.click(overlay);
@@ -134,7 +135,7 @@ describe("ProviderSelectModal", () => {
 
   it("does not close when clicking inside the modal card", () => {
     const { container } = render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     const card = container.querySelector(".modal-card")!;
     fireEvent.click(card);
@@ -143,7 +144,7 @@ describe("ProviderSelectModal", () => {
 
   it("calls onClose on Escape key", () => {
     const { container } = render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
     ));
     const overlay = container.querySelector(".modal-overlay")!;
     fireEvent.keyDown(overlay, { key: "Escape" });
@@ -153,7 +154,7 @@ describe("ProviderSelectModal", () => {
   describe("detail view navigation", () => {
     it("shows API key input when provider row is clicked", async () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       expect(screen.getByLabelText("OpenAI API key")).toBeDefined();
@@ -161,7 +162,7 @@ describe("ProviderSelectModal", () => {
 
     it("returns to list view when back button is clicked", async () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       expect(screen.getByLabelText("OpenAI API key")).toBeDefined();
@@ -178,6 +179,7 @@ describe("ProviderSelectModal", () => {
           providers={[connectedProvider]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
@@ -190,6 +192,7 @@ describe("ProviderSelectModal", () => {
           providers={[connectedProvider]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
@@ -202,6 +205,7 @@ describe("ProviderSelectModal", () => {
           providers={[]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
@@ -214,6 +218,7 @@ describe("ProviderSelectModal", () => {
           providers={[connectedProvider]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
@@ -224,7 +229,7 @@ describe("ProviderSelectModal", () => {
   describe("connecting a provider", () => {
     it("connects a provider when valid API key is entered and Connect clicked", async () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       const input = screen.getByLabelText("OpenAI API key");
@@ -232,7 +237,7 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("Connect"));
 
       await waitFor(() => {
-        expect(mockConnectProvider).toHaveBeenCalledWith({
+        expect(mockConnectProvider).toHaveBeenCalledWith("test-agent", {
           provider: "openai",
           apiKey: VALID_OPENAI_KEY,
         });
@@ -243,7 +248,7 @@ describe("ProviderSelectModal", () => {
 
     it("does not connect when API key is empty", () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
 
@@ -253,7 +258,7 @@ describe("ProviderSelectModal", () => {
 
     it("shows validation error for invalid key prefix", async () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       const input = screen.getByLabelText("OpenAI API key");
@@ -266,7 +271,7 @@ describe("ProviderSelectModal", () => {
 
     it("shows validation error for key that is too short", async () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       const input = screen.getByLabelText("OpenAI API key");
@@ -279,7 +284,7 @@ describe("ProviderSelectModal", () => {
 
     it("clears validation error on input change", async () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       const input = screen.getByLabelText("OpenAI API key");
@@ -295,7 +300,7 @@ describe("ProviderSelectModal", () => {
 
     it("connects on Enter key in API key input", async () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       const input = screen.getByLabelText("OpenAI API key");
@@ -315,13 +320,14 @@ describe("ProviderSelectModal", () => {
           providers={[connectedProvider]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       fireEvent.click(screen.getByLabelText("Disconnect provider"));
 
       await waitFor(() => {
-        expect(mockDisconnectProvider).toHaveBeenCalledWith("openai");
+        expect(mockDisconnectProvider).toHaveBeenCalledWith("test-agent", "openai");
       });
       expect(onUpdate).toHaveBeenCalled();
     });
@@ -336,6 +342,7 @@ describe("ProviderSelectModal", () => {
           providers={[connectedProvider]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
@@ -356,6 +363,7 @@ describe("ProviderSelectModal", () => {
           providers={[connectedProvider]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
@@ -373,7 +381,7 @@ describe("ProviderSelectModal", () => {
       mockConnectProvider.mockRejectedValue(new Error("Failed"));
 
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} />
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
       const input = screen.getByLabelText("OpenAI API key");
@@ -394,6 +402,7 @@ describe("ProviderSelectModal", () => {
           providers={[connectedProvider]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
@@ -410,6 +419,7 @@ describe("ProviderSelectModal", () => {
           providers={[connectedProvider]}
           onClose={onClose}
           onUpdate={onUpdate}
+          agentName="test-agent"
         />
       ));
       fireEvent.click(screen.getByText("OpenAI"));
@@ -420,7 +430,7 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("Save"));
 
       await waitFor(() => {
-        expect(mockConnectProvider).toHaveBeenCalledWith({
+        expect(mockConnectProvider).toHaveBeenCalledWith("test-agent", {
           provider: "openai",
           apiKey: VALID_OPENAI_KEY,
         });

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -242,7 +242,7 @@ describe("Routing — enabled state (providers active)", () => {
     fireEvent.click(modelButtons[modelButtons.length - 1]);
 
     await waitFor(() => {
-      expect(overrideTier).toHaveBeenCalledWith("simple", "claude-opus-4-6");
+      expect(overrideTier).toHaveBeenCalledWith("test-agent", "simple", "claude-opus-4-6");
     });
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith("Routing updated");
@@ -265,7 +265,7 @@ describe("Routing — enabled state (providers active)", () => {
     fireEvent.click(resetBtn);
 
     await waitFor(() => {
-      expect(resetTier).toHaveBeenCalledWith("complex");
+      expect(resetTier).toHaveBeenCalledWith("test-agent", "complex");
     });
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith("Reset to auto");

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -460,28 +460,28 @@ describe("fetchMutate error handling", () => {
 });
 
 describe("getProviders", () => {
-  it("fetches /routing/providers", async () => {
+  it("fetches /routing/:agentName/providers", async () => {
     const payload = [{ id: "1", provider: "openai", is_active: true, connected_at: "2026-01-01" }];
     mockOk(payload);
 
-    const result = await getProviders();
+    const result = await getProviders("my-agent");
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:3000/api/v1/routing/providers",
+      "http://localhost:3000/api/v1/routing/my-agent/providers",
       { credentials: "include" },
     );
   });
 });
 
 describe("connectProvider", () => {
-  it("POSTs to /routing/providers with provider only (no apiKey)", async () => {
+  it("POSTs to /routing/:agentName/providers with provider only (no apiKey)", async () => {
     const payload = { id: "1", provider: "openai", is_active: true };
     mockMutateOk(payload);
 
-    const result = await connectProvider({ provider: "openai" });
+    const result = await connectProvider("my-agent", { provider: "openai" });
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/routing/providers",
+      "/api/v1/routing/my-agent/providers",
       expect.objectContaining({
         method: "POST",
         credentials: "include",
@@ -495,9 +495,9 @@ describe("connectProvider", () => {
     const payload = { id: "1", provider: "openai", is_active: true };
     mockMutateOk(payload);
 
-    await connectProvider({ provider: "openai", apiKey: "sk-test" });
+    await connectProvider("my-agent", { provider: "openai", apiKey: "sk-test" });
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/routing/providers",
+      "/api/v1/routing/my-agent/providers",
       expect.objectContaining({
         body: JSON.stringify({ provider: "openai", apiKey: "sk-test" }),
       }),
@@ -508,33 +508,33 @@ describe("connectProvider", () => {
     const { toast } = await import("../../src/services/toast-store.js");
     mockMutateError(400, "Invalid provider");
 
-    await expect(connectProvider({ provider: "" })).rejects.toThrow("Invalid provider");
+    await expect(connectProvider("my-agent", { provider: "" })).rejects.toThrow("Invalid provider");
     expect(toast.error).toHaveBeenCalledWith("Invalid provider");
   });
 });
 
 describe("deactivateAllProviders", () => {
-  it("POSTs to /routing/providers/deactivate-all", async () => {
+  it("POSTs to /routing/:agentName/providers/deactivate-all", async () => {
     mockMutateOk({ ok: true });
 
-    const result = await deactivateAllProviders();
+    const result = await deactivateAllProviders("my-agent");
     expect(result).toEqual({ ok: true });
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/routing/providers/deactivate-all",
+      "/api/v1/routing/my-agent/providers/deactivate-all",
       expect.objectContaining({ method: "POST", credentials: "include" }),
     );
   });
 });
 
 describe("disconnectProvider", () => {
-  it("sends DELETE to /routing/providers/:provider", async () => {
+  it("sends DELETE to /routing/:agentName/providers/:provider", async () => {
     const payload = { ok: true, notifications: [] };
     mockMutateOk(payload);
 
-    const result = await disconnectProvider("openai");
+    const result = await disconnectProvider("my-agent", "openai");
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/routing/providers/openai",
+      "/api/v1/routing/my-agent/providers/openai",
       expect.objectContaining({ method: "DELETE", credentials: "include" }),
     );
   });
@@ -542,35 +542,35 @@ describe("disconnectProvider", () => {
   it("encodes provider name in URL", async () => {
     mockMutateOk({ ok: true, notifications: [] });
 
-    await disconnectProvider("my provider");
+    await disconnectProvider("my-agent", "my provider");
     const url = mockFetch.mock.calls[0]?.[0] as string;
-    expect(url).toContain("/routing/providers/my%20provider");
+    expect(url).toContain("/routing/my-agent/providers/my%20provider");
   });
 });
 
 describe("getTierAssignments", () => {
-  it("fetches /routing/tiers", async () => {
+  it("fetches /routing/:agentName/tiers", async () => {
     const payload = [{ id: "1", tier: "tier-1", override_model: null, auto_assigned_model: "gpt-4" }];
     mockOk(payload);
 
-    const result = await getTierAssignments();
+    const result = await getTierAssignments("my-agent");
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:3000/api/v1/routing/tiers",
+      "http://localhost:3000/api/v1/routing/my-agent/tiers",
       { credentials: "include" },
     );
   });
 });
 
 describe("overrideTier", () => {
-  it("PUTs to /routing/tiers/:tier with JSON body", async () => {
+  it("PUTs to /routing/:agentName/tiers/:tier with JSON body", async () => {
     const payload = { id: "1", tier: "tier-1", override_model: "gpt-4o", auto_assigned_model: null, updated_at: "2026-01-01" };
     mockMutateOk(payload);
 
-    const result = await overrideTier("tier-1", "gpt-4o");
+    const result = await overrideTier("my-agent", "tier-1", "gpt-4o");
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/routing/tiers/tier-1",
+      "/api/v1/routing/my-agent/tiers/tier-1",
       expect.objectContaining({
         method: "PUT",
         credentials: "include",
@@ -583,19 +583,19 @@ describe("overrideTier", () => {
   it("encodes tier name in URL", async () => {
     mockMutateOk({});
 
-    await overrideTier("tier 1", "gpt-4o");
+    await overrideTier("my-agent", "tier 1", "gpt-4o");
     const url = mockFetch.mock.calls[0]?.[0] as string;
-    expect(url).toContain("/routing/tiers/tier%201");
+    expect(url).toContain("/routing/my-agent/tiers/tier%201");
   });
 });
 
 describe("resetTier", () => {
-  it("sends DELETE to /routing/tiers/:tier", async () => {
+  it("sends DELETE to /routing/:agentName/tiers/:tier", async () => {
     mockMutateOk();
 
-    await resetTier("tier-1");
+    await resetTier("my-agent", "tier-1");
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/routing/tiers/tier-1",
+      "/api/v1/routing/my-agent/tiers/tier-1",
       expect.objectContaining({ method: "DELETE", credentials: "include" }),
     );
   });
@@ -603,33 +603,33 @@ describe("resetTier", () => {
   it("encodes tier name in URL", async () => {
     mockMutateOk();
 
-    await resetTier("tier/special");
+    await resetTier("my-agent", "tier/special");
     const url = mockFetch.mock.calls[0]?.[0] as string;
-    expect(url).toContain("/routing/tiers/tier%2Fspecial");
+    expect(url).toContain("/routing/my-agent/tiers/tier%2Fspecial");
   });
 });
 
 describe("resetAllTiers", () => {
-  it("POSTs to /routing/tiers/reset-all", async () => {
+  it("POSTs to /routing/:agentName/tiers/reset-all", async () => {
     mockMutateOk();
 
-    await resetAllTiers();
+    await resetAllTiers("my-agent");
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/routing/tiers/reset-all",
+      "/api/v1/routing/my-agent/tiers/reset-all",
       expect.objectContaining({ method: "POST", credentials: "include" }),
     );
   });
 });
 
 describe("getAvailableModels", () => {
-  it("fetches /routing/available-models", async () => {
+  it("fetches /routing/:agentName/available-models", async () => {
     const payload = [{ model_name: "gpt-4o", provider: "openai", input_price_per_token: 0.01 }];
     mockOk(payload);
 
-    const result = await getAvailableModels();
+    const result = await getAvailableModels("my-agent");
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
-      "http://localhost:3000/api/v1/routing/available-models",
+      "http://localhost:3000/api/v1/routing/my-agent/available-models",
       { credentials: "include" },
     );
   });


### PR DESCRIPTION
## Summary

- Make routing configuration (provider API keys + tier-to-model assignments) per-agent instead of per-user
- Each agent gets its own independent set of provider connections (with encrypted API keys) and tier assignments
- Creating a new agent shows no providers and routing disabled (isolated from other agents)
- Existing production data is preserved via migration that copies current per-user config to all agents under each user

### Key changes:
- **Entities**: Added `agent_id` column to `user_providers` and `tier_assignments`, with new unique indexes on `(agent_id, provider/tier)`
- **Migration**: Fan-out existing per-user rows to per-agent rows with safe rollback (deduplicates before restoring old indexes)
- **Services**: All routing services (`RoutingService`, `TierAutoAssignService`, `ResolveService`, `ProxyService`) now key on `agentId`
- **Controllers**: Dashboard routing endpoints include `:agentName` param (e.g., `GET /routing/:agentName/status`); resolve/proxy endpoints extract `agentId` from ingestion context
- **Frontend**: All routing API functions take `agentName` as first parameter; `Routing.tsx`, `Limits.tsx`, and `ProviderSelectModal.tsx` updated
- **Local mode**: SQLite fixup for pre-migration databases sets `agent_id` on orphaned rows
- **New tests**: `AgentNameParamDto` validation, `resolveAgent` controller logic, `fixupRoutingAgentIds` bootstrap method

## Test plan

- [x] Backend unit tests pass (1768 tests)
- [x] Backend E2E tests pass (86 tests)
- [x] Frontend tests pass (997 tests)
- [x] TypeScript compiles cleanly (backend + frontend)
- [x] Lint passes (pre-commit hooks)
- [ ] Manual test: create 2 agents, connect provider on Agent A, verify Agent B shows routing disabled