### PR TITLE
fix: revert dynamic redirect_uri, add paste-URL fallback for cloud OAuth

### DIFF
--- a/.changeset/fix-oauth-paste-fallback.md
+++ b/.changeset/fix-oauth-paste-fallback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Revert dynamic OAuth redirect_uri and add paste-URL fallback for cloud deployments

--- a/packages/backend/src/routing/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.spec.ts
@@ -153,6 +153,39 @@ describe('OpenaiOauthController', () => {
     });
   });
 
+  describe('callback (POST)', () => {
+    beforeEach(() => {
+      oauthService.exchangeCode = jest.fn().mockResolvedValue(undefined);
+    });
+
+    it('exchanges code and returns ok', async () => {
+      const result = await controller.callback('auth-code', 'state-123', { id: 'user-1' } as never);
+
+      expect(oauthService.exchangeCode).toHaveBeenCalledWith('state-123', 'auth-code');
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('throws 400 when code is missing', async () => {
+      await expect(controller.callback('', 'state-123', { id: 'user-1' } as never)).rejects.toThrow(
+        HttpException,
+      );
+    });
+
+    it('throws 400 when state is missing', async () => {
+      await expect(controller.callback('auth-code', '', { id: 'user-1' } as never)).rejects.toThrow(
+        HttpException,
+      );
+    });
+
+    it('throws 400 when exchange fails', async () => {
+      oauthService.exchangeCode = jest.fn().mockRejectedValue(new Error('Invalid state'));
+
+      await expect(
+        controller.callback('auth-code', 'bad-state', { id: 'user-1' } as never),
+      ).rejects.toThrow(HttpException);
+    });
+  });
+
   describe('done', () => {
     let res: jest.Mocked<Response>;
 

--- a/packages/backend/src/routing/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Controller,
   Get,
   Post,
@@ -79,35 +80,27 @@ export class OpenaiOauthController {
   }
 
   /**
-   * OAuth callback endpoint for production deployments.
-   * OpenAI redirects here with ?code=...&state=... after user authorizes.
-   * Exchanges the code for tokens, then serves the done page.
+   * Manual OAuth callback for cloud deployments.
+   * When the popup redirects to localhost:1455 and fails (no local server),
+   * the frontend extracts code+state from the failed URL and POSTs here.
    */
-  @Get('callback')
-  @Public()
+  @Post('callback')
   async callback(
-    @Query('code') code: string,
-    @Query('state') state: string,
-    @Query('error') error: string,
-    @Query('error_description') errorDesc: string,
-    @Res() res: Response,
+    @Body('code') code: string,
+    @Body('state') state: string,
+    @CurrentUser() user: AuthUser,
   ) {
-    res.setHeader('Content-Type', 'text/html');
-    res.setHeader('Content-Security-Policy', "default-src 'none'; script-src 'unsafe-inline'");
-
-    if (error) {
-      this.logger.error(`OAuth callback error: ${errorDesc || error}`);
-      if (state) this.oauthService.clearPendingState(state);
-      res.send(oauthDoneHtml(false));
-      return;
+    if (!code || !state) {
+      throw new HttpException('code and state are required', HttpStatus.BAD_REQUEST);
     }
 
     try {
       await this.oauthService.exchangeCode(state, code);
-      res.send(oauthDoneHtml(true));
+      return { ok: true };
     } catch (err) {
-      this.logger.error(`OAuth callback exchange failed: ${err}`);
-      res.send(oauthDoneHtml(false));
+      const message = err instanceof Error ? err.message : 'Token exchange failed';
+      this.logger.error(`OAuth callback exchange failed: ${message}`);
+      throw new HttpException(message, HttpStatus.BAD_REQUEST);
     }
   }
 

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -575,59 +575,17 @@ describe('OpenaiOauthService', () => {
       expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
     });
 
-    it('uses backend URL as redirect_uri when backendUrl is provided (no ephemeral server)', async () => {
-      createServerMock.mockClear();
-
+    it('always uses localhost:1455 as redirect_uri (Codex CLI OAuth app constraint)', async () => {
+      // Even with backendUrl, redirect_uri must be localhost:1455
+      // because the Codex CLI OAuth app only allows that redirect URI
       const url = await service.generateAuthorizationUrl(
         'agent-1',
         'user-1',
         'https://app.manifest.build',
       );
-
-      // Should use backend URL, not localhost:1455
-      expect(url).toContain(
-        `redirect_uri=${encodeURIComponent('https://app.manifest.build/api/v1/oauth/openai/callback')}`,
-      );
-      // Should NOT start a callback server
-      expect(createServerMock).not.toHaveBeenCalled();
-    });
-
-    it('uses localhost:1455 redirect_uri when no backendUrl (local mode)', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (service as any).callbackServer = null;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (service as any).serverReady = null;
-
-      const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
 
       expect(url).toContain(
         `redirect_uri=${encodeURIComponent('http://localhost:1455/auth/callback')}`,
-      );
-    });
-
-    it('exchanges code with matching redirect_uri from pending state', async () => {
-      const url = await service.generateAuthorizationUrl(
-        'agent-1',
-        'user-1',
-        'https://app.manifest.build',
-      );
-      const state = new URL(url).searchParams.get('state')!;
-
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'tok',
-          refresh_token: 'ref',
-          expires_in: 3600,
-        }),
-      });
-
-      await service.exchangeCode(state, 'auth-code');
-
-      // Token exchange should use the same redirect_uri as the authorize request
-      const body = fetchMock.mock.calls[0][1].body as URLSearchParams;
-      expect(body.get('redirect_uri')).toBe(
-        'https://app.manifest.build/api/v1/oauth/openai/callback',
       );
     });
 

--- a/packages/backend/src/routing/openai-oauth.service.ts
+++ b/packages/backend/src/routing/openai-oauth.service.ts
@@ -14,8 +14,7 @@ const TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const REVOKE_URL = 'https://auth.openai.com/oauth/revoke';
 const SCOPE = 'openid profile email offline_access';
 const CALLBACK_PORT = 1455;
-const LOCAL_REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/auth/callback`;
-const CALLBACK_PATH = '/api/v1/oauth/openai/callback';
+const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/auth/callback`;
 const STATE_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 @Injectable()
@@ -51,26 +50,19 @@ export class OpenaiOauthService {
     const verifier = randomBytes(32).toString('base64url');
     const challenge = createHash('sha256').update(verifier).digest('base64url');
 
-    // In production (backendUrl provided), the callback goes to the backend itself.
-    // In local mode (no backendUrl), an ephemeral server on port 1455 handles it.
-    const redirectUri = backendUrl ? `${backendUrl}${CALLBACK_PATH}` : LOCAL_REDIRECT_URI;
-
     this.pending.set(state, {
       verifier,
       agentId,
       userId,
       backendUrl: backendUrl ?? '',
-      redirectUri,
       expiresAt: Date.now() + STATE_TTL_MS,
     });
 
-    if (!backendUrl) {
-      await this.ensureCallbackServer();
-    }
+    await this.ensureCallbackServer();
 
     const params = new URLSearchParams({
       client_id: this.clientId,
-      redirect_uri: redirectUri,
+      redirect_uri: REDIRECT_URI,
       response_type: 'code',
       scope: SCOPE,
       state,
@@ -97,7 +89,7 @@ export class OpenaiOauthService {
       body: new URLSearchParams({
         grant_type: 'authorization_code',
         code,
-        redirect_uri: pending.redirectUri,
+        redirect_uri: REDIRECT_URI,
         client_id: this.clientId,
         code_verifier: pending.verifier,
       }),

--- a/packages/backend/src/routing/openai-oauth.types.ts
+++ b/packages/backend/src/routing/openai-oauth.types.ts
@@ -3,7 +3,6 @@ export interface PendingOAuth {
   agentId: string;
   userId: string;
   backendUrl: string;
-  redirectUri: string;
   expiresAt: number;
 }
 

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -1,7 +1,8 @@
-import { Show, type Component, type Accessor, type Setter } from 'solid-js';
+import { createSignal, Show, type Component, type Accessor, type Setter } from 'solid-js';
 import type { ProviderDef } from '../services/providers.js';
 import {
   getOpenaiOAuthUrl,
+  submitOpenaiOAuthCallback,
   revokeOpenaiOAuth,
   disconnectProvider,
   type AuthType,
@@ -23,8 +24,15 @@ interface Props {
 }
 
 const OAuthDetailView: Component<Props> = (props) => {
+  const [showPasteUrl, setShowPasteUrl] = createSignal(false);
+  const [pasteUrl, setPasteUrl] = createSignal('');
+  const [pasteError, setPasteError] = createSignal<string | null>(null);
+
   const handleOAuthLogin = async () => {
     props.setBusy(true);
+    setShowPasteUrl(false);
+    setPasteUrl('');
+    setPasteError(null);
     try {
       const { url } = await getOpenaiOAuthUrl(props.agentName);
       const popup = window.open(url, 'manifest-oauth', 'width=500,height=700');
@@ -44,11 +52,38 @@ const OAuthDetailView: Component<Props> = (props) => {
           props.setBusy(false);
         },
         onFailure: () => {
-          toast.error('OAuth login failed. Please try again.');
+          // Popup closed without result — show paste URL fallback
+          setShowPasteUrl(true);
           props.setBusy(false);
         },
       });
     } catch {
+      props.setBusy(false);
+    }
+  };
+
+  const handlePasteSubmit = async () => {
+    const raw = pasteUrl().trim();
+    if (!raw) return;
+
+    try {
+      const url = new URL(raw);
+      const code = url.searchParams.get('code');
+      const state = url.searchParams.get('state');
+      if (!code || !state) {
+        setPasteError('URL is missing the authorization code. Make sure you copied the full URL.');
+        return;
+      }
+
+      props.setBusy(true);
+      setPasteError(null);
+      await submitOpenaiOAuthCallback(code, state);
+      toast.success(`${props.provDef.name} subscription connected`);
+      props.onUpdate();
+      props.onClose();
+    } catch {
+      setPasteError('Failed to exchange token. The URL may have expired — try logging in again.');
+    } finally {
       props.setBusy(false);
     }
   };
@@ -91,6 +126,43 @@ const OAuthDetailView: Component<Props> = (props) => {
             Log in with {props.provDef.name}
           </Show>
         </button>
+
+        <Show when={showPasteUrl()}>
+          <div class="provider-detail__field" style="margin-top: 16px;">
+            <p class="provider-detail__hint" style="margin-bottom: 8px;">
+              If the popup didn't redirect back, copy the URL from the popup's address bar and paste
+              it here:
+            </p>
+            <input
+              class="provider-detail__input"
+              classList={{ 'provider-detail__input--error': !!pasteError() }}
+              type="text"
+              autocomplete="off"
+              placeholder="http://localhost:1455/auth/callback?code=..."
+              value={pasteUrl()}
+              onInput={(e) => {
+                setPasteUrl(e.currentTarget.value);
+                setPasteError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handlePasteSubmit();
+              }}
+            />
+            <Show when={pasteError()}>
+              <div class="provider-detail__error">{pasteError()}</div>
+            </Show>
+            <button
+              class="btn btn--primary btn--sm provider-detail__action"
+              style="margin-top: 8px;"
+              disabled={props.busy() || !pasteUrl().trim()}
+              onClick={handlePasteSubmit}
+            >
+              <Show when={!props.busy()} fallback={<span class="spinner" />}>
+                Connect
+              </Show>
+            </button>
+          </div>
+        </Show>
       </Show>
       <Show when={props.connected()}>
         <div class="provider-detail__field">

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -424,6 +424,14 @@ export function getOpenaiOAuthUrl(agentName: string) {
   });
 }
 
+export function submitOpenaiOAuthCallback(code: string, state: string) {
+  return fetchMutate<{ ok: boolean }>(`${BASE_URL}/oauth/openai/callback`, {
+    method: 'POST',
+    body: JSON.stringify({ code, state }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 export function revokeOpenaiOAuth(agentName: string) {
   return fetchMutate<{ ok: boolean }>(
     `${BASE_URL}/oauth/openai/revoke?agentName=${encodeURIComponent(agentName)}`,

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1298,7 +1298,7 @@ describe("ProviderSelectModal", () => {
       vi.restoreAllMocks();
     });
 
-    it("detects failed OAuth callback via polling", async () => {
+    it("detects failed OAuth callback via polling and shows paste URL fallback", async () => {
       const mockPopup = {
         closed: false,
         close: vi.fn(),
@@ -1312,8 +1312,9 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("OpenAI"));
       fireEvent.click(screen.getByText("Log in with OpenAI"));
 
+      // onFailure shows paste URL fallback instead of toast
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith("OAuth login failed. Please try again.");
+        expect(screen.getByPlaceholderText("http://localhost:1455/auth/callback?code=...")).toBeDefined();
       });
       expect(mockPopup.close).toHaveBeenCalled();
       expect(onUpdate).not.toHaveBeenCalled();
@@ -1446,7 +1447,7 @@ describe("ProviderSelectModal", () => {
       vi.restoreAllMocks();
     });
 
-    it("detects failed OAuth via postMessage", async () => {
+    it("detects failed OAuth via postMessage and shows paste URL fallback", async () => {
       const mockPopup = {
         closed: false,
         close: vi.fn(),
@@ -1467,8 +1468,9 @@ describe("ProviderSelectModal", () => {
         new MessageEvent("message", { data: { type: "manifest-oauth-error" } }),
       );
 
+      // onFailure shows paste URL fallback instead of toast
       await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith("OAuth login failed. Please try again.");
+        expect(screen.getByPlaceholderText("http://localhost:1455/auth/callback?code=...")).toBeDefined();
       });
       expect(mockPopup.close).toHaveBeenCalled();
       expect(onUpdate).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Reverts the dynamic `redirect_uri` change from #1155 — the Codex CLI OAuth app only allows `localhost:1455`
- Adds a **paste-URL fallback** for cloud users: when the popup redirects to `localhost:1455` and fails (no local server), the UI shows an input where the user can paste the callback URL from the browser
- The frontend extracts `code` and `state` from the pasted URL and POSTs to `/api/v1/oauth/openai/callback`

## How it works
1. User clicks "Log in with OpenAI" → popup opens to `auth.openai.com`
2. User authenticates → OpenAI redirects to `localhost:1455/auth/callback?code=...&state=...`
3. **Local mode**: ephemeral server on 1455 catches it → done
4. **Cloud mode**: no server on 1455 → popup shows "can't be reached" → popup closes → paste-URL input appears → user pastes the URL → backend exchanges the code

## Test plan
- [ ] Test OAuth flow locally (ephemeral server catches callback automatically)
- [ ] Test OAuth flow on app.manifest.build (paste URL fallback appears after popup fails)
- [ ] Run `npm test --workspace=packages/backend -- --testPathPattern=openai-oauth`
- [ ] Run `npm test --workspace=packages/frontend`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always use the `http://localhost:1455/auth/callback` redirect URI for OpenAI OAuth and add a paste-URL fallback so cloud users can complete login when the popup can’t reach localhost.

- **Bug Fixes**
  - Reverted dynamic redirect_uri; both authorize and token exchange now use `http://localhost:1455/auth/callback` to match the Codex CLI OAuth app.
  - Changed `/api/v1/oauth/openai/callback` from GET to POST (body: `code`, `state`) with proper error handling; always start the local callback server.

- **New Features**
  - Added a paste-URL fallback in the UI: if the popup fails, users paste the `localhost:1455` callback URL; the app extracts `code` and `state` and POSTs via `submitOpenaiOAuthCallback`.
  - Updated tests to cover the fallback for both polling and postMessage failure paths, and the POST `/callback` endpoint.

<sup>Written for commit 0deeda01d931b5643092223a4a1bd1fe21e19213. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

