### PR TITLE
perf: loading states + batch insert optimizations

### DIFF
--- a/.changeset/add-loading-states.md
+++ b/.changeset/add-loading-states.md
@@ -8,3 +8,5 @@ Add loading states to CRUD operations and backend performance improvements
 - Add database indexes on agent_messages, cost_snapshots, and security_event for faster queries
 - Batch quality score updates and use upsert for custom provider pricing
 - Store API key prefix at write time instead of decrypting at read time
+- Batch insert optimizations for OTLP trace/metric/log ingestion and telemetry service
+- Parallelize rollup UPDATEs and agent rename table updates

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -6,7 +6,11 @@ import { Agent } from '../../entities/agent.entity';
 import { rangeToInterval, rangeToPreviousInterval } from '../../common/utils/range.util';
 import { MetricWithTrend, computeTrend, addTenantFilter, formatTimestamp } from './query-helpers';
 import {
-  DbDialect, detectDialect, computeCutoff, sqlCastFloat, sqlSanitizeCost,
+  DbDialect,
+  detectDialect,
+  computeCutoff,
+  sqlCastFloat,
+  sqlSanitizeCost,
 } from '../../common/utils/sql-dialect';
 
 export { MetricWithTrend };
@@ -76,7 +80,11 @@ export class AggregationService {
     };
   }
 
-  async getCostSummary(range: string, userId: string, agentName?: string): Promise<MetricWithTrend> {
+  async getCostSummary(
+    range: string,
+    userId: string,
+    agentName?: string,
+  ): Promise<MetricWithTrend> {
     const interval = rangeToInterval(range);
     const prevInterval = rangeToPreviousInterval(range);
     const cutoff = computeCutoff(interval);
@@ -103,7 +111,11 @@ export class AggregationService {
     return { value: current, trend_pct: computeTrend(current, previous) };
   }
 
-  async getMessageCount(range: string, userId: string, agentName?: string): Promise<MetricWithTrend> {
+  async getMessageCount(
+    range: string,
+    userId: string,
+    agentName?: string,
+  ): Promise<MetricWithTrend> {
     const interval = rangeToInterval(range);
     const prevInterval = rangeToPreviousInterval(range);
     const cutoff = computeCutoff(interval);
@@ -143,7 +155,12 @@ export class AggregationService {
     await this.agentRepo.delete(agent.id);
   }
 
-  async renameAgent(userId: string, currentName: string, newName: string, displayName?: string): Promise<void> {
+  async renameAgent(
+    userId: string,
+    currentName: string,
+    newName: string,
+    displayName?: string,
+  ): Promise<void> {
     const agent = await this.agentRepo
       .createQueryBuilder('a')
       .leftJoin('a.tenant', 't')
@@ -190,15 +207,23 @@ export class AggregationService {
         .where('id = :id', { id: agent.id })
         .execute();
 
-      const tables = ['agent_messages', 'notification_rules', 'notification_logs', 'token_usage_snapshots', 'cost_snapshots'];
-      for (const table of tables) {
-        await manager
-          .createQueryBuilder()
-          .update(table)
-          .set({ agent_name: newName })
-          .where('agent_name = :currentName', { currentName })
-          .execute();
-      }
+      const tables = [
+        'agent_messages',
+        'notification_rules',
+        'notification_logs',
+        'token_usage_snapshots',
+        'cost_snapshots',
+      ];
+      await Promise.all(
+        tables.map((table) =>
+          manager
+            .createQueryBuilder()
+            .update(table)
+            .set({ agent_name: newName })
+            .where('agent_name = :currentName', { currentName })
+            .execute(),
+        ),
+      );
     });
   }
 
@@ -214,9 +239,7 @@ export class AggregationService {
     cursor?: string;
     agent_name?: string;
   }) {
-    const cutoff = params.range
-      ? computeCutoff(rangeToInterval(params.range))
-      : undefined;
+    const cutoff = params.range ? computeCutoff(rangeToInterval(params.range)) : undefined;
 
     const baseQb = this.turnRepo.createQueryBuilder('at');
     if (cutoff) {
@@ -226,11 +249,15 @@ export class AggregationService {
     addTenantFilter(baseQb, params.userId);
 
     if (params.status) baseQb.andWhere('at.status = :status', { status: params.status });
-    if (params.service_type) baseQb.andWhere('at.service_type = :serviceType', { serviceType: params.service_type });
+    if (params.service_type)
+      baseQb.andWhere('at.service_type = :serviceType', { serviceType: params.service_type });
     if (params.model) baseQb.andWhere('at.model = :model', { model: params.model });
-    if (params.cost_min !== undefined) baseQb.andWhere('at.cost_usd >= :costMin', { costMin: params.cost_min });
-    if (params.cost_max !== undefined) baseQb.andWhere('at.cost_usd <= :costMax', { costMax: params.cost_max });
-    if (params.agent_name) baseQb.andWhere('at.agent_name = :filterAgent', { filterAgent: params.agent_name });
+    if (params.cost_min !== undefined)
+      baseQb.andWhere('at.cost_usd >= :costMin', { costMin: params.cost_min });
+    if (params.cost_max !== undefined)
+      baseQb.andWhere('at.cost_usd <= :costMax', { costMax: params.cost_max });
+    if (params.agent_name)
+      baseQb.andWhere('at.agent_name = :filterAgent', { filterAgent: params.agent_name });
 
     // Count (without cursor)
     const countQb = baseQb.clone().select('COUNT(*)', 'total');
@@ -239,7 +266,8 @@ export class AggregationService {
 
     // Data (with cursor) — treat negative costs as NULL (invalid pricing)
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'), this.dialect);
-    const dataQb = baseQb.clone()
+    const dataQb = baseQb
+      .clone()
       .select('at.id', 'id')
       .addSelect('at.timestamp', 'timestamp')
       .addSelect('at.agent_name', 'agent_name')
@@ -265,15 +293,13 @@ export class AggregationService {
         const cursorId = params.cursor.substring(sepIdx + 1);
         dataQb.andWhere(
           new Brackets((sub) => {
-            sub
-              .where('at.timestamp < :cursorTs', { cursorTs })
-              .orWhere(
-                new Brackets((inner) => {
-                  inner
-                    .where('at.timestamp = :cursorTs2', { cursorTs2: cursorTs })
-                    .andWhere('at.id < :cursorId', { cursorId });
-                }),
-              );
+            sub.where('at.timestamp < :cursorTs', { cursorTs }).orWhere(
+              new Brackets((inner) => {
+                inner
+                  .where('at.timestamp = :cursorTs2', { cursorTs2: cursorTs })
+                  .andWhere('at.id < :cursorId', { cursorId });
+              }),
+            );
           }),
         );
       }
@@ -291,8 +317,7 @@ export class AggregationService {
     const ts = lastItem?.['timestamp'];
     const tsStr = ts instanceof Date ? formatTimestamp(ts) : String(ts ?? '');
     const lastId = lastItem?.['id'];
-    const nextCursor = hasMore && lastItem
-      ? `${tsStr}|${String(lastId)}` : null;
+    const nextCursor = hasMore && lastItem ? `${tsStr}|${String(lastId)}` : null;
 
     // Distinct models
     const modelsQb = this.turnRepo

--- a/packages/backend/src/otlp/services/log-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/log-ingest.service.spec.ts
@@ -62,7 +62,7 @@ describe('LogIngestService', () => {
     expect(result.accepted).toBe(1);
     expect(mockInsert).toHaveBeenCalledTimes(1);
 
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.tenant_id).toBe('test-tenant');
     expect(insertArg.agent_id).toBe('test-agent');
     expect(insertArg.agent_name).toBe('bot-1');
@@ -94,7 +94,7 @@ describe('LogIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
 
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.severity).toBe('error');
   });
 
@@ -136,7 +136,8 @@ describe('LogIngestService', () => {
 
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(3);
-    expect(mockInsert).toHaveBeenCalledTimes(3);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockInsert.mock.calls[0][0]).toHaveLength(3);
   });
 
   it('serializes non-string body as JSON', async () => {
@@ -163,7 +164,7 @@ describe('LogIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
 
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.body).toBe('{"intValue":42}');
   });
 
@@ -193,7 +194,7 @@ describe('LogIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
 
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.trace_id).toBe('abc123');
     expect(insertArg.span_id).toBe('def456');
   });
@@ -261,7 +262,7 @@ describe('LogIngestService', () => {
 
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.severity).toBe('info');
   });
 
@@ -288,7 +289,7 @@ describe('LogIngestService', () => {
 
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.body).toBeNull();
   });
 
@@ -316,7 +317,7 @@ describe('LogIngestService', () => {
 
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.attributes).toBeNull();
   });
 
@@ -344,7 +345,7 @@ describe('LogIngestService', () => {
 
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.attributes).toBe(JSON.stringify({ env: 'production' }));
   });
 
