### PR TITLE
fix: return 409 instead of 500 for duplicate agent name

### DIFF
--- a/.changeset/real-humans-wink.md
+++ b/.changeset/real-humans-wink.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Return 409 Conflict instead of 500 when creating an agent with a duplicate name

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -9,7 +9,8 @@ jest.mock('../../common/utils/product-telemetry', () => ({
 import { Test, TestingModule } from '@nestjs/testing';
 import { CacheModule } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
 import { AgentsController } from './agents.controller';
 import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
 import { AggregationService } from '../services/aggregation.service';
@@ -247,5 +248,61 @@ describe('AgentsController', () => {
       BadRequestException,
     );
     expect(mockOnboard).not.toHaveBeenCalled();
+  });
+
+  it('throws ConflictException when onboardAgent hits unique constraint', async () => {
+    const queryError = new QueryFailedError('INSERT', [], new Error('unique constraint violation'));
+    const mockOnboard = jest.fn().mockRejectedValue(queryError);
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CacheModule.register()],
+      controllers: [AgentsController],
+      providers: [
+        { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
+        {
+          provide: AggregationService,
+          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn() },
+        },
+        {
+          provide: ApiKeyGeneratorService,
+          useValue: { onboardAgent: mockOnboard, getKeyForAgent: jest.fn(), rotateKey: jest.fn() },
+        },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+      ],
+    }).compile();
+
+    const ctrl = module.get<AgentsController>(AgentsController);
+    const user = { id: 'user-123', email: 'test@example.com' };
+    await expect(ctrl.createAgent(user as never, { name: 'My Agent' } as never)).rejects.toThrow(
+      ConflictException,
+    );
+  });
+
+  it('re-throws non-duplicate QueryFailedError from onboardAgent', async () => {
+    const queryError = new QueryFailedError('INSERT', [], new Error('connection refused'));
+    const mockOnboard = jest.fn().mockRejectedValue(queryError);
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CacheModule.register()],
+      controllers: [AgentsController],
+      providers: [
+        { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
+        {
+          provide: AggregationService,
+          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn() },
+        },
+        {
+          provide: ApiKeyGeneratorService,
+          useValue: { onboardAgent: mockOnboard, getKeyForAgent: jest.fn(), rotateKey: jest.fn() },
+        },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+      ],
+    }).compile();
+
+    const ctrl = module.get<AgentsController>(AgentsController);
+    const user = { id: 'user-123', email: 'test@example.com' };
+    await expect(ctrl.createAgent(user as never, { name: 'My Agent' } as never)).rejects.toThrow(
+      QueryFailedError,
+    );
   });
 });

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   Body,
+  ConflictException,
   Controller,
   Delete,
   ForbiddenException,
@@ -10,6 +11,7 @@ import {
   Post,
   UseInterceptors,
 } from '@nestjs/common';
+import { QueryFailedError } from 'typeorm';
 import { CacheTTL } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
 import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
@@ -52,12 +54,20 @@ export class AgentsController {
       throw new BadRequestException('Agent name produces an empty slug');
     }
     const displayName = body.name.trim();
-    const result = await this.apiKeyGenerator.onboardAgent({
-      tenantName: user.id,
-      agentName: slug,
-      displayName,
-      email: user.email,
-    });
+    let result: { tenantId: string; agentId: string; apiKey: string };
+    try {
+      result = await this.apiKeyGenerator.onboardAgent({
+        tenantName: user.id,
+        agentName: slug,
+        displayName,
+        email: user.email,
+      });
+    } catch (error) {
+      if (error instanceof QueryFailedError && /unique|duplicate/i.test(error.message)) {
+        throw new ConflictException(`Agent "${slug}" already exists`);
+      }
+      throw error;
+    }
     trackCloudEvent('agent_created', user.id, { agent_name: slug });
     return {
       agent: { id: result.agentId, name: slug, display_name: displayName },


### PR DESCRIPTION
## Summary

- Creating an agent with a duplicate name now returns HTTP 409 Conflict instead of an unhandled 500 error
- Catches `QueryFailedError` with unique/duplicate constraint messages in `createAgent()` and converts to `ConflictException`
- Covers both PostgreSQL and SQLite constraint error messages

## Test plan

- [x] Unit tests added for conflict and re-throw paths
- [x] All backend unit tests pass (2336/2336)
- [x] All e2e tests pass (109/109)
- [x] TypeScript compiles clean (backend + frontend)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creating an agent with a duplicate name now returns HTTP 409 Conflict instead of a 500 error. This makes the API response clear and avoids unhandled errors.

- Bug Fixes
  - Convert unique/duplicate `QueryFailedError` in `createAgent()` to `ConflictException` (HTTP 409), covering PostgreSQL and SQLite messages.
  - Add unit tests for conflict handling and for re-throwing non-duplicate errors.

<sup>Written for commit ba6a7cfb8219737ad6091423e362e09e365ed67a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

