### PR TITLE
fix: eliminate OR pattern in tenant filter queries

### DIFF
--- a/.changeset/fix-tenant-filter-or.md
+++ b/.changeset/fix-tenant-filter-or.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Eliminate OR pattern in tenant filter queries to enable index usage

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -1,5 +1,5 @@
 import { computeTrend, downsample, formatTimestamp, addTenantFilter } from './query-helpers';
-import { SelectQueryBuilder, Brackets } from 'typeorm';
+import { SelectQueryBuilder } from 'typeorm';
 
 describe('computeTrend', () => {
   it('returns positive trend when current exceeds previous', () => {
@@ -122,32 +122,22 @@ describe('addTenantFilter', () => {
     return { qb: qb as unknown as SelectQueryBuilder<never>, mockAndWhere };
   }
 
-  it('adds tenant subquery filter with userId parameter (no tenantId)', () => {
+  it('filters by user_id when no tenantId is provided', () => {
     const { qb, mockAndWhere } = makeMockQb();
     addTenantFilter(qb, 'user-123');
 
     expect(mockAndWhere).toHaveBeenCalledTimes(1);
-    const firstCall = mockAndWhere.mock.calls[0];
-    expect(firstCall[0]).toBeInstanceOf(Brackets);
+    expect(mockAndWhere).toHaveBeenCalledWith('at.user_id = :userId', { userId: 'user-123' });
   });
 
-  it('adds direct tenant_id filter when tenantId is provided', () => {
+  it('filters by tenant_id when tenantId is provided', () => {
     const { qb, mockAndWhere } = makeMockQb();
     addTenantFilter(qb, 'user-123', undefined, 'tenant-456');
 
     expect(mockAndWhere).toHaveBeenCalledTimes(1);
-    const brackets = mockAndWhere.mock.calls[0][0];
-    expect(brackets).toBeInstanceOf(Brackets);
-
-    const mockSub = {
-      where: jest.fn().mockReturnThis(),
-      orWhere: jest.fn().mockReturnThis(),
-    };
-    (brackets as any).whereFactory(mockSub);
-    expect(mockSub.where).toHaveBeenCalledWith('at.tenant_id = :tenantId', {
+    expect(mockAndWhere).toHaveBeenCalledWith('at.tenant_id = :tenantId', {
       tenantId: 'tenant-456',
     });
-    expect(mockSub.orWhere).toHaveBeenCalledWith('at.user_id = :userId', { userId: 'user-123' });
   });
 
   it('adds agent_name filter when agentName is provided', () => {

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -1,4 +1,4 @@
-import { Brackets, ObjectLiteral, SelectQueryBuilder } from 'typeorm';
+import { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
 
 export interface MetricWithTrend {
   value: number;
@@ -46,21 +46,9 @@ export function addTenantFilter<T extends ObjectLiteral>(
   tenantId?: string,
 ): SelectQueryBuilder<T> {
   if (tenantId) {
-    qb.andWhere(
-      new Brackets((sub) => {
-        sub
-          .where('at.tenant_id = :tenantId', { tenantId })
-          .orWhere('at.user_id = :userId', { userId });
-      }),
-    );
+    qb.andWhere('at.tenant_id = :tenantId', { tenantId });
   } else {
-    qb.andWhere(
-      new Brackets((sub) => {
-        sub
-          .where('at.tenant_id IN (SELECT id FROM tenants WHERE name = :userId)', { userId })
-          .orWhere('at.user_id = :userId', { userId });
-      }),
-    );
+    qb.andWhere('at.user_id = :userId', { userId });
   }
   if (agentName) {
     qb.andWhere('at.agent_name = :agentName', { agentName });

--- a/packages/backend/src/telemetry/telemetry.service.spec.ts
+++ b/packages/backend/src/telemetry/telemetry.service.spec.ts
@@ -5,6 +5,7 @@ import { AgentMessage } from '../entities/agent-message.entity';
 import { SecurityEvent } from '../entities/security-event.entity';
 import { TelemetryEventDto } from './dto/create-telemetry.dto';
 import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
+import { TenantCacheService } from '../common/services/tenant-cache.service';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 
 function makeEvent(overrides: Partial<TelemetryEventDto> = {}): TelemetryEventDto {
@@ -22,11 +23,13 @@ describe('TelemetryService', () => {
   let mockTurnInsert: jest.Mock;
   let mockPricingGetByModel: jest.Mock;
   let mockSecurityInsert: jest.Mock;
+  let mockTenantResolve: jest.Mock;
 
   beforeEach(async () => {
     mockTurnInsert = jest.fn().mockResolvedValue({});
     mockPricingGetByModel = jest.fn().mockReturnValue(undefined);
     mockSecurityInsert = jest.fn().mockResolvedValue({});
+    mockTenantResolve = jest.fn().mockResolvedValue('resolved-tenant-id');
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -34,6 +37,7 @@ describe('TelemetryService', () => {
         { provide: getRepositoryToken(AgentMessage), useValue: { insert: mockTurnInsert } },
         { provide: getRepositoryToken(SecurityEvent), useValue: { insert: mockSecurityInsert } },
         { provide: IngestEventBusService, useValue: { emit: jest.fn() } },
+        { provide: TenantCacheService, useValue: { resolve: mockTenantResolve } },
         { provide: ModelPricingCacheService, useValue: { getByModel: mockPricingGetByModel } },
       ],
     }).compile();
@@ -55,6 +59,7 @@ describe('TelemetryService', () => {
       expect.objectContaining({
         input_tokens: 100,
         output_tokens: 50,
+        tenant_id: 'resolved-tenant-id',
         user_id: 'test-user',
       }),
     ]);

--- a/packages/backend/src/telemetry/telemetry.service.ts
+++ b/packages/backend/src/telemetry/telemetry.service.ts
@@ -6,6 +6,7 @@ import { AgentMessage } from '../entities/agent-message.entity';
 import { SecurityEvent } from '../entities/security-event.entity';
 import { TelemetryEventDto } from './dto/create-telemetry.dto';
 import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
+import { TenantCacheService } from '../common/services/tenant-cache.service';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 
 export interface IngestResult {
@@ -24,6 +25,7 @@ export class TelemetryService {
     @InjectRepository(SecurityEvent)
     private readonly securityRepo: Repository<SecurityEvent>,
     private readonly eventBus: IngestEventBusService,
+    private readonly tenantCache: TenantCacheService,
     private readonly pricingCache: ModelPricingCacheService,
   ) {}
 
@@ -33,6 +35,7 @@ export class TelemetryService {
     if (!Array.isArray(events)) {
       return { accepted: 0, rejected: 0, errors: [] };
     }
+    const tenantId = await this.tenantCache.resolve(userId);
     const maxLen = Math.min(events.length, TelemetryService.MAX_EVENTS_PER_BATCH);
     const messageRows: Record<string, unknown>[] = [];
     const securityRows: Record<string, unknown>[] = [];
@@ -40,7 +43,7 @@ export class TelemetryService {
 
     for (let i = 0; i < maxLen; i++) {
       try {
-        const { message, security } = this.buildEventRows(events[i], userId);
+        const { message, security } = this.buildEventRows(events[i], userId, tenantId);
         messageRows.push(message);
         if (security) securityRows.push(security);
       } catch (err) {
@@ -80,6 +83,7 @@ export class TelemetryService {
   private buildEventRows(
     event: TelemetryEventDto,
     userId: string,
+    tenantId: string | null,
   ): { message: Record<string, unknown>; security: Record<string, unknown> | null } {
     const inputTok = event.input_tokens ?? 0;
     const outputTok = event.output_tokens ?? 0;
@@ -111,6 +115,7 @@ export class TelemetryService {
       output_tokens: outputTok,
       skill_name: event.skill_name ?? null,
       cost_usd: costUsd,
+      tenant_id: tenantId,
       user_id: userId,
     };
 

--- a/packages/backend/test/costs.e2e-spec.ts
+++ b/packages/backend/test/costs.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
-import { createTestApp, TEST_API_KEY, TEST_USER_ID } from './helpers';
+import { createTestApp, TEST_API_KEY, TEST_USER_ID, TEST_TENANT_ID } from './helpers';
 import { detectDialect, portableSql, sqlNow } from '../src/common/utils/sql-dialect';
 import { v4 as uuid } from 'uuid';
 
@@ -37,12 +37,12 @@ beforeAll(async () => {
   await ds.query(
     sql(`INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`),
-    [uuid(), now, 'Cost query 1', 'agent', 'ok', 'gpt-4o', 5000, 2000, costUsd1, TEST_USER_ID, null, null],
+    [uuid(), now, 'Cost query 1', 'agent', 'ok', 'gpt-4o', 5000, 2000, costUsd1, TEST_USER_ID, TEST_TENANT_ID, null],
   );
   await ds.query(
     sql(`INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`),
-    [uuid(), now, 'Cost query 2', 'agent', 'ok', 'gpt-4o', 3000, 1000, costUsd2, TEST_USER_ID, null, null],
+    [uuid(), now, 'Cost query 2', 'agent', 'ok', 'gpt-4o', 3000, 1000, costUsd2, TEST_USER_ID, TEST_TENANT_ID, null],
   );
 }, 30000);
 


### PR DESCRIPTION
## Summary
- Replace `WHERE (tenant_id = :id OR user_id = :userId)` with a direct single-column filter in `addTenantFilter()`
- PostgreSQL cannot use a single index for OR conditions, forcing BitmapOr or sequential scans — this was causing 126K sequential scans on `agent_messages`
- Now uses `WHERE tenant_id = :tenantId` when resolved (via `TenantCacheService`), falls back to `WHERE user_id = :userId` only when no tenant exists
- Fix telemetry ingestion to resolve and set `tenant_id` on inserted records (was previously only setting `user_id`)

## Before / After

```sql
-- Before (forces seq scan or BitmapOr):
WHERE (tenant_id = :id OR user_id = :userId)

-- After (uses tenant_id index directly):
WHERE tenant_id = :tenantId
```

## Test plan
- [x] All 125 backend unit tests pass
- [x] All 16 E2E tests pass (updated costs E2E to seed with tenant_id)
- [x] TypeScript compiles with no errors
- [ ] After deploy: verify sequential scan count on `agent_messages` decreases

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the OR-based tenant filter with a single-column filter to enable index scans and reduce sequential scans on `agent_messages`. Telemetry ingestion now resolves and writes `tenant_id` so queries hit the index.

- **Bug Fixes**
  - `addTenantFilter()` now uses `tenant_id = :tenantId` when available, otherwise falls back to `user_id = :userId`.
  - Telemetry ingestion resolves tenant via `TenantCacheService` and sets `tenant_id` on inserted records.
  - Updated tests and E2E to seed `tenant_id` data.

<sup>Written for commit 9293a9517909831e0a427c1c36639c09eaad32e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

