### PR TITLE
Optimize frontend performance with code splitting and lazy loading

### DIFF
--- a/.changeset/frontend-performance-optimizations.md
+++ b/.changeset/frontend-performance-optimizations.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Improve frontend performance with route-level code splitting, vendor chunk separation, and asset loading optimizations

--- a/packages/frontend/src/components/CostChart.tsx
+++ b/packages/frontend/src/components/CostChart.tsx
@@ -1,6 +1,7 @@
-import type { Component } from "solid-js";
-import uPlot from "uplot";
-import { getHsl, getHslA } from "../services/theme.js";
+import type { Component } from 'solid-js';
+import uPlot from 'uplot';
+import 'uplot/dist/uPlot.min.css';
+import { getHsl, getHslA } from '../services/theme.js';
 import {
   makeGradientFillFromVar,
   useChartLifecycle,
@@ -10,7 +11,7 @@ import {
   timeScaleRange,
   formatLegendTimestamp,
   formatLegendCost,
-} from "../services/chart-utils.js";
+} from '../services/chart-utils.js';
 
 interface CostChartProps {
   data: Array<{ date?: string; hour?: string; cost: number }>;
@@ -28,10 +29,10 @@ const CostChart: Component<CostChartProps> = (props) => {
       const w = el.clientWidth || el.getBoundingClientRect().width;
       if (w === 0) return null;
 
-      const c1 = getHsl("--chart-1");
-      const axisColor = getHslA("--foreground", 0.55);
-      const gridColor = getHslA("--foreground", 0.05);
-      const bgColor = getHsl("--card");
+      const c1 = getHsl('--chart-1');
+      const axisColor = getHslA('--foreground', 0.55);
+      const gridColor = getHslA('--foreground', 0.05);
+      const bgColor = getHsl('--card');
 
       const axes = createBaseAxes(axisColor, gridColor, props.range);
       axes[1] = {
@@ -39,21 +40,31 @@ const CostChart: Component<CostChartProps> = (props) => {
         values: (_u: uPlot, vals: number[]) => vals.map((v) => `$${v.toFixed(2)}`),
       };
 
-      return new uPlot({
-        width: w,
-        height: 260,
-        padding: [16, 16, 0, 0],
-        cursor: createCursorSnap(bgColor, c1),
-        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max > 0 ? max * 1.15 : 1] } },
-        axes,
-        series: [
-          { value: formatLegendTimestamp },
-          { label: "Cost", stroke: c1, width: 2.5, fill: makeGradientFillFromVar("--chart-1", 0.25), value: formatLegendCost },
-        ],
-      }, [
-        parseTimestamps(props.data),
-        props.data.map((d) => d.cost),
-      ], el);
+      return new uPlot(
+        {
+          width: w,
+          height: 260,
+          padding: [16, 16, 0, 0],
+          cursor: createCursorSnap(bgColor, c1),
+          scales: {
+            x: { time: true, range: timeScaleRange },
+            y: { auto: true, range: (_u, _min, max) => [0, max > 0 ? max * 1.15 : 1] },
+          },
+          axes,
+          series: [
+            { value: formatLegendTimestamp },
+            {
+              label: 'Cost',
+              stroke: c1,
+              width: 2.5,
+              fill: makeGradientFillFromVar('--chart-1', 0.25),
+              value: formatLegendCost,
+            },
+          ],
+        },
+        [parseTimestamps(props.data), props.data.map((d) => d.cost)],
+        el,
+      );
     },
   });
 

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -1,7 +1,7 @@
 import { createSignal, For, Show, type Component } from 'solid-js';
 import { providerIcon } from './ProviderIcon.js';
 import { resolveProviderId, stripCustomPrefix } from '../services/routing-utils.js';
