### PR TITLE
fix(routing): prevent proxy crash on fallback exhaustion by stripping transfer headers

### DIFF
--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -169,10 +169,15 @@ export class ProxyService {
 
         // All fallbacks exhausted — return non-retriable 424 so the gateway
         // does not retry the entire chain in an infinite loop.
+        const safeHeaders = new Headers(forward.response.headers);
+        safeHeaders.delete('content-encoding');
+        safeHeaders.delete('content-length');
+        safeHeaders.delete('transfer-encoding');
+
         const rebuilt = new Response(primaryErrorBody, {
           status: FALLBACK_EXHAUSTED_STATUS,
           statusText: 'Failed Dependency',
-          headers: forward.response.headers,
+          headers: safeHeaders,
         });
         this.momentum.recordTier(sessionKey, resolved.tier as Tier);
         return {


### PR DESCRIPTION
## Summary
This prevents the proxy from crashing with a `zlib: incorrect header check` error (and subsequently returning a generic 500) when the entire fallback chain is exhausted.

## Problem
Closes #1119. 

When the LLM routing proxy exhausts the full fallback chain and returns the primary error response, it was incorrectly passing the original `forward.response.headers` (which could contain `content-encoding: gzip`) into the new `Response` constructor alongside a decoded plaintext string (`primaryErrorBody`).
When the proxy controller called `.text()` on this rebuilt response, Node's `undici` threw a decompression error because the body was no longer gzipped. This exception was caught by the global handler, which swallowed the original provider error and sent an `Internal proxy error` (500) back to the client. Because clients (like the OpenAI SDK) automatically retry 500s indefinitely (or up to their limit), this caused the "system retries the entire chain in a loop" behavior described in the issue.

## Solution
Create a new `Headers` instance and strip out `content-encoding`, `content-length`, and `transfer-encoding` before passing it to the rebuilt `Response`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crash and 500 retry loops when all fallbacks are exhausted by stripping transfer headers and returning 424 Failed Dependency. Closes #1119.

- **Bug Fixes**
  - Rebuild the primary error response with `new Headers(forward.response.headers)`, delete `content-encoding`, `content-length`, and `transfer-encoding`, and set `status: 424`/`statusText: 'Failed Dependency'` to avoid `undici` decompression errors and stop retries.

<sup>Written for commit e27cbb86a631ee946cf3fe8dbd1c09de0ddafd6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

