### PR TITLE
fix: skip ephemeral callback server in cloud mode, show paste URL immediately

### DIFF
--- a/.changeset/fix-oauth-cloud-ux.md
+++ b/.changeset/fix-oauth-cloud-ux.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Skip ephemeral callback server in cloud mode and show paste-URL input immediately after OAuth popup opens

--- a/packages/backend/src/routing/openai-oauth.service.ts
+++ b/packages/backend/src/routing/openai-oauth.service.ts
@@ -58,10 +58,10 @@ export class OpenaiOauthService {
       expiresAt: Date.now() + STATE_TTL_MS,
     });
 
-    // Only start the ephemeral callback server in local mode.
-    // In cloud mode, the redirect goes to the user's localhost (not the server's),
+    // Skip the ephemeral callback server in cloud mode.
+    // In cloud, the redirect goes to the user's localhost (not the server's),
     // so the frontend handles it via the paste-URL fallback.
-    if (process.env['MANIFEST_MODE'] === 'local') {
+    if (process.env['MANIFEST_MODE'] !== 'cloud') {
       await this.ensureCallbackServer();
     }
 

--- a/packages/backend/src/routing/openai-oauth.service.ts
+++ b/packages/backend/src/routing/openai-oauth.service.ts
@@ -58,7 +58,12 @@ export class OpenaiOauthService {
       expiresAt: Date.now() + STATE_TTL_MS,
     });
 