-import { getModelLabel } from '../services/providers.js';
+import { getModelLabel } from '../services/provider-utils.js';
 import {
   setFallbacks,
   clearFallbacks,

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { A, useLocation, useNavigate } from '@solidjs/router';
-import { Show, createSignal, onCleanup, onMount, type Component } from 'solid-js';
+import { Show, createSignal, createEffect, onCleanup, onMount, type Component } from 'solid-js';
 import { useAgentName } from '../services/routing.js';
 import { authClient } from '../services/auth-client.js';
 import { checkLocalMode, isLocalMode } from '../services/local-mode.js';
@@ -8,6 +8,9 @@ import { agentDisplayName } from '../services/agent-display-name.js';
 
 const GITHUB_REPO = 'mnfst/manifest';
 const STAR_DISMISSED_KEY = 'github-star-dismissed';
+const STAR_CACHE_KEY = 'github-star-count';
+const STAR_CACHE_TS_KEY = 'github-star-ts';
+const STAR_CACHE_TTL = 3600000; // 1 hour
 
 const Header: Component = () => {
   const getAgentName = useAgentName();
@@ -23,11 +26,19 @@ const Header: Component = () => {
   onMount(() => {
     checkLocalMode();
     if (!starDismissed()) {
+      const cachedCount = sessionStorage.getItem(STAR_CACHE_KEY);
+      const cachedTs = sessionStorage.getItem(STAR_CACHE_TS_KEY);
+      if (cachedCount && cachedTs && Date.now() - Number(cachedTs) < STAR_CACHE_TTL) {
+        setStarCount(Number(cachedCount));
+        return;
+      }
       fetch('/api/v1/github/stars')
         .then((r) => r.json())
         .then((data) => {
           if (typeof data.stars === 'number') {
             setStarCount(data.stars);
+            sessionStorage.setItem(STAR_CACHE_KEY, String(data.stars));
+            sessionStorage.setItem(STAR_CACHE_TS_KEY, String(Date.now()));
           }
         })
         .catch(() => {});
@@ -77,8 +88,12 @@ const Header: Component = () => {
     }
   };
 
-  document.addEventListener('click', handleClickOutside);
-  onCleanup(() => document.removeEventListener('click', handleClickOutside));
+  createEffect(() => {
+    if (menuOpen()) {
+      document.addEventListener('click', handleClickOutside);
+      onCleanup(() => document.removeEventListener('click', handleClickOutside));
+    }
+  });
 
   return (
     <header class="header">

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, Show, type Component } from 'solid-js';
-import { PROVIDERS, validateApiKey } from '../services/providers.js';
+import { PROVIDERS } from '../services/providers.js';
+import { validateApiKey } from '../services/provider-utils.js';
 import { providerIcon } from './ProviderIcon.js';
 import {
   connectProvider,

--- a/packages/frontend/src/components/SingleTokenChart.tsx
+++ b/packages/frontend/src/components/SingleTokenChart.tsx
@@ -1,6 +1,7 @@
-import type { Component } from "solid-js";
-import uPlot from "uplot";
-import { getHsl, getHslA } from "../services/theme.js";
+import type { Component } from 'solid-js';
+import uPlot from 'uplot';
+import 'uplot/dist/uPlot.min.css';
+import { getHsl, getHslA } from '../services/theme.js';
 import {
   makeGradientFillFromVar,
   useChartLifecycle,
@@ -8,7 +9,7 @@ import {
   createBaseAxes,
   timeScaleRange,
   formatLegendTimestamp,
-} from "../services/chart-utils.js";
+} from '../services/chart-utils.js';
 
 interface SingleTokenChartProps {
   data: Array<{ time: string; value: number }>;
@@ -29,25 +30,37 @@ const SingleTokenChart: Component<SingleTokenChartProps> = (props) => {
       if (w === 0) return null;
 
       const color = getHsl(props.colorVar);
-      const axisColor = getHslA("--foreground", 0.55);
-      const gridColor = getHslA("--foreground", 0.05);
-      const bgColor = getHsl("--card");
+      const axisColor = getHslA('--foreground', 0.55);
+      const gridColor = getHslA('--foreground', 0.05);
+      const bgColor = getHsl('--card');
 
-      return new uPlot({
-        width: w,
-        height: 260,
-        padding: [16, 16, 0, 0],
-        cursor: createCursorSnap(bgColor, color),
-        scales: { x: { time: true, range: timeScaleRange }, y: { auto: true, range: (_u, _min, max) => [0, max > 0 ? max * 1.1 : 10] } },
-        axes: createBaseAxes(axisColor, gridColor, props.range),
-        series: [
-          { value: formatLegendTimestamp },
-          { label: props.label, stroke: color, width: 2.5, fill: makeGradientFillFromVar(props.colorVar, 0.25) },
+      return new uPlot(
+        {
+          width: w,
+          height: 260,
+          padding: [16, 16, 0, 0],
+          cursor: createCursorSnap(bgColor, color),
+          scales: {
+            x: { time: true, range: timeScaleRange },
+            y: { auto: true, range: (_u, _min, max) => [0, max > 0 ? max * 1.1 : 10] },
+          },
+          axes: createBaseAxes(axisColor, gridColor, props.range),
+          series: [
+            { value: formatLegendTimestamp },
+            {
+              label: props.label,
+              stroke: color,
+              width: 2.5,
+              fill: makeGradientFillFromVar(props.colorVar, 0.25),
+            },
+          ],
+        },
+        [
+          props.data.map((d) => new Date(d.time.replace(' ', 'T') + 'Z').getTime() / 1000),
+          props.data.map((d) => d.value),
         ],
-      }, [
-        props.data.map((d) => new Date(d.time.replace(" ", "T") + "Z").getTime() / 1000),
-        props.data.map((d) => d.value),
-      ], el);
+        el,
+      );
     },
   });
 

--- a/packages/frontend/src/components/TokenChart.tsx
+++ b/packages/frontend/src/components/TokenChart.tsx
@@ -1,6 +1,7 @@
-import type { Component } from "solid-js";
-import uPlot from "uplot";
-import { getHsl, getHslA } from "../services/theme.js";
+import type { Component } from 'solid-js';
+import uPlot from 'uplot';
+import 'uplot/dist/uPlot.min.css';
+import { getHsl, getHslA } from '../services/theme.js';
 import {
   makeGradientFillFromVar,
   useChartLifecycle,
@@ -10,7 +11,7 @@ import {
   timeScaleRange,
   formatLegendTimestamp,
   formatLegendTokens,
-} from "../services/chart-utils.js";
+} from '../services/chart-utils.js';
 
 interface TokenChartProps {
   data: Array<{ hour?: string; date?: string; input_tokens: number; output_tokens: number }>;
@@ -28,54 +29,75 @@ const TokenChart: Component<TokenChartProps> = (props) => {
       const w = el.clientWidth || el.getBoundingClientRect().width;
       if (w === 0) return null;
 
-      const inputColor = getHsl("--bar-input");
-      const outputColor = getHsl("--bar-output");
-      const axisColor = getHslA("--foreground", 0.55);
-      const gridColor = getHslA("--foreground", 0.05);
-      const bgColor = getHsl("--card");
+      const inputColor = getHsl('--bar-input');
+      const outputColor = getHsl('--bar-output');
+      const axisColor = getHslA('--foreground', 0.55);
+      const gridColor = getHslA('--foreground', 0.05);
+      const bgColor = getHsl('--card');
 
-      const yRange = (_u: uPlot, _min: number, max: number): [number, number] => [0, max > 0 ? max * 1.1 : 100];
+      const yRange = (_u: uPlot, _min: number, max: number): [number, number] => [
+        0,
+        max > 0 ? max * 1.1 : 100,
+      ];
 
-      return new uPlot({
-        width: w,
-        height: 260,
-        padding: [16, 0, 0, 0],
-        cursor: createCursorSnap(bgColor, inputColor),
-        scales: {
-          x: { time: true, range: timeScaleRange },
-          y: { auto: true, range: yRange },
-          y2: { auto: true, range: yRange },
+      return new uPlot(
+        {
+          width: w,
+          height: 260,
+          padding: [16, 0, 0, 0],
+          cursor: createCursorSnap(bgColor, inputColor),
+          scales: {
+            x: { time: true, range: timeScaleRange },
+            y: { auto: true, range: yRange },
+            y2: { auto: true, range: yRange },
+          },
+          axes: (() => {
+            const a = createBaseAxes(axisColor, gridColor, props.range);
+            a[1] = {
+              ...a[1]!,
+              stroke: inputColor,
+              values: (u: uPlot, vals: number[]) => vals.map((v) => formatLegendTokens(u, v)),
+            };
+            a.push({
+              scale: 'y2',
+              side: 1,
+              stroke: outputColor,
+              grid: { show: false },
+              ticks: { show: false },
+              font: '11px "Inter"',
+              size: 54,
+              gap: 8,
+              values: (u: uPlot, vals: number[]) => vals.map((v) => formatLegendTokens(u, v)),
+            });
+            return a;
+          })(),
+          series: [
+            { value: formatLegendTimestamp },
+            {
+              label: 'Sent to AI',
+              scale: 'y',
+              stroke: inputColor,
+              width: 2.5,
+              fill: makeGradientFillFromVar('--bar-input', 0.25),
+              value: formatLegendTokens,
+            },
+            {
+              label: 'Received from AI',
+              scale: 'y2',
+              stroke: outputColor,
+              width: 2,
+              fill: makeGradientFillFromVar('--bar-output', 0.15),
+              value: formatLegendTokens,
+            },
+          ],
         },
-        axes: (() => {
-          const a = createBaseAxes(axisColor, gridColor, props.range);
-          a[1] = {
-            ...a[1]!,
-            stroke: inputColor,
-            values: (u: uPlot, vals: number[]) => vals.map((v) => formatLegendTokens(u, v)),
-          };
-          a.push({
-            scale: "y2",
-            side: 1,
-            stroke: outputColor,
-            grid: { show: false },
-            ticks: { show: false },
-            font: '11px "Inter"',
-            size: 54,
-            gap: 8,
-            values: (u: uPlot, vals: number[]) => vals.map((v) => formatLegendTokens(u, v)),
-          });
-          return a;
-        })(),
-        series: [
-          { value: formatLegendTimestamp },
-          { label: "Sent to AI", scale: "y", stroke: inputColor, width: 2.5, fill: makeGradientFillFromVar("--bar-input", 0.25), value: formatLegendTokens },
-          { label: "Received from AI", scale: "y2", stroke: outputColor, width: 2, fill: makeGradientFillFromVar("--bar-output", 0.15), value: formatLegendTokens },
+        [
+          parseTimestamps(props.data),
+          props.data.map((d) => d.input_tokens),
+          props.data.map((d) => d.output_tokens),
         ],
-      }, [
-        parseTimestamps(props.data),
-        props.data.map((d) => d.input_tokens),
-        props.data.map((d) => d.output_tokens),
-      ], el);
+        el,
+      );
     },
   });
 

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -1,28 +1,29 @@
 /* @refresh reload */
-import { render } from "solid-js/web";
-import { Router, Route } from "@solidjs/router";
-import { MetaProvider, Title } from "@solidjs/meta";
-import App from "./App.jsx";
-import AuthLayout from "./layouts/AuthLayout.jsx";
-import Workspace from "./pages/Workspace.jsx";
-import Overview from "./pages/Overview.jsx";
-import MessageLog from "./pages/MessageLog.jsx";
-import Settings from "./pages/Settings.jsx";
-import Routing from "./pages/Routing.jsx";
-import Limits from "./pages/Limits.jsx";
-import Account from "./pages/Account.jsx";
-import Login from "./pages/Login.jsx";
-import Register from "./pages/Register.jsx";
-import ResetPassword from "./pages/ResetPassword.jsx";
-import ModelPrices from "./pages/ModelPrices.jsx";
-import Help from "./pages/Help.jsx";
-import AgentGuard from "./components/AgentGuard.jsx";
-import GuestGuard from "./components/GuestGuard.jsx";
-import NotFound from "./pages/NotFound.jsx";
-import ToastContainer from "./components/ToastContainer.jsx";
-import type { ParentComponent } from "solid-js";
-import "uplot/dist/uPlot.min.css";
-import "./styles/theme.css";
+import { render } from 'solid-js/web';
+import { lazy } from 'solid-js';
+import { Router, Route } from '@solidjs/router';
+import { MetaProvider, Title } from '@solidjs/meta';
+import App from './App.jsx';
+import AuthLayout from './layouts/AuthLayout.jsx';
+import Workspace from './pages/Workspace.jsx';
+import AgentGuard from './components/AgentGuard.jsx';
+import GuestGuard from './components/GuestGuard.jsx';
+import NotFound from './pages/NotFound.jsx';
+import ToastContainer from './components/ToastContainer.jsx';
+import type { ParentComponent } from 'solid-js';
+import './styles/theme.css';
+
+const Overview = lazy(() => import('./pages/Overview.jsx'));
+const MessageLog = lazy(() => import('./pages/MessageLog.jsx'));
+const Settings = lazy(() => import('./pages/Settings.jsx'));
+const Routing = lazy(() => import('./pages/Routing.jsx'));
+const Limits = lazy(() => import('./pages/Limits.jsx'));
+const Account = lazy(() => import('./pages/Account.jsx'));
+const Login = lazy(() => import('./pages/Login.jsx'));
+const Register = lazy(() => import('./pages/Register.jsx'));
+const ResetPassword = lazy(() => import('./pages/ResetPassword.jsx'));
+const ModelPrices = lazy(() => import('./pages/ModelPrices.jsx'));
+const Help = lazy(() => import('./pages/Help.jsx'));
 
 const GuestLayout: ParentComponent = (props) => (
   <GuestGuard>
@@ -30,10 +31,10 @@ const GuestLayout: ParentComponent = (props) => (
   </GuestGuard>
 );
 
-const root = document.getElementById("root");
+const root = document.getElementById('root');
 
 if (!root) {
-  throw new Error("Root element not found");
+  throw new Error('Root element not found');
 }
 
 render(

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -333,6 +333,7 @@ const MessageLog: Component = () => {
                       src="/example-messages.svg"
                       alt="Example message log showing LLM call history"
                       class="empty-state__img"
+                      loading="lazy"
                     />
                   </div>
                 </div>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -332,6 +332,7 @@ const Overview: Component = () => {
                       src="/example-overview.svg"
                       alt="Example dashboard overview showing cost and token charts"
                       class="empty-state__img"
+                      loading="lazy"
                     />
                   </div>
                 </div>

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -1,7 +1,8 @@
 import { createSignal, createResource, For, Show, type Component } from 'solid-js';
 import { useParams } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
-import { STAGES, PROVIDERS, getModelLabel } from '../services/providers.js';
+import { STAGES, PROVIDERS } from '../services/providers.js';
+import { getModelLabel } from '../services/provider-utils.js';
 import { providerIcon } from '../components/ProviderIcon.js';
 import ProviderSelectModal from '../components/ProviderSelectModal.js';
 import RoutingInstructionModal from '../components/RoutingInstructionModal.js';

--- a/packages/frontend/src/services/model-display.ts
+++ b/packages/frontend/src/services/model-display.ts
@@ -1,5 +1,5 @@
 import { getModelPrices } from './api.js';
-import { getModelLabel } from './providers.js';
+import { getModelLabel } from './provider-utils.js';
 import { inferProviderFromModel, stripCustomPrefix } from './routing-utils.js';
 
 interface ModelPriceEntry {

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -21,7 +21,7 @@ vi.mock("../../src/services/routing-utils.js", () => ({
   stripCustomPrefix: (m: string) => m.replace(/^custom:[^/]+\//, ""),
 }));
 
-vi.mock("../../src/services/providers.js", () => ({
+vi.mock("../../src/services/provider-utils.js", () => ({
   getModelLabel: (_providerId: string, model: string) => model,
 }));
 

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -97,6 +97,14 @@ describe("Header", () => {
       expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true });
     });
   });
+
+  it("closes dropdown when clicking outside", async () => {
+    render(() => <Header />);
+    await fireEvent.click(screen.getByLabelText("User menu"));
+    expect(screen.getByText("Alice")).toBeDefined();
+    await fireEvent.click(document.body);
+    expect(screen.queryByText("Alice")).toBeNull();
+  });
 });
 
 describe("Header - GitHub star button", () => {
@@ -207,6 +215,41 @@ describe("Header - GitHub star button", () => {
     );
     render(() => <Header />);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses cached star count from sessionStorage", async () => {
+    sessionStorage.setItem("github-star-count", "9999");
+    sessionStorage.setItem("github-star-ts", String(Date.now()));
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    render(() => <Header />);
+    await vi.waitFor(() => {
+      expect(screen.getByText("9,999")).toBeDefined();
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches fresh count when cache is expired", async () => {
+    sessionStorage.setItem("github-star-count", "9999");
+    sessionStorage.setItem("github-star-ts", String(Date.now() - 4000000));
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 5555 }))
+    );
+    render(() => <Header />);
+    await vi.waitFor(() => {
+      expect(screen.getByText("5,555")).toBeDefined();
+    });
+  });
+
+  it("caches star count in sessionStorage after fetch", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ stars: 4321 }))
+    );
+    render(() => <Header />);
+    await vi.waitFor(() => {
+      expect(screen.getByText("4,321")).toBeDefined();
+    });
+    expect(sessionStorage.getItem("github-star-count")).toBe("4321");
+    expect(sessionStorage.getItem("github-star-ts")).toBeDefined();
   });
 });
 

--- a/packages/frontend/tests/services/model-display.test.ts
+++ b/packages/frontend/tests/services/model-display.test.ts
@@ -5,7 +5,7 @@ vi.mock("../../src/services/api.js", () => ({
   getModelPrices: () => mockGetModelPrices(),
 }));
 
-vi.mock("../../src/services/providers.js", () => ({
+vi.mock("../../src/services/provider-utils.js", () => ({
   getModelLabel: (_providerId: string, model: string) => `label:${model}`,
 }));
 

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -20,6 +20,21 @@ export default defineConfig({
   },
   build: {
     target: "esnext",
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes("node_modules/solid-js") || id.includes("node_modules/@solidjs/")) {
+            return "vendor";
+          }
+          if (id.includes("node_modules/uplot")) {
+            return "charts";
+          }
+          if (id.includes("node_modules/better-auth")) {
+            return "auth";
+          }
+        },
+      },
+    },
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
## Summary
This PR improves frontend performance through route-level code splitting, vendor chunk separation, and optimized asset loading. It also includes code organization improvements and bug fixes for event listener management.

## Key Changes

### Performance Optimizations
- **Route-level code splitting**: Converted page imports to lazy-loaded components in `index.tsx` (Overview, MessageLog, Settings, Routing, Limits, Account, Login, Register, ResetPassword, ModelPrices, Help)
- **Vendor chunk separation**: Added Vite rollup configuration to split dependencies into separate chunks:
  - `vendor`: Solid.js and @solidjs packages
  - `charts`: uPlot library
  - `auth`: better-auth library
- **Asset loading**: Added explicit uPlot CSS imports to chart components (TokenChart, CostChart, SingleTokenChart) and removed duplicate import from main index file

### Code Quality Improvements
- **String quote normalization**: Converted all double quotes to single quotes across chart components and index file for consistency
- **Code formatting**: Improved readability of uPlot configuration objects with better line breaks and indentation
- **Module organization**: Extracted `getModelLabel` and `validateApiKey` utilities to new `provider-utils.js` module for better separation of concerns

### Bug Fixes
- **Event listener management**: Fixed Header component's click-outside handler to only attach/detach listeners when menu is open using `createEffect`, preventing unnecessary event listener overhead
- **GitHub star caching**: Implemented sessionStorage-based caching with 1-hour TTL for GitHub star count to reduce API calls and improve performance

## Implementation Details
- Lazy loading uses Solid.js's `lazy()` function for automatic code splitting
- Chart components now explicitly import their CSS dependencies instead of relying on global imports
- Event listener lifecycle is properly managed with `createEffect` and `onCleanup` to prevent memory leaks
- Cache validation checks both stored count and timestamp before deciding to fetch fresh data

https://claude.ai/code/session_01PShZtLUjgdEh42g4bum8RP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the frontend by splitting routes into lazy-loaded chunks and separating vendor bundles, reducing initial load. Also fixes the header dropdown listener and cuts repeated GitHub star fetches.

- **New Features**
  - Route-level code splitting using Solid `lazy()` for 11 pages in `index.tsx`.
  - `vite` manualChunks to split `vendor` (`solid-js`, `@solidjs/*`), `charts` (`uplot`), and `auth` (`better-auth`).
  - Move `uplot` CSS imports into chart components; remove global import.
  - Add `loading="lazy"` to large empty-state SVGs.
  - Extract `getModelLabel` and `validateApiKey` to `provider-utils` to avoid circular deps.

- **Bug Fixes**
  - Header dropdown: add/remove click-outside listener only when menu is open via `createEffect`.
  - Cache GitHub star count in `sessionStorage` with a 1-hour TTL to reduce network calls.

<sup>Written for commit 100b33d785da28ba92a0bc1b208b8f0e06fa41ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

