### PR TITLE
fix: replace unusable status/model filters with provider filter on Messages page

### DIFF
--- a/.changeset/fix-message-filters.md
+++ b/.changeset/fix-message-filters.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Replace unusable status and model filters on the Messages page with a provider filter that only shows providers present in the user's data. Add horizontal scroll for the message table on small screens.

--- a/packages/backend/src/analytics/controllers/messages.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.spec.ts
@@ -11,7 +11,7 @@ describe('MessagesController', () => {
       items: [],
       next_cursor: null,
       total_count: 0,
-      models: [],
+      providers: [],
     });
 
     const module: TestingModule = await Test.createTestingModule({
@@ -34,9 +34,8 @@ describe('MessagesController', () => {
     expect(mockGetMessages).toHaveBeenCalledWith({
       range: undefined,
       userId: 'u1',
-      status: undefined,
+      provider: undefined,
       service_type: undefined,
-      model: undefined,
       cost_min: undefined,
       cost_max: undefined,
       limit: 50,
@@ -49,9 +48,8 @@ describe('MessagesController', () => {
     const user = { id: 'u1' };
     const query = {
       range: '7d',
-      status: 'error',
+      provider: 'openai',
       service_type: 'agent',
-      model: 'claude-opus-4-6',
       cost_min: 0.01,
       cost_max: 10.0,
       limit: 25,
@@ -63,9 +61,8 @@ describe('MessagesController', () => {
     expect(mockGetMessages).toHaveBeenCalledWith({
       range: '7d',
       userId: 'u1',
-      status: 'error',
+      provider: 'openai',
       service_type: 'agent',
-      model: 'claude-opus-4-6',
       cost_min: 0.01,
       cost_max: 10.0,
       limit: 25,
@@ -87,7 +84,7 @@ describe('MessagesController', () => {
       items: [{ id: '1' }],
       next_cursor: 'ts|id',
       total_count: 100,
-      models: ['claude-opus-4-6'],
+      providers: ['anthropic', 'openai'],
     };
     mockGetMessages.mockResolvedValue(expected);
 

--- a/packages/backend/src/analytics/controllers/messages.controller.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.ts
@@ -13,9 +13,8 @@ export class MessagesController {
     return this.messagesQuery.getMessages({
       range: query.range,
       userId: user.id,
-      status: query.status,
+      provider: query.provider,
       service_type: query.service_type,
-      model: query.model,
       cost_min: query.cost_min,
       cost_max: query.cost_max,
       limit: Math.min(query.limit ?? 50, 200),

--- a/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
@@ -13,9 +13,8 @@ describe('MessagesQueryDto', () => {
   it('accepts valid string fields', async () => {
     const dto = plainToInstance(MessagesQueryDto, {
       range: '24h',
-      status: 'ok',
+      provider: 'openai',
       service_type: 'agent',
-      model: 'gpt-4o',
       cursor: 'abc123',
       agent_name: 'my-bot',
     });

--- a/packages/backend/src/analytics/dto/messages-query.dto.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.ts
@@ -8,15 +8,11 @@ export class MessagesQueryDto {
 
   @IsOptional()
   @IsString()
-  status?: string;
+  provider?: string;
 
   @IsOptional()
   @IsString()
   service_type?: string;
-
-  @IsOptional()
-  @IsString()
-  model?: string;
 
   @IsOptional()
   @IsNumber()

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -104,7 +104,7 @@ describe('MessagesQueryService', () => {
     expect(result.items[0]).toHaveProperty('duration_ms', 1200);
   });
 
-  it('returns paginated messages with total count and models list', async () => {
+  it('returns paginated messages with total count and providers list', async () => {
     mockGetRawOne.mockResolvedValueOnce({ total: 42 });
     mockGetRawMany.mockResolvedValueOnce([
       { id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o', cost: 0.01 },
@@ -121,7 +121,7 @@ describe('MessagesQueryService', () => {
     expect(result.total_count).toBe(42);
     expect(result.items).toHaveLength(2);
     expect(result.next_cursor).toBeNull();
-    expect(result.models).toEqual(['claude-opus-4-6', 'gpt-4o']);
+    expect(result.providers).toEqual(['anthropic', 'openai']);
   });
 
   it('returns next_cursor when more items exist', async () => {
@@ -195,7 +195,7 @@ describe('MessagesQueryService', () => {
     expect(result.total_count).toBe(0);
     expect(result.items).toEqual([]);
     expect(result.next_cursor).toBeNull();
-    expect(result.models).toEqual([]);
+    expect(result.providers).toEqual([]);
   });
 
   it('should apply cursor-based pagination when cursor has pipe separator', async () => {
@@ -248,24 +248,25 @@ describe('MessagesQueryService', () => {
 
     expect(result.total_count).toBe(5);
     expect(result.items).toHaveLength(1);
-    expect(result.models).toEqual(['gpt-4o']);
+    expect(result.providers).toEqual(['openai']);
   });
 
   it('should apply all optional filter parameters', async () => {
+    // Provider filter needs models list to resolve matching models
+    mockGetRawMany.mockResolvedValueOnce([{ model: 'gpt-4o' }]); // getDistinctModels for provider filter
     mockGetRawOne.mockResolvedValueOnce({ total: 3 });
     mockGetRawMany
       .mockResolvedValueOnce([
         { id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o', cost: 0.05 },
       ])
-      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]); // getDistinctModels for providers response
 
     const result = await service.getMessages({
       range: '24h',
       userId: 'test-user',
       limit: 20,
-      status: 'success',
+      provider: 'openai',
       service_type: 'chat',
-      model: 'gpt-4o',
       cost_min: 0.01,
       cost_max: 1.0,
       agent_name: 'my-agent',
@@ -333,7 +334,7 @@ describe('MessagesQueryService', () => {
       userId: 'test-user',
       limit: 20,
     });
-    expect(result1.models).toEqual(['gpt-4o', 'claude-opus-4-6']);
+    expect(result1.providers).toEqual(['anthropic', 'openai']);
 
     // Second call — models query should NOT be called again
     mockGetRawOne.mockResolvedValueOnce({ total: 1 });
@@ -348,8 +349,8 @@ describe('MessagesQueryService', () => {
       limit: 20,
     });
 
-    // Should still return cached models from first call
-    expect(result2.models).toEqual(['gpt-4o', 'claude-opus-4-6']);
+    // Should still return cached providers from first call
+    expect(result2.providers).toEqual(['anthropic', 'openai']);
     // getRawMany should have been called 3 times total:
     // call 1: data rows + models = 2, call 2: data rows only = 1
     expect(mockGetRawMany).toHaveBeenCalledTimes(3);
@@ -420,8 +421,6 @@ describe('MessagesQueryService', () => {
     await service.getMessages({ range: '24h', userId: 'test-user', limit: 20 });
 
     // Expired entry was deleted first, then re-added — no eviction of other entries
-    // Size might be 4999 (expired entry deleted, then re-added = 5000, but if the
-    // has(key) check fires after delete, it won't evict)
     expect(cache.has('test-user::24h')).toBe(true);
   });
 
@@ -457,7 +456,7 @@ describe('MessagesQueryService', () => {
       limit: 20,
     });
 
-    expect(result.models).toEqual(['gpt-4o', 'claude-opus-4-6']);
+    expect(result.providers).toEqual(['anthropic', 'openai']);
     // 2 from first call + 2 from second call = 4
     expect(mockGetRawMany).toHaveBeenCalledTimes(4);
   });
@@ -626,6 +625,76 @@ describe('MessagesQueryService', () => {
     });
 
     expect(result.total_count).toBe(0);
+  });
+
+  it('provider filter returns empty result when no models match', async () => {
+    // getDistinctModels returns models that don't match the requested provider
+    mockGetRawMany.mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      provider: 'anthropic',
+    });
+
+    expect(result.total_count).toBe(0);
+    expect(result.items).toEqual([]);
+    expect(result.providers).toEqual(['openai']);
+  });
+
+  it('provider filter applies IN clause for matching models', async () => {
+    // getDistinctModels for provider filter resolution
+    mockGetRawMany.mockResolvedValueOnce([
+      { model: 'gpt-4o' },
+      { model: 'gpt-4.1' },
+      { model: 'claude-opus-4-6' },
+    ]);
+    mockGetRawOne.mockResolvedValueOnce({ total: 2 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o', cost: 0.01 },
+        { id: 'msg-2', timestamp: '2026-02-16 09:00:00', model: 'gpt-4.1', cost: 0.02 },
+      ])
+      .mockResolvedValueOnce([
+        { model: 'gpt-4o' },
+        { model: 'gpt-4.1' },
+        { model: 'claude-opus-4-6' },
+      ]);
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      provider: 'openai',
+    });
+
+    expect(result.total_count).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect(result.providers).toEqual(['anthropic', 'openai']);
+  });
+
+  it('derives providers from multiple model types', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 3 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-1', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o' },
+        { id: 'msg-2', timestamp: '2026-02-16 09:00:00', model: 'claude-opus-4-6' },
+        { id: 'msg-3', timestamp: '2026-02-16 08:00:00', model: 'gemini-2.0-flash' },
+      ])
+      .mockResolvedValueOnce([
+        { model: 'claude-opus-4-6' },
+        { model: 'gemini-2.0-flash' },
+        { model: 'gpt-4o' },
+      ]);
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+    });
+
+    expect(result.providers).toEqual(['anthropic', 'gemini', 'openai']);
   });
 });
 

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -12,6 +12,7 @@ import {
   sqlCastFloat,
   sqlSanitizeCost,
 } from '../../common/utils/sql-dialect';
+import { inferProviderFromModel } from '../../common/utils/provider-inference';
 
 const MODELS_CACHE_TTL_MS = 60_000;
 const COUNT_CACHE_TTL_MS = 30_000;
@@ -45,9 +46,8 @@ export class MessagesQueryService {
   async getMessages(params: {
     range?: string;
     userId: string;
-    status?: string;
+    provider?: string;
     service_type?: string;
-    model?: string;
     cost_min?: number;
     cost_max?: number;
     limit: number;
@@ -64,16 +64,31 @@ export class MessagesQueryService {
 
     addTenantFilter(baseQb, params.userId, undefined, tenantId);
 
-    if (params.status) baseQb.andWhere('at.status = :status', { status: params.status });
     if (params.service_type)
       baseQb.andWhere('at.service_type = :serviceType', { serviceType: params.service_type });
-    if (params.model) baseQb.andWhere('at.model = :model', { model: params.model });
     if (params.cost_min !== undefined)
       baseQb.andWhere('at.cost_usd >= :costMin', { costMin: params.cost_min });
     if (params.cost_max !== undefined)
       baseQb.andWhere('at.cost_usd <= :costMax', { costMax: params.cost_max });
     if (params.agent_name)
       baseQb.andWhere('at.agent_name = :filterAgent', { filterAgent: params.agent_name });
+
+    // Provider filter: resolve matching models from the cached distinct list
+    if (params.provider) {
+      const allModels = await this.getDistinctModels(
+        params.userId,
+        params.range,
+        tenantId,
+        params.agent_name,
+      );
+      const matching = allModels.filter((m) => inferProviderFromModel(m) === params.provider);
+      if (matching.length === 0) {
+        // No models match this provider — short-circuit with empty result
+        const providers = this.deriveProviders(allModels);
+        return { items: [], next_cursor: null, total_count: 0, providers };
+      }
+      baseQb.andWhere('at.model IN (:...providerModels)', { providerModels: matching });
+    }
 
     // Count (without cursor) — use cache for repeat/paginated requests
     const countCacheKey = this.buildCountCacheKey(params);
@@ -126,7 +141,7 @@ export class MessagesQueryService {
     // Run count, data, and models queries in parallel (count cached on paginated requests)
     const cachedCount = params.cursor ? this.countCache.get(countCacheKey) : undefined;
     const countHit = cachedCount && cachedCount.expiresAt > Date.now();
-    const [countResult, rows, models] = await Promise.all([
+    const [countResult, rows, allModels] = await Promise.all([
       countHit ? null : countQb.getRawOne(),
       dataQb
         .orderBy('at.timestamp', 'DESC')
@@ -151,12 +166,24 @@ export class MessagesQueryService {
     const lastId = lastItem?.['id'];
     const nextCursor = hasMore && lastItem ? `${tsStr}|${String(lastId)}` : null;
 
+    const providers = this.deriveProviders(allModels);
+
     return {
       items,
       next_cursor: nextCursor,
       total_count: totalCount,
-      models,
+      providers,
     };
+  }
+
+  /** Derive sorted unique provider IDs from a list of model names. */
+  private deriveProviders(models: string[]): string[] {
+    const seen = new Set<string>();
+    for (const m of models) {
+      const p = inferProviderFromModel(m);
+      if (p) seen.add(p);
+    }
+    return [...seen].sort();
   }
 
   private async getDistinctModels(
@@ -196,9 +223,8 @@ export class MessagesQueryService {
   private buildCountCacheKey(params: {
     userId: string;
     range?: string;
-    status?: string;
+    provider?: string;
     service_type?: string;
-    model?: string;
     agent_name?: string;
     cost_min?: number;
     cost_max?: number;
@@ -206,9 +232,8 @@ export class MessagesQueryService {
     return [
       params.userId,
       params.range ?? '',
-      params.status ?? '',
+      params.provider ?? '',
       params.service_type ?? '',
-      params.model ?? '',
       params.agent_name ?? '',
       params.cost_min ?? '',
       params.cost_max ?? '',

--- a/packages/backend/src/common/utils/provider-inference.spec.ts
+++ b/packages/backend/src/common/utils/provider-inference.spec.ts
@@ -1,0 +1,78 @@
+import { inferProviderFromModel } from './provider-inference';
+
+describe('inferProviderFromModel', () => {
+  it('returns "custom" for custom:<uuid>/model pattern', () => {
+    expect(inferProviderFromModel('custom:abc-123/my-llama')).toBe('custom');
+  });
+
+  it('returns "ollama" for colon-tagged models (not :free)', () => {
+    expect(inferProviderFromModel('qwen2.5:0.5b')).toBe('ollama');
+    expect(inferProviderFromModel('llama3:latest')).toBe('ollama');
+  });
+
+  it('returns "openrouter" for openrouter/ prefix', () => {
+    expect(inferProviderFromModel('openrouter/auto')).toBe('openrouter');
+  });
+
+  it('returns "anthropic" for claude- prefix', () => {
+    expect(inferProviderFromModel('claude-opus-4-6')).toBe('anthropic');
+    expect(inferProviderFromModel('claude-3-5-sonnet-20241022')).toBe('anthropic');
+  });
+
+  it('returns "openai" for gpt- and o-series models', () => {
+    expect(inferProviderFromModel('gpt-4o')).toBe('openai');
+    expect(inferProviderFromModel('gpt-4.1')).toBe('openai');
+    expect(inferProviderFromModel('o3-mini')).toBe('openai');
+    expect(inferProviderFromModel('o4-mini')).toBe('openai');
+    expect(inferProviderFromModel('chatgpt-4o-latest')).toBe('openai');
+  });
+
+  it('returns "gemini" for gemini- prefix', () => {
+    expect(inferProviderFromModel('gemini-2.0-flash')).toBe('gemini');
+    expect(inferProviderFromModel('gemini-2.5-pro')).toBe('gemini');
+  });
+
+  it('returns "deepseek" for deepseek- prefix', () => {
+    expect(inferProviderFromModel('deepseek-chat')).toBe('deepseek');
+    expect(inferProviderFromModel('deepseek-reasoner')).toBe('deepseek');
+  });
+
+  it('returns "xai" for grok- prefix', () => {
+    expect(inferProviderFromModel('grok-3')).toBe('xai');
+  });
+
+  it('returns "mistral" for mistral-/codestral/pixtral/open-mistral', () => {
+    expect(inferProviderFromModel('mistral-large')).toBe('mistral');
+    expect(inferProviderFromModel('codestral')).toBe('mistral');
+    expect(inferProviderFromModel('pixtral-large-latest')).toBe('mistral');
+    expect(inferProviderFromModel('open-mistral-nemo')).toBe('mistral');
+  });
+
+  it('returns "moonshot" for kimi-/moonshot- prefix', () => {
+    expect(inferProviderFromModel('kimi-k2')).toBe('moonshot');
+    expect(inferProviderFromModel('moonshot-v1-128k')).toBe('moonshot');
+  });
+
+  it('returns "minimax" for minimax- prefix', () => {
+    expect(inferProviderFromModel('MiniMax-M2.5')).toBe('minimax');
+  });
+
+  it('returns "zai" for glm- prefix', () => {
+    expect(inferProviderFromModel('glm-5')).toBe('zai');
+  });
+
+  it('returns "qwen" for qwen/qwq models', () => {
+    expect(inferProviderFromModel('qwen2.5-72b-instruct')).toBe('qwen');
+    expect(inferProviderFromModel('qwen3-235b-a22b')).toBe('qwen');
+    expect(inferProviderFromModel('qwq-32b')).toBe('qwen');
+  });
+
+  it('returns "openrouter" for vendor/model format', () => {
+    expect(inferProviderFromModel('stepfun/step-3.5-flash:free')).toBe('openrouter');
+  });
+
+  it('returns undefined for unrecognized models', () => {
+    expect(inferProviderFromModel('whisper-large')).toBeUndefined();
+    expect(inferProviderFromModel('unknown-model')).toBeUndefined();
+  });
+});

--- a/packages/backend/src/common/utils/provider-inference.ts
+++ b/packages/backend/src/common/utils/provider-inference.ts
@@ -1,0 +1,28 @@
+/**
+ * Infer a provider ID from a model name string.
+ * Mirrors the frontend logic in services/routing-utils.ts.
+ */
+const MODEL_PREFIX_MAP: [RegExp, string][] = [
+  [/^openrouter\//, 'openrouter'],
+  [/^claude-/, 'anthropic'],
+  [/^gpt-|^o[134]-|^o[134] |^chatgpt-/, 'openai'],
+  [/^gemini-/, 'gemini'],
+  [/^deepseek-/, 'deepseek'],
+  [/^grok-/, 'xai'],
+  [/^mistral-|^codestral|^pixtral|^open-mistral/, 'mistral'],
+  [/^kimi-|^moonshot-/, 'moonshot'],
+  [/^minimax-/i, 'minimax'],
+  [/^glm-/, 'zai'],
+  [/^qwen[23]|^qwq-/, 'qwen'],
+  [/^[a-z][\w-]*\//, 'openrouter'],
+];
+
+export function inferProviderFromModel(model: string): string | undefined {
+  if (model.startsWith('custom:')) return 'custom';
+  if (/:/.test(model) && !model.endsWith(':free')) return 'ollama';
+  const lower = model.toLowerCase();
+  for (const [re, id] of MODEL_PREFIX_MAP) {
+    if (re.test(lower)) return id;
+  }
+  return undefined;
+}

--- a/packages/backend/test/messages.e2e-spec.ts
+++ b/packages/backend/test/messages.e2e-spec.ts
@@ -75,14 +75,14 @@ describe('GET /api/v1/messages', () => {
     expect(item).toHaveProperty('status');
   });
 
-  it('filters by status', async () => {
+  it('filters by provider', async () => {
     const res = await request(app.getHttpServer())
-      .get('/api/v1/messages?range=24h&status=error')
+      .get('/api/v1/messages?range=24h&provider=openai')
       .set('x-api-key', TEST_API_KEY)
       .expect(200);
 
     expect(
-      res.body.items.every((item: Record<string, string>) => item['status'] === 'error'),
+      res.body.items.every((item: Record<string, string>) => item['model'] === 'gpt-4o'),
     ).toBe(true);
   });
 

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -37,6 +37,7 @@ import { pingCount } from '../services/sse.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import SetupModal from '../components/SetupModal.jsx';
 import { createCursorPagination } from '../services/cursor-pagination.js';
+import { PROVIDERS } from '../services/providers.js';
 import '../styles/overview.css';
 
 interface MessageItem {
@@ -64,14 +65,13 @@ interface MessagesData {
   items: MessageItem[];
   next_cursor: string | null;
   total_count: number;
-  models: string[];
+  providers: string[];
 }
 
 const MessageLog: Component = () => {
   const params = useParams<{ agentName: string }>();
   preloadModelDisplayNames();
-  const [statusFilter, setStatusFilter] = createSignal('');
-  const [modelFilter, setModelFilter] = createSignal('');
+  const [providerFilter, setProviderFilter] = createSignal('');
   const [costMin, setCostMin] = createSignal('');
   const [costMax, setCostMax] = createSignal('');
   const [setupOpen, setSetupOpen] = createSignal(false);
@@ -110,14 +110,11 @@ const MessageLog: Component = () => {
     costMaxTimer = setTimeout(() => setCostMax(val), 400);
   };
 
-  createEffect(
-    on([statusFilter, modelFilter, costMin, costMax], () => pager.resetPage(), { defer: true }),
-  );
+  createEffect(on([providerFilter, costMin, costMax], () => pager.resetPage(), { defer: true }));
 
   const [data, { refetch }] = createResource(
     () => ({
-      status: statusFilter(),
-      model: modelFilter(),
+      provider: providerFilter(),
       costMin: costMin(),
       costMax: costMax(),
       agentName: params.agentName,
@@ -127,8 +124,7 @@ const MessageLog: Component = () => {
     }),
     (p) => {
       const q: Record<string, string> = {};
-      if (p.status) q.status = p.status;
-      if (p.model) q.model = p.model;
+      if (p.provider) q.provider = p.provider;
       if (p.costMin) q.cost_min = p.costMin;
       if (p.costMax) q.cost_max = p.costMax;
       if (p.agentName) q.agent_name = p.agentName;
@@ -147,8 +143,7 @@ const MessageLog: Component = () => {
     ),
   );
 
-  const hasActiveFilters = () =>
-    statusFilter() !== '' || modelFilter() !== '' || costMin() !== '' || costMax() !== '';
+  const hasActiveFilters = () => providerFilter() !== '' || costMin() !== '' || costMax() !== '';
 
   const hasNoData = () => {
     const d = data();
@@ -159,10 +154,15 @@ const MessageLog: Component = () => {
   const isAgentEmpty = () => hasNoData() && !hasActiveFilters();
 
   const clearFilters = () => {
-    setStatusFilter('');
-    setModelFilter('');
+    setProviderFilter('');
     setCostMin('');
     setCostMax('');
+  };
+
+  /** Resolve provider ID to display name */
+  const providerDisplayName = (id: string): string => {
+    const prov = PROVIDERS.find((p) => p.id === id);
+    return prov?.name ?? id;
   };
 
   const scrollToFallbackSuccess = (model: string) => {
@@ -184,35 +184,24 @@ const MessageLog: Component = () => {
       </Title>
       <Meta
         name="description"
-        content={`Browse all messages sent and received by ${agentDisplayName() ?? decodeURIComponent(params.agentName)}. Filter by status, model, or cost.`}
+        content={`Browse all messages sent and received by ${agentDisplayName() ?? decodeURIComponent(params.agentName)}. Filter by provider or cost.`}
       />
       <div class="page-header">
         <div>
           <h1>Messages</h1>
-          <span class="breadcrumb">
-            Full log of every LLM call. Filter by status, model, or cost.
-          </span>
+          <span class="breadcrumb">Full log of every LLM call. Filter by provider or cost.</span>
         </div>
         <div class="header-controls">
           <Show when={!isAgentEmpty()}>
             <Select
-              value={statusFilter()}
-              onChange={setStatusFilter}
+              value={providerFilter()}
+              onChange={setProviderFilter}
               options={[
-                { label: 'All statuses', value: '' },
-                { label: 'Successful', value: 'ok' },
-                { label: 'Rate Limited', value: 'rate_limited' },
-                { label: 'Retried', value: 'retry' },
-                { label: 'Handled', value: 'fallback_error' },
-                { label: 'Failed', value: 'error' },
-              ]}
-            />
-            <Select
-              value={modelFilter()}
-              onChange={setModelFilter}
-              options={[
-                { label: 'All models', value: '' },
-                ...(data()?.models ?? []).map((m) => ({ label: getModelDisplayName(m), value: m })),
+                { label: 'All providers', value: '' },
+                ...(data()?.providers ?? []).map((id) => ({
+                  label: providerDisplayName(id),
+                  value: id,
+                })),
               ]}
             />
             <div class="cost-range-filter">
@@ -259,60 +248,62 @@ const MessageLog: Component = () => {
               <div class="skeleton skeleton--text" style="width: 80px; height: 16px;" />
               <div class="skeleton skeleton--text" style="width: 60px; height: 14px;" />
             </div>
-            <table class="data-table">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Message</th>
-                  <th>Cost</th>
-                  <th>Total Tokens</th>
-                  <th>Input</th>
-                  <th>Output</th>
-                  <th>Model</th>
-                  <th>Cache</th>
-                  <th>Duration</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                <For each={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}>
-                  {() => (
-                    <tr>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 90px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 55px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 40px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 40px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 35px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 35px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 110px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 90px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 35px;" />
-                      </td>
-                      <td>
-                        <div class="skeleton skeleton--text" style="width: 50px;" />
-                      </td>
-                    </tr>
-                  )}
-                </For>
-              </tbody>
-            </table>
+            <div class="data-table-scroll">
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Message</th>
+                    <th>Cost</th>
+                    <th>Total Tokens</th>
+                    <th>Input</th>
+                    <th>Output</th>
+                    <th>Model</th>
+                    <th>Cache</th>
+                    <th>Duration</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <For each={[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]}>
+                    {() => (
+                      <tr>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 90px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 55px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 40px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 40px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 35px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 35px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 110px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 90px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 35px;" />
+                        </td>
+                        <td>
+                          <div class="skeleton skeleton--text" style="width: 50px;" />
+                        </td>
+                      </tr>
+                    )}
+                  </For>
+                </tbody>
+              </table>
+            </div>
           </div>
         }
       >
@@ -359,32 +350,34 @@ const MessageLog: Component = () => {
                       0 total
                     </span>
                   </div>
-                  <table class="data-table">
-                    <thead>
-                      <tr>
-                        <th>Date</th>
-                        <th>Message</th>
-                        <th>Cost</th>
-                        <th>Total Tokens</th>
-                        <th>Input</th>
-                        <th>Output</th>
-                        <th>Model</th>
-                        <th>Cache</th>
-                        <th>Duration</th>
-                        <th>Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      <tr>
-                        <td
-                          colspan="10"
-                          style="text-align: center; color: hsl(var(--muted-foreground)); padding: var(--gap-lg);"
-                        >
-                          Messages will appear here
-                        </td>
-                      </tr>
-                    </tbody>
-                  </table>
+                  <div class="data-table-scroll">
+                    <table class="data-table">
+                      <thead>
+                        <tr>
+                          <th>Date</th>
+                          <th>Message</th>
+                          <th>Cost</th>
+                          <th>Total Tokens</th>
+                          <th>Input</th>
+                          <th>Output</th>
+                          <th>Model</th>
+                          <th>Cache</th>
+                          <th>Duration</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td
+                            colspan="10"
+                            style="text-align: center; color: hsl(var(--muted-foreground)); padding: var(--gap-lg);"
+                          >
+                            Messages will appear here
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               </div>
             </Show>
@@ -402,7 +395,7 @@ const MessageLog: Component = () => {
               <div class="model-filter__empty">
                 <p class="model-filter__empty-title">No messages match your filters</p>
                 <p class="model-filter__empty-hint">
-                  Try adjusting your status, model, or cost filters to see more results.
+                  Try adjusting your provider or cost filters to see more results.
                 </p>
                 <button class="btn btn--outline" onClick={clearFilters} type="button">
                   Clear filters
@@ -420,215 +413,221 @@ const MessageLog: Component = () => {
                   {data()!.total_count} total
                 </span>
               </div>
-              <table class="data-table">
-                <thead>
-                  <tr>
-                    <th>Date</th>
-                    <th>Message</th>
-                    <th>Cost</th>
-                    <th>
-                      Total Tokens
-                      <InfoTooltip text="Tokens are units of text that AI models process. More tokens = higher cost." />
-                    </th>
-                    <th>
-                      Input
-                      <InfoTooltip text="Tokens sent to the model (your prompt). Also called 'input tokens'." />
-                    </th>
-                    <th>
-                      Output
-                      <InfoTooltip text="Tokens returned by the model (its response). Also called 'output tokens'." />
-                    </th>
-                    <th>Model</th>
-                    <th>Cache</th>
-                    <th>Duration</th>
-                    <th>Status</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <For each={data()?.items}>
-                    {(item) => (
-                      <tr id={`msg-${item.id}`}>
-                        <td style="white-space: nowrap; font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                          {formatTime(item.timestamp)}
-                        </td>
-                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                          {item.id.slice(0, 8)}
-                          {item.routing_reason === 'heartbeat' && (
-                            <span
-                              title="Heartbeat"
-                              style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;"
-                            >
-                              <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                width="12"
-                                height="12"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                stroke-linecap="round"
-                                stroke-linejoin="round"
-                                aria-hidden="true"
-                              >
-                                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-                              </svg>
-                            </span>
-                          )}
-                        </td>
-                        <td style="font-family: var(--font-mono);">
-                          <Show
-                            when={item.auth_type === 'subscription'}
-                            fallback={
+              <div class="data-table-scroll">
+                <table class="data-table">
+                  <thead>
+                    <tr>
+                      <th>Date</th>
+                      <th>Message</th>
+                      <th>Cost</th>
+                      <th>
+                        Total Tokens
+                        <InfoTooltip text="Tokens are units of text that AI models process. More tokens = higher cost." />
+                      </th>
+                      <th>
+                        Input
+                        <InfoTooltip text="Tokens sent to the model (your prompt). Also called 'input tokens'." />
+                      </th>
+                      <th>
+                        Output
+                        <InfoTooltip text="Tokens returned by the model (its response). Also called 'output tokens'." />
+                      </th>
+                      <th>Model</th>
+                      <th>Cache</th>
+                      <th>Duration</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <For each={data()?.items}>
+                      {(item) => (
+                        <tr id={`msg-${item.id}`}>
+                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            {formatTime(item.timestamp)}
+                          </td>
+                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            {item.id.slice(0, 8)}
+                            {item.routing_reason === 'heartbeat' && (
                               <span
-                                title={
-                                  item.cost != null && item.cost > 0 && item.cost < 0.01
-                                    ? `$${item.cost.toFixed(6)}`
-                                    : undefined
-                                }
+                                title="Heartbeat"
+                                style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;"
                               >
-                                {item.cost != null ? (formatCost(item.cost) ?? '\u2014') : '\u2014'}
-                              </span>
-                            }
-                          >
-                            <span
-                              style="color: hsl(var(--muted-foreground));"
-                              title="Included in subscription"
-                            >
-                              $0.00
-                            </span>
-                          </Show>
-                        </td>
-                        <td style="font-family: var(--font-mono);">
-                          {item.total_tokens != null ? formatNumber(item.total_tokens) : '\u2014'}
-                        </td>
-                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                          {item.input_tokens != null ? formatNumber(item.input_tokens) : '\u2014'}
-                        </td>
-                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                          {item.output_tokens != null ? formatNumber(item.output_tokens) : '\u2014'}
-                        </td>
-                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                          <span style="display: inline-flex; align-items: center; gap: 4px;">
-                            {item.model && inferProviderFromModel(item.model) === 'custom' ? (
-                              (() => {
-                                const provName = customProviderName(item.model!);
-                                const letter = (provName ?? stripCustomPrefix(item.model!))
-                                  .charAt(0)
-                                  .toUpperCase();
-                                return (
-                                  <span
-                                    class="provider-card__logo-letter"
-                                    title={provName}
-                                    style={{
-                                      background: customProviderColor(provName ?? ''),
-                                      width: '16px',
-                                      height: '16px',
-                                      'font-size': '9px',
-                                      'flex-shrink': '0',
-                                      'border-radius': '50%',
-                                    }}
-                                  >
-                                    {letter}
-                                  </span>
-                                );
-                              })()
-                            ) : item.model && inferProviderFromModel(item.model) ? (
-                              <span
-                                role="img"
-                                aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
-                                title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
-                                style="display: inline-flex; flex-shrink: 0; position: relative;"
-                              >
-                                {providerIcon(inferProviderFromModel(item.model)!, 14)}
-                                {authBadgeFor(item.auth_type, 8)}
-                              </span>
-                            ) : null}
-                            {item.model ? getModelDisplayName(item.model) : '\u2014'}
-                            {item.routing_tier && (
-                              <span class={`tier-badge tier-badge--${item.routing_tier}`}>
-                                {item.routing_tier}
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  width="12"
+                                  height="12"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  stroke-width="2"
+                                  stroke-linecap="round"
+                                  stroke-linejoin="round"
+                                  aria-hidden="true"
+                                >
+                                  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+                                </svg>
                               </span>
                             )}
-                            {item.fallback_from_model && (
-                              <span
-                                class="tier-badge tier-badge--fallback"
-                                title={`Fallback from ${getModelDisplayName(item.fallback_from_model)}`}
-                              >
-                                fallback
-                              </span>
-                            )}
-                          </span>
-                        </td>
-                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                          {(item.cache_read_tokens ?? 0) > 0 ||
-                          (item.cache_creation_tokens ?? 0) > 0
-                            ? `Read: ${formatNumber(item.cache_read_tokens ?? 0)} / Write: ${formatNumber(item.cache_creation_tokens ?? 0)}`
-                            : '\u2014'}
-                        </td>
-                        <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                          {item.duration_ms != null ? formatDuration(item.duration_ms) : '\u2014'}
-                        </td>
-                        <td>
-                          <Show
-                            when={item.error_message}
-                            fallback={
-                              <span class={`status-badge status-badge--${item.status}`}>
-                                {item.status === 'rate_limited' ? (
-                                  <A
-                                    href={`/agents/${encodeURIComponent(params.agentName)}/limits`}
-                                  >
-                                    {formatStatus(item.status)}
-                                  </A>
-                                ) : (
-                                  formatStatus(item.status)
-                                )}
-                              </span>
-                            }
-                          >
-                            <span
-                              class="status-badge-tooltip"
-                              tabindex="0"
-                              role="note"
-                              aria-label={formatErrorMessage(item.error_message!)}
+                          </td>
+                          <td style="font-family: var(--font-mono);">
+                            <Show
+                              when={item.auth_type === 'subscription'}
+                              fallback={
+                                <span
+                                  title={
+                                    item.cost != null && item.cost > 0 && item.cost < 0.01
+                                      ? `$${item.cost.toFixed(6)}`
+                                      : undefined
+                                  }
+                                >
+                                  {item.cost != null
+                                    ? (formatCost(item.cost) ?? '\u2014')
+                                    : '\u2014'}
+                                </span>
+                              }
                             >
                               <span
-                                class={`status-badge status-badge--${item.status}`}
-                                onClick={
-                                  item.status === 'fallback_error' && item.model
-                                    ? () => scrollToFallbackSuccess(item.model!)
-                                    : undefined
-                                }
+                                style="color: hsl(var(--muted-foreground));"
+                                title="Included in subscription"
                               >
-                                {item.status === 'fallback_error' && (
-                                  <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    width="11"
-                                    height="11"
-                                    viewBox="0 0 24 24"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    stroke-width="2.5"
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    style="margin-right: 3px; flex-shrink: 0;"
-                                  >
-                                    <polyline points="15 17 20 12 15 7" />
-                                    <path d="M4 18v-2a4 4 0 0 1 4-4h12" />
-                                  </svg>
-                                )}
-                                {formatStatus(item.status)}
+                                $0.00
                               </span>
-                              <span class="status-badge-tooltip__bubble">
-                                {formatErrorMessage(item.error_message!)}
-                              </span>
+                            </Show>
+                          </td>
+                          <td style="font-family: var(--font-mono);">
+                            {item.total_tokens != null ? formatNumber(item.total_tokens) : '\u2014'}
+                          </td>
+                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            {item.input_tokens != null ? formatNumber(item.input_tokens) : '\u2014'}
+                          </td>
+                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            {item.output_tokens != null
+                              ? formatNumber(item.output_tokens)
+                              : '\u2014'}
+                          </td>
+                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            <span style="display: inline-flex; align-items: center; gap: 4px;">
+                              {item.model && inferProviderFromModel(item.model) === 'custom' ? (
+                                (() => {
+                                  const provName = customProviderName(item.model!);
+                                  const letter = (provName ?? stripCustomPrefix(item.model!))
+                                    .charAt(0)
+                                    .toUpperCase();
+                                  return (
+                                    <span
+                                      class="provider-card__logo-letter"
+                                      title={provName}
+                                      style={{
+                                        background: customProviderColor(provName ?? ''),
+                                        width: '16px',
+                                        height: '16px',
+                                        'font-size': '9px',
+                                        'flex-shrink': '0',
+                                        'border-radius': '50%',
+                                      }}
+                                    >
+                                      {letter}
+                                    </span>
+                                  );
+                                })()
+                              ) : item.model && inferProviderFromModel(item.model) ? (
+                                <span
+                                  role="img"
+                                  aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
+                                  title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
+                                  style="display: inline-flex; flex-shrink: 0; position: relative;"
+                                >
+                                  {providerIcon(inferProviderFromModel(item.model)!, 14)}
+                                  {authBadgeFor(item.auth_type, 8)}
+                                </span>
+                              ) : null}
+                              {item.model ? getModelDisplayName(item.model) : '\u2014'}
+                              {item.routing_tier && (
+                                <span class={`tier-badge tier-badge--${item.routing_tier}`}>
+                                  {item.routing_tier}
+                                </span>
+                              )}
+                              {item.fallback_from_model && (
+                                <span
+                                  class="tier-badge tier-badge--fallback"
+                                  title={`Fallback from ${getModelDisplayName(item.fallback_from_model)}`}
+                                >
+                                  fallback
+                                </span>
+                              )}
                             </span>
-                          </Show>
-                        </td>
-                      </tr>
-                    )}
-                  </For>
-                </tbody>
-              </table>
+                          </td>
+                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            {(item.cache_read_tokens ?? 0) > 0 ||
+                            (item.cache_creation_tokens ?? 0) > 0
+                              ? `Read: ${formatNumber(item.cache_read_tokens ?? 0)} / Write: ${formatNumber(item.cache_creation_tokens ?? 0)}`
+                              : '\u2014'}
+                          </td>
+                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            {item.duration_ms != null ? formatDuration(item.duration_ms) : '\u2014'}
+                          </td>
+                          <td>
+                            <Show
+                              when={item.error_message}
+                              fallback={
+                                <span class={`status-badge status-badge--${item.status}`}>
+                                  {item.status === 'rate_limited' ? (
+                                    <A
+                                      href={`/agents/${encodeURIComponent(params.agentName)}/limits`}
+                                    >
+                                      {formatStatus(item.status)}
+                                    </A>
+                                  ) : (
+                                    formatStatus(item.status)
+                                  )}
+                                </span>
+                              }
+                            >
+                              <span
+                                class="status-badge-tooltip"
+                                tabindex="0"
+                                role="note"
+                                aria-label={formatErrorMessage(item.error_message!)}
+                              >
+                                <span
+                                  class={`status-badge status-badge--${item.status}`}
+                                  onClick={
+                                    item.status === 'fallback_error' && item.model
+                                      ? () => scrollToFallbackSuccess(item.model!)
+                                      : undefined
+                                  }
+                                >
+                                  {item.status === 'fallback_error' && (
+                                    <svg
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      width="11"
+                                      height="11"
+                                      viewBox="0 0 24 24"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      stroke-width="2.5"
+                                      stroke-linecap="round"
+                                      stroke-linejoin="round"
+                                      style="margin-right: 3px; flex-shrink: 0;"
+                                    >
+                                      <polyline points="15 17 20 12 15 7" />
+                                      <path d="M4 18v-2a4 4 0 0 1 4-4h12" />
+                                    </svg>
+                                  )}
+                                  {formatStatus(item.status)}
+                                </span>
+                                <span class="status-badge-tooltip__bubble">
+                                  {formatErrorMessage(item.error_message!)}
+                                </span>
+                              </span>
+                            </Show>
+                          </td>
+                        </tr>
+                      )}
+                    </For>
+                  </tbody>
+                </table>
+              </div>
               <Pagination
                 currentPage={pager.currentPage}
                 totalItems={() => data()?.total_count ?? 0}

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -507,40 +507,49 @@ const MessageLog: Component = () => {
                           </td>
                           <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
                             <span style="display: inline-flex; align-items: center; gap: 4px;">
-                              {item.model && inferProviderFromModel(item.model) === 'custom' ? (
-                                (() => {
-                                  const provName = customProviderName(item.model!);
-                                  const letter = (provName ?? stripCustomPrefix(item.model!))
-                                    .charAt(0)
-                                    .toUpperCase();
-                                  return (
-                                    <span
-                                      class="provider-card__logo-letter"
-                                      title={provName}
-                                      style={{
-                                        background: customProviderColor(provName ?? ''),
-                                        width: '16px',
-                                        height: '16px',
-                                        'font-size': '9px',
-                                        'flex-shrink': '0',
-                                        'border-radius': '50%',
-                                      }}
-                                    >
-                                      {letter}
-                                    </span>
-                                  );
-                                })()
-                              ) : item.model && inferProviderFromModel(item.model) ? (
-                                <span
-                                  role="img"
-                                  aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
-                                  title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
-                                  style="display: inline-flex; flex-shrink: 0; position: relative;"
-                                >
-                                  {providerIcon(inferProviderFromModel(item.model)!, 14)}
-                                  {authBadgeFor(item.auth_type, 8)}
-                                </span>
-                              ) : null}
+                              {item.model && inferProviderFromModel(item.model) === 'custom'
+                                ? (() => {
+                                    const provName = customProviderName(item.model!);
+                                    const letter = (provName ?? stripCustomPrefix(item.model!))
+                                      .charAt(0)
+                                      .toUpperCase();
+                                    return (
+                                      <span
+                                        class="provider-card__logo-letter"
+                                        title={provName}
+                                        style={{
+                                          background: customProviderColor(provName ?? ''),
+                                          width: '16px',
+                                          height: '16px',
+                                          'font-size': '9px',
+                                          'flex-shrink': '0',
+                                          'border-radius': '50%',
+                                        }}
+                                      >
+                                        {letter}
+                                      </span>
+                                    );
+                                  })()
+                                : item.model && inferProviderFromModel(item.model)
+                                  ? (() => {
+                                      const icon = providerIcon(
+                                        inferProviderFromModel(item.model!)!,
+                                        14,
+                                      );
+                                      const badge = authBadgeFor(item.auth_type, 8);
+                                      return (
+                                        <span
+                                          role="img"
+                                          aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
+                                          title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
+                                          style="display: inline-flex; flex-shrink: 0; position: relative;"
+                                        >
+                                          {icon}
+                                          {badge}
+                                        </span>
+                                      );
+                                    })()
+                                  : null}
                               {item.model ? getModelDisplayName(item.model) : '\u2014'}
                               {item.routing_tier && (
                                 <span class={`tier-badge tier-badge--${item.routing_tier}`}>

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -67,11 +67,13 @@ export function getCosts(range = '24h', agentName?: string) {
 export function getMessages(
   params: {
     range?: string;
-    status?: string;
+    provider?: string;
     service_type?: string;
     cursor?: string;
     limit?: string;
     agent_name?: string;
+    cost_min?: string;
+    cost_max?: string;
   } = {},
 ) {
   return fetchJson('/messages', params);

--- a/packages/frontend/src/styles/data.css
+++ b/packages/frontend/src/styles/data.css
@@ -21,6 +21,7 @@
   padding: 12px var(--gap-md);
   border-bottom: 1px solid hsl(var(--border));
   height: 40px;
+  white-space: nowrap;
 }
 
 .data-table__sortable {
@@ -36,6 +37,13 @@
   padding: 12px var(--gap-md);
   border-bottom: 1px solid hsl(var(--border));
   color: hsl(var(--foreground));
+  white-space: nowrap;
+}
+
+/* Horizontal scroll wrapper for data tables */
+.data-table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .data-table tbody tr {

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -87,7 +87,7 @@ const messagesData = {
   ],
   next_cursor: null,
   total_count: 2,
-  models: ["gpt-4o", "claude-3.5-sonnet"],
+  providers: ["anthropic", "openai"],
 };
 
 describe("MessageLog", () => {
@@ -161,7 +161,7 @@ describe("MessageLog", () => {
   });
 
   it("shows empty state for new agent", async () => {
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: [] });
+    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       expect(container.textContent).toContain("No messages recorded");
@@ -173,11 +173,11 @@ describe("MessageLog", () => {
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       const selects = container.querySelectorAll('[data-testid="select"]');
-      expect(selects.length).toBeGreaterThanOrEqual(2);
+      expect(selects.length).toBeGreaterThanOrEqual(1);
     });
     const selects = container.querySelectorAll('[data-testid="select"]');
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: ["gpt-4o"] });
-    await fireEvent.change(selects[0], { target: { value: "error" } });
+    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
+    await fireEvent.change(selects[0], { target: { value: "openai" } });
     await vi.waitFor(() => {
       expect(container.textContent).toContain("No messages match your filters");
     });
@@ -188,11 +188,11 @@ describe("MessageLog", () => {
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       const selects = container.querySelectorAll('[data-testid="select"]');
-      expect(selects.length).toBeGreaterThanOrEqual(2);
+      expect(selects.length).toBeGreaterThanOrEqual(1);
     });
     const selects = container.querySelectorAll('[data-testid="select"]');
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: ["gpt-4o"] });
-    await fireEvent.change(selects[0], { target: { value: "error" } });
+    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
+    await fireEvent.change(selects[0], { target: { value: "openai" } });
     await vi.waitFor(() => {
       expect(container.textContent).not.toContain("Waiting for data");
       expect(container.textContent).not.toContain("No messages recorded");
@@ -204,7 +204,7 @@ describe("MessageLog", () => {
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       const selects = container.querySelectorAll('[data-testid="select"]');
-      expect(selects.length).toBeGreaterThanOrEqual(2);
+      expect(selects.length).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -259,7 +259,7 @@ describe("MessageLog", () => {
     // Trigger a refetch that never resolves
     mockGetMessages.mockReturnValue(new Promise(() => {}));
     const selects = container.querySelectorAll('[data-testid="select"]');
-    await fireEvent.change(selects[0], { target: { value: "ok" } });
+    await fireEvent.change(selects[0], { target: { value: "openai" } });
 
     // Should still show old data, not skeletons
     expect(container.textContent).toContain("msg-1234");
@@ -440,12 +440,12 @@ describe("MessageLog", () => {
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       const selects = container.querySelectorAll('[data-testid="select"]');
-      expect(selects.length).toBeGreaterThanOrEqual(2);
+      expect(selects.length).toBeGreaterThanOrEqual(1);
     });
     // Set a filter to trigger filtered empty state
     const selects = container.querySelectorAll('[data-testid="select"]');
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: ["gpt-4o"] });
-    await fireEvent.change(selects[0], { target: { value: "error" } });
+    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
+    await fireEvent.change(selects[0], { target: { value: "openai" } });
     await vi.waitFor(() => {
       expect(container.textContent).toContain("No messages match your filters");
     });
@@ -478,7 +478,7 @@ describe("MessageLog", () => {
   it("closes setup modal via onClose callback", async () => {
     // To trigger setup modal, we need a new agent without setup completed
     localStorage.removeItem("setup_completed_test-agent");
-    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: [] });
+    mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
     const { container } = render(() => <MessageLog />);
     // The setup-close button in our mock will call onClose
     const closeBtn = container.querySelector('[data-testid="setup-close"]');
@@ -493,7 +493,7 @@ describe("MessageLog", () => {
     it("should treat setup as completed for local-agent in local mode", async () => {
       mockAgentName = "local-agent";
       mockIsLocalMode = true;
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: [] });
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         expect(container.textContent).toContain("Messages will show up");
@@ -503,7 +503,7 @@ describe("MessageLog", () => {
     it("should not show Set up agent button for local-agent in local mode", async () => {
       mockAgentName = "local-agent";
       mockIsLocalMode = true;
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: [] });
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         const setupBtn = container.querySelector(".btn--primary");
@@ -514,7 +514,7 @@ describe("MessageLog", () => {
     it("should show Set up agent button for non-local-agent even in local mode", async () => {
       mockAgentName = "other-agent";
       mockIsLocalMode = true;
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: [] });
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         expect(container.textContent).toContain("No messages recorded");
@@ -524,7 +524,7 @@ describe("MessageLog", () => {
     it("should show Set up agent button for local-agent when not in local mode", async () => {
       mockAgentName = "local-agent";
       mockIsLocalMode = false;
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: [] });
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         expect(container.textContent).toContain("No messages recorded");
@@ -539,7 +539,7 @@ describe("MessageLog", () => {
       ],
       next_cursor: null,
       total_count: 1,
-      models: ["custom:abc-123/my-llama"],
+      providers: ["custom"],
     };
 
     it("renders custom provider icon letter in message rows", async () => {
@@ -579,13 +579,13 @@ describe("MessageLog", () => {
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
         const selects = container.querySelectorAll('[data-testid="select"]');
-        expect(selects.length).toBeGreaterThanOrEqual(2);
+        expect(selects.length).toBeGreaterThanOrEqual(1);
       });
 
       // Set a filter
       const selects = container.querySelectorAll('[data-testid="select"]');
-      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, models: ["gpt-4o"] });
-      await fireEvent.change(selects[0], { target: { value: "error" } });
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
+      await fireEvent.change(selects[0], { target: { value: "openai" } });
 
       await vi.waitFor(() => {
         expect(container.textContent).toContain("No messages match your filters");
@@ -796,7 +796,7 @@ describe("MessageLog", () => {
         },
       ],
       total_count: 2,
-      models: ["deepseek-chat", "gemini-flash"],
+      providers: ["deepseek", "gemini"],
     };
     mockGetMessages.mockResolvedValue(dataWithChain);
     const { container } = render(() => <MessageLog />);

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -208,6 +208,25 @@ describe("MessageLog", () => {
     });
   });
 
+  it("renders provider display names in the filter dropdown", async () => {
+    const dataWithUnknown = {
+      ...messagesData,
+      providers: ["anthropic", "openai", "unknown-provider"],
+    };
+    mockGetMessages.mockResolvedValue(dataWithUnknown);
+    const { container } = render(() => <MessageLog />);
+    await vi.waitFor(() => {
+      const select = container.querySelector('[data-testid="select"]');
+      expect(select).not.toBeNull();
+      // Known providers resolve to display names
+      expect(select!.textContent).toContain("Anthropic");
+      expect(select!.textContent).toContain("OpenAI");
+      // Unknown providers fall back to the raw ID
+      expect(select!.textContent).toContain("unknown-provider");
+      expect(select!.textContent).toContain("All providers");
+    });
+  });
+
   it("debounces cost filter inputs", async () => {
     vi.useFakeTimers();
     mockGetMessages.mockResolvedValue(messagesData);
@@ -631,6 +650,25 @@ describe("MessageLog", () => {
     const { container } = render(() => <MessageLog />);
     await vi.waitFor(() => {
       expect(container.textContent).toContain("$0.05");
+    });
+  });
+
+  it("renders provider icon SVG for known provider model", async () => {
+    const dataWithProvider = {
+      ...messagesData,
+      items: [
+        { ...messagesData.items[0], model: "gpt-4o", auth_type: null },
+      ],
+      total_count: 1,
+    };
+    mockGetMessages.mockResolvedValue(dataWithProvider);
+    const { container } = render(() => <MessageLog />);
+    await vi.waitFor(() => {
+      // providerIcon returns an inline SVG for known providers
+      const providerSpan = container.querySelector('[role="img"]');
+      expect(providerSpan).not.toBeNull();
+      const svg = providerSpan!.querySelector("svg");
+      expect(svg).not.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- Removed the hardcoded status filter (with non-existent statuses like "Retried") and the model filter (showing default models not matching user data)
- Replaced both with a single **provider filter** populated dynamically from the user's actual message data
- Added `white-space: nowrap` on all table cells and horizontal scroll (`overflow-x: auto`) so nothing wraps to multiple lines on small screens

## Test plan

- [x] Backend unit tests pass (2380 tests)
- [x] Frontend unit tests pass (1451 tests)
- [x] New `provider-inference` utility fully tested
- [x] E2E test updated for provider filter
- [x] Build succeeds
- [ ] Verify provider dropdown shows only providers from actual messages
- [ ] Verify table rows never wrap on narrow viewports (horizontal scroll appears)

Closes #1031

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the broken status/model filters on the Messages page with a single provider filter populated from real user data, and enforced single-line table rows with horizontal scroll. Also improved provider icon rendering and display names with full test coverage. Closes #1031.

- New Features
  - Added a provider filter powered by model-to-provider inference; backend now accepts `provider` and returns a `providers` list.
  - Implemented `inferProviderFromModel` and cached distinct models; short-circuits when no models match the provider.
  - Updated UI: removed status/model selects, added provider dropdown with friendly names (via `PROVIDERS`), and added `white-space: nowrap` with a `.data-table-scroll` wrapper.
  - Expanded tests: provider inference, E2E for provider filter, provider icon/auth badge rendering coverage, display name resolution, and SVG icon rendering.

- Migration
  - `GET /messages` changes:
    - Request: use `provider`; `status` and `model` are no longer supported.
    - Response: `providers` replaces `models`.

<sup>Written for commit 8eb8b4359b279078aab2e997e03bf7fb9fbf92d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

