### PR TITLE
fix: security hardening across backend services

### DIFF
--- a/.changeset/security-remediation.md
+++ b/.changeset/security-remediation.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Security hardening: SSRF validation for custom provider URLs, encrypted email provider API keys, OTLP auth guard improvements (min token length, hashed cache keys, cache invalidation on rotation), telemetry DTO string length limits, SessionGuard exception handling, login rate limiting, provider error sanitization, DATABASE_URL validation, API key guard audit logging, domain length validation, test email recipient validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1425,6 +1425,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3619,7 +3620,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.57.1",
@@ -3632,7 +3634,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.57.1",
@@ -3645,7 +3648,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.57.1",
@@ -3658,7 +3662,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.57.1",
@@ -3671,7 +3676,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.57.1",
@@ -3684,7 +3690,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.57.1",
@@ -3697,7 +3704,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.57.1",
@@ -3710,7 +3718,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.57.1",
@@ -3723,7 +3732,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.57.1",
@@ -3736,7 +3746,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.57.1",
@@ -3749,7 +3760,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.57.1",
@@ -3762,7 +3774,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.57.1",
@@ -3775,7 +3788,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.57.1",
@@ -3788,7 +3802,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.57.1",
@@ -3801,7 +3816,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.57.1",
@@ -3814,7 +3830,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.57.1",
@@ -3825,7 +3842,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.57.1",
@@ -3836,7 +3854,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.57.1",
@@ -3849,7 +3868,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.57.1",
@@ -3862,7 +3882,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.57.1",
@@ -3875,7 +3896,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.57.1",
@@ -3888,7 +3910,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.57.1",
@@ -3901,7 +3924,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.57.1",
@@ -3914,7 +3938,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
@@ -7156,6 +7181,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extendable-error": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
@@ -8055,6 +8098,15 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -11186,7 +11238,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/rou3": {
       "version": "0.7.12",
@@ -13218,6 +13271,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13827,6 +13881,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "compression": "^1.8.1",
+        "express-rate-limit": "^8.3.1",
         "helmet": "^8.1.0",
         "pg": "^8.13.0",
         "protobufjs": "^8.0.0",
@@ -14184,7 +14239,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.24.2",
+      "version": "5.25.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -35,6 +35,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "compression": "^1.8.1",
+    "express-rate-limit": "^8.3.1",
     "helmet": "^8.1.0",
     "pg": "^8.13.0",
     "protobufjs": "^8.0.0",

--- a/packages/backend/src/auth/session.guard.spec.ts
+++ b/packages/backend/src/auth/session.guard.spec.ts
@@ -17,10 +17,10 @@ import { SessionGuard } from './session.guard';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { auth } = require('./auth.instance');
 
-function createMockContext(overrides: {
-  ip?: string;
-  headers?: Record<string, string>;
-}): { context: ExecutionContext; request: Record<string, unknown> } {
+function createMockContext(overrides: { ip?: string; headers?: Record<string, string> }): {
+  context: ExecutionContext;
+  request: Record<string, unknown>;
+} {
   const request: Record<string, unknown> = {
     ip: overrides.ip ?? '127.0.0.1',
     headers: overrides.headers ?? {},
@@ -88,6 +88,17 @@ describe('SessionGuard', () => {
   it('returns true even when no session found', async () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
     (auth.api.getSession as jest.Mock).mockResolvedValue(null);
+    const { context, request } = createMockContext({});
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(request['user']).toBeUndefined();
+  });
+
+  it('returns true and leaves user undefined when getSession throws', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+    (auth.api.getSession as jest.Mock).mockRejectedValue(new Error('DB connection lost'));
     const { context, request } = createMockContext({});
 
     const result = await guard.canActivate(context);

--- a/packages/backend/src/auth/session.guard.ts
+++ b/packages/backend/src/auth/session.guard.ts
@@ -1,8 +1,4 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  Injectable,
-} from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable, Logger } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { fromNodeHeaders } from 'better-auth/node';
@@ -11,6 +7,8 @@ import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
 
 @Injectable()
 export class SessionGuard implements CanActivate {
+  private readonly logger = new Logger(SessionGuard.name);
+
   constructor(private readonly reflector: Reflector) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -28,13 +26,17 @@ export class SessionGuard implements CanActivate {
     // In local mode, Better Auth is not initialized
     if (!auth) return true;
 
-    const session = await auth.api.getSession({
-      headers: fromNodeHeaders(request.headers),
-    });
+    try {
+      const session = await auth.api.getSession({
+        headers: fromNodeHeaders(request.headers),
+      });
 
-    if (session) {
-      (request as Request & { user: unknown }).user = session.user;
-      (request as Request & { session: unknown }).session = session.session;
+      if (session) {
+        (request as Request & { user: unknown }).user = session.user;
+        (request as Request & { session: unknown }).session = session.session;
+      }
+    } catch (err) {
+      this.logger.warn(`Session lookup failed: ${(err as Error).message}`);
     }
 
     // Always pass — let ApiKeyGuard handle unauthenticated requests

--- a/packages/backend/src/common/guards/api-key.guard.ts
+++ b/packages/backend/src/common/guards/api-key.guard.ts
@@ -53,7 +53,7 @@ export class ApiKeyGuard implements CanActivate {
       (request as Request & { apiKeyUserId: string }).apiKeyUserId = String(found.user_id);
       this.apiKeyRepo
         .update({ key_hash: hash }, { last_used_at: () => 'CURRENT_TIMESTAMP' } as never)
-        .catch(() => {});
+        .catch((err: Error) => this.logger.warn(`Failed to update last_used_at: ${err.message}`));
       return true;
     }
 

--- a/packages/backend/src/common/utils/url-validation.spec.ts
+++ b/packages/backend/src/common/utils/url-validation.spec.ts
@@ -1,0 +1,186 @@
+import { isPrivateIp, validatePublicUrl } from './url-validation';
+
+jest.mock('dns/promises', () => ({
+  lookup: jest.fn(),
+}));
+
+import { lookup } from 'dns/promises';
+
+const mockLookup = lookup as jest.MockedFunction<typeof lookup>;
+
+describe('isPrivateIp', () => {
+  it('detects 127.0.0.1 as private', () => {
+    expect(isPrivateIp('127.0.0.1')).toBe(true);
+  });
+
+  it('detects 127.255.255.255 as private', () => {
+    expect(isPrivateIp('127.255.255.255')).toBe(true);
+  });
+
+  it('detects 10.0.0.1 as private', () => {
+    expect(isPrivateIp('10.0.0.1')).toBe(true);
+  });
+
+  it('detects 172.16.0.1 as private', () => {
+    expect(isPrivateIp('172.16.0.1')).toBe(true);
+  });
+
+  it('detects 172.31.255.255 as private', () => {
+    expect(isPrivateIp('172.31.255.255')).toBe(true);
+  });
+
+  it('allows 172.32.0.1 (outside private range)', () => {
+    expect(isPrivateIp('172.32.0.1')).toBe(false);
+  });
+
+  it('detects 192.168.1.1 as private', () => {
+    expect(isPrivateIp('192.168.1.1')).toBe(true);
+  });
+
+  it('detects 169.254.0.1 as private (link-local)', () => {
+    expect(isPrivateIp('169.254.0.1')).toBe(true);
+  });
+
+  it('detects 0.0.0.0 as private', () => {
+    expect(isPrivateIp('0.0.0.0')).toBe(true);
+  });
+
+  it('allows 8.8.8.8 (public)', () => {
+    expect(isPrivateIp('8.8.8.8')).toBe(false);
+  });
+
+  it('allows 1.2.3.4 (public)', () => {
+    expect(isPrivateIp('1.2.3.4')).toBe(false);
+  });
+
+  it('detects ::1 as private IPv6', () => {
+    expect(isPrivateIp('::1')).toBe(true);
+  });
+
+  it('detects fc00::1 as private IPv6', () => {
+    expect(isPrivateIp('fc00::1')).toBe(true);
+  });
+
+  it('detects fd00::1 as private IPv6', () => {
+    expect(isPrivateIp('fd00::1')).toBe(true);
+  });
+
+  it('detects fe80::1 as private IPv6 (link-local)', () => {
+    expect(isPrivateIp('fe80::1')).toBe(true);
+  });
+
+  it('detects ::ffff:127.0.0.1 as private (mapped IPv4)', () => {
+    expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true);
+  });
+
+  it('detects ::ffff:10.0.0.1 as private (mapped IPv4)', () => {
+    expect(isPrivateIp('::ffff:10.0.0.1')).toBe(true);
+  });
+
+  it('allows ::ffff:8.8.8.8 (mapped public IPv4)', () => {
+    expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false);
+  });
+
+  it('returns false for invalid IP format', () => {
+    expect(isPrivateIp('not-an-ip')).toBe(false);
+  });
+});
+
+describe('validatePublicUrl', () => {
+  const origNodeEnv = process.env['NODE_ENV'];
+  const origManifestMode = process.env['MANIFEST_MODE'];
+
+  beforeEach(() => {
+    mockLookup.mockReset();
+    // Force non-test mode for validation to run
+    process.env['NODE_ENV'] = 'production';
+    delete process.env['MANIFEST_MODE'];
+  });
+
+  afterEach(() => {
+    process.env['NODE_ENV'] = origNodeEnv;
+    if (origManifestMode) process.env['MANIFEST_MODE'] = origManifestMode;
+    else delete process.env['MANIFEST_MODE'];
+  });
+
+  it('skips validation in test mode', async () => {
+    process.env['NODE_ENV'] = 'test';
+    await expect(validatePublicUrl('http://127.0.0.1:8080')).resolves.toBeUndefined();
+  });
+
+  it('skips validation in local mode', async () => {
+    process.env['MANIFEST_MODE'] = 'local';
+    await expect(validatePublicUrl('http://127.0.0.1:8080')).resolves.toBeUndefined();
+  });
+
+  it('accepts public URL that resolves to public IP', async () => {
+    mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+    await expect(validatePublicUrl('https://example.com/api')).resolves.toBeUndefined();
+  });
+
+  it('rejects invalid URL format', async () => {
+    await expect(validatePublicUrl('not-a-url')).rejects.toThrow('Invalid URL format');
+  });
+
+  it('rejects non-http/https schemes', async () => {
+    await expect(validatePublicUrl('ftp://example.com')).rejects.toThrow(
+      'Only http and https URLs are allowed',
+    );
+  });
+
+  it('rejects file scheme', async () => {
+    await expect(validatePublicUrl('file:///etc/passwd')).rejects.toThrow(
+      'Only http and https URLs are allowed',
+    );
+  });
+
+  it('rejects IP literal pointing to private network', async () => {
+    await expect(validatePublicUrl('http://127.0.0.1:8080')).rejects.toThrow('private or internal');
+  });
+
+  it('rejects IP literal 10.x.x.x', async () => {
+    await expect(validatePublicUrl('http://10.0.0.5/api')).rejects.toThrow('private or internal');
+  });
+
+  it('rejects IP literal 192.168.x.x', async () => {
+    await expect(validatePublicUrl('http://192.168.1.100:3000')).rejects.toThrow(
+      'private or internal',
+    );
+  });
+
+  it('rejects hostname that resolves to private IP', async () => {
+    mockLookup.mockResolvedValue([{ address: '192.168.1.1', family: 4 }] as never);
+    await expect(validatePublicUrl('https://evil.example.com')).rejects.toThrow(
+      'private or internal',
+    );
+  });
+
+  it('rejects hostname that resolves to loopback', async () => {
+    mockLookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }] as never);
+    await expect(validatePublicUrl('https://localhost.example.com')).rejects.toThrow(
+      'private or internal',
+    );
+  });
+
+  it('rejects when any resolved IP is private', async () => {
+    mockLookup.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.0.0.1', family: 4 },
+    ] as never);
+    await expect(validatePublicUrl('https://dual.example.com')).rejects.toThrow(
+      'private or internal',
+    );
+  });
+
+  it('rejects when DNS resolution fails', async () => {
+    mockLookup.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(validatePublicUrl('https://nonexistent.invalid')).rejects.toThrow(
+      'Failed to resolve hostname',
+    );
+  });
+
+  it('accepts http scheme', async () => {
+    mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+    await expect(validatePublicUrl('http://example.com/api')).resolves.toBeUndefined();
+  });
+});

