### PR TITLE
feat: add database indexes for dashboard and ingestion performance

### DIFF
--- a/.changeset/add-dashboard-indexes.md
+++ b/.changeset/add-dashboard-indexes.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add database indexes for dashboard query performance

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -44,6 +44,7 @@ import { PerAgentRouting1772500000000 } from './migrations/1772500000000-PerAgen
 import { AddCustomProviders1772668898071 } from './migrations/1772668898071-AddCustomProviders';
 import { NullablePricing1772682112419 } from './migrations/1772682112419-NullablePricing';
 import { AddPerformanceIndexes1772843035514 } from './migrations/1772843035514-AddPerformanceIndexes';
+import { AddDashboardIndexes1772905146384 } from './migrations/1772905146384-AddDashboardIndexes';
 
 const entities = [
   AgentMessage,
@@ -92,6 +93,7 @@ const migrations = [
   AddCustomProviders1772668898071,
   NullablePricing1772682112419,
   AddPerformanceIndexes1772843035514,
+  AddDashboardIndexes1772905146384,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';

--- a/packages/backend/src/database/datasource.ts
+++ b/packages/backend/src/database/datasource.ts
@@ -16,14 +16,13 @@ function createDataSource(): DataSource {
   }
 
   const databaseUrl =
-    process.env['DATABASE_URL'] ??
-    'postgresql://myuser:mypassword@localhost:5432/mydatabase';
+    process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/mydatabase';
 
   return new DataSource({
     type: 'postgres',
     url: databaseUrl,
     entities: ['src/entities/!(*.spec).ts'],
-    migrations: ['src/database/migrations/*.ts'],
+    migrations: ['src/database/migrations/!(*.spec).ts'],
   });
 }
 

--- a/packages/backend/src/database/migrations/1772905146384-AddDashboardIndexes.spec.ts
+++ b/packages/backend/src/database/migrations/1772905146384-AddDashboardIndexes.spec.ts
@@ -1,0 +1,80 @@
+import { QueryRunner } from 'typeorm';
+import { AddDashboardIndexes1772905146384 } from './1772905146384-AddDashboardIndexes';
+
+describe('AddDashboardIndexes1772905146384', () => {
+  let migration: AddDashboardIndexes1772905146384;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new AddDashboardIndexes1772905146384();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('should create all 6 indexes', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(6);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_timestamp'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_trace'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_notification_rules_user_agent'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_notification_rules_tenant_agent'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_model'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_agent_status'),
+      );
+    });
+
+    it('should use CREATE INDEX IF NOT EXISTS', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      for (const call of queryRunner.query.mock.calls) {
+        expect(call[0]).toMatch(/^CREATE INDEX IF NOT EXISTS/);
+      }
+    });
+  });
+
+  describe('down', () => {
+    it('should drop all 6 indexes', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(6);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_agent_status'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_model'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_notification_rules_tenant_agent'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_notification_rules_user_agent'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_trace'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_timestamp'),
+      );
+    });
+
+    it('should use DROP INDEX IF EXISTS', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      for (const call of queryRunner.query.mock.calls) {
+        expect(call[0]).toMatch(/^DROP INDEX IF EXISTS/);
+      }
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1772905146384-AddDashboardIndexes.ts
+++ b/packages/backend/src/database/migrations/1772905146384-AddDashboardIndexes.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddDashboardIndexes1772905146384 implements MigrationInterface {
+  name = 'AddDashboardIndexes1772905146384';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Dashboard aggregate queries (overview, tokens, costs, timeseries)
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_tenant_timestamp" ON "agent_messages" ("tenant_id", "timestamp")`,
+    );
+
+    // OTLP trace dedup check on ingestion
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_tenant_trace" ON "agent_messages" ("tenant_id", "trace_id")`,
+    );
+
+    // notification_rules: listRules() by user_id + agent_name
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_notification_rules_user_agent" ON "notification_rules" ("user_id", "agent_name")`,
+    );
+
+    // notification_rules: getActiveBlockRules() by tenant_id + agent_name
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_notification_rules_tenant_agent" ON "notification_rules" ("tenant_id", "agent_name")`,
+    );
+
+    // getDistinctModels() — faster DISTINCT scan
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_tenant_model" ON "agent_messages" ("tenant_id", "model")`,
+    );
+
+    // OTLP trace dedup: recent error lookup per agent on every ingested span
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_agent_messages_tenant_agent_status" ON "agent_messages" ("tenant_id", "agent_id", "status")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_tenant_agent_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_tenant_model"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notification_rules_tenant_agent"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_notification_rules_user_agent"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_tenant_trace"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_tenant_timestamp"`);
+  }
+}

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -5,6 +5,10 @@ import { timestampType } from '../common/utils/sql-dialect';
 @Index(['tenant_id', 'agent_id', 'timestamp'])
 @Index(['user_id', 'timestamp'])
 @Index(['tenant_id', 'agent_name', 'timestamp'])
+@Index(['tenant_id', 'timestamp'])
+@Index(['tenant_id', 'trace_id'])
+@Index(['tenant_id', 'model'])
+@Index(['tenant_id', 'agent_id', 'status'])
 export class AgentMessage {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/backend/src/entities/notification-rule.entity.ts
+++ b/packages/backend/src/entities/notification-rule.entity.ts
@@ -1,13 +1,10 @@
-import {
-  Entity,
-  Column,
-  PrimaryColumn,
-  Index,
-} from 'typeorm';
+import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType, timestampDefault } from '../common/utils/sql-dialect';
 
 @Entity('notification_rules')
 @Index(['tenant_id', 'agent_id'])
+@Index(['user_id', 'agent_name'])
+@Index(['tenant_id', 'agent_name'])
 export class NotificationRule {
   @PrimaryColumn('varchar')
   id!: string;


### PR DESCRIPTION
## Summary

- Add 6 database indexes to improve query performance on growing `agent_messages` and `notification_rules` tables
- `agent_messages(tenant_id, timestamp)` — all dashboard aggregate queries (overview, tokens, costs, timeseries)
- `agent_messages(tenant_id, trace_id)` — OTLP trace dedup on every ingestion
- `agent_messages(tenant_id, model)` — faster `getDistinctModels()` DISTINCT scan
- `agent_messages(tenant_id, agent_id, status)` — OTLP error dedup lookup (runs per ingested span)
- `notification_rules(user_id, agent_name)` — `listRules()` query
- `notification_rules(tenant_id, agent_name)` — `getActiveBlockRules()` query
- Includes migration, entity `@Index` decorators for local/SQLite mode, and 100% test coverage

## Test plan

- [x] TypeScript compiles with no errors
- [x] 124 unit test suites pass (2054 tests)
- [x] 16 E2E test suites pass (105 tests)
- [x] Migration spec covers all CREATE/DROP INDEX calls at 100% line coverage
- [x] Changeset included (`manifest` patch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add six database indexes to speed up dashboard aggregates and OTLP ingestion dedup, with a safe migration and @Index decorators for local/SQLite. Also fixes the TypeORM CLI migration glob to exclude spec files.

- **New Features**
  - agent_messages: (tenant_id, timestamp), (tenant_id, trace_id), (tenant_id, model), (tenant_id, agent_id, status) to accelerate dashboards, model lookups, and trace/error dedup.
  - notification_rules: (user_id, agent_name) and (tenant_id, agent_name) for faster listRules() and getActiveBlockRules().

- **Bug Fixes**
  - Exclude .spec.ts from TypeORM migration glob to prevent CLI failures.

<sup>Written for commit 3c10b84b871089d27a32479bfcfa90be4ff02ced. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

