### PR TITLE
fix: sync openclaw.plugin.json version with package.json

### DIFF
--- a/.changeset/sync-plugin-version.md
+++ b/.changeset/sync-plugin-version.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Sync openclaw.plugin.json version with package.json automatically during changeset version bumps

--- a/package-lock.json
+++ b/package-lock.json
@@ -14240,7 +14240,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "manifest",
-      "version": "5.25.4",
+      "version": "5.26.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint": "eslint packages/backend/src packages/frontend/src packages/openclaw-plugin/src",
     "format": "prettier --write 'packages/*/src/**/*.{ts,tsx,css}'",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && node scripts/sync-plugin-version.js",
     "release": "changeset publish",
     "prepare": "husky"
   },

--- a/packages/openclaw-plugin/__tests__/build.test.ts
+++ b/packages/openclaw-plugin/__tests__/build.test.ts
@@ -237,4 +237,11 @@ describe("build configuration", () => {
     expect(buildContent).toContain("./server");
     expect(buildContent).toMatch(/external.*\.\/server/);
   });
+
+  it("openclaw.plugin.json version matches package.json version", () => {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    const pluginJsonPath = resolve(__dirname, "../openclaw.plugin.json");
+    const pluginJson = JSON.parse(readFileSync(pluginJsonPath, "utf-8"));
+    expect(pluginJson.version).toBe(pkg.version);
+  });
 });

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "manifest",
   "kind": "observability",
   "name": "Manifest — Agent Observability",
-  "version": "5.9.7",
+  "version": "5.26.0",
   "description": "Traces, metrics, and cost tracking for your OpenClaw agent. Zero-config local dashboard included.",
   "author": "MNFST Inc.",
   "homepage": "https://manifest.build",

--- a/scripts/sync-plugin-version.js
+++ b/scripts/sync-plugin-version.js
@@ -1,0 +1,16 @@
+const { readFileSync, writeFileSync } = require('fs');
+const { join } = require('path');
+
+const pkgPath = join(__dirname, '..', 'packages', 'openclaw-plugin', 'package.json');
+const pluginJsonPath = join(__dirname, '..', 'packages', 'openclaw-plugin', 'openclaw.plugin.json');
+
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+const pluginJson = JSON.parse(readFileSync(pluginJsonPath, 'utf-8'));
+
+if (pluginJson.version !== pkg.version) {
+  pluginJson.version = pkg.version;
+  writeFileSync(pluginJsonPath, JSON.stringify(pluginJson, null, 2) + '\n');
+  console.log(`Synced openclaw.plugin.json version to ${pkg.version}`);
+} else {
+  console.log(`openclaw.plugin.json version already in sync (${pkg.version})`);
+}


### PR DESCRIPTION
## Summary

- Fix stale version in `openclaw.plugin.json` (`5.9.7` → `5.26.0`) to match `package.json`
- Add `scripts/sync-plugin-version.js` that auto-syncs the version during `changeset version`
- Add a test to catch future version drift between the two files

Closes #1147

## Test plan

- [x] `node scripts/sync-plugin-version.js` prints "already in sync"
- [x] `npm test --workspace=packages/openclaw-plugin` passes (344 tests, 100% line coverage)
- [x] Manually setting a wrong version in `openclaw.plugin.json` causes the new test to fail
- [x] Running the sync script after a mismatch fixes it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale version in `openclaw.plugin.json` and adds automation to keep it aligned with `package.json`. Prevents future mismatches during releases.

- **Bug Fixes**
  - Updated `openclaw.plugin.json` version from `5.9.7` to `5.26.0` to match `package.json`.
  - Added `scripts/sync-plugin-version.js` and wired it to run after `changeset version`.
  - Added a test to fail when the manifest version drifts from `package.json`.

<sup>Written for commit d9e34c2abdb530498672cd16e4cdbd0146148402. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

