### PR TITLE
Fix reasoning content forwarding

### DIFF
--- a/.changeset/clever-buses-rest.md
+++ b/.changeset/clever-buses-rest.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Strip DeepSeek-specific `reasoning_content` from forwarded chat history unless the target endpoint/model supports it, preventing cross-provider chat completion failures when a conversation switches models.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -526,6 +526,17 @@ describe('ProviderClient', () => {
       service_tier: 'default',
       stream_options: { include_usage: true },
     };
+    const makeBodyWithReasoningContent = () => ({
+      messages: [
+        { role: 'user', content: 'Hello' },
+        {
+          role: 'assistant',
+          content: 'Hi',
+          reasoning_content: 'Detailed internal reasoning',
+        },
+      ],
+      temperature: 0.7,
+    });
 
     it('strips OpenAI-only fields for Mistral', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
@@ -566,6 +577,113 @@ describe('ProviderClient', () => {
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.store).toBeUndefined();
       expect(sentBody.service_tier).toBeUndefined();
+    });
+
+    it('strips reasoning_content for Mistral assistant messages without mutating the input', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningContent = makeBodyWithReasoningContent();
+
+      await client.forward('mistral', 'sk-mi', 'mistral-small', bodyWithReasoningContent, false);
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_content).toBeUndefined();
+      expect(bodyWithReasoningContent.messages[1].reasoning_content).toBe(
+        'Detailed internal reasoning',
+      );
+    });
+
+    it('preserves reasoning_content for DeepSeek reasoning models', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningContent = makeBodyWithReasoningContent();
+
+      await client.forward(
+        'deepseek',
+        'sk-ds',
+        'deepseek-reasoner',
+        bodyWithReasoningContent,
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
+    });
+
+    it('strips reasoning_content for native OpenAI targets', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningContent = makeBodyWithReasoningContent();
+
+      await client.forward('openai', 'sk-test', 'gpt-4o', bodyWithReasoningContent, false);
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_content).toBeUndefined();
+    });
+
+    it('strips reasoning_content for non-DeepSeek OpenRouter targets', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningContent = makeBodyWithReasoningContent();
+
+      await client.forward('openrouter', 'sk-or', 'openai/gpt-4o', bodyWithReasoningContent, false);
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_content).toBeUndefined();
+    });
+
+    it('preserves reasoning_content for DeepSeek models on OpenRouter', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithReasoningContent = makeBodyWithReasoningContent();
+
+      await client.forward(
+        'openrouter',
+        'sk-or',
+        'deepseek/deepseek-r1',
+        bodyWithReasoningContent,
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[1].reasoning_content).toBe('Detailed internal reasoning');
+    });
+
+    it('leaves non-array messages unchanged during sanitization', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithNonArrayMessages = {
+        messages: { role: 'assistant', reasoning_content: 'Detailed internal reasoning' },
+        temperature: 0.7,
+      };
+
+      await client.forward(
+        'mistral',
+        'sk-mi',
+        'mistral-small',
+        bodyWithNonArrayMessages as unknown as Record<string, unknown>,
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toEqual(bodyWithNonArrayMessages.messages);
+    });
+
+    it('preserves non-object entries inside the messages array', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithMixedMessages = {
+        messages: [
+          'unexpected-entry',
+          { role: 'assistant', reasoning_content: 'Detailed internal reasoning' },
+        ],
+        temperature: 0.7,
+      };
+
+      await client.forward(
+        'mistral',
+        'sk-mi',
+        'mistral-small',
+        bodyWithMixedMessages as unknown as Record<string, unknown>,
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages[0]).toBe('unexpected-entry');
+      expect(sentBody.messages[1].reasoning_content).toBeUndefined();
     });
 
     it('preserves all fields for OpenAI', async () => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -25,9 +25,33 @@ const OPENAI_ONLY_FIELDS = new Set([
 ]);
 
 /**
- * Providers that accept the full OpenAI request schema without modification.
+ * Providers that accept the full OpenAI top-level request schema without modification.
+ * Nested message fields may still need target-aware cleanup.
  */
 const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
+
+function supportsReasoningContent(endpointKey: string, model: string): boolean {
+  if (endpointKey === 'deepseek') return true;
+  if (endpointKey === 'openrouter') return model.toLowerCase().startsWith('deepseek/');
+  return false;
+}
+
+function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: string): unknown {
+  if (!Array.isArray(messages)) return messages;
+
+  const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
+  return messages.map((message) => {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+      return message;
+    }
+
+    const cleaned = { ...(message as Record<string, unknown>) };
+    if (!preserveReasoningContent) {
+      delete cleaned.reasoning_content;
+    }
+    return cleaned;
+  });
+}
 
 /**
  * Strip OpenAI-specific fields and normalise `max_completion_tokens` → `max_tokens`
@@ -36,11 +60,20 @@ const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
 function sanitizeOpenAiBody(
   body: Record<string, unknown>,
   endpointKey: string,
+  model: string,
 ): Record<string, unknown> {
-  if (PASSTHROUGH_PROVIDERS.has(endpointKey)) return body;
+  const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
+    if (key === 'messages') {
+      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model);
+      continue;
+    }
+    if (passthroughTopLevel) {
+      cleaned[key] = value;
+      continue;
+    }
     if (OPENAI_ONLY_FIELDS.has(key)) continue;
     if (key === 'max_completion_tokens') {
       // Convert to max_tokens unless already set
@@ -124,7 +157,7 @@ export class ProviderClient {
     } else {
       url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`;
       headers = endpoint.buildHeaders(apiKey, authType);
-      const sanitized = sanitizeOpenAiBody(body, endpointKey!);
+      const sanitized = sanitizeOpenAiBody(body, endpointKey, model);
       requestBody = { ...sanitized, model: bareModel, stream };
 
       // Inject cache_control for OpenRouter requests targeting Anthropic models


### PR DESCRIPTION
## Summary

Fixes cross-provider chat failures caused by forwarding DeepSeek-specific `reasoning_content` into providers that reject unknown message fields.

Example: a conversation routed from DeepSeek R1 to Mistral could fail with `422` because the proxy resent `messages[*].reasoning_content` unchanged.

## Changes

- Sanitize nested `messages[*].reasoning_content` in the proxy forwarding path
- Preserve it only for DeepSeek-compatible targets:
  - DeepSeek native
  - OpenRouter `deepseek/*`
- Strip it for other OpenAI-compatible targets such as Mistral and OpenAI
- Keep sanitization immutable so retries/fallbacks do not mutate the original body
- Add regression tests for strip/preserve behavior

## Rationale

`capability_reasoning` is used for routing/tier selection, not request-schema compatibility. Whether `reasoning_content` is valid depends on the target API/model transport, so the fix is target-aware rather than capability-based.

Fixes #1074 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cross-provider chat failures by stripping DeepSeek-only `reasoning_content` from forwarded messages unless the target supports it. Prevents 422 errors when routing (e.g., DeepSeek → Mistral/OpenAI) while keeping it for DeepSeek-native and OpenRouter `deepseek/*` models.

- **Bug Fixes**
  - Clean `messages[*].reasoning_content` for all targets; preserve only for DeepSeek and OpenRouter `deepseek/*`; strip for OpenAI, Mistral, and other OpenRouter models.
  - Run message cleanup even with top-level passthrough; keep sanitization immutable and continue passthrough of top-level OpenAI fields for `openai`/`openrouter`.
  - Add tests for preserve/strip behavior and edge cases (non-array `messages`, mixed entries), ensuring inputs are not mutated.

<sup>Written for commit aed1eb52c125b783eec9119c3058d6b4c70804b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

