### PR TITLE
Replace password inputs with masked text inputs for API keys

### DIFF
--- a/.changeset/fix-token-autosave.md
+++ b/.changeset/fix-token-autosave.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Prevent browser password save prompt on API key and token inputs by using CSS text-security masking instead of type="password"

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -234,9 +234,9 @@ const CustomProviderForm: Component<Props> = (props) => {
           <Show when={!isEdit() || editingKey()}>
             <input
               id="cp-api-key"
-              class="provider-detail__input"
-              type="password"
-              autocomplete="new-password"
+              class="provider-detail__input provider-detail__input--masked"
+              type="text"
+              autocomplete="off"
               placeholder="sk-..."
               value={apiKey()}
               onInput={(e) => setApiKey(e.currentTarget.value)}

--- a/packages/frontend/src/components/EmailProviderModal.tsx
+++ b/packages/frontend/src/components/EmailProviderModal.tsx
@@ -332,8 +332,9 @@ const EmailProviderModal: Component<Props> = (props) => {
               <input
                 class="modal-card__input"
                 classList={{ 'modal-card__input--error': !!keyError() }}
-                type="password"
-                autocomplete="new-password"
+                type="text"
+                autocomplete="off"
+                style="-webkit-text-security: disc; text-security: disc;"
                 placeholder={keyPlaceholder()}
                 value={apiKey()}
                 onInput={(e) => {

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -663,9 +663,12 @@ const ProviderSelectModal: Component<Props> = (props) => {
                       <label class="provider-detail__label">{fieldLabel()}</label>
                       <input
                         class="provider-detail__input"
-                        classList={{ 'provider-detail__input--error': !!validationError() }}
-                        type="password"
-                        autocomplete="new-password"
+                        classList={{
+                          'provider-detail__input--error': !!validationError(),
+                          'provider-detail__input--masked': true,
+                        }}
+                        type="text"
+                        autocomplete="off"
                         placeholder={placeholder()}
                         aria-label={inputAriaLabel()}
                         value={keyInput()}
@@ -761,9 +764,12 @@ const ProviderSelectModal: Component<Props> = (props) => {
                       <Show when={editing()}>
                         <input
                           class="provider-detail__input"
-                          classList={{ 'provider-detail__input--error': !!validationError() }}
-                          type="password"
-                          autocomplete="new-password"
+                          classList={{
+                            'provider-detail__input--error': !!validationError(),
+                            'provider-detail__input--masked': true,
+                          }}
+                          type="text"
+                          autocomplete="off"
                           placeholder={placeholder()}
                           aria-label={editAriaLabel()}
                           value={keyInput()}

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -323,6 +323,11 @@
   color: hsl(var(--muted-foreground) / 0.6);
 }
 
+.provider-detail__input--masked {
+  -webkit-text-security: disc;
+  text-security: disc;
+}
+
 .provider-detail__input--disabled {
   opacity: 0.7;
   font-family: var(--font-mono, monospace);

--- a/packages/frontend/tests/components/EmailProviderModal.test.tsx
+++ b/packages/frontend/tests/components/EmailProviderModal.test.tsx
@@ -84,9 +84,9 @@ describe("EmailProviderModal", () => {
     expect(link.getAttribute("target")).toBe("_blank");
   });
 
-  it("shows password input for API key in create mode", () => {
+  it("shows masked input for API key in create mode", () => {
     render(() => <EmailProviderModal {...defaultProps} />);
-    expect(q('input[type="password"]')).not.toBeNull();
+    expect(q('input[autocomplete="off"]')).not.toBeNull();
   });
 
   it("shows Notification email field", () => {
@@ -117,7 +117,7 @@ describe("EmailProviderModal", () => {
 
   it("buttons become enabled when API key is entered", async () => {
     render(() => <EmailProviderModal {...defaultProps} />);
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "re_testkey12345" } });
     await vi.waitFor(() => {
       const primaryBtn = q(".btn--primary") as HTMLButtonElement;
@@ -148,7 +148,7 @@ describe("EmailProviderModal", () => {
 
   it("calls onClose on Escape key", () => {
     render(() => <EmailProviderModal {...defaultProps} />);
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.keyDown(input, { key: "Escape" });
     expect(defaultProps.onClose).toHaveBeenCalled();
   });
@@ -170,20 +170,20 @@ describe("EmailProviderModal", () => {
     expect(screen.getByText("Change")).toBeDefined();
   });
 
-  it("does not show password input when masked key is displayed", () => {
+  it("does not show editable input when masked key is displayed", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} editMode={true} existingKeyPrefix="re_abc12" />
     ));
-    expect(q('input[type="password"]')).toBeNull();
+    expect(q('input[autocomplete="off"]')).toBeNull();
   });
 
-  it("shows password input after clicking Change", async () => {
+  it("shows editable input after clicking Change", async () => {
     render(() => (
       <EmailProviderModal {...defaultProps} editMode={true} existingKeyPrefix="re_abc12" />
     ));
     fireEvent.click(screen.getByText("Change"));
     await vi.waitFor(() => {
-      expect(q('input[type="password"]')).not.toBeNull();
+      expect(q('input[autocomplete="off"]')).not.toBeNull();
     });
   });
 
@@ -215,7 +215,7 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} />
     ));
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "re_testkey12345" } });
     const testBtn = screen.getByText("Send test email");
     fireEvent.click(testBtn);
@@ -247,7 +247,7 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} />
     ));
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "re_testkey12345" } });
     const saveBtn = screen.getByText("Test & Connect");
     fireEvent.click(saveBtn);
@@ -282,7 +282,7 @@ describe("EmailProviderModal", () => {
     });
   });
 
-  it("shows empty password input after switching to different provider", async () => {
+  it("shows empty input after switching to different provider", async () => {
     render(() => (
       <EmailProviderModal
         {...defaultProps}
@@ -296,7 +296,7 @@ describe("EmailProviderModal", () => {
     fireEvent.click(screen.getByText("SendGrid"));
 
     await vi.waitFor(() => {
-      const input = q('input[type="password"]') as HTMLInputElement;
+      const input = q('input[autocomplete="off"]') as HTMLInputElement;
       expect(input).not.toBeNull();
       expect(input.value).toBe("");
     });
@@ -363,9 +363,9 @@ describe("EmailProviderModal", () => {
     // Switch to SendGrid and enter a new key
     fireEvent.click(screen.getByText("SendGrid"));
     await vi.waitFor(() => {
-      expect(q('input[type="password"]')).not.toBeNull();
+      expect(q('input[autocomplete="off"]')).not.toBeNull();
     });
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "SG.newkeyhere12345" } });
 
     fireEvent.click(screen.getByText("Send test email"));
@@ -390,9 +390,9 @@ describe("EmailProviderModal", () => {
     // Switch to SendGrid and enter a new key
     fireEvent.click(screen.getByText("SendGrid"));
     await vi.waitFor(() => {
-      expect(q('input[type="password"]')).not.toBeNull();
+      expect(q('input[autocomplete="off"]')).not.toBeNull();
     });
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "SG.newkeyhere12345" } });
 
     fireEvent.click(screen.getByText("Test & Save"));
@@ -416,14 +416,14 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} initialProvider="mailgun" existingDomain="mg.example.com" />
     ));
-    const domainInput = q('input[type="text"]') as HTMLInputElement;
+    const domainInput = q('input[placeholder*="notifications"]') as HTMLInputElement;
     expect(domainInput.value).toBe("mg.example.com");
   });
 
   it("shows validation error for empty API key on save attempt", async () => {
     render(() => <EmailProviderModal {...defaultProps} />);
     // Enter short key to trigger validation
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "short" } });
     const saveBtn = q(".btn--primary")!;
     fireEvent.click(saveBtn);
@@ -434,7 +434,7 @@ describe("EmailProviderModal", () => {
 
   it("shows validation error for invalid Resend key prefix", async () => {
     render(() => <EmailProviderModal {...defaultProps} />);
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "wrong_prefix_key" } });
     const saveBtn = q(".btn--primary")!;
     fireEvent.click(saveBtn);
@@ -447,7 +447,7 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} initialProvider="sendgrid" />
     ));
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "wrong_prefix_key" } });
     const saveBtn = q(".btn--primary")!;
     fireEvent.click(saveBtn);
