### PR TITLE
fix: recalculate tier assignments on local-mode startup

### DIFF
--- a/.changeset/fix-local-provider-restart.md
+++ b/.changeset/fix-local-provider-restart.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: recalculate tier assignments on local-mode startup and remove hardcoded model seed

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -36,9 +36,13 @@ jest.mock('../entities/tenant.entity', () => ({ Tenant: jest.fn() }));
 jest.mock('../entities/agent.entity', () => ({ Agent: jest.fn() }));
 jest.mock('../entities/agent-api-key.entity', () => ({ AgentApiKey: jest.fn() }));
 jest.mock('../entities/agent-message.entity', () => ({ AgentMessage: jest.fn() }));
-jest.mock('../entities/model-pricing.entity', () => ({ ModelPricing: jest.fn() }));
 jest.mock('../entities/user-provider.entity', () => ({ UserProvider: jest.fn() }));
 jest.mock('../entities/tier-assignment.entity', () => ({ TierAssignment: jest.fn() }));
+
+// Mock tier-auto-assign to avoid deep import chain
+jest.mock('../routing/tier-auto-assign.service', () => ({
+  TierAutoAssignService: class TierAutoAssignService {},
+}));
 
 import { LocalBootstrapService } from './local-bootstrap.service';
 import { trackEvent } from '../common/utils/product-telemetry';
