### PR TITLE
fix: disable auto-migrations in production, drop 14 redundant indexes

### DIFF
--- a/.changeset/drop-redundant-indexes.md
+++ b/.changeset/drop-redundant-indexes.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Disable auto-migrations in production and drop 14 redundant single-column indexes

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -46,6 +46,7 @@ import { NullablePricing1772682112419 } from './migrations/1772682112419-Nullabl
 import { AddPerformanceIndexes1772843035514 } from './migrations/1772843035514-AddPerformanceIndexes';
 import { AddDashboardIndexes1772905146384 } from './migrations/1772905146384-AddDashboardIndexes';
 import { AddFallbacks1772905260464 } from './migrations/1772905260464-AddFallbacks';
+import { DropRedundantIndexes1772940000000 } from './migrations/1772940000000-DropRedundantIndexes';
 
 const entities = [
   AgentMessage,
@@ -96,6 +97,7 @@ const migrations = [
   AddPerformanceIndexes1772843035514,
   AddDashboardIndexes1772905146384,
   AddFallbacks1772905260464,
+  DropRedundantIndexes1772940000000,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';
@@ -128,7 +130,7 @@ function buildModeServices() {
           url: config.get<string>('app.databaseUrl'),
           entities,
           synchronize: false,
-          migrationsRun: true,
+          migrationsRun: config.get<string>('app.nodeEnv') !== 'production',
           migrationsTransactionMode: 'all' as const,
           migrations,
           logging: false,

--- a/packages/backend/src/database/datasource.ts
+++ b/packages/backend/src/database/datasource.ts
@@ -16,7 +16,9 @@ function createDataSource(): DataSource {
   }
 
   const databaseUrl =
-    process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/mydatabase';
+    process.env['MIGRATION_DATABASE_URL'] ??
+    process.env['DATABASE_URL'] ??
+    'postgresql://myuser:mypassword@localhost:5432/mydatabase';
 
   return new DataSource({
     type: 'postgres',

--- a/packages/backend/src/database/migrations/1772940000000-DropRedundantIndexes.spec.ts
+++ b/packages/backend/src/database/migrations/1772940000000-DropRedundantIndexes.spec.ts
@@ -1,0 +1,111 @@
+import { QueryRunner } from 'typeorm';
+import { DropRedundantIndexes1772940000000 } from './1772940000000-DropRedundantIndexes';
+
+describe('DropRedundantIndexes1772940000000', () => {
+  let migration: DropRedundantIndexes1772940000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new DropRedundantIndexes1772940000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('should drop all 14 redundant indexes', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(14);
+    });
+
+    it('should use DROP INDEX IF EXISTS', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      for (const call of queryRunner.query.mock.calls) {
+        expect(call[0]).toMatch(/^DROP INDEX IF EXISTS/);
+      }
+    });
+
+    it('should drop agent_messages single-column indexes', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_519ec0b8e9fc7c2e53d300c69c'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_1d3c0f0f21ffa94c7300a2e996'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_cc0146344144249cd7dde2f8ad'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_timestamp'),
+      );
+    });
+
+    it('should drop tool_executions single-column indexes', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_7fc8d9c06936a673fd5c404706'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_a24432cde19440451cc7b5d15f'),
+      );
+    });
+
+    it('should drop llm_calls single-column indexes', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_ff92361a95863b8f0de3a371e5'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_e3e44ae5bdb48ceeb10d7880cf'),
+      );
+    });
+
+    it('should drop agent_logs single-column indexes', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_e981397068db115bcd95a39396'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_039a398c03e68e46a0fc0bc998'),
+      );
+    });
+
+    it('should drop snapshot single-column indexes', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_305fe9e3e5efff31a20a90c12e'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_49c9b53af0ef0839174ce670ef'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_468b7d3a69ee28a127cd8287b9'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_3bf823e7c31aa4a5f12fcde527'),
+      );
+    });
+  });
+
+  describe('down', () => {
+    it('should recreate all 14 indexes', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(14);
+    });
+
+    it('should use CREATE INDEX', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      for (const call of queryRunner.query.mock.calls) {
+        expect(call[0]).toMatch(/^CREATE INDEX/);
+      }
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1772940000000-DropRedundantIndexes.ts
+++ b/packages/backend/src/database/migrations/1772940000000-DropRedundantIndexes.ts
@@ -1,0 +1,93 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DropRedundantIndexes1772940000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // agent_messages: single-column indexes subsumed by composites
+    // (tenant_id) → covered by (tenant_id, timestamp), (tenant_id, agent_id, timestamp), etc.
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_519ec0b8e9fc7c2e53d300c69c"`);
+    // (agent_id) → covered by (tenant_id, agent_id, timestamp), (tenant_id, agent_id, status)
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_1d3c0f0f21ffa94c7300a2e996"`);
+    // (user_id) → covered by (user_id, timestamp)
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_cc0146344144249cd7dde2f8ad"`);
+    // (timestamp) → all queries filter by tenant_id first
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_timestamp"`);
+
+    // tool_executions: write-only table, zero read queries
+    // (tenant_id) → covered by (tenant_id, agent_id)
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_7fc8d9c06936a673fd5c404706"`);
+    // (agent_id) → covered by (tenant_id, agent_id)
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_a24432cde19440451cc7b5d15f"`);
+
+    // llm_calls: write-only table, zero read queries
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_ff92361a95863b8f0de3a371e5"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_e3e44ae5bdb48ceeb10d7880cf"`);
+
+    // agent_logs: single-column indexes subsumed by (tenant_id, agent_id, timestamp)
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_e981397068db115bcd95a39396"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_039a398c03e68e46a0fc0bc998"`);
+
+    // token_usage_snapshots: subsumed by (tenant_id, agent_id, snapshot_time)
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_305fe9e3e5efff31a20a90c12e"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_49c9b53af0ef0839174ce670ef"`);
+
+    // cost_snapshots: subsumed by (tenant_id, agent_id, snapshot_time)
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_468b7d3a69ee28a127cd8287b9"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_3bf823e7c31aa4a5f12fcde527"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // agent_messages
+    await queryRunner.query(
+      `CREATE INDEX "IDX_519ec0b8e9fc7c2e53d300c69c" ON "agent_messages" ("tenant_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1d3c0f0f21ffa94c7300a2e996" ON "agent_messages" ("agent_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_cc0146344144249cd7dde2f8ad" ON "agent_messages" ("user_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_agent_messages_timestamp" ON "agent_messages" ("timestamp")`,
+    );
+
+    // tool_executions
+    await queryRunner.query(
+      `CREATE INDEX "IDX_7fc8d9c06936a673fd5c404706" ON "tool_executions" ("tenant_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a24432cde19440451cc7b5d15f" ON "tool_executions" ("agent_id")`,
+    );
+
+    // llm_calls
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ff92361a95863b8f0de3a371e5" ON "llm_calls" ("tenant_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e3e44ae5bdb48ceeb10d7880cf" ON "llm_calls" ("agent_id")`,
+    );
+
+    // agent_logs
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e981397068db115bcd95a39396" ON "agent_logs" ("tenant_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_039a398c03e68e46a0fc0bc998" ON "agent_logs" ("agent_id")`,
+    );
+
+    // token_usage_snapshots
+    await queryRunner.query(
+      `CREATE INDEX "IDX_305fe9e3e5efff31a20a90c12e" ON "token_usage_snapshots" ("tenant_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_49c9b53af0ef0839174ce670ef" ON "token_usage_snapshots" ("agent_id")`,
+    );
+
+    // cost_snapshots
+    await queryRunner.query(
+      `CREATE INDEX "IDX_468b7d3a69ee28a127cd8287b9" ON "cost_snapshots" ("tenant_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_3bf823e7c31aa4a5f12fcde527" ON "cost_snapshots" ("agent_id")`,
+    );
+  }
+}

--- a/packages/backend/src/entities/agent-log.entity.ts
+++ b/packages/backend/src/entities/agent-log.entity.ts
@@ -7,11 +7,9 @@ export class AgentLog {
   @PrimaryColumn('varchar')
   id!: string;
 
-  @Index()
   @Column('varchar', { nullable: true })
   tenant_id!: string | null;
 
-  @Index()
   @Column('varchar', { nullable: true })
   agent_id!: string | null;
 

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -13,11 +13,9 @@ export class AgentMessage {
   @PrimaryColumn('varchar')
   id!: string;
 
-  @Index()
   @Column('varchar', { nullable: true })
   tenant_id!: string | null;
 
-  @Index()
   @Column('varchar', { nullable: true })
   agent_id!: string | null;
 
@@ -30,7 +28,6 @@ export class AgentMessage {
   @Column('varchar', { nullable: true })
   session_id!: string | null;
 
-  @Index()
   @Column(timestampType())
   timestamp!: string;
 
@@ -85,7 +82,6 @@ export class AgentMessage {
   @Column('integer', { nullable: true })
   fallback_index!: number | null;
 
-  @Index()
   @Column('varchar', { nullable: true })
   user_id!: string | null;
 }

--- a/packages/backend/src/entities/cost-snapshot.entity.ts
+++ b/packages/backend/src/entities/cost-snapshot.entity.ts
@@ -7,11 +7,9 @@ export class CostSnapshot {
   @PrimaryColumn('varchar')
   id!: string;
 
-  @Index()
   @Column('varchar', { nullable: true })
   tenant_id!: string | null;
 
-  @Index()
   @Column('varchar', { nullable: true })
   agent_id!: string | null;
 

--- a/packages/backend/src/entities/llm-call.entity.ts
+++ b/packages/backend/src/entities/llm-call.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import { Entity, Column, PrimaryColumn } from 'typeorm';
 import { timestampType } from '../common/utils/sql-dialect';
 
 @Entity('llm_calls')
@@ -6,11 +6,9 @@ export class LlmCall {
   @PrimaryColumn('varchar')
   id!: string;
 
-  @Index()
   @Column('varchar', { nullable: true })
   tenant_id!: string | null;
 
-  @Index()
   @Column('varchar', { nullable: true })
   agent_id!: string | null;
 

--- a/packages/backend/src/entities/token-usage-snapshot.entity.ts
+++ b/packages/backend/src/entities/token-usage-snapshot.entity.ts
@@ -7,11 +7,9 @@ export class TokenUsageSnapshot {
   @PrimaryColumn('varchar')
   id!: string;
 
-  @Index()
   @Column('varchar', { nullable: true })
   tenant_id!: string | null;
 
-  @Index()
   @Column('varchar', { nullable: true })
   agent_id!: string | null;
 

--- a/packages/backend/src/entities/tool-execution.entity.ts
+++ b/packages/backend/src/entities/tool-execution.entity.ts
@@ -6,11 +6,9 @@ export class ToolExecution {
   @PrimaryColumn('varchar')
   id!: string;
 
-  @Index()
   @Column('varchar', { nullable: true })
   tenant_id!: string | null;
 
-  @Index()
   @Column('varchar', { nullable: true })
   agent_id!: string | null;
 


### PR DESCRIPTION
## Summary
- Disable `migrationsRun` in production to prevent repeated ALTER TABLE locks on every app restart (was causing 1762s of cumulative migration time across 399 calls)
- Add migration to drop 14 single-column indexes that are fully subsumed by existing composite indexes across 6 tables
- Remove corresponding `@Index()` decorators from entity files to keep metadata consistent

## Indexes dropped

| Table | Index | Reason |
|-------|-------|--------|
| agent_messages | `(tenant_id)` | Covered by `(tenant_id, timestamp)`, `(tenant_id, agent_id, timestamp)`, etc. |
| agent_messages | `(agent_id)` | Covered by `(tenant_id, agent_id, timestamp)`, `(tenant_id, agent_id, status)` |
| agent_messages | `(user_id)` | Covered by `(user_id, timestamp)` |
| agent_messages | `(timestamp)` | All queries filter by tenant_id first |
| tool_executions | `(tenant_id)`, `(agent_id)` | Write-only table; covered by `(tenant_id, agent_id)` |
| llm_calls | `(tenant_id)`, `(agent_id)` | Write-only table, zero read queries |
| agent_logs | `(tenant_id)`, `(agent_id)` | Covered by `(tenant_id, agent_id, timestamp)` |
| token_usage_snapshots | `(tenant_id)`, `(agent_id)` | Covered by `(tenant_id, agent_id, snapshot_time)` |
| cost_snapshots | `(tenant_id)`, `(agent_id)` | Covered by `(tenant_id, agent_id, snapshot_time)` |

## Deploy note
With `migrationsRun` disabled in production, migrations must be run as a separate deploy step: `npm run migration:run`

## Test plan
- [x] All 126 backend unit tests pass
- [x] All 16 E2E tests pass
- [x] TypeScript compiles with no errors
- [x] New migration has dedicated test coverage
- [ ] After deploy: verify indexes dropped via `pg_stat_user_indexes`
- [ ] After deploy: monitor seq_scan counts on `agent_messages` and `tool_executions`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable TypeORM auto-migrations in production to stop repeated table locks and slow restarts; add a migration that drops 14 redundant single-column indexes and remove matching `@Index()` decorators to reduce index bloat and write overhead. The migration CLI now prefers `MIGRATION_DATABASE_URL` to connect directly to Postgres and bypass PgBouncer.

- **Migration**
  - In production, run migrations as a deploy step: `npm run migration:run` (CLI uses `MIGRATION_DATABASE_URL` if set).

<sup>Written for commit 528edc53a7217ae02d9c9ed4929e3f397c4b2f61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

