### PR TITLE
fix: heartbeat detection checks only the last user message

### DIFF
--- a/.changeset/fix-heartbeat-detection.md
+++ b/.changeset/fix-heartbeat-detection.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix heartbeat detection to check only the last user message instead of all messages in conversation history

--- a/package-lock.json
+++ b/package-lock.json
@@ -14211,7 +14211,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.21.2",
+      "version": "5.23.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -345,7 +345,7 @@ describe('ProxyService', () => {
       );
     });
 
-    it('detects heartbeat when HEARTBEAT_OK is in an earlier user message', async () => {
+    it('does NOT detect heartbeat when HEARTBEAT_OK is only in an earlier user message', async () => {
       const buriedHeartbeatBody = {
         messages: [
           { role: 'system', content: 'You are a helpful assistant.' },
@@ -355,6 +355,42 @@ describe('ProxyService', () => {
           },
           { role: 'assistant', content: 'HEARTBEAT_OK' },
           { role: 'user', content: 'Thanks, anything else?' },
+        ],
+        stream: false,
+      };
+
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 5,
+        reason: 'scored',
+      });
+      routingService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+      });
+
+      const result = await service.proxyRequest('agent-1', 'user-1', buriedHeartbeatBody, 'sess-1');
+
+      expect(resolveService.resolve).toHaveBeenCalled();
+      expect(result.meta.tier).toBe('standard');
+      expect(result.meta.reason).toBe('scored');
+    });
+
+    it('detects heartbeat when HEARTBEAT_OK is in the last user message with prior history', async () => {
+      const lastMsgHeartbeatBody = {
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant.' },
+          { role: 'user', content: 'What is the weather?' },
+          { role: 'assistant', content: 'It is sunny.' },
+          {
+            role: 'user',
+            content: 'Check tasks and reply HEARTBEAT_OK if nothing needs attention.',
+          },
         ],
         stream: false,
       };
@@ -374,7 +410,12 @@ describe('ProxyService', () => {
         isAnthropic: false,
       });
 
-      const result = await service.proxyRequest('agent-1', 'user-1', buriedHeartbeatBody, 'sess-1');
+      const result = await service.proxyRequest(
+        'agent-1',
+        'user-1',
+        lastMsgHeartbeatBody,
+        'sess-1',
+      );
 
       expect(resolveService.resolveForTier).toHaveBeenCalledWith('agent-1', 'simple');
       expect(resolveService.resolve).not.toHaveBeenCalled();

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -312,17 +312,15 @@ export class ProxyService {
   }
 
   private detectHeartbeat(scoringMessages: ScorerMessage[]): boolean {
-    return scoringMessages.some((m) => {
-      if (m.role !== 'user') return false;
-      if (typeof m.content === 'string') return m.content.includes('HEARTBEAT_OK');
-      if (Array.isArray(m.content)) {
-        return m.content.some(
-          (p: { type?: string; text?: string }) =>
-            p.type === 'text' && typeof p.text === 'string' && p.text.includes('HEARTBEAT_OK'),
-        );
-      }
-      return false;
-    });
+    const lastUser = [...scoringMessages].reverse().find((m) => m.role === 'user');
+    if (!lastUser) return false;
+    if (typeof lastUser.content === 'string') return lastUser.content.includes('HEARTBEAT_OK');
+    if (Array.isArray(lastUser.content)) {
+      return (lastUser.content as { type?: string; text?: string }[]).some(
+        (p) => p.type === 'text' && typeof p.text === 'string' && p.text.includes('HEARTBEAT_OK'),
+      );
+    }
+    return false;
   }
 
   private async forwardToProvider(

--- a/packages/openclaw-plugin/__tests__/hooks.test.ts
+++ b/packages/openclaw-plugin/__tests__/hooks.test.ts
@@ -911,6 +911,78 @@ describe("registerHooks", () => {
       );
     });
 
+    it("does not detect heartbeat when HEARTBEAT_OK is only in an earlier user message", () => {
+      api.emit("message_received", { sessionKey: "hb-buried-sess" });
+      api.emit("before_agent_start", { sessionKey: "hb-buried-sess" });
+
+      const turnSpan = tracer.spans[1];
+
+      api.emit("agent_end", {
+        sessionKey: "hb-buried-sess",
+        messages: [
+          { role: "user", content: "Check tasks and reply HEARTBEAT_OK if nothing needs attention." },
+          {
+            role: "assistant",
+            model: "gpt-4o-mini",
+            provider: "OpenAI",
+            usage: { input: 50, output: 10 },
+          },
+          { role: "user", content: "Thanks, anything else?" },
+          {
+            role: "assistant",
+            model: "gpt-4o",
+            provider: "OpenAI",
+            usage: { input: 500, output: 200 },
+          },
+        ],
+      });
+
+      expect(turnSpan.setAttribute).not.toHaveBeenCalledWith(
+        ATTRS.ROUTING_REASON,
+        "heartbeat",
+      );
+      expect(turnSpan.setAttribute).not.toHaveBeenCalledWith(
+        ATTRS.ROUTING_TIER,
+        "simple",
+      );
+    });
+
+    it("detects heartbeat when HEARTBEAT_OK is in the last user message of multi-turn conversation", () => {
+      api.emit("message_received", { sessionKey: "hb-last-sess" });
+      api.emit("before_agent_start", { sessionKey: "hb-last-sess" });
+
+      const turnSpan = tracer.spans[1];
+
+      api.emit("agent_end", {
+        sessionKey: "hb-last-sess",
+        messages: [
+          { role: "user", content: "What is the weather?" },
+          {
+            role: "assistant",
+            model: "gpt-4o",
+            provider: "OpenAI",
+            usage: { input: 100, output: 50 },
+          },
+          { role: "user", content: "Check tasks and reply HEARTBEAT_OK if nothing needs attention." },
+          {
+            role: "assistant",
+            model: "gpt-4o-mini",
+            provider: "OpenAI",
+            usage: { input: 50, output: 10 },
+          },
+        ],
+      });
+
+      expect(turnSpan.setAttribute).toHaveBeenCalledWith(
+        ATTRS.ROUTING_REASON,
+        "heartbeat",
+      );
+      expect(turnSpan.setAttribute).toHaveBeenCalledWith(
+        ATTRS.ROUTING_TIER,
+        "simple",
+      );
+    });
+
     it("does not set ROUTING_REASON when no heartbeat sentinel", () => {
       api.emit("message_received", { sessionKey: "no-hb-sess" });
       api.emit("before_agent_start", { sessionKey: "no-hb-sess" });

--- a/packages/openclaw-plugin/public/index.html
+++ b/packages/openclaw-plugin/public/index.html
@@ -30,8 +30,10 @@
     />
     <meta name="twitter:image" content="https://app.manifest.build/og-image.png" />
     <script src="/theme-init.js"></script>
-    <script type="module" crossorigin src="/assets/index-DTGQHgtK.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-ZONKAiYj.css">
+    <script type="module" crossorigin src="/assets/index-bz68j7f_.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/vendor-COodrVsO.js">
+    <link rel="modulepreload" crossorigin href="/assets/auth-yjhjkKyr.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-D4x6Xoo9.css">
   </head>
   <body>
     <div id="root"></div>

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -228,20 +228,19 @@ export function registerHooks(
       }
     }
 
-    // Detect heartbeat from messages — if any user message contains
-    // HEARTBEAT_OK, override the reason so it's identifiable in telemetry.
+    // Detect heartbeat — only if the LAST user message contains HEARTBEAT_OK.
     // Content can be a string or array of content parts (multi-modal format).
-    const hasHeartbeat = messages.some((m: any) => {
-      if (!m || m.role !== 'user') return false;
-      if (typeof m.content === 'string') return m.content.includes('HEARTBEAT_OK');
-      if (Array.isArray(m.content)) {
-        return m.content.some(
-          (p: any) =>
-            p.type === 'text' && typeof p.text === 'string' && p.text.includes('HEARTBEAT_OK'),
-        );
-      }
-      return false;
-    });
+    const lastUserMsg = [...messages].reverse().find((m: any) => m?.role === 'user');
+    const hasHeartbeat = lastUserMsg
+      ? typeof lastUserMsg.content === 'string'
+        ? lastUserMsg.content.includes('HEARTBEAT_OK')
+        : Array.isArray(lastUserMsg.content)
+          ? lastUserMsg.content.some(
+              (p: any) =>
+                p.type === 'text' && typeof p.text === 'string' && p.text.includes('HEARTBEAT_OK'),
+            )
+          : false
+      : false;
     if (hasHeartbeat) {
       routingReason = 'heartbeat';
       routingTier = 'simple';


### PR DESCRIPTION
## Summary

- Fix heartbeat detection in both backend proxy service and OpenClaw plugin to check only the **last** user message for `HEARTBEAT_OK`, instead of scanning all messages in conversation history
- Previously, `messages.some(...)` would match if ANY earlier user message contained the sentinel, causing all subsequent turns in a conversation to be falsely tagged as heartbeats
- Updated tests to verify buried heartbeats are no longer detected, and added tests for last-message detection with prior history

## Test plan

- [x] Backend unit tests pass (2324 tests)
- [x] Backend e2e tests pass (106 tests)
- [x] Frontend tests pass (1383 tests)
- [x] Plugin tests pass with 100% line coverage (329 tests)
- [x] TypeScript compiles cleanly in both backend and frontend

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix heartbeat detection to only check the last user message for HEARTBEAT_OK, preventing false heartbeat tagging across turns in both the backend proxy and the `packages/openclaw-plugin`.

- **Bug Fixes**
  - Backend (`packages/backend`): `detectHeartbeat` now inspects only the last user message (string or multi-part). Added tests to ignore buried heartbeats and verify last-message detection.
  - Plugin (`packages/openclaw-plugin`): Updated `hooks.ts` to mirror last-message detection so telemetry only flags heartbeats when appropriate. Added tests.

<sup>Written for commit 76dba1c1a45982073e7caeb705eb01aebfbed414. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

