### PR TITLE
fix(backend): preserve compatible OpenRouter models

### DIFF
--- a/.changeset/wise-pans-smash.md
+++ b/.changeset/wise-pans-smash.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Preserve compatible OpenRouter text models during pricing sync while filtering out non-chat OpenRouter models from the local model list.

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -365,6 +365,17 @@ describe('LocalBootstrapService', () => {
       expect(mockPricingRepo.delete).not.toHaveBeenCalled();
     });
 
+    it('preserves OpenRouter provider models even if not curated', async () => {
+      mockPricingRepo.find.mockResolvedValue([
+        { model_name: 'qwen/qwen3-235b-a22b', provider: 'OpenRouter' },
+      ]);
+
+      await service.onModuleInit();
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockPricingRepo.delete).not.toHaveBeenCalled();
+    });
+
     it('preserves custom: prefixed models even if not curated', async () => {
       mockPricingRepo.find.mockResolvedValue([
         { model_name: 'custom:provider-uuid/my-model', provider: 'Custom' },
@@ -391,6 +402,7 @@ describe('LocalBootstrapService', () => {
         { model_name: 'random-model-1', provider: 'Unknown' },
         { model_name: 'random-model-2', provider: 'Unknown' },
         { model_name: 'llama3:latest', provider: 'Ollama' }, // preserved
+        { model_name: 'qwen/qwen3-235b-a22b', provider: 'OpenRouter' }, // preserved
         { model_name: 'custom:uuid/my-llm', provider: 'Custom' }, // preserved
       ]);
 
@@ -404,6 +416,7 @@ describe('LocalBootstrapService', () => {
       );
       expect(deleteArg.model_name._value).not.toContain('claude-opus-4-6');
       expect(deleteArg.model_name._value).not.toContain('llama3:latest');
+      expect(deleteArg.model_name._value).not.toContain('qwen/qwen3-235b-a22b');
       expect(deleteArg.model_name._value).not.toContain('custom:uuid/my-llm');
     });
   });

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -193,6 +193,7 @@ export class LocalBootstrapService implements OnModuleInit {
         (row) =>
           !curatedNames.has(row.model_name) &&
           row.provider !== 'Ollama' &&
+          row.provider !== 'OpenRouter' &&
           !row.model_name.startsWith('custom:'),
       )
       .map((row) => row.model_name);

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -160,6 +160,56 @@ describe('PricingSyncService', () => {
     expect(updated).toBe(0);
   });
 
+  it('skips models with non-text output modalities', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'google/gemini-3.1-flash-image-preview',
+            architecture: {
+              input_modalities: ['text', 'image'],
+              output_modalities: ['text', 'image'],
+            },
+            pricing: { prompt: '0.0000005', completion: '0.000003' },
+          },
+        ],
+      }),
+    });
+
+    const updated = await service.syncPricing();
+    expect(updated).toBe(0);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('keeps multimodal-input models with text-only output modalities', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'openai/gpt-5.4',
+            architecture: {
+              input_modalities: ['text', 'image', 'file'],
+              output_modalities: ['text'],
+            },
+            pricing: { prompt: '0.0000025', completion: '0.000015' },
+          },
+        ],
+      }),
+    });
+
+    const updated = await service.syncPricing();
+    expect(updated).toBe(1);
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ model_name: 'gpt-5.4' }), [
+      'model_name',
+    ]);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ model_name: 'openai/gpt-5.4', provider: 'OpenRouter' }),
+      ['model_name'],
+    );
+  });
+
   it('handles empty data array', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
@@ -445,6 +495,49 @@ describe('PricingSyncService', () => {
     expect(deleteArg.model_name._value).not.toContain('openai/gpt-4o');
     expect(deleteArg.model_name._value).not.toContain('bytedance-seed/seed-2.0-lite');
     expect(deleteArg.model_name._value).not.toContain('openrouter/auto');
+    expect(deleteArg.model_name._value).not.toContain('gpt-4o');
+  });
+
+  it('removes previously synced non-chat-compatible models on sync', async () => {
+    mockFind.mockResolvedValue([
+      { model_name: 'gemini-3.1-flash-image-preview', provider: 'Google' },
+      { model_name: 'google/gemini-3.1-flash-image-preview', provider: 'OpenRouter' },
+      { model_name: 'gpt-4o', provider: 'OpenAI' },
+    ]);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'google/gemini-3.1-flash-image-preview',
+            architecture: {
+              input_modalities: ['text', 'image'],
+              output_modalities: ['text', 'image'],
+            },
+            pricing: { prompt: '0.0000005', completion: '0.000003' },
+          },
+          {
+            id: 'openai/gpt-4o',
+            architecture: {
+              input_modalities: ['text', 'image'],
+              output_modalities: ['text'],
+            },
+            pricing: { prompt: '0.0000025', completion: '0.00001' },
+          },
+        ],
+      }),
+    });
+
+    await service.syncPricing();
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    const deleteArg = mockDelete.mock.calls[0][0];
+    expect(deleteArg.model_name._value).toEqual(
+      expect.arrayContaining([
+        'gemini-3.1-flash-image-preview',
+        'google/gemini-3.1-flash-image-preview',
+      ]),
+    );
     expect(deleteArg.model_name._value).not.toContain('gpt-4o');
   });
 

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -541,6 +541,53 @@ describe('PricingSyncService', () => {
     expect(deleteArg.model_name._value).not.toContain('gpt-4o');
   });
 
