### PR TITLE
fix: return 424 when fallback chain is exhausted

### DIFF
--- a/.changeset/fix-fallback-exhausted.md
+++ b/.changeset/fix-fallback-exhausted.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Return HTTP 424 when fallback chain is exhausted to prevent infinite retry loops

--- a/packages/backend/src/routing/proxy/__tests__/fallback-status-codes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/fallback-status-codes.spec.ts
@@ -1,14 +1,24 @@
-import { shouldTriggerFallback } from '../fallback-status-codes';
+import { shouldTriggerFallback, FALLBACK_EXHAUSTED_STATUS } from '../fallback-status-codes';
 
 describe('shouldTriggerFallback', () => {
   it.each([429, 500, 502, 503, 504])('should return true for retriable status %d', (status) => {
     expect(shouldTriggerFallback(status)).toBe(true);
   });
 
-  it.each([200, 201, 204, 301, 302, 400, 401, 403, 404, 405, 409, 422, 501])(
+  it.each([200, 201, 204, 301, 302, 400, 401, 403, 404, 405, 409, 422, 424, 501])(
     'should return false for non-retriable status %d',
     (status) => {
       expect(shouldTriggerFallback(status)).toBe(false);
     },
   );
+});
+
+describe('FALLBACK_EXHAUSTED_STATUS', () => {
+  it('should be 424', () => {
+    expect(FALLBACK_EXHAUSTED_STATUS).toBe(424);
+  });
+
+  it('should not trigger fallback', () => {
+    expect(shouldTriggerFallback(FALLBACK_EXHAUSTED_STATUS)).toBe(false);
+  });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -106,7 +106,9 @@ describe('ProxyController', () => {
       convertAnthropicStreamChunk: jest.fn(),
     };
     mockMessageManager = {
-      transaction: jest.fn(async (cb: (manager: unknown) => Promise<unknown>) => cb(mockMessageManager)),
+      transaction: jest.fn(async (cb: (manager: unknown) => Promise<unknown>) =>
+        cb(mockMessageManager),
+      ),
       getRepository: jest.fn(),
       query: jest.fn().mockResolvedValue([]),
       connection: { options: { type: 'sqlite' } },
@@ -523,13 +525,11 @@ describe('ProxyController', () => {
     const insertGate = new Promise<void>((resolve) => {
       releaseInsert = resolve;
     });
-    mockMessageRepo.findOne
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
-        id: 'existing-otlp-row',
-        input_tokens: 500,
-        output_tokens: 200,
-      });
+    mockMessageRepo.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: 'existing-otlp-row',
+      input_tokens: 500,
+      output_tokens: 200,
+    });
     mockMessageRepo.insert.mockImplementationOnce(async () => {
       await insertGate;
       return {};
@@ -2541,7 +2541,7 @@ describe('ProxyController', () => {
 
     it('should record failed fallback attempts as separate messages', async () => {
       const mockProviderResp = new Response('primary error', {
-        status: 400,
+        status: 424,
         headers: { 'Content-Type': 'text/plain' },
       });
 
@@ -2566,7 +2566,7 @@ describe('ProxyController', () => {
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
-      const { res } = mockResponse();
+      const { res, headers } = mockResponse();
 
       await controller.chatCompletions(req as never, res as never);
       await new Promise((r) => setTimeout(r, 10));
@@ -2589,13 +2589,19 @@ describe('ProxyController', () => {
           error_message: 'auth fail',
         }),
       );
+      expect(headers['X-Manifest-Fallback-Exhausted']).toBe('true');
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ type: 'fallback_exhausted' }),
+        }),
+      );
     });
 
     it('should handle DB failure in recordFailedFallbacks when all fallbacks fail', async () => {
       mockMessageRepo.insert.mockRejectedValue(new Error('DB write failed'));
 
       const mockProviderResp = new Response('primary error', {
-        status: 500,
+        status: 424,
         headers: { 'Content-Type': 'text/plain' },
       });
 
@@ -2626,14 +2632,15 @@ describe('ProxyController', () => {
       await controller.chatCompletions(req as never, res as never);
       await new Promise((r) => setTimeout(r, 50));
 
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({
-        error: {
-          message: 'Upstream provider internal error',
-          type: 'upstream_error',
-          status: 500,
-        },
-      });
+      expect(res.status).toHaveBeenCalledWith(424);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            type: 'fallback_exhausted',
+            status: 424,
+          }),
+        }),
+      );
     });
 
     it('should handle DB failure in recordPrimaryFailure on successful fallback', async () => {
@@ -2716,7 +2723,7 @@ describe('ProxyController', () => {
 
     it('should mark intermediate failures as handled when all fallbacks fail', async () => {
       const mockProviderResp = new Response('primary error', {
-        status: 500,
+        status: 424,
         headers: { 'Content-Type': 'text/plain' },
       });
 
@@ -2780,7 +2787,7 @@ describe('ProxyController', () => {
 
   it('should pass authType to recordFailedFallbacks when all fallbacks fail', async () => {
     const mockProviderResp = new Response('primary error', {
-      status: 500,
+      status: 424,
       headers: { 'Content-Type': 'text/plain' },
     });
 
@@ -2826,6 +2833,122 @@ describe('ProxyController', () => {
         auth_type: 'subscription',
       }),
     );
+  });
+
+  it('should return 424 with fallback_exhausted type and X-Manifest-Fallback-Exhausted header', async () => {
+    const mockProviderResp = new Response('primary error', {
+      status: 424,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+      failedFallbacks: [
+        {
+          model: 'claude-sonnet-4',
+          provider: 'Anthropic',
+          fallbackIndex: 0,
+          status: 503,
+          errorBody: 'overloaded',
+        },
+        {
+          model: 'deepseek-chat',
+          provider: 'DeepSeek',
+          fallbackIndex: 1,
+          status: 500,
+          errorBody: 'server error',
+        },
+      ],
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res, headers } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(424);
+    expect(headers['X-Manifest-Fallback-Exhausted']).toBe('true');
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        type: 'fallback_exhausted',
+        status: 424,
+        primary_model: 'gpt-4o',
+        primary_provider: 'OpenAI',
+        attempted_fallbacks: [
+          { model: 'claude-sonnet-4', provider: 'Anthropic', status: 503 },
+          { model: 'deepseek-chat', provider: 'DeepSeek', status: 500 },
+        ],
+      }),
+    });
+  });
+
+  it('should NOT set X-Manifest-Fallback-Exhausted when error has no failed fallbacks', async () => {
+    const mockProviderResp = new Response('bad request', {
+      status: 400,
+      headers: { 'Content-Type': 'text/plain' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o-mini',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res, headers } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(headers['X-Manifest-Fallback-Exhausted']).toBeUndefined();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ type: 'upstream_error' }),
+      }),
+    );
+  });
+
+  it('should NOT set X-Manifest-Fallback-Exhausted when a fallback succeeded', async () => {
+    const responseBody = { choices: [{ message: { content: 'hello' } }] };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'simple',
+        model: 'deepseek-chat',
+        provider: 'DeepSeek',
+        confidence: 0.8,
+        reason: 'scored',
+        fallbackFromModel: 'gemini-flash',
+        fallbackIndex: 0,
+        primaryErrorStatus: 500,
+        primaryErrorBody: 'primary failed',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res, headers } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(headers['X-Manifest-Fallback-Exhausted']).toBeUndefined();
   });
 
   describe('auth_type and subscription cost', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -7,6 +7,7 @@ import { ProviderClient } from '../provider-client';
 import { SessionMomentumService } from '../session-momentum.service';
 import { LimitCheckService } from '../../../notifications/services/limit-check.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
+import { shouldTriggerFallback } from '../fallback-status-codes';
 
 describe('ProxyService', () => {
   let service: ProxyService;
@@ -1615,7 +1616,7 @@ describe('ProxyService', () => {
       const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
 
       expect(result.forward.response.ok).toBe(false);
-      expect(result.forward.response.status).toBe(500);
+      expect(result.forward.response.status).toBe(424);
       expect(result.failedFallbacks).toHaveLength(1);
       expect(result.failedFallbacks![0]).toEqual({
         model: 'deepseek-chat',
@@ -1624,6 +1625,46 @@ describe('ProxyService', () => {
         status: 504,
         errorBody: 'gateway timeout',
       });
+    });
+
+    it('returns non-retriable 424 status when all fallbacks are exhausted', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.5,
+        reason: 'scored',
+      });
+      routingService.getProviderApiKey.mockResolvedValue('sk-test');
+
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('rate limited', { status: 429 }),
+          isGoogle: false,
+          isAnthropic: false,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('overloaded', { status: 503 }),
+          isGoogle: false,
+          isAnthropic: false,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('server error', { status: 500 }),
+          isGoogle: false,
+          isAnthropic: false,
+        });
+
+      routingService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: ['claude-sonnet-4', 'deepseek-chat'] },
+      ] as never);
+      pricingCache.getByModel.mockReturnValue({ provider: 'Anthropic' } as never);
+
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
+
+      expect(result.forward.response.status).toBe(424);
+      expect(shouldTriggerFallback(result.forward.response.status)).toBe(false);
+      expect(result.failedFallbacks).toHaveLength(2);
     });
   });
 });

