### PR TITLE
fix: improve routing fallback chain resilience

### DIFF
--- a/.changeset/fix-fallback-routing.md
+++ b/.changeset/fix-fallback-routing.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix routing fallback chain: trigger fallback on all 4xx/5xx errors, resolve providers via connected provider cache, record real usage data on fallback success, and show fallback icon on all handled messages

--- a/package-lock.json
+++ b/package-lock.json
@@ -14240,7 +14240,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.25.2",
+      "version": "5.25.4",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",
@@ -14259,6 +14259,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "compression": "^1.8.1",
+        "express-rate-limit": "^8.3.1",
         "helmet": "^8.1.0",
         "pg": "^8.13.0",
         "protobufjs": "^8.0.0",

--- a/packages/backend/src/routing/proxy/__tests__/fallback-status-codes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/fallback-status-codes.spec.ts
@@ -1,16 +1,20 @@
 import { shouldTriggerFallback, FALLBACK_EXHAUSTED_STATUS } from '../fallback-status-codes';
 
 describe('shouldTriggerFallback', () => {
-  it.each([429, 500, 502, 503, 504])('should return true for retriable status %d', (status) => {
-    expect(shouldTriggerFallback(status)).toBe(true);
-  });
-
-  it.each([200, 201, 204, 301, 302, 400, 401, 403, 404, 405, 409, 422, 424, 501])(
-    'should return false for non-retriable status %d',
+  it.each([400, 401, 403, 404, 405, 409, 422, 429, 500, 501, 502, 503, 504])(
+    'should return true for error status %d',
     (status) => {
-      expect(shouldTriggerFallback(status)).toBe(false);
+      expect(shouldTriggerFallback(status)).toBe(true);
     },
   );
+
+  it.each([200, 201, 204, 301, 302])('should return false for non-error status %d', (status) => {
+    expect(shouldTriggerFallback(status)).toBe(false);
+  });
+
+  it('should return false for 424 (fallback exhausted)', () => {
+    expect(shouldTriggerFallback(424)).toBe(false);
+  });
 });
 
 describe('FALLBACK_EXHAUSTED_STATUS', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -706,7 +706,7 @@ describe('ProxyController', () => {
     expect(mockMessageRepo.insert).not.toHaveBeenCalled();
   });
 
-  it('should not record success message for fallback responses', async () => {
+  it('should record usage data on fallback success', async () => {
     const responseBody = {
       choices: [{ message: { content: 'hello' } }],
       usage: { prompt_tokens: 500, completion_tokens: 200 },
@@ -735,14 +735,67 @@ describe('ProxyController', () => {
     await controller.chatCompletions(req as never, res as never);
     await new Promise((r) => setTimeout(r, 10));
 
-    // Only the fallback chain messages should be recorded, not a duplicate success
     const insertCalls = mockMessageRepo.insert.mock.calls;
-    const hasSuccessWithTokens = insertCalls.some(
+    const successRecord = insertCalls.find(
       (call: unknown[]) =>
         (call[0] as Record<string, unknown>).status === 'ok' &&
         (call[0] as Record<string, unknown>).input_tokens === 500,
     );
-    expect(hasSuccessWithTokens).toBe(false);
+    expect(successRecord).toBeDefined();
+    const record = successRecord![0] as Record<string, unknown>;
+    expect(record.output_tokens).toBe(200);
+    expect(record.fallback_from_model).toBe('claude-sonnet-4-20250514');
+    expect(record.fallback_index).toBe(0);
+  });
+
+  it('should compute cost on fallback success when pricing is available', async () => {
+    mockPricingCache.getByModel.mockReturnValue({
+      input_price_per_token: 0.000005,
+      output_price_per_token: 0.00002,
+    });
+
+    const responseBody = {
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 800, completion_tokens: 300 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: { response: mockProviderResp, isGoogle: false, isAnthropic: false },
+      meta: {
+        tier: 'standard',
+        model: 'deepseek-chat',
+        provider: 'DeepSeek',
+        confidence: 0.8,
+        reason: 'scored',
+        fallbackFromModel: 'gpt-4o',
+        fallbackIndex: 0,
+        primaryErrorStatus: 401,
+        primaryErrorBody: 'Unauthorized',
+      },
+    });
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+    const { res } = mockResponse();
+
+    await controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const insertCalls = mockMessageRepo.insert.mock.calls;
+    const successRecord = insertCalls.find(
+      (call: unknown[]) =>
+        (call[0] as Record<string, unknown>).status === 'ok' &&
+        (call[0] as Record<string, unknown>).input_tokens === 800,
+    );
+    expect(successRecord).toBeDefined();
+    const record = successRecord![0] as Record<string, unknown>;
+    expect(record.output_tokens).toBe(300);
+    expect(record.cost_usd).toBe(800 * 0.000005 + 300 * 0.00002);
+    expect(record.fallback_from_model).toBe('gpt-4o');
+    expect(record.fallback_index).toBe(0);
   });
 
   it('should compute cost when pricing is available', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -28,6 +28,7 @@ describe('ProxyService', () => {
       getProviderApiKey: jest.fn(),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       getTiers: jest.fn().mockResolvedValue([]),
+      findProviderForModel: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<RoutingService>;
 
     providerClient = {
@@ -1285,7 +1286,7 @@ describe('ProxyService', () => {
       });
     });
 
-    it('stops fallback chain on non-retriable error', async () => {
+    it('stops fallback chain on 424 (fallback exhausted)', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         model: 'gpt-4o',
@@ -1305,7 +1306,7 @@ describe('ProxyService', () => {
           isAnthropic: false,
         })
         .mockResolvedValueOnce({
-          response: new Response('bad request', { status: 400 }),
+          response: new Response('exhausted', { status: 424 }),
           isGoogle: false,
           isAnthropic: false,
         });
@@ -1316,14 +1317,14 @@ describe('ProxyService', () => {
 
       const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
 
-      // Chain stopped at model-a's 400, model-b never tried
+      // Chain stopped at model-a's 424, model-b never tried
       expect(result.forward.response.ok).toBe(false);
       expect(providerClient.forward).toHaveBeenCalledTimes(2);
       expect(result.failedFallbacks).toHaveLength(1);
-      expect(result.failedFallbacks![0].status).toBe(400);
+      expect(result.failedFallbacks![0].status).toBe(424);
     });
 
-    it('does not attempt fallbacks when primary returns non-retriable error', async () => {
+    it('does not attempt fallbacks when primary returns a redirect', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         model: 'gpt-4o',
@@ -1334,7 +1335,7 @@ describe('ProxyService', () => {
       });
       routingService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward.mockResolvedValue({
-        response: new Response('bad request', { status: 400 }),
+        response: new Response('redirect', { status: 301 }),
         isGoogle: false,
         isAnthropic: false,
       });
@@ -1342,7 +1343,7 @@ describe('ProxyService', () => {
       const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
 
       expect(routingService.getTiers).not.toHaveBeenCalled();
-      expect(result.forward.response.status).toBe(400);
+      expect(result.forward.response.status).toBe(301);
     });
 
     it('falls back from api_key primary to subscription fallback model', async () => {
@@ -1583,6 +1584,48 @@ describe('ProxyService', () => {
       // Verify getAuthType was called for both fallback providers
       expect(routingService.getAuthType).toHaveBeenCalledWith('agent-1', 'Anthropic');
       expect(routingService.getAuthType).toHaveBeenCalledWith('agent-1', 'DeepSeek');
+    });
+
+    it('resolves fallback provider via findProviderForModel when pricing and name inference fail', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      routingService.getProviderApiKey
+        .mockResolvedValueOnce('sk-test') // primary
+        .mockResolvedValueOnce('sk-niche'); // fallback
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('auth error', { status: 401 }),
+          isGoogle: false,
+          isAnthropic: false,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+        });
+      routingService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: ['niche-model-v1'] },
+      ] as never);
+      // No pricing data for this model
+      pricingCache.getByModel.mockReturnValue(null as never);
+      // inferProviderFromModelName returns undefined (no slash prefix)
+      // findProviderForModel finds it in the user's connected providers
+      routingService.findProviderForModel.mockResolvedValue('niche-provider');
+
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
+
+      expect(routingService.findProviderForModel).toHaveBeenCalledWith('agent-1', 'niche-model-v1');
+      expect(result.meta.model).toBe('niche-model-v1');
+      expect(result.meta.provider).toBe('niche-provider');
+      expect(result.meta.fallbackFromModel).toBe('gpt-4o');
+      expect(result.meta.fallbackIndex).toBe(0);
+      expect(result.meta.primaryErrorStatus).toBe(401);
     });
 
     it('returns all failed fallbacks when all fail', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1628,6 +1628,42 @@ describe('ProxyService', () => {
       expect(result.meta.primaryErrorStatus).toBe(401);
     });
 
+    it('resolves custom provider fallback via model prefix', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      routingService.getProviderApiKey
+        .mockResolvedValueOnce('sk-test')
+        .mockResolvedValueOnce('sk-custom');
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('error', { status: 500 }),
+          isGoogle: false,
+          isAnthropic: false,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+        });
+      routingService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: ['custom:cp-abc/my-model'] },
+      ] as never);
+      customProviderService.getById.mockResolvedValue({
+        base_url: 'https://my-endpoint.com/v1',
+      } as never);
+
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
+
+      expect(result.meta.model).toBe('custom:cp-abc/my-model');
+      expect(result.meta.fallbackFromModel).toBe('gpt-4o');
+    });
+
     it('returns all failed fallbacks when all fail', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'simple',

--- a/packages/backend/src/routing/proxy/fallback-status-codes.ts
+++ b/packages/backend/src/routing/proxy/fallback-status-codes.ts
@@ -1,7 +1,6 @@
-const RETRIABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
-
 export const FALLBACK_EXHAUSTED_STATUS = 424;
 
 export function shouldTriggerFallback(status: number): boolean {
-  return RETRIABLE_STATUSES.has(status);
+  if (status === FALLBACK_EXHAUSTED_STATUS) return false;
+  return status >= 400;
 }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -159,11 +159,13 @@ export class ProxyController {
       // Failed upstream responses (retries by the gateway) are free.
       this.rateLimiter.recordSuccess(userId);
 
-      // When a fallback was used, record the full chain with coordinated
-      // timestamps so messages appear in order: primary (earliest) → intermediate
-      // failures → fallback success (latest, appears first in list).
+      // When a fallback was used, record failures now (they don't need token data).
+      // The fallback success record is deferred until after the response is processed
+      // so we can include real usage/cost data.
+      let fallbackBaseTime: number | undefined;
+      let fallbackSuccessTs: string | undefined;
       if (meta.fallbackFromModel) {
-        const baseTime = Date.now();
+        fallbackBaseTime = Date.now();
         const failures = failedFallbacks ?? [];
 
         this.recordPrimaryFailure(
@@ -171,7 +173,7 @@ export class ProxyController {
           meta.tier,
           meta.fallbackFromModel,
           meta.primaryErrorBody ?? `Provider returned HTTP ${meta.primaryErrorStatus ?? 500}`,
-          new Date(baseTime).toISOString(),
+          new Date(fallbackBaseTime).toISOString(),
           meta.auth_type,
         ).catch((e) => this.logger.warn(`Failed to record primary failure: ${e}`));
 
@@ -181,21 +183,11 @@ export class ProxyController {
             meta.tier,
             meta.fallbackFromModel,
             failures,
-            { baseTimeMs: baseTime, markHandled: true, authType: meta.auth_type },
+            { baseTimeMs: fallbackBaseTime, markHandled: true, authType: meta.auth_type },
           ).catch((e) => this.logger.warn(`Failed to record fallback errors: ${e}`));
         }
 
-        const successTs = new Date(baseTime + (failures.length + 1) * 100).toISOString();
-        this.recordFallbackSuccess(
-          req.ingestionContext,
-          meta.model,
-          meta.tier,
-          traceId,
-          meta.fallbackFromModel,
-          meta.fallbackIndex ?? 0,
-          successTs,
-          meta.auth_type,
-        ).catch((e) => this.logger.warn(`Failed to record fallback success: ${e}`));
+        fallbackSuccessTs = new Date(fallbackBaseTime + (failures.length + 1) * 100).toISOString();
       }
 
       let streamUsage: StreamUsage | null = null;
@@ -247,9 +239,20 @@ export class ProxyController {
         res.json(responseBody);
       }
 
-      // Record successful message with real token data (non-fallback only).
-      // For fallback successes, recordFallbackSuccess already creates the record.
-      if (!meta.fallbackFromModel && streamUsage) {
+      // Record successful message with real token data.
+      if (meta.fallbackFromModel && fallbackSuccessTs) {
+        this.recordFallbackSuccess(
+          req.ingestionContext,
+          meta.model,
+          meta.tier,
+          traceId,
+          meta.fallbackFromModel,
+          meta.fallbackIndex ?? 0,
+          fallbackSuccessTs,
+          meta.auth_type,
+          streamUsage ?? undefined,
+        ).catch((e) => this.logger.warn(`Failed to record fallback success: ${e}`));
+      } else if (streamUsage) {
         this.recordSuccessMessage(
           req.ingestionContext,
           meta.model,
@@ -414,10 +417,21 @@ export class ProxyController {
     fallbackIndex?: number,
     timestamp?: string,
     authType?: string,
+    usage?: StreamUsage,
   ): Promise<void> {
+    const inputTokens = usage?.prompt_tokens ?? 0;
+    const outputTokens = usage?.completion_tokens ?? 0;
+
     let costUsd: number | null = null;
     if (authType === 'subscription') {
       costUsd = 0;
+    } else if (usage) {
+      const pricing = this.pricingCache.getByModel(model);
+      if (pricing?.input_price_per_token != null && pricing?.output_price_per_token != null) {
+        costUsd =
+          inputTokens * Number(pricing.input_price_per_token) +
+          outputTokens * Number(pricing.output_price_per_token);
+      }
     }
 
     await this.messageRepo.insert({
@@ -430,10 +444,10 @@ export class ProxyController {
       agent_name: ctx.agentName,
       model,
       routing_tier: tier,
-      input_tokens: 0,
-      output_tokens: 0,
-      cache_read_tokens: 0,
-      cache_creation_tokens: 0,
+      input_tokens: inputTokens,
+      output_tokens: outputTokens,
+      cache_read_tokens: usage?.cache_read_tokens ?? 0,
+      cache_creation_tokens: usage?.cache_creation_tokens ?? 0,
       cost_usd: costUsd,
       auth_type: authType ?? null,
       fallback_from_model: fallbackFromModel ?? null,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -236,13 +236,16 @@ export class ProxyService {
       const model = fallbackModels[i];
       const pricing = this.pricingCache.getByModel(model);
 
-      // Determine provider: custom models use their prefix, others use pricing cache
+      // Determine provider: custom prefix → model name inference → pricing cache → user's connected providers
       let provider: string | undefined;
       if (CustomProviderService.isCustom(model)) {
         const slashIdx = model.indexOf('/');
         provider = slashIdx > 0 ? model.substring(0, slashIdx) : model;
-      } else if (pricing) {
-        provider = inferProviderFromModelName(model) ?? pricing.provider;
+      } else {
+        provider =
+          inferProviderFromModelName(model) ??
+          pricing?.provider ??
+          (await this.routingService.findProviderForModel(agentId, model));
       }
 
       if (!provider) {

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -2040,4 +2040,35 @@ describe('RoutingService', () => {
       expect(invalidateSpy).toHaveBeenCalledWith('agent-1');
     });
   });
+
+  describe('findProviderForModel', () => {
+    it('should return the provider that has the model in cached_models', async () => {
+      mockProviderRepo.find.mockResolvedValue([
+        { provider: 'anthropic', is_active: true, cached_models: [{ id: 'claude-opus-4-6' }] },
+        { provider: 'gemini', is_active: true, cached_models: [{ id: 'gemini-2.5-flash' }] },
+      ]);
+
+      const result = await service.findProviderForModel('a1', 'claude-opus-4-6');
+      expect(result).toBe('anthropic');
+    });
+
+    it('should return undefined when no provider has the model', async () => {
+      mockProviderRepo.find.mockResolvedValue([
+        { provider: 'anthropic', is_active: true, cached_models: [{ id: 'claude-opus-4-6' }] },
+      ]);
+
+      const result = await service.findProviderForModel('a1', 'unknown-model');
+      expect(result).toBeUndefined();
+    });
+
+    it('should skip providers with null cached_models', async () => {
+      mockProviderRepo.find.mockResolvedValue([
+        { provider: 'anthropic', is_active: true, cached_models: null },
+        { provider: 'gemini', is_active: true, cached_models: [{ id: 'gemini-2.5-flash' }] },
+      ]);
+
+      const result = await service.findProviderForModel('a1', 'gemini-2.5-flash');
+      expect(result).toBe('gemini');
+    });
+  });
 });

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -588,6 +588,17 @@ export class RoutingService {
     return withKey?.auth_type ?? matches[0]?.auth_type ?? 'api_key';
   }
 
+  /* ── Provider lookup by cached models ── */
+
+  async findProviderForModel(agentId: string, model: string): Promise<string | undefined> {
+    const providers = await this.getProviders(agentId);
+    for (const p of providers) {
+      if (!p.cached_models) continue;
+      if (p.cached_models.some((m) => m.id === model)) return p.provider;
+    }
+    return undefined;
+  }
+
   /* ── Runtime helper ── */
 
   async getEffectiveModel(agentId: string, assignment: TierAssignment): Promise<string | null> {

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -236,6 +236,7 @@ const CustomProviderForm: Component<Props> = (props) => {
               id="cp-api-key"
               class="provider-detail__input"
               type="password"
+              autocomplete="new-password"
               placeholder="sk-..."
               value={apiKey()}
               onInput={(e) => setApiKey(e.currentTarget.value)}

--- a/packages/frontend/src/components/EmailProviderModal.tsx
+++ b/packages/frontend/src/components/EmailProviderModal.tsx
@@ -333,6 +333,7 @@ const EmailProviderModal: Component<Props> = (props) => {
                 class="modal-card__input"
                 classList={{ 'modal-card__input--error': !!keyError() }}
                 type="password"
+                autocomplete="new-password"
                 placeholder={keyPlaceholder()}
                 value={apiKey()}
                 onInput={(e) => {

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -665,6 +665,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
                         class="provider-detail__input"
                         classList={{ 'provider-detail__input--error': !!validationError() }}
                         type="password"
+                        autocomplete="new-password"
                         placeholder={placeholder()}
                         aria-label={inputAriaLabel()}
                         value={keyInput()}
@@ -762,6 +763,7 @@ const ProviderSelectModal: Component<Props> = (props) => {
                           class="provider-detail__input"
                           classList={{ 'provider-detail__input--error': !!validationError() }}
                           type="password"
+                          autocomplete="new-password"
                           placeholder={placeholder()}
                           aria-label={editAriaLabel()}
                           value={keyInput()}

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -24,40 +24,44 @@ const MONO = 'font-family: var(--font-mono);';
 const MONO_XS =
   'font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));';
 
-export const HEARTBEAT_SVG = (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="12"
-    height="12"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    aria-hidden="true"
-  >
-    <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
-  </svg>
-);
+export function HeartbeatIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </svg>
+  );
+}
 
-export const FALLBACK_SVG = (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="11"
-    height="11"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    stroke-width="2.5"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    style="margin-right: 3px; flex-shrink: 0;"
-  >
-    <polyline points="15 17 20 12 15 7" />
-    <path d="M4 18v-2a4 4 0 0 1 4-4h12" />
-  </svg>
-);
+export function FallbackIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      style="margin-right: 3px; flex-shrink: 0;"
+    >
+      <polyline points="15 17 20 12 15 7" />
+      <path d="M4 18v-2a4 4 0 0 1 4-4h12" />
+    </svg>
+  );
+}
 
 const HEADER_LABELS: Record<MessageColumnKey, string> = {
   date: 'Date',
@@ -104,7 +108,7 @@ export function MessageCell(item: MessageRow): JSX.Element {
           title="Heartbeat"
           style="display: inline-flex; align-items: center; margin-left: 4px; color: hsl(var(--muted-foreground)); opacity: 0.7;"
         >
-          {HEARTBEAT_SVG}
+          {<HeartbeatIcon />}
         </span>
       )}
     </td>
@@ -230,6 +234,7 @@ export function StatusCell(
         when={item.error_message}
         fallback={
           <span class={`status-badge status-badge--${item.status}`}>
+            {item.status === 'fallback_error' && <FallbackIcon />}
             {item.status === 'rate_limited' ? (
               <A href={`/agents/${encodeURIComponent(agentName)}/limits`}>
                 {formatStatus(item.status)}
@@ -254,7 +259,7 @@ export function StatusCell(
                 : undefined
             }
           >
-            {item.status === 'fallback_error' && FALLBACK_SVG}
+            {item.status === 'fallback_error' && <FallbackIcon />}
             {formatStatus(item.status)}
           </span>
           <span class="status-badge-tooltip__bubble">

--- a/packages/frontend/src/services/routing-utils.ts
+++ b/packages/frontend/src/services/routing-utils.ts
@@ -40,7 +40,7 @@ const MODEL_PREFIX_MAP: [RegExp, string][] = [
   [/^openrouter\//, 'openrouter'],
   [/^claude-/, 'anthropic'],
   [/^gpt-|^o[134]-|^o[134] |^chatgpt-/, 'openai'],
-  [/^gemini-/, 'gemini'],
+  [/^gemini-|^gemma-/, 'gemini'],
   [/^deepseek-/, 'deepseek'],
   [/^grok-/, 'xai'],
   [/^mistral-|^codestral|^pixtral|^open-mistral/, 'mistral'],

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -424,6 +424,28 @@ describe('MessageTable', () => {
       expect(badge!.querySelector('svg')).not.toBeNull();
     });
 
+    it('renders separate SVG icons for multiple fallback_error rows', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[
+            makeRow({ id: 'row-1', status: 'fallback_error', error_message: 'err 1' }),
+            makeRow({ id: 'row-2', status: 'fallback_error', error_message: 'err 2' }),
+          ]}
+          columns={['status']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      const badges = container.querySelectorAll('.status-badge--fallback_error');
+      expect(badges.length).toBe(2);
+      const svg1 = badges[0]!.querySelector('svg');
+      const svg2 = badges[1]!.querySelector('svg');
+      expect(svg1).not.toBeNull();
+      expect(svg2).not.toBeNull();
+      // Each row has its own SVG node (not the same DOM element)
+      expect(svg1).not.toBe(svg2);
+    });
+
     it('calls onFallbackErrorClick when fallback_error badge is clicked', () => {
       const handler = vi.fn();
       const { container } = render(() => (

--- a/packages/frontend/tests/services/routing-utils.test.ts
+++ b/packages/frontend/tests/services/routing-utils.test.ts
@@ -104,6 +104,12 @@ describe("inferProviderFromModel", () => {
     expect(inferProviderFromModel("gemini-2.5-pro")).toBe("gemini");
   });
 
+  it("detects Gemma models as Gemini (Google) provider", () => {
+    expect(inferProviderFromModel("gemma-3n-e2b-it")).toBe("gemini");
+    expect(inferProviderFromModel("gemma-2-9b")).toBe("gemini");
+    expect(inferProviderFromModel("gemma-7b")).toBe("gemini");
+  });
+
   it("detects DeepSeek models", () => {
     expect(inferProviderFromModel("deepseek-chat")).toBe("deepseek");
     expect(inferProviderFromModel("deepseek-reasoner")).toBe("deepseek");


### PR DESCRIPTION
## Summary

- Trigger fallback on all 4xx/5xx provider errors instead of only 429/5xx, so auth errors (400/401/403) from providers with bad keys try the next model
- Resolve fallback model providers via user's connected providers (`cached_models`) when the pricing cache and model name inference fail
- Record real token counts, cost, and cache data on fallback success (previously recorded zeroes)
- Fix SolidJS DOM node reuse bug where only the last table row displayed the fallback/heartbeat SVG icon
- Show fallback arrow icon on all handled fallback messages, not just the primary
- Add `gemma-*` model prefix to Google provider mapping for provider icon display
- Prevent browser password save prompt on API key inputs with `autocomplete="new-password"`

## Test plan

- [x] Backend unit tests pass (2565 tests)
- [x] Frontend unit tests pass (1540 tests)
- [x] TypeScript compiles with no errors in both packages
- [x] New tests added for fallback status codes, provider resolution via cached_models, fallback success usage recording, gemma provider mapping, and SolidJS FallbackIcon rendering
- [ ] Manual: set a dummy API key on a provider, configure fallback models from a different provider, send a message — verify fallback chain triggers and all messages show correct icons/data

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the routing fallback chain so provider errors fail over more reliably and usage is recorded correctly, with small UI fixes for fallback icons and model mapping.

- **Bug Fixes**
  - Trigger fallback on all 4xx/5xx errors (except 424 “fallback exhausted”); do not attempt fallback on redirects.
  - Resolve fallback providers via the user’s connected `cached_models` when pricing and model-name inference can’t determine a provider.
  - Record real token counts, cost, and cache metrics for fallback successes.
  - Fix SolidJS SVG reuse by converting icons to components and show the fallback arrow on all handled fallback messages.
  - Map `gemma-*` models to the Google/Gemini provider for correct icon display.
  - Prevent browser password save prompts on API key inputs with `autocomplete="new-password"`.

<sup>Written for commit 4afb22b60a4348538addc9629b1b7d611fda2868. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

