### PR TITLE
feat: show display names and provider icons in model prices table

### DIFF
--- a/.changeset/lean-bright-fc59.md
+++ b/.changeset/lean-bright-fc59.md
@@ -1,5 +1,5 @@
 ---
-'manifest': patch
+"manifest": patch
 ---
 
 Show display names and provider icons in model prices table

--- a/.changeset/lean-bright-fc59.md
+++ b/.changeset/lean-bright-fc59.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show display names and provider icons in model prices table

--- a/packages/frontend/src/components/ModelPricesFilterBar.tsx
+++ b/packages/frontend/src/components/ModelPricesFilterBar.tsx
@@ -1,4 +1,5 @@
 import { createSignal, createMemo, For, Show, onCleanup, type Component } from 'solid-js';
+import { getModelDisplayName } from '../services/model-display.js';
 import { resolveProviderId } from '../services/routing-utils.js';
 import { providerIcon } from './ProviderIcon.jsx';
 
@@ -266,7 +267,9 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
                           role="option"
                           aria-selected={highlightIndex() === idx()}
                         >
-                          <span class="model-filter__dropdown-item-name">{model}</span>
+                          <span class="model-filter__dropdown-item-name">
+                            {getModelDisplayName(model)}
+                          </span>
                           <span class="model-filter__dropdown-item-type">Model</span>
                         </button>
                       );