--- a/packages/backend/src/routing/proxy/fallback-status-codes.ts
+++ b/packages/backend/src/routing/proxy/fallback-status-codes.ts
@@ -1,5 +1,7 @@
 const RETRIABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 
+export const FALLBACK_EXHAUSTED_STATUS = 424;
+
 export function shouldTriggerFallback(status: number): boolean {
   return RETRIABLE_STATUSES.has(status);
 }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -130,19 +130,39 @@ export class ProxyController implements OnModuleDestroy {
             primaryTs,
             meta.auth_type,
           ).catch((e) => this.logger.warn(`Failed to record primary failure: ${e}`));
-        } else {
-          this.recordProviderError(
-            req.ingestionContext,
-            errorStatus,
-            errorBody,
-            meta.model,
-            meta.tier,
-            traceId,
-            meta.fallbackFromModel,
-            meta.fallbackIndex,
-            meta.auth_type,
-          ).catch((e) => this.logger.warn(`Failed to record provider error: ${e}`));
+
+          this.logger.warn(`Fallback chain exhausted: ${errorBody.slice(0, 200)}`);
+          res.status(errorStatus);
+          for (const [k, v] of Object.entries(metaHeaders)) res.setHeader(k, v);
+          res.setHeader('X-Manifest-Fallback-Exhausted', 'true');
+          res.json({
+            error: {
+              message: sanitizeProviderError(errorStatus, errorBody),
+              type: 'fallback_exhausted',
+              status: errorStatus,
+              primary_model: meta.model,
+              primary_provider: meta.provider,
+              attempted_fallbacks: failedFallbacks.map((f) => ({
+                model: f.model,
+                provider: f.provider,
+                status: f.status,
+              })),
+            },
+          });
+          return;
         }
