### PR TITLE
fix: reduce TypeORM pool size from 20 to 5 per replica

### DIFF
--- a/.changeset/famous-colts-sleep.md
+++ b/.changeset/famous-colts-sleep.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Reduce TypeORM connection pool from 20 to 5 per replica to avoid exhausting PgBouncer client connections during rolling deploys.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -135,7 +135,7 @@ function buildModeServices() {
           migrations,
           logging: false,
           extra: {
-            max: 20,
+            max: 5,
             idleTimeoutMillis: 30000,
           },
         };


### PR DESCRIPTION
## Summary
- Reduce TypeORM connection pool from `max: 20` to `max: 5` per replica
- With 4 replicas behind PgBouncer, 20 × 4 = 80 client connections (160 during rolling deploys when old + new replicas overlap)
- Reducing to 5 keeps worst-case at 40, well within PgBouncer limits
- PgBouncer handles connection multiplexing to PostgreSQL anyway, so large app-side pools add no benefit

## Test plan
- [x] TypeScript compiles with no errors
- [x] Unit tests pass
- [ ] Verify Railway deploy succeeds and no connection errors in logs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lower `TypeORM` pool max from 20 to 5 per backend replica to prevent exhausting `PgBouncer` client connections during rolling deploys. With 4 replicas, this reduces worst-case from 160 to 40; `PgBouncer` already multiplexes to Postgres, so larger app pools add no benefit.

<sup>Written for commit 712c78a71aa656d4e4def9df2659cfe5467120eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

