### PR TITLE
Add MiniMax OAuth subscription flow

### DIFF
--- a/packages/backend/src/routing/minimax-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.spec.ts
@@ -1,0 +1,57 @@
+import { HttpException } from '@nestjs/common';
+import { MinimaxOauthController } from './minimax-oauth.controller';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { ResolveAgentService } from './resolve-agent.service';
+
+describe('MinimaxOauthController', () => {
+  let controller: MinimaxOauthController;
+  let oauthService: jest.Mocked<MinimaxOauthService>;
+  let resolveAgent: jest.Mocked<ResolveAgentService>;
+
+  beforeEach(() => {
+    oauthService = {
+      startAuthorization: jest.fn(),
+      pollAuthorization: jest.fn(),
+    } as unknown as jest.Mocked<MinimaxOauthService>;
+
+    resolveAgent = {
+      resolve: jest.fn(),
+    } as unknown as jest.Mocked<ResolveAgentService>;
+
+    controller = new MinimaxOauthController(oauthService, resolveAgent);
+  });
+
+  it('starts MiniMax OAuth for the resolved agent', async () => {
+    resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+    oauthService.startAuthorization.mockResolvedValue({
+      flowId: 'flow-1',
+      userCode: 'ABCD-1234',
+      verificationUri: 'https://www.minimax.io/verify',
+      expiresAt: Date.now() + 60_000,
+      pollIntervalMs: 2000,
+    });
+
+    const result = await controller.start('my-agent', { id: 'user-1' } as never);
+
+    expect(resolveAgent.resolve).toHaveBeenCalledWith('user-1', 'my-agent');
+    expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1');
+    expect(result.flowId).toBe('flow-1');
+  });
+
+  it('throws 400 when agentName is missing', async () => {
+    await expect(controller.start('', { id: 'user-1' } as never)).rejects.toThrow(HttpException);
+  });
+
+  it('polls MiniMax OAuth state', async () => {
+    oauthService.pollAuthorization.mockResolvedValue({ status: 'pending' });
+
+    const result = await controller.poll('flow-1', { id: 'user-1' } as never);
+
+    expect(oauthService.pollAuthorization).toHaveBeenCalledWith('flow-1', 'user-1');
+    expect(result).toEqual({ status: 'pending' });
+  });
+
+  it('throws 400 when flowId is missing', async () => {
+    await expect(controller.poll('', { id: 'user-1' } as never)).rejects.toThrow(HttpException);
+  });
+});