@@ -374,7 +375,7 @@ describe('LogIngestService', () => {
 
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.agent_name).toBe('log-level-bot');
   });
 
@@ -404,7 +405,7 @@ describe('LogIngestService', () => {
 
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
-    const insertArg = mockInsert.mock.calls[0][0];
+    const insertArg = mockInsert.mock.calls[0][0][0];
     expect(insertArg.agent_name).toBe('my-service');
   });
 });

--- a/packages/backend/src/otlp/services/log-ingest.service.ts
+++ b/packages/backend/src/otlp/services/log-ingest.service.ts
@@ -24,35 +24,33 @@ export class LogIngestService {
     request: OtlpExportLogsServiceRequest,
     ctx: IngestionContext,
   ): Promise<{ accepted: number }> {
-    let accepted = 0;
+    const rows: Record<string, unknown>[] = [];
 
     for (const rl of request.resourceLogs ?? []) {
       const resourceAttrs = extractAttributes(rl.resource?.attributes);
-      const agentName = attrString(resourceAttrs, 'agent.name') ?? attrString(resourceAttrs, 'service.name');
+      const agentName =
+        attrString(resourceAttrs, 'agent.name') ?? attrString(resourceAttrs, 'service.name');
 
       for (const sl of rl.scopeLogs ?? []) {
         for (const log of sl.logRecords ?? []) {
           const logAttrs = extractAttributes(log.attributes);
-          const severity = log.severityText ?? severityNumberToString(log.severityNumber);
-          const body = log.body?.stringValue ?? (log.body ? JSON.stringify(log.body) : null);
-
-          await this.logRepo.insert({
+          rows.push({
             id: uuidv4(),
             tenant_id: ctx.tenantId,
             agent_id: ctx.agentId,
             timestamp: nanoToDatetime(log.timeUnixNano),
             agent_name: attrString(logAttrs, 'agent.name') ?? agentName,
-            severity,
-            body,
+            severity: log.severityText ?? severityNumberToString(log.severityNumber),
+            body: log.body?.stringValue ?? (log.body ? JSON.stringify(log.body) : null),
             trace_id: log.traceId ? toHexString(log.traceId) : null,
             span_id: log.spanId ? toHexString(log.spanId) : null,
             attributes: Object.keys(logAttrs).length > 0 ? JSON.stringify(logAttrs) : null,
           });
-          accepted++;
         }
       }
     }
 
-    return { accepted };
+    if (rows.length > 0) await this.logRepo.insert(rows);
+    return { accepted: rows.length };
   }
 }

--- a/packages/backend/src/otlp/services/metric-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/metric-ingest.service.spec.ts
@@ -69,13 +69,13 @@ describe('MetricIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
     expect(mockTokenInsert).toHaveBeenCalledTimes(1);
-    expect(mockTokenInsert).toHaveBeenCalledWith(
+    expect(mockTokenInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         tenant_id: 'test-tenant',
         agent_id: 'test-agent',
         input_tokens: 500,
       }),
-    );
+    ]);
   });
 
   it('ingests cost metric data points as cost snapshots', async () => {
@@ -116,14 +116,14 @@ describe('MetricIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
     expect(mockCostInsert).toHaveBeenCalledTimes(1);
-    expect(mockCostInsert).toHaveBeenCalledWith(
+    expect(mockCostInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         tenant_id: 'test-tenant',
         agent_id: 'test-agent',
         cost_usd: 0.025,
         model: 'claude-opus-4-6',
       }),
-    );
+    ]);
   });
 
   it('ignores metrics that are not token or cost metrics', async () => {
@@ -191,11 +191,11 @@ describe('MetricIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
     expect(mockTokenInsert).toHaveBeenCalledTimes(1);
-    expect(mockTokenInsert).toHaveBeenCalledWith(
+    expect(mockTokenInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         output_tokens: 300,
       }),
-    );
+    ]);
   });
 
   it('handles multiple data points in a single metric', async () => {
@@ -226,7 +226,8 @@ describe('MetricIngestService', () => {
 
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(3);
-    expect(mockTokenInsert).toHaveBeenCalledTimes(3);
+    expect(mockTokenInsert).toHaveBeenCalledTimes(1);
+    expect(mockTokenInsert.mock.calls[0][0]).toHaveLength(3);
   });
 
   it('handles missing resourceMetrics', async () => {

--- a/packages/backend/src/otlp/services/metric-ingest.service.ts
+++ b/packages/backend/src/otlp/services/metric-ingest.service.ts
@@ -16,10 +16,7 @@ const TOKEN_METRIC_NAMES = new Set([
   'gen_ai.usage.cache_creation_tokens',
 ]);
 
-const COST_METRIC_NAMES = new Set([
-  'gen_ai.usage.cost',
-  'gen_ai.cost.usd',
-]);
+const COST_METRIC_NAMES = new Set(['gen_ai.usage.cost', 'gen_ai.cost.usd']);
 
 @Injectable()
 export class MetricIngestService {
@@ -38,7 +35,8 @@ export class MetricIngestService {
 
     for (const rm of request.resourceMetrics ?? []) {
       const resourceAttrs = extractAttributes(rm.resource?.attributes);
-      const agentName = attrString(resourceAttrs, 'agent.name') ?? attrString(resourceAttrs, 'service.name');
+      const agentName =
+        attrString(resourceAttrs, 'agent.name') ?? attrString(resourceAttrs, 'service.name');
 
       for (const sm of rm.scopeMetrics ?? []) {
         for (const metric of sm.metrics ?? []) {
@@ -64,26 +62,24 @@ export class MetricIngestService {
     agentName: string | null,
     ctx: IngestionContext,
   ): Promise<void> {
-    for (const pt of points) {
+    const rows = points.map((pt) => {
       const pointAttrs = extractAttributes(pt.attributes);
       const agent = attrString(pointAttrs, 'agent.name') ?? agentName;
-      const value = getNumericValue(pt);
-      const ts = nanoToDatetime(pt.timeUnixNano);
-
-      const fields = this.mapTokenField(metricName, value);
-      await this.tokenRepo.insert({
+      const fields = this.mapTokenField(metricName, getNumericValue(pt));
+      return {
         id: uuidv4(),
         tenant_id: ctx.tenantId,
         agent_id: ctx.agentId,
         agent_name: agent,
-        snapshot_time: ts,
+        snapshot_time: nanoToDatetime(pt.timeUnixNano),
         input_tokens: fields.input,
         output_tokens: fields.output,
         cache_read_tokens: fields.cacheRead,
         cache_creation_tokens: fields.cacheCreate,
         total_tokens: fields.total,
-      });
-    }
+      };
+    });
+    if (rows.length > 0) await this.tokenRepo.insert(rows);
   }
 
   private mapTokenField(name: string, value: number) {
@@ -101,20 +97,18 @@ export class MetricIngestService {
     agentName: string | null,
     ctx: IngestionContext,
   ): Promise<void> {
-    for (const pt of points) {
+    const rows = points.map((pt) => {
       const pointAttrs = extractAttributes(pt.attributes);
-      const agent = attrString(pointAttrs, 'agent.name') ?? agentName;
-      const model = attrString(pointAttrs, 'gen_ai.request.model');
-
-      await this.costRepo.insert({
+      return {
         id: uuidv4(),
         tenant_id: ctx.tenantId,
         agent_id: ctx.agentId,
-        agent_name: agent,
+        agent_name: attrString(pointAttrs, 'agent.name') ?? agentName,
         snapshot_time: nanoToDatetime(pt.timeUnixNano),
         cost_usd: getNumericValue(pt),
-        model,
-      });
-    }
+        model: attrString(pointAttrs, 'gen_ai.request.model'),
+      };
+    });
+    if (rows.length > 0) await this.costRepo.insert(rows);
   }
 }

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -104,13 +104,13 @@ describe('TraceIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         tenant_id: 'test-tenant',
         agent_id: 'test-agent',
         agent_name: 'bot-1',
       }),
-    );
+    ]);
   });
 
   it('ingests an llm_call span (has gen_ai.system attribute)', async () => {
@@ -142,7 +142,7 @@ describe('TraceIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(2);
     expect(mockLlmInsert).toHaveBeenCalledTimes(1);
-    expect(mockLlmInsert).toHaveBeenCalledWith(
+    expect(mockLlmInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         tenant_id: 'test-tenant',
         gen_ai_system: 'anthropic',
@@ -150,7 +150,7 @@ describe('TraceIngestService', () => {
         input_tokens: 100,
         output_tokens: 50,
       }),
-    );
+    ]);
   });
 
   it('ingests a tool_execution span (has tool.name attribute)', async () => {
@@ -177,12 +177,12 @@ describe('TraceIngestService', () => {
     const result = await service.ingest(request, testCtx);
     expect(result.accepted).toBe(1);
     expect(mockToolInsert).toHaveBeenCalledTimes(1);
-    expect(mockToolInsert).toHaveBeenCalledWith(
+    expect(mockToolInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         tenant_id: 'test-tenant',
         tool_name: 'web_search',
       }),
-    );
+    ]);
   });
 
   it('computes cost from model pricing when available', async () => {
@@ -213,11 +213,11 @@ describe('TraceIngestService', () => {
 
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
     // cost = 100 * 0.001 + 50 * 0.002 = 0.2
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         cost_usd: expect.closeTo(0.2, 4),
       }),
-    );
+    ]);
   });
 
   it('handles error status on spans', async () => {
@@ -238,12 +238,12 @@ describe('TraceIngestService', () => {
     await service.ingest(request, testCtx);
 
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         status: 'error',
         error_message: 'something went wrong',
       }),
-    );
+    ]);
   });
 
   it('persists routing_reason from manifest.routing.reason attribute', async () => {
@@ -266,12 +266,12 @@ describe('TraceIngestService', () => {
 
     await service.ingest(request, testCtx);
 
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         routing_tier: 'simple',
         routing_reason: 'heartbeat',
       }),
-    );
+    ]);
   });
 
   it('rolls up routing_reason from llm_call child into parent agent_message', async () => {
@@ -468,12 +468,12 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         status: 'ok',
         error_message: null,
       }),
