### PR TITLE
perf: optimize slow backend endpoints for sub-500ms response times

### DIFF
--- a/.changeset/goofy-baboons-lose.md
+++ b/.changeset/goofy-baboons-lose.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Optimize slow backend endpoints for sub-500ms response times: parallelize independent DB queries, batch saves, pre-fetch dedup context, derive summaries from timeseries data, and group notification cron evaluation.

--- a/packages/backend/src/analytics/controllers/costs.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/costs.controller.spec.ts
@@ -6,15 +6,15 @@ import { TimeseriesQueriesService } from '../services/timeseries-queries.service
 
 describe('CostsController', () => {
   let controller: CostsController;
-  let mockGetCostSummary: jest.Mock;
+  let mockGetPreviousCostTotal: jest.Mock;
   let mockGetDailyCosts: jest.Mock;
   let mockGetHourlyCosts: jest.Mock;
   let mockGetCostByModel: jest.Mock;
 
   beforeEach(async () => {
-    mockGetCostSummary = jest.fn().mockResolvedValue({ value: 12.5, trend_pct: 10 });
+    mockGetPreviousCostTotal = jest.fn().mockResolvedValue(10);
     mockGetDailyCosts = jest.fn().mockResolvedValue([]);
-    mockGetHourlyCosts = jest.fn().mockResolvedValue([]);
+    mockGetHourlyCosts = jest.fn().mockResolvedValue([{ hour: '2026-02-16T10:00:00', cost: 12.5 }]);
     mockGetCostByModel = jest.fn().mockResolvedValue([]);
 
     const module: TestingModule = await Test.createTestingModule({
@@ -23,7 +23,7 @@ describe('CostsController', () => {
       providers: [
         {
           provide: AggregationService,
-          useValue: { getCostSummary: mockGetCostSummary },
+          useValue: { getPreviousCostTotal: mockGetPreviousCostTotal },
         },
         {
           provide: TimeseriesQueriesService,
@@ -39,11 +39,12 @@ describe('CostsController', () => {
     controller = module.get<CostsController>(CostsController);
   });
 
-  it('returns cost summary with daily, hourly, and by_model data', async () => {
+  it('returns cost summary derived from hourly data with trend', async () => {
     const user = { id: 'u1' };
     const result = await controller.getCosts({ range: '7d' }, user as never);
 
     expect(result.summary.weekly_cost.value).toBe(12.5);
+    expect(result.summary.weekly_cost.trend_pct).toBe(25);
     expect(result.daily).toBeDefined();
     expect(result.hourly).toBeDefined();
     expect(result.by_model).toBeDefined();
@@ -53,16 +54,35 @@ describe('CostsController', () => {
     const user = { id: 'u1' };
     await controller.getCosts({}, user as never);
 
-    expect(mockGetCostSummary).toHaveBeenCalledWith('7d', 'u1', undefined);
+    expect(mockGetPreviousCostTotal).toHaveBeenCalledWith('7d', 'u1', undefined);
   });
 
   it('passes agent_name to service calls', async () => {
     const user = { id: 'u1' };
     await controller.getCosts({ range: '30d', agent_name: 'bot' }, user as never);
 
-    expect(mockGetCostSummary).toHaveBeenCalledWith('30d', 'u1', 'bot');
+    expect(mockGetPreviousCostTotal).toHaveBeenCalledWith('30d', 'u1', 'bot');
     expect(mockGetDailyCosts).toHaveBeenCalledWith('30d', 'u1', 'bot');
     expect(mockGetHourlyCosts).toHaveBeenCalledWith('30d', 'u1', 'bot');
     expect(mockGetCostByModel).toHaveBeenCalledWith('30d', 'u1', 'bot');
+  });
+
+  it('returns zero trend when previous cost is zero', async () => {
+    mockGetPreviousCostTotal.mockResolvedValue(0);
+    const user = { id: 'u1' };
+    const result = await controller.getCosts({ range: '7d' }, user as never);
+
+    expect(result.summary.weekly_cost.trend_pct).toBe(0);
+  });
+
+  it('computes summary from multiple hourly buckets', async () => {
+    mockGetHourlyCosts.mockResolvedValue([
+      { hour: '2026-02-16T10:00:00', cost: 5.0 },
+      { hour: '2026-02-16T11:00:00', cost: 7.5 },
+    ]);
+    const user = { id: 'u1' };
+    const result = await controller.getCosts({ range: '7d' }, user as never);
+
+    expect(result.summary.weekly_cost.value).toBe(12.5);
   });
 });

--- a/packages/backend/src/analytics/controllers/costs.controller.ts
+++ b/packages/backend/src/analytics/controllers/costs.controller.ts
@@ -7,6 +7,7 @@ import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
 import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { computeTrend } from '../services/query-helpers';
 
 @Controller('api/v1')
 @UseInterceptors(UserCacheInterceptor)
@@ -22,15 +23,23 @@ export class CostsController {
     const range = query.range ?? '7d';
     const agentName = query.agent_name;
 
-    const [costSummary, daily, hourly, byModel] = await Promise.all([
-      this.aggregation.getCostSummary(range, user.id, agentName),
-      this.timeseries.getDailyCosts(range, user.id, agentName),
+    const [hourly, daily, byModel, prevCost] = await Promise.all([
       this.timeseries.getHourlyCosts(range, user.id, agentName),
+      this.timeseries.getDailyCosts(range, user.id, agentName),
       this.timeseries.getCostByModel(range, user.id, agentName),
+      this.aggregation.getPreviousCostTotal(range, user.id, agentName),
     ]);
 
+    // Derive cost summary from hourly timeseries data (avoids separate aggregation query)
+    const currentCost = hourly.reduce((s, h) => s + h.cost, 0);
+
     return {
-      summary: { weekly_cost: costSummary },
+      summary: {
+        weekly_cost: {
+          value: currentCost,
+          trend_pct: computeTrend(currentCost, prevCost),
+        },
+      },
       daily,
       hourly,
       by_model: byModel,

--- a/packages/backend/src/analytics/controllers/tokens.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/tokens.controller.spec.ts
@@ -6,19 +6,17 @@ import { TimeseriesQueriesService } from '../services/timeseries-queries.service
 
 describe('TokensController', () => {
   let controller: TokensController;
-  let mockGetTokenSummary: jest.Mock;
+  let mockGetPreviousTokenTotal: jest.Mock;
   let mockGetHourlyTokens: jest.Mock;
   let mockGetDailyTokens: jest.Mock;
 
   beforeEach(async () => {
-    mockGetTokenSummary = jest.fn().mockResolvedValue({
-      tokens_today: { value: 5000, trend_pct: 25 },
-      input_tokens: 3000,
-      output_tokens: 2000,
-    });
+    mockGetPreviousTokenTotal = jest.fn().mockResolvedValue(4000);
     mockGetHourlyTokens = jest
       .fn()
-      .mockResolvedValue([{ hour: '2026-02-16T10:00:00', input_tokens: 100, output_tokens: 50 }]);
+      .mockResolvedValue([
+        { hour: '2026-02-16T10:00:00', input_tokens: 3000, output_tokens: 2000 },
+      ]);
     mockGetDailyTokens = jest
       .fn()
       .mockResolvedValue([{ date: '2026-02-16', input_tokens: 1000, output_tokens: 500 }]);
@@ -29,7 +27,7 @@ describe('TokensController', () => {
       providers: [
         {
           provide: AggregationService,
-          useValue: { getTokenSummary: mockGetTokenSummary },
+          useValue: { getPreviousTokenTotal: mockGetPreviousTokenTotal },
         },
         {
           provide: TimeseriesQueriesService,
@@ -44,11 +42,13 @@ describe('TokensController', () => {
     controller = module.get<TokensController>(TokensController);
   });
 
-  it('returns token summary with hourly and daily data', async () => {
+  it('returns token summary derived from hourly data with trend', async () => {
     const user = { id: 'u1' };
     const result = await controller.getTokens({ range: '24h' }, user as never);
 
     expect(result.summary.total_tokens.value).toBe(5000);
+    expect(result.summary.total_tokens.trend_pct).toBe(25);
+    expect(result.summary.total_tokens.sub_values).toEqual({ input: 3000, output: 2000 });
     expect(result.summary.input_tokens).toBe(3000);
     expect(result.summary.output_tokens).toBe(2000);
     expect(result.hourly).toHaveLength(1);
@@ -59,15 +59,36 @@ describe('TokensController', () => {
     const user = { id: 'u1' };
     await controller.getTokens({}, user as never);
 
-    expect(mockGetTokenSummary).toHaveBeenCalledWith('24h', 'u1', undefined);
+    expect(mockGetPreviousTokenTotal).toHaveBeenCalledWith('24h', 'u1', undefined);
   });
 
   it('passes agent_name to service calls', async () => {
     const user = { id: 'u1' };
     await controller.getTokens({ range: '7d', agent_name: 'bot' }, user as never);
 
-    expect(mockGetTokenSummary).toHaveBeenCalledWith('7d', 'u1', 'bot');
+    expect(mockGetPreviousTokenTotal).toHaveBeenCalledWith('7d', 'u1', 'bot');
     expect(mockGetHourlyTokens).toHaveBeenCalledWith('7d', 'u1', 'bot');
     expect(mockGetDailyTokens).toHaveBeenCalledWith('7d', 'u1', 'bot');
+  });
+
+  it('returns zero trend when previous tokens is zero', async () => {
+    mockGetPreviousTokenTotal.mockResolvedValue(0);
+    const user = { id: 'u1' };
+    const result = await controller.getTokens({ range: '24h' }, user as never);
+
+    expect(result.summary.total_tokens.trend_pct).toBe(0);
+  });
+
+  it('computes summary from multiple hourly buckets', async () => {
+    mockGetHourlyTokens.mockResolvedValue([
+      { hour: '2026-02-16T10:00:00', input_tokens: 100, output_tokens: 50 },
+      { hour: '2026-02-16T11:00:00', input_tokens: 200, output_tokens: 100 },
+    ]);
+    const user = { id: 'u1' };
+    const result = await controller.getTokens({ range: '24h' }, user as never);
+
+    expect(result.summary.total_tokens.value).toBe(450);
+    expect(result.summary.input_tokens).toBe(300);
+    expect(result.summary.output_tokens).toBe(150);
   });
 });

--- a/packages/backend/src/analytics/controllers/tokens.controller.ts
+++ b/packages/backend/src/analytics/controllers/tokens.controller.ts
@@ -7,6 +7,7 @@ import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
 import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { computeTrend } from '../services/query-helpers';
 
 @Controller('api/v1')
 @UseInterceptors(UserCacheInterceptor)
@@ -22,17 +23,26 @@ export class TokensController {
     const range = query.range ?? '24h';
     const agentName = query.agent_name;
 
-    const [tokenSummary, hourly, daily] = await Promise.all([
-      this.aggregation.getTokenSummary(range, user.id, agentName),
+    const [hourly, daily, prevTokens] = await Promise.all([
       this.timeseries.getHourlyTokens(range, user.id, agentName),
       this.timeseries.getDailyTokens(range, user.id, agentName),
+      this.aggregation.getPreviousTokenTotal(range, user.id, agentName),
     ]);
+
+    // Derive summary from hourly timeseries data (avoids separate aggregation query)
+    const inputTotal = hourly.reduce((s, h) => s + h.input_tokens, 0);
+    const outputTotal = hourly.reduce((s, h) => s + h.output_tokens, 0);
+    const current = inputTotal + outputTotal;
 
     return {
       summary: {
-        total_tokens: tokenSummary.tokens_today,
-        input_tokens: tokenSummary.input_tokens,
-        output_tokens: tokenSummary.output_tokens,
+        total_tokens: {
+          value: current,
+          trend_pct: computeTrend(current, prevTokens),
+          sub_values: { input: inputTotal, output: outputTotal },
+        },
+        input_tokens: inputTotal,
+        output_tokens: outputTotal,
       },
       hourly,
       daily,

--- a/packages/backend/src/analytics/services/aggregation.service.spec.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.spec.ts
@@ -363,6 +363,46 @@ describe('AggregationService', () => {
     });
   });
 
+  describe('getPreviousTokenTotal', () => {
+    it('returns previous period token total', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ total: 4000 });
+      const result = await service.getPreviousTokenTotal('24h', 'test-user');
+      expect(result).toBe(4000);
+    });
+
+    it('returns 0 when no previous data', async () => {
+      mockGetRawOne.mockResolvedValueOnce(null);
+      const result = await service.getPreviousTokenTotal('24h', 'test-user');
+      expect(result).toBe(0);
+    });
+
+    it('passes agentName to tenant filter', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ total: 500 });
+      const result = await service.getPreviousTokenTotal('7d', 'test-user', 'my-agent');
+      expect(result).toBe(500);
+    });
+  });
+
+  describe('getPreviousCostTotal', () => {
+    it('returns previous period cost total', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ total: 2.5 });
+      const result = await service.getPreviousCostTotal('7d', 'test-user');
+      expect(result).toBe(2.5);
+    });
+
+    it('returns 0 when no previous data', async () => {
+      mockGetRawOne.mockResolvedValueOnce(null);
+      const result = await service.getPreviousCostTotal('7d', 'test-user');
+      expect(result).toBe(0);
+    });
+
+    it('passes agentName to tenant filter', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ total: 1.0 });
+      const result = await service.getPreviousCostTotal('30d', 'test-user', 'my-agent');
+      expect(result).toBe(1.0);
+    });
+  });
+
   describe('getSummaryMetrics', () => {
     it('returns merged token, cost, and message metrics with trends', async () => {
       mockGetRawOne

--- a/packages/backend/src/analytics/services/aggregation.service.ts
+++ b/packages/backend/src/analytics/services/aggregation.service.ts
@@ -143,6 +143,41 @@ export class AggregationService {
     return { value: current, trend_pct: computeTrend(current, previous) };
   }
 
+  async getPreviousTokenTotal(range: string, userId: string, agentName?: string): Promise<number> {
+    const tenantId = (await this.tenantCache.resolve(userId)) ?? undefined;
+    const interval = rangeToInterval(range);
+    const prevInterval = rangeToPreviousInterval(range);
+    const cutoff = computeCutoff(interval);
+    const prevCutoff = computeCutoff(prevInterval);
+
+    const prevQb = this.turnRepo
+      .createQueryBuilder('at')
+      .select('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'total')
+      .where('at.timestamp >= :prevCutoff', { prevCutoff })
+      .andWhere('at.timestamp < :cutoff', { cutoff });
+    addTenantFilter(prevQb, userId, agentName, tenantId);
+    const row = await prevQb.getRawOne();
+    return Number(row?.total ?? 0);
+  }
+
+  async getPreviousCostTotal(range: string, userId: string, agentName?: string): Promise<number> {
+    const tenantId = (await this.tenantCache.resolve(userId)) ?? undefined;
+    const interval = rangeToInterval(range);
+    const prevInterval = rangeToPreviousInterval(range);
+    const cutoff = computeCutoff(interval);
+    const prevCutoff = computeCutoff(prevInterval);
+
+    const safeCost = sqlSanitizeCost('at.cost_usd');
+    const prevQb = this.turnRepo
+      .createQueryBuilder('at')
+      .select(`COALESCE(SUM(${safeCost}), 0)`, 'total')
+      .where('at.timestamp >= :prevCutoff', { prevCutoff })
+      .andWhere('at.timestamp < :cutoff', { cutoff });
+    addTenantFilter(prevQb, userId, agentName, tenantId);
+    const row = await prevQb.getRawOne();
+    return Number(row?.total ?? 0);
+  }
+
   async getSummaryMetrics(range: string, userId: string, tenantId?: string, agentName?: string) {
     const interval = rangeToInterval(range);
     const prevInterval = rangeToPreviousInterval(range);

--- a/packages/backend/src/notifications/services/notification-cron.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.spec.ts
@@ -94,6 +94,17 @@ describe('NotificationCronService', () => {
     loggerSpy.mockRestore();
   });
 
+  it('skips rule when consumption fetch fails', async () => {
+    mockGetAllActiveRules.mockResolvedValue([activeRule]);
+    mockGetConsumption.mockRejectedValue(new Error('DB timeout'));
+
+    const loggerSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+    const result = await service.checkThresholds();
+    expect(result).toBe(0);
+    expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('Error fetching consumption'));
+    loggerSpy.mockRestore();
+  });
+
   it('skips rule when already notified for current period (dedup)', async () => {
     mockGetAllActiveRules.mockResolvedValue([activeRule]);
     mockGetConsumption.mockResolvedValue(200000);

--- a/packages/backend/src/notifications/services/notification-cron.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.spec.ts
@@ -96,17 +96,17 @@ describe('NotificationCronService', () => {
 
   it('skips rule when already notified for current period (dedup)', async () => {
     mockGetAllActiveRules.mockResolvedValue([activeRule]);
+    mockGetConsumption.mockResolvedValue(200000);
     mockQuery.mockResolvedValueOnce([{ 1: 1 }]); // dedup check returns existing log
 
     const result = await service.checkThresholds();
     expect(result).toBe(0);
-    expect(mockGetConsumption).not.toHaveBeenCalled();
   });
 
   it('does not trigger when consumption is below threshold', async () => {
     mockGetAllActiveRules.mockResolvedValue([activeRule]);
-    mockQuery.mockResolvedValueOnce([]); // no dedup
     mockGetConsumption.mockResolvedValue(50000); // below threshold
+    mockQuery.mockResolvedValueOnce([]); // no dedup
 
     const result = await service.checkThresholds();
     expect(result).toBe(0);
@@ -171,6 +171,7 @@ describe('NotificationCronService', () => {
 
   it('uses PostgreSQL numbered params ($1, $2) in dedup query', async () => {
     mockGetAllActiveRules.mockResolvedValue([activeRule]);
+    mockGetConsumption.mockResolvedValue(200000);
     mockQuery.mockResolvedValueOnce([{ 1: 1 }]); // dedup hit
 
     await service.checkThresholds();
@@ -222,16 +223,18 @@ describe('NotificationCronService', () => {
     const rule2 = { ...activeRule, id: 'rule-2', threshold: 500000 };
     mockGetAllActiveRules.mockResolvedValue([activeRule, rule2]);
 
-    // Rule 1: triggers
+    // Both rules share the same group (same tenant/agent/period/metric)
+    // Consumption fetched once for the group
+    mockGetConsumption.mockResolvedValueOnce(150000); // above 100k, below 500k
+
+    // Rule 1: triggers (150k > 100k)
     mockQuery
       .mockResolvedValueOnce([]) // no dedup rule-1
       .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email rule-1
       .mockResolvedValueOnce(undefined); // INSERT rule-1
-    mockGetConsumption.mockResolvedValueOnce(150000); // above 100k
 
-    // Rule 2: does not trigger
+    // Rule 2: does not trigger (150k < 500k)
     mockQuery.mockResolvedValueOnce([]); // no dedup rule-2
-    mockGetConsumption.mockResolvedValueOnce(100000); // below 500k
 
     const result = await service.checkThresholds();
     expect(result).toBe(1);
@@ -281,7 +284,10 @@ describe('NotificationCronService', () => {
     const rule2 = { ...activeRule, id: 'rule-2' };
     mockGetAllActiveRules.mockResolvedValue([activeRule, rule2]);
 
-    // Rule 1: throws
+    // Both rules share same group; consumption fetched once
+    mockGetConsumption.mockResolvedValueOnce(200000);
+
+    // Rule 1: dedup query throws
     mockQuery.mockRejectedValueOnce(new Error('DB down'));
 
     // Rule 2: triggers
@@ -289,7 +295,6 @@ describe('NotificationCronService', () => {
       .mockResolvedValueOnce([]) // no dedup
       .mockResolvedValueOnce([{ email: 'user@test.com' }]) // email
       .mockResolvedValueOnce(undefined); // INSERT
-    mockGetConsumption.mockResolvedValueOnce(200000);
 
     const result = await service.checkThresholds();
     expect(result).toBe(1);
@@ -405,6 +410,7 @@ describe('NotificationCronService (sql.js / local mode)', () => {
 
   it('uses ? placeholders in dedup query for sql.js', async () => {
     mockGetAllActiveRules.mockResolvedValue([localRule]);
+    mockGetConsumption.mockResolvedValue(200000);
     mockQuery.mockResolvedValueOnce([{ 1: 1 }]); // dedup hit
 
     await service.checkThresholds();

--- a/packages/backend/src/notifications/services/notification-cron.service.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.ts
@@ -57,14 +57,50 @@ export class NotificationCronService implements OnModuleInit {
     if (!rules.length) return 0;
 
     this.logger.log(`Checking ${rules.length} notification rules...`);
-    let triggered = 0;
 
+    // Group rules by (tenant_id, agent_name, period) to deduplicate consumption queries
+    const groups = new Map<string, { rules: ActiveRule[]; consumption: Map<string, number> }>();
     for (const rule of rules) {
-      try {
-        const sent = await this.evaluateRule(rule);
-        if (sent) triggered++;
-      } catch (err) {
-        this.logger.error(`Error evaluating rule ${rule.id}: ${err}`);
+      const key = `${rule.tenant_id}|${rule.agent_name}|${rule.period}`;
+      if (!groups.has(key)) groups.set(key, { rules: [], consumption: new Map() });
+      groups.get(key)!.rules.push(rule);
+    }
+
+    // Fetch consumption once per group+metric combination
+    for (const [, group] of groups) {
+      const sample = group.rules[0];
+      const { periodStart, periodEnd } = computePeriodBoundaries(sample.period);
+      const metrics = new Set(group.rules.map((r) => r.metric_type));
+      for (const metric of metrics) {
+        try {
+          const value = await this.rulesService.getConsumption(
+            sample.tenant_id,
+            sample.agent_name,
+            metric,
+            periodStart,
+            periodEnd,
+          );
+          group.consumption.set(metric, value);
+        } catch (err) {
+          this.logger.error(
+            `Error fetching consumption for ${sample.agent_name}/${metric}: ${err}`,
+          );
+        }
+      }
+    }
+
+    // Evaluate rules against pre-fetched consumption
+    let triggered = 0;
+    for (const [, group] of groups) {
+      for (const rule of group.rules) {
+        try {
+          const actual = group.consumption.get(rule.metric_type);
+          if (actual === undefined) continue;
+          const sent = await this.evaluateRule(rule, actual);
+          if (sent) triggered++;
+        } catch (err) {
+          this.logger.error(`Error evaluating rule ${rule.id}: ${err}`);
+        }
       }
     }
 
@@ -74,7 +110,7 @@ export class NotificationCronService implements OnModuleInit {
     return triggered;
   }
 
-  private async evaluateRule(rule: ActiveRule): Promise<boolean> {
+  private async evaluateRule(rule: ActiveRule, actual: number): Promise<boolean> {
     const { periodStart, periodEnd } = computePeriodBoundaries(rule.period);
 
     const alreadySent = await this.ds.query(
@@ -82,14 +118,6 @@ export class NotificationCronService implements OnModuleInit {
       [rule.id, periodStart],
     );
     if (alreadySent.length > 0) return false;
-
-    const actual = await this.rulesService.getConsumption(
-      rule.tenant_id,
-      rule.agent_name,
-      rule.metric_type,
-      periodStart,
-      periodEnd,
-    );
 
     if (actual < rule.threshold) return false;
 

--- a/packages/backend/src/notifications/services/notification-rules.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.spec.ts
@@ -30,6 +30,8 @@ describe('NotificationRulesService', () => {
       expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('FROM notification_rules'), [
         'user-1',
         'my-agent',
+        'user-1',
+        'my-agent',
       ]);
     });
   });
@@ -341,7 +343,7 @@ describe('NotificationRulesService', () => {
   });
 
   describe('listRules with PG params', () => {
-    it('uses $1 and $2 numbered params for user and agent', async () => {
+    it('uses $1–$4 numbered params for user and agent', async () => {
       mockQuery.mockResolvedValueOnce([]);
 
       await service.listRules('user-1', 'agent-x');
@@ -349,6 +351,10 @@ describe('NotificationRulesService', () => {
       const sql = mockQuery.mock.calls[0][0] as string;
       expect(sql).toContain('$1');
       expect(sql).toContain('$2');
+      expect(sql).toContain('$3');
+      expect(sql).toContain('$4');
+      const params = mockQuery.mock.calls[0][1];
+      expect(params).toEqual(['user-1', 'agent-x', 'user-1', 'agent-x']);
     });
   });
 

--- a/packages/backend/src/notifications/services/notification-rules.service.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.ts
@@ -22,12 +22,15 @@ export class NotificationRulesService {
         `SELECT nr.*, COALESCE(nl.trigger_count, 0) AS trigger_count
          FROM notification_rules nr
          LEFT JOIN (
-           SELECT rule_id, COUNT(*) AS trigger_count FROM notification_logs GROUP BY rule_id
+           SELECT rule_id, COUNT(*) AS trigger_count
+           FROM notification_logs
+           WHERE rule_id IN (SELECT id FROM notification_rules WHERE user_id = $1 AND agent_name = $2)
+           GROUP BY rule_id
          ) nl ON nl.rule_id = nr.id
-         WHERE nr.user_id = $1 AND nr.agent_name = $2
+         WHERE nr.user_id = $3 AND nr.agent_name = $4
          ORDER BY nr.created_at DESC`,
       ),
-      [userId, agentName],
+      [userId, agentName, userId, agentName],
     );
   }
 
@@ -42,12 +45,25 @@ export class NotificationRulesService {
          (id, tenant_id, agent_id, agent_name, user_id, metric_type, threshold, period, action, is_active, created_at, updated_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
       ),
-      [id, agent.tenant_id, agent.id, dto.agent_name, userId,
-       dto.metric_type, dto.threshold, dto.period, dto.action ?? 'notify',
-       this.dialect === 'sqlite' ? 1 : true, now, now],
+      [
+        id,
+        agent.tenant_id,
+        agent.id,
+        dto.agent_name,
+        userId,
+        dto.metric_type,
+        dto.threshold,
+        dto.period,
+        dto.action ?? 'notify',
+        this.dialect === 'sqlite' ? 1 : true,
+        now,
+        now,
+      ],
     );
 
-    const rows = await this.ds.query(this.sql(`SELECT * FROM notification_rules WHERE id = $1`), [id]);
+    const rows = await this.ds.query(this.sql(`SELECT * FROM notification_rules WHERE id = $1`), [
+      id,
+    ]);
     return rows[0];
   }
 
@@ -58,10 +74,22 @@ export class NotificationRulesService {
     const params: unknown[] = [];
     let paramIdx = 1;
 
-    if (dto.metric_type !== undefined) { sets.push(`metric_type = $${paramIdx++}`); params.push(dto.metric_type); }
-    if (dto.threshold !== undefined) { sets.push(`threshold = $${paramIdx++}`); params.push(dto.threshold); }
-    if (dto.period !== undefined) { sets.push(`period = $${paramIdx++}`); params.push(dto.period); }
-    if (dto.action !== undefined) { sets.push(`action = $${paramIdx++}`); params.push(dto.action); }
+    if (dto.metric_type !== undefined) {
+      sets.push(`metric_type = $${paramIdx++}`);
+      params.push(dto.metric_type);
+    }
+    if (dto.threshold !== undefined) {
+      sets.push(`threshold = $${paramIdx++}`);
+      params.push(dto.threshold);
+    }
+    if (dto.period !== undefined) {
+      sets.push(`period = $${paramIdx++}`);
+      params.push(dto.period);
+    }
+    if (dto.action !== undefined) {
+      sets.push(`action = $${paramIdx++}`);
+      params.push(dto.action);
+    }
     if (dto.is_active !== undefined) {
       sets.push(`is_active = $${paramIdx++}`);
       params.push(this.dialect === 'sqlite' ? (dto.is_active ? 1 : 0) : dto.is_active);
@@ -74,9 +102,14 @@ export class NotificationRulesService {
     params.push(now);
     params.push(ruleId);
 
-    await this.ds.query(this.sql(`UPDATE notification_rules SET ${sets.join(', ')} WHERE id = $${paramIdx}`), params);
+    await this.ds.query(
+      this.sql(`UPDATE notification_rules SET ${sets.join(', ')} WHERE id = $${paramIdx}`),
+      params,
+    );
 
-    const rows = await this.ds.query(this.sql(`SELECT * FROM notification_rules WHERE id = $1`), [ruleId]);
+    const rows = await this.ds.query(this.sql(`SELECT * FROM notification_rules WHERE id = $1`), [
+      ruleId,
+    ]);
     return rows[0];
   }
 
@@ -92,9 +125,10 @@ export class NotificationRulesService {
     periodStart: string,
     periodEnd: string,
   ): Promise<number> {
-    const expr = metric === 'tokens'
-      ? 'COALESCE(SUM(input_tokens + output_tokens), 0)'
-      : 'COALESCE(SUM(cost_usd), 0)';
+    const expr =
+      metric === 'tokens'
+        ? 'COALESCE(SUM(input_tokens + output_tokens), 0)'
+        : 'COALESCE(SUM(cost_usd), 0)';
 
     const rows = await this.ds.query(
       this.sql(
@@ -152,7 +186,9 @@ export class NotificationRulesService {
   }
 
   async getRule(ruleId: string) {
-    const rows = await this.ds.query(this.sql(`SELECT * FROM notification_rules WHERE id = $1`), [ruleId]);
+    const rows = await this.ds.query(this.sql(`SELECT * FROM notification_rules WHERE id = $1`), [
+      ruleId,
+    ]);
     return rows[0];
   }
 }

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -1279,12 +1279,15 @@ describe('TraceIngestService', () => {
   });
 
   it('deduplicates agent_message when proxy error exists near span timestamp', async () => {
-    // findOne (trace_id check) returns null; find (timestamp fallback) returns a nearby error
+    // findOne (trace_id check) returns null; batch dedup recentErrors returns a nearby error
     mockTurnFindOne.mockResolvedValue(null);
     const nearbyTs = new Date(Number(BigInt('1708000000000000000') / 1_000_000n)).toISOString();
     mockTurnFind
-      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass) — no match
-      .mockResolvedValueOnce([{ id: 'proxy-error-id', timestamp: nearbyTs }]); // recentErrors
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([]) // buildDedupContext: errorByTrace
+      .mockResolvedValueOnce([{ id: 'proxy-error-id', timestamp: nearbyTs }]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([]) // buildDedupContext: recentOkMessages
+      .mockResolvedValueOnce([]); // buildDedupContext: recentMessages
 
     const span = makeSpan({
       traceId: 'trace-with-delayed-otlp',
@@ -1301,8 +1304,8 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnFindOne).toHaveBeenCalledTimes(2); // pre-pass fallback check + error dedup
-    expect(mockTurnFind).toHaveBeenCalledTimes(2); // unfilled fallback + timestamp fallback
+    expect(mockTurnFindOne).toHaveBeenCalledTimes(1); // pre-pass fallback check only
+    expect(mockTurnFind).toHaveBeenCalledTimes(5); // unfilled fallback + 4 buildDedupContext
     expect(mockTurnInsert).not.toHaveBeenCalled();
   });
 
@@ -1676,9 +1679,12 @@ describe('TraceIngestService', () => {
     const spanTime = new Date(Number(BigInt('1708000000000000000') / 1_000_000n));
     const nearbyTs = new Date(spanTime.getTime() + 5000).toISOString();
 
-    // First find call returns [] (no errors), second find call returns data-bearing message
+    // Batch dedup context: errorByTrace=[], recentErrors=[], recentOkMessages=[], recentMessages=[data]
     mockTurnFind
-      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([]) // buildDedupContext: errorByTrace
+      .mockResolvedValueOnce([]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([]) // buildDedupContext: recentOkMessages
       .mockResolvedValueOnce([
         {
           id: 'existing-data',
@@ -1687,7 +1693,7 @@ describe('TraceIngestService', () => {
           output_tokens: 200,
           model: 'gpt-4o',
         },
-      ]); // recentMessages (DB ghost fallback)
+      ]); // buildDedupContext: recentMessages
 
     const ghostSpan = makeSpan({
       spanId: 'span-cross-ghost',
@@ -1706,7 +1712,6 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnFind).toHaveBeenCalledTimes(2);
     expect(mockTurnInsert).not.toHaveBeenCalled();
   });
 
@@ -1749,7 +1754,10 @@ describe('TraceIngestService', () => {
     const nearbyTs = new Date(spanTime.getTime() + 5000).toISOString();
 
     mockTurnFind
-      .mockResolvedValueOnce([]) // recentErrors
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([]) // buildDedupContext: errorByTrace
+      .mockResolvedValueOnce([]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([]) // buildDedupContext: recentOkMessages
       .mockResolvedValueOnce([
         {
           id: 'model-only',
@@ -1777,7 +1785,7 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnFind).toHaveBeenCalledTimes(2);
+    expect(mockTurnFind).toHaveBeenCalledTimes(5);
     expect(mockTurnInsert).not.toHaveBeenCalled();
   });
 
@@ -1786,9 +1794,10 @@ describe('TraceIngestService', () => {
     const nearbyTs = new Date(spanTime.getTime() + 5000).toISOString();
 
     mockTurnFind
-      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
-      .mockResolvedValueOnce([]) // recentErrors
-      .mockResolvedValueOnce([]) // proxyDedup (no proxy-recorded messages)
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([]) // buildDedupContext: errorByTrace
+      .mockResolvedValueOnce([]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([]) // buildDedupContext: recentOkMessages
       .mockResolvedValueOnce([
         {
           id: 'session-data',
@@ -1796,8 +1805,9 @@ describe('TraceIngestService', () => {
           input_tokens: 100,
           output_tokens: 50,
           model: 'gpt-4o',
+          session_key: 'session-abc',
         },
-      ]);
+      ]); // buildDedupContext: recentMessages — matching session_key
 
     const ghostSpan = makeSpan({
       spanId: 'span-session-ghost',
@@ -1816,12 +1826,8 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    // Verify the fourth find() call includes session_key in where clause
-    // (first is unfilled fallback, second is recentErrors, third is proxyDedup, fourth is ghost dedup)
-    const fourthFindCall = mockTurnFind.mock.calls[3];
-    expect(fourthFindCall[0].where).toEqual(
-      expect.objectContaining({ session_key: 'session-abc' }),
-    );
+    // session_key filtering now happens in-memory (buildAgentMessage filters recentMessages by session_key)
+    expect(mockTurnFind).toHaveBeenCalledTimes(5);
     expect(mockTurnInsert).not.toHaveBeenCalled();
   });
 
@@ -1871,10 +1877,11 @@ describe('TraceIngestService', () => {
 
   it('inserts empty ok span via DB fallback when no nearby data message exists', async () => {
     mockTurnFind
-      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
-      .mockResolvedValueOnce([]) // recentErrors
-      .mockResolvedValueOnce([]) // proxyDedup (no proxy-recorded messages)
-      .mockResolvedValueOnce([]); // recentMessages (DB ghost fallback)
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([]) // buildDedupContext: errorByTrace
+      .mockResolvedValueOnce([]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([]) // buildDedupContext: recentOkMessages
+      .mockResolvedValueOnce([]); // buildDedupContext: recentMessages (no nearby data)
 
     const emptySpan = makeSpan({
       spanId: 'span-db-pass',
@@ -1893,16 +1900,21 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    expect(mockTurnFind).toHaveBeenCalledTimes(4);
+    expect(mockTurnFind).toHaveBeenCalledTimes(5);
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
   });
 
   it('returns null from buildAgentMessage when existing error turn matches trace_id (dedup)', async () => {
     // Pre-pass remap: findOne (fallback_from_model: Not(IsNull())) → null (no fallback record)
-    // buildAgentMessage: findOne (status: In(['error', 'rate_limited'])) → existing record
-    mockTurnFindOne
-      .mockResolvedValueOnce(null) // remapFallbackSpans — no fallback match
-      .mockResolvedValueOnce({ id: 'existing-error-turn' }); // buildAgentMessage — error dedup hit (line 390)
+    // buildDedupContext: batch errorByTrace find returns a match for trace_id
+    mockTurnFindOne.mockResolvedValueOnce(null); // remapFallbackSpans — no fallback match
+
+    mockTurnFind
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([{ id: 'existing-error-turn', trace_id: 'trace-error-dedup' }]) // buildDedupContext: errorByTrace — match!
+      .mockResolvedValueOnce([]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([]) // buildDedupContext: recentOkMessages
+      .mockResolvedValueOnce([]); // buildDedupContext: recentMessages
 
     const span = makeSpan({
       traceId: 'trace-error-dedup',
@@ -1920,9 +1932,9 @@ describe('TraceIngestService', () => {
 
     await service.ingest(request, testCtx);
 
-    // The first findOne (remap pre-pass) returned null, so span is NOT in fallbackSkipIds.
-    // The second findOne (buildAgentMessage line 382) returns a match, so line 390 returns null.
-    expect(mockTurnFindOne).toHaveBeenCalledTimes(2);
+    // findOne only called once (remap pre-pass). errorByTrace now uses batch find.
+    expect(mockTurnFindOne).toHaveBeenCalledTimes(1);
+    expect(mockTurnFind).toHaveBeenCalledTimes(5);
     expect(mockTurnInsert).not.toHaveBeenCalled();
   });
 
@@ -1971,9 +1983,11 @@ describe('TraceIngestService', () => {
     const nearbyTs = new Date(spanTime.getTime() + 2000).toISOString();
 
     mockTurnFind
-      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
-      .mockResolvedValueOnce([]) // recentErrors
-      .mockResolvedValueOnce([{ id: 'proxy-msg', timestamp: nearbyTs, input_tokens: 500 }]); // proxyDedup — proxy recorded a message with real tokens
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([]) // buildDedupContext: errorByTrace
+      .mockResolvedValueOnce([]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([{ id: 'proxy-msg', timestamp: nearbyTs, input_tokens: 500 }]) // buildDedupContext: recentOkMessages — proxy recorded a message with real tokens
+      .mockResolvedValueOnce([]); // buildDedupContext: recentMessages
 
     const span = makeSpan({
       spanId: 'span-proxy-dedup',
@@ -2000,9 +2014,11 @@ describe('TraceIngestService', () => {
     const nearbyTs = new Date(spanTime.getTime() + 2000).toISOString();
 
     mockTurnFind
-      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
-      .mockResolvedValueOnce([]) // recentErrors
-      .mockResolvedValueOnce([{ id: 'null-tokens-msg', timestamp: nearbyTs, input_tokens: null }]); // proxyDedup — nearby message but with null tokens (doesn't count)
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([]) // buildDedupContext: errorByTrace
+      .mockResolvedValueOnce([]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([{ id: 'null-tokens-msg', timestamp: nearbyTs, input_tokens: null }]) // buildDedupContext: recentOkMessages — null tokens treated as 0
+      .mockResolvedValueOnce([]); // buildDedupContext: recentMessages
 
     const span = makeSpan({
       spanId: 'span-null-tokens',
@@ -2027,9 +2043,11 @@ describe('TraceIngestService', () => {
 
   it('allows 0-token OTLP span when no proxy message exists nearby', async () => {
     mockTurnFind
-      .mockResolvedValueOnce([]) // findUnfilledFallback (pre-pass)
-      .mockResolvedValueOnce([]) // recentErrors
-      .mockResolvedValueOnce([]); // proxyDedup — no proxy data
+      .mockResolvedValueOnce([]) // remapFallbackSpans: unfilled fallback
+      .mockResolvedValueOnce([]) // buildDedupContext: errorByTrace
+      .mockResolvedValueOnce([]) // buildDedupContext: recentErrors
+      .mockResolvedValueOnce([]) // buildDedupContext: recentOkMessages — no proxy data
+      .mockResolvedValueOnce([]); // buildDedupContext: recentMessages
 
     const span = makeSpan({
       spanId: 'span-no-proxy',
@@ -2073,8 +2091,7 @@ describe('TraceIngestService', () => {
 
     await service.ingest(request, testCtx);
     expect(mockTurnInsert).toHaveBeenCalledTimes(1);
-    // Proxy dedup should NOT run (span has tokens), so find() calls are fewer
-    // findUnfilledFallback + recentErrors = 2 (no proxy dedup, no ghost dedup since has model+tokens)
-    expect(mockTurnFind).toHaveBeenCalledTimes(2);
+    // buildDedupContext always runs all 4 batch queries upfront, plus 1 for unfilled fallback
+    expect(mockTurnFind).toHaveBeenCalledTimes(5);
   });
 });

--- a/packages/backend/src/otlp/services/trace-ingest.service.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.ts
@@ -8,7 +8,7 @@ import { ToolExecution } from '../../entities/tool-execution.entity';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { OtlpExportTraceServiceRequest, OtlpSpan, OtlpResourceSpans } from '../interfaces';
 import { IngestionContext } from '../interfaces/ingestion-context.interface';
-import { In, Not, IsNull } from 'typeorm';
+import { In, Not, IsNull, MoreThanOrEqual } from 'typeorm';
 import {
   extractAttributes,
   nanoToDatetime,
@@ -24,6 +24,20 @@ interface SpanEntry {
   uuid: string;
   type: 'agent_message' | 'llm_call' | 'tool_execution' | 'root_request';
   spanId: string;
+}
+
+interface DedupContext {
+  errorTraceIds: Set<string>;
+  recentErrors: { id: string; timestamp: string }[];
+  recentOkMessages: { id: string; timestamp: string; input_tokens: number }[];
+  recentMessages: {
+    id: string;
+    timestamp: string;
+    input_tokens: number;
+    output_tokens: number;
+    model: string | null;
+    session_key: string | null;
+  }[];
 }
 
 @Injectable()
@@ -170,7 +184,8 @@ export class TraceIngestService {
     span: OtlpSpan,
     ctx: IngestionContext,
   ): Promise<Pick<AgentMessage, 'id' | 'model'> | null> {
-    const spanTime = new Date(nanoToDatetime(span.startTimeUnixNano)).getTime();
+    const spanTime = new Date(nanoToDatetime(span.startTimeUnixNano));
+    const cutoff = new Date(spanTime.getTime() - 5 * 60_000).toISOString();
     const candidates = await this.turnRepo.find({
       where: {
         tenant_id: ctx.tenantId,
@@ -179,6 +194,7 @@ export class TraceIngestService {
         status: 'ok',
         input_tokens: 0,
         output_tokens: 0,
+        timestamp: MoreThanOrEqual(cutoff),
       },
       select: ['id', 'model', 'timestamp'],
       order: { timestamp: 'DESC' },
@@ -186,7 +202,82 @@ export class TraceIngestService {
     });
     if (candidates.length === 0) return null;
     const cTime = new Date(candidates[0].timestamp).getTime();
-    return Math.abs(cTime - spanTime) <= 60_000 ? candidates[0] : null;
+    return Math.abs(cTime - spanTime.getTime()) <= 60_000 ? candidates[0] : null;
+  }
+
+  private async buildDedupContext(
+    spans: OtlpSpan[],
+    spanMap: Map<string, SpanEntry>,
+    ghostSpanIds: Set<string>,
+    fallbackSkipIds: Set<string>,
+    ctx: IngestionContext,
+  ): Promise<DedupContext> {
+    // Collect trace IDs from agent_message spans that need dedup
+    const traceIds: string[] = [];
+    for (const span of spans) {
+      const spanId = toHexString(span.spanId);
+      const entry = spanMap.get(spanId);
+      if (entry?.type !== 'agent_message') continue;
+      if (ghostSpanIds.has(spanId) || fallbackSkipIds.has(spanId)) continue;
+      const traceId = toHexString(span.traceId);
+      if (traceId) traceIds.push(traceId);
+    }
+
+    // Batch fetch all dedup data in parallel
+    const [errorByTrace, recentErrors, recentOkMessages, recentMessages] = await Promise.all([
+      traceIds.length > 0
+        ? this.turnRepo.find({
+            where: {
+              trace_id: In(traceIds),
+              tenant_id: ctx.tenantId,
+              status: In(['error', 'rate_limited']),
+            },
+            select: ['id', 'trace_id'],
+          })
+        : Promise.resolve([]),
+      this.turnRepo.find({
+        where: {
+          tenant_id: ctx.tenantId,
+          agent_id: ctx.agentId,
+          status: In(['error', 'rate_limited']),
+        },
+        select: ['id', 'timestamp'],
+        order: { timestamp: 'DESC' },
+        take: 10,
+      }),
+      this.turnRepo.find({
+        where: { tenant_id: ctx.tenantId, agent_id: ctx.agentId, status: 'ok' },
+        select: ['id', 'timestamp', 'input_tokens'],
+        order: { timestamp: 'DESC' },
+        take: 10,
+      }),
+      this.turnRepo.find({
+        where: { tenant_id: ctx.tenantId, agent_id: ctx.agentId },
+        select: ['id', 'timestamp', 'input_tokens', 'output_tokens', 'model', 'session_key'],
+        order: { timestamp: 'DESC' },
+        take: 10,
+      }),
+    ]);
+
+    return {
+      errorTraceIds: new Set(
+        errorByTrace.map((e) => (e as unknown as { trace_id: string }).trace_id),
+      ),
+      recentErrors: recentErrors.map((e) => ({ id: e.id, timestamp: e.timestamp })),
+      recentOkMessages: recentOkMessages.map((m) => ({
+        id: m.id,
+        timestamp: m.timestamp,
+        input_tokens: m.input_tokens ?? 0,
+      })),
+      recentMessages: recentMessages.map((m) => ({
+        id: m.id,
+        timestamp: m.timestamp,
+        input_tokens: m.input_tokens ?? 0,
+        output_tokens: m.output_tokens ?? 0,
+        model: m.model ?? null,
+        session_key: (m as unknown as { session_key: string | null }).session_key ?? null,
+      })),
+    };
   }
 
   private async insertAll(
@@ -208,6 +299,16 @@ export class TraceIngestService {
       fallbackModelOverrides,
       fallbackDurations,
     );
+
+    // Batch pre-fetch all dedup data (replaces per-span DB queries)
+    const dedupCtx = await this.buildDedupContext(
+      spans,
+      spanMap,
+      ghostSpanIds,
+      fallbackSkipIds,
+      ctx,
+    );
+
     const messageAggregates = new Map<
       string,
       {
@@ -234,7 +335,7 @@ export class TraceIngestService {
       if (entry.type === 'root_request') continue;
       if (entry.type === 'agent_message') {
         if (ghostSpanIds.has(spanId) || fallbackSkipIds.has(spanId)) continue;
-        const row = await this.buildAgentMessage(span, attrs, entry, ctx);
+        const row = this.buildAgentMessage(span, attrs, entry, ctx, dedupCtx);
         if (row) agentMessageRows.push(row);
       } else if (entry.type === 'llm_call') {
         llmCallRows.push(this.buildLlmCall(span, attrs, entry, spanMap, ctx));
@@ -370,80 +471,48 @@ export class TraceIngestService {
     if (updates.length > 0) await Promise.all(updates);
   }
 
-  private async buildAgentMessage(
+  private buildAgentMessage(
     span: OtlpSpan,
     attrs: AttributeMap,
     entry: SpanEntry,
     ctx: IngestionContext,
-  ): Promise<Record<string, unknown> | null> {
+    dedup: DedupContext,
+  ): Record<string, unknown> | null {
     // Skip if the proxy already recorded an error for this trace (avoids duplicates).
     const traceId = toHexString(span.traceId);
-    if (traceId) {
-      const existing = await this.turnRepo.findOne({
-        where: {
-          trace_id: traceId,
-          tenant_id: ctx.tenantId,
-          status: In(['error', 'rate_limited']),
-        },
-        select: ['id'],
-      });
-      if (existing) return null;
-    }
+    if (traceId && dedup.errorTraceIds.has(traceId)) return null;
 
-    // Fallback dedup: fetch recent errors for this agent and check timestamp proximity.
+    // Fallback dedup: check pre-fetched recent errors for timestamp proximity.
     const spanTime = new Date(nanoToDatetime(span.startTimeUnixNano)).getTime();
-    const recentErrors = await this.turnRepo.find({
-      where: {
-        tenant_id: ctx.tenantId,
-        agent_id: ctx.agentId,
-        status: In(['error', 'rate_limited']),
-      },
-      select: ['id', 'timestamp'],
-      order: { timestamp: 'DESC' },
-      take: 5,
-    });
-    const hasNearbyError = recentErrors.some((e) => {
+    const hasNearbyError = dedup.recentErrors.some((e) => {
       const errorTime = new Date(e.timestamp).getTime();
       return Math.abs(errorTime - spanTime) <= 30_000;
     });
     if (hasNearbyError) return null;
 
-    // Proxy dedup: if this span carries 0 tokens, check if the proxy already
-    // recorded a success message with real tokens for the same agent within 60s.
+    // Proxy dedup: if this span carries 0 tokens, check pre-fetched OK messages.
     const spanInputTokens = attrNumber(attrs, 'gen_ai.usage.input_tokens') ?? 0;
     const spanOutputTokens = attrNumber(attrs, 'gen_ai.usage.output_tokens') ?? 0;
     if (spanInputTokens === 0 && spanOutputTokens === 0) {
-      const recentOkMessages = await this.turnRepo.find({
-        where: { tenant_id: ctx.tenantId, agent_id: ctx.agentId, status: 'ok' },
-        select: ['id', 'timestamp', 'input_tokens'],
-        order: { timestamp: 'DESC' },
-        take: 3,
-      });
-      const hasProxyData = recentOkMessages.some((m) => {
+      const hasProxyData = dedup.recentOkMessages.some((m) => {
         const mTime = new Date(m.timestamp).getTime();
-        return Math.abs(mTime - spanTime) <= 60_000 && (m.input_tokens ?? 0) > 0;
+        return Math.abs(mTime - spanTime) <= 60_000 && m.input_tokens > 0;
       });
       if (hasProxyData) return null;
     }
 
-    // DB-level ghost dedup: if this span is empty-ok, check if a data-bearing
-    // message for the same agent already exists within 60s (cross-batch case).
+    // DB-level ghost dedup: if this span is empty-ok, check pre-fetched recent messages.
     // Scope by session_key when available to avoid cross-session false positives.
     if (this.isEmptyOkSpan(span, attrs)) {
       const sessionKey = attrString(attrs, 'session.key');
-      const where: Record<string, string> = { tenant_id: ctx.tenantId, agent_id: ctx.agentId };
-      if (sessionKey) where.session_key = sessionKey;
-      const recentMessages = await this.turnRepo.find({
-        where,
-        select: ['id', 'timestamp', 'input_tokens', 'output_tokens', 'model'],
-        order: { timestamp: 'DESC' },
-        take: 5,
-      });
-      const hasNearbyData = recentMessages.some((m) => {
+      const candidates = sessionKey
+        ? dedup.recentMessages.filter((m) => m.session_key === sessionKey)
+        : dedup.recentMessages;
+      const hasNearbyData = candidates.some((m) => {
         const mTime = new Date(m.timestamp).getTime();
         return (
           Math.abs(mTime - spanTime) <= 60_000 &&
-          ((m.input_tokens ?? 0) > 0 || (m.output_tokens ?? 0) > 0 || m.model != null)
+          (m.input_tokens > 0 || m.output_tokens > 0 || m.model != null)
         );
       });
       if (hasNearbyData) return null;

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -425,10 +425,10 @@ describe('RoutingService', () => {
         tier: 'complex',
         override_model: 'gpt-4o',
       });
-      mockTierRepo.find.mockResolvedValueOnce([override]); // overrides query
-      mockTierRepo.findOne.mockResolvedValue({
-        auto_assigned_model: 'claude-opus-4-6',
-      });
+      mockTierRepo.find
+        .mockResolvedValueOnce([override]) // overrides query
+        .mockResolvedValueOnce([]) // allTiers query (fallback cleanup)
+        .mockResolvedValueOnce([{ tier: 'complex', auto_assigned_model: 'claude-opus-4-6' }]); // notification batch fetch
 
       mockPricingCache.getByModel.mockReturnValue({
         provider: 'OpenAI',
@@ -438,7 +438,7 @@ describe('RoutingService', () => {
 
       expect(override.override_model).toBeNull();
       expect(mockTierRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({ override_model: null }),
+        expect.arrayContaining([expect.objectContaining({ override_model: null })]),
       );
       expect(result.notifications).toHaveLength(1);
       expect(result.notifications[0]).toContain('gpt-4o');
@@ -460,10 +460,10 @@ describe('RoutingService', () => {
         tier: 'simple',
         override_model: 'gpt-4o',
       });
-      mockTierRepo.find.mockResolvedValueOnce([override]);
-      mockTierRepo.findOne.mockResolvedValue({
-        auto_assigned_model: null,
-      });
+      mockTierRepo.find
+        .mockResolvedValueOnce([override]) // overrides query
+        .mockResolvedValueOnce([]) // allTiers (fallback cleanup)
+        .mockResolvedValueOnce([{ tier: 'simple', auto_assigned_model: null }]); // notification batch fetch
       mockPricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' } as ModelPricing);
 
       const result = await service.removeProvider('a1', 'openai');
@@ -486,10 +486,10 @@ describe('RoutingService', () => {
         tier: 'custom_tier',
         override_model: 'gpt-4o',
       });
-      mockTierRepo.find.mockResolvedValueOnce([override]);
-      mockTierRepo.findOne.mockResolvedValue({
-        auto_assigned_model: null,
-      });
+      mockTierRepo.find
+        .mockResolvedValueOnce([override]) // overrides query
+        .mockResolvedValueOnce([]) // allTiers (fallback cleanup)
+        .mockResolvedValueOnce([{ tier: 'custom_tier', auto_assigned_model: null }]); // notification batch fetch
       mockPricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' } as ModelPricing);
 
       const result = await service.removeProvider('a1', 'openai');
@@ -524,13 +524,9 @@ describe('RoutingService', () => {
       await service.removeProvider('a1', 'openai');
 
       // The save for fallback cleanup should have only claude-sonnet-4
-      const fallbackSaveCall = mockTierRepo.save.mock.calls.find(
-        (c: unknown[]) => (c[0] as { fallback_models?: string[] }).fallback_models !== undefined,
+      expect(mockTierRepo.save).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ fallback_models: ['claude-sonnet-4'] })]),
       );
-      expect(fallbackSaveCall).toBeDefined();
-      expect(
-        (fallbackSaveCall![0] as { fallback_models: string[] | null }).fallback_models,
-      ).toEqual(['claude-sonnet-4']);
     });
 
     it('should skip tiers with null or empty fallback_models during cleanup', async () => {
@@ -568,13 +564,9 @@ describe('RoutingService', () => {
       await service.removeProvider('a1', 'openai');
 
       // Only the standard tier (with actual fallback_models) should be saved
-      const fallbackSaveCall = mockTierRepo.save.mock.calls.find(
-        (c: unknown[]) => (c[0] as { fallback_models?: string[] }).fallback_models !== undefined,
+      expect(mockTierRepo.save).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ fallback_models: ['claude-sonnet-4'] })]),
       );
-      expect(fallbackSaveCall).toBeDefined();
-      expect(
-        (fallbackSaveCall![0] as { fallback_models: string[] | null }).fallback_models,
-      ).toEqual(['claude-sonnet-4']);
     });
 
     it('should set fallback_models to null when all belong to removed provider', async () => {
@@ -601,14 +593,10 @@ describe('RoutingService', () => {
 
       await service.removeProvider('a1', 'openai');
 
-      // All fallbacks removed → fallback_models set to null (line 121)
-      const fallbackSaveCall = mockTierRepo.save.mock.calls.find(
-        (c: unknown[]) => 'fallback_models' in (c[0] as Record<string, unknown>),
+      // All fallbacks removed → fallback_models set to null
+      expect(mockTierRepo.save).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ fallback_models: null })]),
       );
-      expect(fallbackSaveCall).toBeDefined();
-      expect(
-        (fallbackSaveCall![0] as { fallback_models: string[] | null }).fallback_models,
-      ).toBeNull();
     });
 
     it('should not invalidate overrides from other providers', async () => {
@@ -771,7 +759,9 @@ describe('RoutingService', () => {
 
       expect(tier1.override_model).toBeNull();
       expect(tier2.override_model).toBeNull();
-      expect(mockTierRepo.save).toHaveBeenCalledTimes(2);
+      // Batch save: all tiers saved in one call
+      expect(mockTierRepo.save).toHaveBeenCalledTimes(1);
+      expect(mockTierRepo.save).toHaveBeenCalledWith(expect.arrayContaining([tier1, tier2]));
       expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
       expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a2');
     });
@@ -793,7 +783,7 @@ describe('RoutingService', () => {
 
       // Should save with only the kept model
       expect(mockTierRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({ fallback_models: ['keep-model'] }),
+        expect.arrayContaining([expect.objectContaining({ fallback_models: ['keep-model'] })]),
       );
       expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
     });
@@ -812,7 +802,7 @@ describe('RoutingService', () => {
       await service.invalidateOverridesForRemovedModels(['removed-model']);
 
       expect(mockTierRepo.save).toHaveBeenCalledWith(
-        expect.objectContaining({ fallback_models: null }),
+        expect.arrayContaining([expect.objectContaining({ fallback_models: null })]),
       );
       expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
     });

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -99,18 +99,20 @@ export class RoutingService {
     });
 
     const invalidated: { tier: string; modelName: string }[] = [];
+    const tiersToSave: TierAssignment[] = [];
     for (const tier of overrides) {
       const pricing = this.pricingCache.getByModel(tier.override_model!);
       if (pricing && pricing.provider.toLowerCase() === provider.toLowerCase()) {
         invalidated.push({ tier: tier.tier, modelName: tier.override_model! });
         tier.override_model = null;
         tier.updated_at = new Date().toISOString();
-        await this.tierRepo.save(tier);
+        tiersToSave.push(tier);
       }
     }
 
     // Clean fallback models belonging to the disconnected provider
     const allTiers = await this.tierRepo.find({ where: { agent_id: agentId } });
+    const savedIds = new Set(tiersToSave.map((t) => t.id));
     for (const tier of allTiers) {
       if (!tier.fallback_models || tier.fallback_models.length === 0) continue;
       const filtered = tier.fallback_models.filter((m) => {
@@ -120,9 +122,12 @@ export class RoutingService {
       if (filtered.length !== tier.fallback_models.length) {
         tier.fallback_models = filtered.length > 0 ? filtered : null;
         tier.updated_at = new Date().toISOString();
-        await this.tierRepo.save(tier);
+        if (!savedIds.has(tier.id)) tiersToSave.push(tier);
       }
     }
+
+    // Batch save all tier mutations
+    if (tiersToSave.length > 0) await this.tierRepo.save(tiersToSave);
 
     // Deactivate provider and recalculate
     existing.is_active = false;
@@ -131,18 +136,23 @@ export class RoutingService {
     await this.autoAssign.recalculate(agentId);
     this.routingCache.invalidateAgent(agentId);
 
-    // Build notification messages
+    // Build notification messages — batch fetch updated tiers
     const notifications: string[] = [];
-    for (const { tier, modelName } of invalidated) {
-      const updated = await this.tierRepo.findOne({
-        where: { agent_id: agentId, tier },
+    if (invalidated.length > 0) {
+      const tierNames = invalidated.map((i) => i.tier);
+      const updatedTiers = await this.tierRepo.find({
+        where: { agent_id: agentId, tier: In(tierNames) },
       });
-      const newModel = updated?.auto_assigned_model ?? null;
-      const tierLabel = TIER_LABELS[tier] ?? tier;
-      const suffix = newModel
-        ? `${tierLabel} is back to automatic mode (${newModel}).`
-        : `${tierLabel} is back to automatic mode.`;
-      notifications.push(`${modelName} is no longer available. ${suffix}`);
+      const tierMap = new Map(updatedTiers.map((t) => [t.tier, t]));
+      for (const { tier, modelName } of invalidated) {
+        const updated = tierMap.get(tier);
+        const newModel = updated?.auto_assigned_model ?? null;
+        const tierLabel = TIER_LABELS[tier] ?? tier;
+        const suffix = newModel
+          ? `${tierLabel} is back to automatic mode (${newModel}).`
+          : `${tierLabel} is back to automatic mode.`;
+        notifications.push(`${modelName} is no longer available. ${suffix}`);
+      }
     }
 
     return { notifications };
@@ -173,35 +183,47 @@ export class RoutingService {
     });
 
     const agentIds = new Set<string>();
+    const tiersToSave: TierAssignment[] = [];
     for (const tier of affected) {
       this.logger.warn(
         `Clearing override ${tier.override_model} for agent ${tier.agent_id} tier ${tier.tier} (model removed)`,
       );
       tier.override_model = null;
       tier.updated_at = new Date().toISOString();
-      await this.tierRepo.save(tier);
+      tiersToSave.push(tier);
       agentIds.add(tier.agent_id);
     }
 
-    // Also clean fallback models referencing removed models
-    const allTiers = await this.tierRepo.find();
-    for (const tier of allTiers) {
+    // Also clean fallback models referencing removed models.
+    // Scope to affected agents first; if none found, scan all tiers with fallbacks.
+    const fallbackTiers =
+      agentIds.size > 0
+        ? await this.tierRepo.find({ where: { agent_id: In([...agentIds]) } })
+        : await this.tierRepo.find();
+    const savedIds = new Set(tiersToSave.map((t) => t.id));
+    for (const tier of fallbackTiers) {
       if (!tier.fallback_models || tier.fallback_models.length === 0) continue;
       const filtered = tier.fallback_models.filter((m) => !removedSet.has(m));
       if (filtered.length !== tier.fallback_models.length) {
         tier.fallback_models = filtered.length > 0 ? filtered : null;
         tier.updated_at = new Date().toISOString();
-        await this.tierRepo.save(tier);
+        if (!savedIds.has(tier.id)) tiersToSave.push(tier);
         agentIds.add(tier.agent_id);
       }
     }
 
+    // Batch save all tier mutations
+    if (tiersToSave.length > 0) await this.tierRepo.save(tiersToSave);
+
     if (agentIds.size === 0) return;
 
-    for (const agentId of agentIds) {
-      await this.autoAssign.recalculate(agentId);
-      this.routingCache.invalidateAgent(agentId);
-    }
+    // Parallel recalculate + cache invalidation
+    await Promise.all(
+      [...agentIds].map((agentId) => {
+        this.routingCache.invalidateAgent(agentId);
+        return this.autoAssign.recalculate(agentId);
+      }),
+    );
 
     this.logger.log(
       `Invalidated ${affected.length} overrides for ${agentIds.size} agents (removed models: ${removedModels.join(', ')})`,

--- a/packages/backend/src/security/security.service.ts
+++ b/packages/backend/src/security/security.service.ts
@@ -18,14 +18,24 @@ export class SecurityService {
     const interval = rangeToInterval(range);
     const cutoff = computeCutoff(interval);
 
-    const countRows = await this.securityRepo
-      .createQueryBuilder('se')
-      .select('se.severity', 'severity')
-      .addSelect('COUNT(*)', 'cnt')
-      .where('se.timestamp >= :cutoff', { cutoff })
-      .andWhere('se.user_id = :userId', { userId })
-      .groupBy('se.severity')
-      .getRawMany();
+    const [countRows, events] = await Promise.all([
+      this.securityRepo
+        .createQueryBuilder('se')
+        .select('se.severity', 'severity')
+        .addSelect('COUNT(*)', 'cnt')
+        .where('se.timestamp >= :cutoff', { cutoff })
+        .andWhere('se.user_id = :userId', { userId })
+        .groupBy('se.severity')
+        .getRawMany(),
+      this.securityRepo
+        .createQueryBuilder('se')
+        .select(['se.id', 'se.timestamp', 'se.severity', 'se.category', 'se.description'])
+        .where('se.timestamp >= :cutoff', { cutoff })
+        .andWhere('se.user_id = :userId', { userId })
+        .orderBy('se.timestamp', 'DESC')
+        .limit(50)
+        .getMany(),
+    ]);
 
     let criticalCount = 0;
     let warningCount = 0;
@@ -33,15 +43,6 @@ export class SecurityService {
       if (row.severity === 'critical') criticalCount = Number(row.cnt);
       if (row.severity === 'warning') warningCount = Number(row.cnt);
     }
-
-    const events = await this.securityRepo
-      .createQueryBuilder('se')
-      .select(['se.id', 'se.timestamp', 'se.severity', 'se.category', 'se.description'])
-      .where('se.timestamp >= :cutoff', { cutoff })
-      .andWhere('se.user_id = :userId', { userId })
-      .orderBy('se.timestamp', 'DESC')
-      .limit(50)
-      .getMany();
 
     const score = this.computeRiskScore(criticalCount, warningCount);
 
@@ -62,7 +63,9 @@ export class SecurityService {
   private computeRiskScore(criticalCount: number, warningCount: number) {
     const value = Math.max(
       0,
-      100 - criticalCount * SecurityService.CRITICAL_PENALTY - warningCount * SecurityService.WARNING_PENALTY,
+      100 -
+        criticalCount * SecurityService.CRITICAL_PENALTY -
+        warningCount * SecurityService.WARNING_PENALTY,
     );
 
     let riskLevel: string;


### PR DESCRIPTION
## Summary

- **Security endpoint**: Parallelize independent count + events queries with `Promise.all()`
- **Notification rules**: Fix unfiltered `LEFT JOIN` subquery — scope to user's rule IDs to avoid full `notification_logs` table scan; fix SQLite positional parameter bug (`$1`/`$2` reuse)
- **Routing service**: Batch tier saves in `removeProvider()` and `invalidateOverridesForRemovedModels()` instead of N+1 individual saves; parallelize recalculations
- **Trace ingestion**: Pre-fetch all dedup context (error traces, recent errors, OK messages, ghost messages) in 4 parallel batch queries upfront instead of per-span DB lookups; add 5-minute time cutoff to `findUnfilledFallback()`
- **Tokens endpoint**: Derive summary from hourly timeseries data + lightweight `getPreviousTokenTotal()` (eliminates separate `getTokenSummary()` call)
- **Costs endpoint**: Same pattern — derive summary from hourly data + `getPreviousCostTotal()`
- **Notification cron**: Group rules by `(tenant_id, agent_name, period)` to deduplicate consumption queries

## Test plan

- [x] All 2230 backend unit tests pass
- [x] All 106 backend E2E tests pass (including previously failing `notifications.e2e-spec` and `limits.e2e-spec`)
- [x] All 1312 frontend tests pass
- [x] TypeScript compiles with no errors
- [x] Lint-staged hooks pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes slow backend endpoints to respond under 500ms by parallelizing DB work, batching writes, and deriving analytics summaries from timeseries data. Removes redundant queries and N+1 patterns across security, analytics, routing, notifications, and trace ingestion.

- **Refactors**
  - Security: run counts and events queries in parallel.
  - Tokens/Costs: derive summaries from hourly series and `getPreviousTokenTotal`/`getPreviousCostTotal` for trends; remove separate aggregation query.
  - Routing: batch tier saves and fallback cleanup; parallel auto-assign recalculation; fewer DB roundtrips.
  - Trace ingestion: pre-fetch dedup context (error-by-trace, recent errors/ok/messages) once; add 5‑minute cutoff to unfilled fallback; avoid per-span DB queries.
  - Notification cron: group rules by tenant/agent/period; fetch consumption once per group+metric.

- **Bug Fixes**
  - Notification rules: scope `LEFT JOIN` subquery to the user’s rule IDs to avoid full `notification_logs` scans.
  - Fix positional parameter handling in PG/SQLite (e.g., `listRules`) to prevent `$1/$2` reuse and ensure correct binding.
  - Notification cron: handle consumption fetch errors by skipping the rule and continuing.

<sup>Written for commit d490f1e06fddb0f821836c4365432028ab965b1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

