### PR TITLE
fix(plugin): add missing compression runtime dependency

### DIFF
--- a/.changeset/clever-plants-hide.md
+++ b/.changeset/clever-plants-hide.md
@@ -1,3 +1,5 @@
+---
 "manifest": patch
+---
 
 Add the missing `compression` runtime dependency to the published OpenClaw plugin package and test that plugin runtime dependencies stay in sync with backend runtime dependencies.

--- a/.changeset/clever-plants-hide.md
+++ b/.changeset/clever-plants-hide.md
@@ -1,0 +1,3 @@
+"manifest": patch
+
+Add the missing `compression` runtime dependency to the published OpenClaw plugin package and test that plugin runtime dependencies stay in sync with backend runtime dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14160,6 +14160,7 @@
         "cache-manager": "^7.2.8",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
+        "compression": "^1.8.1",
         "helmet": "^8.1.0",
         "pg": "^8.13.0",
         "protobufjs": "^8.0.0",

--- a/packages/openclaw-plugin/__tests__/build.test.ts
+++ b/packages/openclaw-plugin/__tests__/build.test.ts
@@ -3,6 +3,7 @@ import { resolve, join } from "path";
 
 const distPath = resolve(__dirname, "../dist/index.js");
 const pkgPath = resolve(__dirname, "../package.json");
+const backendPkgPath = resolve(__dirname, "../../backend/package.json");
 
 // These tests verify properties of the built bundle.
 // They require `npm run build` to have been run first.
@@ -127,6 +128,22 @@ describe("build configuration", () => {
     };
     expect(deps).not.toHaveProperty("@opentelemetry/sdk-trace-node");
     expect(deps).toHaveProperty("@opentelemetry/sdk-trace-base");
+  });
+
+  it("package.json includes backend runtime dependencies", () => {
+    const pluginPkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+      dependencies?: Record<string, string>;
+    };
+    const backendPkg = JSON.parse(readFileSync(backendPkgPath, "utf-8")) as {
+      dependencies?: Record<string, string>;
+    };
+
+    const missingOrMismatched = Object.entries(backendPkg.dependencies ?? {})
+      .filter(([name]) => !name.startsWith("@types/"))
+      .filter(([name, version]) => pluginPkg.dependencies?.[name] !== version)
+      .map(([name, version]) => `${name}@${version}`);
+
+    expect(missingOrMismatched).toEqual([]);
   });
 
   it("build.ts reads version from package.json", () => {

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -96,6 +96,7 @@
     "cache-manager": "^7.2.8",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "compression": "^1.8.1",
     "helmet": "^8.1.0",
     "pg": "^8.13.0",
     "protobufjs": "^8.0.0",


### PR DESCRIPTION
## Summary
- add the missing `compression` runtime dependency to the published OpenClaw plugin package
- add a regression test that ensures plugin runtime deps stay in sync with backend runtime deps
- add a patch changeset for the published `manifest` package

## Why
The plugin ships `dist/backend` and executes backend code in isolation when installed by OpenClaw. `compression` was added to `packages/backend/package.json` but not to `packages/openclaw-plugin/package.json`, so monorepo installs worked via hoisting while standalone plugin installs failed at runtime.

## Testing
- npm run build --workspace=packages/openclaw-plugin
- npm test --workspace=packages/openclaw-plugin -- --runInBand


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runtime failures in standalone OpenClaw plugin installs by adding the missing `compression` dependency. Adds a regression test to keep plugin runtime deps aligned with the backend and corrects the changeset to publish the patch.

- **Bug Fixes**
  - Add `compression` ^1.8.1 to `packages/openclaw-plugin` runtime dependencies.
  - Add regression test that asserts plugin deps match backend runtime deps (ignores `@types/*`).
  - Fix changeset frontmatter and publish patch for `manifest`.

<sup>Written for commit fb0e0f99a86f210831b8110d0f99f431a243cbaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



Related to https://github.com/mnfst/manifest/issues/927
