### PR TITLE
feat: subscription model discovery with fallback and auth-type dedup

### DIFF
--- a/.changeset/subscription-model-discovery.md
+++ b/.changeset/subscription-model-discovery.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add subscription model discovery with fallback models and auth-type-aware deduplication

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
@@ -3,6 +3,7 @@ import { ProviderModelFetcherService } from './provider-model-fetcher.service';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { DiscoveredModel } from './model-fetcher';
+import { buildSubscriptionFallbackModels } from './model-fallback';
 
 jest.mock('../../common/utils/crypto.util', () => ({
   decrypt: jest.fn(),
@@ -719,6 +720,333 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].inputPricePerToken).toBe(0.000015);
       expect(result[0].provider).toBe('anthropic');
       expect(result[1].id).toBe('claude-sonnet-4.6');
+    });
+
+    it('should stamp authType as api_key for regular providers', async () => {
+      const models = [makeModel({ id: 'gpt-4o' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider({ auth_type: 'api_key' }));
+
+      expect(result[0].authType).toBe('api_key');
+    });
+
+    it('should stamp authType as subscription for subscription providers', async () => {
+      const models = [makeModel({ id: 'claude-sonnet-4' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(
+        makeProvider({
+          provider: 'anthropic',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted-token',
+        }),
+      );
+
+      expect(result[0].authType).toBe('subscription');
+    });
+
+    it('should use subscription fallback when auth_type is subscription and no token', async () => {
+      const orMap = new Map([
+        [
+          'anthropic/claude-opus-4-20260301',
+          {
+            input: 0.000015,
+            output: 0.000075,
+            contextWindow: 200000,
+            displayName: 'Claude Opus 4',
+          },
+        ],
+        [
+          'anthropic/claude-sonnet-4-20260301',
+          {
+            input: 0.000003,
+            output: 0.000015,
+            contextWindow: 200000,
+            displayName: 'Claude Sonnet 4',
+          },
+        ],
+        [
+          'anthropic/claude-haiku-4-20260301',
+          {
+            input: 0.0000008,
+            output: 0.000004,
+            contextWindow: 200000,
+            displayName: 'Claude Haiku 4',
+          },
+        ],
+        [
+          'anthropic/claude-2.1',
+          {
+            input: 0.000008,
+            output: 0.000024,
+            contextWindow: 200000,
+            displayName: 'Claude 2.1',
+          },
+        ],
+        [
+          'openai/gpt-4o',
+          {
+            input: 0.0000025,
+            output: 0.00001,
+            contextWindow: 128000,
+            displayName: 'GPT-4o',
+          },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = await service.discoverModels(
+        makeProvider({
+          provider: 'anthropic',
+          auth_type: 'subscription',
+          api_key_encrypted: null,
+        }),
+      );
+
+      // Should only include models matching knownModels prefixes (claude-opus-4, claude-sonnet-4, claude-haiku-4)
+      // and NOT claude-2.1 or openai models
+      expect(result).toHaveLength(3);
+      expect(result.map((m) => m.id).sort()).toEqual([
+        'claude-haiku-4-20260301',
+        'claude-opus-4-20260301',
+        'claude-sonnet-4-20260301',
+      ]);
+      // All should be stamped as subscription
+      for (const m of result) {
+        expect(m.authType).toBe('subscription');
+      }
+      // Should NOT have called the fetcher (no token to call with)
+      expect(fetcher.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should cap context window via subscription capabilities', async () => {
+      const orMap = new Map([
+        [
+          'anthropic/claude-opus-4-20260301',
+          {
+            input: 0.000015,
+            output: 0.000075,
+            contextWindow: 1000000,
+            displayName: 'Claude Opus 4',
+          },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = await service.discoverModels(
+        makeProvider({
+          provider: 'anthropic',
+          auth_type: 'subscription',
+          api_key_encrypted: null,
+        }),
+      );
+
+      expect(result).toHaveLength(1);
+      // Anthropic subscription caps at 200000
+      expect(result[0].contextWindow).toBe(200000);
+    });
+
+    it('should return empty when subscription provider has no known models', async () => {
+      const orMap = new Map([
+        [
+          'openai/gpt-4o',
+          { input: 0.0000025, output: 0.00001, contextWindow: 128000, displayName: 'GPT-4o' },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = await service.discoverModels(
+        makeProvider({
+          provider: 'openai',
+          auth_type: 'subscription',
+          api_key_encrypted: null,
+        }),
+      );
+
+      // openai has no knownModels in subscription-capabilities, returns empty
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty subscription fallback when pricingSync is null', async () => {
+      const serviceNoPricing = new ModelDiscoveryService(
+        providerRepo as never,
+        customProviderRepo as never,
+        fetcher as unknown as ProviderModelFetcherService,
+        null,
+      );
+
+      const result = await serviceNoPricing.discoverModels(
+        makeProvider({
+          provider: 'anthropic',
+          auth_type: 'subscription',
+          api_key_encrypted: null,
+        }),
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  /* ── getModelsForAgent auth-type deduplication ── */
+
+  describe('getModelsForAgent (auth-type dedup)', () => {
+    it('should prefer subscription model over api_key duplicate', async () => {
+      const providers = [
+        makeProvider({
+          id: 'p1',
+          provider: 'anthropic',
+          cached_models: [
+            makeModel({ id: 'claude-sonnet-4', provider: 'anthropic', authType: 'api_key' }),
+          ],
+        }),
+        makeProvider({
+          id: 'p2',
+          provider: 'anthropic',
+          cached_models: [
+            makeModel({
+              id: 'claude-sonnet-4',
+              provider: 'anthropic',
+              authType: 'subscription',
+              contextWindow: 200000,
+            }),
+          ],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('claude-sonnet-4');
+      expect(result[0].authType).toBe('subscription');
+      expect(result[0].contextWindow).toBe(200000);
+    });
+
+    it('should not replace subscription with api_key duplicate', async () => {
+      const providers = [
+        makeProvider({
+          id: 'p1',
+          provider: 'anthropic',
+          cached_models: [
+            makeModel({
+              id: 'claude-sonnet-4',
+              provider: 'anthropic',
+              authType: 'subscription',
+            }),
+          ],
+        }),
+        makeProvider({
+          id: 'p2',
+          provider: 'anthropic',
+          cached_models: [
+            makeModel({ id: 'claude-sonnet-4', provider: 'anthropic', authType: 'api_key' }),
+          ],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].authType).toBe('subscription');
+    });
+  });
+
+  /* ── buildSubscriptionFallbackModels ── */
+
+  describe('buildSubscriptionFallbackModels', () => {
+    it('should return empty for unsupported providers', () => {
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'openai');
+      expect(result).toEqual([]);
+    });
+
+    it('should filter OpenRouter cache by known model prefixes', () => {
+      const orMap = new Map([
+        [
+          'anthropic/claude-opus-4-latest',
+          {
+            input: 0.000015,
+            output: 0.000075,
+            contextWindow: 200000,
+            displayName: 'Claude Opus 4',
+          },
+        ],
+        [
+          'anthropic/claude-2.1',
+          { input: 0.000008, output: 0.000024, contextWindow: 200000, displayName: 'Claude 2.1' },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('claude-opus-4-latest');
+      expect(result[0].provider).toBe('anthropic');
+    });
+
+    it('should apply maxContextWindow cap from subscription capabilities', () => {
+      const orMap = new Map([
+        [
+          'anthropic/claude-sonnet-4-20260301',
+          { input: 0.000003, output: 0.000015, contextWindow: 1000000, displayName: 'Sonnet' },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].contextWindow).toBe(200000);
+    });
+
+    it('should return empty when pricingSync is null', () => {
+      const result = buildSubscriptionFallbackModels(null as never, 'anthropic');
+      expect(result).toEqual([]);
+    });
+
+    it('should deduplicate models by id', () => {
+      const orMap = new Map([
+        [
+          'anthropic/claude-opus-4',
+          { input: 0.000015, output: 0.000075, contextWindow: 200000, displayName: 'Opus 4' },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
+      expect(result).toHaveLength(1);
+    });
+
+    it('should use default context window when entry has none', () => {
+      const orMap = new Map([
+        ['anthropic/claude-haiku-4-latest', { input: 0.0000008, output: 0.000004 }],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
+
+      expect(result).toHaveLength(1);
+      // Default 128000 is below maxContextWindow 200000, so no cap applied
+      expect(result[0].contextWindow).toBe(128000);
+    });
+
+    it('should use model id as displayName when entry has no displayName', () => {
+      const orMap = new Map([
+        [
+          'anthropic/claude-opus-4-latest',
+          { input: 0.000015, output: 0.000075, contextWindow: 200000, displayName: '' },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'anthropic');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].displayName).toBe('claude-opus-4-latest');
     });
   });
 });

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
@@ -953,6 +953,34 @@ describe('ModelDiscoveryService', () => {
       expect(result).toHaveLength(1);
       expect(result[0].authType).toBe('subscription');
     });
+
+    it('should use provider auth_type as fallback when cached model has no authType', async () => {
+      const providers = [
+        makeProvider({
+          id: 'p1',
+          provider: 'anthropic',
+          auth_type: 'api_key',
+          cached_models: [
+            makeModel({ id: 'claude-sonnet-4', provider: 'anthropic' }), // no authType
+          ],
+        }),
+        makeProvider({
+          id: 'p2',
+          provider: 'anthropic',
+          auth_type: 'subscription',
+          cached_models: [
+            makeModel({ id: 'claude-sonnet-4', provider: 'anthropic' }), // no authType
+          ],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result).toHaveLength(1);
+      // Legacy model from subscription provider should replace the api_key one
+    });
   });
 
   /* ── buildSubscriptionFallbackModels ── */

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.ts
@@ -7,11 +7,13 @@ import { ProviderModelFetcherService } from './provider-model-fetcher.service';
 import { DiscoveredModel } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
 import { computeQualityScore } from '../../database/quality-score.util';
-import {
-  OPENROUTER_PREFIX_TO_PROVIDER,
-  PROVIDER_BY_ID_OR_ALIAS,
-} from '../../common/constants/providers';
 import { PricingSyncService } from '../../database/pricing-sync.service';
+import {
+  findOpenRouterPrefix,
+  lookupWithVariants,
+  buildFallbackModels,
+  buildSubscriptionFallbackModels,
+} from './model-fallback';
 // Import static helpers directly to avoid circular dependency with RoutingModule
 const customProviderKey = (id: string) => `custom:${id}`;
 const customModelKey = (id: string, modelName: string) => `custom:${id}/${modelName}`;
@@ -42,19 +44,35 @@ export class ModelDiscoveryService {
       }
     }
 
-    let raw = await this.fetcher.fetch(provider.provider, apiKey, provider.auth_type);
+    let raw: DiscoveredModel[];
 
-    // If native API returned no models, fall back to OpenRouter + manual pricing
-    if (raw.length === 0) {
-      raw = this.buildFallbackModels(provider.provider);
+    // Subscription providers without a token: use curated fallback
+    if (provider.auth_type === 'subscription' && !apiKey) {
+      raw = buildSubscriptionFallbackModels(this.pricingSync, provider.provider);
       if (raw.length > 0) {
         this.logger.log(
-          `Native API returned 0 models for ${provider.provider} — using ${raw.length} models from pricing data`,
+          `No token for subscription provider ${provider.provider} — using ${raw.length} fallback models`,
         );
+      }
+    } else {
+      raw = await this.fetcher.fetch(provider.provider, apiKey, provider.auth_type);
+
+      // If native API returned no models, fall back to OpenRouter + manual pricing
+      if (raw.length === 0) {
+        raw = buildFallbackModels(this.pricingSync, provider.provider);
+        if (raw.length > 0) {
+          this.logger.log(
+            `Native API returned 0 models for ${provider.provider} — using ${raw.length} models from pricing data`,
+          );
+        }
       }
     }
 
-    const enriched = raw.map((model) => this.enrichModel(model, provider.provider));
+    const authType = provider.auth_type === 'subscription' ? 'subscription' : 'api_key';
+    const enriched = raw.map((model) => ({
+      ...this.enrichModel(model, provider.provider),
+      authType: authType as 'api_key' | 'subscription',
+    }));
 
     provider.cached_models = enriched;
     provider.models_fetched_at = new Date().toISOString();
@@ -87,7 +105,7 @@ export class ModelDiscoveryService {
     });
 
     const models: DiscoveredModel[] = [];
-    const seen = new Set<string>();
+    const seen = new Map<string, number>();
 
     for (const p of providers) {
       if (p.provider.startsWith('custom:')) continue;
@@ -95,8 +113,13 @@ export class ModelDiscoveryService {
       if (!Array.isArray(cached)) continue;
       for (const m of cached) {
         if (!seen.has(m.id)) {
-          seen.add(m.id);
+          seen.set(m.id, models.length);
           models.push(m);
+        } else if (
+          m.authType === 'subscription' &&
+          models[seen.get(m.id)!]?.authType !== 'subscription'
+        ) {
+          models[seen.get(m.id)!] = m;
         }
       }
     }
@@ -111,7 +134,7 @@ export class ModelDiscoveryService {
       for (const m of cp.models) {
         const modelKey = customModelKey(cp.id, m.model_name);
         if (seen.has(modelKey)) continue;
-        seen.add(modelKey);
+        seen.set(modelKey, models.length);
         const inputPerToken =
           m.input_price_per_million_tokens != null
             ? m.input_price_per_million_tokens / 1_000_000
@@ -142,21 +165,15 @@ export class ModelDiscoveryService {
     return all.find((m) => m.id === modelName);
   }
 
-  /**
-   * Enrich a discovered model with pricing from OpenRouter cache or manual reference.
-   * Provider native APIs return model lists but NOT pricing, so we look it up.
-   */
   private enrichModel(model: DiscoveredModel, providerId: string): DiscoveredModel {
-    // If the fetcher already provided pricing (e.g. OpenRouter), use it
     if (model.inputPricePerToken !== null && model.inputPricePerToken > 0) {
       return this.computeScore(model);
     }
 
-    // Look up pricing from OpenRouter cache using vendor-prefixed ID
     if (this.pricingSync) {
-      const orPrefix = this.findOpenRouterPrefix(providerId);
+      const orPrefix = findOpenRouterPrefix(providerId);
       if (orPrefix) {
-        const orPricing = this.lookupWithVariants(orPrefix, model.id);
+        const orPricing = lookupWithVariants(this.pricingSync, orPrefix, model.id);
         if (orPricing) {
           return this.computeScore({
             ...model,
@@ -167,7 +184,6 @@ export class ModelDiscoveryService {
           });
         }
       }
-      // Also try exact match (for models like "openrouter/auto")
       const exactPricing = this.pricingSync.lookupPricing(model.id);
       if (exactPricing) {
         return this.computeScore({
@@ -181,111 +197,6 @@ export class ModelDiscoveryService {
     }
 
     return this.computeScore(model);
-  }
-
-  /**
-   * Find the OpenRouter vendor prefix for a provider ID.
-   * E.g. "anthropic" → "anthropic", "gemini" → "google", "qwen" → "qwen"
-   */
-  private findOpenRouterPrefix(providerId: string): string | null {
-    const lower = providerId.toLowerCase();
-    // Check if the provider ID is itself an OpenRouter prefix
-    if (OPENROUTER_PREFIX_TO_PROVIDER.has(lower)) return lower;
-
-    // Use the provider registry to resolve aliases → check each OpenRouter prefix
-    const entry = PROVIDER_BY_ID_OR_ALIAS.get(lower);
-    if (entry) {
-      for (const prefix of entry.openRouterPrefixes) {
-        if (OPENROUTER_PREFIX_TO_PROVIDER.has(prefix)) return prefix;
-      }
-    }
-
-    // Last resort: check display name match
-    for (const [prefix, displayName] of OPENROUTER_PREFIX_TO_PROVIDER) {
-      if (displayName.toLowerCase() === lower) return prefix;
-    }
-    return null;
-  }
-
-  /**
-   * Look up pricing with name normalization variants.
-   * Providers use different conventions: Anthropic uses dashes (claude-sonnet-4-6),
-   * OpenRouter uses dots (claude-sonnet-4.6). Try both.
-   */
-  private lookupWithVariants(
-    prefix: string,
-    modelId: string,
-  ): { input: number; output: number; contextWindow?: number; displayName?: string } | null {
-    if (!this.pricingSync) return null;
-
-    // Try exact match first
-    const exact = this.pricingSync.lookupPricing(`${prefix}/${modelId}`);
-    if (exact) return exact;
-
-    // Try dash-to-dot normalization (claude-sonnet-4-6 → claude-sonnet-4.6)
-    const dotVariant = modelId.replace(/-(\d+)-(\d)/g, '-$1.$2');
-    if (dotVariant !== modelId) {
-      const dotResult = this.pricingSync.lookupPricing(`${prefix}/${dotVariant}`);
-      if (dotResult) return dotResult;
-    }
-
-    // Try dot-to-dash normalization (claude-sonnet-4.6 → claude-sonnet-4-6)
-    const dashVariant = modelId.replace(/\.(\d)/g, '-$1');
-    if (dashVariant !== modelId) {
-      const dashResult = this.pricingSync.lookupPricing(`${prefix}/${dashVariant}`);
-      if (dashResult) return dashResult;
-    }
-
-    // Try stripping date suffix (claude-sonnet-4-5-20250929 → claude-sonnet-4-5)
-    const noDate = modelId.replace(/-\d{8}$/, '');
-    if (noDate !== modelId) {
-      const noDateResult = this.pricingSync.lookupPricing(`${prefix}/${noDate}`);
-      if (noDateResult) return noDateResult;
-
-      // Also try dot variant without date
-      const noDateDot = noDate.replace(/-(\d+)-(\d)/g, '-$1.$2');
-      if (noDateDot !== noDate) {
-        const noDateDotResult = this.pricingSync.lookupPricing(`${prefix}/${noDateDot}`);
-        if (noDateDotResult) return noDateDotResult;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Build a fallback model list from OpenRouter cache + manual pricing
-   * for providers whose native /models API is unavailable.
-   */
-  private buildFallbackModels(providerId: string): DiscoveredModel[] {
-    const models: DiscoveredModel[] = [];
-    const seen = new Set<string>();
-
-    // Check OpenRouter cache for models from this provider
-    if (this.pricingSync) {
-      const orPrefix = this.findOpenRouterPrefix(providerId);
-      if (orPrefix) {
-        for (const [fullId, entry] of this.pricingSync.getAll()) {
-          if (!fullId.startsWith(`${orPrefix}/`)) continue;
-          const modelId = fullId.substring(orPrefix.length + 1);
-          if (seen.has(modelId)) continue;
-          seen.add(modelId);
-          models.push({
-            id: modelId,
-            displayName: entry.displayName || modelId,
-            provider: providerId,
-            contextWindow: entry.contextWindow ?? 128000,
-            inputPricePerToken: entry.input,
-            outputPricePerToken: entry.output,
-            capabilityReasoning: false,
-            capabilityCode: false,
-            qualityScore: 3,
-          });
-        }
-      }
-    }
-
-    return models;
   }
 
   private computeScore(model: DiscoveredModel): DiscoveredModel {

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.ts
@@ -111,12 +111,14 @@ export class ModelDiscoveryService {
       if (p.provider.startsWith('custom:')) continue;
       const cached = p.cached_models;
       if (!Array.isArray(cached)) continue;
+      const providerAuthType = p.auth_type === 'subscription' ? 'subscription' : 'api_key';
       for (const m of cached) {
+        const effectiveAuthType = m.authType ?? providerAuthType;
         if (!seen.has(m.id)) {
           seen.set(m.id, models.length);
           models.push(m);
         } else if (
-          m.authType === 'subscription' &&
+          effectiveAuthType === 'subscription' &&
           models[seen.get(m.id)!]?.authType !== 'subscription'
         ) {
           models[seen.get(m.id)!] = m;

--- a/packages/backend/src/routing/model-discovery/model-fallback.ts
+++ b/packages/backend/src/routing/model-discovery/model-fallback.ts
@@ -1,0 +1,166 @@
+import { DiscoveredModel } from './model-fetcher';
+import {
+  OPENROUTER_PREFIX_TO_PROVIDER,
+  PROVIDER_BY_ID_OR_ALIAS,
+} from '../../common/constants/providers';
+import {
+  getSubscriptionKnownModels,
+  getSubscriptionCapabilities,
+} from '../../../../subscription-capabilities';
+
+interface PricingLookup {
+  lookupPricing(key: string): {
+    input: number;
+    output: number;
+    contextWindow?: number;
+    displayName?: string;
+  } | null;
+  getAll(): Map<
+    string,
+    { input: number; output: number; contextWindow?: number; displayName?: string }
+  >;
+}
+
+/**
+ * Find the OpenRouter vendor prefix for a provider ID.
+ * E.g. "anthropic" → "anthropic", "gemini" → "google", "qwen" → "qwen"
+ */
+export function findOpenRouterPrefix(providerId: string): string | null {
+  const lower = providerId.toLowerCase();
+  if (OPENROUTER_PREFIX_TO_PROVIDER.has(lower)) return lower;
+
+  const entry = PROVIDER_BY_ID_OR_ALIAS.get(lower);
+  if (entry) {
+    for (const prefix of entry.openRouterPrefixes) {
+      if (OPENROUTER_PREFIX_TO_PROVIDER.has(prefix)) return prefix;
+    }
+  }
+
+  for (const [prefix, displayName] of OPENROUTER_PREFIX_TO_PROVIDER) {
+    if (displayName.toLowerCase() === lower) return prefix;
+  }
+  return null;
+}
+
+/**
+ * Look up pricing with name normalization variants.
+ * Providers use different conventions: Anthropic uses dashes (claude-sonnet-4-6),
+ * OpenRouter uses dots (claude-sonnet-4.6). Try both.
+ */
+export function lookupWithVariants(
+  pricingSync: PricingLookup,
+  prefix: string,
+  modelId: string,
+): { input: number; output: number; contextWindow?: number; displayName?: string } | null {
+  const exact = pricingSync.lookupPricing(`${prefix}/${modelId}`);
+  if (exact) return exact;
+
+  const dotVariant = modelId.replace(/-(\d+)-(\d)/g, '-$1.$2');
+  if (dotVariant !== modelId) {
+    const dotResult = pricingSync.lookupPricing(`${prefix}/${dotVariant}`);
+    if (dotResult) return dotResult;
+  }
+
+  const dashVariant = modelId.replace(/\.(\d)/g, '-$1');
+  if (dashVariant !== modelId) {
+    const dashResult = pricingSync.lookupPricing(`${prefix}/${dashVariant}`);
+    if (dashResult) return dashResult;
+  }
+
+  const noDate = modelId.replace(/-\d{8}$/, '');
+  if (noDate !== modelId) {
+    const noDateResult = pricingSync.lookupPricing(`${prefix}/${noDate}`);
+    if (noDateResult) return noDateResult;
+
+    const noDateDot = noDate.replace(/-(\d+)-(\d)/g, '-$1.$2');
+    if (noDateDot !== noDate) {
+      const noDateDotResult = pricingSync.lookupPricing(`${prefix}/${noDateDot}`);
+      if (noDateDotResult) return noDateDotResult;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Build a fallback model list from OpenRouter cache
+ * for providers whose native /models API is unavailable.
+ */
+export function buildFallbackModels(
+  pricingSync: PricingLookup | null,
+  providerId: string,
+): DiscoveredModel[] {
+  if (!pricingSync) return [];
+  const models: DiscoveredModel[] = [];
+  const seen = new Set<string>();
+
+  const orPrefix = findOpenRouterPrefix(providerId);
+  if (!orPrefix) return [];
+
+  for (const [fullId, entry] of pricingSync.getAll()) {
+    if (!fullId.startsWith(`${orPrefix}/`)) continue;
+    const modelId = fullId.substring(orPrefix.length + 1);
+    if (seen.has(modelId)) continue;
+    seen.add(modelId);
+    models.push({
+      id: modelId,
+      displayName: entry.displayName || modelId,
+      provider: providerId,
+      contextWindow: entry.contextWindow ?? 128000,
+      inputPricePerToken: entry.input,
+      outputPricePerToken: entry.output,
+      capabilityReasoning: false,
+      capabilityCode: false,
+      qualityScore: 3,
+    });
+  }
+
+  return models;
+}
+
+/**
+ * Build a curated fallback model list for subscription providers without a token.
+ * Uses knownModels prefixes from subscription-capabilities to filter the OpenRouter cache,
+ * and applies capability restrictions (e.g., context window caps).
+ */
+export function buildSubscriptionFallbackModels(
+  pricingSync: PricingLookup | null,
+  providerId: string,
+): DiscoveredModel[] {
+  const knownPrefixes = getSubscriptionKnownModels(providerId);
+  if (!knownPrefixes || !pricingSync) return [];
+
+  const orPrefix = findOpenRouterPrefix(providerId);
+  if (!orPrefix) return [];
+
+  const capabilities = getSubscriptionCapabilities(providerId);
+  const models: DiscoveredModel[] = [];
+  const seen = new Set<string>();
+
+  for (const [fullId, entry] of pricingSync.getAll()) {
+    if (!fullId.startsWith(`${orPrefix}/`)) continue;
+    const modelId = fullId.substring(orPrefix.length + 1);
+    if (!knownPrefixes.some((p: string) => modelId.startsWith(p))) continue;
+    if (seen.has(modelId)) continue;
+    seen.add(modelId);
+
+    let contextWindow = entry.contextWindow ?? 128000;
+    if (capabilities?.maxContextWindow && contextWindow > capabilities.maxContextWindow) {
+      contextWindow = capabilities.maxContextWindow;
+    }
+
+    models.push({
+      id: modelId,
+      displayName: entry.displayName || modelId,
+      provider: providerId,
+      contextWindow,
+      inputPricePerToken: entry.input,
+      outputPricePerToken: entry.output,
+      capabilityReasoning: false,
+      capabilityCode: false,
+      qualityScore: 3,
+    });
+  }
+
+  return models;
+}

--- a/packages/backend/src/routing/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/routing/model-discovery/model-fetcher.ts
@@ -16,6 +16,7 @@ export interface DiscoveredModel {
   capabilityReasoning: boolean;
   capabilityCode: boolean;
   qualityScore: number;
+  authType?: 'api_key' | 'subscription';
 }
 
 export interface FetcherConfig {

--- a/packages/backend/src/routing/routing.controller.spec.ts
+++ b/packages/backend/src/routing/routing.controller.spec.ts
@@ -561,6 +561,7 @@ describe('RoutingController', () => {
       expect(result[0]).toEqual({
         model_name: 'gpt-4o',
         provider: 'openai',
+        auth_type: 'api_key',
         input_price_per_token: 0.0000025,
         output_price_per_token: 0.00001,
         context_window: 128000,
@@ -579,6 +580,7 @@ describe('RoutingController', () => {
       const result = await controller.getAvailableModels(mockUser, mockAgentName);
 
       expect(Object.keys(result[0]).sort()).toEqual([
+        'auth_type',
         'capability_code',
         'capability_reasoning',
         'context_window',

--- a/packages/backend/src/routing/routing.controller.ts
+++ b/packages/backend/src/routing/routing.controller.ts
@@ -228,6 +228,7 @@ export class RoutingController {
       return {
         model_name: m.id,
         provider: m.provider,
+        auth_type: m.authType ?? 'api_key',
         input_price_per_token: m.inputPricePerToken,
         output_price_per_token: m.outputPricePerToken,
         context_window: m.contextWindow,

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -102,10 +102,7 @@ describe('RoutingService', () => {
 
       const result = await service.getTiers('a1');
 
-      // 2B: providers are now passed to avoid duplicate query
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1', [
-        { provider: 'openai', is_active: true },
-      ]);
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
       expect(result).toHaveLength(4);
       expect(result[0].auto_assigned_model).toBe('gpt-4o');
     });
@@ -165,7 +162,7 @@ describe('RoutingService', () => {
           }),
         ]),
       );
-      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1', []);
+      expect(mockAutoAssign.recalculate).toHaveBeenCalledWith('a1');
       expect(result).toEqual(recalculatedRows);
     });
 

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -184,7 +184,7 @@ export class RoutingService {
         removedProviders,
       );
       if (hadTierAssignments) {
-        await this.autoAssign.recalculate(agentId, usableProviders);
+        await this.autoAssign.recalculate(agentId);
       }
     }
     this.routingCache.invalidateAgent(agentId);
@@ -393,13 +393,12 @@ export class RoutingService {
       await this.tierRepo.insert(created);
 
       // If agent has active providers, recalculate immediately
-      // 2B: Pass providers to avoid duplicate query in recalculate()
       const providers = await this.providerRepo.find({
         where: { agent_id: agentId, is_active: true },
       });
       const usableProviders = providers.filter(isManifestUsableProvider);
       if (usableProviders.length > 0) {
-        await this.autoAssign.recalculate(agentId, usableProviders);
+        await this.autoAssign.recalculate(agentId);
         const result = await this.tierRepo.find({ where: { agent_id: agentId } });
         this.routingCache.setTiers(agentId, result);
         return result;

--- a/packages/backend/src/routing/tier-auto-assign.service.spec.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.spec.ts
@@ -29,21 +29,15 @@ function makeMockRepo() {
 describe('TierAutoAssignService', () => {
   let service: TierAutoAssignService;
   let mockDiscoveryService: { getModelsForAgent: jest.Mock };
-  let mockProviderRepo: ReturnType<typeof makeMockRepo>;
   let mockTierRepo: ReturnType<typeof makeMockRepo>;
 
   beforeEach(() => {
     mockDiscoveryService = {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
     };
-    mockProviderRepo = makeMockRepo();
     mockTierRepo = makeMockRepo();
 
-    service = new TierAutoAssignService(
-      mockDiscoveryService as never,
-      mockProviderRepo as never,
-      mockTierRepo as never,
-    );
+    service = new TierAutoAssignService(mockDiscoveryService as never, mockTierRepo as never);
   });
 
   describe('pickBest', () => {
@@ -379,9 +373,6 @@ describe('TierAutoAssignService', () => {
 
   describe('recalculate', () => {
     it('should assign a single model to all 4 tiers (one provider, one model)', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'openai', is_active: true, auth_type: 'api_key' },
-      ]);
       const model = makeModel({ id: 'gpt-4o', provider: 'OpenAI' });
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([model]);
       mockTierRepo.find.mockResolvedValue([]);
@@ -399,7 +390,6 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should set all auto_assigned_model to null with no models', async () => {
-      mockProviderRepo.find.mockResolvedValue([]);
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([]);
       mockTierRepo.find.mockResolvedValue([]);
 
@@ -416,9 +406,6 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should save all 4 existing tiers when they already exist', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'openai', is_active: true, auth_type: 'api_key' },
-      ]);
       const model = makeModel({ id: 'gpt-4o', provider: 'OpenAI' });
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([model]);
 
@@ -447,9 +434,6 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should set auto_assigned_model to null when pickBest returns null for existing tier', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'openai', is_active: true, auth_type: 'api_key' },
-      ]);
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([]);
 
       mockTierRepo.find.mockResolvedValue(
@@ -476,16 +460,13 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should prioritize subscription models over api_key models', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'anthropic', is_active: true, auth_type: 'subscription' },
-        { provider: 'google', is_active: true, auth_type: 'api_key' },
-      ]);
       const geminiFlash = makeModel({
         id: 'gemini-2.5-flash',
         provider: 'Google',
         inputPricePerToken: 0.0000001,
         outputPricePerToken: 0.0000004,
         qualityScore: 2,
+        authType: 'api_key',
       });
       const claudeSonnet = makeModel({
         id: 'claude-sonnet-4',
@@ -493,6 +474,7 @@ describe('TierAutoAssignService', () => {
         inputPricePerToken: 0.000003,
         outputPricePerToken: 0.000015,
         qualityScore: 4,
+        authType: 'subscription',
       });
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([geminiFlash, claudeSonnet]);
       mockTierRepo.find.mockResolvedValue([]);
@@ -511,13 +493,11 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should fall back to api_key models when no subscription models available', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'openai', is_active: true, auth_type: 'api_key' },
-      ]);
       const gpt4o = makeModel({
         id: 'gpt-4o',
         provider: 'OpenAI',
         qualityScore: 4,
+        authType: 'api_key',
       });
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([gpt4o]);
       mockTierRepo.find.mockResolvedValue([]);
@@ -535,16 +515,13 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should use subscription models even when api_key models are cheaper', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'anthropic', is_active: true, auth_type: 'subscription' },
-        { provider: 'openai', is_active: true, auth_type: 'api_key' },
-      ]);
       const cheapOpenAI = makeModel({
         id: 'gpt-4.1-nano',
         provider: 'OpenAI',
         inputPricePerToken: 0.0000001,
         outputPricePerToken: 0.0000003,
         qualityScore: 1,
+        authType: 'api_key',
       });
       const expensiveSub = makeModel({
         id: 'claude-sonnet-4',
@@ -552,6 +529,7 @@ describe('TierAutoAssignService', () => {
         inputPricePerToken: 0.000003,
         outputPricePerToken: 0.000015,
         qualityScore: 4,
+        authType: 'subscription',
       });
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([cheapOpenAI, expensiveSub]);
       mockTierRepo.find.mockResolvedValue([]);
@@ -568,17 +546,14 @@ describe('TierAutoAssignService', () => {
       }
     });
 
-    it('should match models to subscription providers via case-insensitive provider name', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'anthropic', is_active: true, auth_type: 'subscription' },
-        { provider: 'google', is_active: true, auth_type: 'subscription' },
-      ]);
+    it('should split models by authType field for subscription prioritization', async () => {
       const claude = makeModel({
         id: 'claude-sonnet-4',
         provider: 'Anthropic',
         inputPricePerToken: 0.000003,
         outputPricePerToken: 0.000015,
         qualityScore: 4,
+        authType: 'subscription',
       });
       const gemini = makeModel({
         id: 'gemini-2.5-flash',
@@ -586,6 +561,7 @@ describe('TierAutoAssignService', () => {
         inputPricePerToken: 0.0000001,
         outputPricePerToken: 0.0000004,
         qualityScore: 2,
+        authType: 'subscription',
       });
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([claude, gemini]);
       mockTierRepo.find.mockResolvedValue([]);
@@ -609,10 +585,7 @@ describe('TierAutoAssignService', () => {
       expect(complexTier!.auto_assigned_model).toBe('claude-sonnet-4');
     });
 
-    it('should NOT match OpenRouter models to subscription providers', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'anthropic', is_active: true, auth_type: 'subscription' },
-      ]);
+    it('should treat models without authType as api_key', async () => {
       const orModel = makeModel({
         id: 'anthropic/claude-sonnet-4',
         provider: 'OpenRouter',
@@ -635,11 +608,7 @@ describe('TierAutoAssignService', () => {
       }
     });
 
-    it('should assign null when no models match any provider', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'anthropic', is_active: true, auth_type: 'subscription' },
-      ]);
-      // No models returned by discovery
+    it('should assign null when no models available', async () => {
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([]);
       mockTierRepo.find.mockResolvedValue([]);
 
@@ -654,14 +623,12 @@ describe('TierAutoAssignService', () => {
       }
     });
 
-    it('should match OpenRouter models as api_key (lowercase match)', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'openrouter', is_active: true, auth_type: 'api_key' },
-      ]);
+    it('should treat models with api_key authType as non-subscription', async () => {
       const orModel = makeModel({
         id: 'anthropic/claude-sonnet-4',
         provider: 'OpenRouter',
         qualityScore: 4,
+        authType: 'api_key',
       });
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([orModel]);
       mockTierRepo.find.mockResolvedValue([]);
@@ -678,9 +645,6 @@ describe('TierAutoAssignService', () => {
     });
 
     it('should preserve manual overrides during recalculation', async () => {
-      mockProviderRepo.find.mockResolvedValue([
-        { provider: 'openai', is_active: true, auth_type: 'api_key' },
-      ]);
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([
         makeModel({ id: 'gpt-4o', provider: 'OpenAI' }),
       ]);
@@ -711,18 +675,32 @@ describe('TierAutoAssignService', () => {
       );
     });
 
-    it('should accept optional providers parameter to skip DB query', async () => {
-      const providers = [{ provider: 'openai', is_active: true, auth_type: 'api_key' }];
-      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
-        makeModel({ id: 'gpt-4o', provider: 'OpenAI' }),
-      ]);
+    it('should use authType field from models to separate subscription and api_key', async () => {
+      const subModel = makeModel({
+        id: 'claude-sonnet-4',
+        provider: 'Anthropic',
+        qualityScore: 4,
+        authType: 'subscription',
+      });
+      const keyModel = makeModel({
+        id: 'gpt-4o',
+        provider: 'OpenAI',
+        qualityScore: 3,
+        authType: 'api_key',
+      });
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([subModel, keyModel]);
       mockTierRepo.find.mockResolvedValue([]);
 
-      await service.recalculate('agent-1', providers as never[]);
+      await service.recalculate('agent-1');
 
-      // Should not query providers from DB
-      expect(mockProviderRepo.find).not.toHaveBeenCalled();
       expect(mockTierRepo.insert).toHaveBeenCalledTimes(1);
+      const inserted = mockTierRepo.insert.mock.calls[0][0] as {
+        auto_assigned_model: string;
+      }[];
+      // Subscription models are prioritized — claude-sonnet-4 should win all tiers
+      for (const record of inserted) {
+        expect(record.auto_assigned_model).toBe('claude-sonnet-4');
+      }
     });
   });
 });

--- a/packages/backend/src/routing/tier-auto-assign.service.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UserProvider } from '../entities/user-provider.entity';
 import { TierAssignment } from '../entities/tier-assignment.entity';
 import { ModelDiscoveryService } from './model-discovery/model-discovery.service';
 import { DiscoveredModel } from './model-discovery/model-fetcher';
@@ -19,28 +18,16 @@ export class TierAutoAssignService {
 
   constructor(
     private readonly discoveryService: ModelDiscoveryService,
-    @InjectRepository(UserProvider)
-    private readonly providerRepo: Repository<UserProvider>,
     @InjectRepository(TierAssignment)
     private readonly tierRepo: Repository<TierAssignment>,
   ) {}
 
-  async recalculate(agentId: string, _providers?: UserProvider[]): Promise<void> {
+  async recalculate(agentId: string): Promise<void> {
     const allModels = await this.discoveryService.getModelsForAgent(agentId);
 
-    // Separate subscription vs API key models by checking provider records
-    const providers =
-      _providers ??
-      (await this.providerRepo.find({
-        where: { agent_id: agentId, is_active: true },
-      }));
-
-    const subProviders = new Set(
-      providers.filter((p) => p.auth_type === 'subscription').map((p) => p.provider.toLowerCase()),
-    );
-
-    const subModels = allModels.filter((m) => subProviders.has(m.provider.toLowerCase()));
-    const keyModels = allModels.filter((m) => !subProviders.has(m.provider.toLowerCase()));
+    // Separate subscription vs API key models using the authType field on each model
+    const subModels = allModels.filter((m) => m.authType === 'subscription');
+    const keyModels = allModels.filter((m) => m.authType !== 'subscription');
 
     // Batch read all tiers in one query
     const allTiers = await this.tierRepo.find({ where: { agent_id: agentId } });

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -498,6 +498,7 @@ export function clearFallbacks(agentName: string, tier: string) {
 export interface AvailableModel {
   model_name: string;
   provider: string;
+  auth_type?: AuthType;
   input_price_per_token: number | null;
   output_price_per_token: number | null;
   context_window: number;

--- a/packages/subscription-capabilities/index.d.ts
+++ b/packages/subscription-capabilities/index.d.ts
@@ -1,9 +1,17 @@
+export interface SubscriptionCapabilities {
+  maxContextWindow: number;
+  supportsPromptCaching: boolean;
+  supportsBatching: boolean;
+}
+
 export interface SubscriptionProviderConfig {
   supportsSubscription: true;
   subscriptionLabel: string;
   subscriptionKeyPlaceholder: string;
   subscriptionCommand?: string;
   subscriptionTokenPrefix?: string;
+  knownModels?: readonly string[];
+  subscriptionCapabilities?: Readonly<SubscriptionCapabilities>;
 }
 
 export declare const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
@@ -17,3 +25,11 @@ export declare function getSubscriptionProviderConfig(
 ): Readonly<SubscriptionProviderConfig> | null;
 
 export declare function supportsSubscriptionProvider(providerId: string): boolean;
+
+export declare function getSubscriptionKnownModels(
+  providerId: string,
+): readonly string[] | null;
+
+export declare function getSubscriptionCapabilities(
+  providerId: string,
+): Readonly<SubscriptionCapabilities> | null;

--- a/packages/subscription-capabilities/index.js
+++ b/packages/subscription-capabilities/index.js
@@ -5,6 +5,12 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
     subscriptionKeyPlaceholder: 'Paste your setup-token',
     subscriptionCommand: 'claude setup-token',
     subscriptionTokenPrefix: 'sk-ant-oat',
+    knownModels: Object.freeze(['claude-opus-4', 'claude-sonnet-4', 'claude-haiku-4']),
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
   }),
 });
 
@@ -24,9 +30,21 @@ function supportsSubscriptionProvider(providerId) {
   return getSubscriptionProviderConfig(providerId) !== null;
 }
 
+function getSubscriptionKnownModels(providerId) {
+  const config = getSubscriptionProviderConfig(providerId);
+  return config?.knownModels ?? null;
+}
+
+function getSubscriptionCapabilities(providerId) {
+  const config = getSubscriptionProviderConfig(providerId);
+  return config?.subscriptionCapabilities ?? null;
+}
+
 module.exports = {
   SUBSCRIPTION_PROVIDER_CONFIGS,
   SUPPORTED_SUBSCRIPTION_PROVIDER_IDS,
   getSubscriptionProviderConfig,
   supportsSubscriptionProvider,
+  getSubscriptionKnownModels,
+  getSubscriptionCapabilities,
 };


### PR DESCRIPTION
## Summary

- Subscription providers registered via the OpenClaw plugin previously had `cached_models: null`, contributing zero models to routing/tier assignment
- Added `knownModels` prefixes and `subscriptionCapabilities` to subscription-capabilities config (Anthropic as first provider)
- Added `authType` field to `DiscoveredModel` interface to distinguish subscription vs API key models
- When a subscription provider has no token, builds curated fallback models from the OpenRouter pricing cache filtered by known model prefixes
- Auth-type-aware deduplication: subscription models replace API key duplicates for the same model ID
- Simplified tier assignment to use `authType` directly from each model instead of querying provider records
- Exposed `auth_type` on the available-models API response and frontend type
- Extracted pricing lookup/fallback helpers into `model-fallback.ts` to keep service under 300 lines

## Test plan

- [ ] Backend unit tests pass (`npm test --workspace=packages/backend`) — 15 new tests added
- [ ] Backend E2E tests pass (`npm run test:e2e --workspace=packages/backend`)
- [ ] Frontend tests pass (`npm test --workspace=packages/frontend`)
- [ ] TypeScript compiles with no errors in both backend and frontend
- [ ] Register subscription provider via plugin (no token) → fallback models appear in available-models
- [ ] Connect Anthropic with subscription token → live models override fallback
- [ ] Both API key + subscription connected → subscription models preferred in tier assignment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds subscription model discovery with curated fallbacks and auth-type-aware dedup so subscription providers contribute models even without tokens. Also exposes `auth_type` in the available-models API and prefers subscription models in tier auto-assign.

- **New Features**
  - Added `authType` on `DiscoveredModel` and expose `auth_type` in available-models and frontend `AvailableModel`.
  - Curated subscription fallback when no token: builds models from OpenRouter pricing filtered by known prefixes (Anthropic first).
  - Deduplication prefers subscription models over API key duplicates for the same model ID.
  - Added `knownModels` and `subscriptionCapabilities` to `subscription-capabilities` (Anthropic caps context window to 200k).
  - Extracted helpers in `model-fallback.ts`: `buildSubscriptionFallbackModels`, `buildFallbackModels`, `findOpenRouterPrefix`, `lookupWithVariants`.

- **Refactors**
  - Simplified tier auto-assign to split by `authType` instead of querying provider records; removed providers arg from `recalculate`.
  - In model discovery, enrich models with pricing via extracted helpers; subscription providers without tokens skip native fetch and use curated fallback.
  - `getModelsForAgent` now prefers subscription versions on ID match and falls back to the provider’s `auth_type` when a cached model lacks `authType` (ensures legacy subscription models override API key duplicates).

<sup>Written for commit 31ee5557058e6e8f101c529c9608b78cea54530a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

