### PR TITLE
fix: backfill tenant_id on agent_messages for addTenantFilter

### DIFF
--- a/.changeset/backfill-tenant-id-migration.md
+++ b/.changeset/backfill-tenant-id-migration.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add migration to backfill tenant_id on agent_messages from tenants table

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -48,6 +48,7 @@ import { AddDashboardIndexes1772905146384 } from './migrations/1772905146384-Add
 import { AddFallbacks1772905260464 } from './migrations/1772905260464-AddFallbacks';
 import { AddModelDisplayName1772920000000 } from './migrations/1772920000000-AddModelDisplayName';
 import { DropRedundantIndexes1772940000000 } from './migrations/1772940000000-DropRedundantIndexes';
+import { BackfillTenantId1772948502780 } from './migrations/1772948502780-BackfillTenantId';
 
 const entities = [
   AgentMessage,
@@ -100,6 +101,7 @@ const migrations = [
   AddFallbacks1772905260464,
   AddModelDisplayName1772920000000,
   DropRedundantIndexes1772940000000,
+  BackfillTenantId1772948502780,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';

--- a/packages/backend/src/database/migrations/1772948502780-BackfillTenantId.spec.ts
+++ b/packages/backend/src/database/migrations/1772948502780-BackfillTenantId.spec.ts
@@ -1,0 +1,55 @@
+import { QueryRunner } from 'typeorm';
+import { BackfillTenantId1772948502780 } from './1772948502780-BackfillTenantId';
+
+describe('BackfillTenantId1772948502780', () => {
+  let migration: BackfillTenantId1772948502780;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new BackfillTenantId1772948502780();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('should run the backfill UPDATE', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('should join agent_messages to tenants via user_id = name', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain('agent_messages.user_id = t.name');
+    });
+
+    it('should only update rows where tenant_id IS NULL', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain('agent_messages.tenant_id IS NULL');
+    });
+
+    it('should skip rows where user_id IS NULL', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain('agent_messages.user_id IS NOT NULL');
+    });
+
+    it('should set tenant_id from tenants table', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain('SET tenant_id = t.id');
+      expect(sql).toContain('FROM tenants t');
+    });
+  });
+
+  describe('down', () => {
+    it('should be a no-op', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1772948502780-BackfillTenantId.ts
+++ b/packages/backend/src/database/migrations/1772948502780-BackfillTenantId.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BackfillTenantId1772948502780 implements MigrationInterface {
+  name = 'BackfillTenantId1772948502780';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE agent_messages
+      SET tenant_id = t.id
+      FROM tenants t
+      WHERE agent_messages.user_id = t.name
+        AND agent_messages.tenant_id IS NULL
+        AND agent_messages.user_id IS NOT NULL
+    `);
+  }
+
+  public async down(_queryRunner: QueryRunner): Promise<void> {
+    // no-op: cannot reliably determine which rows had NULL tenant_id before
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a migration (`BackfillTenantId1772948502780`) to backfill `tenant_id` on `agent_messages` rows where it is NULL
- Historical records ingested via `/api/v1/telemetry` only had `user_id` set — after deploying the `addTenantFilter` fix (single `WHERE tenant_id = :tenantId`), those records become invisible
- The migration joins `agent_messages.user_id` to `tenants.name` to populate `tenant_id`; idempotent via `IS NULL` guard
- Registered the migration in `database.module.ts` as the last entry

## Test plan
- [x] Migration unit tests: 6 tests covering SQL structure, join condition, NULL guards, and no-op down
- [x] Full backend unit tests pass (127 suites, 2143 tests)
- [x] Full E2E tests pass (16 suites, 105 tests)
- [ ] After deploy: verify `pg_stat_user_tables` for `agent_messages` — `seq_scan` counter should stop growing rapidly
- [ ] After deploy: `EXPLAIN ANALYZE` on an overview query should show index scans on `IDX_agent_messages_tenant_timestamp`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills `tenant_id` on historical `agent_messages` so tenant-scoped queries added by `addTenantFilter` include old telemetry and use indexes. Restores missing dashboard data and reduces full scans.

- **Bug Fixes**
  - Added migration `BackfillTenantId1772948502780` to set `tenant_id` by joining `agent_messages.user_id` to `tenants.name`, only where `tenant_id IS NULL` (no-op down).
  - Registered the migration after merging main, added unit tests for SQL shape/guards, and added a changeset to release a patch for `manifest`.

<sup>Written for commit 5b82fd56d498895b6ea6335d5d225a6270424d6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