+  it('does not delete a compatible canonical model when an incompatible alias shares the same name', async () => {
+    mockFind.mockResolvedValue([
+      { model_name: 'model-x', provider: 'OpenAI' },
+      { model_name: 'openai/model-x', provider: 'OpenRouter' },
+      { model_name: 'google/model-x', provider: 'OpenRouter' },
+    ]);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'google/model-x',
+            architecture: {
+              input_modalities: ['text', 'image'],
+              output_modalities: ['image'],
+            },
+            pricing: { prompt: '0.0000005', completion: '0.000003' },
+          },
+          {
+            id: 'openai/model-x',
+            architecture: {
+              input_modalities: ['text'],
+              output_modalities: ['text'],
+            },
+            pricing: { prompt: '0.0000025', completion: '0.00001' },
+          },
+        ],
+      }),
+    });
+
+    await service.syncPricing();
+
+    expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ model_name: 'model-x' }), [
+      'model_name',
+    ]);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ model_name: 'openai/model-x', provider: 'OpenRouter' }),
+      ['model_name'],
+    );
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    const deleteArg = mockDelete.mock.calls[0][0];
+    expect(deleteArg.model_name._value).toContain('google/model-x');
+    expect(deleteArg.model_name._value).not.toContain('model-x');
+    expect(deleteArg.model_name._value).not.toContain('openai/model-x');
+  });
+
   describe('onModuleInit', () => {
     it('returns immediately in local mode without calling syncPricing', async () => {
       const original = process.env['MANIFEST_MODE'];

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -182,6 +182,28 @@ describe('PricingSyncService', () => {
     expect(mockUpsert).not.toHaveBeenCalled();
   });
 
+  it('skips models with non-text input modalities', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'google/image-only-input-model',
+            architecture: {
+              input_modalities: ['image'],
+              output_modalities: ['text'],
+            },
+            pricing: { prompt: '0.0000005', completion: '0.000003' },
+          },
+        ],
+      }),
+    });
+
+    const updated = await service.syncPricing();
+    expect(updated).toBe(0);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
   it('keeps multimodal-input models with text-only output modalities', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
@@ -494,6 +516,24 @@ describe('PricingSyncService', () => {
     );
     expect(deleteArg.model_name._value).not.toContain('openai/gpt-4o');
     expect(deleteArg.model_name._value).not.toContain('bytedance-seed/seed-2.0-lite');
+    expect(deleteArg.model_name._value).not.toContain('openrouter/auto');
+    expect(deleteArg.model_name._value).not.toContain('gpt-4o');
+  });
+
+  it('removeUnsupportedModels defaults to an empty incompatible set and preserves openrouter/ prefixes', async () => {
+    mockFind.mockResolvedValue([
+      { model_name: 'ai21/jamba-1-5-large', provider: 'AI21' },
+      { model_name: 'openrouter/auto', provider: 'Legacy' },
+      { model_name: 'gpt-4o', provider: 'OpenAI' },
+    ]);
+
+    await (
+      service as never as { removeUnsupportedModels: () => Promise<void> }
+    ).removeUnsupportedModels();
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    const deleteArg = mockDelete.mock.calls[0][0];
+    expect(deleteArg.model_name._value).toContain('ai21/jamba-1-5-large');
     expect(deleteArg.model_name._value).not.toContain('openrouter/auto');
     expect(deleteArg.model_name._value).not.toContain('gpt-4o');
   });

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -68,7 +68,7 @@ describe('PricingSyncService', () => {
     else delete process.env['MANIFEST_MODE'];
   });
 
