### PR TITLE
feat: filter model prices to supported providers only

### DIFF
--- a/.changeset/filter-model-prices.md
+++ b/.changeset/filter-model-prices.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Filter model prices to supported providers only during pricing sync

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -313,8 +313,8 @@ describe('DatabaseSeederService', () => {
 
       await service.onModuleInit();
 
-      // All curated models are always upserted (80 total)
-      expect(mockPricingRepo.upsert).toHaveBeenCalledTimes(80);
+      // All curated models are always upserted (73 total)
+      expect(mockPricingRepo.upsert).toHaveBeenCalledTimes(73);
     });
 
     it('should upsert with model_name as conflict key', async () => {

--- a/packages/backend/src/database/database-seeder.service.ts
+++ b/packages/backend/src/database/database-seeder.service.ts
@@ -226,13 +226,6 @@ export class DatabaseSeederService implements OnModuleInit {
       ['x-ai/grok-3', 'OpenRouter', 0.000003, 0.000015, 131072, true, true],
       // OpenRouter free models
       ['openrouter/free', 'OpenRouter', 0, 0, 200000, true, true],
-      ['stepfun/step-3.5-flash:free', 'OpenRouter', 0, 0, 256000, false, true],
-      ['arcee-ai/trinity-large-preview:free', 'OpenRouter', 0, 0, 131072, false, true],
-      ['upstage/solar-pro-3:free', 'OpenRouter', 0, 0, 128000, false, true],
-      ['liquid/lfm-2.5-1.2b-thinking:free', 'OpenRouter', 0, 0, 32768, true, false],
-      ['liquid/lfm-2.5-1.2b-instruct:free', 'OpenRouter', 0, 0, 32768, false, false],
-      ['arcee-ai/trinity-mini:free', 'OpenRouter', 0, 0, 131072, false, false],
-      ['nvidia/nemotron-3-nano-30b-a3b:free', 'OpenRouter', 0, 0, 256000, false, true],
       ['minimax/minimax-m2.5', 'OpenRouter', 0.000000295, 0.0000012, 196608, true, true],
       ['minimax/minimax-m1', 'OpenRouter', 0.0000004, 0.0000022, 1000000, true, true],
       // MiniMax

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -200,13 +200,6 @@ export class LocalBootstrapService implements OnModuleInit {
       ['x-ai/grok-3', 'OpenRouter', 0.000003, 0.000015, 131072, true, true],
       // OpenRouter free models
       ['openrouter/free', 'OpenRouter', 0, 0, 200000, true, true],
-      ['stepfun/step-3.5-flash:free', 'OpenRouter', 0, 0, 256000, false, true],
-      ['arcee-ai/trinity-large-preview:free', 'OpenRouter', 0, 0, 131072, false, true],
-      ['upstage/solar-pro-3:free', 'OpenRouter', 0, 0, 128000, false, true],
-      ['liquid/lfm-2.5-1.2b-thinking:free', 'OpenRouter', 0, 0, 32768, true, false],
-      ['liquid/lfm-2.5-1.2b-instruct:free', 'OpenRouter', 0, 0, 32768, false, false],
-      ['arcee-ai/trinity-mini:free', 'OpenRouter', 0, 0, 131072, false, false],
-      ['nvidia/nemotron-3-nano-30b-a3b:free', 'OpenRouter', 0, 0, 256000, false, true],
       // MiniMax
       ['minimax-m2.5', 'MiniMax', 0.000000295, 0.0000012, 196608, true, true],
       ['minimax-m2.5-highspeed', 'MiniMax', 0.000000295, 0.0000012, 196608, true, true],

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -6,10 +6,14 @@ import { UnresolvedModelTrackerService } from '../model-prices/unresolved-model-
 const mockFindOneBy = jest.fn().mockResolvedValue(null);
 const mockUpsert = jest.fn().mockResolvedValue(undefined);
 const mockCount = jest.fn().mockResolvedValue(0);
+const mockFind = jest.fn().mockResolvedValue([]);
+const mockDelete = jest.fn().mockResolvedValue(undefined);
 const mockRepo = {
   findOneBy: mockFindOneBy,
   upsert: mockUpsert,
   count: mockCount,
+  find: mockFind,
+  delete: mockDelete,
 } as never;
 
 const mockReload = jest.fn().mockResolvedValue(undefined);
@@ -53,6 +57,8 @@ describe('PricingSyncService', () => {
     mockGetAll.mockReturnValue([]);
     mockGetUnresolved.mockResolvedValue([]);
     mockCount.mockResolvedValue(0);
+    mockFind.mockResolvedValue([]);
+    mockDelete.mockResolvedValue(undefined);
   });
 
   it('creates only OpenRouter copies for new models not in seeder', async () => {
@@ -60,7 +66,10 @@ describe('PricingSyncService', () => {
       ok: true,
       json: async () => ({
         data: [
-          { id: 'anthropic/claude-opus-4', pricing: { prompt: '0.000015', completion: '0.000075' } },
+          {
+            id: 'anthropic/claude-opus-4',
+            pricing: { prompt: '0.000015', completion: '0.000075' },
+          },
           { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
         ],
       }),
@@ -84,17 +93,13 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
     await service.syncPricing();
     // Canonical upsert should NOT include provider
-    const canonicalCall = mockUpsert.mock.calls.find(
-      (call) => call[0].model_name === 'gpt-4o',
-    );
+    const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'gpt-4o');
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
     expect(canonicalCall![0]).toMatchObject({
@@ -108,9 +113,7 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0', completion: '0' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0', completion: '0' } }],
       }),
     });
 
@@ -180,9 +183,7 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
@@ -204,9 +205,7 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
@@ -232,18 +231,12 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
     await service.syncPricing();
-    expect(mockRecordChange).toHaveBeenCalledWith(
-      existing,
-      expect.any(Object),
-      'sync',
-    );
+    expect(mockRecordChange).toHaveBeenCalledWith(existing, expect.any(Object), 'sync');
   });
 
   it('detects removed models and calls invalidateOverridesForRemovedModels', async () => {
@@ -252,16 +245,12 @@ describe('PricingSyncService', () => {
         { model_name: 'gpt-4o', provider: 'OpenAI' },
         { model_name: 'old-model', provider: 'OpenAI' },
       ])
-      .mockReturnValueOnce([
-        { model_name: 'gpt-4o', provider: 'OpenAI' },
-      ]);
+      .mockReturnValueOnce([{ model_name: 'gpt-4o', provider: 'OpenAI' }]);
 
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
@@ -280,16 +269,12 @@ describe('PricingSyncService', () => {
         { model_name: 'gpt-4o', provider: 'OpenAI' },
         { model_name: 'removed', provider: 'OpenAI' },
       ])
-      .mockReturnValueOnce([
-        { model_name: 'gpt-4o', provider: 'OpenAI' },
-      ]);
+      .mockReturnValueOnce([{ model_name: 'gpt-4o', provider: 'OpenAI' }]);
 
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
@@ -303,16 +288,12 @@ describe('PricingSyncService', () => {
   });
 
   it('resolves unresolved models after sync', async () => {
-    mockGetUnresolved.mockResolvedValue([
-      { model_name: 'gpt-4o', resolved: false },
-    ]);
+    mockGetUnresolved.mockResolvedValue([{ model_name: 'gpt-4o', resolved: false }]);
 
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
@@ -321,21 +302,67 @@ describe('PricingSyncService', () => {
   });
 
   it('does not resolve models that are not in OpenRouter data', async () => {
-    mockGetUnresolved.mockResolvedValue([
-      { model_name: 'nonexistent-model', resolved: false },
-    ]);
+    mockGetUnresolved.mockResolvedValue([{ model_name: 'nonexistent-model', resolved: false }]);
 
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
     await service.syncPricing();
     expect(mockMarkResolved).not.toHaveBeenCalled();
+  });
+
+  it('skips models from unsupported providers', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: 'ai21/jamba-1-5-large', pricing: { prompt: '0.000002', completion: '0.000008' } },
+          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
+        ],
+      }),
+    });
+
+    const updated = await service.syncPricing();
+    // Only OpenAI model should be upserted (OpenRouter copy), ai21 is skipped entirely
+    expect(updated).toBe(1);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ model_name: 'openai/gpt-4o' }),
+      ['model_name'],
+    );
+    // ai21 should not appear in any upsert call
+    for (const call of mockUpsert.mock.calls) {
+      expect(call[0].model_name).not.toContain('ai21');
+    }
+  });
+
+  it('removes existing unsupported provider rows on sync', async () => {
+    mockFind.mockResolvedValue([
+      { model_name: 'ai21/jamba-1-5-large' },
+      { model_name: 'openai/gpt-4o' },
+      { model_name: 'aion-labs/some-model' },
+      { model_name: 'openrouter/auto' },
+      { model_name: 'gpt-4o' },
+    ]);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.syncPricing();
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    const deleteArg = mockDelete.mock.calls[0][0];
+    // Should delete ai21 and aion-labs, but NOT openai, openrouter, or bare models
+    expect(deleteArg.model_name._value).toEqual(
+      expect.arrayContaining(['ai21/jamba-1-5-large', 'aion-labs/some-model']),
+    );
+    expect(deleteArg.model_name._value).not.toContain('openai/gpt-4o');
+    expect(deleteArg.model_name._value).not.toContain('openrouter/auto');
+    expect(deleteArg.model_name._value).not.toContain('gpt-4o');
   });
 
   describe('onModuleInit', () => {
@@ -352,16 +379,17 @@ describe('PricingSyncService', () => {
         ok: true,
         json: async () => ({
           data: [
-            { id: 'anthropic/claude-opus-4', pricing: { prompt: '0.000015', completion: '0.000075' } },
+            {
+              id: 'anthropic/claude-opus-4',
+              pricing: { prompt: '0.000015', completion: '0.000075' },
+            },
           ],
         }),
       });
 
       await service.onModuleInit();
       await new Promise((r) => setTimeout(r, 10));
-      expect(mockFetch).toHaveBeenCalledWith(
-        'https://openrouter.ai/api/v1/models',
-      );
+      expect(mockFetch).toHaveBeenCalledWith('https://openrouter.ai/api/v1/models');
     });
 
     it('does not crash if startup sync fails', async () => {
@@ -439,9 +467,7 @@ describe('PricingSyncService', () => {
 
     await service.syncPricing();
     // Canonical upsert preserves existing provider (no provider field)
-    const canonicalCall = mockUpsert.mock.calls.find(
-      (call) => call[0].model_name === 'glm-4-plus',
-    );
+    const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'glm-4-plus');
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
     // Also stores OpenRouter copy
@@ -467,9 +493,7 @@ describe('PricingSyncService', () => {
 
     await service.syncPricing();
     // Canonical upsert preserves existing provider (no provider field)
-    const canonicalCall = mockUpsert.mock.calls.find(
-      (call) => call[0].model_name === 'nova-pro',
-    );
+    const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'nova-pro');
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
     // Also stores OpenRouter copy
@@ -486,9 +510,7 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openrouter/auto', pricing: { prompt: '0.000003', completion: '0.000015' } },
-        ],
+        data: [{ id: 'openrouter/auto', pricing: { prompt: '0.000003', completion: '0.000015' } }],
       }),
     });
 
