### PR TITLE
fix: humanize user-facing website text

### DIFF
--- a/.changeset/humanize-website-text.md
+++ b/.changeset/humanize-website-text.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Rewrite user-facing text to remove AI writing patterns (em dashes, promotional language, verbose empty states)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ OpenClaw costs
 
 ## What do you get?
 
-- 🔀 **Routes every request to the right model** — and cuts costs up to 70%
-- 📊 **Track your expenses** — real-time dashboard that shows tokens and costs per model
-- 🔔 **Set limits** — set up alerts (soft or hard) if your consumption exceeds a certain volume
+- 🔀 **Route requests to the right model** — cut costs up to 70%
+- 📊 **Track spending** — see tokens and costs per model in real time
+- 🔔 **Set limits** — get alerts when usage goes over a threshold
 
 ## Why Manifest
 
@@ -122,7 +122,7 @@ Or add `"telemetryOptOut": true` to `~/.openclaw/manifest/config.json`.
 
 ## Supported Providers
 
-Manifest supports **300+ models** across all major LLM providers. Every provider supports smart routing, real-time cost tracking, and OTLP telemetry.
+Works with **300+ models** across these providers:
 
 | Provider | Models |
 |----------|--------|

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -7,12 +7,12 @@
     <link href="/fonts/boxicons/boxicons-duotone.min.css" rel="stylesheet" />
     <meta
       name="description"
-      content="Open Source platform to monitor and control OpenClaw costs and performance."
+      content="Monitor and control your OpenClaw costs."
     />
     <meta property="og:title" content="Manifest" />
     <meta
       property="og:description"
-      content="Open Source platform to monitor and control OpenClaw costs and performance."
+      content="Monitor and control your OpenClaw costs."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://app.manifest.build" />
@@ -21,7 +21,7 @@
     <meta name="twitter:title" content="Manifest" />
     <meta
       name="twitter:description"
-      content="Open Source platform to monitor and control OpenClaw costs and performance."
+      content="Monitor and control your OpenClaw costs."
     />
     <meta name="twitter:image" content="https://app.manifest.build/og-image.png" />
     <script src="/theme-init.js"></script>

--- a/packages/frontend/src/components/EmailProviderSetup.tsx
+++ b/packages/frontend/src/components/EmailProviderSetup.tsx
@@ -1,5 +1,5 @@
-import { createSignal, type Component } from "solid-js";
-import EmailProviderModal from "./EmailProviderModal.jsx";
+import { createSignal, type Component } from 'solid-js';
+import EmailProviderModal from './EmailProviderModal.jsx';
 
 interface Props {
   onConfigured: () => void;
@@ -7,7 +7,7 @@ interface Props {
 
 const EmailProviderSetup: Component<Props> = (props) => {
   const [modalOpen, setModalOpen] = createSignal(false);
-  const [selectedProvider, setSelectedProvider] = createSignal<string>("resend");
+  const [selectedProvider, setSelectedProvider] = createSignal<string>('resend');
 
   const openModal = (provider: string) => {
     setSelectedProvider(provider);
@@ -22,25 +22,25 @@ const EmailProviderSetup: Component<Props> = (props) => {
       </p>
 
       <div class="provider-setup-grid">
-        <button class="provider-setup-card" onClick={() => openModal("resend")}>
+        <button class="provider-setup-card" onClick={() => openModal('resend')}>
           <img src="/logos/resend.svg" alt="" class="provider-setup-card__logo" />
           <div>
             <div class="provider-setup-card__name">Resend</div>
-            <div class="provider-setup-card__desc">Modern email API</div>
+            <div class="provider-setup-card__desc">Email API</div>
           </div>
         </button>
-        <button class="provider-setup-card" onClick={() => openModal("mailgun")}>
+        <button class="provider-setup-card" onClick={() => openModal('mailgun')}>
           <img src="/logos/mailgun.svg" alt="" class="provider-setup-card__logo" />
           <div>
             <div class="provider-setup-card__name">Mailgun</div>
-            <div class="provider-setup-card__desc">Reliable email service</div>
+            <div class="provider-setup-card__desc">Transactional email</div>
           </div>
         </button>
-        <button class="provider-setup-card" onClick={() => openModal("sendgrid")}>
+        <button class="provider-setup-card" onClick={() => openModal('sendgrid')}>
           <img src="/logos/sendgrid.svg" alt="" class="provider-setup-card__logo" />
           <div>
             <div class="provider-setup-card__name">SendGrid</div>
-            <div class="provider-setup-card__desc">Scalable email delivery</div>
+            <div class="provider-setup-card__desc">Email delivery</div>
           </div>
         </button>
       </div>

--- a/packages/frontend/src/components/SetupModal.tsx
+++ b/packages/frontend/src/components/SetupModal.tsx
@@ -1,48 +1,65 @@
-import { createResource, createSignal, For, Show, type Component } from 'solid-js'
-import SetupStepInstall from './SetupStepInstall.jsx'
-import SetupStepConfigure from './SetupStepConfigure.jsx'
-import SetupStepVerify from './SetupStepVerify.jsx'
-import SetupStepLocalConfigure from './SetupStepLocalConfigure.jsx'
-import { getAgentKey, getHealth } from '../services/api.js'
+import { createResource, createSignal, For, Show, type Component } from 'solid-js';
+import SetupStepInstall from './SetupStepInstall.jsx';
+import SetupStepConfigure from './SetupStepConfigure.jsx';
+import SetupStepVerify from './SetupStepVerify.jsx';
+import SetupStepLocalConfigure from './SetupStepLocalConfigure.jsx';
+import { getAgentKey, getHealth } from '../services/api.js';
 
-interface StepDef { n: number; label: string }
+interface StepDef {
+  n: number;
+  label: string;
+}
 
 const CLOUD_STEPS: StepDef[] = [
   { n: 1, label: 'Install' },
   { n: 2, label: 'Configure' },
   { n: 3, label: 'Activate' },
-]
+];
 
 const LOCAL_STEPS: StepDef[] = [
   { n: 1, label: 'Configure' },
   { n: 2, label: 'Verify' },
-]
+];
 
-const SetupModal: Component<{ open: boolean; agentName: string; apiKey?: string | null; onClose: () => void; onDone?: () => void }> = (props) => {
-  const [step, setStep] = createSignal(1)
+const SetupModal: Component<{
+  open: boolean;
+  agentName: string;
+  apiKey?: string | null;
+  onClose: () => void;
+  onDone?: () => void;
+}> = (props) => {
+  const [step, setStep] = createSignal(1);
 
-  const [healthData] = createResource(() => props.open, (open) => open ? getHealth() : null)
-  const isLocal = () => (healthData() as { mode?: string })?.mode === 'local'
+  const [healthData] = createResource(
+    () => props.open,
+    (open) => (open ? getHealth() : null),
+  );
+  const isLocal = () => (healthData() as { mode?: string })?.mode === 'local';
 
   const [apiKeyData] = createResource(
     () => (props.open ? props.agentName : null),
     (n) => (n ? getAgentKey(n) : null),
-  )
+  );
 
   const endpoint = () => {
-    const custom = apiKeyData()?.pluginEndpoint
-    if (custom) return custom
-    const host = window.location.hostname
-    if (host === 'app.manifest.build') return null
-    return `${window.location.origin}/otlp`
-  }
+    const custom = apiKeyData()?.pluginEndpoint;
+    if (custom) return custom;
+    const host = window.location.hostname;
+    if (host === 'app.manifest.build') return null;
+    return `${window.location.origin}/otlp`;
+  };
 
-  const steps = () => isLocal() ? LOCAL_STEPS : CLOUD_STEPS
-  const totalSteps = () => steps().length
+  const steps = () => (isLocal() ? LOCAL_STEPS : CLOUD_STEPS);
+  const totalSteps = () => steps().length;
 
   return (
     <Show when={props.open}>
-      <div class="modal-overlay setup-modal__overlay" onClick={(e) => { if (e.target === e.currentTarget) props.onClose(); }}>
+      <div
+        class="modal-overlay setup-modal__overlay"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) props.onClose();
+        }}
+      >
         <div class="modal-card" style="max-width: 600px;">
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-sm);">
             <div class="modal-card__title">Set up your agent</div>
@@ -51,14 +68,35 @@ const SetupModal: Component<{ open: boolean; agentName: string; apiKey?: string 
               onClick={() => props.onClose()}
               aria-label="Close"
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
             </button>
           </div>
           <p class="modal-card__desc">
-            <Show when={isLocal()} fallback={
-              <>Follow these steps to send telemetry from your agent to Manifest. Once your first messages arrive, <strong>your dashboard populates automatically</strong>.</>
-            }>
-              <>Your local server is running. Configure the OpenClaw plugin and verify that telemetry data is flowing.</>
+            <Show
+              when={isLocal()}
+              fallback={
+                <>
+                  Follow these steps to send telemetry from your agent to Manifest. Once your first
+                  messages arrive, <strong>your dashboard updates on its own</strong>.
+                </>
+              }
+            >
+              <>
+                Your local server is running. Configure the OpenClaw plugin and verify that
+                telemetry data is flowing.
+              </>
             </Show>
           </p>
 
@@ -80,7 +118,16 @@ const SetupModal: Component<{ open: boolean; agentName: string; apiKey?: string 
                   >
                     <div class="modal-stepper__circle">
                       <Show when={step() > s.n} fallback={s.n}>
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12" /></svg>
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="3"
+                        >
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
                       </Show>
                     </div>
                     <span class="modal-stepper__label">{s.label}</span>
@@ -130,18 +177,21 @@ const SetupModal: Component<{ open: boolean; agentName: string; apiKey?: string 
             >
               Back
             </button>
-            <Show when={step() < totalSteps()} fallback={
-              <button
-                class="setup-modal__next"
-                onClick={() => { props.onDone?.(); props.onClose(); }}
-              >
-                Done
-              </button>
-            }>
-              <button
-                class="setup-modal__next"
-                onClick={() => setStep((s) => s + 1)}
-              >
+            <Show
+              when={step() < totalSteps()}
+              fallback={
+                <button
+                  class="setup-modal__next"
+                  onClick={() => {
+                    props.onDone?.();
+                    props.onClose();
+                  }}
+                >
+                  Done
+                </button>
+              }
+            >
+              <button class="setup-modal__next" onClick={() => setStep((s) => s + 1)}>
                 Next
               </button>
             </Show>
@@ -149,7 +199,7 @@ const SetupModal: Component<{ open: boolean; agentName: string; apiKey?: string 
         </div>
       </div>
     </Show>
-  )
-}
+  );
+};
 
