### PR TITLE
fix: allow LAN access in local mode

### DIFF
--- a/.changeset/allow-lan-local-mode.md
+++ b/.changeset/allow-lan-local-mode.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Allow LAN access in local mode by accepting RFC1918 private network IPs alongside loopback

--- a/packages/backend/src/auth/local-auth.guard.spec.ts
+++ b/packages/backend/src/auth/local-auth.guard.spec.ts
@@ -107,9 +107,23 @@ describe('LocalAuthGuard', () => {
     expect(request['user']).toBeUndefined();
   });
 
-  it('denies non-loopback requests without API key', async () => {
+  it('auto-authenticates private network IP (192.168.x.x)', async () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
     const { context, request } = createMockContext({ ip: '192.168.1.100' });
+
+    const result = await guard.canActivate(context);
+
+    expect(result).toBe(true);
+    expect(request['user']).toEqual({
+      id: 'local-user-001',
+      name: 'Local User',
+      email: 'local@manifest.local',
+    });
+  });
+
+  it('denies public IP requests without API key', async () => {
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+    const { context, request } = createMockContext({ ip: '8.8.8.8' });
 
     const result = await guard.canActivate(context);
 

--- a/packages/backend/src/auth/local-auth.guard.ts
+++ b/packages/backend/src/auth/local-auth.guard.ts
@@ -1,14 +1,13 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  Injectable,
-} from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
-import { LOCAL_USER_ID, LOCAL_EMAIL, readLocalNotificationEmail } from '../common/constants/local-mode.constants';
-
-const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+import {
+  LOCAL_USER_ID,
+  LOCAL_EMAIL,
+  readLocalNotificationEmail,
+} from '../common/constants/local-mode.constants';
+import { isAllowedLocalIp } from '../common/utils/local-ip';
 
 @Injectable()
 export class LocalAuthGuard implements CanActivate {
@@ -27,7 +26,7 @@ export class LocalAuthGuard implements CanActivate {
     if (request.headers['x-api-key']) return true;
 
     const clientIp = request.ip ?? '';
-    if (LOOPBACK_IPS.has(clientIp)) {
+    if (isAllowedLocalIp(clientIp)) {
       const configEmail = readLocalNotificationEmail();
       (request as Request & { user: unknown }).user = {
         id: LOCAL_USER_ID,

--- a/packages/backend/src/common/utils/local-ip.spec.ts
+++ b/packages/backend/src/common/utils/local-ip.spec.ts
@@ -1,0 +1,48 @@
+import { isLoopbackIp, isAllowedLocalIp } from './local-ip';
+
+describe('isLoopbackIp', () => {
+  it.each([
+    ['127.0.0.1', true],
+    ['::1', true],
+    ['::ffff:127.0.0.1', true],
+    ['10.0.0.1', false],
+    ['192.168.1.1', false],
+    ['172.16.0.1', false],
+    ['8.8.8.8', false],
+    ['', false],
+  ])('isLoopbackIp(%s) → %s', (ip, expected) => {
+    expect(isLoopbackIp(ip)).toBe(expected);
+  });
+});
+
+describe('isAllowedLocalIp', () => {
+  it.each([
+    // Loopback
+    ['127.0.0.1', true],
+    ['::1', true],
+    ['::ffff:127.0.0.1', true],
+    // 10.0.0.0/8
+    ['10.0.0.1', true],
+    ['10.255.255.255', true],
+    // 172.16.0.0/12
+    ['172.16.0.1', true],
+    ['172.31.255.255', true],
+    ['172.15.0.1', false],
+    ['172.32.0.1', false],
+    // 192.168.0.0/16
+    ['192.168.0.1', true],
+    ['192.168.1.100', true],
+    ['192.168.255.255', true],
+    // IPv4-mapped IPv6 private
+    ['::ffff:192.168.1.50', true],
+    ['::ffff:10.0.0.1', true],
+    // Public IPs
+    ['8.8.8.8', false],
+    ['1.1.1.1', false],
+    ['203.0.113.1', false],
+    // Edge cases
+    ['', false],
+  ])('isAllowedLocalIp(%s) → %s', (ip, expected) => {
+    expect(isAllowedLocalIp(ip)).toBe(expected);
+  });
+});

--- a/packages/backend/src/common/utils/local-ip.ts
+++ b/packages/backend/src/common/utils/local-ip.ts
@@ -1,0 +1,31 @@
+const FFMPEG_PREFIX = '::ffff:';
+
+export function isLoopbackIp(ip: string): boolean {
+  return ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1';
+}
+
+function parseIpv4(ip: string): string {
+  return ip.startsWith(FFMPEG_PREFIX) ? ip.slice(FFMPEG_PREFIX.length) : ip;
+}
+
+function isPrivateIpv4(ipv4: string): boolean {
+  const parts = ipv4.split('.');
+  if (parts.length !== 4) return false;
+
+  const [a, b] = parts.map(Number);
+
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+
+  return false;
+}
+
+export function isAllowedLocalIp(ip: string): boolean {
+  if (isLoopbackIp(ip)) return true;
+  const ipv4 = parseIpv4(ip);
+  return isPrivateIpv4(ipv4);
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -7,8 +7,7 @@ import { AppModule } from './app.module';
 import { auth } from './auth/auth.instance';
 import { LOCAL_USER_ID, LOCAL_EMAIL } from './common/constants/local-mode.constants';
 import { SpaFallbackFilter } from './common/filters/spa-fallback.filter';
-
-const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+import { isAllowedLocalIp } from './common/utils/local-ip';
 
 export async function bootstrap() {
   const logger = new Logger('Bootstrap');
@@ -67,7 +66,7 @@ export async function bootstrap() {
     // Local mode: simple session endpoints (no Better Auth needed)
     const localSessionHandler = (req: express.Request, res: express.Response) => {
       const ip = req.ip ?? '';
-      if (!LOOPBACK_IPS.has(ip)) {
+      if (!isAllowedLocalIp(ip)) {
         res.status(403).json({ error: 'Forbidden' });
         return;
       }

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
@@ -214,9 +214,24 @@ describe('OtlpAuthGuard', () => {
       });
     });
 
-    it('still requires auth for non-loopback IPs in local mode', async () => {
+    it('allows private network IPs without auth in local mode', async () => {
       process.env['MANIFEST_MODE'] = 'local';
-      const { ctx } = makeContext({}, '192.168.1.100');
+      const { ctx, req } = makeContext({}, '192.168.1.100');
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(req.ingestionContext).toEqual({
+        tenantId: 'local-tenant-001',
+        agentId: 'local-agent-001',
+        agentName: 'local-agent',
+        userId: 'local-user-001',
+      });
+      expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('still requires auth for public IPs in local mode', async () => {
+      process.env['MANIFEST_MODE'] = 'local';
+      const { ctx } = makeContext({}, '8.8.8.8');
       await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
     });
 
@@ -235,9 +250,24 @@ describe('OtlpAuthGuard', () => {
       expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
     });
 
-    it('rejects non-mnfst token from non-loopback IP in local mode', async () => {
+    it('allows non-mnfst token from private network IP in local mode', async () => {
       process.env['MANIFEST_MODE'] = 'local';
-      const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '192.168.1.100');
+      const { ctx, req } = makeContext({ authorization: 'Bearer dev-no-auth' }, '192.168.1.100');
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(req.ingestionContext).toEqual({
+        tenantId: 'local-tenant-001',
+        agentId: 'local-agent-001',
+        agentName: 'local-agent',
+        userId: 'local-user-001',
+      });
+      expect(mockCreateQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('rejects non-mnfst token from public IP in local mode', async () => {
+      process.env['MANIFEST_MODE'] = 'local';
+      const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '8.8.8.8');
       await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
     });
 

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.spec.ts
@@ -6,7 +6,7 @@ function testCacheKey(token: string): string {
   return createHash('sha256').update(token).digest('hex');
 }
 
-function makeContext(headers: Record<string, string | undefined>, ip = '10.0.0.1') {
+function makeContext(headers: Record<string, string | undefined>, ip = '203.0.113.1') {
   const request: Record<string, unknown> = { headers, ip };
   return {
     req: request,

--- a/packages/backend/src/otlp/guards/otlp-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/otlp-auth.guard.ts
@@ -20,8 +20,7 @@ import {
   LOCAL_AGENT_NAME,
   LOCAL_USER_ID,
 } from '../../common/constants/local-mode.constants';
-
-const LOOPBACK_IPS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+import { isLoopbackIp, isAllowedLocalIp } from '../../common/utils/local-ip';
 const MIN_TOKEN_LENGTH = 12;
 
 function cacheKey(token: string): string {
@@ -63,9 +62,10 @@ export class OtlpAuthGuard implements CanActivate, OnModuleDestroy {
     const request = context.switchToHttp().getRequest<Request>();
     const authHeader = request.headers['authorization'];
 
-    const isLoopback = LOOPBACK_IPS.has(request.ip ?? '');
-    const isLocal = process.env['MANIFEST_MODE'] === 'local' && isLoopback;
-    const isDevLoopback = process.env['NODE_ENV'] === 'development' && isLoopback;
+    const ip = request.ip ?? '';
+    const loopback = isLoopbackIp(ip);
+    const isLocal = process.env['MANIFEST_MODE'] === 'local' && isAllowedLocalIp(ip);
+    const isDevLoopback = process.env['NODE_ENV'] === 'development' && loopback;
 
     // In local mode, trust loopback connections without requiring an API key.
     // Also handles dev-mode gateways that send a dummy/non-mnfst token.


### PR DESCRIPTION
## Summary

- Extracts IP checking logic into a shared `local-ip.ts` utility with `isLoopbackIp()` and `isAllowedLocalIp()` functions
- Allows RFC1918 private network IPs (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`) alongside loopback in local mode across all three guard points (`main.ts`, `LocalAuthGuard`, `OtlpAuthGuard`)
- Dev-mode loopback bypass remains loopback-only for security

Fixes #927

## Test plan

- [x] New `local-ip.spec.ts` with comprehensive coverage for both functions
- [x] Updated `local-auth.guard.spec.ts` — private IPs now allowed, public IPs denied
- [x] Updated `otlp-auth.guard.spec.ts` — private IPs allowed in local mode, public IPs denied, dev-mode still loopback-only
- [x] All 2531 unit tests pass
- [x] All 121 E2E tests pass
- [x] TypeScript compiles cleanly
- [x] 100% line coverage on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow LAN access in local mode by accepting RFC1918 private IPs alongside loopback in auth guards and session endpoints. This unblocks dashboard and OTLP access from devices on your network; dev-mode bypass remains loopback-only.

- **Bug Fixes**
  - Use `isAllowedLocalIp()` in `main.ts`, `LocalAuthGuard`, and `OtlpAuthGuard` to allow `10.x.x.x`, `172.16–31.x.x`, and `192.168.x.x` in local mode; public IPs still require auth.
  - Switch default test IP in `otlp-auth.guard.spec` to `203.0.113.1` (TEST-NET-3) to avoid accidental local-mode bypass in CI.

- **Refactors**
  - Extract IP checks to `local-ip.ts` with `isLoopbackIp()` and `isAllowedLocalIp()` plus targeted tests.

<sup>Written for commit bcb0dd7e8d8188543cd700bc89c1fb347edc5866. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

