### PR TITLE
fix: distinguish subscription providers in PostHog tracking

### DIFF
--- a/.changeset/fix-subscription-provider-tracking.md
+++ b/.changeset/fix-subscription-provider-tracking.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Distinguish subscription providers from API key providers in PostHog tracking by appending (Subscription) suffix

--- a/packages/backend/src/routing/resolve.controller.spec.ts
+++ b/packages/backend/src/routing/resolve.controller.spec.ts
@@ -8,6 +8,11 @@ import {
 import { ResolveService } from './resolve.service';
 import { RoutingService } from './routing.service';
 import { ResolveResponse } from './dto/resolve-response';
+import * as telemetry from '../common/utils/product-telemetry';
+
+jest.mock('../common/utils/product-telemetry', () => ({
+  trackCloudEvent: jest.fn(),
+}));
 
 describe('ResolveController', () => {
   let controller: ResolveController;
@@ -24,6 +29,7 @@ describe('ResolveController', () => {
   };
 
   beforeEach(() => {
+    jest.clearAllMocks();
     mockResolveService = {
       resolve: jest.fn().mockResolvedValue(mockResponse),
     };
@@ -143,6 +149,29 @@ describe('ResolveController', () => {
         undefined,
         'subscription',
       );
+    });
+
+    it('should fire routing_provider_connected with (Subscription) suffix for new providers', async () => {
+      const req = {
+        ingestionContext: { userId: 'u1', tenantId: 't1', agentId: 'a1', agentName: 'n1' },
+      } as never;
+
+      await controller.registerSubscriptions({ providers: [{ provider: 'anthropic' }] }, req);
+
+      expect(telemetry.trackCloudEvent).toHaveBeenCalledWith('routing_provider_connected', 'u1', {
+        provider: 'anthropic (Subscription)',
+      });
+    });
+
+    it('should not fire event when subscription provider already exists', async () => {
+      mockRoutingService.upsertProvider.mockResolvedValue({ provider: {}, isNew: false });
+      const req = {
+        ingestionContext: { userId: 'u1', tenantId: 't1', agentId: 'a1', agentName: 'n1' },
+      } as never;
+
+      await controller.registerSubscriptions({ providers: [{ provider: 'anthropic' }] }, req);
+
+      expect(telemetry.trackCloudEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/routing/resolve.controller.ts
+++ b/packages/backend/src/routing/resolve.controller.ts
@@ -9,6 +9,7 @@ import { ResolveService } from './resolve.service';
 import { RoutingService } from './routing.service';
 import { ResolveRequestDto } from './dto/resolve-request.dto';
 import { ResolveResponse } from './dto/resolve-response';
+import { trackCloudEvent } from '../common/utils/product-telemetry';
 
 export class SubscriptionProviderItem {
   @IsString()
@@ -59,13 +60,18 @@ export class ResolveController {
     let registered = 0;
 
     for (const item of body.providers) {
-      await this.routingService.upsertProvider(
+      const { isNew } = await this.routingService.upsertProvider(
         agentId,
         userId,
         item.provider,
         undefined,
         'subscription',
       );
+      if (isNew) {
+        trackCloudEvent('routing_provider_connected', userId, {
+          provider: `${item.provider} (Subscription)`,
+        });
+      }
       registered++;
     }
 

--- a/packages/backend/src/routing/routing.controller.spec.ts
+++ b/packages/backend/src/routing/routing.controller.spec.ts
@@ -231,6 +231,24 @@ describe('RoutingController', () => {
       );
     });
 
+    it('should append (Subscription) to provider label for subscription auth type', async () => {
+      mockRoutingService.upsertProvider.mockResolvedValue({
+        provider: { id: 'p1', provider: 'anthropic', is_active: true, auth_type: 'subscription' },
+        isNew: true,
+      });
+
+      await controller.upsertProvider(mockUser, mockAgentName, {
+        provider: 'anthropic',
+        authType: 'subscription',
+      });
+
+      expect(telemetry.trackCloudEvent).toHaveBeenCalledWith(
+        'routing_provider_connected',
+        'user-1',
+        { provider: 'anthropic (Subscription)' },
+      );
+    });
+
     it('should not fire event when provider already exists', async () => {
       mockRoutingService.upsertProvider.mockResolvedValue({
         provider: { id: 'p1', provider: 'openai', is_active: true },

--- a/packages/backend/src/routing/routing.controller.ts
+++ b/packages/backend/src/routing/routing.controller.ts
@@ -76,8 +76,10 @@ export class RoutingController {
     );
 
     if (isNew) {
+      const providerLabel =
+        body.authType === 'subscription' ? `${body.provider} (Subscription)` : body.provider;
       trackCloudEvent('routing_provider_connected', user.id, {
-        provider: body.provider,
+        provider: providerLabel,
       });
     }
 


### PR DESCRIPTION
## Summary
- Appends `(Subscription)` suffix to provider name in `routing_provider_connected` PostHog events when `authType` is `subscription`, so subscription connections (e.g. Claude Max/Pro) are distinguishable from API key connections
- Adds PostHog tracking to the `POST /subscription-providers` endpoint (used by the OpenClaw plugin), which was previously untracked
- Covers both dashboard UI and plugin registration paths

## Test plan
- [x] Backend unit tests pass (2330 tests)
- [x] Backend e2e tests pass (106 tests)
- [x] Frontend tests pass (1450 tests)
- [x] TypeScript compiles cleanly
- [ ] Verify in PostHog that new subscription connections show as `anthropic (Subscription)` instead of `Anthropic`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Distinguishes subscription provider connections in PostHog from API key connections.

- Bug Fixes
  - Appends "(Subscription)" to the provider label in `routing_provider_connected` when `authType` is `subscription` (only for new connections).
  - Adds tracking for `POST /subscription-providers` (OpenClaw plugin path) to record subscription registrations from both dashboard and plugin flows.

<sup>Written for commit 436f58309679cb5e45430799b808625f0a97c7fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

