### PR TITLE
Fix local-mode SPA refresh fallback

### DIFF
--- a/packages/backend/src/app.module.spec.ts
+++ b/packages/backend/src/app.module.spec.ts
@@ -1,0 +1,99 @@
+import 'reflect-metadata';
+import { MODULE_METADATA } from '@nestjs/common/constants';
+
+function loadServeStaticOptions(frontendDir: string | null) {
+  jest.resetModules();
+  jest.doMock('./common/utils/frontend-path', () => ({
+    resolveFrontendDir: () => frontendDir,
+  }));
+  jest.doMock('./auth/session.guard', () => ({
+    SessionGuard: class SessionGuard {},
+  }));
+  jest.doMock('./auth/local-auth.guard', () => ({
+    LocalAuthGuard: class LocalAuthGuard {},
+  }));
+  jest.doMock('./common/guards/api-key.guard', () => ({
+    ApiKeyGuard: class ApiKeyGuard {},
+  }));
+  for (const [path, exportName] of [
+    ['./database/database.module', 'DatabaseModule'],
+    ['./auth/auth.module', 'AuthModule'],
+    ['./health/health.module', 'HealthModule'],
+    ['./telemetry/telemetry.module', 'TelemetryModule'],
+    ['./analytics/analytics.module', 'AnalyticsModule'],
+    ['./security/security.module', 'SecurityModule'],
+    ['./otlp/otlp.module', 'OtlpModule'],
+    ['./model-prices/model-prices.module', 'ModelPricesModule'],
+    ['./notifications/notifications.module', 'NotificationsModule'],
+    ['./routing/routing.module', 'RoutingModule'],
+    ['./common/common.module', 'CommonModule'],
+    ['./sse/sse.module', 'SseModule'],
+    ['./github/github.module', 'GithubModule'],
+  ] as const) {
+    jest.doMock(path, () => ({
+      [exportName]: class MockModule {},
+    }));
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { AppModule } = require('./app.module') as typeof import('./app.module');
+  const imports = Reflect.getMetadata(MODULE_METADATA.IMPORTS, AppModule) ?? [];
+  const serveStaticModule = imports.find(
+    (entry: { module?: { name?: string } }) => entry?.module?.name === 'ServeStaticModule',
+  ) as
+    | {
+        providers?: Array<{ provide?: string; useValue?: unknown }>;
+      }
+    | undefined;
+
+  return serveStaticModule?.providers?.find(
+    (provider) => provider.provide === 'SERVE_STATIC_MODULE_OPTIONS',
+  ) as
+    | {
+        useValue?: Array<Record<string, unknown>>;
+      }
+    | undefined;
+}
+
+describe('AppModule', () => {
+  const originalManifestMode = process.env['MANIFEST_MODE'];
+
+  beforeEach(() => {
+    process.env['MANIFEST_MODE'] = 'local';
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.dontMock('./common/utils/frontend-path');
+  });
+
+  afterAll(() => {
+    if (originalManifestMode === undefined) {
+      delete process.env['MANIFEST_MODE'];
+    } else {
+      process.env['MANIFEST_MODE'] = originalManifestMode;
+    }
+  });
+
+  it('disables ServeStaticModule SPA catch-all and keeps static asset serving', () => {
+    const optionsProvider = loadServeStaticOptions('/mock/frontend');
+
+    expect(optionsProvider?.useValue).toEqual([
+      expect.objectContaining({
+        rootPath: '/mock/frontend',
+        renderPath: '/__manifest_internal_static_fallback__',
+        exclude: ['/api/{*path}', '/otlp/{*path}', '/v1/{*path}'],
+        serveStaticOptions: expect.objectContaining({
+          immutable: true,
+          maxAge: 365 * 24 * 60 * 60 * 1000,
+          setHeaders: expect.any(Function),
+        }),
+      }),
+    ]);
+  });
+
+  it('omits ServeStaticModule when no frontend bundle is available', () => {
+    const optionsProvider = loadServeStaticOptions(null);
+    expect(optionsProvider).toBeUndefined();
+  });
+});

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -31,10 +31,14 @@ const sessionGuardClass = isLocalMode ? LocalAuthGuard : SessionGuard;
 
 const frontendPath = resolveFrontendDir();
 const ONE_YEAR_S = 365 * 24 * 60 * 60;
+const DISABLED_SPA_RENDER_PATH = '/__manifest_internal_static_fallback__';
 const serveStaticImports = frontendPath
   ? [
       ServeStaticModule.forRoot({
         rootPath: frontendPath,
+        // Let Nest's SpaFallbackFilter handle deep-link refreshes instead of
+        // @nestjs/serve-static's Express-layer catch-all.
+        renderPath: DISABLED_SPA_RENDER_PATH,
         exclude: ['/api/{*path}', '/otlp/{*path}', '/v1/{*path}'],
         serveStaticOptions: {
           maxAge: ONE_YEAR_S * 1000,


### PR DESCRIPTION
## Summary
- disable @nestjs/serve-static's Express catch-all for SPA deep links
- let the existing Nest SpaFallbackFilter serve index.html on local-mode refreshes
- add a focused module spec covering the static config handoff

## Verification
- npm test --workspace=packages/backend -- app.module.spec.ts spa-fallback.filter.spec.ts

Note: the PR branch was prepared in a clean worktree from upstream/main. That worktree does not have its own node_modules, so the verification command was run from the existing workspace using the same patch.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SPA deep-link refresh in local mode by disabling `@nestjs/serve-static`’s catch-all and letting the app’s SpaFallbackFilter serve index.html. Static assets remain served with long-term caching.

- **Bug Fixes**
  - Set `renderPath` to `/__manifest_internal_static_fallback__` to disable the Express catch-all while keeping `exclude` routes.
  - Preserve static asset serving with 1-year cache headers.
  - Added `app.module.spec.ts` to verify ServeStatic options and omit the module when no frontend bundle is present.

<sup>Written for commit 742e7bc44a635171d6d7ae657d8c30369b1d0e19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

