### PR TITLE
fix: restrict routing model picker to curated models

### DIFF
--- a/.changeset/fix-routing-model-picker.md
+++ b/.changeset/fix-routing-model-picker.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix routing model picker showing non-curated models from OpenRouter

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,5 @@
 codecov:
   branch: main
-ignore:
-  - "packages/backend/src/database/migrations/**"
-  - "packages/backend/src/**/*.module.ts"
-  - "packages/backend/src/main.ts"
-  - "packages/backend/src/database/datasource.ts"
-  - "packages/backend/src/otlp/interfaces/index.ts"
-  - "packages/backend/src/otlp/proto/**"
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,12 @@
 codecov:
   branch: main
+ignore:
+  - "packages/backend/src/database/migrations/**"
+  - "packages/backend/src/**/*.module.ts"
+  - "packages/backend/src/main.ts"
+  - "packages/backend/src/database/datasource.ts"
+  - "packages/backend/src/otlp/interfaces/index.ts"
+  - "packages/backend/src/otlp/proto/**"
 coverage:
   status:
     project:

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -50,6 +50,7 @@ import { AddModelDisplayName1772920000000 } from './migrations/1772920000000-Add
 import { DropRedundantIndexes1772940000000 } from './migrations/1772940000000-DropRedundantIndexes';
 import { BackfillTenantId1772948502780 } from './migrations/1772948502780-BackfillTenantId';
 import { DropUnusedIndexes1772960000000 } from './migrations/1772960000000-DropUnusedIndexes';
