### PR TITLE
perf: reduce agents endpoint latency with parallel queries

### DIFF
--- a/.changeset/agents-latency.md
+++ b/.changeset/agents-latency.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Reduce agents endpoint latency by parallelizing queries and using daily sparkline buckets

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -16,6 +16,7 @@ import { AggregationService } from '../services/aggregation.service';
 import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
 import { readLocalApiKey } from '../../common/constants/local-mode.constants';
 import { trackCloudEvent } from '../../common/utils/product-telemetry';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
 
 const mockReadLocalApiKey = readLocalApiKey as jest.MockedFunction<typeof readLocalApiKey>;
 
@@ -27,6 +28,7 @@ describe('AgentsController', () => {
   let mockConfigGet: jest.Mock;
   let mockDeleteAgent: jest.Mock;
   let mockRenameAgent: jest.Mock;
+  let mockTenantResolve: jest.Mock;
 
   const origMode = process.env['MANIFEST_MODE'];
 
@@ -45,6 +47,7 @@ describe('AgentsController', () => {
     mockConfigGet = jest.fn().mockReturnValue('');
     mockDeleteAgent = jest.fn().mockResolvedValue(undefined);
     mockRenameAgent = jest.fn().mockResolvedValue(undefined);
+    mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
 
     const module: TestingModule = await Test.createTestingModule({
       imports: [CacheModule.register()],
@@ -70,6 +73,10 @@ describe('AgentsController', () => {
           provide: ConfigService,
           useValue: { get: mockConfigGet },
         },
+        {
+          provide: TenantCacheService,
+          useValue: { resolve: mockTenantResolve },
+        },
       ],
     }).compile();
 
@@ -82,7 +89,15 @@ describe('AgentsController', () => {
 
     expect(result.agents).toHaveLength(2);
     expect(result.agents[0].agent_name).toBe('bot-1');
-    expect(mockGetAgentList).toHaveBeenCalledWith('u1');
+    expect(mockGetAgentList).toHaveBeenCalledWith('u1', 'tenant-123');
+  });
+
+  it('passes undefined tenantId when tenant not found', async () => {
+    mockTenantResolve.mockResolvedValueOnce(null);
+    const user = { id: 'u1' };
+    await controller.getAgents(user as never);
+
+    expect(mockGetAgentList).toHaveBeenCalledWith('u1', undefined);
   });
 
   it('returns agent key prefix without pluginEndpoint when env is not set', async () => {
@@ -185,6 +200,7 @@ describe('AgentsController', () => {
           useValue: { onboardAgent: mockOnboard, getKeyForAgent: jest.fn(), rotateKey: jest.fn() },
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
       ],
     }).compile();
 
@@ -221,6 +237,7 @@ describe('AgentsController', () => {
           useValue: { onboardAgent: mockOnboard, getKeyForAgent: jest.fn(), rotateKey: jest.fn() },
         },
         { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
       ],
     }).compile();
 

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -24,6 +24,7 @@ import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants'
 import { readLocalApiKey } from '../../common/constants/local-mode.constants';
 import { trackCloudEvent } from '../../common/utils/product-telemetry';
 import { slugify } from '../../common/utils/slugify';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
 
 @Controller('api/v1')
 export class AgentsController {
@@ -32,13 +33,15 @@ export class AgentsController {
     private readonly aggregation: AggregationService,
     private readonly apiKeyGenerator: ApiKeyGeneratorService,
     private readonly config: ConfigService,
+    private readonly tenantCache: TenantCacheService,
   ) {}
 
   @Get('agents')
   @UseInterceptors(UserCacheInterceptor)
   @CacheTTL(AGENT_LIST_CACHE_TTL_MS)
   async getAgents(@CurrentUser() user: AuthUser) {
-    const agents = await this.timeseries.getAgentList(user.id);
+    const tenantId = (await this.tenantCache.resolve(user.id)) ?? undefined;
+    const agents = await this.timeseries.getAgentList(user.id, tenantId);
     return { agents };
   }
 

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -237,8 +237,8 @@ describe('TimeseriesQueriesService', () => {
           },
         ])
         .mockResolvedValueOnce([
-          { agent_name: 'bot-1', hour: '2026-02-16T09:00:00', tokens: 100 },
-          { agent_name: 'bot-1', hour: '2026-02-16T10:00:00', tokens: 200 },
+          { agent_name: 'bot-1', date: '2026-02-15', tokens: 100 },
+          { agent_name: 'bot-1', date: '2026-02-16', tokens: 200 },
         ]);
 
       const result = await service.getAgentList('u1');

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -4,7 +4,7 @@ import { DataSource, Repository } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { Agent } from '../../entities/agent.entity';
 import { rangeToInterval } from '../../common/utils/range.util';
-import { addTenantFilter, downsample } from './query-helpers';
+import { addTenantFilter } from './query-helpers';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import {
   DbDialect,
@@ -236,22 +236,16 @@ export class TimeseriesQueriesService {
     }));
   }
 
-  async getAgentList(userId: string) {
-    const tenantId = (await this.tenantCache.resolve(userId)) ?? undefined;
+  async getAgentList(userId: string, tenantId?: string) {
+    const resolved = tenantId ?? (await this.tenantCache.resolve(userId)) ?? undefined;
 
-    // 1C: Skip tenant JOIN when tenantId is cached
     const agentQb = this.agentRepo.createQueryBuilder('a');
-    if (tenantId) {
-      agentQb.where('a.tenant_id = :tenantId', { tenantId });
+    if (resolved) {
+      agentQb.where('a.tenant_id = :tenantId', { tenantId: resolved });
     } else {
       agentQb.leftJoin('a.tenant', 't').where('t.name = :userId', { userId });
     }
-    const agents = await agentQb
-      .andWhere('a.is_active = true')
-      .orderBy('a.created_at', 'DESC')
-      .getMany();
 
-    // 1A: Add 30-day timestamp filter to stats query
     const statsCutoff = computeCutoff('30 days');
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'), this.dialect);
     const statsQb = this.turnRepo
@@ -263,27 +257,27 @@ export class TimeseriesQueriesService {
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'total_tokens')
       .where('at.agent_name IS NOT NULL')
       .andWhere('at.timestamp >= :statsCutoff', { statsCutoff });
-    addTenantFilter(statsQb, userId, undefined, tenantId);
+    addTenantFilter(statsQb, userId, undefined, resolved);
 
     const sparkCutoff = computeCutoff('7 days');
-    const hourExpr = sqlHourBucket('at.timestamp', this.dialect);
+    const dateExpr = sqlDateBucket('at.timestamp', this.dialect);
     const sparkQb = this.turnRepo
       .createQueryBuilder('at')
       .select('at.agent_name', 'agent_name')
-      .addSelect(hourExpr, 'hour')
+      .addSelect(dateExpr, 'date')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'tokens')
       .where('at.timestamp >= :sparkCutoff', { sparkCutoff })
       .andWhere('at.agent_name IS NOT NULL');
-    addTenantFilter(sparkQb, userId, undefined, tenantId);
+    addTenantFilter(sparkQb, userId, undefined, resolved);
 
-    // 1B: Parallelize stats + sparkline queries
-    const [statsRows, sparkRows] = await Promise.all([
+    const [agents, statsRows, sparkRows] = await Promise.all([
+      agentQb.andWhere('a.is_active = true').orderBy('a.created_at', 'DESC').getMany(),
       statsQb.groupBy('at.agent_name').orderBy('last_active', 'DESC').getRawMany(),
       sparkQb
         .groupBy('at.agent_name')
-        .addGroupBy('hour')
+        .addGroupBy('date')
         .orderBy('at.agent_name', 'ASC')
-        .addOrderBy('hour', 'ASC')
+        .addOrderBy('date', 'ASC')
         .getRawMany(),
     ]);
 
@@ -309,7 +303,7 @@ export class TimeseriesQueriesService {
         last_active: String(stats?.['last_active'] ?? a.created_at ?? ''),
         total_cost: Number(stats?.['total_cost'] ?? 0),
         total_tokens: Number(stats?.['total_tokens'] ?? 0),
-        sparkline: downsample(sparkMap.get(name) ?? [], 24),
+        sparkline: sparkMap.get(name) ?? [],
       };
     });
   }


### PR DESCRIPTION
## Summary

- Parallelize all 3 database queries in `getAgentList()` (agents list + stats + sparkline) via `Promise.all` instead of sequential agents fetch → parallel stats+sparkline
- Switch sparkline from 168 hourly buckets (downsampled to 24 in memory) to 7 daily buckets directly in SQL, eliminating post-processing overhead
- Resolve tenant once in controller and pass to service, avoiding redundant `TenantCacheService.resolve()` call
- Remove unused `downsample` import from timeseries-queries service

## Test plan

- [x] All 2189 unit tests pass
- [x] All 106 E2E tests pass
- [x] TypeScript compiles with no errors
- [x] 100% line coverage on all modified files
- [ ] Verify agents endpoint responds in <1s on production data

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce agents endpoint latency by running the agents list, stats, and sparkline queries in parallel and computing the sparkline as 7 daily buckets in SQL. Also resolve the tenant once in the controller and pass it to the service to avoid redundant lookups.

- **Performance**
  - Parallelize agents list, stats, and sparkline queries with Promise.all.
  - Switch sparkline to 7 daily buckets computed in SQL; remove in-memory downsampling and unused `downsample` import.
  - Resolve tenant once in the controller and pass to the service; service still resolves if tenant is missing.
  - Inject `TenantCacheService` in the controller and update tests and `getAgentList(userId, tenantId)` usage.

<sup>Written for commit b226346c11cf4135344dcfeeb0f0a39f296097b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

