### PR TITLE
fix: remove build obfuscation patterns triggering VirusTotal false positives

### DIFF
--- a/.changeset/fix-virustotal-flagging.md
+++ b/.changeset/fix-virustotal-flagging.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Remove process.env string obfuscation, reduce minification level, add source maps, and externalize child_process to avoid VirusTotal false positives

--- a/packages/openclaw-plugin/__tests__/build.test.ts
+++ b/packages/openclaw-plugin/__tests__/build.test.ts
@@ -17,8 +17,12 @@ describeIfBuilt("built bundle (dist/index.js)", () => {
     pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
   });
 
-  it("does not contain child_process references", () => {
-    expect(bundleContent).not.toContain("child_process");
+  it("does not contain inlined child_process code", () => {
+    // child_process is externalized, and since nothing actually imports it
+    // (the transitive dep was via @opentelemetry/resources which is stubbed),
+    // it should be completely absent from the bundle.
+    expect(bundleContent).not.toContain("execSync");
+    expect(bundleContent).not.toContain("spawnSync");
   });
 
   it("does not contain eval( calls", () => {
@@ -60,14 +64,13 @@ describeIfBuilt("built bundle (dist/index.js)", () => {
     expect(matches.length).toBeLessThanOrEqual(5);
   });
 
-  it("does not contain literal process.env references", () => {
-    // process.env is replaced with __fromEnv to avoid scanner flagging
-    // env access + network send as credential harvesting
-    expect(bundleContent).not.toMatch(/\bprocess\.env\b/);
+  it("does not contain string concatenation obfuscation", () => {
+    expect(bundleContent).not.toContain('"proc"+"ess"');
+    expect(bundleContent).not.toContain("__fromEnv");
   });
 
-  it("sets up __fromEnv in the banner for runtime env access", () => {
-    expect(bundleContent).toContain("__fromEnv");
+  it("includes source map reference", () => {
+    expect(bundleContent).toContain("//# sourceMappingURL=");
   });
 
   it("dist/backend/ contains no .js.map or .d.ts files", () => {
@@ -156,12 +159,12 @@ describe("build configuration", () => {
     expect(typeof stub.exec).toBe("function");
   });
 
-  it("build.ts aliases child_process to the stub", () => {
+  it("build.ts externalizes child_process", () => {
     const buildPath = resolve(__dirname, "../build.ts");
     const buildContent = readFileSync(buildPath, "utf-8");
 
     expect(buildContent).toContain("child_process");
-    expect(buildContent).toContain("stubs/child_process.js");
+    expect(buildContent).toMatch(/external.*child_process/s);
   });
 
   it("stubs/resources.js exports a Resource class with merge/empty/default", () => {

--- a/packages/openclaw-plugin/build.ts
+++ b/packages/openclaw-plugin/build.ts
@@ -12,20 +12,19 @@ async function main() {
     target: "node20",
     format: "cjs",
     outfile: "dist/index.js",
-    sourcemap: false,
-    minify: true,
-    external: ["./server"],
+    sourcemap: true,
+    minifyWhitespace: true,
+    minifySyntax: true,
+    external: ["./server", "child_process"],
     alias: {
       "@protobufjs/inquire": "./stubs/inquire.js",
-      "child_process": "./stubs/child_process.js",
       "@opentelemetry/resources": "./stubs/resources.js",
     },
     banner: {
-      js: '/* manifest — OpenClaw Observability Plugin */\nvar __fromEnv=globalThis["proc"+"ess"]?.env||{};',
+      js: "/* manifest — OpenClaw Observability Plugin */",
     },
     define: {
       "process.env.PLUGIN_VERSION": JSON.stringify(pkg.version),
-      "process.env": "__fromEnv",
     },
     logLevel: "info",
   });

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -16,6 +16,7 @@
   },
   "files": [
     "dist/index.js",
+    "dist/index.js.map",
     "dist/server.js",
     "dist/server.d.ts",
     "dist/backend",

--- a/packages/openclaw-plugin/src/server.ts
+++ b/packages/openclaw-plugin/src/server.ts
@@ -37,15 +37,19 @@ export async function start(options: StartOptions = {}): Promise<unknown> {
   // Generate a random persistent secret for local mode
   if (!process.env['BETTER_AUTH_SECRET']) {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const constants = require(`${BACKEND_DIR}/common/constants/local-mode.constants`);
+    const constants = require(
+      join(__dirname, BACKEND_DIR, 'common', 'constants', 'local-mode.constants'),
+    );
     process.env['BETTER_AUTH_SECRET'] = constants.getLocalAuthSecret();
   }
 
-  const backendMain = await import(`${BACKEND_DIR}/main`);
+  const backendMain = await import(join(__dirname, BACKEND_DIR, 'main'));
   const app = await backendMain.bootstrap();
 
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { trackEvent } = require(`${BACKEND_DIR}/common/utils/product-telemetry`);
+  const { trackEvent } = require(
+    join(__dirname, BACKEND_DIR, 'common', 'utils', 'product-telemetry'),
+  );
   trackEvent('server_started', { package_version: version });
 
   return app;


### PR DESCRIPTION
## Summary

- Remove `"proc"+"ess"` string concatenation and `__fromEnv` env variable shim from the esbuild banner — this was the primary pattern triggering VirusTotal AV heuristics
- Replace full identifier mangling (`minify: true`) with `minifyWhitespace + minifySyntax` to keep readable function/variable names in the bundle
- Enable source maps (`dist/index.js.map`) so scanners and humans can verify the bundle maps to legitimate source
- Move `child_process` from an inlined stub alias to `external`, removing all child_process code from the bundle
- Replace template-literal `require()` calls in `server.ts` with `path.join()` for transparency to static analysis

## Test plan

- [x] Plugin tests pass (343/343)
- [x] Backend unit tests pass (2387/2387)
- [x] Backend e2e tests pass (109/109)
- [x] Frontend tests pass (1469/1469)
- [x] TypeScript compiles cleanly (backend + frontend)
- [x] Rebuilt bundle verified: no `__fromEnv`, no `"proc"+"ess"`, readable identifiers, source map present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes build obfuscation and adjusts `esbuild` settings in `manifest` to prevent VirusTotal false positives. The bundle is now more transparent and easier to audit.

- **Bug Fixes**
  - Removed `"proc"+"ess"` and the `__fromEnv` shim from the `esbuild` banner; reduced minification to `minifyWhitespace` + `minifySyntax`.
  - Enabled source maps and ship `dist/index.js.map`.
  - Externalized `child_process` to eliminate inlined stub code.
  - Replaced template-literal `require()` calls in `server.ts` with `path.join()` to improve static analysis.

<sup>Written for commit 2232b79d71e2d4c71951c8899c5f7eda4c3ed96d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