@@ -506,9 +528,7 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openrouter/auto', pricing: { prompt: '0.000003', completion: '0.000015' } },
-        ],
+        data: [{ id: 'openrouter/auto', pricing: { prompt: '0.000003', completion: '0.000015' } }],
       }),
     });
 
@@ -531,7 +551,11 @@ describe('PricingSyncService', () => {
       ok: true,
       json: async () => ({
         data: [
-          { id: 'openai/gpt-4o', context_length: 128000, pricing: { prompt: '0.0000025', completion: '0.00001' } },
+          {
+            id: 'openai/gpt-4o',
+            context_length: 128000,
+            pricing: { prompt: '0.0000025', completion: '0.00001' },
+          },
         ],
       }),
     });
@@ -555,16 +579,18 @@ describe('PricingSyncService', () => {
       ok: true,
       json: async () => ({
         data: [
-          { id: 'openai/gpt-4o', context_length: 128000, pricing: { prompt: '0.0000025', completion: '0.00001' } },
+          {
+            id: 'openai/gpt-4o',
+            context_length: 128000,
+            pricing: { prompt: '0.0000025', completion: '0.00001' },
+          },
         ],
       }),
     });
 
     await service.syncPricing();
     // Canonical upsert includes context_window
-    const canonicalCall = mockUpsert.mock.calls.find(
-      (call) => call[0].model_name === 'gpt-4o',
-    );
+    const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'gpt-4o');
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).toMatchObject({
       context_window: 128000,
@@ -576,9 +602,7 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } },
-        ],
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
       }),
     });
 
