### PR TITLE
refactor: replace 3-mode system with 2-axis (mode × devMode)

### DIFF
--- a/.changeset/refactor-devmode-2axis.md
+++ b/.changeset/refactor-devmode-2axis.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Replace 3-mode system (cloud/local/dev) with 2-axis configuration (mode × devMode). The `mode` field now only accepts `cloud` or `local` for deployment model, while `devMode` (boolean) independently controls development behaviors like skipping API keys and faster metrics. The old `mode: "dev"` is still accepted for backward compatibility but logs a deprecation warning. `devMode` is auto-detected when the endpoint is a loopback address and no `mnfst_*` API key is provided.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Manifest Development Guidelines
 
-Last updated: 2026-03-05
+Last updated: 2026-03-11
 
 ## IMPORTANT: Local Mode First
 
@@ -17,14 +17,15 @@ MANIFEST_MODE=local PORT=38238 BIND_ADDRESS=127.0.0.1 \
   node -r dotenv/config packages/backend/dist/main.js
 
 # 2. Configure the plugin
-openclaw config set plugins.entries.manifest.config.mode dev
+openclaw config set plugins.entries.manifest.config.mode cloud
+openclaw config set plugins.entries.manifest.config.devMode true
 openclaw config set plugins.entries.manifest.config.endpoint http://localhost:38238/otlp
 
 # 3. Restart the gateway
 openclaw gateway restart
 ```
 
-No API key needed. The dashboard shows an orange **Dev** badge in the header when running in local mode. Dev mode uses the OTLP loopback bypass — the `OtlpAuthGuard` trusts same-machine connections without Bearer token auth.
+No API key needed. The dashboard shows an orange **Dev** badge in the header when running in development environment (`NODE_ENV !== 'production'`). Dev mode uses the OTLP loopback bypass — the `OtlpAuthGuard` trusts same-machine connections without Bearer token auth. Note: `devMode` is auto-detected when the endpoint is a loopback address and no `mnfst_*` API key is provided.
 
 ### Resetting OpenClaw Plugin Settings
 
@@ -32,7 +33,8 @@ If the plugin gets into a bad state (stale config, wrong endpoint, cached errors
 
 ```bash
 # Reset plugin config to defaults
-openclaw config set plugins.entries.manifest.config.mode dev
+openclaw config set plugins.entries.manifest.config.mode cloud
+openclaw config set plugins.entries.manifest.config.devMode true
 openclaw config set plugins.entries.manifest.config.endpoint http://localhost:<PORT>/otlp
 
 # Force restart the gateway (kills existing process and starts fresh)
@@ -41,7 +43,7 @@ openclaw gateway restart
 
 **Important notes:**
 - The OpenClaw config lives at `~/.openclaw/openclaw.json`. The gateway may restore certain fields (like `apiKey`) on restart — editing the file directly doesn't always stick.
-- In dev mode, the gateway sends `Authorization: Bearer dev-no-auth` to the proxy. The `OtlpAuthGuard` accepts any non-`mnfst_*` token from loopback IPs in local mode, so this works without real API keys.
+- When `devMode` is true, the gateway sends `Authorization: Bearer dev-no-auth` to the proxy. The `OtlpAuthGuard` accepts any non-`mnfst_*` token from loopback IPs in local mode, so this works without real API keys.
 - After restarting the backend server, **always restart the gateway too** (`openclaw gateway restart`) — the OTLP pipeline doesn't automatically reconnect.
 - The gateway batches OTLP telemetry and sends it every ~10-30 seconds. New messages may take a moment to appear in the dashboard.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,11 @@ MANIFEST_MODE=local PORT=38238 BIND_ADDRESS=127.0.0.1 \
   node -r dotenv/config packages/backend/dist/main.js
 ```
 
-2. Configure the plugin to use dev mode:
+2. Configure the plugin with `devMode` enabled:
 
 ```bash
-openclaw config set plugins.entries.manifest.config.mode dev
+openclaw config set plugins.entries.manifest.config.mode cloud
+openclaw config set plugins.entries.manifest.config.devMode true
 openclaw config set plugins.entries.manifest.config.endpoint http://localhost:38238/otlp
 ```
 
@@ -99,7 +100,9 @@ openclaw config set plugins.entries.manifest.config.endpoint http://localhost:38
 openclaw gateway restart
 ```
 
-That's it — no API key needed. Telemetry from your agent flows directly to the local backend. Open `http://localhost:38238` to see the dashboard (you'll see an orange **Dev** badge in the header).
+That's it — no API key needed. Telemetry from your agent flows directly to the local backend. Open `http://localhost:38238` to see the dashboard (you'll see **Local** and **Dev** badges in the header).
+
+> **Note:** `devMode` is auto-detected when the endpoint is a loopback address and no `mnfst_*` API key is provided. The old `mode: "dev"` is still accepted for backward compatibility but is deprecated — it maps to `mode: "cloud"` + `devMode: true` internally.
 
 **When to use dev mode:**
 
@@ -126,7 +129,7 @@ The scripts work without Claude Code. Run them directly from the repo root:
 
 ```bash
 bash skills/manifest-status/scripts/manifest_status.sh
-bash skills/setup-manifest-plugin/scripts/setup_manifest.sh 38238 --mode dev
+bash skills/setup-manifest-plugin/scripts/setup_manifest.sh 38238 --mode local
 bash skills/uninstall-manifest-plugin/scripts/uninstall_manifest.sh
 ```
 
@@ -137,7 +140,7 @@ Requires `jq` and the `openclaw` CLI.
 | Skill | Command | What it does |
 | --- | --- | --- |
 | `manifest-status` | `/manifest-status` | Prints a diagnostic table of the current plugin configuration (mode, endpoint, keys, default model) |
-| `setup-manifest-plugin` | `/setup-manifest-plugin` | Configures the OpenClaw gateway to route through a local Manifest backend. Accepts a port and optional mode (`dev`/`local`/`cloud`). Restarts the gateway. |
+| `setup-manifest-plugin` | `/setup-manifest-plugin` | Configures the OpenClaw gateway to route through a local Manifest backend. Accepts a port and optional mode (`local`/`cloud`). Restarts the gateway. |
 | `uninstall-manifest-plugin` | `/uninstall-manifest-plugin` | Removes the Manifest plugin, cleans up auth profiles and local data, detects available providers, and sets the best default model. |
 
 ### Typical Workflow
@@ -184,20 +187,21 @@ Requires `jq` and the `openclaw` CLI.
 
 #### Plugin Settings
 
-The plugin exposes 5 user-facing settings via `openclaw.plugin.json`. Cloud mode is the default. Set `mode` to `local` for zero-config local mode.
+The plugin exposes 6 user-facing settings via `openclaw.plugin.json`. Cloud mode is the default. Set `mode` to `local` for zero-config local mode.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `mode` | `string` | `cloud` | Controls the plugin's operating mode. `cloud` exports telemetry to `app.manifest.build` (default). `local` starts an embedded NestJS server backed by sql.js. `dev` connects to a local backend without API key management (uses OTLP loopback bypass). |
-| `apiKey` | `string` | env `MANIFEST_API_KEY` | OTLP ingest key (must start with `mnfst_`). Required in cloud mode. Auto-generated and persisted to `~/.openclaw/manifest/config.json` in local mode. Ignored in dev mode. |
-| `endpoint` | `string` | `https://app.manifest.build/api/v1/otlp` | Base URL for the OTLP exporters. The SDK appends `/v1/traces`, `/v1/metrics`, `/v1/logs` automatically. Only used in cloud and dev modes — local mode overrides this to `http://{host}:{port}/otlp`. |
+| `mode` | `string` | `cloud` | Deployment model: `cloud` exports telemetry to `app.manifest.build` (default). `local` starts an embedded NestJS server backed by sql.js. (`dev` is accepted for backward compatibility but deprecated — use `devMode` instead.) |
+| `devMode` | `boolean` | auto | Development environment flag. Skips API key validation, uses faster metrics interval (10s), disables product telemetry. Auto-detected when endpoint is a loopback address and no `mnfst_*` API key is provided. |
+| `apiKey` | `string` | env `MANIFEST_API_KEY` | OTLP ingest key (must start with `mnfst_`). Required in cloud mode when `devMode` is false. Auto-generated in local mode. Ignored when `devMode` is true. |
+| `endpoint` | `string` | `https://app.manifest.build/api/v1/otlp` | Base URL for the OTLP exporters. The SDK appends `/v1/traces`, `/v1/metrics`, `/v1/logs` automatically. Only used in cloud mode — local mode overrides this to `http://{host}:{port}/otlp`. |
 | `port` | `number` | `2099` | Bind port for the embedded server (local mode only). Also used for the dashboard URL and the injected OpenAI-compatible provider config. |
 | `host` | `string` | `127.0.0.1` | Bind address for the embedded server (local mode only). |
 
 Settings are parsed in `src/config.ts` (`parseConfig`) and validated in `validateConfig`. The JSON schema in `openclaw.plugin.json` (package root) is the source of truth — the build copies it to `dist/`. Some internal values are not user-configurable:
 
 - **`serviceName`**: Always `"openclaw-gateway"` (hardcoded via `DEFAULTS.SERVICE_NAME` in `src/constants.ts`)
-- **`metricsIntervalMs`**: 10s for local/dev, 30s for cloud (computed per mode in `src/telemetry.ts`)
+- **`metricsIntervalMs`**: 10s when `devMode` or local, 30s for cloud production (computed in `src/telemetry.ts`)
 
 ## Making Changes
 

