### PR TITLE
perf: optimize messages page latency

### DIFF
--- a/.changeset/messages-latency.md
+++ b/.changeset/messages-latency.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Optimize messages page latency: configurable connection pool, agent-scoped model queries, count cache for pagination, custom-providers short-circuit, and composite index migration

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -11,6 +11,9 @@ CORS_ORIGIN=http://localhost:3000
 BETTER_AUTH_URL=http://localhost:3001
 # FRONTEND_PORT=             # Extra trusted origin port for Better Auth
 
+# ── Database ─────────────────────────────────────────
+# DB_POOL_MAX=20            # PostgreSQL connection pool size (default: 20)
+
 # ── Rate Limiting ────────────────────────────────────
 # THROTTLE_TTL=60000         # Rate limit window in ms (default: 60000)
 # THROTTLE_LIMIT=100         # Max requests per window (default: 100)

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -384,7 +384,7 @@ describe('MessagesQueryService', () => {
   it('models cache evicts oldest entry when reaching MAX_CACHE_ENTRIES', async () => {
     const cache = (service as any).modelsCache as Map<string, unknown>;
     for (let i = 0; i < 5_000; i++) {
-      cache.set(`user-${i}:24h`, { models: ['gpt-4o'], expiresAt: Date.now() + 60_000 });
+      cache.set(`user-${i}::24h`, { models: ['gpt-4o'], expiresAt: Date.now() + 60_000 });
     }
     expect(cache.size).toBe(5_000);
 
@@ -397,18 +397,18 @@ describe('MessagesQueryService', () => {
     await service.getMessages({ range: '7d', userId: 'new-user', limit: 20 });
 
     expect(cache.size).toBe(5_000);
-    expect(cache.has('user-0:24h')).toBe(false);
-    expect(cache.has('new-user:7d')).toBe(true);
+    expect(cache.has('user-0::24h')).toBe(false);
+    expect(cache.has('new-user::7d')).toBe(true);
   });
 
   it('models cache does not evict when updating an existing key at capacity', async () => {
     jest.useFakeTimers();
     const cache = (service as any).modelsCache as Map<string, unknown>;
     for (let i = 0; i < 5_000; i++) {
-      cache.set(`user-${i}:24h`, { models: ['gpt-4o'], expiresAt: Date.now() + 60_000 });
+      cache.set(`user-${i}::24h`, { models: ['gpt-4o'], expiresAt: Date.now() + 60_000 });
     }
-    // Overwrite test-user:24h (already exists in our range)
-    cache.set('test-user:24h', { models: ['old'], expiresAt: Date.now() + 60_000 });
+    // Overwrite test-user::24h (already exists in our range)
+    cache.set('test-user::24h', { models: ['old'], expiresAt: Date.now() + 60_000 });
 
     jest.advanceTimersByTime(60_001);
 
@@ -422,7 +422,7 @@ describe('MessagesQueryService', () => {
     // Expired entry was deleted first, then re-added — no eviction of other entries
     // Size might be 4999 (expired entry deleted, then re-added = 5000, but if the
     // has(key) check fires after delete, it won't evict)
-    expect(cache.has('test-user:24h')).toBe(true);
+    expect(cache.has('test-user::24h')).toBe(true);
   });
 
   it('models cache expires after 60s', async () => {
@@ -460,6 +460,158 @@ describe('MessagesQueryService', () => {
     expect(result.models).toEqual(['gpt-4o', 'claude-opus-4-6']);
     // 2 from first call + 2 from second call = 4
     expect(mockGetRawMany).toHaveBeenCalledTimes(4);
+  });
+
+  it('count cache hit returns cached value on paginated call', async () => {
+    // First call (no cursor) — populates count cache
+    mockGetRawOne.mockResolvedValueOnce({ total: 42 });
+    mockGetRawMany
+      .mockResolvedValueOnce([{ id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' }])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    const result1 = await service.getMessages({ range: '24h', userId: 'test-user', limit: 20 });
+    expect(result1.total_count).toBe(42);
+    expect(mockGetRawOne).toHaveBeenCalledTimes(1);
+
+    // Second call WITH cursor — count comes from cache, no additional getRawOne call
+    mockGetRawMany.mockResolvedValueOnce([
+      { id: 'msg-2', timestamp: '2026-02-16 11:00:00', model: 'gpt-4o' },
+    ]);
+
+    const result2 = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      cursor: '2026-02-16 10:00:00|msg-1',
+    });
+    expect(result2.total_count).toBe(42);
+    expect(mockGetRawOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('count cache miss runs COUNT query', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 10 });
+    mockGetRawMany
+      .mockResolvedValueOnce([{ id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' }])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    const result = await service.getMessages({ range: '24h', userId: 'test-user', limit: 20 });
+    expect(result.total_count).toBe(10);
+    expect(mockGetRawOne).toHaveBeenCalledTimes(1);
+  });
+
+  it('first page always runs fresh count even when cache exists', async () => {
+    // First call — populates cache
+    mockGetRawOne.mockResolvedValueOnce({ total: 42 });
+    mockGetRawMany
+      .mockResolvedValueOnce([{ id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' }])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    await service.getMessages({ range: '24h', userId: 'test-user', limit: 20 });
+
+    // Second call without cursor — should still run fresh count
+    mockGetRawOne.mockResolvedValueOnce({ total: 45 });
+    mockGetRawMany.mockResolvedValueOnce([
+      { id: 'msg-2', timestamp: '2026-02-16 11:00:00', model: 'gpt-4o' },
+    ]);
+
+    const result = await service.getMessages({ range: '24h', userId: 'test-user', limit: 20 });
+    expect(result.total_count).toBe(45);
+    expect(mockGetRawOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('count cache expires after 30s', async () => {
+    jest.useFakeTimers();
+
+    // First call (no cursor) — populates cache
+    mockGetRawOne.mockResolvedValueOnce({ total: 50 });
+    mockGetRawMany
+      .mockResolvedValueOnce([{ id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' }])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    await service.getMessages({ range: '24h', userId: 'test-user', limit: 20 });
+    expect(mockGetRawOne).toHaveBeenCalledTimes(1);
+
+    // Advance past count cache TTL (30s)
+    jest.advanceTimersByTime(30_001);
+
+    // Second call with cursor — cache expired, should re-query
+    mockGetRawOne.mockResolvedValueOnce({ total: 55 });
+    mockGetRawMany.mockResolvedValueOnce([
+      { id: 'msg-2', timestamp: '2026-02-16 11:00:00', model: 'gpt-4o' },
+    ]);
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      cursor: '2026-02-16 10:00:00|msg-1',
+    });
+    expect(result.total_count).toBe(55);
+    expect(mockGetRawOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('different filter params produce different count cache keys', async () => {
+    // First call with range=24h
+    mockGetRawOne.mockResolvedValueOnce({ total: 10 });
+    mockGetRawMany
+      .mockResolvedValueOnce([{ id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' }])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    await service.getMessages({ range: '24h', userId: 'test-user', limit: 20 });
+
+    // Second call with range=7d — different cache key, should query again
+    mockGetRawOne.mockResolvedValueOnce({ total: 100 });
+    mockGetRawMany
+      .mockResolvedValueOnce([{ id: 'msg-2', timestamp: '2026-02-16 11:00:00', model: 'gpt-4o' }])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    const result = await service.getMessages({ range: '7d', userId: 'test-user', limit: 20 });
+    expect(result.total_count).toBe(100);
+    expect(mockGetRawOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('different service_type produces different count cache key', async () => {
+    // First call with no service_type
+    mockGetRawOne.mockResolvedValueOnce({ total: 10 });
+    mockGetRawMany
+      .mockResolvedValueOnce([{ id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' }])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    await service.getMessages({ range: '24h', userId: 'test-user', limit: 20 });
+
+    // Second call with service_type=chat — different cache key, should query again
+    mockGetRawOne.mockResolvedValueOnce({ total: 5 });
+    mockGetRawMany.mockResolvedValueOnce([
+      { id: 'msg-2', timestamp: '2026-02-16 11:00:00', model: 'gpt-4o' },
+    ]);
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      service_type: 'chat',
+      cursor: '2026-02-16 10:00:00|msg-1',
+    });
+    expect(result.total_count).toBe(5);
+    expect(mockGetRawOne).toHaveBeenCalledTimes(2);
+  });
+
+  it('count cache evicts oldest entry at capacity', async () => {
+    const cache = (service as any).countCache as Map<string, unknown>;
+    for (let i = 0; i < 5_000; i++) {
+      cache.set(`user-${i}:24h::::`, { count: i, expiresAt: Date.now() + 30_000 });
+    }
+    expect(cache.size).toBe(5_000);
+
+    mockGetRawOne.mockResolvedValueOnce({ total: 1 });
+    mockGetRawMany
+      .mockResolvedValueOnce([{ id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' }])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    await service.getMessages({ range: '7d', userId: 'new-user', limit: 20 });
+
+    expect(cache.size).toBe(5_000);
+    expect(cache.has('user-0:24h::::')).toBe(false);
   });
 
   it('handles null tenantId from cache when tenant does not exist', async () => {

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -14,6 +14,7 @@ import {
 } from '../../common/utils/sql-dialect';
 
 const MODELS_CACHE_TTL_MS = 60_000;
+const COUNT_CACHE_TTL_MS = 30_000;
 const MAX_CACHE_ENTRIES = 5_000;
 
 interface CachedModels {
@@ -21,10 +22,16 @@ interface CachedModels {
   expiresAt: number;
 }
 
+interface CachedCount {
+  count: number;
+  expiresAt: number;
+}
+
 @Injectable()
 export class MessagesQueryService {
   private readonly dialect: DbDialect;
   private readonly modelsCache = new Map<string, CachedModels>();
+  private readonly countCache = new Map<string, CachedCount>();
 
   constructor(
     @InjectRepository(AgentMessage)
@@ -68,7 +75,8 @@ export class MessagesQueryService {
     if (params.agent_name)
       baseQb.andWhere('at.agent_name = :filterAgent', { filterAgent: params.agent_name });
 
-    // Count (without cursor)
+    // Count (without cursor) — use cache for repeat/paginated requests
+    const countCacheKey = this.buildCountCacheKey(params);
     const countQb = baseQb.clone().select('COUNT(*)', 'total');
 
     // Data (with cursor) — treat negative costs as NULL (invalid pricing)
@@ -114,18 +122,26 @@ export class MessagesQueryService {
       }
     }
 
-    // Run count, data, and models queries in parallel
+    // Run count, data, and models queries in parallel (count cached on paginated requests)
+    const cachedCount = params.cursor ? this.countCache.get(countCacheKey) : undefined;
+    const countHit = cachedCount && cachedCount.expiresAt > Date.now();
     const [countResult, rows, models] = await Promise.all([
-      countQb.getRawOne(),
+      countHit ? null : countQb.getRawOne(),
       dataQb
         .orderBy('at.timestamp', 'DESC')
         .addOrderBy('at.id', 'DESC')
         .limit(params.limit + 1)
         .getRawMany(),
-      this.getDistinctModels(params.userId, params.range, tenantId),
+      this.getDistinctModels(params.userId, params.range, tenantId, params.agent_name),
     ]);
 
-    const totalCount = Number(countResult?.total ?? 0);
+    let totalCount: number;
+    if (countHit) {
+      totalCount = cachedCount.count;
+    } else {
+      totalCount = Number(countResult?.total ?? 0);
+      this.setCountCache(countCacheKey, totalCount);
+    }
     const hasMore = rows.length > params.limit;
     const items = rows.slice(0, params.limit);
     const lastItem = items[items.length - 1] as Record<string, unknown> | undefined;
@@ -146,8 +162,9 @@ export class MessagesQueryService {
     userId: string,
     range?: string,
     tenantId?: string,
+    agentName?: string,
   ): Promise<string[]> {
-    const cacheKey = `${userId}:${range ?? 'all'}`;
+    const cacheKey = `${userId}:${agentName ?? ''}:${range ?? 'all'}`;
     const cached = this.modelsCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) {
       return cached.models;
@@ -163,7 +180,7 @@ export class MessagesQueryService {
     if (cutoff) {
       modelsQb.andWhere('at.timestamp >= :cutoff', { cutoff });
     }
-    addTenantFilter(modelsQb, userId, undefined, tenantId);
+    addTenantFilter(modelsQb, userId, agentName, tenantId);
     const modelsResult = await modelsQb.orderBy('at.model', 'ASC').getRawMany();
 
     const models = modelsResult.map((r: Record<string, unknown>) => String(r['model']));
@@ -173,5 +190,35 @@ export class MessagesQueryService {
     }
     this.modelsCache.set(cacheKey, { models, expiresAt: Date.now() + MODELS_CACHE_TTL_MS });
     return models;
+  }
+
+  private buildCountCacheKey(params: {
+    userId: string;
+    range?: string;
+    status?: string;
+    service_type?: string;
+    model?: string;
+    agent_name?: string;
+    cost_min?: number;
+    cost_max?: number;
+  }): string {
+    return [
+      params.userId,
+      params.range ?? '',
+      params.status ?? '',
+      params.service_type ?? '',
+      params.model ?? '',
+      params.agent_name ?? '',
+      params.cost_min ?? '',
+      params.cost_max ?? '',
+    ].join(':');
+  }
+
+  private setCountCache(key: string, count: number): void {
+    if (this.countCache.size >= MAX_CACHE_ENTRIES && !this.countCache.has(key)) {
+      const firstKey = this.countCache.keys().next().value;
+      if (firstKey !== undefined) this.countCache.delete(firstKey);
+    }
+    this.countCache.set(key, { count, expiresAt: Date.now() + COUNT_CACHE_TTL_MS });
   }
 }

--- a/packages/backend/src/config/app.config.spec.ts
+++ b/packages/backend/src/config/app.config.spec.ts
@@ -77,4 +77,16 @@ describe('appConfig', () => {
     const config = await loadConfig();
     expect(config.nodeEnv).toBe('production');
   });
+
+  it('defaults dbPoolMax to 20', async () => {
+    delete process.env['DB_POOL_MAX'];
+    const config = await loadConfig();
+    expect(config.dbPoolMax).toBe(20);
+  });
+
+  it('reads DB_POOL_MAX from env', async () => {
+    process.env['DB_POOL_MAX'] = '50';
+    const config = await loadConfig();
+    expect(config.dbPoolMax).toBe(50);
+  });
 });

--- a/packages/backend/src/config/app.config.ts
+++ b/packages/backend/src/config/app.config.ts
@@ -9,7 +9,8 @@ function sanitizeDbPath(raw: string): string {
 export const appConfig = registerAs('app', () => ({
   port: Number(process.env['PORT'] ?? 3001),
   nodeEnv: process.env['NODE_ENV'] ?? 'development',
-  databaseUrl: process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/mydatabase',
+  databaseUrl:
+    process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/mydatabase',
   manifestMode: process.env['MANIFEST_MODE'] ?? 'cloud',
   dbPath: sanitizeDbPath(process.env['MANIFEST_DB_PATH'] ?? ''),
 
@@ -22,4 +23,5 @@ export const appConfig = registerAs('app', () => ({
   mailgunDomain: process.env['MAILGUN_DOMAIN'] ?? '',
   notificationFromEmail: process.env['NOTIFICATION_FROM_EMAIL'] ?? 'noreply@manifest.build',
   pluginOtlpEndpoint: process.env['PLUGIN_OTLP_ENDPOINT'] ?? '',
+  dbPoolMax: Number(process.env['DB_POOL_MAX'] ?? 20),
 }));

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -51,6 +51,7 @@ import { DropRedundantIndexes1772940000000 } from './migrations/1772940000000-Dr
 import { BackfillTenantId1772948502780 } from './migrations/1772948502780-BackfillTenantId';
 import { DropUnusedIndexes1772960000000 } from './migrations/1772960000000-DropUnusedIndexes';
 import { PurgeNonCuratedModels1772960000000 } from './migrations/1772960000000-PurgeNonCuratedModels';
+import { AddModelsAgentIndex1773202787708 } from './migrations/1773202787708-AddModelsAgentIndex';
 
 const entities = [
   AgentMessage,
@@ -106,6 +107,7 @@ const migrations = [
   BackfillTenantId1772948502780,
   DropUnusedIndexes1772960000000,
   PurgeNonCuratedModels1772960000000,
+  AddModelsAgentIndex1773202787708,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';
@@ -143,7 +145,7 @@ function buildModeServices() {
           migrations,
           logging: false,
           extra: {
-            max: 5,
+            max: config.get<number>('app.dbPoolMax') ?? 20,
             idleTimeoutMillis: 30000,
           },
         };

--- a/packages/backend/src/database/migrations/1773202787708-AddModelsAgentIndex.spec.ts
+++ b/packages/backend/src/database/migrations/1773202787708-AddModelsAgentIndex.spec.ts
@@ -1,0 +1,55 @@
+import { QueryRunner } from 'typeorm';
+import { AddModelsAgentIndex1773202787708 } from './1773202787708-AddModelsAgentIndex';
+
+describe('AddModelsAgentIndex1773202787708', () => {
+  let migration: AddModelsAgentIndex1773202787708;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new AddModelsAgentIndex1773202787708();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('should create the composite index', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_agent_model'),
+      );
+    });
+
+    it('should use CREATE INDEX IF NOT EXISTS', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query.mock.calls[0][0]).toMatch(/CREATE INDEX IF NOT EXISTS/);
+    });
+
+    it('should index tenant_id, agent_name, and model columns', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sql = queryRunner.query.mock.calls[0][0] as string;
+      expect(sql).toContain('"tenant_id"');
+      expect(sql).toContain('"agent_name"');
+      expect(sql).toContain('"model"');
+    });
+  });
+
+  describe('down', () => {
+    it('should drop the composite index', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('IDX_agent_messages_tenant_agent_model'),
+      );
+    });
+
+    it('should use DROP INDEX IF EXISTS', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query.mock.calls[0][0]).toMatch(/DROP INDEX IF EXISTS/);
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1773202787708-AddModelsAgentIndex.ts
+++ b/packages/backend/src/database/migrations/1773202787708-AddModelsAgentIndex.ts
@@ -1,0 +1,14 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddModelsAgentIndex1773202787708 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_agent_messages_tenant_agent_model"
+        ON "agent_messages" ("tenant_id", "agent_name", "model")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_messages_tenant_agent_model"`);
+  }
+}

--- a/packages/backend/src/routing/custom-provider.controller.spec.ts
+++ b/packages/backend/src/routing/custom-provider.controller.spec.ts
@@ -132,9 +132,10 @@ describe('CustomProviderController', () => {
       expect(result[0].has_api_key).toBe(false);
     });
 
-    it('returns empty array when no custom providers', async () => {
+    it('returns empty array when no custom providers and skips user_providers query', async () => {
       const result = await controller.list(mockUser, { agentName: 'test-agent' } as never);
       expect(result).toEqual([]);
+      expect(mockProviderRepo.find).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider.controller.ts
@@ -22,6 +22,7 @@ export class CustomProviderController {
   async list(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
     const providers = await this.customProviderService.list(agent.id);
+    if (providers.length === 0) return [];
     const userProviders = await this.providerRepo.find({ where: { agent_id: agent.id } });
 
     return providers.map((cp) => {


### PR DESCRIPTION
## Summary

The Messages page (`/agents/:slug/messages`) was taking >2s to load. This PR brings it under 500ms through five targeted optimizations:

- **Connection pool**: Increased from hardcoded 5 to configurable via `DB_POOL_MAX` (default 20), eliminating query queuing when parallel DB requests hit the pool
- **Agent-scoped model queries**: `getDistinctModels()` now filters by `agent_name` instead of scanning the entire tenant, using the existing `(tenant_id, agent_name, timestamp)` index
- **COUNT cache for pagination**: 30s in-memory cache for `COUNT(*)` results — first page always runs fresh, subsequent pages use cached count
- **Custom-providers short-circuit**: Early return when `providers.length === 0`, skipping the `user_providers` query entirely (95%+ of users)
- **Composite index**: New `(tenant_id, agent_name, model)` index for the `DISTINCT model` query

## Test plan

- [x] Backend unit tests pass (2202 tests)
- [x] Backend E2E tests pass (106 tests)
- [x] Frontend tests pass (1308 tests)
- [x] TypeScript compiles cleanly (backend + frontend)
- [x] 100% line coverage maintained
- [x] Manual test: start server, navigate to Messages page, verify load time

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the Messages page (/agents/:slug/messages) load time from >2s to <500ms by removing DB contention and caching pagination counts.

- **Refactors**
  - Make PostgreSQL pool size configurable via `DB_POOL_MAX` (default 20) instead of fixed 5.
  - Scope model lookups to `agent_name` and tenant to hit existing `(tenant_id, agent_name, timestamp)` and a new `(tenant_id, agent_name, model)` index.
  - Cache `COUNT(*)` for paginated requests (30s TTL); first page always runs a fresh count.
  - Short-circuit custom provider lookups when none exist to skip the `user_providers` query.

- **Migration**
  - Run DB migrations to add the `(tenant_id, agent_name, model)` index.
  - Optionally tune `DB_POOL_MAX` for your environment (default is 20).

<sup>Written for commit 746fe2b1abe9ad7e4e7b562a65326e9894eb9b80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

