### PR TITLE
fix: update routing button styles and fallback card design

### DIFF
--- a/.changeset/update-btn-style.md
+++ b/.changeset/update-btn-style.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Update routing page button styles: responsive icon-only change button, fallback card background colors, and streamlined add-fallback button text

--- a/package-lock.json
+++ b/package-lock.json
@@ -14184,7 +14184,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.24.2",
+      "version": "5.25.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -301,7 +301,23 @@ const FallbackList: Component<FallbackListProps> = (props) => {
               onClick={props.onAddFallback}
               disabled={props.adding}
             >
-              {props.adding ? <span class="spinner" /> : '+ Add fallback'}
+              {props.adding ? (
+                <span class="spinner" />
+              ) : (
+                <>
+                  <svg
+                    width="16"
+                    height="16"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path d="m7.12,20.57c.2.23.55.23.75,0l2.4-2.74c.28-.32.05-.83-.38-.83h-1.9V3.5c0-.28-.22-.5-.5-.5s-.5.22-.5.5v13.5h-1.9c-.43,0-.66.51-.38.83l2.4,2.74Z" />
+                    <path d="m14.1,7h1.9v13.5c0,.28.22.5.5.5s.5-.22.5-.5V7h1.9c.43,0,.66-.51.38-.83l-2.4-2.74c-.2-.23-.55-.23-.75,0l-2.4,2.74c-.28.32-.05.83.38.83Z" />
+                  </svg>
+                  Add fallback
+                </>
+              )}
             </button>
           </div>
         }