@@ -594,7 +618,10 @@ describe('PricingSyncService', () => {
       ok: true,
       json: async () => ({
         data: [
-          { id: 'anthropic/claude-opus-4', pricing: { prompt: '0.000015', completion: '0.000075' } },
+          {
+            id: 'anthropic/claude-opus-4',
+            pricing: { prompt: '0.000015', completion: '0.000075' },
+          },
         ],
       }),
     });
@@ -626,7 +653,10 @@ describe('PricingSyncService', () => {
       ok: true,
       json: async () => ({
         data: [
-          { id: 'anthropic/claude-opus-4', pricing: { prompt: '0.000015', completion: '0.000075' } },
+          {
+            id: 'anthropic/claude-opus-4',
+            pricing: { prompt: '0.000015', completion: '0.000075' },
+          },
         ],
       }),
     });
@@ -641,9 +671,7 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'bare-model', pricing: { prompt: '0.000001', completion: '0.000001' } },
-        ],
+        data: [{ id: 'bare-model', pricing: { prompt: '0.000001', completion: '0.000001' } }],
       }),
     });
 
@@ -657,9 +685,7 @@ describe('PricingSyncService', () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [
-          { id: 'openrouter/bodybuilder', pricing: { prompt: '-1', completion: '-1' } },
-        ],
+        data: [{ id: 'openrouter/bodybuilder', pricing: { prompt: '-1', completion: '-1' } }],
       }),
     });
 

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MoreThan, Repository } from 'typeorm';
+import { In, MoreThan, Repository } from 'typeorm';
 import { ModelPricing } from '../entities/model-pricing.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { PricingHistoryService } from './pricing-history.service';
