### PR TITLE
fix: show plugin version in local mode, hide in cloud mode

### DIFF
--- a/.changeset/fix-version-indicator.md
+++ b/.changeset/fix-version-indicator.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix version indicator: show plugin version in local mode, hide in cloud mode, fix upgrade command

--- a/packages/backend/src/health/health.controller.spec.ts
+++ b/packages/backend/src/health/health.controller.spec.ts
@@ -1,14 +1,10 @@
-jest.mock('fs', () => ({
-  readFileSync: jest.fn().mockReturnValue(JSON.stringify({ version: '1.2.3' })),
-}));
-
 import { HealthController } from './health.controller';
 import { VersionCheckService } from './version-check.service';
 
 function createMockVersionCheck(overrides: Partial<VersionCheckService> = {}): VersionCheckService {
   return {
     onModuleInit: jest.fn(),
-    getCurrentVersion: jest.fn().mockReturnValue('1.2.3'),
+    getCurrentVersion: jest.fn().mockReturnValue('5.20.0'),
     getUpdateInfo: jest.fn().mockReturnValue({}),
     isNewer: jest.fn().mockReturnValue(false),
     fetchLatestVersion: jest.fn().mockResolvedValue(null),
@@ -21,6 +17,7 @@ describe('HealthController', () => {
   let mockVersionCheck: VersionCheckService;
 
   beforeEach(() => {
+    delete process.env['MANIFEST_MODE'];
     mockVersionCheck = createMockVersionCheck();
     controller = new HealthController(mockVersionCheck);
   });
@@ -30,9 +27,16 @@ describe('HealthController', () => {
     expect(result.status).toBe('healthy');
   });
 
-  it('returns version from package.json', () => {
+  it('returns plugin version in local mode', () => {
+    process.env['MANIFEST_MODE'] = 'local';
     const result = controller.getHealth();
-    expect(result.version).toBe('1.2.3');
+    expect(result.version).toBe('5.20.0');
+  });
+
+  it('omits version in cloud mode', () => {
+    delete process.env['MANIFEST_MODE'];
+    const result = controller.getHealth();
+    expect(result).not.toHaveProperty('version');
   });
 
   it('returns uptime in seconds', () => {
@@ -48,11 +52,9 @@ describe('HealthController', () => {
   });
 
   it('returns local mode when MANIFEST_MODE=local', () => {
-    const orig = process.env['MANIFEST_MODE'];
     process.env['MANIFEST_MODE'] = 'local';
     const result = controller.getHealth();
     expect(result.mode).toBe('local');
-    process.env['MANIFEST_MODE'] = orig;
   });
 
   it('includes update info when available', () => {

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -1,10 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { Public } from '../common/decorators/public.decorator';
-import { readFileSync } from 'fs';
-import { join } from 'path';
 import { VersionCheckService } from './version-check.service';
-
-const pkg = JSON.parse(readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8')) as { version: string };
 
 @Controller('api/v1')
 export class HealthController {
@@ -15,12 +11,13 @@ export class HealthController {
   @Public()
   @Get('health')
   getHealth() {
+    const isLocal = process.env['MANIFEST_MODE'] === 'local';
     const optOut = process.env['MANIFEST_TELEMETRY_OPTOUT'];
     return {
       status: 'healthy',
       uptime_seconds: Math.floor((Date.now() - this.startTime) / 1000),
-      version: pkg.version,
-      mode: process.env['MANIFEST_MODE'] === 'local' ? 'local' : 'cloud',
+      ...(isLocal ? { version: this.versionCheck.getCurrentVersion() } : {}),
+      mode: isLocal ? 'local' : 'cloud',
       telemetryOptOut: optOut === '1' || optOut === 'true',
       ...this.versionCheck.getUpdateInfo(),
     };

--- a/packages/backend/test/health.e2e-spec.ts
+++ b/packages/backend/test/health.e2e-spec.ts
@@ -20,7 +20,7 @@ describe('GET /api/v1/health', () => {
 
     expect(res.body).toHaveProperty('status', 'healthy');
     expect(res.body).toHaveProperty('uptime_seconds');
-    expect(res.body).toHaveProperty('version', '0.1.0');
+    expect(res.body).toHaveProperty('version', '0.0.0');
     expect(typeof res.body.uptime_seconds).toBe('number');
   });
 });

--- a/packages/frontend/src/components/VersionIndicator.tsx
+++ b/packages/frontend/src/components/VersionIndicator.tsx
@@ -1,7 +1,7 @@
-import { createSignal, Show } from "solid-js";
-import { updateInfo } from "../services/local-mode.js";
+import { createSignal, Show } from 'solid-js';
+import { updateInfo } from '../services/local-mode.js';
 
-const UPGRADE_COMMAND = "openclaw plugins upgrade manifest";
+const UPGRADE_COMMAND = 'openclaw plugins update';
 
 const VersionIndicator = () => {
   const info = () => updateInfo();
@@ -9,27 +9,25 @@ const VersionIndicator = () => {
   const [copied, setCopied] = createSignal(false);
 
   function copyCommand() {
-    navigator.clipboard.writeText(UPGRADE_COMMAND).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }).catch(() => {});
+    navigator.clipboard
+      .writeText(UPGRADE_COMMAND)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
   }
 
   return (
     <Show when={info()}>
       <div
         class="version-indicator"
-        classList={{ "version-indicator--update": hasUpdate() }}
+        classList={{ 'version-indicator--update': hasUpdate() }}
         aria-label={
-          hasUpdate()
-            ? `Update available: v${info()!.latestVersion}`
-            : `Version ${info()!.version}`
+          hasUpdate() ? `Update available: v${info()!.latestVersion}` : `Version ${info()!.version}`
         }
       >
-        <Show
-          when={hasUpdate()}
-          fallback={<span>v{info()!.version}</span>}
-        >
+        <Show when={hasUpdate()} fallback={<span>v{info()!.version}</span>}>
           <div class="version-indicator__tooltip-wrap">
             <span>New version available</span>
             <div class="version-indicator__bubble" role="tooltip">
@@ -37,16 +35,14 @@ const VersionIndicator = () => {
                 v{info()!.version} &rarr; v{info()!.latestVersion}
               </span>
               <div class="version-indicator__command-row">
-                <code class="version-indicator__command">
-                  {UPGRADE_COMMAND}
-                </code>
+                <code class="version-indicator__command">{UPGRADE_COMMAND}</code>
                 <button
                   class="version-indicator__copy-btn"
                   onClick={copyCommand}
-                  title={copied() ? "Copied!" : "Copy command"}
+                  title={copied() ? 'Copied!' : 'Copy command'}
                   aria-label="Copy upgrade command"
                 >
-                  {copied() ? "\u2713" : "\u2398"}
+                  {copied() ? '\u2713' : '\u2398'}
                 </button>
               </div>
             </div>

--- a/packages/frontend/tests/components/VersionIndicator.test.tsx
+++ b/packages/frontend/tests/components/VersionIndicator.test.tsx
@@ -72,7 +72,7 @@ describe("VersionIndicator", () => {
     const { container } = render(() => <VersionIndicator />);
     const cmd = container.querySelector(".version-indicator__command");
     expect(cmd).not.toBeNull();
-    expect(cmd!.textContent).toContain("openclaw plugins upgrade manifest");
+    expect(cmd!.textContent).toContain("openclaw plugins update");
   });
 
   it("renders copy button in tooltip", () => {


### PR DESCRIPTION
## Summary

- **Cloud mode**: version badge no longer shows a meaningless `v0.1.0` (backend's private package version). The `version` field is omitted from the health endpoint, so the frontend renders nothing.
- **Local mode**: version badge now shows the actual plugin version from `MANIFEST_PACKAGE_VERSION` (e.g. `v5.20.0`) instead of the backend's `0.1.0`.
- **Upgrade command**: fixed tooltip from `openclaw plugins upgrade manifest` to `openclaw plugins update` (the actual CLI command).

## Test plan

- [x] Backend unit tests pass (1775 tests)
- [x] Backend e2e tests pass (86 tests)
- [x] Frontend tests pass (997 tests)
- [x] TypeScript compiles cleanly in both packages
- [x] Manual: local mode — version badge shows plugin version
- [x] Manual: cloud mode — no version badge appears