-    await this.ensureCallbackServer();
+    // Only start the ephemeral callback server in local mode.
+    // In cloud mode, the redirect goes to the user's localhost (not the server's),
+    // so the frontend handles it via the paste-URL fallback.
+    if (process.env['MANIFEST_MODE'] === 'local') {
+      await this.ensureCallbackServer();
+    }
 
     const params = new URLSearchParams({
       client_id: this.clientId,

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -24,13 +24,12 @@ interface Props {
 }
 
 const OAuthDetailView: Component<Props> = (props) => {
-  const [showPasteUrl, setShowPasteUrl] = createSignal(false);
+  const [popupOpened, setPopupOpened] = createSignal(false);
   const [pasteUrl, setPasteUrl] = createSignal('');
   const [pasteError, setPasteError] = createSignal<string | null>(null);
 
   const handleOAuthLogin = async () => {
     props.setBusy(true);
-    setShowPasteUrl(false);
     setPasteUrl('');
     setPasteError(null);
     try {
@@ -44,17 +43,17 @@ const OAuthDetailView: Component<Props> = (props) => {
         return;
       }
 
+      setPopupOpened(true);
+      props.setBusy(false);
+
       monitorOAuthPopup(popup, {
         onSuccess: () => {
           toast.success(`${props.provDef.name} subscription connected`);
           props.onUpdate();
           props.onClose();
-          props.setBusy(false);
         },
         onFailure: () => {
-          // Popup closed without result — show paste URL fallback
-          setShowPasteUrl(true);
-          props.setBusy(false);
+          // Popup closed without auto-redirect — user needs to paste the URL
         },
       });
     } catch {
@@ -113,26 +112,34 @@ const OAuthDetailView: Component<Props> = (props) => {
 
   return (
     <>
-      <p class="provider-detail__hint">
-        Log in with your {props.provDef.name} account to connect your subscription.
-      </p>
       <Show when={!props.connected()}>
-        <button
-          class="btn btn--primary provider-detail__action"
-          disabled={props.busy()}
-          onClick={handleOAuthLogin}
+        <Show
+          when={popupOpened()}
+          fallback={
+            <>
+              <p class="provider-detail__hint">
+                Log in with your {props.provDef.name} account to connect your subscription.
+              </p>
+              <button
+                class="btn btn--primary provider-detail__action"
+                disabled={props.busy()}
+                onClick={handleOAuthLogin}
+              >
+                <Show when={!props.busy()} fallback={<span class="spinner" />}>
+                  Log in with {props.provDef.name}
+                </Show>
+              </button>
+            </>
+          }
         >
-          <Show when={!props.busy()} fallback={<span class="spinner" />}>
-            Log in with {props.provDef.name}
-          </Show>
-        </button>
-
-        <Show when={showPasteUrl()}>
-          <div class="provider-detail__field" style="margin-top: 16px;">
-            <p class="provider-detail__hint" style="margin-bottom: 8px;">
-              If the popup didn't redirect back, copy the URL from the popup's address bar and paste
-              it here:
-            </p>
+          <p class="provider-detail__hint">
+            A login window has opened. After you sign in, the popup will show a "can't be reached"
+            page — this is expected.
+          </p>
+          <p class="provider-detail__hint" style="margin-top: 8px; font-weight: 500;">
+            Copy the full URL from the popup's address bar and paste it below:
+          </p>
+          <div class="provider-detail__field" style="margin-top: 12px;">
             <input
               class="provider-detail__input"
               classList={{ 'provider-detail__input--error': !!pasteError() }}

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1298,11 +1298,13 @@ describe("ProviderSelectModal", () => {
       vi.restoreAllMocks();
     });
 
-    it("detects failed OAuth callback via polling and shows paste URL fallback", async () => {
+    it("shows paste URL input immediately after clicking login", async () => {
       const mockPopup = {
         closed: false,
         close: vi.fn(),
-        location: { href: "http://localhost:3000/oauth/openai/done?ok=0" },
+        get location(): { href: string } {
+          throw new DOMException("cross-origin");
+        },
       };
       vi.spyOn(window, "open").mockReturnValue(mockPopup as unknown as Window);
 
@@ -1312,11 +1314,10 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("OpenAI"));
       fireEvent.click(screen.getByText("Log in with OpenAI"));
 
-      // onFailure shows paste URL fallback instead of toast
+      // Paste URL field appears immediately (not after popup closes)
       await waitFor(() => {
         expect(screen.getByPlaceholderText("http://localhost:1455/auth/callback?code=...")).toBeDefined();
       });
-      expect(mockPopup.close).toHaveBeenCalled();
       expect(onUpdate).not.toHaveBeenCalled();
 
       vi.restoreAllMocks();
@@ -1447,7 +1448,7 @@ describe("ProviderSelectModal", () => {
       vi.restoreAllMocks();
     });
 
-    it("detects failed OAuth via postMessage and shows paste URL fallback", async () => {
+    it("keeps paste URL visible after failed OAuth via postMessage", async () => {
       const mockPopup = {
         closed: false,
         close: vi.fn(),
@@ -1463,16 +1464,17 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("OpenAI"));
       fireEvent.click(screen.getByText("Log in with OpenAI"));
 
-      await new Promise((r) => setTimeout(r, 50));
-      window.dispatchEvent(
-        new MessageEvent("message", { data: { type: "manifest-oauth-error" } }),
-      );
-
-      // onFailure shows paste URL fallback instead of toast
+      // Paste URL field is already visible before any message
       await waitFor(() => {
         expect(screen.getByPlaceholderText("http://localhost:1455/auth/callback?code=...")).toBeDefined();
       });
-      expect(mockPopup.close).toHaveBeenCalled();
+
+      // Error message arrives — paste field still visible, no crash
+      window.dispatchEvent(
+        new MessageEvent("message", { data: { type: "manifest-oauth-error" } }),
+      );
+      await new Promise((r) => setTimeout(r, 50));
+      expect(screen.getByPlaceholderText("http://localhost:1455/auth/callback?code=...")).toBeDefined();
       expect(onUpdate).not.toHaveBeenCalled();
 
       vi.restoreAllMocks();


### PR DESCRIPTION
## Summary
- Skip starting localhost:1455 callback server when `MANIFEST_MODE` is not `local` — it's useless in cloud since the redirect goes to the user's machine, not the server
- Show the paste-URL input **immediately** after clicking "Log in with OpenAI" with clear instructions explaining the popup will show "can't be reached"
- No more 30s timeout wait before the paste field appears

## Test plan
- [ ] Cloud mode: click "Log in with OpenAI" → paste URL input appears immediately with instructions
- [ ] Local mode: OAuth flow still works automatically via ephemeral server
- [ ] `npm test --workspace=packages/backend -- --testPathPattern=openai-oauth`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the ephemeral localhost callback server in cloud mode (only start it in local) and show the paste-URL input immediately with a note to copy the popup URL. Fixes cloud OAuth, removes the 30s wait, keeps local flow working, and updates tests.

<sup>Written for commit 3d2b4da402724e6cc5a78a3e7022c1ae468ca663. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

