### PR TITLE
fix: fall back to static labels when display_name is empty

### DIFF
--- a/.changeset/fix-display-name-fallback.md
+++ b/.changeset/fix-display-name-fallback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix blank model names in picker when display_name column is empty

--- a/packages/backend/src/model-prices/model-prices.service.spec.ts
+++ b/packages/backend/src/model-prices/model-prices.service.spec.ts
@@ -65,7 +65,7 @@ describe('ModelPricesService', () => {
       const result = await service.getAll();
 
       expect(result.models[0].provider).toBe('Unknown');
-      expect(result.models[0].display_name).toBe('');
+      expect(result.models[0].display_name).toBeNull();
     });
 
     it('should return null lastSyncedAt when no updated_at values', async () => {

--- a/packages/backend/src/model-prices/model-prices.service.ts
+++ b/packages/backend/src/model-prices/model-prices.service.ts
@@ -42,7 +42,7 @@ export class ModelPricesService {
           r.input_price_per_token != null ? Number(r.input_price_per_token) * 1_000_000 : null,
         output_price_per_million:
           r.output_price_per_token != null ? Number(r.output_price_per_token) * 1_000_000 : null,
-        display_name: r.display_name || '',
+        display_name: r.display_name || null,
       })),
       lastSyncedAt,
     };

--- a/packages/backend/src/routing/routing.controller.ts
+++ b/packages/backend/src/routing/routing.controller.ts
@@ -213,7 +213,7 @@ export class RoutingController {
           quality_score: m.quality_score,
           display_name: isCustom
             ? CustomProviderService.rawModelName(m.model_name)
-            : m.display_name || '',
+            : m.display_name || null,
           ...(isCustom && {
             provider_display_name: cpNameMap.get(m.provider) ?? m.provider,
           }),

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -75,7 +75,7 @@ const ModelPickerModal: Component<Props> = (props) => {
           : (provDef?.name ?? m.provider);
         groupMap.set(provId, { provId, name, models: [] });
       }
-      const label = m.display_name ?? labelForModel(m.model_name, labels);
+      const label = m.display_name || labelForModel(m.model_name, labels);
       groupMap.get(provId)!.models.push({
         value: m.model_name,
         label,


### PR DESCRIPTION
## Summary
- Backend returned `display_name: ''` (empty string) instead of `null` when the column has no value, and the frontend used `??` (nullish coalescing) which doesn't catch empty strings — resulting in blank model names in the picker modal.
- Backend now returns `null` instead of `''` for empty display names (both `routing.controller.ts` and `model-prices.service.ts`).
- Frontend `ModelPickerModal` now uses `||` instead of `??` so it falls back to the static `PROVIDERS` label map on any falsy value.

## Test plan
- [x] Backend unit tests pass (2135/2135)
- [x] Backend e2e tests pass (105/105)
- [x] Frontend tests pass (1304/1304)
- [x] TypeScript compiles cleanly in both packages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank model names in the model picker by standardizing empty display names to null and falling back to static labels. Ensures consistent labels for all models.

- **Bug Fixes**
  - Backend: return `null` for missing `display_name` in `routing.controller.ts` and `model-prices.service.ts`.
  - Frontend: `ModelPickerModal` uses `||` to fall back to the static `PROVIDERS` label map when `display_name` is falsy.

<sup>Written for commit f04075118d5d39be747ab01642953e29c52eb82a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

