### PR TITLE
fix: resolve 404 on page reload for SPA routes in local mode

### DIFF
--- a/.changeset/fix-spa-fallback-local-mode.md
+++ b/.changeset/fix-spa-fallback-local-mode.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix 404 on page reload for SPA routes in local mode by centralizing frontend directory resolution with proper fallback chain for both monorepo and embedded npm package layouts.

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -5,9 +5,8 @@ import { ConfigModule } from '@nestjs/config';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { join } from 'path';
-import { existsSync } from 'fs';
 import { appConfig } from './config/app.config';
+import { resolveFrontendDir } from './common/utils/frontend-path';
 import { DASHBOARD_CACHE_TTL_MS } from './common/constants/cache.constants';
 import { ApiKeyGuard } from './common/guards/api-key.guard';
 import { ApiKey } from './entities/api-key.entity';
@@ -30,10 +29,9 @@ import { GithubModule } from './github/github.module';
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';
 const sessionGuardClass = isLocalMode ? LocalAuthGuard : SessionGuard;
 
-const frontendPath =
-  process.env['MANIFEST_FRONTEND_DIR'] || join(__dirname, '..', '..', 'frontend', 'dist');
+const frontendPath = resolveFrontendDir();
 const ONE_YEAR_S = 365 * 24 * 60 * 60;