-    );
+    ]);
   });
 
   it('sets null messageId when llm_call parent is not an agent_message', async () => {
@@ -501,7 +501,7 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockLlmInsert).toHaveBeenCalledWith(expect.objectContaining({ turn_id: null }));
+    expect(mockLlmInsert).toHaveBeenCalledWith([expect.objectContaining({ turn_id: null })]);
   });
 
   it('sets null llmCallId when tool parent is not an llm_call', async () => {
@@ -526,7 +526,7 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockToolInsert).toHaveBeenCalledWith(expect.objectContaining({ llm_call_id: null }));
+    expect(mockToolInsert).toHaveBeenCalledWith([expect.objectContaining({ llm_call_id: null })]);
   });
 
   it('uses tool.name from resource attributes for tool_execution classification', async () => {
@@ -553,9 +553,9 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockToolInsert).toHaveBeenCalledWith(
+    expect(mockToolInsert).toHaveBeenCalledWith([
       expect.objectContaining({ tool_name: 'resource-tool' }),
-    );
+    ]);
   });
 
   it('sets error_message on tool_execution spans with error status', async () => {
@@ -575,12 +575,12 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockToolInsert).toHaveBeenCalledWith(
+    expect(mockToolInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         status: 'error',
         error_message: 'tool failed',
       }),
-    );
+    ]);
   });
 
   it('sets null error_message on tool_execution spans with ok status', async () => {
@@ -600,12 +600,12 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockToolInsert).toHaveBeenCalledWith(
+    expect(mockToolInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         status: 'ok',
         error_message: null,
       }),
-    );
+    ]);
   });
 
   it('does not accumulate to message when llm_call parent is not agent_message', async () => {
@@ -772,7 +772,7 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnInsert).toHaveBeenCalledWith(expect.objectContaining({ cost_usd: null }));
+    expect(mockTurnInsert).toHaveBeenCalledWith([expect.objectContaining({ cost_usd: null })]);
   });
 
   it('returns null cost when no model attribute is present', async () => {
@@ -794,7 +794,7 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnInsert).toHaveBeenCalledWith(expect.objectContaining({ cost_usd: null }));
+    expect(mockTurnInsert).toHaveBeenCalledWith([expect.objectContaining({ cost_usd: null })]);
   });
 
   it('returns null cost when model exists but pricing is not found', async () => {
@@ -819,7 +819,7 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnInsert).toHaveBeenCalledWith(expect.objectContaining({ cost_usd: null }));
+    expect(mockTurnInsert).toHaveBeenCalledWith([expect.objectContaining({ cost_usd: null })]);
   });
 
   it('uses gen_ai.response.model as fallback when gen_ai.request.model is absent', async () => {
@@ -848,12 +848,12 @@ describe('TraceIngestService', () => {
 
     await service.ingest(request, testCtx);
     expect(mockPricingGetByModel).toHaveBeenCalledWith('claude-3-haiku');
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         model: 'claude-3-haiku',
         cost_usd: expect.closeTo(0.02, 4),
       }),
-    );
+    ]);
   });
 
   it('uses fallback model from gen_ai.response.model in accumulation', async () => {
@@ -1024,9 +1024,9 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({ agent_name: 'test-agent' }),
-    );
+    ]);
   });
 
   it('sets null cost in rollup when model is null in aggregates', async () => {
@@ -1103,12 +1103,12 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockLlmInsert).toHaveBeenCalledWith(
+    expect(mockLlmInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         cache_read_tokens: 30,
         cache_creation_tokens: 20,
       }),
-    );
+    ]);
   });
 
   it('sets null error_message when error status has no message field', async () => {
@@ -1127,12 +1127,12 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         status: 'error',
         error_message: null,
       }),
