### PR TITLE
fix: capture real token usage from proxy responses

### DIFF
--- a/.changeset/fix-proxy-token-capture.md
+++ b/.changeset/fix-proxy-token-capture.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix token values showing as 0 for OTLP-ingested messages by capturing usage directly from proxy responses

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -1272,9 +1272,9 @@ describe('TraceIngestService', () => {
 
     await service.ingest(request, testCtx);
     // trace_id-based dedup is skipped; remapFallbackSpans calls find() for unfilled
-    // fallback, then buildAgentMessage calls find() for recent errors + ghost dedup
+    // fallback, then buildAgentMessage calls find() for recent errors + proxy dedup + ghost dedup
     expect(mockTurnFindOne).not.toHaveBeenCalled();
-    expect(mockTurnFind).toHaveBeenCalledTimes(3);
+    expect(mockTurnFind).toHaveBeenCalledTimes(4);
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
   });
 
@@ -1788,6 +1788,7 @@ describe('TraceIngestService', () => {
     mockTurnFind
       .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
       .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([]) // proxyDedup (no proxy-recorded messages)
       .mockResolvedValueOnce([
         {
           id: 'session-data',
@@ -1815,10 +1816,12 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    // Verify the third find() call includes session_key in where clause
-    // (first is unfilled fallback, second is recentErrors, third is ghost dedup)
-    const thirdFindCall = mockTurnFind.mock.calls[2];
-    expect(thirdFindCall[0].where).toEqual(expect.objectContaining({ session_key: 'session-abc' }));
+    // Verify the fourth find() call includes session_key in where clause
+    // (first is unfilled fallback, second is recentErrors, third is proxyDedup, fourth is ghost dedup)
+    const fourthFindCall = mockTurnFind.mock.calls[3];
+    expect(fourthFindCall[0].where).toEqual(
+      expect.objectContaining({ session_key: 'session-abc' }),
+    );
     expect(mockTurnInsert).not.toHaveBeenCalled();
   });
 
@@ -1870,6 +1873,7 @@ describe('TraceIngestService', () => {
     mockTurnFind
       .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
       .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([]) // proxyDedup (no proxy-recorded messages)
       .mockResolvedValueOnce([]); // recentMessages (DB ghost fallback)
 
     const emptySpan = makeSpan({
@@ -1889,7 +1893,7 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnFind).toHaveBeenCalledTimes(3);
+    expect(mockTurnFind).toHaveBeenCalledTimes(4);
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
   });
 
@@ -1960,5 +1964,87 @@ describe('TraceIngestService', () => {
         cache_creation_tokens: 0,
       }),
     ]);
+  });
+
+  it('skips 0-token OTLP span when proxy already recorded message with tokens (proxy dedup)', async () => {
+    const spanTime = new Date(Number(BigInt('1708000000000000000') / 1_000_000n));
+    const nearbyTs = new Date(spanTime.getTime() + 2000).toISOString();
+
+    mockTurnFind
+      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
+      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([{ id: 'proxy-msg', timestamp: nearbyTs, input_tokens: 500 }]); // proxyDedup — proxy recorded a message with real tokens
+
+    const span = makeSpan({
+      spanId: 'span-proxy-dedup',
+      name: 'openclaw.agent.turn',
+      attributes: [{ key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } }],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).not.toHaveBeenCalled();
+  });
+
+  it('allows 0-token OTLP span when no proxy message exists nearby', async () => {
+    mockTurnFind
+      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
+      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([]); // proxyDedup — no proxy data
+
+    const span = makeSpan({
+      spanId: 'span-no-proxy',
+      name: 'openclaw.agent.turn',
+      attributes: [{ key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } }],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run proxy dedup on spans with tokens', async () => {
+    const span = makeSpan({
+      spanId: 'span-with-tokens',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
+    // Proxy dedup should NOT run (span has tokens), so find() calls are fewer
+    // findUnfilledFallback + recentErrors = 2 (no proxy dedup, no ghost dedup since has model+tokens)
+    expect(mockTurnFind).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -1995,6 +1995,36 @@ describe('TraceIngestService', () => {
     expect(mockTurnInsert).not.toHaveBeenCalled();
   });
 
+  it('ignores proxy messages with null input_tokens during dedup check', async () => {
+    const spanTime = new Date(Number(BigInt('1708000000000000000') / 1_000_000n));
+    const nearbyTs = new Date(spanTime.getTime() + 2000).toISOString();
+
+    mockTurnFind
+      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
+      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([{ id: 'null-tokens-msg', timestamp: nearbyTs, input_tokens: null }]); // proxyDedup — nearby message but with null tokens (doesn't count)
+
+    const span = makeSpan({
+      spanId: 'span-null-tokens',
+      name: 'openclaw.agent.turn',
+      attributes: [{ key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } }],
+      status: { code: 1 },
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    // null input_tokens treated as 0, so proxy dedup does NOT suppress this span
+    expect(mockTurnInsert).toHaveBeenCalledTimes(1);
+  });
+
   it('allows 0-token OTLP span when no proxy message exists nearby', async () => {
     mockTurnFind
       .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)

--- a/packages/backend/src/otlp/services/trace-ingest.service.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.ts
@@ -408,6 +408,24 @@ export class TraceIngestService {
     });
     if (hasNearbyError) return null;
 
+    // Proxy dedup: if this span carries 0 tokens, check if the proxy already
+    // recorded a success message with real tokens for the same agent within 60s.
+    const spanInputTokens = attrNumber(attrs, 'gen_ai.usage.input_tokens') ?? 0;
+    const spanOutputTokens = attrNumber(attrs, 'gen_ai.usage.output_tokens') ?? 0;
+    if (spanInputTokens === 0 && spanOutputTokens === 0) {
+      const recentOkMessages = await this.turnRepo.find({
+        where: { tenant_id: ctx.tenantId, agent_id: ctx.agentId, status: 'ok' },
+        select: ['id', 'timestamp', 'input_tokens'],
+        order: { timestamp: 'DESC' },
+        take: 3,
+      });
+      const hasProxyData = recentOkMessages.some((m) => {
+        const mTime = new Date(m.timestamp).getTime();
+        return Math.abs(mTime - spanTime) <= 60_000 && (m.input_tokens ?? 0) > 0;
+      });
+      if (hasProxyData) return null;
+    }
+
     // DB-level ghost dedup: if this span is empty-ok, check if a data-bearing
     // message for the same agent already exists within 60s (cross-batch case).
     // Scope by session_key when available to avoid cross-session false positives.

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -554,5 +554,33 @@ describe('Google Adapter', () => {
       const chunk = JSON.stringify({ candidates: [] });
       expect(transformGoogleStreamChunk(chunk, 'gemini-2.0-flash')).toBeNull();
     });
+
+    it('defaults missing token counts to 0 in usage', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [] }, finishReason: 'STOP' }],
+        usageMetadata: {},
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      expect(result).toContain('"prompt_tokens":0');
+      expect(result).toContain('"completion_tokens":0');
+      expect(result).toContain('"total_tokens":0');
+    });
+
+    it('handles parts without text property', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [{ functionCall: { name: 'fn', args: {} } }] } }],
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      expect(result).toBeNull(); // no text + no usage = null
+    });
+
+    it('emits usage when candidates field is missing', () => {
+      const chunk = JSON.stringify({
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      expect(result).toContain('"prompt_tokens":10');
+      expect(result).toContain('"finish_reason":"stop"');
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -526,5 +526,33 @@ describe('Google Adapter', () => {
       const chunk = JSON.stringify({ candidates: [{ content: { parts: [] } }] });
       expect(transformGoogleStreamChunk(chunk, 'gemini-2.0-flash')).toBeNull();
     });
+
+    it('emits usage event when usageMetadata is present', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [{ text: 'done' }] }, finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 50, totalTokenCount: 150 },
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      expect(result).toContain('"content":"done"');
+      expect(result).toContain('"prompt_tokens":100');
+      expect(result).toContain('"completion_tokens":50');
+      expect(result).toContain('"finish_reason":"stop"');
+    });
+
+    it('emits usage-only event when no text but usageMetadata exists', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [] }, finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 200, candidatesTokenCount: 80, totalTokenCount: 280 },
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      expect(result).not.toBeNull();
+      expect(result).toContain('"prompt_tokens":200');
+      expect(result).toContain('"completion_tokens":80');
+    });
+
+    it('returns null when no candidates and no usageMetadata', () => {
+      const chunk = JSON.stringify({ candidates: [] });
+      expect(transformGoogleStreamChunk(chunk, 'gemini-2.0-flash')).toBeNull();
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -249,6 +249,69 @@ describe('ProxyController', () => {
     );
   });
 
+  it('should skip recording when response has zero tokens', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // recordSuccessMessage returns early when both tokens are 0
+    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it('should default completion_tokens to 0 when missing from response', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 500 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ input_tokens: 500, output_tokens: 0 }),
+    );
+  });
+
   it('should not record success message when response has no usage', async () => {
     const responseBody = { choices: [{ message: { content: 'hello' } }] };
     const mockProviderResp = new Response(JSON.stringify(responseBody), {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -76,6 +76,7 @@ describe('ProxyController', () => {
     convertAnthropicStreamChunk: jest.Mock;
   };
   let mockMessageRepo: { insert: jest.Mock };
+  let mockPricingCache: { getByModel: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -93,11 +94,13 @@ describe('ProxyController', () => {
       convertAnthropicStreamChunk: jest.fn(),
     };
     mockMessageRepo = { insert: jest.fn().mockResolvedValue({}) };
+    mockPricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
     controller = new ProxyController(
       proxyService as never,
       rateLimiter as never,
       providerClient as never,
       mockMessageRepo as never,
+      mockPricingCache as never,
     );
   });
 
@@ -205,6 +208,185 @@ describe('ProxyController', () => {
       'claude-sonnet-4-20250514',
     );
     expect(res.json).toHaveBeenCalledWith(convertedBody);
+  });
+
+  it('should record success message with usage from non-streaming response', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 500, completion_tokens: 200, cache_read_tokens: 100 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'ok',
+        model: 'gpt-4o',
+        routing_tier: 'simple',
+        input_tokens: 500,
+        output_tokens: 200,
+        cache_read_tokens: 100,
+      }),
+    );
+  });
+
+  it('should not record success message when response has no usage', async () => {
+    const responseBody = { choices: [{ message: { content: 'hello' } }] };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it('should not record success message for fallback responses', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 500, completion_tokens: 200 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+        fallbackFromModel: 'claude-sonnet-4-20250514',
+        fallbackIndex: 0,
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Only the fallback chain messages should be recorded, not a duplicate success
+    const insertCalls = mockMessageRepo.insert.mock.calls;
+    const hasSuccessWithTokens = insertCalls.some(
+      (call: unknown[]) =>
+        (call[0] as Record<string, unknown>).status === 'ok' &&
+        (call[0] as Record<string, unknown>).input_tokens === 500,
+    );
+    expect(hasSuccessWithTokens).toBe(false);
+  });
+
+  it('should compute cost when pricing is available', async () => {
+    mockPricingCache.getByModel.mockReturnValue({
+      input_price_per_token: 0.000003,
+      output_price_per_token: 0.000015,
+    });
+
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 1000, completion_tokens: 500 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input_tokens: 1000,
+        output_tokens: 500,
+        cost_usd: 1000 * 0.000003 + 500 * 0.000015,
+      }),
+    );
+  });
+
+  it('should warn when recordSuccessMessage fails', async () => {
+    mockMessageRepo.insert.mockRejectedValue(new Error('DB write failed'));
+
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 100, completion_tokens: 50 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The catch handler should log a warning, not throw
+    expect(res.status).toHaveBeenCalledWith(200);
   });
 
   it('should forward provider error status and body', async () => {
@@ -1429,6 +1611,7 @@ describe('ProxyController', () => {
         rateLimiter as never,
         providerClient as never,
         mockMessageRepo as never,
+        mockPricingCache as never,
       );
 
       const cooldownMap = (timedController as any).rateLimitCooldown as Map<string, number>;
@@ -1450,6 +1633,7 @@ describe('ProxyController', () => {
         rateLimiter as never,
         providerClient as never,
         mockMessageRepo as never,
+        mockPricingCache as never,
       );
 
       timedController.onModuleDestroy();

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -452,6 +452,40 @@ describe('pipeStream', () => {
 
     expect(usage).toBeNull();
   });
+
+  it('should capture usage from passthrough stream with missing completion_tokens', async () => {
+    const { res } = mockResponse();
+    const usageChunk = `data: ${JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 300 },
+    })}\n\n`;
+    const stream = createReadableStream([usageChunk, 'data: [DONE]\n\n']);
+
+    const usage = await pipeStream(stream, res as never);
+
+    expect(usage).toEqual({
+      prompt_tokens: 300,
+      completion_tokens: 0,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: undefined,
+    });
+  });
+
+  it('should capture usage from leftover buffer in flush section with transform', async () => {
+    const { res } = mockResponse();
+    const usagePayload = JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 50, completion_tokens: 25 },
+    });
+    // Send a chunk that ends mid-event so it stays in the buffer until flush
+    const stream = createReadableStream([`data: ${usagePayload}`]);
+    const transform = (chunk: string) =>
+      `data: ${JSON.stringify({ choices: [], usage: JSON.parse(chunk).usage })}\n\n`;
+
+    const usage = await pipeStream(stream, res as never, transform);
+
+    expect(usage).toEqual(expect.objectContaining({ prompt_tokens: 50, completion_tokens: 25 }));
+  });
 });
 
 describe('extractUsageFromSse', () => {
@@ -484,5 +518,19 @@ describe('extractUsageFromSse', () => {
 
   it('should handle invalid JSON gracefully', () => {
     expect(extractUsageFromSse('data: {invalid json')).toBeNull();
+  });
+
+  it('should default completion_tokens to 0 when missing', () => {
+    const sseText = `data: ${JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 100 },
+    })}\n\n`;
+
+    expect(extractUsageFromSse(sseText)).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 0,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: undefined,
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -1,4 +1,4 @@
-import { initSseHeaders, parseSseEvents, pipeStream } from '../stream-writer';
+import { initSseHeaders, parseSseEvents, pipeStream, extractUsageFromSse } from '../stream-writer';
 
 function mockResponse(): {
   res: Record<string, jest.Mock | boolean>;
@@ -401,5 +401,88 @@ describe('pipeStream', () => {
     // The event should be reassembled and transformed
     expect(written).toContain('out:{"part":"complete"}\n\n');
     expect(written).toContain('data: [DONE]\n\n');
+  });
+
+  it('should capture usage from transformed stream output', async () => {
+    const { res } = mockResponse();
+    const usageChunk = JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 100, completion_tokens: 50, cache_read_tokens: 20 },
+    });
+    const stream = createReadableStream([`data: ${usageChunk}\n\n`]);
+    const transform = (chunk: string) => `data: ${chunk}\n\n`;
+
+    const usage = await pipeStream(stream, res as never, transform);
+
+    expect(usage).toEqual({
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      cache_read_tokens: 20,
+      cache_creation_tokens: undefined,
+    });
+  });
+
+  it('should capture usage from passthrough stream', async () => {
+    const { res } = mockResponse();
+    const contentChunk = `data: ${JSON.stringify({ choices: [{ delta: { content: 'hi' } }] })}\n\n`;
+    const usageChunk = `data: ${JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 200, completion_tokens: 80, cache_creation_tokens: 10 },
+    })}\n\n`;
+    const stream = createReadableStream([contentChunk, usageChunk, 'data: [DONE]\n\n']);
+
+    const usage = await pipeStream(stream, res as never);
+
+    expect(usage).toEqual({
+      prompt_tokens: 200,
+      completion_tokens: 80,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: 10,
+    });
+  });
+
+  it('should return null usage when stream has no usage data', async () => {
+    const { res } = mockResponse();
+    const stream = createReadableStream([
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'text' } }] })}\n\n`,
+      'data: [DONE]\n\n',
+    ]);
+
+    const usage = await pipeStream(stream, res as never);
+
+    expect(usage).toBeNull();
+  });
+});
+
+describe('extractUsageFromSse', () => {
+  it('should extract usage from SSE text with data prefix', () => {
+    const sseText = `data: ${JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 150, completion_tokens: 60 },
+    })}\n\n`;
+
+    expect(extractUsageFromSse(sseText)).toEqual({
+      prompt_tokens: 150,
+      completion_tokens: 60,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: undefined,
+    });
+  });
+
+  it('should return null for SSE text without usage', () => {
+    const sseText = `data: ${JSON.stringify({ choices: [{ delta: { content: 'hi' } }] })}\n\n`;
+    expect(extractUsageFromSse(sseText)).toBeNull();
+  });
+
+  it('should return null for [DONE] event', () => {
+    expect(extractUsageFromSse('data: [DONE]\n\n')).toBeNull();
+  });
+
+  it('should return null for non-data lines', () => {
+    expect(extractUsageFromSse('event: message\nid: 123')).toBeNull();
+  });
+
+  it('should handle invalid JSON gracefully', () => {
+    expect(extractUsageFromSse('data: {invalid json')).toBeNull();
   });
 });

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -227,21 +227,48 @@ export function transformGoogleStreamChunk(chunk: string, model: string): string
 
   const candidates = (data.candidates as Array<Record<string, unknown>>) || [];
   const candidate = candidates[0];
-  if (!candidate) return null;
-
-  const content = candidate.content as { parts?: Array<Record<string, unknown>> } | undefined;
+  const content = candidate?.content as { parts?: Array<Record<string, unknown>> } | undefined;
   const parts = content?.parts || [];
   const text = parts.map((p) => p.text || '').join('');
 
-  if (!text) return null;
+  let result = '';
 
-  const sseData = {
-    id: `chatcmpl-${randomUUID()}`,
-    object: 'chat.completion.chunk',
-    created: Math.floor(Date.now() / 1000),
-    model,
-    choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
-  };
+  if (text) {
+    result += `data: ${JSON.stringify({
+      id: `chatcmpl-${randomUUID()}`,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model,
+      choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+    })}\n\n`;
+  }
 
-  return `data: ${JSON.stringify(sseData)}\n\n`;
+  const usage = data.usageMetadata as Record<string, number> | undefined;
+  if (usage) {
+    const finishReason = mapFinishReason(candidate ?? {});
+    result += `data: ${JSON.stringify({
+      id: `chatcmpl-${randomUUID()}`,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: finishReason }],
+    })}\n\n`;
+    result += `data: ${JSON.stringify({
+      id: `chatcmpl-${randomUUID()}`,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model,
+      choices: [],
+      usage: {
+        prompt_tokens: usage.promptTokenCount ?? 0,
+        completion_tokens: usage.candidatesTokenCount ?? 0,
+        total_tokens: usage.totalTokenCount ?? 0,
+        prompt_tokens_details: { cached_tokens: usage.cachedContentTokenCount ?? 0 },
+        cache_read_tokens: usage.cachedContentTokenCount ?? 0,
+        cache_creation_tokens: 0,
+      },
+    })}\n\n`;
+  }
+
+  return result || null;
 }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -17,10 +17,11 @@ import { Public } from '../../common/decorators/public.decorator';
 import { OtlpAuthGuard } from '../../otlp/guards/otlp-auth.guard';
 import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interface';
 import { AgentMessage } from '../../entities/agent-message.entity';
+import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ProxyService, FailedFallback } from './proxy.service';
 import { ProxyRateLimiter } from './proxy-rate-limiter';
 import { ProviderClient } from './provider-client';
-import { initSseHeaders, pipeStream } from './stream-writer';
+import { initSseHeaders, pipeStream, StreamUsage } from './stream-writer';
 import { trackCloudEvent } from '../../common/utils/product-telemetry';
 
 const MAX_SEEN_USERS = 10_000;
@@ -43,6 +44,7 @@ export class ProxyController implements OnModuleDestroy {
     private readonly providerClient: ProviderClient,
     @InjectRepository(AgentMessage)
     private readonly messageRepo: Repository<AgentMessage>,
+    private readonly pricingCache: ModelPricingCacheService,
   ) {
     this.cooldownCleanupTimer = setInterval(() => this.evictExpiredCooldowns(), 60_000);
     if (typeof this.cooldownCleanupTimer === 'object' && 'unref' in this.cooldownCleanupTimer) {
@@ -184,22 +186,24 @@ export class ProxyController implements OnModuleDestroy {
         ).catch((e) => this.logger.warn(`Failed to record fallback success: ${e}`));
       }
 
+      let streamUsage: StreamUsage | null = null;
+
       if (isStream && providerResponse.body) {
         initSseHeaders(res, metaHeaders);
         headersSent = true;
 
         if (forward.isGoogle) {
-          await pipeStream(providerResponse.body, res, (chunk) =>
+          streamUsage = await pipeStream(providerResponse.body, res, (chunk) =>
             this.providerClient.convertGoogleStreamChunk(chunk, meta.model),
           );
         } else if (forward.isAnthropic) {
-          await pipeStream(
+          streamUsage = await pipeStream(
             providerResponse.body,
             res,
             this.providerClient.createAnthropicStreamTransformer(meta.model),
           );
         } else {
-          await pipeStream(providerResponse.body, res);
+          streamUsage = await pipeStream(providerResponse.body, res);
         }
       } else {
         let responseBody: unknown;
@@ -214,9 +218,34 @@ export class ProxyController implements OnModuleDestroy {
           responseBody = await providerResponse.json();
         }
 
+        // Extract usage from the OpenAI-format response body
+        const body = responseBody as Record<string, unknown> | undefined;
+        const usage = body?.usage as Record<string, number> | undefined;
+        if (usage && typeof usage.prompt_tokens === 'number') {
+          streamUsage = {
+            prompt_tokens: usage.prompt_tokens,
+            completion_tokens: usage.completion_tokens ?? 0,
+            cache_read_tokens: usage.cache_read_tokens,
+            cache_creation_tokens: usage.cache_creation_tokens,
+          };
+        }
+
         res.status(200);
         for (const [k, v] of Object.entries(metaHeaders)) res.setHeader(k, v);
         res.json(responseBody);
+      }
+
+      // Record successful message with real token data (non-fallback only).
+      // For fallback successes, recordFallbackSuccess already creates the record.
+      if (!meta.fallbackFromModel && streamUsage) {
+        this.recordSuccessMessage(
+          req.ingestionContext,
+          meta.model,
+          meta.tier,
+          meta.reason,
+          streamUsage,
+          traceId,
+        ).catch((e) => this.logger.warn(`Failed to record success message: ${e}`));
       }
     } catch (err: unknown) {
       if (clientAbort.signal.aborted) {
@@ -390,6 +419,45 @@ export class ProxyController implements OnModuleDestroy {
       cache_creation_tokens: 0,
       fallback_from_model: fallbackFromModel ?? null,
       fallback_index: fallbackIndex ?? null,
+    });
+  }
+
+  private async recordSuccessMessage(
+    ctx: IngestionContext,
+    model: string,
+    tier: string,
+    reason: string,
+    usage: StreamUsage,
+    traceId?: string,
+  ): Promise<void> {
+    if (usage.prompt_tokens === 0 && usage.completion_tokens === 0) return;
+
+    let costUsd: number | null = null;
+    const pricing = this.pricingCache.getByModel(model);
+    if (pricing?.input_price_per_token != null && pricing?.output_price_per_token != null) {
+      costUsd =
+        usage.prompt_tokens * Number(pricing.input_price_per_token) +
+        usage.completion_tokens * Number(pricing.output_price_per_token);
+    }
+
+    await this.messageRepo.insert({
+      id: uuid(),
+      tenant_id: ctx.tenantId,
+      agent_id: ctx.agentId,
+      trace_id: traceId ?? null,
+      timestamp: new Date().toISOString(),
+      status: 'ok',
+      agent_name: ctx.agentName,
+      model,
+      routing_tier: tier,
+      routing_reason: reason,
+      input_tokens: usage.prompt_tokens,
+      output_tokens: usage.completion_tokens,
+      cache_read_tokens: usage.cache_read_tokens ?? 0,
+      cache_creation_tokens: usage.cache_creation_tokens ?? 0,
+      cost_usd: costUsd,
+      fallback_from_model: null,
+      fallback_index: null,
     });
   }
 

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -1,5 +1,36 @@
 import { Response as ExpressResponse } from 'express';
 
+export interface StreamUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  cache_read_tokens?: number;
+  cache_creation_tokens?: number;
+}
+
+/** Extract usage data from an SSE-formatted text chunk (e.g. `data: {...}\n\n`). */
+export function extractUsageFromSse(sseText: string): StreamUsage | null {
+  for (const line of sseText.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('data:')) continue;
+    const json = trimmed.slice(5).trim();
+    if (json === '[DONE]') continue;
+    try {
+      const obj = JSON.parse(json);
+      if (obj.usage && typeof obj.usage.prompt_tokens === 'number') {
+        return {
+          prompt_tokens: obj.usage.prompt_tokens,
+          completion_tokens: obj.usage.completion_tokens ?? 0,
+          cache_read_tokens: obj.usage.cache_read_tokens,
+          cache_creation_tokens: obj.usage.cache_creation_tokens,
+        };
+      }
+    } catch {
+      /* ignore parse errors */
+    }
+  }
+  return null;
+}
+
 export function initSseHeaders(
   res: ExpressResponse,
   extraHeaders: Record<string, string> = {},
@@ -52,10 +83,12 @@ export async function pipeStream(
   source: ReadableStream<Uint8Array>,
   dest: ExpressResponse,
   transform?: (chunk: string) => string | null,
-): Promise<void> {
+): Promise<StreamUsage | null> {
   const reader = source.getReader();
   const decoder = new TextDecoder();
   let sseBuffer = '';
+  let passthroughBuffer = '';
+  let capturedUsage: StreamUsage | null = null;
 
   try {
     let done = false;
@@ -78,10 +111,32 @@ export async function pipeStream(
 
           for (const event of events) {
             const transformed = transform(event);
-            if (transformed) dest.write(transformed);
+            if (transformed) {
+              dest.write(transformed);
+              const usage = extractUsageFromSse(transformed);
+              if (usage) capturedUsage = usage;
+            }
           }
         } else {
           dest.write(text);
+          passthroughBuffer += text;
+          const { events: ptEvents, remaining } = parseSseEvents(passthroughBuffer);
+          passthroughBuffer = remaining;
+          for (const ev of ptEvents) {
+            try {
+              const obj = JSON.parse(ev);
+              if (obj.usage && typeof obj.usage.prompt_tokens === 'number') {
+                capturedUsage = {
+                  prompt_tokens: obj.usage.prompt_tokens,
+                  completion_tokens: obj.usage.completion_tokens ?? 0,
+                  cache_read_tokens: obj.usage.cache_read_tokens,
+                  cache_creation_tokens: obj.usage.cache_creation_tokens,
+                };
+              }
+            } catch {
+              /* ignore non-JSON events */
+            }
+          }
         }
       }
     }
@@ -95,7 +150,11 @@ export async function pipeStream(
         .trim();
       if (payload && payload !== '[DONE]') {
         const transformed = transform(payload);
-        if (transformed) dest.write(transformed);
+        if (transformed) {
+          dest.write(transformed);
+          const usage = extractUsageFromSse(transformed);
+          if (usage) capturedUsage = usage;
+        }
       }
     }
 
@@ -109,4 +168,6 @@ export async function pipeStream(
     reader.releaseLock();
     if (!dest.writableEnded) dest.end();
   }
+
+  return capturedUsage;
 }

--- a/packages/backend/test/otlp-roundtrip.e2e-spec.ts
+++ b/packages/backend/test/otlp-roundtrip.e2e-spec.ts
@@ -136,6 +136,24 @@ describe('OTLP ingest-then-query round-trip', () => {
     expect(after.body.total_count).toBe(baselineCount + 1);
   });
 
+  it('messages endpoint returns token values from OTLP traces', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    // Find any message with non-zero tokens (from makeTracePayload or ghost-test)
+    const withTokens = res.body.items.find(
+      (m: Record<string, unknown>) => Number(m.total_tokens) > 0,
+    );
+    expect(withTokens).toBeDefined();
+    expect(Number(withTokens.input_tokens)).toBeGreaterThan(0);
+    expect(Number(withTokens.output_tokens)).toBeGreaterThan(0);
+    expect(Number(withTokens.total_tokens)).toBe(
+      Number(withTokens.input_tokens) + Number(withTokens.output_tokens),
+    );
+  });
+
   it('overview reflects OTLP-ingested data', async () => {
     const res = await request(app.getHttpServer())
       .get('/api/v1/overview?range=24h')

--- a/packages/openclaw-plugin/__tests__/hooks.test.ts
+++ b/packages/openclaw-plugin/__tests__/hooks.test.ts
@@ -552,6 +552,117 @@ describe("registerHooks", () => {
       expect(outputCounter?.add).toHaveBeenCalledWith(13, expect.any(Object));
     });
 
+    it("extracts tokens from OpenAI-format usage (prompt_tokens/completion_tokens)", () => {
+      api.emit("message_received", { sessionKey: "sess-oai" });
+      api.emit("before_agent_start", { sessionKey: "sess-oai" });
+      api.emit("agent_end", {
+        sessionKey: "sess-oai",
+        messages: [
+          {
+            role: "assistant",
+            model: "gpt-4o",
+            provider: "OpenAI",
+            usage: { prompt_tokens: 1500, completion_tokens: 400, total_tokens: 1900 },
+          },
+        ],
+      });
+
+      const turnSpan = tracer.spans[tracer.spans.length - 1];
+      expect(turnSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [ATTRS.INPUT_TOKENS]: 1500,
+          [ATTRS.OUTPUT_TOKENS]: 400,
+        }),
+      );
+
+      const inputCounter = meter.counters.get(METRICS.LLM_TOKENS_INPUT);
+      expect(inputCounter?.add).toHaveBeenCalledWith(1500, expect.any(Object));
+    });
+
+    it("extracts cache tokens from OpenAI-format prompt_tokens_details", () => {
+      api.emit("message_received", { sessionKey: "sess-oai-cache" });
+      api.emit("before_agent_start", { sessionKey: "sess-oai-cache" });
+      api.emit("agent_end", {
+        sessionKey: "sess-oai-cache",
+        messages: [
+          {
+            role: "assistant",
+            model: "claude-sonnet-4-5",
+            provider: "Anthropic",
+            usage: {
+              prompt_tokens: 2000,
+              completion_tokens: 500,
+              prompt_tokens_details: { cached_tokens: 800 },
+              cache_read_tokens: 800,
+              cache_creation_tokens: 150,
+            },
+          },
+        ],
+      });
+
+      const turnSpan = tracer.spans[tracer.spans.length - 1];
+      expect(turnSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [ATTRS.INPUT_TOKENS]: 2000,
+          [ATTRS.OUTPUT_TOKENS]: 500,
+          [ATTRS.CACHE_READ_TOKENS]: 800,
+          [ATTRS.CACHE_WRITE_TOKENS]: 150,
+        }),
+      );
+
+      const cacheCounter = meter.counters.get(METRICS.LLM_TOKENS_CACHE_READ);
+      expect(cacheCounter?.add).toHaveBeenCalledWith(800, expect.any(Object));
+    });
+
+    it("extracts cache tokens from prompt_tokens_details.cached_tokens fallback", () => {
+      api.emit("message_received", { sessionKey: "sess-oai-ptd" });
+      api.emit("before_agent_start", { sessionKey: "sess-oai-ptd" });
+      api.emit("agent_end", {
+        sessionKey: "sess-oai-ptd",
+        messages: [
+          {
+            role: "assistant",
+            model: "gpt-4o",
+            provider: "OpenAI",
+            usage: {
+              prompt_tokens: 3000,
+              completion_tokens: 600,
+              prompt_tokens_details: { cached_tokens: 1200 },
+            },
+          },
+        ],
+      });
+
+      const turnSpan = tracer.spans[tracer.spans.length - 1];
+      expect(turnSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          [ATTRS.CACHE_READ_TOKENS]: 1200,
+        }),
+      );
+    });
+
+    it("extracts tokens from camelCase OpenAI usage (promptTokens/completionTokens)", () => {
+      api.emit("message_received", { sessionKey: "sess-camel" });
+      api.emit("before_agent_start", { sessionKey: "sess-camel" });
+      api.emit("agent_end", {
+        sessionKey: "sess-camel",
+        messages: [
+          {
+            role: "assistant",
+            model: "gpt-4o",
+            provider: "OpenAI",
+            usage: { promptTokens: 700, completionTokens: 150 },
+          },
+        ],
+      });
+
+      const inputCounter = meter.counters.get(METRICS.LLM_TOKENS_INPUT);
+      expect(inputCounter?.add).toHaveBeenCalledWith(700, expect.any(Object));
+
+      const outputCounter = meter.counters.get(METRICS.LLM_TOKENS_OUTPUT);
+      expect(outputCounter?.add).toHaveBeenCalledWith(150, expect.any(Object));
+    });
+
     it("defaults to 'unknown' model/provider when missing", () => {
       api.emit("message_received", { sessionKey: "sess-7" });
       api.emit("before_agent_start", { sessionKey: "sess-7" });

--- a/packages/openclaw-plugin/__tests__/hooks.test.ts
+++ b/packages/openclaw-plugin/__tests__/hooks.test.ts
@@ -641,6 +641,28 @@ describe("registerHooks", () => {
       );
     });
 
+    it("extracts tokens via inputTokens fallback path", () => {
+      api.emit("message_received", { sessionKey: "sess-input-tokens" });
+      api.emit("before_agent_start", { sessionKey: "sess-input-tokens" });
+      api.emit("agent_end", {
+        sessionKey: "sess-input-tokens",
+        messages: [
+          {
+            role: "assistant",
+            model: "gpt-4o",
+            provider: "OpenAI",
+            usage: { inputTokens: 800, outputTokens: 200 },
+          },
+        ],
+      });
+
+      const inputCounter = meter.counters.get(METRICS.LLM_TOKENS_INPUT);
+      expect(inputCounter?.add).toHaveBeenCalledWith(800, expect.any(Object));
+
+      const outputCounter = meter.counters.get(METRICS.LLM_TOKENS_OUTPUT);
+      expect(outputCounter?.add).toHaveBeenCalledWith(200, expect.any(Object));
+    });
+
     it("extracts tokens from camelCase OpenAI usage (promptTokens/completionTokens)", () => {
       api.emit("message_received", { sessionKey: "sess-camel" });
       api.emit("before_agent_start", { sessionKey: "sess-camel" });

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -8,11 +8,11 @@ import {
   Meter,
   Counter,
   Histogram,
-} from "@opentelemetry/api";
-import { SPANS, METRICS, ATTRS } from "./constants";
-import { ManifestConfig } from "./config";
-import { PluginLogger } from "./telemetry";
-import { resolveRouting } from "./routing";
+} from '@opentelemetry/api';
+import { SPANS, METRICS, ATTRS } from './constants';
+import { ManifestConfig } from './config';
+import { PluginLogger } from './telemetry';
+import { resolveRouting } from './routing';
 
 interface ActiveSpans {
   root: Span;
@@ -35,33 +35,33 @@ let messagesReceived: Counter;
 
 export function initMetrics(meter: Meter): void {
   llmRequests = meter.createCounter(METRICS.LLM_REQUESTS, {
-    description: "Total LLM inference requests",
+    description: 'Total LLM inference requests',
   });
   llmTokensInput = meter.createCounter(METRICS.LLM_TOKENS_INPUT, {
-    description: "Total input tokens sent to LLM",
+    description: 'Total input tokens sent to LLM',
   });
   llmTokensOutput = meter.createCounter(METRICS.LLM_TOKENS_OUTPUT, {
-    description: "Total output tokens from LLM",
+    description: 'Total output tokens from LLM',
   });
   llmTokensCacheRead = meter.createCounter(METRICS.LLM_TOKENS_CACHE_READ, {
-    description: "Total cache-read tokens",
+    description: 'Total cache-read tokens',
   });
   llmDuration = meter.createHistogram(METRICS.LLM_DURATION, {
-    description: "LLM request duration in ms",
-    unit: "ms",
+    description: 'LLM request duration in ms',
+    unit: 'ms',
   });
   toolCalls = meter.createCounter(METRICS.TOOL_CALLS, {
-    description: "Total tool invocations",
+    description: 'Total tool invocations',
   });
   toolErrors = meter.createCounter(METRICS.TOOL_ERRORS, {
-    description: "Total tool errors",
+    description: 'Total tool errors',
   });
   toolDuration = meter.createHistogram(METRICS.TOOL_DURATION, {
-    description: "Tool execution duration in ms",
-    unit: "ms",
+    description: 'Tool execution duration in ms',
+    unit: 'ms',
   });
   messagesReceived = meter.createCounter(METRICS.MESSAGES_RECEIVED, {
-    description: "Total messages received from users",
+    description: 'Total messages received from users',
   });
 }
 
@@ -74,9 +74,9 @@ export function initMetrics(meter: Meter): void {
  * it's confirmed to work, fall back to registerHook() for forward compat.
  */
 function hookOn(api: any, event: string, handler: (...args: any[]) => any): void {
-  if (typeof api.on === "function") {
+  if (typeof api.on === 'function') {
     api.on(event, handler);
-  } else if (typeof api.registerHook === "function") {
+  } else if (typeof api.registerHook === 'function') {
     api.registerHook(event, handler);
   }
 }
@@ -89,10 +89,10 @@ export function registerHooks(
 ): void {
   // --- message_received ---
   // Creates the root span for the entire request lifecycle.
-  hookOn(api, "message_received", (event: any) => {
+  hookOn(api, 'message_received', (event: any) => {
     const sessionKey =
-      event.sessionKey || event.session?.key || `agent:${event.agent || "main"}:main`;
-    const channel = event.channel || "unknown";
+      event.sessionKey || event.session?.key || `agent:${event.agent || 'main'}:main`;
+    const channel = event.channel || 'unknown';
 
     const rootSpan = tracer.startSpan(SPANS.REQUEST, {
       kind: SpanKind.SERVER,
@@ -109,12 +109,10 @@ export function registerHooks(
 
   // --- before_agent_start ---
   // Creates a child span under the root for the agent turn.
-  hookOn(api, "before_agent_start", (event: any) => {
+  hookOn(api, 'before_agent_start', (event: any) => {
     const sessionKey =
-      event.sessionKey ||
-      event.session?.key ||
-      `agent:${event.agent || "main"}:main`;
-    const agentName = event.agent || "main";
+      event.sessionKey || event.session?.key || `agent:${event.agent || 'main'}:main`;
+    const agentName = event.agent || 'main';
 
     const active = activeSpans.get(sessionKey);
     const parentContext = active?.root
@@ -139,18 +137,16 @@ export function registerHooks(
       activeSpans.set(sessionKey, { root: turnSpan, turn: turnSpan });
     }
 
-    logger.debug(
-      `[manifest] Agent turn started: agent=${agentName}, session=${sessionKey}`,
-    );
+    logger.debug(`[manifest] Agent turn started: agent=${agentName}, session=${sessionKey}`);
   });
 
   // --- tool_result_persist ---
   // Records tool metrics and creates a child span.
-  hookOn(api, "tool_result_persist", (event: any) => {
-    const toolName = event.toolName || event.tool || "unknown";
+  hookOn(api, 'tool_result_persist', (event: any) => {
+    const toolName = event.toolName || event.tool || 'unknown';
     const durationMs = event.durationMs || 0;
     const success = event.error == null;
-    const sessionKey = event.sessionKey || "unknown";
+    const sessionKey = event.sessionKey || 'unknown';
 
     const active = activeSpans.get(sessionKey);
     const parentContext = active?.turn
@@ -173,7 +169,7 @@ export function registerHooks(
     if (!success) {
       toolSpan.setStatus({
         code: SpanStatusCode.ERROR,
-        message: event.error?.message || "Tool execution failed",
+        message: event.error?.message || 'Tool execution failed',
       });
       toolErrors.add(1, { [ATTRS.TOOL_NAME]: toolName });
     }
@@ -187,28 +183,34 @@ export function registerHooks(
   // Records LLM metrics and closes all spans.
   // Event shape: { messages: Message[], success: boolean, durationMs: number }
   // Usage data lives on each assistant message, not at the top level.
-  hookOn(api, "agent_end", async (event: any) => {
+  hookOn(api, 'agent_end', async (event: any) => {
     const sessionKey =
-      event.sessionKey ||
-      event.session?.key ||
-      `agent:${event.agent || "main"}:main`;
+      event.sessionKey || event.session?.key || `agent:${event.agent || 'main'}:main`;
 
     // Extract data from the last assistant message with usage info
     const messages: any[] = event.messages || [];
     const lastAssistant = [...messages]
       .reverse()
-      .find((m: any) => m.role === "assistant" && m.usage);
+      .find((m: any) => m.role === 'assistant' && m.usage);
 
-    const model = lastAssistant?.model || event.model || "unknown";
-    const provider = lastAssistant?.provider || event.provider || "unknown";
+    const model = lastAssistant?.model || event.model || 'unknown';
+    const provider = lastAssistant?.provider || event.provider || 'unknown';
     const usage = lastAssistant?.usage || event.usage || {};
-    const inputTokens = usage.input || usage.inputTokens || 0;
-    const outputTokens = usage.output || usage.outputTokens || 0;
+    const inputTokens =
+      usage.input || usage.inputTokens || usage.prompt_tokens || usage.promptTokens || 0;
+    const outputTokens =
+      usage.output || usage.outputTokens || usage.completion_tokens || usage.completionTokens || 0;
 
-    // Gateway provides cache read via usage.cacheRead (from OpenAI prompt_tokens_details.cached_tokens).
-    // Cache creation is not available from the gateway's event data (Anthropic-specific).
-    const cacheReadTokens = usage.cacheRead || usage.cacheReadTokens || 0;
-    const cacheWriteTokens = usage.cacheWrite || usage.cacheWriteTokens || 0;
+    // Cache tokens: try gateway-native fields first, then OpenAI format.
+    const promptDetails = usage.prompt_tokens_details || {};
+    const cacheReadTokens =
+      usage.cacheRead ||
+      usage.cacheReadTokens ||
+      usage.cache_read_tokens ||
+      promptDetails.cached_tokens ||
+      0;
+    const cacheWriteTokens =
+      usage.cacheWrite || usage.cacheWriteTokens || usage.cache_creation_tokens || 0;
 
     // If model is "auto" (routed through manifest proxy), resolve the actual model
     let finalModel = model;
@@ -216,7 +218,7 @@ export function registerHooks(
     let routingTier: string | null = null;
     let routingReason: string | null = null;
 
-    if (finalModel === "auto") {
+    if (finalModel === 'auto') {
       const resolved = await resolveRouting(config, messages, sessionKey, logger);
       if (resolved) {
         finalModel = resolved.model;
@@ -230,18 +232,19 @@ export function registerHooks(
     // HEARTBEAT_OK, override the reason so it's identifiable in telemetry.
     // Content can be a string or array of content parts (multi-modal format).
     const hasHeartbeat = messages.some((m: any) => {
-      if (!m || m.role !== "user") return false;
-      if (typeof m.content === "string") return m.content.includes("HEARTBEAT_OK");
+      if (!m || m.role !== 'user') return false;
+      if (typeof m.content === 'string') return m.content.includes('HEARTBEAT_OK');
       if (Array.isArray(m.content)) {
         return m.content.some(
-          (p: any) => p.type === "text" && typeof p.text === "string" && p.text.includes("HEARTBEAT_OK"),
+          (p: any) =>
+            p.type === 'text' && typeof p.text === 'string' && p.text.includes('HEARTBEAT_OK'),
         );
       }
       return false;
     });
     if (hasHeartbeat) {
-      routingReason = "heartbeat";
-      routingTier = "simple";
+      routingReason = 'heartbeat';
+      routingTier = 'simple';
     }
 
     const active = activeSpans.get(sessionKey);
@@ -262,11 +265,10 @@ export function registerHooks(
         active.turn.setAttribute(ATTRS.ROUTING_REASON, routingReason);
       }
       if (event.success === false) {
-        const errMsg =
-          event.error?.message || event.errorMessage || "Agent turn failed";
+        const errMsg = event.error?.message || event.errorMessage || 'Agent turn failed';
         active.turn.setStatus({
           code: SpanStatusCode.ERROR,
-          message: typeof errMsg === "string" ? errMsg.slice(0, 500) : String(errMsg),
+          message: typeof errMsg === 'string' ? errMsg.slice(0, 500) : String(errMsg),
         });
       }
       active.turn.end();
@@ -294,5 +296,5 @@ export function registerHooks(
     logger.debug(`[manifest] Trace completed for session=${sessionKey}`);
   });
 
-  logger.debug("[manifest] All hooks registered");
+  logger.debug('[manifest] All hooks registered');
 }


### PR DESCRIPTION
## Summary

- **Stream usage capture**: `pipeStream()` now returns `StreamUsage` by parsing usage from SSE events in both transform (Google/Anthropic) and passthrough (OpenAI) paths
- **Proxy recording**: `ProxyController` records `agent_messages` directly with real token data and cost calculation via `ModelPricingCacheService`, bypassing the gateway's broken `{input: 0, output: 0}` usage reporting
- **OTLP dedup**: `TraceIngestService` skips 0-token OTLP spans when the proxy already recorded a message with real tokens within 60s
- **Google streaming fix**: `transformGoogleStreamChunk` was silently dropping `usageMetadata` from final chunks — now emits `finish_reason` + usage events
- **Plugin hooks**: Added OpenAI-format token extraction (`prompt_tokens`/`completion_tokens`, `prompt_tokens_details.cached_tokens`)

## Test plan

- [ ] Verify tokens appear in Messages list for routed calls (Google, Anthropic, OpenAI)
- [ ] Verify cost values are computed when model pricing exists
- [ ] Verify no duplicate messages from OTLP + proxy recording
- [ ] Run `npx jest --coverage` in backend — 100% line coverage maintained
- [ ] Run e2e tests — OTLP roundtrip token regression test passes
- [ ] Run plugin tests — OpenAI-format token extraction tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 0‑token messages by parsing real token usage from proxy responses and recording it with cost. Also deduplicates OTLP spans and fixes Google streaming usage events.

- **New Features**
  - `pipeStream()` parses SSE usage for transformed and passthrough streams and returns it; added `extractUsageFromSse`.
  - `ProxyController` records successful non‑fallback `agent_messages` with prompt/completion/cache tokens and computes `cost_usd` via `ModelPricingCacheService`; reads usage from non‑stream JSON, defaults missing `completion_tokens` to 0, and skips recording when both tokens are 0.

- **Bug Fixes**
  - `TraceIngestService` skips 0‑token OTLP spans when a proxy message with tokens exists within 60s, ignores proxy rows with null tokens, and skips proxy dedup when spans already have tokens.
  - `transformGoogleStreamChunk` emits final `finish_reason` plus usage from `usageMetadata` (including usage‑only events) and defaults missing token counts to 0.
  - `openclaw-plugin` hooks extract OpenAI‑format usage (`prompt_tokens`, `completion_tokens`, `prompt_tokens_details.cached_tokens`, camelCase variants).

<sup>Written for commit e995598e01114d684e637e8197e626ac96d60f94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

