### PR TITLE
fix: filter ghost duplicate messages in OTLP trace ingestion

### DIFF
--- a/.changeset/filter-ghost-duplicates.md
+++ b/.changeset/filter-ghost-duplicates.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Filter ghost duplicate messages in OTLP trace ingestion

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -1271,9 +1271,10 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    // trace_id-based dedup is skipped; fallback calls find() for recent errors
+    // trace_id-based dedup is skipped; fallback calls find() for recent errors,
+    // then DB ghost fallback calls find() again for empty-ok spans
     expect(mockTurnFindOne).not.toHaveBeenCalled();
-    expect(mockTurnFind).toHaveBeenCalledTimes(1);
+    expect(mockTurnFind).toHaveBeenCalledTimes(2);
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
   });
 
@@ -1352,6 +1353,192 @@ describe('TraceIngestService', () => {
     expect(setArg.routing_tier()).toBe('COALESCE(routing_tier, :tier)');
     expect(typeof setArg.routing_reason).toBe('function');
     expect(setArg.routing_reason()).toBe('COALESCE(routing_reason, :reason)');
+  });
+
+  it('skips ghost span when data sibling exists in same batch', async () => {
+    const dataSpan = makeSpan({
+      spanId: 'span-data',
+      traceId: 'trace-data',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-opus-4-6' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 500 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 200 } },
+      ],
+    });
+
+    const ghostSpan = makeSpan({
+      spanId: 'span-ghost',
+      traceId: 'trace-ghost',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [dataSpan, ghostSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ trace_id: 'trace-data' }),
+    );
+  });
+
+  it('skips ghost span regardless of ordering (ghost first, data second)', async () => {
+    const ghostSpan = makeSpan({
+      spanId: 'span-ghost-first',
+      traceId: 'trace-ghost-first',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+      status: { code: 1 },
+    });
+
+    const dataSpan = makeSpan({
+      spanId: 'span-data-second',
+      traceId: 'trace-data-second',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [ghostSpan, dataSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ trace_id: 'trace-data-second' }),
+    );
+  });
+
+  it('does NOT skip empty ok span when no data sibling exists in batch', async () => {
+    const emptySpan = makeSpan({
+      spanId: 'span-empty-alone',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [emptySpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT skip empty error span even with data sibling', async () => {
+    const dataSpan = makeSpan({
+      spanId: 'span-data-err',
+      traceId: 'trace-data-err',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const errorSpan = makeSpan({
+      spanId: 'span-error',
+      traceId: 'trace-error',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+      status: { code: 2, message: 'failed' },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [dataSpan, errorSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    // Both should be inserted (error span is not ghost-filtered)
+    expect(mockTurnInsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips ghost via DB fallback when data message already exists in DB', async () => {
+    const spanTime = new Date(Number(BigInt('1708000000000000000') / 1_000_000n));
+    const nearbyTs = new Date(spanTime.getTime() + 5000).toISOString();
+
+    // First find call returns [] (no errors), second find call returns data-bearing message
+    mockTurnFind
+      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([
+        { id: 'existing-data', timestamp: nearbyTs, input_tokens: 500, output_tokens: 200, model: 'gpt-4o' },
+      ]); // recentMessages (DB ghost fallback)
+
+    const ghostSpan = makeSpan({
+      spanId: 'span-cross-ghost',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [ghostSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnFind).toHaveBeenCalledTimes(2);
+    expect(mockTurnInsert).not.toHaveBeenCalled();
+  });
+
+  it('inserts empty ok span via DB fallback when no nearby data message exists', async () => {
+    // First find call returns [] (no errors), second find call returns [] (no data messages)
+    mockTurnFind
+      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([]); // recentMessages (DB ghost fallback)
+
+    const emptySpan = makeSpan({
+      spanId: 'span-db-pass',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [emptySpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnFind).toHaveBeenCalledTimes(2);
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
   });
 
   it('defaults llm_call cache tokens to 0 when attributes are absent', async () => {

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -1514,6 +1514,148 @@ describe('TraceIngestService', () => {
     expect(mockTurnInsert).not.toHaveBeenCalled();
   });
 
+  it('treats span with only gen_ai.response.model as non-empty (not ghost)', async () => {
+    const responseModelSpan = makeSpan({
+      spanId: 'span-resp-model',
+      traceId: 'trace-resp-model',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.response.model', value: { stringValue: 'gpt-4o' } },
+      ],
+      status: { code: 1 },
+    });
+
+    const ghostSpan = makeSpan({
+      spanId: 'span-ghost-resp',
+      traceId: 'trace-ghost-resp',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [responseModelSpan, ghostSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    // responseModelSpan is not empty (has model), ghostSpan is filtered as ghost
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
+    expect(mockTurnInsert).toHaveBeenCalledWith(
+      expect.objectContaining({ trace_id: 'trace-resp-model' }),
+    );
+  });
+
+  it('skips ghost via DB fallback when nearby message has model but 0 tokens', async () => {
+    const spanTime = new Date(Number(BigInt('1708000000000000000') / 1_000_000n));
+    const nearbyTs = new Date(spanTime.getTime() + 5000).toISOString();
+
+    mockTurnFind
+      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([
+        { id: 'model-only', timestamp: nearbyTs, input_tokens: 0, output_tokens: 0, model: 'gpt-4o' },
+      ]); // recentMessages — has model but 0 tokens
+
+    const ghostSpan = makeSpan({
+      spanId: 'span-ghost-model-only',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [ghostSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnFind).toHaveBeenCalledTimes(2);
+    expect(mockTurnInsert).not.toHaveBeenCalled();
+  });
+
+  it('scopes DB ghost fallback by session_key when available', async () => {
+    const spanTime = new Date(Number(BigInt('1708000000000000000') / 1_000_000n));
+    const nearbyTs = new Date(spanTime.getTime() + 5000).toISOString();
+
+    mockTurnFind
+      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([
+        { id: 'session-data', timestamp: nearbyTs, input_tokens: 100, output_tokens: 50, model: 'gpt-4o' },
+      ]);
+
+    const ghostSpan = makeSpan({
+      spanId: 'span-session-ghost',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'session.key', value: { stringValue: 'session-abc' } },
+      ],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [ghostSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    // Verify the second find() call includes session_key in where clause
+    const secondFindCall = mockTurnFind.mock.calls[1];
+    expect(secondFindCall[0].where).toEqual(
+      expect.objectContaining({ session_key: 'session-abc' }),
+    );
+    expect(mockTurnInsert).not.toHaveBeenCalled();
+  });
+
+  it('does NOT ghost-filter span with tokens but no model (not empty)', async () => {
+    const tokensNoModelSpan = makeSpan({
+      spanId: 'span-tokens-nomodel',
+      traceId: 'trace-tokens-nomodel',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+      status: { code: 1 },
+    });
+
+    const dataSpan = makeSpan({
+      spanId: 'span-data-alongside',
+      traceId: 'trace-data-alongside',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 200 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 100 } },
+      ],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [tokensNoModelSpan, dataSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    // Both should be inserted — span with tokens is not empty, not ghost-filtered
+    expect(mockTurnInsert).toHaveBeenCalledTimes(2);
+  });
+
   it('inserts empty ok span via DB fallback when no nearby data message exists', async () => {
     // First find call returns [] (no errors), second find call returns [] (no data messages)
     mockTurnFind

--- a/packages/backend/src/otlp/services/trace-ingest.service.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.ts
@@ -305,9 +305,13 @@ export class TraceIngestService {
 
     // DB-level ghost dedup: if this span is empty-ok, check if a data-bearing
     // message for the same agent already exists within 60s (cross-batch case).
+    // Scope by session_key when available to avoid cross-session false positives.
     if (this.isEmptyOkSpan(span, attrs)) {
+      const sessionKey = attrString(attrs, 'session.key');
+      const where: Record<string, string> = { tenant_id: ctx.tenantId, agent_id: ctx.agentId };
+      if (sessionKey) where.session_key = sessionKey;
       const recentMessages = await this.turnRepo.find({
-        where: { tenant_id: ctx.tenantId, agent_id: ctx.agentId },
+        where,
         select: ['id', 'timestamp', 'input_tokens', 'output_tokens', 'model'],
         order: { timestamp: 'DESC' },
         take: 5,

--- a/packages/backend/src/otlp/services/trace-ingest.service.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.ts
@@ -83,12 +83,49 @@ export class TraceIngestService {
     return map;
   }
 
+  private isEmptyOkSpan(span: OtlpSpan, attrs: AttributeMap): boolean {
+    if (spanStatusToString(span.status?.code) !== 'ok') return false;
+    if (attrString(attrs, 'gen_ai.request.model') || attrString(attrs, 'gen_ai.response.model'))
+      return false;
+    const input = attrNumber(attrs, 'gen_ai.usage.input_tokens') ?? 0;
+    const output = attrNumber(attrs, 'gen_ai.usage.output_tokens') ?? 0;
+    return input === 0 && output === 0;
+  }
+
+  private filterGhostSpans(
+    spans: OtlpSpan[],
+    resourceAttrs: AttributeMap,
+    spanMap: Map<string, SpanEntry>,
+  ): Set<string> {
+    const ghostIds = new Set<string>();
+    const msgSpans: { spanId: string; time: number; empty: boolean }[] = [];
+
+    for (const span of spans) {
+      const spanId = toHexString(span.spanId);
+      const entry = spanMap.get(spanId);
+      if (entry?.type !== 'agent_message') continue;
+      const attrs = { ...resourceAttrs, ...extractAttributes(span.attributes) };
+      const time = new Date(nanoToDatetime(span.startTimeUnixNano)).getTime();
+      msgSpans.push({ spanId, time, empty: this.isEmptyOkSpan(span, attrs) });
+    }
+
+    for (const ms of msgSpans) {
+      if (!ms.empty) continue;
+      const hasSibling = msgSpans.some(
+        (other) => !other.empty && Math.abs(other.time - ms.time) <= 60_000,
+      );
+      if (hasSibling) ghostIds.add(ms.spanId);
+    }
+    return ghostIds;
+  }
+
   private async insertAll(
     spans: OtlpSpan[],
     resourceAttrs: AttributeMap,
     spanMap: Map<string, SpanEntry>,
     ctx: IngestionContext,
   ): Promise<void> {
+    const ghostSpanIds = this.filterGhostSpans(spans, resourceAttrs, spanMap);
     const messageAggregates = new Map<
       string,
       {
@@ -110,6 +147,7 @@ export class TraceIngestService {
 
       if (entry.type === 'root_request') continue;
       if (entry.type === 'agent_message') {
+        if (ghostSpanIds.has(spanId)) continue;
         await this.insertAgentMessage(span, attrs, entry, spanMap, ctx);
       } else if (entry.type === 'llm_call') {
         await this.insertLlmCall(span, attrs, entry, spanMap, ctx);
@@ -264,6 +302,25 @@ export class TraceIngestService {
       return Math.abs(errorTime - spanTime) <= 30_000;
     });
     if (hasNearbyError) return;
+
+    // DB-level ghost dedup: if this span is empty-ok, check if a data-bearing
+    // message for the same agent already exists within 60s (cross-batch case).
+    if (this.isEmptyOkSpan(span, attrs)) {
+      const recentMessages = await this.turnRepo.find({
+        where: { tenant_id: ctx.tenantId, agent_id: ctx.agentId },
+        select: ['id', 'timestamp', 'input_tokens', 'output_tokens', 'model'],
+        order: { timestamp: 'DESC' },
+        take: 5,
+      });
+      const hasNearbyData = recentMessages.some((m) => {
+        const mTime = new Date(m.timestamp).getTime();
+        return (
+          Math.abs(mTime - spanTime) <= 60_000 &&
+          ((m.input_tokens ?? 0) > 0 || (m.output_tokens ?? 0) > 0 || m.model != null)
+        );
+      });
+      if (hasNearbyData) return;
+    }
 
     const cost = this.computeCost(attrs);
     await this.turnRepo.insert({

--- a/packages/backend/test/otlp-roundtrip.e2e-spec.ts
+++ b/packages/backend/test/otlp-roundtrip.e2e-spec.ts
@@ -66,6 +66,76 @@ describe('OTLP ingest-then-query round-trip', () => {
       .expect(200);
   });
 
+  it('filters ghost duplicate from same batch', async () => {
+    // Get baseline message count
+    const before = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    const baselineCount = before.body.total_count;
+
+    const startNano = makeCurrentTimeNano();
+    const endNano = (BigInt(startNano) + 1_000_000_000n).toString();
+
+    const batchPayload = {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: 'service.name', value: { stringValue: 'agent' } },
+              { key: 'agent.name', value: { stringValue: 'test-agent' } },
+            ],
+          },
+          scopeSpans: [
+            {
+              scope: { name: 'ghost-test' },
+              spans: [
+                {
+                  traceId: 'ddee112233445566ddee112233445566',
+                  spanId: 'ff11223344556677',
+                  name: 'openclaw.agent.turn',
+                  kind: 1,
+                  startTimeUnixNano: startNano,
+                  endTimeUnixNano: endNano,
+                  attributes: [
+                    { key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } },
+                    { key: 'gen_ai.usage.input_tokens', value: { intValue: 1000 } },
+                    { key: 'gen_ai.usage.output_tokens', value: { intValue: 500 } },
+                  ],
+                  status: { code: 1 },
+                },
+                {
+                  traceId: 'eeff112233445566eeff112233445566',
+                  spanId: 'aa11223344556677',
+                  name: 'openclaw.agent.turn',
+                  kind: 1,
+                  startTimeUnixNano: startNano,
+                  endTimeUnixNano: endNano,
+                  attributes: [],
+                  status: { code: 1 },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    await request(app.getHttpServer())
+      .post('/otlp/v1/traces')
+      .set('Authorization', AUTH_HEADER)
+      .send(batchPayload)
+      .expect(200);
+
+    const after = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    // Only 1 message should be added (ghost filtered), not 2
+    expect(after.body.total_count).toBe(baselineCount + 1);
+  });
+
   it('overview reflects OTLP-ingested data', async () => {
     const res = await request(app.getHttpServer())
       .get('/api/v1/overview?range=24h')


### PR DESCRIPTION
## Summary

- Fix ghost duplicate messages appearing in the dashboard when the OpenClaw gateway fires a second `before_agent_start` + `agent_end` cycle
- Add batch-level pre-filtering to detect and skip empty-ok spans (0 tokens, no model) when a data-bearing sibling exists within 60s
- Add DB-level fallback for cross-batch ghost dedup — queries recent messages before inserting empty-ok spans

## Test plan

- [x] 6 new unit tests covering ghost filtering (both orderings, error span exclusion, DB fallback)
- [x] 1 new E2E test verifying only 1 message is created from a batch with data + ghost spans
- [x] All 2006 unit tests pass with 100% line coverage
- [x] All 105 E2E tests pass
- [x] TypeScript compiles with no errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate dashboard messages by filtering ghost agent_message spans during OTLP trace ingestion. Integrated with the new batch insert path so only real, data-bearing spans create messages.

- **Bug Fixes**
  - Batch-level: skip empty-ok spans (status ok, 0 tokens, no model) when a data-bearing sibling exists within 60s; order-independent and keeps error spans.
  - DB-level: for empty-ok spans, query recent messages and skip if a nearby data-bearing message exists within 60s; scoped by session_key when present.
  - Integration and correctness: ghost filter runs before buildAgentMessage/batch insert; DB fallback skips via null; treat gen_ai.response.model as non-empty; tokens-without-model are non-empty; model-only DB matches count as data-bearing. Adds unit and E2E tests for in-batch, cross-batch, session scoping, and edge cases.

<sup>Written for commit e6fc511f1c4d2619d9d3069ee9a8f684d7aa0ed4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