@@ -468,9 +468,9 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} initialProvider="mailgun" />
     ));
-    const keyInput = q('input[type="password"]')!;
+    const keyInput = q('input[autocomplete="off"]')!;
     fireEvent.input(keyInput, { target: { value: "key-abcdefgh" } });
-    const domainInput = q('input[type="text"]')!;
+    const domainInput = q('input[placeholder*="notifications"]')!;
     fireEvent.input(domainInput, { target: { value: "invalid domain!" } });
     const saveBtn = q(".btn--primary")!;
     fireEvent.click(saveBtn);
@@ -483,11 +483,11 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} initialProvider="mailgun" />
     ));
-    const keyInput = q('input[type="password"]')!;
+    const keyInput = q('input[autocomplete="off"]')!;
     fireEvent.input(keyInput, { target: { value: "key-abcdefgh" } });
     // Enter a domain then clear it to bypass the disabled state,
     // or trigger validation via Enter key which bypasses disabled check
-    const domainInput = q('input[type="text"]')!;
+    const domainInput = q('input[placeholder*="notifications"]')!;
     fireEvent.input(domainInput, { target: { value: "d" } });
     fireEvent.input(domainInput, { target: { value: "" } });
     // Use Enter key to trigger handleSave (which calls validateFields)
@@ -505,9 +505,9 @@ describe("EmailProviderModal", () => {
     // Switch to resend -- domain value persists internally but input is hidden
     fireEvent.click(screen.getByText("Resend"));
     await vi.waitFor(() => {
-      expect(q('input[type="password"]')).not.toBeNull();
+      expect(q('input[autocomplete="off"]')).not.toBeNull();
     });
-    const keyInput = q('input[type="password"]')!;
+    const keyInput = q('input[autocomplete="off"]')!;
     fireEvent.input(keyInput, { target: { value: "re_abcdefghij" } });
     // Trigger validation via Enter key -- should fail validation silently (domain error set but hidden)
     fireEvent.keyDown(keyInput, { key: "Enter" });
@@ -522,7 +522,7 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} />
     ));
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "re_testkey12345" } });
     const testBtn = screen.getByText("Send test email");
     fireEvent.click(testBtn);
