### PR TITLE
fix: consistent model display names across Overview and Messages pages

### DIFF
--- a/.changeset/consistent-model-display.md
+++ b/.changeset/consistent-model-display.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Resolve model display names on the backend via LEFT JOIN with model_pricing, ensuring consistent display names between Overview and Messages pages regardless of frontend cache state.

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -19,6 +19,7 @@ describe('MessagesQueryService', () => {
     const mockQb: Record<string, jest.Mock> = {
       select: jest.fn(),
       addSelect: jest.fn(),
+      leftJoin: jest.fn(),
       where: jest.fn(),
       andWhere: jest.fn(),
       orWhere: jest.fn(),
@@ -34,6 +35,7 @@ describe('MessagesQueryService', () => {
     const chainableMethods = [
       'select',
       'addSelect',
+      'leftJoin',
       'where',
       'andWhere',
       'orWhere',
@@ -712,6 +714,7 @@ describe('MessagesQueryService (sql.js / local mode)', () => {
     const mockQb = {
       select: jest.fn().mockReturnThis(),
       addSelect: mockAddSelect,
+      leftJoin: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       orWhere: jest.fn().mockReturnThis(),

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -98,10 +98,12 @@ export class MessagesQueryService {
     const costExpr = sqlCastFloat(sqlSanitizeCost('at.cost_usd'), this.dialect);
     const dataQb = baseQb
       .clone()
+      .leftJoin('model_pricing', 'mp', 'at.model = mp.model_name')
       .select('at.id', 'id')
       .addSelect('at.timestamp', 'timestamp')
       .addSelect('at.agent_name', 'agent_name')
       .addSelect('at.model', 'model')
+      .addSelect("COALESCE(NULLIF(mp.display_name, ''), at.model)", 'display_name')
       .addSelect('at.description', 'description')
       .addSelect('at.service_type', 'service_type')
       .addSelect('at.input_tokens', 'input_tokens')

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -18,6 +18,7 @@ describe('TimeseriesQueriesService', () => {
     const mockTurnQb = {
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       orWhere: jest.fn().mockReturnThis(),
@@ -135,6 +136,30 @@ describe('TimeseriesQueriesService', () => {
       expect(result[1].share_pct).toBe(30);
       expect(result[0].auth_type).toBe('subscription');
       expect(result[1].auth_type).toBe('api_key');
+    });
+
+    it('returns display_name from model_pricing when available', async () => {
+      mockGetRawMany.mockResolvedValue([
+        {
+          model: 'gpt-4o',
+          display_name: 'GPT-4o',
+          tokens: 500,
+          estimated_cost: 2.0,
+          auth_type: null,
+        },
+      ]);
+
+      const result = await service.getCostByModel('7d', 'u1');
+      expect(result[0].display_name).toBe('GPT-4o');
+    });
+
+    it('falls back to model slug when display_name is missing', async () => {
+      mockGetRawMany.mockResolvedValue([
+        { model: 'custom-model', tokens: 100, estimated_cost: 1.0, auth_type: null },
+      ]);
+
+      const result = await service.getCostByModel('7d', 'u1');
+      expect(result[0].display_name).toBe('custom-model');
     });
 
     it('returns 0 share_pct when total tokens is 0', async () => {
@@ -397,6 +422,7 @@ describe('TimeseriesQueriesService (sql.js / local mode)', () => {
     const mockTurnQb = {
       select: mockSelect,
       addSelect: mockAddSelect,
+      leftJoin: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       orWhere: jest.fn().mockReturnThis(),

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -242,10 +242,12 @@ export class TimeseriesQueriesService {
 
     const qb = this.turnRepo
       .createQueryBuilder('at')
+      .leftJoin('model_pricing', 'mp', 'at.model = mp.model_name')
       .select('at.id', 'id')
       .addSelect('at.timestamp', 'timestamp')
       .addSelect('at.agent_name', 'agent_name')
       .addSelect('at.model', 'model')
+      .addSelect("COALESCE(NULLIF(mp.display_name, ''), at.model)", 'display_name')
       .addSelect('at.input_tokens', 'input_tokens')
       .addSelect('at.output_tokens', 'output_tokens')
       .addSelect('at.status', 'status')
@@ -269,7 +271,9 @@ export class TimeseriesQueriesService {
 
     const qb = this.turnRepo
       .createQueryBuilder('at')
+      .leftJoin('model_pricing', 'mp', 'at.model = mp.model_name')
       .select("COALESCE(at.model, 'unknown')", 'model')
+      .addSelect("COALESCE(NULLIF(mp.display_name, ''), at.model)", 'display_name')
       .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
       .addSelect(`COALESCE(SUM(${sqlSanitizeCost('at.cost_usd')}), 0)`, 'estimated_cost')
       .addSelect('at.auth_type', 'auth_type')
@@ -280,6 +284,7 @@ export class TimeseriesQueriesService {
     const rows = await qb
       .groupBy('at.model')
       .addGroupBy('at.auth_type')
+      .addGroupBy('mp.display_name')
       .orderBy('tokens', 'DESC')
       .getRawMany();
 
@@ -289,6 +294,7 @@ export class TimeseriesQueriesService {
     );
     return rows.map((r: Record<string, unknown>) => ({
       model: String(r['model']),
+      display_name: r['display_name'] ? String(r['display_name']) : String(r['model']),
       tokens: Number(r['tokens'] ?? 0),
       share_pct:
         totalTokens === 0 ? 0 : Math.round((Number(r['tokens'] ?? 0) / totalTokens) * 1000) / 10,

--- a/packages/frontend/src/components/MessageTable.tsx
+++ b/packages/frontend/src/components/MessageTable.tsx
@@ -1,0 +1,329 @@
+import { For, Show, type JSX } from 'solid-js';
+import { A } from '@solidjs/router';
+import type { MessageRow, MessageColumnKey } from './message-table-types.js';
+import InfoTooltip from './InfoTooltip.jsx';
+import {
+  formatCost,
+  formatErrorMessage,
+  formatNumber,
+  formatStatus,
+  formatTime,
+  formatDuration,
+  customProviderColor,
+} from '../services/formatters.js';
+import {
+  inferProviderFromModel,
+  inferProviderName,
+  stripCustomPrefix,
+} from '../services/routing-utils.js';
+import { getModelDisplayName } from '../services/model-display.js';
+import { providerIcon } from './ProviderIcon.jsx';
+import { authBadgeFor, authLabel } from './AuthBadge.js';
+
+export interface MessageTableProps {
+  items: MessageRow[];
+  columns: MessageColumnKey[];
+  agentName: string;
+  customProviderName: (model: string) => string | undefined;
+  onFallbackErrorClick?: (model: string) => void;
+  rowIdPrefix?: string;
+  showHeaderTooltips?: boolean;
+}
+
+const MONO = 'font-family: var(--font-mono);';
+const MONO_XS =
+  'font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));';
+
+const HEARTBEAT_SVG = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+  </svg>
+);
+
+const FALLBACK_SVG = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="11"
+    height="11"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    style="margin-right: 3px; flex-shrink: 0;"
+  >
+    <polyline points="15 17 20 12 15 7" />
+    <path d="M4 18v-2a4 4 0 0 1 4-4h12" />
+  </svg>
+);
+
+const HEADER_LABELS: Record<MessageColumnKey, string> = {
+  date: 'Date',
+  message: 'Message',
+  cost: 'Cost',
+  totalTokens: 'Tokens',
+  input: 'Input',
+  output: 'Output',
+  model: 'Model',
+  cache: 'Cache',
+  duration: 'Duration',
+  status: 'Status',
+};
+
+const TOOLTIP_TEXT: Partial<Record<MessageColumnKey, string>> = {
+  totalTokens: 'Tokens are units of text that AI models process. More tokens = higher cost.',
+  input: "Tokens sent to the model (your prompt). Also called 'input tokens'.",
+  output: "Tokens returned by the model (its response). Also called 'output tokens'.",
+};
+
+function columnHeader(key: MessageColumnKey, tooltips?: boolean): JSX.Element {
+  const label = key === 'totalTokens' && tooltips ? 'Total Tokens' : HEADER_LABELS[key];
+  const tip = TOOLTIP_TEXT[key];
+  return tip && (tooltips || key !== 'totalTokens') ? (
+    <>
+      {label}
+      <InfoTooltip text={tip} />
+    </>
+  ) : (
+    <>{label}</>
+  );
+}
+
+function DateCell(item: MessageRow): JSX.Element {
+  return <td style={`white-space: nowrap; ${MONO_XS}`}>{formatTime(item.timestamp)}</td>;
+}
+
+function MessageCell(item: MessageRow): JSX.Element {
+  return (
+    <td style={MONO_XS}>
+      {item.id.slice(0, 8)}
+      {item.routing_reason === 'heartbeat' && (
+        <span
+          title="Heartbeat"
+          style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;"
+        >
+          {HEARTBEAT_SVG}
+        </span>
+      )}
+    </td>
+  );
+}
+
+function CostCell(item: MessageRow): JSX.Element {
+  return (
+    <td style={MONO}>
+      <Show
+        when={item.auth_type === 'subscription'}
+        fallback={
+          <span
+            title={
+              item.cost != null && item.cost > 0 && item.cost < 0.01
+                ? `$${item.cost.toFixed(6)}`
+                : undefined
+            }
+          >
+            {item.cost != null ? (formatCost(item.cost) ?? '\u2014') : '\u2014'}
+          </span>
+        }
+      >
+        <span style="color: hsl(var(--muted-foreground));" title="Included in subscription">
+          $0.00
+        </span>
+      </Show>
+    </td>
+  );
+}
+
+function ModelCell(
+  item: MessageRow,
+  customProviderName: (m: string) => string | undefined,
+): JSX.Element {
+  return (
+    <td style={MONO_XS}>
+      <span style="display: inline-flex; align-items: center; gap: 4px;">
+        {item.model && inferProviderFromModel(item.model) === 'custom' ? (
+          (() => {
+            const provName = customProviderName(item.model!);
+            const letter = (provName ?? stripCustomPrefix(item.model!)).charAt(0).toUpperCase();
+            return (
+              <span
+                class="provider-card__logo-letter"
+                title={provName}
+                style={{
+                  background: customProviderColor(provName ?? ''),
+                  width: '16px',
+                  height: '16px',
+                  'font-size': '9px',
+                  'flex-shrink': '0',
+                  'border-radius': '50%',
+                }}
+              >
+                {letter}
+              </span>
+            );
+          })()
+        ) : item.model && inferProviderFromModel(item.model) ? (
+          <span
+            role="img"
+            aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
+            title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
+            style="display: inline-flex; flex-shrink: 0; position: relative;"
+          >
+            {providerIcon(inferProviderFromModel(item.model)!, 14)}
+            {authBadgeFor(item.auth_type, 8)}
+          </span>
+        ) : null}
+        {item.model ? item.display_name || getModelDisplayName(item.model) : '\u2014'}
+        {item.routing_tier && (
+          <span class={`tier-badge tier-badge--${item.routing_tier}`}>{item.routing_tier}</span>
+        )}
+        {item.fallback_from_model && (
+          <span
+            class="tier-badge tier-badge--fallback"
+            title={`Fallback from ${getModelDisplayName(item.fallback_from_model)}`}
+          >
+            fallback
+          </span>
+        )}
+      </span>
+    </td>
+  );
+}
+
+function TokenCell(value: number | null): JSX.Element {
+  return <td style={MONO}>{value != null ? formatNumber(value) : '\u2014'}</td>;
+}
+
+function SmallTokenCell(value: number | null): JSX.Element {
+  return <td style={MONO_XS}>{value != null ? formatNumber(value) : '\u2014'}</td>;
+}
+
+function CacheCell(item: MessageRow): JSX.Element {
+  const has = (item.cache_read_tokens ?? 0) > 0 || (item.cache_creation_tokens ?? 0) > 0;
+  return (
+    <td style={MONO_XS}>
+      {has
+        ? `Read: ${formatNumber(item.cache_read_tokens ?? 0)} / Write: ${formatNumber(item.cache_creation_tokens ?? 0)}`
+        : '\u2014'}
+    </td>
+  );
+}
+
+function DurationCell(item: MessageRow): JSX.Element {
+  return (
+    <td style={MONO_XS}>
+      {item.duration_ms != null ? formatDuration(item.duration_ms) : '\u2014'}
+    </td>
+  );
+}
+
+function StatusCell(
+  item: MessageRow,
+  agentName: string,
+  onFallbackErrorClick?: (model: string) => void,
+): JSX.Element {
+  return (
+    <td>
+      <Show
+        when={item.error_message}
+        fallback={
+          <span class={`status-badge status-badge--${item.status}`}>
+            {item.status === 'rate_limited' ? (
+              <A href={`/agents/${encodeURIComponent(agentName)}/limits`}>
+                {formatStatus(item.status)}
+              </A>
+            ) : (
+              formatStatus(item.status)
+            )}
+          </span>
+        }
+      >
+        <span
+          class="status-badge-tooltip"
+          tabindex="0"
+          role="note"
+          aria-label={formatErrorMessage(item.error_message!)}
+        >
+          <span
+            class={`status-badge status-badge--${item.status}`}
+            onClick={
+              item.status === 'fallback_error' && item.model && onFallbackErrorClick
+                ? () => onFallbackErrorClick(item.model!)
+                : undefined
+            }
+          >
+            {item.status === 'fallback_error' && FALLBACK_SVG}
+            {formatStatus(item.status)}
+          </span>
+          <span class="status-badge-tooltip__bubble">
+            {formatErrorMessage(item.error_message!)}
+          </span>
+        </span>
+      </Show>
+    </td>
+  );
+}
+
+function renderCell(
+  key: MessageColumnKey,
+  item: MessageRow,
+  props: MessageTableProps,
+): JSX.Element {
+  switch (key) {
+    case 'date':
+      return DateCell(item);
+    case 'message':
+      return MessageCell(item);
+    case 'cost':
+      return CostCell(item);
+    case 'totalTokens':
+      return TokenCell(item.total_tokens);
+    case 'input':
+      return SmallTokenCell(item.input_tokens);
+    case 'output':
+      return SmallTokenCell(item.output_tokens);
+    case 'model':
+      return ModelCell(item, props.customProviderName);
+    case 'cache':
+      return CacheCell(item);
+    case 'duration':
+      return DurationCell(item);
+    case 'status':
+      return StatusCell(item, props.agentName, props.onFallbackErrorClick);
+  }
+}
+
+export default function MessageTable(props: MessageTableProps): JSX.Element {
+  return (
+    <table class="data-table">
+      <thead>
+        <tr>
+          <For each={props.columns}>
+            {(col) => <th>{columnHeader(col, props.showHeaderTooltips)}</th>}
+          </For>
+        </tr>
+      </thead>
+      <tbody>
+        <For each={props.items}>
+          {(item) => (
+            <tr id={props.rowIdPrefix ? `${props.rowIdPrefix}${item.id}` : undefined}>
+              <For each={props.columns}>{(col) => renderCell(col, item, props)}</For>
+            </tr>
+          )}
+        </For>
+      </tbody>
+    </table>
+  );
+}

--- a/packages/frontend/src/components/message-table-types.ts
+++ b/packages/frontend/src/components/message-table-types.ts
@@ -1,0 +1,55 @@
+export interface MessageRow {
+  id: string;
+  timestamp: string;
+  agent_name: string | null;
+  model: string | null;
+  display_name?: string | null;
+  routing_tier?: string;
+  routing_reason?: string;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+  cost: number | null;
+  status: string;
+  error_message?: string | null;
+  auth_type?: string | null;
+  fallback_from_model?: string | null;
+  fallback_index?: number | null;
+  cache_read_tokens?: number | null;
+  cache_creation_tokens?: number | null;
+  duration_ms?: number | null;
+}
+
+export type MessageColumnKey =
+  | 'date'
+  | 'message'
+  | 'cost'
+  | 'totalTokens'
+  | 'input'
+  | 'output'
+  | 'model'
+  | 'cache'
+  | 'duration'
+  | 'status';
+
+export const COMPACT_COLUMNS: MessageColumnKey[] = [
+  'date',
+  'message',
+  'cost',
+  'model',
+  'totalTokens',
+  'status',
+];
+
+export const DETAILED_COLUMNS: MessageColumnKey[] = [
+  'date',
+  'message',
+  'cost',
+  'totalTokens',
+  'input',
+  'output',
+  'model',
+  'cache',
+  'duration',
+  'status',
+];

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -45,6 +45,7 @@ interface MessageItem {
   timestamp: string;
   agent_name: string | null;
   model: string | null;
+  display_name?: string | null;
   routing_tier?: string;
   routing_reason?: string;
   input_tokens: number | null;
@@ -550,7 +551,9 @@ const MessageLog: Component = () => {
                                       );
                                     })()
                                   : null}
-                              {item.model ? getModelDisplayName(item.model) : '\u2014'}
+                              {item.model
+                                ? item.display_name || getModelDisplayName(item.model)
+                                : '\u2014'}
                               {item.routing_tier && (
                                 <span class={`tier-badge tier-badge--${item.routing_tier}`}>
                                   {item.routing_tier}

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -8,30 +8,16 @@ import {
   For,
   type Component,
 } from 'solid-js';
-import { A, useParams } from '@solidjs/router';
+import { useParams } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
 import ErrorState from '../components/ErrorState.jsx';
 import Pagination from '../components/Pagination.jsx';
+import MessageTable from '../components/MessageTable.jsx';
+import { DETAILED_COLUMNS, type MessageRow } from '../components/message-table-types.js';
 import { getMessages, getCustomProviders, type CustomProviderData } from '../services/api.js';
-import {
-  formatNumber,
-  formatCost,
-  formatErrorMessage,
-  customProviderColor,
-  formatTime,
-  formatStatus,
-  formatDuration,
-} from '../services/formatters.js';
-import {
-  inferProviderFromModel,
-  inferProviderName,
-  stripCustomPrefix,
-} from '../services/routing-utils.js';
-import { getModelDisplayName, preloadModelDisplayNames } from '../services/model-display.js';
-import { providerIcon } from '../components/ProviderIcon.jsx';
-import { authBadgeFor, authLabel } from '../components/AuthBadge.js';
+import { inferProviderFromModel } from '../services/routing-utils.js';
+import { preloadModelDisplayNames } from '../services/model-display.js';
 import Select from '../components/Select.jsx';
-import InfoTooltip from '../components/InfoTooltip.jsx';
 import { isLocalMode } from '../services/local-mode.js';
 import { pingCount } from '../services/sse.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
@@ -40,30 +26,8 @@ import { createCursorPagination } from '../services/cursor-pagination.js';
 import { PROVIDERS } from '../services/providers.js';
 import '../styles/overview.css';
 
-interface MessageItem {
-  id: string;
-  timestamp: string;
-  agent_name: string | null;
-  model: string | null;
-  display_name?: string | null;
-  routing_tier?: string;
-  routing_reason?: string;
-  input_tokens: number | null;
-  output_tokens: number | null;
-  total_tokens: number | null;
-  status: string;
-  cost: number | null;
-  cache_read_tokens: number | null;
-  cache_creation_tokens: number | null;
-  duration_ms: number | null;
-  error_message?: string | null;
-  auth_type?: string | null;
-  fallback_from_model?: string | null;
-  fallback_index?: number | null;
-}
-
 interface MessagesData {
-  items: MessageItem[];
+  items: MessageRow[];
   next_cursor: string | null;
   total_count: number;
   providers: string[];
@@ -415,230 +379,15 @@ const MessageLog: Component = () => {
                 </span>
               </div>
               <div class="data-table-scroll">
-                <table class="data-table">
-                  <thead>
-                    <tr>
-                      <th>Date</th>
-                      <th>Message</th>
-                      <th>Cost</th>
-                      <th>
-                        Total Tokens
-                        <InfoTooltip text="Tokens are units of text that AI models process. More tokens = higher cost." />
-                      </th>
-                      <th>
-                        Input
-                        <InfoTooltip text="Tokens sent to the model (your prompt). Also called 'input tokens'." />
-                      </th>
-                      <th>
-                        Output
-                        <InfoTooltip text="Tokens returned by the model (its response). Also called 'output tokens'." />
-                      </th>
-                      <th>Model</th>
-                      <th>Cache</th>
-                      <th>Duration</th>
-                      <th>Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <For each={data()?.items}>
-                      {(item) => (
-                        <tr id={`msg-${item.id}`}>
-                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                            {formatTime(item.timestamp)}
-                          </td>
-                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                            {item.id.slice(0, 8)}
-                            {item.routing_reason === 'heartbeat' && (
-                              <span
-                                title="Heartbeat"
-                                style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;"
-                              >
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  width="12"
-                                  height="12"
-                                  viewBox="0 0 24 24"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  stroke-width="2"
-                                  stroke-linecap="round"
-                                  stroke-linejoin="round"
-                                  aria-hidden="true"
-                                >
-                                  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-                                </svg>
-                              </span>
-                            )}
-                          </td>
-                          <td style="font-family: var(--font-mono);">
-                            <Show
-                              when={item.auth_type === 'subscription'}
-                              fallback={
-                                <span
-                                  title={
-                                    item.cost != null && item.cost > 0 && item.cost < 0.01
-                                      ? `$${item.cost.toFixed(6)}`
-                                      : undefined
-                                  }
-                                >
-                                  {item.cost != null
-                                    ? (formatCost(item.cost) ?? '\u2014')
-                                    : '\u2014'}
-                                </span>
-                              }
-                            >
-                              <span
-                                style="color: hsl(var(--muted-foreground));"
-                                title="Included in subscription"
-                              >
-                                $0.00
-                              </span>
-                            </Show>
-                          </td>
-                          <td style="font-family: var(--font-mono);">
-                            {item.total_tokens != null ? formatNumber(item.total_tokens) : '\u2014'}
-                          </td>
-                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                            {item.input_tokens != null ? formatNumber(item.input_tokens) : '\u2014'}
-                          </td>
-                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                            {item.output_tokens != null
-                              ? formatNumber(item.output_tokens)
-                              : '\u2014'}
-                          </td>
-                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                            <span style="display: inline-flex; align-items: center; gap: 4px;">
-                              {item.model && inferProviderFromModel(item.model) === 'custom'
-                                ? (() => {
-                                    const provName = customProviderName(item.model!);
-                                    const letter = (provName ?? stripCustomPrefix(item.model!))
-                                      .charAt(0)
-                                      .toUpperCase();
-                                    return (
-                                      <span
-                                        class="provider-card__logo-letter"
-                                        title={provName}
-                                        style={{
-                                          background: customProviderColor(provName ?? ''),
-                                          width: '16px',
-                                          height: '16px',
-                                          'font-size': '9px',
-                                          'flex-shrink': '0',
-                                          'border-radius': '50%',
-                                        }}
-                                      >
-                                        {letter}
-                                      </span>
-                                    );
-                                  })()
-                                : item.model && inferProviderFromModel(item.model)
-                                  ? (() => {
-                                      const icon = providerIcon(
-                                        inferProviderFromModel(item.model!)!,
-                                        14,
-                                      );
-                                      const badge = authBadgeFor(item.auth_type, 8);
-                                      return (
-                                        <span
-                                          role="img"
-                                          aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
-                                          title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
-                                          style="display: inline-flex; flex-shrink: 0; position: relative;"
-                                        >
-                                          {icon}
-                                          {badge}
-                                        </span>
-                                      );
-                                    })()
-                                  : null}
-                              {item.model
-                                ? item.display_name || getModelDisplayName(item.model)
-                                : '\u2014'}
-                              {item.routing_tier && (
-                                <span class={`tier-badge tier-badge--${item.routing_tier}`}>
-                                  {item.routing_tier}
-                                </span>
-                              )}
-                              {item.fallback_from_model && (
-                                <span
-                                  class="tier-badge tier-badge--fallback"
-                                  title={`Fallback from ${getModelDisplayName(item.fallback_from_model)}`}
-                                >
-                                  fallback
-                                </span>
-                              )}
-                            </span>
-                          </td>
-                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                            {(item.cache_read_tokens ?? 0) > 0 ||
-                            (item.cache_creation_tokens ?? 0) > 0
-                              ? `Read: ${formatNumber(item.cache_read_tokens ?? 0)} / Write: ${formatNumber(item.cache_creation_tokens ?? 0)}`
-                              : '\u2014'}
-                          </td>
-                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                            {item.duration_ms != null ? formatDuration(item.duration_ms) : '\u2014'}
-                          </td>
-                          <td>
-                            <Show
-                              when={item.error_message}
-                              fallback={
-                                <span class={`status-badge status-badge--${item.status}`}>
-                                  {item.status === 'rate_limited' ? (
-                                    <A
-                                      href={`/agents/${encodeURIComponent(params.agentName)}/limits`}
-                                    >
-                                      {formatStatus(item.status)}
-                                    </A>
-                                  ) : (
-                                    formatStatus(item.status)
-                                  )}
-                                </span>
-                              }
-                            >
-                              <span
-                                class="status-badge-tooltip"
-                                tabindex="0"
-                                role="note"
-                                aria-label={formatErrorMessage(item.error_message!)}
-                              >
-                                <span
-                                  class={`status-badge status-badge--${item.status}`}
-                                  onClick={
-                                    item.status === 'fallback_error' && item.model
-                                      ? () => scrollToFallbackSuccess(item.model!)
-                                      : undefined
-                                  }
-                                >
-                                  {item.status === 'fallback_error' && (
-                                    <svg
-                                      xmlns="http://www.w3.org/2000/svg"
-                                      width="11"
-                                      height="11"
-                                      viewBox="0 0 24 24"
-                                      fill="none"
-                                      stroke="currentColor"
-                                      stroke-width="2.5"
-                                      stroke-linecap="round"
-                                      stroke-linejoin="round"
-                                      style="margin-right: 3px; flex-shrink: 0;"
-                                    >
-                                      <polyline points="15 17 20 12 15 7" />
-                                      <path d="M4 18v-2a4 4 0 0 1 4-4h12" />
-                                    </svg>
-                                  )}
-                                  {formatStatus(item.status)}
-                                </span>
-                                <span class="status-badge-tooltip__bubble">
-                                  {formatErrorMessage(item.error_message!)}
-                                </span>
-                              </span>
-                            </Show>
-                          </td>
-                        </tr>
-                      )}
-                    </For>
-                  </tbody>
-                </table>
+                <MessageTable
+                  items={data()?.items ?? []}
+                  columns={DETAILED_COLUMNS}
+                  agentName={params.agentName}
+                  customProviderName={customProviderName}
+                  onFallbackErrorClick={scrollToFallbackSuccess}
+                  rowIdPrefix="msg-"
+                  showHeaderTooltips
+                />
               </div>
               <Pagination
                 currentPage={pager.currentPage}

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -35,6 +35,7 @@ interface RecentMessage {
   timestamp: string;
   agent_name: string | null;
   model: string | null;
+  display_name?: string | null;
   routing_tier?: string;
   routing_reason?: string;
   input_tokens: number | null;
@@ -69,6 +70,7 @@ interface OverviewData {
   message_usage: Array<{ hour?: string; date?: string; count: number }>;
   cost_by_model: Array<{
     model: string;
+    display_name?: string;
     tokens: number;
     share_pct: number;
     estimated_cost: number;
@@ -699,7 +701,9 @@ const Overview: Component = () => {
                                       {authBadgeFor(item.auth_type, 8)}
                                     </span>
                                   ) : null}
-                                  {item.model ? getModelDisplayName(item.model) : '\u2014'}
+                                  {item.model
+                                    ? item.display_name || getModelDisplayName(item.model)
+                                    : '\u2014'}
                                   {item.routing_tier && (
                                     <span class={`tier-badge tier-badge--${item.routing_tier}`}>
                                       {item.routing_tier}
@@ -833,7 +837,9 @@ const Overview: Component = () => {
                                       {authBadgeFor(row.auth_type, 8)}
                                     </span>
                                   ) : null}
-                                  {row.model ? getModelDisplayName(row.model) : row.model}
+                                  {row.model
+                                    ? row.display_name || getModelDisplayName(row.model)
+                                    : row.model}
                                 </span>
                               </td>
                               <td>{formatNumber(row.tokens)}</td>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -28,26 +28,9 @@ import { authBadgeFor, authLabel } from '../components/AuthBadge.js';
 import { isLocalMode } from '../services/local-mode.js';
 import { pingCount } from '../services/sse.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
+import MessageTable from '../components/MessageTable.jsx';
+import { COMPACT_COLUMNS, type MessageRow } from '../components/message-table-types.js';
 import '../styles/overview.css';
-
-interface RecentMessage {
-  id: string;
-  timestamp: string;
-  agent_name: string | null;
-  model: string | null;
-  display_name?: string | null;
-  routing_tier?: string;
-  routing_reason?: string;
-  input_tokens: number | null;
-  output_tokens: number | null;
-  total_tokens: number | null;
-  cost: number | null;
-  status: string;
-  error_message?: string | null;
-  auth_type?: string | null;
-  fallback_from_model?: string | null;
-  fallback_index?: number | null;
-}
 
 interface OverviewData {
   summary: {
@@ -76,7 +59,7 @@ interface OverviewData {
     estimated_cost: number;
     auth_type: string | null;
   }>;
-  recent_activity: RecentMessage[];
+  recent_activity: MessageRow[];
   active_skills: Array<{
     name: string;
     agent_name: string | null;
@@ -598,186 +581,12 @@ const Overview: Component = () => {
                         View more
                       </A>
                     </div>
-                    <table class="data-table">
-                      <thead>
-                        <tr>
-                          <th>Date</th>
-                          <th>Message</th>
-                          <th>Cost</th>
-                          <th>Model</th>
-                          <th>Tokens</th>
-                          <th>Status</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        <For each={d().recent_activity?.slice(0, 5) ?? []}>
-                          {(item) => (
-                            <tr>
-                              <td style="white-space: nowrap; font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                                {formatTime(item.timestamp)}
-                              </td>
-                              <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                                {item.id.slice(0, 8)}
-                                {item.routing_reason === 'heartbeat' && (
-                                  <span
-                                    title="Heartbeat"
-                                    style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;"
-                                  >
-                                    <svg
-                                      xmlns="http://www.w3.org/2000/svg"
-                                      width="12"
-                                      height="12"
-                                      viewBox="0 0 24 24"
-                                      fill="none"
-                                      stroke="currentColor"
-                                      stroke-width="2"
-                                      stroke-linecap="round"
-                                      stroke-linejoin="round"
-                                      aria-hidden="true"
-                                    >
-                                      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-                                    </svg>
-                                  </span>
-                                )}
-                              </td>
-                              <td style="font-family: var(--font-mono);">
-                                <Show
-                                  when={item.auth_type === 'subscription'}
-                                  fallback={
-                                    <span
-                                      title={
-                                        item.cost != null && item.cost > 0 && item.cost < 0.01
-                                          ? `$${item.cost.toFixed(6)}`
-                                          : undefined
-                                      }
-                                    >
-                                      {item.cost != null
-                                        ? (formatCost(item.cost) ?? '\u2014')
-                                        : '\u2014'}
-                                    </span>
-                                  }
-                                >
-                                  <span
-                                    style="color: hsl(var(--muted-foreground));"
-                                    title="Included in subscription"
-                                  >
-                                    $0.00
-                                  </span>
-                                </Show>
-                              </td>
-                              <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                                <span style="display: inline-flex; align-items: center; gap: 4px;">
-                                  {item.model && inferProviderFromModel(item.model) === 'custom' ? (
-                                    (() => {
-                                      const provName = customProviderName(item.model!);
-                                      const letter = (provName ?? stripCustomPrefix(item.model!))
-                                        .charAt(0)
-                                        .toUpperCase();
-                                      return (
-                                        <span
-                                          class="provider-card__logo-letter"
-                                          title={provName}
-                                          style={{
-                                            background: customProviderColor(provName ?? ''),
-                                            width: '16px',
-                                            height: '16px',
-                                            'font-size': '9px',
-                                            'flex-shrink': '0',
-                                            'border-radius': '50%',
-                                          }}
-                                        >
-                                          {letter}
-                                        </span>
-                                      );
-                                    })()
-                                  ) : item.model && inferProviderFromModel(item.model) ? (
-                                    <span
-                                      role="img"
-                                      aria-label={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
-                                      title={`${inferProviderName(item.model)} (${authLabel(item.auth_type)})`}
-                                      style="display: inline-flex; flex-shrink: 0; position: relative;"
-                                    >
-                                      {providerIcon(inferProviderFromModel(item.model)!, 14)}
-                                      {authBadgeFor(item.auth_type, 8)}
-                                    </span>
-                                  ) : null}
-                                  {item.model
-                                    ? item.display_name || getModelDisplayName(item.model)
-                                    : '\u2014'}
-                                  {item.routing_tier && (
-                                    <span class={`tier-badge tier-badge--${item.routing_tier}`}>
-                                      {item.routing_tier}
-                                    </span>
-                                  )}
-                                  {item.fallback_from_model && (
-                                    <span
-                                      class="tier-badge tier-badge--fallback"
-                                      title={`Fallback from ${getModelDisplayName(item.fallback_from_model)}`}
-                                    >
-                                      fallback
-                                    </span>
-                                  )}
-                                </span>
-                              </td>
-                              <td style="font-family: var(--font-mono);">
-                                {item.total_tokens != null
-                                  ? formatNumber(item.total_tokens)
-                                  : '\u2014'}
-                              </td>
-                              <td>
-                                <Show
-                                  when={item.error_message}
-                                  fallback={
-                                    <span class={`status-badge status-badge--${item.status}`}>
-                                      {item.status === 'rate_limited' ? (
-                                        <A
-                                          href={`/agents/${encodeURIComponent(params.agentName)}/limits`}
-                                        >
-                                          {formatStatus(item.status)}
-                                        </A>
-                                      ) : (
-                                        formatStatus(item.status)
-                                      )}
-                                    </span>
-                                  }
-                                >
-                                  <span
-                                    class="status-badge-tooltip"
-                                    tabindex="0"
-                                    role="note"
-                                    aria-label={formatErrorMessage(item.error_message!)}
-                                  >
-                                    <span class={`status-badge status-badge--${item.status}`}>
-                                      {item.status === 'fallback_error' && (
-                                        <svg
-                                          xmlns="http://www.w3.org/2000/svg"
-                                          width="11"
-                                          height="11"
-                                          viewBox="0 0 24 24"
-                                          fill="none"
-                                          stroke="currentColor"
-                                          stroke-width="2.5"
-                                          stroke-linecap="round"
-                                          stroke-linejoin="round"
-                                          style="margin-right: 3px; flex-shrink: 0;"
-                                        >
-                                          <polyline points="15 17 20 12 15 7" />
-                                          <path d="M4 18v-2a4 4 0 0 1 4-4h12" />
-                                        </svg>
-                                      )}
-                                      {formatStatus(item.status)}
-                                    </span>
-                                    <span class="status-badge-tooltip__bubble">
-                                      {formatErrorMessage(item.error_message!)}
-                                    </span>
-                                  </span>
-                                </Show>
-                              </td>
-                            </tr>
-                          )}
-                        </For>
-                      </tbody>
-                    </table>
+                    <MessageTable
+                      items={d().recent_activity?.slice(0, 5) ?? []}
+                      columns={COMPACT_COLUMNS}
+                      agentName={params.agentName}
+                      customProviderName={customProviderName}
+                    />
                   </div>
 
                   {/* Cost by Model */}

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -1,0 +1,545 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import type { MessageRow } from '../../src/components/message-table-types';
+import { COMPACT_COLUMNS, DETAILED_COLUMNS } from '../../src/components/message-table-types';
+
+vi.mock('@solidjs/router', () => ({
+  A: (props: any) => (
+    <a href={props.href} class={props.class}>
+      {props.children}
+    </a>
+  ),
+}));
+
+vi.mock('../../src/services/formatters.js', () => ({
+  formatCost: (v: number) => (v < 0 ? null : `$${v.toFixed(2)}`),
+  formatNumber: (v: number) => String(v),
+  formatStatus: (s: string) => s,
+  formatTime: (t: string) => t,
+  formatDuration: (ms: number) => `${ms}ms`,
+  formatErrorMessage: (s: string) => s,
+  customProviderColor: () => '#6366f1',
+}));
+
+vi.mock('../../src/services/routing-utils.js', () => ({
+  inferProviderFromModel: (m: string) => {
+    if (m.startsWith('gpt')) return 'openai';
+    if (m.startsWith('claude')) return 'anthropic';
+    if (m.startsWith('custom:')) return 'custom';
+    return null;
+  },
+  inferProviderName: (m: string) => {
+    if (m.startsWith('gpt')) return 'OpenAI';
+    if (m.startsWith('claude')) return 'Anthropic';
+    return m;
+  },
+  stripCustomPrefix: (m: string) => m.replace(/^custom:[^/]+\//, ''),
+}));
+
+vi.mock('../../src/services/model-display.js', () => ({
+  getModelDisplayName: (slug: string) => slug,
+}));
+
+vi.mock('../../src/components/ProviderIcon.jsx', () => ({
+  providerIcon: (id: string) => <span data-testid={`icon-${id}`} />,
+}));
+
+vi.mock('../../src/components/AuthBadge.js', () => ({
+  authBadgeFor: (authType: string | null | undefined) =>
+    authType ? <span data-testid={`auth-${authType}`} /> : null,
+  authLabel: (authType: string | null | undefined) =>
+    authType === 'subscription' ? 'Subscription' : 'API Key',
+}));
+
+vi.mock('../../src/components/InfoTooltip.jsx', () => ({
+  default: (props: any) => <span data-testid="info-tooltip" title={props.text} />,
+}));
+
+import MessageTable from '../../src/components/MessageTable';
+
+function makeRow(overrides: Partial<MessageRow> = {}): MessageRow {
+  return {
+    id: 'abc12345-6789',
+    timestamp: '2026-02-16 10:00:00',
+    agent_name: 'test-agent',
+    model: 'gpt-4o',
+    input_tokens: 100,
+    output_tokens: 50,
+    total_tokens: 150,
+    cost: 0.05,
+    status: 'ok',
+    ...overrides,
+  };
+}
+
+const noopProvider = () => undefined;
+
+describe('MessageTable', () => {
+  describe('column configuration', () => {
+    it('renders compact column headers', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[]}
+          columns={COMPACT_COLUMNS}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const headers = container.querySelectorAll('th');
+      expect(headers.length).toBe(6);
+      expect(headers[0]!.textContent).toContain('Date');
+      expect(headers[1]!.textContent).toContain('Message');
+      expect(headers[2]!.textContent).toContain('Cost');
+      expect(headers[3]!.textContent).toContain('Model');
+      expect(headers[4]!.textContent).toContain('Tokens');
+      expect(headers[5]!.textContent).toContain('Status');
+    });
+
+    it('renders detailed column headers with tooltips', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[]}
+          columns={DETAILED_COLUMNS}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          showHeaderTooltips
+        />
+      ));
+      const headers = container.querySelectorAll('th');
+      expect(headers.length).toBe(10);
+      expect(headers[0]!.textContent).toContain('Date');
+      expect(headers[3]!.textContent).toContain('Total Tokens');
+      expect(headers[7]!.textContent).toContain('Cache');
+      expect(headers[8]!.textContent).toContain('Duration');
+      // Tooltips should be present for token columns
+      const tooltips = container.querySelectorAll('[data-testid="info-tooltip"]');
+      expect(tooltips.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('renders "Tokens" without tooltip when showHeaderTooltips is false', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[]}
+          columns={COMPACT_COLUMNS}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const tokensHeader = container.querySelectorAll('th')[4]!;
+      expect(tokensHeader.textContent).toBe('Tokens');
+      expect(tokensHeader.querySelector('[data-testid="info-tooltip"]')).toBeNull();
+    });
+
+    it('renders same number of columns for each row as headers', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow()]}
+          columns={DETAILED_COLUMNS}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          showHeaderTooltips
+        />
+      ));
+      const headers = container.querySelectorAll('th');
+      const cells = container.querySelectorAll('tbody td');
+      expect(cells.length).toBe(headers.length);
+    });
+  });
+
+  describe('data rendering', () => {
+    it('renders date cell', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow()]}
+          columns={['date']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('2026-02-16 10:00:00');
+    });
+
+    it('renders message ID (first 8 chars)', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ id: 'e83a3049-xxxx' })]}
+          columns={['message']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('e83a3049');
+    });
+
+    it('renders heartbeat icon when routing_reason is heartbeat', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ routing_reason: 'heartbeat' })]}
+          columns={['message']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const heartbeat = container.querySelector('[title="Heartbeat"]');
+      expect(heartbeat).toBeDefined();
+      expect(heartbeat).not.toBeNull();
+    });
+
+    it('renders cost value', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ cost: 1.5 })]}
+          columns={['cost']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('$1.50');
+    });
+
+    it('renders subscription cost as $0.00', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ auth_type: 'subscription', cost: 0.05 })]}
+          columns={['cost']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('$0.00');
+    });
+
+    it('renders em dash for null cost', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ cost: null })]}
+          columns={['cost']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('\u2014');
+    });
+
+    it('renders total tokens', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ total_tokens: 1500 })]}
+          columns={['totalTokens']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('1500');
+    });
+
+    it('renders input and output tokens', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ input_tokens: 200, output_tokens: 80 })]}
+          columns={['input', 'output']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('200');
+      expect(container.textContent).toContain('80');
+    });
+
+    it('renders cache tokens', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ cache_read_tokens: 500, cache_creation_tokens: 100 })]}
+          columns={['cache']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('Read: 500');
+      expect(container.textContent).toContain('Write: 100');
+    });
+
+    it('renders em dash for zero cache tokens', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ cache_read_tokens: 0, cache_creation_tokens: 0 })]}
+          columns={['cache']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('\u2014');
+    });
+
+    it('renders duration', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ duration_ms: 450 })]}
+          columns={['duration']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('450ms');
+    });
+  });
+
+  describe('model column', () => {
+    it('renders known provider icon and model name', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ model: 'gpt-4o' })]}
+          columns={['model']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.querySelector('[data-testid="icon-openai"]')).not.toBeNull();
+      expect(container.textContent).toContain('gpt-4o');
+    });
+
+    it('prefers display_name over model slug', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ model: 'gpt-4o', display_name: 'GPT-4o' })]}
+          columns={['model']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('GPT-4o');
+    });
+
+    it('renders custom provider letter avatar', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ model: 'custom:abc/my-model' })]}
+          columns={['model']}
+          agentName="agent-1"
+          customProviderName={() => 'MyProvider'}
+        />
+      ));
+      const avatar = container.querySelector('.provider-card__logo-letter');
+      expect(avatar).not.toBeNull();
+      expect(avatar!.textContent).toBe('M');
+    });
+
+    it('renders em dash for null model', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ model: null })]}
+          columns={['model']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('\u2014');
+    });
+
+    it('renders routing tier badge', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ routing_tier: 'fast' })]}
+          columns={['model']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const badge = container.querySelector('.tier-badge--fast');
+      expect(badge).not.toBeNull();
+      expect(badge!.textContent).toBe('fast');
+    });
+
+    it('renders fallback badge', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ fallback_from_model: 'claude-opus-4-6' })]}
+          columns={['model']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const badge = container.querySelector('.tier-badge--fallback');
+      expect(badge).not.toBeNull();
+      expect(badge!.textContent).toBe('fallback');
+    });
+  });
+
+  describe('status column', () => {
+    it('renders success status badge', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ status: 'ok' })]}
+          columns={['status']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.querySelector('.status-badge--ok')).not.toBeNull();
+    });
+
+    it('renders rate_limited status with link', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ status: 'rate_limited' })]}
+          columns={['status']}
+          agentName="my-agent"
+          customProviderName={noopProvider}
+        />
+      ));
+      const link = container.querySelector('a');
+      expect(link).not.toBeNull();
+      expect(link!.getAttribute('href')).toContain('/agents/my-agent/limits');
+    });
+
+    it('renders error tooltip for error messages', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ status: 'error', error_message: 'timeout' })]}
+          columns={['status']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const tooltip = container.querySelector('.status-badge-tooltip');
+      expect(tooltip).not.toBeNull();
+      expect(tooltip!.getAttribute('aria-label')).toBe('timeout');
+    });
+
+    it('renders fallback_error with SVG icon', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ status: 'fallback_error', error_message: 'rate limited' })]}
+          columns={['status']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const badge = container.querySelector('.status-badge--fallback_error');
+      expect(badge).not.toBeNull();
+      expect(badge!.querySelector('svg')).not.toBeNull();
+    });
+
+    it('calls onFallbackErrorClick when fallback_error badge is clicked', () => {
+      const handler = vi.fn();
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ status: 'fallback_error', error_message: 'err', model: 'gpt-4o' })]}
+          columns={['status']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          onFallbackErrorClick={handler}
+        />
+      ));
+      const badge = container.querySelector('.status-badge--fallback_error') as HTMLElement;
+      fireEvent.click(badge);
+      expect(handler).toHaveBeenCalledWith('gpt-4o');
+    });
+  });
+
+  describe('row configuration', () => {
+    it('sets row id with rowIdPrefix', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ id: 'test-id-123' })]}
+          columns={['date']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          rowIdPrefix="msg-"
+        />
+      ));
+      const row = container.querySelector('tr[id="msg-test-id-123"]');
+      expect(row).not.toBeNull();
+    });
+
+    it('does not set row id when rowIdPrefix is omitted', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow()]}
+          columns={['date']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const bodyRow = container.querySelector('tbody tr');
+      expect(bodyRow!.getAttribute('id')).toBeNull();
+    });
+  });
+
+  describe('consistency guarantees', () => {
+    it('compact and detailed columns render identical model cell for same data', () => {
+      const row = makeRow({ model: 'gpt-4o', display_name: 'GPT-4o', routing_tier: 'fast' });
+
+      const { container: compact } = render(() => (
+        <MessageTable
+          items={[row]}
+          columns={COMPACT_COLUMNS}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const { container: detailed } = render(() => (
+        <MessageTable
+          items={[row]}
+          columns={DETAILED_COLUMNS}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          showHeaderTooltips
+        />
+      ));
+
+      // Both should show the same model text
+      const compactModel = compact.querySelector('.tier-badge--fast');
+      const detailedModel = detailed.querySelector('.tier-badge--fast');
+      expect(compactModel).not.toBeNull();
+      expect(detailedModel).not.toBeNull();
+      expect(compactModel!.textContent).toBe(detailedModel!.textContent);
+    });
+
+    it('compact and detailed columns render identical status cell for same data', () => {
+      const row = makeRow({ status: 'error', error_message: 'timeout' });
+
+      const { container: compact } = render(() => (
+        <MessageTable
+          items={[row]}
+          columns={COMPACT_COLUMNS}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const { container: detailed } = render(() => (
+        <MessageTable
+          items={[row]}
+          columns={DETAILED_COLUMNS}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          showHeaderTooltips
+        />
+      ));
+
+      const compactTooltip = compact.querySelector('.status-badge-tooltip');
+      const detailedTooltip = detailed.querySelector('.status-badge-tooltip');
+      expect(compactTooltip!.getAttribute('aria-label')).toBe(
+        detailedTooltip!.getAttribute('aria-label'),
+      );
+    });
+
+    it('supports custom column subsets for future pages', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ duration_ms: 300 })]}
+          columns={['date', 'cost', 'totalTokens', 'duration', 'status']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const headers = container.querySelectorAll('th');
+      expect(headers.length).toBe(5);
+      expect(headers[0]!.textContent).toContain('Date');
+      expect(headers[1]!.textContent).toContain('Cost');
+      expect(headers[2]!.textContent).toContain('Tokens');
+      expect(headers[3]!.textContent).toContain('Duration');
+      expect(headers[4]!.textContent).toContain('Status');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Resolve model display names on the backend by LEFT JOINing `model_pricing` in the overview, messages, and cost-by-model queries
- Both pages now receive `display_name` directly from the database, eliminating inconsistencies caused by frontend cache timing
- Frontend prefers backend-provided `display_name`, falling back to client-side resolution for models not in `model_pricing`

Closes #1124

## Test plan

- [x] Backend unit tests pass (2492/2492) with new display_name assertions
- [x] Backend e2e tests pass (110/110)
- [x] Frontend tests pass (1477/1477)
- [x] TypeScript compiles cleanly (both backend and frontend)
- [ ] Verify Overview "Recent Messages" shows display names (e.g. "GPT-5 Nano" not "gpt-5-nano")
- [ ] Verify Messages page shows identical display names for the same messages
- [ ] Verify Cost by Model table shows display names

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes model display names consistent across Overview and Messages by resolving `display_name` in the backend and unifies table rendering via a shared `MessageTable` component used by both pages. Prevents frontend cache mismatches and keeps Cost by Model, Recent Messages, and Message Log aligned. Closes #1124.

- **Bug Fixes**
  - Backend: join `model_pricing` and select `COALESCE(NULLIF(mp.display_name, ''), at.model)` in messages and timeseries queries, including Cost by Model.
  - Frontend: prefer backend `display_name`, fallback to client-side resolution when missing.
  - Tests: added assertions for display name selection and fallback across messages and Cost by Model.

- **Refactors**
  - Extracted reusable `MessageTable` with configurable columns (`COMPACT_COLUMNS`, `DETAILED_COLUMNS`) and tooltips; replaced duplicated tables in `Overview.tsx` and `MessageLog.tsx`.
  - Tests: added coverage to ensure identical model/cost/status rendering and interactions across column sets.

<sup>Written for commit 11d4024a321c42af265aeebb803913170d0a1456. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