--- a/packages/backend/src/common/utils/url-validation.ts
+++ b/packages/backend/src/common/utils/url-validation.ts
@@ -1,0 +1,80 @@
+import { lookup } from 'dns/promises';
+
+const PRIVATE_RANGES: { addr: bigint; mask: bigint }[] = [
+  cidr('127.0.0.0', 8), // Loopback
+  cidr('10.0.0.0', 8), // Class A private
+  cidr('172.16.0.0', 12), // Class B private
+  cidr('192.168.0.0', 16), // Class C private
+  cidr('169.254.0.0', 16), // Link-local
+  cidr('0.0.0.0', 8), // Current network
+];
+
+const PRIVATE_V6_PREFIXES = ['::1', 'fc00::', 'fd00::', 'fe80::'];
+
+function cidr(base: string, prefix: number): { addr: bigint; mask: bigint } {
+  const addr = ipv4ToBigInt(base);
+  const mask = (BigInt('0xFFFFFFFF') << BigInt(32 - prefix)) & BigInt('0xFFFFFFFF');
+  return { addr: addr & mask, mask };
+}
+
+function ipv4ToBigInt(ip: string): bigint {
+  const parts = ip.split('.').map(Number);
+  return (
+    BigInt((parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]) & BigInt('0xFFFFFFFF')
+  );
+}
+
+export function isPrivateIp(ip: string): boolean {
+  // Handle IPv4-mapped IPv6 addresses (::ffff:a.b.c.d)
+  const mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  const normalizedIp = mapped ? mapped[1] : ip;
+
+  // Check IPv6 private ranges
+  if (normalizedIp.includes(':')) {
+    const lower = normalizedIp.toLowerCase();
+    return PRIVATE_V6_PREFIXES.some((prefix) => lower.startsWith(prefix));
+  }
+
+  // Check IPv4 private ranges
+  const parsed = normalizedIp.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!parsed) return false;
+
+  const addr = ipv4ToBigInt(normalizedIp);
+  return PRIVATE_RANGES.some((range) => (addr & range.mask) === range.addr);
+}
+
+export async function validatePublicUrl(url: string): Promise<void> {
+  // Skip SSRF validation in test and local modes
+  if (process.env['NODE_ENV'] === 'test' || process.env['MANIFEST_MODE'] === 'local') return;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error('Invalid URL format');
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Only http and https URLs are allowed');
+  }
+
+  // Reject IP literals directly in the URL
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  if (isPrivateIp(hostname)) {
+    throw new Error('URLs pointing to private or internal networks are not allowed');
+  }
+
+  // Resolve DNS and check all resolved IPs
+  try {
+    const result = await lookup(hostname, { all: true });
+    const addresses = Array.isArray(result) ? result : [result];
+    for (const entry of addresses) {
+      if (isPrivateIp(entry.address)) {
+        throw new Error('URLs pointing to private or internal networks are not allowed');
+      }
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('private')) throw err;
+    throw new Error(`Failed to resolve hostname: ${hostname}`);
+  }
+}

--- a/packages/backend/src/config/app.config.spec.ts
+++ b/packages/backend/src/config/app.config.spec.ts
@@ -68,12 +68,14 @@ describe('appConfig', () => {
 
   it('defaults nodeEnv to development when NODE_ENV is not set', async () => {
     delete process.env['NODE_ENV'];
+    process.env['DATABASE_URL'] = 'postgresql://test:test@localhost/test';
     const config = await loadConfig();
     expect(config.nodeEnv).toBe('development');
   });
 
   it('reads NODE_ENV from env', async () => {
     process.env['NODE_ENV'] = 'production';
+    process.env['DATABASE_URL'] = 'postgresql://test:test@localhost/test';
     const config = await loadConfig();
     expect(config.nodeEnv).toBe('production');
   });
@@ -88,5 +90,27 @@ describe('appConfig', () => {
     process.env['DB_POOL_MAX'] = '50';
     const config = await loadConfig();
     expect(config.dbPoolMax).toBe(50);
+  });
+
+  it('throws when DATABASE_URL is missing in cloud mode', async () => {
+    delete process.env['DATABASE_URL'];
+    delete process.env['MANIFEST_MODE'];
+    process.env['NODE_ENV'] = 'production';
+    await expect(loadConfig()).rejects.toThrow('DATABASE_URL is required in cloud mode');
+  });
+
+  it('returns empty string when DATABASE_URL is missing in local mode', async () => {
+    delete process.env['DATABASE_URL'];
+    process.env['MANIFEST_MODE'] = 'local';
+    const config = await loadConfig();
+    expect(config.databaseUrl).toBe('');
+  });
+
+  it('returns default URL when DATABASE_URL is missing in test mode', async () => {
+    delete process.env['DATABASE_URL'];
+    process.env['NODE_ENV'] = 'test';
+    delete process.env['MANIFEST_MODE'];
+    const config = await loadConfig();
+    expect(config.databaseUrl).toContain('postgresql://');
   });
 });