@@ -60,11 +64,12 @@ describe('LocalBootstrapService', () => {
   let mockAgentRepo: ReturnType<typeof makeMockRepo>;
   let mockAgentKeyRepo: ReturnType<typeof makeMockRepo>;
   let mockMessageRepo: ReturnType<typeof makeMockRepo>;
-  let mockPricingRepo: ReturnType<typeof makeMockRepo>;
   let mockProviderRepo: ReturnType<typeof makeMockRepo>;
   let mockTierRepo: ReturnType<typeof makeMockRepo>;
   let mockPricingCache: { reload: jest.Mock };
   let mockPricingSync: { syncPricing: jest.Mock };
+  let mockRecalculate: jest.Mock;
+  let mockModuleRef: { get: jest.Mock };
 
   beforeEach(() => {
     (trackEvent as jest.Mock).mockClear();
@@ -72,22 +77,23 @@ describe('LocalBootstrapService', () => {
     mockAgentRepo = makeMockRepo();
     mockAgentKeyRepo = makeMockRepo();
     mockMessageRepo = makeMockRepo();
-    mockPricingRepo = makeMockRepo();
     mockProviderRepo = makeMockRepo();
     mockTierRepo = makeMockRepo();
     mockPricingCache = { reload: jest.fn().mockResolvedValue(undefined) };
     mockPricingSync = { syncPricing: jest.fn().mockResolvedValue(undefined) };
+    mockRecalculate = jest.fn().mockResolvedValue(undefined);
+    mockModuleRef = { get: jest.fn().mockReturnValue({ recalculate: mockRecalculate }) };
 
     service = new LocalBootstrapService(
       mockTenantRepo as never,
       mockAgentRepo as never,
       mockAgentKeyRepo as never,
       mockMessageRepo as never,
-      mockPricingRepo as never,
       mockProviderRepo as never,
       mockTierRepo as never,
       mockPricingCache as never,
       mockPricingSync as never,
+      mockModuleRef as never,
     );
   });
 
@@ -95,7 +101,6 @@ describe('LocalBootstrapService', () => {
     it('runs full bootstrap sequence', async () => {
       await service.onModuleInit();
 
-      expect(mockPricingRepo.upsert).toHaveBeenCalled();
       expect(mockPricingCache.reload).toHaveBeenCalled();
       // Verify tenant name equals LOCAL_USER_ID (guard/bootstrap consistency)
       // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -141,14 +146,6 @@ describe('LocalBootstrapService', () => {
 
       expect(trackEvent).not.toHaveBeenCalled();
     });
-
-    it('skips model pricing seed when models already exist', async () => {
-      mockPricingRepo.count.mockResolvedValue(28);
-
-      await service.onModuleInit();
-
-      expect(mockPricingRepo.upsert).not.toHaveBeenCalled();
-    });
   });
 
   describe('config reading', () => {
@@ -177,7 +174,6 @@ describe('LocalBootstrapService', () => {
     });
 
     it('registers API key when config file exists with apiKey', async () => {
-
       (existsSync as jest.Mock).mockReturnValue(true);
       (readFileSync as jest.Mock).mockReturnValue(
         JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
@@ -198,7 +194,6 @@ describe('LocalBootstrapService', () => {
     });
 
     it('skips API key registration when key hash already exists', async () => {
-
       (existsSync as jest.Mock).mockReturnValue(true);
       (readFileSync as jest.Mock).mockReturnValue(
         JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
@@ -211,7 +206,6 @@ describe('LocalBootstrapService', () => {
     });
 
     it('reconciles API key even when tenant already exists', async () => {
-
       (existsSync as jest.Mock).mockReturnValue(true);
       (readFileSync as jest.Mock).mockReturnValue(
         JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
@@ -293,6 +287,34 @@ describe('LocalBootstrapService', () => {
 
       expect(mockProviderRepo.save).not.toHaveBeenCalled();
       expect(mockTierRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recalculateTiersIfNeeded', () => {
+    it('recalculates tiers when active providers exist on startup', async () => {
+      mockProviderRepo.count.mockResolvedValue(2);
+
+      await service.onModuleInit();
+
+      expect(mockModuleRef.get).toHaveBeenCalled();
+      expect(mockRecalculate).toHaveBeenCalledWith('local-agent-001');
+    });
+
+    it('skips tier recalculation when no active providers', async () => {
+      mockProviderRepo.count.mockResolvedValue(0);
+
+      await service.onModuleInit();
+
+      expect(mockRecalculate).not.toHaveBeenCalled();
+    });
+
+    it('handles tier recalculation failure gracefully', async () => {
+      mockProviderRepo.count.mockResolvedValue(1);
+      mockModuleRef.get.mockImplementation(() => {
+        throw new Error('Module not found');
+      });
+
+      await expect(service.onModuleInit()).resolves.not.toThrow();
     });
   });
 });

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
 import { readFileSync, existsSync } from 'fs';
@@ -8,7 +9,6 @@ import { Tenant } from '../entities/tenant.entity';
 import { Agent } from '../entities/agent.entity';
 import { AgentApiKey } from '../entities/agent-api-key.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
-import { ModelPricing } from '../entities/model-pricing.entity';
 import { UserProvider } from '../entities/user-provider.entity';
 import { TierAssignment } from '../entities/tier-assignment.entity';
 import { hashKey, keyPrefix } from '../common/utils/hash.util';
@@ -33,18 +33,18 @@ export class LocalBootstrapService implements OnModuleInit {
     @InjectRepository(Agent) private readonly agentRepo: Repository<Agent>,
     @InjectRepository(AgentApiKey) private readonly agentKeyRepo: Repository<AgentApiKey>,
     @InjectRepository(AgentMessage) private readonly messageRepo: Repository<AgentMessage>,
-    @InjectRepository(ModelPricing) private readonly pricingRepo: Repository<ModelPricing>,
     @InjectRepository(UserProvider) private readonly providerRepo: Repository<UserProvider>,
     @InjectRepository(TierAssignment) private readonly tierRepo: Repository<TierAssignment>,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly pricingSync: PricingSyncService,
+    private readonly moduleRef: ModuleRef,
   ) {}
 
   async onModuleInit() {
-    await this.seedModelPricing();
     await this.pricingCache.reload();
     await this.ensureTenantAndAgent();
     await this.fixupRoutingAgentIds();
+    await this.recalculateTiersIfNeeded();
     await seedAgentMessages(this.messageRepo, LOCAL_USER_ID, this.logger, {
       tenantId: LOCAL_TENANT_ID,
       agentId: LOCAL_AGENT_ID,
@@ -147,95 +147,19 @@ export class LocalBootstrapService implements OnModuleInit {
     }
   }
 
-  private async seedModelPricing() {
-    const count = await this.pricingRepo.count();
-    if (count > 0) return;
+  private async recalculateTiersIfNeeded() {
+    const activeProviders = await this.providerRepo.count({
+      where: { agent_id: LOCAL_AGENT_ID, is_active: true },
+    });
+    if (activeProviders === 0) return;
 
-    // [model_id, provider, input/tok, output/tok, context_window, reasoning, code]
-    const models: ReadonlyArray<
-      readonly [string, string, number, number, number, boolean, boolean]
-    > = [
-      ['claude-opus-4-6', 'Anthropic', 0.000015, 0.000075, 200000, true, true],
-      ['claude-sonnet-4-5-20250929', 'Anthropic', 0.000003, 0.000015, 200000, true, true],
-      ['claude-sonnet-4-20250514', 'Anthropic', 0.000003, 0.000015, 200000, true, true],
-      ['claude-haiku-4-5-20251001', 'Anthropic', 0.000001, 0.000005, 200000, false, true],
-      ['gpt-4o', 'OpenAI', 0.0000025, 0.00001, 128000, false, true],
-      ['gpt-4o-mini', 'OpenAI', 0.00000015, 0.0000006, 128000, false, true],
-      ['gpt-4.1', 'OpenAI', 0.000002, 0.000008, 1047576, false, true],
-      ['gpt-4.1-mini', 'OpenAI', 0.0000004, 0.0000016, 1047576, false, true],
-      ['gpt-4.1-nano', 'OpenAI', 0.0000001, 0.0000004, 1047576, false, false],
-      ['o3', 'OpenAI', 0.000002, 0.000008, 200000, true, true],
-      ['o3-mini', 'OpenAI', 0.0000011, 0.0000044, 200000, true, true],
-      ['o4-mini', 'OpenAI', 0.0000011, 0.0000044, 200000, true, true],
-      ['gemini-2.5-pro', 'Google', 0.00000125, 0.00001, 1048576, true, true],
-      ['gemini-2.5-flash', 'Google', 0.00000015, 0.0000006, 1048576, false, true],
-      ['gemini-2.5-flash-lite', 'Google', 0.0000001, 0.0000004, 1048576, false, false],
-      ['gemini-2.0-flash', 'Google', 0.0000001, 0.0000004, 1048576, false, true],
-      ['deepseek-chat', 'DeepSeek', 0.00000014, 0.00000028, 128000, false, true],
-      ['deepseek-reasoner', 'DeepSeek', 0.00000055, 0.00000219, 128000, true, false],
-      ['kimi-k2', 'Moonshot', 0.0000006, 0.0000024, 262144, true, true],
-      ['qwen-2.5-72b-instruct', 'Alibaba', 0.00000034, 0.00000039, 131072, false, true],
-      ['qwq-32b', 'Alibaba', 0.00000012, 0.00000018, 131072, true, false],
-      ['qwen-2.5-coder-32b-instruct', 'Alibaba', 0.00000018, 0.00000018, 131072, false, true],
-      ['qwen3-235b-a22b', 'Alibaba', 0.0000003, 0.0000012, 131072, true, true],
-      ['qwen3-32b', 'Alibaba', 0.0000001, 0.0000003, 131072, true, true],
-      ['mistral-large-latest', 'Mistral', 0.000002, 0.000006, 128000, false, true],
-      ['mistral-small', 'Mistral', 0.0000002, 0.0000006, 128000, false, false],
-      ['codestral-latest', 'Mistral', 0.0000003, 0.0000009, 256000, false, true],
-      ['grok-3', 'xAI', 0.000003, 0.000015, 131072, true, true],
-      ['grok-3-mini', 'xAI', 0.0000003, 0.0000005, 131072, true, true],
-      ['grok-3-fast', 'xAI', 0.000005, 0.000025, 131072, false, true],
-      ['grok-3-mini-fast', 'xAI', 0.0000006, 0.000004, 131072, false, true],
-      // OpenRouter
-      ['openrouter/auto', 'OpenRouter', 0.000003, 0.000015, 200000, true, true],
-      ['anthropic/claude-opus-4-6', 'OpenRouter', 0.000015, 0.000075, 200000, true, true],
-      ['anthropic/claude-sonnet-4-5', 'OpenRouter', 0.000003, 0.000015, 200000, true, true],
-      ['openai/gpt-4o', 'OpenRouter', 0.0000025, 0.00001, 128000, false, true],
-      ['openai/o3', 'OpenRouter', 0.000002, 0.000008, 200000, true, true],
-      ['google/gemini-2.5-pro', 'OpenRouter', 0.00000125, 0.00001, 1048576, true, true],
-      ['google/gemini-2.5-flash', 'OpenRouter', 0.00000015, 0.0000006, 1048576, false, true],
-      ['deepseek/deepseek-r1', 'OpenRouter', 0.00000055, 0.00000219, 128000, true, false],
-      ['deepseek/deepseek-chat-v3-0324', 'OpenRouter', 0.00000014, 0.00000028, 128000, false, true],
-      ['meta-llama/llama-4-maverick', 'OpenRouter', 0.0000003, 0.0000009, 128000, false, true],
-      ['mistralai/mistral-large', 'OpenRouter', 0.000002, 0.000006, 128000, false, true],
-      ['x-ai/grok-3', 'OpenRouter', 0.000003, 0.000015, 131072, true, true],
-      // OpenRouter free models
-      ['openrouter/free', 'OpenRouter', 0, 0, 200000, true, true],
-      // MiniMax
-      ['minimax-m2.5', 'MiniMax', 0.000000295, 0.0000012, 196608, true, true],
-      ['minimax-m2.5-highspeed', 'MiniMax', 0.000000295, 0.0000012, 196608, true, true],
-      ['minimax-m2.1', 'MiniMax', 0.00000027, 0.00000095, 196608, true, true],
-      ['minimax-m2.1-highspeed', 'MiniMax', 0.00000027, 0.00000095, 196608, true, true],
-      ['minimax-m2', 'MiniMax', 0.000000255, 0.000001, 196608, true, true],
-      ['minimax-m1', 'MiniMax', 0.0000004, 0.0000022, 1000000, true, true],
-      // Z.ai (GLM)
-      ['glm-5', 'Z.ai', 0.00000095, 0.00000255, 204800, true, true],
-      ['glm-4.7', 'Z.ai', 0.0000003, 0.0000014, 202752, true, true],
-      ['glm-4.7-flash', 'Z.ai', 0.00000006, 0.0000004, 202752, false, false],
-      ['glm-4.6', 'Z.ai', 0.00000035, 0.00000171, 202752, true, true],
-      ['glm-4.6v', 'Z.ai', 0.0000003, 0.0000009, 131072, false, false],
-      ['glm-4.5', 'Z.ai', 0.00000055, 0.000002, 131000, true, true],
-      ['glm-4.5-air', 'Z.ai', 0.00000013, 0.00000085, 131072, false, false],
-      ['glm-4.5-flash', 'Z.ai', 0, 0, 131072, false, false],
-      // Zhipu (GLM) — legacy
-      ['glm-4-plus', 'Zhipu', 0.0000005, 0.0000005, 128000, false, true],
-      ['glm-4-flash', 'Zhipu', 0.00000005, 0.00000005, 128000, false, false],
-    ];
-
-    for (const [name, provider, inputPrice, outputPrice, ctxWindow, reasoning, code] of models) {
-      await this.pricingRepo.upsert(
-        {
-          model_name: name,
-          provider,
-          input_price_per_token: inputPrice,
-          output_price_per_token: outputPrice,
-          context_window: ctxWindow,
-          capability_reasoning: reasoning,
-          capability_code: code,
-        },
-        ['model_name'],
-      );
+    try {
+      const { TierAutoAssignService } = await import('../routing/tier-auto-assign.service');
+      const autoAssign = this.moduleRef.get(TierAutoAssignService, { strict: false });
+      await autoAssign.recalculate(LOCAL_AGENT_ID);
+      this.logger.log('Recalculated tier assignments on startup');
+    } catch (err) {
+      this.logger.warn(`Failed to recalculate tiers: ${err}`);
     }
-    this.logger.log('Seeded model pricing data');
   }
 }


### PR DESCRIPTION
## Summary

Fix #1009 — Custom providers stop working after server restart in local mode.

- **Recalculate tier assignments on startup**: `TierAutoAssignService.recalculate()` is now called during `LocalBootstrapService.onModuleInit()` when active providers exist. Uses `ModuleRef` for lazy resolution to avoid circular dependency between `DatabaseModule` and `RoutingModule`.
- **Remove hardcoded model seed**: Deleted the ~60 hardcoded models from `seedModelPricing()`. `PricingSyncService` already fetches real pricing from OpenRouter on startup (when data is stale) and daily via cron, making the hardcoded seed redundant and potentially stale.

## Test plan

- [x] Backend unit tests pass (124 suites, 2056 tests)
- [x] Frontend tests pass (70 suites, 1259 tests)
- [x] TypeScript compiles cleanly (both packages)
- [x] Manual verification: server starts in local mode, pricing populates from OpenRouter (236 models), bootstrap completes successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recalculates tier assignments on local-mode startup so custom providers keep working after a server restart. Also removes the hardcoded model pricing seed and relies on OpenRouter pricing sync. Fixes #1009.

- **Bug Fixes**
  - Call TierAutoAssignService.recalculate() in LocalBootstrapService.onModuleInit() when active providers exist.
  - Resolve the service via ModuleRef to avoid circular deps; handle failures gracefully and skip when none.

- **Refactors**
  - Remove hardcoded model pricing seed; PricingSyncService populates pricing on startup and via cron.
  - Adjust tests and bootstrap flow; keep pricing cache reload.

<sup>Written for commit 5a2500b856de0bb990cc11ca6274cc1ccd6cc74d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