--- a/packages/backend/src/health/health.controller.spec.ts
+++ b/packages/backend/src/health/health.controller.spec.ts
@@ -18,6 +18,7 @@ describe('HealthController', () => {
 
   beforeEach(() => {
     delete process.env['MANIFEST_MODE'];
+    delete process.env['NODE_ENV'];
     mockVersionCheck = createMockVersionCheck();
     controller = new HealthController(mockVersionCheck);
   });
@@ -74,5 +75,23 @@ describe('HealthController', () => {
     const result = controller.getHealth();
     expect(result).not.toHaveProperty('latestVersion');
     expect(result).not.toHaveProperty('updateAvailable');
+  });
+
+  it('returns devMode true when NODE_ENV is not production', () => {
+    process.env['NODE_ENV'] = 'development';
+    const result = controller.getHealth();
+    expect(result.devMode).toBe(true);
+  });
+
+  it('returns devMode false when NODE_ENV is production', () => {
+    process.env['NODE_ENV'] = 'production';
+    const result = controller.getHealth();
+    expect(result.devMode).toBe(false);
+  });
+
+  it('returns devMode true when NODE_ENV is unset', () => {
+    delete process.env['NODE_ENV'];
+    const result = controller.getHealth();
+    expect(result.devMode).toBe(true);
   });
 });