--- a/packages/backend/src/config/app.config.ts
+++ b/packages/backend/src/config/app.config.ts
@@ -6,11 +6,19 @@ function sanitizeDbPath(raw: string): string {
   return resolve(raw);
 }
 
+function resolveDatabaseUrl(): string {
+  const url = process.env['DATABASE_URL'];
+  if (url) return url;
+  if (process.env['MANIFEST_MODE'] === 'local') return '';
+  if (process.env['NODE_ENV'] === 'test')
+    return 'postgresql://myuser:mypassword@localhost:5432/mydatabase';
+  throw new Error('DATABASE_URL is required in cloud mode. Set it in your .env file.');
+}
+
 export const appConfig = registerAs('app', () => ({
   port: Number(process.env['PORT'] ?? 3001),
   nodeEnv: process.env['NODE_ENV'] ?? 'development',
-  databaseUrl:
-    process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/mydatabase',
+  databaseUrl: resolveDatabaseUrl(),
   manifestMode: process.env['MANIFEST_MODE'] ?? 'cloud',
   dbPath: sanitizeDbPath(process.env['MANIFEST_DB_PATH'] ?? ''),
 

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -56,6 +56,7 @@ import { ExpandProviderUniqueKey1773000000000 } from './migrations/1773000000000
 import { AddOverrideAuthType1773100000000 } from './migrations/1773100000000-AddOverrideAuthType';
 import { AddMessageAuthType1773200000000 } from './migrations/1773200000000-AddMessageAuthType';
 import { AddModelsAgentIndex1773202787708 } from './migrations/1773202787708-AddModelsAgentIndex';
+import { AddEmailProviderKeyPrefix1773300000000 } from './migrations/1773300000000-AddEmailProviderKeyPrefix';
 
 const entities = [
   AgentMessage,
@@ -116,6 +117,7 @@ const migrations = [
   AddOverrideAuthType1773100000000,
   AddMessageAuthType1773200000000,
   AddModelsAgentIndex1773202787708,
+  AddEmailProviderKeyPrefix1773300000000,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';

--- a/packages/backend/src/database/migrations/1773300000000-AddEmailProviderKeyPrefix.spec.ts
+++ b/packages/backend/src/database/migrations/1773300000000-AddEmailProviderKeyPrefix.spec.ts
@@ -1,0 +1,43 @@
+import { QueryRunner } from 'typeorm';
+import { AddEmailProviderKeyPrefix1773300000000 } from './1773300000000-AddEmailProviderKeyPrefix';
+
+describe('AddEmailProviderKeyPrefix1773300000000', () => {
+  let migration: AddEmailProviderKeyPrefix1773300000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new AddEmailProviderKeyPrefix1773300000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('should add key_prefix column', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      expect(queryRunner.query).toHaveBeenCalledWith(expect.stringContaining('key_prefix'));
+    });
+
+    it('should use ALTER TABLE ADD COLUMN', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query.mock.calls[0][0]).toMatch(/ALTER TABLE/);
+      expect(queryRunner.query.mock.calls[0][0]).toMatch(/ADD COLUMN/);
+    });
+  });
+
+  describe('down', () => {
+    it('should drop key_prefix column', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(1);
+      expect(queryRunner.query).toHaveBeenCalledWith(expect.stringContaining('key_prefix'));
+    });
+
+    it('should use ALTER TABLE DROP COLUMN', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query.mock.calls[0][0]).toMatch(/DROP COLUMN/);
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1773300000000-AddEmailProviderKeyPrefix.ts
+++ b/packages/backend/src/database/migrations/1773300000000-AddEmailProviderKeyPrefix.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEmailProviderKeyPrefix1773300000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "email_provider_configs" ADD COLUMN "key_prefix" varchar NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "email_provider_configs" DROP COLUMN "key_prefix"`);
+  }
+}

--- a/packages/backend/src/entities/email-provider-config.entity.ts
+++ b/packages/backend/src/entities/email-provider-config.entity.ts
@@ -1,9 +1,4 @@
-import {
-  Entity,
-  Column,
-  PrimaryColumn,
-  Index,
-} from 'typeorm';
+import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType, timestampDefault } from '../common/utils/sql-dialect';
 
 @Entity('email_provider_configs')
@@ -20,6 +15,9 @@ export class EmailProviderConfig {
 
   @Column('varchar')
   api_key_encrypted!: string;
+
+  @Column('varchar', { nullable: true })
+  key_prefix!: string | null;
 
   @Column('varchar', { nullable: true })
   domain!: string | null;

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -79,6 +79,18 @@ export async function bootstrap() {
       res.status(404).json({ error: 'Not available in local mode' });
     });
   } else {
+    // Rate limit login attempts (Better Auth runs outside NestJS, so ThrottlerGuard doesn't apply)
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const rateLimit = require('express-rate-limit');
+    const loginLimiter = rateLimit.default({
+      windowMs: 15 * 60 * 1000,
+      max: 20,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: { error: 'Too many login attempts. Try again later.' },
+    });
+    expressApp.use('/api/auth/sign-in', loginLimiter);
+
     // Cloud mode: mount Better Auth handler (needs raw body, before express.json)
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { toNodeHandler } = require('better-auth/node');

--- a/packages/backend/src/notifications/dto/set-email-provider.dto.spec.ts
+++ b/packages/backend/src/notifications/dto/set-email-provider.dto.spec.ts
@@ -148,9 +148,7 @@ describe('SetEmailProviderDto', () => {
         notificationEmail: 'not-an-email',
       });
       const errors = await validate(dto);
-      const emailError = errors.find(
-        (e) => e.property === 'notificationEmail',
-      );
+      const emailError = errors.find((e) => e.property === 'notificationEmail');
       expect(emailError).toBeDefined();
     });
 
@@ -376,7 +374,7 @@ describe('TestEmailProviderDto', () => {
       expect(toError).toBeDefined();
     });
 
-    it('should accept a valid to string', async () => {
+    it('should accept a valid email address', async () => {
       const dto = create({
         provider: 'resend',
         apiKey: 'valid-api-key-123',
@@ -384,6 +382,17 @@ describe('TestEmailProviderDto', () => {
       });
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
+    });
+
+    it('should reject an invalid email address', async () => {
+      const dto = create({
+        provider: 'resend',
+        apiKey: 'valid-api-key-123',
+        to: 'not-an-email',
+      });
+      const errors = await validate(dto);
+      const toError = errors.find((e) => e.property === 'to');
+      expect(toError).toBeDefined();
     });
   });
 

--- a/packages/backend/src/notifications/dto/set-email-provider.dto.ts
+++ b/packages/backend/src/notifications/dto/set-email-provider.dto.ts
@@ -9,18 +9,18 @@ export class SetEmailProviderDto {
   @IsOptional()
   @IsString()
   @MinLength(8)
-  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   apiKey?: string;
 
   @ValidateIf((o) => o.provider === 'mailgun')
   @IsString()
   @MinLength(1)
-  @Transform(({ value }) => typeof value === 'string' ? value.trim().toLowerCase() : value)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
   domain?: string;
 
   @IsOptional()
   @IsEmail()
-  @Transform(({ value }) => typeof value === 'string' ? value.trim().toLowerCase() : value)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
   notificationEmail?: string;
 }
 
@@ -31,15 +31,15 @@ export class TestEmailProviderDto {
 
   @IsString()
   @MinLength(8)
-  @Transform(({ value }) => typeof value === 'string' ? value.trim() : value)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   apiKey!: string;
 
   @ValidateIf((o) => o.provider === 'mailgun')
   @IsString()
   @MinLength(1)
-  @Transform(({ value }) => typeof value === 'string' ? value.trim().toLowerCase() : value)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
   domain?: string;
 
-  @IsString()
+  @IsEmail()
   to!: string;
 }

--- a/packages/backend/src/notifications/services/email-provider-config.service.spec.ts
+++ b/packages/backend/src/notifications/services/email-provider-config.service.spec.ts
@@ -14,6 +14,13 @@ jest.mock('./email-providers/resolve-provider', () => ({
   })),
 }));
 
+jest.mock('../../common/utils/crypto.util', () => ({
+  encrypt: jest.fn((plaintext: string) => `ENC:${plaintext}`),
+  decrypt: jest.fn((ciphertext: string) => ciphertext.replace('ENC:', '')),
+  isEncrypted: jest.fn((value: string) => value.startsWith('ENC:')),
+  getEncryptionSecret: jest.fn(() => 'test-secret-32-chars-long-enough!!'),
+}));
+
 import { BadRequestException } from '@nestjs/common';
 import { EmailProviderConfigService } from './email-provider-config.service';
 import { createProvider } from './email-providers/resolve-provider';
@@ -50,7 +57,7 @@ describe('EmailProviderConfigService', () => {
           {
             provider: 'resend',
             domain: 'example.com',
-            api_key_encrypted: 're_abcdef123456',
+            key_prefix: 're_abcde',
             is_active: 1,
             notification_email: 'alerts@test.com',
           },
@@ -73,7 +80,7 @@ describe('EmailProviderConfigService', () => {
           {
             provider: 'resend',
             domain: undefined,
-            api_key_encrypted: 're_testkey1234',
+            key_prefix: 're_testk',
             is_active: 1,
             notification_email: undefined,
           },
@@ -83,6 +90,23 @@ describe('EmailProviderConfigService', () => {
       const result = await service.getConfig('user-1');
       expect(result!.domain).toBeNull();
       expect(result!.notificationEmail).toBeNull();
+    });
+
+    it('returns **** when key_prefix is null (legacy data)', async () => {
+      const ds = createMockDataSource([
+        [
+          {
+            provider: 'resend',
+            domain: null,
+            key_prefix: null,
+            is_active: 1,
+            notification_email: null,
+          },
+        ],
+      ]);
+      const service = new EmailProviderConfigService(ds);
+      const result = await service.getConfig('user-1');
+      expect(result!.keyPrefix).toBe('****');
     });
   });
 
@@ -122,7 +146,7 @@ describe('EmailProviderConfigService', () => {
 
     it('updates without API key — keeps existing key', async () => {
       const ds = createMockDataSource([
-        [{ id: 'existing-id', api_key_encrypted: 're_existingkey123' }], // SELECT existing
+        [{ id: 'existing-id', api_key_encrypted: 'ENC:re_existingkey123', key_prefix: 're_exist' }],
         [], // UPDATE
       ]);
       const service = new EmailProviderConfigService(ds);
@@ -137,7 +161,7 @@ describe('EmailProviderConfigService', () => {
 
     it('throws when existing config has invalid provider config on update without new API key', async () => {
       const ds = createMockDataSource([
-        [{ id: 'existing-id', api_key_encrypted: 'short' }], // existing with short key
+        [{ id: 'existing-id', api_key_encrypted: 'ENC:short' }], // existing with short key
       ]);
       const service = new EmailProviderConfigService(ds);
       await expect(service.upsert('user-1', { provider: 'mailgun' })).rejects.toThrow(
@@ -206,12 +230,12 @@ describe('EmailProviderConfigService', () => {
       expect(result).toBeNull();
     });
 
-    it('returns full config with API key', async () => {
+    it('returns full config with decrypted API key', async () => {
       const ds = createMockDataSource([
         [
           {
             provider: 'resend',
-            api_key_encrypted: 're_fullkey12345678',
+            api_key_encrypted: 'ENC:re_fullkey12345678',
             domain: 'example.com',
             notification_email: 'alerts@test.com',
           },
@@ -227,12 +251,28 @@ describe('EmailProviderConfigService', () => {
       });
     });
 
+    it('returns plaintext key for backwards compatibility', async () => {
+      const ds = createMockDataSource([
+        [
+          {
+            provider: 'resend',
+            api_key_encrypted: 're_plaintext_legacy_key',
+            domain: null,
+            notification_email: null,
+          },
+        ],
+      ]);
+      const service = new EmailProviderConfigService(ds);
+      const result = await service.getFullConfig('user-1');
+      expect(result!.apiKey).toBe('re_plaintext_legacy_key');
+    });
+
     it('returns null domain and email when not set', async () => {
       const ds = createMockDataSource([
         [
           {
             provider: 'resend',
-            api_key_encrypted: 're_fullkey12345678',
+            api_key_encrypted: 'ENC:re_fullkey12345678',
             domain: undefined,
             notification_email: undefined,
           },
@@ -291,12 +331,12 @@ describe('EmailProviderConfigService', () => {
       expect(result).toEqual({ success: false, error: 'No email provider configured' });
     });
 
-    it('calls testConfig with saved credentials', async () => {
+    it('calls testConfig with decrypted credentials', async () => {
       const ds = createMockDataSource([
         [
           {
             provider: 'resend',
-            api_key_encrypted: 're_savedkey12345678',
+            api_key_encrypted: 'ENC:re_savedkey12345678',
             domain: null,
             notification_email: null,
           },

--- a/packages/backend/src/notifications/services/email-provider-config.service.ts
+++ b/packages/backend/src/notifications/services/email-provider-config.service.ts
@@ -3,6 +3,7 @@ import { DataSource } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 import { render } from '@react-email/render';
 import { detectDialect, portableSql, type DbDialect } from '../../common/utils/sql-dialect';
+import { encrypt, decrypt, isEncrypted, getEncryptionSecret } from '../../common/utils/crypto.util';
 import { validateProviderConfig } from './email-provider-validation';
 import { createProvider } from './email-providers/resolve-provider';
 import { TestEmail } from '../emails/test-email';
@@ -35,9 +36,19 @@ export class EmailProviderConfigService {
     return portableSql(query, this.dialect);
   }
 
+  private decryptKey(stored: string): string {
+    if (isEncrypted(stored)) {
+      return decrypt(stored, getEncryptionSecret());
+    }
+    // Backwards compatibility: plaintext keys from before encryption was added
+    return stored;
+  }
+
   async getConfig(userId: string): Promise<EmailProviderPublicConfig | null> {
     const rows = await this.ds.query(
-      this.sql(`SELECT provider, domain, api_key_encrypted, is_active, notification_email FROM email_provider_configs WHERE user_id = $1`),
+      this.sql(
+        `SELECT provider, domain, key_prefix, is_active, notification_email FROM email_provider_configs WHERE user_id = $1`,
+      ),
       [userId],
     );
     if (!rows.length) return null;
@@ -46,7 +57,7 @@ export class EmailProviderConfigService {
     return {
       provider: row.provider,
       domain: row.domain ?? null,
-      keyPrefix: row.api_key_encrypted.substring(0, 8),
+      keyPrefix: row.key_prefix ?? '****',
       is_active: !!row.is_active,
       notificationEmail: row.notification_email ?? null,
     };
@@ -66,22 +77,25 @@ export class EmailProviderConfigService {
 
     // When updating without a new API key, keep the existing one
     if (existing.length > 0 && !dto.apiKey) {
-      const existingKey = existing[0].api_key_encrypted;
-      const validation = validateProviderConfig(dto.provider, existingKey, dto.domain);
+      const storedKey = existing[0].api_key_encrypted;
+      const plainKey = this.decryptKey(storedKey);
+      const validation = validateProviderConfig(dto.provider, plainKey, dto.domain);
       if (!validation.valid) {
         throw new BadRequestException(validation.errors);
       }
       const { domain, provider } = validation.normalized;
 
       await this.ds.query(
-        this.sql(`UPDATE email_provider_configs SET provider = $1, domain = $2, is_active = $3, updated_at = $4, notification_email = $5 WHERE user_id = $6`),
+        this.sql(
+          `UPDATE email_provider_configs SET provider = $1, domain = $2, is_active = $3, updated_at = $4, notification_email = $5 WHERE user_id = $6`,
+        ),
         [provider, domain || null, 1, now, notificationEmail, userId],
       );
 
       return {
         provider,
         domain: domain || null,
-        keyPrefix: existingKey.substring(0, 8),
+        keyPrefix: existing[0].key_prefix ?? plainKey.substring(0, 8),
         is_active: true,
         notificationEmail,
       };
@@ -98,38 +112,57 @@ export class EmailProviderConfigService {
     }
 
     const { apiKey, domain, provider } = validation.normalized;
+    const secret = getEncryptionSecret();
+    const encryptedKey = encrypt(apiKey, secret);
+    const prefix = apiKey.substring(0, 8);
 
     if (existing.length > 0) {
       await this.ds.query(
-        this.sql(`UPDATE email_provider_configs SET provider = $1, api_key_encrypted = $2, domain = $3, is_active = $4, updated_at = $5, notification_email = $6 WHERE user_id = $7`),
-        [provider, apiKey, domain || null, 1, now, notificationEmail, userId],
+        this.sql(
+          `UPDATE email_provider_configs SET provider = $1, api_key_encrypted = $2, key_prefix = $3, domain = $4, is_active = $5, updated_at = $6, notification_email = $7 WHERE user_id = $8`,
+        ),
+        [provider, encryptedKey, prefix, domain || null, 1, now, notificationEmail, userId],
       );
     } else {
       await this.ds.query(
-        this.sql(`INSERT INTO email_provider_configs (id, user_id, provider, api_key_encrypted, domain, is_active, created_at, updated_at, notification_email) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`),
-        [uuid(), userId, provider, apiKey, domain || null, 1, now, now, notificationEmail],
+        this.sql(
+          `INSERT INTO email_provider_configs (id, user_id, provider, api_key_encrypted, key_prefix, domain, is_active, created_at, updated_at, notification_email) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+        ),
+        [
+          uuid(),
+          userId,
+          provider,
+          encryptedKey,
+          prefix,
+          domain || null,
+          1,
+          now,
+          now,
+          notificationEmail,
+        ],
       );
     }
 
     return {
       provider,
       domain: domain || null,
-      keyPrefix: apiKey.substring(0, 8),
+      keyPrefix: prefix,
       is_active: true,
       notificationEmail,
     };
   }
 
   async remove(userId: string): Promise<void> {
-    await this.ds.query(
-      this.sql(`DELETE FROM email_provider_configs WHERE user_id = $1`),
-      [userId],
-    );
+    await this.ds.query(this.sql(`DELETE FROM email_provider_configs WHERE user_id = $1`), [
+      userId,
+    ]);
   }
 
   async getFullConfig(userId: string): Promise<EmailProviderFullConfig | null> {
     const rows = await this.ds.query(
-      this.sql(`SELECT provider, api_key_encrypted, domain, notification_email FROM email_provider_configs WHERE user_id = $1 AND is_active = $2`),
+      this.sql(
+        `SELECT provider, api_key_encrypted, domain, notification_email FROM email_provider_configs WHERE user_id = $1 AND is_active = $2`,
+      ),
       [userId, 1],
     );
     if (!rows.length) return null;
@@ -137,7 +170,7 @@ export class EmailProviderConfigService {
     const row = rows[0];
     return {
       provider: row.provider,
-      apiKey: row.api_key_encrypted,
+      apiKey: this.decryptKey(row.api_key_encrypted),
       domain: row.domain ?? null,
       notificationEmail: row.notification_email ?? null,
     };
@@ -160,7 +193,9 @@ export class EmailProviderConfigService {
 
     if (existing.length > 0) {
       await this.ds.query(
-        this.sql(`UPDATE email_provider_configs SET notification_email = $1, updated_at = $2 WHERE user_id = $3`),
+        this.sql(
+          `UPDATE email_provider_configs SET notification_email = $1, updated_at = $2 WHERE user_id = $3`,
+        ),
         [email.trim().toLowerCase(), now, userId],
       );
     }

--- a/packages/backend/src/notifications/services/email-provider-validation.spec.ts
+++ b/packages/backend/src/notifications/services/email-provider-validation.spec.ts
@@ -114,4 +114,27 @@ describe('validateProviderConfig', () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain('Invalid domain format');
   });
+
+  it('rejects domain exceeding 253 characters for Mailgun', () => {
+    const longDomain = 'a'.repeat(250) + '.com';
+    const result = validateProviderConfig('mailgun', 'key-12345678', longDomain);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Domain name exceeds maximum length');
+  });
+
+  it('rejects domain exceeding 253 characters for non-Mailgun providers', () => {
+    const longDomain = 'a'.repeat(250) + '.com';
+    const result = validateProviderConfig('resend', 're_abcdefghij', longDomain);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Domain name exceeds maximum length');
+  });
+
+  it('accepts domain at exactly 253 characters', () => {
+    // Build a valid domain that is exactly 253 chars
+    const label = 'a'.repeat(63);
+    const domain = `${label}.${label}.${label}.${label.substring(0, 253 - 63 * 3 - 3)}`;
+    const result = validateProviderConfig('mailgun', 'key-12345678', domain);
+    // Should pass domain length check (may fail regex, but not the length check)
+    expect(result.errors).not.toContain('Domain name exceeds maximum length');
+  });
 });

