### PR TITLE
perf: reduce overview endpoint latency by merging queries

### DIFF
--- a/.changeset/overview-latency.md
+++ b/.changeset/overview-latency.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Reduce overview endpoint latency by merging parallel queries and resolving tenant once

--- a/packages/backend/src/analytics/controllers/overview.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.spec.ts
@@ -3,30 +3,32 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { OverviewController } from './overview.controller';
 import { AggregationService } from '../services/aggregation.service';
 import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
 
 function mockAggregation(): Record<string, jest.Mock> {
   return {
-    getTokenSummary: jest.fn().mockResolvedValue({
-      tokens_today: { value: 1000, trend_pct: 10 },
-      input_tokens: 600,
-      output_tokens: 400,
+    getSummaryMetrics: jest.fn().mockResolvedValue({
+      tokens: {
+        tokens_today: { value: 1000, trend_pct: 10, sub_values: { input: 600, output: 400 } },
+        input_tokens: 600,
+        output_tokens: 400,
+      },
+      cost: { value: 5.0, trend_pct: 20 },
+      messages: { value: 50, trend_pct: 5 },
     }),
-    getCostSummary: jest.fn().mockResolvedValue({ value: 5.0, trend_pct: 20 }),
-    getMessageCount: jest.fn().mockResolvedValue({ value: 50, trend_pct: 5 }),
     hasAnyData: jest.fn().mockResolvedValue(true),
   };
 }
 
 function mockTimeseries(): Record<string, jest.Mock> {
   return {
+    getTimeseries: jest.fn().mockResolvedValue({
+      tokenUsage: [],
+      costUsage: [],
+      messageUsage: [],
+    }),
     getCostByModel: jest.fn().mockResolvedValue([]),
     getRecentActivity: jest.fn().mockResolvedValue([]),
-    getHourlyTokens: jest.fn().mockResolvedValue([]),
-    getDailyTokens: jest.fn().mockResolvedValue([]),
-    getHourlyCosts: jest.fn().mockResolvedValue([]),
-    getDailyCosts: jest.fn().mockResolvedValue([]),
-    getHourlyMessages: jest.fn().mockResolvedValue([]),
-    getDailyMessages: jest.fn().mockResolvedValue([]),
     getActiveSkills: jest.fn().mockResolvedValue([]),
   };
 }
@@ -35,10 +37,12 @@ describe('OverviewController', () => {
   let controller: OverviewController;
   let agg: Record<string, jest.Mock>;
   let ts: Record<string, jest.Mock>;
+  let mockTenantResolve: jest.Mock;
 
   beforeEach(async () => {
     agg = mockAggregation();
     ts = mockTimeseries();
+    mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
 
     const module: TestingModule = await Test.createTestingModule({
       imports: [CacheModule.register()],
@@ -46,46 +50,48 @@ describe('OverviewController', () => {
       providers: [
         { provide: AggregationService, useValue: agg },
         { provide: TimeseriesQueriesService, useValue: ts },
+        { provide: TenantCacheService, useValue: { resolve: mockTenantResolve } },
       ],
     }).compile();
 
     controller = module.get<OverviewController>(OverviewController);
   });
 
-  it('returns overview with hourly data for 24h range', async () => {
+  it('returns overview with hourly timeseries for 24h range', async () => {
     const user = { id: 'u1' };
     const result = await controller.getOverview({ range: '24h' }, user as never);
 
     expect(result.summary.tokens_today).toBeDefined();
     expect(result.summary.cost_today).toBeDefined();
     expect(result.summary.messages).toBeDefined();
-    expect(ts.getHourlyTokens).toHaveBeenCalledWith('24h', 'u1', undefined);
-    expect(ts.getDailyTokens).not.toHaveBeenCalled();
+    expect(ts.getTimeseries).toHaveBeenCalledWith('24h', 'u1', true, 'tenant-123', undefined);
   });
 
-  it('returns overview with daily data for 7d range', async () => {
+  it('returns overview with daily timeseries for 7d range', async () => {
     const user = { id: 'u1' };
     const result = await controller.getOverview({ range: '7d' }, user as never);
 
     expect(result.token_usage).toBeDefined();
-    expect(ts.getDailyTokens).toHaveBeenCalledWith('7d', 'u1', undefined);
-    expect(ts.getHourlyTokens).not.toHaveBeenCalled();
+    expect(ts.getTimeseries).toHaveBeenCalledWith('7d', 'u1', false, 'tenant-123', undefined);
   });
 
   it('defaults range to 24h when not specified', async () => {
     const user = { id: 'u1' };
     await controller.getOverview({}, user as never);
 
-    expect(agg.getTokenSummary).toHaveBeenCalledWith('24h', 'u1', undefined);
+    expect(agg.getSummaryMetrics).toHaveBeenCalledWith('24h', 'u1', 'tenant-123', undefined);
   });
 
-  it('passes agent_name to all aggregation calls', async () => {
+  it('passes agent_name and tenantId to all calls', async () => {
     const user = { id: 'u1' };
     await controller.getOverview({ range: '24h', agent_name: 'bot-1' }, user as never);
 
-    expect(agg.getTokenSummary).toHaveBeenCalledWith('24h', 'u1', 'bot-1');
-    expect(agg.getCostSummary).toHaveBeenCalledWith('24h', 'u1', 'bot-1');
-    expect(agg.getMessageCount).toHaveBeenCalledWith('24h', 'u1', 'bot-1');
+    expect(agg.getSummaryMetrics).toHaveBeenCalledWith('24h', 'u1', 'tenant-123', 'bot-1');
+    expect(ts.getTimeseries).toHaveBeenCalledWith('24h', 'u1', true, 'tenant-123', 'bot-1');
+    expect(ts.getCostByModel).toHaveBeenCalledWith('24h', 'u1', 'bot-1', 'tenant-123');
+    expect(ts.getRecentActivity).toHaveBeenCalledWith('24h', 'u1', 5, 'bot-1', 'tenant-123');
+    expect(ts.getActiveSkills).toHaveBeenCalledWith('24h', 'u1', 'bot-1', 'tenant-123');
+    expect(agg.hasAnyData).toHaveBeenCalledWith('u1', 'bot-1', 'tenant-123');
   });
 
   it('includes services_hit placeholder in summary', async () => {
@@ -108,5 +114,21 @@ describe('OverviewController', () => {
     const result = await controller.getOverview({ range: '24h' }, user as never);
 
     expect(result.has_data).toBe(false);
+  });
+
+  it('resolves tenant once and passes to all services', async () => {
+    const user = { id: 'u1' };
+    await controller.getOverview({ range: '24h' }, user as never);
+
+    expect(mockTenantResolve).toHaveBeenCalledTimes(1);
+    expect(mockTenantResolve).toHaveBeenCalledWith('u1');
+  });
+
+  it('passes undefined tenantId when tenant not found', async () => {
+    mockTenantResolve.mockResolvedValueOnce(null);
+    const user = { id: 'u1' };
+    await controller.getOverview({ range: '24h' }, user as never);
+
+    expect(agg.getSummaryMetrics).toHaveBeenCalledWith('24h', 'u1', undefined, undefined);
   });
 });

--- a/packages/backend/src/analytics/controllers/overview.controller.ts
+++ b/packages/backend/src/analytics/controllers/overview.controller.ts
@@ -8,6 +8,7 @@ import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
 import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
 
 @Controller('api/v1')
 @UseInterceptors(UserCacheInterceptor)
@@ -16,6 +17,7 @@ export class OverviewController {
   constructor(
     private readonly aggregation: AggregationService,
     private readonly timeseries: TimeseriesQueriesService,
+    private readonly tenantCache: TenantCacheService,
   ) {}
 
   @Get('overview')
@@ -23,38 +25,29 @@ export class OverviewController {
     const range = query.range ?? '24h';
     const agentName = query.agent_name;
     const hourly = isHourlyRange(range);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
 
-    const [
-      tokenSummary, costSummary, messages, costByModel, recentActivity,
-      hourlyTokens, dailyTokens, hourlyCosts, dailyCosts,
-      hourlyMessages, dailyMessages, activeSkills, hasData,
-    ] = await Promise.all([
-      this.aggregation.getTokenSummary(range, user.id, agentName),
-      this.aggregation.getCostSummary(range, user.id, agentName),
-      this.aggregation.getMessageCount(range, user.id, agentName),
-      this.timeseries.getCostByModel(range, user.id, agentName),
-      this.timeseries.getRecentActivity(range, user.id, 5, agentName),
-      hourly ? this.timeseries.getHourlyTokens(range, user.id, agentName) : Promise.resolve([]),
-      hourly ? Promise.resolve([]) : this.timeseries.getDailyTokens(range, user.id, agentName),
-      hourly ? this.timeseries.getHourlyCosts(range, user.id, agentName) : Promise.resolve([]),
-      hourly ? Promise.resolve([]) : this.timeseries.getDailyCosts(range, user.id, agentName),
-      hourly ? this.timeseries.getHourlyMessages(range, user.id, agentName) : Promise.resolve([]),
-      hourly ? Promise.resolve([]) : this.timeseries.getDailyMessages(range, user.id, agentName),
-      this.timeseries.getActiveSkills(range, user.id, agentName),
-      this.aggregation.hasAnyData(user.id, agentName),
-    ]);
+    const [summary, tsData, costByModel, recentActivity, activeSkills, hasData] = await Promise.all(
+      [
+        this.aggregation.getSummaryMetrics(range, user.id, tenantId, agentName),
+        this.timeseries.getTimeseries(range, user.id, hourly, tenantId, agentName),
+        this.timeseries.getCostByModel(range, user.id, agentName, tenantId),
+        this.timeseries.getRecentActivity(range, user.id, 5, agentName, tenantId),
+        this.timeseries.getActiveSkills(range, user.id, agentName, tenantId),
+        this.aggregation.hasAnyData(user.id, agentName, tenantId),
+      ],
+    );
 
     return {
       summary: {
-        tokens_today: tokenSummary.tokens_today,
-        cost_today: costSummary,
-        messages,
-        // TODO: implement real service health tracking
+        tokens_today: summary.tokens.tokens_today,
+        cost_today: summary.cost,
+        messages: summary.messages,
         services_hit: { total: 0, healthy: 0, issues: 0 },
       },
-      token_usage: hourly ? hourlyTokens : dailyTokens,
-      cost_usage: hourly ? hourlyCosts : dailyCosts,
-      message_usage: hourly ? hourlyMessages : dailyMessages,
+      token_usage: tsData.tokenUsage,
+      cost_usage: tsData.costUsage,
+      message_usage: tsData.messageUsage,
       cost_by_model: costByModel,
       recent_activity: recentActivity,
       active_skills: activeSkills,

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -362,6 +362,56 @@ describe('AggregationService', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('getSummaryMetrics', () => {
+    it('returns merged token, cost, and message metrics with trends', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ msg_count: 50, inp: 3000, out: 2000, cost: 5.5 })
+        .mockResolvedValueOnce({ msg_count: 40, tokens: 4000, cost: 4.0 });
+
+      const result = await service.getSummaryMetrics('24h', 'u1', 'tenant-123');
+      expect(result.tokens.tokens_today.value).toBe(5000);
+      expect(result.tokens.tokens_today.trend_pct).toBe(25);
+      expect(result.tokens.tokens_today.sub_values).toEqual({ input: 3000, output: 2000 });
+      expect(result.tokens.input_tokens).toBe(3000);
+      expect(result.tokens.output_tokens).toBe(2000);
+      expect(result.cost.value).toBe(5.5);
+      expect(result.cost.trend_pct).toBeGreaterThan(0);
+      expect(result.messages.value).toBe(50);
+      expect(result.messages.trend_pct).toBe(25);
+    });
+
+    it('handles null query results gracefully', async () => {
+      mockGetRawOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+
+      const result = await service.getSummaryMetrics('24h', 'u1', 'tenant-123');
+      expect(result.tokens.tokens_today.value).toBe(0);
+      expect(result.tokens.input_tokens).toBe(0);
+      expect(result.tokens.output_tokens).toBe(0);
+      expect(result.cost.value).toBe(0);
+      expect(result.messages.value).toBe(0);
+    });
+
+    it('passes agentName to tenant filter', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ msg_count: 10, inp: 100, out: 50, cost: 1.0 })
+        .mockResolvedValueOnce({ msg_count: 8, tokens: 120, cost: 0.8 });
+
+      const result = await service.getSummaryMetrics('7d', 'u1', 'tenant-123', 'bot-1');
+      expect(result.messages.value).toBe(10);
+    });
+
+    it('returns zero trends when no previous data', async () => {
+      mockGetRawOne
+        .mockResolvedValueOnce({ msg_count: 10, inp: 100, out: 50, cost: 1.0 })
+        .mockResolvedValueOnce({ msg_count: 0, tokens: 0, cost: 0 });
+
+      const result = await service.getSummaryMetrics('24h', 'u1');
+      expect(result.tokens.tokens_today.trend_pct).toBe(0);
+      expect(result.cost.trend_pct).toBe(0);
+      expect(result.messages.trend_pct).toBe(0);
+    });
+  });
 });
 
 describe('AggregationService (sql.js / local mode)', () => {

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -30,10 +30,10 @@ export class AggregationService {
     this.dialect = detectDialect(this.dataSource.options.type as string);
   }
 
-  async hasAnyData(userId: string, agentName?: string): Promise<boolean> {
-    const tenantId = await this.tenantCache.resolve(userId);
+  async hasAnyData(userId: string, agentName?: string, tenantId?: string): Promise<boolean> {
+    const resolved = tenantId ?? (await this.tenantCache.resolve(userId)) ?? undefined;
     const qb = this.turnRepo.createQueryBuilder('at').select('1').limit(1);
-    addTenantFilter(qb, userId, agentName, tenantId ?? undefined);
+    addTenantFilter(qb, userId, agentName, resolved);
     const row = await qb.getRawOne();
     return row != null;
   }
@@ -141,6 +141,58 @@ export class AggregationService {
     const current = Number(currentRow?.total ?? 0);
     const previous = Number(prevRow?.total ?? 0);
     return { value: current, trend_pct: computeTrend(current, previous) };
+  }
+
+  async getSummaryMetrics(range: string, userId: string, tenantId?: string, agentName?: string) {
+    const interval = rangeToInterval(range);
+    const prevInterval = rangeToPreviousInterval(range);
+    const cutoff = computeCutoff(interval);
+    const prevCutoff = computeCutoff(prevInterval);
+
+    const safeCost = sqlSanitizeCost('at.cost_usd');
+
+    const currentQb = this.turnRepo
+      .createQueryBuilder('at')
+      .select('COUNT(*)', 'msg_count')
+      .addSelect('COALESCE(SUM(at.input_tokens), 0)', 'inp')
+      .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'out')
+      .addSelect(`COALESCE(SUM(${safeCost}), 0)`, 'cost')
+      .where('at.timestamp >= :cutoff', { cutoff });
+    addTenantFilter(currentQb, userId, agentName, tenantId);
+
+    const prevQb = this.turnRepo
+      .createQueryBuilder('at')
+      .select('COUNT(*)', 'msg_count')
+      .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
+      .addSelect(`COALESCE(SUM(${safeCost}), 0)`, 'cost')
+      .where('at.timestamp >= :prevCutoff', { prevCutoff })
+      .andWhere('at.timestamp < :cutoff', { cutoff });
+    addTenantFilter(prevQb, userId, agentName, tenantId);
+
+    const [cur, prev] = await Promise.all([currentQb.getRawOne(), prevQb.getRawOne()]);
+
+    const inputTotal = Number(cur?.inp ?? 0);
+    const outputTotal = Number(cur?.out ?? 0);
+    const curTokens = inputTotal + outputTotal;
+    const prevTokens = Number(prev?.tokens ?? 0);
+    const curCost = Number(cur?.cost ?? 0);
+    const prevCost = Number(prev?.cost ?? 0);
+    const curMsgs = Number(cur?.msg_count ?? 0);
+    const prevMsgs = Number(prev?.msg_count ?? 0);
+
+    return {
+      tokens: {
+        tokens_today: {
+          value: curTokens,
+          trend_pct: computeTrend(curTokens, prevTokens),
+          sub_values: { input: inputTotal, output: outputTotal },
+        } as MetricWithTrend,
+        input_tokens: inputTotal,
+        output_tokens: outputTotal,
+      },
+      cost: { value: curCost, trend_pct: computeTrend(curCost, prevCost) } as MetricWithTrend,
+      messages: { value: curMsgs, trend_pct: computeTrend(curMsgs, prevMsgs) } as MetricWithTrend,
+    };
   }
 
   async deleteAgent(userId: string, agentName: string): Promise<void> {

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -221,6 +221,78 @@ describe('TimeseriesQueriesService', () => {
     });
   });
 
+  describe('getTimeseries', () => {
+    it('returns merged token, cost, and message timeseries for hourly', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { hour: '2026-02-16T10:00:00', input_tokens: 100, output_tokens: 50, cost: 1.5, count: 5 },
+        { hour: '2026-02-16T11:00:00', input_tokens: 200, output_tokens: 80, cost: 2.0, count: 8 },
+      ]);
+
+      const result = await service.getTimeseries('24h', 'u1', true, 'tenant-123');
+      expect(result.tokenUsage).toHaveLength(2);
+      expect(result.costUsage).toHaveLength(2);
+      expect(result.messageUsage).toHaveLength(2);
+      expect(result.tokenUsage[0]).toEqual({
+        hour: '2026-02-16T10:00:00',
+        input_tokens: 100,
+        output_tokens: 50,
+      });
+      expect(result.costUsage[1]).toEqual({ hour: '2026-02-16T11:00:00', cost: 2.0 });
+      expect(result.messageUsage[0]).toEqual({ hour: '2026-02-16T10:00:00', count: 5 });
+    });
+
+    it('returns merged timeseries for daily buckets', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { date: '2026-02-15', input_tokens: 500, output_tokens: 300, cost: 5.0, count: 20 },
+      ]);
+
+      const result = await service.getTimeseries('7d', 'u1', false, 'tenant-123');
+      expect(result.tokenUsage).toHaveLength(1);
+      expect(result.tokenUsage[0]).toEqual({
+        date: '2026-02-15',
+        input_tokens: 500,
+        output_tokens: 300,
+      });
+      expect(result.costUsage[0]).toEqual({ date: '2026-02-15', cost: 5.0 });
+      expect(result.messageUsage[0]).toEqual({ date: '2026-02-15', count: 20 });
+    });
+
+    it('returns empty arrays when no data', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      const result = await service.getTimeseries('24h', 'u1', true, 'tenant-123');
+      expect(result.tokenUsage).toEqual([]);
+      expect(result.costUsage).toEqual([]);
+      expect(result.messageUsage).toEqual([]);
+    });
+
+    it('defaults null values to 0', async () => {
+      mockGetRawMany.mockResolvedValue([
+        {
+          hour: '2026-02-16T10:00:00',
+          input_tokens: null,
+          output_tokens: null,
+          cost: null,
+          count: null,
+        },
+      ]);
+
+      const result = await service.getTimeseries('24h', 'u1', true);
+      expect(result.tokenUsage[0]).toEqual({
+        hour: '2026-02-16T10:00:00',
+        input_tokens: 0,
+        output_tokens: 0,
+      });
+      expect(result.costUsage[0]).toEqual({ hour: '2026-02-16T10:00:00', cost: 0 });
+      expect(result.messageUsage[0]).toEqual({ hour: '2026-02-16T10:00:00', count: 0 });
+    });
+
+    it('passes agentName to tenant filter', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      const result = await service.getTimeseries('24h', 'u1', true, 'tenant-123', 'bot-1');
+      expect(result.tokenUsage).toEqual([]);
+    });
+  });
+
   describe('getAgentList', () => {
     it('returns agents with sparkline data and display_name', async () => {
       mockGetMany.mockResolvedValueOnce([

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -155,8 +155,56 @@ export class TimeseriesQueriesService {
     }));
   }
 
-  async getActiveSkills(range: string, userId: string, agentName?: string) {
-    const tenantId = (await this.tenantCache.resolve(userId)) ?? undefined;
+  async getTimeseries(
+    range: string,
+    userId: string,
+    hourly: boolean,
+    tenantId?: string,
+    agentName?: string,
+  ) {
+    const interval = rangeToInterval(range);
+    const cutoff = computeCutoff(interval);
+    const bucketExpr = hourly
+      ? sqlHourBucket('at.timestamp', this.dialect)
+      : sqlDateBucket('at.timestamp', this.dialect);
+    const bucketAlias = hourly ? 'hour' : 'date';
+
+    const qb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(bucketExpr, bucketAlias)
+      .addSelect('COALESCE(SUM(at.input_tokens), 0)', 'input_tokens')
+      .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'output_tokens')
+      .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'cost')
+      .addSelect('COUNT(*)', 'count')
+      .where('at.timestamp >= :cutoff', { cutoff });
+    addTenantFilter(qb, userId, agentName, tenantId);
+    const rows = await qb.groupBy(bucketAlias).orderBy(bucketAlias, 'ASC').getRawMany();
+
+    const tokenUsage: {
+      hour?: string;
+      date?: string;
+      input_tokens: number;
+      output_tokens: number;
+    }[] = [];
+    const costUsage: { hour?: string; date?: string; cost: number }[] = [];
+    const messageUsage: { hour?: string; date?: string; count: number }[] = [];
+
+    for (const r of rows) {
+      const bucket = String(r[bucketAlias]);
+      tokenUsage.push({
+        [bucketAlias]: bucket,
+        input_tokens: Number(r['input_tokens'] ?? 0),
+        output_tokens: Number(r['output_tokens'] ?? 0),
+      } as never);
+      costUsage.push({ [bucketAlias]: bucket, cost: Number(r['cost'] ?? 0) } as never);
+      messageUsage.push({ [bucketAlias]: bucket, count: Number(r['count'] ?? 0) } as never);
+    }
+
+    return { tokenUsage, costUsage, messageUsage };
+  }
+
+  async getActiveSkills(range: string, userId: string, agentName?: string, tenantId?: string) {
+    const resolved = tenantId ?? (await this.tenantCache.resolve(userId)) ?? undefined;
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
 
@@ -168,7 +216,7 @@ export class TimeseriesQueriesService {
       .addSelect('MAX(at.timestamp)', 'last_active_at')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.skill_name IS NOT NULL');
-    addTenantFilter(qb, userId, agentName, tenantId);
+    addTenantFilter(qb, userId, agentName, resolved);
     const rows = await qb.groupBy('at.skill_name').orderBy('run_count', 'DESC').getRawMany();
     return rows.map((r: Record<string, unknown>) => ({
       name: String(r['name']),
@@ -179,8 +227,14 @@ export class TimeseriesQueriesService {
     }));
   }
 
-  async getRecentActivity(range: string, userId: string, limit = 5, agentName?: string) {
-    const tenantId = (await this.tenantCache.resolve(userId)) ?? undefined;
+  async getRecentActivity(
+    range: string,
+    userId: string,
+    limit = 5,
+    agentName?: string,
+    tenantId?: string,
+  ) {
+    const resolved = tenantId ?? (await this.tenantCache.resolve(userId)) ?? undefined;
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
 
@@ -203,12 +257,12 @@ export class TimeseriesQueriesService {
       .addSelect('at.fallback_from_model', 'fallback_from_model')
       .addSelect('at.fallback_index', 'fallback_index')
       .where('at.timestamp >= :cutoff', { cutoff });
-    addTenantFilter(qb, userId, agentName, tenantId);
+    addTenantFilter(qb, userId, agentName, resolved);
     return qb.orderBy('at.timestamp', 'DESC').limit(limit).getRawMany();
   }
 
-  async getCostByModel(range: string, userId: string, agentName?: string) {
-    const tenantId = (await this.tenantCache.resolve(userId)) ?? undefined;
+  async getCostByModel(range: string, userId: string, agentName?: string, tenantId?: string) {
+    const resolved = tenantId ?? (await this.tenantCache.resolve(userId)) ?? undefined;
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
 
@@ -220,7 +274,7 @@ export class TimeseriesQueriesService {
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL')
       .andWhere("at.model != ''");
-    addTenantFilter(qb, userId, agentName, tenantId);
+    addTenantFilter(qb, userId, agentName, resolved);
     const rows = await qb.groupBy('at.model').orderBy('tokens', 'DESC').getRawMany();
 
     const totalTokens = rows.reduce(


### PR DESCRIPTION
## Summary

- Merge 6 aggregation queries into 2 via new `getSummaryMetrics()` method (tokens + cost + messages in a single current-period query and a single previous-period query)
- Merge 3 timeseries queries into 1 via new `getTimeseries()` method (tokens, cost, and message counts from a single grouped query)
- Resolve tenant once in the controller and pass to all service calls, eliminating redundant `TenantCacheService.resolve()` lookups
- Total DB round-trips reduced from 12 to 7 per overview request

## Test plan

- [x] All 2199 unit tests pass
- [x] All 106 E2E tests pass
- [x] TypeScript compiles with no errors
- [x] 100% line coverage on all modified files
- [ ] Verify overview endpoint responds in <500ms on production data

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce overview endpoint latency by merging analytics queries and resolving the tenant once. Cuts DB round-trips from 12 to 7 while returning the same data with fewer calls.

- **Refactors**
  - Add `getSummaryMetrics()` to fetch tokens, cost, and messages (current and previous period) in 2 queries.
  - Add `getTimeseries()` to return token, cost, and message series from a single grouped query (hourly/daily).
  - Resolve tenant once in `OverviewController` and pass `tenantId` to all service calls; update services to accept it.
  - Simplify controller response wiring and update tests for the new shapes and tenant flow.

<sup>Written for commit 07f3fb9e94ad8baf59c76ed1d0d6caf5cfb5e48d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

