### PR TITLE
fix: use backend URL as OAuth redirect_uri in production

### DIFF
--- a/.changeset/fix-oauth-redirect-prod.md
+++ b/.changeset/fix-oauth-redirect-prod.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix OpenAI OAuth callback to use backend URL in production instead of hardcoded localhost:1455

--- a/packages/backend/src/routing/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.ts
@@ -79,6 +79,38 @@ export class OpenaiOauthController {
   }
 
   /**
+   * OAuth callback endpoint for production deployments.
+   * OpenAI redirects here with ?code=...&state=... after user authorizes.
+   * Exchanges the code for tokens, then serves the done page.
+   */
+  @Get('callback')
+  @Public()
+  async callback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Query('error') error: string,
+    @Query('error_description') errorDesc: string,
+    @Res() res: Response,
+  ) {
+    res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Content-Security-Policy', "default-src 'none'; script-src 'unsafe-inline'");
+
+    if (error) {
+      this.logger.error(`OAuth callback error: ${errorDesc || error}`);
+      res.send(oauthDoneHtml(false));
+      return;
+    }
+
+    try {
+      await this.oauthService.exchangeCode(state, code);
+      res.send(oauthDoneHtml(true));
+    } catch (err) {
+      this.logger.error(`OAuth callback exchange failed: ${err}`);
+      res.send(oauthDoneHtml(false));
+    }
+  }
+
+  /**
    * Completion page served on the main backend's origin.
    * The port-1455 callback server redirects here after token exchange
    * so that postMessage reaches the opener (same origin).

--- a/packages/backend/src/routing/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.ts
@@ -97,6 +97,7 @@ export class OpenaiOauthController {
 
     if (error) {
       this.logger.error(`OAuth callback error: ${errorDesc || error}`);
+      if (state) this.oauthService.clearPendingState(state);
       res.send(oauthDoneHtml(false));
       return;
     }

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -575,26 +575,41 @@ describe('OpenaiOauthService', () => {
       expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
     });
 
-    it('callback server redirects to backendUrl on success when set', async () => {
-      let requestHandler: (req: unknown, res: unknown) => void;
-      createServerMock.mockImplementationOnce((handler: (req: unknown, res: unknown) => void) => {
-        requestHandler = handler;
-        return {
-          listen: jest.fn((_p: number, _h: string, cb?: () => void) => cb?.()),
-          close: jest.fn(),
-          on: jest.fn(),
-          unref: jest.fn(),
-        };
-      });
+    it('uses backend URL as redirect_uri when backendUrl is provided (no ephemeral server)', async () => {
+      createServerMock.mockClear();
 
+      const url = await service.generateAuthorizationUrl(
+        'agent-1',
+        'user-1',
+        'https://app.manifest.build',
+      );
+
+      // Should use backend URL, not localhost:1455
+      expect(url).toContain(
+        `redirect_uri=${encodeURIComponent('https://app.manifest.build/api/v1/oauth/openai/callback')}`,
+      );
+      // Should NOT start a callback server
+      expect(createServerMock).not.toHaveBeenCalled();
+    });
+
+    it('uses localhost:1455 redirect_uri when no backendUrl (local mode)', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (service as any).callbackServer = null;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (service as any).serverReady = null;
+
+      const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
+
+      expect(url).toContain(
+        `redirect_uri=${encodeURIComponent('http://localhost:1455/auth/callback')}`,
+      );
+    });
+
+    it('exchanges code with matching redirect_uri from pending state', async () => {
       const url = await service.generateAuthorizationUrl(
         'agent-1',
         'user-1',
-        'http://localhost:34379',
+        'https://app.manifest.build',
       );
       const state = new URL(url).searchParams.get('state')!;
 
@@ -607,17 +622,16 @@ describe('OpenaiOauthService', () => {
         }),
       });
 
-      const res = { writeHead: jest.fn(), end: jest.fn() };
-      requestHandler!({ url: `/auth/callback?code=the-code&state=${state}` }, res);
+      await service.exchangeCode(state, 'auth-code');
 
-      await new Promise((r) => setTimeout(r, 50));
-      expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: 'http://localhost:34379/api/v1/oauth/openai/done?ok=1',
-      });
-      expect(res.end).toHaveBeenCalled();
+      // Token exchange should use the same redirect_uri as the authorize request
+      const body = fetchMock.mock.calls[0][1].body as URLSearchParams;
+      expect(body.get('redirect_uri')).toBe(
+        'https://app.manifest.build/api/v1/oauth/openai/callback',
+      );
     });
 
-    it('callback server redirects to backendUrl on failure when set', async () => {
+    it('callback server redirects to backendUrl on failure when set (local mode)', async () => {
       let requestHandler: (req: unknown, res: unknown) => void;
       createServerMock.mockImplementationOnce((handler: (req: unknown, res: unknown) => void) => {
         requestHandler = handler;
@@ -633,11 +647,8 @@ describe('OpenaiOauthService', () => {
       (service as any).callbackServer = null;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (service as any).serverReady = null;
-      const url = await service.generateAuthorizationUrl(
-        'agent-1',
-        'user-1',
-        'http://localhost:34379',
-      );
+      // No backendUrl → local mode → ephemeral server started
+      const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
       const state = new URL(url).searchParams.get('state')!;
 
       fetchMock.mockResolvedValueOnce({
@@ -649,9 +660,9 @@ describe('OpenaiOauthService', () => {
       requestHandler!({ url: `/auth/callback?code=code&state=${state}` }, res);
 
       await new Promise((r) => setTimeout(r, 50));
-      expect(res.writeHead).toHaveBeenCalledWith(302, {
-        Location: 'http://localhost:34379/api/v1/oauth/openai/done?ok=0',
-      });
+      // No backendUrl → inline error HTML, not a redirect
+      expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+      expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
     });
   });
 });

--- a/packages/backend/src/routing/openai-oauth.service.ts
+++ b/packages/backend/src/routing/openai-oauth.service.ts
@@ -238,6 +238,11 @@ export class OpenaiOauthService {
     return this.pending.size;
   }
 
+  /** Remove a pending OAuth state (e.g., when the provider returns an error). */
+  clearPendingState(state: string): void {
+    this.pending.delete(state);
+  }
+
   /**
    * Spins up a tiny HTTP server on port 1455 to receive the OAuth callback.
    * OpenAI's registered redirect_uri for this client_id is

--- a/packages/backend/src/routing/openai-oauth.service.ts
+++ b/packages/backend/src/routing/openai-oauth.service.ts
@@ -14,7 +14,8 @@ const TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const REVOKE_URL = 'https://auth.openai.com/oauth/revoke';
 const SCOPE = 'openid profile email offline_access';
 const CALLBACK_PORT = 1455;
-const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/auth/callback`;
+const LOCAL_REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/auth/callback`;
+const CALLBACK_PATH = '/api/v1/oauth/openai/callback';
 const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 @Injectable()
@@ -50,19 +51,26 @@ export class OpenaiOauthService {
     const verifier = randomBytes(32).toString('base64url');
     const challenge = createHash('sha256').update(verifier).digest('base64url');
 
+    // In production (backendUrl provided), the callback goes to the backend itself.
+    // In local mode (no backendUrl), an ephemeral server on port 1455 handles it.
+    const redirectUri = backendUrl ? `${backendUrl}${CALLBACK_PATH}` : LOCAL_REDIRECT_URI;
+
     this.pending.set(state, {
       verifier,
       agentId,
       userId,
       backendUrl: backendUrl ?? '',
+      redirectUri,
       expiresAt: Date.now() + STATE_TTL_MS,
     });
 
-    await this.ensureCallbackServer();
+    if (!backendUrl) {
+      await this.ensureCallbackServer();
+    }
 
     const params = new URLSearchParams({
       client_id: this.clientId,
-      redirect_uri: REDIRECT_URI,
+      redirect_uri: redirectUri,
       response_type: 'code',
       scope: SCOPE,
       state,
@@ -89,7 +97,7 @@ export class OpenaiOauthService {
       body: new URLSearchParams({
         grant_type: 'authorization_code',
         code,
-        redirect_uri: REDIRECT_URI,
+        redirect_uri: pending.redirectUri,
         client_id: this.clientId,
         code_verifier: pending.verifier,
       }),

--- a/packages/backend/src/routing/openai-oauth.types.ts
+++ b/packages/backend/src/routing/openai-oauth.types.ts
@@ -3,6 +3,7 @@ export interface PendingOAuth {
   agentId: string;
   userId: string;
   backendUrl: string;
+  redirectUri: string;
   expiresAt: number;
 }
 


### PR DESCRIPTION
## Summary
- The OpenAI OAuth callback was hardcoded to `localhost:1455`, which only works for local CLI usage
- In production (app.manifest.build), the callback now routes through the backend itself at `/api/v1/oauth/openai/callback`
- Falls back to the ephemeral `localhost:1455` server only in local mode (no `backendUrl`)

## Test plan
- [ ] Verify OpenAI OAuth flow works on app.manifest.build (callback redirects to backend, not localhost)
- [ ] Verify local mode OAuth still works via ephemeral server on port 1455
- [ ] Run `npm test --workspace=packages/backend -- --testPathPattern=openai-oauth`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI OAuth redirects in production by using the backend URL instead of `localhost`. Adds a backend callback endpoint; local CLI flow unchanged.

- **Bug Fixes**
  - Use `backendUrl + /api/v1/oauth/openai/callback` as `redirect_uri` when `backendUrl` is set; fall back to `http://localhost:1455/auth/callback` in local mode.
  - Add `@Public()` callback in `packages/backend/src/routing/openai-oauth.controller.ts` to exchange the code, clear pending state on provider errors, and serve the done page with a strict CSP.
  - Store `redirectUri` in pending state for correct token exchange; expand tests for prod vs local flows.

<sup>Written for commit aa8d1f7e891cd83733da234ac7518d10d0431dae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

