### PR TITLE
fix: hide Agent setup tab on Settings page in local mode

### DIFF
--- a/.changeset/hide-settings-tabs-local-mode.md
+++ b/.changeset/hide-settings-tabs-local-mode.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Hide Agent setup tab on Settings page in local mode

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -76,7 +76,7 @@ const Settings: Component = () => {
     }
   };
 
-  const TABS = () => ['General', 'Agent setup'] as const;
+  const TABS = () => (isLocalMode() ? [] : (['General', 'Agent setup'] as const));
   type Tab = 'General' | 'Agent setup';
   const [tab, setTab] = createSignal<Tab>('General');
 
@@ -186,7 +186,7 @@ const Settings: Component = () => {
       </Show>
 
       {/* -- Tab: Agent setup ------------------------- */}
-      <Show when={tab() === 'Agent setup'}>
+      <Show when={tab() === 'Agent setup' && !isLocalMode()}>
         <h3 class="settings-section__title">API Key</h3>
 
         <div class="settings-card">

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -88,7 +88,7 @@ describe("Settings", () => {
     expect(screen.queryByText("LLM Providers")).toBeNull();
   });
 
-  it("renders only two tab buttons", () => {
+  it("renders both tab buttons in cloud mode", () => {
     render(() => <Settings />);
     expect(screen.getByText("General")).toBeDefined();
     expect(screen.getByText("Agent setup")).toBeDefined();
@@ -353,10 +353,16 @@ describe("Settings", () => {
       expect(screen.getByLabelText("Agent name")).toBeDefined();
     });
 
-    it("shows both tabs in local mode", () => {
+    it("hides tabs in local mode", () => {
+      const { container } = render(() => <Settings />);
+      expect(container.querySelector(".panel__tabs")).toBeNull();
+      expect(screen.queryByText("Agent setup")).toBeNull();
+    });
+
+    it("still shows General content without tab switcher", () => {
       render(() => <Settings />);
-      expect(screen.getByText("General")).toBeDefined();
-      expect(screen.getByText("Agent setup")).toBeDefined();
+      expect(screen.getByLabelText("Agent name")).toBeDefined();
+      expect(screen.getByText("Save")).toBeDefined();
     });
 
     it("hides Danger zone in local mode", () => {


### PR DESCRIPTION
## Summary

- Hide the tab switcher (General / Agent setup) on the Settings page when running in local mode
- The Agent setup tab content (OTLP key, setup instructions) is not useful in local mode since auth uses loopback bypass
- In local mode, only the General tab content (agent rename) is shown without tabs

## Test plan

- [x] Frontend tests updated and passing (33 tests)
- [ ] Verify in local mode: no tab switcher visible, agent rename still works
- [ ] Verify in cloud mode: both tabs (General + Agent setup) are visible and functional

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Agent setup tab and the tab switcher on the Settings page in local mode, showing only the General content (agent rename). This avoids showing API key/setup info that doesn’t apply; cloud mode still shows both tabs.

<sup>Written for commit 9b71393e1193e0be3b88708694c4df7803b7bd13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

