### PR TITLE
fix: remove broken models and add Moonshot provider endpoint

### DIFF
--- a/.changeset/filter-broken-models.md
+++ b/.changeset/filter-broken-models.md
@@ -1,0 +1,9 @@
+---
+"manifest": patch
+---
+
+Remove broken models from catalog and add Moonshot provider endpoint
+
+- Remove models that don't exist or return errors: gpt-5.3, gpt-5.3-codex, gpt-5.3-mini, grok-2, minimax-m2-her, minimax-01, nova-pro, nova-lite, nova-micro
+- Rename mistral-large to mistral-large-latest and codestral to codestral-latest
+- Add Moonshot provider endpoint for kimi-k2 model

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -313,8 +313,8 @@ describe('DatabaseSeederService', () => {
 
       await service.onModuleInit();
 
-      // All curated models are always upserted (73 total)
-      expect(mockPricingRepo.upsert).toHaveBeenCalledTimes(73);
+      // All curated models are always upserted (64 total)
+      expect(mockPricingRepo.upsert).toHaveBeenCalledTimes(64);
     });
 
     it('should upsert with model_name as conflict key', async () => {

--- a/packages/backend/src/database/database-seeder.service.ts
+++ b/packages/backend/src/database/database-seeder.service.ts
@@ -181,10 +181,6 @@ export class DatabaseSeederService implements OnModuleInit {
       ['o3', 'OpenAI', 0.000002, 0.000008, 200000, true, true],
       ['o3-mini', 'OpenAI', 0.0000011, 0.0000044, 200000, true, true],
       ['o4-mini', 'OpenAI', 0.0000011, 0.0000044, 200000, true, true],
-      // OpenAI GPT-5.3
-      ['gpt-5.3', 'OpenAI', 0.00001, 0.00003, 200000, true, true],
-      ['gpt-5.3-codex', 'OpenAI', 0.00001, 0.00003, 200000, true, true],
-      ['gpt-5.3-mini', 'OpenAI', 0.0000015, 0.000006, 200000, true, true],
       // Google Gemini
       ['gemini-2.5-pro', 'Google', 0.00000125, 0.00001, 1048576, true, true],
       ['gemini-2.5-flash', 'Google', 0.00000015, 0.0000006, 1048576, false, true],
@@ -202,15 +198,14 @@ export class DatabaseSeederService implements OnModuleInit {
       ['qwen3-235b-a22b', 'Alibaba', 0.0000003, 0.0000012, 131072, true, true],
       ['qwen3-32b', 'Alibaba', 0.0000001, 0.0000003, 131072, true, true],
       // Mistral
-      ['mistral-large', 'Mistral', 0.000002, 0.000006, 128000, false, true],
+      ['mistral-large-latest', 'Mistral', 0.000002, 0.000006, 128000, false, true],
       ['mistral-small', 'Mistral', 0.0000002, 0.0000006, 128000, false, false],
-      ['codestral', 'Mistral', 0.0000003, 0.0000009, 256000, false, true],
+      ['codestral-latest', 'Mistral', 0.0000003, 0.0000009, 256000, false, true],
       // xAI (Grok)
       ['grok-3', 'xAI', 0.000003, 0.000015, 131072, true, true],
       ['grok-3-mini', 'xAI', 0.0000003, 0.0000005, 131072, true, true],
       ['grok-3-fast', 'xAI', 0.000005, 0.000025, 131072, false, true],
       ['grok-3-mini-fast', 'xAI', 0.0000006, 0.000004, 131072, false, true],
-      ['grok-2', 'xAI', 0.000002, 0.00001, 131072, false, true],
       // OpenRouter
       ['openrouter/auto', 'OpenRouter', 0.000003, 0.000015, 200000, true, true],
       ['anthropic/claude-opus-4-6', 'OpenRouter', 0.000015, 0.000075, 200000, true, true],
@@ -234,9 +229,7 @@ export class DatabaseSeederService implements OnModuleInit {
       ['minimax-m2.1', 'MiniMax', 0.00000027, 0.00000095, 196608, true, true],
       ['minimax-m2.1-highspeed', 'MiniMax', 0.00000027, 0.00000095, 196608, true, true],
       ['minimax-m2', 'MiniMax', 0.000000255, 0.000001, 196608, true, true],
-      ['minimax-m2-her', 'MiniMax', 0.0000003, 0.0000012, 65536, false, false],
       ['minimax-m1', 'MiniMax', 0.0000004, 0.0000022, 1000000, true, true],
-      ['minimax-01', 'MiniMax', 0.0000002, 0.0000011, 1000192, false, false],
       // Z.ai (GLM)
       ['glm-5', 'Z.ai', 0.00000095, 0.00000255, 204800, true, true],
       ['glm-4.7', 'Z.ai', 0.0000003, 0.0000014, 202752, true, true],
@@ -252,10 +245,6 @@ export class DatabaseSeederService implements OnModuleInit {
       // Zhipu (GLM) — legacy
       ['glm-4-plus', 'Zhipu', 0.0000005, 0.0000005, 128000, false, true],
       ['glm-4-flash', 'Zhipu', 0.00000005, 0.00000005, 128000, false, false],
-      // Amazon Nova
-      ['nova-pro', 'Amazon', 0.0000008, 0.0000032, 300000, false, true],
-      ['nova-lite', 'Amazon', 0.00000006, 0.00000024, 300000, false, true],
-      ['nova-micro', 'Amazon', 0.000000035, 0.00000014, 128000, false, false],
     ];
 
     for (const [name, provider, inputPrice, outputPrice, ctxWindow, reasoning, code] of models) {

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -162,9 +162,6 @@ export class LocalBootstrapService implements OnModuleInit {
       ['o3', 'OpenAI', 0.000002, 0.000008, 200000, true, true],
       ['o3-mini', 'OpenAI', 0.0000011, 0.0000044, 200000, true, true],
       ['o4-mini', 'OpenAI', 0.0000011, 0.0000044, 200000, true, true],
-      ['gpt-5.3', 'OpenAI', 0.00001, 0.00003, 200000, true, true],
-      ['gpt-5.3-codex', 'OpenAI', 0.00001, 0.00003, 200000, true, true],
-      ['gpt-5.3-mini', 'OpenAI', 0.0000015, 0.000006, 200000, true, true],
       ['gemini-2.5-pro', 'Google', 0.00000125, 0.00001, 1048576, true, true],
       ['gemini-2.5-flash', 'Google', 0.00000015, 0.0000006, 1048576, false, true],
       ['gemini-2.5-flash-lite', 'Google', 0.0000001, 0.0000004, 1048576, false, false],
@@ -177,14 +174,13 @@ export class LocalBootstrapService implements OnModuleInit {
       ['qwen-2.5-coder-32b-instruct', 'Alibaba', 0.00000018, 0.00000018, 131072, false, true],
       ['qwen3-235b-a22b', 'Alibaba', 0.0000003, 0.0000012, 131072, true, true],
       ['qwen3-32b', 'Alibaba', 0.0000001, 0.0000003, 131072, true, true],
-      ['mistral-large', 'Mistral', 0.000002, 0.000006, 128000, false, true],
+      ['mistral-large-latest', 'Mistral', 0.000002, 0.000006, 128000, false, true],
       ['mistral-small', 'Mistral', 0.0000002, 0.0000006, 128000, false, false],
-      ['codestral', 'Mistral', 0.0000003, 0.0000009, 256000, false, true],
+      ['codestral-latest', 'Mistral', 0.0000003, 0.0000009, 256000, false, true],
       ['grok-3', 'xAI', 0.000003, 0.000015, 131072, true, true],
       ['grok-3-mini', 'xAI', 0.0000003, 0.0000005, 131072, true, true],
       ['grok-3-fast', 'xAI', 0.000005, 0.000025, 131072, false, true],
       ['grok-3-mini-fast', 'xAI', 0.0000006, 0.000004, 131072, false, true],
-      ['grok-2', 'xAI', 0.000002, 0.00001, 131072, false, true],
       // OpenRouter
       ['openrouter/auto', 'OpenRouter', 0.000003, 0.000015, 200000, true, true],
       ['anthropic/claude-opus-4-6', 'OpenRouter', 0.000015, 0.000075, 200000, true, true],
@@ -206,9 +202,7 @@ export class LocalBootstrapService implements OnModuleInit {
       ['minimax-m2.1', 'MiniMax', 0.00000027, 0.00000095, 196608, true, true],
       ['minimax-m2.1-highspeed', 'MiniMax', 0.00000027, 0.00000095, 196608, true, true],
       ['minimax-m2', 'MiniMax', 0.000000255, 0.000001, 196608, true, true],
-      ['minimax-m2-her', 'MiniMax', 0.0000003, 0.0000012, 65536, false, false],
       ['minimax-m1', 'MiniMax', 0.0000004, 0.0000022, 1000000, true, true],
-      ['minimax-01', 'MiniMax', 0.0000002, 0.0000011, 1000192, false, false],
       // Z.ai (GLM)
       ['glm-5', 'Z.ai', 0.00000095, 0.00000255, 204800, true, true],
       ['glm-4.7', 'Z.ai', 0.0000003, 0.0000014, 202752, true, true],
@@ -221,9 +215,6 @@ export class LocalBootstrapService implements OnModuleInit {
       // Zhipu (GLM) — legacy
       ['glm-4-plus', 'Zhipu', 0.0000005, 0.0000005, 128000, false, true],
       ['glm-4-flash', 'Zhipu', 0.00000005, 0.00000005, 128000, false, false],
-      ['nova-pro', 'Amazon', 0.0000008, 0.0000032, 300000, false, true],
-      ['nova-lite', 'Amazon', 0.00000006, 0.00000024, 300000, false, true],
-      ['nova-micro', 'Amazon', 0.000000035, 0.00000014, 128000, false, false],
     ];
 
     for (const [name, provider, inputPrice, outputPrice, ctxWindow, reasoning, code] of models) {

--- a/packages/backend/src/database/quality-score.util.ts
+++ b/packages/backend/src/database/quality-score.util.ts
@@ -11,8 +11,7 @@ export const QUALITY_OVERRIDES: ReadonlyMap<string, number> = new Map([
   ['claude-sonnet-4-20250514', 4],
   // Expensive code-only models that benchmark as mid-range, not tier-1.5
   ['gpt-4o', 3],
-  ['grok-2', 3],
-  ['mistral-large', 3],
+  ['mistral-large-latest', 3],
   ['kimi-k2', 3],
   // Meta-router — computed score from price data doesn't reflect frontier capability
   ['openrouter/auto', 5],
@@ -32,11 +31,17 @@ const MINI_VARIANT = /\b(mini|nano|haiku|micro)\b/i;
  *   2 = cost-optimized: has code capability
  *   1 = ultra-low: no code, very cheap
  */
-export function computeQualityScore(model: Pick<
-  ModelPricing,
-  'model_name' | 'input_price_per_token' | 'output_price_per_token' |
-  'capability_reasoning' | 'capability_code' | 'context_window'
->): number {
+export function computeQualityScore(
+  model: Pick<
+    ModelPricing,
+    | 'model_name'
+    | 'input_price_per_token'
+    | 'output_price_per_token'
+    | 'capability_reasoning'
+    | 'capability_code'
+    | 'context_window'
+  >,
+): number {
   const override = QUALITY_OVERRIDES.get(model.model_name);
   if (override !== undefined) return override;
 
@@ -67,8 +72,8 @@ export function computeQualityScore(model: Pick<
 
   // Q3: Mid-range — mid-price code (not mini), cheap dual-cap, or reasoning minis
   if (totalPerM >= 3.0 && hasCode && !isMini) return 3;
-  if (totalPerM >= 0.50 && hasBoth && !isMini) return 3;
-  if (hasReasoning && isMini && totalPerM >= 0.50) return 3;
+  if (totalPerM >= 0.5 && hasBoth && !isMini) return 3;
+  if (hasReasoning && isMini && totalPerM >= 0.5) return 3;
 
   // Q2: Cost-optimized — has code capability
   if (hasCode) return 2;

--- a/packages/backend/src/model-prices/model-name-normalizer.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.ts
@@ -23,9 +23,10 @@ const KNOWN_ALIASES: ReadonlyArray<readonly [string, string]> = [
   ['MiniMax-M2.1', 'minimax-m2.1'],
   ['MiniMax-M2.1-highspeed', 'minimax-m2.1-highspeed'],
   ['MiniMax-M2', 'minimax-m2'],
-  ['MiniMax-M2-her', 'minimax-m2-her'],
   ['MiniMax-M1', 'minimax-m1'],
-  ['MiniMax-01', 'minimax-01'],
+  // Mistral version aliases
+  ['mistral-large', 'mistral-large-latest'],
+  ['codestral', 'codestral-latest'],
 ];
 
 const PROVIDER_PREFIXES = [
@@ -61,9 +62,7 @@ export function stripDateSuffix(name: string): string {
   return name.replace(DATE_SUFFIX_RE, '');
 }
 
-export function buildAliasMap(
-  canonicalNames: ReadonlyArray<string>,
-): Map<string, string> {
+export function buildAliasMap(canonicalNames: ReadonlyArray<string>): Map<string, string> {
   const map = new Map<string, string>();
 
   for (const name of canonicalNames) {
@@ -77,10 +76,7 @@ export function buildAliasMap(
   return map;
 }
 
-export function resolveModelName(
-  name: string,
-  aliasMap: Map<string, string>,
-): string | undefined {
+export function resolveModelName(name: string, aliasMap: Map<string, string>): string | undefined {
   const exact = aliasMap.get(name);
   if (exact) return exact;
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -53,7 +53,7 @@ describe('ProviderClient', () => {
 
     it('builds correct URL for mistral', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
-      await client.forward('mistral', 'sk-mi', 'mistral-large', body, false);
+      await client.forward('mistral', 'sk-mi', 'mistral-large-latest', body, false);
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://api.mistral.ai/v1/chat/completions',
@@ -61,9 +61,19 @@ describe('ProviderClient', () => {
       );
     });
 
+    it('builds correct URL for moonshot', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward('moonshot', 'sk-moon', 'kimi-k2', body, false);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.moonshot.cn/v1/chat/completions',
+        expect.any(Object),
+      );
+    });
+
     it('builds correct URL for xai', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
-      await client.forward('xai', 'sk-xai', 'grok-2', body, false);
+      await client.forward('xai', 'sk-xai', 'grok-3', body, false);
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://api.x.ai/v1/chat/completions',
@@ -258,7 +268,7 @@ describe('ProviderClient', () => {
     it('merges extraHeaders into outgoing request', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
-      await client.forward('xai', 'sk-xai', 'grok-2', body, false, undefined, {
+      await client.forward('xai', 'sk-xai', 'grok-3', body, false, undefined, {
         'x-grok-conv-id': 'session-123',
       });
 

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -57,6 +57,12 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: openaiPath,
     format: 'openai',
   },
+  moonshot: {
+    baseUrl: 'https://api.moonshot.cn',
+    buildHeaders: openaiHeaders,
+    buildPath: openaiPath,
+    format: 'openai',
+  },
   zai: {
     baseUrl: 'https://api.z.ai',
     buildHeaders: openaiHeaders,
@@ -66,8 +72,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   google: {
     baseUrl: 'https://generativelanguage.googleapis.com',
     buildHeaders: () => ({ 'Content-Type': 'application/json' }),
-    buildPath: (model: string) =>
-      `/v1beta/models/${model}:generateContent`,
+    buildPath: (model: string) => `/v1beta/models/${model}:generateContent`,
     format: 'google',
   },
   openrouter: {


### PR DESCRIPTION
## Summary

Systematically tested all 50 models across 9 providers by sending 2 messages each through the routing proxy. Removed or fixed all models that return 400/404 from their upstream APIs.

**Removed broken models (8):**
- `gpt-5.3`, `gpt-5.3-codex`, `gpt-5.3-mini` — don't exist on OpenAI
- `grok-2` — removed from xAI API
- `minimax-m2-her`, `minimax-01` — unknown models on MiniMax API
- `nova-pro`, `nova-lite`, `nova-micro` — Amazon not a supported provider

**Renamed to correct API identifiers (2):**
- `mistral-large` → `mistral-large-latest`
- `codestral` → `codestral-latest`

**Added Moonshot provider endpoint:**
- OpenAI-compatible at `https://api.moonshot.cn` for `kimi-k2`

## Test plan

- [x] Tested all 50 models via routing proxy (2 messages each)
- [x] All 1797 backend unit tests pass
- [x] All 1035 frontend tests pass
- [x] TypeScript compiles with no errors
- [x] Changeset included