### PR TITLE
fix: preserve custom providers and x-ai models during pricing sync

### DIFF
--- a/.changeset/fix-pricing-sync-custom-providers.md
+++ b/.changeset/fix-pricing-sync-custom-providers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: preserve custom provider models and x-ai prefix during pricing sync cleanup

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -537,6 +537,45 @@ describe('PricingSyncService', () => {
     expect(deleteArg.model_name._value).not.toContain('gpt-4o');
   });
 
+  it('preserves custom provider models during removeUnsupportedModels', async () => {
+    const customUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+    mockFind.mockResolvedValue([
+      { model_name: `custom:${customUuid}/my-local-model`, provider: `custom:${customUuid}` },
+      { model_name: 'ai21/jamba-1-5-large', provider: 'AI21' },
+      { model_name: 'gpt-4o', provider: 'OpenAI' },
+    ]);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.syncPricing();
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    const deleteArg = mockDelete.mock.calls[0][0];
+    expect(deleteArg.model_name._value).toContain('ai21/jamba-1-5-large');
+    expect(deleteArg.model_name._value).not.toContain(`custom:${customUuid}/my-local-model`);
+    expect(deleteArg.model_name._value).not.toContain('gpt-4o');
+  });
+
+  it('preserves x-ai/ prefixed models as a supported provider', async () => {
+    mockFind.mockResolvedValue([
+      { model_name: 'x-ai/grok-3', provider: 'xAI' },
+      { model_name: 'ai21/jamba-1-5-large', provider: 'AI21' },
+    ]);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.syncPricing();
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    const deleteArg = mockDelete.mock.calls[0][0];
+    expect(deleteArg.model_name._value).toContain('ai21/jamba-1-5-large');
+    expect(deleteArg.model_name._value).not.toContain('x-ai/grok-3');
+  });
+
   it('removes previously synced non-chat-compatible models on sync', async () => {
     mockFind.mockResolvedValue([
       { model_name: 'gemini-3.1-flash-image-preview', provider: 'Google' },
@@ -750,6 +789,13 @@ describe('PricingSyncService', () => {
       expect(service.deriveNames('minimax/minimax-m2.5')).toEqual({
         canonical: 'minimax-m2.5',
         provider: 'MiniMax',
+      });
+    });
+
+    it('maps x-ai prefix to xAI provider', () => {
+      expect(service.deriveNames('x-ai/grok-3')).toEqual({
+        canonical: 'grok-3',
+        provider: 'xAI',
       });
     });
 

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -41,6 +41,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   'meta-llama': 'Meta',
   cohere: 'Cohere',
   xai: 'xAI',
+  'x-ai': 'xAI',
   minimax: 'MiniMax',
   'z-ai': 'Z.ai',
   openrouter: 'OpenRouter',
@@ -348,6 +349,7 @@ export class PricingSyncService implements OnModuleInit {
       if (slashIdx === -1) continue;
       const prefix = row.model_name.substring(0, slashIdx);
       if (prefix === 'openrouter') continue;
+      if (prefix.startsWith('custom:')) continue;
       if (!SUPPORTED_PREFIXES.has(prefix)) toDelete.push(row.model_name);
     }
     if (toDelete.length > 0) {


### PR DESCRIPTION
## Summary

- **Fixes #1132 and #1133** — custom provider models (`custom:<UUID>/<model>`) and `x-ai/` prefixed models (e.g. `x-ai/grok-3`) were silently deleted during pricing sync because `removeUnsupportedModels()` didn't recognize them
- Added `custom:` prefix guard in `removeUnsupportedModels()` to skip custom provider models
- Added `x-ai` to `PROVIDER_DISPLAY_NAMES` mapping to `xAI` so OpenRouter's `x-ai/` prefix is treated as supported

## Test plan

- [x] Unit tests: 3 new test cases covering custom provider preservation, x-ai prefix preservation, and x-ai → xAI provider mapping
- [x] All 2507 backend unit tests pass
- [x] All 121 backend e2e tests pass
- [x] All 1508 frontend tests pass
- [x] TypeScript compiles cleanly (backend + frontend)
- [x] Linter passes (pre-commit hook)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents custom provider models and `x-ai/` prefixed models from being removed during pricing sync by recognizing `custom:` providers and mapping `x-ai` to `xAI`. Fixes #1132 and #1133.

- **Bug Fixes**
  - Skip deletion for `custom:` models in `removeUnsupportedModels()`.
  - Map `'x-ai'` to provider `xAI` so `x-ai/<model>` is treated as supported.

<sup>Written for commit dac8d014a1d40448451dbd35807f6ddfdcd23e9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