-    );
+    ]);
   });
 
   it('sets llmCallId when tool parent is an llm_call', async () => {
@@ -1168,14 +1168,14 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockToolInsert).toHaveBeenCalledWith(
+    expect(mockToolInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         llm_call_id: expect.any(String),
         tool_name: 'file_read',
       }),
-    );
+    ]);
     // Verify llm_call_id is not null (it should be the uuid of the llm span entry)
-    const insertArg = mockToolInsert.mock.calls[0][0];
+    const insertArg = mockToolInsert.mock.calls[0][0][0];
     expect(insertArg.llm_call_id).not.toBeNull();
   });
 
@@ -1196,12 +1196,12 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockToolInsert).toHaveBeenCalledWith(
+    expect(mockToolInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         status: 'error',
         error_message: null,
       }),
-    );
+    ]);
   });
 
   it('skips agent_message insert when proxy error already recorded for same trace_id', async () => {
@@ -1384,13 +1384,13 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockLlmInsert).toHaveBeenCalledWith(
+    expect(mockLlmInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         input_tokens: 0,
         output_tokens: 0,
         cache_read_tokens: 0,
         cache_creation_tokens: 0,
       }),
-    );
+    ]);
   });
 });

--- a/packages/backend/src/otlp/services/trace-ingest.service.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.ts
@@ -103,6 +103,10 @@ export class TraceIngestService {
       }
     >();
 
