### PR TITLE
fix: create canonical models in local mode and improve routing UX

### DIFF
--- a/.changeset/fix-local-models-and-routing-ux.md
+++ b/.changeset/fix-local-models-and-routing-ux.md
@@ -1,0 +1,10 @@
+---
+"manifest": patch
+---
+
+Fix missing canonical provider models in local mode and improve routing page UX
+
+- Create canonical model entries (e.g. `gemini-2.5-pro` with provider "Google") during pricing sync when no seeded entry exists, fixing local mode showing only OpenRouter-branded models
+- Replace full tier list refetch with local state mutations on model change, reset, and fallback operations for instant UI updates
+- Add loading indicator ("Changing...") on the Change button while model override is saving
+- Add toast notification when removing a fallback model

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -61,7 +61,7 @@ describe('PricingSyncService', () => {
     mockDelete.mockResolvedValue(undefined);
   });
 
-  it('creates only OpenRouter copies for new models not in seeder', async () => {
+  it('creates canonical + OpenRouter copies for new vendor-prefixed models', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -77,8 +77,8 @@ describe('PricingSyncService', () => {
 
     const updated = await service.syncPricing();
     expect(updated).toBe(2);
-    // No canonical entries for new models — only 2 OpenRouter copies
-    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    // 2 canonical + 2 OpenRouter copies = 4 upserts
+    expect(mockUpsert).toHaveBeenCalledTimes(4);
     expect(mockRecordChange).toHaveBeenCalledTimes(2);
   });
 
@@ -220,8 +220,8 @@ describe('PricingSyncService', () => {
       }),
       'sync',
     );
-    // Only OpenRouter copy (canonical skipped for new models)
-    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    // Canonical + OpenRouter copy for new vendor-prefixed models
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
   });
 
   it('passes existing model to recordChange when found', async () => {
@@ -659,8 +659,16 @@ describe('PricingSyncService', () => {
     });
 
     await service.syncPricing();
-    // New model — only OpenRouter copy (canonical skipped)
-    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    // Canonical + OpenRouter copy for new vendor-prefixed models
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model_name: 'gpt-4o',
+        provider: 'OpenAI',
+        context_window: 128000,
+      }),
+      ['model_name'],
+    );
     expect(mockUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         model_name: 'openai/gpt-4o',
@@ -725,8 +733,17 @@ describe('PricingSyncService', () => {
     });
 
     await service.syncPricing();
-    // New model — only OpenRouter copy (no canonical entry)
-    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    // Canonical + OpenRouter copy for new vendor-prefixed models
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model_name: 'claude-opus-4',
+        provider: 'Anthropic',
+        input_price_per_token: 0.000015,
+        output_price_per_token: 0.000075,
+      }),
+      ['model_name'],
+    );
     expect(mockUpsert).toHaveBeenCalledWith(
       expect.objectContaining({
         model_name: 'anthropic/claude-opus-4',

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -171,6 +171,8 @@ export class PricingSyncService implements OnModuleInit {
 
         await this.pricingHistory.recordChange(existing, incoming, 'sync');
 
+        const hasVendorPrefix = model.id.includes('/') && !model.id.startsWith('openrouter/');
+
         let upserted = false;
         if (existing) {
           // Seeded model — update pricing only, preserve provider
@@ -186,10 +188,24 @@ export class PricingSyncService implements OnModuleInit {
             ['model_name'],
           );
           upserted = true;
+        } else if (hasVendorPrefix) {
+          // No seeded entry — create canonical model with proper provider
+          await this.pricingRepo.upsert(
+            {
+              model_name: canonical,
+              provider,
+              input_price_per_token: prompt,
+              output_price_per_token: completion,
+              ...(contextWindow != null && { context_window: contextWindow }),
+              ...(displayName && { display_name: displayName }),
+              updated_at: now,
+            },
+            ['model_name'],
+          );
+          upserted = true;
         }
 
         // Store an OpenRouter copy with the full vendor-prefixed ID
-        const hasVendorPrefix = model.id.includes('/') && !model.id.startsWith('openrouter/');
         if (hasVendorPrefix) {
           try {
             await this.pricingRepo.upsert(

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -8,6 +8,7 @@ import {
   type AvailableModel,
   type CustomProviderData,
 } from '../services/api.js';
+import { toast } from '../services/toast-store.js';
 
 interface FallbackListProps {
   agentName: string;
@@ -15,7 +16,7 @@ interface FallbackListProps {
   fallbacks: string[];
   models: AvailableModel[];
   customProviders: CustomProviderData[];
-  onUpdate: () => void;
+  onUpdate: (updatedFallbacks: string[]) => void;
   onAddFallback: () => void;
   adding?: boolean;
 }
@@ -48,7 +49,8 @@ const FallbackList: Component<FallbackListProps> = (props) => {
       } else {
         await setFallbacks(props.agentName, props.tier, updated);
       }
-      props.onUpdate();
+      props.onUpdate(updated);
+      toast.success('Fallback removed');
     } catch {
       // error toast from fetchMutate
     } finally {

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -48,7 +48,10 @@ const Routing: Component = () => {
   const params = useParams<{ agentName: string }>();
   const agentName = () => decodeURIComponent(params.agentName);
 
-  const [tiers, { refetch: refetchTiers }] = createResource(() => agentName(), getTierAssignments);
+  const [tiers, { refetch: refetchTiers, mutate: mutateTiers }] = createResource(
+    () => agentName(),
+    getTierAssignments,
+  );
   const [models, { refetch: refetchModels }] = createResource(
     () => agentName(),
     getAvailableModels,
@@ -67,6 +70,7 @@ const Routing: Component = () => {
   const [confirmDisable, setConfirmDisable] = createSignal(false);
   const [instructionModal, setInstructionModal] = createSignal<'enable' | 'disable' | null>(null);
   const [resettingTier, setResettingTier] = createSignal<string | null>(null);
+  const [changingTier, setChangingTier] = createSignal<string | null>(null);
   const [resettingAll, setResettingAll] = createSignal(false);
   const [fallbackPickerTier, setFallbackPickerTier] = createSignal<string | null>(null);
   const [addingFallback, setAddingFallback] = createSignal<string | null>(null);
@@ -121,12 +125,15 @@ const Routing: Component = () => {
 
   const handleOverride = async (tierId: string, modelName: string) => {
     setDropdownTier(null);
+    setChangingTier(tierId);
     try {
-      await overrideTier(agentName(), tierId, modelName);
-      await refetchTiers();
+      const updated = await overrideTier(agentName(), tierId, modelName);
+      mutateTiers((prev) => prev?.map((t) => (t.tier === tierId ? updated : t)));
       toast.success('Routing updated');
     } catch {
       // error toast from fetchMutate
+    } finally {
+      setChangingTier(null);
     }
   };
 
@@ -134,7 +141,9 @@ const Routing: Component = () => {
     setResettingTier(tierId);
     try {
       await resetTier(agentName(), tierId);
-      await refetchTiers();
+      mutateTiers((prev) =>
+        prev?.map((t) => (t.tier === tierId ? { ...t, override_model: null } : t)),
+      );
       toast.success('Reset to auto');
     } catch {
       // error toast from fetchMutate
@@ -147,7 +156,7 @@ const Routing: Component = () => {
     setResettingAll(true);
     try {
       await resetAllTiers(agentName());
-      await refetchTiers();
+      mutateTiers((prev) => prev?.map((t) => ({ ...t, override_model: null })));
       toast.success('All tiers reset to auto');
     } catch {
       // error toast from fetchMutate
@@ -166,7 +175,9 @@ const Routing: Component = () => {
     setAddingFallback(tierId);
     try {
       await setFallbacks(agentName(), tierId, updated);
-      await refetchTiers();
+      mutateTiers((prev) =>
+        prev?.map((t) => (t.tier === tierId ? { ...t, fallback_models: updated } : t)),
+      );
       toast.success('Fallback added');
     } catch {
       setFallbackOverrides((prev) => {
@@ -402,8 +413,12 @@ const Routing: Component = () => {
                     <Show when={eff()}>
                       <div class="routing-card__right">
                         <div class="routing-card__actions">
-                          <button class="routing-action" onClick={() => setDropdownTier(stage.id)}>
-                            Change
+                          <button
+                            class="routing-action"
+                            onClick={() => setDropdownTier(stage.id)}
+                            disabled={changingTier() === stage.id}
+                          >
+                            {changingTier() === stage.id ? 'Changing...' : 'Change'}
                           </button>
                           <Show when={isManual()}>
                             <button
@@ -421,13 +436,19 @@ const Routing: Component = () => {
                           fallbacks={getFallbacksFor(stage.id)}
                           models={models() ?? []}
                           customProviders={customProviders() ?? []}
-                          onUpdate={() => {
+                          onUpdate={(updatedFallbacks) => {
                             setFallbackOverrides((prev) => {
                               const next = { ...prev };
                               delete next[stage.id];
                               return next;
                             });
-                            refetchTiers();
+                            mutateTiers((prev) =>
+                              prev?.map((t) =>
+                                t.tier === stage.id
+                                  ? { ...t, fallback_models: updatedFallbacks }
+                                  : t,
+                              ),
+                            );
                           }}
                           onAddFallback={() => setFallbackPickerTier(stage.id)}
                           adding={addingFallback() === stage.id}


### PR DESCRIPTION
## Summary
- **Fix missing canonical provider models in local mode**: The pricing sync now creates canonical model entries (e.g. `gemini-2.5-pro` / Google) when no seeded entry exists, instead of only creating OpenRouter-branded copies. This fixes local mode showing only OpenRouter models in the model prices page.
- **Optimize routing page updates**: Replace full tier list refetch (`refetchTiers()`) with local state mutations (`mutateTiers()`) on model change, reset, and fallback add/remove operations — eliminates the page scroll jump and unnecessary API call.
- **Add loading indicator on Change button**: Shows "Changing..." while the model override API call is in progress.
- **Add toast on fallback removal**: Shows "Fallback removed" success message when a fallback model is removed.

## Test plan
- [x] Backend unit tests pass (2137)
- [x] Backend e2e tests pass (105)
- [x] Frontend tests pass (1304)
- [x] TypeScript compilation clean (both packages)
- [ ] Open routing page in local mode → verify models from Google, Anthropic, OpenAI, etc. appear (not just OpenRouter)
- [ ] Change a tier model → verify "Changing..." appears, other tiers don't re-render
- [ ] Reset a tier → verify only that card updates
- [ ] Add/remove fallback → verify only that card updates, toast appears on remove

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing canonical provider models in local mode and makes the routing page update instantly with smoother UI feedback.

- **Bug Fixes**
  - Create canonical entries (e.g., `gemini-2.5-pro` with provider "Google") during pricing sync when no seeded entry exists, so local mode shows vendor models on the model prices page.

- **Refactors**
  - Replace tier refetches with `mutateTiers()` on model change/reset and fallback add/remove to prevent scroll jumps and extra API calls.
  - Show "Changing..." on the Change button while saving, and display a "Fallback removed" toast on removal.

<sup>Written for commit 45dd66778d17d3e48bffc6313346ae3558343cd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

