### PR TITLE
feat: unify email templates and differentiate soft/hard alerts

### DIFF
--- a/.changeset/unify-emails-soft-hard.md
+++ b/.changeset/unify-emails-soft-hard.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Unify all email templates with PNG logo and copyright footer; differentiate soft (warning) and hard (blocking) threshold alerts with distinct colors and messaging

--- a/packages/backend/src/common/utils/period.util.spec.ts
+++ b/packages/backend/src/common/utils/period.util.spec.ts
@@ -1,4 +1,4 @@
-import { computePeriodBoundaries } from './period.util';
+import { computePeriodBoundaries, computePeriodResetDate } from './period.util';
 
 describe('computePeriodBoundaries', () => {
   it('returns periodStart and periodEnd as formatted strings', () => {
@@ -56,5 +56,64 @@ describe('computePeriodBoundaries', () => {
     const end = new Date(periodEnd.replace(' ', 'T') + 'Z').getTime();
     expect(end).toBeGreaterThanOrEqual(before - 1000);
     expect(end).toBeLessThanOrEqual(after + 1000);
+  });
+});
+
+describe('computePeriodResetDate', () => {
+  it('returns a formatted datetime string', () => {
+    const result = computePeriodResetDate('day');
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('hour: returns start of next hour UTC', () => {
+    const now = new Date();
+    const result = computePeriodResetDate('hour');
+    const reset = new Date(result.replace(' ', 'T') + 'Z');
+    const expectedHour = (now.getUTCHours() + 1) % 24;
+    expect(reset.getUTCHours()).toBe(expectedHour);
+    expect(reset.getUTCMinutes()).toBe(0);
+    expect(reset.getUTCSeconds()).toBe(0);
+  });
+
+  it('day: returns midnight UTC next day', () => {
+    const now = new Date();
+    const result = computePeriodResetDate('day');
+    const reset = new Date(result.replace(' ', 'T') + 'Z');
+    expect(reset.getUTCHours()).toBe(0);
+    expect(reset.getUTCMinutes()).toBe(0);
+    const expectedDate = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+    expect(reset.getUTCDate()).toBe(expectedDate.getUTCDate());
+  });
+
+  it('week: returns next Monday at midnight UTC', () => {
+    const result = computePeriodResetDate('week');
+    const reset = new Date(result.replace(' ', 'T') + 'Z');
+    expect(reset.getUTCDay()).toBe(1); // Monday
+    expect(reset.getUTCHours()).toBe(0);
+    expect(reset.getUTCMinutes()).toBe(0);
+    expect(reset.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('month: returns first of next month UTC', () => {
+    const now = new Date();
+    const result = computePeriodResetDate('month');
+    const reset = new Date(result.replace(' ', 'T') + 'Z');
+    expect(reset.getUTCDate()).toBe(1);
+    expect(reset.getUTCHours()).toBe(0);
+    const expectedMonth = (now.getUTCMonth() + 1) % 12;
+    expect(reset.getUTCMonth()).toBe(expectedMonth);
+  });
+
+  it('unknown period: defaults to hour-like behavior', () => {
+    const result = computePeriodResetDate('unknown');
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+  });
+
+  it('reset date is always in the future', () => {
+    for (const period of ['hour', 'day', 'week', 'month']) {
+      const result = computePeriodResetDate(period);
+      const reset = new Date(result.replace(' ', 'T') + 'Z');
+      expect(reset.getTime()).toBeGreaterThan(Date.now() - 1000);
+    }
   });
 });

--- a/packages/backend/src/common/utils/period.util.ts
+++ b/packages/backend/src/common/utils/period.util.ts
@@ -3,6 +3,8 @@ export interface PeriodBoundaries {
   periodEnd: string;
 }
 
+const fmt = (d: Date) => d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+
 export function computePeriodBoundaries(period: string): PeriodBoundaries {
   const now = new Date();
   let start: Date;
@@ -28,7 +30,32 @@ export function computePeriodBoundaries(period: string): PeriodBoundaries {
   }
 
   const end = new Date(now.getTime());
-  const fmt = (d: Date) => d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
-
   return { periodStart: fmt(start), periodEnd: fmt(end) };
+}
+
+export function computePeriodResetDate(period: string): string {
+  const now = new Date();
+  let reset: Date;
+
+  switch (period) {
+    case 'hour':
+      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 1));
+      break;
+    case 'day':
+      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+      break;
+    case 'week': {
+      const dayOfWeek = now.getUTCDay();
+      const daysUntilMonday = ((8 - dayOfWeek) % 7) || 7;
+      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + daysUntilMonday));
+      break;
+    }
+    case 'month':
+      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+      break;
+    default:
+      reset = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), now.getUTCHours() + 1));
+  }
+
+  return fmt(reset);
 }

