### PR TITLE
feat: add pagination to Messages and Model Prices

### DIFF
--- a/.changeset/loud-pillows-melt.md
+++ b/.changeset/loud-pillows-melt.md
@@ -1,2 +1,5 @@
 ---
+"manifest": minor
 ---
+
+Add pagination to Messages and Model Prices pages with shared Pagination component, cursor-based and client-side pagination primitives, filter empty state improvements, and unified provider icon system in filter bar

--- a/packages/frontend/src/components/ModelPricesFilterBar.tsx
+++ b/packages/frontend/src/components/ModelPricesFilterBar.tsx
@@ -1,4 +1,6 @@
-import { createSignal, createMemo, For, Show, onCleanup, type Component } from "solid-js";
+import { createSignal, createMemo, For, Show, onCleanup, type Component } from 'solid-js';
+import { resolveProviderId } from '../services/routing-utils.js';
+import { providerIcon } from './ProviderIcon.jsx';
 
 interface ModelPricesFilterBarProps {
   allModels: string[];
@@ -15,66 +17,53 @@ interface ModelPricesFilterBarProps {
 }
 
 interface Suggestion {
-  type: "Provider" | "Model";
+  type: 'Provider' | 'Model';
   value: string;
 }
 
 interface Tag {
-  type: "Provider" | "Model";
+  type: 'Provider' | 'Model';
   value: string;
 }
 
-/** Maps provider display names to icon filenames in /icons/providers/ */
-const providerIconMap: Record<string, string> = {
-  OpenAI: "openai",
-  Anthropic: "anthropic",
-  Google: "google",
-  DeepSeek: "deepseek",
-  Mistral: "mistral",
-  Meta: "meta",
-  Amazon: "amazon",
-  Alibaba: "alibaba",
-  Moonshot: "moonshot",
-  Zhipu: "zhipu",
-  Cohere: "cohere",
-  xAI: "xai",
-};
-
-/** Providers whose icons are monochrome (dark fill) and need inversion in dark mode */
-const monoProviders = new Set(["OpenAI", "Anthropic", "Moonshot", "xAI"]);
-
-const getProviderIconSrc = (provider: string): string | null => {
-  const key = providerIconMap[provider];
-  return key ? `/icons/providers/${key}.svg` : null;
-};
-
-const ProviderIcon: Component<{ provider: string; size?: number }> = (props) => {
-  const src = () => getProviderIconSrc(props.provider);
+const FilterProviderIcon: Component<{ provider: string; size?: number }> = (props) => {
   const size = () => props.size ?? 16;
-  const isMono = () => monoProviders.has(props.provider);
+  const id = () => resolveProviderId(props.provider);
+  const icon = () => {
+    const pid = id();
+    return pid ? providerIcon(pid, size()) : null;
+  };
 
   return (
-    <Show when={src()} fallback={
-      <svg class="model-filter__provider-icon" width={size()} height={size()} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <rect x="3" y="3" width="18" height="18" rx="3" />
-        <circle cx="12" cy="12" r="3" />
-      </svg>
-    }>
-      <img
-        class="model-filter__provider-icon"
-        classList={{ "model-filter__provider-icon--mono": isMono() }}
-        src={src()!}
-        alt=""
-        width={size()}
-        height={size()}
-        aria-hidden="true"
-      />
+    <Show
+      when={icon()}
+      fallback={
+        <svg
+          class="model-filter__provider-icon"
+          width={size()}
+          height={size()}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="3" y="3" width="18" height="18" rx="3" />
+          <circle cx="12" cy="12" r="3" />
+        </svg>
+      }
+    >
+      <span class="model-filter__provider-icon" aria-hidden="true">
+        {icon()}
+      </span>
     </Show>
   );
 };
 
 const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
-  const [query, setQuery] = createSignal("");
+  const [query, setQuery] = createSignal('');
   const [dropdownOpen, setDropdownOpen] = createSignal(false);
   const [highlightIndex, setHighlightIndex] = createSignal(-1);
   let comboboxRef: HTMLDivElement | undefined;
@@ -85,10 +74,10 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
   const activeTags = createMemo<Tag[]>(() => {
     const tags: Tag[] = [];
     for (const p of props.selectedProviders) {
-      tags.push({ type: "Provider", value: p });
+      tags.push({ type: 'Provider', value: p });
     }
     for (const m of props.selectedModels) {
-      tags.push({ type: "Model", value: m });
+      tags.push({ type: 'Model', value: m });
     }
     return tags;
   });
@@ -112,28 +101,28 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
   const flatSuggestions = createMemo<Suggestion[]>(() => {
     const suggestions: Suggestion[] = [];
     for (const p of matchingProviders()) {
-      suggestions.push({ type: "Provider", value: p });
+      suggestions.push({ type: 'Provider', value: p });
     }
     for (const m of matchingModels()) {
-      suggestions.push({ type: "Model", value: m });
+      suggestions.push({ type: 'Model', value: m });
     }
     return suggestions;
   });
 
   const selectSuggestion = (suggestion: Suggestion) => {
-    if (suggestion.type === "Provider") {
+    if (suggestion.type === 'Provider') {
       props.onAddProvider(suggestion.value);
     } else {
       props.onAddModel(suggestion.value);
     }
-    setQuery("");
+    setQuery('');
     setDropdownOpen(false);
     setHighlightIndex(-1);
     inputRef?.focus();
   };
 
   const removeTag = (tag: Tag) => {
-    if (tag.type === "Provider") {
+    if (tag.type === 'Provider') {
       props.onRemoveProvider(tag.value);
     } else {
       props.onRemoveModel(tag.value);
@@ -150,25 +139,25 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
   const handleKeyDown = (e: KeyboardEvent) => {
     const suggestions = flatSuggestions();
 
-    if (e.key === "ArrowDown") {
+    if (e.key === 'ArrowDown') {
       e.preventDefault();
       if (!dropdownOpen() && query().trim().length >= 2) {
         setDropdownOpen(true);
       }
       setHighlightIndex((i) => Math.min(i + 1, suggestions.length - 1));
-    } else if (e.key === "ArrowUp") {
+    } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setHighlightIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter") {
+    } else if (e.key === 'Enter') {
       e.preventDefault();
       const idx = highlightIndex();
       if (idx >= 0 && idx < suggestions.length) {
         selectSuggestion(suggestions[idx]!);
       }
-    } else if (e.key === "Escape") {
+    } else if (e.key === 'Escape') {
       setDropdownOpen(false);
       setHighlightIndex(-1);
-    } else if (e.key === "Backspace" && query() === "") {
+    } else if (e.key === 'Backspace' && query() === '') {
       const tags = activeTags();
       if (tags.length > 0) {
         removeTag(tags[tags.length - 1]!);
@@ -183,10 +172,10 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
     }
   };
 
-  if (typeof document !== "undefined") {
-    document.addEventListener("click", handleClickOutside);
+  if (typeof document !== 'undefined') {
+    document.addEventListener('click', handleClickOutside);
     onCleanup(() => {
-      document.removeEventListener("click", handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     });
   }
 
@@ -231,19 +220,24 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
                   <div class="model-filter__dropdown-label">Providers</div>
                   <For each={matchingProviders()}>
                     {(provider) => {
-                      const idx = () => flatSuggestions().findIndex((s) => s.type === "Provider" && s.value === provider);
+                      const idx = () =>
+                        flatSuggestions().findIndex(
+                          (s) => s.type === 'Provider' && s.value === provider,
+                        );
                       return (
                         <button
                           class="model-filter__dropdown-item"
-                          classList={{ "model-filter__dropdown-item--highlighted": highlightIndex() === idx() }}
-                          onClick={() => selectSuggestion({ type: "Provider", value: provider })}
+                          classList={{
+                            'model-filter__dropdown-item--highlighted': highlightIndex() === idx(),
+                          }}
+                          onClick={() => selectSuggestion({ type: 'Provider', value: provider })}
                           onMouseEnter={() => setHighlightIndex(idx())}
                           type="button"
                           role="option"
                           aria-selected={highlightIndex() === idx()}
                         >
                           <span class="model-filter__dropdown-item-name">
-                            <ProviderIcon provider={provider} size={16} />
+                            <FilterProviderIcon provider={provider} size={16} />
                             {provider}
                           </span>
                           <span class="model-filter__dropdown-item-type">Provider</span>
@@ -258,12 +252,15 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
                   <div class="model-filter__dropdown-label">Models</div>
                   <For each={matchingModels()}>
                     {(model) => {
-                      const idx = () => flatSuggestions().findIndex((s) => s.type === "Model" && s.value === model);
+                      const idx = () =>
+                        flatSuggestions().findIndex((s) => s.type === 'Model' && s.value === model);
                       return (
                         <button
                           class="model-filter__dropdown-item"
-                          classList={{ "model-filter__dropdown-item--highlighted": highlightIndex() === idx() }}
-                          onClick={() => selectSuggestion({ type: "Model", value: model })}
+                          classList={{
+                            'model-filter__dropdown-item--highlighted': highlightIndex() === idx(),
+                          }}
+                          onClick={() => selectSuggestion({ type: 'Model', value: model })}
                           onMouseEnter={() => setHighlightIndex(idx())}
                           type="button"
                           role="option"
@@ -281,13 +278,17 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
           </Show>
         </div>
         <div class="model-filter__summary">
-          <Show when={hasActiveFilters()} fallback={
-            <span>{props.totalCount} models</span>
-          }>
-            <span>{props.filteredCount} of {props.totalCount} models</span>
+          <Show when={hasActiveFilters()} fallback={<span>{props.totalCount} models</span>}>
+            <span>
+              {props.filteredCount} of {props.totalCount} models
+            </span>
             <button
               class="model-filter__clear-all"
-              onClick={() => { props.onClearFilters(); setQuery(""); setDropdownOpen(false); }}
+              onClick={() => {
+                props.onClearFilters();
+                setQuery('');
+                setDropdownOpen(false);
+              }}
               type="button"
             >
               Clear filters
@@ -299,11 +300,14 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
         <div class="model-filter__tags">
           <For each={activeTags()}>
             {(tag) => (
-              <span class="model-filter__tag" classList={{ "model-filter__tag--provider": tag.type === "Provider" }}>
-                <Show when={tag.type === "Provider"}>
-                  <ProviderIcon provider={tag.value} size={16} />
+              <span
+                class="model-filter__tag"
+                classList={{ 'model-filter__tag--provider': tag.type === 'Provider' }}
+              >
+                <Show when={tag.type === 'Provider'}>
+                  <FilterProviderIcon provider={tag.value} size={16} />
                 </Show>
-                <Show when={tag.type === "Model"}>
+                <Show when={tag.type === 'Model'}>
                   <span class="model-filter__tag-type">Model:</span>
                 </Show>
                 <span class="model-filter__tag-value">{tag.value}</span>
@@ -313,7 +317,17 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
                   type="button"
                   aria-label={`Remove ${tag.type} ${tag.value}`}
                 >
-                  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <svg
+                    width="10"
+                    height="10"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2.5"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
                     <path d="M18 6 6 18" />
                     <path d="m6 6 12 12" />
                   </svg>

--- a/packages/frontend/src/components/Pagination.tsx
+++ b/packages/frontend/src/components/Pagination.tsx
@@ -1,0 +1,45 @@
+import { Show, type Component, type Accessor } from 'solid-js';
+
+export interface PaginationProps {
+  currentPage: Accessor<number>;
+  totalItems: Accessor<number>;
+  pageSize: number;
+  hasNextPage: Accessor<boolean>;
+  isLoading?: Accessor<boolean>;
+  onPrevious: () => void;
+  onNext: () => void;
+}
+
+const Pagination: Component<PaginationProps> = (props) => {
+  const start = () => (props.currentPage() - 1) * props.pageSize + 1;
+  const end = () => Math.min(props.currentPage() * props.pageSize, props.totalItems());
+  const loading = () => props.isLoading?.() ?? false;
+
+  return (
+    <Show when={props.totalItems() > props.pageSize}>
+      <nav class="pagination" role="navigation" aria-label="Pagination">
+        <span class="pagination__summary">
+          Showing {start()}&ndash;{end()} of {props.totalItems()}
+        </span>
+        <div class="pagination__controls">
+          <button
+            class="btn btn--outline btn--sm pagination__btn"
+            disabled={props.currentPage() <= 1 || loading()}
+            onClick={props.onPrevious}
+          >
+            Previous
+          </button>
+          <button
+            class="btn btn--outline btn--sm pagination__btn"
+            disabled={!props.hasNextPage() || loading()}
+            onClick={props.onNext}
+          >
+            Next
+          </button>
+        </div>
+      </nav>
+    </Show>
+  );
+};
+
+export default Pagination;

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -1,17 +1,34 @@
-import { createSignal, createResource, Show, For, type Component } from "solid-js";
-import { A, useParams } from "@solidjs/router";
-import { Title, Meta } from "@solidjs/meta";
-import ErrorState from "../components/ErrorState.jsx";
-import { getMessages } from "../services/api.js";
-import { formatNumber, formatCost, formatErrorMessage, formatTime, formatStatus, formatDuration } from "../services/formatters.js";
-import { inferProviderFromModel, inferProviderName } from "../services/routing-utils.js";
-import { providerIcon } from "../components/ProviderIcon.jsx";
-import Select from "../components/Select.jsx";
-import InfoTooltip from "../components/InfoTooltip.jsx";
-import { isLocalMode } from "../services/local-mode.js";
-import { pingCount } from "../services/sse.js";
-import SetupModal from "../components/SetupModal.jsx";
-import "../styles/overview.css";
+import {
+  createSignal,
+  createResource,
+  createEffect,
+  on,
+  Show,
+  For,
+  type Component,
+} from 'solid-js';
+import { A, useParams } from '@solidjs/router';
+import { Title, Meta } from '@solidjs/meta';
+import ErrorState from '../components/ErrorState.jsx';
+import Pagination from '../components/Pagination.jsx';
+import { getMessages } from '../services/api.js';
+import {
+  formatNumber,
+  formatCost,
+  formatErrorMessage,
+  formatTime,
+  formatStatus,
+  formatDuration,
+} from '../services/formatters.js';
+import { inferProviderFromModel, inferProviderName } from '../services/routing-utils.js';
+import { providerIcon } from '../components/ProviderIcon.jsx';
+import Select from '../components/Select.jsx';
+import InfoTooltip from '../components/InfoTooltip.jsx';
+import { isLocalMode } from '../services/local-mode.js';
+import { pingCount } from '../services/sse.js';
+import SetupModal from '../components/SetupModal.jsx';
+import { createCursorPagination } from '../services/cursor-pagination.js';
+import '../styles/overview.css';
 
 interface MessageItem {
   id: string;
@@ -40,17 +57,33 @@ interface MessagesData {
 
 const MessageLog: Component = () => {
   const params = useParams<{ agentName: string }>();
-  const [statusFilter, setStatusFilter] = createSignal("");
-  const [modelFilter, setModelFilter] = createSignal("");
-  const [costMin, setCostMin] = createSignal("");
-  const [costMax, setCostMax] = createSignal("");
+  const [statusFilter, setStatusFilter] = createSignal('');
+  const [modelFilter, setModelFilter] = createSignal('');
+  const [costMin, setCostMin] = createSignal('');
+  const [costMax, setCostMax] = createSignal('');
   const [setupOpen, setSetupOpen] = createSignal(false);
   const [setupCompleted] = createSignal(
     !!localStorage.getItem(`setup_completed_${params.agentName}`) ||
-    (isLocalMode() === true && params.agentName === 'local-agent')
+      (isLocalMode() === true && params.agentName === 'local-agent'),
   );
+
+  const pager = createCursorPagination(50);
+
+  createEffect(
+    on([statusFilter, modelFilter, costMin, costMax], () => pager.resetPage(), { defer: true }),
+  );
+
   const [data, { refetch }] = createResource(
-    () => ({ status: statusFilter(), model: modelFilter(), costMin: costMin(), costMax: costMax(), agentName: params.agentName, _ping: pingCount() }),
+    () => ({
+      status: statusFilter(),
+      model: modelFilter(),
+      costMin: costMin(),
+      costMax: costMax(),
+      agentName: params.agentName,
+      _ping: pingCount(),
+      cursor: pager.currentCursor(),
+      limit: pager.pageSize,
+    }),
     (p) => {
       const q: Record<string, string> = {};
       if (p.status) q.status = p.status;
@@ -58,42 +91,71 @@ const MessageLog: Component = () => {
       if (p.costMin) q.cost_min = p.costMin;
       if (p.costMax) q.cost_max = p.costMax;
       if (p.agentName) q.agent_name = p.agentName;
+      if (p.cursor) q.cursor = p.cursor;
+      q.limit = String(p.limit);
       return getMessages(q) as Promise<MessagesData>;
     },
   );
+
+  createEffect(
+    on(
+      () => data(),
+      (d) => {
+        if (d) pager.recordResponse(d.next_cursor);
+      },
+    ),
+  );
+
+  const hasActiveFilters = () =>
+    statusFilter() !== '' || modelFilter() !== '' || costMin() !== '' || costMax() !== '';
 
   const hasNoData = () => {
     const d = data();
     return d && d.total_count === 0;
   };
 
+  const isFilteredEmpty = () => hasNoData() && hasActiveFilters();
+  const isAgentEmpty = () => hasNoData() && !hasActiveFilters();
+
+  const clearFilters = () => {
+    setStatusFilter('');
+    setModelFilter('');
+    setCostMin('');
+    setCostMax('');
+  };
+
   return (
     <div class="container--full">
       <Title>{decodeURIComponent(params.agentName)} Messages - Manifest</Title>
-      <Meta name="description" content={`Browse all messages sent and received by ${decodeURIComponent(params.agentName)}. Filter by status, model, or cost.`} />
+      <Meta
+        name="description"
+        content={`Browse all messages sent and received by ${decodeURIComponent(params.agentName)}. Filter by status, model, or cost.`}
+      />
       <div class="page-header">
         <div>
           <h1>Messages</h1>
-          <span class="breadcrumb">Full log of every LLM call &mdash; filter by status, model, or cost</span>
+          <span class="breadcrumb">
+            Full log of every LLM call &mdash; filter by status, model, or cost
+          </span>
         </div>
         <div class="header-controls">
-          <Show when={!hasNoData()}>
+          <Show when={!isAgentEmpty()}>
             <Select
               value={statusFilter()}
               onChange={setStatusFilter}
               options={[
-                { label: "All statuses", value: "" },
-                { label: "Successful", value: "ok" },
-                { label: "Rate Limited", value: "rate_limited" },
-                { label: "Retried", value: "retry" },
-                { label: "Failed", value: "error" },
+                { label: 'All statuses', value: '' },
+                { label: 'Successful', value: 'ok' },
+                { label: 'Rate Limited', value: 'rate_limited' },
+                { label: 'Retried', value: 'retry' },
+                { label: 'Failed', value: 'error' },
               ]}
             />
             <Select
               value={modelFilter()}
               onChange={setModelFilter}
               options={[
-                { label: "All models", value: "" },
+                { label: 'All models', value: '' },
                 ...(data()?.models ?? []).map((m) => ({ label: m, value: m })),
               ]}
             />
@@ -119,7 +181,13 @@ const MessageLog: Component = () => {
               />
             </div>
           </Show>
-          <Show when={hasNoData() && !(isLocalMode() && params.agentName === 'local-agent') && !setupCompleted()}>
+          <Show
+            when={
+              isAgentEmpty() &&
+              !(isLocalMode() && params.agentName === 'local-agent') &&
+              !setupCompleted()
+            }
+          >
             <button class="btn btn--primary" onClick={() => setSetupOpen(true)}>
               Set up agent
             </button>
@@ -127,178 +195,289 @@ const MessageLog: Component = () => {
         </div>
       </div>
 
-      <Show when={!data.loading} fallback={
-        <div class="panel">
-          <div class="skeleton skeleton--text" style="width: 120px; height: 16px; margin-bottom: 16px;" />
-          <For each={[1, 2, 3, 4, 5, 6, 7, 8]}>
-            {() => (
-              <div style="display: flex; gap: 16px; padding: 12px 0; border-bottom: 1px solid hsl(var(--border));">
-                <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 70px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 40px; height: 14px;" />
-              </div>
-            )}
-          </For>
-        </div>
-      }>
-        <Show when={!data.error} fallback={
-          <ErrorState error={data.error} onRetry={refetch} />
-        }>
-        <Show when={!hasNoData()} fallback={
-          <Show when={(isLocalMode() && params.agentName === 'local-agent') || setupCompleted()} fallback={
-            <div class="empty-state">
-              <div class="empty-state__title">No messages recorded</div>
-              <p>Connect your agent to Manifest and send your first message. Each LLM call will be logged here with its cost, tokens, and status.</p>
-              <button class="btn btn--primary" style="margin-top: var(--gap-md);" onClick={() => setSetupOpen(true)}>
-                Set up agent
-              </button>
-              <div class="empty-state__img-wrapper">
-                <img src="/example-messages.svg" alt="" class="empty-state__img" />
-              </div>
-            </div>
-          }>
-            <div class="waiting-banner">
-              <i class="bxd bx-florist" />
-              <p>Waiting for data &mdash; messages will appear within seconds of your agent's first LLM call.</p>
-            </div>
-            <div class="demo-dashboard">
-              <div class="panel">
-                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
-                  <div class="panel__title" style="margin-bottom: 0;">Messages</div>
-                  <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                    0 total
-                  </span>
+      <Show
+        when={!data.loading}
+        fallback={
+          <div class="panel">
+            <div
+              class="skeleton skeleton--text"
+              style="width: 120px; height: 16px; margin-bottom: 16px;"
+            />
+            <For each={[1, 2, 3, 4, 5, 6, 7, 8]}>
+              {() => (
+                <div style="display: flex; gap: 16px; padding: 12px 0; border-bottom: 1px solid hsl(var(--border));">
+                  <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 70px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 40px; height: 14px;" />
                 </div>
-                <table class="data-table">
-                  <thead>
-                    <tr>
-                      <th>Date</th>
-                      <th>Message</th>
-                      <th>Cost</th>
-                      <th>Total Tokens</th>
-                      <th>Input</th>
-                      <th>Output</th>
-                      <th>Model</th>
-                      <th>Cache</th>
-                      <th>Duration</th>
-                      <th>Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td colspan="10" style="text-align: center; color: hsl(var(--muted-foreground)); padding: var(--gap-lg);">
-                        Messages will appear here
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
+              )}
+            </For>
+          </div>
+        }
+      >
+        <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
+          <Show when={isAgentEmpty()}>
+            <Show
+              when={(isLocalMode() && params.agentName === 'local-agent') || setupCompleted()}
+              fallback={
+                <div class="empty-state">
+                  <div class="empty-state__title">No messages recorded</div>
+                  <p>
+                    Connect your agent to Manifest and send your first message. Each LLM call will
+                    be logged here with its cost, tokens, and status.
+                  </p>
+                  <button
+                    class="btn btn--primary"
+                    style="margin-top: var(--gap-md);"
+                    onClick={() => setSetupOpen(true)}
+                  >
+                    Set up agent
+                  </button>
+                  <div class="empty-state__img-wrapper">
+                    <img src="/example-messages.svg" alt="" class="empty-state__img" />
+                  </div>
+                </div>
+              }
+            >
+              <div class="waiting-banner">
+                <i class="bxd bx-florist" />
+                <p>
+                  Waiting for data &mdash; messages will appear within seconds of your agent's first
+                  LLM call.
+                </p>
+              </div>
+              <div class="demo-dashboard">
+                <div class="panel">
+                  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
+                    <div class="panel__title" style="margin-bottom: 0;">
+                      Messages
+                    </div>
+                    <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                      0 total
+                    </span>
+                  </div>
+                  <table class="data-table">
+                    <thead>
+                      <tr>
+                        <th>Date</th>
+                        <th>Message</th>
+                        <th>Cost</th>
+                        <th>Total Tokens</th>
+                        <th>Input</th>
+                        <th>Output</th>
+                        <th>Model</th>
+                        <th>Cache</th>
+                        <th>Duration</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td
+                          colspan="10"
+                          style="text-align: center; color: hsl(var(--muted-foreground)); padding: var(--gap-lg);"
+                        >
+                          Messages will appear here
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </Show>
+          </Show>
+          <Show when={isFilteredEmpty()}>
+            <div class="panel">
+              <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
+                <div class="panel__title" style="margin-bottom: 0;">
+                  Messages
+                </div>
+                <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                  0 results
+                </span>
+              </div>
+              <div class="model-filter__empty">
+                <p class="model-filter__empty-title">No messages match your filters</p>
+                <p class="model-filter__empty-hint">
+                  Try adjusting your status, model, or cost filters to see more results.
+                </p>
+                <button class="btn btn--outline" onClick={clearFilters} type="button">
+                  Clear filters
+                </button>
               </div>
             </div>
           </Show>
-        }>
-          <div class="panel">
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
-              <div class="panel__title" style="margin-bottom: 0;">Messages</div>
-              <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                {data()!.total_count} total
-              </span>
-            </div>
-            <table class="data-table">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Message</th>
-                  <th>Cost</th>
-                  <th>Total Tokens<InfoTooltip text="Tokens are units of text that AI models process. More tokens = higher cost." /></th>
-                  <th>Input<InfoTooltip text="Tokens sent to the model (your prompt). Also called 'input tokens'." /></th>
-                  <th>Output<InfoTooltip text="Tokens returned by the model (its response). Also called 'output tokens'." /></th>
-                  <th>Model</th>
-                  <th>Cache</th>
-                  <th>Duration</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                <For each={data()?.items}>
-                  {(item) => (
-                    <tr>
-                      <td style="white-space: nowrap; font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                        {formatTime(item.timestamp)}
-                      </td>
-                      <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                        {item.id.slice(0, 8)}
-                        {item.routing_reason === 'heartbeat' && (
-                          <span title="Heartbeat" style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                              <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-                            </svg>
-                          </span>
-                        )}
-                      </td>
-                      <td style="font-family: var(--font-mono);" title={item.cost != null && item.cost > 0 && item.cost < 0.01 ? `$${item.cost.toFixed(6)}` : undefined}>
-                        {item.cost != null ? (formatCost(item.cost) ?? "\u2014") : "\u2014"}
-                      </td>
-                      <td style="font-family: var(--font-mono);">
-                        {item.total_tokens != null ? formatNumber(item.total_tokens) : "\u2014"}
-                      </td>
-                      <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                        {item.input_tokens != null ? formatNumber(item.input_tokens) : "\u2014"}
-                      </td>
-                      <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                        {item.output_tokens != null ? formatNumber(item.output_tokens) : "\u2014"}
-                      </td>
-                      <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                        <span style="display: inline-flex; align-items: center; gap: 4px;">
-                          {item.model && inferProviderFromModel(item.model) && (
-                            <span title={inferProviderName(item.model)} style="display: inline-flex; flex-shrink: 0;">{providerIcon(inferProviderFromModel(item.model)!, 14)}</span>
-                          )}
-                          {item.model ?? "\u2014"}
-                          {item.routing_tier && <span class={`tier-badge tier-badge--${item.routing_tier}`}>{item.routing_tier}</span>}
-                        </span>
-                      </td>
-                      <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                        {(item.cache_read_tokens ?? 0) > 0 || (item.cache_creation_tokens ?? 0) > 0
-                          ? `Read: ${formatNumber(item.cache_read_tokens ?? 0)} / Write: ${formatNumber(item.cache_creation_tokens ?? 0)}`
-                          : "\u2014"}
-                      </td>
-                      <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                        {item.duration_ms != null ? formatDuration(item.duration_ms) : "\u2014"}
-                      </td>
-                      <td>
-                        <Show when={item.error_message}
-                          fallback={
-                            <span class={`status-badge status-badge--${item.status}`}>
-                              {item.status === 'rate_limited'
-                                ? <A href={`/agents/${encodeURIComponent(params.agentName)}/limits`}>{formatStatus(item.status)}</A>
-                                : formatStatus(item.status)}
+          <Show when={!hasNoData()}>
+            <div class="panel">
+              <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
+                <div class="panel__title" style="margin-bottom: 0;">
+                  Messages
+                </div>
+                <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                  {data()!.total_count} total
+                </span>
+              </div>
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Message</th>
+                    <th>Cost</th>
+                    <th>
+                      Total Tokens
+                      <InfoTooltip text="Tokens are units of text that AI models process. More tokens = higher cost." />
+                    </th>
+                    <th>
+                      Input
+                      <InfoTooltip text="Tokens sent to the model (your prompt). Also called 'input tokens'." />
+                    </th>
+                    <th>
+                      Output
+                      <InfoTooltip text="Tokens returned by the model (its response). Also called 'output tokens'." />
+                    </th>
+                    <th>Model</th>
+                    <th>Cache</th>
+                    <th>Duration</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={data()?.items}>
+                    {(item) => (
+                      <tr>
+                        <td style="white-space: nowrap; font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                          {formatTime(item.timestamp)}
+                        </td>
+                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                          {item.id.slice(0, 8)}
+                          {item.routing_reason === 'heartbeat' && (
+                            <span
+                              title="Heartbeat"
+                              style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;"
+                            >
+                              <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                width="12"
+                                height="12"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                              >
+                                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+                              </svg>
                             </span>
+                          )}
+                        </td>
+                        <td
+                          style="font-family: var(--font-mono);"
+                          title={
+                            item.cost != null && item.cost > 0 && item.cost < 0.01
+                              ? `$${item.cost.toFixed(6)}`
+                              : undefined
                           }
                         >
-                          <span class="status-badge-tooltip" tabindex="0" role="note"
-                                aria-label={formatErrorMessage(item.error_message!)}>
-                            <span class={`status-badge status-badge--${item.status}`}>
-                              {formatStatus(item.status)}
-                            </span>
-                            <span class="status-badge-tooltip__bubble">{formatErrorMessage(item.error_message!)}</span>
+                          {item.cost != null ? (formatCost(item.cost) ?? '\u2014') : '\u2014'}
+                        </td>
+                        <td style="font-family: var(--font-mono);">
+                          {item.total_tokens != null ? formatNumber(item.total_tokens) : '\u2014'}
+                        </td>
+                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                          {item.input_tokens != null ? formatNumber(item.input_tokens) : '\u2014'}
+                        </td>
+                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                          {item.output_tokens != null ? formatNumber(item.output_tokens) : '\u2014'}
+                        </td>
+                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                          <span style="display: inline-flex; align-items: center; gap: 4px;">
+                            {item.model && inferProviderFromModel(item.model) && (
+                              <span
+                                title={inferProviderName(item.model)}
+                                style="display: inline-flex; flex-shrink: 0;"
+                              >
+                                {providerIcon(inferProviderFromModel(item.model)!, 14)}
+                              </span>
+                            )}
+                            {item.model ?? '\u2014'}
+                            {item.routing_tier && (
+                              <span class={`tier-badge tier-badge--${item.routing_tier}`}>
+                                {item.routing_tier}
+                              </span>
+                            )}
                           </span>
-                        </Show>
-                      </td>
-                    </tr>
-                  )}
-                </For>
-              </tbody>
-            </table>
-          </div>
-        </Show>
+                        </td>
+                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                          {(item.cache_read_tokens ?? 0) > 0 ||
+                          (item.cache_creation_tokens ?? 0) > 0
+                            ? `Read: ${formatNumber(item.cache_read_tokens ?? 0)} / Write: ${formatNumber(item.cache_creation_tokens ?? 0)}`
+                            : '\u2014'}
+                        </td>
+                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                          {item.duration_ms != null ? formatDuration(item.duration_ms) : '\u2014'}
+                        </td>
+                        <td>
+                          <Show
+                            when={item.error_message}
+                            fallback={
+                              <span class={`status-badge status-badge--${item.status}`}>
+                                {item.status === 'rate_limited' ? (
+                                  <A
+                                    href={`/agents/${encodeURIComponent(params.agentName)}/limits`}
+                                  >
+                                    {formatStatus(item.status)}
+                                  </A>
+                                ) : (
+                                  formatStatus(item.status)
+                                )}
+                              </span>
+                            }
+                          >
+                            <span
+                              class="status-badge-tooltip"
+                              tabindex="0"
+                              role="note"
+                              aria-label={formatErrorMessage(item.error_message!)}
+                            >
+                              <span class={`status-badge status-badge--${item.status}`}>
+                                {formatStatus(item.status)}
+                              </span>
+                              <span class="status-badge-tooltip__bubble">
+                                {formatErrorMessage(item.error_message!)}
+                              </span>
+                            </span>
+                          </Show>
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+              <Pagination
+                currentPage={pager.currentPage}
+                totalItems={() => data()?.total_count ?? 0}
+                pageSize={pager.pageSize}
+                hasNextPage={pager.hasNextPage}
+                isLoading={() => data.loading}
+                onPrevious={pager.previousPage}
+                onNext={pager.nextPage}
+              />
+            </div>
+          </Show>
         </Show>
       </Show>
 
-      <SetupModal open={setupOpen()} agentName={decodeURIComponent(params.agentName)} onClose={() => setSetupOpen(false)} />
+      <SetupModal
+        open={setupOpen()}
+        agentName={decodeURIComponent(params.agentName)}
+        onClose={() => setSetupOpen(false)}
+      />
     </div>
   );
 };

--- a/packages/frontend/src/pages/ModelPrices.tsx
+++ b/packages/frontend/src/pages/ModelPrices.tsx
@@ -1,9 +1,20 @@
-import { createSignal, createResource, Show, For, createMemo, type Component } from "solid-js";
-import { Title, Meta } from "@solidjs/meta";
-import ErrorState from "../components/ErrorState.jsx";
-import InfoTooltip from "../components/InfoTooltip.jsx";
-import ModelPricesFilterBar from "../components/ModelPricesFilterBar.jsx";
-import { getModelPrices } from "../services/api.js";
+import {
+  createSignal,
+  createResource,
+  createEffect,
+  on,
+  Show,
+  For,
+  createMemo,
+  type Component,
+} from 'solid-js';
+import { Title, Meta } from '@solidjs/meta';
+import ErrorState from '../components/ErrorState.jsx';
+import InfoTooltip from '../components/InfoTooltip.jsx';
+import ModelPricesFilterBar from '../components/ModelPricesFilterBar.jsx';
+import Pagination from '../components/Pagination.jsx';
+import { getModelPrices } from '../services/api.js';
+import { createClientPagination } from '../services/pagination.js';
 
 interface ModelPrice {
   model_name: string;
@@ -17,8 +28,8 @@ interface ModelPricesData {
   lastSyncedAt: string | null;
 }
 
-type SortKey = "model_name" | "provider" | "input_price_per_million" | "output_price_per_million";
-type SortDir = "asc" | "desc";
+type SortKey = 'model_name' | 'provider' | 'input_price_per_million' | 'output_price_per_million';
+type SortDir = 'asc' | 'desc';
 
 function formatPrice(price: number): string {
   if (price < 0.01) return `$${price.toFixed(4)}`;
@@ -28,17 +39,17 @@ function formatPrice(price: number): string {
 
 const ModelPrices: Component = () => {
   const [data, { refetch }] = createResource(() => getModelPrices() as Promise<ModelPricesData>);
-  const [sortKey, setSortKey] = createSignal<SortKey>("provider");
-  const [sortDir, setSortDir] = createSignal<SortDir>("asc");
+  const [sortKey, setSortKey] = createSignal<SortKey>('provider');
+  const [sortDir, setSortDir] = createSignal<SortDir>('asc');
   const [selectedModels, setSelectedModels] = createSignal<Set<string>>(new Set());
   const [selectedProviders, setSelectedProviders] = createSignal<Set<string>>(new Set());
 
   const handleSort = (key: SortKey) => {
     if (sortKey() === key) {
-      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
     } else {
       setSortKey(key);
-      setSortDir("asc");
+      setSortDir('asc');
     }
   };
 
@@ -77,16 +88,24 @@ const ModelPrices: Component = () => {
     return [...models].sort((a, b) => {
       const av = a[key];
       const bv = b[key];
-      if (typeof av === "string" && typeof bv === "string") {
-        return dir === "asc" ? av.localeCompare(bv) : bv.localeCompare(av);
+      if (typeof av === 'string' && typeof bv === 'string') {
+        return dir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
       }
-      return dir === "asc" ? (av as number) - (bv as number) : (bv as number) - (av as number);
+      return dir === 'asc' ? (av as number) - (bv as number) : (bv as number) - (av as number);
     });
   });
 
+  const pager = createClientPagination(sortedModels, 25);
+
+  createEffect(
+    on([selectedModels, selectedProviders, sortKey, sortDir], () => pager.resetPage(), {
+      defer: true,
+    }),
+  );
+
   const indicator = (key: SortKey) => {
-    if (sortKey() !== key) return "";
-    return sortDir() === "asc" ? " \u25B2" : " \u25BC";
+    if (sortKey() !== key) return '';
+    return sortDir() === 'asc' ? ' \u25B2' : ' \u25BC';
   };
 
   const addModel = (model: string) => {
@@ -127,25 +146,30 @@ const ModelPrices: Component = () => {
   };
 
   const formatSyncTime = (ts: string | null) => {
-    if (!ts) return "Never";
+    if (!ts) return 'Never';
     const d = new Date(ts);
-    return d.toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
+    return d.toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
     });
   };
 
   return (
     <div class="container--full">
       <Title>Model Prices - Manifest</Title>
-      <Meta name="description" content="Compare per-token pricing across all major LLM providers." />
+      <Meta
+        name="description"
+        content="Compare per-token pricing across all major LLM providers."
+      />
       <div class="page-header">
         <div>
           <h1>Model Prices</h1>
-          <span class="breadcrumb">Compare per-token pricing across all supported LLM providers and models</span>
+          <span class="breadcrumb">
+            Compare per-token pricing across all supported LLM providers and models
+          </span>
         </div>
         <Show when={data()?.lastSyncedAt}>
           <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
@@ -154,87 +178,111 @@ const ModelPrices: Component = () => {
         </Show>
       </div>
 
-      <Show when={!data.loading} fallback={
-        <div class="panel">
-          <div class="skeleton skeleton--text" style="width: 120px; height: 16px; margin-bottom: 16px;" />
-          <For each={[1, 2, 3, 4, 5, 6, 7, 8]}>
-            {() => (
-              <div style="display: flex; gap: 16px; padding: 12px 0; border-bottom: 1px solid hsl(var(--border));">
-                <div class="skeleton skeleton--text" style="width: 200px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 100px; height: 14px;" />
-                <div class="skeleton skeleton--text" style="width: 100px; height: 14px;" />
-              </div>
-            )}
-          </For>
-        </div>
-      }>
-        <Show when={!data.error} fallback={
-          <ErrorState error={data.error} onRetry={refetch} />
-        }>
-        <div class="panel">
-          <ModelPricesFilterBar
-            allModels={allModelNames()}
-            allProviders={allProviders()}
-            selectedModels={selectedModels()}
-            selectedProviders={selectedProviders()}
-            onAddModel={addModel}
-            onRemoveModel={removeModel}
-            onAddProvider={addProvider}
-            onRemoveProvider={removeProvider}
-            onClearFilters={clearFilters}
-            totalCount={data()?.models?.length ?? 0}
-            filteredCount={filteredModels().length}
-          />
-          <Show when={sortedModels().length > 0} fallback={
-            <div class="model-filter__empty">
-              <p class="model-filter__empty-title">No models match your filters</p>
-              <p class="model-filter__empty-hint">Try selecting a different provider or model, or clear all filters to see every model.</p>
-              <button class="btn btn--outline" onClick={clearFilters} type="button">
-                Clear filters
-              </button>
-            </div>
-          }>
-            <table class="data-table">
-              <thead>
-                <tr>
-                  <th class="data-table__sortable" onClick={() => handleSort("model_name")}>
-                    Model{indicator("model_name")}
-                  </th>
-                  <th class="data-table__sortable" onClick={() => handleSort("provider")}>
-                    Provider{indicator("provider")}
-                  </th>
-                  <th class="data-table__sortable" onClick={() => handleSort("input_price_per_million")}>
-                    Cost to send / 1M tokens{indicator("input_price_per_million")}
-                    <InfoTooltip text="Tokens are small chunks of text. Send cost is what you pay for the input you give the model." />
-                  </th>
-                  <th class="data-table__sortable" onClick={() => handleSort("output_price_per_million")}>
-                    Cost to receive / 1M tokens{indicator("output_price_per_million")}
-                    <InfoTooltip text="Tokens are small chunks of text. Receive cost is what you pay for the output the model returns." />
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <For each={sortedModels()}>
-                  {(model) => (
-                    <tr>
-                      <td style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
-                        {model.model_name}
-                      </td>
-                      <td>{model.provider}</td>
-                      <td style="font-family: var(--font-mono);">
-                        {formatPrice(model.input_price_per_million)}
-                      </td>
-                      <td style="font-family: var(--font-mono);">
-                        {formatPrice(model.output_price_per_million)}
-                      </td>
-                    </tr>
-                  )}
-                </For>
-              </tbody>
-            </table>
-          </Show>
-        </div>
+      <Show
+        when={!data.loading}
+        fallback={
+          <div class="panel">
+            <div
+              class="skeleton skeleton--text"
+              style="width: 120px; height: 16px; margin-bottom: 16px;"
+            />
+            <For each={[1, 2, 3, 4, 5, 6, 7, 8]}>
+              {() => (
+                <div style="display: flex; gap: 16px; padding: 12px 0; border-bottom: 1px solid hsl(var(--border));">
+                  <div class="skeleton skeleton--text" style="width: 200px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 100px; height: 14px;" />
+                  <div class="skeleton skeleton--text" style="width: 100px; height: 14px;" />
+                </div>
+              )}
+            </For>
+          </div>
+        }
+      >
+        <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
+          <div class="panel">
+            <ModelPricesFilterBar
+              allModels={allModelNames()}
+              allProviders={allProviders()}
+              selectedModels={selectedModels()}
+              selectedProviders={selectedProviders()}
+              onAddModel={addModel}
+              onRemoveModel={removeModel}
+              onAddProvider={addProvider}
+              onRemoveProvider={removeProvider}
+              onClearFilters={clearFilters}
+              totalCount={data()?.models?.length ?? 0}
+              filteredCount={filteredModels().length}
+            />
+            <Show
+              when={pager.totalItems() > 0}
+              fallback={
+                <div class="model-filter__empty">
+                  <p class="model-filter__empty-title">No models match your filters</p>
+                  <p class="model-filter__empty-hint">
+                    Try selecting a different provider or model, or clear all filters to see every
+                    model.
+                  </p>
+                  <button class="btn btn--outline" onClick={clearFilters} type="button">
+                    Clear filters
+                  </button>
+                </div>
+              }
+            >
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th class="data-table__sortable" onClick={() => handleSort('model_name')}>
+                      Model{indicator('model_name')}
+                    </th>
+                    <th class="data-table__sortable" onClick={() => handleSort('provider')}>
+                      Provider{indicator('provider')}
+                    </th>
+                    <th
+                      class="data-table__sortable"
+                      onClick={() => handleSort('input_price_per_million')}
+                    >
+                      Cost to send / 1M tokens{indicator('input_price_per_million')}
+                      <InfoTooltip text="Tokens are small chunks of text. Send cost is what you pay for the input you give the model." />
+                    </th>
+                    <th
+                      class="data-table__sortable"
+                      onClick={() => handleSort('output_price_per_million')}
+                    >
+                      Cost to receive / 1M tokens{indicator('output_price_per_million')}
+                      <InfoTooltip text="Tokens are small chunks of text. Receive cost is what you pay for the output the model returns." />
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={pager.pageItems()}>
+                    {(model) => (
+                      <tr>
+                        <td style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
+                          {model.model_name}
+                        </td>
+                        <td>{model.provider}</td>
+                        <td style="font-family: var(--font-mono);">
+                          {formatPrice(model.input_price_per_million)}
+                        </td>
+                        <td style="font-family: var(--font-mono);">
+                          {formatPrice(model.output_price_per_million)}
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+              <Pagination
+                currentPage={pager.currentPage}
+                totalItems={pager.totalItems}
+                pageSize={pager.pageSize}
+                hasNextPage={pager.hasNextPage}
+                onPrevious={pager.previousPage}
+                onNext={pager.nextPage}
+              />
+            </Show>
+          </div>
         </Show>
       </Show>
     </div>

--- a/packages/frontend/src/services/cursor-pagination.ts
+++ b/packages/frontend/src/services/cursor-pagination.ts
@@ -1,0 +1,63 @@
+import { createSignal, createMemo, type Accessor } from 'solid-js';
+
+export interface CursorPagination {
+  currentPage: Accessor<number>;
+  currentCursor: Accessor<string | undefined>;
+  hasNextPage: Accessor<boolean>;
+  previousPage: () => void;
+  nextPage: () => void;
+  recordResponse: (nextCursor: string | null | undefined) => void;
+  resetPage: () => void;
+  pageSize: number;
+}
+
+export function createCursorPagination(pageSize = 50): CursorPagination {
+  const [cursorStack, setCursorStack] = createSignal<(string | undefined)[]>([undefined]);
+  const [pageIndex, setPageIndex] = createSignal(0);
+  const [nextCursorAvailable, setNextCursorAvailable] = createSignal(false);
+
+  const currentPage = createMemo(() => pageIndex() + 1);
+  const currentCursor = createMemo(() => cursorStack()[pageIndex()]);
+  const hasNextPage = createMemo(() => nextCursorAvailable());
+
+  function recordResponse(nextCursor: string | null | undefined) {
+    if (nextCursor) {
+      setNextCursorAvailable(true);
+      setCursorStack((stack) => {
+        const nextIdx = pageIndex() + 1;
+        const copy = [...stack];
+        copy[nextIdx] = nextCursor;
+        return copy;
+      });
+    } else {
+      setNextCursorAvailable(false);
+    }
+  }
+
+  function nextPage() {
+    if (!nextCursorAvailable()) return;
+    setPageIndex((i) => i + 1);
+  }
+
+  function previousPage() {
+    if (pageIndex() <= 0) return;
+    setPageIndex((i) => i - 1);
+  }
+
+  function resetPage() {
+    setCursorStack([undefined]);
+    setPageIndex(0);
+    setNextCursorAvailable(false);
+  }
+
+  return {
+    currentPage,
+    currentCursor,
+    hasNextPage,
+    previousPage,
+    nextPage,
+    recordResponse,
+    resetPage,
+    pageSize,
+  };
+}

--- a/packages/frontend/src/services/pagination.ts
+++ b/packages/frontend/src/services/pagination.ts
@@ -1,0 +1,48 @@
+import { createSignal, createMemo, type Accessor } from 'solid-js';
+
+export interface ClientPagination<T> {
+  currentPage: Accessor<number>;
+  pageItems: Accessor<T[]>;
+  totalItems: Accessor<number>;
+  totalPages: Accessor<number>;
+  hasNextPage: Accessor<boolean>;
+  previousPage: () => void;
+  nextPage: () => void;
+  resetPage: () => void;
+  pageSize: number;
+}
+
+export function createClientPagination<T>(
+  items: Accessor<T[]>,
+  pageSize = 25,
+): ClientPagination<T> {
+  const [rawPage, setRawPage] = createSignal(1);
+
+  const totalItems = createMemo(() => items().length);
+  const totalPages = createMemo(() => Math.max(1, Math.ceil(totalItems() / pageSize)));
+
+  const safePage = createMemo(() => {
+    const p = rawPage();
+    const max = totalPages();
+    return Math.min(Math.max(1, p), max);
+  });
+
+  const pageItems = createMemo(() => {
+    const start = (safePage() - 1) * pageSize;
+    return items().slice(start, start + pageSize);
+  });
+
+  const hasNextPage = createMemo(() => safePage() < totalPages());
+
+  return {
+    currentPage: safePage,
+    pageItems,
+    totalItems,
+    totalPages,
+    hasNextPage,
+    previousPage: () => setRawPage((p) => Math.max(1, p - 1)),
+    nextPage: () => setRawPage((p) => (p < totalPages() ? p + 1 : p)),
+    resetPage: () => setRawPage(1),
+    pageSize,
+  };
+}

--- a/packages/frontend/src/styles/data.css
+++ b/packages/frontend/src/styles/data.css
@@ -132,10 +132,22 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
-.tier-badge--simple    { background: hsl(var(--success) / 0.1);     color: hsl(var(--success)); }
-.tier-badge--standard  { background: hsl(var(--chart-2) / 0.15);    color: hsl(var(--chart-2)); }
-.tier-badge--complex   { background: hsl(var(--chart-5) / 0.15);    color: hsl(var(--chart-5)); }
-.tier-badge--reasoning { background: hsl(var(--destructive) / 0.1); color: hsl(var(--destructive)); }
+.tier-badge--simple {
+  background: hsl(var(--success) / 0.1);
+  color: hsl(var(--success));
+}
+.tier-badge--standard {
+  background: hsl(var(--chart-2) / 0.15);
+  color: hsl(var(--chart-2));
+}
+.tier-badge--complex {
+  background: hsl(var(--chart-5) / 0.15);
+  color: hsl(var(--chart-5));
+}
+.tier-badge--reasoning {
+  background: hsl(var(--destructive) / 0.1);
+  color: hsl(var(--destructive));
+}
 
 /* ── Security Events ─────────────────────────────── */
 .security-event {
@@ -148,8 +160,12 @@
   border-radius: calc(var(--radius) - 2px);
 }
 
-.security-event:last-child { border-bottom: none; }
-.security-event:hover { background: hsl(var(--muted) / 0.5); }
+.security-event:last-child {
+  border-bottom: none;
+}
+.security-event:hover {
+  background: hsl(var(--muted) / 0.5);
+}
 
 .security-event__dot {
   width: 8px;
@@ -158,11 +174,21 @@
   flex-shrink: 0;
 }
 
-.security-event__dot--critical { background: hsl(var(--destructive)); }
-.security-event__dot--warning { background: hsl(var(--chart-5)); }
-.security-event__dot--info { background: hsl(var(--chart-2)); }
+.security-event__dot--critical {
+  background: hsl(var(--destructive));
+}
+.security-event__dot--warning {
+  background: hsl(var(--chart-5));
+}
+.security-event__dot--info {
+  background: hsl(var(--chart-2));
+}
 
-.security-event__desc { flex: 1; font-size: var(--font-size-sm); color: hsl(var(--foreground)); }
+.security-event__desc {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  color: hsl(var(--foreground));
+}
 
 .security-event__badge {
   font-size: var(--font-size-xs);
@@ -198,7 +224,9 @@
   border-radius: calc(var(--radius) - 2px);
 }
 
-.feed-item:last-child { border-bottom: none; }
+.feed-item:last-child {
+  border-bottom: none;
+}
 
 .skill-dot {
   width: 6px;
@@ -246,7 +274,7 @@
 }
 
 .feed-item__sub span + span::before {
-  content: "\00B7";
+  content: '\00B7';
   margin-right: 6px;
 }
 
@@ -319,7 +347,7 @@
 }
 
 .empty-state__img-wrapper::after {
-  content: "";
+  content: '';
   position: absolute;
   inset: 0;
   background: linear-gradient(to bottom, transparent 60%, hsl(var(--background)));
@@ -333,4 +361,28 @@
 
 .dark .empty-state__img {
   filter: invert(0.92) hue-rotate(180deg);
+}
+
+/* ── Pagination ───────────────────────────────────── */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--gap-md);
+  border-top: 1px solid hsl(var(--border));
+}
+
+.pagination__summary {
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  font-variant-numeric: tabular-nums;
+}
+
+.pagination__controls {
+  display: flex;
+  gap: var(--gap-sm);
+}
+
+.pagination__btn {
+  min-width: 80px;
 }

--- a/packages/frontend/tests/components/Pagination.test.tsx
+++ b/packages/frontend/tests/components/Pagination.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+import Pagination from "../../src/components/Pagination";
+
+describe("Pagination", () => {
+  it("renders summary text", () => {
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 1}
+        totalItems={() => 100}
+        pageSize={25}
+        hasNextPage={() => true}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    expect(container.textContent).toContain("Showing 1");
+    expect(container.textContent).toContain("25");
+    expect(container.textContent).toContain("100");
+  });
+
+  it("shows correct range on page 2", () => {
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 2}
+        totalItems={() => 60}
+        pageSize={25}
+        hasNextPage={() => true}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    expect(container.textContent).toContain("26");
+    expect(container.textContent).toContain("50");
+    expect(container.textContent).toContain("60");
+  });
+
+  it("clamps end to totalItems on last page", () => {
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 3}
+        totalItems={() => 60}
+        pageSize={25}
+        hasNextPage={() => false}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    expect(container.textContent).toContain("51");
+    expect(container.textContent).toContain("60");
+  });
+
+  it("Previous disabled on page 1", () => {
+    render(() => (
+      <Pagination
+        currentPage={() => 1}
+        totalItems={() => 100}
+        pageSize={25}
+        hasNextPage={() => true}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    const prev = screen.getByText("Previous");
+    expect(prev.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("Next disabled when no next page", () => {
+    render(() => (
+      <Pagination
+        currentPage={() => 2}
+        totalItems={() => 50}
+        pageSize={25}
+        hasNextPage={() => false}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    const next = screen.getByText("Next");
+    expect(next.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("calls onPrevious when Previous clicked", () => {
+    const onPrevious = vi.fn();
+    render(() => (
+      <Pagination
+        currentPage={() => 2}
+        totalItems={() => 100}
+        pageSize={25}
+        hasNextPage={() => true}
+        onPrevious={onPrevious}
+        onNext={() => {}}
+      />
+    ));
+    fireEvent.click(screen.getByText("Previous"));
+    expect(onPrevious).toHaveBeenCalled();
+  });
+
+  it("calls onNext when Next clicked", () => {
+    const onNext = vi.fn();
+    render(() => (
+      <Pagination
+        currentPage={() => 1}
+        totalItems={() => 100}
+        pageSize={25}
+        hasNextPage={() => true}
+        onPrevious={() => {}}
+        onNext={onNext}
+      />
+    ));
+    fireEvent.click(screen.getByText("Next"));
+    expect(onNext).toHaveBeenCalled();
+  });
+
+  it("hidden when items fit on one page", () => {
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 1}
+        totalItems={() => 10}
+        pageSize={25}
+        hasNextPage={() => false}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    expect(container.querySelector(".pagination")).toBeNull();
+  });
+
+  it("both buttons disabled when loading", () => {
+    render(() => (
+      <Pagination
+        currentPage={() => 2}
+        totalItems={() => 100}
+        pageSize={25}
+        hasNextPage={() => true}
+        isLoading={() => true}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    expect(screen.getByText("Previous").hasAttribute("disabled")).toBe(true);
+    expect(screen.getByText("Next").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("has navigation role and aria-label", () => {
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 1}
+        totalItems={() => 100}
+        pageSize={25}
+        hasNextPage={() => true}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    const nav = container.querySelector("nav");
+    expect(nav).not.toBeNull();
+    expect(nav?.getAttribute("role")).toBe("navigation");
+    expect(nav?.getAttribute("aria-label")).toBe("Pagination");
+  });
+});

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
 
 let mockAgentName = "test-agent";
 vi.mock("@solidjs/router", () => ({
@@ -52,6 +52,18 @@ vi.mock("../../src/components/Select.jsx", () => ({
 
 vi.mock("../../src/components/ErrorState.jsx", () => ({
   default: (props: any) => <div data-testid="error-state">{props.title}</div>,
+}));
+
+vi.mock("../../src/components/Pagination.jsx", () => ({
+  default: (props: any) => {
+    const total = props.totalItems();
+    return total > props.pageSize ? (
+      <div data-testid="pagination">
+        <button data-testid="pagination-prev" onClick={props.onPrevious} disabled={props.currentPage() <= 1}>Previous</button>
+        <button data-testid="pagination-next" onClick={props.onNext} disabled={!props.hasNextPage()}>Next</button>
+      </div>
+    ) : null;
+  },
 }));
 
 import MessageLog from "../../src/pages/MessageLog";
@@ -140,6 +152,37 @@ describe("MessageLog", () => {
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       expect(container.textContent).toContain("No messages recorded");
+    });
+  });
+
+  it("shows 'no messages match' when filters return 0 results", async () => {
+    mockGetMessages.mockResolvedValue(messagesData);
+    const { container } = render(() => <MessageLog />);
+    await vi.waitFor(() => {
+      const selects = container.querySelectorAll('[data-testid="select"]');
+      expect(selects.length).toBeGreaterThanOrEqual(2);
+    });
+    const selects = container.querySelectorAll('[data-testid="select"]');
+    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: ["gpt-4o"] });
+    await fireEvent.change(selects[0], { target: { value: "error" } });
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("No messages match your filters");
+    });
+  });
+
+  it("does not show waiting banner when filters return 0 results", async () => {
+    mockGetMessages.mockResolvedValue(messagesData);
+    const { container } = render(() => <MessageLog />);
+    await vi.waitFor(() => {
+      const selects = container.querySelectorAll('[data-testid="select"]');
+      expect(selects.length).toBeGreaterThanOrEqual(2);
+    });
+    const selects = container.querySelectorAll('[data-testid="select"]');
+    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: ["gpt-4o"] });
+    await fireEvent.change(selects[0], { target: { value: "error" } });
+    await vi.waitFor(() => {
+      expect(container.textContent).not.toContain("Waiting for data");
+      expect(container.textContent).not.toContain("No messages recorded");
     });
   });
 
@@ -279,6 +322,44 @@ describe("MessageLog", () => {
       await vi.waitFor(() => {
         const tooltip = container.querySelector(".status-badge-tooltip");
         expect(tooltip?.getAttribute("aria-label")).toBe("timeout");
+      });
+    });
+  });
+
+  describe("pagination", () => {
+    it("shows pagination when total_count exceeds page size", async () => {
+      const bigData = { ...messagesData, total_count: 120, next_cursor: "cursor-2" };
+      mockGetMessages.mockResolvedValue(bigData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector('[data-testid="pagination"]')).not.toBeNull();
+      });
+    });
+
+    it("hides pagination when total_count is within page size", async () => {
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("2 total");
+        expect(container.querySelector('[data-testid="pagination"]')).toBeNull();
+      });
+    });
+
+    it("Next calls getMessages with cursor after navigating", async () => {
+      const bigData = { ...messagesData, total_count: 120, next_cursor: "cursor-for-page-2" };
+      mockGetMessages.mockResolvedValue(bigData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector('[data-testid="pagination-next"]')).not.toBeNull();
+      });
+      mockGetMessages.mockClear();
+      mockGetMessages.mockResolvedValue({ ...messagesData, total_count: 120, next_cursor: null });
+      const nextBtn = container.querySelector('[data-testid="pagination-next"]') as HTMLButtonElement;
+      nextBtn.click();
+      await vi.waitFor(() => {
+        expect(mockGetMessages).toHaveBeenCalledWith(
+          expect.objectContaining({ cursor: "cursor-for-page-2" }),
+        );
       });
     });
   });

--- a/packages/frontend/tests/pages/ModelPrices.test.tsx
+++ b/packages/frontend/tests/pages/ModelPrices.test.tsx
@@ -19,6 +19,18 @@ vi.mock("../../src/services/toast-store.js", () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
+vi.mock("../../src/components/Pagination.jsx", () => ({
+  default: (props: any) => {
+    const total = props.totalItems();
+    return total > props.pageSize ? (
+      <div data-testid="pagination">
+        <button data-testid="pagination-prev" onClick={props.onPrevious}>Previous</button>
+        <button data-testid="pagination-next" onClick={props.onNext}>Next</button>
+      </div>
+    ) : null;
+  },
+}));
+
 import ModelPrices from "../../src/pages/ModelPrices";
 
 const modelData = {
@@ -347,6 +359,40 @@ describe("ModelPrices - autocomplete filter", () => {
     });
   });
 
+  it("shows pagination when models exceed page size", async () => {
+    const manyModels = Array.from({ length: 30 }, (_, i) => ({
+      model_name: `model-${i}`,
+      provider: "TestProvider",
+      input_price_per_million: 1,
+      output_price_per_million: 2,
+    }));
+    mockGetModelPrices.mockResolvedValue({ models: manyModels, lastSyncedAt: null });
+    const { container } = render(() => <ModelPrices />);
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="pagination"]')).not.toBeNull();
+    });
+  });
+
+  it("only renders pageSize items per page", async () => {
+    const manyModels = Array.from({ length: 30 }, (_, i) => ({
+      model_name: `model-${String(i).padStart(2, "0")}`,
+      provider: "TestProvider",
+      input_price_per_million: 1,
+      output_price_per_million: 2,
+    }));
+    mockGetModelPrices.mockResolvedValue({ models: manyModels, lastSyncedAt: null });
+    const { container } = render(() => <ModelPrices />);
+    await vi.waitFor(() => {
+      const rows = container.querySelectorAll("tbody tr");
+      expect(rows.length).toBe(25);
+    });
+  });
+
+  it("hides pagination when all models fit on one page", async () => {
+    const { container } = await renderAndWait();
+    expect(container.querySelector('[data-testid="pagination"]')).toBeNull();
+  });
+
   it("does not show already-selected providers in dropdown", async () => {
     const { container } = await renderAndWait();
     // Select OpenAI
@@ -370,16 +416,16 @@ describe("ModelPrices - autocomplete filter", () => {
     });
   });
 
-  it("renders provider icon as img for known providers", async () => {
+  it("renders provider icon for known providers", async () => {
     const { container } = await renderAndWait();
     await typeInSearch(container, "open");
     await vi.waitFor(() => {
       expect(container.querySelector(".model-filter__dropdown")).not.toBeNull();
     });
-    const iconImg = container.querySelector(".model-filter__dropdown .model-filter__provider-icon");
-    expect(iconImg).not.toBeNull();
-    expect(iconImg?.tagName.toLowerCase()).toBe("img");
-    expect((iconImg as HTMLImageElement)?.src).toContain("/icons/providers/openai.svg");
+    const icon = container.querySelector(".model-filter__dropdown .model-filter__provider-icon");
+    expect(icon).not.toBeNull();
+    // Inline SVG icon rendered via providerIcon()
+    expect(icon?.querySelector("svg")).not.toBeNull();
   });
 
   it("shows group labels in dropdown", async () => {

--- a/packages/frontend/tests/services/cursor-pagination.test.ts
+++ b/packages/frontend/tests/services/cursor-pagination.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { createRoot } from "solid-js";
+import { createCursorPagination } from "../../src/services/cursor-pagination";
+
+function withRoot<T>(fn: () => T): T {
+  let result!: T;
+  createRoot((dispose) => {
+    result = fn();
+    dispose();
+  });
+  return result;
+}
+
+describe("createCursorPagination", () => {
+  it("starts on page 1 with no cursor", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(50);
+      expect(pager.currentPage()).toBe(1);
+      expect(pager.currentCursor()).toBeUndefined();
+      expect(pager.hasNextPage()).toBe(false);
+      expect(pager.pageSize).toBe(50);
+    });
+  });
+
+  it("enables next after recordResponse with cursor", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(50);
+      pager.recordResponse("cursor-page-2");
+      expect(pager.hasNextPage()).toBe(true);
+    });
+  });
+
+  it("does not enable next when recordResponse receives null", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(50);
+      pager.recordResponse(null);
+      expect(pager.hasNextPage()).toBe(false);
+    });
+  });
+
+  it("navigates to next page with correct cursor", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(50);
+      pager.recordResponse("cursor-page-2");
+      pager.nextPage();
+      expect(pager.currentPage()).toBe(2);
+      expect(pager.currentCursor()).toBe("cursor-page-2");
+    });
+  });
+
+  it("navigates back to previous page", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(50);
+      pager.recordResponse("cursor-page-2");
+      pager.nextPage();
+      pager.previousPage();
+      expect(pager.currentPage()).toBe(1);
+      expect(pager.currentCursor()).toBeUndefined();
+    });
+  });
+
+  it("cursor history works across multiple pages", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(10);
+      pager.recordResponse("cursor-2");
+      pager.nextPage();
+      pager.recordResponse("cursor-3");
+      pager.nextPage();
+      expect(pager.currentPage()).toBe(3);
+      expect(pager.currentCursor()).toBe("cursor-3");
+      pager.previousPage();
+      expect(pager.currentPage()).toBe(2);
+      expect(pager.currentCursor()).toBe("cursor-2");
+      pager.previousPage();
+      expect(pager.currentPage()).toBe(1);
+      expect(pager.currentCursor()).toBeUndefined();
+    });
+  });
+
+  it("previousPage is no-op on page 1", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(50);
+      pager.previousPage();
+      expect(pager.currentPage()).toBe(1);
+    });
+  });
+
+  it("nextPage is no-op when no next cursor", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(50);
+      pager.nextPage();
+      expect(pager.currentPage()).toBe(1);
+    });
+  });
+
+  it("resetPage clears all state", () => {
+    withRoot(() => {
+      const pager = createCursorPagination(50);
+      pager.recordResponse("cursor-2");
+      pager.nextPage();
+      pager.recordResponse("cursor-3");
+      pager.nextPage();
+      pager.resetPage();
+      expect(pager.currentPage()).toBe(1);
+      expect(pager.currentCursor()).toBeUndefined();
+      expect(pager.hasNextPage()).toBe(false);
+    });
+  });
+
+  it("uses default page size of 50", () => {
+    withRoot(() => {
+      const pager = createCursorPagination();
+      expect(pager.pageSize).toBe(50);
+    });
+  });
+});

--- a/packages/frontend/tests/services/pagination.test.ts
+++ b/packages/frontend/tests/services/pagination.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import { createClientPagination } from "../../src/services/pagination";
+
+function withRoot<T>(fn: () => T): T {
+  let result!: T;
+  createRoot((dispose) => {
+    result = fn();
+    dispose();
+  });
+  return result;
+}
+
+describe("createClientPagination", () => {
+  it("returns first page items", () => {
+    withRoot(() => {
+      const [items] = createSignal([1, 2, 3, 4, 5]);
+      const pager = createClientPagination(items, 3);
+      expect(pager.pageItems()).toEqual([1, 2, 3]);
+      expect(pager.currentPage()).toBe(1);
+      expect(pager.totalItems()).toBe(5);
+      expect(pager.totalPages()).toBe(2);
+      expect(pager.hasNextPage()).toBe(true);
+    });
+  });
+
+  it("navigates to next page", () => {
+    withRoot(() => {
+      const [items] = createSignal([1, 2, 3, 4, 5]);
+      const pager = createClientPagination(items, 3);
+      pager.nextPage();
+      expect(pager.currentPage()).toBe(2);
+      expect(pager.pageItems()).toEqual([4, 5]);
+      expect(pager.hasNextPage()).toBe(false);
+    });
+  });
+
+  it("navigates back with previousPage", () => {
+    withRoot(() => {
+      const [items] = createSignal([1, 2, 3, 4, 5]);
+      const pager = createClientPagination(items, 3);
+      pager.nextPage();
+      pager.previousPage();
+      expect(pager.currentPage()).toBe(1);
+      expect(pager.pageItems()).toEqual([1, 2, 3]);
+    });
+  });
+
+  it("previousPage is no-op on page 1", () => {
+    withRoot(() => {
+      const [items] = createSignal([1, 2, 3]);
+      const pager = createClientPagination(items, 2);
+      pager.previousPage();
+      expect(pager.currentPage()).toBe(1);
+    });
+  });
+
+  it("nextPage is no-op on last page", () => {
+    withRoot(() => {
+      const [items] = createSignal([1, 2, 3]);
+      const pager = createClientPagination(items, 3);
+      pager.nextPage();
+      expect(pager.currentPage()).toBe(1);
+    });
+  });
+
+  it("clamps page when list shrinks", () => {
+    withRoot(() => {
+      const [items, setItems] = createSignal([1, 2, 3, 4, 5, 6]);
+      const pager = createClientPagination(items, 3);
+      pager.nextPage();
+      expect(pager.currentPage()).toBe(2);
+      setItems([1, 2]);
+      expect(pager.currentPage()).toBe(1);
+      expect(pager.pageItems()).toEqual([1, 2]);
+    });
+  });
+
+  it("resetPage returns to page 1", () => {
+    withRoot(() => {
+      const [items] = createSignal([1, 2, 3, 4, 5]);
+      const pager = createClientPagination(items, 2);
+      pager.nextPage();
+      pager.nextPage();
+      expect(pager.currentPage()).toBe(3);
+      pager.resetPage();
+      expect(pager.currentPage()).toBe(1);
+    });
+  });
+
+  it("handles empty input", () => {
+    withRoot(() => {
+      const [items] = createSignal<number[]>([]);
+      const pager = createClientPagination(items, 5);
+      expect(pager.currentPage()).toBe(1);
+      expect(pager.totalPages()).toBe(1);
+      expect(pager.totalItems()).toBe(0);
+      expect(pager.pageItems()).toEqual([]);
+      expect(pager.hasNextPage()).toBe(false);
+    });
+  });
+
+  it("handles partial last page", () => {
+    withRoot(() => {
+      const [items] = createSignal([1, 2, 3, 4]);
+      const pager = createClientPagination(items, 3);
+      expect(pager.totalPages()).toBe(2);
+      pager.nextPage();
+      expect(pager.pageItems()).toEqual([4]);
+    });
+  });
+
+  it("uses default page size of 25", () => {
+    withRoot(() => {
+      const [items] = createSignal(Array.from({ length: 60 }, (_, i) => i));
+      const pager = createClientPagination(items);
+      expect(pager.pageSize).toBe(25);
+      expect(pager.pageItems().length).toBe(25);
+      expect(pager.totalPages()).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Cursor-based pagination** for the Messages page — navigates API pages via cursor history stack (50 items/page)
- **Client-side pagination** for the Model Prices page — slices the filtered/sorted list into pages (25 items/page)
- **Shared `<Pagination>` component** with "Showing X–Y of Z" summary and Previous/Next buttons
- **Filter empty state fix** — Messages page now shows "No messages match your filters" instead of the setup/waiting view when filters return 0 results
- **Provider icon unification** — Model Prices filter bar now uses the same `resolveProviderId()` + `providerIcon()` system as the routing page, fixing missing icons for OpenRouter, MiniMax, etc.

## New files

| File | Purpose |
|------|---------|
| `src/services/cursor-pagination.ts` | Cursor-based pagination primitive (manages cursor stack for API pages) |
| `src/services/pagination.ts` | Client-side pagination primitive (slices reactive arrays) |
| `src/components/Pagination.tsx` | Shared stateless pagination UI component |
| `tests/services/cursor-pagination.test.ts` | 10 tests for cursor pagination |
| `tests/services/pagination.test.ts` | 10 tests for client pagination |
| `tests/components/Pagination.test.tsx` | 10 tests for Pagination component |

## Modified files

| File | Changes |
|------|---------|
| `src/pages/MessageLog.tsx` | Cursor pagination integration, filter empty state logic |
| `src/pages/ModelPrices.tsx` | Client pagination integration |
| `src/components/ModelPricesFilterBar.tsx` | Replaced local icon map with shared provider icon system |
| `src/styles/data.css` | Pagination CSS styles |
| `tests/pages/MessageLog.test.tsx` | Pagination + filter empty state tests |
| `tests/pages/ModelPrices.test.tsx` | Pagination + icon system tests |

## Test plan

- [x] All 1035 frontend tests pass
- [x] TypeScript compiles with no errors
- [x] Lint passes (pre-commit hook)
- [ ] Manual: Messages page with >50 messages shows pagination, Previous/Next work
- [ ] Manual: Filter change resets to page 1
- [ ] Manual: Model Prices shows 25 models per page, pagination hidden when filtered list fits one page
- [ ] Manual: Provider icons in filter bar match routing page icons