--- a/packages/backend/src/health/health.controller.ts
+++ b/packages/backend/src/health/health.controller.ts
@@ -12,12 +12,14 @@ export class HealthController {
   @Get('health')
   getHealth() {
     const isLocal = process.env['MANIFEST_MODE'] === 'local';
+    const isDev = process.env['NODE_ENV'] !== 'production';
     const optOut = process.env['MANIFEST_TELEMETRY_OPTOUT'];
     return {
       status: 'healthy',
       uptime_seconds: Math.floor((Date.now() - this.startTime) / 1000),
       ...(isLocal ? { version: this.versionCheck.getCurrentVersion() } : {}),
       mode: isLocal ? 'local' : 'cloud',
+      devMode: isDev,
       telemetryOptOut: optOut === '1' || optOut === 'true',
       ...this.versionCheck.getUpdateInfo(),
     };

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { A, useLocation, useNavigate } from '@solidjs/router';
 import { Show, createSignal, createEffect, onCleanup, onMount, type Component } from 'solid-js';
 import { useAgentName } from '../services/routing.js';
 import { authClient } from '../services/auth-client.js';
-import { checkLocalMode, isLocalMode } from '../services/local-mode.js';
+import { checkLocalMode, isLocalMode, isDevMode } from '../services/local-mode.js';
 import { displayName } from '../services/display-name.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 
@@ -107,6 +107,9 @@ const Header: Component = () => {
           />
         </A>
         <Show when={isLocalMode()}>
+          <span class="header__mode-badge">Local</span>
+        </Show>
+        <Show when={isDevMode()}>
           <span class="header__mode-badge header__mode-badge--dev">Dev</span>
         </Show>
         <Show when={getAgentName()}>

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -64,16 +64,14 @@ const Sidebar: Component = () => {
         >
           Limits
         </A>
-        <Show when={!isLocalMode()}>
-          <A
-            href={path('/settings')}
-            class="sidebar__link"
-            classList={{ active: isActive('/settings') }}
-            aria-current={isActive('/settings') ? 'page' : undefined}
-          >
-            Settings
-          </A>
-        </Show>
+        <A
+          href={path('/settings')}
+          class="sidebar__link"
+          classList={{ active: isActive('/settings') }}
+          aria-current={isActive('/settings') ? 'page' : undefined}
+        >
+          Settings
+        </A>
       </Show>
 
       <Show when={getAgentName()}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -17,11 +17,6 @@ const Settings: Component = () => {
   const location = useLocation<{ newApiKey?: string }>();
   const agentName = () => decodeURIComponent(params.agentName);
 
-  // In local mode, settings (rename/delete) are not available — redirect to overview.
-  if (isLocalMode()) {
-    navigate(`/agents/${params.agentName}`, { replace: true });
-    return null;
-  }
   const [name, setName] = createSignal(agentName());
   const [saving, setSaving] = createSignal(false);
   const [saved, setSaved] = createSignal(false);
@@ -81,7 +76,7 @@ const Settings: Component = () => {
     }
   };
 
-  const TABS = () => (isLocalMode() ? ([] as const) : (['General', 'Agent setup'] as const));
+  const TABS = () => ['General', 'Agent setup'] as const;
   type Tab = 'General' | 'Agent setup';
   const [tab, setTab] = createSignal<Tab>('General');
 
@@ -227,7 +222,7 @@ const Settings: Component = () => {
               </button>
             </div>
           </div>
-          <Show when={rotatedKey() && !isLocalMode()}>
+          <Show when={rotatedKey()}>
             <div style="padding: 0 var(--gap-md) var(--gap-md);">
               <div style="background: hsl(var(--chart-5) / 0.1); border: 1px solid hsl(var(--chart-5) / 0.3); border-radius: var(--radius); padding: 10px 14px; margin-bottom: 12px; font-size: var(--font-size-sm); color: hsl(var(--foreground));">
                 Copy your new API key now — it won't be shown again.

--- a/packages/frontend/src/services/local-mode.ts
+++ b/packages/frontend/src/services/local-mode.ts
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createSignal } from 'solid-js';
 
 export interface UpdateInfo {
   version: string;
@@ -8,6 +8,7 @@ export interface UpdateInfo {
 
 interface HealthResponse {
   mode?: string;
+  devMode?: boolean;
   version?: string;
   latestVersion?: string;
   updateAvailable?: boolean;
@@ -15,6 +16,7 @@ interface HealthResponse {
 }
 
 const [isLocalMode, setIsLocalMode] = createSignal<boolean | null>(null);
+const [isDevMode, setIsDevMode] = createSignal<boolean>(false);
 const [updateInfo, setUpdateInfo] = createSignal<UpdateInfo | null>(null);
 const [telemetryOptOut, setTelemetryOptOut] = createSignal<boolean>(false);
 
@@ -24,11 +26,12 @@ export function checkLocalMode(): Promise<boolean> {
   if (isLocalMode() !== null) return Promise.resolve(isLocalMode()!);
 
   if (!fetchPromise) {
-    fetchPromise = fetch("/api/v1/health")
+    fetchPromise = fetch('/api/v1/health')
       .then((res) => res.json())
       .then((data: HealthResponse) => {
-        const local = data.mode === "local";
+        const local = data.mode === 'local';
         setIsLocalMode(local);
+        setIsDevMode(data.devMode === true);
         setTelemetryOptOut(data.telemetryOptOut === true);
 
         if (data.version) {
@@ -50,4 +53,4 @@ export function checkLocalMode(): Promise<boolean> {
   return fetchPromise;
 }
 
-export { isLocalMode, updateInfo, telemetryOptOut };
+export { isLocalMode, isDevMode, updateInfo, telemetryOptOut };

--- a/packages/frontend/src/styles/controls.css
+++ b/packages/frontend/src/styles/controls.css
@@ -340,20 +340,28 @@
   margin-bottom: 9px;
 }
 
-.header__logo-img--dark { display: none; }
-.dark .header__logo-img--light { display: none; }
-.dark .header__logo-img--dark { display: block; }
+.header__logo-img--dark {
+  display: none;
+}
+.dark .header__logo-img--light {
+  display: none;
+}
+.dark .header__logo-img--dark {
+  display: block;
+}
 
 .header__mode-badge {
+  display: inline-flex;
+  align-items: center;
   font-size: 10px;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: 2px 7px;
+  padding: 4px 7px 3px;
   border-radius: var(--radius);
   background: hsl(var(--success) / 0.15);
   color: hsl(var(--success));
-  line-height: 1.4;
+  line-height: 1;
   user-select: none;
 }
 

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -26,9 +26,11 @@ vi.mock("../../src/services/routing.js", () => ({
 }));
 
 let mockIsLocalMode: boolean | null = false;
+let mockIsDevMode = false;
 vi.mock("../../src/services/local-mode.js", () => ({
   checkLocalMode: vi.fn().mockResolvedValue(false),
   isLocalMode: () => mockIsLocalMode,
+  isDevMode: () => mockIsDevMode,
 }));
 
 let mockAgentDisplayName: string | null = null;
@@ -43,6 +45,7 @@ beforeEach(() => {
   sessionStorage.clear();
   mockAgentName = null;
   mockIsLocalMode = false;
+  mockIsDevMode = false;
   mockAgentDisplayName = null;
 });
 
@@ -268,16 +271,37 @@ describe("Header - local mode", () => {
     expect(logoLink.getAttribute("href")).toBe("/");
   });
 
-  it("hides Cloud badge in local mode", () => {
+  it("shows Local badge in local mode", () => {
     mockIsLocalMode = true;
     render(() => <Header />);
-    expect(screen.queryByText("Cloud")).toBeNull();
+    expect(screen.getByText("Local")).toBeDefined();
   });
 
-  it("hides Dev badge in cloud mode", () => {
+  it("hides Local badge in cloud mode", () => {
     mockIsLocalMode = false;
     render(() => <Header />);
+    expect(screen.queryByText("Local")).toBeNull();
+  });
+
+  it("shows Dev badge when devMode is true and not local", () => {
+    mockIsDevMode = true;
+    mockIsLocalMode = false;
+    render(() => <Header />);
+    expect(screen.getByText("Dev")).toBeDefined();
+  });
+
+  it("hides Dev badge when devMode is false", () => {
+    mockIsDevMode = false;
+    render(() => <Header />);
     expect(screen.queryByText("Dev")).toBeNull();
+  });
+
+  it("shows both Local and Dev badges when both local and devMode", () => {
+    mockIsLocalMode = true;
+    mockIsDevMode = true;
+    render(() => <Header />);
+    expect(screen.getByText("Local")).toBeDefined();
+    expect(screen.getByText("Dev")).toBeDefined();
   });
 
   it("hides Workspace breadcrumb in local mode", () => {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -57,9 +57,9 @@ describe("Sidebar with agent", () => {
     expect(screen.getByText("MANAGE")).toBeDefined();
   });
 
-  it("hides Settings link in local mode", () => {
-    const { container } = render(() => <Sidebar />);
-    expect(container.textContent).not.toContain("Settings");
+  it("shows Settings link in local mode", () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText("Settings")).toBeDefined();
   });
 
   it("renders Settings link in cloud mode", () => {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -347,16 +347,22 @@ describe("Settings", () => {
       mockIsLocalMode = true;
     });
 
-    it("redirects to agent overview in local mode", () => {
-      const { container } = render(() => <Settings />);
-      expect(mockNavigate).toHaveBeenCalledWith(`/agents/${mockAgentName}`, { replace: true });
-      expect(container.textContent).toBe("");
+    it("renders Settings page in local mode", () => {
+      render(() => <Settings />);
+      expect(screen.getByText("Settings")).toBeDefined();
+      expect(screen.getByLabelText("Agent name")).toBeDefined();
     });
 
-    it("does not render any settings content in local mode", () => {
+    it("shows both tabs in local mode", () => {
+      render(() => <Settings />);
+      expect(screen.getByText("General")).toBeDefined();
+      expect(screen.getByText("Agent setup")).toBeDefined();
+    });
+
+    it("hides Danger zone in local mode", () => {
       const { container } = render(() => <Settings />);
-      expect(container.textContent).not.toContain("Settings");
-      expect(container.textContent).not.toContain("Agent name");
+      expect(container.textContent).not.toContain("Danger zone");
+      expect(container.textContent).not.toContain("Delete agent");
     });
   });
 });

--- a/packages/frontend/tests/services/local-mode.test.ts
+++ b/packages/frontend/tests/services/local-mode.test.ts
@@ -113,4 +113,37 @@ describe("local-mode", () => {
 
     expect(updateInfo()).toBeNull();
   });
+
+  it("sets isDevMode to true when health response has devMode true", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      json: () => Promise.resolve({ mode: "cloud", devMode: true }),
+    });
+
+    const { checkLocalMode, isDevMode } = await import("../../src/services/local-mode.js");
+    await checkLocalMode();
+
+    expect(isDevMode()).toBe(true);
+  });
+
+  it("defaults isDevMode to false when devMode is absent", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      json: () => Promise.resolve({ mode: "cloud" }),
+    });
+
+    const { checkLocalMode, isDevMode } = await import("../../src/services/local-mode.js");
+    await checkLocalMode();
+
+    expect(isDevMode()).toBe(false);
+  });
+
+  it("sets isDevMode to false when devMode is false", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      json: () => Promise.resolve({ mode: "cloud", devMode: false }),
+    });
+
+    const { checkLocalMode, isDevMode } = await import("../../src/services/local-mode.js");
+    await checkLocalMode();
+
+    expect(isDevMode()).toBe(false);
+  });
 });

--- a/packages/openclaw-plugin/README.md
+++ b/packages/openclaw-plugin/README.md
@@ -11,7 +11,7 @@ The `packages/openclaw-plugin` directory contains the OpenClaw plugin that power
 | File | Purpose |
 |------|---------|
 | `index.ts` | Plugin entry point — registers hooks, routing, tools, and commands with the OpenClaw API |
-| `config.ts` | Configuration parsing and validation (`mode`, `apiKey`, `endpoint`, etc.) |
+| `config.ts` | Configuration parsing and validation (`mode`, `devMode`, `apiKey`, `endpoint`, etc.) |
 | `hooks.ts` | OpenClaw lifecycle hooks (`message_received`, `before_agent_start`, `tool_result_persist`, `agent_end`) |
 | `routing.ts` | LLM router — scores queries across 23 dimensions and selects the optimal model/provider |
 | `telemetry.ts` | OpenTelemetry SDK setup — creates traces, spans, and metrics for each request |
@@ -19,7 +19,7 @@ The `packages/openclaw-plugin` directory contains the OpenClaw plugin that power
 | `tools.ts` | Agent self-query tools (`manifest_usage`, `manifest_costs`, `manifest_health`) |
 | `command.ts` | CLI command registration for `openclaw manifest ...` |
 | `local-mode.ts` | Local mode bootstrap — starts the embedded NestJS server and injects provider config |
-| `server.ts` | Embedded server entry point (imports and starts the backend in local/dev mode) |
+| `server.ts` | Embedded server entry point (imports and starts the backend in local mode) |
 | `product-telemetry.ts` | Anonymous product analytics (opt-out via `MANIFEST_TELEMETRY_OPTOUT=1`) |
 | `verify.ts` | Connection verification — checks endpoint reachability on startup |
 | `constants.ts` | Shared constants (endpoints, defaults, version) |

--- a/packages/openclaw-plugin/__tests__/command.test.ts
+++ b/packages/openclaw-plugin/__tests__/command.test.ts
@@ -15,7 +15,8 @@ const mockLogger = {
 };
 
 const config: ManifestConfig = {
-  mode: "dev",
+  mode: "cloud",
+  devMode: true,
   apiKey: "",
   endpoint: "http://localhost:38238/otlp",
   port: 2099,
@@ -59,7 +60,7 @@ describe("registerCommand", () => {
     const cmd = api.registerCommand.mock.calls[0][0];
     const result = await cmd.execute();
 
-    expect(result).toContain("Mode: dev");
+    expect(result).toContain("Mode: cloud");
     expect(result).toContain("Endpoint reachable: yes");
     expect(result).toContain("Auth valid: yes");
     expect(result).toContain("Agent: test-agent");
@@ -122,7 +123,7 @@ describe("registerCommand", () => {
     const cmd = api.registerCommand.mock.calls[0][0];
     const result = await cmd.execute();
 
-    expect(result).toContain("Mode: dev");
+    expect(result).toContain("Mode: cloud");
     expect(result).toContain("Endpoint reachable: yes");
     expect(result).not.toContain("Agent:");
   });

--- a/packages/openclaw-plugin/__tests__/config.test.ts
+++ b/packages/openclaw-plugin/__tests__/config.test.ts
@@ -1,5 +1,5 @@
-import { parseConfig, validateConfig } from "../src/config";
-import { API_KEY_PREFIX, DEFAULTS, DEV_DEFAULTS, ENV, LOCAL_DEFAULTS } from "../src/constants";
+import { parseConfig, parseConfigWithDeprecation, validateConfig } from "../src/config";
+import { API_KEY_PREFIX, DEFAULTS, ENV, LOCAL_DEFAULTS } from "../src/constants";
 
 describe("API_KEY_PREFIX constant", () => {
   it("equals mnfst_ (catches accidental revert)", () => {
@@ -30,18 +30,6 @@ describe("LOCAL_DEFAULTS constant", () => {
 
   it("uses a shorter interval than the cloud DEFAULTS", () => {
     expect(LOCAL_DEFAULTS.METRICS_INTERVAL_MS).toBeLessThan(
-      DEFAULTS.METRICS_INTERVAL_MS,
-    );
-  });
-});
-
-describe("DEV_DEFAULTS constant", () => {
-  it("has METRICS_INTERVAL_MS set to 10 seconds", () => {
-    expect(DEV_DEFAULTS.METRICS_INTERVAL_MS).toBe(10_000);
-  });
-
-  it("uses a shorter interval than the cloud DEFAULTS", () => {
-    expect(DEV_DEFAULTS.METRICS_INTERVAL_MS).toBeLessThan(
       DEFAULTS.METRICS_INTERVAL_MS,
     );
   });
@@ -98,17 +86,19 @@ describe("parseConfig", () => {
     expect(result.mode).toBe("local");
   });
 
-  it("parses explicit mode: dev", () => {
+  it("maps mode: dev to mode: cloud with devMode: true", () => {
     const result = parseConfig({ mode: "dev", endpoint: "http://localhost:38238/otlp" });
-    expect(result.mode).toBe("dev");
+    expect(result.mode).toBe("cloud");
+    expect(result.devMode).toBe(true);
   });
 
-  it("preserves mode: dev through nested config wrapper", () => {
+  it("preserves mode: dev backward compat through nested config wrapper", () => {
     const result = parseConfig({
       enabled: true,
       config: { mode: "dev", endpoint: "http://localhost:38238/otlp" },
     });
-    expect(result.mode).toBe("dev");
+    expect(result.mode).toBe("cloud");
+    expect(result.devMode).toBe(true);
   });
 
   it("falls back to cloud for unknown mode string", () => {
@@ -211,9 +201,111 @@ describe("parseConfig", () => {
   });
 });
 
+describe("parseConfig — devMode", () => {
+  it("auto-detects devMode when endpoint is loopback and no mnfst_ key", () => {
+    const result = parseConfig({
+      endpoint: "http://localhost:38238/otlp",
+    });
+    expect(result.devMode).toBe(true);
+  });
+
+  it("auto-detects devMode for 127.0.0.1", () => {
+    const result = parseConfig({
+      endpoint: "http://127.0.0.1:38238/otlp",
+    });
+    expect(result.devMode).toBe(true);
+  });
+
+  it("auto-detects devMode for ::1", () => {
+    const result = parseConfig({
+      endpoint: "http://[::1]:38238/otlp",
+    });
+    expect(result.devMode).toBe(true);
+  });
+
+  it("does not auto-detect devMode when mnfst_ key is present", () => {
+    const result = parseConfig({
+      endpoint: "http://localhost:38238/otlp",
+      apiKey: "mnfst_abc",
+    });
+    expect(result.devMode).toBe(false);
+  });
+
+  it("does not auto-detect devMode for remote endpoints", () => {
+    const result = parseConfig({
+      endpoint: "https://app.manifest.build/otlp",
+    });
+    expect(result.devMode).toBe(false);
+  });
+
+  it("respects explicit devMode: true", () => {
+    const result = parseConfig({
+      devMode: true,
+      endpoint: "https://app.manifest.build/otlp",
+      apiKey: "mnfst_abc",
+    });
+    expect(result.devMode).toBe(true);
+  });
+
+  it("respects explicit devMode: false even with loopback", () => {
+    const result = parseConfig({
+      devMode: false,
+      endpoint: "http://localhost:38238/otlp",
+    });
+    expect(result.devMode).toBe(false);
+  });
+
+  it("does not auto-detect devMode with non-URL endpoint", () => {
+    const result = parseConfig({
+      endpoint: "not-a-url",
+    });
+    expect(result.devMode).toBe(false);
+  });
+
+  it("auto-detects devMode false for default cloud endpoint with no key", () => {
+    const result = parseConfig({});
+    expect(result.devMode).toBe(false);
+  });
+});
+
+describe("parseConfigWithDeprecation", () => {
+  it("sets _deprecatedDevMode when mode is dev", () => {
+    const { _deprecatedDevMode } = parseConfigWithDeprecation({
+      mode: "dev",
+      endpoint: "http://localhost:38238/otlp",
+    });
+    expect(_deprecatedDevMode).toBe(true);
+  });
+
+  it("does not set _deprecatedDevMode for cloud mode", () => {
+    const { _deprecatedDevMode } = parseConfigWithDeprecation({
+      mode: "cloud",
+      apiKey: "mnfst_abc",
+    });
+    expect(_deprecatedDevMode).toBe(false);
+  });
+
+  it("does not set _deprecatedDevMode for local mode", () => {
+    const { _deprecatedDevMode } = parseConfigWithDeprecation({
+      mode: "local",
+    });
+    expect(_deprecatedDevMode).toBe(false);
+  });
+
+  it("does not set _deprecatedDevMode when using devMode: true directly", () => {
+    const { _deprecatedDevMode } = parseConfigWithDeprecation({
+      mode: "cloud",
+      devMode: true,
+      endpoint: "http://localhost:38238/otlp",
+    });
+    expect(_deprecatedDevMode).toBe(false);
+  });
+});
+
 describe("validateConfig", () => {
   const validConfig = {
     mode: "cloud" as const,
+    devMode: false,
     apiKey: "mnfst_abc",
     endpoint: "https://app.manifest.build/otlp",
     port: 2099,
@@ -229,30 +321,30 @@ describe("validateConfig", () => {
     expect(validateConfig(config)).toBeNull();
   });
 
-  it("accepts dev mode with valid http endpoint (no apiKey required)", () => {
+  it("accepts devMode with valid http endpoint (no apiKey required)", () => {
     const config = {
       ...validConfig,
-      mode: "dev" as const,
+      devMode: true,
       apiKey: "",
       endpoint: "http://localhost:38238/otlp",
     };
     expect(validateConfig(config)).toBeNull();
   });
 
-  it("accepts dev mode with https endpoint", () => {
+  it("accepts devMode with https endpoint", () => {
     const config = {
       ...validConfig,
-      mode: "dev" as const,
+      devMode: true,
       apiKey: "",
       endpoint: "https://dev.example.com/otlp",
     };
     expect(validateConfig(config)).toBeNull();
   });
 
-  it("rejects dev mode with invalid endpoint", () => {
+  it("rejects devMode with invalid endpoint", () => {
     const config = {
       ...validConfig,
-      mode: "dev" as const,
+      devMode: true,
       apiKey: "",
       endpoint: "not-a-url",
     };

--- a/packages/openclaw-plugin/__tests__/hooks.test.ts
+++ b/packages/openclaw-plugin/__tests__/hooks.test.ts
@@ -76,6 +76,7 @@ const mockLogger = {
 
 const config: ManifestConfig = {
   mode: "cloud",
+  devMode: false,
   apiKey: "mnfst_test",
   endpoint: "http://localhost:3001/otlp",
   port: 2099,
@@ -84,6 +85,7 @@ const config: ManifestConfig = {
 
 const localConfig: ManifestConfig = {
   mode: "local",
+  devMode: false,
   apiKey: "",
   endpoint: "http://localhost:38238/otlp",
   port: 2099,
@@ -91,7 +93,8 @@ const localConfig: ManifestConfig = {
 };
 
 const devConfig: ManifestConfig = {
-  mode: "dev",
+  mode: "cloud",
+  devMode: true,
   apiKey: "",
   endpoint: "http://localhost:38238/otlp",
   port: 2099,

--- a/packages/openclaw-plugin/__tests__/local-mode.test.ts
+++ b/packages/openclaw-plugin/__tests__/local-mode.test.ts
@@ -327,6 +327,7 @@ describe("registerLocalMode — EADDRINUSE handling", () => {
 
   const testConfig = {
     mode: "local" as const,
+    devMode: false,
     apiKey: "",
     endpoint: "",
     port: 2099,
@@ -769,6 +770,7 @@ describe("readJsonSafe — corrupt JSON", () => {
 describe("loadOrGenerateApiKey — edge cases", () => {
   const testConfig = {
     mode: "local" as const,
+    devMode: false,
     apiKey: "",
     endpoint: "",
     port: 2099,
@@ -883,6 +885,7 @@ describe("registerLocalMode — server module load failure", () => {
 
     const cfg = {
       mode: "local" as const,
+      devMode: false,
       apiKey: "",
       endpoint: "",
       port: 2099,

--- a/packages/openclaw-plugin/__tests__/register.test.ts
+++ b/packages/openclaw-plugin/__tests__/register.test.ts
@@ -1,5 +1,6 @@
 jest.mock("../src/config", () => ({
   parseConfig: jest.fn(),
+  parseConfigWithDeprecation: jest.fn(),
   validateConfig: jest.fn(),
 }));
 jest.mock("../src/telemetry", () => ({
@@ -31,7 +32,7 @@ jest.mock("../src/product-telemetry", () => ({
   trackPluginEvent: jest.fn(),
 }));
 
-import { parseConfig, validateConfig } from "../src/config";
+import { parseConfigWithDeprecation, validateConfig } from "../src/config";
 import { registerLocalMode, injectProviderConfig, injectAuthProfile } from "../src/local-mode";
 import { initTelemetry, shutdownTelemetry } from "../src/telemetry";
 import { registerHooks, initMetrics } from "../src/hooks";
@@ -64,12 +65,16 @@ beforeEach(() => {
 
 describe("register — mode routing", () => {
   it("delegates to registerLocalMode when mode is explicitly local", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "local",
-      apiKey: "",
-      endpoint: "",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "local",
+        devMode: false,
+        apiKey: "",
+        endpoint: "",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
 
     const api = makeApi();
@@ -79,12 +84,16 @@ describe("register — mode routing", () => {
   });
 
   it("does NOT delegate to registerLocalMode for cloud mode", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "cloud",
-      apiKey: "mnfst_abc",
-      endpoint: "https://app.manifest.build/otlp",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "cloud",
+        devMode: false,
+        apiKey: "mnfst_abc",
+        endpoint: "https://app.manifest.build/otlp",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
@@ -95,12 +104,16 @@ describe("register — mode routing", () => {
   });
 
   it("tracks plugin_mode_selected event with correct mode", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "local",
-      apiKey: "",
-      endpoint: "",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "local",
+        devMode: false,
+        apiKey: "",
+        endpoint: "",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
 
     const api = makeApi();
@@ -113,12 +126,16 @@ describe("register — mode routing", () => {
   });
 
   it("passes config.mode as third argument to trackPluginEvent in cloud mode", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "cloud",
-      apiKey: "mnfst_abc",
-      endpoint: "https://app.manifest.build/otlp",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "cloud",
+        devMode: false,
+        apiKey: "mnfst_abc",
+        endpoint: "https://app.manifest.build/otlp",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
@@ -131,13 +148,17 @@ describe("register — mode routing", () => {
     }, "cloud");
   });
 
-  it("calls trackPluginEvent exactly twice for non-dev modes", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "cloud",
-      apiKey: "mnfst_abc",
-      endpoint: "https://app.manifest.build/otlp",
-      port: 2099,
-      host: "127.0.0.1",
+  it("calls trackPluginEvent exactly twice for non-devMode modes", () => {
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "cloud",
+        devMode: false,
+        apiKey: "mnfst_abc",
+        endpoint: "https://app.manifest.build/otlp",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
@@ -148,17 +169,21 @@ describe("register — mode routing", () => {
   });
 });
 
-describe("register — dev mode", () => {
+describe("register — cloud mode with devMode", () => {
   const devConfig = {
-    mode: "dev" as const,
+    mode: "cloud" as const,
+    devMode: true,
     apiKey: "",
     endpoint: "http://localhost:38238/otlp",
     port: 2099,
     host: "127.0.0.1",
   };
 
-  it("does NOT call trackPluginEvent in dev mode", () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+  it("does NOT call trackPluginEvent when devMode is true", () => {
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -168,7 +193,10 @@ describe("register — dev mode", () => {
   });
 
   it("does NOT delegate to registerLocalMode", () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -177,8 +205,11 @@ describe("register — dev mode", () => {
     expect(registerLocalMode).not.toHaveBeenCalled();
   });
 
-  it("calls injectProviderConfig and injectAuthProfile", () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+  it("calls injectProviderConfig and injectAuthProfile with dev-no-auth", () => {
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -191,7 +222,10 @@ describe("register — dev mode", () => {
   });
 
   it("initializes telemetry, hooks, and routing", () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -204,7 +238,10 @@ describe("register — dev mode", () => {
   });
 
   it("registers tools when registerTool is available", () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -214,7 +251,10 @@ describe("register — dev mode", () => {
   });
 
   it("registers a manifest-dev service", () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -226,7 +266,10 @@ describe("register — dev mode", () => {
   });
 
   it("logs dashboard URL", () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -239,7 +282,10 @@ describe("register — dev mode", () => {
 
   it("derives port 443 for https endpoints without explicit port", () => {
     const httpsConfig = { ...devConfig, endpoint: "https://dev.example.com/otlp" };
-    (parseConfig as jest.Mock).mockReturnValue(httpsConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: httpsConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -251,7 +297,10 @@ describe("register — dev mode", () => {
   });
 
   it("service start invokes verifyConnection", async () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockResolvedValue({ error: null, agentName: "test-agent" });
 
@@ -269,7 +318,10 @@ describe("register — dev mode", () => {
   });
 
   it("service start logs warning on verify error", async () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockResolvedValue({
       error: "Cannot reach endpoint",
@@ -289,7 +341,10 @@ describe("register — dev mode", () => {
   });
 
   it("service start handles verify rejection", async () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockRejectedValue(new Error("boom"));
 
@@ -307,7 +362,10 @@ describe("register — dev mode", () => {
   });
 
   it("service stop shuts down telemetry", async () => {
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -319,9 +377,12 @@ describe("register — dev mode", () => {
     expect(shutdownTelemetry).toHaveBeenCalledWith(api.logger);
   });
 
-  it("logs error message for non-cloud validation errors in dev mode", () => {
+  it("logs error message for validation errors in devMode", () => {
     const badDevConfig = { ...devConfig, endpoint: "not-a-url" };
-    (parseConfig as jest.Mock).mockReturnValue(badDevConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: badDevConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue("Invalid endpoint URL");
 
     const api = makeApi();
@@ -333,9 +394,58 @@ describe("register — dev mode", () => {
   });
 });
 
+describe("register — deprecation warning", () => {
+  it("logs deprecation warning when _deprecatedDevMode is true", () => {
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "cloud",
+        devMode: true,
+        apiKey: "",
+        endpoint: "http://localhost:38238/otlp",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: true,
+    });
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("deprecated"),
+    );
+  });
+
+  it("does not log deprecation warning when _deprecatedDevMode is false", () => {
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "cloud",
+        devMode: true,
+        apiKey: "",
+        endpoint: "http://localhost:38238/otlp",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
+    });
+    (validateConfig as jest.Mock).mockReturnValue(null);
+
+    const api = makeApi();
+    plugin.register(api);
+
+    const warnCalls = api.logger.warn.mock.calls;
+    const deprecationCalls = warnCalls.filter(
+      (call: string[]) => typeof call[0] === "string" && call[0].includes("deprecated"),
+    );
+    expect(deprecationCalls).toHaveLength(0);
+  });
+});
+
 describe("register — cloud mode full path", () => {
   const cloudConfig = {
     mode: "cloud" as const,
+    devMode: false,
     apiKey: "mnfst_abc",
     endpoint: "https://app.manifest.build/otlp",
     port: 2099,
@@ -343,7 +453,10 @@ describe("register — cloud mode full path", () => {
   };
 
   it("initializes telemetry, hooks, routing, tools, and command in cloud mode", () => {
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -358,7 +471,10 @@ describe("register — cloud mode full path", () => {
   });
 
   it("calls injectProviderConfig and injectAuthProfile in cloud mode", () => {
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -371,7 +487,10 @@ describe("register — cloud mode full path", () => {
   });
 
   it("registers manifest-telemetry service in cloud mode", () => {
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -383,7 +502,10 @@ describe("register — cloud mode full path", () => {
   });
 
   it("cloud service start invokes verifyConnection and logs success", async () => {
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockResolvedValue({
       error: null,
@@ -404,7 +526,10 @@ describe("register — cloud mode full path", () => {
   });
 
   it("cloud service start logs warning on verify error", async () => {
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockResolvedValue({
       error: "Cannot reach endpoint",
@@ -424,7 +549,10 @@ describe("register — cloud mode full path", () => {
   });
 
   it("cloud service start handles verify rejection silently", async () => {
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockRejectedValue(new Error("boom"));
 
@@ -442,7 +570,10 @@ describe("register — cloud mode full path", () => {
   });
 
   it("cloud service stop shuts down telemetry", async () => {
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -455,7 +586,10 @@ describe("register — cloud mode full path", () => {
   });
 
   it("skips registerTools when registerTool is not a function", () => {
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -471,12 +605,16 @@ describe("register — cloud mode full path", () => {
 
 describe("register — fallback logger", () => {
   it("uses console-based logger when api.logger is not provided", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "local",
-      apiKey: "",
-      endpoint: "",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "local",
+        devMode: false,
+        apiKey: "",
+        endpoint: "",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
 
     const api = {
@@ -494,12 +632,16 @@ describe("register — fallback logger", () => {
   });
 
   it("fallback logger.info delegates to console.log", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "local",
-      apiKey: "",
-      endpoint: "",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "local",
+        devMode: false,
+        apiKey: "",
+        endpoint: "",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
 
     let capturedLogger: any;
@@ -523,12 +665,16 @@ describe("register — fallback logger", () => {
   });
 
   it("fallback logger.error delegates to console.error", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "local",
-      apiKey: "",
-      endpoint: "",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "local",
+        devMode: false,
+        apiKey: "",
+        endpoint: "",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
 
     let capturedLogger: any;
@@ -552,12 +698,16 @@ describe("register — fallback logger", () => {
   });
 
   it("fallback logger.warn delegates to console.warn", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "local",
-      apiKey: "",
-      endpoint: "",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "local",
+        devMode: false,
+        apiKey: "",
+        endpoint: "",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
 
     let capturedLogger: any;
@@ -581,12 +731,16 @@ describe("register — fallback logger", () => {
   });
 
   it("fallback logger.debug is a no-op", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "local",
-      apiKey: "",
-      endpoint: "",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "local",
+        devMode: false,
+        apiKey: "",
+        endpoint: "",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
 
     let capturedLogger: any;
@@ -610,12 +764,16 @@ describe("register — fallback logger", () => {
 
 describe("register — diagnostics-otel conflict", () => {
   it("aborts registration when diagnostics-otel is enabled", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "cloud",
-      apiKey: "mnfst_abc",
-      endpoint: "https://app.manifest.build/otlp",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "cloud",
+        devMode: false,
+        apiKey: "mnfst_abc",
+        endpoint: "https://app.manifest.build/otlp",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
@@ -648,15 +806,19 @@ describe("register — diagnostics-otel conflict", () => {
 });
 
 describe("register — registerCommand wiring", () => {
-  it("calls registerCommand in dev mode", () => {
+  it("calls registerCommand in devMode", () => {
     const devConfig = {
-      mode: "dev" as const,
+      mode: "cloud" as const,
+      devMode: true,
       apiKey: "",
       endpoint: "http://localhost:38238/otlp",
       port: 2099,
       host: "127.0.0.1",
     };
-    (parseConfig as jest.Mock).mockReturnValue(devConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -668,12 +830,16 @@ describe("register — registerCommand wiring", () => {
   it("calls registerCommand in cloud mode", () => {
     const cloudConfig = {
       mode: "cloud" as const,
+      devMode: false,
       apiKey: "mnfst_abc",
       endpoint: "https://app.manifest.build/otlp",
       port: 2099,
       host: "127.0.0.1",
     };
-    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -685,12 +851,16 @@ describe("register — registerCommand wiring", () => {
 
 describe("register — cloud mode missing API key", () => {
   it("logs cloud mode requires API key message", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "cloud",
-      apiKey: "",
-      endpoint: "https://app.manifest.build/otlp",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "cloud",
+        devMode: false,
+        apiKey: "",
+        endpoint: "https://app.manifest.build/otlp",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
     (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
 
@@ -703,12 +873,16 @@ describe("register — cloud mode missing API key", () => {
   });
 
   it("includes tip about local mode in the message", () => {
-    (parseConfig as jest.Mock).mockReturnValue({
-      mode: "cloud",
-      apiKey: "",
-      endpoint: "https://app.manifest.build/otlp",
-      port: 2099,
-      host: "127.0.0.1",
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: {
+        mode: "cloud",
+        devMode: false,
+        apiKey: "",
+        endpoint: "https://app.manifest.build/otlp",
+        port: 2099,
+        host: "127.0.0.1",
+      },
+      _deprecatedDevMode: false,
     });
     (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
 

--- a/packages/openclaw-plugin/__tests__/routing.test.ts
+++ b/packages/openclaw-plugin/__tests__/routing.test.ts
@@ -13,6 +13,7 @@ const mockLogger = {
 
 const cloudConfig: ManifestConfig = {
   mode: "cloud",
+  devMode: false,
   apiKey: "mnfst_test_key",
   endpoint: "http://localhost:3001/otlp",
   port: 2099,
@@ -20,7 +21,8 @@ const cloudConfig: ManifestConfig = {
 };
 
 const devConfig: ManifestConfig = {
-  mode: "dev",
+  mode: "cloud",
+  devMode: true,
   apiKey: "",
   endpoint: "http://localhost:38238/otlp",
   port: 2099,

--- a/packages/openclaw-plugin/__tests__/telemetry.test.ts
+++ b/packages/openclaw-plugin/__tests__/telemetry.test.ts
@@ -61,6 +61,7 @@ import { MeterProvider, PeriodicExportingMetricReader } from "@opentelemetry/sdk
 
 const config: ManifestConfig = {
   mode: "cloud",
+  devMode: false,
   apiKey: "mnfst_test_key",
   endpoint: "http://localhost:3001/otlp",
   port: 2099,
@@ -126,8 +127,8 @@ describe("initTelemetry", () => {
     });
   });
 
-  it("sends empty headers when apiKey is empty (dev mode)", () => {
-    const devConfig = { ...config, mode: "dev" as const, apiKey: "" };
+  it("sends empty headers when apiKey is empty (devMode)", () => {
+    const devConfig = { ...config, devMode: true, apiKey: "" };
     initTelemetry(devConfig, mockLogger);
 
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
@@ -176,8 +177,8 @@ describe("initTelemetry", () => {
     );
   });
 
-  it("uses 10s metrics interval in dev mode", () => {
-    const devConfig = { ...config, mode: "dev" as const, apiKey: "" };
+  it("uses 10s metrics interval when devMode is true", () => {
+    const devConfig = { ...config, devMode: true, apiKey: "" };
     initTelemetry(devConfig, mockLogger);
 
     expect(PeriodicExportingMetricReader).toHaveBeenCalledWith(

--- a/packages/openclaw-plugin/__tests__/tools.test.ts
+++ b/packages/openclaw-plugin/__tests__/tools.test.ts
@@ -13,6 +13,7 @@ const mockLogger = {
 
 const config: ManifestConfig = {
   mode: "cloud",
+  devMode: false,
   apiKey: "mnfst_test_key",
   endpoint: "http://localhost:3001/otlp",
   port: 2099,
@@ -391,12 +392,13 @@ describe("registerTools", () => {
   });
 });
 
-describe("registerTools — no apiKey (dev mode)", () => {
+describe("registerTools — no apiKey (devMode)", () => {
   const devConfig: ManifestConfig = {
-    mode: "dev",
+    mode: "cloud",
+    devMode: true,
     apiKey: "",
     endpoint: "http://localhost:38238/otlp",
-      port: 2099,
+    port: 2099,
     host: "127.0.0.1",
   };
 

--- a/packages/openclaw-plugin/__tests__/verify.test.ts
+++ b/packages/openclaw-plugin/__tests__/verify.test.ts
@@ -3,6 +3,7 @@ import { ManifestConfig } from "../src/config";
 
 const baseConfig: ManifestConfig = {
   mode: "cloud",
+  devMode: false,
   apiKey: "mnfst_test123",
   endpoint: "http://localhost:3001/otlp",
   port: 2099,
@@ -177,8 +178,8 @@ describe("verifyConnection", () => {
     expect(result.error).toContain("500");
   });
 
-  it("sends no Authorization header when apiKey is empty (dev mode)", async () => {
-    const devConfig = { ...baseConfig, mode: "dev" as const, apiKey: "" };
+  it("sends no Authorization header when apiKey is empty (devMode)", async () => {
+    const devConfig = { ...baseConfig, devMode: true, apiKey: "" };
     mockFetch
       .mockResolvedValueOnce({ ok: true, status: 200 })
       .mockResolvedValueOnce({

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -14,7 +14,12 @@
         "type": "string",
         "enum": ["cloud", "local", "dev"],
         "default": "cloud",
-        "description": "Run mode: 'cloud' sends telemetry to app.manifest.build (default), 'local' starts an embedded server (zero config), 'dev' connects to a dev server without API key"
+        "description": "Run mode: 'cloud' (default) or 'local' for embedded server. 'dev' is deprecated — use devMode instead."
+      },
+      "devMode": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable for development: skips API key, faster metrics, disables product telemetry. Auto-detected when endpoint is localhost without an API key."
       },
       "apiKey": {
         "type": "string",
@@ -41,6 +46,10 @@
     "mode": {
       "label": "Mode",
       "description": "Choose 'cloud' to send data to app.manifest.build (default), or 'local' for a self-contained server with sql.js"
+    },
+    "devMode": {
+      "label": "Dev Mode",
+      "description": "Enable for development: skips API key, faster metrics, disables product telemetry"
     },
     "apiKey": {
       "label": "API Key",

--- a/packages/openclaw-plugin/src/command.ts
+++ b/packages/openclaw-plugin/src/command.ts
@@ -1,15 +1,11 @@
-import { ManifestConfig } from "./config";
-import { PluginLogger } from "./telemetry";
-import { verifyConnection } from "./verify";
+import { ManifestConfig } from './config';
+import { PluginLogger } from './telemetry';
+import { verifyConnection } from './verify';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export function registerCommand(
-  api: any,
-  config: ManifestConfig,
-  logger: PluginLogger,
-): void {
-  if (typeof api.registerCommand !== "function") {
-    logger.debug("[manifest] registerCommand not available, skipping /manifest command");
+export function registerCommand(api: any, config: ManifestConfig, logger: PluginLogger): void {
+  if (typeof api.registerCommand !== 'function') {
+    logger.debug('[manifest] registerCommand not available, skipping /manifest command');
     return;
   }
 
@@ -18,8 +14,9 @@ export function registerCommand(
       const check = await verifyConnection(config);
       const lines = [
         `Mode: ${config.mode}`,
-        `Endpoint reachable: ${check.endpointReachable ? "yes" : "no"}`,
-        `Auth valid: ${check.authValid ? "yes" : "no"}`,
+        `Dev mode: ${config.devMode ? 'yes' : 'no'}`,
+        `Endpoint reachable: ${check.endpointReachable ? 'yes' : 'no'}`,
+        `Auth valid: ${check.authValid ? 'yes' : 'no'}`,
       ];
       if (check.agentName) {
         lines.push(`Agent: ${check.agentName}`);
@@ -27,7 +24,7 @@ export function registerCommand(
       if (check.error) {
         lines.push(`Error: ${check.error}`);
       }
-      return lines.join("\n");
+      return lines.join('\n');
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       return `Manifest status check failed: ${msg}`;
@@ -35,11 +32,11 @@ export function registerCommand(
   };
 
   api.registerCommand({
-    name: "manifest",
-    description: "Show Manifest plugin status and connection info",
+    name: 'manifest',
+    description: 'Show Manifest plugin status and connection info',
     handler: commandHandler,
     execute: commandHandler,
   });
 
-  logger.debug("[manifest] Registered /manifest command");
+  logger.debug('[manifest] Registered /manifest command');
 }

--- a/packages/openclaw-plugin/src/config.ts
+++ b/packages/openclaw-plugin/src/config.ts
@@ -1,74 +1,101 @@
-import { API_KEY_PREFIX, DEFAULTS, ENV } from "./constants";
+import { API_KEY_PREFIX, DEFAULTS, ENV } from './constants';
 
 export interface ManifestConfig {
-  mode: "cloud" | "local" | "dev";
+  mode: 'cloud' | 'local';
+  devMode: boolean;
   apiKey: string;
   endpoint: string;
   port: number;
   host: string;
 }
 
+export interface ParseResult {
+  config: ManifestConfig;
+  _deprecatedDevMode: boolean;
+}
+
+function isLoopback(endpoint: string): boolean {
+  try {
+    const url = new URL(endpoint);
+    const host = url.hostname;
+    return host === 'localhost' || host === '127.0.0.1' || host === '::1' || host === '[::1]';
+  } catch {
+    return false;
+  }
+}
+
 export function parseConfig(raw: unknown): ManifestConfig {
+  return parseConfigWithDeprecation(raw).config;
+}
+
+export function parseConfigWithDeprecation(raw: unknown): ParseResult {
   // OpenClaw may pass the full plugin entry { enabled, config: {...} }
   // or just the inner config object. Handle both.
   let obj: Record<string, unknown> =
-    raw && typeof raw === "object" && !Array.isArray(raw)
-      ? (raw as Record<string, unknown>)
-      : {};
+    raw && typeof raw === 'object' && !Array.isArray(raw) ? (raw as Record<string, unknown>) : {};
 
-  if (
-    obj.config &&
-    typeof obj.config === "object" &&
-    !Array.isArray(obj.config)
-  ) {
+  if (obj.config && typeof obj.config === 'object' && !Array.isArray(obj.config)) {
     obj = obj.config as Record<string, unknown>;
   }
 
-  const mode =
-    obj.mode === "local"
-      ? "local" as const
-      : obj.mode === "dev"
-        ? "dev" as const
-        : "cloud" as const;
+  // Backward compat: mode: "dev" → mode: "cloud" + devMode: true
+  let _deprecatedDevMode = false;
+  let mode: 'cloud' | 'local';
+  if (obj.mode === 'local') {
+    mode = 'local';
+  } else if (obj.mode === 'dev') {
+    mode = 'cloud';
+    _deprecatedDevMode = true;
+  } else {
+    mode = 'cloud';
+  }
 
   const apiKey =
-    typeof obj.apiKey === "string" && obj.apiKey.length > 0
+    typeof obj.apiKey === 'string' && obj.apiKey.length > 0
       ? obj.apiKey
-      : process.env[ENV.API_KEY] || "";
+      : process.env[ENV.API_KEY] || '';
 
   const envEndpoint = process.env[ENV.ENDPOINT];
 
   const endpoint =
-    typeof obj.endpoint === "string" && obj.endpoint.length > 0
+    typeof obj.endpoint === 'string' && obj.endpoint.length > 0
       ? obj.endpoint
       : envEndpoint && envEndpoint.length > 0
         ? envEndpoint
         : DEFAULTS.ENDPOINT;
 
-  const port =
-    typeof obj.port === "number" && obj.port > 0
-      ? obj.port
-      : 2099;
+  const port = typeof obj.port === 'number' && obj.port > 0 ? obj.port : 2099;
 
-  const host =
-    typeof obj.host === "string" && obj.host.length > 0
-      ? obj.host
-      : "127.0.0.1";
+  const host = typeof obj.host === 'string' && obj.host.length > 0 ? obj.host : '127.0.0.1';
 
-  return { mode, apiKey, endpoint, port, host };
+  // Determine devMode: explicit > deprecated mode: "dev" > auto-detect
+  let devMode: boolean;
+  if (typeof obj.devMode === 'boolean') {
+    devMode = obj.devMode;
+  } else if (_deprecatedDevMode) {
+    devMode = true;
+  } else {
+    // Auto-detect: loopback endpoint + no mnfst_ API key
+    devMode = isLoopback(endpoint) && !apiKey.startsWith(API_KEY_PREFIX);
+  }
+
+  return {
+    config: { mode, devMode, apiKey, endpoint, port, host },
+    _deprecatedDevMode,
+  };
 }
 
 export function validateConfig(config: ManifestConfig): string | null {
   // In local mode, API key is auto-generated — skip validation
-  if (config.mode === "local") return null;
+  if (config.mode === 'local') return null;
 
-  // Dev mode requires an endpoint but no API key
-  if (config.mode === "dev") {
-    if (!config.endpoint.startsWith("http")) {
+  // devMode requires an endpoint but no API key
+  if (config.devMode) {
+    if (!config.endpoint.startsWith('http')) {
       return (
         `Invalid endpoint URL '${config.endpoint}'. ` +
-        "Must start with http:// or https://. Fix it via:\n" +
-        "  openclaw config set plugins.entries.manifest.config.endpoint http://localhost:38238/otlp"
+        'Must start with http:// or https://. Fix it via:\n' +
+        '  openclaw config set plugins.entries.manifest.config.endpoint http://localhost:38238/otlp'
       );
     }
     return null;
@@ -76,23 +103,23 @@ export function validateConfig(config: ManifestConfig): string | null {
 
   if (!config.apiKey) {
     return (
-      "Missing apiKey. Set it via:\n" +
+      'Missing apiKey. Set it via:\n' +
       `  openclaw config set manifest.apiKey ${API_KEY_PREFIX}YOUR_KEY\n` +
       `  or export MANIFEST_API_KEY=${API_KEY_PREFIX}YOUR_KEY`
     );
   }
   if (!config.apiKey.startsWith(API_KEY_PREFIX)) {
     return (
-      "Invalid apiKey format. " +
+      'Invalid apiKey format. ' +
       `Keys must start with '${API_KEY_PREFIX}'. Fix it via:\n` +
       `  openclaw config set manifest.apiKey ${API_KEY_PREFIX}YOUR_KEY`
     );
   }
-  if (!config.endpoint.startsWith("http")) {
+  if (!config.endpoint.startsWith('http')) {
     return (
       `Invalid endpoint URL '${config.endpoint}'. ` +
-      "Must start with http:// or https://. Fix it via:\n" +
-      "  openclaw config set plugins.entries.manifest.config.endpoint https://app.manifest.build/otlp"
+      'Must start with http:// or https://. Fix it via:\n' +
+      '  openclaw config set plugins.entries.manifest.config.endpoint https://app.manifest.build/otlp'
     );
   }
   return null;

--- a/packages/openclaw-plugin/src/constants.ts
+++ b/packages/openclaw-plugin/src/constants.ts
@@ -1,60 +1,56 @@
 // Span names
 export const SPANS = {
-  REQUEST: "openclaw.request",
-  AGENT_TURN: "openclaw.agent.turn",
-  TOOL_PREFIX: "tool.",
+  REQUEST: 'openclaw.request',
+  AGENT_TURN: 'openclaw.agent.turn',
+  TOOL_PREFIX: 'tool.',
 } as const;
 
 // Metric names
 export const METRICS = {
-  LLM_REQUESTS: "openclaw.llm.requests",
-  LLM_TOKENS_INPUT: "openclaw.llm.tokens.input",
-  LLM_TOKENS_OUTPUT: "openclaw.llm.tokens.output",
-  LLM_TOKENS_CACHE_READ: "openclaw.llm.tokens.cache_read",
-  LLM_DURATION: "openclaw.llm.duration",
-  TOOL_CALLS: "openclaw.tool.calls",
-  TOOL_ERRORS: "openclaw.tool.errors",
-  TOOL_DURATION: "openclaw.tool.duration",
-  MESSAGES_RECEIVED: "openclaw.messages.received",
+  LLM_REQUESTS: 'openclaw.llm.requests',
+  LLM_TOKENS_INPUT: 'openclaw.llm.tokens.input',
+  LLM_TOKENS_OUTPUT: 'openclaw.llm.tokens.output',
+  LLM_TOKENS_CACHE_READ: 'openclaw.llm.tokens.cache_read',
+  LLM_DURATION: 'openclaw.llm.duration',
+  TOOL_CALLS: 'openclaw.tool.calls',
+  TOOL_ERRORS: 'openclaw.tool.errors',
+  TOOL_DURATION: 'openclaw.tool.duration',
+  MESSAGES_RECEIVED: 'openclaw.messages.received',
 } as const;
 
 // Attribute keys
 export const ATTRS = {
-  SESSION_KEY: "openclaw.session.key",
-  CHANNEL: "openclaw.message.channel",
-  MODEL: "gen_ai.request.model",
-  PROVIDER: "gen_ai.system",
-  INPUT_TOKENS: "gen_ai.usage.input_tokens",
-  OUTPUT_TOKENS: "gen_ai.usage.output_tokens",
-  CACHE_READ_TOKENS: "gen_ai.usage.cache_read_input_tokens",
-  CACHE_WRITE_TOKENS: "gen_ai.usage.cache_creation_input_tokens",
-  TOOL_NAME: "tool.name",
-  TOOL_SUCCESS: "tool.success",
-  AGENT_NAME: "openclaw.agent.name",
-  ROUTING_TIER: "manifest.routing.tier",
-  ROUTING_REASON: "manifest.routing.reason",
+  SESSION_KEY: 'openclaw.session.key',
+  CHANNEL: 'openclaw.message.channel',
+  MODEL: 'gen_ai.request.model',
+  PROVIDER: 'gen_ai.system',
+  INPUT_TOKENS: 'gen_ai.usage.input_tokens',
+  OUTPUT_TOKENS: 'gen_ai.usage.output_tokens',
+  CACHE_READ_TOKENS: 'gen_ai.usage.cache_read_input_tokens',
+  CACHE_WRITE_TOKENS: 'gen_ai.usage.cache_creation_input_tokens',
+  TOOL_NAME: 'tool.name',
+  TOOL_SUCCESS: 'tool.success',
+  AGENT_NAME: 'openclaw.agent.name',
+  ROUTING_TIER: 'manifest.routing.tier',
+  ROUTING_REASON: 'manifest.routing.reason',
 } as const;
 
 // Environment variable names (fallback when plugin config is missing)
 export const ENV = {
-  API_KEY: "MANIFEST_API_KEY",
-  ENDPOINT: "MANIFEST_ENDPOINT",
+  API_KEY: 'MANIFEST_API_KEY',
+  ENDPOINT: 'MANIFEST_ENDPOINT',
 } as const;
 
 // API key prefix — must match the backend's API_KEY_PREFIX
-export const API_KEY_PREFIX = "mnfst_" as const;
+export const API_KEY_PREFIX = 'mnfst_' as const;
 
 // Plugin defaults
 export const DEFAULTS = {
-  ENDPOINT: "https://app.manifest.build/otlp",
-  SERVICE_NAME: "openclaw-gateway",
+  ENDPOINT: 'https://app.manifest.build/otlp',
+  SERVICE_NAME: 'openclaw-gateway',
   METRICS_INTERVAL_MS: 30_000,
 } as const;
 
 export const LOCAL_DEFAULTS = {
-  METRICS_INTERVAL_MS: 10_000,
-} as const;
-
-export const DEV_DEFAULTS = {
   METRICS_INTERVAL_MS: 10_000,
 } as const;

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1,4 +1,4 @@
-import { parseConfig, validateConfig, ManifestConfig } from './config';
+import { parseConfigWithDeprecation, validateConfig, ManifestConfig } from './config';
 import { initTelemetry, shutdownTelemetry, PluginLogger } from './telemetry';
 import { registerHooks, initMetrics } from './hooks';
 import { registerRouting } from './routing';
@@ -21,8 +21,17 @@ module.exports = {
       warn: (...args: unknown[]) => console.warn(...args),
     };
 
-    const config: ManifestConfig = parseConfig(api.pluginConfig);
-    if (config.mode !== 'dev') {
+    const { config, _deprecatedDevMode } = parseConfigWithDeprecation(api.pluginConfig);
+
+    if (_deprecatedDevMode) {
+      logger.warn?.(
+        '[manifest] mode: "dev" is deprecated. Use mode: "cloud" with devMode: true instead.\n' +
+          '  openclaw config set plugins.entries.manifest.config.mode cloud\n' +
+          '  openclaw config set plugins.entries.manifest.config.devMode true',
+      );
+    }
+
+    if (!config.devMode) {
       trackPluginEvent('plugin_registered', undefined, config.mode);
       trackPluginEvent('plugin_mode_selected', { mode: config.mode }, config.mode);
     }
@@ -34,7 +43,7 @@ module.exports = {
 
     const error = validateConfig(config);
     if (error) {
-      if (config.mode === 'cloud' && !config.apiKey) {
+      if (!config.devMode && config.mode === 'cloud' && !config.apiKey) {
         logger.info(
           '[manifest] Cloud mode requires an API key:\n' +
             '  openclaw config set plugins.entries.manifest.config.apiKey mnfst_YOUR_KEY\n' +
@@ -63,61 +72,20 @@ module.exports = {
     }
 
     // Derive the base origin from the OTLP endpoint (strip /otlp suffix).
-    // Used by both dev and cloud modes to build the provider baseUrl.
     const baseOrigin = config.endpoint.replace(/\/otlp(\/v1)?\/?$/, '');
 
-    // Dev mode: connect to an external server without API key
-    if (config.mode === 'dev') {
-      logger.info('[manifest] Dev mode — connecting to external server...');
+    // Unified cloud/dev path
+    const effectiveKey = config.devMode ? 'dev-no-auth' : config.apiKey;
+    const serviceId = config.devMode ? 'manifest-dev' : 'manifest-telemetry';
 
-      const devPlaceholderKey = 'dev-no-auth';
-      injectProviderConfig(api, `${baseOrigin}/v1`, devPlaceholderKey, logger);
-      injectAuthProfile(devPlaceholderKey, logger);
+    logger.info(
+      config.devMode
+        ? '[manifest] Dev mode — connecting to external server...'
+        : '[manifest] Initializing observability pipeline...',
+    );
 
-      const { tracer, meter } = initTelemetry(config, logger);
-      initMetrics(meter);
-      registerHooks(api, tracer, config, logger);
-      registerRouting(api, config, logger);
-
-      if (typeof api.registerTool === 'function') {
-        registerTools(api, config, logger);
-      }
-      registerCommand(api, config, logger);
-
-      logger.info(`[manifest]   Dashboard: ${baseOrigin}`);
-
-      api.registerService({
-        id: 'manifest-dev',
-        start: () => {
-          logger.info('[manifest] Dev mode pipeline active');
-          logger.info(`[manifest]   Endpoint=${config.endpoint}`);
-
-          verifyConnection(config)
-            .then((check) => {
-              if (check.error) {
-                logger.warn?.(`[manifest] Connection check failed: ${check.error}`);
-                return;
-              }
-              const agent = check.agentName ? ` (agent: ${check.agentName})` : '';
-              logger.info(`[manifest] Connection verified${agent}`);
-            })
-            .catch(() => {});
-        },
-        stop: async () => {
-          await shutdownTelemetry(logger);
-        },
-      });
-
-      return;
-    }
-
-    // Cloud mode
-    logger.info('[manifest] Initializing observability pipeline...');
-
-    // Sync the provider config file so the gateway uses the correct
-    // baseUrl and apiKey for proxy requests after restarts.
-    injectProviderConfig(api, `${baseOrigin}/v1`, config.apiKey, logger);
-    injectAuthProfile(config.apiKey, logger);
+    injectProviderConfig(api, `${baseOrigin}/v1`, effectiveKey, logger);
+    injectAuthProfile(effectiveKey, logger);
 
     const { tracer, meter } = initTelemetry(config, logger);
     initMetrics(meter);
@@ -126,18 +94,25 @@ module.exports = {
 
     if (typeof api.registerTool === 'function') {
       registerTools(api, config, logger);
-    } else {
+    } else if (!config.devMode) {
       logger.info('[manifest] Agent tools not available in this OpenClaw version');
     }
     registerCommand(api, config, logger);
 
+    if (config.devMode) {
+      logger.info(`[manifest]   Dashboard: ${baseOrigin}`);
+    }
+
     api.registerService({
-      id: 'manifest-telemetry',
+      id: serviceId,
       start: () => {
-        logger.info('[manifest] Observability pipeline active');
+        logger.info(
+          config.devMode
+            ? '[manifest] Dev mode pipeline active'
+            : '[manifest] Observability pipeline active',
+        );
         logger.info(`[manifest]   Endpoint=${config.endpoint}`);
 
-        // Non-blocking connection verify after startup
         verifyConnection(config)
           .then((check) => {
             if (check.error) {
@@ -147,9 +122,7 @@ module.exports = {
             const agent = check.agentName ? ` (agent: ${check.agentName})` : '';
             logger.info(`[manifest] Connection verified${agent}`);
           })
-          .catch(() => {
-            // Swallow — startup should never fail on verify
-          });
+          .catch(() => {});
       },
       stop: async () => {
         await shutdownTelemetry(logger);

--- a/packages/openclaw-plugin/src/telemetry.ts
+++ b/packages/openclaw-plugin/src/telemetry.ts
@@ -1,17 +1,11 @@
-import {
-  BasicTracerProvider,
-  BatchSpanProcessor,
-} from "@opentelemetry/sdk-trace-base";
-import {
-  MeterProvider,
-  PeriodicExportingMetricReader,
-} from "@opentelemetry/sdk-metrics";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
-import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
-import { Resource } from "@opentelemetry/resources";
-import { trace, metrics, Tracer, Meter } from "@opentelemetry/api";
-import { ManifestConfig } from "./config";
-import { DEFAULTS, DEV_DEFAULTS, LOCAL_DEFAULTS } from "./constants";
+import { BasicTracerProvider, BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { MeterProvider, PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { trace, metrics, Tracer, Meter } from '@opentelemetry/api';
+import { ManifestConfig } from './config';
+import { DEFAULTS, LOCAL_DEFAULTS } from './constants';
 
 export interface PluginLogger {
   info: (...args: unknown[]) => void;
@@ -30,9 +24,9 @@ export function initTelemetry(
   logger: PluginLogger,
 ): { tracer: Tracer; meter: Meter } {
   const resource = new Resource({
-    "service.name": DEFAULTS.SERVICE_NAME,
-    "service.version": process.env.PLUGIN_VERSION || "0.0.0",
-    "manifest.plugin": "true",
+    'service.name': DEFAULTS.SERVICE_NAME,
+    'service.version': process.env.PLUGIN_VERSION || '0.0.0',
+    'manifest.plugin': 'true',
   });
 
   const headers: Record<string, string> = config.apiKey
@@ -65,8 +59,8 @@ export function initTelemetry(
   });
 
   const metricsIntervalMs =
-    config.mode === "dev" ? DEV_DEFAULTS.METRICS_INTERVAL_MS
-      : config.mode === "local" ? LOCAL_DEFAULTS.METRICS_INTERVAL_MS
+    config.devMode || config.mode === 'local'
+      ? LOCAL_DEFAULTS.METRICS_INTERVAL_MS
       : DEFAULTS.METRICS_INTERVAL_MS;
 
   meterProvider = new MeterProvider({
@@ -84,26 +78,24 @@ export function initTelemetry(
       `(interval=${metricsIntervalMs}ms)`,
   );
 
-  tracer = trace.getTracer("manifest-plugin", process.env.PLUGIN_VERSION);
-  meter = metrics.getMeter("manifest-plugin", process.env.PLUGIN_VERSION);
+  tracer = trace.getTracer('manifest-plugin', process.env.PLUGIN_VERSION);
+  meter = metrics.getMeter('manifest-plugin', process.env.PLUGIN_VERSION);
 
   return { tracer, meter };
 }
 
 export function getTracer(): Tracer {
-  if (!tracer) throw new Error("[manifest] Telemetry not initialized");
+  if (!tracer) throw new Error('[manifest] Telemetry not initialized');
   return tracer;
 }
 
 export function getMeter(): Meter {
-  if (!meter) throw new Error("[manifest] Telemetry not initialized");
+  if (!meter) throw new Error('[manifest] Telemetry not initialized');
   return meter;
 }
 
-export async function shutdownTelemetry(
-  logger: PluginLogger,
-): Promise<void> {
-  logger.info("[manifest] Shutting down telemetry...");
+export async function shutdownTelemetry(logger: PluginLogger): Promise<void> {
+  logger.info('[manifest] Shutting down telemetry...');
   if (tracerProvider) {
     await tracerProvider.shutdown();
     tracerProvider = null;
@@ -114,5 +106,5 @@ export async function shutdownTelemetry(
   }
   tracer = null;
   meter = null;
-  logger.info("[manifest] Telemetry shut down");
+  logger.info('[manifest] Telemetry shut down');
 }


### PR DESCRIPTION
## Summary

- **Plugin**: Replace `mode: "cloud" | "local" | "dev"` with `mode: "cloud" | "local"` + `devMode: boolean`. The old `mode: "dev"` is silently mapped to `mode: "cloud", devMode: true` with a deprecation warning. `devMode` is auto-detected when endpoint is loopback and no `mnfst_*` key is provided.
- **Backend**: Health endpoint now exposes `devMode` based on `NODE_ENV !== 'production'`.
- **Frontend**: Show **Local** badge in local mode and **Dev** badge when `devMode` is true (both can appear simultaneously). Settings page now works in local mode with General + Agent setup tabs. Rotated key banner shows in all modes.
- **Docs**: Updated CLAUDE.md, CONTRIBUTING.md, and plugin README to reflect the new 2-axis config model.

## Test plan

- [ ] All plugin tests pass with 100% line coverage (309 tests)
- [ ] All backend unit tests pass (2223 tests)
- [ ] All backend e2e tests pass (106 tests)
- [ ] All frontend tests pass (1319 tests)
- [ ] TypeScript compiles clean in all packages
- [ ] `mode: "dev"` in plugin config still works (backward compat → maps to cloud + devMode)
- [ ] Local mode shows both Local and Dev badges in header
- [ ] Settings page accessible and functional in local mode
- [ ] Key rotation shows result banner in local mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the plugin config from a 3-mode system to a 2-axis model (deployment `mode` × `devMode`) to separate environment behavior from where you run. This simplifies setup, unifies cloud/dev behavior, and improves UI and health reporting.

- **Refactors**
  - Plugin (`packages/openclaw-plugin`): add `devMode` (boolean), auto-detect it on loopback endpoints without `mnfst_*` keys, merge cloud/dev paths using `dev-no-auth`, and use 10s metrics when `devMode` or local. Schema updated to include `devMode`.
  - Backend (`packages/backend`): `GET /api/v1/health` now returns `devMode` based on `NODE_ENV !== 'production'`.
  - Frontend (`packages/frontend`): add `isDevMode`, show both Local and Dev badges, enable Settings in local mode (General + Agent setup tabs), and show the rotated key banner in all modes.
  - Docs: updated `CLAUDE.md`, `CONTRIBUTING.md`, and plugin `README.md`.

- **Migration**
  - Use `mode: "cloud" | "local"` plus `devMode: true | false`. `mode: "dev"` is deprecated; it maps to `cloud` + `devMode: true` and logs a warning.
  - `devMode` auto-enables when the endpoint is loopback and no `mnfst_*` key is set. In cloud production, provide a valid `mnfst_*` API key.
  - Scripts now use `--mode local` for local setup. No API key is required when `devMode` is true.

<sup>Written for commit dab83ca8d23aaa0d64a3c8c892a5bb7e39bac4f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