+    const agentMessageRows: Record<string, unknown>[] = [];
+    const llmCallRows: Record<string, unknown>[] = [];
+    const toolExecutionRows: Record<string, unknown>[] = [];
+
     for (const span of spans) {
       const spanId = toHexString(span.spanId);
       const entry = spanMap.get(spanId)!;
@@ -110,14 +114,21 @@ export class TraceIngestService {
 
       if (entry.type === 'root_request') continue;
       if (entry.type === 'agent_message') {
-        await this.insertAgentMessage(span, attrs, entry, spanMap, ctx);
+        const row = await this.buildAgentMessage(span, attrs, entry, ctx);
+        if (row) agentMessageRows.push(row);
       } else if (entry.type === 'llm_call') {
-        await this.insertLlmCall(span, attrs, entry, spanMap, ctx);
+        llmCallRows.push(this.buildLlmCall(span, attrs, entry, spanMap, ctx));
         this.accumulateToMessage(span, attrs, spanMap, messageAggregates);
       } else {
-        await this.insertToolExecution(span, attrs, entry, spanMap, ctx);
+        toolExecutionRows.push(this.buildToolExecution(span, attrs, entry, spanMap, ctx));
       }
     }
+
+    const inserts: Promise<unknown>[] = [];
+    if (agentMessageRows.length > 0) inserts.push(this.turnRepo.insert(agentMessageRows));
+    if (llmCallRows.length > 0) inserts.push(this.llmRepo.insert(llmCallRows));
+    if (toolExecutionRows.length > 0) inserts.push(this.toolRepo.insert(toolExecutionRows));
+    await Promise.all(inserts);
 
     await this.rollUpMessageAggregates(messageAggregates);
   }