--- a/packages/backend/src/routing/minimax-oauth.controller.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, HttpException, HttpStatus, Post, Query } from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../auth/auth.instance';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { ResolveAgentService } from './resolve-agent.service';
+
+@Controller('api/v1/oauth/minimax')
+export class MinimaxOauthController {
+  constructor(
+    private readonly oauthService: MinimaxOauthService,
+    private readonly resolveAgent: ResolveAgentService,
+  ) {}
+
+  @Post('start')
+  async start(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    return this.oauthService.startAuthorization(agent.id, user.id);
+  }
+
+  @Get('poll')
+  async poll(@Query('flowId') flowId: string, @CurrentUser() user: AuthUser) {
+    if (!flowId) {
+      throw new HttpException('flowId query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    return this.oauthService.pollAuthorization(flowId, user.id);
+  }
+}

--- a/packages/backend/src/routing/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.spec.ts
@@ -1,0 +1,159 @@
+import { ConfigService } from '@nestjs/config';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { RoutingService } from './routing.service';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fetchMock = jest.fn() as jest.Mock<Promise<any>>;
+global.fetch = fetchMock;
+
+describe('MinimaxOauthService', () => {
+  let service: MinimaxOauthService;
+  let routingService: jest.Mocked<RoutingService>;
+  let configService: jest.Mocked<ConfigService>;
+  let discoveryService: { discoverModels: jest.Mock };
+
+  beforeEach(() => {
+    routingService = {
+      upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
+      recalculateTiers: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<RoutingService>;
+
+    configService = {
+      get: jest.fn().mockReturnValue(undefined),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    discoveryService = {
+      discoverModels: jest.fn().mockResolvedValue([]),
+    };
+
+    service = new MinimaxOauthService(routingService, configService, discoveryService as never);
+    fetchMock.mockReset();
+  });
+
+  describe('startAuthorization', () => {
+    it('returns device-code payload and stores a pending flow', async () => {
+      fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+        const params = new URLSearchParams(init?.body as string);
+        return {
+          ok: true,
+          json: async () => ({
+            user_code: 'ABCD-1234',
+            verification_uri: 'https://www.minimax.io/verify',
+            expired_in: Date.now() + 60_000,
+            interval: 2000,
+            state: params.get('state'),
+          }),
+        };
+      });
+
+      const result = await service.startAuthorization('agent-1', 'user-1');
+
+      expect(result.userCode).toBe('ABCD-1234');
+      expect(result.verificationUri).toBe('https://www.minimax.io/verify');
+      expect(service.getPendingCount()).toBe(1);
+    });
+  });
+
+  describe('pollAuthorization', () => {
+    it('stores MiniMax tokens after approval', async () => {
+      fetchMock
+        .mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+          const params = new URLSearchParams(init?.body as string);
+          return {
+            ok: true,
+            json: async () => ({
+              user_code: 'ABCD-1234',
+              verification_uri: 'https://www.minimax.io/verify',
+              expired_in: Date.now() + 60_000,
+              interval: 2000,
+              state: params.get('state'),
+            }),
+          };
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () =>
+            JSON.stringify({
+              status: 'success',
+              access_token: 'access-123',
+              refresh_token: 'refresh-456',
+              expired_in: 3600,
+              resource_url: 'https://api.minimax.io/anthropic',
+            }),
+        });
+
+      const start = await service.startAuthorization('agent-1', 'user-1');
+      const result = await service.pollAuthorization(start.flowId, 'user-1');
+
+      expect(result).toEqual({ status: 'success' });
+      expect(routingService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'minimax',
+        expect.any(String),
+        'subscription',
+      );
+      expect(discoveryService.discoverModels).toHaveBeenCalled();
+    });
+
+    it('returns pending while approval has not completed', async () => {
+      fetchMock
+        .mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+          const params = new URLSearchParams(init?.body as string);
+          return {
+            ok: true,
+            json: async () => ({
+              user_code: 'ABCD-1234',
+              verification_uri: 'https://www.minimax.io/verify',
+              expired_in: Date.now() + 60_000,
+              interval: 2000,
+              state: params.get('state'),
+            }),
+          };
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ status: 'pending' }),
+        });
+
+      const start = await service.startAuthorization('agent-1', 'user-1');
+      const result = await service.pollAuthorization(start.flowId, 'user-1');
+
+      expect(result.status).toBe('pending');
+      expect(routingService.upsertProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unwrapToken', () => {
+    it('refreshes expired tokens and preserves resource URL', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expired_in: 7200,
+        }),
+      });
+
+      const result = await service.unwrapToken(
+        JSON.stringify({
+          t: 'old-access',
+          r: 'old-refresh',
+          e: Date.now() - 1000,
+          u: 'https://api.minimax.io/anthropic',
+        }),
+        'agent-1',
+        'user-1',
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          t: 'new-access',
+          r: 'new-refresh',
+          u: 'https://api.minimax.io/anthropic',
+        }),
+      );
+      expect(routingService.upsertProvider).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/routing/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.ts
@@ -1,0 +1,314 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash, randomBytes, randomUUID } from 'crypto';
+import { RoutingService } from './routing.service';
+import { ModelDiscoveryService } from './model-discovery/model-discovery.service';
+import { OAuthTokenBlob } from './openai-oauth.types';
+
+const DEFAULT_CLIENT_ID = '78257093-7e40-4613-99e0-527b14b39113';
+const DEFAULT_BASE_URL = 'https://api.minimax.io';
+const DEFAULT_RESOURCE_URL = `${DEFAULT_BASE_URL}/anthropic`;
+const CODE_URL = `${DEFAULT_BASE_URL}/oauth/code`;
+const TOKEN_URL = `${DEFAULT_BASE_URL}/oauth/token`;
+const SCOPE = 'group_id profile model.completion';
+const USER_CODE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:user_code';
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+interface PendingMinimaxOAuth {
+  verifier: string;
+  userCode: string;
+  agentId: string;
+  userId: string;
+  expiresAt: number;
+  pollIntervalMs: number;
+}
+
+interface MinimaxCodeResponse {
+  user_code: string;
+  verification_uri: string;
+  expired_in: number;
+  interval?: number;
+  state: string;
+  error?: string;
+}
+
+interface MinimaxTokenResponse {
+  status?: string;
+  access_token?: string | null;
+  refresh_token?: string | null;
+  expired_in?: number | null;
+  resource_url?: string;
+  notification_message?: string;
+  base_resp?: { status_code?: number; status_msg?: string };
+}
+
+export interface MinimaxOAuthStartResult {
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+  pollIntervalMs: number;
+}
+
+export interface MinimaxOAuthPollResult {
+  status: 'pending' | 'success' | 'error';
+  message?: string;
+  pollIntervalMs?: number;
+}
+
+@Injectable()
+export class MinimaxOauthService {
+  private readonly logger = new Logger(MinimaxOauthService.name);
+  private readonly pending = new Map<string, PendingMinimaxOAuth>();
+  private readonly clientId: string;
+
+  constructor(
+    private readonly routingService: RoutingService,
+    private readonly configService: ConfigService,
+    private readonly discoveryService: ModelDiscoveryService,
+  ) {
+    this.clientId = this.configService.get<string>('MINIMAX_OAUTH_CLIENT_ID') ?? DEFAULT_CLIENT_ID;
+  }
+
+  async startAuthorization(agentId: string, userId: string): Promise<MinimaxOAuthStartResult> {
+    this.cleanupExpired();
+
+    const verifier = randomBytes(32).toString('base64url');
+    const challenge = createHash('sha256').update(verifier).digest('base64url');
+    const flowId = randomBytes(16).toString('base64url');
+
+    const response = await fetch(CODE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        'x-request-id': randomUUID(),
+      },
+      body: new URLSearchParams({
+        response_type: 'code',
+        client_id: this.clientId,
+        scope: SCOPE,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        state: flowId,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`MiniMax OAuth code request failed: ${text}`);
+      throw new Error('Failed to start MiniMax OAuth');
+    }
+
+    const payload = (await response.json()) as MinimaxCodeResponse;
+    if (!payload.user_code || !payload.verification_uri || !payload.expired_in) {
+      throw new Error(
+        payload.error ??
+          'MiniMax OAuth returned an incomplete authorization payload.',
+      );
+    }
+    if (payload.state !== flowId) {
+      throw new Error('MiniMax OAuth state mismatch');
+    }
+
+    const pollIntervalMs =
+      payload.interval && payload.interval > 0 ? payload.interval : DEFAULT_POLL_INTERVAL_MS;
+
+    this.pending.set(flowId, {
+      verifier,
+      userCode: payload.user_code,
+      agentId,
+      userId,
+      expiresAt: payload.expired_in,
+      pollIntervalMs,
+    });
+
+    return {
+      flowId,
+      userCode: payload.user_code,
+      verificationUri: payload.verification_uri,
+      expiresAt: payload.expired_in,
+      pollIntervalMs,
+    };
+  }
+
+  async pollAuthorization(flowId: string, userId: string): Promise<MinimaxOAuthPollResult> {
+    this.cleanupExpired();
+
+    const pending = this.pending.get(flowId);
+    if (!pending) {
+      return { status: 'error', message: 'MiniMax login expired. Start again.' };
+    }
+    if (pending.userId !== userId) {
+      return { status: 'error', message: 'MiniMax login session does not match the current user.' };
+    }
+    if (Date.now() >= pending.expiresAt) {
+      this.pending.delete(flowId);
+      return { status: 'error', message: 'MiniMax login expired. Start again.' };
+    }
+
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: USER_CODE_GRANT_TYPE,
+        client_id: this.clientId,
+        user_code: pending.userCode,
+        code_verifier: pending.verifier,
+      }),
+    });
+
+    const text = await response.text();
+    const payload = this.parseTokenResponse(text);
+
+    if (!response.ok) {
+      const message = payload?.base_resp?.status_msg ?? text ?? 'MiniMax OAuth failed';
+      this.pending.delete(flowId);
+      return { status: 'error', message };
+    }
+
+    if (!payload) {
+      this.pending.delete(flowId);
+      return { status: 'error', message: 'MiniMax OAuth returned an invalid token response.' };
+    }
+
+    if (payload.status === 'error') {
+      this.pending.delete(flowId);
+      return { status: 'error', message: 'MiniMax OAuth failed. Please try again later.' };
+    }
+
+    if (payload.status !== 'success') {
+      return {
+        status: 'pending',
+        message: 'Waiting for MiniMax approval…',
+        pollIntervalMs: pending.pollIntervalMs,
+      };
+    }
+
+    if (!payload.access_token || !payload.refresh_token || !payload.expired_in) {
+      this.pending.delete(flowId);
+      return { status: 'error', message: 'MiniMax OAuth returned an incomplete token payload.' };
+    }
+
+    this.pending.delete(flowId);
+
+    const blob: OAuthTokenBlob = {
+      t: payload.access_token,
+      r: payload.refresh_token,
+      e: Date.now() + payload.expired_in * 1000,
+      ...(payload.resource_url ? { u: payload.resource_url } : {}),
+    };
+
+    const { provider: savedProvider } = await this.routingService.upsertProvider(
+      pending.agentId,
+      pending.userId,
+      'minimax',
+      JSON.stringify(blob),
+      'subscription',
+    );
+
+    try {
+      await this.discoveryService.discoverModels(savedProvider);
+      await this.routingService.recalculateTiers(pending.agentId);
+    } catch (err) {
+      this.logger.warn(`Model discovery after MiniMax OAuth failed: ${err}`);
+    }
+
+    this.logger.log(`MiniMax OAuth token stored for agent=${pending.agentId}`);
+    return { status: 'success' };
+  }
+
+  async refreshAccessToken(
+    refreshToken: string,
+    resourceUrl?: string,
+  ): Promise<OAuthTokenBlob> {
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: this.clientId,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`MiniMax token refresh failed: ${text}`);
+      throw new Error('Token refresh failed');
+    }
+
+    const payload = (await response.json()) as MinimaxTokenResponse;
+    if (!payload.access_token || !payload.expired_in) {
+      throw new Error('MiniMax token refresh returned an incomplete payload');
+    }
+
+    const nextResourceUrl = payload.resource_url ?? resourceUrl;
+    return {
+      t: payload.access_token,
+      r: payload.refresh_token || refreshToken,
+      e: Date.now() + payload.expired_in * 1000,
+      ...(nextResourceUrl ? { u: nextResourceUrl } : {}),
+    };
+  }
+
+  async unwrapToken(
+    rawValue: string,
+    agentId: string,
+    userId: string,
+  ): Promise<OAuthTokenBlob | null> {
+    let blob: OAuthTokenBlob;
+    try {
+      blob = JSON.parse(rawValue) as OAuthTokenBlob;
+    } catch {
+      return null;
+    }
+
+    if (!blob.t || !blob.r || !blob.e) return null;
+    if (Date.now() < blob.e - 60_000) return blob;
+
+    try {
+      const refreshed = await this.refreshAccessToken(blob.r, blob.u);
+      await this.routingService.upsertProvider(
+        agentId,
+        userId,
+        'minimax',
+        JSON.stringify(refreshed),
+        'subscription',
+      );
+      this.logger.log(`MiniMax OAuth token refreshed for agent=${agentId}`);
+      return refreshed;
+    } catch (err) {
+      this.logger.error(`Failed to refresh MiniMax token: ${err}`);
+      return blob;
+    }
+  }
+
+  getPendingCount(): number {
+    return this.pending.size;
+  }
+
+  private cleanupExpired(): void {
+    const now = Date.now();
+    for (const [flowId, pending] of this.pending.entries()) {
+      if (pending.expiresAt <= now) this.pending.delete(flowId);
+    }
+  }
+
+  private parseTokenResponse(text: string): MinimaxTokenResponse | null {
+    if (!text) return null;
+    try {
+      return JSON.parse(text) as MinimaxTokenResponse;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export { DEFAULT_RESOURCE_URL as MINIMAX_DEFAULT_RESOURCE_URL };

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
@@ -126,7 +126,7 @@ describe('ModelDiscoveryService', () => {
 
       expect(mockGetSecret).toHaveBeenCalled();
       expect(mockDecrypt).toHaveBeenCalledWith('encrypted-key', expect.any(String));
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'decrypted-key', 'api_key');
+      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'decrypted-key', 'api_key', undefined);
       expect(result).toHaveLength(1);
       expect(provider.cached_models).toEqual(result);
       expect(provider.models_fetched_at).toBeDefined();
@@ -150,7 +150,7 @@ describe('ModelDiscoveryService', () => {
       await service.discoverModels(provider);
 
       expect(mockDecrypt).not.toHaveBeenCalled();
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', '', 'api_key');
+      expect(fetcher.fetch).toHaveBeenCalledWith('openai', '', 'api_key', undefined);
     });
 
     it('should enrich models with openRouter pricing when available', async () => {
@@ -742,7 +742,12 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Should pass the unwrapped access token, not the JSON blob
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'access-token-123', 'subscription');
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'openai',
+        'access-token-123',
+        'subscription',
+        undefined,
+      );
     });
 
     it('should use raw key when OpenAI subscription blob has no t field', async () => {
@@ -760,7 +765,7 @@ describe('ModelDiscoveryService', () => {
       );
 
       // No `t` field — should use the raw JSON string
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', blob, 'subscription');
+      expect(fetcher.fetch).toHaveBeenCalledWith('openai', blob, 'subscription', undefined);
     });
 
     it('should use raw key when OpenAI subscription value is not JSON', async () => {
@@ -776,7 +781,12 @@ describe('ModelDiscoveryService', () => {
         }),
       );
 
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'plain-token-value', 'subscription');
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'openai',
+        'plain-token-value',
+        'subscription',
+        undefined,
+      );
     });
 
     it('should not unwrap blob for non-OpenAI subscription providers', async () => {
@@ -794,7 +804,34 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Should pass the raw JSON string for Anthropic (no unwrapping)
-      expect(fetcher.fetch).toHaveBeenCalledWith('anthropic', blob, 'subscription');
+      expect(fetcher.fetch).toHaveBeenCalledWith('anthropic', blob, 'subscription', undefined);
+    });
+
+    it('should unwrap MiniMax OAuth blob and forward resource URL for subscription discovery', async () => {
+      const blob = JSON.stringify({
+        t: 'minimax-access',
+        r: 'minimax-refresh',
+        e: Date.now() + 60000,
+        u: 'https://api.minimax.io/anthropic',
+      });
+      mockDecrypt.mockReturnValue(blob);
+
+      fetcher.fetch.mockResolvedValue([]);
+
+      await service.discoverModels(
+        makeProvider({
+          provider: 'minimax',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted-blob',
+        }),
+      );
+
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'minimax',
+        'minimax-access',
+        'subscription',
+        'https://api.minimax.io/anthropic',
+      );
     });
 
     it('should fall back to subscription fallback when OpenAI token fetch returns empty', async () => {

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.ts
@@ -8,6 +8,7 @@ import { DiscoveredModel } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
 import { computeQualityScore } from '../../database/quality-score.util';
 import { PricingSyncService } from '../../database/pricing-sync.service';
+import { parseOAuthTokenBlob } from '../openai-oauth.types';
 import {
   findOpenRouterPrefix,
   lookupWithVariants,
@@ -36,6 +37,7 @@ export class ModelDiscoveryService {
 
   async discoverModels(provider: UserProvider): Promise<DiscoveredModel[]> {
     let apiKey = '';
+    let endpointOverride: string | undefined;
     if (provider.api_key_encrypted) {
       try {
         apiKey = decrypt(provider.api_key_encrypted, getEncryptionSecret());
@@ -45,20 +47,18 @@ export class ModelDiscoveryService {
       }
     }
 
-    // For OpenAI subscription, the stored "key" is a JSON blob with access/refresh tokens.
-    // Unwrap it to get the actual Bearer token for the models API.
-    if (
-      provider.auth_type === 'subscription' &&
-      provider.provider.toLowerCase() === 'openai' &&
-      apiKey
-    ) {
-      try {
-        const blob = JSON.parse(apiKey) as { t?: string };
-        if (blob.t) {
+    // OAuth-backed subscription providers store an encrypted token blob.
+    // Unwrap it so model discovery can call the provider-native /models endpoint.
+    if (provider.auth_type === 'subscription' && apiKey) {
+      const lowerProvider = provider.provider.toLowerCase();
+      if (lowerProvider === 'openai' || lowerProvider === 'minimax') {
+        const blob = parseOAuthTokenBlob(apiKey);
+        if (blob?.t) {
           apiKey = blob.t;
+          if (lowerProvider === 'minimax' && blob.u) {
+            endpointOverride = blob.u;
+          }
         }
-      } catch {
-        // Not a JSON blob — use as-is
       }
     }
 
@@ -73,7 +73,12 @@ export class ModelDiscoveryService {
         );
       }
     } else {
-      raw = await this.fetcher.fetch(provider.provider, apiKey, provider.auth_type);
+      raw = await this.fetcher.fetch(
+        provider.provider,
+        apiKey,
+        provider.auth_type,
+        endpointOverride,
+      );
 
       // If native API returned no models, fall back to OpenRouter + manual pricing
       if (raw.length === 0) {

--- a/packages/backend/src/routing/model-discovery/model-fallback.ts
+++ b/packages/backend/src/routing/model-discovery/model-fallback.ts
@@ -130,6 +130,7 @@ export function buildSubscriptionFallbackModels(
 ): DiscoveredModel[] {
   const knownPrefixes = getSubscriptionKnownModels(providerId);
   if (!knownPrefixes) return [];
+  const normalizedKnownPrefixes = knownPrefixes.map((modelId) => modelId.toLowerCase());
 
   const capabilities = getSubscriptionCapabilities(providerId);
   const models: DiscoveredModel[] = [];
@@ -141,7 +142,9 @@ export function buildSubscriptionFallbackModels(
     for (const [fullId, entry] of pricingSync.getAll()) {
       if (!fullId.startsWith(`${orPrefix}/`)) continue;
       const modelId = fullId.substring(orPrefix.length + 1);
-      if (!knownPrefixes.some((p: string) => modelId.startsWith(p))) continue;
+      if (!normalizedKnownPrefixes.some((p: string) => modelId.toLowerCase().startsWith(p))) {
+        continue;
+      }
       if (seen.has(modelId)) continue;
       seen.add(modelId);
 
@@ -169,7 +172,11 @@ export function buildSubscriptionFallbackModels(
   // (e.g., "claude-opus-4" is covered by "claude-opus-4-20260301").
   const defaultCtx = capabilities?.maxContextWindow ?? 200000;
   for (const modelId of knownPrefixes) {
-    const covered = models.some((m) => m.id === modelId || m.id.startsWith(`${modelId}-`));
+    const lowerModelId = modelId.toLowerCase();
+    const covered = models.some((m) => {
+      const lowerDiscovered = m.id.toLowerCase();
+      return lowerDiscovered === lowerModelId || lowerDiscovered.startsWith(`${lowerModelId}-`);
+    });
     if (covered) continue;
     models.push({
       id: modelId,
@@ -203,8 +210,12 @@ export function supplementWithKnownModels(
   const defaultCtx = capabilities?.maxContextWindow ?? 200000;
 
   for (const modelId of knownModels) {
+    const lowerModelId = modelId.toLowerCase();
     // Skip if this model or a more specific version (e.g., with date suffix) already exists
-    const covered = raw.some((m) => m.id === modelId || m.id.startsWith(`${modelId}-`));
+    const covered = raw.some((m) => {
+      const lowerDiscovered = m.id.toLowerCase();
+      return lowerDiscovered === lowerModelId || lowerDiscovered.startsWith(`${lowerModelId}-`);
+    });
     if (covered) continue;
     raw.push({
       id: modelId,

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
@@ -6,6 +6,7 @@ const FETCH_TIMEOUT_MS = 5000;
 const DEFAULT_CONTEXT_WINDOW = 128000;
 const ANTHROPIC_DEFAULT_CONTEXT = 200000;
 const GEMINI_DEFAULT_CONTEXT = 1000000;
+const MINIMAX_SUBSCRIPTION_MODELS_URL = 'https://api.minimax.io/anthropic/v1/models?limit=100';
 
 /* ── Shared OpenAI-compatible parser ── */
 
@@ -41,6 +42,10 @@ function parseOpenAI(body: unknown, provider: string): DiscoveredModel[] {
 
 function bearerHeaders(key: string): Record<string, string> {
   return { Authorization: `Bearer ${key}` };
+}
+
+function normalizeProviderBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
 }
 
 /* ── Provider-specific parsers ── */
@@ -253,6 +258,14 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     buildHeaders: bearerHeaders,
     parse: parseOpenAI,
   },
+  'minimax-subscription': {
+    endpoint: MINIMAX_SUBSCRIPTION_MODELS_URL,
+    buildHeaders: (key: string) => ({
+      Authorization: `Bearer ${key}`,
+      'anthropic-version': '2023-06-01',
+    }),
+    parse: parseAnthropic,
+  },
   qwen: {
     endpoint: 'https://dashscope.aliyuncs.com/compatible-mode/v1/models',
     buildHeaders: bearerHeaders,
@@ -301,11 +314,18 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
 export class ProviderModelFetcherService {
   private readonly logger = new Logger(ProviderModelFetcherService.name);
 
-  async fetch(providerId: string, apiKey: string, authType?: string): Promise<DiscoveredModel[]> {
+  async fetch(
+    providerId: string,
+    apiKey: string,
+    authType?: string,
+    endpointOverride?: string,
+  ): Promise<DiscoveredModel[]> {
     let configKey = providerId.toLowerCase();
     // OpenAI subscription tokens use a different models endpoint
     if (configKey === 'openai' && authType === 'subscription') {
       configKey = 'openai-subscription';
+    } else if (configKey === 'minimax' && authType === 'subscription') {
+      configKey = 'minimax-subscription';
     }
     const config = PROVIDER_CONFIGS[configKey];
     if (!config) {
@@ -313,7 +333,10 @@ export class ProviderModelFetcherService {
       return [];
     }
 
-    const url = typeof config.endpoint === 'function' ? config.endpoint(apiKey) : config.endpoint;
+    let url = typeof config.endpoint === 'function' ? config.endpoint(apiKey) : config.endpoint;
+    if (endpointOverride && configKey === 'minimax-subscription') {
+      url = `${normalizeProviderBaseUrl(endpointOverride)}/v1/models?limit=100`;
+    }
 
     const headers = config.buildHeaders(apiKey, authType);
 

--- a/packages/backend/src/routing/openai-oauth.types.ts
+++ b/packages/backend/src/routing/openai-oauth.types.ts
@@ -13,6 +13,24 @@ export interface OAuthTokenBlob {
   r: string;
   /** expires at (epoch ms) */
   e: number;
+  /** provider-specific resource URL / base URL */
+  u?: string;
+}
+
+export function parseOAuthTokenBlob(rawValue: string): OAuthTokenBlob | null {
+  try {
+    const parsed = JSON.parse(rawValue) as Partial<OAuthTokenBlob>;
+    if (
+      typeof parsed?.t !== 'string' ||
+      typeof parsed?.r !== 'string' ||
+      typeof parsed?.e !== 'number'
+    ) {
+      return null;
+    }
+    return parsed as OAuthTokenBlob;
+  } catch {
+    return null;
+  }
 }
 
 export function oauthDoneHtml(success: boolean): string {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -4,6 +4,7 @@ import { ResolveService } from '../../resolve.service';
 import { RoutingService } from '../../routing.service';
 import { CustomProviderService } from '../../custom-provider.service';
 import { OpenaiOauthService } from '../../openai-oauth.service';
+import { MinimaxOauthService } from '../../minimax-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { SessionMomentumService } from '../session-momentum.service';
 import { LimitCheckService } from '../../../notifications/services/limit-check.service';
@@ -16,6 +17,7 @@ describe('ProxyService', () => {
   let routingService: jest.Mocked<RoutingService>;
   let customProviderService: jest.Mocked<CustomProviderService>;
   let openaiOauth: jest.Mocked<OpenaiOauthService>;
+  let minimaxOauth: jest.Mocked<MinimaxOauthService>;
   let providerClient: jest.Mocked<ProviderClient>;
   let momentum: SessionMomentumService;
   let limitCheck: jest.Mocked<LimitCheckService>;
@@ -55,6 +57,13 @@ describe('ProxyService', () => {
       refreshAccessToken: jest.fn(),
     } as unknown as jest.Mocked<OpenaiOauthService>;
 
+    minimaxOauth = {
+      unwrapToken: jest.fn().mockResolvedValue(null),
+      startAuthorization: jest.fn(),
+      pollAuthorization: jest.fn(),
+      refreshAccessToken: jest.fn(),
+    } as unknown as jest.Mocked<MinimaxOauthService>;
+
     pricingCache = {
       getByModel: jest.fn().mockReturnValue(null),
       getAll: jest.fn().mockReturnValue([]),
@@ -65,6 +74,7 @@ describe('ProxyService', () => {
       routingService,
       customProviderService,
       openaiOauth,
+      minimaxOauth,
       providerClient,
       momentum,
       limitCheck,
@@ -1872,6 +1882,7 @@ describe('ProxyService', () => {
       await service.proxyRequest('agent-1', 'user-1', body, 'sess');
 
       expect(openaiOauth.unwrapToken).not.toHaveBeenCalled();
+      expect(minimaxOauth.unwrapToken).not.toHaveBeenCalled();
     });
 
     it('skips unwrap for OpenAI api_key auth', async () => {
@@ -1944,6 +1955,55 @@ describe('ProxyService', () => {
         'user-1',
       );
       expect(result.meta.model).toBe('gpt-4o');
+    });
+
+    it('unwraps JSON token blob for MiniMax subscription and forwards resource URL', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'MiniMax-M2.5',
+        provider: 'minimax',
+        confidence: 1.0,
+        score: 0.5,
+        reason: 'scored',
+        auth_type: 'subscription',
+      });
+      const tokenBlob = JSON.stringify({
+        t: 'minimax-access',
+        r: 'minimax-refresh',
+        e: Date.now() + 60000,
+        u: 'https://api.minimax.io/anthropic',
+      });
+      routingService.getProviderApiKey.mockResolvedValue(tokenBlob);
+      minimaxOauth.unwrapToken.mockResolvedValue({
+        t: 'minimax-access',
+        r: 'minimax-refresh',
+        e: Date.now() + 60000,
+        u: 'https://api.minimax.io/anthropic',
+      });
+      providerClient.forward.mockResolvedValue({
+        response: new Response('ok', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+
+      await service.proxyRequest('agent-1', 'user-1', body, 'sess');
+
+      expect(minimaxOauth.unwrapToken).toHaveBeenCalledWith(tokenBlob, 'agent-1', 'user-1');
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        'minimax',
+        'minimax-access',
+        'MiniMax-M2.5',
+        expect.any(Object),
+        false,
+        undefined,
+        undefined,
+        expect.objectContaining({
+          baseUrl: 'https://api.minimax.io/anthropic',
+          format: 'anthropic',
+        }),
+        'subscription',
+      );
     });
   });
 });

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -142,6 +142,8 @@ export class ProviderClient {
       // ChatGPT subscription tokens use a different backend endpoint
       if (resolved === 'openai' && authType === 'subscription') {
         resolved = 'openai-subscription';
+      } else if (resolved === 'minimax' && authType === 'subscription') {
+        resolved = 'minimax-subscription';
       }
       endpointKey = resolved;
       endpoint = PROVIDER_ENDPOINTS[endpointKey];

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -8,6 +8,10 @@ export interface ProviderEndpoint {
   format: 'openai' | 'google' | 'anthropic' | 'chatgpt';
 }
 
+function normalizeProviderBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
+}
+
 const openaiHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
@@ -29,6 +33,12 @@ const anthropicHeaders = (apiKey: string, authType?: string): Record<string, str
   return headers;
 };
 
+const anthropicBearerHeaders = (apiKey: string): Record<string, string> => ({
+  Authorization: `Bearer ${apiKey}`,
+  'Content-Type': 'application/json',
+  'anthropic-version': '2023-06-01',
+});
+
 /**
  * ChatGPT subscription OAuth tokens use the Codex backend,
  * which requires specific headers to avoid 403 responses.
@@ -36,6 +46,7 @@ const anthropicHeaders = (apiKey: string, authType?: string): Record<string, str
  * endpoint to accept requests, but may break if OpenAI changes validation.
  */
 const CHATGPT_SUBSCRIPTION_BASE = 'https://chatgpt.com/backend-api';
+const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
 const chatgptSubscriptionHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
@@ -86,6 +97,12 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: openaiPath,
     format: 'openai',
   },
+  'minimax-subscription': {
+    baseUrl: MINIMAX_SUBSCRIPTION_BASE,
+    buildHeaders: anthropicBearerHeaders,
+    buildPath: () => '/v1/messages',
+    format: 'anthropic',
+  },
   moonshot: {
     baseUrl: 'https://api.moonshot.cn',
     buildHeaders: openaiHeaders,
@@ -121,12 +138,23 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
 /** Build a ProviderEndpoint for a custom provider with the given base URL. */
 export function buildCustomEndpoint(baseUrl: string): ProviderEndpoint {
   // Strip trailing /v1 (or /v1/) since openaiPath already includes /v1
-  const normalized = baseUrl.replace(/\/v1\/?$/, '');
+  const normalized = normalizeProviderBaseUrl(baseUrl);
   return {
     baseUrl: normalized,
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+  };
+}
+
+export function buildEndpointOverride(baseUrl: string, templateKey: string): ProviderEndpoint {
+  const template = PROVIDER_ENDPOINTS[templateKey];
+  if (!template) {
+    throw new Error(`No provider endpoint template configured for: ${templateKey}`);
+  }
+  return {
+    ...template,
+    baseUrl: normalizeProviderBaseUrl(baseUrl),
   };
 }
 

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -3,9 +3,10 @@ import { ResolveService } from '../resolve.service';
 import { RoutingService } from '../routing.service';
 import { CustomProviderService } from '../custom-provider.service';
 import { OpenaiOauthService } from '../openai-oauth.service';
+import { MinimaxOauthService } from '../minimax-oauth.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ProviderClient, ForwardResult } from './provider-client';
-import { buildCustomEndpoint, ProviderEndpoint } from './provider-endpoints';
+import { buildCustomEndpoint, buildEndpointOverride, ProviderEndpoint } from './provider-endpoints';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
 import { shouldTriggerFallback, FALLBACK_EXHAUSTED_STATUS } from './fallback-status-codes';
@@ -57,6 +58,7 @@ export class ProxyService {
     private readonly routingService: RoutingService,
     private readonly customProviderService: CustomProviderService,
     private readonly openaiOauth: OpenaiOauthService,
+    private readonly minimaxOauth: MinimaxOauthService,
     private readonly providerClient: ProviderClient,
     private readonly momentum: SessionMomentumService,
     private readonly limitCheck: LimitCheckService,
@@ -116,7 +118,7 @@ export class ProxyService {
       );
     }
 
-    apiKey = await this.resolveApiKey(
+    const resolvedCredentials = await this.resolveApiKey(
       resolved.provider,
       apiKey,
       resolved.auth_type,
@@ -131,13 +133,14 @@ export class ProxyService {
     const stream = body.stream === true;
     const forward = await this.forwardToProvider(
       resolved.provider,
-      apiKey,
+      resolvedCredentials.apiKey,
       resolved.model,
       body,
       stream,
       sessionKey,
       signal,
       resolved.auth_type,
+      resolvedCredentials.resourceUrl,
     );
 
     if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {
@@ -274,7 +277,13 @@ export class ProxyService {
         continue;
       }
 
-      apiKey = await this.resolveApiKey(provider, apiKey, authType, agentId, userId);
+      const resolvedCredentials = await this.resolveApiKey(
+        provider,
+        apiKey,
+        authType,
+        agentId,
+        userId,
+      );
 
       this.logger.log(
         `Fallback ${i}: trying model=${model} provider=${provider} auth_type=${authType} (primary=${primaryModel})`,
@@ -282,13 +291,14 @@ export class ProxyService {
 
       const forward = await this.forwardToProvider(
         provider,
-        apiKey,
+        resolvedCredentials.apiKey,
         model,
         body,
         stream,
         sessionKey,
         signal,
         authType,
+        resolvedCredentials.resourceUrl,
       );
 
       if (forward.response.ok) {
@@ -314,12 +324,19 @@ export class ProxyService {
     authType: string | undefined,
     agentId: string,
     userId: string,
-  ): Promise<string> {
-    if (authType === 'subscription' && provider.toLowerCase() === 'openai') {
-      const unwrapped = await this.openaiOauth.unwrapToken(apiKey, agentId, userId);
-      if (unwrapped) return unwrapped;
+  ): Promise<{ apiKey: string; resourceUrl?: string }> {
+    if (authType === 'subscription') {
+      const lower = provider.toLowerCase();
+      if (lower === 'openai') {
+        const unwrapped = await this.openaiOauth.unwrapToken(apiKey, agentId, userId);
+        if (unwrapped) return { apiKey: unwrapped };
+      }
+      if (lower === 'minimax') {
+        const unwrapped = await this.minimaxOauth.unwrapToken(apiKey, agentId, userId);
+        if (unwrapped) return { apiKey: unwrapped.t, resourceUrl: unwrapped.u };
+      }
     }
-    return apiKey;
+    return { apiKey };
   }
 
   private async enforceLimits(tenantId?: string, agentName?: string): Promise<void> {
@@ -374,6 +391,7 @@ export class ProxyService {
     sessionKey: string,
     signal?: AbortSignal,
     authType?: string,
+    resourceUrl?: string,
   ): Promise<ForwardResult> {
     const extraHeaders: Record<string, string> = {};
     if (provider === 'xai') {
@@ -391,6 +409,12 @@ export class ProxyService {
         customEndpoint = buildCustomEndpoint(cp.base_url);
         forwardModel = CustomProviderService.rawModelName(model);
       }
+    } else if (
+      authType === 'subscription' &&
+      provider.toLowerCase() === 'minimax' &&
+      resourceUrl
+    ) {
+      customEndpoint = buildEndpointOverride(resourceUrl, 'minimax-subscription');
     }
 
     return this.providerClient.forward(

--- a/packages/backend/src/routing/routing.module.ts
+++ b/packages/backend/src/routing/routing.module.ts
@@ -30,6 +30,8 @@ import { OllamaSyncService } from '../database/ollama-sync.service';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { OpenaiOauthService } from './openai-oauth.service';
 import { OpenaiOauthController } from './openai-oauth.controller';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { MinimaxOauthController } from './minimax-oauth.controller';
 
 @Module({
   imports: [
@@ -52,6 +54,7 @@ import { OpenaiOauthController } from './openai-oauth.controller';
     ResolveController,
     ProxyController,
     OpenaiOauthController,
+    MinimaxOauthController,
   ],
   providers: [
     RoutingService,
@@ -69,6 +72,7 @@ import { OpenaiOauthController } from './openai-oauth.controller';
     SessionMomentumService,
     OllamaSyncService,
     OpenaiOauthService,
+    MinimaxOauthService,
   ],
   exports: [
     RoutingService,
@@ -77,6 +81,7 @@ import { OpenaiOauthController } from './openai-oauth.controller';
     TierAutoAssignService,
     ResolveAgentService,
     OpenaiOauthService,
+    MinimaxOauthService,
   ],
 })
 export class RoutingModule {}

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -1,0 +1,242 @@
+import { createSignal, onCleanup, Show, type Accessor, type Component, type Setter } from 'solid-js';
+import type { ProviderDef } from '../services/providers.js';
+import {
+  disconnectProvider,
+  pollMinimaxOAuth,
+  startMinimaxOAuth,
+  type AuthType,
+} from '../services/api.js';
+import { toast } from '../services/toast-store.js';
+import { CopyButton } from './SetupStepInstall.js';
+
+interface Props {
+  provDef: ProviderDef;
+  provId: string;
+  agentName: string;
+  connected: Accessor<boolean>;
+  selectedAuthType: Accessor<AuthType>;
+  busy: Accessor<boolean>;
+  setBusy: Setter<boolean>;
+  onBack: () => void;
+  onUpdate: () => void;
+  onClose: () => void;
+}
+
+interface DeviceCodeFlow {
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+  pollIntervalMs: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+const DeviceCodeDetailView: Component<Props> = (props) => {
+  const [flow, setFlow] = createSignal<DeviceCodeFlow | null>(null);
+  const [statusMessage, setStatusMessage] = createSignal<string | null>(null);
+  const [flowError, setFlowError] = createSignal<string | null>(null);
+  let pollTimer: number | undefined;
+
+  const clearPollTimer = () => {
+    if (pollTimer !== undefined) {
+      window.clearTimeout(pollTimer);
+      pollTimer = undefined;
+    }
+  };
+
+  const schedulePoll = (delayMs: number) => {
+    clearPollTimer();
+    pollTimer = window.setTimeout(() => {
+      void runPoll();
+    }, delayMs);
+  };
+
+  const openVerificationPage = () => {
+    const current = flow();
+    if (!current) return;
+    window.open(current.verificationUri, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleDisconnect = async () => {
+    props.setBusy(true);
+    try {
+      const result = await disconnectProvider(
+        props.agentName,
+        props.provId,
+        props.selectedAuthType(),
+      );
+      if (result?.notifications?.length) {
+        for (const msg of result.notifications) {
+          toast.error(msg);
+        }
+      }
+      props.onBack();
+      props.onUpdate();
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const runPoll = async () => {
+    const current = flow();
+    if (!current) return;
+
+    if (Date.now() >= current.expiresAt) {
+      setFlowError('This verification code expired. Start again to generate a new one.');
+      setStatusMessage(null);
+      clearPollTimer();
+      return;
+    }
+
+    try {
+      const result = await pollMinimaxOAuth(current.flowId);
+
+      if (result.status === 'success') {
+        clearPollTimer();
+        toast.success(`${props.provDef.name} subscription connected`);
+        props.onUpdate();
+        props.onClose();
+        return;
+      }
+
+      if (result.status === 'error') {
+        clearPollTimer();
+        setFlowError(result.message ?? 'MiniMax login failed. Start again to retry.');
+        setStatusMessage(null);
+        return;
+      }
+
+      setFlowError(null);
+      setStatusMessage(result.message ?? 'Waiting for approval…');
+      schedulePoll(result.pollIntervalMs ?? current.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    } catch {
+      clearPollTimer();
+      setFlowError('Failed to check approval status. Start again to retry.');
+      setStatusMessage(null);
+    }
+  };
+
+  const handleStart = async () => {
+    props.setBusy(true);
+    clearPollTimer();
+    setFlowError(null);
+    setStatusMessage(null);
+    try {
+      const nextFlow = await startMinimaxOAuth(props.agentName);
+      setFlow(nextFlow);
+      window.open(nextFlow.verificationUri, '_blank', 'noopener,noreferrer');
+      schedulePoll(0);
+    } catch {
+      setFlow(null);
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  onCleanup(() => clearPollTimer());
+
+  return (
+    <>
+      <Show when={!props.connected()}>
+        <Show
+          when={flow()}
+          fallback={
+            <>
+              <p class="provider-detail__hint">
+                Open the verification page, enter a one-time code, and we will finish the
+                connection automatically.
+              </p>
+              <button
+                class="btn btn--primary provider-detail__action"
+                disabled={props.busy()}
+                onClick={handleStart}
+              >
+                <Show when={!props.busy()} fallback={<span class="spinner" />}>
+                  Connect with {props.provDef.name}
+                </Show>
+              </button>
+            </>
+          }
+        >
+          {(activeFlow) => (
+            <>
+              <p class="provider-detail__hint">
+                Enter this code at the MiniMax verification page to approve access.
+              </p>
+              <div class="provider-detail__field" style="margin-top: 12px;">
+                <label class="provider-detail__label">Verification Code</label>
+                <div class="provider-detail__key-row">
+                  <input
+                    class="provider-detail__input provider-detail__input--disabled"
+                    type="text"
+                    value={activeFlow().userCode}
+                    readonly
+                    aria-label={`${props.provDef.name} verification code`}
+                  />
+                  <CopyButton text={activeFlow().userCode} />
+                </div>
+              </div>
+              <div class="provider-detail__field" style="margin-top: 12px;">
+                <label class="provider-detail__label">Verification Link</label>
+                <div class="provider-detail__key-row">
+                  <input
+                    class="provider-detail__input provider-detail__input--disabled"
+                    type="text"
+                    value={activeFlow().verificationUri}
+                    readonly
+                    aria-label={`${props.provDef.name} verification link`}
+                  />
+                  <CopyButton text={activeFlow().verificationUri} />
+                </div>
+              </div>
+              <div class="provider-detail__field" style="margin-top: 12px;">
+                <button class="btn btn--outline btn--sm" onClick={openVerificationPage}>
+                  Open verification page
+                </button>
+                <button
+                  class="btn btn--ghost btn--sm"
+                  style="margin-left: 8px;"
+                  disabled={props.busy()}
+                  onClick={handleStart}
+                >
+                  Start over
+                </button>
+              </div>
+              <Show when={statusMessage()}>
+                <p class="provider-detail__hint" style="margin-top: 12px;">
+                  {statusMessage()}
+                </p>
+              </Show>
+              <Show when={flowError()}>
+                <div class="provider-detail__error" style="margin-top: 12px;">
+                  {flowError()}
+                </div>
+              </Show>
+            </>
+          )}
+        </Show>
+      </Show>
+      <Show when={props.connected()}>
+        <div class="provider-detail__field">
+          <span class="provider-detail__no-key">
+            Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+          </span>
+        </div>
+        <button
+          class="btn btn--outline provider-detail__action provider-detail__disconnect"
+          disabled={props.busy()}
+          onClick={handleDisconnect}
+        >
+          <Show when={!props.busy()} fallback={<span class="spinner" />}>
+            Disconnect
+          </Show>
+        </button>
+      </Show>
+    </>
+  );
+};
+
+export default DeviceCodeDetailView;

--- a/packages/frontend/src/components/ProviderDetailView.tsx
+++ b/packages/frontend/src/components/ProviderDetailView.tsx
@@ -12,6 +12,7 @@ import { toast } from '../services/toast-store.js';
 import { CopyButton } from './SetupStepInstall.js';
 import ProviderKeyForm from './ProviderKeyForm.js';
 import OAuthDetailView from './OAuthDetailView.js';
+import DeviceCodeDetailView from './DeviceCodeDetailView.js';
 
 export interface ProviderDetailViewProps {
   provId: string;
@@ -64,17 +65,24 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
   };
 
   const isSubMode = () => props.selectedAuthType() === 'subscription';
-  const isOAuthFlow = () => isSubMode() && !!provDef.subscriptionOAuth;
+  const subscriptionAuthMode = () =>
+    provDef.subscriptionAuthMode ??
+    (provDef.subscriptionOAuth ? 'popup_oauth' : undefined) ??
+    (provDef.subscriptionKeyPlaceholder ? 'token' : undefined);
+  const isPopupOAuthFlow = () => isSubMode() && subscriptionAuthMode() === 'popup_oauth';
+  const isDeviceCodeFlow = () => isSubMode() && subscriptionAuthMode() === 'device_code';
   const isCommandOnly = () =>
     isSubMode() &&
     !!provDef.subscriptionCommand &&
     !provDef.subscriptionKeyPlaceholder &&
-    !provDef.subscriptionOAuth;
+    !subscriptionAuthMode();
   const connected = () =>
     isSubMode()
       ? isCommandOnly()
         ? isSubscriptionConnected()
-        : isSubscriptionWithToken()
+        : subscriptionAuthMode() === 'token'
+          ? isSubscriptionWithToken()
+          : isSubscriptionConnected()
       : isConnectedApiKey() || isNoKeyConnected();
   const isOllama = provDef.noKeyRequired;
 
@@ -98,7 +106,7 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      if (provDef.subscriptionOAuth && props.selectedAuthType() === 'subscription') {
+      if (isPopupOAuthFlow()) {
         await revokeOpenaiOAuth(props.agentName).catch(() => {});
       }
       const result = await disconnectProvider(
@@ -145,8 +153,10 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
           <div class="routing-modal__title">Connect providers</div>
           <div class="routing-modal__subtitle">
             {isSubMode()
-              ? isOAuthFlow()
+              ? isPopupOAuthFlow()
                 ? 'Log in to connect your subscription'
+                : isDeviceCodeFlow()
+                  ? 'Verify your account to connect your subscription'
                 : isCommandOnly()
                   ? 'Log in via your browser to connect your subscription'
                   : 'Paste your setup-token to enable routing'
@@ -230,8 +240,24 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
       </Show>
 
       {/* OAuth subscription */}
-      <Show when={isOAuthFlow()}>
+      <Show when={isPopupOAuthFlow()}>
         <OAuthDetailView
+          provDef={provDef}
+          provId={props.provId}
+          agentName={props.agentName}
+          connected={connected}
+          selectedAuthType={props.selectedAuthType}
+          busy={props.busy}
+          setBusy={props.setBusy}
+          onBack={props.onBack}
+          onUpdate={props.onUpdate}
+          onClose={props.onClose}
+        />
+      </Show>
+
+      {/* Device-code subscription */}
+      <Show when={isDeviceCodeFlow()}>
+        <DeviceCodeDetailView
           provDef={provDef}
           provId={props.provId}
           agentName={props.agentName}
@@ -275,7 +301,7 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
       </Show>
 
       {/* API key / subscription token form (non-Ollama, non-command-only, non-OAuth) */}
-      <Show when={!isOllama && !isCommandOnly() && !isOAuthFlow()}>
+      <Show when={!isOllama && !isCommandOnly() && !isPopupOAuthFlow() && !isDeviceCodeFlow()}>
         <ProviderKeyForm
           provDef={provDef}
           provId={props.provId}

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -31,6 +31,8 @@ export interface ProviderKeyFormProps {
 }
 
 const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
+  const isPopupOAuth = () =>
+    props.provDef.subscriptionAuthMode === 'popup_oauth' || !!props.provDef.subscriptionOAuth;
   const fieldLabel = () => (props.isSubMode() ? 'Setup Token' : 'API Key');
   const placeholder = () =>
     props.isSubMode()
@@ -100,7 +102,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      if (props.provDef.subscriptionOAuth && props.selectedAuthType() === 'subscription') {
+      if (isPopupOAuth() && props.selectedAuthType() === 'subscription') {
         await revokeOpenaiOAuth(props.agentName).catch(() => {});
       }
       const result = await disconnectProvider(

--- a/packages/frontend/src/components/ProviderSubscriptionTab.tsx
+++ b/packages/frontend/src/components/ProviderSubscriptionTab.tsx
@@ -13,6 +13,11 @@ interface Props {
 }
 
 const ProviderSubscriptionTab: Component<Props> = (props) => {
+  const getSubscriptionAuthMode = (prov: ProviderDef) =>
+    prov.subscriptionAuthMode ??
+    (prov.subscriptionOAuth ? 'popup_oauth' : undefined) ??
+    (prov.subscriptionKeyPlaceholder ? 'token' : undefined);
+
   return (
     <>
       <div class="provider-modal__tab-hint">
@@ -25,9 +30,10 @@ const ProviderSubscriptionTab: Component<Props> = (props) => {
             const hasDetailView = () =>
               !!prov.subscriptionKeyPlaceholder ||
               !!prov.subscriptionCommand ||
-              !!prov.subscriptionOAuth;
+              !!getSubscriptionAuthMode(prov);
+            const requiresStoredToken = () => getSubscriptionAuthMode(prov) === 'token';
             const connected = () =>
-              prov.subscriptionKeyPlaceholder || prov.subscriptionOAuth
+              requiresStoredToken()
                 ? props.isSubscriptionWithToken(prov.id)
                 : props.isSubscriptionConnected(prov.id);
 

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -393,6 +393,20 @@ export interface RoutingProvider {
   connected_at: string;
 }
 
+export interface MinimaxOAuthStartResponse {
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+  pollIntervalMs: number;
+}
+
+export interface MinimaxOAuthPollResponse {
+  status: 'pending' | 'success' | 'error';
+  message?: string;
+  pollIntervalMs?: number;
+}
+
 export function getProviders(agentName: string) {
   return fetchJson<RoutingProvider[]>(`/routing/${encodeURIComponent(agentName)}/providers`);
 }
@@ -437,6 +451,19 @@ export function revokeOpenaiOAuth(agentName: string) {
     `${BASE_URL}/oauth/openai/revoke?agentName=${encodeURIComponent(agentName)}`,
     { method: 'POST' },
   );
+}
+
+export function startMinimaxOAuth(agentName: string) {
+  return fetchMutate<MinimaxOAuthStartResponse>(
+    `${BASE_URL}/oauth/minimax/start?agentName=${encodeURIComponent(agentName)}`,
+    { method: 'POST' },
+  );
+}
+
+export function pollMinimaxOAuth(flowId: string) {
+  return fetchJson<MinimaxOAuthPollResponse>(`/oauth/minimax/poll`, {
+    flowId,
+  });
 }
 
 export function disconnectProvider(agentName: string, provider: string, authType?: AuthType) {

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -20,7 +20,9 @@ export interface ProviderDef {
   subscriptionKeyPlaceholder?: string;
   /** Instructions text shown in the subscription detail view. */
   subscriptionCommand?: string;
-  /** Provider uses browser-based OAuth flow (popup window). */
+  /** UI auth mode for subscription flows. */
+  subscriptionAuthMode?: 'popup_oauth' | 'device_code' | 'token';
+  /** Deprecated compatibility flag for popup OAuth providers. */
   subscriptionOAuth?: boolean;
 }
 
@@ -47,6 +49,7 @@ export const PROVIDERS: ProviderDef[] = [
     keyPlaceholder: 'sk-ant-...',
     supportsSubscription: true,
     subscriptionLabel: 'Claude Max / Pro subscription',
+    subscriptionAuthMode: 'token',
     subscriptionKeyPlaceholder: 'Paste your setup-token',
     subscriptionCommand: 'claude setup-token',
     models: [],
@@ -82,6 +85,9 @@ export const PROVIDERS: ProviderDef[] = [
     keyPrefix: 'sk-api-',
     minKeyLength: 30,
     keyPlaceholder: 'sk-api-...',
+    supportsSubscription: true,
+    subscriptionLabel: 'MiniMax Coding Plan',
+    subscriptionAuthMode: 'device_code',
     models: [],
   },
   {
@@ -130,7 +136,7 @@ export const PROVIDERS: ProviderDef[] = [
     keyPlaceholder: 'sk-...',
     supportsSubscription: true,
     subscriptionLabel: 'ChatGPT Plus/Pro/Team',
-    subscriptionOAuth: true,
+    subscriptionAuthMode: 'popup_oauth',
     models: [
       { label: 'GPT-4o', value: 'gpt-4o' },
       { label: 'GPT-4o Mini', value: 'gpt-4o-mini' },

--- a/packages/frontend/tests/components/ProviderSelectModal-commandonly.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal-commandonly.test.tsx
@@ -4,12 +4,16 @@ import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockPollMinimaxOAuth = vi.fn();
+const mockStartMinimaxOAuth = vi.fn();
 
 vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: () => Promise.resolve({ ok: true }),
+  startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({
@@ -63,6 +67,14 @@ describe("ProviderSelectModal -- command-only subscription detail view", () => {
     onClose = vi.fn();
     onUpdate = vi.fn();
     mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    mockPollMinimaxOAuth.mockResolvedValue({ status: "pending", pollIntervalMs: 2000 });
+    mockStartMinimaxOAuth.mockResolvedValue({
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: Date.now() + 60_000,
+      pollIntervalMs: 2000,
+    });
   });
 
   it("shows command-only subtitle and hint text when not connected", () => {

--- a/packages/frontend/tests/components/ProviderSelectModal-subscription.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal-subscription.test.tsx
@@ -4,12 +4,16 @@ import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockPollMinimaxOAuth = vi.fn();
+const mockStartMinimaxOAuth = vi.fn();
 
 vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: () => Promise.resolve({ ok: true }),
+  startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({
@@ -62,6 +66,14 @@ describe("ProviderSelectModal — subscription toggle (no subscriptionKeyPlaceho
     onUpdate = vi.fn();
     mockConnectProvider.mockResolvedValue({});
     mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    mockPollMinimaxOAuth.mockResolvedValue({ status: "pending", pollIntervalMs: 2000 });
+    mockStartMinimaxOAuth.mockResolvedValue({
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: Date.now() + 60_000,
+      pollIntervalMs: 2000,
+    });
   });
 
   it("connects a subscription provider via toggle when not connected", async () => {

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1,10 +1,40 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 
+const broadcastChannelRegistry = new Map<string, Set<MockBroadcastChannel>>();
+
+class MockBroadcastChannel {
+  name: string;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+
+  constructor(name: string) {
+    this.name = name;
+    if (!broadcastChannelRegistry.has(name)) {
+      broadcastChannelRegistry.set(name, new Set());
+    }
+    broadcastChannelRegistry.get(name)!.add(this);
+  }
+
+  postMessage(data: unknown) {
+    const listeners = broadcastChannelRegistry.get(this.name);
+    if (!listeners) return;
+    for (const channel of listeners) {
+      if (channel === this) continue;
+      channel.onmessage?.({ data });
+    }
+  }
+
+  close() {
+    broadcastChannelRegistry.get(this.name)?.delete(this);
+  }
+}
+
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockPollMinimaxOAuth = vi.fn();
 const mockRevokeOpenaiOAuth = vi.fn();
+const mockStartMinimaxOAuth = vi.fn();
 const mockCreateCustomProvider = vi.fn();
 const mockUpdateCustomProvider = vi.fn();
 const mockDeleteCustomProvider = vi.fn();
@@ -13,7 +43,9 @@ vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
+  startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
   createCustomProvider: (...args: unknown[]) => mockCreateCustomProvider(...args),
   updateCustomProvider: (...args: unknown[]) => mockUpdateCustomProvider(...args),
   deleteCustomProvider: (...args: unknown[]) => mockDeleteCustomProvider(...args),
@@ -67,13 +99,27 @@ describe("ProviderSelectModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    broadcastChannelRegistry.clear();
+    vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
     mockLocalMode = false;
     onClose = vi.fn();
     onUpdate = vi.fn();
     mockConnectProvider.mockResolvedValue({});
     mockDisconnectProvider.mockResolvedValue({ notifications: [] });
     mockGetOpenaiOAuthUrl.mockResolvedValue({ url: "https://auth.openai.com/oauth/authorize?test=1" });
+    mockPollMinimaxOAuth.mockResolvedValue({
+      status: "pending",
+      message: "Waiting for MiniMax approval…",
+      pollIntervalMs: 2000,
+    });
     mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
+    mockStartMinimaxOAuth.mockResolvedValue({
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: Date.now() + 60_000,
+      pollIntervalMs: 2000,
+    });
   });
 
   it("renders modal with title", () => {
@@ -1153,6 +1199,68 @@ describe("ProviderSelectModal", () => {
         <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       expect(screen.getByText("ChatGPT Plus/Pro/Team")).toBeDefined();
+    });
+
+    it("shows MiniMax subscription label in list", () => {
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+      expect(screen.getByText("MiniMax Coding Plan")).toBeDefined();
+    });
+
+    it("opens MiniMax device-code detail view", () => {
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+      fireEvent.click(screen.getByText("MiniMax"));
+      expect(screen.getByText("Verify your account to connect your subscription")).toBeDefined();
+      expect(screen.getByText("Connect with MiniMax")).toBeDefined();
+    });
+
+    it("starts MiniMax device-code flow and shows code details", async () => {
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith("test-agent");
+      });
+      expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+      expect(screen.getByDisplayValue("https://www.minimax.io/verify")).toBeDefined();
+      expect(window.open).toHaveBeenCalledWith(
+        "https://www.minimax.io/verify",
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      vi.restoreAllMocks();
+    });
+
+    it("shows Disconnect button for connected MiniMax subscription", () => {
+      const subProvider: RoutingProvider = {
+        id: "p-minimax-sub",
+        provider: "minimax",
+        is_active: true,
+        has_api_key: true,
+        key_prefix: '{"t":"mm',
+        connected_at: "2025-01-01",
+        auth_type: "subscription",
+      };
+      render(() => (
+        <ProviderSelectModal
+          providers={[subProvider]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
+      ));
+      fireEvent.click(screen.getByText("MiniMax"));
+      expect(screen.getByText("Disconnect")).toBeDefined();
+      expect(screen.getByText(/Connected via MiniMax Coding Plan/)).toBeDefined();
     });
 
     it("does not show paste field for OAuth provider", () => {

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -18,7 +18,9 @@ import {
   deactivateAllProviders,
   disconnectProvider,
   getOpenaiOAuthUrl,
+  pollMinimaxOAuth,
   revokeOpenaiOAuth,
+  startMinimaxOAuth,
   getTierAssignments,
   overrideTier,
   resetTier,
@@ -560,6 +562,39 @@ describe("revokeOpenaiOAuth", () => {
       "/api/v1/oauth/openai/revoke?agentName=my-agent",
       expect.objectContaining({ method: "POST", credentials: "include" }),
     );
+  });
+});
+
+describe("startMinimaxOAuth", () => {
+  it("sends POST to /oauth/minimax/start with agentName param", async () => {
+    const payload = {
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: 1760000000000,
+      pollIntervalMs: 2000,
+    };
+    mockMutateOk(payload);
+
+    const result = await startMinimaxOAuth("my-agent");
+    expect(result).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/oauth/minimax/start?agentName=my-agent",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
+  });
+});
+
+describe("pollMinimaxOAuth", () => {
+  it("fetches /oauth/minimax/poll with flowId param", async () => {
+    const payload = { status: "pending", message: "Waiting", pollIntervalMs: 2000 };
+    mockOk(payload);
+
+    const result = await pollMinimaxOAuth("flow-1");
+    expect(result).toEqual(payload);
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/api/v1/oauth/minimax/poll");
+    expect(url).toContain("flowId=flow-1");
   });
 });
 

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -279,13 +279,21 @@ describe("PROVIDERS", () => {
     expect(openai.subscriptionLabel).toBe("ChatGPT Plus/Pro/Team");
     expect(openai.subscriptionKeyPlaceholder).toBeUndefined();
     expect(openai.subscriptionCommand).toBeUndefined();
-    expect(openai.subscriptionOAuth).toBe(true);
+    expect(openai.subscriptionAuthMode).toBe("popup_oauth");
   });
 
   it("Anthropic supports subscription", () => {
     const anthropic = PROVIDERS.find((p) => p.id === "anthropic")!;
     expect(anthropic.supportsSubscription).toBe(true);
     expect(anthropic.subscriptionLabel).toBe("Claude Max / Pro subscription");
+    expect(anthropic.subscriptionAuthMode).toBe("token");
+  });
+
+  it("MiniMax supports subscription with device-code flow", () => {
+    const minimax = PROVIDERS.find((p) => p.id === "minimax")!;
+    expect(minimax.supportsSubscription).toBe(true);
+    expect(minimax.subscriptionLabel).toBe("MiniMax Coding Plan");
+    expect(minimax.subscriptionAuthMode).toBe("device_code");
   });
 
   it("requires an API key URL for every provider that needs one", () => {

--- a/packages/openclaw-plugin/__tests__/subscription.test.ts
+++ b/packages/openclaw-plugin/__tests__/subscription.test.ts
@@ -204,6 +204,7 @@ describe("discoverSubscriptionProviders", () => {
           c: { type: "oauth", provider: "qwen-portal" },
           d: { type: "oauth", provider: "kimi" },
           e: { type: "oauth", provider: "minimax" },
+          f: { type: "oauth", provider: "minimax-portal" },
         },
       }),
     );
@@ -212,6 +213,7 @@ describe("discoverSubscriptionProviders", () => {
     expect(result).toEqual([
       { openclawId: "anthropic", manifestId: "anthropic", authType: "oauth" },
       { openclawId: "github-copilot", manifestId: "openai", authType: "oauth" },
+      { openclawId: "minimax", manifestId: "minimax", authType: "oauth" },
     ]);
   });
 });

--- a/packages/openclaw-plugin/src/subscription.ts
+++ b/packages/openclaw-plugin/src/subscription.ts
@@ -42,6 +42,7 @@ const OPENCLAW_TO_MANIFEST: Record<string, string> = {
   moonshot: 'moonshot',
   kimi: 'moonshot',
   minimax: 'minimax',
+  'minimax-portal': 'minimax',
 };
 
 /**

--- a/packages/openclaw-plugin/subscription-capabilities/index.js
+++ b/packages/openclaw-plugin/subscription-capabilities/index.js
@@ -30,6 +30,16 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
       supportsBatching: false,
     }),
   }),
+  minimax: Object.freeze({
+    supportsSubscription: true,
+    subscriptionLabel: 'MiniMax Coding Plan',
+    knownModels: Object.freeze(['minimax-m2.1', 'minimax-m2.5']),
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
 });
 
 const SUPPORTED_SUBSCRIPTION_PROVIDER_IDS = Object.freeze(

--- a/packages/subscription-capabilities/index.js
+++ b/packages/subscription-capabilities/index.js
@@ -30,6 +30,16 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
       supportsBatching: false,
     }),
   }),
+  minimax: Object.freeze({
+    supportsSubscription: true,
+    subscriptionLabel: 'MiniMax Coding Plan',
+    knownModels: Object.freeze(['minimax-m2.1', 'minimax-m2.5']),
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
 });
 
 const SUPPORTED_SUBSCRIPTION_PROVIDER_IDS = Object.freeze(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add MiniMax subscription login via device-code OAuth, letting users connect their MiniMax Coding Plan. Backend stores and refreshes tokens (with provider-specific `resource_url`) and routes requests to the Anthropic-compatible endpoint; the frontend adds a simple flow to start and poll authorization.

- **New Features**
  - Backend: `POST /api/v1/oauth/minimax/start` and `GET /api/v1/oauth/minimax/poll` to start and poll device-code auth; token refresh and unwrap with `resource_url` support; model discovery passes an endpoint override; proxy forwards via `minimax-subscription` (Anthropic format) using the stored base URL.
  - Frontend: New device-code UI in the provider modal for MiniMax; added `startMinimaxOAuth` and `pollMinimaxOAuth`; provider defs use `subscriptionAuthMode` (`device_code` for MiniMax, `popup_oauth` for OpenAI, `token` for Anthropic).
  - Capabilities: Added MiniMax subscription config and OpenClaw mapping.

- **Refactors**
  - Model discovery now parses generic OAuth blobs and forwards endpoint overrides; fallback model matching is case-insensitive.
  - Proxy and provider endpoint utilities support per-provider endpoint overrides and `minimax-subscription`.
  - Tests updated across backend, frontend, and plugins.

<sup>Written for commit 1e831a06b43a592152276ad82326690f18243220. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

