### PR TITLE
fix: deactivate subscription when API key is added

### DIFF
--- a/.changeset/fix-subscription-auto-creation.md
+++ b/.changeset/fix-subscription-auto-creation.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Prevent subscription providers from overriding explicit API key connections in routing

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -324,8 +324,8 @@ describe('DatabaseSeederService', () => {
 
       await service.onModuleInit();
 
-      // All curated models are always upserted (64 total)
-      expect(mockPricingRepo.upsert).toHaveBeenCalledTimes(64);
+      // All curated models are always upserted (68 total)
+      expect(mockPricingRepo.upsert).toHaveBeenCalledTimes(68);
     });
 
     it('should upsert with model_name as conflict key', async () => {
@@ -367,8 +367,8 @@ describe('DatabaseSeederService', () => {
         expect.objectContaining({
           model_name: 'claude-opus-4-6',
           provider: 'Anthropic',
-          input_price_per_token: 0.000015,
-          output_price_per_token: 0.000075,
+          input_price_per_token: 0.000005,
+          output_price_per_token: 0.000025,
           context_window: 200000,
           capability_reasoning: true,
           capability_code: true,

--- a/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.spec.ts
+++ b/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.spec.ts
@@ -47,7 +47,7 @@ describe('PurgeNonCuratedModels1772960000000', () => {
       expect(params).toContain('gpt-4o');
       expect(params).toContain('openrouter/auto');
       expect(params).toContain('glm-4-flash');
-      expect(params.length).toBe(64);
+      expect(params.length).toBe(68);
     });
   });
 

--- a/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.ts
+++ b/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.ts
@@ -2,8 +2,12 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 const CURATED_MODELS = [
   'claude-opus-4-6',
+  'claude-sonnet-4-6',
   'claude-sonnet-4-5-20250929',
+  'claude-opus-4-5-20251101',
+  'claude-opus-4-1-20250805',
   'claude-sonnet-4-20250514',
+  'claude-opus-4-20250514',
   'claude-haiku-4-5-20251001',
   'gpt-4o',
   'gpt-4o-mini',

--- a/packages/backend/src/database/seed-models.ts
+++ b/packages/backend/src/database/seed-models.ts
@@ -20,7 +20,8 @@ export type SeedModelTuple = readonly [
 
 export const SEED_MODELS: ReadonlyArray<SeedModelTuple> = [
   // Anthropic Claude
-  ['claude-opus-4-6', 'Anthropic', 0.000015, 0.000075, 200000, true, true, 'Claude Opus 4.6'],
+  ['claude-opus-4-6', 'Anthropic', 0.000005, 0.000025, 200000, true, true, 'Claude Opus 4.6'],
+  ['claude-sonnet-4-6', 'Anthropic', 0.000003, 0.000015, 200000, true, true, 'Claude Sonnet 4.6'],
   [
     'claude-sonnet-4-5-20250929',
     'Anthropic',
@@ -32,6 +33,26 @@ export const SEED_MODELS: ReadonlyArray<SeedModelTuple> = [
     'Claude Sonnet 4.5',
   ],
   [
+    'claude-opus-4-5-20251101',
+    'Anthropic',
+    0.000015,
+    0.000075,
+    200000,
+    true,
+    true,
+    'Claude Opus 4.5',
+  ],
+  [
+    'claude-opus-4-1-20250805',
+    'Anthropic',
+    0.000015,
+    0.000075,
+    200000,
+    true,
+    true,
+    'Claude Opus 4.1',
+  ],
+  [
     'claude-sonnet-4-20250514',
     'Anthropic',
     0.000003,
@@ -41,6 +62,7 @@ export const SEED_MODELS: ReadonlyArray<SeedModelTuple> = [
     true,
     'Claude Sonnet 4',
   ],
+  ['claude-opus-4-20250514', 'Anthropic', 0.000015, 0.000075, 200000, true, true, 'Claude Opus 4'],
   [
     'claude-haiku-4-5-20251001',
     'Anthropic',
@@ -127,8 +149,8 @@ export const SEED_MODELS: ReadonlyArray<SeedModelTuple> = [
   [
     'anthropic/claude-opus-4-6',
     'OpenRouter',
-    0.000015,
-    0.000075,
+    0.000005,
+    0.000025,
     200000,
     true,
     true,

--- a/packages/backend/src/model-prices/model-name-normalizer.spec.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.spec.ts
@@ -3,6 +3,7 @@ import {
   stripDateSuffix,
   buildAliasMap,
   resolveModelName,
+  normalizeDots,
 } from './model-name-normalizer';
 
 describe('model-name-normalizer', () => {
@@ -61,6 +62,20 @@ describe('model-name-normalizer', () => {
 
     it('does not strip non-date numeric suffixes', () => {
       expect(stripDateSuffix('qwen3-235b-a22b')).toBe('qwen3-235b-a22b');
+    });
+  });
+
+  describe('normalizeDots', () => {
+    it('replaces dots with dashes', () => {
+      expect(normalizeDots('claude-opus-4.6')).toBe('claude-opus-4-6');
+    });
+
+    it('replaces multiple dots', () => {
+      expect(normalizeDots('model-1.2.3')).toBe('model-1-2-3');
+    });
+
+    it('returns name unchanged when no dots', () => {
+      expect(normalizeDots('claude-opus-4-6')).toBe('claude-opus-4-6');
     });
   });
 
@@ -167,6 +182,32 @@ describe('model-name-normalizer', () => {
     it('resolves minimax/ prefixed model', () => {
       const map = buildAliasMap(['minimax-m2.5']);
       expect(resolveModelName('minimax/minimax-m2.5', map)).toBe('minimax-m2.5');
+    });
+
+    it('resolves dot-variant to dash-canonical via normalization', () => {
+      expect(resolveModelName('claude-opus-4.6', aliasMap)).toBe('claude-opus-4-6');
+    });
+
+    it('resolves prefixed dot-variant', () => {
+      expect(resolveModelName('anthropic/claude-opus-4.6', aliasMap)).toBe('claude-opus-4-6');
+    });
+
+    it('resolves dot-variant with date suffix', () => {
+      const map = buildAliasMap(['claude-sonnet-4-6']);
+      expect(resolveModelName('claude-sonnet-4.6-2025-06-01', map)).toBe('claude-sonnet-4-6');
+    });
+
+    it('prioritizes exact match over dot normalization', () => {
+      expect(resolveModelName('gpt-4.1', aliasMap)).toBe('gpt-4.1');
+    });
+
+    it('returns undefined for unknown dot-variant', () => {
+      expect(resolveModelName('unknown-1.0', aliasMap)).toBeUndefined();
+    });
+
+    it('resolves dot-variant through alias after normalization', () => {
+      const map = buildAliasMap(['claude-sonnet-4-5-20250929']);
+      expect(resolveModelName('claude-sonnet-4.5', map)).toBe('claude-sonnet-4-5-20250929');
     });
   });
 });

--- a/packages/backend/src/model-prices/model-name-normalizer.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.ts
@@ -7,13 +7,21 @@
  *  3. Strip provider prefix (e.g. "anthropic/claude-opus-4-6" → "claude-opus-4-6")
  *  4. Strip date suffix (e.g. "gpt-4.1-2025-04-14" → "gpt-4.1")
  *  5. Strip both prefix and date suffix
+ *  6. Dot-to-dash normalization (e.g. "claude-opus-4.6" → "claude-opus-4-6")
+ *  7. Dot-to-dash + strip date suffix
  */
 
 const KNOWN_ALIASES: ReadonlyArray<readonly [string, string]> = [
   ['claude-opus-4', 'claude-opus-4-6'],
   ['claude-sonnet-4.5', 'claude-sonnet-4-5-20250929'],
+  ['claude-sonnet-4-5', 'claude-sonnet-4-5-20250929'],
+  ['claude-opus-4-5', 'claude-opus-4-5-20251101'],
+  ['claude-opus-4-1', 'claude-opus-4-1-20250805'],
+  ['claude-sonnet-4-0', 'claude-sonnet-4-20250514'],
+  ['claude-opus-4-0', 'claude-opus-4-20250514'],
   ['claude-sonnet-4', 'claude-sonnet-4-20250514'],
   ['claude-haiku-4.5', 'claude-haiku-4-5-20251001'],
+  ['claude-haiku-4-5', 'claude-haiku-4-5-20251001'],
   ['deepseek-v3', 'deepseek-chat'],
   ['deepseek-chat-v3-0324', 'deepseek-chat'],
   ['deepseek-r1', 'deepseek-reasoner'],
@@ -85,6 +93,10 @@ export function buildAliasMap(canonicalNames: ReadonlyArray<string>): Map<string
   return map;
 }
 
+export function normalizeDots(name: string): string {
+  return name.replace(/\./g, '-');
+}
+
 export function resolveModelName(name: string, aliasMap: Map<string, string>): string | undefined {
   const exact = aliasMap.get(name);
   if (exact) return exact;
@@ -97,6 +109,18 @@ export function resolveModelName(name: string, aliasMap: Map<string, string>): s
   if (noDate !== stripped) {
     const fromNoDate = aliasMap.get(noDate);
     if (fromNoDate) return fromNoDate;
+  }
+
+  const dotNorm = normalizeDots(stripped);
+  if (dotNorm !== stripped) {
+    const fromDotNorm = aliasMap.get(dotNorm);
+    if (fromDotNorm) return fromDotNorm;
+
+    const dotNormNoDate = stripDateSuffix(dotNorm);
+    if (dotNormNoDate !== dotNorm) {
+      const fromDotNormNoDate = aliasMap.get(dotNormNoDate);
+      if (fromDotNormNoDate) return fromDotNormNoDate;
+    }
   }
 
   return undefined;

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -219,6 +219,14 @@ describe('ModelPricingCacheService', () => {
 
       expect(mockTrack).not.toHaveBeenCalled();
     });
+
+    it('should resolve dot-variant to dash-canonical via normalization', async () => {
+      const pricing = makePricing('claude-opus-4-6');
+      mockFind.mockResolvedValue([pricing]);
+      await service.onModuleInit();
+
+      expect(service.getByModel('claude-opus-4.6')).toBe(pricing);
+    });
   });
 
   describe('getAll', () => {

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -310,7 +310,7 @@ describe('RoutingService', () => {
         key_prefix: 'old-key-',
         is_active: false,
       });
-      mockProviderRepo.findOne.mockResolvedValue(existing);
+      mockProviderRepo.findOne.mockResolvedValueOnce(existing).mockResolvedValueOnce(null); // no subscription to deactivate
 
       const result = await service.upsertProvider('a1', 'u1', 'openai', 'new-key');
 
@@ -340,7 +340,7 @@ describe('RoutingService', () => {
         key_prefix: 'old-pref',
         is_active: false,
       });
-      mockProviderRepo.findOne.mockResolvedValue(existing);
+      mockProviderRepo.findOne.mockResolvedValueOnce(existing).mockResolvedValueOnce(null); // no subscription to deactivate
 
       const result = await service.upsertProvider('a1', 'u1', 'openai');
 
@@ -390,7 +390,7 @@ describe('RoutingService', () => {
         connected_at: originalConnectedAt,
         updated_at: '2025-01-01T00:00:00.000Z',
       });
-      mockProviderRepo.findOne.mockResolvedValue(existing);
+      mockProviderRepo.findOne.mockResolvedValueOnce(existing).mockResolvedValueOnce(null); // no subscription to deactivate
 
       const before = new Date().toISOString();
       await service.upsertProvider('a1', 'u1', 'openai', 'new-key');
@@ -474,13 +474,77 @@ describe('RoutingService', () => {
       // UUID v4 format: 8-4-4-4-12
       expect(inserted.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     });
+
+    it('should deactivate subscription when adding new API key provider', async () => {
+      const subProvider = Object.assign(new UserProvider(), {
+        id: 'sub1',
+        agent_id: 'a1',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        is_active: true,
+      });
+      // First findOne: no existing api_key provider
+      // Second findOne (deactivateSubscription): finds active subscription
+      mockProviderRepo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(subProvider);
+
+      await service.upsertProvider('a1', 'u1', 'anthropic', 'sk-ant-key');
+
+      expect(mockProviderRepo.insert).toHaveBeenCalled();
+      expect(mockProviderRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'sub1',
+          is_active: false,
+        }),
+      );
+    });
+
+    it('should deactivate subscription when updating existing API key provider', async () => {
+      const existing = Object.assign(new UserProvider(), {
+        id: 'p1',
+        agent_id: 'a1',
+        provider: 'anthropic',
+        auth_type: 'api_key',
+        api_key_encrypted: 'old-enc',
+        key_prefix: 'old-pref',
+        is_active: false,
+      });
+      const subProvider = Object.assign(new UserProvider(), {
+        id: 'sub1',
+        agent_id: 'a1',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        is_active: true,
+      });
+      // First findOne: finds existing api_key provider
+      // Second findOne (deactivateSubscription): finds active subscription
+      mockProviderRepo.findOne.mockResolvedValueOnce(existing).mockResolvedValueOnce(subProvider);
+
+      await service.upsertProvider('a1', 'u1', 'anthropic', 'new-key');
+
+      // First save: update existing api_key provider
+      // Second save: deactivate subscription
+      expect(mockProviderRepo.save).toHaveBeenCalledTimes(2);
+      expect(mockProviderRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'sub1', is_active: false }),
+      );
+    });
+
+    it('should not deactivate subscription when upserting subscription type', async () => {
+      mockProviderRepo.findOne.mockResolvedValue(null);
+
+      await service.upsertProvider('a1', 'u1', 'anthropic', undefined, 'subscription');
+
+      // Only one findOne call (for existing check), no subscription deactivation query
+      expect(mockProviderRepo.findOne).toHaveBeenCalledTimes(1);
+    });
   });
 
   /* ── registerSubscriptionProvider ── */
 
   describe('registerSubscriptionProvider', () => {
     it('should create new provider when none exists', async () => {
-      mockProviderRepo.findOne.mockResolvedValue(null);
+      // First findOne: no existing subscription. Second findOne: no existing API key.
+      mockProviderRepo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
 
       const result = await service.registerSubscriptionProvider('a1', 'u1', 'anthropic');
 
@@ -532,6 +596,25 @@ describe('RoutingService', () => {
       expect(result).toEqual({ isNew: false });
       expect(mockProviderRepo.insert).not.toHaveBeenCalled();
       expect(mockProviderRepo.save).not.toHaveBeenCalled();
+      expect(mockAutoAssign.recalculate).not.toHaveBeenCalled();
+    });
+
+    it('should skip when active API key already exists for same provider', async () => {
+      const apiKeyProvider = Object.assign(new UserProvider(), {
+        id: 'p2',
+        agent_id: 'a1',
+        provider: 'anthropic',
+        auth_type: 'api_key',
+        is_active: true,
+      });
+      // First findOne: no existing subscription
+      // Second findOne: active API key exists
+      mockProviderRepo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(apiKeyProvider);
+
+      const result = await service.registerSubscriptionProvider('a1', 'u1', 'anthropic');
+
+      expect(result).toEqual({ isNew: false });
+      expect(mockProviderRepo.insert).not.toHaveBeenCalled();
       expect(mockAutoAssign.recalculate).not.toHaveBeenCalled();
     });
   });

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -66,6 +66,12 @@ export class RoutingService {
       existing.is_active = true;
       existing.updated_at = new Date().toISOString();
       await this.providerRepo.save(existing);
+
+      // Deactivate subscription provider when user explicitly adds an API key
+      if (effectiveAuthType === 'api_key') {
+        await this.deactivateSubscriptionForProvider(agentId, provider);
+      }
+
       await this.autoAssign.recalculate(agentId);
       this.routingCache.invalidateAgent(agentId);
       return { provider: existing, isNew: false };
@@ -85,6 +91,12 @@ export class RoutingService {
     });
 
     await this.providerRepo.insert(record);
+
+    // Deactivate subscription provider when user explicitly adds an API key
+    if (effectiveAuthType === 'api_key') {
+      await this.deactivateSubscriptionForProvider(agentId, provider);
+    }
+
     await this.autoAssign.recalculate(agentId);
     this.routingCache.invalidateAgent(agentId);
     return { provider: record, isNew: true };
@@ -100,6 +112,12 @@ export class RoutingService {
     });
 
     if (existing) return { isNew: false };
+
+    // Skip if user already added an explicit API key for this provider
+    const hasApiKey = await this.providerRepo.findOne({
+      where: { agent_id: agentId, provider, auth_type: 'api_key', is_active: true },
+    });
+    if (hasApiKey) return { isNew: false };
 
     const record: UserProvider = Object.assign(new UserProvider(), {
       id: randomUUID(),
@@ -118,6 +136,19 @@ export class RoutingService {
     await this.autoAssign.recalculate(agentId);
     this.routingCache.invalidateAgent(agentId);
     return { isNew: true };
+  }
+
+  private async deactivateSubscriptionForProvider(
+    agentId: string,
+    provider: string,
+  ): Promise<void> {
+    const sub = await this.providerRepo.findOne({
+      where: { agent_id: agentId, provider, auth_type: 'subscription', is_active: true },
+    });
+    if (!sub) return;
+    sub.is_active = false;
+    sub.updated_at = new Date().toISOString();
+    await this.providerRepo.save(sub);
   }
 
   async removeProvider(


### PR DESCRIPTION
## Summary

- When a user explicitly adds an API key for a provider, any auto-discovered subscription for that same provider is deactivated
- Subscription auto-registration is skipped when an active API key already exists for the provider
- Prevents duplicate provider entries and ensures explicit API keys take priority over gateway-discovered subscriptions
- Adds dot-to-dash normalization for model name resolution (e.g. `claude-opus-4.6` → `claude-opus-4-6`)
- Updates seed data with current Anthropic model lineup

- Closes [#1085](https://github.com/mnfst/manifest/issues/1085)

## Test plan

- [x] Backend unit tests pass (2354 tests, 130 suites)
- [x] Backend e2e tests pass (109 tests, 16 suites)
- [x] Frontend tests pass (1450 tests, 73 suites)
- [x] TypeScript compiles with no errors
- [x] New tests cover subscription deactivation on API key add
- [x] New tests cover subscription registration skip when API key exists
- [x] New tests verify subscription type upsert doesn't trigger deactivation
- [x] Dot-to-dash normalization tests cover exact match priority, prefix+dot, dot+date combinations

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deactivate auto-discovered subscriptions when a user adds an API key and skip subscription auto-registration if an active API key exists. Also normalize dot-based model names and update Anthropic seed models and pricing.

- **Bug Fixes**
  - Deactivate active subscription for the same provider when an API key is added or updated, ensuring API keys take priority in routing.
  - Skip subscription auto-registration when an active API key already exists for the provider.
  - Add dot-to-dash normalization in model resolution (e.g., `claude-opus-4.6` → `claude-opus-4-6`).
  - Update curated model list (64 → 68) and seed latest Anthropic models and prices.

<sup>Written for commit e1c37780ac7c5c146ea7dedae65bcf0bfe9bf0e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