@@ -310,7 +313,9 @@ const ModelPricesFilterBar: Component<ModelPricesFilterBarProps> = (props) => {
                 <Show when={tag.type === 'Model'}>
                   <span class="model-filter__tag-type">Model:</span>
                 </Show>
-                <span class="model-filter__tag-value">{tag.value}</span>
+                <span class="model-filter__tag-value">
+                  {tag.type === 'Model' ? getModelDisplayName(tag.value) : tag.value}
+                </span>
                 <button
                   class="model-filter__tag-remove"
                   onClick={() => removeTag(tag)}

--- a/packages/frontend/src/pages/ModelPrices.tsx
+++ b/packages/frontend/src/pages/ModelPrices.tsx
@@ -13,12 +13,16 @@ import ErrorState from '../components/ErrorState.jsx';
 import InfoTooltip from '../components/InfoTooltip.jsx';
 import ModelPricesFilterBar from '../components/ModelPricesFilterBar.jsx';
 import Pagination from '../components/Pagination.jsx';
+import { providerIcon } from '../components/ProviderIcon.jsx';
 import { getModelPrices } from '../services/api.js';
+import { getModelDisplayName, preloadModelDisplayNames } from '../services/model-display.js';
 import { createClientPagination } from '../services/pagination.js';
+import { resolveProviderId } from '../services/routing-utils.js';
 
 interface ModelPrice {
   model_name: string;
   provider: string;
+  display_name: string | null;
   input_price_per_million: number | null;
   output_price_per_million: number | null;
 }
@@ -39,6 +43,7 @@ function formatPrice(price: number | null): string {
 }
 
 const ModelPrices: Component = () => {
+  preloadModelDisplayNames();
   const [data, { refetch }] = createResource(() => getModelPrices() as Promise<ModelPricesData>);
   const [sortKey, setSortKey] = createSignal<SortKey>('provider');
   const [sortDir, setSortDir] = createSignal<SortDir>('asc');
@@ -288,20 +293,37 @@ const ModelPrices: Component = () => {
                 </thead>
                 <tbody>
                   <For each={pager.pageItems()}>
-                    {(model) => (
-                      <tr>
-                        <td style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
-                          {model.model_name}
-                        </td>
-                        <td>{model.provider}</td>
-                        <td style="font-family: var(--font-mono);">
-                          {formatPrice(model.input_price_per_million)}
-                        </td>
-                        <td style="font-family: var(--font-mono);">
-                          {formatPrice(model.output_price_per_million)}
-                        </td>
-                      </tr>
-                    )}
+                    {(model) => {
+                      const displayName = () =>
+                        model.display_name || getModelDisplayName(model.model_name);
+                      const pid = () => resolveProviderId(model.provider);
+                      return (
+                        <tr>
+                          <td>
+                            <div style="font-size: var(--font-size-sm);">{displayName()}</div>
+                            <div style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                              {model.model_name}
+                            </div>
+                          </td>
+                          <td>
+                            <span style="display: inline-flex; align-items: center; gap: 6px;">
+                              <Show when={pid()}>
+                                <span style="display: inline-flex; flex-shrink: 0;">
+                                  {providerIcon(pid()!, 16)}
+                                </span>
+                              </Show>
+                              {model.provider}
+                            </span>
+                          </td>
+                          <td style="font-family: var(--font-mono);">
+                            {formatPrice(model.input_price_per_million)}
+                          </td>
+                          <td style="font-family: var(--font-mono);">
+                            {formatPrice(model.output_price_per_million)}
+                          </td>
+                        </tr>
+                      );
+                    }}
                   </For>
                 </tbody>
               </table>

--- a/packages/frontend/tests/components/ModelPricesFilterBar.test.tsx
+++ b/packages/frontend/tests/components/ModelPricesFilterBar.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@solidjs/testing-library";
 
+vi.mock("../../src/services/model-display.js", () => ({
+  getModelDisplayName: (slug: string) => slug,
+}));
+
 vi.mock("../../src/services/routing-utils.js", () => ({
   resolveProviderId: (provider: string) => {
     const map: Record<string, string> = { OpenAI: "openai", Anthropic: "anthropic" };

--- a/packages/frontend/tests/pages/ModelPrices.test.tsx
+++ b/packages/frontend/tests/pages/ModelPrices.test.tsx
@@ -15,6 +15,22 @@ vi.mock("../../src/services/api.js", () => ({
   getModelPrices: () => mockGetModelPrices(),
 }));
 
+vi.mock("../../src/services/model-display.js", () => ({
+  getModelDisplayName: (slug: string) => slug,
+  preloadModelDisplayNames: () => {},
+}));
+
+vi.mock("../../src/services/routing-utils.js", () => ({
+  resolveProviderId: (provider: string) => {
+    const map: Record<string, string> = { OpenAI: "openai", Anthropic: "anthropic", Google: "gemini" };
+    return map[provider] ?? null;
+  },
+}));
+
+vi.mock("../../src/components/ProviderIcon.jsx", () => ({
+  providerIcon: (id: string, size: number) => <svg data-provider={id} width={size} height={size} />,
+}));
+
 vi.mock("../../src/services/toast-store.js", () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));


### PR DESCRIPTION
## Summary

- Show human-readable model display names as primary text in the Model column, with raw model slugs shown as secondary muted text underneath
- Add provider SVG icons (16px) next to provider names in the Provider column, matching the visual pattern used in MessageLog and Overview pages
- Update filter bar model suggestions and tags to show display names instead of raw slugs

## Test plan

- [x] Frontend tests pass (1508/1508)
- [x] TypeScript compilation passes
- [x] 100% line coverage on changed files
- [ ] Open Model Prices page and verify display names appear as primary text
- [ ] Verify provider icons render next to provider names
- [ ] Test filter bar: search for a model and confirm display name shown in dropdown
- [ ] Test filter tags: add a model filter and confirm tag shows display name

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show human-readable model display names and provider icons in the Model Prices table and filter bar. Preload display names to avoid flashes. Also fix the changeset to use double quotes for CI.

- **New Features**
  - Model column: display name as primary; slug underneath in monospace, muted.
  - Provider column: 16px SVG icon next to provider name via `providerIcon` and `resolveProviderId`.
  - Filter bar: suggestions and Model tags use display names via `getModelDisplayName`.

<sup>Written for commit 957a119e142bf092c5f031809fd75dea0b65b395. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