--- a/packages/backend/src/notifications/services/email-provider-validation.ts
+++ b/packages/backend/src/notifications/services/email-provider-validation.ts
@@ -34,11 +34,17 @@ export function validateProviderConfig(
   if (provider === 'mailgun') {
     if (!trimmedDomain) {
       errors.push('Domain is required for Mailgun');
+    } else if (trimmedDomain.length > 253) {
+      errors.push('Domain name exceeds maximum length');
     } else if (!DOMAIN_RE.test(trimmedDomain)) {
       errors.push('Invalid domain format');
     }
-  } else if (trimmedDomain && !DOMAIN_RE.test(trimmedDomain)) {
-    errors.push('Invalid domain format');
+  } else if (trimmedDomain) {
+    if (trimmedDomain.length > 253) {
+      errors.push('Domain name exceeds maximum length');
+    } else if (!DOMAIN_RE.test(trimmedDomain)) {
+      errors.push('Invalid domain format');
+    }
   }
 
   return {

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
@@ -1,5 +1,10 @@
 import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { createHash } from 'crypto';
 import { OtlpAuthGuard } from './otlp-auth.guard';
+
+function testCacheKey(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
 
 function makeContext(headers: Record<string, string | undefined>, ip = '10.0.0.1') {
   const request: Record<string, unknown> = { headers, ip };
@@ -67,6 +72,19 @@ describe('OtlpAuthGuard', () => {
   it('rejects token without mnfst_ prefix', async () => {
     const { ctx } = makeContext({ authorization: 'Bearer osk_some_old_key' });
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
+    expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('rejects mnfst_ token shorter than minimum length', async () => {
+    const { ctx } = makeContext({ authorization: 'Bearer mnfst_ab' });
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
+    expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
+  });
+
+  it('rejects bare mnfst_ prefix with no suffix', async () => {
+    const { ctx } = makeContext({ authorization: 'Bearer mnfst_' });
     await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
     expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
   });
@@ -393,8 +411,9 @@ describe('OtlpAuthGuard', () => {
     const internalCache = (guard as any).cache as Map<string, unknown>;
 
     // Fill to exactly MAX_CACHE_SIZE so the next insert triggers eviction
+    const firstFillerHash = testCacheKey('mnfst_filler-0');
     for (let i = 0; i < 10_000; i++) {
-      internalCache.set(`mnfst_filler-${i}`, {
+      internalCache.set(testCacheKey(`mnfst_filler-${i}`), {
         tenantId: 't',
         agentId: 'a',
         agentName: 'n',
@@ -418,16 +437,18 @@ describe('OtlpAuthGuard', () => {
 
     expect(result).toBe(true);
     // The first filler key should have been evicted
-    expect(internalCache.has('mnfst_filler-0')).toBe(false);
-    // The new key should be in the cache
-    expect(internalCache.has('mnfst_overflow-key')).toBe(true);
+    expect(internalCache.has(firstFillerHash)).toBe(false);
+    // The new key should be in the cache (stored as hash)
+    expect(internalCache.has(testCacheKey('mnfst_overflow-key'))).toBe(true);
   });
 
   it('evictExpired removes entries whose expiresAt has passed', async () => {
     const internalCache = (guard as any).cache as Map<string, unknown>;
 
-    // Insert an expired entry
-    internalCache.set('mnfst_expired-cache', {
+    // Insert an expired entry (using hashed keys as the cache now stores hashes)
+    const expiredHash = testCacheKey('mnfst_expired-cache');
+    const validHash = testCacheKey('mnfst_valid-cache');
+    internalCache.set(expiredHash, {
       tenantId: 't',
       agentId: 'a',
       agentName: 'n',
@@ -435,7 +456,7 @@ describe('OtlpAuthGuard', () => {
       expiresAt: Date.now() - 1000, // expired 1 second ago
     });
     // Insert a valid entry
-    internalCache.set('mnfst_valid-cache', {
+    internalCache.set(validHash, {
       tenantId: 't2',
       agentId: 'a2',
       agentName: 'n2',
@@ -458,11 +479,11 @@ describe('OtlpAuthGuard', () => {
     await guard.canActivate(ctx);
 
     // The expired entry should have been removed
-    expect(internalCache.has('mnfst_expired-cache')).toBe(false);
+    expect(internalCache.has(expiredHash)).toBe(false);
     // The valid entry should still be there
-    expect(internalCache.has('mnfst_valid-cache')).toBe(true);
-    // The new key should also be cached
-    expect(internalCache.has('mnfst_trigger-evict-key')).toBe(true);
+    expect(internalCache.has(validHash)).toBe(true);
+    // The new key should also be cached (as hash)
+    expect(internalCache.has(testCacheKey('mnfst_trigger-evict-key'))).toBe(true);
   });
 
   it('periodic timer fires evictExpired', () => {
@@ -476,7 +497,7 @@ describe('OtlpAuthGuard', () => {
     const timedGuard = new OtlpAuthGuard(mockRepo);
 
     const internalCache = (timedGuard as any).cache as Map<string, unknown>;
-    internalCache.set('mnfst_stale', {
+    internalCache.set(testCacheKey('mnfst_stale'), {
       tenantId: 't',
       agentId: 'a',
       agentName: 'n',
@@ -506,7 +527,7 @@ describe('OtlpAuthGuard', () => {
     timedGuard.onModuleDestroy();
 
     // After destroy, add an expired entry — timer should not evict it
-    internalCache.set('mnfst_leftover', {
+    internalCache.set(testCacheKey('mnfst_leftover'), {
       tenantId: 't',
       agentId: 'a',
       agentName: 'n',
@@ -518,6 +539,26 @@ describe('OtlpAuthGuard', () => {
     expect(internalCache.size).toBe(1);
 
     jest.useRealTimers();
+  });
+
+  it('does not store plaintext tokens in cache', async () => {
+    mockGetOne.mockResolvedValue({
+      tenant_id: 'tenant-1',
+      agent_id: 'agent-1',
+      expires_at: null,
+      agent: { name: 'test-agent' },
+      tenant: { name: 'user-1' },
+    });
+
+    const token = 'mnfst_plaintext-check-key';
+    const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+    await guard.canActivate(ctx);
+
+    const internalCache = (guard as any).cache as Map<string, unknown>;
+    // The cache must NOT contain the plaintext token as a key
+    expect(internalCache.has(token)).toBe(false);
+    // It should contain the SHA-256 hash of the token
+    expect(internalCache.has(testCacheKey(token))).toBe(true);
   });
 
   it('invalidateCache removes a specific key from cache', async () => {

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { createHash } from 'crypto';
 import { Request } from 'express';
 import { AgentApiKey } from '../../entities/agent-api-key.entity';
 import { IngestionContext } from '../interfaces/ingestion-context.interface';
@@ -21,6 +22,11 @@ import {
 } from '../../common/constants/local-mode.constants';
 
 const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+const MIN_TOKEN_LENGTH = 12;
+
+function cacheKey(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
 
 interface CachedKey {
   tenantId: string;
@@ -115,7 +121,11 @@ export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
       throw new UnauthorizedException('Invalid API key format');
     }
 
-    const cached = this.cache.get(token);
+    if (token.length < MIN_TOKEN_LENGTH) {
+      throw new UnauthorizedException('Invalid API key format');
+    }
+
+    const cached = this.cache.get(cacheKey(token));
     if (cached && cached.expiresAt > Date.now()) {
       (request as Request & { ingestionContext: IngestionContext }).ingestionContext = {
         tenantId: cached.tenantId,
@@ -154,7 +164,7 @@ export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
       if (firstKey) this.cache.delete(firstKey);
     }
 
-    this.cache.set(token, {
+    this.cache.set(cacheKey(token), {
       tenantId: keyRecord.tenant_id,
       agentId: keyRecord.agent_id,
       agentName: keyRecord.agent.name,
@@ -173,7 +183,7 @@ export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
   }
 
   invalidateCache(key: string) {
-    this.cache.delete(key);
+    this.cache.delete(cacheKey(key));
   }
 
   clearCache() {

--- a/packages/backend/src/otlp/services/api-key.service.spec.ts
+++ b/packages/backend/src/otlp/services/api-key.service.spec.ts
@@ -5,6 +5,7 @@ import { ApiKeyGeneratorService } from './api-key.service';
 import { Tenant } from '../../entities/tenant.entity';
 import { Agent } from '../../entities/agent.entity';
 import { AgentApiKey } from '../../entities/agent-api-key.entity';
+import { OtlpAuthGuard } from '../guards/otlp-auth.guard';
 import { hashKey, keyPrefix } from '../../common/utils/hash.util';
 import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
 
@@ -41,6 +42,7 @@ describe('ApiKeyGeneratorService', () => {
   let mockKeyQb: Record<string, jest.Mock>;
   let mockAgentGetOne: jest.Mock;
   let mockAgentQb: Record<string, jest.Mock>;
+  let mockClearCache: jest.Mock;
 
   beforeEach(async () => {
     mockTenantFindOne = jest.fn();
@@ -51,6 +53,8 @@ describe('ApiKeyGeneratorService', () => {
     mockKeyDelete = jest.fn().mockResolvedValue({});
     mockKeyGetOne = jest.fn();
     mockAgentGetOne = jest.fn();
+
+    mockClearCache = jest.fn();
 
     mockKeyQb = {
       leftJoin: jest.fn().mockReturnThis(),
@@ -91,6 +95,10 @@ describe('ApiKeyGeneratorService', () => {
             delete: mockKeyDelete,
             createQueryBuilder: jest.fn().mockReturnValue(mockKeyQb),
           },
+        },
+        {
+          provide: OtlpAuthGuard,
+          useValue: { clearCache: mockClearCache },
         },
       ],
     }).compile();
@@ -467,6 +475,24 @@ describe('ApiKeyGeneratorService', () => {
       await service.rotateKey('user-1', 'my-agent');
 
       expect(callOrder).toEqual(['delete', 'insert']);
+    });
+
+    it('should call clearCache after deleting the old key', async () => {
+      mockAgentGetOne.mockResolvedValue(existingAgent);
+
+      await service.rotateKey('user-1', 'my-agent');
+
+      expect(mockClearCache).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onboardAgent does not clear cache', () => {
+    it('should not call clearCache during onboarding', async () => {
+      mockTenantFindOne.mockResolvedValue(null);
+
+      await service.onboardAgent({ tenantName: 'user-42', agentName: 'my-agent' });
+
+      expect(mockClearCache).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/otlp/services/api-key.service.ts
+++ b/packages/backend/src/otlp/services/api-key.service.ts
@@ -8,6 +8,7 @@ import { Agent } from '../../entities/agent.entity';
 import { AgentApiKey } from '../../entities/agent-api-key.entity';
 import { hashKey, keyPrefix } from '../../common/utils/hash.util';
 import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
+import { OtlpAuthGuard } from '../guards/otlp-auth.guard';
 
 @Injectable()
 export class ApiKeyGeneratorService {
@@ -18,6 +19,7 @@ export class ApiKeyGeneratorService {
     private readonly agentRepo: Repository<Agent>,
     @InjectRepository(AgentApiKey)
     private readonly keyRepo: Repository<AgentApiKey>,
+    private readonly otlpAuthGuard: OtlpAuthGuard,
   ) {}
 
   private generateKey(): string {
@@ -102,6 +104,7 @@ export class ApiKeyGeneratorService {
     if (!agent) throw new NotFoundException('Agent not found or access denied');
 
     await this.keyRepo.delete({ agent_id: agent.id });
+    this.otlpAuthGuard.clearCache();
 
     const rawKey = this.generateKey();
     const keyId = uuidv4();

--- a/packages/backend/src/routing/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider.service.spec.ts
@@ -1,4 +1,12 @@
+jest.mock('../common/utils/url-validation', () => ({
+  validatePublicUrl: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { BadRequestException } from '@nestjs/common';
 import { CustomProviderService } from './custom-provider.service';
+import { validatePublicUrl } from '../common/utils/url-validation';
+
+const mockValidatePublicUrl = validatePublicUrl as jest.MockedFunction<typeof validatePublicUrl>;
 
 describe('CustomProviderService (static helpers)', () => {
   describe('providerKey', () => {
@@ -138,6 +146,21 @@ describe('CustomProviderService (with mocks)', () => {
       expect(mockPricingRepo.upsert).toHaveBeenCalledTimes(1);
       expect(mockRoutingService.upsertProvider).toHaveBeenCalledTimes(1);
       expect(mockPricingCache.reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects private/internal URLs via SSRF validation', async () => {
+      mockValidatePublicUrl.mockRejectedValueOnce(
+        new Error('URLs pointing to private or internal networks are not allowed'),
+      );
+      const dto = {
+        name: 'Evil',
+        base_url: 'http://127.0.0.1:8080',
+        models: [{ model_name: 'test' }],
+      };
+      await expect(service.create('agent-1', 'user-1', dto as never)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(mockValidatePublicUrl).toHaveBeenCalledWith('http://127.0.0.1:8080');
     });
 
     it('throws ConflictException for duplicate name', async () => {
@@ -283,6 +306,18 @@ describe('CustomProviderService (with mocks)', () => {
       expect(result.name).toBe('Updated Groq');
       expect(result.base_url).toBe('https://new-url.com/v1');
       expect(mockRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects private URL on base_url update', async () => {
+      mockValidatePublicUrl.mockRejectedValueOnce(
+        new Error('URLs pointing to private or internal networks are not allowed'),
+      );
+      await expect(
+        service.update('agent-1', 'cp-1', 'user-1', {
+          base_url: 'http://10.0.0.5:3000',
+        } as never),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockValidatePublicUrl).toHaveBeenCalledWith('http://10.0.0.5:3000');
     });
 
     it('throws NotFoundException when provider not found', async () => {

--- a/packages/backend/src/routing/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  ConflictException,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
@@ -10,6 +15,7 @@ import { RoutingCacheService } from './routing-cache.service';
 import { TierAutoAssignService } from './tier-auto-assign.service';
 import { CreateCustomProviderDto, UpdateCustomProviderDto } from './dto/custom-provider.dto';
 import { computeQualityScore } from '../database/quality-score.util';
+import { validatePublicUrl } from '../common/utils/url-validation';
 
 @Injectable()
 export class CustomProviderService {
@@ -72,6 +78,12 @@ export class CustomProviderService {
       throw new ConflictException(`Custom provider "${dto.name}" already exists for this agent`);
     }
 
+    try {
+      await validatePublicUrl(dto.base_url);
+    } catch (err) {
+      throw new BadRequestException((err as Error).message);
+    }
+
     const id = randomUUID();
     const provKey = CustomProviderService.providerKey(id);
 
@@ -124,6 +136,11 @@ export class CustomProviderService {
     }
 
     if (dto.base_url !== undefined) {
+      try {
+        await validatePublicUrl(dto.base_url);
+      } catch (err) {
+        throw new BadRequestException((err as Error).message);
+      }
       cp.base_url = dto.base_url;
     }
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -476,7 +476,13 @@ describe('ProxyController', () => {
     await controller.chatCompletions(req as never, res as never);
 
     expect(res.status).toHaveBeenCalledWith(429);
-    expect(res.send).toHaveBeenCalledWith(errorBody);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        message: 'Rate limited by upstream provider',
+        type: 'upstream_error',
+        status: 429,
+      },
+    });
   });
 
   it('should handle 500 errors from proxyService', async () => {
@@ -877,7 +883,13 @@ describe('ProxyController', () => {
       await new Promise((r) => setTimeout(r, 10));
 
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.send).toHaveBeenCalledWith('{"error":"bad request"}');
+      expect(res.json).toHaveBeenCalledWith({
+        error: {
+          message: 'Bad request to upstream provider',
+          type: 'upstream_error',
+          status: 400,
+        },
+      });
     });
 
     it('should apply 429 cooldown for provider responses', async () => {
@@ -1479,8 +1491,13 @@ describe('ProxyController', () => {
       await controller.chatCompletions(req as never, res as never);
 
       expect(res.status).toHaveBeenCalledWith(502);
-      expect(res.send).toHaveBeenCalledWith('{"error":"bad gateway"}');
-      expect(headers['Content-Type']).toBe('application/json');
+      expect(res.json).toHaveBeenCalledWith({
+        error: {
+          message: 'Upstream provider returned bad gateway',
+          type: 'upstream_error',
+          status: 502,
+        },
+      });
       // Meta headers should still be set
       expect(headers['X-Manifest-Provider']).toBe('OpenAI');
     });
@@ -2239,7 +2256,13 @@ describe('ProxyController', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.send).toHaveBeenCalledWith('primary error');
+      expect(res.json).toHaveBeenCalledWith({
+        error: {
+          message: 'Upstream provider internal error',
+          type: 'upstream_error',
+          status: 500,
+        },
+      });
     });
 
     it('should handle DB failure in recordPrimaryFailure on successful fallback', async () => {

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -1,0 +1,53 @@
+import { sanitizeProviderError } from './proxy-error-sanitizer';
+
+describe('sanitizeProviderError', () => {
+  it('extracts error.message from JSON body', () => {
+    const body = JSON.stringify({ error: { message: 'Rate limit exceeded' } });
+    expect(sanitizeProviderError(429, body)).toBe('Rate limit exceeded');
+  });
+
+  it('extracts top-level message from JSON body', () => {
+    const body = JSON.stringify({ message: 'Invalid model' });
+    expect(sanitizeProviderError(400, body)).toBe('Invalid model');
+  });
+
+  it('truncates long messages to 500 characters', () => {
+    const longMsg = 'x'.repeat(600);
+    const body = JSON.stringify({ error: { message: longMsg } });
+    expect(sanitizeProviderError(500, body)).toHaveLength(500);
+  });
+
+  it('returns known message for 401 with non-JSON body', () => {
+    expect(sanitizeProviderError(401, 'Unauthorized')).toBe(
+      'Authentication failed with upstream provider',
+    );
+  });
+
+  it('returns known message for 429 with empty JSON error', () => {
+    const body = JSON.stringify({ error: {} });
+    expect(sanitizeProviderError(429, body)).toBe('Rate limited by upstream provider');
+  });
+
+  it('returns generic message for unknown status with non-JSON body', () => {
+    expect(sanitizeProviderError(418, '<html>Teapot</html>')).toBe(
+      'Upstream provider returned HTTP 418',
+    );
+  });
+
+  it('returns known message for each mapped status code', () => {
+    expect(sanitizeProviderError(400, '')).toBe('Bad request to upstream provider');
+    expect(sanitizeProviderError(403, '')).toBe('Forbidden by upstream provider');
+    expect(sanitizeProviderError(404, '')).toBe('Model or endpoint not found');
+    expect(sanitizeProviderError(408, '')).toBe('Upstream provider request timed out');
+    expect(sanitizeProviderError(422, '')).toBe('Upstream provider rejected the request');
+    expect(sanitizeProviderError(500, '')).toBe('Upstream provider internal error');
+    expect(sanitizeProviderError(502, '')).toBe('Upstream provider returned bad gateway');
+    expect(sanitizeProviderError(503, '')).toBe('Upstream provider temporarily unavailable');
+    expect(sanitizeProviderError(504, '')).toBe('Upstream provider gateway timeout');
+  });
+
+  it('ignores empty string message in JSON', () => {
+    const body = JSON.stringify({ error: { message: '' } });
+    expect(sanitizeProviderError(500, body)).toBe('Upstream provider internal error');
+  });
+});

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -1,0 +1,28 @@
+const KNOWN_ERROR_MESSAGES: Record<number, string> = {
+  400: 'Bad request to upstream provider',
+  401: 'Authentication failed with upstream provider',
+  403: 'Forbidden by upstream provider',
+  404: 'Model or endpoint not found',
+  408: 'Upstream provider request timed out',
+  422: 'Upstream provider rejected the request',
+  429: 'Rate limited by upstream provider',
+  500: 'Upstream provider internal error',
+  502: 'Upstream provider returned bad gateway',
+  503: 'Upstream provider temporarily unavailable',
+  504: 'Upstream provider gateway timeout',
+};
+
+export function sanitizeProviderError(status: number, rawBody: string): string {
+  try {
+    const parsed = JSON.parse(rawBody) as Record<string, unknown>;
+    const error = parsed.error as Record<string, unknown> | undefined;
+    const message = error?.message ?? parsed.message;
+    if (typeof message === 'string' && message.length > 0) {
+      return message.slice(0, 500);
+    }
+  } catch {
+    // Not JSON — fall through to generic message
+  }
+
+  return KNOWN_ERROR_MESSAGES[status] ?? `Upstream provider returned HTTP ${status}`;
+}

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -22,6 +22,7 @@ import { ProxyService, FailedFallback } from './proxy.service';
 import { ProxyRateLimiter } from './proxy-rate-limiter';
 import { ProviderClient } from './provider-client';
 import { initSseHeaders, pipeStream, StreamUsage } from './stream-writer';
+import { sanitizeProviderError } from './proxy-error-sanitizer';
 import { trackCloudEvent } from '../../common/utils/product-telemetry';
 
 const MAX_SEEN_USERS = 10_000;
@@ -140,11 +141,16 @@ export class ProxyController implements OnModuleDestroy {
           ).catch((e) => this.logger.warn(`Failed to record provider error: ${e}`));
         }
 
+        this.logger.warn(`Upstream error ${errorStatus}: ${errorBody.slice(0, 200)}`);
         res.status(errorStatus);
         for (const [k, v] of Object.entries(metaHeaders)) res.setHeader(k, v);
-        const contentType = providerResponse.headers.get('content-type');
-        if (contentType) res.setHeader('Content-Type', contentType);
-        res.send(errorBody);
+        res.json({
+          error: {
+            message: sanitizeProviderError(errorStatus, errorBody),
+            type: 'upstream_error',
+            status: errorStatus,
+          },
+        });
         return;
       }
 

--- a/packages/backend/src/telemetry/dto/create-telemetry.dto.spec.ts
+++ b/packages/backend/src/telemetry/dto/create-telemetry.dto.spec.ts
@@ -14,6 +14,26 @@ describe('SecurityEventDto', () => {
     expect(errors).toHaveLength(0);
   });
 
+  it('rejects category exceeding max length', async () => {
+    const dto = plainToInstance(SecurityEventDto, {
+      severity: 'critical',
+      category: 'x'.repeat(257),
+      description: 'test',
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects description exceeding max length', async () => {
+    const dto = plainToInstance(SecurityEventDto, {
+      severity: 'critical',
+      category: 'test',
+      description: 'x'.repeat(4097),
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
   it('rejects invalid severity', async () => {
     const dto = plainToInstance(SecurityEventDto, {
       severity: 'high',
@@ -51,6 +71,64 @@ describe('TelemetryEventDto', () => {
     });
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);
+  });
+
+  it('rejects timestamp exceeding max length', async () => {
+    const dto = plainToInstance(TelemetryEventDto, {
+      timestamp: 'x'.repeat(51),
+      description: 'test',
+      service_type: 'agent',
+      status: 'ok',
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects description exceeding max length', async () => {
+    const dto = plainToInstance(TelemetryEventDto, {
+      timestamp: '2024-01-01T00:00:00Z',
+      description: 'x'.repeat(4097),
+      service_type: 'agent',
+      status: 'ok',
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects model exceeding max length', async () => {
+    const dto = plainToInstance(TelemetryEventDto, {
+      timestamp: '2024-01-01T00:00:00Z',
+      description: 'test',
+      service_type: 'agent',
+      status: 'ok',
+      model: 'x'.repeat(257),
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects agent_name exceeding max length', async () => {
+    const dto = plainToInstance(TelemetryEventDto, {
+      timestamp: '2024-01-01T00:00:00Z',
+      description: 'test',
+      service_type: 'agent',
+      status: 'ok',
+      agent_name: 'x'.repeat(257),
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects skill_name exceeding max length', async () => {
+    const dto = plainToInstance(TelemetryEventDto, {
+      timestamp: '2024-01-01T00:00:00Z',
+      description: 'test',
+      service_type: 'agent',
+      status: 'ok',
+      skill_name: 'x'.repeat(257),
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
   });
 
   it('rejects negative input_tokens', async () => {

--- a/packages/backend/src/telemetry/dto/create-telemetry.dto.ts
+++ b/packages/backend/src/telemetry/dto/create-telemetry.dto.ts
@@ -8,6 +8,7 @@ import {
   IsObject,
   IsOptional,
   IsString,
+  MaxLength,
   Min,
   ValidateNested,
 } from 'class-validator';
@@ -17,17 +18,21 @@ export class SecurityEventDto {
   severity!: string;
 
   @IsString()
+  @MaxLength(256)
   category!: string;
 
   @IsString()
+  @MaxLength(4096)
   description!: string;
 }
 
 export class TelemetryEventDto {
   @IsString()
+  @MaxLength(50)
   timestamp!: string;
 
   @IsString()
+  @MaxLength(4096)
   description!: string;
 
   @IsIn(['agent', 'browser', 'voice', 'whatsapp', 'api', 'other'])
@@ -38,14 +43,17 @@ export class TelemetryEventDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(256)
   model?: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(256)
   agent_name?: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(256)
   skill_name?: string;
 
   @IsOptional()


### PR DESCRIPTION
## Summary

- **SSRF protection**: Validate custom provider URLs against private/internal IP ranges with DNS resolution checks. Blocks loopback, RFC 1918, link-local, and IPv6 private addresses.
- **Email provider key encryption**: Encrypt API keys at rest with AES-256-GCM. Added `key_prefix` column for safe display. Backwards-compatible with existing plaintext keys.
- **OTLP auth guard hardening**: Reject tokens shorter than 12 chars before DB lookup. Store SHA-256 hashes as cache keys instead of plaintext tokens. Clear cache immediately on key rotation.
- **Telemetry DTO limits**: Added `@MaxLength()` decorators to all string fields to prevent oversized payloads.
- **SessionGuard resilience**: Wrap `getSession()` in try-catch so auth service failures degrade gracefully instead of returning 500.
- **Login rate limiting**: Added `express-rate-limit` middleware on `/api/auth/sign-in` (20 requests per 15 minutes, cloud mode only).
- **Provider error sanitization**: Upstream provider errors are now sanitized before being sent to clients. Raw error bodies are logged server-side only.
- **DATABASE_URL validation**: Cloud mode now fails fast with a clear error message if `DATABASE_URL` is not configured.
- **API key guard logging**: Silent `.catch(() => {})` on `last_used_at` update replaced with warning log.
- **Input validation**: Domain length check (max 253 chars), test email recipient `@IsEmail()` validation.

## Test plan

- [x] All 2456 backend unit tests pass
- [x] All 109 E2E tests pass
- [x] All 1469 frontend tests pass
- [x] TypeScript compiles cleanly (both backend and frontend)
- [x] 100% line coverage maintained
- [x] Lint and prettier pass (pre-commit hooks)
- [ ] Verify custom provider creation with `http://127.0.0.1:8080` is rejected (Fix 1)
- [ ] Verify key rotation immediately invalidates cached keys (Fix 8)
- [ ] Verify upstream provider errors return sanitized envelope (Fix 12)
- [ ] Verify app fails to start without DATABASE_URL in cloud mode (Fix 10)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens backend security by blocking SSRF, encrypting email provider API keys, tightening OTLP auth, sanitizing upstream errors, and rate limiting login attempts. Adds stricter validation and fail-fast config checks for safer defaults.

- **New Features - New features added**
  - Block SSRF for custom provider `base_url` (only public http/https; DNS resolution; rejects private/loopback and IPv6 private ranges).
  - Encrypt email provider API keys at rest (AES-256-GCM) and store `key_prefix` for safe display; legacy plaintext keys are still read.
  - OTLP auth guard: require minimum token length, store cache keys as SHA-256 hashes, and clear cache on key rotation.
  - Sanitize upstream provider errors before sending to clients; return a safe JSON envelope with a generic message.
  - Rate limit `/api/auth/sign-in` in cloud mode (20 requests per 15 minutes) using `express-rate-limit`.
  - Validation and guard hardening: max lengths on telemetry DTO strings; domain length and test email `@IsEmail()` checks; wrap session lookup in try/catch; warn on `last_used_at` update failures; fail fast without `DATABASE_URL` in cloud mode.

- **Migration**
  - Run DB migrations to add `key_prefix` to `email_provider_configs`.
  - No action required for existing keys; plaintext legacy keys continue to work until updated.

<sup>Written for commit d89b44d274fde8a77242df96ca4decdea9dd312a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