-const serveStaticImports = existsSync(frontendPath)
+const serveStaticImports = frontendPath
   ? [
       ServeStaticModule.forRoot({
         rootPath: frontendPath,

--- a/packages/backend/src/common/filters/spa-fallback.filter.spec.ts
+++ b/packages/backend/src/common/filters/spa-fallback.filter.spec.ts
@@ -1,15 +1,12 @@
 import { NotFoundException } from '@nestjs/common';
-import { SpaFallbackFilter } from './spa-fallback.filter';
 
-// Mock fs.existsSync to control indexPath resolution
-jest.mock('fs', () => ({
-  ...jest.requireActual('fs'),
-  existsSync: jest.fn(),
+jest.mock('../utils/frontend-path', () => ({
+  resolveFrontendDir: jest.fn(),
 }));
 
-import { existsSync } from 'fs';
+import { resolveFrontendDir } from '../utils/frontend-path';
 
-const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+const mockResolveFrontendDir = resolveFrontendDir as jest.MockedFunction<typeof resolveFrontendDir>;
 
 function createMockHost(method: string, url: string) {
   const json = jest.fn();
@@ -24,6 +21,7 @@ function createMockHost(method: string, url: string) {
         getRequest: () => req,
         getResponse: () => res,
       }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any,
     req,
     res,
@@ -33,18 +31,30 @@ function createMockHost(method: string, url: string) {
 describe('SpaFallbackFilter', () => {
   const exception = new NotFoundException();
 
+  // Must re-import after mock setup to pick up the mocked module
+  function loadFilter() {
+    jest.resetModules();
+    jest.mock('../utils/frontend-path', () => ({
+      resolveFrontendDir: mockResolveFrontendDir,
+    }));
+    const { SpaFallbackFilter } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require('./spa-fallback.filter') as typeof import('./spa-fallback.filter');
+    return new SpaFallbackFilter();
+  }
+
   describe('when index.html exists', () => {
-    let filter: SpaFallbackFilter;
+    let filter: ReturnType<typeof loadFilter>;
 
     beforeEach(() => {
-      mockExistsSync.mockReturnValue(true);
-      filter = new SpaFallbackFilter();
+      mockResolveFrontendDir.mockReturnValue('/mock/frontend');
+      filter = loadFilter();
     });
 
     it('serves index.html for GET to a deep SPA route', () => {
       const { host, res } = createMockHost('GET', '/agents/foo/routing');
       filter.catch(exception, host);
-      expect(res.sendFile).toHaveBeenCalledWith(expect.stringContaining('index.html'));
+      expect(res.sendFile).toHaveBeenCalledWith('/mock/frontend/index.html');
       expect(res.status).not.toHaveBeenCalled();
     });
 
@@ -78,11 +88,11 @@ describe('SpaFallbackFilter', () => {
   });
 
   describe('when index.html does not exist', () => {
-    let filter: SpaFallbackFilter;
+    let filter: ReturnType<typeof loadFilter>;
 
     beforeEach(() => {
-      mockExistsSync.mockReturnValue(false);
-      filter = new SpaFallbackFilter();
+      mockResolveFrontendDir.mockReturnValue(null);
+      filter = loadFilter();
     });
 
     it('returns JSON 404 even for GET to a deep SPA route', () => {

--- a/packages/backend/src/common/filters/spa-fallback.filter.ts
+++ b/packages/backend/src/common/filters/spa-fallback.filter.ts
@@ -1,12 +1,7 @@
-import {
-  ExceptionFilter,
-  Catch,
-  NotFoundException,
-  ArgumentsHost,
-} from '@nestjs/common';
+import { ExceptionFilter, Catch, NotFoundException, ArgumentsHost } from '@nestjs/common';
 import { Response, Request } from 'express';
 import { join } from 'path';
-import { existsSync } from 'fs';
+import { resolveFrontendDir } from '../utils/frontend-path';
 
 const API_PREFIXES = ['/api/', '/otlp/', '/v1/'];
 
@@ -15,11 +10,8 @@ export class SpaFallbackFilter implements ExceptionFilter {
   private readonly indexPath: string | null;
 
   constructor() {
-    const frontendDir =
-      process.env['MANIFEST_FRONTEND_DIR'] ||
-      join(__dirname, '..', '..', '..', '..', 'frontend', 'dist');
-    const candidate = join(frontendDir, 'index.html');
-    this.indexPath = existsSync(candidate) ? candidate : null;
+    const frontendDir = resolveFrontendDir();
+    this.indexPath = frontendDir ? join(frontendDir, 'index.html') : null;
   }
 
   catch(exception: NotFoundException, host: ArgumentsHost) {

--- a/packages/backend/src/common/utils/frontend-path.spec.ts
+++ b/packages/backend/src/common/utils/frontend-path.spec.ts
@@ -1,0 +1,64 @@
+import { join } from 'path';
+import { existsSync } from 'fs';
+
+// __dirname in compiled output is dist/common/utils
+const monorepoIndex = join(__dirname, '..', '..', '..', '..', 'frontend', 'dist', 'index.html');
+const embeddedIndex = join(__dirname, '..', '..', '..', '..', 'public', 'index.html');
+
+describe('resolveFrontendDir', () => {
+  const originalEnv = process.env;
+  let mockExistsSync: jest.MockedFunction<typeof existsSync>;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    mockExistsSync = jest.fn().mockReturnValue(false);
+    jest.mock('fs', () => ({
+      ...jest.requireActual('fs'),
+      existsSync: mockExistsSync,
+    }));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function loadModule() {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('./frontend-path') as typeof import('./frontend-path');
+  }
+
+  it('returns env var path when MANIFEST_FRONTEND_DIR is set and valid', () => {
+    process.env['MANIFEST_FRONTEND_DIR'] = '/custom/frontend';
+    mockExistsSync.mockImplementation((p) => p === join('/custom/frontend', 'index.html'));
+    const { resolveFrontendDir } = loadModule();
+    expect(resolveFrontendDir()).toBe('/custom/frontend');
+  });
+
+  it('skips env var when directory has no index.html', () => {
+    process.env['MANIFEST_FRONTEND_DIR'] = '/bad/path';
+    mockExistsSync.mockImplementation((p) => p === monorepoIndex);
+    const { resolveFrontendDir } = loadModule();
+    expect(resolveFrontendDir()).toBe(join(__dirname, '..', '..', '..', '..', 'frontend', 'dist'));
+  });
+
+  it('returns monorepo path when env var is absent', () => {
+    delete process.env['MANIFEST_FRONTEND_DIR'];
+    mockExistsSync.mockImplementation((p) => p === monorepoIndex);
+    const { resolveFrontendDir } = loadModule();
+    expect(resolveFrontendDir()).toBe(join(__dirname, '..', '..', '..', '..', 'frontend', 'dist'));
+  });
+
+  it('returns embedded path when monorepo path fails', () => {
+    delete process.env['MANIFEST_FRONTEND_DIR'];
+    mockExistsSync.mockImplementation((p) => p === embeddedIndex);
+    const { resolveFrontendDir } = loadModule();
+    expect(resolveFrontendDir()).toBe(join(__dirname, '..', '..', '..', '..', 'public'));
+  });
+
+  it('returns null when nothing matches', () => {
+    delete process.env['MANIFEST_FRONTEND_DIR'];
+    const { resolveFrontendDir } = loadModule();
+    expect(resolveFrontendDir()).toBeNull();
+  });
+});

--- a/packages/backend/src/common/utils/frontend-path.ts
+++ b/packages/backend/src/common/utils/frontend-path.ts
@@ -1,0 +1,25 @@
+import { join } from 'path';
+import { existsSync } from 'fs';
+
+function hasIndex(dir: string): boolean {
+  return existsSync(join(dir, 'index.html'));
+}
+
+/**
+ * Resolves the frontend dist directory across both monorepo and
+ * embedded npm package layouts. Returns `null` if no valid directory found.
+ */
+export function resolveFrontendDir(): string | null {
+  const envDir = process.env['MANIFEST_FRONTEND_DIR'];
+  if (envDir && hasIndex(envDir)) return envDir;
+
+  // Monorepo: dist/common/utils/ → ../../../../frontend/dist
+  const monorepo = join(__dirname, '..', '..', '..', '..', 'frontend', 'dist');
+  if (hasIndex(monorepo)) return monorepo;
+
+  // Embedded npm package: dist/backend/common/utils/ → ../../../../public
+  const embedded = join(__dirname, '..', '..', '..', '..', 'public');
+  if (hasIndex(embedded)) return embedded;
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Centralizes frontend directory resolution into `resolveFrontendDir()` utility that checks `MANIFEST_FRONTEND_DIR` env var, monorepo layout (`../frontend/dist`), and embedded npm package layout (`../public`) in order
- Both `app.module.ts` and `spa-fallback.filter.ts` now use the shared utility instead of duplicated path logic that only resolved correctly in the monorepo layout
- Fixes #1117

## Test plan

- [x] Backend unit tests pass (2484 tests, 135 suites)
- [x] Backend e2e tests pass (109 tests, 16 suites)
- [x] Frontend tests pass (1469 tests, 73 suites)
- [x] TypeScript compiles clean (backend + frontend)
- [x] ESLint passes on all changed files
- [x] Verified monorepo layout: `npm run build && MANIFEST_MODE=local node packages/backend/dist/main.js` — reload `/agents/local-agent` returns `index.html`
- [x] Verified embedded layout: built openclaw-plugin, booted via `dist/server.js` — reload `/agents/local-agent` returns `index.html`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404 on page reload for SPA routes in local mode by centralizing frontend build directory resolution and using it for both static serving and SPA fallback. Ensures deep links work in both monorepo and embedded package layouts.

- **Bug Fixes**
  - Added `resolveFrontendDir()` that checks `MANIFEST_FRONTEND_DIR`, `frontend/dist` (monorepo), then `public` (embedded) and returns `null` if none match.
  - Updated `app.module.ts` and SPA fallback filter to use the shared utility and serve `index.html` for non-API GETs.
  - Added tests for path resolution and filter behavior across layouts.

<sup>Written for commit f28b9520f6ecdebb5cedaaa842cc6e293c415ff7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