+import { PurgeNonCuratedModels1772960000000 } from './migrations/1772960000000-PurgeNonCuratedModels';
 
 const entities = [
   AgentMessage,
@@ -104,6 +105,7 @@ const migrations = [
   DropRedundantIndexes1772940000000,
   BackfillTenantId1772948502780,
   DropUnusedIndexes1772960000000,
+  PurgeNonCuratedModels1772960000000,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';

--- a/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.spec.ts
+++ b/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.spec.ts
@@ -1,0 +1,61 @@
+import { QueryRunner } from 'typeorm';
+import { PurgeNonCuratedModels1772960000000 } from './1772960000000-PurgeNonCuratedModels';
+
+describe('PurgeNonCuratedModels1772960000000', () => {
+  let migration: PurgeNonCuratedModels1772960000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new PurgeNonCuratedModels1772960000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('should execute a single DELETE query', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('should delete non-curated models while preserving curated ones', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain('DELETE FROM model_pricing');
+      expect(sql).toContain('NOT IN');
+    });
+
+    it('should exclude Ollama models from deletion', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain("provider != 'Ollama'");
+    });
+
+    it('should exclude custom provider models from deletion', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain("model_name NOT LIKE 'custom:%'");
+    });
+
+    it('should pass curated model names as parameterized values', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const params = queryRunner.query.mock.calls[0][1] as string[];
+      expect(params).toContain('claude-opus-4-6');
+      expect(params).toContain('gpt-4o');
+      expect(params).toContain('openrouter/auto');
+      expect(params).toContain('glm-4-flash');
+      expect(params.length).toBe(64);
+    });
+  });
+
+  describe('down', () => {
+    it('should be a no-op', async () => {
+      await migration.down();
+
+      expect(queryRunner.query).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.ts
+++ b/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.ts
@@ -1,0 +1,85 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const CURATED_MODELS = [
+  'claude-opus-4-6',
+  'claude-sonnet-4-5-20250929',
+  'claude-sonnet-4-20250514',
+  'claude-haiku-4-5-20251001',
+  'gpt-4o',
+  'gpt-4o-mini',
+  'gpt-4.1',
+  'gpt-4.1-mini',
+  'gpt-4.1-nano',
+  'o3',
+  'o3-mini',
+  'o4-mini',
+  'gemini-2.5-pro',
+  'gemini-2.5-flash',
+  'gemini-2.5-flash-lite',
+  'gemini-2.0-flash',
+  'deepseek-chat',
+  'deepseek-reasoner',
+  'kimi-k2',
+  'qwen-2.5-72b-instruct',
+  'qwq-32b',
+  'qwen-2.5-coder-32b-instruct',
+  'qwen3-235b-a22b',
+  'qwen3-32b',
+  'mistral-large-latest',
+  'mistral-small',
+  'codestral-latest',
+  'grok-3',
+  'grok-3-mini',
+  'grok-3-fast',
+  'grok-3-mini-fast',
+  'openrouter/auto',
+  'anthropic/claude-opus-4-6',
+  'anthropic/claude-sonnet-4-5',
+  'openai/gpt-4o',
+  'openai/o3',
+  'google/gemini-2.5-pro',
+  'google/gemini-2.5-flash',
+  'deepseek/deepseek-r1',
+  'deepseek/deepseek-chat-v3-0324',
+  'meta-llama/llama-4-maverick',
+  'mistralai/mistral-large',
+  'x-ai/grok-3',
+  'openrouter/free',
+  'minimax/minimax-m2.5',
+  'minimax/minimax-m1',
+  'minimax-m2.5',
+  'minimax-m2.5-highspeed',
+  'minimax-m2.1',
+  'minimax-m2.1-highspeed',
+  'minimax-m2',
+  'minimax-m1',
+  'glm-5',
+  'glm-4.7',
+  'glm-4.7-flash',
+  'glm-4.6',
+  'glm-4.6v',
+  'glm-4.5',
+  'glm-4.5-air',
+  'glm-4.5-flash',
+  'z-ai/glm-5',
+  'z-ai/glm-4.7',
+  'glm-4-plus',
+  'glm-4-flash',
+];
+
+export class PurgeNonCuratedModels1772960000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const placeholders = CURATED_MODELS.map((_, i) => `$${i + 1}`).join(', ');
+    await queryRunner.query(
+      `DELETE FROM model_pricing
+       WHERE model_name NOT IN (${placeholders})
+         AND provider != 'Ollama'
+         AND model_name NOT LIKE 'custom:%'`,
+      CURATED_MODELS,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No-op: seeder re-creates curated models on next startup
+  }
+}

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -61,7 +61,7 @@ describe('PricingSyncService', () => {
     mockDelete.mockResolvedValue(undefined);
   });
 
-  it('creates canonical + OpenRouter copies for new vendor-prefixed models', async () => {
+  it('creates canonical models for new vendor-prefixed models (no OpenRouter copies)', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -77,8 +77,8 @@ describe('PricingSyncService', () => {
 
     const updated = await service.syncPricing();
     expect(updated).toBe(2);
-    // 2 canonical + 2 OpenRouter copies = 4 upserts
-    expect(mockUpsert).toHaveBeenCalledTimes(4);
+    // 2 canonical upserts only — no OpenRouter copies for non-existing models
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
     expect(mockRecordChange).toHaveBeenCalledTimes(2);
   });
 
@@ -110,6 +110,7 @@ describe('PricingSyncService', () => {
   });
 
   it('syncs free models with zero pricing', async () => {
+    mockFindOneBy.mockResolvedValue({ model_name: 'gpt-4o', provider: 'OpenAI' });
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -119,15 +120,12 @@ describe('PricingSyncService', () => {
 
     const updated = await service.syncPricing();
     expect(updated).toBe(1);
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model_name: 'openai/gpt-4o',
-        provider: 'OpenRouter',
-        input_price_per_token: 0,
-        output_price_per_token: 0,
-      }),
-      ['model_name'],
-    );
+    const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'gpt-4o');
+    expect(canonicalCall).toBeDefined();
+    expect(canonicalCall![0]).toMatchObject({
+      input_price_per_token: 0,
+      output_price_per_token: 0,
+    });
   });
 
   it('skips models with missing pricing field', async () => {
@@ -180,6 +178,7 @@ describe('PricingSyncService', () => {
   });
 
   it('reloads cache when models were updated', async () => {
+    mockFindOneBy.mockResolvedValue({ model_name: 'gpt-4o', provider: 'OpenAI' });
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -220,8 +219,8 @@ describe('PricingSyncService', () => {
       }),
       'sync',
     );
-    // Canonical + OpenRouter copy for new vendor-prefixed models
-    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    // Canonical only — no OpenRouter copy for non-existing model
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
   });
 
   it('passes existing model to recordChange when found', async () => {
@@ -379,6 +378,7 @@ describe('PricingSyncService', () => {
   });
 
   it('skips models from unsupported providers', async () => {
+    mockFindOneBy.mockResolvedValue({ model_name: 'gpt-4o', provider: 'OpenAI' });
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -390,12 +390,11 @@ describe('PricingSyncService', () => {
     });
 
     const updated = await service.syncPricing();
-    // Only OpenAI model should be upserted (OpenRouter copy), ai21 is skipped entirely
+    // Only OpenAI model should be upserted, ai21 is skipped entirely
     expect(updated).toBe(1);
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({ model_name: 'openai/gpt-4o' }),
-      ['model_name'],
-    );
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ model_name: 'gpt-4o' }), [
+      'model_name',
+    ]);
     // ai21 should not appear in any upsert call
     for (const call of mockUpsert.mock.calls) {
       expect(call[0].model_name).not.toContain('ai21');
@@ -568,14 +567,10 @@ describe('PricingSyncService', () => {
     const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'glm-4-plus');
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
-    // Also stores OpenRouter copy
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model_name: 'zhipuai/glm-4-plus',
-        provider: 'OpenRouter',
-      }),
-      ['model_name'],
-    );
+    // Also updates OpenRouter copy (preserves existing provider)
+    const orCall = mockUpsert.mock.calls.find((c) => c[0].model_name === 'zhipuai/glm-4-plus');
+    expect(orCall).toBeDefined();
+    expect(orCall![0]).not.toHaveProperty('provider');
   });
 
   it('maps Amazon provider correctly', async () => {
@@ -594,14 +589,10 @@ describe('PricingSyncService', () => {
     const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'nova-pro');
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
-    // Also stores OpenRouter copy
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model_name: 'amazon/nova-pro',
-        provider: 'OpenRouter',
-      }),
-      ['model_name'],
-    );
+    // Also updates OpenRouter copy (preserves existing provider)
+    const orCall = mockUpsert.mock.calls.find((c) => c[0].model_name === 'amazon/nova-pro');
+    expect(orCall).toBeDefined();
+    expect(orCall![0]).not.toHaveProperty('provider');
   });
 
   it('skips openrouter/auto entirely when not in seeder', async () => {
@@ -644,7 +635,8 @@ describe('PricingSyncService', () => {
     expect(mockUpsert.mock.calls[0][0]).not.toHaveProperty('provider');
   });
 
-  it('stores context_length as context_window when present (new model)', async () => {
+  it('stores context_length as context_window in OpenRouter copy', async () => {
+    mockFindOneBy.mockResolvedValue({ model_name: 'gpt-4o', provider: 'OpenAI' });
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -659,24 +651,11 @@ describe('PricingSyncService', () => {
     });
 
     await service.syncPricing();
-    // Canonical + OpenRouter copy for new vendor-prefixed models
-    expect(mockUpsert).toHaveBeenCalledTimes(2);
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model_name: 'gpt-4o',
-        provider: 'OpenAI',
-        context_window: 128000,
-      }),
-      ['model_name'],
-    );
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model_name: 'openai/gpt-4o',
-        provider: 'OpenRouter',
-        context_window: 128000,
-      }),
-      ['model_name'],
-    );
+    // Both canonical and OpenRouter copy upserted with context_window
+    const orCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'openai/gpt-4o');
+    expect(orCall).toBeDefined();
+    expect(orCall![0]).toMatchObject({ context_window: 128000 });
+    expect(orCall![0]).not.toHaveProperty('provider');
   });
 
   it('stores context_length as context_window for existing models', async () => {
@@ -705,6 +684,7 @@ describe('PricingSyncService', () => {
   });
 
   it('omits context_window when context_length is missing (uses DB default)', async () => {
+    mockFindOneBy.mockResolvedValue({ model_name: 'gpt-4o', provider: 'OpenAI' });
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -719,7 +699,8 @@ describe('PricingSyncService', () => {
     }
   });
 
-  it('stores OpenRouter copy with full vendor-prefixed ID', async () => {
+  it('updates existing OpenRouter copy with full vendor-prefixed ID', async () => {
+    mockFindOneBy.mockResolvedValue({ model_name: 'claude-opus-4', provider: 'Anthropic' });
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -733,26 +714,16 @@ describe('PricingSyncService', () => {
     });
 
     await service.syncPricing();
-    // Canonical + OpenRouter copy for new vendor-prefixed models
-    expect(mockUpsert).toHaveBeenCalledTimes(2);
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model_name: 'claude-opus-4',
-        provider: 'Anthropic',
-        input_price_per_token: 0.000015,
-        output_price_per_token: 0.000075,
-      }),
-      ['model_name'],
+    const orCall = mockUpsert.mock.calls.find(
+      (call) => call[0].model_name === 'anthropic/claude-opus-4',
     );
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model_name: 'anthropic/claude-opus-4',
-        provider: 'OpenRouter',
-        input_price_per_token: 0.000015,
-        output_price_per_token: 0.000075,
-      }),
-      ['model_name'],
-    );
+    expect(orCall).toBeDefined();
+    expect(orCall![0]).toMatchObject({
+      model_name: 'anthropic/claude-opus-4',
+      input_price_per_token: 0.000015,
+      output_price_per_token: 0.000075,
+    });
+    expect(orCall![0]).not.toHaveProperty('provider');
   });
 
   it('logs warning when OpenRouter copy upsert fails', async () => {
@@ -836,8 +807,10 @@ describe('PricingSyncService', () => {
   });
 
   it('catches and counts per-model errors in syncAllModels', async () => {
-    // findOneBy throws for a specific model, triggering the catch block (lines 211-216)
-    mockFindOneBy.mockRejectedValueOnce(new Error('DB constraint error'));
+    // findOneBy throws for a specific model, triggering the catch block
+    mockFindOneBy
+      .mockRejectedValueOnce(new Error('DB constraint error'))
+      .mockResolvedValue({ model_name: 'gpt-4o', provider: 'OpenAI' });
 
     mockFetch.mockResolvedValue({
       ok: true,
@@ -850,7 +823,7 @@ describe('PricingSyncService', () => {
     });
 
     const updated = await service.syncPricing();
-    // First model failed, second succeeded (OpenRouter copy only)
+    // First model failed, second succeeded
     expect(updated).toBe(1);
   });
 
@@ -895,6 +868,7 @@ describe('PricingSyncService', () => {
   });
 
   it('omits display_name when OpenRouter name is missing', async () => {
+    mockFindOneBy.mockResolvedValue({ model_name: 'gpt-4o', provider: 'OpenAI' });
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -927,13 +901,54 @@ describe('PricingSyncService', () => {
     );
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
-    // Also stores OpenRouter copy
-    expect(mockUpsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model_name: 'qwen/qwen3-235b-a22b',
-        provider: 'OpenRouter',
-      }),
-      ['model_name'],
+    // Also updates OpenRouter copy (preserves existing provider)
+    const orCall = mockUpsert.mock.calls.find(
+      (call) => call[0].model_name === 'qwen/qwen3-235b-a22b',
     );
+    expect(orCall).toBeDefined();
+    expect(orCall![0]).not.toHaveProperty('provider');
+  });
+
+  it('skips OpenRouter copy when copy does not exist in DB', async () => {
+    // Canonical model exists, but OpenRouter copy does not
+    mockFindOneBy
+      .mockResolvedValueOnce({ model_name: 'gpt-4o', provider: 'OpenAI' }) // canonical
+      .mockResolvedValueOnce(null); // OR copy lookup
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.0000025', completion: '0.00001' } }],
+      }),
+    });
+
+    await service.syncPricing();
+    // Only canonical upsert, no OpenRouter copy
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ model_name: 'gpt-4o' }), [
+      'model_name',
+    ]);
+  });
+
+  it('updates existing OpenRouter copy pricing', async () => {
+    mockFindOneBy.mockResolvedValue({ model_name: 'gpt-4o', provider: 'OpenAI' });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'openai/gpt-4o', pricing: { prompt: '0.000005', completion: '0.00002' } }],
+      }),
+    });
+
+    await service.syncPricing();
+    // Both canonical and OpenRouter copy upserted
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    const orCall = mockUpsert.mock.calls.find((c) => c[0].model_name === 'openai/gpt-4o');
+    expect(orCall).toBeDefined();
+    expect(orCall![0]).toMatchObject({
+      input_price_per_token: 0.000005,
+      output_price_per_token: 0.00002,
+    });
+    expect(orCall![0]).not.toHaveProperty('provider');
   });
 });

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -726,7 +726,7 @@ describe('PricingSyncService', () => {
     expect(orCall![0]).not.toHaveProperty('provider');
   });
 
