### PR TITLE
fix: parse comma as decimal separator in custom model pricing

### DIFF
--- a/.changeset/fix-comma-decimal-prices.md
+++ b/.changeset/fix-comma-decimal-prices.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix custom model pricing fields ignoring comma decimal separators (e.g. "0,59" now correctly parsed as 0.59)

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -61,11 +61,17 @@ const CustomProviderForm: Component<Props> = (props) => {
 
   const canSubmit = () => name().trim() && baseUrl().trim() && validModels().length > 0 && !busy();
 
+  const parsePrice = (v: string): number => Number(v.replace(',', '.'));
+
   const buildModels = (): CustomProviderModel[] =>
     validModels().map((r) => ({
       model_name: r.model_name.trim(),
-      ...(r.input_price !== '' ? { input_price_per_million_tokens: Number(r.input_price) } : {}),
-      ...(r.output_price !== '' ? { output_price_per_million_tokens: Number(r.output_price) } : {}),
+      ...(r.input_price !== ''
+        ? { input_price_per_million_tokens: parsePrice(r.input_price) }
+        : {}),
+      ...(r.output_price !== ''
+        ? { output_price_per_million_tokens: parsePrice(r.output_price) }
+        : {}),
     }));
 
   const handleCreate = async () => {

--- a/packages/frontend/tests/components/CustomProviderForm.test.tsx
+++ b/packages/frontend/tests/components/CustomProviderForm.test.tsx
@@ -208,6 +208,45 @@ describe("CustomProviderForm", () => {
     });
   });
 
+  it("converts comma decimal separators to dots in pricing fields", async () => {
+    render(() => (
+      <CustomProviderForm agentName="test-agent" onCreated={onCreated} onBack={onBack} />
+    ));
+
+    fireEvent.input(screen.getByPlaceholderText("e.g. Groq, vLLM, Azure"), {
+      target: { value: "Groq" },
+    });
+    fireEvent.input(screen.getByPlaceholderText("https://api.example.com/v1"), {
+      target: { value: "https://api.groq.com/v1" },
+    });
+    fireEvent.input(screen.getByPlaceholderText("Model name"), {
+      target: { value: "llama-3.1-70b" },
+    });
+    fireEvent.input(screen.getByPlaceholderText("$/M in"), {
+      target: { value: "0,59" },
+    });
+    fireEvent.input(screen.getByPlaceholderText("$/M out"), {
+      target: { value: "0,79" },
+    });
+
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => {
+      expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
+        name: "Groq",
+        base_url: "https://api.groq.com/v1",
+        apiKey: undefined,
+        models: [
+          {
+            model_name: "llama-3.1-70b",
+            input_price_per_million_tokens: 0.59,
+            output_price_per_million_tokens: 0.79,
+          },
+        ],
+      });
+    });
+  });
+
   it("shows generic error message for non-Error exceptions", async () => {
     mockCreateCustomProvider.mockRejectedValue("string error");
 


### PR DESCRIPTION
## Summary

- Fix custom provider model pricing fields silently dropping values when users enter commas as decimal separators (e.g. `0,59`)
- Replace commas with dots before `Number()` conversion so European-format decimals are correctly parsed
- Add test coverage for comma decimal input

## Test plan

- [ ] Create a custom provider with pricing using comma decimals (e.g. `0,59`) — verify prices are saved correctly
- [ ] Create a custom provider with dot decimals (e.g. `0.59`) — verify existing behavior unchanged
- [ ] Edit an existing custom provider's pricing with comma decimals — verify prices update correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom model pricing inputs using commas as decimal separators from being ignored. Comma decimals (e.g. 0,59) now parse correctly and save as expected.

- **Bug Fixes**
  - Normalize comma decimals to dots before parsing in `CustomProviderForm.tsx`.
  - Added test coverage for comma inputs; dot decimals unchanged.

<sup>Written for commit 22897a1cb7534513298f2d81ee3b0eee379e882b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

