### PR TITLE
Fix number formatting in threshold alert messages

### DIFF
--- a/.changeset/fix-threshold-numbers.md
+++ b/.changeset/fix-threshold-numbers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix number formatting in threshold alert emails - tokens now display with comma separators and no decimal places, costs display with 2 decimal places and comma separators

--- a/package-lock.json
+++ b/package-lock.json
@@ -14211,7 +14211,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.23.1",
+      "version": "5.24.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/backend/src/notifications/emails/threshold-alert.tsx
+++ b/packages/backend/src/notifications/emails/threshold-alert.tsx
@@ -40,8 +40,10 @@ function formatTimestamp(raw: string): string {
 }
 
 function formatValue(value: number, metric: string): string {
-  if (metric === 'cost') return `$${value.toFixed(4)}`;
-  return value.toLocaleString();
+  const num = Number(value);
+  if (metric === 'cost')
+    return `$${num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  return num.toLocaleString(undefined, { maximumFractionDigits: 0 });
 }
 
 export function ThresholdAlertEmail(props: ThresholdAlertProps) {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -287,12 +287,12 @@ export class ProxyService {
 
     const fmt =
       exceeded.metricType === 'cost'
-        ? `$${exceeded.actual.toFixed(2)}`
-        : exceeded.actual.toLocaleString();
+        ? `$${Number(exceeded.actual).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+        : Number(exceeded.actual).toLocaleString(undefined, { maximumFractionDigits: 0 });
     const threshFmt =
       exceeded.metricType === 'cost'
-        ? `$${exceeded.threshold.toFixed(2)}`
-        : exceeded.threshold.toLocaleString();
+        ? `$${Number(exceeded.threshold).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+        : Number(exceeded.threshold).toLocaleString(undefined, { maximumFractionDigits: 0 });
     throw new HttpException(
       {
         error: {


### PR DESCRIPTION
## Summary
Updated number formatting logic in threshold alert messages to use `toLocaleString()` with explicit formatting options instead of `toFixed()`, providing better internationalization support and consistent number display across the application.

## Key Changes
- **Proxy Service**: Updated cost and token threshold formatting to use `toLocaleString()` with locale-aware formatting options
  - Cost values: Display with 2 decimal places and comma separators
  - Token values: Display with no decimal places and comma separators
  
- **Threshold Alert Email**: Aligned email formatting with proxy service changes
  - Changed cost formatting from 4 decimal places to 2 decimal places
  - Updated token formatting to include comma separators for readability

## Implementation Details
- Replaced `toFixed()` calls with `toLocaleString(undefined, { minimumFractionDigits, maximumFractionDigits })` for better locale support
- Ensured consistent number formatting across both error responses and email notifications
- Cost metrics now display with exactly 2 decimal places (e.g., `$1,234.56`)
- Token metrics now display with no decimal places and comma separators (e.g., `1,000,000`)

https://claude.ai/code/session_01UtZvdPrWBrUi6Ep7dKEPQF