-  it('logs warning when OpenRouter copy upsert fails', async () => {
+  it('logs warning when OpenRouter copy upsert fails with Error', async () => {
     mockFindOneBy.mockResolvedValue({
       model_name: 'claude-opus-4',
       provider: 'Anthropic',
@@ -749,6 +749,32 @@ describe('PricingSyncService', () => {
 
     const updated = await service.syncPricing();
     // Model still counts as updated (canonical upsert succeeded)
+    expect(updated).toBe(1);
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs warning when OpenRouter copy upsert fails with non-Error', async () => {
+    mockFindOneBy.mockResolvedValue({
+      model_name: 'claude-opus-4',
+      provider: 'Anthropic',
+    });
+    mockUpsert
+      .mockResolvedValueOnce(undefined) // canonical upsert succeeds
+      .mockRejectedValueOnce('string rejection'); // non-Error thrown
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'anthropic/claude-opus-4',
+            pricing: { prompt: '0.000015', completion: '0.000075' },
+          },
+        ],
+      }),
+    });
+
+    const updated = await service.syncPricing();
     expect(updated).toBe(1);
     expect(mockUpsert).toHaveBeenCalledTimes(2);
   });

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -205,26 +205,30 @@ export class PricingSyncService implements OnModuleInit {
           upserted = true;
         }
 
