### PR TITLE
fix: prevent subscription providers from re-activating on gateway restart

### DIFF
--- a/.changeset/fix-subscription-reactivation.md
+++ b/.changeset/fix-subscription-reactivation.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix subscription providers being re-activated on every gateway restart

--- a/packages/backend/src/routing/resolve.controller.spec.ts
+++ b/packages/backend/src/routing/resolve.controller.spec.ts
@@ -17,7 +17,7 @@ jest.mock('../common/utils/product-telemetry', () => ({
 describe('ResolveController', () => {
   let controller: ResolveController;
   let mockResolveService: { resolve: jest.Mock };
-  let mockRoutingService: { upsertProvider: jest.Mock };
+  let mockRoutingService: { registerSubscriptionProvider: jest.Mock };
 
   const mockResponse: ResolveResponse = {
     tier: 'simple',
@@ -34,7 +34,7 @@ describe('ResolveController', () => {
       resolve: jest.fn().mockResolvedValue(mockResponse),
     };
     mockRoutingService = {
-      upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
+      registerSubscriptionProvider: jest.fn().mockResolvedValue({ isNew: true }),
     };
     controller = new ResolveController(
       mockResolveService as unknown as ResolveService,
@@ -134,20 +134,16 @@ describe('ResolveController', () => {
       );
 
       expect(result).toEqual({ registered: 2 });
-      expect(mockRoutingService.upsertProvider).toHaveBeenCalledTimes(2);
-      expect(mockRoutingService.upsertProvider).toHaveBeenCalledWith(
+      expect(mockRoutingService.registerSubscriptionProvider).toHaveBeenCalledTimes(2);
+      expect(mockRoutingService.registerSubscriptionProvider).toHaveBeenCalledWith(
         'a1',
         'u1',
         'anthropic',
-        undefined,
-        'subscription',
       );
-      expect(mockRoutingService.upsertProvider).toHaveBeenCalledWith(
+      expect(mockRoutingService.registerSubscriptionProvider).toHaveBeenCalledWith(
         'a1',
         'u1',
         'openai',
-        undefined,
-        'subscription',
       );
     });
 
@@ -164,7 +160,7 @@ describe('ResolveController', () => {
     });
 
     it('should not fire event when subscription provider already exists', async () => {
-      mockRoutingService.upsertProvider.mockResolvedValue({ provider: {}, isNew: false });
+      mockRoutingService.registerSubscriptionProvider.mockResolvedValue({ isNew: false });
       const req = {
         ingestionContext: { userId: 'u1', tenantId: 't1', agentId: 'a1', agentName: 'n1' },
       } as never;
@@ -172,6 +168,23 @@ describe('ResolveController', () => {
       await controller.registerSubscriptions({ providers: [{ provider: 'anthropic' }] }, req);
 
       expect(telemetry.trackCloudEvent).not.toHaveBeenCalled();
+    });
+
+    it('should only count newly created providers', async () => {
+      mockRoutingService.registerSubscriptionProvider
+        .mockResolvedValueOnce({ isNew: true })
+        .mockResolvedValueOnce({ isNew: false });
+
+      const req = {
+        ingestionContext: { userId: 'u1', tenantId: 't1', agentId: 'a1', agentName: 'n1' },
+      } as never;
+
+      const result = await controller.registerSubscriptions(
+        { providers: [{ provider: 'anthropic' }, { provider: 'openai' }] },
+        req,
+      );
+
+      expect(result).toEqual({ registered: 1 });
     });
   });
 });

--- a/packages/backend/src/routing/resolve.controller.ts
+++ b/packages/backend/src/routing/resolve.controller.ts
@@ -60,19 +60,17 @@ export class ResolveController {
     let registered = 0;
 
     for (const item of body.providers) {
-      const { isNew } = await this.routingService.upsertProvider(
+      const { isNew } = await this.routingService.registerSubscriptionProvider(
         agentId,
         userId,
         item.provider,
-        undefined,
-        'subscription',
       );
       if (isNew) {
         trackCloudEvent('routing_provider_connected', userId, {
           provider: `${item.provider} (Subscription)`,
         });
+        registered++;
       }
-      registered++;
     }
 
     return { registered };

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -476,6 +476,66 @@ describe('RoutingService', () => {
     });
   });
 
+  /* ── registerSubscriptionProvider ── */
+
+  describe('registerSubscriptionProvider', () => {
+    it('should create new provider when none exists', async () => {
+      mockProviderRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.registerSubscriptionProvider('a1', 'u1', 'anthropic');
+
+      expect(result).toEqual({ isNew: true });
+      expect(mockProviderRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent_id: 'a1',
+          user_id: 'u1',
+          provider: 'anthropic',
+          auth_type: 'subscription',
+          is_active: true,
+          api_key_encrypted: null,
+          key_prefix: null,
+        }),
+      );
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
+    });
+
+    it('should skip active existing provider', async () => {
+      const existing = Object.assign(new UserProvider(), {
+        id: 'p1',
+        agent_id: 'a1',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        is_active: true,
+      });
+      mockProviderRepo.findOne.mockResolvedValue(existing);
+
+      const result = await service.registerSubscriptionProvider('a1', 'u1', 'anthropic');
+
+      expect(result).toEqual({ isNew: false });
+      expect(mockProviderRepo.insert).not.toHaveBeenCalled();
+      expect(mockProviderRepo.save).not.toHaveBeenCalled();
+      expect(mockAutoAssign.recalculate).not.toHaveBeenCalled();
+    });
+
+    it('should skip inactive (user-deactivated) provider', async () => {
+      const existing = Object.assign(new UserProvider(), {
+        id: 'p1',
+        agent_id: 'a1',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        is_active: false,
+      });
+      mockProviderRepo.findOne.mockResolvedValue(existing);
+
+      const result = await service.registerSubscriptionProvider('a1', 'u1', 'anthropic');
+
+      expect(result).toEqual({ isNew: false });
+      expect(mockProviderRepo.insert).not.toHaveBeenCalled();
+      expect(mockProviderRepo.save).not.toHaveBeenCalled();
+      expect(mockAutoAssign.recalculate).not.toHaveBeenCalled();
+    });
+  });
+
   /* ── removeProvider ── */
 
   describe('removeProvider', () => {

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -90,6 +90,36 @@ export class RoutingService {
     return { provider: record, isNew: true };
   }
 
+  async registerSubscriptionProvider(
+    agentId: string,
+    userId: string,
+    provider: string,
+  ): Promise<{ isNew: boolean }> {
+    const existing = await this.providerRepo.findOne({
+      where: { agent_id: agentId, provider, auth_type: 'subscription' },
+    });
+
+    if (existing) return { isNew: false };
+
+    const record: UserProvider = Object.assign(new UserProvider(), {
+      id: randomUUID(),
+      user_id: userId,
+      agent_id: agentId,
+      provider,
+      auth_type: 'subscription',
+      api_key_encrypted: null,
+      key_prefix: null,
+      is_active: true,
+      connected_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+
+    await this.providerRepo.insert(record);
+    await this.autoAssign.recalculate(agentId);
+    this.routingCache.invalidateAgent(agentId);
+    return { isNew: true };
+  }
+
   async removeProvider(
     agentId: string,
     provider: string,

--- a/packages/backend/test/routing-flow.e2e-spec.ts
+++ b/packages/backend/test/routing-flow.e2e-spec.ts
@@ -208,6 +208,70 @@ describe('Routing enabled → scorer routes by query complexity', () => {
   });
 });
 
+describe('Subscription providers are not re-activated on restart', () => {
+  beforeAll(async () => {
+    // Start fresh: deactivate all, then register via subscription endpoint
+    await auth(api().post('/api/v1/routing/test-agent/providers/deactivate-all'))
+      .expect(201);
+  });
+
+  it('registers subscription providers as active', async () => {
+    const res = await bearer(api().post('/api/v1/routing/subscription-providers'))
+      .send({ providers: [{ provider: 'openai' }, { provider: 'anthropic' }] })
+      .expect(200);
+
+    expect(res.body.registered).toBe(2);
+
+    // Verify they are active
+    const providers = await auth(api().get('/api/v1/routing/test-agent/providers'))
+      .expect(200);
+    const subs = providers.body.filter(
+      (p: { auth_type: string }) => p.auth_type === 'subscription',
+    );
+    expect(subs).toHaveLength(2);
+    expect(subs.every((p: { is_active: boolean }) => p.is_active)).toBe(true);
+  });
+
+  it('removes a provider → deactivated', async () => {
+    await auth(
+      api().delete('/api/v1/routing/test-agent/providers/openai?authType=subscription'),
+    ).expect(200);
+
+    const providers = await auth(api().get('/api/v1/routing/test-agent/providers'))
+      .expect(200);
+    const openai = providers.body.find(
+      (p: { provider: string; auth_type: string }) =>
+        p.provider === 'openai' && p.auth_type === 'subscription',
+    );
+    expect(openai.is_active).toBe(false);
+  });
+
+  it('re-registering same providers does not re-activate removed one', async () => {
+    const res = await bearer(api().post('/api/v1/routing/subscription-providers'))
+      .send({ providers: [{ provider: 'openai' }, { provider: 'anthropic' }] })
+      .expect(200);
+
+    // Both already exist → nothing new registered
+    expect(res.body.registered).toBe(0);
+
+    // openai subscription should still be inactive
+    const providers = await auth(api().get('/api/v1/routing/test-agent/providers'))
+      .expect(200);
+    const openai = providers.body.find(
+      (p: { provider: string; auth_type: string }) =>
+        p.provider === 'openai' && p.auth_type === 'subscription',
+    );
+    expect(openai.is_active).toBe(false);
+
+    // anthropic subscription should still be active
+    const anthropic = providers.body.find(
+      (p: { provider: string; auth_type: string }) =>
+        p.provider === 'anthropic' && p.auth_type === 'subscription',
+    );
+    expect(anthropic.is_active).toBe(true);
+  });
+});
+
 describe('Routing disabled after deactivation → falls back to null', () => {
   it('deactivating all providers removes model assignments', async () => {
     await auth(api().post('/api/v1/routing/test-agent/providers/deactivate-all'))


### PR DESCRIPTION
## Summary

- Added `registerSubscriptionProvider()` to `RoutingService` that only creates new records and never modifies existing ones (active or inactive)
- Updated `registerSubscriptions` controller endpoint to use the new method, so the plugin's automated re-registration on gateway restart no longer overrides user-removed providers
- Only truly new providers are counted in the `registered` response

## Context

The OpenClaw plugin re-registers subscription providers on every gateway restart. Previously, `upsertProvider()` unconditionally set `is_active = true`, which re-activated providers the user explicitly removed. Now, `registerSubscriptionProvider()` checks if a record already exists and skips it entirely — preserving the user's removal.

Closes #1086

## Test plan

- [x] Unit tests: `registerSubscriptionProvider()` creates new, skips active existing, skips inactive (user-deactivated)
- [x] Controller tests: correct `registered` count, telemetry only fires for new providers
- [x] E2E test: register → remove → re-register confirms removed provider stays inactive
- [x] All existing routing tests pass (2334 unit, 15 E2E)
- [x] 100% line coverage on changed files
- [x] TypeScript compiles cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents subscription providers from re-activating on gateway restart. The subscription registration endpoint now only creates missing records and never updates existing ones, so user-removed providers stay inactive.

- **Bug Fixes**
  - Added `RoutingService.registerSubscriptionProvider` to insert only when no record exists; on insert, recalculates auto-assign and invalidates the agent cache.
  - Updated `registerSubscriptions` to use this; `registered` counts only new providers and telemetry fires only for new.
  - Tests added/updated (unit, controller, E2E) to cover create/skip behavior, correct `registered` count, and re-registration not reactivating removed providers.

<sup>Written for commit 3c62a818a78f4fd40bc8983fef6c43af9818658d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