-  it('creates canonical models for new vendor-prefixed models (no OpenRouter copies)', async () => {
+  it('creates canonical and OpenRouter copies for new vendor-prefixed models', async () => {
     mockFetch.mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -84,9 +84,22 @@ describe('PricingSyncService', () => {
 
     const updated = await service.syncPricing();
     expect(updated).toBe(2);
-    // 2 canonical upserts only — no OpenRouter copies for non-existing models
-    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    expect(mockUpsert).toHaveBeenCalledTimes(4);
     expect(mockRecordChange).toHaveBeenCalledTimes(2);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model_name: 'anthropic/claude-opus-4',
+        provider: 'OpenRouter',
+      }),
+      ['model_name'],
+    );
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model_name: 'openai/gpt-4o',
+        provider: 'OpenRouter',
+      }),
+      ['model_name'],
+    );
   });
 
   it('updates pricing but preserves provider for existing models', async () => {
@@ -226,8 +239,7 @@ describe('PricingSyncService', () => {
       }),
       'sync',
     );
-    // Canonical only — no OpenRouter copy for non-existing model
-    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
   });
 
   it('passes existing model to recordChange when found', async () => {
@@ -408,13 +420,14 @@ describe('PricingSyncService', () => {
     }
   });
 
-  it('removes existing unsupported provider rows on sync', async () => {
+  it('removes existing unsupported provider rows on sync but keeps OpenRouter-hosted rows', async () => {
     mockFind.mockResolvedValue([
-      { model_name: 'ai21/jamba-1-5-large' },
-      { model_name: 'openai/gpt-4o' },
-      { model_name: 'aion-labs/some-model' },
-      { model_name: 'openrouter/auto' },
-      { model_name: 'gpt-4o' },
+      { model_name: 'ai21/jamba-1-5-large', provider: 'AI21' },
+      { model_name: 'openai/gpt-4o', provider: 'OpenRouter' },
+      { model_name: 'aion-labs/some-model', provider: 'Aion Labs' },
+      { model_name: 'bytedance-seed/seed-2.0-lite', provider: 'OpenRouter' },
+      { model_name: 'openrouter/auto', provider: 'OpenRouter' },
+      { model_name: 'gpt-4o', provider: 'OpenAI' },
     ]);
 
     mockFetch.mockResolvedValue({
@@ -425,11 +438,12 @@ describe('PricingSyncService', () => {
     await service.syncPricing();
     expect(mockDelete).toHaveBeenCalledTimes(1);
     const deleteArg = mockDelete.mock.calls[0][0];
-    // Should delete ai21 and aion-labs, but NOT openai, openrouter, or bare models
+    // Should delete unsupported native rows, but NOT OpenRouter-hosted or bare models
     expect(deleteArg.model_name._value).toEqual(
       expect.arrayContaining(['ai21/jamba-1-5-large', 'aion-labs/some-model']),
     );
     expect(deleteArg.model_name._value).not.toContain('openai/gpt-4o');
+    expect(deleteArg.model_name._value).not.toContain('bytedance-seed/seed-2.0-lite');
     expect(deleteArg.model_name._value).not.toContain('openrouter/auto');
     expect(deleteArg.model_name._value).not.toContain('gpt-4o');
   });
@@ -591,10 +605,10 @@ describe('PricingSyncService', () => {
     const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'glm-4-plus');
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
-    // Also updates OpenRouter copy (preserves existing provider)
+    // Also updates the OpenRouter-hosted copy
     const orCall = mockUpsert.mock.calls.find((c) => c[0].model_name === 'zhipuai/glm-4-plus');
     expect(orCall).toBeDefined();
-    expect(orCall![0]).not.toHaveProperty('provider');
+    expect(orCall![0]).toMatchObject({ provider: 'OpenRouter' });
   });
 
   it('maps Amazon provider correctly', async () => {
@@ -613,10 +627,10 @@ describe('PricingSyncService', () => {
     const canonicalCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'nova-pro');
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
-    // Also updates OpenRouter copy (preserves existing provider)
+    // Also updates the OpenRouter-hosted copy
     const orCall = mockUpsert.mock.calls.find((c) => c[0].model_name === 'amazon/nova-pro');
     expect(orCall).toBeDefined();
-    expect(orCall![0]).not.toHaveProperty('provider');
+    expect(orCall![0]).toMatchObject({ provider: 'OpenRouter' });
   });
 
   it('creates canonical entry for openrouter/auto even when not in seeder', async () => {
@@ -708,8 +722,7 @@ describe('PricingSyncService', () => {
     // Both canonical and OpenRouter copy upserted with context_window
     const orCall = mockUpsert.mock.calls.find((call) => call[0].model_name === 'openai/gpt-4o');
     expect(orCall).toBeDefined();
-    expect(orCall![0]).toMatchObject({ context_window: 128000 });
-    expect(orCall![0]).not.toHaveProperty('provider');
+    expect(orCall![0]).toMatchObject({ context_window: 128000, provider: 'OpenRouter' });
   });
 
   it('stores context_length as context_window for existing models', async () => {
@@ -774,10 +787,10 @@ describe('PricingSyncService', () => {
     expect(orCall).toBeDefined();
     expect(orCall![0]).toMatchObject({
       model_name: 'anthropic/claude-opus-4',
+      provider: 'OpenRouter',
       input_price_per_token: 0.000015,
       output_price_per_token: 0.000075,
     });
-    expect(orCall![0]).not.toHaveProperty('provider');
   });
 
   it('logs warning when OpenRouter copy upsert fails with Error', async () => {
@@ -981,19 +994,16 @@ describe('PricingSyncService', () => {
     );
     expect(canonicalCall).toBeDefined();
     expect(canonicalCall![0]).not.toHaveProperty('provider');
-    // Also updates OpenRouter copy (preserves existing provider)
+    // Also updates the OpenRouter-hosted copy
     const orCall = mockUpsert.mock.calls.find(
       (call) => call[0].model_name === 'qwen/qwen3-235b-a22b',
     );
     expect(orCall).toBeDefined();
-    expect(orCall![0]).not.toHaveProperty('provider');
+    expect(orCall![0]).toMatchObject({ provider: 'OpenRouter' });
   });
 
-  it('skips OpenRouter copy when copy does not exist in DB', async () => {
-    // Canonical model exists, but OpenRouter copy does not
-    mockFindOneBy
-      .mockResolvedValueOnce({ model_name: 'gpt-4o', provider: 'OpenAI' }) // canonical
-      .mockResolvedValueOnce(null); // OR copy lookup
+  it('creates OpenRouter copy when copy does not exist in DB', async () => {
+    mockFindOneBy.mockResolvedValueOnce({ model_name: 'gpt-4o', provider: 'OpenAI' });
 
     mockFetch.mockResolvedValue({
       ok: true,
@@ -1003,11 +1013,17 @@ describe('PricingSyncService', () => {
     });
 
     await service.syncPricing();
-    // Only canonical upsert, no OpenRouter copy
-    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
     expect(mockUpsert).toHaveBeenCalledWith(expect.objectContaining({ model_name: 'gpt-4o' }), [
       'model_name',
     ]);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model_name: 'openai/gpt-4o',
+        provider: 'OpenRouter',
+      }),
+      ['model_name'],
+    );
   });
 
   it('updates existing OpenRouter copy pricing', async () => {
@@ -1026,9 +1042,9 @@ describe('PricingSyncService', () => {
     const orCall = mockUpsert.mock.calls.find((c) => c[0].model_name === 'openai/gpt-4o');
     expect(orCall).toBeDefined();
     expect(orCall![0]).toMatchObject({
+      provider: 'OpenRouter',
       input_price_per_token: 0.000005,
       output_price_per_token: 0.00002,
     });
-    expect(orCall![0]).not.toHaveProperty('provider');
   });
 });

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -222,30 +222,27 @@ export class PricingSyncService implements OnModuleInit {
           upserted = true;
         }
 
-        // Update existing OpenRouter copy with the full vendor-prefixed ID
+        // Store an OpenRouter-hosted copy with the full vendor-prefixed ID so
+        // the same model can be surfaced under both its native provider and OpenRouter.
         if (hasVendorPrefix) {
-          const existingCopy = await this.pricingRepo.findOneBy({
-            model_name: model.id,
-          });
-          if (existingCopy) {
-            try {
-              await this.pricingRepo.upsert(
-                {
-                  model_name: model.id,
-                  input_price_per_token: prompt,
-                  output_price_per_token: completion,
-                  ...(contextWindow != null && { context_window: contextWindow }),
-                  ...(displayName && { display_name: displayName }),
-                  updated_at: now,
-                },
-                ['model_name'],
-              );
-              upserted = true;
-            } catch (copyErr) {
-              this.logger.warn(
-                `Failed to store OpenRouter copy for ${model.id}: ${copyErr instanceof Error ? copyErr.message : copyErr}`,
-              );
-            }
+          try {
+            await this.pricingRepo.upsert(
+              {
+                model_name: model.id,
+                provider: 'OpenRouter',
+                input_price_per_token: prompt,
+                output_price_per_token: completion,
+                ...(contextWindow != null && { context_window: contextWindow }),
+                ...(displayName && { display_name: displayName }),
+                updated_at: now,
+              },
+              ['model_name'],
+            );
+            upserted = true;
+          } catch (copyErr) {
+            this.logger.warn(
+              `Failed to store OpenRouter copy for ${model.id}: ${copyErr instanceof Error ? copyErr.message : copyErr}`,
+            );
           }
         }
         if (upserted) updated++;
@@ -297,9 +294,10 @@ export class PricingSyncService implements OnModuleInit {
   }
 
   private async removeUnsupportedModels(): Promise<void> {
-    const all = await this.pricingRepo.find({ select: ['model_name'] });
+    const all = await this.pricingRepo.find({ select: ['model_name', 'provider'] });
     const toDelete: string[] = [];
     for (const row of all) {
+      if (row.provider === 'OpenRouter') continue;
       const slashIdx = row.model_name.indexOf('/');
       if (slashIdx === -1) continue;
       const prefix = row.model_name.substring(0, slashIdx);

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -91,14 +91,22 @@ export class PricingSyncService implements OnModuleInit {
     if (!data) return 0;
 
     const compatibleModels: OpenRouterModel[] = [];
+    const compatibleCanonicals = new Set<string>();
+    for (const model of data) {
+      if (!this.isChatCompatible(model)) continue;
+      compatibleModels.push(model);
+      const { canonical } = this.deriveNames(model.id);
+      compatibleCanonicals.add(canonical);
+    }
+
     const incompatibleNames = new Set<string>();
     for (const model of data) {
-      if (this.isChatCompatible(model)) {
-        compatibleModels.push(model);
-        continue;
-      }
+      if (this.isChatCompatible(model)) continue;
+
       const { canonical } = this.deriveNames(model.id);
-      incompatibleNames.add(canonical);
+      if (!compatibleCanonicals.has(canonical)) {
+        incompatibleNames.add(canonical);
+      }
       incompatibleNames.add(model.id);
     }
 

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -13,6 +13,10 @@ interface OpenRouterModel {
   id: string;
   name?: string;
   context_length?: number;
+  architecture?: {
+    input_modalities?: string[];
+    output_modalities?: string[];
+  };
   pricing?: {
     prompt?: string;
     completion?: string;
@@ -86,9 +90,21 @@ export class PricingSyncService implements OnModuleInit {
     const data = await this.fetchOpenRouterModels();
     if (!data) return 0;
 
-    const updated = await this.syncAllModels(data);
-    await this.resolveUnresolvedModels(data);
-    await this.removeUnsupportedModels();
+    const compatibleModels: OpenRouterModel[] = [];
+    const incompatibleNames = new Set<string>();
+    for (const model of data) {
+      if (this.isChatCompatible(model)) {
+        compatibleModels.push(model);
+        continue;
+      }
+      const { canonical } = this.deriveNames(model.id);
+      incompatibleNames.add(canonical);
+      incompatibleNames.add(model.id);
+    }
+
+    const updated = await this.syncAllModels(compatibleModels);
+    await this.resolveUnresolvedModels(compatibleModels);
+    await this.removeUnsupportedModels(incompatibleNames);
 
     this.logger.log(`Pricing sync complete: ${updated} models updated`);
     if (updated > 0) {
@@ -293,10 +309,30 @@ export class PricingSyncService implements OnModuleInit {
     return str.charAt(0).toUpperCase() + str.slice(1);
   }
 
-  private async removeUnsupportedModels(): Promise<void> {
+  private isChatCompatible(model: OpenRouterModel): boolean {
+    const inputModalities = model.architecture?.input_modalities?.map((m) => m.toLowerCase());
+    if (inputModalities && inputModalities.length > 0 && !inputModalities.includes('text')) {
+      return false;
+    }
+
+    const outputModalities = model.architecture?.output_modalities?.map((m) => m.toLowerCase());
+    if (outputModalities && outputModalities.length > 0) {
+      return outputModalities.every((m) => m === 'text');
+    }
+
+    return true;
+  }
+
+  private async removeUnsupportedModels(
+    incompatibleNames: ReadonlySet<string> = new Set(),
+  ): Promise<void> {
     const all = await this.pricingRepo.find({ select: ['model_name', 'provider'] });
     const toDelete: string[] = [];
     for (const row of all) {
+      if (incompatibleNames.has(row.model_name)) {
+        toDelete.push(row.model_name);
+        continue;
+      }
       if (row.provider === 'OpenRouter') continue;
       const slashIdx = row.model_name.indexOf('/');
       if (slashIdx === -1) continue;

--- a/packages/backend/src/routing/routing.controller.spec.ts
+++ b/packages/backend/src/routing/routing.controller.spec.ts
@@ -497,6 +497,21 @@ describe('RoutingController', () => {
       expect(result[0].model_name).toBe('anthropic/claude-sonnet-4');
     });
 
+    it('should include OpenRouter-hosted vendor-prefixed models when OpenRouter is active', async () => {
+      mockRoutingService.getProviders.mockResolvedValue([
+        { provider: 'openrouter', is_active: true },
+      ]);
+      mockPricingCache.getAll.mockReturnValue([
+        makePricing({ model_name: 'qwen/qwen3-235b-a22b', provider: 'OpenRouter' }),
+        makePricing({ model_name: 'qwen3-235b-a22b', provider: 'Alibaba' }),
+      ]);
+
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
+
+      expect(result.map((m) => m.model_name)).toContain('qwen/qwen3-235b-a22b');
+      expect(result.map((m) => m.model_name)).not.toContain('qwen3-235b-a22b');
+    });
+
     it('should return empty array when no active providers', async () => {
       mockRoutingService.getProviders.mockResolvedValue([{ provider: 'openai', is_active: false }]);
       mockPricingCache.getAll.mockReturnValue([


### PR DESCRIPTION
## Summary
- preserve OpenRouter-hosted vendor-prefixed models during local bootstrap and available-model resolution
- store OpenRouter-hosted copies for vendor-prefixed models during pricing sync
- filter out non-chat OpenRouter models based on modality metadata and delete stale incompatible rows

## Why
OpenRouter-hosted models with vendor-prefixed IDs need to remain available locally, but image-output / non-chat models should not be proposed in Manifest's text model picker. This keeps OpenRouter chat models surfaced while removing incompatible entries like image-preview-only rows from the synced pricing table.

## Testing
- npm test --workspace=packages/backend -- --runInBand src/database/pricing-sync.service.spec.ts


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves chat‑compatible OpenRouter models, always creates OpenRouter‑hosted vendor‑prefixed copies with `provider: 'OpenRouter'`, and filters non‑chat entries while avoiding canonical name collisions during cleanup.

- **New Features**
  - Upsert an OpenRouter‑hosted copy for vendor‑prefixed models (e.g., `openai/gpt-4o`) alongside the canonical entry, with `provider: 'OpenRouter'`.
  - Local bootstrap and available‑model resolution keep `OpenRouter` provider models even if not curated; available models include vendor‑prefixed IDs when `openrouter` is active.

- **Bug Fixes**
  - Modality filter for chat: require text input; allow multimodal input; enforce text‑only output.
  - Cleanup removes stale non‑chat entries and unsupported native vendor‑prefixed rows, but keeps OpenRouter‑hosted rows and canonicals; avoids deleting a compatible canonical when an incompatible alias shares the same name.

<sup>Written for commit 9acb4f30152840eed1675e62898daf2d9031e601. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



Fixes https://github.com/mnfst/manifest/issues/1088