### PR TITLE
fix: reconcile local API key on every boot to prevent 401

### DIFF
--- a/.changeset/fix-local-api-key-reconciliation.md
+++ b/.changeset/fix-local-api-key-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix local API key reconciliation on boot to prevent 401 errors and clean stale models.json entries on mode switch

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -42,6 +42,7 @@ jest.mock('../entities/tier-assignment.entity', () => ({ TierAssignment: jest.fn
 
 import { LocalBootstrapService } from './local-bootstrap.service';
 import { trackEvent } from '../common/utils/product-telemetry';
+import { existsSync, readFileSync } from 'fs';
 
 function makeMockRepo() {
   return {
@@ -176,8 +177,7 @@ describe('LocalBootstrapService', () => {
     });
 
     it('registers API key when config file exists with apiKey', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { existsSync, readFileSync } = require('fs');
+
       (existsSync as jest.Mock).mockReturnValue(true);
       (readFileSync as jest.Mock).mockReturnValue(
         JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
@@ -198,8 +198,7 @@ describe('LocalBootstrapService', () => {
     });
 
     it('skips API key registration when key hash already exists', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { existsSync, readFileSync } = require('fs');
+
       (existsSync as jest.Mock).mockReturnValue(true);
       (readFileSync as jest.Mock).mockReturnValue(
         JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
@@ -212,7 +211,7 @@ describe('LocalBootstrapService', () => {
     });
 
     it('reconciles API key even when tenant already exists', async () => {
-      const { existsSync, readFileSync } = require('fs');
+
       (existsSync as jest.Mock).mockReturnValue(true);
       (readFileSync as jest.Mock).mockReturnValue(
         JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -158,7 +158,7 @@ describe('LocalBootstrapService', () => {
 
       await service.onModuleInit();
 
-      expect(mockAgentKeyRepo.insert).not.toHaveBeenCalled();
+      expect(mockAgentKeyRepo.upsert).not.toHaveBeenCalled();
     });
 
     it('returns null when readFileSync throws (catches error in readApiKeyFromConfig)', async () => {
@@ -185,7 +185,7 @@ describe('LocalBootstrapService', () => {
 
       await service.onModuleInit();
 
-      expect(mockAgentKeyRepo.insert).toHaveBeenCalledWith(
+      expect(mockAgentKeyRepo.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'local-otlp-key-001',
           label: 'Local OTLP ingest key',
@@ -193,6 +193,7 @@ describe('LocalBootstrapService', () => {
           agent_id: 'local-agent-001',
           is_active: true,
         }),
+        ['id'],
       );
     });
 
@@ -207,7 +208,28 @@ describe('LocalBootstrapService', () => {
 
       await service.onModuleInit();
 
-      expect(mockAgentKeyRepo.insert).not.toHaveBeenCalled();
+      expect(mockAgentKeyRepo.upsert).not.toHaveBeenCalled();
+    });
+
+    it('reconciles API key even when tenant already exists', async () => {
+      const { existsSync, readFileSync } = require('fs');
+      (existsSync as jest.Mock).mockReturnValue(true);
+      (readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
+      );
+      mockTenantRepo.count.mockResolvedValue(1);
+
+      await service.onModuleInit();
+
+      expect(mockTenantRepo.insert).not.toHaveBeenCalled();
+      expect(mockAgentKeyRepo.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'local-otlp-key-001',
+          tenant_id: 'local-tenant-001',
+          agent_id: 'local-agent-001',
+        }),
+        ['id'],
+      );
     });
   });
 

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -60,31 +60,33 @@ export class LocalBootstrapService implements OnModuleInit {
 
   private async ensureTenantAndAgent() {
     const count = await this.tenantRepo.count({ where: { id: LOCAL_TENANT_ID } });
-    if (count > 0) return;
+    if (count === 0) {
+      await this.tenantRepo.insert({
+        id: LOCAL_TENANT_ID,
+        name: LOCAL_USER_ID,
+        organization_name: 'Local',
+        email: LOCAL_EMAIL,
+        is_active: true,
+      });
 
-    await this.tenantRepo.insert({
-      id: LOCAL_TENANT_ID,
-      name: LOCAL_USER_ID,
-      organization_name: 'Local',
-      email: LOCAL_EMAIL,
-      is_active: true,
-    });
+      await this.agentRepo.insert({
+        id: LOCAL_AGENT_ID,
+        name: LOCAL_AGENT_NAME,
+        description: 'Default local agent',
+        is_active: true,
+        tenant_id: LOCAL_TENANT_ID,
+      });
+      trackEvent('agent_created', { agent_name: LOCAL_AGENT_NAME });
 
-    await this.agentRepo.insert({
-      id: LOCAL_AGENT_ID,
-      name: LOCAL_AGENT_NAME,
-      description: 'Default local agent',
-      is_active: true,
-      tenant_id: LOCAL_TENANT_ID,
-    });
-    trackEvent('agent_created', { agent_name: LOCAL_AGENT_NAME });
+      this.logger.log(`Created tenant/agent for local mode`);
+    }
 
+    // Always reconcile the API key — it may have been regenerated
+    // since the tenant was first created.
     const apiKey = this.readApiKeyFromConfig();
     if (apiKey) {
       await this.registerApiKey(apiKey);
     }
-
-    this.logger.log(`Created tenant/agent for local mode`);
   }
 
   private readApiKeyFromConfig(): string | null {
@@ -103,16 +105,19 @@ export class LocalBootstrapService implements OnModuleInit {
     const existing = await this.agentKeyRepo.count({ where: { key_hash: hash } });
     if (existing > 0) return;
 
-    await this.agentKeyRepo.insert({
-      id: 'local-otlp-key-001',
-      key: null,
-      key_hash: hash,
-      key_prefix: keyPrefix(apiKey),
-      label: 'Local OTLP ingest key',
-      tenant_id: LOCAL_TENANT_ID,
-      agent_id: LOCAL_AGENT_ID,
-      is_active: true,
-    });
+    await this.agentKeyRepo.upsert(
+      {
+        id: 'local-otlp-key-001',
+        key: null,
+        key_hash: hash,
+        key_prefix: keyPrefix(apiKey),
+        label: 'Local OTLP ingest key',
+        tenant_id: LOCAL_TENANT_ID,
+        agent_id: LOCAL_AGENT_ID,
+        is_active: true,
+      },
+      ['id'],
+    );
   }
 
   private async fixupRoutingAgentIds() {

--- a/packages/openclaw-plugin/__tests__/local-mode.test.ts
+++ b/packages/openclaw-plugin/__tests__/local-mode.test.ts
@@ -639,6 +639,104 @@ describe("injectAuthProfile — edge cases", () => {
   });
 });
 
+describe("injectProviderConfig — stale models.json cleanup", () => {
+  const agentsDir = join("/mock-home", ".openclaw", "agents");
+
+  it("removes manifest entry from per-agent models.json", () => {
+    (existsSync as jest.Mock).mockImplementation((p: string) => {
+      if (p === agentsDir) return true;
+      if (p.includes("models.json")) return true;
+      return false;
+    });
+    (readdirSync as jest.Mock).mockReturnValue([
+      { name: "bot-1", isDirectory: () => true },
+    ]);
+    (readFileSync as jest.Mock).mockImplementation((p: string) => {
+      if (typeof p === "string" && p.includes("models.json")) {
+        return JSON.stringify({ providers: { manifest: { baseUrl: "old" }, other: {} } });
+      }
+      return "{}";
+    });
+
+    const api = { config: {} };
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_test", mockLogger);
+
+    // atomicWriteJson writes via writeFileSync+renameSync — find the models.json write
+    const writes = (writeFileSync as jest.Mock).mock.calls;
+    const modelsWrite = writes.find((c: any[]) => String(c[0]).includes("models.json"));
+    expect(modelsWrite).toBeDefined();
+    const data = JSON.parse(modelsWrite![1]);
+    expect(data.providers.manifest).toBeUndefined();
+    expect(data.providers.other).toBeDefined();
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("Removed stale manifest entry"),
+    );
+  });
+
+  it("skips agent when models.json does not exist", () => {
+    (existsSync as jest.Mock).mockImplementation((p: string) => {
+      if (p === agentsDir) return true;
+      if (typeof p === "string" && p.includes("models.json")) return false;
+      return false;
+    });
+    (readdirSync as jest.Mock).mockReturnValue([
+      { name: "bot-2", isDirectory: () => true },
+    ]);
+
+    const api = { config: {} };
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_test", mockLogger);
+
+    // No models.json write should happen (only openclaw.json write)
+    const writes = (writeFileSync as jest.Mock).mock.calls;
+    const modelsWrite = writes.find((c: any[]) => String(c[0]).includes("models.json"));
+    expect(modelsWrite).toBeUndefined();
+  });
+
+  it("skips agent when models.json has no manifest provider", () => {
+    (existsSync as jest.Mock).mockImplementation((p: string) => {
+      if (p === agentsDir) return true;
+      if (typeof p === "string" && p.includes("models.json")) return true;
+      return false;
+    });
+    (readdirSync as jest.Mock).mockReturnValue([
+      { name: "bot-3", isDirectory: () => true },
+    ]);
+    (readFileSync as jest.Mock).mockImplementation((p: string) => {
+      if (typeof p === "string" && p.includes("models.json")) {
+        return JSON.stringify({ providers: { openai: {} } });
+      }
+      return "{}";
+    });
+
+    const api = { config: {} };
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_test", mockLogger);
+
+    const writes = (writeFileSync as jest.Mock).mock.calls;
+    const modelsWrite = writes.find((c: any[]) => String(c[0]).includes("models.json"));
+    expect(modelsWrite).toBeUndefined();
+  });
+
+  it("logs debug when cleanup throws", () => {
+    (existsSync as jest.Mock).mockImplementation((p: string) => {
+      if (p === agentsDir) return true;
+      return false;
+    });
+    (readdirSync as jest.Mock).mockImplementation((p: string, opts: any) => {
+      if (typeof p === "string" && p.includes("agents") && opts?.withFileTypes) {
+        throw new Error("permission denied");
+      }
+      return [];
+    });
+
+    const api = { config: {} };
+    injectProviderConfig(api, "http://127.0.0.1:2099/v1", "mnfst_test", mockLogger);
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      expect.stringContaining("Could not clean agent models.json"),
+    );
+  });
+});
+
 describe("readJsonSafe — corrupt JSON", () => {
   it("returns empty object when file contains invalid JSON", () => {
     // readJsonSafe is called by injectProviderConfig when reading openclaw.json.

--- a/packages/openclaw-plugin/src/local-mode.ts
+++ b/packages/openclaw-plugin/src/local-mode.ts
@@ -135,7 +135,37 @@ export function injectProviderConfig(
     logger.debug(`[manifest] Could not write openclaw.json: ${msg}`);
   }
 
-  // 2. Set runtime config for immediate availability
+  // 2. Remove stale manifest entries from per-agent models.json files.
+  //    OpenClaw caches models.json at startup (before plugins run), so
+  //    updating the file doesn't help for the current boot.  Removing the
+  //    entry forces the model resolver to fall through to the runtime
+  //    config (api.config.models.providers) which we set in step 3 below.
+  //    This also prevents cloud→local (or local→cloud) mode switches
+  //    from leaving a stale baseUrl behind.
+  try {
+    const agentsDir = join(OPENCLAW_DIR, "agents");
+    if (existsSync(agentsDir)) {
+      const agentDirs = readdirSync(agentsDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory());
+
+      for (const dir of agentDirs) {
+        const modelsPath = join(agentsDir, dir.name, "agent", "models.json");
+        if (!existsSync(modelsPath)) continue;
+
+        const data = readJsonSafe(modelsPath);
+        if (!data.providers?.manifest) continue;
+
+        delete data.providers.manifest;
+        atomicWriteJson(modelsPath, data);
+        logger.debug(`[manifest] Removed stale manifest entry from models.json for agent ${dir.name}`);
+      }
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.debug(`[manifest] Could not clean agent models.json: ${msg}`);
+  }
+
+  // 3. Set runtime config for immediate availability
   try {
     if (api.config) {
       if (!api.config.models) api.config.models = {};


### PR DESCRIPTION
  In local mode, if the API key in `~/.openclaw/manifest/config.json` is regenerated
  after initial bootstrap (e.g. plugin reinstall), the new key is never stored in
  `agent_api_keys`. OtlpAuthGuard hashes the new Bearer token, finds no match, and
  returns 401 on proxy/OTLP endpoints.

  **Changes:**
  - Move key registration outside the early return so it runs on every boot
  - Use `upsert` instead of `insert` to handle existing rows when the key changes
  - Added test for key reconciliation when tenant already exists