### PR TITLE
perf: speed up Overview and Messages pages

### DIFF
--- a/.changeset/speed-up-overview-messages.md
+++ b/.changeset/speed-up-overview-messages.md
@@ -1,0 +1,9 @@
+---
+"manifest": patch
+---
+
+Speed up Overview and Messages pages
+
+- Parallelize messages endpoint DB queries (count, data, models run concurrently via Promise.all)
+- Show stale data during SSE refetches instead of flashing skeleton loaders
+- Debounce cost filter inputs on Messages page (400ms) to prevent rapid-fire API calls

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -70,8 +70,6 @@ export class MessagesQueryService {
 
     // Count (without cursor)
     const countQb = baseQb.clone().select('COUNT(*)', 'total');
-    const countResult = await countQb.getRawOne();
-    const totalCount = Number(countResult?.total ?? 0);
 
     // Data (with cursor) — treat negative costs as NULL (invalid pricing)
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'), this.dialect);
@@ -116,12 +114,18 @@ export class MessagesQueryService {
       }
     }
 
-    const rows = await dataQb
-      .orderBy('at.timestamp', 'DESC')
-      .addOrderBy('at.id', 'DESC')
-      .limit(params.limit + 1)
-      .getRawMany();
+    // Run count, data, and models queries in parallel
+    const [countResult, rows, models] = await Promise.all([
+      countQb.getRawOne(),
+      dataQb
+        .orderBy('at.timestamp', 'DESC')
+        .addOrderBy('at.id', 'DESC')
+        .limit(params.limit + 1)
+        .getRawMany(),
+      this.getDistinctModels(params.userId, params.range, tenantId),
+    ]);
 
+    const totalCount = Number(countResult?.total ?? 0);
     const hasMore = rows.length > params.limit;
     const items = rows.slice(0, params.limit);
     const lastItem = items[items.length - 1] as Record<string, unknown> | undefined;