@@ -312,7 +328,23 @@ const FallbackList: Component<FallbackListProps> = (props) => {
             onClick={props.onAddFallback}
             disabled={props.adding || removingIndex() !== null}
           >
-            {props.adding ? <span class="spinner" /> : '+ Add fallback'}
+            {props.adding ? (
+              <span class="spinner" />
+            ) : (
+              <>
+                <svg
+                  width="16"
+                  height="16"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path d="m7.12,20.57c.2.23.55.23.75,0l2.4-2.74c.28-.32.05-.83-.38-.83h-1.9V3.5c0-.28-.22-.5-.5-.5s-.5.22-.5.5v13.5h-1.9c-.43,0-.66.51-.38.83l2.4,2.74Z" />
+                  <path d="m14.1,7h1.9v13.5c0,.28.22.5.5.5s.5-.22.5-.5V7h1.9c.43,0,.66-.51.38-.83l-2.4-2.74c-.2-.23-.55-.23-.75,0l-2.4,2.74c-.28.32-.05.83.38.83Z" />
+                </svg>
+                Add fallback
+              </>
+            )}
           </button>
         </Show>
       </Show>

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -393,11 +393,20 @@ const ProviderSelectModal: Component<Props> = (props) => {
                 </For>
                 <div class="provider-modal__request-sub">
                   <a
-                    class="provider-modal__request-sub-btn"
+                    class="btn btn--outline btn--sm provider-modal__request-sub-btn"
                     href="https://github.com/mnfst/manifest/discussions/973"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
+                    <svg
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                      aria-hidden="true"
+                    >
+                      <path d="m18.5,9h-1.5v-3.5c0-1.38-1.12-2.5-2.5-2.5H5.5c-1.38,0-2.5,1.12-2.5,2.5v6c0,1.38,1.12,2.5,2.5,2.5h.5v1.5c0,.38.21.73.56.9.14.07.29.11.45.11.21,0,.42-.07.6-.2l2.4-1.8v1c0,1.38,1.12,2.5,2.5,2.5h1.83l3.06,2.3c.18.13.39.2.6.2.15,0,.3-.03.44-.11.34-.17.56-.51.56-.9v-1.55c.48-.1.92-.33,1.26-.68.48-.47.74-1.09.74-1.77v-4c0-1.38-1.12-2.5-2.5-2.5Zm-11.5,6.5v-2c0-.28-.22-.5-.5-.5h-1c-.83,0-1.5-.67-1.5-1.5v-6c0-.83.67-1.5,1.5-1.5h9c.83,0,1.5.67,1.5,1.5v6c0,.83-.67,1.5-1.5,1.5h-4c-.1,0-.19.04-.27.09,0,0-.02,0-.03.01l-3.2,2.4Zm13,0c0,.4-.16.78-.45,1.06-.28.28-.65.44-1.05.44-.28,0-.5.22-.5.5v2l-3.2-2.4c-.09-.06-.19-.1-.3-.1h-2c-.83,0-1.5-.67-1.5-1.5v-1.5h3.5c1.38,0,2.5-1.12,2.5-2.5v-1.5h1.5c.83,0,1.5.67,1.5,1.5v4Z" />
+                    </svg>
                     Request another provider
                   </a>
                 </div>
@@ -478,7 +487,10 @@ const ProviderSelectModal: Component<Props> = (props) => {
                   }}
                 </For>
                 <div class="provider-modal__add-custom">
-                  <button class="provider-modal__add-custom-btn" onClick={openCustomForm}>
+                  <button
+                    class="btn btn--outline btn--sm provider-modal__add-custom-btn"
+                    onClick={openCustomForm}
+                  >
                     <svg
                       width="16"
                       height="16"

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -549,10 +549,20 @@ const Routing: Component = () => {
                                     </Show>
                                   </div>
                                   <button
-                                    class="btn btn--outline btn--sm"
+                                    class="btn btn--outline btn--sm routing-card__change-btn"
                                     onClick={() => setDropdownTier(stage.id)}
                                   >
-                                    Change
+                                    <svg
+                                      class="routing-card__change-icon"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      width="16"
+                                      height="16"
+                                      fill="currentColor"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path d="m19.41,3.71c-.76-.76-2.07-.76-2.83,0l-2.09,2.09-.94-.94c-.57-.57-1.55-.57-2.12,0l-4.79,4.79c-.2.2-.2.51,0,.71.1.1.23.15.35.15s.26-.05.35-.15l4.79-4.79c.2-.2.51-.2.71,0l.94.94L4.65,15.65s-.09.1-.11.17l-1.35,3.37c-.19.47-.08.99.28,1.35.24.24.55.37.88.37.16,0,.32-.03.47-.09l3.38-1.35c.06-.03.12-.06.17-.11l11.94-11.94c.78-.78.78-2.05,0-2.83l-.88-.88Zm-11.69,14.87l-3.28,1.31c-.14.06-.24-.02-.27-.06-.04-.03-.11-.13-.06-.27l1.31-3.28L14.5,7.21l2.29,2.29-9.07,9.07Zm11.87-11.87l-2.09,2.09-2.29-2.29,2.09-2.09c.38-.38,1.04-.38,1.41,0l.88.88c.39.39.39,1.02,0,1.41Z" />
+                                    </svg>
+                                    <span class="routing-card__change-label">Change</span>
                                   </button>
                                 </div>
                                 <Show
@@ -573,19 +583,7 @@ const Routing: Component = () => {
                       <Show when={eff()}>
                         <div class="routing-card__fallbacks">
                           <Show when={getFallbacksFor(stage.id).length > 0}>
-                            <div class="routing-card__fallbacks-label">
-                              <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                width="14"
-                                height="14"
-                                fill="currentColor"
-                                viewBox="0 0 24 24"
-                                aria-hidden="true"
-                              >
-                                <path d="M6 22h2V8h4L7 2 2 8h4zM19 2h-2v14h-4l5 6 5-6h-4z" />
-                              </svg>
-                              Fallbacks
-                            </div>
+                            <div class="routing-card__fallbacks-label">Fallbacks</div>
                           </Show>
                           <FallbackList
                             agentName={agentName()}

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -542,33 +542,8 @@
 }
 
 .provider-modal__request-sub-btn {
-  display: inline-flex;
-  align-items: center;
-  background: none;
-  border: 1px solid hsl(var(--border));
-  cursor: pointer;
-  font-family: var(--font-family);
-  font-size: var(--font-size-xs);
-  font-weight: 500;
-  color: hsl(var(--muted-foreground));
-  padding: 4px 10px;
-  border-radius: var(--radius);
+  gap: 6px;
   text-decoration: none;
-  transition:
-    color var(--transition-fast),
-    background var(--transition-fast),
-    border-color var(--transition-fast);
-}
-
-.provider-modal__request-sub-btn:hover {
-  color: hsl(var(--foreground));
-  background: hsl(var(--muted) / 0.5);
-  border-color: hsl(var(--foreground) / 0.3);
-}
-
-.provider-modal__request-sub-btn:focus-visible {
-  outline: 2px solid hsl(var(--ring));
-  outline-offset: 2px;
 }
 
 .provider-modal__add-custom {
@@ -578,31 +553,7 @@
 }
 
 .provider-modal__add-custom-btn {
-  display: inline-flex;
-  align-items: center;
   gap: 6px;
-  background: none;
-  border: 1px solid hsl(var(--border));
-  cursor: pointer;
-  font-family: var(--font-family);
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  color: hsl(var(--foreground));
-  padding: 6px 14px;
-  border-radius: var(--radius);
-  transition:
-    background var(--transition-fast),
-    border-color var(--transition-fast);
-}
-
-.provider-modal__add-custom-btn:hover {
-  background: hsl(var(--muted) / 0.5);
-  border-color: hsl(var(--foreground) / 0.3);
-}
-
-.provider-modal__add-custom-btn:focus-visible {
-  outline: 2px solid hsl(var(--ring));
-  outline-offset: 2px;
 }
 
 .custom-provider-item {

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -138,7 +138,7 @@
   border: none;
   cursor: pointer;
   font-family: var(--font-family);
-  padding: 2px 6px;
+  padding: 2px 0;
   border-radius: var(--radius);
   transition: color var(--transition-fast);
 }
@@ -365,9 +365,9 @@
   font-size: var(--font-size-xs);
   color: hsl(var(--foreground));
   padding: 6px 8px;
-  border: 1px dashed hsl(var(--border));
+  border: none;
   border-radius: var(--radius);
-  background: hsl(var(--card));
+  background: #f7f5ed;
   cursor: grab;
   transition:
     border-color var(--transition-fast),
@@ -377,8 +377,11 @@
   position: relative;
 }
 
+.dark .fallback-list__card {
+  background: #121212;
+}
+
 .fallback-list__card:hover {
-  border-color: hsl(var(--foreground) / 0.2);
   background: hsl(var(--muted) / 0.3);
 }
 
@@ -466,6 +469,7 @@
 /* Add fallback — uses btn btn--outline btn--sm, just adds spacing */
 .fallback-list__add {
   margin-top: 6px;
+  gap: 6px;
 }
 
 /* Empty state — no fallbacks placeholder */
@@ -478,7 +482,6 @@
   width: 100%;
   height: 224px;
   padding: 20px 12px;
-  border: 1px dashed hsl(var(--border));
   border-radius: var(--radius);
   background: hsl(var(--muted) / 0.15);
   box-sizing: border-box;
@@ -501,6 +504,35 @@
   color: hsl(var(--muted-foreground) / 0.7);
   line-height: 1.4;
   max-width: 200px;
+}
+
+/* ── Change button: icon/label toggle ────────────── */
+.routing-card__change-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.routing-card__change-icon {
+  display: none;
+}
+
+@media (max-width: 1520px) {
+  .btn.routing-card__change-btn {
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .routing-card__change-icon {
+    display: block;
+  }
+
+  .routing-card__change-label {
+    display: none;
+  }
 }
 
 /* ── Responsive ──────────────────────────────────── */

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -105,7 +105,7 @@ describe("FallbackList", () => {
       <FallbackList {...defaultProps} fallbacks={fiveFallbacks} />
     ));
 
-    expect(screen.queryByText("+ Add fallback")).toBeNull();
+    expect(screen.queryByText("Add fallback")).toBeNull();
   });
 
   it("calls setFallbacks on remove with remaining items", async () => {
@@ -300,7 +300,7 @@ describe("FallbackList", () => {
       <FallbackList {...defaultProps} fallbacks={["model-a", "model-b"]} />
     ));
 
-    expect(screen.getByText("+ Add fallback")).toBeDefined();
+    expect(screen.getByText("Add fallback")).toBeDefined();
   });
 
   it("sets aria-label on remove buttons with model label", () => {
@@ -402,7 +402,7 @@ describe("FallbackList", () => {
     fireEvent.click(removeButtons[0]);
 
     await waitFor(() => {
-      const addBtn = screen.getByText("+ Add fallback");
+      const addBtn = screen.getByText("Add fallback");
       expect((addBtn as HTMLButtonElement).disabled).toBe(true);
     });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -884,7 +884,7 @@ describe("Routing — fallback management", () => {
 
   it("opens fallback picker when Add fallback is clicked", async () => {
     render(() => <Routing />);
-    const addButtons = await screen.findAllByText("+ Add fallback");
+    const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]);
     // The model picker modal should open
     expect(await screen.findByText("Select a model")).toBeDefined();
@@ -892,7 +892,7 @@ describe("Routing — fallback management", () => {
 
   it("calls setFallbacks when a fallback model is picked", async () => {
     render(() => <Routing />);
-    const addButtons = await screen.findAllByText("+ Add fallback");
+    const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]); // simple tier
     await screen.findByText("Select a model");
 
@@ -918,8 +918,8 @@ describe("Routing — fallback management", () => {
     ]);
 
     const { container } = render(() => <Routing />);
-    // Simple tier has 1 fallback, so it shows the standalone "+ Add fallback" button (not inside empty state)
-    await screen.findAllByText("+ Add fallback");
+    // Simple tier has 1 fallback, so it shows the standalone "Add fallback" button (not inside empty state)
+    await screen.findAllByText("Add fallback");
     const standaloneAddBtn = container.querySelector(".fallback-list__add:not(.fallback-list__empty .fallback-list__add)") as HTMLButtonElement;
     fireEvent.click(standaloneAddBtn);
     await screen.findByText("Select a model");
@@ -933,7 +933,7 @@ describe("Routing — fallback management", () => {
     let resolveSetFallbacks: () => void;
     vi.mocked(setFallbacks).mockReturnValueOnce(new Promise<void>((r) => { resolveSetFallbacks = r; }) as any);
     render(() => <Routing />);
-    const addButtons = await screen.findAllByText("+ Add fallback");
+    const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]); // simple tier
     await screen.findByText("Select a model");
 
@@ -952,7 +952,7 @@ describe("Routing — fallback management", () => {
   it("handles setFallbacks error gracefully and rolls back optimistic state", async () => {
     vi.mocked(setFallbacks).mockRejectedValueOnce(new Error("fail"));
     render(() => <Routing />);
-    const addButtons = await screen.findAllByText("+ Add fallback");
+    const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]);
     await screen.findByText("Select a model");
 
@@ -1020,7 +1020,7 @@ describe("Routing — fallback management", () => {
 
   it("closes fallback picker when close button is clicked", async () => {
     render(() => <Routing />);
-    const addButtons = await screen.findAllByText("+ Add fallback");
+    const addButtons = await screen.findAllByText("Add fallback");
     fireEvent.click(addButtons[0]);
     expect(await screen.findByText("Select a model")).toBeDefined();
 


### PR DESCRIPTION
## Summary
- Replace "Change" button text with an edit icon on screens narrower than 1520px (icon-only square button)
- Update fallback card backgrounds to #F7F5ED (light) and #121212 (dark), remove dashed borders
- Streamline provider modal buttons to use shared btn classes
- Update "Add fallback" button text (remove leading "+") and add reorder icon

## Test plan
- [ ] Verify "Change" button shows text on wide screens (>1520px) and icon on narrow screens
- [ ] Check fallback cards have correct background in both light and dark mode
- [ ] Confirm add-fallback buttons display correctly with new icon and text
- [ ] Verify all frontend tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the routing UI for clarity and consistency. The "Change" button becomes icon-only below 1520px; fallback cards use new backgrounds (#F7F5ED light, #121212 dark) with no dashed borders; provider modal buttons use shared btn styles; and "Add fallback" removes the "+" and adds a reorder icon.

<sup>Written for commit a1987174cc7406cceb1ea239e2a4397371b7e876. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

