### PR TITLE
fix: address memory leaks causing OOM crashes under load

### DIFF
--- a/.changeset/fix-oom-memory-leaks.md
+++ b/.changeset/fix-oom-memory-leaks.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix memory leaks causing OOM crashes under load: remove rawBody duplication on JSON requests, add SSE buffer size limit, add periodic cache eviction timers, and cap unbounded cache growth.

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -18,20 +18,22 @@ export async function bootstrap() {
   app.enableShutdownHooks();
   app.useGlobalFilters(new SpaFallbackFilter());
 
-  app.use(helmet({
-    contentSecurityPolicy: {
-      directives: {
-        defaultSrc: ["'self'"],
-        scriptSrc: ["'self'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
-        imgSrc: ["'self'", "data:"],
-        connectSrc: ["'self'", "https://eu.i.posthog.com"],
-        fontSrc: ["'self'"],
-        objectSrc: ["'none'"],
-        frameAncestors: ["'none'"],
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+          imgSrc: ["'self'", 'data:'],
+          connectSrc: ["'self'", 'https://eu.i.posthog.com'],
+          fontSrc: ["'self'"],
+          objectSrc: ["'none'"],
+          frameAncestors: ["'none'"],
+        },
       },
-    },
-  }));
+    }),
+  );
 
   const isDev = process.env['NODE_ENV'] !== 'production';
   if (isDev) {
@@ -80,20 +82,21 @@ export async function bootstrap() {
     expressApp.all('/api/auth/*splat', toNodeHandler(auth!));
   }
 
-  // Re-add body parsing for NestJS routes, with rawBody capture for OTLP protobuf
-  expressApp.use(express.json({
-    limit: '1mb',
-    verify: (req: express.Request & { rawBody?: Buffer }, _res: express.Response, buf: Buffer) => {
-      req.rawBody = buf;
-    },
-  }));
-  expressApp.use(express.raw({
-    type: 'application/x-protobuf',
-    limit: '5mb',
-    verify: (req: express.Request & { rawBody?: Buffer }, _res: express.Response, buf: Buffer) => {
-      req.rawBody = buf;
-    },
-  }));
+  // Re-add body parsing for NestJS routes
+  expressApp.use(express.json({ limit: '1mb' }));
+  expressApp.use(
+    express.raw({
+      type: 'application/x-protobuf',
+      limit: '5mb',
+      verify: (
+        req: express.Request & { rawBody?: Buffer },
+        _res: express.Response,
+        buf: Buffer,
+      ) => {
+        req.rawBody = buf;
+      },
+    }),
+  );
   expressApp.use(express.urlencoded({ extended: true, limit: '1mb' }));
 
   const port = Number(process.env['PORT'] ?? 3001);

--- a/packages/backend/src/notifications/services/limit-check.service.spec.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.spec.ts
@@ -247,6 +247,56 @@ describe('LimitCheckService', () => {
     expect(mockGetActiveBlockRules).toHaveBeenCalledTimes(3);
   });
 
+  it('evicts oldest rules cache entry when MAX_CACHE_SIZE is reached', async () => {
+    const rulesCache = (service as any).rulesCache as Map<string, unknown>;
+    const now = Date.now();
+
+    // Fill to exactly MAX_CACHE_SIZE so the next insert triggers eviction
+    for (let i = 0; i < 10_000; i++) {
+      rulesCache.set(`t-${i}:a-${i}`, { data: [], expiresAt: now + 999_999 });
+    }
+    expect(rulesCache.size).toBe(10_000);
+
+    mockGetActiveBlockRules.mockResolvedValue([]);
+    await service.checkLimits('tenant-new', 'agent-new');
+
+    // The first filler entry should have been evicted
+    expect(rulesCache.has('t-0:a-0')).toBe(false);
+    // The new entry should be present
+    expect(rulesCache.has('tenant-new:agent-new')).toBe(true);
+  });
+
+  it('evicts oldest consumption cache entry when MAX_CACHE_SIZE is reached', async () => {
+    const consumptionCache = (service as any).consumptionCache as Map<string, unknown>;
+    const now = Date.now();
+
+    for (let i = 0; i < 10_000; i++) {
+      consumptionCache.set(`t-${i}:a-${i}:tokens:2026-01-01`, {
+        data: 0,
+        expiresAt: now + 999_999,
+      });
+    }
+    expect(consumptionCache.size).toBe(10_000);
+
+    mockGetActiveBlockRules.mockResolvedValue([
+      {
+        id: 'r1',
+        tenant_id: 'tenant-new',
+        agent_name: 'agent-new',
+        user_id: 'u1',
+        metric_type: 'tokens',
+        threshold: 100000,
+        period: 'day',
+      },
+    ]);
+    mockGetConsumption.mockResolvedValue(0);
+
+    await service.checkLimits('tenant-new', 'agent-new');
+
+    // The first filler entry should have been evicted
+    expect(consumptionCache.has('t-0:a-0:tokens:2026-01-01')).toBe(false);
+  });
+
   describe('email notification on block', () => {
     const rule = {
       id: 'r1',

--- a/packages/backend/src/notifications/services/limit-check.service.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.ts
@@ -37,6 +37,7 @@ interface CacheEntry<T> {
 }
 
 const CACHE_TTL_MS = 60_000;
+const MAX_CACHE_SIZE = 10_000;
 
 @Injectable()
 export class LimitCheckService implements OnModuleInit, OnModuleDestroy {
@@ -196,6 +197,7 @@ export class LimitCheckService implements OnModuleInit, OnModuleDestroy {
     if (cached && cached.expiresAt > now) return cached.data;
 
     this.evictExpired(this.rulesCache, now);
+    this.evictOldestIfFull(this.rulesCache);
     const rules = await this.rulesService.getActiveBlockRules(tenantId, agentName);
     this.rulesCache.set(key, { data: rules, expiresAt: now + CACHE_TTL_MS });
     return rules;
@@ -214,6 +216,7 @@ export class LimitCheckService implements OnModuleInit, OnModuleDestroy {
     if (cached && cached.expiresAt > now) return cached.data;
 
     this.evictExpired(this.consumptionCache, now);
+    this.evictOldestIfFull(this.consumptionCache);
     const actual = await this.rulesService.getConsumption(
       tenantId,
       agentName,
@@ -228,6 +231,13 @@ export class LimitCheckService implements OnModuleInit, OnModuleDestroy {
   private evictExpired<T>(cache: Map<string, CacheEntry<T>>, now: number): void {
     for (const [k, v] of cache) {
       if (v.expiresAt <= now) cache.delete(k);
+    }
+  }
+
+  private evictOldestIfFull<T>(cache: Map<string, CacheEntry<T>>): void {
+    if (cache.size >= MAX_CACHE_SIZE) {
+      const firstKey = cache.keys().next().value;
+      if (firstKey) cache.delete(firstKey);
     }
   }
 }

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
@@ -42,6 +42,10 @@ describe('OtlpAuthGuard', () => {
     guard.clearCache();
   });
 
+  afterEach(() => {
+    guard.onModuleDestroy();
+  });
+
   it('throws UnauthorizedException when Authorization header is missing', async () => {
     const { ctx } = makeContext({});
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
@@ -347,6 +351,53 @@ describe('OtlpAuthGuard', () => {
     expect(internalCache.has('mnfst_valid-cache')).toBe(true);
     // The new key should also be cached
     expect(internalCache.has('mnfst_trigger-evict-key')).toBe(true);
+  });
+
+  it('periodic timer fires evictExpired', () => {
+    jest.useFakeTimers();
+
+    const mockRepo = { createQueryBuilder: mockCreateQueryBuilder, update: mockUpdate } as never;
+    const timedGuard = new OtlpAuthGuard(mockRepo);
+
+    const internalCache = (timedGuard as any).cache as Map<string, unknown>;
+    internalCache.set('mnfst_stale', {
+      tenantId: 't',
+      agentId: 'a',
+      agentName: 'n',
+      userId: 'u',
+      expiresAt: Date.now() - 1000,
+    });
+
+    expect(internalCache.size).toBe(1);
+    jest.advanceTimersByTime(60_000);
+    expect(internalCache.size).toBe(0);
+
+    timedGuard.onModuleDestroy();
+    jest.useRealTimers();
+  });
+
+  it('onModuleDestroy stops the periodic cleanup timer', () => {
+    jest.useFakeTimers();
+
+    const mockRepo = { createQueryBuilder: mockCreateQueryBuilder, update: mockUpdate } as never;
+    const timedGuard = new OtlpAuthGuard(mockRepo);
+
+    const internalCache = (timedGuard as any).cache as Map<string, unknown>;
+    timedGuard.onModuleDestroy();
+
+    // After destroy, add an expired entry — timer should not evict it
+    internalCache.set('mnfst_leftover', {
+      tenantId: 't',
+      agentId: 'a',
+      agentName: 'n',
+      userId: 'u',
+      expiresAt: Date.now() - 1000,
+    });
+
+    jest.advanceTimersByTime(120_000);
+    expect(internalCache.size).toBe(1);
+
+    jest.useRealTimers();
   });
 
   it('invalidateCache removes a specific key from cache', async () => {

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.ts
@@ -3,6 +3,7 @@ import {
   ExecutionContext,
   Injectable,
   Logger,
+  OnModuleDestroy,
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -30,16 +31,26 @@ interface CachedKey {
 }
 
 @Injectable()
-export class OtlpAuthGuard implements CanActivate {
+export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
   private readonly logger = new Logger(OtlpAuthGuard.name);
   private cache = new Map<string, CachedKey>();
   private readonly CACHE_TTL_MS = 5 * 60 * 1000;
   private readonly MAX_CACHE_SIZE = 10_000;
+  private readonly cleanupTimer: ReturnType<typeof setInterval>;
 
   constructor(
     @InjectRepository(AgentApiKey)
     private readonly keyRepo: Repository<AgentApiKey>,
-  ) {}
+  ) {
+    this.cleanupTimer = setInterval(() => this.evictExpired(), 60_000);
+    if (typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  onModuleDestroy(): void {
+    clearInterval(this.cleanupTimer);
+  }
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -30,7 +30,7 @@ function mockResponse(): {
       statusCode = code;
       return res;
     }),
-    on: jest.fn(),
+    once: jest.fn(),
     writableEnded: false,
   };
   return {
@@ -99,6 +99,10 @@ describe('ProxyController', () => {
       providerClient as never,
       mockMessageRepo as never,
     );
+  });
+
+  afterEach(() => {
+    controller.onModuleDestroy();
   });
 
   it('should return JSON response for non-streaming OpenAI provider', async () => {
@@ -820,7 +824,7 @@ describe('ProxyController', () => {
 
       await controller.chatCompletions(req as never, res as never);
 
-      expect(res.on).toHaveBeenCalledWith('close', expect.any(Function));
+      expect(res.once).toHaveBeenCalledWith('close', expect.any(Function));
     });
 
     it('should pass AbortSignal to proxyService', async () => {
@@ -854,7 +858,7 @@ describe('ProxyController', () => {
       const { res } = mockResponse();
 
       // Capture the close callback and wire it to our AbortController
-      (res.on as jest.Mock).mockImplementation((event: string, cb: () => void) => {
+      (res.once as jest.Mock).mockImplementation((event: string, cb: () => void) => {
         if (event === 'close') {
           abortController.signal.addEventListener('abort', cb);
         }
@@ -877,7 +881,7 @@ describe('ProxyController', () => {
       const { res } = mockResponse();
       res.writableEnded = true;
 
-      (res.on as jest.Mock).mockImplementation((event: string, cb: () => void) => {
+      (res.once as jest.Mock).mockImplementation((event: string, cb: () => void) => {
         if (event === 'close') {
           abortController.signal.addEventListener('abort', cb);
         }
@@ -899,7 +903,7 @@ describe('ProxyController', () => {
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
       const { res } = mockResponse();
 
-      (res.on as jest.Mock).mockImplementation((event: string, cb: () => void) => {
+      (res.once as jest.Mock).mockImplementation((event: string, cb: () => void) => {
         if (event === 'close') {
           abortController.signal.addEventListener('abort', cb);
         }
@@ -1412,6 +1416,51 @@ describe('ProxyController', () => {
       // All 1001 expired entries should have been evicted, leaving only the fresh one
       expect(cooldownMap.size).toBe(1);
       expect(cooldownMap.has('tenant-1:agent-1')).toBe(true);
+    });
+  });
+
+  describe('periodic cooldown cleanup', () => {
+    it('periodic timer evicts expired cooldown entries', () => {
+      jest.useFakeTimers();
+      controller.onModuleDestroy(); // stop timer from beforeEach controller
+
+      const timedController = new ProxyController(
+        proxyService as never,
+        rateLimiter as never,
+        providerClient as never,
+        mockMessageRepo as never,
+      );
+
+      const cooldownMap = (timedController as any).rateLimitCooldown as Map<string, number>;
+      cooldownMap.set('t:a', Date.now() - 120_000); // expired
+
+      jest.advanceTimersByTime(60_000);
+      expect(cooldownMap.size).toBe(0);
+
+      timedController.onModuleDestroy();
+      jest.useRealTimers();
+    });
+
+    it('onModuleDestroy stops the periodic cleanup timer', () => {
+      jest.useFakeTimers();
+      controller.onModuleDestroy(); // stop timer from beforeEach controller
+
+      const timedController = new ProxyController(
+        proxyService as never,
+        rateLimiter as never,
+        providerClient as never,
+        mockMessageRepo as never,
+      );
+
+      timedController.onModuleDestroy();
+
+      const cooldownMap = (timedController as any).rateLimitCooldown as Map<string, number>;
+      cooldownMap.set('t:a', Date.now() - 120_000);
+
+      jest.advanceTimersByTime(120_000);
+      expect(cooldownMap.size).toBe(1); // not evicted because timer stopped
+
+      jest.useRealTimers();
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -375,6 +375,20 @@ describe('pipeStream', () => {
     expect(written).toContain('data: [DONE]\n\n');
   });
 
+  it('should throw when SSE buffer exceeds MAX_SSE_BUFFER_SIZE', async () => {
+    const { res } = mockResponse();
+    // Create a stream that sends a massive chunk with no event boundary (\n\n)
+    const hugeChunk = 'x'.repeat(1_048_577); // 1 byte over the 1MB limit
+    const stream = createReadableStream([hugeChunk]);
+
+    const transform = (chunk: string) => `out:${chunk}\n\n`;
+
+    await expect(pipeStream(stream, res as never, transform)).rejects.toThrow(
+      'SSE buffer overflow: provider sent data without event boundaries',
+    );
+    expect(res.end).toHaveBeenCalled();
+  });
+
   it('should handle multiple chunks that split an SSE event with transform', async () => {
     const { res, written } = mockResponse();
     // An SSE event split across two TCP reads

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Post, Req, Res, UseGuards, Logger, HttpException } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+  Logger,
+  HttpException,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Request, Response as ExpressResponse } from 'express';
@@ -20,12 +29,13 @@ const MAX_SEEN_USERS = 10_000;
 @Public()
 @UseGuards(OtlpAuthGuard)
 @SkipThrottle()
-export class ProxyController {
+export class ProxyController implements OnModuleDestroy {
   private readonly logger = new Logger(ProxyController.name);
   private readonly seenUsers = new Set<string>();
   private readonly rateLimitCooldown = new Map<string, number>();
   private readonly RATE_LIMIT_COOLDOWN_MS = 60_000;
   private readonly MAX_COOLDOWN_ENTRIES = 1_000;
+  private readonly cooldownCleanupTimer: ReturnType<typeof setInterval>;
 
   constructor(
     private readonly proxyService: ProxyService,
@@ -33,7 +43,16 @@ export class ProxyController {
     private readonly providerClient: ProviderClient,
     @InjectRepository(AgentMessage)
     private readonly messageRepo: Repository<AgentMessage>,
-  ) {}
+  ) {
+    this.cooldownCleanupTimer = setInterval(() => this.evictExpiredCooldowns(), 60_000);
+    if (typeof this.cooldownCleanupTimer === 'object' && 'unref' in this.cooldownCleanupTimer) {
+      this.cooldownCleanupTimer.unref();
+    }
+  }
+
+  onModuleDestroy(): void {
+    clearInterval(this.cooldownCleanupTimer);
+  }
 
   @Post('chat/completions')
   async chatCompletions(
@@ -49,7 +68,7 @@ export class ProxyController {
     let slotAcquired = false;
 
     const clientAbort = new AbortController();
-    res.on('close', () => clientAbort.abort());
+    res.once('close', () => clientAbort.abort());
 
     try {
       this.rateLimiter.checkLimit(userId);
@@ -216,6 +235,13 @@ export class ProxyController {
     if (!header) return undefined;
     const parts = header.split('-');
     return parts.length >= 2 ? parts[1] : undefined;
+  }
+
+  private evictExpiredCooldowns(): void {
+    const now = Date.now();
+    for (const [k, v] of this.rateLimitCooldown) {
+      if (now - v >= this.RATE_LIMIT_COOLDOWN_MS) this.rateLimitCooldown.delete(k);
+    }
   }
 
   private trackFirstProxyRequest(

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -19,9 +19,7 @@ export function initSseHeaders(
  * Handles `data: ` prefixes, multi-event chunks, and partial
  * chunks that split across TCP reads.
  */
-export function parseSseEvents(
-  buffer: string,
-): { events: string[]; remaining: string } {
+export function parseSseEvents(buffer: string): { events: string[]; remaining: string } {
   const events: string[] = [];
   let remaining = buffer;
 
@@ -48,6 +46,8 @@ export function parseSseEvents(
   return { events, remaining };
 }
 
+const MAX_SSE_BUFFER_SIZE = 1_048_576;
+
 export async function pipeStream(
   source: ReadableStream<Uint8Array>,
   dest: ExpressResponse,
@@ -70,6 +70,9 @@ export async function pipeStream(
 
         if (transform) {
           sseBuffer += text;
+          if (sseBuffer.length > MAX_SSE_BUFFER_SIZE) {
+            throw new Error('SSE buffer overflow: provider sent data without event boundaries');
+          }
           const { events, remaining } = parseSseEvents(sseBuffer);
           sseBuffer = remaining;
 


### PR DESCRIPTION
## Summary

Fixes multiple memory inefficiencies that compound under load, causing OOM crashes (SIGTERM kills every ~4-5 minutes on Railway with 32GB RAM).

- **Remove rawBody duplication on JSON requests** — The `express.json()` verify callback stored the raw Buffer on every JSON request, but `rawBody` is only needed for `application/x-protobuf` (OTLP). Every proxy request held two copies of the body (parsed JSON + raw Buffer). Removed the verify callback; protobuf rawBody capture via `express.raw()` is unchanged.
- **Add 1MB SSE buffer size limit** — `sseBuffer` in `pipeStream` grew unbounded if a provider sent malformed data without `\n\n` event terminators. Now throws at 1MB.
- **Add periodic cache eviction to OtlpAuthGuard** — `evictExpired()` only ran on cache miss. Added a 60s interval timer (matching `ProxyRateLimiter` pattern) so expired entries are cleaned up even under high hit rates.
- **Add periodic cooldown cleanup + `res.once` in ProxyController** — `rateLimitCooldown` Map only cleaned up reactively at 1K entries. Added periodic timer. Changed `res.on('close')` to `res.once('close')` to prevent duplicate listener accumulation.
- **Add max cache size to LimitCheckService** — `rulesCache` and `consumptionCache` had TTL but no max size cap. Added 10K entry limit with oldest-first eviction.

## Test plan

- [x] All 2004 backend unit tests pass
- [x] All modified files have 100% line coverage
- [x] Changeset included for `manifest` package (patch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory leaks and unbounded buffers that caused OOM crashes under load. Reduces per-request memory and adds caps/periodic cleanup to prevent unbounded growth.

- **Bug Fixes**
  - Stop storing rawBody for JSON requests; keep raw capture only for application/x-protobuf.
  - Enforce 1MB cap for SSE buffers; throw on overflow when no event boundaries are found.
  - Add 60s periodic eviction in OtlpAuthGuard cache; clear interval on shutdown.
  - Add 60s periodic cleanup for rateLimitCooldown; switch to res.once('close') to avoid listener leaks.
  - Cap LimitCheckService caches at 10k entries with oldest-first eviction (TTL still enforced).

<sup>Written for commit d96b659a3c850b89213609484e8b9d12f8e95a38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