-export default SetupModal
+export default SetupModal;

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
-import { A, useLocation } from "@solidjs/router";
-import { Show, type Component } from "solid-js";
-import { useAgentName, agentPath } from "../services/routing.js";
-import { isLocalMode } from "../services/local-mode.js";
+import { A, useLocation } from '@solidjs/router';
+import { Show, type Component } from 'solid-js';
+import { useAgentName, agentPath } from '../services/routing.js';
+import { isLocalMode } from '../services/local-mode.js';
 
 const Sidebar: Component = () => {
   const location = useLocation();
@@ -11,7 +11,7 @@ const Sidebar: Component = () => {
 
   const isActive = (sub: string) => {
     const p = path(sub);
-    if (sub === "") return location.pathname === p;
+    if (sub === '') return location.pathname === p;
     return location.pathname.startsWith(p);
   };
 
@@ -21,8 +21,8 @@ const Sidebar: Component = () => {
         <A
           href="/"
           class="sidebar__link"
-          classList={{ active: location.pathname === "/" }}
-          aria-current={location.pathname === "/" ? "page" : undefined}
+          classList={{ active: location.pathname === '/' }}
+          aria-current={location.pathname === '/' ? 'page' : undefined}
         >
           Agents
         </A>
@@ -31,41 +31,46 @@ const Sidebar: Component = () => {
       <Show when={getAgentName()}>
         <div class="sidebar__section-label">MONITORING</div>
         <A
-          href={path("")}
+          href={path('')}
           class="sidebar__link"
-          classList={{ active: isActive("") }}
-          aria-current={isActive("") ? "page" : undefined}
+          classList={{ active: isActive('') }}
+          aria-current={isActive('') ? 'page' : undefined}
         >
           Overview
         </A>
         <A
-          href={path("/messages")}
+          href={path('/messages')}
           class="sidebar__link"
-          classList={{ active: isActive("/messages") }}
-          aria-current={isActive("/messages") ? "page" : undefined}
+          classList={{ active: isActive('/messages') }}
+          aria-current={isActive('/messages') ? 'page' : undefined}
         >
           Messages
         </A>
 
         <div class="sidebar__section-label">MANAGE</div>
         <A
-          href={path("/routing")}
+          href={path('/routing')}
           class="sidebar__link"
-          classList={{ active: isActive("/routing") }}
-          aria-current={isActive("/routing") ? "page" : undefined}
+          classList={{ active: isActive('/routing') }}
+          aria-current={isActive('/routing') ? 'page' : undefined}
         >
           Routing
         </A>
         <A
-          href={path("/limits")}
+          href={path('/limits')}
           class="sidebar__link"
-          classList={{ active: isActive("/limits") }}
-          aria-current={isActive("/limits") ? "page" : undefined}
+          classList={{ active: isActive('/limits') }}
+          aria-current={isActive('/limits') ? 'page' : undefined}
         >
           Limits
         </A>
         <Show when={!isLocalMode()}>
-          <A href={path("/settings")} class="sidebar__link" classList={{ active: isActive("/settings") }} aria-current={isActive("/settings") ? "page" : undefined}>
+          <A
+            href={path('/settings')}
+            class="sidebar__link"
+            classList={{ active: isActive('/settings') }}
+            aria-current={isActive('/settings') ? 'page' : undefined}
+          >
             Settings
           </A>
         </Show>
@@ -74,18 +79,18 @@ const Sidebar: Component = () => {
       <Show when={getAgentName()}>
         <div class="sidebar__section-label">RESOURCES</div>
         <A
-          href={path("/model-prices")}
+          href={path('/model-prices')}
           class="sidebar__link"
-          classList={{ active: isActive("/model-prices") }}
-          aria-current={isActive("/model-prices") ? "page" : undefined}
+          classList={{ active: isActive('/model-prices') }}
+          aria-current={isActive('/model-prices') ? 'page' : undefined}
         >
           Model Prices
         </A>
         <A
-          href={path("/help")}
+          href={path('/help')}
           class="sidebar__link"
-          classList={{ active: isActive("/help") }}
-          aria-current={isActive("/help") ? "page" : undefined}
+          classList={{ active: isActive('/help') }}
+          aria-current={isActive('/help') ? 'page' : undefined}
         >
           Help
         </A>
@@ -103,9 +108,7 @@ const Sidebar: Component = () => {
           <i class="bxd bx-message-bubble-detail" />
           Feedback
         </span>
-        <p class="sidebar__feedback-hint">
-          Help shape Manifest's roadmap &mdash; share feature ideas, report bugs, or suggest improvements.
-        </p>
+        <p class="sidebar__feedback-hint">Share ideas or report bugs.</p>
       </a>
     </nav>
   );

--- a/packages/frontend/src/pages/Help.tsx
+++ b/packages/frontend/src/pages/Help.tsx
@@ -1,15 +1,20 @@
-import type { Component } from "solid-js";
-import { Title, Meta } from "@solidjs/meta";
+import type { Component } from 'solid-js';
+import { Title, Meta } from '@solidjs/meta';
 
 const Help: Component = () => {
   return (
     <div class="container--sm">
       <Title>Help & Support - Manifest</Title>
-      <Meta name="description" content="Get help with Manifest. Schedule a call or contact support." />
+      <Meta
+        name="description"
+        content="Get help with Manifest. Schedule a call or contact support."
+      />
       <div class="page-header">
         <div>
           <h1>Help & Support</h1>
-          <span class="breadcrumb">Questions or issues? Reach out and we'll get back to you quickly</span>
+          <span class="breadcrumb">
+            Questions or issues? Reach out and we'll get back to you quickly
+          </span>
         </div>
       </div>
 
@@ -17,7 +22,9 @@ const Help: Component = () => {
         <div class="settings-card__row">
           <div class="settings-card__label">
             <span class="settings-card__label-title">Schedule a Call</span>
-            <span class="settings-card__label-desc">Book a 30-min session with our team to discuss setup, integrations, or troubleshooting.</span>
+            <span class="settings-card__label-desc">
+              Book a 30-min call with us to get help setting things up.
+            </span>
           </div>
           <div class="settings-card__control">
             <a
@@ -28,14 +35,30 @@ const Help: Component = () => {
               style="font-size: var(--font-size-sm); text-decoration: none;"
             >
               Book
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-left: 4px;"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="margin-left: 4px;"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
             </a>
           </div>
         </div>
         <div class="settings-card__row">
           <div class="settings-card__label">
             <span class="settings-card__label-title">Email Support</span>
-            <span class="settings-card__label-desc">sebastien@manifest.build &mdash; we typically respond within 24 hours.</span>
+            <span class="settings-card__label-desc">
+              sebastien@manifest.build &mdash; we typically respond within 24 hours.
+            </span>
           </div>
           <div class="settings-card__control">
             <a
@@ -44,7 +67,20 @@ const Help: Component = () => {
               style="font-size: var(--font-size-sm); text-decoration: none;"
             >
               Contact
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="margin-left: 4px;"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="margin-left: 4px;"
+              >
+                <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+                <polyline points="22,6 12,13 2,6" />
+              </svg>
             </a>
           </div>
         </div>

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -196,8 +196,8 @@ const Limits: Component = () => {
             <line x1="12" y1="17" x2="12.01" y2="17" />
           </svg>
           <span>
-            One or more hard limits have been triggered &mdash; new proxy requests for this agent
-            will be blocked until the usage resets in the next period.
+            One or more hard limits triggered. New proxy requests for this agent will be blocked
+            until the usage resets in the next period.
           </span>
         </div>
       </Show>
@@ -256,10 +256,7 @@ const Limits: Component = () => {
           fallback={
             <div class="empty-state">
               <div class="empty-state__title">No rules yet</div>
-              <p>
-                Set up email alerts to get notified when usage spikes, or create hard limits to
-                automatically block requests that exceed your budget.
-              </p>
+              <p>Set up alerts for usage spikes, or hard limits to block requests over budget.</p>
             </div>
           }
         >

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -135,7 +135,7 @@ const MessageLog: Component = () => {
         <div>
           <h1>Messages</h1>
           <span class="breadcrumb">
-            Full log of every LLM call &mdash; filter by status, model, or cost
+            Full log of every LLM call. Filter by status, model, or cost.
           </span>
         </div>
         <div class="header-controls">
@@ -227,10 +227,7 @@ const MessageLog: Component = () => {
               fallback={
                 <div class="empty-state">
                   <div class="empty-state__title">No messages recorded</div>
-                  <p>
-                    Connect your agent to Manifest and send your first message. Each LLM call will
-                    be logged here with its cost, tokens, and status.
-                  </p>
+                  <p>Connect your agent and send a message. Each LLM call gets logged here.</p>
                   <button
                     class="btn btn--primary"
                     style="margin-top: var(--gap-md);"
@@ -247,8 +244,8 @@ const MessageLog: Component = () => {
               <div class="waiting-banner">
                 <i class="bxd bx-florist" />
                 <p>
-                  Waiting for data &mdash; messages will appear within seconds of your agent's first
-                  LLM call.
+                  Waiting for data. Messages will show up within seconds of your agent's first LLM
+                  call.
                 </p>
               </div>
               <div class="demo-dashboard">

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -1,142 +1,137 @@
-import { Meta, Title } from '@solidjs/meta'
-import { A, useLocation, useParams } from '@solidjs/router'
-import {
-  createEffect,
-  createResource,
-  createSignal,
-  For,
-  Show,
-  type Component,
-} from 'solid-js'
-import CostChart from '../components/CostChart.jsx'
-import ErrorState from '../components/ErrorState.jsx'
-import InfoTooltip from '../components/InfoTooltip.jsx'
-import Select from '../components/Select.jsx'
-import SetupModal from '../components/SetupModal.jsx'
-import SingleTokenChart from '../components/SingleTokenChart.jsx'
-import TokenChart from '../components/TokenChart.jsx'
-import { getOverview } from '../services/api.js'
+import { Meta, Title } from '@solidjs/meta';
+import { A, useLocation, useParams } from '@solidjs/router';
+import { createEffect, createResource, createSignal, For, Show, type Component } from 'solid-js';
+import CostChart from '../components/CostChart.jsx';
+import ErrorState from '../components/ErrorState.jsx';
+import InfoTooltip from '../components/InfoTooltip.jsx';
+import Select from '../components/Select.jsx';
+import SetupModal from '../components/SetupModal.jsx';
+import SingleTokenChart from '../components/SingleTokenChart.jsx';
+import TokenChart from '../components/TokenChart.jsx';
+import { getOverview } from '../services/api.js';
 import {
   formatCost,
   formatErrorMessage,
   formatNumber,
   formatStatus,
   formatTime,
-} from '../services/formatters.js'
-import { inferProviderFromModel, inferProviderName } from '../services/routing-utils.js'
-import { providerIcon } from '../components/ProviderIcon.jsx'
-import { isLocalMode } from '../services/local-mode.js'
-import { pingCount } from '../services/sse.js'
-import '../styles/overview.css'
+} from '../services/formatters.js';
+import { inferProviderFromModel, inferProviderName } from '../services/routing-utils.js';
+import { providerIcon } from '../components/ProviderIcon.jsx';
+import { isLocalMode } from '../services/local-mode.js';
+import { pingCount } from '../services/sse.js';
+import '../styles/overview.css';
 
 interface RecentMessage {
-  id: string
-  timestamp: string
-  agent_name: string | null
-  model: string | null
-  routing_tier?: string
-  routing_reason?: string
-  input_tokens: number | null
-  output_tokens: number | null
-  total_tokens: number | null
-  cost: number | null
-  status: string
-  error_message?: string | null
+  id: string;
+  timestamp: string;
+  agent_name: string | null;
+  model: string | null;
+  routing_tier?: string;
+  routing_reason?: string;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+  cost: number | null;
+  status: string;
+  error_message?: string | null;
 }
 
 interface OverviewData {
   summary: {
     tokens_today: {
-      value: number
-      trend_pct: number
-      sub_values?: { input: number; output: number }
-    }
-    cost_today: { value: number; trend_pct: number }
-    messages: { value: number; trend_pct: number }
-    services_hit: { total: number; healthy: number; issues: number }
-  }
+      value: number;
+      trend_pct: number;
+      sub_values?: { input: number; output: number };
+    };
+    cost_today: { value: number; trend_pct: number };
+    messages: { value: number; trend_pct: number };
+    services_hit: { total: number; healthy: number; issues: number };
+  };
   token_usage: Array<{
-    hour?: string
-    date?: string
-    input_tokens: number
-    output_tokens: number
-  }>
-  cost_usage: Array<{ hour?: string; date?: string; cost: number }>
-  message_usage: Array<{ hour?: string; date?: string; count: number }>
+    hour?: string;
+    date?: string;
+    input_tokens: number;
+    output_tokens: number;
+  }>;
+  cost_usage: Array<{ hour?: string; date?: string; cost: number }>;
+  message_usage: Array<{ hour?: string; date?: string; count: number }>;
   cost_by_model: Array<{
-    model: string
-    tokens: number
-    share_pct: number
-    estimated_cost: number
-  }>
-  recent_activity: RecentMessage[]
+    model: string;
+    tokens: number;
+    share_pct: number;
+    estimated_cost: number;
+  }>;
+  recent_activity: RecentMessage[];
   active_skills: Array<{
-    name: string
-    agent_name: string | null
-    run_count: number
-    last_active_at: string
-    status: string
-  }>
-  has_data?: boolean
+    name: string;
+    agent_name: string | null;
+    run_count: number;
+    last_active_at: string;
+    status: string;
+  }>;
+  has_data?: boolean;
 }
 
-type ActiveView = 'cost' | 'tokens' | 'messages'
+type ActiveView = 'cost' | 'tokens' | 'messages';
 
 const Overview: Component = () => {
-  const params = useParams<{ agentName: string }>()
-  const location = useLocation<{ newAgent?: boolean; newApiKey?: string }>()
-  const [range, setRange] = createSignal('7d')
-  const [activeView, setActiveView] = createSignal<ActiveView>('cost')
+  const params = useParams<{ agentName: string }>();
+  const location = useLocation<{ newAgent?: boolean; newApiKey?: string }>();
+  const [range, setRange] = createSignal('7d');
+  const [activeView, setActiveView] = createSignal<ActiveView>('cost');
   const [setupOpen, setSetupOpen] = createSignal(
-    !!(location.state as { newAgent?: boolean } | undefined)?.newAgent
-  )
+    !!(location.state as { newAgent?: boolean } | undefined)?.newAgent,
+  );
   const [setupCompleted, setSetupCompleted] = createSignal(
-    !!localStorage.getItem(`setup_completed_${params.agentName}`)
-  )
+    !!localStorage.getItem(`setup_completed_${params.agentName}`),
+  );
   const [data, { refetch }] = createResource(
     () => ({ range: range(), agentName: params.agentName, _ping: pingCount() }),
     (p) => getOverview(p.range, p.agentName) as Promise<OverviewData>,
-  )
+  );
 
   const isNewAgent = () => {
-    const d = data()
-    return d && d.has_data === false
-  }
+    const d = data();
+    return d && d.has_data === false;
+  };
 
   createEffect(() => {
     if (isLocalMode() === true && params.agentName === 'local-agent') {
-      localStorage.setItem(`setup_completed_${params.agentName}`, '1')
-      setSetupCompleted(true)
-      return
+      localStorage.setItem(`setup_completed_${params.agentName}`, '1');
+      setSetupCompleted(true);
+      return;
     }
-    if (isNewAgent() && !setupCompleted() && !localStorage.getItem(`setup_dismissed_${params.agentName}`)) {
-      setSetupOpen(true)
+    if (
+      isNewAgent() &&
+      !setupCompleted() &&
+      !localStorage.getItem(`setup_dismissed_${params.agentName}`)
+    ) {
+      setSetupOpen(true);
     }
-  })
+  });
 
   const trendBadge = (pct: number, value?: number) => {
-    if (pct === 0) return null
+    if (pct === 0) return null;
     // Don't show trend when the metric value itself is effectively zero
-    if (value !== undefined && Math.abs(value) < 0.005) return null
+    if (value !== undefined && Math.abs(value) < 0.005) return null;
     // Clamp absurd percentages (safety net for floating-point edge cases)
-    const clamped = Math.max(-999, Math.min(999, Math.round(pct)))
-    if (clamped === 0) return null
-    const cls = clamped > 0 ? 'trend trend--up' : 'trend trend--down'
-    const sign = clamped > 0 ? '+' : ''
+    const clamped = Math.max(-999, Math.min(999, Math.round(pct)));
+    if (clamped === 0) return null;
+    const cls = clamped > 0 ? 'trend trend--up' : 'trend trend--down';
+    const sign = clamped > 0 ? '+' : '';
     return (
       <span class={cls}>
         {sign}
         {clamped}%
       </span>
-    )
-  }
+    );
+  };
 
   const getMessageChartData = () => {
-    const src = data()?.message_usage
-    return (
-      src?.map((d) => ({ time: d.hour ?? d.date ?? '', value: d.count })) ?? []
-    )
-  }
+    const src = data()?.message_usage;
+    return src?.map((d) => ({ time: d.hour ?? d.date ?? '', value: d.count })) ?? [];
+  };
 
   return (
     <div class="container--md">
@@ -148,7 +143,7 @@ const Overview: Component = () => {
       <div class="page-header">
         <div>
           <h1>Overview</h1>
-          <span class="breadcrumb">Real-time summary of your agent's spending, token consumption, and message history</span>
+          <span class="breadcrumb">Real-time summary of spending, tokens, and messages</span>
         </div>
         <div class="header-controls">
           <Show when={!isNewAgent()}>
@@ -163,7 +158,13 @@ const Overview: Component = () => {
               ]}
             />
           </Show>
-          <Show when={isNewAgent() && !(isLocalMode() && params.agentName === 'local-agent') && !setupCompleted()}>
+          <Show
+            when={
+              isNewAgent() &&
+              !(isLocalMode() && params.agentName === 'local-agent') &&
+              !setupCompleted()
+            }
+          >
             <button class="btn btn--primary" onClick={() => setSetupOpen(true)}>
               Set up agent
             </button>
@@ -178,33 +179,21 @@ const Overview: Component = () => {
             <div class="chart-card" style="min-height: 360px;">
               <div class="chart-card__header">
                 <div class="chart-card__stat" style="flex: 1;">
-                  <div
-                    class="skeleton skeleton--text"
-                    style="width: 60px; height: 14px;"
-                  />
+                  <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
                   <div
                     class="skeleton skeleton--text"
                     style="width: 100px; height: 28px; margin-top: 6px;"
                   />
                 </div>
                 <div class="chart-card__stat" style="flex: 1;">
-                  <div
-                    class="skeleton skeleton--text"
-                    style="width: 80px; height: 14px;"
-                  />
+                  <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
                   <div
                     class="skeleton skeleton--text"
                     style="width: 100px; height: 28px; margin-top: 6px;"
                   />
                 </div>
-                <div
-                  class="chart-card__stat"
-                  style="flex: 1; border-right: none;"
-                >
-                  <div
-                    class="skeleton skeleton--text"
-                    style="width: 60px; height: 14px;"
-                  />
+                <div class="chart-card__stat" style="flex: 1; border-right: none;">
+                  <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
                   <div
                     class="skeleton skeleton--text"
                     style="width: 80px; height: 28px; margin-top: 6px;"
@@ -212,10 +201,7 @@ const Overview: Component = () => {
                 </div>
               </div>
               <div class="chart-card__body">
-                <div
-                  class="skeleton skeleton--rect"
-                  style="width: 100%; height: 240px;"
-                />
+                <div class="skeleton skeleton--rect" style="width: 100%; height: 240px;" />
               </div>
             </div>
             <div class="panel">
@@ -226,30 +212,12 @@ const Overview: Component = () => {
               <For each={[1, 2, 3, 4, 5]}>
                 {() => (
                   <div style="display: flex; gap: 16px; padding: 12px 0; border-bottom: 1px solid hsl(var(--border));">
-                    <div
-                      class="skeleton skeleton--text"
-                      style="width: 60px; height: 14px;"
-                    />
-                    <div
-                      class="skeleton skeleton--text"
-                      style="width: 60px; height: 14px;"
-                    />
-                    <div
-                      class="skeleton skeleton--text"
-                      style="width: 50px; height: 14px;"
-                    />
-                    <div
-                      class="skeleton skeleton--text"
-                      style="width: 80px; height: 14px;"
-                    />
-                    <div
-                      class="skeleton skeleton--text"
-                      style="width: 60px; height: 14px;"
-                    />
-                    <div
-                      class="skeleton skeleton--text"
-                      style="width: 40px; height: 14px;"
-                    />
+                    <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
+                    <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
+                    <div class="skeleton skeleton--text" style="width: 50px; height: 14px;" />
+                    <div class="skeleton skeleton--text" style="width: 80px; height: 14px;" />
+                    <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
+                    <div class="skeleton skeleton--text" style="width: 40px; height: 14px;" />
                   </div>
                 )}
               </For>
@@ -257,220 +225,71 @@ const Overview: Component = () => {
           </>
         }
       >
-        <Show when={!data.error} fallback={
-          <ErrorState error={data.error} onRetry={refetch} />
-        }>
-        <Show when={isNewAgent()}>
-          <Show when={(isLocalMode() && params.agentName === 'local-agent') || setupCompleted()} fallback={
-            <div class="empty-state">
-              <div class="empty-state__title">No activity yet</div>
-              <p>Connect your agent to Manifest and send your first message. Usage data will appear here automatically.</p>
-              <button class="btn btn--primary" style="margin-top: var(--gap-md);" onClick={() => setSetupOpen(true)}>
-                Set up agent
-              </button>
-              <div class="empty-state__img-wrapper">
-                <img src="/example-overview.svg" alt="" class="empty-state__img" />
-              </div>
-            </div>
-          }>
-            <div class="waiting-banner">
-              <i class="bxd bx-florist" />
-              <p>Waiting for data &mdash; your dashboard will populate within seconds of your agent's first LLM call.</p>
-            </div>
-            <div class="demo-dashboard">
-              <div class="chart-card">
-                <div class="chart-card__header">
-                  <div class="chart-card__stat chart-card__stat--active">
-                    <span class="chart-card__label">Cost</span>
-                    <div class="chart-card__value-row">
-                      <span class="chart-card__value">$0.00</span>
-                    </div>
-                  </div>
-                  <div class="chart-card__stat">
-                    <span class="chart-card__label">Token usage</span>
-                    <div class="chart-card__value-row">
-                      <span class="chart-card__value">0</span>
-                    </div>
-                  </div>
-                  <div class="chart-card__stat">
-                    <span class="chart-card__label">Messages</span>
-                    <div class="chart-card__value-row">
-                      <span class="chart-card__value">0</span>
-                    </div>
+        <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
+          <Show when={isNewAgent()}>
+            <Show
+              when={(isLocalMode() && params.agentName === 'local-agent') || setupCompleted()}
+              fallback={
+                <div class="empty-state">
+                  <div class="empty-state__title">No activity yet</div>
+                  <p>Connect your agent and send a message. Usage data shows up here.</p>
+                  <button
+                    class="btn btn--primary"
+                    style="margin-top: var(--gap-md);"
+                    onClick={() => setSetupOpen(true)}
+                  >
+                    Set up agent
+                  </button>
+                  <div class="empty-state__img-wrapper">
+                    <img src="/example-overview.svg" alt="" class="empty-state__img" />
                   </div>
                 </div>
-                <div class="chart-card__body">
-                  <div style="height: 260px; color: hsl(var(--muted-foreground)); display: flex; align-items: center; justify-content: center;">
-                    No data yet &mdash; activity will appear once your agent starts sending messages
-                  </div>
-                </div>
-              </div>
-              <div class="panel">
-                <div class="panel__title" style="display: flex; justify-content: space-between; align-items: center;">
-                  Recent Messages
-                  <span class="view-more-link" style="pointer-events: none;">View more</span>
-                </div>
-                <table class="data-table">
-                  <thead>
-                    <tr>
-                      <th>Date</th>
-                      <th>Message</th>
-                      <th>Cost</th>
-                      <th>Model</th>
-                      <th>Tokens</th>
-                      <th>Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td colspan="6" style="text-align: center; color: hsl(var(--muted-foreground)); padding: var(--gap-lg);">
-                        Messages will appear here
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <div class="panel" style="margin-top: var(--gap-lg);">
-                <div class="panel__title">Cost by Model</div>
-                <p style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); margin: -8px 0 12px;">
-                  How much each AI model is costing you
+              }
+            >
+              <div class="waiting-banner">
+                <i class="bxd bx-florist" />
+                <p>
+                  Waiting for data. Your dashboard will update within seconds of your agent's first
+                  LLM call.
                 </p>
-                <table class="data-table">
-                  <thead>
-                    <tr>
-                      <th>Model</th>
-                      <th>Tokens</th>
-                      <th>% of total</th>
-                      <th>Cost</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td colspan="4" style="text-align: center; color: hsl(var(--muted-foreground)); padding: var(--gap-lg);">
-                        Model costs will appear here
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
               </div>
-            </div>
-          </Show>
-        </Show>
-        <Show when={data()?.summary && !isNewAgent()}>
-          {(_summary) => {
-            const d = () => data() as OverviewData
-            return (
-              <>
-                {/* Chart card with clickable stats */}
+              <div class="demo-dashboard">
                 <div class="chart-card">
                   <div class="chart-card__header">
-                    <div
-                      class="chart-card__stat chart-card__stat--clickable"
-                      classList={{
-                        'chart-card__stat--active': activeView() === 'cost',
-                      }}
-                      onClick={() => setActiveView('cost')}
-                    >
+                    <div class="chart-card__stat chart-card__stat--active">
                       <span class="chart-card__label">Cost</span>
                       <div class="chart-card__value-row">
-                        <span class="chart-card__value">
-                          {formatCost(d().summary?.cost_today?.value ?? 0) ?? '$0.00'}
-                        </span>
-                        {trendBadge(d().summary?.cost_today?.trend_pct ?? 0, d().summary?.cost_today?.value ?? 0)}
+                        <span class="chart-card__value">$0.00</span>
                       </div>
                     </div>
-                    <div
-                      class="chart-card__stat chart-card__stat--clickable"
-                      classList={{
-                        'chart-card__stat--active': activeView() === 'tokens',
-                      }}
-                      onClick={() => setActiveView('tokens')}
-                    >
-                      <span class="chart-card__label">
-                        Token usage
-                        <InfoTooltip text="Tokens are units of text that AI models process. More tokens = higher cost." />
-                      </span>
+                    <div class="chart-card__stat">
+                      <span class="chart-card__label">Token usage</span>
                       <div class="chart-card__value-row">
-                        <span class="chart-card__value">
-                          {formatNumber(d().summary?.tokens_today?.value ?? 0)}
-                        </span>
-                        {trendBadge(d().summary?.tokens_today?.trend_pct ?? 0, d().summary?.tokens_today?.value ?? 0)}
+                        <span class="chart-card__value">0</span>
                       </div>
                     </div>
-                    <div
-                      class="chart-card__stat chart-card__stat--clickable"
-                      classList={{
-                        'chart-card__stat--active': activeView() === 'messages',
-                      }}
-                      onClick={() => setActiveView('messages')}
-                    >
+                    <div class="chart-card__stat">
                       <span class="chart-card__label">Messages</span>
                       <div class="chart-card__value-row">
-                        <span class="chart-card__value">
-                          {d().summary?.messages?.value ?? 0}
-                        </span>
-                        {trendBadge(d().summary?.messages?.trend_pct ?? 0, d().summary?.messages?.value ?? 0)}
+                        <span class="chart-card__value">0</span>
                       </div>
                     </div>
                   </div>
                   <div class="chart-card__body">
-                    <Show when={activeView() === 'cost'}>
-                      <Show
-                        when={d().cost_usage?.length}
-                        fallback={
-                          <div style="height: 260px; color: hsl(var(--muted-foreground)); display: flex; align-items: center; justify-content: center;">
-                            No cost data for this time range
-                          </div>
-                        }
-                      >
-                        <CostChart data={d().cost_usage} range={range()} />
-                      </Show>
-                    </Show>
-                    <Show when={activeView() === 'tokens'}>
-                      <Show
-                        when={d().token_usage?.length}
-                        fallback={
-                          <div style="height: 260px; color: hsl(var(--muted-foreground)); display: flex; align-items: center; justify-content: center;">
-                            No token data for this time range
-                          </div>
-                        }
-                      >
-                        <TokenChart data={d().token_usage} range={range()} />
-                      </Show>
-                    </Show>
-                    <Show when={activeView() === 'messages'}>
-                      <Show
-                        when={getMessageChartData().length}
-                        fallback={
-                          <div style="height: 260px; color: hsl(var(--muted-foreground)); display: flex; align-items: center; justify-content: center;">
-                            No message data for this time range
-                          </div>
-                        }
-                      >
-                        <SingleTokenChart
-                          data={getMessageChartData()}
-                          label="Messages"
-                          colorVar="--chart-1"
-                          range={range()}
-                        />
-                      </Show>
-                    </Show>
+                    <div style="height: 260px; color: hsl(var(--muted-foreground)); display: flex; align-items: center; justify-content: center;">
+                      No data yet. Activity will appear once your agent starts sending messages.
+                    </div>
                   </div>
                 </div>
-
-                {/* Recent Messages */}
                 <div class="panel">
                   <div
                     class="panel__title"
                     style="display: flex; justify-content: space-between; align-items: center;"
                   >
                     Recent Messages
-                    <A
-                      href={`/agents/${params.agentName}/messages`}
-                      class="view-more-link"
-                    >
+                    <span class="view-more-link" style="pointer-events: none;">
                       View more
-                    </A>
+                    </span>
                   </div>
                   <table class="data-table">
                     <thead>
@@ -484,72 +303,21 @@ const Overview: Component = () => {
                       </tr>
                     </thead>
                     <tbody>
-                      <For each={d().recent_activity?.slice(0, 5) ?? []}>
-                        {(item) => (
-                          <tr>
-                            <td style="white-space: nowrap; font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                              {formatTime(item.timestamp)}
-                            </td>
-                            <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                              {item.id.slice(0, 8)}
-                              {item.routing_reason === 'heartbeat' && (
-                                <span title="Heartbeat" style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;">
-                                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                    <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-                                  </svg>
-                                </span>
-                              )}
-                            </td>
-                            <td style="font-family: var(--font-mono);" title={item.cost != null && item.cost > 0 && item.cost < 0.01 ? `$${item.cost.toFixed(6)}` : undefined}>
-                              {item.cost != null
-                                ? (formatCost(item.cost) ?? '\u2014')
-                                : '\u2014'}
-                            </td>
-                            <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                              <span style="display: inline-flex; align-items: center; gap: 4px;">
-                                {item.model && inferProviderFromModel(item.model) && (
-                                  <span title={inferProviderName(item.model)} style="display: inline-flex; flex-shrink: 0;">{providerIcon(inferProviderFromModel(item.model)!, 14)}</span>
-                                )}
-                                {item.model ?? '\u2014'}
-                                {item.routing_tier && <span class={`tier-badge tier-badge--${item.routing_tier}`}>{item.routing_tier}</span>}
-                              </span>
-                            </td>
-                            <td style="font-family: var(--font-mono);">
-                              {item.total_tokens != null
-                                ? formatNumber(item.total_tokens)
-                                : '\u2014'}
-                            </td>
-                            <td>
-                              <Show when={item.error_message}
-                                fallback={
-                                  <span class={`status-badge status-badge--${item.status}`}>
-                                    {item.status === 'rate_limited'
-                                      ? <A href={`/agents/${encodeURIComponent(params.agentName)}/limits`}>{formatStatus(item.status)}</A>
-                                      : formatStatus(item.status)}
-                                  </span>
-                                }
-                              >
-                                <span class="status-badge-tooltip" tabindex="0" role="note"
-                                      aria-label={formatErrorMessage(item.error_message!)}>
-                                  <span class={`status-badge status-badge--${item.status}`}>
-                                    {formatStatus(item.status)}
-                                  </span>
-                                  <span class="status-badge-tooltip__bubble">{formatErrorMessage(item.error_message!)}</span>
-                                </span>
-                              </Show>
-                            </td>
-                          </tr>
-                        )}
-                      </For>
+                      <tr>
+                        <td
+                          colspan="6"
+                          style="text-align: center; color: hsl(var(--muted-foreground)); padding: var(--gap-lg);"
+                        >
+                          Messages will appear here
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>
-
-                {/* Cost by Model */}
                 <div class="panel" style="margin-top: var(--gap-lg);">
                   <div class="panel__title">Cost by Model</div>
                   <p style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); margin: -8px 0 12px;">
-                    Breakdown of spending per model for the selected time range
+                    How much each AI model is costing you
                   </p>
                   <table class="data-table">
                     <thead>
@@ -561,43 +329,318 @@ const Overview: Component = () => {
                       </tr>
                     </thead>
                     <tbody>
-                      <For each={d().cost_by_model ?? []}>
-                        {(row) => (
-                          <tr>
-                            <td style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
-                              <span style="display: inline-flex; align-items: center; gap: 4px;">
-                                {row.model && inferProviderFromModel(row.model) && (
-                                  <span title={inferProviderName(row.model)} style="display: inline-flex; flex-shrink: 0;">{providerIcon(inferProviderFromModel(row.model)!, 14)}</span>
-                                )}
-                                {row.model}
-                              </span>
-                            </td>
-                            <td>{formatNumber(row.tokens)}</td>
-                            <td>
-                              <div style="display: flex; align-items: center; gap: 8px;">
-                                <div style="width: 40px; height: 4px; border-radius: 2px; background: hsl(var(--muted)); overflow: hidden;">
-                                  <div
-                                    style={`width: ${row.share_pct}%; height: 100%; background: hsl(var(--chart-1)); border-radius: 2px;`}
-                                  />
-                                </div>
-                                <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                                  {Math.round(row.share_pct)}%
-                                </span>
-                              </div>
-                            </td>
-                            <td style="font-weight: 600;" title={row.estimated_cost > 0 && row.estimated_cost < 0.01 ? `$${row.estimated_cost.toFixed(6)}` : undefined}>
-                              {formatCost(row.estimated_cost) ?? '\u2014'}
-                            </td>
-                          </tr>
-                        )}
-                      </For>
+                      <tr>
+                        <td
+                          colspan="4"
+                          style="text-align: center; color: hsl(var(--muted-foreground)); padding: var(--gap-lg);"
+                        >
+                          Model costs will appear here
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>
-              </>
-            )
-          }}
-        </Show>
+              </div>
+            </Show>
+          </Show>
+          <Show when={data()?.summary && !isNewAgent()}>
+            {(_summary) => {
+              const d = () => data() as OverviewData;
+              return (
+                <>
+                  {/* Chart card with clickable stats */}
+                  <div class="chart-card">
+                    <div class="chart-card__header">
+                      <div
+                        class="chart-card__stat chart-card__stat--clickable"
+                        classList={{
+                          'chart-card__stat--active': activeView() === 'cost',
+                        }}
+                        onClick={() => setActiveView('cost')}
+                      >
+                        <span class="chart-card__label">Cost</span>
+                        <div class="chart-card__value-row">
+                          <span class="chart-card__value">
+                            {formatCost(d().summary?.cost_today?.value ?? 0) ?? '$0.00'}
+                          </span>
+                          {trendBadge(
+                            d().summary?.cost_today?.trend_pct ?? 0,
+                            d().summary?.cost_today?.value ?? 0,
+                          )}
+                        </div>
+                      </div>
+                      <div
+                        class="chart-card__stat chart-card__stat--clickable"
+                        classList={{
+                          'chart-card__stat--active': activeView() === 'tokens',
+                        }}
+                        onClick={() => setActiveView('tokens')}
+                      >
+                        <span class="chart-card__label">
+                          Token usage
+                          <InfoTooltip text="Tokens are units of text that AI models process. More tokens = higher cost." />
+                        </span>
+                        <div class="chart-card__value-row">
+                          <span class="chart-card__value">
+                            {formatNumber(d().summary?.tokens_today?.value ?? 0)}
+                          </span>
+                          {trendBadge(
+                            d().summary?.tokens_today?.trend_pct ?? 0,
+                            d().summary?.tokens_today?.value ?? 0,
+                          )}
+                        </div>
+                      </div>
+                      <div
+                        class="chart-card__stat chart-card__stat--clickable"
+                        classList={{
+                          'chart-card__stat--active': activeView() === 'messages',
+                        }}
+                        onClick={() => setActiveView('messages')}
+                      >
+                        <span class="chart-card__label">Messages</span>
+                        <div class="chart-card__value-row">
+                          <span class="chart-card__value">{d().summary?.messages?.value ?? 0}</span>
+                          {trendBadge(
+                            d().summary?.messages?.trend_pct ?? 0,
+                            d().summary?.messages?.value ?? 0,
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div class="chart-card__body">
+                      <Show when={activeView() === 'cost'}>
+                        <Show
+                          when={d().cost_usage?.length}
+                          fallback={
+                            <div style="height: 260px; color: hsl(var(--muted-foreground)); display: flex; align-items: center; justify-content: center;">
+                              No cost data for this time range
+                            </div>
+                          }
+                        >
+                          <CostChart data={d().cost_usage} range={range()} />
+                        </Show>
+                      </Show>
+                      <Show when={activeView() === 'tokens'}>
+                        <Show
+                          when={d().token_usage?.length}
+                          fallback={
+                            <div style="height: 260px; color: hsl(var(--muted-foreground)); display: flex; align-items: center; justify-content: center;">
+                              No token data for this time range
+                            </div>
+                          }
+                        >
+                          <TokenChart data={d().token_usage} range={range()} />
+                        </Show>
+                      </Show>
+                      <Show when={activeView() === 'messages'}>
+                        <Show
+                          when={getMessageChartData().length}
+                          fallback={
+                            <div style="height: 260px; color: hsl(var(--muted-foreground)); display: flex; align-items: center; justify-content: center;">
+                              No message data for this time range
+                            </div>
+                          }
+                        >
+                          <SingleTokenChart
+                            data={getMessageChartData()}
+                            label="Messages"
+                            colorVar="--chart-1"
+                            range={range()}
+                          />
+                        </Show>
+                      </Show>
+                    </div>
+                  </div>
+
+                  {/* Recent Messages */}
+                  <div class="panel">
+                    <div
+                      class="panel__title"
+                      style="display: flex; justify-content: space-between; align-items: center;"
+                    >
+                      Recent Messages
+                      <A href={`/agents/${params.agentName}/messages`} class="view-more-link">
+                        View more
+                      </A>
+                    </div>
+                    <table class="data-table">
+                      <thead>
+                        <tr>
+                          <th>Date</th>
+                          <th>Message</th>
+                          <th>Cost</th>
+                          <th>Model</th>
+                          <th>Tokens</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <For each={d().recent_activity?.slice(0, 5) ?? []}>
+                          {(item) => (
+                            <tr>
+                              <td style="white-space: nowrap; font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                                {formatTime(item.timestamp)}
+                              </td>
+                              <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                                {item.id.slice(0, 8)}
+                                {item.routing_reason === 'heartbeat' && (
+                                  <span
+                                    title="Heartbeat"
+                                    style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;"
+                                  >
+                                    <svg
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      width="12"
+                                      height="12"
+                                      viewBox="0 0 24 24"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      stroke-width="2"
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                    >
+                                      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+                                    </svg>
+                                  </span>
+                                )}
+                              </td>
+                              <td
+                                style="font-family: var(--font-mono);"
+                                title={
+                                  item.cost != null && item.cost > 0 && item.cost < 0.01
+                                    ? `$${item.cost.toFixed(6)}`
+                                    : undefined
+                                }
+                              >
+                                {item.cost != null ? (formatCost(item.cost) ?? '\u2014') : '\u2014'}
+                              </td>
+                              <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                                <span style="display: inline-flex; align-items: center; gap: 4px;">
+                                  {item.model && inferProviderFromModel(item.model) && (
+                                    <span
+                                      title={inferProviderName(item.model)}
+                                      style="display: inline-flex; flex-shrink: 0;"
+                                    >
+                                      {providerIcon(inferProviderFromModel(item.model)!, 14)}
+                                    </span>
+                                  )}
+                                  {item.model ?? '\u2014'}
+                                  {item.routing_tier && (
+                                    <span class={`tier-badge tier-badge--${item.routing_tier}`}>
+                                      {item.routing_tier}
+                                    </span>
+                                  )}
+                                </span>
+                              </td>
+                              <td style="font-family: var(--font-mono);">
+                                {item.total_tokens != null
+                                  ? formatNumber(item.total_tokens)
+                                  : '\u2014'}
+                              </td>
+                              <td>
+                                <Show
+                                  when={item.error_message}
+                                  fallback={
+                                    <span class={`status-badge status-badge--${item.status}`}>
+                                      {item.status === 'rate_limited' ? (
+                                        <A
+                                          href={`/agents/${encodeURIComponent(params.agentName)}/limits`}
+                                        >
+                                          {formatStatus(item.status)}
+                                        </A>
+                                      ) : (
+                                        formatStatus(item.status)
+                                      )}
+                                    </span>
+                                  }
+                                >
+                                  <span
+                                    class="status-badge-tooltip"
+                                    tabindex="0"
+                                    role="note"
+                                    aria-label={formatErrorMessage(item.error_message!)}
+                                  >
+                                    <span class={`status-badge status-badge--${item.status}`}>
+                                      {formatStatus(item.status)}
+                                    </span>
+                                    <span class="status-badge-tooltip__bubble">
+                                      {formatErrorMessage(item.error_message!)}
+                                    </span>
+                                  </span>
+                                </Show>
+                              </td>
+                            </tr>
+                          )}
+                        </For>
+                      </tbody>
+                    </table>
+                  </div>
+
+                  {/* Cost by Model */}
+                  <div class="panel" style="margin-top: var(--gap-lg);">
+                    <div class="panel__title">Cost by Model</div>
+                    <p style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); margin: -8px 0 12px;">
+                      How much each model costs you
+                    </p>
+                    <table class="data-table">
+                      <thead>
+                        <tr>
+                          <th>Model</th>
+                          <th>Tokens</th>
+                          <th>% of total</th>
+                          <th>Cost</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <For each={d().cost_by_model ?? []}>
+                          {(row) => (
+                            <tr>
+                              <td style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
+                                <span style="display: inline-flex; align-items: center; gap: 4px;">
+                                  {row.model && inferProviderFromModel(row.model) && (
+                                    <span
+                                      title={inferProviderName(row.model)}
+                                      style="display: inline-flex; flex-shrink: 0;"
+                                    >
+                                      {providerIcon(inferProviderFromModel(row.model)!, 14)}
+                                    </span>
+                                  )}
+                                  {row.model}
+                                </span>
+                              </td>
+                              <td>{formatNumber(row.tokens)}</td>
+                              <td>
+                                <div style="display: flex; align-items: center; gap: 8px;">
+                                  <div style="width: 40px; height: 4px; border-radius: 2px; background: hsl(var(--muted)); overflow: hidden;">
+                                    <div
+                                      style={`width: ${row.share_pct}%; height: 100%; background: hsl(var(--chart-1)); border-radius: 2px;`}
+                                    />
+                                  </div>
+                                  <span style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                                    {Math.round(row.share_pct)}%
+                                  </span>
+                                </div>
+                              </td>
+                              <td
+                                style="font-weight: 600;"
+                                title={
+                                  row.estimated_cost > 0 && row.estimated_cost < 0.01
+                                    ? `$${row.estimated_cost.toFixed(6)}`
+                                    : undefined
+                                }
+                              >
+                                {formatCost(row.estimated_cost) ?? '\u2014'}
+                              </td>
+                            </tr>
+                          )}
+                        </For>
+                      </tbody>
+                    </table>
+                  </div>
+                </>
+              );
+            }}
+          </Show>
         </Show>
       </Show>
 
@@ -606,16 +649,16 @@ const Overview: Component = () => {
         agentName={decodeURIComponent(params.agentName)}
         apiKey={(location.state as { newApiKey?: string } | undefined)?.newApiKey ?? null}
         onClose={() => {
-          localStorage.setItem(`setup_dismissed_${params.agentName}`, '1')
-          setSetupOpen(false)
+          localStorage.setItem(`setup_dismissed_${params.agentName}`, '1');
+          setSetupOpen(false);
         }}
         onDone={() => {
-          localStorage.setItem(`setup_completed_${params.agentName}`, '1')
-          setSetupCompleted(true)
+          localStorage.setItem(`setup_completed_${params.agentName}`, '1');
+          setSetupCompleted(true);
         }}
       />
     </div>
-  )
-}
+  );
+};
 
-export default Overview
+export default Overview;

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -1,16 +1,16 @@
-import { A } from "@solidjs/router";
-import { Title, Meta } from "@solidjs/meta";
-import { type Component, createSignal, Show } from "solid-js";
-import SocialButtons from "../components/SocialButtons.jsx";
-import { authClient } from "../services/auth-client.js";
+import { A } from '@solidjs/router';
+import { Title, Meta } from '@solidjs/meta';
+import { type Component, createSignal, Show } from 'solid-js';
+import SocialButtons from '../components/SocialButtons.jsx';
+import { authClient } from '../services/auth-client.js';
 
 const RESEND_COOLDOWN_SECONDS = 60;
 
 const Register: Component = () => {
-  const [name, setName] = createSignal("");
-  const [email, setEmail] = createSignal("");
-  const [password, setPassword] = createSignal("");
-  const [error, setError] = createSignal("");
+  const [name, setName] = createSignal('');
+  const [email, setEmail] = createSignal('');
+  const [password, setPassword] = createSignal('');
+  const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
   const [emailSent, setEmailSent] = createSignal(false);
   const [resendCooldown, setResendCooldown] = createSignal(0);
@@ -30,7 +30,7 @@ const Register: Component = () => {
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
-    setError("");
+    setError('');
     setLoading(true);
 
     const { error: authError } = await authClient.signUp.email({
@@ -42,7 +42,7 @@ const Register: Component = () => {
     setLoading(false);
 
     if (authError) {
-      setError(authError.message ?? "Registration failed");
+      setError(authError.message ?? 'Registration failed');
       return;
     }
 
@@ -55,11 +55,11 @@ const Register: Component = () => {
 
     const { error: resendError } = await authClient.sendVerificationEmail({
       email: email(),
-      callbackURL: "/",
+      callbackURL: '/',
     });
 
     if (resendError) {
-      setError(resendError.message ?? "Failed to resend verification email");
+      setError(resendError.message ?? 'Failed to resend verification email');
       return;
     }
 
@@ -69,71 +69,84 @@ const Register: Component = () => {
   return (
     <>
       <Title>Sign Up - Manifest</Title>
-      <Meta name="description" content="Create a Manifest account to start monitoring your AI agents." />
-      <Show when={emailSent()} fallback={
-        <>
-          <div class="auth-header">
-            <h1 class="auth-header__title">Create an account</h1>
-            <p class="auth-header__subtitle">Start monitoring your AI agents in minutes</p>
-          </div>
+      <Meta
+        name="description"
+        content="Create a Manifest account to start monitoring your AI agents."
+      />
+      <Show
+        when={emailSent()}
+        fallback={
+          <>
+            <div class="auth-header">
+              <h1 class="auth-header__title">Create an account</h1>
+              <p class="auth-header__subtitle">Monitor your AI agents' costs and usage</p>
+            </div>
 
-          <SocialButtons />
+            <SocialButtons />
 
-          <div class="auth-divider">
-            <span class="auth-divider__text">or</span>
-          </div>
+            <div class="auth-divider">
+              <span class="auth-divider__text">or</span>
+            </div>
 
-          <form class="auth-form" onSubmit={handleSubmit}>
-            {error() && <div class="auth-form__error">{error()}</div>}
-            <label class="auth-form__label">
-              Name
-              <input
-                class="auth-form__input"
-                type="text"
-                placeholder="Your name"
-                value={name()}
-                onInput={(e) => setName(e.currentTarget.value)}
-                required
-              />
-            </label>
-            <label class="auth-form__label">
-              Email
-              <input
-                class="auth-form__input"
-                type="email"
-                placeholder="you@example.com"
-                value={email()}
-                onInput={(e) => setEmail(e.currentTarget.value)}
-                required
-              />
-            </label>
-            <label class="auth-form__label">
-              Password
-              <input
-                class="auth-form__input"
-                type="password"
-                placeholder="Create a password"
-                value={password()}
-                onInput={(e) => setPassword(e.currentTarget.value)}
-                required
-                minLength={8}
-              />
-            </label>
-            <button class="auth-form__submit" type="submit" disabled={loading()}>
-              {loading() ? "Creating account..." : "Create account"}
-            </button>
-          </form>
-          <p class="auth-terms">
-            By signing up, you agree to our{" "}
-            <a href="#" class="auth-terms__link">Terms</a> and{" "}
-            <a href="#" class="auth-terms__link">Privacy Policy</a>
-          </p>
-          <div class="auth-footer">
-            <span>Already have an account? </span>
-            <A href="/login" class="auth-footer__link">Sign in</A>
-          </div>
-        </>
-      }>
+            <form class="auth-form" onSubmit={handleSubmit}>
+              {error() && <div class="auth-form__error">{error()}</div>}
+              <label class="auth-form__label">
+                Name
+                <input
+                  class="auth-form__input"
+                  type="text"
+                  placeholder="Your name"
+                  value={name()}
+                  onInput={(e) => setName(e.currentTarget.value)}
+                  required
+                />
+              </label>
+              <label class="auth-form__label">
+                Email
+                <input
+                  class="auth-form__input"
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email()}
+                  onInput={(e) => setEmail(e.currentTarget.value)}
+                  required
+                />
+              </label>
+              <label class="auth-form__label">
+                Password
+                <input
+                  class="auth-form__input"
+                  type="password"
+                  placeholder="Create a password"
+                  value={password()}
+                  onInput={(e) => setPassword(e.currentTarget.value)}
+                  required
+                  minLength={8}
+                />
+              </label>
+              <button class="auth-form__submit" type="submit" disabled={loading()}>
+                {loading() ? 'Creating account...' : 'Create account'}
+              </button>
+            </form>
+            <p class="auth-terms">
+              By signing up, you agree to our{' '}
+              <a href="#" class="auth-terms__link">
+                Terms
+              </a>{' '}
+              and{' '}
+              <a href="#" class="auth-terms__link">
+                Privacy Policy
+              </a>
+            </p>
+            <div class="auth-footer">
+              <span>Already have an account? </span>
+              <A href="/login" class="auth-footer__link">
+                Sign in
+              </A>
+            </div>
+          </>
+        }
+      >
         <div class="auth-header">
           <h1 class="auth-header__title">Check your email</h1>
           <p class="auth-header__subtitle">
@@ -151,14 +164,14 @@ const Register: Component = () => {
             onClick={handleResend}
             disabled={resendCooldown() > 0}
           >
-            {resendCooldown() > 0
-              ? `Resend in ${resendCooldown()}s`
-              : "Resend verification email"}
+            {resendCooldown() > 0 ? `Resend in ${resendCooldown()}s` : 'Resend verification email'}
           </button>
         </div>
 
         <div class="auth-footer">
-          <A href="/login" class="auth-footer__link">Back to sign in</A>
+          <A href="/login" class="auth-footer__link">
+            Back to sign in
+          </A>
         </div>
       </Show>
     </>

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -201,9 +201,8 @@ const Routing: Component = () => {
               </div>
               <h2 class="routing-enable-card__title">Smart model routing</h2>
               <p class="routing-enable-card__desc">
-                Route each request to the best model for its complexity level &mdash; use cheaper
-                models for simple tasks and more capable models for complex ones. Connect your LLM
-                providers and Manifest handles the rest.
+                Send simple tasks to cheap models, complex ones to better models. Connect your LLM
+                providers to get started.
               </p>
               <button class="btn btn--primary" onClick={handleEnable}>
                 Enable Routing

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -1,19 +1,12 @@
-import {
-  createResource,
-  createSignal,
-  onMount,
-  Show,
-  For,
-  type Component,
-} from "solid-js";
-import { A, useNavigate } from "@solidjs/router";
-import { Title, Meta } from "@solidjs/meta";
-import ErrorState from "../components/ErrorState.jsx";
-import { getAgents, createAgent } from "../services/api.js";
-import { toast } from "../services/toast-store.js";
-import { formatNumber, formatCost } from "../services/formatters.js";
-import Sparkline from "../components/Sparkline.jsx";
-import { checkLocalMode } from "../services/local-mode.js";
+import { createResource, createSignal, onMount, Show, For, type Component } from 'solid-js';
+import { A, useNavigate } from '@solidjs/router';
+import { Title, Meta } from '@solidjs/meta';
+import ErrorState from '../components/ErrorState.jsx';
+import { getAgents, createAgent } from '../services/api.js';
+import { toast } from '../services/toast-store.js';
+import { formatNumber, formatCost } from '../services/formatters.js';
+import Sparkline from '../components/Sparkline.jsx';
+import { checkLocalMode } from '../services/local-mode.js';
 
 interface Agent {
   agent_name: string;
@@ -29,11 +22,9 @@ interface AgentsData {
   agents: Agent[];
 }
 
-const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
-  props,
-) => {
+const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props) => {
   const navigate = useNavigate();
-  const [name, setName] = createSignal("");
+  const [name, setName] = createSignal('');
 
   const handleCreate = async () => {
     const agentName = name().trim();
@@ -42,7 +33,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
       const result = await createAgent(agentName);
       toast.success(`Agent "${agentName}" connected`);
       props.onClose();
-      setName("");
+      setName('');
       const slug = result?.agent?.name ?? agentName;
       const url = `/agents/${encodeURIComponent(slug)}`;
       navigate(url, { state: { newAgent: true, newApiKey: result?.apiKey } });
@@ -52,10 +43,10 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter") handleCreate();
-    if (e.key === "Escape") {
+    if (e.key === 'Enter') handleCreate();
+    if (e.key === 'Escape') {
       props.onClose();
-      setName("");
+      setName('');
     }
   };
 
@@ -65,7 +56,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
         class="modal-overlay"
         onClick={() => {
           props.onClose();
-          setName("");
+          setName('');
         }}
       >
         <div
@@ -94,11 +85,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (
           />
 
           <div class="modal-card__footer">
-            <button
-              class="btn btn--primary"
-              onClick={handleCreate}
-              disabled={!name().trim()}
-            >
+            <button class="btn btn--primary" onClick={handleCreate} disabled={!name().trim()}>
               Create
             </button>
           </div>
@@ -116,14 +103,17 @@ const Workspace: Component = () => {
   onMount(async () => {
     const local = await checkLocalMode();
     if (local) {
-      navigate("/agents/local-agent", { replace: true });
+      navigate('/agents/local-agent', { replace: true });
     }
   });
 
   return (
     <div class="container--md">
       <Title>My Agents - Manifest</Title>
-      <Meta name="description" content="View and manage all your AI agents. Monitor usage, messages, and costs." />
+      <Meta
+        name="description"
+        content="View and manage all your AI agents. Monitor usage, messages, and costs."
+      />
       <div class="page-header">
         <div>
           <h1>My Agents</h1>
@@ -154,19 +144,10 @@ const Workspace: Component = () => {
             <For each={[1, 2, 3, 4, 5, 6]}>
               {() => (
                 <div class="agent-card agent-card--skeleton">
-                  <div
-                    class="skeleton skeleton--text"
-                    style="width: 60%; height: 20px;"
-                  />
+                  <div class="skeleton skeleton--text" style="width: 60%; height: 20px;" />
                   <div style="display: flex; gap: 16px; margin-top: 12px;">
-                    <div
-                      class="skeleton skeleton--text"
-                      style="width: 30%; height: 14px;"
-                    />
-                    <div
-                      class="skeleton skeleton--text"
-                      style="width: 30%; height: 14px;"
-                    />
+                    <div class="skeleton skeleton--text" style="width: 30%; height: 14px;" />
+                    <div class="skeleton skeleton--text" style="width: 30%; height: 14px;" />
                   </div>
                   <div
                     class="skeleton skeleton--rect"
@@ -178,59 +159,56 @@ const Workspace: Component = () => {
           </div>
         }
       >
-        <Show when={!data.error} fallback={
-          <ErrorState error={data.error} onRetry={refetch} />
-        }>
-        <Show
-          when={data()?.agents?.length}
-          fallback={
-            <div class="empty-state">
-              <div class="empty-state__title">No agents yet</div>
-              <p>Create an agent to start monitoring its LLM calls, token usage, and costs.</p>
-              <button class="btn btn--primary" style="margin-top: var(--gap-md);" onClick={() => setModalOpen(true)}>
-                Connect your first agent
-              </button>
-            </div>
-          }
-        >
-          <div class="agents-grid">
-            <For each={data()!.agents}>
-              {(agent) => (
-                <A
-                  href={`/agents/${encodeURIComponent(agent.agent_name)}`}
-                  class="agent-card"
+        <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
+          <Show
+            when={data()?.agents?.length}
+            fallback={
+              <div class="empty-state">
+                <div class="empty-state__title">No agents yet</div>
+                <p>Create an agent to see its LLM calls, tokens, and costs.</p>
+                <button
+                  class="btn btn--primary"
+                  style="margin-top: var(--gap-md);"
+                  onClick={() => setModalOpen(true)}
                 >
-                  <div class="agent-card__top">
-                    <span class="agent-card__name">{agent.display_name ?? agent.agent_name}</span>
-                  </div>
-                  <div class="agent-card__stats">
-                    <div class="agent-card__stat">
-                      <span class="agent-card__stat-label">Total tokens</span>
-                      <span class="agent-card__stat-value">
-                        {formatNumber(agent.total_tokens)}
-                      </span>
+                  Connect your first agent
+                </button>
+              </div>
+            }
+          >
+            <div class="agents-grid">
+              <For each={data()!.agents}>
+                {(agent) => (
+                  <A href={`/agents/${encodeURIComponent(agent.agent_name)}`} class="agent-card">
+                    <div class="agent-card__top">
+                      <span class="agent-card__name">{agent.display_name ?? agent.agent_name}</span>
                     </div>
-                    <div class="agent-card__stat">
-                      <span class="agent-card__stat-label">Messages</span>
-                      <span class="agent-card__stat-value">
-                        {agent.message_count}
-                      </span>
+                    <div class="agent-card__stats">
+                      <div class="agent-card__stat">
+                        <span class="agent-card__stat-label">Total tokens</span>
+                        <span class="agent-card__stat-value">
+                          {formatNumber(agent.total_tokens)}
+                        </span>
+                      </div>
+                      <div class="agent-card__stat">
+                        <span class="agent-card__stat-label">Messages</span>
+                        <span class="agent-card__stat-value">{agent.message_count}</span>
+                      </div>
+                      <div class="agent-card__stat">
+                        <span class="agent-card__stat-label">Total cost</span>
+                        <span class="agent-card__stat-value">
+                          {formatCost(agent.total_cost) ?? '$0.00'}
+                        </span>
+                      </div>
                     </div>
-                    <div class="agent-card__stat">
-                      <span class="agent-card__stat-label">Total cost</span>
-                      <span class="agent-card__stat-value">
-                        {formatCost(agent.total_cost) ?? '$0.00'}
-                      </span>
+                    <div class="agent-card__chart">
+                      <Sparkline data={agent.sparkline} width={280} height={50} />
                     </div>
-                  </div>
-                  <div class="agent-card__chart">
-                    <Sparkline data={agent.sparkline} width={280} height={50} />
-                  </div>
-                </A>
-              )}
-            </For>
-          </div>
-        </Show>
+                  </A>
+                )}
+              </For>
+            </div>
+          </Show>
         </Show>
       </Show>
 

--- a/packages/frontend/tests/components/EmailProviderSetup.test.tsx
+++ b/packages/frontend/tests/components/EmailProviderSetup.test.tsx
@@ -52,9 +52,9 @@ describe("EmailProviderSetup", () => {
 
   it("renders provider descriptions", () => {
     render(() => <EmailProviderSetup onConfigured={onConfigured} />);
-    expect(screen.getByText("Modern email API")).toBeDefined();
-    expect(screen.getByText("Reliable email service")).toBeDefined();
-    expect(screen.getByText("Scalable email delivery")).toBeDefined();
+    expect(screen.getByText("Email API")).toBeDefined();
+    expect(screen.getByText("Transactional email")).toBeDefined();
+    expect(screen.getByText("Email delivery")).toBeDefined();
   });
 
   it("renders provider logos", () => {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -118,7 +118,7 @@ describe("Sidebar with agent", () => {
 
   it("shows feedback hint text", () => {
     const { container } = render(() => <Sidebar />);
-    expect(container.textContent).toContain("Help shape Manifest");
+    expect(container.textContent).toContain("Share ideas or report bugs");
   });
 
   it("feedback link is external with correct attributes", () => {

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -115,7 +115,7 @@ describe("Limits page", () => {
   it("renders empty state when no rules", () => {
     render(() => <Limits />);
     expect(screen.getByText("No rules yet")).toBeDefined();
-    expect(screen.getByText("Set up email alerts to get notified when usage spikes, or create hard limits to automatically block requests that exceed your budget.")).toBeDefined();
+    expect(screen.getByText("Set up alerts for usage spikes, or hard limits to block requests over budget.")).toBeDefined();
   });
 
   it("renders rules table when rules exist", async () => {
@@ -247,7 +247,7 @@ describe("Limits page", () => {
     const { container } = render(() => <Limits />);
 
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("One or more hard limits have been triggered");
+      expect(container.textContent).toContain("One or more hard limits triggered");
     });
   });
 
@@ -261,7 +261,7 @@ describe("Limits page", () => {
     const { container } = render(() => <Limits />);
 
     await vi.waitFor(() => {
-      expect(container.textContent).not.toContain("One or more hard limits have been triggered");
+      expect(container.textContent).not.toContain("One or more hard limits triggered");
     });
   });
 
@@ -275,7 +275,7 @@ describe("Limits page", () => {
     const { container } = render(() => <Limits />);
 
     await vi.waitFor(() => {
-      expect(container.textContent).not.toContain("One or more hard limits have been triggered");
+      expect(container.textContent).not.toContain("One or more hard limits triggered");
     });
   });
 

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -371,7 +371,7 @@ describe("MessageLog", () => {
       mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: [] });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("messages will appear");
+        expect(container.textContent).toContain("Messages will show up");
       });
     });
 

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -104,7 +104,7 @@ describe("Overview", () => {
   it("renders breadcrumb subtitle", () => {
     mockGetOverview.mockResolvedValue(overviewData);
     render(() => <Overview />);
-    expect(screen.getByText(/Real-time summary of your agent/)).toBeDefined();
+    expect(screen.getByText(/Real-time summary of spending/)).toBeDefined();
   });
 
   it("shows loading skeleton while fetching", () => {
@@ -319,7 +319,7 @@ describe("Overview", () => {
       mockGetOverview.mockResolvedValue({ ...overviewData, has_data: false, summary: null });
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("dashboard will populate");
+        expect(container.textContent).toContain("dashboard will update");
       });
     });
 


### PR DESCRIPTION
## Summary

- Replace em dashes with periods across dashboard pages (Overview, MessageLog, Limits, Sidebar, Routing)
- Remove promotional language from registration subtitle, routing description, and email provider descriptors
- Simplify verbose empty state copy and stiff verbs ("populate" → "update", "token consumption" → "tokens")
- Tighten README feature bullets and provider section intro
- Simplify index.html meta/og/twitter descriptions
- Update test assertions to match new copy

## Test plan

- [x] All 1035 frontend tests pass
- [ ] Visual scan of each page to confirm copy reads naturally