@@ -536,7 +536,7 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} />
     ));
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "re_testkey12345" } });
     const testBtn = screen.getByText("Send test email");
     fireEvent.click(testBtn);
@@ -552,7 +552,7 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} />
     ));
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "re_testkey12345" } });
     const saveBtn = q(".btn--primary")!;
     fireEvent.click(saveBtn);
@@ -564,7 +564,7 @@ describe("EmailProviderModal", () => {
 
   it("triggers Enter key to save", async () => {
     render(() => <EmailProviderModal {...defaultProps} />);
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "re_testkey12345" } });
     fireEvent.keyDown(input, { key: "Enter" });
     // handleSave is called, validation passes, then testEmailProvider runs async
@@ -577,14 +577,14 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} initialProvider="mailgun" />
     ));
-    const input = q('input[type="password"]') as HTMLInputElement;
+    const input = q('input[autocomplete="off"]') as HTMLInputElement;
     expect(input.placeholder).toBe("key-xxxx...");
   });
 
   it("shows API key required error when submitting with empty key", async () => {
     render(() => <EmailProviderModal {...defaultProps} />);
     // Use Enter key to bypass disabled button
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.keyDown(input, { key: "Enter" });
     await vi.waitFor(() => {
       expect(document.body.textContent).toContain("API key is required");
@@ -595,9 +595,9 @@ describe("EmailProviderModal", () => {
     render(() => (
       <EmailProviderModal {...defaultProps} initialProvider="mailgun" />
     ));
-    const keyInput = q('input[type="password"]')!;
+    const keyInput = q('input[autocomplete="off"]')!;
     fireEvent.input(keyInput, { target: { value: "key-abcdefgh" } });
-    const domainInput = q('input[type="text"]')!;
+    const domainInput = q('input[placeholder*="notifications"]')!;
     fireEvent.input(domainInput, { target: { value: "mg.example.com" } });
     const saveBtn = q(".btn--primary")!;
     fireEvent.click(saveBtn);
@@ -666,7 +666,7 @@ describe("EmailProviderModal", () => {
     mockUserEmail = null;
     const { toast } = await import("../../src/services/toast-store.js");
     render(() => <EmailProviderModal {...defaultProps} />);
-    const input = q('input[type="password"]')!;
+    const input = q('input[autocomplete="off"]')!;
     fireEvent.input(input, { target: { value: "re_testkey12345" } });
     // Clear notification email (should be empty since session has no email)
     const emailInput = q('input[type="email"]') as HTMLInputElement;

--- a/packages/frontend/tests/components/EmailProviderSetup.test.tsx
+++ b/packages/frontend/tests/components/EmailProviderSetup.test.tsx
@@ -112,7 +112,7 @@ describe("EmailProviderSetup", () => {
       expect(document.querySelector(".modal-overlay")).not.toBeNull();
     });
     // Enter API key
-    const keyInput = document.querySelector('input[type="password"]')!;
+    const keyInput = document.querySelector('input[autocomplete="off"]')!;
     fireEvent.input(keyInput, { target: { value: "re_testkey12345" } });
     // Click Test & Save
     const saveBtn = document.querySelector(".btn--primary")!;

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -445,7 +445,7 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("OpenAI"));
       fireEvent.click(screen.getByText("Change"));
 
-      // Edit mode shows a password input and Save button
+      // Edit mode shows a masked input and Save button
       expect(screen.getByLabelText("New OpenAI API key")).toBeDefined();
       expect(screen.getByText("Save")).toBeDefined();
     });


### PR DESCRIPTION
## Summary
This PR replaces `type="password"` inputs with `type="text"` inputs that use CSS text-security masking for API key and token fields. This prevents browsers from triggering password save/autofill prompts on sensitive credential inputs while maintaining visual masking of the entered values.

## Key Changes
- **EmailProviderModal**: Changed API key input from `type="password"` with `autocomplete="new-password"` to `type="text"` with `autocomplete="off"` and CSS text-security styling
- **ProviderSelectModal**: Updated both API key input fields to use masked text inputs instead of password inputs, added `provider-detail__input--masked` class
- **CustomProviderForm**: Changed API key input to use masked text styling with `type="text"` and `autocomplete="off"`
- **Styling**: Added `.provider-detail__input--masked` CSS class with `-webkit-text-security: disc` and `text-security: disc` properties for cross-browser compatibility
- **Tests**: Updated all test selectors from `input[type="password"]` to `input[autocomplete="off"]` and `input[placeholder*="notifications"]` to match the new input structure

## Implementation Details
- Uses CSS `text-security` property (with `-webkit-` prefix for Safari) to visually mask input characters as dots, similar to password fields
- Sets `autocomplete="off"` to prevent browser credential managers from treating these as password fields
- Maintains the same visual appearance and user experience while avoiding unwanted browser autofill behavior
- Added changeset documenting the fix to prevent browser password save prompts

https://claude.ai/code/session_01AEKJRNDqBHCpjcagyi3UYV

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop password manager prompts on API key/token fields by switching from password inputs to masked text inputs. The fields still look masked but no longer trigger save/autofill banners.

- **Bug Fixes**
  - Replaced password inputs with masked text inputs in EmailProviderModal, ProviderSelectModal, and CustomProviderForm.
  - Added `provider-detail__input--masked` with `-webkit-text-security`/`text-security: disc` and `autocomplete="off"`; EmailProviderModal uses inline masking.
  - Updated tests/selectors to target masked inputs (including EmailProviderSetup); no UI or workflow changes.

<sup>Written for commit 22c8cd08c718f6718a86bb2a9b9bf9513343941e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

