### PR TITLE
feat: add API key source links in provider modals

### DIFF
--- a/.changeset/wise-oranges-double.md
+++ b/.changeset/wise-oranges-double.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add "Where to get API key" links below provider API key inputs in routing and email provider modals.

--- a/packages/frontend/src/components/EmailProviderModal.tsx
+++ b/packages/frontend/src/components/EmailProviderModal.tsx
@@ -3,6 +3,7 @@ import { Portal } from 'solid-js/web';
 import { setEmailProvider, testEmailProvider, testSavedEmailProvider } from '../services/api.js';
 import { authClient } from '../services/auth-client.js';
 import { isLocalMode } from '../services/local-mode.js';
+import { getEmailProviderApiKeyUrl } from '../services/provider-api-key-urls.js';
 import { toast } from '../services/toast-store.js';
 
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
@@ -238,6 +239,8 @@ const EmailProviderModal: Component<Props> = (props) => {
     return props.editMode ? 'Test & Save' : 'Test & Connect';
   };
 
+  const keyDocsUrl = () => getEmailProviderApiKeyUrl(provider());
+
   const keyPlaceholder = () => {
     switch (provider()) {
       case 'resend':
@@ -342,6 +345,18 @@ const EmailProviderModal: Component<Props> = (props) => {
             </Show>
             <Show when={keyError()}>
               <p class="modal-card__field-error">{keyError()}</p>
+            </Show>
+            <Show when={keyDocsUrl()}>
+              <p class="modal-card__field-hint">
+                <a
+                  class="modal-card__field-link"
+                  href={keyDocsUrl()!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get {PROVIDER_NAMES[provider()] ?? provider()} API key
+                </a>
+              </p>
             </Show>
 
             <Show when={needsDomain()}>

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -6,6 +6,7 @@ import {
   type CustomProviderData,
   type RoutingProvider,
 } from '../services/api.js';
+import { getRoutingProviderApiKeyUrl } from '../services/provider-api-key-urls.js';
 import { isLocalMode } from '../services/local-mode.js';
 import { PROVIDERS, validateApiKey, validateSubscriptionKey } from '../services/providers.js';
 import { customProviderColor } from '../services/formatters.js';
@@ -526,6 +527,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
                   ? isSubscriptionWithToken(provId)
                   : isConnected(provId) || isNoKeyConnected(provId);
               const isOllama = provDef.noKeyRequired;
+              const whereToGetUrl = getRoutingProviderApiKeyUrl(provId);
               const fieldLabel = () => (isSubMode() ? 'Setup Token' : 'API Key');
               const placeholder = () =>
                 isSubMode()
@@ -677,6 +679,18 @@ const ProviderSelectModal: Component<Props> = (props) => {
                       <Show when={validationError()}>
                         <div class="provider-detail__error">{validationError()}</div>
                       </Show>
+                      <Show when={whereToGetUrl}>
+                        <p class="provider-detail__key-help">
+                          <a
+                            class="provider-detail__key-help-link"
+                            href={whereToGetUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            Get {provDef.name} API key
+                          </a>
+                        </p>
+                      </Show>
                     </div>
                     <button
                       class="btn btn--primary btn--sm provider-detail__action"
@@ -761,6 +775,18 @@ const ProviderSelectModal: Component<Props> = (props) => {
                         />
                         <Show when={validationError()}>
                           <div class="provider-detail__error">{validationError()}</div>
+                        </Show>
+                        <Show when={whereToGetUrl}>
+                          <p class="provider-detail__key-help">
+                            <a
+                              class="provider-detail__key-help-link"
+                              href={whereToGetUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              Get {provDef.name} API key
+                            </a>
+                          </p>
                         </Show>
                         <button
                           class="btn btn--primary btn--sm provider-detail__action"

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -1,0 +1,25 @@
+export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
+  anthropic: 'https://console.anthropic.com/settings/keys',
+  deepseek: 'https://platform.deepseek.com/api_keys',
+  gemini: 'https://aistudio.google.com/apikey',
+  minimax: 'https://platform.minimax.io/docs/api-reference/api-overview',
+  mistral: 'https://console.mistral.ai/api-keys/',
+  moonshot: 'https://platform.moonshot.ai/',
+  openai: 'https://platform.openai.com/api-keys',
+  openrouter: 'https://openrouter.ai/keys',
+  qwen: 'https://www.alibabacloud.com/help/en/model-studio/developer-reference/get-api-key',
+  xai: 'https://docs.x.ai/docs/api-reference',
+  zai: 'https://z.ai/manage-apikey/apikey-list',
+};
+
+export const getRoutingProviderApiKeyUrl = (providerId: string): string | undefined =>
+  ROUTING_PROVIDER_API_KEY_URLS[providerId];
+
+export const EMAIL_PROVIDER_API_KEY_URLS: Record<string, string> = {
+  resend: 'https://resend.com/api-keys',
+  mailgun: 'https://app.mailgun.com/app/account/security/api_keys',
+  sendgrid: 'https://app.sendgrid.com/settings/api_keys',
+};
+
+export const getEmailProviderApiKeyUrl = (providerId: string): string | undefined =>
+  EMAIL_PROVIDER_API_KEY_URLS[providerId];

--- a/packages/frontend/src/styles/notifications.css
+++ b/packages/frontend/src/styles/notifications.css
@@ -439,6 +439,16 @@
   line-height: 1.4;
 }
 
+.modal-card__field-link {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.modal-card__field-link:hover {
+  color: hsl(var(--foreground));
+}
+
 .modal-card__footer--split {
   display: flex;
   justify-content: space-between;

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -344,6 +344,21 @@
   margin-top: 4px;
 }
 
+.provider-detail__key-help {
+  margin: 6px 0 0;
+  font-size: var(--font-size-xs);
+}
+
+.provider-detail__key-help-link {
+  color: hsl(var(--muted-foreground));
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.provider-detail__key-help-link:hover {
+  color: hsl(var(--foreground));
+}
+
 .provider-detail__key-row {
   display: flex;
   align-items: center;

--- a/packages/frontend/tests/components/EmailProviderModal.test.tsx
+++ b/packages/frontend/tests/components/EmailProviderModal.test.tsx
@@ -77,6 +77,13 @@ describe("EmailProviderModal", () => {
     expect(screen.getByText("API Key")).toBeDefined();
   });
 
+  it("shows where-to-get API key link for selected provider", () => {
+    render(() => <EmailProviderModal {...defaultProps} />);
+    const link = screen.getByRole("link", { name: "Get Resend API key" });
+    expect(link.getAttribute("href")).toBe("https://resend.com/api-keys");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
   it("shows password input for API key in create mode", () => {
     render(() => <EmailProviderModal {...defaultProps} />);
     expect(q('input[type="password"]')).not.toBeNull();

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -168,6 +168,18 @@ describe("ProviderSelectModal", () => {
       expect(screen.getByLabelText("OpenAI API key")).toBeDefined();
     });
 
+    it("shows where-to-get API key link for selected provider", () => {
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+      fireEvent.click(screen.getByText("API Keys"));
+      fireEvent.click(screen.getByText("OpenAI"));
+
+      const link = screen.getByRole("link", { name: "Get OpenAI API key" });
+      expect(link.getAttribute("href")).toBe("https://platform.openai.com/api-keys");
+      expect(link.getAttribute("target")).toBe("_blank");
+    });
+
     it("returns to list view when back button is clicked", async () => {
       render(() => (
         <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -7,6 +7,7 @@ import {
   PROVIDERS,
   STAGES,
 } from "../../src/services/providers";
+import { ROUTING_PROVIDER_API_KEY_URLS, EMAIL_PROVIDER_API_KEY_URLS } from "../../src/services/provider-api-key-urls";
 
 /* ── getProvider ────────────────────────────────── */
 
@@ -237,6 +238,13 @@ describe("PROVIDERS", () => {
     }
   });
 
+  it("requires an API key URL for every provider that needs one", () => {
+    const missingProviderIds = PROVIDERS.filter(
+      (provider) => !provider.noKeyRequired && !ROUTING_PROVIDER_API_KEY_URLS[provider.id],
+    ).map((provider) => provider.id);
+    expect(missingProviderIds).toEqual([]);
+  });
+
   it("does not have API-key-specific fields", () => {
     for (const p of PROVIDERS) {
       expect(p).not.toHaveProperty("inputType");
@@ -258,5 +266,15 @@ describe("STAGES", () => {
 
   it("has correct stage IDs", () => {
     expect(STAGES.map((s) => s.id)).toEqual(["simple", "standard", "complex", "reasoning"]);
+  });
+});
+
+/* ── EMAIL_PROVIDER_API_KEY_URLS ─────────────── */
+
+describe("EMAIL_PROVIDER_API_KEY_URLS", () => {
+  it("has a URL for every email provider", () => {
+    expect(EMAIL_PROVIDER_API_KEY_URLS).toHaveProperty("resend");
+    expect(EMAIL_PROVIDER_API_KEY_URLS).toHaveProperty("mailgun");
+    expect(EMAIL_PROVIDER_API_KEY_URLS).toHaveProperty("sendgrid");
   });
 });

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -7,7 +7,7 @@ import {
   PROVIDERS,
   STAGES,
 } from "../../src/services/providers";
-import { ROUTING_PROVIDER_API_KEY_URLS, EMAIL_PROVIDER_API_KEY_URLS } from "../../src/services/provider-api-key-urls";
+import { ROUTING_PROVIDER_API_KEY_URLS, EMAIL_PROVIDER_API_KEY_URLS, getRoutingProviderApiKeyUrl, getEmailProviderApiKeyUrl } from "../../src/services/provider-api-key-urls";
 
 /* ── getProvider ────────────────────────────────── */
 
@@ -276,5 +276,29 @@ describe("EMAIL_PROVIDER_API_KEY_URLS", () => {
     expect(EMAIL_PROVIDER_API_KEY_URLS).toHaveProperty("resend");
     expect(EMAIL_PROVIDER_API_KEY_URLS).toHaveProperty("mailgun");
     expect(EMAIL_PROVIDER_API_KEY_URLS).toHaveProperty("sendgrid");
+  });
+});
+
+/* ── getRoutingProviderApiKeyUrl ─────────────── */
+
+describe("getRoutingProviderApiKeyUrl", () => {
+  it("returns a URL for a known provider", () => {
+    expect(getRoutingProviderApiKeyUrl("openai")).toBe("https://platform.openai.com/api-keys");
+  });
+
+  it("returns undefined for an unknown provider", () => {
+    expect(getRoutingProviderApiKeyUrl("unknown")).toBeUndefined();
+  });
+});
+
+/* ── getEmailProviderApiKeyUrl ───────────────── */
+
+describe("getEmailProviderApiKeyUrl", () => {
+  it("returns a URL for a known email provider", () => {
+    expect(getEmailProviderApiKeyUrl("resend")).toBe("https://resend.com/api-keys");
+  });
+
+  it("returns undefined for an unknown provider", () => {
+    expect(getEmailProviderApiKeyUrl("unknown")).toBeUndefined();
   });
 });


### PR DESCRIPTION
  Add "Get API key" links below provider API key inputs in the routing and email provider modals, so users can quickly navigate to key creation pages.

  **Changes:**
  - Added provider-to-URL mapping in `ProviderSelectModal.tsx` and `EmailProviderModal.tsx`
  - Rendered conditional helper links below API key fields
  - Added styling and tests