### PR TITLE
Add auth badge consistency across all pages

### DIFF
--- a/.changeset/auth-badge-consistency.md
+++ b/.changeset/auth-badge-consistency.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add auth badge (subscription/api key) to provider icons across all pages for consistency

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -125,14 +125,16 @@ describe('TimeseriesQueriesService', () => {
   describe('getCostByModel', () => {
     it('computes share_pct for each model', async () => {
       mockGetRawMany.mockResolvedValue([
-        { model: 'claude-opus-4-6', tokens: 700, estimated_cost: 10.0 },
-        { model: 'gpt-4o', tokens: 300, estimated_cost: 5.0 },
+        { model: 'claude-opus-4-6', tokens: 700, estimated_cost: 10.0, auth_type: 'subscription' },
+        { model: 'gpt-4o', tokens: 300, estimated_cost: 5.0, auth_type: 'api_key' },
       ]);
 
       const result = await service.getCostByModel('7d', 'u1');
       expect(result).toHaveLength(2);
       expect(result[0].share_pct).toBe(70);
       expect(result[1].share_pct).toBe(30);
+      expect(result[0].auth_type).toBe('subscription');
+      expect(result[1].auth_type).toBe('api_key');
     });
 
     it('returns 0 share_pct when total tokens is 0', async () => {
@@ -140,6 +142,7 @@ describe('TimeseriesQueriesService', () => {
 
       const result = await service.getCostByModel('7d', 'u1');
       expect(result[0].share_pct).toBe(0);
+      expect(result[0].auth_type).toBeNull();
     });
   });
 
@@ -500,13 +503,15 @@ describe('TimeseriesQueriesService (sql.js / local mode)', () => {
 
   it('getCostByModel works with sqlite dialect', async () => {
     mockGetRawMany.mockResolvedValue([
-      { model: 'gpt-4o', tokens: 500, estimated_cost: 2.0 },
-      { model: 'claude', tokens: 500, estimated_cost: 3.0 },
+      { model: 'gpt-4o', tokens: 500, estimated_cost: 2.0, auth_type: 'api_key' },
+      { model: 'claude', tokens: 500, estimated_cost: 3.0, auth_type: null },
     ]);
 
     const result = await service.getCostByModel('7d', 'u1');
     expect(result).toHaveLength(2);
     expect(result[0].share_pct).toBe(50);
+    expect(result[0].auth_type).toBe('api_key');
+    expect(result[1].auth_type).toBeNull();
     expect(result[1].share_pct).toBe(50);
   });
 });

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -272,11 +272,16 @@ export class TimeseriesQueriesService {
       .select("COALESCE(at.model, 'unknown')", 'model')
       .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
       .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'estimated_cost')
+      .addSelect('at.auth_type', 'auth_type')
       .where('at.timestamp >= :cutoff', { cutoff })
       .andWhere('at.model IS NOT NULL')
       .andWhere("at.model != ''");
     addTenantFilter(qb, userId, agentName, resolved);
-    const rows = await qb.groupBy('at.model').orderBy('tokens', 'DESC').getRawMany();
+    const rows = await qb
+      .groupBy('at.model')
+      .addGroupBy('at.auth_type')
+      .orderBy('tokens', 'DESC')
+      .getRawMany();
 
     const totalTokens = rows.reduce(
       (sum: number, r: Record<string, unknown>) => sum + Number(r['tokens'] ?? 0),
@@ -288,6 +293,7 @@ export class TimeseriesQueriesService {
       share_pct:
         totalTokens === 0 ? 0 : Math.round((Number(r['tokens'] ?? 0) / totalTokens) * 1000) / 10,
       estimated_cost: Number(r['estimated_cost'] ?? 0),
+      auth_type: r['auth_type'] ? String(r['auth_type']) : null,
     }));
   }
 

--- a/packages/frontend/src/components/AuthBadge.tsx
+++ b/packages/frontend/src/components/AuthBadge.tsx
@@ -1,0 +1,66 @@
+import type { JSX } from 'solid-js';
+
+const USER_ICON = (s: number) => (
+  <svg
+    width={s}
+    height={s}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
+const KEY_ICON = (s: number) => (
+  <svg
+    width={s}
+    height={s}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="3"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4" />
+  </svg>
+);
+
+export function authLabel(authType: string | null | undefined): string {
+  return authType === 'subscription' ? 'Subscription' : 'API Key';
+}
+
+export function authBadgeFor(
+  authType: string | null | undefined,
+  size: number,
+): JSX.Element | null {
+  const overlay = size <= 8 ? ' provider-auth-badge--overlay' : '';
+  if (authType === 'subscription')
+    return (
+      <span
+        class={`provider-auth-badge provider-auth-badge--sub${overlay}`}
+        style={{ width: `${size}px`, height: `${size}px` }}
+        aria-label="Subscription"
+      >
+        {USER_ICON(size * 0.58)}
+      </span>
+    );
+  if (authType === 'api_key')
+    return (
+      <span
+        class={`provider-auth-badge provider-auth-badge--key${overlay}`}
+        style={{ width: `${size}px`, height: `${size}px` }}
+        aria-label="API Key"
+      >
+        {KEY_ICON(size * 0.58)}
+      </span>
+    );
+  return null;
+}

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -1,12 +1,15 @@
 import { createSignal, For, Show, type Component } from 'solid-js';
 import { providerIcon } from './ProviderIcon.js';
+import { authBadgeFor } from './AuthBadge.js';
 import { resolveProviderId, stripCustomPrefix } from '../services/routing-utils.js';
 import { getModelLabel } from '../services/provider-utils.js';
+import { PROVIDERS } from '../services/providers.js';
 import {
   setFallbacks,
   clearFallbacks,
   type AvailableModel,
   type CustomProviderData,
+  type RoutingProvider,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 
@@ -16,6 +19,7 @@ interface FallbackListProps {
   fallbacks: string[];
   models: AvailableModel[];
   customProviders: CustomProviderData[];
+  connectedProviders: RoutingProvider[];
   onUpdate: (updatedFallbacks: string[]) => void;
   onAddFallback: () => void;
   adding?: boolean;
@@ -38,6 +42,24 @@ const FallbackList: Component<FallbackListProps> = (props) => {
     const info = props.models.find((m) => m.model_name === model);
     if (info) return resolveProviderId(info.provider);
     return undefined;
+  };
+
+  const authTypeFor = (providerId: string | undefined): string | null => {
+    if (!providerId) return null;
+    const provs = props.connectedProviders.filter(
+      (p) => p.provider.toLowerCase() === providerId.toLowerCase(),
+    );
+    if (provs.some((p) => p.auth_type === 'subscription')) return 'subscription';
+    if (provs.some((p) => p.auth_type === 'api_key')) return 'api_key';
+    return null;
+  };
+
+  const providerTitle = (providerId: string | undefined, authType: string | null): string => {
+    if (!providerId) return '';
+    const provDef = PROVIDERS.find((p) => p.id === providerId);
+    const name = provDef?.name ?? providerId;
+    const method = authType === 'subscription' ? 'Subscription' : 'API Key';
+    return `${name} (${method})`;
   };
 
   const handleRemove = async (index: number) => {
@@ -69,11 +91,16 @@ const FallbackList: Component<FallbackListProps> = (props) => {
             {(model, i) => {
               const provId = () => providerIdFor(model);
               const isCustom = () => provId()?.startsWith('custom:');
+              const auth = () => authTypeFor(provId());
+              const title = () => providerTitle(provId(), auth());
               return (
                 <li class="fallback-list__item">
                   <span class="fallback-list__rank">{i() + 1}.</span>
                   <Show when={provId() && !isCustom()}>
-                    <span class="fallback-list__icon">{providerIcon(provId()!, 14)}</span>
+                    <span class="fallback-list__icon" title={title()}>
+                      {providerIcon(provId()!, 14)}
+                      {authBadgeFor(auth(), 8)}
+                    </span>
                   </Show>
                   <Show when={isCustom()}>
                     {(() => {
@@ -82,6 +109,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                       return (
                         <span
                           class="provider-card__logo-letter fallback-list__icon"
+                          title={cp?.name ?? 'Custom'}
                           style={{
                             background: 'var(--custom-provider-color)',
                             width: '14px',

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -378,6 +378,14 @@ const ProviderSelectModal: Component<Props> = (props) => {
                     );
                   }}
                 </For>
+                <a
+                  class="provider-modal__request-link"
+                  href="https://github.com/mnfst/manifest/discussions/973"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Request new subscription model
+                </a>
               </div>
             </Show>
 

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -28,6 +28,7 @@ import {
 } from '../services/routing-utils.js';
 import { getModelDisplayName, preloadModelDisplayNames } from '../services/model-display.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
+import { authBadgeFor, authLabel } from '../components/AuthBadge.js';
 import Select from '../components/Select.jsx';
 import InfoTooltip from '../components/InfoTooltip.jsx';
 import { isLocalMode } from '../services/local-mode.js';
@@ -533,25 +534,12 @@ const MessageLog: Component = () => {
                             ) : item.model && inferProviderFromModel(item.model) ? (
                               <span
                                 role="img"
-                                aria-label={
-                                  item.auth_type === 'subscription'
-                                    ? `${inferProviderName(item.model)} (Subscription)`
-                                    : inferProviderName(item.model)
-                                }
-                                title={
-                                  item.auth_type === 'subscription'
-                                    ? `${inferProviderName(item.model)} (Subscription)`
-                                    : inferProviderName(item.model)
-                                }
+                                aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
+                                title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
                                 style="display: inline-flex; flex-shrink: 0; position: relative;"
                               >
                                 {providerIcon(inferProviderFromModel(item.model)!, 14)}
-                                {item.auth_type === 'subscription' && (
-                                  <span
-                                    class="provider-auth-badge provider-auth-badge--sub provider-auth-badge--overlay"
-                                    aria-hidden="true"
-                                  />
-                                )}
+                                {authBadgeFor(item.auth_type, 8)}
                               </span>
                             ) : null}
                             {item.model ? getModelDisplayName(item.model) : '\u2014'}

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -23,6 +23,7 @@ import {
 } from '../services/routing-utils.js';
 import { getModelDisplayName, preloadModelDisplayNames } from '../services/model-display.js';
 import { providerIcon } from '../components/ProviderIcon.jsx';
+import { authBadgeFor, authLabel } from '../components/AuthBadge.js';
 import { isLocalMode } from '../services/local-mode.js';
 import { pingCount } from '../services/sse.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
@@ -70,6 +71,7 @@ interface OverviewData {
     tokens: number;
     share_pct: number;
     estimated_cost: number;
+    auth_type: string | null;
   }>;
   recent_activity: RecentMessage[];
   active_skills: Array<{
@@ -651,25 +653,12 @@ const Overview: Component = () => {
                                   ) : item.model && inferProviderFromModel(item.model) ? (
                                     <span
                                       role="img"
-                                      aria-label={
-                                        item.auth_type === 'subscription'
-                                          ? `${inferProviderName(item.model)} (Subscription)`
-                                          : inferProviderName(item.model)
-                                      }
-                                      title={
-                                        item.auth_type === 'subscription'
-                                          ? `${inferProviderName(item.model)} (Subscription)`
-                                          : inferProviderName(item.model)
-                                      }
+                                      aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
+                                      title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
                                       style="display: inline-flex; flex-shrink: 0; position: relative;"
                                     >
                                       {providerIcon(inferProviderFromModel(item.model)!, 14)}
-                                      {item.auth_type === 'subscription' && (
-                                        <span
-                                          class="provider-auth-badge provider-auth-badge--sub provider-auth-badge--overlay"
-                                          aria-hidden="true"
-                                        />
-                                      )}
+                                      {authBadgeFor(item.auth_type, 8)}
                                     </span>
                                   ) : null}
                                   {item.model ? getModelDisplayName(item.model) : '\u2014'}
@@ -765,7 +754,11 @@ const Overview: Component = () => {
                         </tr>
                       </thead>
                       <tbody>
-                        <For each={d().cost_by_model ?? []}>
+                        <For
+                          each={[...(d().cost_by_model ?? [])].sort(
+                            (a, b) => b.estimated_cost - a.estimated_cost,
+                          )}
+                        >
                           {(row) => (
                             <tr>
                               <td style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
@@ -795,10 +788,11 @@ const Overview: Component = () => {
                                     })()
                                   ) : row.model && inferProviderFromModel(row.model) ? (
                                     <span
-                                      title={inferProviderName(row.model)}
-                                      style="display: inline-flex; flex-shrink: 0;"
+                                      title={`${inferProviderName(row.model)} (${authLabel(row.auth_type)})`}
+                                      style="display: inline-flex; flex-shrink: 0; position: relative;"
                                     >
                                       {providerIcon(inferProviderFromModel(row.model)!, 14)}
+                                      {authBadgeFor(row.auth_type, 8)}
                                     </span>
                                   ) : null}
                                   {row.model ? getModelDisplayName(row.model) : row.model}

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -1,9 +1,10 @@
-import { createSignal, createResource, For, Show, type Component, type JSX } from 'solid-js';
+import { createSignal, createResource, For, Show, type Component } from 'solid-js';
 import { useParams } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
 import { STAGES, PROVIDERS } from '../services/providers.js';
 import { getModelLabel } from '../services/provider-utils.js';
 import { providerIcon } from '../components/ProviderIcon.js';
+import { authBadgeFor } from '../components/AuthBadge.js';
 import ProviderSelectModal from '../components/ProviderSelectModal.js';
 import RoutingInstructionModal from '../components/RoutingInstructionModal.js';
 import ModelPickerModal from '../components/ModelPickerModal.js';
@@ -53,63 +54,6 @@ function providerIdForModel(model: string, apiModels: AvailableModel[]): string 
     }
   }
   return undefined;
-}
-
-const USER_ICON = (s: number) => (
-  <svg
-    width={s}
-    height={s}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="3"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
-    <circle cx="12" cy="7" r="4" />
-  </svg>
-);
-
-const KEY_ICON = (s: number) => (
-  <svg
-    width={s}
-    height={s}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="3"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <path d="m21 2-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0 3 3L22 7l-3-3m-3.5 3.5L19 4" />
-  </svg>
-);
-
-function authBadgeFor(authType: string | null | undefined, size: number): JSX.Element | null {
-  if (authType === 'subscription')
-    return (
-      <span
-        class="provider-auth-badge provider-auth-badge--sub"
-        style={{ width: `${size}px`, height: `${size}px` }}
-        aria-label="Subscription"
-      >
-        {USER_ICON(size * 0.58)}
-      </span>
-    );
-  if (authType === 'api_key')
-    return (
-      <span
-        class="provider-auth-badge provider-auth-badge--key"
-        style={{ width: `${size}px`, height: `${size}px` }}
-        aria-label="API Key"
-      >
-        {KEY_ICON(size * 0.58)}
-      </span>
-    );
-  return null;
 }
 
 const Routing: Component = () => {
@@ -298,7 +242,10 @@ const Routing: Component = () => {
       refetchModels(),
     ]);
     if (!wasEnabled && isEnabled()) {
-      setInstructionModal('enable');
+      // Only show setup instructions when a non-subscription provider is active,
+      // since subscription models don't require OpenClaw routing configuration.
+      const hasNonSub = activeProviders().some((p) => p.auth_type !== 'subscription');
+      if (hasNonSub) setInstructionModal('enable');
     }
   };
 
@@ -643,6 +590,7 @@ const Routing: Component = () => {
                             fallbacks={getFallbacksFor(stage.id)}
                             models={models() ?? []}
                             customProviders={customProviders() ?? []}
+                            connectedProviders={activeProviders()}
                             onUpdate={(updatedFallbacks) => {
                               setFallbackOverrides((prev) => {
                                 const next = { ...prev };

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -336,6 +336,7 @@
   display: flex;
   align-items: center;
   flex-shrink: 0;
+  position: relative;
 }
 
 .fallback-list__model {

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -16,6 +16,17 @@ vi.mock("../../src/components/ProviderIcon.js", () => ({
   providerIcon: () => null,
 }));
 
+vi.mock("../../src/components/AuthBadge.js", () => ({
+  authBadgeFor: () => null,
+}));
+
+vi.mock("../../src/services/providers.js", () => ({
+  PROVIDERS: [
+    { id: "openai", name: "OpenAI" },
+    { id: "anthropic", name: "Anthropic" },
+  ],
+}));
+
 vi.mock("../../src/services/routing-utils.js", () => ({
   resolveProviderId: (p: string) => p.toLowerCase(),
   stripCustomPrefix: (m: string) => m.replace(/^custom:[^/]+\//, ""),
@@ -38,6 +49,10 @@ const defaultProps = {
   fallbacks: [] as string[],
   models,
   customProviders: [] as any[],
+  connectedProviders: [
+    { provider: "openai", auth_type: "api_key", is_active: true },
+    { provider: "anthropic", auth_type: "subscription", is_active: true },
+  ] as any[],
   onUpdate: vi.fn(),
   onAddFallback: vi.fn(),
 };
@@ -383,6 +398,50 @@ describe("FallbackList", () => {
     });
 
     resolveRemove!();
+  });
+
+  it("renders auth badge on fallback icon via authBadgeFor", () => {
+    const { container } = render(() => (
+      <FallbackList
+        {...defaultProps}
+        fallbacks={["model-a"]}
+      />
+    ));
+
+    const iconSpan = container.querySelector(".fallback-list__icon");
+    expect(iconSpan).not.toBeNull();
+    // title should show "OpenAI (API Key)" since model-a → openai → api_key
+    expect(iconSpan?.getAttribute("title")).toBe("OpenAI (API Key)");
+  });
+
+  it("renders subscription title on fallback icon", () => {
+    const { container } = render(() => (
+      <FallbackList
+        {...defaultProps}
+        fallbacks={["model-b"]}
+      />
+    ));
+
+    const iconSpan = container.querySelector(".fallback-list__icon");
+    expect(iconSpan?.getAttribute("title")).toBe("Anthropic (Subscription)");
+  });
+
+  it("returns null auth type when provider not in connectedProviders", () => {
+    const modelsUnknown = [
+      { model_name: "model-x", provider: "Unknown" },
+    ] as any[];
+    const { container } = render(() => (
+      <FallbackList
+        {...defaultProps}
+        fallbacks={["model-x"]}
+        models={modelsUnknown}
+        connectedProviders={[]}
+      />
+    ));
+
+    const iconSpan = container.querySelector(".fallback-list__icon");
+    // Provider "unknown" not in PROVIDERS mock, so providerTitle falls back to providerId
+    expect(iconSpan?.getAttribute("title")).toBe("unknown (API Key)");
   });
 
   it("clears removingIndex after failed removal", async () => {

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -649,7 +649,7 @@ describe("MessageLog", () => {
     });
   });
 
-  it("does not render subscription auth badge when auth_type is not subscription", async () => {
+  it("renders api_key auth badge when auth_type is api_key", async () => {
     const dataWithApiKey = {
       ...messagesData,
       items: [
@@ -660,8 +660,10 @@ describe("MessageLog", () => {
     mockGetMessages.mockResolvedValue(dataWithApiKey);
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".provider-auth-badge--sub");
-      expect(badge).toBeNull();
+      const badge = container.querySelector(".provider-auth-badge--key");
+      expect(badge).not.toBeNull();
+      const subBadge = container.querySelector(".provider-auth-badge--sub");
+      expect(subBadge).toBeNull();
     });
   });
 

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -89,8 +89,8 @@ const overviewData = {
   cost_usage: [{ hour: "2026-02-18 10:00:00", cost: 0.5 }],
   message_usage: [{ hour: "2026-02-18 10:00:00", count: 5 }],
   cost_by_model: [
-    { model: "gpt-4o", tokens: 30000, share_pct: 60, estimated_cost: 2.1 },
-    { model: "claude-3.5-sonnet", tokens: 20000, share_pct: 40, estimated_cost: 1.4 },
+    { model: "gpt-4o", tokens: 30000, share_pct: 60, estimated_cost: 2.1, auth_type: "api_key" },
+    { model: "claude-3.5-sonnet", tokens: 20000, share_pct: 40, estimated_cost: 1.4, auth_type: "subscription" },
   ],
   recent_activity: [
     { id: "msg-12345678", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "gpt-4o", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok" },
@@ -220,6 +220,43 @@ describe("Overview", () => {
     });
   });
 
+  it("sorts cost by model rows by estimated_cost descending", async () => {
+    const data = {
+      ...overviewData,
+      cost_by_model: [
+        { model: "claude-3.5-sonnet", tokens: 20000, share_pct: 40, estimated_cost: 1.4, auth_type: "subscription" },
+        { model: "gpt-4o", tokens: 30000, share_pct: 60, estimated_cost: 2.1, auth_type: "api_key" },
+      ],
+    };
+    mockGetOverview.mockResolvedValue(data);
+    const { container } = render(() => <Overview />);
+    await vi.waitFor(() => {
+      const panels = container.querySelectorAll(".panel");
+      // Find the Cost by Model panel
+      const costPanel = Array.from(panels).find(p => p.textContent?.includes("Cost by Model"));
+      expect(costPanel).toBeDefined();
+      const rows = costPanel!.querySelectorAll("tbody tr");
+      expect(rows.length).toBe(2);
+      // gpt-4o ($2.1) should come before claude ($1.4) even though claude is first in data
+      expect(rows[0].textContent).toContain("gpt-4o");
+      expect(rows[1].textContent).toContain("claude-3.5-sonnet");
+    });
+  });
+
+  it("renders auth badges on cost by model provider icons", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <Overview />);
+    await vi.waitFor(() => {
+      const panels = container.querySelectorAll(".panel");
+      const costPanel = Array.from(panels).find(p => p.textContent?.includes("Cost by Model"));
+      expect(costPanel).toBeDefined();
+      const keyBadge = costPanel!.querySelector(".provider-auth-badge--key");
+      const subBadge = costPanel!.querySelector(".provider-auth-badge--sub");
+      expect(keyBadge).not.toBeNull();
+      expect(subBadge).not.toBeNull();
+    });
+  });
+
   it("shows empty state for new agent with no data", async () => {
     mockGetOverview.mockResolvedValue({ ...overviewData, has_data: false, summary: null });
     const { container } = render(() => <Overview />);
@@ -328,7 +365,7 @@ describe("Overview", () => {
         { id: "msg-cp1", timestamp: "2026-02-18T10:00:00Z", agent_name: "test-agent", model: "custom:abc-123/my-llama", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok" },
       ],
       cost_by_model: [
-        { model: "custom:abc-123/my-llama", tokens: 30000, share_pct: 100, estimated_cost: 2.1 },
+        { model: "custom:abc-123/my-llama", tokens: 30000, share_pct: 100, estimated_cost: 2.1, auth_type: "api_key" },
       ],
     };
 
@@ -534,18 +571,21 @@ describe("Overview", () => {
     });
   });
 
-  it("does not render subscription auth badge when auth_type is not subscription", async () => {
+  it("renders api_key auth badge when auth_type is api_key", async () => {
     const dataWithApiKey = {
       ...overviewData,
       recent_activity: [
         { ...overviewData.recent_activity[0], model: "claude-sonnet-4", auth_type: "api_key" },
       ],
+      cost_by_model: overviewData.cost_by_model.map(r => ({ ...r, auth_type: "api_key" })),
     };
     mockGetOverview.mockResolvedValue(dataWithApiKey);
     const { container } = render(() => <Overview />);
     await vi.waitFor(() => {
-      const badge = container.querySelector(".provider-auth-badge--sub");
-      expect(badge).toBeNull();
+      const badge = container.querySelector(".provider-auth-badge--key");
+      expect(badge).not.toBeNull();
+      const subBadge = container.querySelector(".provider-auth-badge--sub");
+      expect(subBadge).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- Extract shared `AuthBadge` component (`authBadgeFor()`, `authLabel()`) to eliminate duplicate badge logic across pages
- Add auth badges (subscription/api key) to provider icons on **Routing** fallback list, **Overview** Cost by Model table, and **Recent Messages** across Overview and MessageLog
- Sort Cost by Model rows by estimated cost descending
- Add `auth_type` to the `getCostByModel` backend query (group by auth type)
- Add "Request new subscription model" link in the subscription tab of provider select modal
- Skip routing instruction modal when only subscription providers are activated

## Test plan
- [ ] Verify auth badges appear on fallback list provider icons (Routing page)
- [ ] Verify Cost by Model table rows are sorted by cost descending and show auth badges
- [ ] Verify Recent Messages show correct auth badge for both subscription and api_key
- [ ] Verify "Request new subscription model" link appears below subscription models list
- [ ] Verify enabling only subscription providers does not trigger routing instruction modal
- [ ] All existing tests pass (backend unit, e2e, frontend)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared `AuthBadge` to consistently show Subscription/API Key badges on provider icons across Routing, Overview, and MessageLog. Also surface `auth_type` in cost-by-model data, sort that table by estimated cost, add a request link for new subscription models, and skip routing instructions when only subscription providers are active.

- **New Features**
  - Extracted shared `AuthBadge` (`authBadgeFor()`, `authLabel()`) and applied to Routing fallback list, Overview (Cost by Model and Recent Messages), and MessageLog.
  - Improved Cost by Model: rows now sort by `estimated_cost` (desc), and badges display using `auth_type` from backend `getCostByModel` (now grouped and selected by `auth_type`).
  - Added “Request new subscription model” link in the subscription tab of the provider select modal.
  - Skip routing instruction modal when only subscription providers are enabled.

<sup>Written for commit 8758f8c6fb27ac0f172386a3201c0568ee88644e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

