### PR TITLE
fix: prevent stale agent list after deletion

### DIFF
--- a/.changeset/fix-stale-agent-list.md
+++ b/.changeset/fix-stale-agent-list.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix stale agent list after deletion by disabling browser HTTP cache on API requests

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -7,6 +7,7 @@ import { toast } from '../services/toast-store.js';
 import { formatNumber, formatCost } from '../services/formatters.js';
 import Sparkline from '../components/Sparkline.jsx';
 import { checkLocalMode } from '../services/local-mode.js';
+import { pingCount } from '../services/sse.js';
 
 interface Agent {
   agent_name: string;
@@ -106,7 +107,10 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
 
 const Workspace: Component = () => {
   const navigate = useNavigate();
-  const [data, { refetch }] = createResource(() => getAgents() as Promise<AgentsData>);
+  const [data, { refetch }] = createResource(
+    () => ({ _ping: pingCount() }),
+    () => getAgents() as Promise<AgentsData>,
+  );
   const [modalOpen, setModalOpen] = createSignal(false);
 
   onMount(async () => {

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -10,7 +10,7 @@ async function fetchJson<T>(path: string, params?: Record<string, string | undef
     }
   }
 
-  const res = await fetch(url.toString(), { credentials: 'include' });
+  const res = await fetch(url.toString(), { credentials: 'include', cache: 'no-store' });
   if (res.status === 401) {
     // Session expired or user logged out — silently redirect to login
     if (window.location.pathname !== '/login') {

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -37,6 +37,10 @@ vi.mock("../../src/services/local-mode.js", () => ({
   checkLocalMode: (...args: unknown[]) => mockCheckLocalMode(...args),
 }));
 
+vi.mock("../../src/services/sse.js", () => ({
+  pingCount: () => 0,
+}));
+
 import Workspace from "../../src/pages/Workspace";
 
 describe("Workspace", () => {

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -111,7 +111,7 @@ describe("getAgents", () => {
 
     const result = await getAgents();
     expect(result).toEqual(payload);
-    expect(mockFetch).toHaveBeenCalledWith("http://localhost:3000/api/v1/agents", { credentials: "include" });
+    expect(mockFetch).toHaveBeenCalledWith("http://localhost:3000/api/v1/agents", { credentials: "include", cache: "no-store" });
   });
 });
 
@@ -266,7 +266,7 @@ describe("getAgentKey", () => {
 
     expect(mockFetch).toHaveBeenCalledWith(
       expect.stringContaining("/api/v1/agents/bot/key"),
-      { credentials: "include" },
+      { credentials: "include", cache: "no-store" },
     );
   });
 });
@@ -428,7 +428,7 @@ describe("getModelPrices", () => {
     expect(result).toEqual(prices);
     expect(mockFetch).toHaveBeenCalledWith(
       "http://localhost:3000/api/v1/model-prices",
-      { credentials: "include" },
+      { credentials: "include", cache: "no-store" },
     );
   });
 });
@@ -476,7 +476,7 @@ describe("getProviders", () => {
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
       "http://localhost:3000/api/v1/routing/my-agent/providers",
-      { credentials: "include" },
+      { credentials: "include", cache: "no-store" },
     );
   });
 });
@@ -573,7 +573,7 @@ describe("getTierAssignments", () => {
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
       "http://localhost:3000/api/v1/routing/my-agent/tiers",
-      { credentials: "include" },
+      { credentials: "include", cache: "no-store" },
     );
   });
 });
@@ -659,7 +659,7 @@ describe("getAvailableModels", () => {
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
       "http://localhost:3000/api/v1/routing/my-agent/available-models",
-      { credentials: "include" },
+      { credentials: "include", cache: "no-store" },
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add `cache: 'no-store'` to `fetchJson` to prevent browser HTTP caching on API GET requests, ensuring the workspace shows fresh data after deleting an agent
- Add SSE ping-driven auto-refresh to the workspace agent grid so stats (message counts, costs, sparklines) update in real-time, matching Overview and MessageLog behavior

## Test plan
- [ ] Delete an agent from Settings → verify agent disappears from workspace immediately
- [ ] Open workspace while telemetry is being ingested → verify agent card stats update in real-time
- [ ] All existing frontend tests pass (1538 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale agent list after deleting an agent by disabling browser caching on API GETs. Also adds SSE ping-based auto-refresh so workspace agent stats update in real time.

- **Bug Fixes**
  - Set `cache: 'no-store'` on `fetchJson` to always fetch fresh data, so deleted agents disappear immediately.

- **New Features**
  - Hooked the workspace agent grid to `pingCount` from `sse` to trigger refetches.
  - Stats (message counts, costs, sparklines) now update live to match Overview and MessageLog.

<sup>Written for commit e338ab8d640783c306353897362d3922ab734fd4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