-        // Store an OpenRouter copy with the full vendor-prefixed ID
+        // Update existing OpenRouter copy with the full vendor-prefixed ID
         if (hasVendorPrefix) {
-          try {
-            await this.pricingRepo.upsert(
-              {
-                model_name: model.id,
-                provider: 'OpenRouter',
-                input_price_per_token: prompt,
-                output_price_per_token: completion,
-                ...(contextWindow != null && { context_window: contextWindow }),
-                ...(displayName && { display_name: displayName }),
-                updated_at: now,
-              },
-              ['model_name'],
-            );
-            upserted = true;
-          } catch (copyErr) {
-            this.logger.warn(
-              `Failed to store OpenRouter copy for ${model.id}: ${copyErr instanceof Error ? copyErr.message : copyErr}`,
-            );
+          const existingCopy = await this.pricingRepo.findOneBy({
+            model_name: model.id,
+          });
+          if (existingCopy) {
+            try {
+              await this.pricingRepo.upsert(
+                {
+                  model_name: model.id,
+                  input_price_per_token: prompt,
+                  output_price_per_token: completion,
+                  ...(contextWindow != null && { context_window: contextWindow }),
+                  ...(displayName && { display_name: displayName }),
+                  updated_at: now,
+                },
+                ['model_name'],
+              );
+              upserted = true;
+            } catch (copyErr) {
+              this.logger.warn(
+                `Failed to store OpenRouter copy for ${model.id}: ${copyErr instanceof Error ? copyErr.message : copyErr}`,
+              );
+            }
           }
         }
         if (upserted) updated++;


### PR DESCRIPTION
## Summary

- Gate OpenRouter copy creation in `PricingSyncService` behind a DB existence check, so only seeded (curated) models get their pricing updated — prevents hundreds of non-curated OpenRouter models from appearing in the routing model picker
- Add migration `PurgeNonCuratedModels` to delete stale non-curated rows from production databases (preserves Ollama and `custom:` provider models)
- Remove `provider` field from OpenRouter copy upsert payload to preserve the seeder's original value

## Test plan

- [x] Backend unit tests pass (2145 tests)
- [x] Backend e2e tests pass (105 tests)
- [x] Frontend tests pass (1304 tests)
- [x] TypeScript compiles with no errors
- [x] New migration test covers `up()` (parameterized DELETE, exclusions) and `down()` (no-op)
- [x] New sync tests: "skips OpenRouter copy when copy does not exist in DB" and "updates existing OpenRouter copy pricing"
- [x] Updated 14 existing sync tests to reflect gated behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the routing model picker to curated models by only syncing OpenRouter pricing for seeded entries and purging non‑curated rows, preserving `Ollama` and `custom:` models.

- **Bug Fixes**
  - Gate OpenRouter copy updates in `PricingSyncService` behind a DB existence check so only seeded models are updated.
  - Stop setting `provider` on OpenRouter copy upserts to preserve the seeder’s value.
  - Add tests for gated behavior (skip missing copies, update existing) and the non‑Error branch in failure handling.

- **Migration**
  - `PurgeNonCuratedModels`: delete non‑curated `model_pricing` rows while excluding `Ollama` and `custom:` entries.

<sup>Written for commit d5478b0b752e2fc1596be4a8c7f175e7516c37b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