+
+        this.recordProviderError(
+          req.ingestionContext,
+          errorStatus,
+          errorBody,
+          meta.model,
+          meta.tier,
+          traceId,
+          meta.fallbackFromModel,
+          meta.fallbackIndex,
+          meta.auth_type,
+        ).catch((e) => this.logger.warn(`Failed to record provider error: ${e}`));
 
         this.logger.warn(`Upstream error ${errorStatus}: ${errorBody.slice(0, 200)}`);
         res.status(errorStatus);

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -7,7 +7,7 @@ import { ProviderClient, ForwardResult } from './provider-client';
 import { buildCustomEndpoint, ProviderEndpoint } from './provider-endpoints';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
-import { shouldTriggerFallback } from './fallback-status-codes';
+import { shouldTriggerFallback, FALLBACK_EXHAUSTED_STATUS } from './fallback-status-codes';
 import { inferProviderFromModelName } from '../provider-aliases';
 import { Tier, ScorerMessage } from '../scorer/types';
 
@@ -167,11 +167,11 @@ export class ProxyService {
           };
         }
 
-        // All fallbacks exhausted — rebuild the primary error response
-        // since the original body was consumed.
+        // All fallbacks exhausted — return non-retriable 424 so the gateway
+        // does not retry the entire chain in an infinite loop.
         const rebuilt = new Response(primaryErrorBody, {
-          status: forward.response.status,
-          statusText: forward.response.statusText,
+          status: FALLBACK_EXHAUSTED_STATUS,
+          statusText: 'Failed Dependency',
           headers: forward.response.headers,
         });
         this.momentum.recordTier(sessionKey, resolved.tier as Tier);


### PR DESCRIPTION
## Summary

- When all fallback models fail with retriable statuses (429/500/502/503/504), the proxy now returns HTTP 424 (Failed Dependency) instead of forwarding the original retriable status
- Adds `X-Manifest-Fallback-Exhausted: true` response header and `fallback_exhausted` error type with details about the primary model and attempted fallbacks
- Prevents the gateway from interpreting the response as "temporary, retry" and creating an infinite retry loop

Fix #1119

## Test plan

- [x] Updated existing fallback-exhausted tests to expect 424 status and `fallback_exhausted` error type
- [x] Added test verifying 424 status, `X-Manifest-Fallback-Exhausted` header, and `fallback_exhausted` error body
- [x] Added negative test: header is NOT set when error has no failed fallbacks
- [x] Added negative test: header is NOT set when a fallback succeeded
- [x] Added test for `FALLBACK_EXHAUSTED_STATUS` constant value and non-retriability
- [x] All backend unit tests pass (2486 tests)
- [x] All frontend tests pass (1469 tests)
- [x] TypeScript compilation clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return HTTP 424 (Failed Dependency) when all model fallbacks are exhausted to stop gateway retry loops and give clients clear, structured errors.

- **Bug Fixes**
  - Return 424 when all fallbacks fail with retriable statuses (429/500/502/503/504) instead of forwarding a retriable status.
  - Add X-Manifest-Fallback-Exhausted: true and a fallback_exhausted error with primary model/provider and attempted fallbacks; not set when no fallbacks failed or a fallback succeeds.
  - Treat 424 as non-retriable in fallback logic and update controller/service and tests accordingly.

<sup>Written for commit 2773025b401f50f604c92da44c8f6ad6b5372018. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

