### PR TITLE
fix: link cloud mode telemetry identities via PostHog $identify

### DIFF
--- a/.changeset/fix-cloud-telemetry-funnel.md
+++ b/.changeset/fix-cloud-telemetry-funnel.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix cloud mode product telemetry funnel by linking plugin and backend identities via PostHog $identify

--- a/packages/backend/src/analytics/controllers/agent-analytics.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agent-analytics.controller.spec.ts
@@ -3,13 +3,19 @@ import { CacheModule } from '@nestjs/cache-manager';
 import { AgentAnalyticsController } from './agent-analytics.controller';
 import { AgentAnalyticsService } from '../services/agent-analytics.service';
 import { OtlpAuthGuard } from '../../otlp/guards/otlp-auth.guard';
+import { hashForTelemetry } from '../../common/utils/product-telemetry';
 
 describe('AgentAnalyticsController', () => {
   let controller: AgentAnalyticsController;
   let mockGetUsage: jest.Mock;
   let mockGetCosts: jest.Mock;
 
-  const ingestionContext = { tenantId: 't1', agentId: 'a1', agentName: 'test-agent' };
+  const ingestionContext = {
+    tenantId: 't1',
+    agentId: 'a1',
+    agentName: 'test-agent',
+    userId: 'user-1',
+  };
   const mockReq = { ingestionContext } as never;
 
   beforeEach(async () => {
@@ -55,6 +61,8 @@ describe('AgentAnalyticsController', () => {
       expect(result.total_tokens).toBe(5000);
       expect(result.input_tokens).toBe(3000);
       expect(result.message_count).toBe(10);
+      expect(result.agentName).toBe('test-agent');
+      expect(result.telemetryId).toBe(hashForTelemetry('user-1'));
     });
 
     it('passes custom range', async () => {

--- a/packages/backend/src/analytics/controllers/agent-analytics.controller.ts
+++ b/packages/backend/src/analytics/controllers/agent-analytics.controller.ts
@@ -8,6 +8,7 @@ import { AgentAnalyticsService } from '../services/agent-analytics.service';
 import { RangeQueryDto } from '../../common/dto/range-query.dto';
 import { AgentCacheInterceptor } from '../../common/interceptors/agent-cache.interceptor';
 import { DASHBOARD_CACHE_TTL_MS } from '../../common/constants/cache.constants';
+import { hashForTelemetry } from '../../common/utils/product-telemetry';
 
 interface AuthenticatedRequest extends Request {
   ingestionContext: IngestionContext;
@@ -25,7 +26,12 @@ export class AgentAnalyticsController {
   async getUsage(@Query() query: RangeQueryDto, @Req() req: AuthenticatedRequest) {
     const range = query.range ?? '24h';
     const ctx = req.ingestionContext;
-    return this.analytics.getUsage(range, ctx);
+    const usage = await this.analytics.getUsage(range, ctx);
+    return {
+      ...usage,
+      agentName: ctx.agentName,
+      telemetryId: hashForTelemetry(ctx.userId),
+    };
   }
 
   @Get('costs')

--- a/packages/backend/src/common/utils/product-telemetry.spec.ts
+++ b/packages/backend/src/common/utils/product-telemetry.spec.ts
@@ -5,7 +5,7 @@ jest.mock('./posthog-sender', () => ({
   sendToPostHog: jest.fn(),
 }));
 
-import { getMachineId, trackEvent, trackCloudEvent } from './product-telemetry';
+import { getMachineId, trackEvent, trackCloudEvent, hashForTelemetry } from './product-telemetry';
 import { sendToPostHog } from './posthog-sender';
 
 const mockedSend = sendToPostHog as jest.Mock;
@@ -32,6 +32,25 @@ describe('getMachineId', () => {
       .digest('hex')
       .slice(0, 16);
     expect(getMachineId()).toBe(expected);
+  });
+});
+
+describe('hashForTelemetry', () => {
+  it('returns a 16-character hex string', () => {
+    expect(hashForTelemetry('test-id')).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('is deterministic', () => {
+    expect(hashForTelemetry('user-123')).toBe(hashForTelemetry('user-123'));
+  });
+
+  it('produces different hashes for different inputs', () => {
+    expect(hashForTelemetry('user-a')).not.toBe(hashForTelemetry('user-b'));
+  });
+
+  it('matches manual SHA256 computation', () => {
+    const expected = createHash('sha256').update('tenant-xyz').digest('hex').slice(0, 16);
+    expect(hashForTelemetry('tenant-xyz')).toBe(expected);
   });
 });
 
@@ -102,10 +121,7 @@ describe('trackCloudEvent', () => {
     trackCloudEvent('agent_created', 'tenant-123');
 
     const props = mockedSend.mock.calls[0][1];
-    const expected = createHash('sha256')
-      .update('tenant-123')
-      .digest('hex')
-      .slice(0, 16);
+    const expected = createHash('sha256').update('tenant-123').digest('hex').slice(0, 16);
     expect(props.distinct_id).toBe(expected);
   });
 

--- a/packages/backend/src/common/utils/product-telemetry.ts
+++ b/packages/backend/src/common/utils/product-telemetry.ts
@@ -20,10 +20,7 @@ function getPackageVersion(): string | undefined {
   return process.env['MANIFEST_PACKAGE_VERSION'] || undefined;
 }
 
-export function trackEvent(
-  event: string,
-  properties?: Record<string, unknown>,
-): void {
+export function trackEvent(event: string, properties?: Record<string, unknown>): void {
   if (isOptedOut()) return;
   const version = getPackageVersion();
   sendToPostHog(event, {
@@ -37,16 +34,19 @@ export function trackEvent(
   });
 }
 
+export function hashForTelemetry(id: string): string {
+  return createHash('sha256').update(id).digest('hex').slice(0, 16);
+}
+
 export function trackCloudEvent(
   event: string,
   tenantId: string,
   properties?: Record<string, unknown>,
 ): void {
   if (isOptedOut()) return;
-  const hashedTenant = createHash('sha256').update(tenantId).digest('hex').slice(0, 16);
   const version = getPackageVersion();
   sendToPostHog(event, {
-    distinct_id: hashedTenant,
+    distinct_id: hashForTelemetry(tenantId),
     os: platform(),
     os_version: release(),
     node_version: process.versions.node,

--- a/packages/backend/src/otlp/otlp.controller.spec.ts
+++ b/packages/backend/src/otlp/otlp.controller.spec.ts
@@ -144,12 +144,14 @@ describe('OtlpController', () => {
       delete process.env['MANIFEST_MODE'];
       await controller.ingestTraces(makeReq('application/json', {}, undefined));
 
-      expect(trackCloudEvent).toHaveBeenCalledWith('plugin_registered', 'test-user', {
-        source: 'backend',
-      });
       expect(trackCloudEvent).toHaveBeenCalledWith('first_telemetry_received', 'test-user', {
         agent_id_hash: 'test-age',
       });
+      expect(trackCloudEvent).not.toHaveBeenCalledWith(
+        'plugin_registered',
+        expect.anything(),
+        expect.anything(),
+      );
       expect(trackEvent).not.toHaveBeenCalled();
     });
 
@@ -178,32 +180,36 @@ describe('OtlpController', () => {
       await controller.ingestTraces(makeReq('application/json', {}, undefined));
       await controller.ingestTraces(makeReq('application/json', {}, undefined));
 
-      // 2 calls on first ingest (plugin_registered + first_telemetry_received), 0 on second
-      expect(trackCloudEvent).toHaveBeenCalledTimes(2);
+      // 1 call on first ingest (first_telemetry_received), 0 on second
+      expect(trackCloudEvent).toHaveBeenCalledTimes(1);
     });
 
-    it('emits plugin_registered with source backend via metrics ingestion', async () => {
+    it('emits first_telemetry_received via metrics ingestion', async () => {
       delete process.env['MANIFEST_MODE'];
       await controller.ingestMetrics(makeReq('application/json', {}, undefined));
 
-      expect(trackCloudEvent).toHaveBeenCalledWith('plugin_registered', 'test-user', {
-        source: 'backend',
-      });
       expect(trackCloudEvent).toHaveBeenCalledWith('first_telemetry_received', 'test-user', {
         agent_id_hash: 'test-age',
       });
+      expect(trackCloudEvent).not.toHaveBeenCalledWith(
+        'plugin_registered',
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
-    it('emits plugin_registered with source backend via logs ingestion', async () => {
+    it('emits first_telemetry_received via logs ingestion', async () => {
       delete process.env['MANIFEST_MODE'];
       await controller.ingestLogs(makeReq('application/json', {}, undefined));
 
-      expect(trackCloudEvent).toHaveBeenCalledWith('plugin_registered', 'test-user', {
-        source: 'backend',
-      });
       expect(trackCloudEvent).toHaveBeenCalledWith('first_telemetry_received', 'test-user', {
         agent_id_hash: 'test-age',
       });
+      expect(trackCloudEvent).not.toHaveBeenCalledWith(
+        'plugin_registered',
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
     it('deduplicates across different ingestion methods for the same agent', async () => {
@@ -212,8 +218,8 @@ describe('OtlpController', () => {
       await controller.ingestMetrics(makeReq('application/json', {}, undefined));
       await controller.ingestLogs(makeReq('application/json', {}, undefined));
 
-      // Only the first call (traces) should trigger events
-      expect(trackCloudEvent).toHaveBeenCalledTimes(2);
+      // Only the first call (traces) should trigger the event
+      expect(trackCloudEvent).toHaveBeenCalledTimes(1);
     });
 
     it('tracks separately for different agentIds in cloud mode', async () => {
@@ -246,8 +252,8 @@ describe('OtlpController', () => {
       await controller.ingestTraces(reqAgent1);
       await controller.ingestTraces(reqAgent2);
 
-      // 2 events per agent = 4 total
-      expect(trackCloudEvent).toHaveBeenCalledTimes(4);
+      // 1 event per agent = 2 total
+      expect(trackCloudEvent).toHaveBeenCalledTimes(2);
     });
 
     it('uses userId as the distinct_id key for trackCloudEvent', async () => {
@@ -267,12 +273,14 @@ describe('OtlpController', () => {
 
       await controller.ingestTraces(req);
 
-      expect(trackCloudEvent).toHaveBeenCalledWith('plugin_registered', 'user-abc-123', {
-        source: 'backend',
-      });
       expect(trackCloudEvent).toHaveBeenCalledWith('first_telemetry_received', 'user-abc-123', {
         agent_id_hash: 'my-agent',
       });
+      expect(trackCloudEvent).not.toHaveBeenCalledWith(
+        'plugin_registered',
+        expect.anything(),
+        expect.anything(),
+      );
     });
 
     it('does not emit events when no data is accepted', async () => {

--- a/packages/backend/src/otlp/otlp.controller.ts
+++ b/packages/backend/src/otlp/otlp.controller.ts
@@ -89,9 +89,6 @@ export class OtlpController {
     } else {
       if (this.seenAgents.has(ctx.agentId)) return;
       this.seenAgents.add(ctx.agentId);
-      trackCloudEvent('plugin_registered', ctx.userId, {
-        source: 'backend',
-      });
       trackCloudEvent('first_telemetry_received', ctx.userId, {
         agent_id_hash: ctx.agentId.slice(0, 8),
       });

--- a/packages/openclaw-plugin/__tests__/command.test.ts
+++ b/packages/openclaw-plugin/__tests__/command.test.ts
@@ -51,6 +51,7 @@ describe("registerCommand", () => {
       endpointReachable: true,
       authValid: true,
       agentName: "test-agent",
+      telemetryId: null,
       error: null,
     });
 
@@ -72,6 +73,7 @@ describe("registerCommand", () => {
       endpointReachable: false,
       authValid: false,
       agentName: null,
+      telemetryId: null,
       error: "Cannot reach endpoint: ECONNREFUSED",
     });
 
@@ -114,6 +116,7 @@ describe("registerCommand", () => {
       endpointReachable: true,
       authValid: true,
       agentName: null,
+      telemetryId: null,
       error: null,
     });
 

--- a/packages/openclaw-plugin/__tests__/product-telemetry.test.ts
+++ b/packages/openclaw-plugin/__tests__/product-telemetry.test.ts
@@ -2,10 +2,92 @@ jest.mock("../src/telemetry-config", () => ({
   getTelemetryConfig: jest.fn(),
 }));
 
-import { trackPluginEvent } from "../src/product-telemetry";
+import { trackPluginEvent, identifyUser, getMachineId } from "../src/product-telemetry";
 import { getTelemetryConfig } from "../src/telemetry-config";
 
 const mockGetTelemetryConfig = getTelemetryConfig as jest.Mock;
+
+describe("getMachineId", () => {
+  it("returns a 16-character hex string", () => {
+    expect(getMachineId()).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("is stable across calls", () => {
+    expect(getMachineId()).toBe(getMachineId());
+  });
+});
+
+describe("identifyUser", () => {
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchSpy = jest
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue({} as Response);
+    mockGetTelemetryConfig.mockReturnValue({
+      optedOut: false,
+      packageVersion: "1.2.3",
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("sends $identify event to PostHog with telemetryId as distinct_id", () => {
+    identifyUser("abc123");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.event).toBe("$identify");
+    expect(body.properties.distinct_id).toBe("abc123");
+    expect(body.properties.$anon_distinct_id).toBe(getMachineId());
+  });
+
+  it("includes PostHog API key in payload", () => {
+    identifyUser("abc123");
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(body.api_key).toBe("phc_g5pLOu5bBRjhVJBwAsx0eCzJFWq0cri2TyVLQLxf045");
+  });
+
+  it("includes timestamp in ISO format", () => {
+    identifyUser("abc123");
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    expect(new Date(body.timestamp).toISOString()).toBe(body.timestamp);
+  });
+
+  it("does not call fetch when telemetry is opted out", () => {
+    mockGetTelemetryConfig.mockReturnValue({
+      optedOut: true,
+      packageVersion: "1.2.3",
+    });
+
+    identifyUser("abc123");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("silently swallows fetch errors", () => {
+    fetchSpy.mockRejectedValue(new Error("Network error"));
+
+    expect(() => identifyUser("abc123")).not.toThrow();
+  });
+
+  it("POSTs to the correct PostHog capture endpoint", () => {
+    identifyUser("abc123");
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://eu.i.posthog.com/capture",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+  });
+});
 
 describe("trackPluginEvent", () => {
   const origMode = process.env["MANIFEST_MODE"];

--- a/packages/openclaw-plugin/__tests__/register.test.ts
+++ b/packages/openclaw-plugin/__tests__/register.test.ts
@@ -30,6 +30,7 @@ jest.mock("../src/command", () => ({
 }));
 jest.mock("../src/product-telemetry", () => ({
   trackPluginEvent: jest.fn(),
+  identifyUser: jest.fn(),
 }));
 
 import { parseConfigWithDeprecation, validateConfig } from "../src/config";
@@ -40,7 +41,7 @@ import { registerRouting } from "../src/routing";
 import { registerTools } from "../src/tools";
 import { registerCommand } from "../src/command";
 import { verifyConnection } from "../src/verify";
-import { trackPluginEvent } from "../src/product-telemetry";
+import { trackPluginEvent, identifyUser } from "../src/product-telemetry";
 
 const plugin = require("../src/index");
 
@@ -302,7 +303,7 @@ describe("register — cloud mode with devMode", () => {
       _deprecatedDevMode: false,
     });
     (validateConfig as jest.Mock).mockReturnValue(null);
-    (verifyConnection as jest.Mock).mockResolvedValue({ error: null, agentName: "test-agent" });
+    (verifyConnection as jest.Mock).mockResolvedValue({ error: null, agentName: "test-agent", telemetryId: null });
 
     const api = makeApi();
     plugin.register(api);
@@ -315,6 +316,50 @@ describe("register — cloud mode with devMode", () => {
     expect(api.logger.info).toHaveBeenCalledWith(
       expect.stringContaining("Connection verified"),
     );
+  });
+
+  it("calls identifyUser when telemetryId is present in verify result", async () => {
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
+    (validateConfig as jest.Mock).mockReturnValue(null);
+    (verifyConnection as jest.Mock).mockResolvedValue({
+      error: null,
+      agentName: "test-agent",
+      telemetryId: "hash1234abcd5678",
+    });
+
+    const api = makeApi();
+    plugin.register(api);
+
+    const serviceCall = api.registerService.mock.calls[0][0];
+    serviceCall.start();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(identifyUser).toHaveBeenCalledWith("hash1234abcd5678");
+  });
+
+  it("does not call identifyUser when telemetryId is null", async () => {
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: devConfig,
+      _deprecatedDevMode: false,
+    });
+    (validateConfig as jest.Mock).mockReturnValue(null);
+    (verifyConnection as jest.Mock).mockResolvedValue({
+      error: null,
+      agentName: "test-agent",
+      telemetryId: null,
+    });
+
+    const api = makeApi();
+    plugin.register(api);
+
+    const serviceCall = api.registerService.mock.calls[0][0];
+    serviceCall.start();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(identifyUser).not.toHaveBeenCalled();
   });
 
   it("service start logs warning on verify error", async () => {
@@ -510,6 +555,7 @@ describe("register — cloud mode full path", () => {
     (verifyConnection as jest.Mock).mockResolvedValue({
       error: null,
       agentName: "cloud-agent",
+      telemetryId: "cloudhash12345678",
     });
 
     const api = makeApi();
@@ -520,9 +566,32 @@ describe("register — cloud mode full path", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(verifyConnection).toHaveBeenCalledWith(cloudConfig);
+    expect(identifyUser).toHaveBeenCalledWith("cloudhash12345678");
     expect(api.logger.info).toHaveBeenCalledWith(
       expect.stringContaining("Connection verified"),
     );
+  });
+
+  it("cloud service start does not call identifyUser on verify error", async () => {
+    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
+      config: cloudConfig,
+      _deprecatedDevMode: false,
+    });
+    (validateConfig as jest.Mock).mockReturnValue(null);
+    (verifyConnection as jest.Mock).mockResolvedValue({
+      error: "Cannot reach endpoint",
+      agentName: null,
+      telemetryId: null,
+    });
+
+    const api = makeApi();
+    plugin.register(api);
+
+    const serviceCall = api.registerService.mock.calls[0][0];
+    serviceCall.start();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(identifyUser).not.toHaveBeenCalled();
   });
 
   it("cloud service start logs warning on verify error", async () => {

--- a/packages/openclaw-plugin/__tests__/verify.test.ts
+++ b/packages/openclaw-plugin/__tests__/verify.test.ts
@@ -24,7 +24,7 @@ describe("verifyConnection", () => {
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
-        json: async () => ({ agentName: "my-agent" }),
+        json: async () => ({ agentName: "my-agent", telemetryId: "abc123" }),
       });
 
     const result = await verifyConnection(baseConfig);
@@ -32,6 +32,7 @@ describe("verifyConnection", () => {
     expect(result.endpointReachable).toBe(true);
     expect(result.authValid).toBe(true);
     expect(result.agentName).toBe("my-agent");
+    expect(result.telemetryId).toBe("abc123");
     expect(result.error).toBeNull();
   });
 
@@ -163,7 +164,36 @@ describe("verifyConnection", () => {
 
     expect(result.authValid).toBe(true);
     expect(result.agentName).toBeNull();
+    expect(result.telemetryId).toBeNull();
     expect(result.error).toBeNull();
+  });
+
+  it("extracts telemetryId from usage response", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ agentName: "agent-1", telemetryId: "hash123456789abc" }),
+      });
+
+    const result = await verifyConnection(baseConfig);
+
+    expect(result.telemetryId).toBe("hash123456789abc");
+  });
+
+  it("sets telemetryId to null when not present in response", async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ agentName: "agent-1" }),
+      });
+
+    const result = await verifyConnection(baseConfig);
+
+    expect(result.telemetryId).toBeNull();
   });
 
   it("handles non-ok status from usage endpoint", async () => {

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -6,7 +6,7 @@ import { registerTools } from './tools';
 import { registerCommand } from './command';
 import { verifyConnection } from './verify';
 import { registerLocalMode, injectProviderConfig, injectAuthProfile } from './local-mode';
-import { trackPluginEvent } from './product-telemetry';
+import { trackPluginEvent, identifyUser } from './product-telemetry';
 import { discoverSubscriptionProviders, registerSubscriptionProviders } from './subscription';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -122,6 +122,9 @@ module.exports = {
             if (check.error) {
               logger.warn?.(`[manifest] Connection check failed: ${check.error}`);
               return;
+            }
+            if (check.telemetryId) {
+              identifyUser(check.telemetryId);
             }
             const agent = check.agentName ? ` (agent: ${check.agentName})` : '';
             logger.info(`[manifest] Connection verified${agent}`);

--- a/packages/openclaw-plugin/src/product-telemetry.ts
+++ b/packages/openclaw-plugin/src/product-telemetry.ts
@@ -5,9 +5,30 @@ import { getTelemetryConfig } from './telemetry-config';
 const POSTHOG_HOST = 'https://eu.i.posthog.com';
 const POSTHOG_API_KEY = 'phc_g5pLOu5bBRjhVJBwAsx0eCzJFWq0cri2TyVLQLxf045';
 
-function getMachineId(): string {
+export function getMachineId(): string {
   const raw = `${hostname()}-${platform()}-${arch()}`;
   return createHash('sha256').update(raw).digest('hex').slice(0, 16);
+}
+
+export function identifyUser(telemetryId: string): void {
+  const config = getTelemetryConfig();
+  if (config.optedOut) return;
+
+  const payload = {
+    api_key: POSTHOG_API_KEY,
+    event: '$identify',
+    properties: {
+      distinct_id: telemetryId,
+      $anon_distinct_id: getMachineId(),
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  fetch(`${POSTHOG_HOST}/capture`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).catch(() => {});
 }
 
 export function trackPluginEvent(

--- a/packages/openclaw-plugin/src/verify.ts
+++ b/packages/openclaw-plugin/src/verify.ts
@@ -1,20 +1,20 @@
-import { ManifestConfig } from "./config";
+import { ManifestConfig } from './config';
 
 export interface VerifyResult {
   endpointReachable: boolean;
   authValid: boolean;
   agentName: string | null;
+  telemetryId: string | null;
   error: string | null;
 }
 
-export async function verifyConnection(
-  config: ManifestConfig,
-): Promise<VerifyResult> {
-  const baseUrl = config.endpoint.replace(/\/otlp(\/v1)?\/?$/, "");
+export async function verifyConnection(config: ManifestConfig): Promise<VerifyResult> {
+  const baseUrl = config.endpoint.replace(/\/otlp(\/v1)?\/?$/, '');
   const result: VerifyResult = {
     endpointReachable: false,
     authValid: false,
     agentName: null,
+    telemetryId: null,
     error: null,
   };
 
@@ -39,15 +39,12 @@ export async function verifyConnection(
     const authHeaders: Record<string, string> = config.apiKey
       ? { Authorization: `Bearer ${config.apiKey}` }
       : {};
-    const usageRes = await fetch(
-      `${baseUrl}/api/v1/agent/usage?range=24h`,
-      {
-        headers: authHeaders,
-        signal: AbortSignal.timeout(5000),
-      },
-    );
+    const usageRes = await fetch(`${baseUrl}/api/v1/agent/usage?range=24h`, {
+      headers: authHeaders,
+      signal: AbortSignal.timeout(5000),
+    });
     if (usageRes.status === 401 || usageRes.status === 403) {
-      result.error = "API key rejected — check your mnfst_ key is correct";
+      result.error = 'API key rejected — check your mnfst_ key is correct';
       return result;
     }
     if (!usageRes.ok) {
@@ -57,8 +54,11 @@ export async function verifyConnection(
     result.authValid = true;
 
     const body = (await usageRes.json()) as Record<string, unknown>;
-    if (body && typeof body.agentName === "string") {
+    if (body && typeof body.agentName === 'string') {
       result.agentName = body.agentName;
+    }
+    if (body && typeof body.telemetryId === 'string') {
+      result.telemetryId = body.telemetryId;
     }
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

- Fix the **Install → Create Agent → First Data** PostHog funnel which had a 97.85% drop-off in cloud mode due to distinct_id mismatch between plugin (`machine_id`) and backend (`SHA256(user.id)`)
- After the plugin verifies its connection, the backend now returns a `telemetryId` in the usage response. The plugin sends a PostHog `$identify` event to merge `machine_id` → `telemetryId`, linking all events under one person
- Remove the redundant backend-side `plugin_registered` event that fired at the wrong time (same time as `first_telemetry_received`)

## Changes

**Backend:**
- Extract `hashForTelemetry()` utility from inline SHA256 hashing in `product-telemetry.ts`
- Add `telemetryId` and `agentName` to the `/api/v1/agent/usage` response
- Remove redundant `plugin_registered` cloud event from `otlp.controller.ts`

**Plugin:**
- Add `identifyUser()` function that sends PostHog `$identify` to merge anonymous machine_id with backend telemetryId
- Export `getMachineId()` for use in identity linking
- Extract `telemetryId` from verify response in `verify.ts`
- Call `identifyUser()` after successful connection verification in `index.ts`

## Test plan

- [x] Backend unit tests pass (130 suites, 2338 tests)
- [x] Backend e2e tests pass (16 suites, 109 tests)
- [x] Frontend tests pass (73 suites, 1450 tests)
- [x] Plugin tests pass (14 suites, 330 tests)
- [x] TypeScript compilation clean (backend, frontend, plugin)
- [x] Verified distinct_id consistency across local and cloud mode for all PostHog funnels
- [ ] Manual: start app in cloud mode, install plugin, verify `$identify` event appears in PostHog linking machine_id to telemetryId

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cloud-mode telemetry identity mismatch by linking the plugin’s `machine_id` to the backend `telemetryId` via PostHog `$identify`, unifying events under one person and restoring the Install → Create Agent → First Data funnel.

- **Bug Fixes**
  - Backend: added `telemetryId` and `agentName` to `/api/v1/agent/usage`, introduced `hashForTelemetry()`, and removed the redundant `plugin_registered` event.
  - Plugin (`packages/openclaw-plugin`): added `identifyUser()` to send `$identify` after a successful verify, extracted `telemetryId` from verify response, and exposed `getMachineId()`.

<sup>Written for commit 894ea4f8b6a258631093f2f6500518a3dbf35aed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

