### PR TITLE
fix: handle streaming tool calls in Anthropic and Google adapters

### DIFF
--- a/.changeset/fix-streaming-tool-calls.md
+++ b/.changeset/fix-streaming-tool-calls.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix streaming tool calls dropped by Anthropic and Google adapters in the LLM proxy

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -664,8 +664,9 @@ describe('Anthropic Adapter', () => {
       expect(data.choices[0].finish_reason).toBeNull();
     });
 
-    it('returns null for content_block_start event', () => {
-      const chunk = 'event: content_block_start\n{"type":"content_block_start"}';
+    it('returns null for text-type content_block_start event', () => {
+      const chunk =
+        'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}';
       const result = transformAnthropicStreamChunk(chunk, 'claude-sonnet-4-20250514');
       expect(result).toBeNull();
     });
@@ -686,9 +687,9 @@ describe('Anthropic Adapter', () => {
       expect(transformAnthropicStreamChunk(chunk, 'claude-sonnet-4-20250514')).toBeNull();
     });
 
-    it('returns null for input_json_delta (tool streaming)', () => {
+    it('returns null for input_json_delta without prior block mapping', () => {
       const chunk =
-        'event: content_block_delta\n{"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\\"q"}}';
+        'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"q"}}';
       const result = transformAnthropicStreamChunk(chunk, 'claude-sonnet-4-20250514');
       expect(result).toBeNull();
     });
@@ -730,6 +731,231 @@ describe('Anthropic Adapter', () => {
   });
 
   describe('createAnthropicStreamTransformer (stateful)', () => {
+    it('emits tool call delta for tool_use content_block_start', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      transform(
+        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":10}}}',
+      );
+
+      const blockStart =
+        'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"web_search"}}';
+      const result = transform(blockStart);
+
+      expect(result).not.toBeNull();
+      const data = JSON.parse(result!.replace('data: ', '').trim());
+      expect(data.choices[0].delta.tool_calls).toEqual([
+        {
+          index: 0,
+          id: 'toolu_1',
+          type: 'function',
+          function: { name: 'web_search', arguments: '' },
+        },
+      ]);
+    });
+
+    it('emits tool call argument deltas for input_json_delta', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      transform(
+        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":10}}}',
+      );
+      transform(
+        'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"search"}}',
+      );
+
+      const jsonDelta =
+        'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"query\\""}}';
+      const result = transform(jsonDelta);
+
+      expect(result).not.toBeNull();
+      const data = JSON.parse(result!.replace('data: ', '').trim());
+      expect(data.choices[0].delta.tool_calls).toEqual([
+        { index: 0, function: { arguments: '{"query"' } },
+      ]);
+    });
+
+    it('streams a full tool call flow end-to-end', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      // message_start
+      const start = transform(
+        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":50}}}',
+      );
+      expect(start).toContain('"role":"assistant"');
+
+      // tool_use block start
+      const blockStart = transform(
+        'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_abc","name":"get_weather"}}',
+      );
+      const bsData = JSON.parse(blockStart!.replace('data: ', '').trim());
+      expect(bsData.choices[0].delta.tool_calls[0].id).toBe('toolu_abc');
+      expect(bsData.choices[0].delta.tool_calls[0].function.name).toBe('get_weather');
+
+      // argument deltas
+      const arg1 = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"loc"}}',
+      );
+      const a1Data = JSON.parse(arg1!.replace('data: ', '').trim());
+      expect(a1Data.choices[0].delta.tool_calls[0].function.arguments).toBe('{"loc');
+
+      const arg2 = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ation\\": \\"NYC\\"}"}}',
+      );
+      const a2Data = JSON.parse(arg2!.replace('data: ', '').trim());
+      expect(a2Data.choices[0].delta.tool_calls[0].function.arguments).toBe('ation": "NYC"}');
+
+      // message_delta with tool_use stop reason
+      const end = transform(
+        'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":30}}',
+      );
+      const parts = end!.split('\n\n').filter(Boolean);
+      const finish = JSON.parse(parts[0].replace('data: ', ''));
+      expect(finish.choices[0].finish_reason).toBe('tool_calls');
+    });
+
+    it('handles multiple tool calls with correct indices', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      transform(
+        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":10}}}',
+      );
+
+      // First tool
+      const tc1 = transform(
+        'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"tool_a"}}',
+      );
+      const tc1Data = JSON.parse(tc1!.replace('data: ', '').trim());
+      expect(tc1Data.choices[0].delta.tool_calls[0].index).toBe(0);
+
+      // Second tool
+      const tc2 = transform(
+        'event: content_block_start\n{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_2","name":"tool_b"}}',
+      );
+      const tc2Data = JSON.parse(tc2!.replace('data: ', '').trim());
+      expect(tc2Data.choices[0].delta.tool_calls[0].index).toBe(1);
+
+      // Delta for second tool uses correct index
+      const delta = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{}"}}',
+      );
+      const dData = JSON.parse(delta!.replace('data: ', '').trim());
+      expect(dData.choices[0].delta.tool_calls[0].index).toBe(1);
+    });
+
+    it('handles text block followed by tool_use block in same stream', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      transform(
+        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":10}}}',
+      );
+
+      // Text content_block_start (returns null)
+      const textBlock = transform(
+        'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      );
+      expect(textBlock).toBeNull();
+
+      // Text delta
+      const textDelta = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me search."}}',
+      );
+      expect(textDelta).toContain('"content":"Let me search."');
+
+      // Tool use content_block_start
+      const toolBlock = transform(
+        'event: content_block_start\n{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_99","name":"search"}}',
+      );
+      const toolData = JSON.parse(toolBlock!.replace('data: ', '').trim());
+      expect(toolData.choices[0].delta.tool_calls[0].index).toBe(0);
+      expect(toolData.choices[0].delta.tool_calls[0].id).toBe('toolu_99');
+
+      // Input JSON delta for tool
+      const argDelta = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"q\\": \\"cats\\"}"}}',
+      );
+      const argData = JSON.parse(argDelta!.replace('data: ', '').trim());
+      expect(argData.choices[0].delta.tool_calls[0].index).toBe(0);
+      expect(argData.choices[0].delta.tool_calls[0].function.arguments).toBe('{"q": "cats"}');
+    });
+
+    it('returns null for content_block_start without content_block field', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      transform(
+        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":5}}}',
+      );
+
+      const result = transform(
+        'event: content_block_start\n{"type":"content_block_start","index":0}',
+      );
+      expect(result).toBeNull();
+    });
+
+    it('handles message_start without message property', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      const result = transform('event: message_start\n{"type":"message_start"}');
+      expect(result).not.toBeNull();
+      const data = JSON.parse(result!.replace('data: ', '').trim());
+      expect(data.choices[0].delta.role).toBe('assistant');
+
+      // Verify tokens default to 0 in subsequent message_delta
+      const end = transform(
+        'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}',
+      );
+      const parts = end!.split('\n\n').filter(Boolean);
+      const usage = JSON.parse(parts[1].replace('data: ', ''));
+      expect(usage.usage.prompt_tokens).toBe(0);
+      expect(usage.usage.cache_read_tokens).toBe(0);
+      expect(usage.usage.cache_creation_tokens).toBe(0);
+    });
+
+    it('handles interleaved text deltas and input_json_deltas across blocks', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      transform(
+        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":10}}}',
+      );
+
+      // Start text block at index 0
+      transform(
+        'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      );
+
+      // Text delta on block 0
+      const t1 = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+      );
+      expect(t1).toContain('"content":"Hello"');
+
+      // Start tool block at index 1
+      const toolStart = transform(
+        'event: content_block_start\n{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_x","name":"fn_a"}}',
+      );
+      expect(toolStart).not.toBeNull();
+
+      // Input JSON delta on block 1
+      const j1 = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"a"}}',
+      );
+      const j1Data = JSON.parse(j1!.replace('data: ', '').trim());
+      expect(j1Data.choices[0].delta.tool_calls[0].index).toBe(0);
+
+      // Another text delta for block 0 (interleaved -- unlikely but valid)
+      const t2 = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}',
+      );
+      expect(t2).toContain('"content":" world"');
+
+      // More JSON delta on block 1
+      const j2 = transform(
+        'event: content_block_delta\n{"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\\": 1}"}}',
+      );
+      const j2Data = JSON.parse(j2!.replace('data: ', '').trim());
+      expect(j2Data.choices[0].delta.tool_calls[0].function.arguments).toBe('": 1}');
+    });
+
     it('accumulates input tokens from message_start into message_delta usage', () => {
       const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
 

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -176,6 +176,43 @@ describe('Google Adapter', () => {
       expect(props.examples.type).toBe('array');
     });
 
+    it('sanitizes array schemas inside tool parameters', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Do something' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'my_tool',
+              description: 'A tool',
+              parameters: {
+                type: 'object',
+                properties: {
+                  tags: {
+                    type: 'array',
+                    items: { type: 'string', title: 'Tag Name', default: 'untitled' },
+                  },
+                },
+                required: ['tags'],
+              },
+            },
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+
+      const tools = result.tools as Array<{
+        functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+      }>;
+      const params = tools[0].functionDeclarations[0].parameters;
+      const props = params.properties as Record<string, Record<string, unknown>>;
+
+      // Items should have unsupported fields stripped
+      expect(props.tags.items).toEqual({ type: 'string' });
+      // required array should pass through unchanged (primitive values)
+      expect(params.required).toEqual(['tags']);
+    });
+
     it('handles tools with no parameters', () => {
       const body = {
         messages: [{ role: 'user', content: 'Do something' }],
@@ -332,6 +369,30 @@ describe('Google Adapter', () => {
       const result = toGoogleRequest(body, 'gemini-2.0-flash');
 
       expect(result.generationConfig).toBeUndefined();
+    });
+
+    it('handles tool_calls with empty arguments string in assistant messages', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'noop', arguments: '' },
+              },
+            ],
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(contents[0].parts[0].functionCall).toEqual({
+        name: 'noop',
+        args: {},
+      });
     });
 
     it('handles tool_calls in assistant messages', () => {
@@ -589,6 +650,22 @@ describe('Google Adapter', () => {
       expect(choices[0].message.content).toBeNull();
     });
 
+    it('maps STOP finish reason to tool_calls when tool calls present', () => {
+      const google = {
+        candidates: [
+          {
+            content: {
+              parts: [{ functionCall: { name: 'search', args: { query: 'cats' } } }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      };
+      const result = fromGoogleResponse(google, 'gemini-2.0-flash');
+      const choices = result.choices as Array<{ finish_reason: string }>;
+      expect(choices[0].finish_reason).toBe('tool_calls');
+    });
+
     it('maps MAX_TOKENS finish reason to length', () => {
       const google = {
         candidates: [
@@ -602,6 +679,93 @@ describe('Google Adapter', () => {
       const result = fromGoogleResponse(google, 'gemini-2.0-flash');
       const choices = result.choices as Array<{ finish_reason: string }>;
       expect(choices[0].finish_reason).toBe('length');
+    });
+
+    it('maps MAX_TOKENS to length even when tool calls are present', () => {
+      const google = {
+        candidates: [
+          {
+            content: {
+              parts: [{ functionCall: { name: 'search', args: { q: 'test' } } }],
+            },
+            finishReason: 'MAX_TOKENS',
+          },
+        ],
+      };
+      const result = fromGoogleResponse(google, 'gemini-2.0-flash');
+      const choices = result.choices as Array<{ finish_reason: string }>;
+      // MAX_TOKENS always maps to 'length' regardless of tool calls
+      expect(choices[0].finish_reason).toBe('length');
+    });
+
+    it('maps missing finishReason to tool_calls when tool calls present', () => {
+      const google = {
+        candidates: [
+          {
+            content: {
+              parts: [{ functionCall: { name: 'get_weather', args: { city: 'NYC' } } }],
+            },
+          },
+        ],
+      };
+      const result = fromGoogleResponse(google, 'gemini-2.0-flash');
+      const choices = result.choices as Array<{ finish_reason: string }>;
+      expect(choices[0].finish_reason).toBe('tool_calls');
+    });
+
+    it('handles candidate with missing content property', () => {
+      const google = {
+        candidates: [{ finishReason: 'STOP' }],
+      };
+      const result = fromGoogleResponse(google, 'gemini-2.0-flash');
+      const choices = result.choices as Array<{
+        message: Record<string, unknown>;
+        finish_reason: string;
+      }>;
+      expect(choices[0].message.content).toBeNull();
+      expect(choices[0].finish_reason).toBe('stop');
+    });
+
+    it('handles usageMetadata with missing individual fields', () => {
+      const google = {
+        candidates: [
+          {
+            content: { parts: [{ text: 'ok' }] },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {},
+      };
+      const result = fromGoogleResponse(google, 'gemini-2.0-flash');
+      const usage = result.usage as Record<string, unknown>;
+      expect(usage.prompt_tokens).toBe(0);
+      expect(usage.completion_tokens).toBe(0);
+      expect(usage.total_tokens).toBe(0);
+      expect(usage.cache_read_tokens).toBe(0);
+    });
+
+    it('handles multiple function calls in response', () => {
+      const google = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { functionCall: { name: 'search', args: { q: 'cats' } } },
+                { functionCall: { name: 'search', args: { q: 'dogs' } } },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      };
+      const result = fromGoogleResponse(google, 'gemini-2.0-flash');
+      const choices = result.choices as Array<{
+        message: Record<string, unknown>;
+        finish_reason: string;
+      }>;
+      const toolCalls = choices[0].message.tool_calls as Array<Record<string, unknown>>;
+      expect(toolCalls).toHaveLength(2);
+      expect(choices[0].finish_reason).toBe('tool_calls');
     });
   });
 
@@ -676,12 +840,123 @@ describe('Google Adapter', () => {
       expect(result).toContain('"total_tokens":0');
     });
 
-    it('handles parts without text property', () => {
+    it('emits tool call delta for functionCall parts', () => {
       const chunk = JSON.stringify({
-        candidates: [{ content: { parts: [{ functionCall: { name: 'fn', args: {} } }] } }],
+        candidates: [
+          { content: { parts: [{ functionCall: { name: 'fn', args: { q: 'test' } } }] } },
+        ],
       });
       const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
-      expect(result).toBeNull(); // no text + no usage = null
+      expect(result).not.toBeNull();
+      const data = JSON.parse(result!.split('\n\n')[0].replace('data: ', ''));
+      expect(data.choices[0].delta.tool_calls).toHaveLength(1);
+      expect(data.choices[0].delta.tool_calls[0].type).toBe('function');
+      expect(data.choices[0].delta.tool_calls[0].function.name).toBe('fn');
+      expect(JSON.parse(data.choices[0].delta.tool_calls[0].function.arguments)).toEqual({
+        q: 'test',
+      });
+    });
+
+    it('emits tool call and text together when both present', () => {
+      const chunk = JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: 'Let me call a tool.' },
+                { functionCall: { name: 'search', args: { query: 'cats' } } },
+              ],
+            },
+          },
+        ],
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      expect(result).not.toBeNull();
+      const data = JSON.parse(result!.split('\n\n')[0].replace('data: ', ''));
+      expect(data.choices[0].delta.content).toBe('Let me call a tool.');
+      expect(data.choices[0].delta.tool_calls).toHaveLength(1);
+      expect(data.choices[0].delta.tool_calls[0].function.name).toBe('search');
+    });
+
+    it('emits finish_reason tool_calls when functionCall with usage', () => {
+      const chunk = JSON.stringify({
+        candidates: [
+          {
+            content: { parts: [{ functionCall: { name: 'fn', args: {} } }] },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      expect(result).toContain('"finish_reason":"tool_calls"');
+    });
+
+    it('handles multiple functionCall parts with sequential indices', () => {
+      const chunk = JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { functionCall: { name: 'tool_a', args: { x: 1 } } },
+                { functionCall: { name: 'tool_b', args: { y: 2 } } },
+              ],
+            },
+          },
+        ],
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      const data = JSON.parse(result!.split('\n\n')[0].replace('data: ', ''));
+      expect(data.choices[0].delta.tool_calls).toHaveLength(2);
+      expect(data.choices[0].delta.tool_calls[0].index).toBe(0);
+      expect(data.choices[0].delta.tool_calls[0].function.name).toBe('tool_a');
+      expect(data.choices[0].delta.tool_calls[1].index).toBe(1);
+      expect(data.choices[0].delta.tool_calls[1].function.name).toBe('tool_b');
+    });
+
+    it('handles functionCall with null args', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [{ functionCall: { name: 'noop', args: null } }] } }],
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      const data = JSON.parse(result!.split('\n\n')[0].replace('data: ', ''));
+      expect(JSON.parse(data.choices[0].delta.tool_calls[0].function.arguments)).toEqual({});
+    });
+
+    it('handles functionCall with undefined args in stream', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [{ functionCall: { name: 'noop' } }] } }],
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      const data = JSON.parse(result!.split('\n\n')[0].replace('data: ', ''));
+      expect(JSON.parse(data.choices[0].delta.tool_calls[0].function.arguments)).toEqual({});
+    });
+
+    it('includes cachedContentTokenCount in stream usage', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [{ text: 'done' }] }, finishReason: 'STOP' }],
+        usageMetadata: {
+          promptTokenCount: 100,
+          candidatesTokenCount: 50,
+          totalTokenCount: 150,
+          cachedContentTokenCount: 80,
+        },
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      expect(result).toContain('"cache_read_tokens":80');
+      expect(result).toContain('"cached_tokens":80');
+    });
+
+    it('emits finish_reason stop for STOP without tool calls in stream with usage', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [{ text: 'done' }] }, finishReason: 'STOP' }],
+        usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5, totalTokenCount: 15 },
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-2.0-flash');
+      const parts = result!.split('\n\n').filter(Boolean);
+      // The finish chunk (second part) should have finish_reason 'stop'
+      const finishChunk = JSON.parse(parts[1].replace('data: ', ''));
+      expect(finishChunk.choices[0].finish_reason).toBe('stop');
     });
 
     it('emits usage when candidates field is missing', () => {

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -66,14 +66,22 @@ function toContentBlocks(content: unknown): ContentBlock[] {
   return [];
 }
 
-function convertMessage(msg: OpenAIMessage): { role: 'user' | 'assistant'; content: ContentBlock[] } | null {
+function convertMessage(
+  msg: OpenAIMessage,
+): { role: 'user' | 'assistant'; content: ContentBlock[] } | null {
   if (msg.role === 'system' || msg.role === 'developer') return null;
 
   if (msg.role === 'tool') {
     const text = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content ?? '');
     return {
       role: 'user',
-      content: [{ type: 'tool_result', tool_use_id: (msg.tool_call_id as string) || 'unknown', content: text }],
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: (msg.tool_call_id as string) || 'unknown',
+          content: text,
+        },
+      ],
     };
   }
 
@@ -100,7 +108,9 @@ function convertTools(tools?: Array<Record<string, unknown>>): AnthropicTool[] |
   if (!tools || tools.length === 0) return undefined;
   const out: AnthropicTool[] = [];
   for (const t of tools) {
-    const fn = t.function as { name: string; description?: string; parameters?: unknown } | undefined;
+    const fn = t.function as
+      | { name: string; description?: string; parameters?: unknown }
+      | undefined;
     if (fn) out.push({ name: fn.name, description: fn.description, input_schema: fn.parameters });
   }
   return out.length > 0 ? out : undefined;
@@ -140,7 +150,12 @@ export function toAnthropicRequest(
 
 function mapStopReason(reason: string | undefined): string {
   if (!reason) return 'stop';
-  const map: Record<string, string> = { end_turn: 'stop', max_tokens: 'length', tool_use: 'tool_calls', stop_sequence: 'stop' };
+  const map: Record<string, string> = {
+    end_turn: 'stop',
+    max_tokens: 'length',
+    tool_use: 'tool_calls',
+    stop_sequence: 'stop',
+  };
   return map[reason] ?? 'stop';
 }
 
@@ -178,21 +193,29 @@ export function fromAnthropicResponse(
     object: 'chat.completion',
     created: Math.floor(Date.now() / 1000),
     model,
-    choices: [{ index: 0, message, finish_reason: mapStopReason(resp.stop_reason as string | undefined) }],
-    usage: usage ? {
-      prompt_tokens: totalInput,
-      completion_tokens: totalOutput,
-      total_tokens: totalInput + totalOutput,
-      prompt_tokens_details: { cached_tokens: cacheRead },
-      cache_read_tokens: cacheRead,
-      cache_creation_tokens: cacheCreation,
-    } : undefined,
+    choices: [
+      { index: 0, message, finish_reason: mapStopReason(resp.stop_reason as string | undefined) },
+    ],
+    usage: usage
+      ? {
+          prompt_tokens: totalInput,
+          completion_tokens: totalOutput,
+          total_tokens: totalInput + totalOutput,
+          prompt_tokens_details: { cached_tokens: cacheRead },
+          cache_read_tokens: cacheRead,
+          cache_creation_tokens: cacheCreation,
+        }
+      : undefined,
   };
 }
 
 /* ── Stream chunk conversion ── */
 
-function makeChunkSse(model: string, delta: Record<string, unknown>, finishReason: string | null): string {
+function makeChunkSse(
+  model: string,
+  delta: Record<string, unknown>,
+  finishReason: string | null,
+): string {
   return `data: ${JSON.stringify({
     id: `chatcmpl-${randomUUID()}`,
     object: 'chat.completion.chunk',
@@ -202,7 +225,9 @@ function makeChunkSse(model: string, delta: Record<string, unknown>, finishReaso
   })}\n\n`;
 }
 
-function parseStreamEvent(chunk: string): { eventType: string; data: Record<string, unknown> } | null {
+function parseStreamEvent(
+  chunk: string,
+): { eventType: string; data: Record<string, unknown> } | null {
   if (!chunk.trim()) return null;
 
   const lines = chunk.split('\n');
@@ -215,7 +240,11 @@ function parseStreamEvent(chunk: string): { eventType: string; data: Record<stri
   }
 
   if (!jsonPayload) return null;
-  try { return { eventType, data: JSON.parse(jsonPayload) }; } catch { return null; }
+  try {
+    return { eventType, data: JSON.parse(jsonPayload) };
+  } catch {
+    return null;
+  }
 }
 
 function makeUsageSse(model: string, usage: Record<string, unknown>): string {
@@ -237,6 +266,8 @@ export function createAnthropicStreamTransformer(model: string): (chunk: string)
   let inputTokens = 0;
   let cacheReadTokens = 0;
   let cacheCreationTokens = 0;
+  let toolCallIndex = 0;
+  const blockToToolIndex = new Map<number, number>();
 
   return (chunk: string): string | null => {
     const parsed = parseStreamEvent(chunk);
@@ -252,11 +283,46 @@ export function createAnthropicStreamTransformer(model: string): (chunk: string)
       return makeChunkSse(model, { role: 'assistant', content: '' }, null);
     }
 
+    if (eventType === 'content_block_start' || data.type === 'content_block_start') {
+      const block = data.content_block as Record<string, unknown> | undefined;
+      if (block?.type === 'tool_use') {
+        const idx = toolCallIndex++;
+        blockToToolIndex.set(data.index as number, idx);
+        return makeChunkSse(
+          model,
+          {
+            tool_calls: [
+              {
+                index: idx,
+                id: block.id as string,
+                type: 'function',
+                function: { name: block.name as string, arguments: '' },
+              },
+            ],
+          },
+          null,
+        );
+      }
+      return null;
+    }
+
     if (eventType === 'content_block_delta' || data.type === 'content_block_delta') {
       const delta = data.delta as Record<string, unknown> | undefined;
       if (!delta) return null;
       if (delta.type === 'text_delta' && typeof delta.text === 'string') {
         return makeChunkSse(model, { content: delta.text }, null);
+      }
+      if (delta.type === 'input_json_delta' && typeof delta.partial_json === 'string') {
+        const idx = blockToToolIndex.get(data.index as number);
+        if (idx !== undefined) {
+          return makeChunkSse(
+            model,
+            {
+              tool_calls: [{ index: idx, function: { arguments: delta.partial_json as string } }],
+            },
+            null,
+          );
+        }
       }
       return null;
     }
@@ -269,7 +335,11 @@ export function createAnthropicStreamTransformer(model: string): (chunk: string)
       const totalInput = inputTokens + cacheReadTokens + cacheCreationTokens;
       const total = totalInput + outputTokens;
 
-      const finishChunk = makeChunkSse(model, {}, mapStopReason(delta?.stop_reason as string | undefined));
+      const finishChunk = makeChunkSse(
+        model,
+        {},
+        mapStopReason(delta?.stop_reason as string | undefined),
+      );
       const usageChunk = makeUsageSse(model, {
         prompt_tokens: totalInput,
         completion_tokens: outputTokens,

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -238,7 +238,9 @@ export function fromGoogleResponse(
     object: 'chat.completion',
     created: Math.floor(Date.now() / 1000),
     model,
-    choices: [{ index: 0, message, finish_reason: mapFinishReason(candidate) }],
+    choices: [
+      { index: 0, message, finish_reason: mapFinishReason(candidate, toolCalls.length > 0) },
+    ],
     usage: usage
       ? {
           prompt_tokens: usage.promptTokenCount ?? 0,
@@ -252,11 +254,12 @@ export function fromGoogleResponse(
   };
 }
 
-function mapFinishReason(candidate: Record<string, unknown>): string {
+function mapFinishReason(candidate: Record<string, unknown>, hasToolCalls = false): string {
   const reason = candidate.finishReason as string | undefined;
-  if (!reason) return 'stop';
+  if (!reason || reason === 'STOP') {
+    return hasToolCalls ? 'tool_calls' : 'stop';
+  }
   const map: Record<string, string> = {
-    STOP: 'stop',
     MAX_TOKENS: 'length',
     SAFETY: 'content_filter',
     RECITATION: 'content_filter',
@@ -282,21 +285,37 @@ export function transformGoogleStreamChunk(chunk: string, model: string): string
   const parts = content?.parts || [];
   const text = parts.map((p) => p.text || '').join('');
 
+  const toolCalls: Record<string, unknown>[] = [];
+  for (const part of parts) {
+    if (part.functionCall) {
+      const fc = part.functionCall as { name: string; args?: Record<string, unknown> };
+      toolCalls.push({
+        index: toolCalls.length,
+        id: `call_${randomUUID()}`,
+        type: 'function',
+        function: { name: fc.name, arguments: JSON.stringify(fc.args ?? {}) },
+      });
+    }
+  }
+
   let result = '';
 
-  if (text) {
+  if (text || toolCalls.length > 0) {
+    const delta: Record<string, unknown> = {};
+    if (text) delta.content = text;
+    if (toolCalls.length > 0) delta.tool_calls = toolCalls;
     result += `data: ${JSON.stringify({
       id: `chatcmpl-${randomUUID()}`,
       object: 'chat.completion.chunk',
       created: Math.floor(Date.now() / 1000),
       model,
-      choices: [{ index: 0, delta: { content: text }, finish_reason: null }],
+      choices: [{ index: 0, delta, finish_reason: null }],
     })}\n\n`;
   }
 
   const usage = data.usageMetadata as Record<string, number> | undefined;
   if (usage) {
-    const finishReason = mapFinishReason(candidate ?? {});
+    const finishReason = mapFinishReason(candidate ?? {}, toolCalls.length > 0);
     result += `data: ${JSON.stringify({
       id: `chatcmpl-${randomUUID()}`,
       object: 'chat.completion.chunk',


### PR DESCRIPTION
## Summary

Fixes #1141

- **Anthropic adapter**: Add state tracking (`toolCallIndex`, `blockToToolIndex` map) to `createAnthropicStreamTransformer`. Handle `content_block_start` with `tool_use` type and `content_block_delta` with `input_json_delta` type to emit tool call deltas in OpenAI streaming format.
- **Google adapter**: Extract `functionCall` parts into `tool_calls` array in `transformGoogleStreamChunk`. Add `hasToolCalls` param to `mapFinishReason` so `STOP` correctly maps to `tool_calls` when function calls are present (both streaming and non-streaming).

## Test plan

- [x] Backend unit tests pass (2554 tests)
- [x] Backend e2e tests pass (121 tests)
- [x] Frontend tests pass (1508 tests)
- [x] TypeScript compilation clean
- [x] 100% line coverage on both adapter files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped streaming tool calls in the Anthropic and Google adapters. Tool calls now stream in OpenAI format with correct indices and finish reasons, restoring real-time tool invocation.

- **Bug Fixes**
  - Anthropic: Track tool blocks and emit `tool_calls` on `tool_use` start; stream argument deltas from `input_json_delta` with correct indices.
  - Google: Convert `functionCall` parts to `tool_calls` in stream chunks; map `STOP`/missing finish reason to `tool_calls` when function calls are present.

<sup>Written for commit 9a13cc635e49e6302fdd7c802fed3fc66f2b5a2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

