### PR TITLE
fix: accept dev-mode loopback auth in cloud mode

### DIFF
--- a/.changeset/fix-dev-loopback-auth.md
+++ b/.changeset/fix-dev-loopback-auth.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Accept dev-mode loopback connections in cloud mode and improve error status reporting in OTLP traces

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
@@ -18,6 +18,7 @@ describe('OtlpAuthGuard', () => {
   let mockGetOne: jest.Mock;
   let mockCreateQueryBuilder: jest.Mock;
   let mockUpdate: jest.Mock;
+  let mockFindOne: jest.Mock;
 
   beforeEach(() => {
     mockGetOne = jest.fn().mockResolvedValue(null);
@@ -37,7 +38,12 @@ describe('OtlpAuthGuard', () => {
       }
       return Promise.resolve({});
     });
-    const mockRepo = { createQueryBuilder: mockCreateQueryBuilder, update: mockUpdate } as never;
+    mockFindOne = jest.fn().mockResolvedValue(null);
+    const mockRepo = {
+      createQueryBuilder: mockCreateQueryBuilder,
+      update: mockUpdate,
+      findOne: mockFindOne,
+    } as never;
     guard = new OtlpAuthGuard(mockRepo);
     guard.clearCache();
   });
@@ -230,6 +236,112 @@ describe('OtlpAuthGuard', () => {
     });
   });
 
