### PR TITLE
fix(proxy): suppress duplicate success logs

### DIFF
--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -112,6 +112,7 @@ describe('TraceIngestService', () => {
       expect.objectContaining({
         tenant_id: 'test-tenant',
         agent_id: 'test-agent',
+        user_id: 'test-user',
         agent_name: 'bot-1',
       }),
     ]);

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -25,6 +25,12 @@ describe('TraceIngestService', () => {
   let mockPricingGetByModel: jest.Mock;
   let mockProviderFind: jest.Mock;
   let mockExecute: jest.Mock;
+  let mockTurnManager: {
+    transaction: jest.Mock;
+    getRepository: jest.Mock;
+    query: jest.Mock;
+    connection: { options: { type: string } };
+  };
 
   beforeEach(async () => {
     mockTurnInsert = jest.fn().mockResolvedValue({});
@@ -43,21 +49,37 @@ describe('TraceIngestService', () => {
       where: jest.fn().mockReturnThis(),
       execute: mockExecute,
     };
+    const mockTurnRepo = {
+      insert: mockTurnInsert,
+      findOne: mockTurnFindOne,
+      find: mockTurnFind,
+      createQueryBuilder: jest.fn().mockReturnValue(mockQb),
+      manager: undefined as unknown as { transaction: jest.Mock },
+    };
+    const mockLlmRepo = { insert: mockLlmInsert };
+    const mockToolRepo = { insert: mockToolInsert };
+    mockTurnManager = {
+      transaction: jest.fn(async (cb: (manager: unknown) => Promise<unknown>) => cb(mockTurnManager)),
+      getRepository: jest.fn((repoClass: unknown) => {
+        if (repoClass === AgentMessage) return mockTurnRepo;
+        if (repoClass === LlmCall) return mockLlmRepo;
+        if (repoClass === ToolExecution) return mockToolRepo;
+        throw new Error(`Unexpected repository request: ${String(repoClass)}`);
+      }),
+      query: jest.fn().mockResolvedValue([]),
+      connection: { options: { type: 'sqlite' } },
+    };
+    mockTurnRepo.manager = { transaction: mockTurnManager.transaction };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TraceIngestService,
         {
           provide: getRepositoryToken(AgentMessage),
-          useValue: {
-            insert: mockTurnInsert,
-            findOne: mockTurnFindOne,
-            find: mockTurnFind,
-            createQueryBuilder: jest.fn().mockReturnValue(mockQb),
-          },
+          useValue: mockTurnRepo,
         },
-        { provide: getRepositoryToken(LlmCall), useValue: { insert: mockLlmInsert } },
-        { provide: getRepositoryToken(ToolExecution), useValue: { insert: mockToolInsert } },
+        { provide: getRepositoryToken(LlmCall), useValue: mockLlmRepo },
+        { provide: getRepositoryToken(ToolExecution), useValue: mockToolRepo },
         { provide: getRepositoryToken(UserProvider), useValue: { find: mockProviderFind } },
         { provide: ModelPricingCacheService, useValue: { getByModel: mockPricingGetByModel } },
       ],
@@ -116,6 +138,35 @@ describe('TraceIngestService', () => {
         agent_name: 'bot-1',
       }),
     ]);
+  });
+
+  it('acquires a postgres row lock before OTLP success dedup reads', async () => {
+    mockTurnManager.connection.options.type = 'postgres';
+    const request = {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              { key: 'service.name', value: { stringValue: 'agent' } },
+              { key: 'agent.name', value: { stringValue: 'bot-1' } },
+            ],
+          },
+          scopeSpans: [
+            {
+              scope: { name: 'test' },
+              spans: [makeSpan({ name: 'openclaw.agent.turn' })],
+            },
+          ],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+
+    expect(mockTurnManager.query).toHaveBeenCalledWith(
+      'SELECT id FROM agents WHERE id = $1 FOR UPDATE',
+      ['test-agent'],
+    );
   });
 
   it('ingests an llm_call span (has gen_ai.system attribute)', async () => {

--- a/packages/backend/src/otlp/services/trace-ingest.service.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { v4 as uuidv4 } from 'uuid';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { LlmCall } from '../../entities/llm-call.entity';
@@ -137,6 +137,7 @@ export class TraceIngestService {
   }
 
   private async remapFallbackSpans(
+    turnRepo: Repository<AgentMessage>,
     spans: OtlpSpan[],
     spanMap: Map<string, SpanEntry>,
     ctx: IngestionContext,
@@ -154,7 +155,7 @@ export class TraceIngestService {
 
       // Strategy 1: match by trace_id (when gateway sends traceparent).
       if (traceId) {
-        fallback = await this.turnRepo.findOne({
+        fallback = await turnRepo.findOne({
           where: {
             trace_id: traceId,
             tenant_id: ctx.tenantId,
@@ -167,7 +168,7 @@ export class TraceIngestService {
 
       // Strategy 2: match recent unfilled fallback success by agent + time proximity.
       if (!fallback) {
-        fallback = await this.findUnfilledFallback(span, ctx);
+        fallback = await this.findUnfilledFallback(turnRepo, span, ctx);
       }
 
       if (fallback) {
@@ -184,12 +185,13 @@ export class TraceIngestService {
   }
 
   private async findUnfilledFallback(
+    turnRepo: Repository<AgentMessage>,
     span: OtlpSpan,
     ctx: IngestionContext,
   ): Promise<Pick<AgentMessage, 'id' | 'model'> | null> {
     const spanTime = new Date(nanoToDatetime(span.startTimeUnixNano));
     const cutoff = new Date(spanTime.getTime() - 5 * 60_000).toISOString();
-    const candidates = await this.turnRepo.find({
+    const candidates = await turnRepo.find({
       where: {
         tenant_id: ctx.tenantId,
         agent_id: ctx.agentId,
@@ -209,6 +211,7 @@ export class TraceIngestService {
   }
 
   private async buildDedupContext(
+    turnRepo: Repository<AgentMessage>,
     spans: OtlpSpan[],
     spanMap: Map<string, SpanEntry>,
     ghostSpanIds: Set<string>,
@@ -229,7 +232,7 @@ export class TraceIngestService {
     // Batch fetch all dedup data in parallel
     const [errorByTrace, recentErrors, recentOkMessages, recentMessages] = await Promise.all([
       traceIds.length > 0
-        ? this.turnRepo.find({
+        ? turnRepo.find({
             where: {
               trace_id: In(traceIds),
               tenant_id: ctx.tenantId,
@@ -238,7 +241,7 @@ export class TraceIngestService {
             select: ['id', 'trace_id'],
           })
         : Promise.resolve([]),
-      this.turnRepo.find({
+      turnRepo.find({
         where: {
           tenant_id: ctx.tenantId,
           agent_id: ctx.agentId,
@@ -248,13 +251,13 @@ export class TraceIngestService {
         order: { timestamp: 'DESC' },
         take: 10,
       }),
-      this.turnRepo.find({
+      turnRepo.find({
         where: { tenant_id: ctx.tenantId, agent_id: ctx.agentId, status: 'ok' },
         select: ['id', 'timestamp', 'input_tokens'],
         order: { timestamp: 'DESC' },
         take: 10,
       }),
-      this.turnRepo.find({
+      turnRepo.find({
         where: { tenant_id: ctx.tenantId, agent_id: ctx.agentId },
         select: ['id', 'timestamp', 'input_tokens', 'output_tokens', 'model', 'session_key'],
         order: { timestamp: 'DESC' },
@@ -290,77 +293,82 @@ export class TraceIngestService {
     ctx: IngestionContext,
   ): Promise<void> {
     const subOnlyProviders = await this.getSubscriptionProviders(ctx.agentId);
-    const ghostSpanIds = this.filterGhostSpans(spans, resourceAttrs, spanMap);
-    const fallbackModelOverrides = new Map<string, string>();
-    const fallbackDurations = new Map<string, number>();
-    // Pre-pass: remap UUIDs for fallback spans BEFORE processing LLM calls,
-    // so accumulateToMessage uses the correct (remapped) message ID regardless
-    // of span ordering within the OTLP batch.
-    const fallbackSkipIds = await this.remapFallbackSpans(
-      spans,
-      spanMap,
-      ctx,
-      fallbackModelOverrides,
-      fallbackDurations,
-    );
+    await this.withTurnWriteTransaction(ctx, async ({ turnRepo, llmRepo, toolRepo }) => {
+      const ghostSpanIds = this.filterGhostSpans(spans, resourceAttrs, spanMap);
+      const fallbackModelOverrides = new Map<string, string>();
+      const fallbackDurations = new Map<string, number>();
+      // Pre-pass: remap UUIDs for fallback spans BEFORE processing LLM calls,
+      // so accumulateToMessage uses the correct (remapped) message ID regardless
+      // of span ordering within the OTLP batch.
+      const fallbackSkipIds = await this.remapFallbackSpans(
+        turnRepo,
+        spans,
+        spanMap,
+        ctx,
+        fallbackModelOverrides,
+        fallbackDurations,
+      );
 
-    // Batch pre-fetch all dedup data (replaces per-span DB queries)
-    const dedupCtx = await this.buildDedupContext(
-      spans,
-      spanMap,
-      ghostSpanIds,
-      fallbackSkipIds,
-      ctx,
-    );
+      // Batch pre-fetch all dedup data (replaces per-span DB queries)
+      const dedupCtx = await this.buildDedupContext(
+        turnRepo,
+        spans,
+        spanMap,
+        ghostSpanIds,
+        fallbackSkipIds,
+        ctx,
+      );
 
-    const messageAggregates = new Map<
-      string,
-      {
-        input: number;
-        output: number;
-        cacheRead: number;
-        cacheCreation: number;
-        model: string | null;
-        tier: string | null;
-        reason: string | null;
-        cost: number;
+      const messageAggregates = new Map<
+        string,
+        {
+          input: number;
+          output: number;
+          cacheRead: number;
+          cacheCreation: number;
+          model: string | null;
+          tier: string | null;
+          reason: string | null;
+          cost: number;
+        }
+      >();
+
+      const agentMessageRows: Record<string, unknown>[] = [];
+      const llmCallRows: Record<string, unknown>[] = [];
+      const toolExecutionRows: Record<string, unknown>[] = [];
+
+      for (const span of spans) {
+        const spanId = toHexString(span.spanId);
+        const entry = spanMap.get(spanId)!;
+        const attrs = { ...resourceAttrs, ...extractAttributes(span.attributes) };
+
+        if (entry.type === 'root_request') continue;
+        if (entry.type === 'agent_message') {
+          if (ghostSpanIds.has(spanId) || fallbackSkipIds.has(spanId)) continue;
+          const row = this.buildAgentMessage(span, attrs, entry, ctx, dedupCtx, subOnlyProviders);
+          if (row) agentMessageRows.push(row);
+        } else if (entry.type === 'llm_call') {
+          llmCallRows.push(this.buildLlmCall(span, attrs, entry, spanMap, ctx));
+          this.accumulateToMessage(span, attrs, spanMap, messageAggregates);
+        } else {
+          toolExecutionRows.push(this.buildToolExecution(span, attrs, entry, spanMap, ctx));
+        }
       }
-    >();
 
-    const agentMessageRows: Record<string, unknown>[] = [];
-    const llmCallRows: Record<string, unknown>[] = [];
-    const toolExecutionRows: Record<string, unknown>[] = [];
+      const inserts: Promise<unknown>[] = [];
+      if (agentMessageRows.length > 0) inserts.push(turnRepo.insert(agentMessageRows));
+      if (llmCallRows.length > 0) inserts.push(llmRepo.insert(llmCallRows));
+      if (toolExecutionRows.length > 0) inserts.push(toolRepo.insert(toolExecutionRows));
+      await Promise.all(inserts);
 
-    for (const span of spans) {
-      const spanId = toHexString(span.spanId);
-      const entry = spanMap.get(spanId)!;
-      const attrs = { ...resourceAttrs, ...extractAttributes(span.attributes) };
-
-      if (entry.type === 'root_request') continue;
-      if (entry.type === 'agent_message') {
-        if (ghostSpanIds.has(spanId) || fallbackSkipIds.has(spanId)) continue;
-        const row = this.buildAgentMessage(span, attrs, entry, ctx, dedupCtx, subOnlyProviders);
-        if (row) agentMessageRows.push(row);
-      } else if (entry.type === 'llm_call') {
-        llmCallRows.push(this.buildLlmCall(span, attrs, entry, spanMap, ctx));
-        this.accumulateToMessage(span, attrs, spanMap, messageAggregates);
-      } else {
-        toolExecutionRows.push(this.buildToolExecution(span, attrs, entry, spanMap, ctx));
-      }
-    }
-
-    const inserts: Promise<unknown>[] = [];
-    if (agentMessageRows.length > 0) inserts.push(this.turnRepo.insert(agentMessageRows));
-    if (llmCallRows.length > 0) inserts.push(this.llmRepo.insert(llmCallRows));
-    if (toolExecutionRows.length > 0) inserts.push(this.toolRepo.insert(toolExecutionRows));
-    await Promise.all(inserts);
-
-    await this.rollUpMessageAggregates(
-      messageAggregates,
-      subOnlyProviders,
-      fallbackModelOverrides,
-      fallbackDurations,
-    );
+      await this.rollUpMessageAggregates(
+        turnRepo,
+        messageAggregates,
+        subOnlyProviders,
+        fallbackModelOverrides,
+        fallbackDurations,
+      );
+    });
   }
 
   private accumulateToMessage(
@@ -411,6 +419,7 @@ export class TraceIngestService {
   }
 
   private async rollUpMessageAggregates(
+    turnRepo: Repository<AgentMessage>,
     aggregates: Map<
       string,
       {
@@ -470,7 +479,7 @@ export class TraceIngestService {
         setClause.duration_ms = () => 'COALESCE(duration_ms, :durationMs)';
       }
 
-      const qb = this.turnRepo
+      const qb = turnRepo
         .createQueryBuilder()
         .update(AgentMessage)
         .set(setClause)
@@ -643,6 +652,29 @@ export class TraceIngestService {
     // Keep dual-auth providers in the set: the routing layer prefers subscription
     // when both exist, so the OTLP heuristic should match (zero cost).
     return sub;
+  }
+
+  private async withTurnWriteTransaction<T>(
+    ctx: IngestionContext,
+    fn: (repos: {
+      turnRepo: Repository<AgentMessage>;
+      llmRepo: Repository<LlmCall>;
+      toolRepo: Repository<ToolExecution>;
+    }) => Promise<T>,
+  ): Promise<T> {
+    return this.turnRepo.manager.transaction(async (manager) => {
+      await this.lockAgentMessageWrites(manager, ctx.agentId);
+      return fn({
+        turnRepo: manager.getRepository(AgentMessage),
+        llmRepo: manager.getRepository(LlmCall),
+        toolRepo: manager.getRepository(ToolExecution),
+      });
+    });
+  }
+
+  private async lockAgentMessageWrites(manager: EntityManager, agentId: string): Promise<void> {
+    if (manager.connection.options.type !== 'postgres') return;
+    await manager.query('SELECT id FROM agents WHERE id = $1 FOR UPDATE', [agentId]);
   }
 
   private computeCost(attrs: AttributeMap, subOnlyProviders?: Set<string>): number | null {

--- a/packages/backend/src/otlp/services/trace-ingest.service.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.ts
@@ -541,6 +541,7 @@ export class TraceIngestService {
       id: entry.uuid,
       tenant_id: ctx.tenantId,
       agent_id: ctx.agentId,
+      user_id: ctx.userId,
       trace_id: toHexString(span.traceId),
       session_key: attrString(attrs, 'session.key'),
       session_id: attrString(attrs, 'session.id'),

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -403,6 +403,127 @@ describe('ProxyController', () => {
     expect(mockMessageRepo.update).not.toHaveBeenCalled();
   });
 
+  it('should scope traceless success fallback by user and session key when available', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 19684, completion_tokens: 13 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    mockMessageRepo.find.mockResolvedValue([
+      {
+        id: 'existing-otlp-row',
+        timestamp: new Date(Date.now() - 2800).toISOString(),
+        input_tokens: 171,
+        output_tokens: 13,
+        cache_read_tokens: 19513,
+        cache_creation_tokens: 0,
+        duration_ms: 2700,
+      },
+    ]);
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'standard',
+        model: 'deepseek-chat',
+        provider: 'DeepSeek',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] }, 'user-42', {
+      'x-session-key': 'sess-42',
+    });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          model: 'deepseek-chat',
+          status: 'ok',
+          user_id: 'user-42',
+          session_key: 'sess-42',
+        }),
+      }),
+    );
+    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it('should serialize concurrent success dedup checks for the same trace', async () => {
+    let releaseInsert!: () => void;
+    const insertGate = new Promise<void>((resolve) => {
+      releaseInsert = resolve;
+    });
+    mockMessageRepo.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'existing-otlp-row',
+        input_tokens: 500,
+        output_tokens: 200,
+      });
+    mockMessageRepo.insert.mockImplementationOnce(async () => {
+      await insertGate;
+      return {};
+    });
+
+    const ctx = {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      agentId: 'agent-1',
+      agentName: 'test-agent',
+    };
+    const usage = {
+      prompt_tokens: 500,
+      completion_tokens: 200,
+      cache_read_tokens: 100,
+    };
+    const recordSuccessMessage = (
+      controller as unknown as {
+        recordSuccessMessage: (...args: unknown[]) => Promise<void>;
+      }
+    ).recordSuccessMessage.bind(controller);
+
+    const firstWrite = recordSuccessMessage(
+      ctx,
+      'gpt-4o',
+      'simple',
+      'scored',
+      usage,
+      'abcdef1234567890abcdef1234567890',
+      undefined,
+      'sess-1',
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    const secondWrite = recordSuccessMessage(
+      ctx,
+      'gpt-4o',
+      'simple',
+      'scored',
+      usage,
+      'abcdef1234567890abcdef1234567890',
+      undefined,
+      'sess-1',
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockMessageRepo.findOne).toHaveBeenCalledTimes(1);
+
+    releaseInsert();
+    await Promise.all([firstWrite, secondWrite]);
+
+    expect(mockMessageRepo.findOne).toHaveBeenCalledTimes(2);
+    expect(mockMessageRepo.insert).toHaveBeenCalledTimes(1);
+  });
+
   it('should skip recording when response has zero tokens', async () => {
     const responseBody = {
       choices: [{ message: { content: 'hello' } }],

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -75,11 +75,18 @@ describe('ProxyController', () => {
     convertAnthropicResponse: jest.Mock;
     convertAnthropicStreamChunk: jest.Mock;
   };
+  let mockMessageManager: {
+    transaction: jest.Mock;
+    getRepository: jest.Mock;
+    query: jest.Mock;
+    connection: { options: { type: string } };
+  };
   let mockMessageRepo: {
     insert: jest.Mock;
     findOne: jest.Mock;
     find: jest.Mock;
     update: jest.Mock;
+    manager: { transaction: jest.Mock };
   };
   let mockPricingCache: { getByModel: jest.Mock };
 
@@ -98,12 +105,20 @@ describe('ProxyController', () => {
       convertAnthropicResponse: jest.fn(),
       convertAnthropicStreamChunk: jest.fn(),
     };
+    mockMessageManager = {
+      transaction: jest.fn(async (cb: (manager: unknown) => Promise<unknown>) => cb(mockMessageManager)),
+      getRepository: jest.fn(),
+      query: jest.fn().mockResolvedValue([]),
+      connection: { options: { type: 'sqlite' } },
+    };
     mockMessageRepo = {
       insert: jest.fn().mockResolvedValue({}),
       findOne: jest.fn().mockResolvedValue(null),
       find: jest.fn().mockResolvedValue([]),
       update: jest.fn().mockResolvedValue({}),
+      manager: { transaction: mockMessageManager.transaction },
     };
+    mockMessageManager.getRepository.mockReturnValue(mockMessageRepo);
     mockPricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
     controller = new ProxyController(
       proxyService as never,
@@ -553,6 +568,40 @@ describe('ProxyController', () => {
 
     // recordSuccessMessage returns early when both tokens are 0
     expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it('should acquire a postgres row lock before success dedup queries', async () => {
+    mockMessageManager.connection.options.type = 'postgres';
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 500, completion_tokens: 200 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageManager.query).toHaveBeenCalledWith(
+      'SELECT id FROM agents WHERE id = $1 FOR UPDATE',
+      ['agent-1'],
+    );
   });
 
   it('should default completion_tokens to 0 when missing from response', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -75,7 +75,12 @@ describe('ProxyController', () => {
     convertAnthropicResponse: jest.Mock;
     convertAnthropicStreamChunk: jest.Mock;
   };
-  let mockMessageRepo: { insert: jest.Mock };
+  let mockMessageRepo: {
+    insert: jest.Mock;
+    findOne: jest.Mock;
+    find: jest.Mock;
+    update: jest.Mock;
+  };
   let mockPricingCache: { getByModel: jest.Mock };
 
   beforeEach(() => {
@@ -93,7 +98,12 @@ describe('ProxyController', () => {
       convertAnthropicResponse: jest.fn(),
       convertAnthropicStreamChunk: jest.fn(),
     };
-    mockMessageRepo = { insert: jest.fn().mockResolvedValue({}) };
+    mockMessageRepo = {
+      insert: jest.fn().mockResolvedValue({}),
+      findOne: jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue({}),
+    };
     mockPricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
     controller = new ProxyController(
       proxyService as never,
@@ -247,6 +257,150 @@ describe('ProxyController', () => {
         cache_read_tokens: 100,
       }),
     );
+  });
+
+  it('should skip proxy success insert when OTLP already recorded a success row for the same trace', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 500, completion_tokens: 200, cache_read_tokens: 100 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    mockMessageRepo.findOne.mockResolvedValue({
+      id: 'existing-otlp-row',
+      input_tokens: 500,
+      output_tokens: 200,
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] }, 'user-1', {
+      traceparent: '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01',
+    });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          trace_id: 'abcdef1234567890abcdef1234567890',
+          status: 'ok',
+        }),
+      }),
+    );
+    expect(mockMessageRepo.update).not.toHaveBeenCalled();
+    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it('should update existing OTLP success row when proxy is the first source of real usage tokens', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 500, completion_tokens: 200, cache_read_tokens: 100 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    mockMessageRepo.findOne.mockResolvedValue({
+      id: 'existing-otlp-row',
+      input_tokens: 0,
+      output_tokens: 0,
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] }, 'user-1', {
+      traceparent: '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01',
+    });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.update).toHaveBeenCalledWith(
+      { id: 'existing-otlp-row' },
+      expect.objectContaining({
+        model: 'gpt-4o',
+        routing_tier: 'simple',
+        routing_reason: 'scored',
+        input_tokens: 500,
+        output_tokens: 200,
+        cache_read_tokens: 100,
+      }),
+    );
+    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+  });
+
+  it('should skip proxy success insert when a recent OTLP row matches by end time without trace or session key', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 19684, completion_tokens: 13 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    mockMessageRepo.find.mockResolvedValue([
+      {
+        id: 'existing-otlp-row',
+        timestamp: new Date(Date.now() - 2800).toISOString(),
+        input_tokens: 171,
+        output_tokens: 13,
+        cache_read_tokens: 19513,
+        cache_creation_tokens: 0,
+        duration_ms: 2700,
+      },
+    ]);
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'standard',
+        model: 'deepseek-chat',
+        provider: 'DeepSeek',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          model: 'deepseek-chat',
+          status: 'ok',
+        }),
+      }),
+    );
+    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+    expect(mockMessageRepo.update).not.toHaveBeenCalled();
   });
 
   it('should skip recording when response has zero tokens', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -471,6 +471,53 @@ describe('ProxyController', () => {
     expect(mockMessageRepo.insert).not.toHaveBeenCalled();
   });
 
+  it('should ignore traceless fallback candidates without usable timing data', async () => {
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 19684, completion_tokens: 13 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    mockMessageRepo.find.mockResolvedValue([
+      {
+        id: 'existing-otlp-row',
+        timestamp: new Date(Date.now() - 2800).toISOString(),
+        input_tokens: 171,
+        output_tokens: 13,
+        cache_read_tokens: 19513,
+        cache_creation_tokens: 0,
+        duration_ms: null,
+      },
+    ]);
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'standard',
+        model: 'deepseek-chat',
+        provider: 'DeepSeek',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'deepseek-chat',
+        input_tokens: 19684,
+        output_tokens: 13,
+      }),
+    );
+  });
+
   it('should serialize concurrent success dedup checks for the same trace', async () => {
     let releaseInsert!: () => void;
     const insertGate = new Promise<void>((resolve) => {

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -9,7 +9,7 @@ import {
   OnModuleDestroy,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { Request, Response as ExpressResponse } from 'express';
 import { v4 as uuid } from 'uuid';
 import { SkipThrottle } from '@nestjs/throttler';
@@ -480,20 +480,48 @@ export class ProxyController implements OnModuleDestroy {
     await this.withSuccessWriteLock(
       this.getSuccessWriteLockKey(ctx, model, traceId, normalizedSessionKey),
       async () => {
-        const existing = await this.findExistingSuccessMessage(
-          ctx,
-          model,
-          usage,
-          traceId,
-          normalizedSessionKey,
-        );
+        await this.withAgentMessageTransaction(ctx, async (messageRepo) => {
+          const existing = await this.findExistingSuccessMessage(
+            messageRepo,
+            ctx,
+            model,
+            usage,
+            traceId,
+            normalizedSessionKey,
+          );
 
-        if (existing) {
-          const hasRecordedTokens =
-            (existing.input_tokens ?? 0) > 0 || (existing.output_tokens ?? 0) > 0;
-          if (hasRecordedTokens) return;
+          if (existing) {
+            const hasRecordedTokens =
+              (existing.input_tokens ?? 0) > 0 || (existing.output_tokens ?? 0) > 0;
+            if (hasRecordedTokens) return;
 
-          const updatePayload: Partial<AgentMessage> = {
+            const updatePayload: Partial<AgentMessage> = {
+              model,
+              routing_tier: tier,
+              routing_reason: reason,
+              input_tokens: usage.prompt_tokens,
+              output_tokens: usage.completion_tokens,
+              cache_read_tokens: usage.cache_read_tokens ?? 0,
+              cache_creation_tokens: usage.cache_creation_tokens ?? 0,
+              cost_usd: costUsd,
+              auth_type: authType ?? null,
+              user_id: ctx.userId,
+            };
+            if (normalizedSessionKey) updatePayload.session_key = normalizedSessionKey;
+
+            await messageRepo.update({ id: existing.id }, updatePayload);
+            return;
+          }
+
+          await messageRepo.insert({
+            id: uuid(),
+            tenant_id: ctx.tenantId,
+            agent_id: ctx.agentId,
+            trace_id: traceId ?? null,
+            session_key: normalizedSessionKey,
+            timestamp: new Date().toISOString(),
+            status: 'ok',
+            agent_name: ctx.agentName,
             model,
             routing_tier: tier,
             routing_reason: reason,
@@ -503,41 +531,17 @@ export class ProxyController implements OnModuleDestroy {
             cache_creation_tokens: usage.cache_creation_tokens ?? 0,
             cost_usd: costUsd,
             auth_type: authType ?? null,
+            fallback_from_model: null,
+            fallback_index: null,
             user_id: ctx.userId,
-          };
-          if (normalizedSessionKey) updatePayload.session_key = normalizedSessionKey;
-
-          await this.messageRepo.update({ id: existing.id }, updatePayload);
-          return;
-        }
-
-        await this.messageRepo.insert({
-          id: uuid(),
-          tenant_id: ctx.tenantId,
-          agent_id: ctx.agentId,
-          trace_id: traceId ?? null,
-          session_key: normalizedSessionKey,
-          timestamp: new Date().toISOString(),
-          status: 'ok',
-          agent_name: ctx.agentName,
-          model,
-          routing_tier: tier,
-          routing_reason: reason,
-          input_tokens: usage.prompt_tokens,
-          output_tokens: usage.completion_tokens,
-          cache_read_tokens: usage.cache_read_tokens ?? 0,
-          cache_creation_tokens: usage.cache_creation_tokens ?? 0,
-          cost_usd: costUsd,
-          auth_type: authType ?? null,
-          fallback_from_model: null,
-          fallback_index: null,
-          user_id: ctx.userId,
+          });
         });
       },
     );
   }
 
   private async findExistingSuccessMessage(
+    messageRepo: Repository<AgentMessage>,
     ctx: IngestionContext,
     model: string,
     usage: StreamUsage,
@@ -554,7 +558,7 @@ export class ProxyController implements OnModuleDestroy {
     | 'duration_ms'
   > | null> {
     if (traceId) {
-      const existing = await this.messageRepo.findOne({
+      const existing = await messageRepo.findOne({
         where: {
           tenant_id: ctx.tenantId,
           agent_id: ctx.agentId,
@@ -576,7 +580,7 @@ export class ProxyController implements OnModuleDestroy {
     }
 
     const now = Date.now();
-    const recentByModel = await this.messageRepo.find({
+    const recentByModel = await messageRepo.find({
       where: {
         tenant_id: ctx.tenantId,
         agent_id: ctx.agentId,
@@ -624,6 +628,21 @@ export class ProxyController implements OnModuleDestroy {
   private normalizeSessionKey(sessionKey?: string | null): string | null {
     if (!sessionKey || sessionKey === 'default') return null;
     return sessionKey;
+  }
+
+  private async withAgentMessageTransaction<T>(
+    ctx: IngestionContext,
+    fn: (messageRepo: Repository<AgentMessage>) => Promise<T>,
+  ): Promise<T> {
+    return this.messageRepo.manager.transaction(async (manager) => {
+      await this.lockAgentMessageWrites(manager, ctx.agentId);
+      return fn(manager.getRepository(AgentMessage));
+    });
+  }
+
+  private async lockAgentMessageWrites(manager: EntityManager, agentId: string): Promise<void> {
+    if (manager.connection.options.type !== 'postgres') return;
+    await manager.query('SELECT id FROM agents WHERE id = $1 FOR UPDATE', [agentId]);
   }
 
   private getSuccessWriteLockKey(

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -36,6 +36,8 @@ export class ProxyController implements OnModuleDestroy {
   private readonly rateLimitCooldown = new Map<string, number>();
   private readonly RATE_LIMIT_COOLDOWN_MS = 60_000;
   private readonly MAX_COOLDOWN_ENTRIES = 1_000;
+  private readonly SUCCESS_SESSION_DEDUP_WINDOW_MS = 30_000;
+  private readonly SUCCESS_END_TIME_GRACE_MS = 5_000;
   private readonly cooldownCleanupTimer: ReturnType<typeof setInterval>;
 
   constructor(
@@ -470,6 +472,30 @@ export class ProxyController implements OnModuleDestroy {
       }
     }
 
+    const existing = await this.findExistingSuccessMessage(ctx, model, usage, traceId);
+
+    if (existing) {
+      const hasRecordedTokens =
+        (existing.input_tokens ?? 0) > 0 || (existing.output_tokens ?? 0) > 0;
+      if (hasRecordedTokens) return;
+
+      await this.messageRepo.update(
+        { id: existing.id },
+        {
+          model,
+          routing_tier: tier,
+          routing_reason: reason,
+          input_tokens: usage.prompt_tokens,
+          output_tokens: usage.completion_tokens,
+          cache_read_tokens: usage.cache_read_tokens ?? 0,
+          cache_creation_tokens: usage.cache_creation_tokens ?? 0,
+          cost_usd: costUsd,
+          auth_type: authType ?? null,
+        },
+      );
+      return;
+    }
+
     await this.messageRepo.insert({
       id: uuid(),
       tenant_id: ctx.tenantId,
@@ -490,6 +516,87 @@ export class ProxyController implements OnModuleDestroy {
       fallback_from_model: null,
       fallback_index: null,
     });
+  }
+
+  private async findExistingSuccessMessage(
+    ctx: IngestionContext,
+    model: string,
+    usage: StreamUsage,
+    traceId?: string,
+  ): Promise<Pick<
+    AgentMessage,
+    | 'id'
+    | 'timestamp'
+    | 'input_tokens'
+    | 'output_tokens'
+    | 'cache_read_tokens'
+    | 'cache_creation_tokens'
+    | 'duration_ms'
+  > | null> {
+    if (traceId) {
+      const existing = await this.messageRepo.findOne({
+        where: {
+          tenant_id: ctx.tenantId,
+          agent_id: ctx.agentId,
+          trace_id: traceId,
+          status: 'ok',
+        },
+        select: [
+          'id',
+          'timestamp',
+          'input_tokens',
+          'output_tokens',
+          'cache_read_tokens',
+          'cache_creation_tokens',
+          'duration_ms',
+        ],
+        order: { timestamp: 'DESC' },
+      });
+      if (existing) return existing;
+    }
+
+    const now = Date.now();
+    const recentByModel = await this.messageRepo.find({
+      where: {
+        tenant_id: ctx.tenantId,
+        agent_id: ctx.agentId,
+        model,
+        status: 'ok',
+      },
+      select: [
+        'id',
+        'timestamp',
+        'input_tokens',
+        'output_tokens',
+        'cache_read_tokens',
+        'cache_creation_tokens',
+        'duration_ms',
+      ],
+      order: { timestamp: 'DESC' },
+      take: 10,
+    });
+
+    return (
+      recentByModel.find((row) => {
+        const rowTime = new Date(row.timestamp).getTime();
+        const durationMs = row.duration_ms ?? null;
+        if (
+          Number.isNaN(rowTime) ||
+          durationMs == null ||
+          now - rowTime > this.SUCCESS_SESSION_DEDUP_WINDOW_MS
+        ) {
+          return false;
+        }
+        const totalPromptTokens =
+          (row.input_tokens ?? 0) + (row.cache_read_tokens ?? 0) + (row.cache_creation_tokens ?? 0);
+        const endTimeDelta = Math.abs(now - rowTime - durationMs);
+        return (
+          totalPromptTokens === usage.prompt_tokens &&
+          (row.output_tokens ?? 0) === usage.completion_tokens &&
+          endTimeDelta <= this.SUCCESS_END_TIME_GRACE_MS
+        );
+      }) ?? null
+    );
   }
 
   private extractTraceId(req: Request): string | undefined {

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -34,6 +34,7 @@ export class ProxyController implements OnModuleDestroy {
   private readonly logger = new Logger(ProxyController.name);
   private readonly seenUsers = new Set<string>();
   private readonly rateLimitCooldown = new Map<string, number>();
+  private readonly successWriteLocks = new Map<string, Promise<void>>();
   private readonly RATE_LIMIT_COOLDOWN_MS = 60_000;
   private readonly MAX_COOLDOWN_ENTRIES = 1_000;
   private readonly SUCCESS_SESSION_DEDUP_WINDOW_MS = 30_000;
@@ -253,6 +254,7 @@ export class ProxyController implements OnModuleDestroy {
           streamUsage,
           traceId,
           meta.auth_type,
+          sessionKey,
         ).catch((e) => this.logger.warn(`Failed to record success message: ${e}`));
       }
     } catch (err: unknown) {
@@ -457,6 +459,7 @@ export class ProxyController implements OnModuleDestroy {
     usage: StreamUsage,
     traceId?: string,
     authType?: string,
+    sessionKey?: string,
   ): Promise<void> {
     if (usage.prompt_tokens === 0 && usage.completion_tokens === 0) return;
 
@@ -472,16 +475,51 @@ export class ProxyController implements OnModuleDestroy {
       }
     }
 
-    const existing = await this.findExistingSuccessMessage(ctx, model, usage, traceId);
+    const normalizedSessionKey = this.normalizeSessionKey(sessionKey);
 
-    if (existing) {
-      const hasRecordedTokens =
-        (existing.input_tokens ?? 0) > 0 || (existing.output_tokens ?? 0) > 0;
-      if (hasRecordedTokens) return;
+    await this.withSuccessWriteLock(
+      this.getSuccessWriteLockKey(ctx, model, traceId, normalizedSessionKey),
+      async () => {
+        const existing = await this.findExistingSuccessMessage(
+          ctx,
+          model,
+          usage,
+          traceId,
+          normalizedSessionKey,
+        );
 
-      await this.messageRepo.update(
-        { id: existing.id },
-        {
+        if (existing) {
+          const hasRecordedTokens =
+            (existing.input_tokens ?? 0) > 0 || (existing.output_tokens ?? 0) > 0;
+          if (hasRecordedTokens) return;
+
+          const updatePayload: Partial<AgentMessage> = {
+            model,
+            routing_tier: tier,
+            routing_reason: reason,
+            input_tokens: usage.prompt_tokens,
+            output_tokens: usage.completion_tokens,
+            cache_read_tokens: usage.cache_read_tokens ?? 0,
+            cache_creation_tokens: usage.cache_creation_tokens ?? 0,
+            cost_usd: costUsd,
+            auth_type: authType ?? null,
+            user_id: ctx.userId,
+          };
+          if (normalizedSessionKey) updatePayload.session_key = normalizedSessionKey;
+
+          await this.messageRepo.update({ id: existing.id }, updatePayload);
+          return;
+        }
+
+        await this.messageRepo.insert({
+          id: uuid(),
+          tenant_id: ctx.tenantId,
+          agent_id: ctx.agentId,
+          trace_id: traceId ?? null,
+          session_key: normalizedSessionKey,
+          timestamp: new Date().toISOString(),
+          status: 'ok',
+          agent_name: ctx.agentName,
           model,
           routing_tier: tier,
           routing_reason: reason,
@@ -491,31 +529,12 @@ export class ProxyController implements OnModuleDestroy {
           cache_creation_tokens: usage.cache_creation_tokens ?? 0,
           cost_usd: costUsd,
           auth_type: authType ?? null,
-        },
-      );
-      return;
-    }
-
-    await this.messageRepo.insert({
-      id: uuid(),
-      tenant_id: ctx.tenantId,
-      agent_id: ctx.agentId,
-      trace_id: traceId ?? null,
-      timestamp: new Date().toISOString(),
-      status: 'ok',
-      agent_name: ctx.agentName,
-      model,
-      routing_tier: tier,
-      routing_reason: reason,
-      input_tokens: usage.prompt_tokens,
-      output_tokens: usage.completion_tokens,
-      cache_read_tokens: usage.cache_read_tokens ?? 0,
-      cache_creation_tokens: usage.cache_creation_tokens ?? 0,
-      cost_usd: costUsd,
-      auth_type: authType ?? null,
-      fallback_from_model: null,
-      fallback_index: null,
-    });
+          fallback_from_model: null,
+          fallback_index: null,
+          user_id: ctx.userId,
+        });
+      },
+    );
   }
 
   private async findExistingSuccessMessage(
@@ -523,6 +542,7 @@ export class ProxyController implements OnModuleDestroy {
     model: string,
     usage: StreamUsage,
     traceId?: string,
+    sessionKey?: string | null,
   ): Promise<Pick<
     AgentMessage,
     | 'id'
@@ -560,8 +580,10 @@ export class ProxyController implements OnModuleDestroy {
       where: {
         tenant_id: ctx.tenantId,
         agent_id: ctx.agentId,
+        user_id: ctx.userId,
         model,
         status: 'ok',
+        ...(sessionKey ? { session_key: sessionKey } : {}),
       },
       select: [
         'id',
@@ -597,6 +619,41 @@ export class ProxyController implements OnModuleDestroy {
         );
       }) ?? null
     );
+  }
+
+  private normalizeSessionKey(sessionKey?: string | null): string | null {
+    if (!sessionKey || sessionKey === 'default') return null;
+    return sessionKey;
+  }
+
+  private getSuccessWriteLockKey(
+    ctx: IngestionContext,
+    model: string,
+    traceId?: string,
+    sessionKey?: string | null,
+  ): string {
+    if (traceId) return `trace:${ctx.tenantId}:${ctx.agentId}:${traceId}`;
+    return `success:${ctx.tenantId}:${ctx.agentId}:${ctx.userId}:${sessionKey ?? 'no-session'}:${model}`;
+  }
+
+  private async withSuccessWriteLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.successWriteLocks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.catch(() => undefined).then(() => current);
+    this.successWriteLocks.set(key, queued);
+    await previous.catch(() => undefined);
+
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.successWriteLocks.get(key) === queued) {
+        this.successWriteLocks.delete(key);
+      }
+    }
   }
 
   private extractTraceId(req: Request): string | undefined {


### PR DESCRIPTION
## Summary

This fixes duplicate `Success` rows in the Messages table when the same LLM call is recorded by both the proxy success path and OTLP trace ingestion.

The change is intentionally narrow. It only updates proxy-side success logging and adds focused regression coverage.

## Root cause

Successful calls could be written twice:

- once by the proxy when `/v1/chat/completions` completed
- once by OTLP ingestion for the same logical request

Those two rows do not always share a stable join key, and they use different timing/token semantics:

- OTLP row timestamp is the span start time
- proxy row timestamp is response completion time
- proxy usage comes from provider `prompt_tokens`
- OTLP usage may split prompt usage into `input_tokens + cache_read_tokens`

That allowed one real request to appear twice in `agent_messages`.

## Fix

Before inserting a proxy success row, the proxy now looks for an existing success row and reuses it when possible.

Matching order:

1. exact `trace_id` match
2. fallback match on:
   - same agent/model
   - same normalized prompt total (`input_tokens + cache_read_tokens + cache_creation_tokens`)
   - same `output_tokens`
   - end-time alignment using `timestamp + duration_ms`

Behavior:

- if the existing row already has tokens, skip the proxy insert
- if the existing row is a zero-token stub, update it in place instead of inserting a second success row

## Scope

This PR only changes:

- `packages/backend/src/routing/proxy/proxy.controller.ts`
- `packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts`

It does not change:

- schema or indexes
- OTLP ingestion logic
- frontend/UI behavior
- analytics/read paths

## Testing

Ran:

```bash
npm test -- --runInBand routing/proxy/__tests__/proxy.controller.spec.ts
```

Fixes #1078 