### PR TITLE
perf: optimize 3 slow API endpoints

### DIFF
--- a/.changeset/optimize-slow-endpoints.md
+++ b/.changeset/optimize-slow-endpoints.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Optimize 3 slow API endpoints: parallelize independent queries, add 30-day stats cutoff, batch tier inserts/updates, and merge redundant token queries

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -128,10 +128,10 @@ describe('AggregationService', () => {
 
   describe('getTokenSummary', () => {
     it('returns token totals with trend', async () => {
+      // 3A: Now 2 parallel queries (detail + prev) instead of 3 sequential
       mockGetRawOne
-        .mockResolvedValueOnce({ total: 5000 })
-        .mockResolvedValueOnce({ total: 4000 })
-        .mockResolvedValueOnce({ inp: 3000, out: 2000 });
+        .mockResolvedValueOnce({ inp: 3000, out: 2000 })
+        .mockResolvedValueOnce({ total: 4000 });
 
       const result = await service.getTokenSummary('24h', 'test-user');
       expect(result.tokens_today.value).toBe(5000);
@@ -142,9 +142,8 @@ describe('AggregationService', () => {
 
     it('returns zero trend when no previous data', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ total: 1000 })
-        .mockResolvedValueOnce({ total: 0 })
-        .mockResolvedValueOnce({ inp: 600, out: 400 });
+        .mockResolvedValueOnce({ inp: 600, out: 400 })
+        .mockResolvedValueOnce({ total: 0 });
 
       const result = await service.getTokenSummary('24h', 'test-user');
       expect(result.tokens_today.trend_pct).toBe(0);
@@ -152,19 +151,15 @@ describe('AggregationService', () => {
 
     it('should pass agentName to tenant filter when provided', async () => {
       mockGetRawOne
-        .mockResolvedValueOnce({ total: 100 })
-        .mockResolvedValueOnce({ total: 50 })
-        .mockResolvedValueOnce({ inp: 60, out: 40 });
+        .mockResolvedValueOnce({ inp: 60, out: 40 })
+        .mockResolvedValueOnce({ total: 50 });
 
       const result = await service.getTokenSummary('24h', 'test-user', 'my-agent');
       expect(result.tokens_today.value).toBe(100);
     });
 
     it('should handle null query results gracefully', async () => {
-      mockGetRawOne
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null);
+      mockGetRawOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
 
       const result = await service.getTokenSummary('24h', 'test-user');
       expect(result.tokens_today.value).toBe(0);
@@ -432,9 +427,8 @@ describe('AggregationService (sql.js / local mode)', () => {
 
   it('business logic works identically on sqlite dialect', async () => {
     mockGetRawOne
-      .mockResolvedValueOnce({ total: 200 })
-      .mockResolvedValueOnce({ total: 100 })
-      .mockResolvedValueOnce({ inp: 120, out: 80 });
+      .mockResolvedValueOnce({ inp: 120, out: 80 })
+      .mockResolvedValueOnce({ total: 100 });
 
     const result = await service.getTokenSummary('24h', 'user-1');
     expect(result.tokens_today.value).toBe(200);

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -44,12 +44,14 @@ export class AggregationService {
     const prevInterval = rangeToPreviousInterval(range);
     const cutoff = computeCutoff(interval);
     const prevCutoff = computeCutoff(prevInterval);
-    const currentQb = this.turnRepo
+
+    // 3A: Merge current total + breakdown into one query (total = input + output)
+    const detailQb = this.turnRepo
       .createQueryBuilder('at')
-      .select('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'total')
+      .select('COALESCE(SUM(at.input_tokens), 0)', 'inp')
+      .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'out')
       .where('at.timestamp >= :cutoff', { cutoff });
-    addTenantFilter(currentQb, userId, agentName, tenantId);
-    const currentRow = await currentQb.getRawOne();
+    addTenantFilter(detailQb, userId, agentName, tenantId);
 
     const prevQb = this.turnRepo
       .createQueryBuilder('at')
@@ -57,20 +59,13 @@ export class AggregationService {
       .where('at.timestamp >= :prevCutoff', { prevCutoff })
       .andWhere('at.timestamp < :cutoff', { cutoff });
     addTenantFilter(prevQb, userId, agentName, tenantId);
-    const prevRow = await prevQb.getRawOne();
 
-    const detailQb = this.turnRepo
-      .createQueryBuilder('at')
-      .select('COALESCE(SUM(at.input_tokens), 0)', 'inp')
-      .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'out')
-      .where('at.timestamp >= :cutoff', { cutoff });
-    addTenantFilter(detailQb, userId, agentName, tenantId);
-    const detail = await detailQb.getRawOne();
+    const [detail, prevRow] = await Promise.all([detailQb.getRawOne(), prevQb.getRawOne()]);
 
-    const current = Number(currentRow?.total ?? 0);
-    const previous = Number(prevRow?.total ?? 0);
     const inputTotal = Number(detail?.inp ?? 0);
     const outputTotal = Number(detail?.out ?? 0);
+    const current = inputTotal + outputTotal;
+    const previous = Number(prevRow?.total ?? 0);
 
     return {
       tokens_today: {
@@ -94,13 +89,13 @@ export class AggregationService {
     const cutoff = computeCutoff(interval);
     const prevCutoff = computeCutoff(prevInterval);
 
+    // 3B: Parallelize current + previous period queries
     const safeCost = sqlSanitizeCost('at.cost_usd');
     const currentQb = this.turnRepo
       .createQueryBuilder('at')
       .select(`COALESCE(SUM(${safeCost}), 0)`, 'total')
       .where('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(currentQb, userId, agentName, tenantId);
-    const currentRow = await currentQb.getRawOne();
 
     const prevQb = this.turnRepo
       .createQueryBuilder('at')
@@ -108,7 +103,8 @@ export class AggregationService {
       .where('at.timestamp >= :prevCutoff', { prevCutoff })
       .andWhere('at.timestamp < :cutoff', { cutoff });
     addTenantFilter(prevQb, userId, agentName, tenantId);
-    const prevRow = await prevQb.getRawOne();
+
+    const [currentRow, prevRow] = await Promise.all([currentQb.getRawOne(), prevQb.getRawOne()]);
 
     const current = Number(currentRow?.total ?? 0);
     const previous = Number(prevRow?.total ?? 0);
@@ -126,12 +122,12 @@ export class AggregationService {
     const cutoff = computeCutoff(interval);
     const prevCutoff = computeCutoff(prevInterval);
 
+    // 3C: Parallelize current + previous period queries
     const currentQb = this.turnRepo
       .createQueryBuilder('at')
       .select('COUNT(*)', 'total')
       .where('at.timestamp >= :cutoff', { cutoff });
     addTenantFilter(currentQb, userId, agentName, tenantId);
-    const currentRow = await currentQb.getRawOne();
 
     const prevQb = this.turnRepo
       .createQueryBuilder('at')
@@ -139,7 +135,8 @@ export class AggregationService {
       .where('at.timestamp >= :prevCutoff', { prevCutoff })
       .andWhere('at.timestamp < :cutoff', { cutoff });
     addTenantFilter(prevQb, userId, agentName, tenantId);
-    const prevRow = await prevQb.getRawOne();
+
+    const [currentRow, prevRow] = await Promise.all([currentQb.getRawOne(), prevQb.getRawOne()]);
 
     const current = Number(currentRow?.total ?? 0);
     const previous = Number(prevRow?.total ?? 0);

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -415,6 +415,17 @@ describe('TimeseriesQueriesService (sql.js / local mode)', () => {
     expect(result).toEqual([{ hour: '2026-02-16T10:00:00', input_tokens: 100, output_tokens: 50 }]);
   });
 
+  it('getAgentList uses leftJoin fallback when tenantId is null', async () => {
+    mockGetMany.mockResolvedValueOnce([
+      { name: 'bot-1', display_name: null, created_at: '2026-02-16' },
+    ]);
+    mockGetRawMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const result = await service.getAgentList('u1');
+    expect(result).toHaveLength(1);
+    expect(result[0].agent_name).toBe('bot-1');
+  });
+
   it('getCostByModel works with sqlite dialect', async () => {
     mockGetRawMany.mockResolvedValue([
       { model: 'gpt-4o', tokens: 500, estimated_cost: 2.0 },

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -238,14 +238,21 @@ export class TimeseriesQueriesService {
 
   async getAgentList(userId: string) {
     const tenantId = (await this.tenantCache.resolve(userId)) ?? undefined;
-    const agents = await this.agentRepo
-      .createQueryBuilder('a')
-      .leftJoin('a.tenant', 't')
-      .where('t.name = :userId', { userId })
+
+    // 1C: Skip tenant JOIN when tenantId is cached
+    const agentQb = this.agentRepo.createQueryBuilder('a');
+    if (tenantId) {
+      agentQb.where('a.tenant_id = :tenantId', { tenantId });
+    } else {
+      agentQb.leftJoin('a.tenant', 't').where('t.name = :userId', { userId });
+    }
+    const agents = await agentQb
       .andWhere('a.is_active = true')
       .orderBy('a.created_at', 'DESC')
       .getMany();
 
+    // 1A: Add 30-day timestamp filter to stats query
+    const statsCutoff = computeCutoff('30 days');
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'), this.dialect);
     const statsQb = this.turnRepo
       .createQueryBuilder('at')
@@ -254,17 +261,9 @@ export class TimeseriesQueriesService {
       .addSelect('MAX(at.timestamp)', 'last_active')
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'total_cost')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'total_tokens')
-      .where('at.agent_name IS NOT NULL');
+      .where('at.agent_name IS NOT NULL')
+      .andWhere('at.timestamp >= :statsCutoff', { statsCutoff });
     addTenantFilter(statsQb, userId, undefined, tenantId);
-    const statsRows = await statsQb
-      .groupBy('at.agent_name')
-      .orderBy('last_active', 'DESC')
-      .getRawMany();
-
-    const statsMap = new Map<string, Record<string, unknown>>();
-    for (const r of statsRows) {
-      statsMap.set(String(r['agent_name']), r);
-    }
 
     const sparkCutoff = computeCutoff('7 days');
     const hourExpr = sqlHourBucket('at.timestamp', this.dialect);
@@ -276,12 +275,22 @@ export class TimeseriesQueriesService {
       .where('at.timestamp >= :sparkCutoff', { sparkCutoff })
       .andWhere('at.agent_name IS NOT NULL');
     addTenantFilter(sparkQb, userId, undefined, tenantId);
-    const sparkRows = await sparkQb
-      .groupBy('at.agent_name')
-      .addGroupBy('hour')
-      .orderBy('at.agent_name', 'ASC')
-      .addOrderBy('hour', 'ASC')
-      .getRawMany();
+
+    // 1B: Parallelize stats + sparkline queries
+    const [statsRows, sparkRows] = await Promise.all([
+      statsQb.groupBy('at.agent_name').orderBy('last_active', 'DESC').getRawMany(),
+      sparkQb
+        .groupBy('at.agent_name')
+        .addGroupBy('hour')
+        .orderBy('at.agent_name', 'ASC')
+        .addOrderBy('hour', 'ASC')
+        .getRawMany(),
+    ]);
+
+    const statsMap = new Map<string, Record<string, unknown>>();
+    for (const r of statsRows) {
+      statsMap.set(String(r['agent_name']), r);
+    }
 
     const sparkMap = new Map<string, number[]>();
     for (const r of sparkRows) {

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -74,10 +74,11 @@ describe('RoutingService', () => {
 
       const result = await service.getTiers('a1');
 
-      expect(mockTierRepo.insert).toHaveBeenCalledTimes(4);
-      const tiers = mockTierRepo.insert.mock.calls.map(
-        (c: unknown[]) => (c[0] as { tier: string }).tier,
-      );
+      // 2A: Batch insert — single call with array of 4 records
+      expect(mockTierRepo.insert).toHaveBeenCalledTimes(1);
+      const inserted = mockTierRepo.insert.mock.calls[0][0] as { tier: string }[];
+      expect(inserted).toHaveLength(4);
+      const tiers = inserted.map((r) => r.tier);
       expect(tiers).toEqual(['simple', 'standard', 'complex', 'reasoning']);
       expect(result).toHaveLength(4);
     });
@@ -96,7 +97,10 @@ describe('RoutingService', () => {
 
       const result = await service.getTiers('a1');
 
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
+      // 2B: providers are now passed to avoid duplicate query
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1', [
+        { provider: 'openai', is_active: true },
+      ]);
       expect(result).toHaveLength(4);
       expect(result[0].auto_assigned_model).toBe('gpt-4o');
     });

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -217,27 +217,26 @@ export class RoutingService {
     const rows = await this.tierRepo.find({ where: { agent_id: agentId } });
 
     if (rows.length === 0) {
-      // Lazy init: create the 4 tier rows
-      const created: TierAssignment[] = [];
-      for (const tier of TIERS) {
-        const record = Object.assign(new TierAssignment(), {
+      // 2A: Batch tier inserts — create all 4 tier rows in one query
+      const created: TierAssignment[] = TIERS.map((tier) =>
+        Object.assign(new TierAssignment(), {
           id: randomUUID(),
           user_id: userId ?? '',
           agent_id: agentId,
           tier,
           override_model: null,
           auto_assigned_model: null,
-        });
-        await this.tierRepo.insert(record);
-        created.push(record);
-      }
+        }),
+      );
+      await this.tierRepo.insert(created);
 
       // If agent has active providers, recalculate immediately
+      // 2B: Pass providers to avoid duplicate query in recalculate()
       const providers = await this.providerRepo.find({
         where: { agent_id: agentId, is_active: true },
       });
       if (providers.length > 0) {
-        await this.autoAssign.recalculate(agentId);
+        await this.autoAssign.recalculate(agentId, providers);
         const result = await this.tierRepo.find({ where: { agent_id: agentId } });
         this.routingCache.setTiers(agentId, result);
         return result;

--- a/packages/backend/src/routing/tier-auto-assign.service.spec.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.spec.ts
@@ -347,24 +347,34 @@ describe('TierAutoAssignService', () => {
       mockProviderRepo.find.mockResolvedValue([{ provider: 'openai', is_active: true }]);
       const model = makeModel({ model_name: 'gpt-4o', provider: 'OpenAI' });
       mockPricingCache.getAll.mockReturnValue([model]);
+      // 2C: Batch find returns empty — all tiers will be batch-inserted
+      mockTierRepo.find.mockResolvedValue([]);
 
       await service.recalculate('agent-1');
 
-      expect(mockTierRepo.insert).toHaveBeenCalledTimes(4);
-      for (const call of mockTierRepo.insert.mock.calls) {
-        expect(call[0].auto_assigned_model).toBe('gpt-4o');
+      // 2C: Single batch insert call with all 4 tiers
+      expect(mockTierRepo.insert).toHaveBeenCalledTimes(1);
+      const inserted = mockTierRepo.insert.mock.calls[0][0] as { auto_assigned_model: string }[];
+      expect(inserted).toHaveLength(4);
+      for (const record of inserted) {
+        expect(record.auto_assigned_model).toBe('gpt-4o');
       }
     });
 
     it('should set all auto_assigned_model to null with no providers', async () => {
       mockProviderRepo.find.mockResolvedValue([]);
       mockPricingCache.getAll.mockReturnValue([]);
+      mockTierRepo.find.mockResolvedValue([]);
 
       await service.recalculate('agent-1');
 
-      expect(mockTierRepo.insert).toHaveBeenCalledTimes(4);
-      for (const call of mockTierRepo.insert.mock.calls) {
-        expect(call[0].auto_assigned_model).toBeNull();
+      expect(mockTierRepo.insert).toHaveBeenCalledTimes(1);
+      const inserted = mockTierRepo.insert.mock.calls[0][0] as {
+        auto_assigned_model: string | null;
+      }[];
+      expect(inserted).toHaveLength(4);
+      for (const record of inserted) {
+        expect(record.auto_assigned_model).toBeNull();
       }
     });
 
@@ -373,23 +383,27 @@ describe('TierAutoAssignService', () => {
       const model = makeModel({ model_name: 'gpt-4o', provider: 'OpenAI' });
       mockPricingCache.getAll.mockReturnValue([model]);
 
-      // All 4 tiers already exist
-      mockTierRepo.findOne.mockResolvedValue({
-        id: 'existing-id',
-        agent_id: 'agent-1',
-        tier: 'simple',
-        override_model: null,
-        auto_assigned_model: null,
-        updated_at: '2024-01-01',
-      });
+      // 2C: Batch find returns all 4 existing tiers
+      mockTierRepo.find.mockResolvedValue(
+        ['simple', 'standard', 'complex', 'reasoning'].map((tier) => ({
+          id: `existing-${tier}`,
+          agent_id: 'agent-1',
+          tier,
+          override_model: null,
+          auto_assigned_model: null,
+          updated_at: '2024-01-01',
+        })),
+      );
 
       await service.recalculate('agent-1');
 
-      // Should save (not insert) all 4 existing tiers
-      expect(mockTierRepo.save).toHaveBeenCalledTimes(4);
+      // 2C: Single batch save call with all 4 tiers
+      expect(mockTierRepo.save).toHaveBeenCalledTimes(1);
       expect(mockTierRepo.insert).not.toHaveBeenCalled();
-      for (const call of mockTierRepo.save.mock.calls) {
-        expect(call[0].auto_assigned_model).toBe('gpt-4o');
+      const saved = mockTierRepo.save.mock.calls[0][0] as { auto_assigned_model: string }[];
+      expect(saved).toHaveLength(4);
+      for (const record of saved) {
+        expect(record.auto_assigned_model).toBe('gpt-4o');
       }
     });
 
@@ -398,48 +412,75 @@ describe('TierAutoAssignService', () => {
       // No models available (getAll returns empty array), so pickBest returns null
       mockPricingCache.getAll.mockReturnValue([]);
 
-      // All 4 tiers already exist
-      mockTierRepo.findOne.mockResolvedValue({
-        id: 'existing-id',
-        agent_id: 'agent-1',
-        tier: 'simple',
-        override_model: null,
-        auto_assigned_model: 'old-model',
-        updated_at: '2024-01-01',
-      });
+      // 2C: Batch find returns all 4 existing tiers
+      mockTierRepo.find.mockResolvedValue(
+        ['simple', 'standard', 'complex', 'reasoning'].map((tier) => ({
+          id: `existing-${tier}`,
+          agent_id: 'agent-1',
+          tier,
+          override_model: null,
+          auto_assigned_model: 'old-model',
+          updated_at: '2024-01-01',
+        })),
+      );
 
       await service.recalculate('agent-1');
 
       // Should save with null auto_assigned_model (best?.model_name ?? null)
-      expect(mockTierRepo.save).toHaveBeenCalledTimes(4);
-      for (const call of mockTierRepo.save.mock.calls) {
-        expect(call[0].auto_assigned_model).toBeNull();
+      expect(mockTierRepo.save).toHaveBeenCalledTimes(1);
+      const saved = mockTierRepo.save.mock.calls[0][0] as {
+        auto_assigned_model: string | null;
+      }[];
+      expect(saved).toHaveLength(4);
+      for (const record of saved) {
+        expect(record.auto_assigned_model).toBeNull();
       }
     });
 
     it('should preserve manual overrides during recalculation', async () => {
-      const existingTier = {
-        id: 'tier-1',
-        agent_id: 'agent-1',
-        tier: 'complex',
-        override_model: 'claude-opus-4-6',
-        auto_assigned_model: 'gpt-4o',
-        updated_at: '2024-01-01',
-      };
-      mockTierRepo.findOne.mockResolvedValueOnce(existingTier);
       mockProviderRepo.find.mockResolvedValue([{ provider: 'openai', is_active: true }]);
       mockPricingCache.getAll.mockReturnValue([
         makeModel({ model_name: 'gpt-4o', provider: 'OpenAI' }),
       ]);
 
+      // 2C: Batch find returns one existing tier with override
+      mockTierRepo.find.mockResolvedValue([
+        {
+          id: 'tier-1',
+          agent_id: 'agent-1',
+          tier: 'complex',
+          override_model: 'claude-opus-4-6',
+          auto_assigned_model: 'gpt-4o',
+          updated_at: '2024-01-01',
+        },
+      ]);
+
       await service.recalculate('agent-1');
 
-      expect(mockTierRepo.save).toHaveBeenCalledWith(
+      // Save call includes the existing tier; insert call includes the 3 missing tiers
+      expect(mockTierRepo.save).toHaveBeenCalledTimes(1);
+      const saved = mockTierRepo.save.mock.calls[0][0] as Record<string, unknown>[];
+      const complexTier = saved.find((t: Record<string, unknown>) => t['tier'] === 'complex');
+      expect(complexTier).toEqual(
         expect.objectContaining({
           override_model: 'claude-opus-4-6',
           auto_assigned_model: 'gpt-4o',
         }),
       );
+    });
+
+    it('should accept optional providers parameter to skip DB query', async () => {
+      const providers = [{ provider: 'openai', is_active: true }];
+      mockPricingCache.getAll.mockReturnValue([
+        makeModel({ model_name: 'gpt-4o', provider: 'OpenAI' }),
+      ]);
+      mockTierRepo.find.mockResolvedValue([]);
+
+      await service.recalculate('agent-1', providers as never[]);
+
+      // Should not query providers from DB
+      expect(mockProviderRepo.find).not.toHaveBeenCalled();
+      expect(mockTierRepo.insert).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/backend/src/routing/tier-auto-assign.service.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.ts
@@ -26,27 +26,35 @@ export class TierAutoAssignService {
     private readonly tierRepo: Repository<TierAssignment>,
   ) {}
 
-  async recalculate(agentId: string): Promise<void> {
-    const providers = await this.providerRepo.find({
-      where: { agent_id: agentId, is_active: true },
-    });
-    const activeProviders = expandProviderNames(providers.map((p) => p.provider));
+  async recalculate(agentId: string, providers?: UserProvider[]): Promise<void> {
+    // 2B: Accept optional providers to avoid duplicate query
+    const resolvedProviders =
+      providers ??
+      (await this.providerRepo.find({
+        where: { agent_id: agentId, is_active: true },
+      }));
+    const activeProviders = expandProviderNames(resolvedProviders.map((p) => p.provider));
 
     const allModels = this.pricingCache.getAll();
     const available = allModels.filter((m) => activeProviders.has(m.provider.toLowerCase()));
 
+    // 2C: Batch read all tiers in one query
+    const allTiers = await this.tierRepo.find({ where: { agent_id: agentId } });
+    const tierMap = new Map(allTiers.map((t) => [t.tier, t]));
+
+    const toSave: TierAssignment[] = [];
+    const toInsert: Record<string, unknown>[] = [];
+
     for (const tier of TIERS) {
       const best = this.pickBest(available, tier);
-      const existing = await this.tierRepo.findOne({
-        where: { agent_id: agentId, tier },
-      });
+      const existing = tierMap.get(tier);
 
       if (existing) {
         existing.auto_assigned_model = best?.model_name ?? null;
         existing.updated_at = new Date().toISOString();
-        await this.tierRepo.save(existing);
+        toSave.push(existing);
       } else {
-        await this.tierRepo.insert({
+        toInsert.push({
           id: randomUUID(),
           user_id: '',
           agent_id: agentId,
@@ -56,6 +64,10 @@ export class TierAutoAssignService {
         });
       }
     }
+
+    // 2C: Batch write
+    if (toSave.length > 0) await this.tierRepo.save(toSave);
+    if (toInsert.length > 0) await this.tierRepo.insert(toInsert);
 
     this.logger.log(`Recalculated tier assignments for agent ${agentId}`);
   }


### PR DESCRIPTION
## Summary

Optimizes the three slowest dashboard API endpoints by eliminating unnecessary DB round-trips:

- **GET /api/v1/agents** — Add 30-day cutoff to stats query (prevents full table scan), parallelize stats + sparkline queries, skip tenant JOIN when tenantId is cached
- **GET /api/v1/routing/:agentName/tiers** — Batch tier inserts (4→1), pass providers to `recalculate()` to avoid duplicate fetch, batch reads/writes in recalculate (8 sequential→2-3)
- **GET /api/v1/overview** — Merge redundant token queries (3 sequential→2 parallel), parallelize current vs previous period in cost and message summaries

## Test plan

- [x] Backend unit tests pass (2131)
- [x] Backend e2e tests pass (105)
- [x] Frontend tests pass (1297)
- [x] TypeScript compiles with no errors
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the three slowest dashboard API endpoints by reducing DB round trips and parallelizing independent queries. This makes the dashboard load faster and cuts DB load.

- **Performance**
  - GET /api/v1/agents: add 30-day stats cutoff; run stats and sparkline queries in parallel; skip tenant JOIN when cached `tenantId` exists and fall back to leftJoin by `userId` when it doesn’t.
  - GET /api/v1/routing/:agentName/tiers: batch insert the 4 tier rows; pass providers to `recalculate()` to avoid a duplicate fetch; batch tier reads/writes inside `recalculate()`.
  - GET /api/v1/overview: merge token queries (3→2, compute total from input+output) and parallelize current vs previous period queries for cost and message counts.

<sup>Written for commit 9e4c3efc15853257049f7c5191ef5b188f95f063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