+  describe('dev loopback bypass in development mode', () => {
+    const origMode = process.env['MANIFEST_MODE'];
+    const origNodeEnv = process.env['NODE_ENV'];
+
+    beforeEach(() => {
+      process.env['MANIFEST_MODE'] = 'cloud';
+      process.env['NODE_ENV'] = 'development';
+    });
+
+    afterEach(() => {
+      if (origMode === undefined) delete process.env['MANIFEST_MODE'];
+      else process.env['MANIFEST_MODE'] = origMode;
+      if (origNodeEnv === undefined) delete process.env['NODE_ENV'];
+      else process.env['NODE_ENV'] = origNodeEnv;
+    });
+
+    it('allows loopback with non-mnfst token in dev mode by resolving first active key', async () => {
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'dev-tenant',
+        agent_id: 'dev-agent',
+        agent: { name: 'demo-agent' },
+        tenant: { name: 'dev-user' },
+      });
+      const { ctx, req } = makeContext({ authorization: 'Bearer dev-no-auth' }, '127.0.0.1');
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(req.ingestionContext).toEqual({
+        tenantId: 'dev-tenant',
+        agentId: 'dev-agent',
+        agentName: 'demo-agent',
+        userId: 'dev-user',
+      });
+      expect(mockFindOne).toHaveBeenCalledWith({
+        where: { is_active: true },
+        relations: ['agent', 'tenant'],
+      });
+    });
+
+    it('allows loopback without auth header in dev mode', async () => {
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'dev-tenant',
+        agent_id: 'dev-agent',
+        agent: { name: 'demo-agent' },
+        tenant: { name: 'dev-user' },
+      });
+      const { ctx, req } = makeContext({}, '127.0.0.1');
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(req.ingestionContext).toEqual({
+        tenantId: 'dev-tenant',
+        agentId: 'dev-agent',
+        agentName: 'demo-agent',
+        userId: 'dev-user',
+      });
+    });
+
+    it('rejects loopback without auth when no active keys exist in DB', async () => {
+      mockFindOne.mockResolvedValue(null);
+      const { ctx } = makeContext({}, '127.0.0.1');
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Authorization header required');
+    });
+
+    it('rejects non-mnfst token when no active keys exist in DB', async () => {
+      mockFindOne.mockResolvedValue(null);
+      const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '127.0.0.1');
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
+    });
+
+    it('rejects non-mnfst token from non-loopback IP in dev mode', async () => {
+      const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '192.168.1.100');
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
+    });
+
+    it('rejects loopback with non-mnfst token in production mode', async () => {
+      process.env['NODE_ENV'] = 'production';
+      const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '127.0.0.1');
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
+    });
+
+    it('rejects loopback with non-mnfst token in test mode', async () => {
+      process.env['NODE_ENV'] = 'test';
+      const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '127.0.0.1');
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
+    });
+
+    it('caches dev context and reuses it on subsequent calls', async () => {
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'dev-tenant',
+        agent_id: 'dev-agent',
+        agent: { name: 'demo-agent' },
+        tenant: { name: 'dev-user' },
+      });
+
+      const { ctx: ctx1 } = makeContext({ authorization: 'Bearer dev-no-auth' }, '127.0.0.1');
+      await guard.canActivate(ctx1);
+      expect(mockFindOne).toHaveBeenCalledTimes(1);
+
+      mockFindOne.mockClear();
+      const { ctx: ctx2 } = makeContext({ authorization: 'Bearer dev-no-auth' }, '::1');
+      await guard.canActivate(ctx2);
+      expect(mockFindOne).not.toHaveBeenCalled();
+    });
+  });
+
   it('handles request.ip being undefined without crashing', async () => {
     const origMode = process.env['MANIFEST_MODE'];
     process.env['MANIFEST_MODE'] = 'local';
@@ -356,7 +468,11 @@ describe('OtlpAuthGuard', () => {
   it('periodic timer fires evictExpired', () => {
     jest.useFakeTimers();
 
-    const mockRepo = { createQueryBuilder: mockCreateQueryBuilder, update: mockUpdate } as never;
+    const mockRepo = {
+      createQueryBuilder: mockCreateQueryBuilder,
+      update: mockUpdate,
+      findOne: mockFindOne,
+    } as never;
     const timedGuard = new OtlpAuthGuard(mockRepo);
 
     const internalCache = (timedGuard as any).cache as Map<string, unknown>;
@@ -379,7 +495,11 @@ describe('OtlpAuthGuard', () => {
   it('onModuleDestroy stops the periodic cleanup timer', () => {
     jest.useFakeTimers();
 
-    const mockRepo = { createQueryBuilder: mockCreateQueryBuilder, update: mockUpdate } as never;
+    const mockRepo = {
+      createQueryBuilder: mockCreateQueryBuilder,
+      update: mockUpdate,
+      findOne: mockFindOne,
+    } as never;
     const timedGuard = new OtlpAuthGuard(mockRepo);
 
     const internalCache = (timedGuard as any).cache as Map<string, unknown>;

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.ts
@@ -34,6 +34,7 @@ interface CachedKey {
 export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
   private readonly logger = new Logger(OtlpAuthGuard.name);
   private cache = new Map<string, CachedKey>();
+  private devContext: { context: IngestionContext; expiresAt: number } | null = null;
   private readonly CACHE_TTL_MS = 5 * 60 * 1000;
   private readonly MAX_CACHE_SIZE = 10_000;
   private readonly cleanupTimer: ReturnType<typeof setInterval>;
@@ -56,7 +57,9 @@ export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
     const request = context.switchToHttp().getRequest<Request>();
     const authHeader = request.headers['authorization'];
 
-    const isLocal = process.env['MANIFEST_MODE'] === 'local' && LOOPBACK_IPS.has(request.ip ?? '');
+    const isLoopback = LOOPBACK_IPS.has(request.ip ?? '');
+    const isLocal = process.env['MANIFEST_MODE'] === 'local' && isLoopback;
+    const isDevLoopback = process.env['NODE_ENV'] === 'development' && isLoopback;
 
     // In local mode, trust loopback connections without requiring an API key.
     // Also handles dev-mode gateways that send a dummy/non-mnfst token.
@@ -68,6 +71,15 @@ export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
         userId: LOCAL_USER_ID,
       };
       return true;
+    }
+
+    // In development, trust loopback connections and resolve to first active agent.
+    if (!authHeader && isDevLoopback) {
+      const devCtx = await this.resolveDevContext();
+      if (devCtx) {
+        (request as Request & { ingestionContext: IngestionContext }).ingestionContext = devCtx;
+        return true;
+      }
     }
 
     if (!authHeader) {
@@ -92,6 +104,13 @@ export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
           userId: LOCAL_USER_ID,
         };
         return true;
+      }
+      if (isDevLoopback) {
+        const devCtx = await this.resolveDevContext();
+        if (devCtx) {
+          (request as Request & { ingestionContext: IngestionContext }).ingestionContext = devCtx;
+          return true;
+        }
       }
       throw new UnauthorizedException('Invalid API key format');
     }
@@ -159,6 +178,29 @@ export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
 
   clearCache() {
     this.cache.clear();
+  }
+
+  private async resolveDevContext(): Promise<IngestionContext | null> {
+    if (this.devContext && this.devContext.expiresAt > Date.now()) {
+      return this.devContext.context;
+    }
+
+    const keyRecord = await this.keyRepo.findOne({
+      where: { is_active: true },
+      relations: ['agent', 'tenant'],
+    });
+
+    if (!keyRecord) return null;
+
+    const ctx: IngestionContext = {
+      tenantId: keyRecord.tenant_id,
+      agentId: keyRecord.agent_id,
+      agentName: keyRecord.agent.name,
+      userId: keyRecord.tenant.name,
+    };
+
+    this.devContext = { context: ctx, expiresAt: Date.now() + this.CACHE_TTL_MS };
+    return ctx;
   }
 
   private evictExpired() {

--- a/packages/openclaw-plugin/__tests__/hooks.test.ts
+++ b/packages/openclaw-plugin/__tests__/hooks.test.ts
@@ -741,6 +741,25 @@ describe("registerHooks", () => {
       });
     });
 
+    it("sets ERROR status on turn span when event.error is present without success=false", () => {
+      api.emit("message_received", { sessionKey: "sess-err-obj" });
+      api.emit("before_agent_start", { sessionKey: "sess-err-obj" });
+
+      const turnSpan = tracer.spans[1];
+
+      api.emit("agent_end", {
+        sessionKey: "sess-err-obj",
+        error: { message: "HTTP 401: Unauthorized" },
+        messages: [],
+      });
+
+      expect(turnSpan.setStatus).toHaveBeenCalledWith({
+        code: SpanStatusCode.ERROR,
+        message: "HTTP 401: Unauthorized",
+      });
+      expect(turnSpan.end).toHaveBeenCalled();
+    });
+
     it("does not set ERROR status when event.success is true", () => {
       api.emit("message_received", { sessionKey: "sess-ok" });
       api.emit("before_agent_start", { sessionKey: "sess-ok" });

--- a/packages/openclaw-plugin/src/hooks.ts
+++ b/packages/openclaw-plugin/src/hooks.ts
@@ -263,7 +263,7 @@ export function registerHooks(
       if (routingReason) {
         active.turn.setAttribute(ATTRS.ROUTING_REASON, routingReason);
       }
-      if (event.success === false) {
+      if (event.success === false || event.error != null) {
         const errMsg = event.error?.message || event.errorMessage || 'Agent turn failed';
         active.turn.setStatus({
           code: SpanStatusCode.ERROR,


### PR DESCRIPTION
## Summary

- **OtlpAuthGuard**: Accept non-`mnfst_*` tokens from loopback IPs when `NODE_ENV=development`, resolving to the first active agent key in the DB. Fixes 401 errors when using the OpenClaw plugin in dev mode with `MANIFEST_MODE=cloud`.
- **Plugin hooks**: Also check `event.error` (not just `event.success === false`) to set `SpanStatusCode.ERROR`, so upstream HTTP errors are correctly reported as failures in OTLP traces instead of showing "Success".

## Test plan

- [ ] Start backend with `MANIFEST_MODE=cloud NODE_ENV=development SEED_DATA=true`
- [ ] Configure plugin in dev mode (`dev-no-auth` token)
- [ ] Verify proxy requests at `/v1/chat/completions` no longer return 401
- [ ] Verify OTLP ingestion at `/otlp/v1/traces` accepts dev tokens
- [ ] Verify messages with upstream errors show "error" status, not "ok"
- [ ] Verify e2e tests still reject unauthenticated requests in test/production mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow dev-mode loopback OTLP requests in cloud mode and improve error status reporting in traces. This unblocks local `openclaw-plugin` development by accepting dev tokens from 127.0.0.1/::1 and marking upstream HTTP failures as errors.

- **Bug Fixes**
  - `OtlpAuthGuard`: In `NODE_ENV=development` with loopback IPs, accept non-`mnfst_*` or missing tokens by resolving the first active agent key from the DB (cached). Still reject in production/test or from non-loopback IPs.
  - `openclaw-plugin` hooks: Set `SpanStatusCode.ERROR` when `event.error` exists, not only when `success === false`.

<sup>Written for commit f6e336d951205d4e5ad203ee9b74002d4e098c14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