@@ -40,6 +40,8 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   openrouter: 'OpenRouter',
 };
 
+const SUPPORTED_PREFIXES = new Set(Object.keys(PROVIDER_DISPLAY_NAMES));
+
 const OPENROUTER_API = 'https://openrouter.ai/api/v1/models';
 
 const FRESHNESS_HOURS = 12;
@@ -75,15 +77,14 @@ export class PricingSyncService implements OnModuleInit {
   async syncPricing(): Promise<number> {
     this.logger.log('Starting daily model pricing sync from OpenRouter...');
 
-    const modelsBefore = new Set(
-      this.pricingCache.getAll().map((m) => m.model_name),
-    );
+    const modelsBefore = new Set(this.pricingCache.getAll().map((m) => m.model_name));
 
     const data = await this.fetchOpenRouterModels();
     if (!data) return 0;
 
     const updated = await this.syncAllModels(data);
     await this.resolveUnresolvedModels(data);
+    await this.removeUnsupportedModels();
 
     this.logger.log(`Pricing sync complete: ${updated} models updated`);
     if (updated > 0) {
@@ -91,17 +92,13 @@ export class PricingSyncService implements OnModuleInit {
     }
 
     // Detect removed models and invalidate routing overrides
-    const modelsAfter = new Set(
-      this.pricingCache.getAll().map((m) => m.model_name),
-    );
+    const modelsAfter = new Set(this.pricingCache.getAll().map((m) => m.model_name));
     const removed = [...modelsBefore].filter((m) => !modelsAfter.has(m));
 
     if (removed.length > 0) {
       this.logger.warn(`Models removed after sync: ${removed.join(', ')}`);
       try {
-        const { RoutingService } = await import(
-          '../routing/routing.service'
-        );
+        const { RoutingService } = await import('../routing/routing.service');
         const routingService = this.moduleRef.get(RoutingService, {
           strict: false,
         });
@@ -150,6 +147,13 @@ export class PricingSyncService implements OnModuleInit {
           continue;
         }
 
+        if (!model.id.startsWith('openrouter/')) {
+          const slashIdx = model.id.indexOf('/');
+          if (slashIdx === -1 || !SUPPORTED_PREFIXES.has(model.id.substring(0, slashIdx))) {
+            continue;
+          }
+        }
+
         const { canonical, provider } = this.deriveNames(model.id);
         const existing = await this.pricingRepo.findOneBy({
           model_name: canonical,
@@ -182,8 +186,7 @@ export class PricingSyncService implements OnModuleInit {
         }
 
         // Store an OpenRouter copy with the full vendor-prefixed ID
-        const hasVendorPrefix =
-          model.id.includes('/') && !model.id.startsWith('openrouter/');
+        const hasVendorPrefix = model.id.includes('/') && !model.id.startsWith('openrouter/');
         if (hasVendorPrefix) {
           try {
             await this.pricingRepo.upsert(
@@ -243,9 +246,23 @@ export class PricingSyncService implements OnModuleInit {
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
 
-  private async resolveUnresolvedModels(
-    data: OpenRouterModel[],
-  ): Promise<void> {
+  private async removeUnsupportedModels(): Promise<void> {
+    const all = await this.pricingRepo.find({ select: ['model_name'] });
+    const toDelete: string[] = [];
+    for (const row of all) {
+      const slashIdx = row.model_name.indexOf('/');
+      if (slashIdx === -1) continue;
+      const prefix = row.model_name.substring(0, slashIdx);
+      if (prefix === 'openrouter') continue;
+      if (!SUPPORTED_PREFIXES.has(prefix)) toDelete.push(row.model_name);
+    }
+    if (toDelete.length > 0) {
+      await this.pricingRepo.delete({ model_name: In(toDelete) });
+      this.logger.log(`Removed ${toDelete.length} models from unsupported providers`);
+    }
+  }
+
+  private async resolveUnresolvedModels(data: OpenRouterModel[]): Promise<void> {
     const unresolved = await this.unresolvedTracker.getUnresolved();
     if (unresolved.length === 0) return;
 
@@ -260,18 +277,12 @@ export class PricingSyncService implements OnModuleInit {
     for (const entry of unresolved) {
       const resolvedName = this.tryResolve(entry.model_name, knownNames);
       if (resolvedName) {
-        await this.unresolvedTracker.markResolved(
-          entry.model_name,
-          resolvedName,
-        );
+        await this.unresolvedTracker.markResolved(entry.model_name, resolvedName);
       }
     }
   }
 
-  private tryResolve(
-    modelName: string,
-    knownNames: Set<string>,
-  ): string | null {
+  private tryResolve(modelName: string, knownNames: Set<string>): string | null {
     if (knownNames.has(modelName)) return modelName;
 
     const stripped = this.stripPrefix(modelName);


### PR DESCRIPTION
## Summary
- Filter pricing sync to only store models from providers listed in `PROVIDER_DISPLAY_NAMES`, skipping ~200+ unsupported vendors (ai21, aion-labs, nvidia, etc.)
- Add `removeUnsupportedModels()` cleanup that deletes existing unsupported vendor-prefixed rows after each sync
- Remove 7 free model entries from unsupported vendors in both database seeders

## Test plan
- [x] All 1777 backend unit tests pass (including 2 new tests for provider filtering and cleanup)
- [x] All 86 backend e2e tests pass
- [x] TypeScript compiles with no errors