### PR TITLE
chore: drop 4 unused indexes on write-only OTLP tables

### DIFF
--- a/.changeset/drop-unused-indexes.md
+++ b/.changeset/drop-unused-indexes.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Drop 4 unused composite indexes on write-only OTLP ingestion tables (tool_executions, token_usage_snapshots, cost_snapshots, agent_logs) to reduce write amplification

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -48,6 +48,7 @@ import { AddDashboardIndexes1772905146384 } from './migrations/1772905146384-Add
 import { AddFallbacks1772905260464 } from './migrations/1772905260464-AddFallbacks';
 import { AddModelDisplayName1772920000000 } from './migrations/1772920000000-AddModelDisplayName';
 import { DropRedundantIndexes1772940000000 } from './migrations/1772940000000-DropRedundantIndexes';
+import { DropUnusedIndexes1772960000000 } from './migrations/1772960000000-DropUnusedIndexes';
 
 const entities = [
   AgentMessage,
@@ -100,6 +101,7 @@ const migrations = [
   AddFallbacks1772905260464,
   AddModelDisplayName1772920000000,
   DropRedundantIndexes1772940000000,
+  DropUnusedIndexes1772960000000,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';

--- a/packages/backend/src/database/migrations/1772960000000-DropUnusedIndexes.spec.ts
+++ b/packages/backend/src/database/migrations/1772960000000-DropUnusedIndexes.spec.ts
@@ -1,0 +1,76 @@
+import { QueryRunner } from 'typeorm';
+import { DropUnusedIndexes1772960000000 } from './1772960000000-DropUnusedIndexes';
+
+describe('DropUnusedIndexes1772960000000', () => {
+  let migration: DropUnusedIndexes1772960000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new DropUnusedIndexes1772960000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('should drop all 4 unused indexes', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(4);
+    });
+
+    it('should use DROP INDEX IF EXISTS', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      for (const call of queryRunner.query.mock.calls) {
+        expect(call[0]).toMatch(/^DROP INDEX IF EXISTS/);
+      }
+    });
+
+    it('should drop tool_executions composite index', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_4d007c4a559001d501d06fb6f4'),
+      );
+    });
+
+    it('should drop token_usage_snapshots composite index', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_3af795abffe699032a63ff5c22'),
+      );
+    });
+
+    it('should drop cost_snapshots composite index', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_cost_snapshots_tenant_agent_time'),
+      );
+    });
+
+    it('should drop agent_logs composite index', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_e9678de7cf6f122f3286bb4075'),
+      );
+    });
+  });
+
+  describe('down', () => {
+    it('should recreate all 4 indexes', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(4);
+    });
+
+    it('should use CREATE INDEX', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      for (const call of queryRunner.query.mock.calls) {
+        expect(call[0]).toMatch(/^CREATE INDEX/);
+      }
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1772960000000-DropUnusedIndexes.ts
+++ b/packages/backend/src/database/migrations/1772960000000-DropUnusedIndexes.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class DropUnusedIndexes1772960000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // tool_executions: write-only table, zero read queries
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_4d007c4a559001d501d06fb6f4"`);
+
+    // token_usage_snapshots: write-only table, zero read queries
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_3af795abffe699032a63ff5c22"`);
+
+    // cost_snapshots: write-only table, zero read queries
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_cost_snapshots_tenant_agent_time"`);
+
+    // agent_logs: write-only table, zero read queries
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_e9678de7cf6f122f3286bb4075"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4d007c4a559001d501d06fb6f4" ON "tool_executions" ("tenant_id", "agent_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_3af795abffe699032a63ff5c22" ON "token_usage_snapshots" ("tenant_id", "agent_id", "snapshot_time")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_cost_snapshots_tenant_agent_time" ON "cost_snapshots" ("tenant_id", "agent_id", "snapshot_time")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_e9678de7cf6f122f3286bb4075" ON "agent_logs" ("tenant_id", "agent_id", "timestamp")`,
+    );
+  }
+}

--- a/packages/backend/src/entities/agent-log.entity.ts
+++ b/packages/backend/src/entities/agent-log.entity.ts
@@ -1,8 +1,7 @@
-import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import { Entity, Column, PrimaryColumn } from 'typeorm';
 import { timestampType } from '../common/utils/sql-dialect';
 
 @Entity('agent_logs')
-@Index(['tenant_id', 'agent_id', 'timestamp'])
 export class AgentLog {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/backend/src/entities/cost-snapshot.entity.ts
+++ b/packages/backend/src/entities/cost-snapshot.entity.ts
@@ -1,8 +1,7 @@
-import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import { Entity, Column, PrimaryColumn } from 'typeorm';
 import { timestampType } from '../common/utils/sql-dialect';
 
 @Entity('cost_snapshots')
-@Index(['tenant_id', 'agent_id', 'snapshot_time'])
 export class CostSnapshot {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/backend/src/entities/token-usage-snapshot.entity.ts
+++ b/packages/backend/src/entities/token-usage-snapshot.entity.ts
@@ -1,8 +1,7 @@
-import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import { Entity, Column, PrimaryColumn } from 'typeorm';
 import { timestampType } from '../common/utils/sql-dialect';
 
 @Entity('token_usage_snapshots')
-@Index(['tenant_id', 'agent_id', 'snapshot_time'])
 export class TokenUsageSnapshot {
   @PrimaryColumn('varchar')
   id!: string;

--- a/packages/backend/src/entities/tool-execution.entity.ts
+++ b/packages/backend/src/entities/tool-execution.entity.ts
@@ -1,7 +1,6 @@
-import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import { Entity, Column, PrimaryColumn } from 'typeorm';
 
 @Entity('tool_executions')
-@Index(['tenant_id', 'agent_id'])
 export class ToolExecution {
   @PrimaryColumn('varchar')
   id!: string;


### PR DESCRIPTION
## Summary
- Drop 4 composite indexes on write-only OTLP ingestion tables (`tool_executions`, `token_usage_snapshots`, `cost_snapshots`, `agent_logs`) that had **0 index scans** in production
- Reduces write amplification on every OTLP insert — these tables are append-only and never queried by the removed index columns
- Reversible migration with `down()` that recreates all 4 indexes

## Test plan
- [x] Backend unit tests pass (2145/2145)
- [x] Backend e2e tests pass (105/105)
- [x] Frontend tests pass (1304/1304)
- [x] TypeScript compilation clean
- [x] Migration spec covers `up` and `down` paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop four unused composite indexes from write-only OTLP tables (`tool_executions`, `token_usage_snapshots`, `cost_snapshots`, `agent_logs`) to reduce write amplification on inserts. These indexes had 0 scans in production; the migration is reversible.

<sup>Written for commit e4f5b1056712906a5006fa49ace67bd471cdc07f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