@@ -129,9 +133,6 @@ export class MessagesQueryService {
     const tsStr = ts instanceof Date ? formatTimestamp(ts) : String(ts ?? '');
     const lastId = lastItem?.['id'];
     const nextCursor = hasMore && lastItem ? `${tsStr}|${String(lastId)}` : null;
-
-    // Distinct models (cached)
-    const models = await this.getDistinctModels(params.userId, params.range, tenantId);
 
     return {
       items,

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -3,6 +3,7 @@ import {
   createResource,
   createEffect,
   on,
+  onCleanup,
   Show,
   For,
   type Component,
@@ -90,6 +91,21 @@ const MessageLog: Component = () => {
   };
 
   const pager = createCursorPagination(50);
+
+  let costMinTimer: ReturnType<typeof setTimeout>;
+  let costMaxTimer: ReturnType<typeof setTimeout>;
+  onCleanup(() => {
+    clearTimeout(costMinTimer);
+    clearTimeout(costMaxTimer);
+  });
+  const debouncedSetCostMin = (val: string) => {
+    clearTimeout(costMinTimer);
+    costMinTimer = setTimeout(() => setCostMin(val), 400);
+  };
+  const debouncedSetCostMax = (val: string) => {
+    clearTimeout(costMaxTimer);
+    costMaxTimer = setTimeout(() => setCostMax(val), 400);
+  };
 
   createEffect(
     on([statusFilter, modelFilter, costMin, costMax], () => pager.resetPage(), { defer: true }),
@@ -204,7 +220,7 @@ const MessageLog: Component = () => {
                 min="0"
                 step="0.01"
                 value={costMin()}
-                onInput={(e) => setCostMin(e.currentTarget.value)}
+                onInput={(e) => debouncedSetCostMin(e.currentTarget.value)}
               />
               <span class="cost-range-filter__sep">&ndash;</span>
               <input
@@ -214,7 +230,7 @@ const MessageLog: Component = () => {
                 min="0"
                 step="0.01"
                 value={costMax()}
-                onInput={(e) => setCostMax(e.currentTarget.value)}
+                onInput={(e) => debouncedSetCostMax(e.currentTarget.value)}
               />
             </div>
           </Show>
@@ -233,7 +249,7 @@ const MessageLog: Component = () => {
       </div>
 
       <Show
-        when={!data.loading}
+        when={data() !== undefined || !data.loading}
         fallback={
           <div class="panel">
             <div

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -196,7 +196,7 @@ const Overview: Component = () => {
       </div>
 
       <Show
-        when={!data.loading}
+        when={data() !== undefined || !data.loading}
         fallback={
           <>
             <div class="chart-card" style="min-height: 360px;">

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -207,6 +207,64 @@ describe("MessageLog", () => {
     });
   });
 
+  it("debounces cost filter inputs", async () => {
+    vi.useFakeTimers();
+    mockGetMessages.mockResolvedValue(messagesData);
+    const { container } = render(() => <MessageLog />);
+    await vi.advanceTimersByTimeAsync(100);
+
+    const inputs = container.querySelectorAll(".cost-range-filter__input");
+    expect(inputs.length).toBe(2);
+
+    mockGetMessages.mockClear();
+
+    // Rapid typing should not fire immediately
+    fireEvent.input(inputs[0], { target: { value: "1" } });
+    fireEvent.input(inputs[0], { target: { value: "1.5" } });
+    expect(mockGetMessages).not.toHaveBeenCalled();
+
+    // After debounce window, the API call fires
+    await vi.advanceTimersByTimeAsync(500);
+    expect(mockGetMessages).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("debounces cost max filter inputs", async () => {
+    vi.useFakeTimers();
+    mockGetMessages.mockResolvedValue(messagesData);
+    const { container } = render(() => <MessageLog />);
+    await vi.advanceTimersByTimeAsync(100);
+
+    const inputs = container.querySelectorAll(".cost-range-filter__input");
+    mockGetMessages.mockClear();
+
+    fireEvent.input(inputs[1], { target: { value: "10" } });
+    expect(mockGetMessages).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(mockGetMessages).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("keeps showing stale data during refetch instead of skeletons", async () => {
+    mockGetMessages.mockResolvedValue(messagesData);
+    const { container } = render(() => <MessageLog />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("msg-1234");
+    });
+
+    // Trigger a refetch that never resolves
+    mockGetMessages.mockReturnValue(new Promise(() => {}));
+    const selects = container.querySelectorAll('[data-testid="select"]');
+    await fireEvent.change(selects[0], { target: { value: "ok" } });
+
+    // Should still show old data, not skeletons
+    expect(container.textContent).toContain("msg-1234");
+    expect(container.querySelectorAll(".skeleton").length).toBe(0);
+  });
+
   it("shows cost range filter inputs", async () => {
     mockGetMessages.mockResolvedValue(messagesData);
     const { container } = render(() => <MessageLog />);

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -127,6 +127,23 @@ describe("Overview", () => {
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
+  it("keeps showing stale data during refetch instead of skeletons", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <Overview />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("$3.50");
+    });
+
+    // Trigger a refetch that never resolves
+    mockGetOverview.mockReturnValue(new Promise(() => {}));
+    const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
+    await fireEvent.change(select, { target: { value: "24h" } });
+
+    // Should still show old data, not skeletons
+    expect(container.textContent).toContain("$3.50");
+    expect(container.querySelectorAll(".skeleton").length).toBe(0);
+  });
+
   it("shows summary stats after data loads", async () => {
     mockGetOverview.mockResolvedValue(overviewData);
     const { container } = render(() => <Overview />);


### PR DESCRIPTION
## Summary

- Parallelize messages endpoint DB queries (count, data, models run concurrently via `Promise.all`) — response time is now the slowest query, not the sum of all three
- Show stale data during SSE-triggered refetches instead of flashing skeleton loaders on Overview and Messages pages
- Debounce cost filter inputs on Messages page (400ms) to prevent rapid-fire API calls while typing

## Test plan

- [ ] Open Messages page, type in cost filter — verify no rapid-fire network requests (only fires after 400ms pause)
- [ ] Open Overview or Messages, wait for SSE ping — verify page doesn't flash skeleton loaders
- [ ] Verify messages endpoint still returns correct data with all filter combinations
- [ ] All backend unit + e2e tests pass
- [ ] All frontend tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the Overview and Messages pages by parallelizing DB work and smoothing refetch UX. Also debounces cost filters to cut needless API calls.

- **Performance**
  - Parallelize messages endpoint queries (count, data, models) via `Promise.all` so latency is the slowest query, not the sum.
  - Keep showing stale data during SSE refetch on Overview and Messages to prevent skeleton flicker.
  - Debounce cost min/max inputs by 400ms on Messages to avoid rapid requests while typing.

<sup>Written for commit a1dd405d369af923296adc7eeea75322ece483ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

