### PR TITLE
fix: standardize all buttons to btn--sm for consistent 32px height

### DIFF
--- a/.changeset/btn-sm-consistency.md
+++ b/.changeset/btn-sm-consistency.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Standardize all buttons to use btn--sm (32px height) for consistent UI across the dashboard

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -321,7 +321,7 @@ const CustomProviderForm: Component<Props> = (props) => {
 
         <button
           type="submit"
-          class="btn btn--primary provider-detail__action"
+          class="btn btn--primary btn--sm provider-detail__action"
           disabled={!canSubmit()}
         >
           {busy() ? <span class="spinner" /> : isEdit() ? 'Save changes' : 'Create'}
@@ -330,7 +330,7 @@ const CustomProviderForm: Component<Props> = (props) => {
         <Show when={isEdit()}>
           <button
             type="button"
-            class="btn btn--outline provider-detail__disconnect"
+            class="btn btn--outline btn--sm provider-detail__disconnect"
             disabled={busy()}
             onClick={() => setShowDeleteConfirm(true)}
             style="margin-top: 16px; align-self: flex-start;"
@@ -379,13 +379,13 @@ const CustomProviderForm: Component<Props> = (props) => {
             </p>
             <div style="display: flex; gap: var(--gap-sm); justify-content: flex-end;">
               <button
-                class="btn btn--outline"
+                class="btn btn--outline btn--sm"
                 onClick={() => setShowDeleteConfirm(false)}
                 disabled={busy()}
               >
                 Cancel
               </button>
-              <button class="btn btn--danger" onClick={handleDelete} disabled={busy()}>
+              <button class="btn btn--danger btn--sm" onClick={handleDelete} disabled={busy()}>
                 {busy() ? <span class="spinner" /> : 'Delete'}
               </button>
             </div>

--- a/packages/frontend/src/components/EmailProviderModal.tsx
+++ b/packages/frontend/src/components/EmailProviderModal.tsx
@@ -314,7 +314,7 @@ const EmailProviderModal: Component<Props> = (props) => {
                 <div class="masked-key">
                   <span class="masked-key__value">{maskedKey()}</span>
                   <button
-                    class="btn btn--ghost masked-key__edit"
+                    class="btn btn--ghost btn--sm masked-key__edit"
                     type="button"
                     onClick={() => {
                       setEditingKey(true);
@@ -380,7 +380,7 @@ const EmailProviderModal: Component<Props> = (props) => {
 
             <div class="modal-card__footer modal-card__footer--split">
               <button
-                class="btn btn--ghost"
+                class="btn btn--ghost btn--sm"
                 onClick={handleTestOnly}
                 disabled={busy() || isDisabled()}
                 type="button"
@@ -388,7 +388,7 @@ const EmailProviderModal: Component<Props> = (props) => {
                 {testing() ? <span class="spinner" /> : 'Send test email'}
               </button>
               <button
-                class="btn btn--primary"
+                class="btn btn--primary btn--sm"
                 onClick={handleSave}
                 disabled={busy() || isDisabled()}
               >

--- a/packages/frontend/src/components/ErrorState.tsx
+++ b/packages/frontend/src/components/ErrorState.tsx
@@ -1,4 +1,4 @@
-import { Show, type Component } from "solid-js";
+import { Show, type Component } from 'solid-js';
 
 interface ErrorStateProps {
   /** The error object from createResource (used to extract a message). */
@@ -13,25 +13,20 @@ interface ErrorStateProps {
 
 function extractMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  return "An unexpected error occurred. Please try again.";
+  if (typeof error === 'string') return error;
+  return 'An unexpected error occurred. Please try again.';
 }
 
 const ErrorState: Component<ErrorStateProps> = (props) => {
-  const displayMessage = () =>
-    props.message ?? extractMessage(props.error);
+  const displayMessage = () => props.message ?? extractMessage(props.error);
 
   return (
     <div class="empty-state" role="alert">
-      <div class="empty-state__title">
-        {props.title ?? "Something went wrong"}
-      </div>
-      <p style="max-width: 420px; margin: 0 auto;">
-        {displayMessage()}
-      </p>
+      <div class="empty-state__title">{props.title ?? 'Something went wrong'}</div>
+      <p style="max-width: 420px; margin: 0 auto;">{displayMessage()}</p>
       <Show when={props.onRetry}>
         <button
-          class="btn btn--outline"
+          class="btn btn--outline btn--sm"
           style="margin-top: var(--gap-md);"
           onClick={props.onRetry}
         >

--- a/packages/frontend/src/components/LimitRuleModal.tsx
+++ b/packages/frontend/src/components/LimitRuleModal.tsx
@@ -212,7 +212,7 @@ const LimitRuleModal: Component<Props> = (props) => {
 
             <div class="modal-card__footer">
               <button
-                class="btn btn--primary"
+                class="btn btn--primary btn--sm"
                 disabled={!threshold() || Number(threshold()) <= 0 || saving()}
                 onClick={handleSave}
               >

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -485,7 +485,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
             </Show>
 
             <div class="provider-modal__footer">
-              <button class="btn btn--primary" onClick={props.onClose}>
+              <button class="btn btn--primary btn--sm" onClick={props.onClose}>
                 Done
               </button>
             </div>
@@ -611,7 +611,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
                     </div>
                     <Show when={!connected()}>
                       <button
-                        class="btn btn--primary provider-detail__action"
+                        class="btn btn--primary btn--sm provider-detail__action"
                         disabled={busy()}
                         onClick={() => handleConnect(provId)}
                       >
@@ -622,7 +622,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
                     </Show>
                     <Show when={connected()}>
                       <button
-                        class="btn btn--outline provider-detail__action provider-detail__disconnect"
+                        class="btn btn--outline btn--sm provider-detail__action provider-detail__disconnect"
                         disabled={busy()}
                         onClick={() => handleDisconnect(provId)}
                       >
@@ -657,7 +657,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
                       </Show>
                     </div>
                     <button
-                      class="btn btn--primary provider-detail__action"
+                      class="btn btn--primary btn--sm provider-detail__action"
                       disabled={busy() || !keyInput().trim()}
                       onClick={() => handleConnect(provId)}
                     >
@@ -741,7 +741,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
                           <div class="provider-detail__error">{validationError()}</div>
                         </Show>
                         <button
-                          class="btn btn--primary provider-detail__action"
+                          class="btn btn--primary btn--sm provider-detail__action"
                           disabled={busy() || !keyInput().trim()}
                           onClick={() => handleUpdateKey(provId)}
                           style="margin-top: 12px;"

--- a/packages/frontend/src/components/RoutingInstructionModal.tsx
+++ b/packages/frontend/src/components/RoutingInstructionModal.tsx
@@ -1,21 +1,21 @@
-import { Show, createSignal, type Component } from "solid-js";
-import { CopyButton } from "./SetupStepInstall.jsx";
-import ModelSelectDropdown from "./ModelSelectDropdown.jsx";
+import { Show, createSignal, type Component } from 'solid-js';
+import { CopyButton } from './SetupStepInstall.jsx';
+import ModelSelectDropdown from './ModelSelectDropdown.jsx';
 
 const ENABLE_CMD = `openclaw config set agents.defaults.model.primary manifest/auto\nopenclaw gateway restart`;
 
 interface Props {
   open: boolean;
-  mode: "enable" | "disable";
+  mode: 'enable' | 'disable';
   onClose: () => void;
 }
 
 const RoutingInstructionModal: Component<Props> = (props) => {
   const [selectedModel, setSelectedModel] = createSignal<string | null>(null);
   const [selectedLabel, setSelectedLabel] = createSignal<string | null>(null);
-  const isEnable = () => props.mode === "enable";
-  const title = () => (isEnable() ? "Activate routing" : "Deactivate routing");
-  const modelOrPlaceholder = () => selectedModel() ?? "<provider/model>";
+  const isEnable = () => props.mode === 'enable';
+  const title = () => (isEnable() ? 'Activate routing' : 'Deactivate routing');
+  const modelOrPlaceholder = () => selectedModel() ?? '<provider/model>';
   const disableCmd = () =>
     `openclaw config set agents.defaults.model.primary ${modelOrPlaceholder()}\nopenclaw gateway restart`;
   const command = () => (isEnable() ? ENABLE_CMD : disableCmd());
@@ -29,8 +29,12 @@ const RoutingInstructionModal: Component<Props> = (props) => {
     <Show when={props.open}>
       <div
         class="modal-overlay"
-        onClick={(e) => { if (e.target === e.currentTarget) props.onClose(); }}
-        onKeyDown={(e) => { if (e.key === "Escape") props.onClose(); }}
+        onClick={(e) => {
+          if (e.target === e.currentTarget) props.onClose();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') props.onClose();
+        }}
       >
         <div
           class="modal-card"
@@ -47,31 +51,41 @@ const RoutingInstructionModal: Component<Props> = (props) => {
               {title()}
             </h2>
             <button class="modal__close" onClick={() => props.onClose()} aria-label="Close">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
               </svg>
             </button>
           </div>
 
           <Show when={isEnable()}>
             <p style="margin: 0 0 16px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-              Run the following command in your agent's terminal to route all requests through Manifest:
+              Run the following command in your agent's terminal to route all requests through
+              Manifest:
             </p>
           </Show>
 
           <Show when={!isEnable()}>
             <p style="margin: 0 0 14px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-              This will stop routing requests through Manifest and restore direct model access in your OpenClaw agent.
+              This will stop routing requests through Manifest and restore direct model access in
+              your OpenClaw agent.
             </p>
 
             <p style="margin: 0 0 8px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
               1. Pick the model your agent should use directly:
             </p>
 
-            <ModelSelectDropdown
-              selectedValue={selectedModel()}
-              onSelect={handleModelSelect}
-            />
+            <ModelSelectDropdown selectedValue={selectedModel()} onSelect={handleModelSelect} />
 
             <p style="margin: 14px 0; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
               2. Run this command in your agent's terminal to restore direct model access:
@@ -91,21 +105,28 @@ const RoutingInstructionModal: Component<Props> = (props) => {
             </div>
             <div class="modal-terminal__body">
               <CopyButton text={command()} />
-              <Show when={isEnable()} fallback={
-                <>
-                  <div>
-                    <span class="modal-terminal__prompt">$</span>
-                    <span class="modal-terminal__code">openclaw config set agents.defaults.model.primary {modelOrPlaceholder()}</span>
-                  </div>
-                  <div style="margin-top: 8px;">
-                    <span class="modal-terminal__prompt">$</span>
-                    <span class="modal-terminal__code">openclaw gateway restart</span>
-                  </div>
-                </>
-              }>
+              <Show
+                when={isEnable()}
+                fallback={
+                  <>
+                    <div>
+                      <span class="modal-terminal__prompt">$</span>
+                      <span class="modal-terminal__code">
+                        openclaw config set agents.defaults.model.primary {modelOrPlaceholder()}
+                      </span>
+                    </div>
+                    <div style="margin-top: 8px;">
+                      <span class="modal-terminal__prompt">$</span>
+                      <span class="modal-terminal__code">openclaw gateway restart</span>
+                    </div>
+                  </>
+                }
+              >
                 <div>
                   <span class="modal-terminal__prompt">$</span>
-                  <span class="modal-terminal__code">openclaw config set agents.defaults.model.primary manifest/auto</span>
+                  <span class="modal-terminal__code">
+                    openclaw config set agents.defaults.model.primary manifest/auto
+                  </span>
                 </div>
                 <div style="margin-top: 8px;">
                   <span class="modal-terminal__prompt">$</span>
@@ -116,7 +137,7 @@ const RoutingInstructionModal: Component<Props> = (props) => {
           </div>
 
           <div style="display: flex; justify-content: flex-end; margin-top: 20px;">
-            <button class="btn btn--primary" onClick={() => props.onClose()}>
+            <button class="btn btn--primary btn--sm" onClick={() => props.onClose()}>
               Done
             </button>
           </div>

--- a/packages/frontend/src/components/SetupWizard.tsx
+++ b/packages/frontend/src/components/SetupWizard.tsx
@@ -1,16 +1,16 @@
-import { createSignal, createResource, Show, type Component } from "solid-js";
-import ErrorState from "./ErrorState.jsx";
-import SetupStepInstall from "./SetupStepInstall.jsx";
-import SetupStepConfigure from "./SetupStepConfigure.jsx";
-import SetupStepVerify from "./SetupStepVerify.jsx";
-import { getAgentKey } from "../services/api.js";
+import { createSignal, createResource, Show, type Component } from 'solid-js';
+import ErrorState from './ErrorState.jsx';
+import SetupStepInstall from './SetupStepInstall.jsx';
+import SetupStepConfigure from './SetupStepConfigure.jsx';
+import SetupStepVerify from './SetupStepVerify.jsx';
+import { getAgentKey } from '../services/api.js';
 
 interface Props {
   agentName: string;
   onClose: () => void;
 }
 
-const STEPS = ["Install", "Configure", "Verify"] as const;
+const STEPS = ['Install', 'Configure', 'Verify'] as const;
 
 const SetupWizard: Component<Props> = (props) => {
   const [step, setStep] = createSignal(0);
@@ -23,7 +23,7 @@ const SetupWizard: Component<Props> = (props) => {
     const custom = apiKeyData()?.pluginEndpoint;
     if (custom) return custom;
     const host = window.location.hostname;
-    if (host === "app.manifest.build") return null;
+    if (host === 'app.manifest.build') return null;
     return `${window.location.origin}/otlp`;
   };
 
@@ -37,8 +37,16 @@ const SetupWizard: Component<Props> = (props) => {
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px;">
           <span class="modal-card__title">Set up {props.agentName}</span>
           <button class="modal__close" onClick={props.onClose}>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
             </svg>
           </button>
         </div>
@@ -52,13 +60,20 @@ const SetupWizard: Component<Props> = (props) => {
               <div
                 class="modal-stepper__step"
                 classList={{
-                  "modal-stepper__step--active": step() === i,
-                  "modal-stepper__step--done": step() > i,
+                  'modal-stepper__step--active': step() === i,
+                  'modal-stepper__step--done': step() > i,
                 }}
               >
                 <div class="modal-stepper__circle">
                   <Show when={step() > i} fallback={i + 1}>
-                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+                    <svg
+                      width="12"
+                      height="12"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="3"
+                    >
                       <polyline points="20 6 9 17 4 12" />
                     </svg>
                   </Show>
@@ -71,14 +86,17 @@ const SetupWizard: Component<Props> = (props) => {
 
         {/* Step content */}
         <div style="min-height: 200px;">
-          <Show when={!apiKeyData.error} fallback={
-            <ErrorState
-              error={apiKeyData.error}
-              title="Could not load API key"
-              message="Failed to fetch your agent's API key. Please try again."
-              onRetry={refetchKey}
-            />
-          }>
+          <Show
+            when={!apiKeyData.error}
+            fallback={
+              <ErrorState
+                error={apiKeyData.error}
+                title="Could not load API key"
+                message="Failed to fetch your agent's API key. Please try again."
+                onRetry={refetchKey}
+              />
+            }
+          >
             <Show when={step() === 0}>
               <SetupStepInstall />
             </Show>
@@ -99,19 +117,19 @@ const SetupWizard: Component<Props> = (props) => {
         {/* Navigation */}
         <div class="modal-card__footer" style="gap: 8px; margin-top: var(--gap-lg);">
           <Show when={step() > 0}>
-            <button class="btn btn--outline" onClick={() => setStep((s) => s - 1)}>
+            <button class="btn btn--outline btn--sm" onClick={() => setStep((s) => s - 1)}>
               Back
             </button>
           </Show>
           <Show
             when={step() < STEPS.length - 1}
             fallback={
-              <button class="btn btn--primary" onClick={props.onClose}>
+              <button class="btn btn--primary btn--sm" onClick={props.onClose}>
                 Done
               </button>
             }
           >
-            <button class="btn btn--primary" onClick={() => setStep((s) => s + 1)}>
+            <button class="btn btn--primary btn--sm" onClick={() => setStep((s) => s + 1)}>
               Next
             </button>
           </Show>

--- a/packages/frontend/src/pages/Help.tsx
+++ b/packages/frontend/src/pages/Help.tsx
@@ -31,8 +31,8 @@ const Help: Component = () => {
               href="https://calendly.com/sebastien-manifest/30min?month=2026-02"
               target="_blank"
               rel="noopener noreferrer"
-              class="btn btn--outline"
-              style="font-size: var(--font-size-sm); text-decoration: none;"
+              class="btn btn--outline btn--sm"
+              style="text-decoration: none;"
             >
               Book
               <svg
@@ -63,8 +63,8 @@ const Help: Component = () => {
           <div class="settings-card__control">
             <a
               href="mailto:sebastien@manifest.build"
-              class="btn btn--outline"
-              style="font-size: var(--font-size-sm); text-decoration: none;"
+              class="btn btn--outline btn--sm"
+              style="text-decoration: none;"
             >
               Contact
               <svg

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -534,7 +534,7 @@ const Limits: Component = () => {
 
               <div class="confirm-modal__footer">
                 <button
-                  class="btn btn--ghost"
+                  class="btn btn--ghost btn--sm"
                   onClick={() => {
                     setDeleteTarget(null);
                     setDeleteConfirmed(false);
@@ -543,7 +543,7 @@ const Limits: Component = () => {
                   Cancel
                 </button>
                 <button
-                  class="btn btn--danger"
+                  class="btn btn--danger btn--sm"
                   disabled={!deleteConfirmed() || deleting()}
                   onClick={handleDelete}
                 >
@@ -576,11 +576,11 @@ const Limits: Component = () => {
               </p>
 
               <div class="confirm-modal__footer">
-                <button class="btn btn--ghost" onClick={() => setShowRemoveProvider(false)}>
+                <button class="btn btn--ghost btn--sm" onClick={() => setShowRemoveProvider(false)}>
                   Cancel
                 </button>
                 <button
-                  class="btn btn--danger"
+                  class="btn btn--danger btn--sm"
                   onClick={handleRemoveProvider}
                   disabled={removingProvider()}
                 >

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -244,7 +244,7 @@ const MessageLog: Component = () => {
               !setupCompleted()
             }
           >
-            <button class="btn btn--primary" onClick={() => setSetupOpen(true)}>
+            <button class="btn btn--primary btn--sm" onClick={() => setSetupOpen(true)}>
               Set up agent
             </button>
           </Show>
@@ -325,7 +325,7 @@ const MessageLog: Component = () => {
                   <div class="empty-state__title">No messages recorded</div>
                   <p>Connect your agent and send a message. Each LLM call gets logged here.</p>
                   <button
-                    class="btn btn--primary"
+                    class="btn btn--primary btn--sm"
                     style="margin-top: var(--gap-md);"
                     onClick={() => setSetupOpen(true)}
                   >
@@ -404,7 +404,7 @@ const MessageLog: Component = () => {
                 <p class="model-filter__empty-hint">
                   Try adjusting your status, model, or cost filters to see more results.
                 </p>
-                <button class="btn btn--outline" onClick={clearFilters} type="button">
+                <button class="btn btn--outline btn--sm" onClick={clearFilters} type="button">
                   Clear filters
                 </button>
               </div>

--- a/packages/frontend/src/pages/ModelPrices.tsx
+++ b/packages/frontend/src/pages/ModelPrices.tsx
@@ -255,7 +255,7 @@ const ModelPrices: Component = () => {
                     Try selecting a different provider or model, or clear all filters to see every
                     model.
                   </p>
-                  <button class="btn btn--outline" onClick={clearFilters} type="button">
+                  <button class="btn btn--outline btn--sm" onClick={clearFilters} type="button">
                     Clear filters
                   </button>
                 </div>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -226,7 +226,7 @@ const Overview: Component = () => {
               !setupCompleted()
             }
           >
-            <button class="btn btn--primary" onClick={() => setSetupOpen(true)}>
+            <button class="btn btn--primary btn--sm" onClick={() => setSetupOpen(true)}>
               Set up agent
             </button>
           </Show>
@@ -359,7 +359,7 @@ const Overview: Component = () => {
                   <div class="empty-state__title">No activity yet</div>
                   <p>Connect your agent and send a message. Usage data shows up here.</p>
                   <button
-                    class="btn btn--primary"
+                    class="btn btn--primary btn--sm"
                     style="margin-top: var(--gap-md);"
                     onClick={() => setSetupOpen(true)}
                   >

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -373,7 +373,7 @@ const Routing: Component = () => {
                 Send simple tasks to cheap models, complex ones to better models. Connect your LLM
                 providers to get started.
               </p>
-              <button class="btn btn--primary" onClick={handleEnable}>
+              <button class="btn btn--primary btn--sm" onClick={handleEnable}>
                 Enable Routing
               </button>
             </div>
@@ -628,8 +628,7 @@ const Routing: Component = () => {
             </button>
             <Show when={hasOverrides()}>
               <button
-                class="btn btn--outline"
-                style="font-size: var(--font-size-sm);"
+                class="btn btn--outline btn--sm"
                 onClick={handleResetAll}
                 disabled={resettingAll() || resettingTier() !== null}
               >
@@ -723,11 +722,11 @@ const Routing: Component = () => {
               each tier.
             </p>
             <div style="display: flex; justify-content: flex-end; gap: 8px;">
-              <button class="btn btn--outline" onClick={() => setConfirmDisable(false)}>
+              <button class="btn btn--outline btn--sm" onClick={() => setConfirmDisable(false)}>
                 Cancel
               </button>
               <button
-                class="btn btn--danger"
+                class="btn btn--danger btn--sm"
                 disabled={disabling()}
                 onClick={async () => {
                   setConfirmDisable(false);

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -135,8 +135,7 @@ const Settings: Component = () => {
           </div>
           <div class="settings-card__footer">
             <button
-              class="btn btn--primary"
-              style="font-size: var(--font-size-sm);"
+              class="btn btn--primary btn--sm"
               onClick={handleSave}
               disabled={saving() || name().trim() === agentName()}
             >
@@ -170,8 +169,7 @@ const Settings: Component = () => {
               </div>
               <div class="settings-card__control">
                 <button
-                  class="btn btn--danger"
-                  style="font-size: var(--font-size-sm);"
+                  class="btn btn--danger btn--sm"
                   onClick={() => {
                     setShowDeleteModal(true);
                     setDeleteConfirmName('');
@@ -205,12 +203,7 @@ const Settings: Component = () => {
               <code style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground));">
                 {apiKeyData()?.keyPrefix ?? '...'}...
               </code>
-              <button
-                class="btn btn--outline"
-                style="font-size: var(--font-size-sm);"
-                onClick={handleRotate}
-                disabled={rotating()}
-              >
+              <button class="btn btn--outline btn--sm" onClick={handleRotate} disabled={rotating()}>
                 {rotating() ? (
                   <>
                     <span class="spinner" />
@@ -319,8 +312,8 @@ const Settings: Component = () => {
               style="width: 100%; margin-bottom: var(--gap-lg);"
             />
             <button
-              class="btn btn--danger"
-              style="width: 100%; font-size: var(--font-size-sm);"
+              class="btn btn--danger btn--sm"
+              style="width: 100%;"
               disabled={deleteConfirmName() !== agentName() || deleting()}
               onClick={async () => {
                 setDeleting(true);

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -91,7 +91,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
 
           <div class="modal-card__footer">
             <button
-              class="btn btn--primary"
+              class="btn btn--primary btn--sm"
               onClick={handleCreate}
               disabled={!name().trim() || creating()}
             >
@@ -128,7 +128,7 @@ const Workspace: Component = () => {
           <h1>My Agents</h1>
           <span class="breadcrumb">View and manage all your connected AI agents</span>
         </div>
-        <button class="btn btn--primary" onClick={() => setModalOpen(true)}>
+        <button class="btn btn--primary btn--sm" onClick={() => setModalOpen(true)}>
           <svg
             width="14"
             height="14"
@@ -176,7 +176,7 @@ const Workspace: Component = () => {
                 <div class="empty-state__title">No agents yet</div>
                 <p>Create an agent to see its LLM calls, tokens, and costs.</p>
                 <button
-                  class="btn btn--primary"
+                  class="btn btn--primary btn--sm"
                   style="margin-top: var(--gap-md);"
                   onClick={() => setModalOpen(true)}
                 >


### PR DESCRIPTION
## Summary

- Add `btn--sm` class to every `btn` element across all pages and components so all buttons render at a uniform 32px height on desktop
- Remove redundant inline `font-size: var(--font-size-sm)` overrides that `btn--sm` already handles (Settings, Routing, Help pages)

## Test plan

- [ ] Verify all buttons across the dashboard render at 32px height
- [ ] Check pages: Workspace, Overview, Settings, Routing, MessageLog, Limits, ModelPrices, Help
- [ ] Check modals: SetupWizard, LimitRuleModal, EmailProviderModal, ProviderSelectModal, RoutingInstructionModal, CustomProviderForm delete confirmation
- [ ] Verify ErrorState retry button sizing
- [ ] Confirm no visual regressions on hover/disabled states

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all dashboard buttons to a uniform 32px height by applying `btn--sm` to every `btn`. This cleans up styles and keeps button sizing consistent across pages and modals.

- **Refactors**
  - Applied `btn--sm` to all `btn` instances across pages and modals to enforce 32px height.
  - Removed inline `font-size` overrides now handled by `btn--sm`; hover/disabled states unchanged.

<sup>Written for commit 2687937625281ec89ddf7735178c1841ccc24c96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