--- a/packages/backend/src/notifications/emails/reset-password.tsx
+++ b/packages/backend/src/notifications/emails/reset-password.tsx
@@ -9,15 +9,18 @@ import {
   Button,
   Preview,
   Hr,
+  Img,
+  Link,
 } from '@react-email/components';
 
 export interface ResetPasswordEmailProps {
   userName: string;
   resetUrl: string;
+  logoUrl?: string;
 }
 
 export function ResetPasswordEmail(props: ResetPasswordEmailProps) {
-  const { userName, resetUrl } = props;
+  const { userName, resetUrl, logoUrl = 'https://app.manifest.build/manifest-logo.png' } = props;
 
   return (
     <Html>
@@ -27,7 +30,7 @@ export function ResetPasswordEmail(props: ResetPasswordEmailProps) {
         <Container style={container}>
           {/* Logo */}
           <Section style={logoSection}>
-            <Text style={logo}>manifest</Text>
+            <Img src={logoUrl} alt="Manifest" width="140" height="32" style={logoImg} />
           </Section>
 
           {/* Main content */}
@@ -63,7 +66,10 @@ export function ResetPasswordEmail(props: ResetPasswordEmailProps) {
           <Hr style={divider} />
           <Section style={footer}>
             <Text style={footerMuted}>
-              manifest.build
+              © 2026 MNFST Inc. All rights reserved.{' '}
+              <Link href="https://manifest.build" style={footerLink}>
+                manifest.build
+              </Link>
             </Text>
           </Section>
         </Container>
@@ -102,12 +108,8 @@ const logoSection: React.CSSProperties = {
   paddingBottom: '32px',
 };
 
-const logo: React.CSSProperties = {
-  fontSize: '22px',
-  fontWeight: 700,
-  letterSpacing: '-0.03em',
-  color: '#22110C',
-  margin: 0,
+const logoImg: React.CSSProperties = {
+  margin: '0 auto',
 };
 
 const card: React.CSSProperties = {
@@ -188,4 +190,9 @@ const footerMuted: React.CSSProperties = {
   fontSize: '12px',
   color: '#94a3b8',
   margin: 0,
+};
+
+const footerLink: React.CSSProperties = {
+  color: '#94a3b8',
+  textDecoration: 'underline',
 };

--- a/packages/backend/src/notifications/emails/test-email.tsx
+++ b/packages/backend/src/notifications/emails/test-email.tsx
@@ -8,9 +8,16 @@ import {
   Text,
   Preview,
   Hr,
+  Img,
+  Link,
 } from '@react-email/components';
 
-export function TestEmail() {
+interface TestEmailProps {
+  logoUrl?: string;
+}
+
+export function TestEmail(props: TestEmailProps = {}) {
+  const { logoUrl = 'https://app.manifest.build/manifest-logo.png' } = props;
   return (
     <Html>
       <Head />
@@ -19,7 +26,7 @@ export function TestEmail() {
         <Container style={container}>
           {/* Logo */}
           <Section style={logoSection}>
-            <Text style={logo}>manifest</Text>
+            <Img src={logoUrl} alt="Manifest" width="140" height="32" style={logoImg} />
           </Section>
 
           {/* Main content */}
@@ -34,8 +41,8 @@ export function TestEmail() {
               email provider configuration is working correctly.
             </Text>
             <Text style={paragraph}>
-              Notification emails — such as threshold alerts — will be delivered
-              to this address.
+              Notification emails, like threshold alerts, will be delivered to
+              this address.
             </Text>
           </Section>
 
@@ -45,7 +52,12 @@ export function TestEmail() {
             <Text style={footerNote}>
               This is a one-time test email sent from Manifest.
             </Text>
-            <Text style={footerMuted}>manifest.build</Text>
+            <Text style={footerMuted}>
+              © 2026 MNFST Inc. All rights reserved.{' '}
+              <Link href="https://manifest.build" style={footerLink}>
+                manifest.build
+              </Link>
+            </Text>
           </Section>
         </Container>
       </Body>
@@ -80,12 +92,8 @@ const logoSection: React.CSSProperties = {
   paddingBottom: '32px',
 };
 
-const logo: React.CSSProperties = {
-  fontSize: '22px',
-  fontWeight: 700,
-  letterSpacing: '-0.03em',
-  color: '#22110C',
-  margin: 0,
+const logoImg: React.CSSProperties = {
+  margin: '0 auto',
 };
 
 const card: React.CSSProperties = {
@@ -149,4 +157,9 @@ const footerMuted: React.CSSProperties = {
   fontSize: '12px',
   color: '#94a3b8',
   margin: 0,
+};
+
+const footerLink: React.CSSProperties = {
+  color: '#94a3b8',
+  textDecoration: 'underline',
 };

--- a/packages/backend/src/notifications/emails/threshold-alert.tsx
+++ b/packages/backend/src/notifications/emails/threshold-alert.tsx
@@ -22,6 +22,8 @@ export interface ThresholdAlertProps {
   timestamp: string;
   agentUrl: string;
   logoUrl?: string;
+  alertType?: 'soft' | 'hard';
+  periodResetDate?: string;
 }
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -52,7 +54,14 @@ export function ThresholdAlertEmail(props: ThresholdAlertProps) {
     timestamp,
     agentUrl,
     logoUrl = 'https://app.manifest.build/manifest-logo.png',
+    alertType = 'hard',
+    periodResetDate,
   } = props;
+
+  const isSoft = alertType === 'soft';
+  const accentColor = isSoft ? '#ea580c' : '#dc2626';
+  const accentBg = isSoft ? '#fff7ed' : '#fef2f2';
+  const accentBorder = isSoft ? '#fed7aa' : '#fecaca';
 
   return (
     <Html>
@@ -71,7 +80,9 @@ export function ThresholdAlertEmail(props: ThresholdAlertProps) {
           <Section style={card}>
             {/* Alert badge */}
             <Section style={alertBadgeContainer}>
-              <Text style={alertBadge}>Threshold exceeded</Text>
+              <Text style={{ ...alertBadge, color: accentColor, backgroundColor: accentBg }}>
+                {isSoft ? 'Warning' : 'Threshold exceeded'}
+              </Text>
             </Section>
 
             <Text style={heading}>
@@ -82,15 +93,27 @@ export function ThresholdAlertEmail(props: ThresholdAlertProps) {
               threshold for the current <strong>{period}</strong> period.
             </Text>
 
+            {/* Context message */}
+            {isSoft ? (
+              <Text style={paragraph}>Requests are still being processed normally.</Text>
+            ) : (
+              <Section style={{ ...hardLimitBox, backgroundColor: accentBg, borderColor: accentBorder }}>
+                <Text style={{ ...hardLimitText, color: accentColor }}>
+                  Requests are now blocked until the next period resets
+                  {periodResetDate ? ` on ${formatTimestamp(periodResetDate)}` : ''}.
+                </Text>
+              </Section>
+            )}
+
             {/* Stats row */}
             <Section style={statsRow}>
               <Section style={statBox}>
                 <Text style={statLabel}>Threshold</Text>
                 <Text style={statValue}>{formatValue(threshold, metricType)}</Text>
               </Section>
-              <Section style={statBoxAlert}>
+              <Section style={{ ...statBoxAlert, backgroundColor: accentBg, borderColor: accentBorder }}>
                 <Text style={statLabel}>Actual usage</Text>
-                <Text style={statValueAlert}>{formatValue(actualValue, metricType)}</Text>
+                <Text style={{ ...statValueAlert, color: accentColor }}>{formatValue(actualValue, metricType)}</Text>
               </Section>
             </Section>
 
@@ -176,8 +199,6 @@ const alertBadge: React.CSSProperties = {
   fontWeight: 600,
   textTransform: 'uppercase' as const,
   letterSpacing: '0.05em',
-  color: '#dc2626',
-  backgroundColor: '#fef2f2',
   padding: '4px 10px',
   borderRadius: '6px',
   margin: 0,
@@ -212,10 +233,23 @@ const statBox: React.CSSProperties = {
 };
 
 const statBoxAlert: React.CSSProperties = {
-  backgroundColor: '#fef2f2',
   borderRadius: '8px',
   padding: '16px 20px',
-  border: '1px solid #fecaca',
+  border: '1px solid',
+};
+
+const hardLimitBox: React.CSSProperties = {
+  padding: '12px 16px',
+  borderRadius: '8px',
+  border: '1px solid',
+  marginBottom: '28px',
+};
+
+const hardLimitText: React.CSSProperties = {
+  fontSize: '14px',
+  fontWeight: 700,
+  margin: 0,
+  lineHeight: '1.5',
 };
 
 const statLabel: React.CSSProperties = {
@@ -238,7 +272,6 @@ const statValue: React.CSSProperties = {
 const statValueAlert: React.CSSProperties = {
   fontSize: '24px',
   fontWeight: 700,
-  color: '#dc2626',
   margin: 0,
   letterSpacing: '-0.02em',
 };

--- a/packages/backend/src/notifications/emails/verify-email.tsx
+++ b/packages/backend/src/notifications/emails/verify-email.tsx
@@ -9,15 +9,18 @@ import {
   Button,
   Preview,
   Hr,
+  Img,
+  Link,
 } from '@react-email/components';
 
 export interface VerifyEmailProps {
   userName: string;
   verificationUrl: string;
+  logoUrl?: string;
 }
 
 export function VerifyEmailEmail(props: VerifyEmailProps) {
-  const { userName, verificationUrl } = props;
+  const { userName, verificationUrl, logoUrl = 'https://app.manifest.build/manifest-logo.png' } = props;
 
   return (
     <Html>
@@ -27,7 +30,7 @@ export function VerifyEmailEmail(props: VerifyEmailProps) {
         <Container style={container}>
           {/* Logo */}
           <Section style={logoSection}>
-            <Text style={logo}>manifest</Text>
+            <Img src={logoUrl} alt="Manifest" width="140" height="32" style={logoImg} />
           </Section>
 
           {/* Main content */}
@@ -62,7 +65,10 @@ export function VerifyEmailEmail(props: VerifyEmailProps) {
           <Hr style={divider} />
           <Section style={footer}>
             <Text style={footerMuted}>
-              manifest.build
+              © 2026 MNFST Inc. All rights reserved.{' '}
+              <Link href="https://manifest.build" style={footerLink}>
+                manifest.build
+              </Link>
             </Text>
           </Section>
         </Container>
@@ -101,12 +107,8 @@ const logoSection: React.CSSProperties = {
   paddingBottom: '32px',
 };
 
-const logo: React.CSSProperties = {
-  fontSize: '22px',
-  fontWeight: 700,
-  letterSpacing: '-0.03em',
-  color: '#22110C',
-  margin: 0,
+const logoImg: React.CSSProperties = {
+  margin: '0 auto',
 };
 
 const card: React.CSSProperties = {
@@ -187,4 +189,9 @@ const footerMuted: React.CSSProperties = {
   fontSize: '12px',
   color: '#94a3b8',
   margin: 0,
+};
+
+const footerLink: React.CSSProperties = {
+  color: '#94a3b8',
+  textDecoration: 'underline',
 };

--- a/packages/backend/src/notifications/services/limit-check.service.spec.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.spec.ts
@@ -205,7 +205,15 @@ describe('LimitCheckService', () => {
 
       expect(mockSendThresholdAlert).toHaveBeenCalledWith(
         'test@example.com',
-        expect.objectContaining({ agentName: 'my-agent', metricType: 'tokens', threshold: 50000, actualValue: 60000, period: 'day' }),
+        expect.objectContaining({
+          agentName: 'my-agent',
+          metricType: 'tokens',
+          threshold: 50000,
+          actualValue: 60000,
+          period: 'day',
+          alertType: 'hard',
+          periodResetDate: expect.any(String),
+        }),
         undefined,
       );
       const insertCall = mockQuery.mock.calls.find(

--- a/packages/backend/src/notifications/services/limit-check.service.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.ts
@@ -6,7 +6,7 @@ import { NotificationRulesService } from './notification-rules.service';
 import { NotificationEmailService } from './notification-email.service';
 import { EmailProviderConfigService } from './email-provider-config.service';
 import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
-import { computePeriodBoundaries } from '../../common/utils/period.util';
+import { computePeriodBoundaries, computePeriodResetDate } from '../../common/utils/period.util';
 import { detectDialect, portableSql, type DbDialect } from '../../common/utils/sql-dialect';
 import {
   LOCAL_EMAIL,
@@ -143,6 +143,8 @@ export class LimitCheckService implements OnModuleInit, OnModuleDestroy {
           period: rule.period,
           timestamp: now,
           agentUrl: `${baseUrl}/agents/${encodeURIComponent(rule.agent_name)}`,
+          alertType: 'hard',
+          periodResetDate: computePeriodResetDate(rule.period),
         },
         providerConfig ?? undefined,
       );

--- a/packages/backend/src/notifications/services/notification-cron.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.spec.ts
@@ -117,6 +117,7 @@ describe('NotificationCronService', () => {
         metricType: 'tokens',
         threshold: 100000,
         actualValue: 150000,
+        alertType: 'soft',
       }),
       undefined,
     );
@@ -453,6 +454,7 @@ describe('NotificationCronService (sql.js / local mode)', () => {
         metricType: 'tokens',
         threshold: 100000,
         actualValue: 150000,
+        alertType: 'soft',
       }),
       undefined,
     );

--- a/packages/backend/src/notifications/services/notification-cron.service.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.ts
@@ -111,6 +111,7 @@ export class NotificationCronService implements OnModuleInit {
           period: rule.period,
           timestamp: now,
           agentUrl: `${baseUrl}/agents/${encodeURIComponent(rule.agent_name)}`,
+          alertType: 'soft',
         },
         providerConfig ?? undefined,
       );

--- a/packages/backend/src/notifications/services/notification-email.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-email.service.spec.ts
@@ -161,4 +161,66 @@ describe('NotificationEmailService', () => {
 
     expect(result).toBe(false);
   });
+
+  it('uses "Warning:" subject prefix for soft alerts', async () => {
+    (sendEmail as jest.Mock).mockResolvedValue(true);
+
+    await service.sendThresholdAlert('user@test.com', {
+      agentName: 'demo-agent',
+      metricType: 'tokens',
+      threshold: 1000,
+      actualValue: 1500,
+      period: 'hour',
+      timestamp: '2024-01-01T00:00:00Z',
+      agentUrl: 'http://localhost:3001/agents/demo-agent',
+      alertType: 'soft',
+    });
+
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Warning: demo-agent exceeded tokens threshold',
+      }),
+    );
+  });
+
+  it('uses "Alert:" subject prefix for hard alerts', async () => {
+    (sendEmail as jest.Mock).mockResolvedValue(true);
+
+    await service.sendThresholdAlert('user@test.com', {
+      agentName: 'demo-agent',
+      metricType: 'cost',
+      threshold: 50,
+      actualValue: 75,
+      period: 'day',
+      timestamp: '2024-01-01T12:00:00Z',
+      agentUrl: 'http://localhost:3001/agents/demo-agent',
+      alertType: 'hard',
+    });
+
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Alert: demo-agent exceeded cost threshold',
+      }),
+    );
+  });
+
+  it('defaults to "Alert:" subject when alertType is not set', async () => {
+    (sendEmail as jest.Mock).mockResolvedValue(true);
+
+    await service.sendThresholdAlert('user@test.com', {
+      agentName: 'demo-agent',
+      metricType: 'tokens',
+      threshold: 1000,
+      actualValue: 1500,
+      period: 'hour',
+      timestamp: '2024-01-01T00:00:00Z',
+      agentUrl: 'http://localhost:3001/agents/demo-agent',
+    });
+
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: 'Alert: demo-agent exceeded tokens threshold',
+      }),
+    );
+  });
 });

--- a/packages/backend/src/notifications/services/notification-email.service.ts
+++ b/packages/backend/src/notifications/services/notification-email.service.ts
@@ -17,7 +17,8 @@ export class NotificationEmailService {
     const element = ThresholdAlertEmail(props);
     const html = await render(element);
     const text = await render(element, { plainText: true });
-    const subject = `Alert: ${props.agentName} exceeded ${props.metricType} threshold`;
+    const prefix = props.alertType === 'soft' ? 'Warning' : 'Alert';
+    const subject = `${prefix}: ${props.agentName} exceeded ${props.metricType} threshold`;
 
     if (providerConfig) {
       const defaultFrom = process.env['NOTIFICATION_FROM_EMAIL'] ?? 'noreply@manifest.build';


### PR DESCRIPTION
## Summary

- Unify all 4 email templates (verify-email, reset-password, test-email, threshold-alert) with consistent PNG logo and copyright footer (`© 2026 MNFST Inc. All rights reserved.` + clickable `manifest.build` link)
- Differentiate soft (warning-only) and hard (request-blocking) threshold alerts with distinct colors and messaging:
  - **Soft:** orange accent (`#ea580c`), "Warning" badge, "Requests are still being processed normally"
  - **Hard:** red accent (`#dc2626`), "Threshold exceeded" badge, blocked-until message with period reset date
- Email subject line: `Warning:` prefix for soft, `Alert:` for hard
- Add `computePeriodResetDate()` utility to calculate when the current period ends
- Cron service (soft limits) passes `alertType: 'soft'`; limit-check service (hard limits) passes `alertType: 'hard'` with `periodResetDate`

## Test plan

- [x] All 1795 unit tests pass
- [x] All 86 e2e tests pass
- [x] TypeScript compiles with no errors (`npx tsc --noEmit`)
- [x] `TestEmail()` still callable with no args (backward compat)
- [x] New tests for `computePeriodResetDate` (7 tests)
- [x] New tests for subject line differentiation (3 tests)
- [x] Updated assertions in cron and limit-check specs for `alertType`