@@ -184,6 +195,7 @@ export class TraceIngestService {
       }
     >,
   ): Promise<void> {
+    const updates: Promise<unknown>[] = [];
     for (const [messageId, agg] of aggregates) {
       if (agg.input === 0 && agg.output === 0) continue;
 
@@ -201,37 +213,37 @@ export class TraceIngestService {
         }
       }
 
-      await this.turnRepo
-        .createQueryBuilder()
-        .update(AgentMessage)
-        .set({
-          input_tokens: agg.input,
-          output_tokens: agg.output,
-          cache_read_tokens: agg.cacheRead,
-          cache_creation_tokens: agg.cacheCreation,
-          model: () => 'COALESCE(model, :model)',
-          routing_tier: () => 'COALESCE(routing_tier, :tier)',
-          routing_reason: () => 'COALESCE(routing_reason, :reason)',
-          cost_usd: cost,
-        })
-        .setParameter('model', agg.model)
-        .setParameter('tier', agg.tier)
-        .setParameter('reason', agg.reason)
-        .where('id = :id', { id: messageId })
-        .execute();
+      updates.push(
+        this.turnRepo
+          .createQueryBuilder()
+          .update(AgentMessage)
+          .set({
+            input_tokens: agg.input,
+            output_tokens: agg.output,
+            cache_read_tokens: agg.cacheRead,
+            cache_creation_tokens: agg.cacheCreation,
+            model: () => 'COALESCE(model, :model)',
+            routing_tier: () => 'COALESCE(routing_tier, :tier)',
+            routing_reason: () => 'COALESCE(routing_reason, :reason)',
+            cost_usd: cost,
+          })
+          .setParameter('model', agg.model)
+          .setParameter('tier', agg.tier)
+          .setParameter('reason', agg.reason)
+          .where('id = :id', { id: messageId })
+          .execute(),
+      );
     }
+    if (updates.length > 0) await Promise.all(updates);
   }
 
-  private async insertAgentMessage(
+  private async buildAgentMessage(
     span: OtlpSpan,
     attrs: AttributeMap,
     entry: SpanEntry,
-    _spanMap: Map<string, SpanEntry>,
     ctx: IngestionContext,
-  ): Promise<void> {
+  ): Promise<Record<string, unknown> | null> {
     // Skip if the proxy already recorded an error for this trace (avoids duplicates).
-    // Two strategies: (1) match by trace_id, (2) match by agent + timestamp proximity.
-    // Strategy 2 covers cases where the proxy doesn't have the traceparent header.
     const traceId = toHexString(span.traceId);
     if (traceId) {
       const existing = await this.turnRepo.findOne({
@@ -242,12 +254,10 @@ export class TraceIngestService {
         },
         select: ['id'],
       });
-      if (existing) return;
+      if (existing) return null;
     }
 
     // Fallback dedup: fetch recent errors for this agent and check timestamp proximity.
-    // Uses the span's own timestamp (not Date.now()) because OTLP batches arrive
-    // 10-30s after the actual event. Compares in JS to avoid SQLite Between issues.
     const spanTime = new Date(nanoToDatetime(span.startTimeUnixNano)).getTime();
     const recentErrors = await this.turnRepo.find({
       where: {
@@ -263,10 +273,9 @@ export class TraceIngestService {
       const errorTime = new Date(e.timestamp).getTime();
       return Math.abs(errorTime - spanTime) <= 30_000;
     });
-    if (hasNearbyError) return;
+    if (hasNearbyError) return null;
 
-    const cost = this.computeCost(attrs);
-    await this.turnRepo.insert({
+    return {
       id: entry.uuid,
       tenant_id: ctx.tenantId,
       agent_id: ctx.agentId,
@@ -279,7 +288,7 @@ export class TraceIngestService {
       output_tokens: attrNumber(attrs, 'gen_ai.usage.output_tokens') ?? 0,
       cache_read_tokens: attrNumber(attrs, 'gen_ai.usage.cache_read_input_tokens') ?? 0,
       cache_creation_tokens: attrNumber(attrs, 'gen_ai.usage.cache_creation_input_tokens') ?? 0,
-      cost_usd: cost,
+      cost_usd: this.computeCost(attrs),
       status: spanStatusToString(span.status?.code),
       error_message: span.status?.code === 2 ? (span.status.message ?? null) : null,
       description: span.name,
@@ -290,21 +299,21 @@ export class TraceIngestService {
       routing_tier: attrString(attrs, 'manifest.routing.tier'),
       routing_reason: attrString(attrs, 'manifest.routing.reason'),
       skill_name: attrString(attrs, 'skill.name'),
-    });
+    };
   }
 
-  private async insertLlmCall(
+  private buildLlmCall(
     span: OtlpSpan,
     attrs: AttributeMap,
     entry: SpanEntry,
     spanMap: Map<string, SpanEntry>,
     ctx: IngestionContext,
-  ): Promise<void> {
+  ): Record<string, unknown> {
     const parentId = toHexString(span.parentSpanId);
     const parentEntry = spanMap.get(parentId);
     const messageId = parentEntry?.type === 'agent_message' ? parentEntry.uuid : null;
 
-    await this.llmRepo.insert({
+    return {
       id: entry.uuid,
       tenant_id: ctx.tenantId,
       agent_id: ctx.agentId,
@@ -322,21 +331,21 @@ export class TraceIngestService {
       temperature: attrNumber(attrs, 'llm.request.temperature'),
       max_output_tokens: attrNumber(attrs, 'llm.request.max_tokens'),
       timestamp: nanoToDatetime(span.startTimeUnixNano),
-    });
+    };
   }
 
-  private async insertToolExecution(
+  private buildToolExecution(
     span: OtlpSpan,
     attrs: AttributeMap,
     entry: SpanEntry,
     spanMap: Map<string, SpanEntry>,
     ctx: IngestionContext,
-  ): Promise<void> {
+  ): Record<string, unknown> {
     const parentId = toHexString(span.parentSpanId);
     const parentEntry = spanMap.get(parentId);
     const llmCallId = parentEntry?.type === 'llm_call' ? parentEntry.uuid : null;
 
-    await this.toolRepo.insert({
+    return {
       id: entry.uuid,
       tenant_id: ctx.tenantId,
       agent_id: ctx.agentId,
@@ -345,7 +354,7 @@ export class TraceIngestService {
       duration_ms: spanDurationMs(span.startTimeUnixNano, span.endTimeUnixNano),
       status: spanStatusToString(span.status?.code),
       error_message: span.status?.code === 2 ? (span.status.message ?? null) : null,
-    });
+    };
   }
 
   private computeCost(attrs: AttributeMap): number | null {

--- a/packages/backend/src/telemetry/telemetry.service.spec.ts
+++ b/packages/backend/src/telemetry/telemetry.service.spec.ts
@@ -51,16 +51,16 @@ describe('TelemetryService', () => {
     expect(result.rejected).toBe(0);
     expect(result.errors).toHaveLength(0);
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         input_tokens: 100,
         output_tokens: 50,
         user_id: 'test-user',
       }),
-    );
+    ]);
   });
 
-  it('reports rejected when insert fails', async () => {
+  it('reports rejected when batch insert fails', async () => {
     mockTurnInsert.mockRejectedValueOnce(new Error('DB error'));
 
     const result = await service.ingest([makeEvent()], 'test-user');
@@ -70,19 +70,21 @@ describe('TelemetryService', () => {
     expect(result.errors[0].reason).toBe('DB error');
   });
 
-  it('handles mixed success and failure', async () => {
-    mockTurnInsert.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('DB error'));
+  it('handles build-time rejection for invalid timestamps', async () => {
+    const validEvent = makeEvent({ input_tokens: 10 });
+    const badEvent = makeEvent({ timestamp: 'not-a-date' });
 
-    const result = await service.ingest([makeEvent(), makeEvent()], 'test-user');
+    const result = await service.ingest([validEvent, badEvent], 'test-user');
 
     expect(result.accepted).toBe(1);
     expect(result.rejected).toBe(1);
+    expect(result.errors[0].index).toBe(1);
   });
 
   it('stores timestamps in ISO-8601 format with trailing Z', async () => {
     await service.ingest([makeEvent({ input_tokens: 10 })], 'test-user');
 
-    const insertedObj = mockTurnInsert.mock.calls[0][0];
+    const insertedObj = mockTurnInsert.mock.calls[0][0][0];
     expect(insertedObj.timestamp).toMatch(/T/);
     expect(insertedObj.timestamp).toMatch(/Z$/);
   });
@@ -94,7 +96,7 @@ describe('TelemetryService', () => {
       mockTurnInsert.mockClear();
       await service.ingest([makeEvent({ timestamp: ts, input_tokens: 1 })], 'test-user');
 
-      const stored = mockTurnInsert.mock.calls[0][0].timestamp;
+      const stored = mockTurnInsert.mock.calls[0][0][0].timestamp;
       expect(stored).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     }
   });
@@ -119,14 +121,14 @@ describe('TelemetryService', () => {
     expect(result.accepted).toBe(1);
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
     expect(mockSecurityInsert).toHaveBeenCalledTimes(1);
-    expect(mockSecurityInsert).toHaveBeenCalledWith(
+    expect(mockSecurityInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         severity: 'critical',
         category: 'injection',
         description: 'Prompt injection detected',
         user_id: 'test-user',
       }),
-    );
+    ]);
   });
 
   it('does not insert security event when event has no security_event', async () => {
@@ -155,11 +157,11 @@ describe('TelemetryService', () => {
 
     expect(result.accepted).toBe(1);
     expect(mockPricingGetByModel).toHaveBeenCalledWith('claude-opus-4-6');
-    expect(mockTurnInsert).toHaveBeenCalledWith(
+    expect(mockTurnInsert).toHaveBeenCalledWith([
       expect.objectContaining({
         // cost = 1000 * 0.000015 + 500 * 0.000075 = 0.0525
         cost_usd: expect.closeTo(0.0525, 4),
       }),
-    );
+    ]);
   });
 });

--- a/packages/backend/src/telemetry/telemetry.service.ts
+++ b/packages/backend/src/telemetry/telemetry.service.ts
@@ -34,22 +34,37 @@ export class TelemetryService {
       return { accepted: 0, rejected: 0, errors: [] };
     }
     const maxLen = Math.min(events.length, TelemetryService.MAX_EVENTS_PER_BATCH);
-    let accepted = 0;
-    let rejected = 0;
+    const messageRows: Record<string, unknown>[] = [];
+    const securityRows: Record<string, unknown>[] = [];
     const errors: Array<{ index: number; reason: string }> = [];
 
     for (let i = 0; i < maxLen; i++) {
       try {
-        await this.insertEvent(events[i], userId);
-        accepted++;
+        const { message, security } = this.buildEventRows(events[i], userId);
+        messageRows.push(message);
+        if (security) securityRows.push(security);
       } catch (err) {
-        rejected++;
         const reason = err instanceof Error ? err.message : 'Insert failed';
         errors.push({ index: i, reason });
         this.logger.warn(`Event ${i} rejected: ${reason}`);
       }
     }
 
+    let accepted = messageRows.length;
+    let rejected = errors.length;
+
+    try {
+      const inserts: Promise<unknown>[] = [];
+      if (messageRows.length > 0) inserts.push(this.turnRepo.insert(messageRows));
+      if (securityRows.length > 0) inserts.push(this.securityRepo.insert(securityRows));
+      await Promise.all(inserts);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : 'Insert failed';
+      this.logger.warn(`Batch insert failed: ${reason}`);
+      rejected += accepted;
+      errors.push({ index: 0, reason });
+      accepted = 0;
+    }
     if (accepted > 0) {
       this.eventBus.emit(userId);
     }
@@ -62,8 +77,10 @@ export class TelemetryService {
     return new Date(ts).toISOString();
   }
 
-  private async insertEvent(event: TelemetryEventDto, userId: string): Promise<void> {
-    const id = uuidv4();
+  private buildEventRows(
+    event: TelemetryEventDto,
+    userId: string,
+  ): { message: Record<string, unknown>; security: Record<string, unknown> | null } {
     const inputTok = event.input_tokens ?? 0;
     const outputTok = event.output_tokens ?? 0;
     const timestamp = this.normalizeTimestamp(event.timestamp);
@@ -82,9 +99,9 @@ export class TelemetryService {
       }
     }
 
-    await this.turnRepo.insert({
-      id,
-      timestamp: timestamp,
+    const message = {
+      id: uuidv4(),
+      timestamp,
       description: event.description,
       service_type: event.service_type,
       agent_name: event.agent_name ?? null,
@@ -95,17 +112,20 @@ export class TelemetryService {
       skill_name: event.skill_name ?? null,
       cost_usd: costUsd,
       user_id: userId,
-    });
+    };
 
+    let security: Record<string, unknown> | null = null;
     if (event.security_event) {
-      await this.securityRepo.insert({
+      security = {
         id: uuidv4(),
-        timestamp: timestamp,
+        timestamp,
         severity: event.security_event.severity,
         category: event.security_event.category,
         description: event.security_event.description,
         user_id: userId,
-      });
+      };
     }
+
+    return { message, security };
   }
 }


### PR DESCRIPTION
## Summary

- **Frontend loading states**: Add loading indicators (disabled buttons + text swap) to 6 CRUD operations to prevent double-submission: create agent, save/delete limit rules, remove email provider, reset routing tiers
- **Database indexes**: Add composite indexes on `agent_messages`, `cost_snapshots`, and `security_event` for faster dashboard queries
- **Key prefix storage**: Store API key prefix at write time instead of decrypting at read time
- **Batch insert optimizations**: Replace N individual INSERT queries with bulk inserts across all ingestion services (trace, metric, log, telemetry), reducing database round-trips from O(spans) to O(1) per entity type
- **Parallel operations**: Parallelize rollup UPDATEs in trace ingestion and agent rename table updates via `Promise.all()`
- **Batch quality scores**: Use `Promise.all()` for quality score updates and `upsert()` for custom provider pricing

## Test plan

- [x] All 1996 backend unit tests pass
- [x] All 104 backend e2e tests pass (including OTLP roundtrip)
- [x] All 1243 frontend tests pass
- [x] TypeScript compiles with no errors (both backend and frontend)
- [x] 100% line coverage on all modified files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds loading states to prevent double submits and switches OTLP/telemetry ingestion to batch inserts to cut DB round-trips and improve throughput. Also speeds up dashboard queries with new indexes and parallelized updates.

- **UI Improvements**
  - Add loading/disabled states to 6 CRUD actions to prevent double submits (agent create, limit rules save/delete, remove email provider, reset routing tiers).

- **Performance**
  - Batch insert for trace, metric, log, and telemetry ingestion (from N inserts per span to one bulk insert per entity type).
  - Parallelize rollup UPDATEs and agent rename table updates with Promise.all().
  - Add composite indexes on agent_messages, cost_snapshots, and security_event for faster queries.
  - Store API key prefix at write time (avoids decrypting at read time) and batch quality score updates; use upsert for custom provider pricing.

<sup>Written for commit f3892ce5ed73c2fc62139d8dde8b68cbebe6123e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

