### PR TITLE
Add MiniMax device-code OAuth subscription flow

### DIFF
--- a/.changeset/fuzzy-roses-pretend.md
+++ b/.changeset/fuzzy-roses-pretend.md
@@ -1,0 +1,4 @@
+"manifest": patch
+---
+
+Fix MiniMax OAuth subscription setup by handling region-specific endpoints, normalizing device-code timing values, and aligning fallback model metadata with the documented MiniMax model IDs.

--- a/.changeset/fuzzy-roses-pretend.md
+++ b/.changeset/fuzzy-roses-pretend.md
@@ -1,3 +1,4 @@
+---
 "manifest": patch
 ---
 

--- a/.changeset/fuzzy-roses-pretend.md
+++ b/.changeset/fuzzy-roses-pretend.md
@@ -1,5 +1,5 @@
 ---
-"manifest": patch
+"manifest": minor
 ---
 
 Fix MiniMax OAuth subscription setup by handling region-specific endpoints, normalizing device-code timing values, and aligning fallback model metadata with the documented MiniMax model IDs.

--- a/packages/backend/src/routing/minimax-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.spec.ts
@@ -1,4 +1,4 @@
-import { HttpException } from '@nestjs/common';
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { MinimaxOauthController } from './minimax-oauth.controller';
 import { MinimaxOauthService } from './minimax-oauth.service';
 import { ResolveAgentService } from './resolve-agent.service';
@@ -61,5 +61,15 @@ describe('MinimaxOauthController', () => {
 
   it('throws 400 when flowId is missing', async () => {
     await expect(controller.poll('', { id: 'user-1' } as never)).rejects.toThrow(HttpException);
+  });
+
+  it('maps startAuthorization failures to 503', async () => {
+    resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+    oauthService.startAuthorization.mockRejectedValue(new Error('MiniMax unavailable'));
+
+    await expect(controller.start('my-agent', 'global', { id: 'user-1' } as never)).rejects.toMatchObject({
+      message: 'MiniMax unavailable',
+      status: HttpStatus.SERVICE_UNAVAILABLE,
+    });
   });
 });

--- a/packages/backend/src/routing/minimax-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.spec.ts
@@ -67,8 +67,19 @@ describe('MinimaxOauthController', () => {
     resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
     oauthService.startAuthorization.mockRejectedValue(new Error('MiniMax unavailable'));
 
-    await expect(controller.start('my-agent', 'global', { id: 'user-1' } as never)).rejects.toMatchObject({
+    await expect(
+      controller.start('my-agent', 'global', { id: 'user-1' } as never),
+    ).rejects.toMatchObject({
       message: 'MiniMax unavailable',
+      status: HttpStatus.SERVICE_UNAVAILABLE,
+    });
+  });
+
+  it('maps pollAuthorization failures to 503', async () => {
+    oauthService.pollAuthorization.mockRejectedValue(new Error('MiniMax poll unavailable'));
+
+    await expect(controller.poll('flow-1', { id: 'user-1' } as never)).rejects.toMatchObject({
+      message: 'MiniMax poll unavailable',
       status: HttpStatus.SERVICE_UNAVAILABLE,
     });
   });

--- a/packages/backend/src/routing/minimax-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.spec.ts
@@ -31,15 +31,23 @@ describe('MinimaxOauthController', () => {
       pollIntervalMs: 2000,
     });
 
-    const result = await controller.start('my-agent', { id: 'user-1' } as never);
+    const result = await controller.start('my-agent', 'cn', { id: 'user-1' } as never);
 
     expect(resolveAgent.resolve).toHaveBeenCalledWith('user-1', 'my-agent');
-    expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1');
+    expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1', 'cn');
     expect(result.flowId).toBe('flow-1');
   });
 
   it('throws 400 when agentName is missing', async () => {
-    await expect(controller.start('', { id: 'user-1' } as never)).rejects.toThrow(HttpException);
+    await expect(controller.start('', 'global', { id: 'user-1' } as never)).rejects.toThrow(
+      HttpException,
+    );
+  });
+
+  it('throws 400 when region is invalid', async () => {
+    await expect(controller.start('my-agent', 'mars', { id: 'user-1' } as never)).rejects.toThrow(
+      HttpException,
+    );
   });
 
   it('polls MiniMax OAuth state', async () => {

--- a/packages/backend/src/routing/minimax-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.spec.ts
@@ -1,0 +1,57 @@
+import { HttpException } from '@nestjs/common';
+import { MinimaxOauthController } from './minimax-oauth.controller';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { ResolveAgentService } from './resolve-agent.service';
+
+describe('MinimaxOauthController', () => {
+  let controller: MinimaxOauthController;
+  let oauthService: jest.Mocked<MinimaxOauthService>;
+  let resolveAgent: jest.Mocked<ResolveAgentService>;
+
+  beforeEach(() => {
+    oauthService = {
+      startAuthorization: jest.fn(),
+      pollAuthorization: jest.fn(),
+    } as unknown as jest.Mocked<MinimaxOauthService>;
+
+    resolveAgent = {
+      resolve: jest.fn(),
+    } as unknown as jest.Mocked<ResolveAgentService>;
+
+    controller = new MinimaxOauthController(oauthService, resolveAgent);
+  });
+
+  it('starts MiniMax OAuth for the resolved agent', async () => {
+    resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+    oauthService.startAuthorization.mockResolvedValue({
+      flowId: 'flow-1',
+      userCode: 'ABCD-1234',
+      verificationUri: 'https://www.minimax.io/verify',
+      expiresAt: Date.now() + 60_000,
+      pollIntervalMs: 2000,
+    });
+
+    const result = await controller.start('my-agent', { id: 'user-1' } as never);
+
+    expect(resolveAgent.resolve).toHaveBeenCalledWith('user-1', 'my-agent');
+    expect(oauthService.startAuthorization).toHaveBeenCalledWith('agent-id-1', 'user-1');
+    expect(result.flowId).toBe('flow-1');
+  });
+
+  it('throws 400 when agentName is missing', async () => {
+    await expect(controller.start('', { id: 'user-1' } as never)).rejects.toThrow(HttpException);
+  });
+
+  it('polls MiniMax OAuth state', async () => {
+    oauthService.pollAuthorization.mockResolvedValue({ status: 'pending' });
+
+    const result = await controller.poll('flow-1', { id: 'user-1' } as never);
+
+    expect(oauthService.pollAuthorization).toHaveBeenCalledWith('flow-1', 'user-1');
+    expect(result).toEqual({ status: 'pending' });
+  });
+
+  it('throws 400 when flowId is missing', async () => {
+    await expect(controller.poll('', { id: 'user-1' } as never)).rejects.toThrow(HttpException);
+  });
+});

--- a/packages/backend/src/routing/minimax-oauth.controller.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.ts
@@ -42,6 +42,11 @@ export class MinimaxOauthController {
     if (!flowId) {
       throw new HttpException('flowId query parameter is required', HttpStatus.BAD_REQUEST);
     }
-    return this.oauthService.pollAuthorization(flowId, user.id);
+    try {
+      return await this.oauthService.pollAuthorization(flowId, user.id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to poll MiniMax OAuth';
+      throw new HttpException(message, HttpStatus.SERVICE_UNAVAILABLE);
+    }
   }
 }

--- a/packages/backend/src/routing/minimax-oauth.controller.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.ts
@@ -29,7 +29,12 @@ export class MinimaxOauthController {
 
     const agent = await this.resolveAgent.resolve(user.id, agentName);
     const selectedRegion = region && isMinimaxRegion(region) ? region : 'global';
-    return this.oauthService.startAuthorization(agent.id, user.id, selectedRegion);
+    try {
+      return await this.oauthService.startAuthorization(agent.id, user.id, selectedRegion);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start MiniMax OAuth';
+      throw new HttpException(message, HttpStatus.SERVICE_UNAVAILABLE);
+    }
   }
 
   @Get('poll')

--- a/packages/backend/src/routing/minimax-oauth.controller.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.ts
@@ -1,0 +1,31 @@
+import { Controller, Get, HttpException, HttpStatus, Post, Query } from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { AuthUser } from '../auth/auth.instance';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { ResolveAgentService } from './resolve-agent.service';
+
+@Controller('api/v1/oauth/minimax')
+export class MinimaxOauthController {
+  constructor(
+    private readonly oauthService: MinimaxOauthService,
+    private readonly resolveAgent: ResolveAgentService,
+  ) {}
+
+  @Post('start')
+  async start(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    return this.oauthService.startAuthorization(agent.id, user.id);
+  }
+
+  @Get('poll')
+  async poll(@Query('flowId') flowId: string, @CurrentUser() user: AuthUser) {
+    if (!flowId) {
+      throw new HttpException('flowId query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    return this.oauthService.pollAuthorization(flowId, user.id);
+  }
+}

--- a/packages/backend/src/routing/minimax-oauth.controller.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, HttpException, HttpStatus, Post, Query } from '@nestjs/common';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
-import { MinimaxOauthService } from './minimax-oauth.service';
+import { isMinimaxRegion, MinimaxOauthService } from './minimax-oauth.service';
 import { ResolveAgentService } from './resolve-agent.service';
 
 @Controller('api/v1/oauth/minimax')
@@ -12,13 +12,24 @@ export class MinimaxOauthController {
   ) {}
 
   @Post('start')
-  async start(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+  async start(
+    @Query('agentName') agentName: string,
+    @Query('region') region: string | undefined,
+    @CurrentUser() user: AuthUser,
+  ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
+    if (region && !isMinimaxRegion(region)) {
+      throw new HttpException(
+        'region query parameter must be one of: global, cn',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
 
     const agent = await this.resolveAgent.resolve(user.id, agentName);
-    return this.oauthService.startAuthorization(agent.id, user.id);
+    const selectedRegion = region && isMinimaxRegion(region) ? region : 'global';
+    return this.oauthService.startAuthorization(agent.id, user.id, selectedRegion);
   }
 
   @Get('poll')

--- a/packages/backend/src/routing/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.spec.ts
@@ -11,8 +11,11 @@ describe('MinimaxOauthService', () => {
   let routingService: jest.Mocked<RoutingService>;
   let configService: jest.Mocked<ConfigService>;
   let discoveryService: { discoverModels: jest.Mock };
+  let dateNowSpy: jest.SpyInstance<number, []>;
+  const now = 1_760_000_000_000;
 
   beforeEach(() => {
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
     routingService = {
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
@@ -30,17 +33,22 @@ describe('MinimaxOauthService', () => {
     fetchMock.mockReset();
   });
 
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+  });
+
   describe('startAuthorization', () => {
-    it('returns device-code payload and stores a pending flow', async () => {
-      fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+    it('returns device-code payload, normalizes timing fields, and stores a pending flow', async () => {
+      fetchMock.mockImplementationOnce(async (url: string, init?: RequestInit) => {
         const params = new URLSearchParams(init?.body as string);
+        expect(url).toBe('https://api.minimax.io/oauth/code');
         return {
           ok: true,
           json: async () => ({
             user_code: 'ABCD-1234',
             verification_uri: 'https://www.minimax.io/verify',
-            expired_in: Date.now() + 60_000,
-            interval: 2000,
+            expired_in: 60,
+            interval: 2,
             state: params.get('state'),
           }),
         };
@@ -50,7 +58,28 @@ describe('MinimaxOauthService', () => {
 
       expect(result.userCode).toBe('ABCD-1234');
       expect(result.verificationUri).toBe('https://www.minimax.io/verify');
+      expect(result.expiresAt).toBe(now + 60_000);
+      expect(result.pollIntervalMs).toBe(2000);
       expect(service.getPendingCount()).toBe(1);
+    });
+
+    it('uses the CN OAuth host when the region is cn', async () => {
+      fetchMock.mockImplementationOnce(async (url: string, init?: RequestInit) => {
+        const params = new URLSearchParams(init?.body as string);
+        expect(url).toBe('https://api.minimaxi.com/oauth/code');
+        return {
+          ok: true,
+          json: async () => ({
+            user_code: 'ABCD-1234',
+            verification_uri: 'https://www.minimax.io/verify',
+            expired_in: 60,
+            interval: 2,
+            state: params.get('state'),
+          }),
+        };
+      });
+
+      await service.startAuthorization('agent-1', 'user-1', 'cn');
     });
   });
 
@@ -64,8 +93,8 @@ describe('MinimaxOauthService', () => {
             json: async () => ({
               user_code: 'ABCD-1234',
               verification_uri: 'https://www.minimax.io/verify',
-              expired_in: Date.now() + 60_000,
-              interval: 2000,
+              expired_in: 60,
+              interval: 2,
               state: params.get('state'),
             }),
           };
@@ -105,8 +134,8 @@ describe('MinimaxOauthService', () => {
             json: async () => ({
               user_code: 'ABCD-1234',
               verification_uri: 'https://www.minimax.io/verify',
-              expired_in: Date.now() + 60_000,
-              interval: 2000,
+              expired_in: 60,
+              interval: 2,
               state: params.get('state'),
             }),
           };
@@ -126,13 +155,16 @@ describe('MinimaxOauthService', () => {
 
   describe('unwrapToken', () => {
     it('refreshes expired tokens and preserves resource URL', async () => {
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          access_token: 'new-access',
-          refresh_token: 'new-refresh',
-          expired_in: 7200,
-        }),
+      fetchMock.mockImplementationOnce(async (url: string) => {
+        expect(url).toBe('https://api.minimax.io/oauth/token');
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: 'new-access',
+            refresh_token: 'new-refresh',
+            expired_in: 7200,
+          }),
+        };
       });
 
       const result = await service.unwrapToken(
@@ -154,6 +186,31 @@ describe('MinimaxOauthService', () => {
         }),
       );
       expect(routingService.upsertProvider).toHaveBeenCalled();
+    });
+
+    it('refreshes against the CN OAuth host when the stored resource URL is regional', async () => {
+      fetchMock.mockImplementationOnce(async (url: string) => {
+        expect(url).toBe('https://api.minimaxi.com/oauth/token');
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: 'new-access',
+            refresh_token: 'new-refresh',
+            expired_in: 7200,
+          }),
+        };
+      });
+
+      await service.unwrapToken(
+        JSON.stringify({
+          t: 'old-access',
+          r: 'old-refresh',
+          e: now - 1000,
+          u: 'https://api.minimaxi.com/anthropic',
+        }),
+        'agent-1',
+        'user-1',
+      );
     });
   });
 });

--- a/packages/backend/src/routing/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.spec.ts
@@ -247,5 +247,26 @@ describe('MinimaxOauthService', () => {
 
       expect(result.e).toBe(now + 7200);
     });
+
+    it('falls back to the default MiniMax OAuth host when the stored resource URL is invalid', async () => {
+      fetchMock.mockImplementationOnce(async (url: string) => {
+        expect(url).toBe('https://api.minimax.io/oauth/token');
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: 'new-access',
+            refresh_token: 'new-refresh',
+            expired_in: 7200,
+          }),
+        };
+      });
+
+      const result = await service.refreshAccessToken(
+        'refresh-token',
+        'https://evil.example/anthropic',
+      );
+
+      expect(result.u).toBe('https://api.minimax.io/anthropic');
+    });
   });
 });

--- a/packages/backend/src/routing/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.spec.ts
@@ -1,0 +1,159 @@
+import { ConfigService } from '@nestjs/config';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { RoutingService } from './routing.service';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fetchMock = jest.fn() as jest.Mock<Promise<any>>;
+global.fetch = fetchMock;
+
+describe('MinimaxOauthService', () => {
+  let service: MinimaxOauthService;
+  let routingService: jest.Mocked<RoutingService>;
+  let configService: jest.Mocked<ConfigService>;
+  let discoveryService: { discoverModels: jest.Mock };
+
+  beforeEach(() => {
+    routingService = {
+      upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
+      recalculateTiers: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<RoutingService>;
+
+    configService = {
+      get: jest.fn().mockReturnValue(undefined),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    discoveryService = {
+      discoverModels: jest.fn().mockResolvedValue([]),
+    };
+
+    service = new MinimaxOauthService(routingService, configService, discoveryService as never);
+    fetchMock.mockReset();
+  });
+
+  describe('startAuthorization', () => {
+    it('returns device-code payload and stores a pending flow', async () => {
+      fetchMock.mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+        const params = new URLSearchParams(init?.body as string);
+        return {
+          ok: true,
+          json: async () => ({
+            user_code: 'ABCD-1234',
+            verification_uri: 'https://www.minimax.io/verify',
+            expired_in: Date.now() + 60_000,
+            interval: 2000,
+            state: params.get('state'),
+          }),
+        };
+      });
+
+      const result = await service.startAuthorization('agent-1', 'user-1');
+
+      expect(result.userCode).toBe('ABCD-1234');
+      expect(result.verificationUri).toBe('https://www.minimax.io/verify');
+      expect(service.getPendingCount()).toBe(1);
+    });
+  });
+
+  describe('pollAuthorization', () => {
+    it('stores MiniMax tokens after approval', async () => {
+      fetchMock
+        .mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+          const params = new URLSearchParams(init?.body as string);
+          return {
+            ok: true,
+            json: async () => ({
+              user_code: 'ABCD-1234',
+              verification_uri: 'https://www.minimax.io/verify',
+              expired_in: Date.now() + 60_000,
+              interval: 2000,
+              state: params.get('state'),
+            }),
+          };
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () =>
+            JSON.stringify({
+              status: 'success',
+              access_token: 'access-123',
+              refresh_token: 'refresh-456',
+              expired_in: 3600,
+              resource_url: 'https://api.minimax.io/anthropic',
+            }),
+        });
+
+      const start = await service.startAuthorization('agent-1', 'user-1');
+      const result = await service.pollAuthorization(start.flowId, 'user-1');
+
+      expect(result).toEqual({ status: 'success' });
+      expect(routingService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'minimax',
+        expect.any(String),
+        'subscription',
+      );
+      expect(discoveryService.discoverModels).toHaveBeenCalled();
+    });
+
+    it('returns pending while approval has not completed', async () => {
+      fetchMock
+        .mockImplementationOnce(async (_url: string, init?: RequestInit) => {
+          const params = new URLSearchParams(init?.body as string);
+          return {
+            ok: true,
+            json: async () => ({
+              user_code: 'ABCD-1234',
+              verification_uri: 'https://www.minimax.io/verify',
+              expired_in: Date.now() + 60_000,
+              interval: 2000,
+              state: params.get('state'),
+            }),
+          };
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => JSON.stringify({ status: 'pending' }),
+        });
+
+      const start = await service.startAuthorization('agent-1', 'user-1');
+      const result = await service.pollAuthorization(start.flowId, 'user-1');
+
+      expect(result.status).toBe('pending');
+      expect(routingService.upsertProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unwrapToken', () => {
+    it('refreshes expired tokens and preserves resource URL', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expired_in: 7200,
+        }),
+      });
+
+      const result = await service.unwrapToken(
+        JSON.stringify({
+          t: 'old-access',
+          r: 'old-refresh',
+          e: Date.now() - 1000,
+          u: 'https://api.minimax.io/anthropic',
+        }),
+        'agent-1',
+        'user-1',
+      );
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          t: 'new-access',
+          r: 'new-refresh',
+          u: 'https://api.minimax.io/anthropic',
+        }),
+      );
+      expect(routingService.upsertProvider).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/routing/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.spec.ts
@@ -156,6 +156,22 @@ describe('MinimaxOauthService', () => {
   });
 
   describe('unwrapToken', () => {
+    it('returns null when the stored OAuth blob has invalid field types', async () => {
+      const result = await service.unwrapToken(
+        JSON.stringify({
+          t: 'old-access',
+          r: 'old-refresh',
+          e: now + 7200,
+          u: { host: 'https://api.minimax.io/anthropic' },
+        }),
+        'agent-1',
+        'user-1',
+      );
+
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('refreshes expired tokens and preserves resource URL', async () => {
       fetchMock.mockImplementationOnce(async (url: string) => {
         expect(url).toBe('https://api.minimax.io/oauth/token');

--- a/packages/backend/src/routing/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.spec.ts
@@ -80,6 +80,8 @@ describe('MinimaxOauthService', () => {
       });
 
       await service.startAuthorization('agent-1', 'user-1', 'cn');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -211,6 +213,23 @@ describe('MinimaxOauthService', () => {
         'agent-1',
         'user-1',
       );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves absolute MiniMax refresh expiry timestamps', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expired_in: now + 7200,
+        }),
+      });
+
+      const result = await service.refreshAccessToken('refresh-token', 'https://api.minimax.io/anthropic');
+
+      expect(result.e).toBe(now + 7200);
     });
   });
 });

--- a/packages/backend/src/routing/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.ts
@@ -1,0 +1,314 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHash, randomBytes, randomUUID } from 'crypto';
+import { RoutingService } from './routing.service';
+import { ModelDiscoveryService } from './model-discovery/model-discovery.service';
+import { OAuthTokenBlob } from './openai-oauth.types';
+
+const DEFAULT_CLIENT_ID = '78257093-7e40-4613-99e0-527b14b39113';
+const DEFAULT_BASE_URL = 'https://api.minimax.io';
+const DEFAULT_RESOURCE_URL = `${DEFAULT_BASE_URL}/anthropic`;
+const CODE_URL = `${DEFAULT_BASE_URL}/oauth/code`;
+const TOKEN_URL = `${DEFAULT_BASE_URL}/oauth/token`;
+const SCOPE = 'group_id profile model.completion';
+const USER_CODE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:user_code';
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+interface PendingMinimaxOAuth {
+  verifier: string;
+  userCode: string;
+  agentId: string;
+  userId: string;
+  expiresAt: number;
+  pollIntervalMs: number;
+}
+
+interface MinimaxCodeResponse {
+  user_code: string;
+  verification_uri: string;
+  expired_in: number;
+  interval?: number;
+  state: string;
+  error?: string;
+}
+
+interface MinimaxTokenResponse {
+  status?: string;
+  access_token?: string | null;
+  refresh_token?: string | null;
+  expired_in?: number | null;
+  resource_url?: string;
+  notification_message?: string;
+  base_resp?: { status_code?: number; status_msg?: string };
+}
+
+export interface MinimaxOAuthStartResult {
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+  pollIntervalMs: number;
+}
+
+export interface MinimaxOAuthPollResult {
+  status: 'pending' | 'success' | 'error';
+  message?: string;
+  pollIntervalMs?: number;
+}
+
+@Injectable()
+export class MinimaxOauthService {
+  private readonly logger = new Logger(MinimaxOauthService.name);
+  private readonly pending = new Map<string, PendingMinimaxOAuth>();
+  private readonly clientId: string;
+
+  constructor(
+    private readonly routingService: RoutingService,
+    private readonly configService: ConfigService,
+    private readonly discoveryService: ModelDiscoveryService,
+  ) {
+    this.clientId = this.configService.get<string>('MINIMAX_OAUTH_CLIENT_ID') ?? DEFAULT_CLIENT_ID;
+  }
+
+  async startAuthorization(agentId: string, userId: string): Promise<MinimaxOAuthStartResult> {
+    this.cleanupExpired();
+
+    const verifier = randomBytes(32).toString('base64url');
+    const challenge = createHash('sha256').update(verifier).digest('base64url');
+    const flowId = randomBytes(16).toString('base64url');
+
+    const response = await fetch(CODE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+        'x-request-id': randomUUID(),
+      },
+      body: new URLSearchParams({
+        response_type: 'code',
+        client_id: this.clientId,
+        scope: SCOPE,
+        code_challenge: challenge,
+        code_challenge_method: 'S256',
+        state: flowId,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`MiniMax OAuth code request failed: ${text}`);
+      throw new Error('Failed to start MiniMax OAuth');
+    }
+
+    const payload = (await response.json()) as MinimaxCodeResponse;
+    if (!payload.user_code || !payload.verification_uri || !payload.expired_in) {
+      throw new Error(
+        payload.error ??
+          'MiniMax OAuth returned an incomplete authorization payload.',
+      );
+    }
+    if (payload.state !== flowId) {
+      throw new Error('MiniMax OAuth state mismatch');
+    }
+
+    const pollIntervalMs =
+      payload.interval && payload.interval > 0 ? payload.interval : DEFAULT_POLL_INTERVAL_MS;
+
+    this.pending.set(flowId, {
+      verifier,
+      userCode: payload.user_code,
+      agentId,
+      userId,
+      expiresAt: payload.expired_in,
+      pollIntervalMs,
+    });
+
+    return {
+      flowId,
+      userCode: payload.user_code,
+      verificationUri: payload.verification_uri,
+      expiresAt: payload.expired_in,
+      pollIntervalMs,
+    };
+  }
+
+  async pollAuthorization(flowId: string, userId: string): Promise<MinimaxOAuthPollResult> {
+    this.cleanupExpired();
+
+    const pending = this.pending.get(flowId);
+    if (!pending) {
+      return { status: 'error', message: 'MiniMax login expired. Start again.' };
+    }
+    if (pending.userId !== userId) {
+      return { status: 'error', message: 'MiniMax login session does not match the current user.' };
+    }
+    if (Date.now() >= pending.expiresAt) {
+      this.pending.delete(flowId);
+      return { status: 'error', message: 'MiniMax login expired. Start again.' };
+    }
+
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: USER_CODE_GRANT_TYPE,
+        client_id: this.clientId,
+        user_code: pending.userCode,
+        code_verifier: pending.verifier,
+      }),
+    });
+
+    const text = await response.text();
+    const payload = this.parseTokenResponse(text);
+
+    if (!response.ok) {
+      const message = payload?.base_resp?.status_msg ?? text ?? 'MiniMax OAuth failed';
+      this.pending.delete(flowId);
+      return { status: 'error', message };
+    }
+
+    if (!payload) {
+      this.pending.delete(flowId);
+      return { status: 'error', message: 'MiniMax OAuth returned an invalid token response.' };
+    }
+
+    if (payload.status === 'error') {
+      this.pending.delete(flowId);
+      return { status: 'error', message: 'MiniMax OAuth failed. Please try again later.' };
+    }
+
+    if (payload.status !== 'success') {
+      return {
+        status: 'pending',
+        message: 'Waiting for MiniMax approval…',
+        pollIntervalMs: pending.pollIntervalMs,
+      };
+    }
+
+    if (!payload.access_token || !payload.refresh_token || !payload.expired_in) {
+      this.pending.delete(flowId);
+      return { status: 'error', message: 'MiniMax OAuth returned an incomplete token payload.' };
+    }
+
+    this.pending.delete(flowId);
+
+    const blob: OAuthTokenBlob = {
+      t: payload.access_token,
+      r: payload.refresh_token,
+      e: Date.now() + payload.expired_in * 1000,
+      ...(payload.resource_url ? { u: payload.resource_url } : {}),
+    };
+
+    const { provider: savedProvider } = await this.routingService.upsertProvider(
+      pending.agentId,
+      pending.userId,
+      'minimax',
+      JSON.stringify(blob),
+      'subscription',
+    );
+
+    try {
+      await this.discoveryService.discoverModels(savedProvider);
+      await this.routingService.recalculateTiers(pending.agentId);
+    } catch (err) {
+      this.logger.warn(`Model discovery after MiniMax OAuth failed: ${err}`);
+    }
+
+    this.logger.log(`MiniMax OAuth token stored for agent=${pending.agentId}`);
+    return { status: 'success' };
+  }
+
+  async refreshAccessToken(
+    refreshToken: string,
+    resourceUrl?: string,
+  ): Promise<OAuthTokenBlob> {
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: this.clientId,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`MiniMax token refresh failed: ${text}`);
+      throw new Error('Token refresh failed');
+    }
+
+    const payload = (await response.json()) as MinimaxTokenResponse;
+    if (!payload.access_token || !payload.expired_in) {
+      throw new Error('MiniMax token refresh returned an incomplete payload');
+    }
+
+    const nextResourceUrl = payload.resource_url ?? resourceUrl;
+    return {
+      t: payload.access_token,
+      r: payload.refresh_token || refreshToken,
+      e: Date.now() + payload.expired_in * 1000,
+      ...(nextResourceUrl ? { u: nextResourceUrl } : {}),
+    };
+  }
+
+  async unwrapToken(
+    rawValue: string,
+    agentId: string,
+    userId: string,
+  ): Promise<OAuthTokenBlob | null> {
+    let blob: OAuthTokenBlob;
+    try {
+      blob = JSON.parse(rawValue) as OAuthTokenBlob;
+    } catch {
+      return null;
+    }
+
+    if (!blob.t || !blob.r || !blob.e) return null;
+    if (Date.now() < blob.e - 60_000) return blob;
+
+    try {
+      const refreshed = await this.refreshAccessToken(blob.r, blob.u);
+      await this.routingService.upsertProvider(
+        agentId,
+        userId,
+        'minimax',
+        JSON.stringify(refreshed),
+        'subscription',
+      );
+      this.logger.log(`MiniMax OAuth token refreshed for agent=${agentId}`);
+      return refreshed;
+    } catch (err) {
+      this.logger.error(`Failed to refresh MiniMax token: ${err}`);
+      return blob;
+    }
+  }
+
+  getPendingCount(): number {
+    return this.pending.size;
+  }
+
+  private cleanupExpired(): void {
+    const now = Date.now();
+    for (const [flowId, pending] of this.pending.entries()) {
+      if (pending.expiresAt <= now) this.pending.delete(flowId);
+    }
+  }
+
+  private parseTokenResponse(text: string): MinimaxTokenResponse | null {
+    if (!text) return null;
+    try {
+      return JSON.parse(text) as MinimaxTokenResponse;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export { DEFAULT_RESOURCE_URL as MINIMAX_DEFAULT_RESOURCE_URL };

--- a/packages/backend/src/routing/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.ts
@@ -103,6 +103,18 @@ function toPollIntervalMs(interval?: number): number {
   return interval >= 1000 ? interval : interval * 1000;
 }
 
+function isOAuthTokenBlob(value: unknown): value is OAuthTokenBlob {
+  if (!value || typeof value !== 'object') return false;
+  const blob = value as Record<string, unknown>;
+  return (
+    typeof blob.t === 'string' &&
+    typeof blob.r === 'string' &&
+    typeof blob.e === 'number' &&
+    Number.isFinite(blob.e) &&
+    (blob.u === undefined || typeof blob.u === 'string')
+  );
+}
+
 @Injectable()
 export class MinimaxOauthService {
   private readonly logger = new Logger(MinimaxOauthService.name);
@@ -317,7 +329,9 @@ export class MinimaxOauthService {
   ): Promise<OAuthTokenBlob | null> {
     let blob: OAuthTokenBlob;
     try {
-      blob = JSON.parse(rawValue) as OAuthTokenBlob;
+      const parsed = JSON.parse(rawValue) as unknown;
+      if (!isOAuthTokenBlob(parsed)) return null;
+      blob = parsed;
     } catch {
       return null;
     }

--- a/packages/backend/src/routing/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.ts
@@ -252,7 +252,7 @@ export class MinimaxOauthService {
     const blob: OAuthTokenBlob = {
       t: payload.access_token,
       r: payload.refresh_token,
-      e: Date.now() + payload.expired_in * 1000,
+      e: toAbsoluteExpiryTimestamp(payload.expired_in),
       u: payload.resource_url ?? pending.resourceUrl,
     };
 
@@ -305,7 +305,7 @@ export class MinimaxOauthService {
     return {
       t: payload.access_token,
       r: payload.refresh_token || refreshToken,
-      e: Date.now() + payload.expired_in * 1000,
+      e: toAbsoluteExpiryTimestamp(payload.expired_in),
       ...(nextResourceUrl ? { u: nextResourceUrl } : {}),
     };
   }

--- a/packages/backend/src/routing/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.ts
@@ -5,20 +5,28 @@ import { RoutingService } from './routing.service';
 import { ModelDiscoveryService } from './model-discovery/model-discovery.service';
 import { OAuthTokenBlob } from './openai-oauth.types';
 
+const MINIMAX_BASE_URLS = {
+  global: 'https://api.minimax.io',
+  cn: 'https://api.minimaxi.com',
+} as const;
+const DEFAULT_REGION = 'global';
+const DEFAULT_BASE_URL = MINIMAX_BASE_URLS[DEFAULT_REGION];
 const DEFAULT_CLIENT_ID = '78257093-7e40-4613-99e0-527b14b39113';
-const DEFAULT_BASE_URL = 'https://api.minimax.io';
 const DEFAULT_RESOURCE_URL = `${DEFAULT_BASE_URL}/anthropic`;
-const CODE_URL = `${DEFAULT_BASE_URL}/oauth/code`;
-const TOKEN_URL = `${DEFAULT_BASE_URL}/oauth/token`;
 const SCOPE = 'group_id profile model.completion';
 const USER_CODE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:user_code';
 const DEFAULT_POLL_INTERVAL_MS = 2000;
+const ABSOLUTE_TIME_THRESHOLD_MS = 10_000_000_000;
+
+export type MinimaxRegion = keyof typeof MINIMAX_BASE_URLS;
 
 interface PendingMinimaxOAuth {
   verifier: string;
   userCode: string;
   agentId: string;
   userId: string;
+  baseUrl: string;
+  resourceUrl: string;
   expiresAt: number;
   pollIntervalMs: number;
 }
@@ -56,6 +64,45 @@ export interface MinimaxOAuthPollResult {
   pollIntervalMs?: number;
 }
 
+function isMinimaxRegion(value: string | undefined): value is MinimaxRegion {
+  return value === 'global' || value === 'cn';
+}
+
+function getMinimaxBaseUrl(region: MinimaxRegion = DEFAULT_REGION): string {
+  return MINIMAX_BASE_URLS[region];
+}
+
+function buildMinimaxCodeUrl(baseUrl: string): string {
+  return `${baseUrl}/oauth/code`;
+}
+
+function buildMinimaxTokenUrl(baseUrl: string): string {
+  return `${baseUrl}/oauth/token`;
+}
+
+function buildMinimaxResourceUrl(baseUrl: string): string {
+  return `${baseUrl}/anthropic`;
+}
+
+function getMinimaxOauthBaseUrl(resourceUrl?: string): string {
+  if (!resourceUrl) return DEFAULT_BASE_URL;
+  try {
+    return new URL(resourceUrl).origin;
+  } catch {
+    return DEFAULT_BASE_URL;
+  }
+}
+
+function toAbsoluteExpiryTimestamp(expiredIn: number): number {
+  if (expiredIn > ABSOLUTE_TIME_THRESHOLD_MS) return expiredIn;
+  return Date.now() + expiredIn * 1000;
+}
+
+function toPollIntervalMs(interval?: number): number {
+  if (!interval || interval <= 0) return DEFAULT_POLL_INTERVAL_MS;
+  return interval >= 1000 ? interval : interval * 1000;
+}
+
 @Injectable()
 export class MinimaxOauthService {
   private readonly logger = new Logger(MinimaxOauthService.name);
@@ -70,14 +117,20 @@ export class MinimaxOauthService {
     this.clientId = this.configService.get<string>('MINIMAX_OAUTH_CLIENT_ID') ?? DEFAULT_CLIENT_ID;
   }
 
-  async startAuthorization(agentId: string, userId: string): Promise<MinimaxOAuthStartResult> {
+  async startAuthorization(
+    agentId: string,
+    userId: string,
+    region: MinimaxRegion = DEFAULT_REGION,
+  ): Promise<MinimaxOAuthStartResult> {
     this.cleanupExpired();
 
     const verifier = randomBytes(32).toString('base64url');
     const challenge = createHash('sha256').update(verifier).digest('base64url');
     const flowId = randomBytes(16).toString('base64url');
+    const baseUrl = getMinimaxBaseUrl(region);
+    const resourceUrl = buildMinimaxResourceUrl(baseUrl);
 
-    const response = await fetch(CODE_URL, {
+    const response = await fetch(buildMinimaxCodeUrl(baseUrl), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -103,23 +156,24 @@ export class MinimaxOauthService {
     const payload = (await response.json()) as MinimaxCodeResponse;
     if (!payload.user_code || !payload.verification_uri || !payload.expired_in) {
       throw new Error(
-        payload.error ??
-          'MiniMax OAuth returned an incomplete authorization payload.',
+        payload.error ?? 'MiniMax OAuth returned an incomplete authorization payload.',
       );
     }
     if (payload.state !== flowId) {
       throw new Error('MiniMax OAuth state mismatch');
     }
 
-    const pollIntervalMs =
-      payload.interval && payload.interval > 0 ? payload.interval : DEFAULT_POLL_INTERVAL_MS;
+    const pollIntervalMs = toPollIntervalMs(payload.interval);
+    const expiresAt = toAbsoluteExpiryTimestamp(payload.expired_in);
 
     this.pending.set(flowId, {
       verifier,
       userCode: payload.user_code,
       agentId,
       userId,
-      expiresAt: payload.expired_in,
+      baseUrl,
+      resourceUrl,
+      expiresAt,
       pollIntervalMs,
     });
 
@@ -127,7 +181,7 @@ export class MinimaxOauthService {
       flowId,
       userCode: payload.user_code,
       verificationUri: payload.verification_uri,
-      expiresAt: payload.expired_in,
+      expiresAt,
       pollIntervalMs,
     };
   }
@@ -147,7 +201,7 @@ export class MinimaxOauthService {
       return { status: 'error', message: 'MiniMax login expired. Start again.' };
     }
 
-    const response = await fetch(TOKEN_URL, {
+    const response = await fetch(buildMinimaxTokenUrl(pending.baseUrl), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -199,7 +253,7 @@ export class MinimaxOauthService {
       t: payload.access_token,
       r: payload.refresh_token,
       e: Date.now() + payload.expired_in * 1000,
-      ...(payload.resource_url ? { u: payload.resource_url } : {}),
+      u: payload.resource_url ?? pending.resourceUrl,
     };
 
     const { provider: savedProvider } = await this.routingService.upsertProvider(
@@ -221,11 +275,9 @@ export class MinimaxOauthService {
     return { status: 'success' };
   }
 
-  async refreshAccessToken(
-    refreshToken: string,
-    resourceUrl?: string,
-  ): Promise<OAuthTokenBlob> {
-    const response = await fetch(TOKEN_URL, {
+  async refreshAccessToken(refreshToken: string, resourceUrl?: string): Promise<OAuthTokenBlob> {
+    const baseUrl = getMinimaxOauthBaseUrl(resourceUrl);
+    const response = await fetch(buildMinimaxTokenUrl(baseUrl), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -249,7 +301,7 @@ export class MinimaxOauthService {
       throw new Error('MiniMax token refresh returned an incomplete payload');
     }
 
-    const nextResourceUrl = payload.resource_url ?? resourceUrl;
+    const nextResourceUrl = payload.resource_url ?? resourceUrl ?? buildMinimaxResourceUrl(baseUrl);
     return {
       t: payload.access_token,
       r: payload.refresh_token || refreshToken,
@@ -311,4 +363,4 @@ export class MinimaxOauthService {
   }
 }
 
-export { DEFAULT_RESOURCE_URL as MINIMAX_DEFAULT_RESOURCE_URL };
+export { DEFAULT_RESOURCE_URL as MINIMAX_DEFAULT_RESOURCE_URL, isMinimaxRegion };

--- a/packages/backend/src/routing/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.ts
@@ -4,6 +4,7 @@ import { createHash, randomBytes, randomUUID } from 'crypto';
 import { RoutingService } from './routing.service';
 import { ModelDiscoveryService } from './model-discovery/model-discovery.service';
 import { OAuthTokenBlob } from './openai-oauth.types';
+import { normalizeMinimaxSubscriptionBaseUrl } from './provider-base-url';
 
 const MINIMAX_BASE_URLS = {
   global: 'https://api.minimax.io',
@@ -84,13 +85,15 @@ function buildMinimaxResourceUrl(baseUrl: string): string {
   return `${baseUrl}/anthropic`;
 }
 
+function getMinimaxResourceUrl(resourceUrl?: string): string | null {
+  if (!resourceUrl) return null;
+  return normalizeMinimaxSubscriptionBaseUrl(resourceUrl);
+}
+
 function getMinimaxOauthBaseUrl(resourceUrl?: string): string {
-  if (!resourceUrl) return DEFAULT_BASE_URL;
-  try {
-    return new URL(resourceUrl).origin;
-  } catch {
-    return DEFAULT_BASE_URL;
-  }
+  const normalized = getMinimaxResourceUrl(resourceUrl);
+  if (!normalized) return DEFAULT_BASE_URL;
+  return new URL(normalized).origin;
 }
 
 function toAbsoluteExpiryTimestamp(expiredIn: number): number {
@@ -261,11 +264,12 @@ export class MinimaxOauthService {
 
     this.pending.delete(flowId);
 
+    const resourceUrl = getMinimaxResourceUrl(payload.resource_url) ?? pending.resourceUrl;
     const blob: OAuthTokenBlob = {
       t: payload.access_token,
       r: payload.refresh_token,
       e: toAbsoluteExpiryTimestamp(payload.expired_in),
-      u: payload.resource_url ?? pending.resourceUrl,
+      u: resourceUrl,
     };
 
     const { provider: savedProvider } = await this.routingService.upsertProvider(
@@ -313,7 +317,10 @@ export class MinimaxOauthService {
       throw new Error('MiniMax token refresh returned an incomplete payload');
     }
 
-    const nextResourceUrl = payload.resource_url ?? resourceUrl ?? buildMinimaxResourceUrl(baseUrl);
+    const nextResourceUrl =
+      getMinimaxResourceUrl(payload.resource_url) ??
+      getMinimaxResourceUrl(resourceUrl) ??
+      buildMinimaxResourceUrl(baseUrl);
     return {
       t: payload.access_token,
       r: payload.refresh_token || refreshToken,

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
@@ -1334,6 +1334,18 @@ describe('ModelDiscoveryService', () => {
         expect(m.outputPricePerToken).toBe(0);
       }
     });
+
+    it('should preserve MiniMax model casing in subscription fallback models', () => {
+      const result = buildSubscriptionFallbackModels(null as never, 'minimax');
+
+      expect(result.map((m) => m.id)).toEqual([
+        'MiniMax-M2.5',
+        'MiniMax-M2.5-highspeed',
+        'MiniMax-M2.1',
+        'MiniMax-M2.1-highspeed',
+        'MiniMax-M2',
+      ]);
+    });
   });
 
   /* ── supplementWithKnownModels ── */
@@ -1394,6 +1406,18 @@ describe('ModelDiscoveryService', () => {
         expect(m.inputPricePerToken).toBe(0);
         expect(m.outputPricePerToken).toBe(0);
       }
+    });
+
+    it('should supplement MiniMax known models with documented casing', () => {
+      const raw: DiscoveredModel[] = [
+        makeModel({ id: 'MiniMax-M2.5-highspeed', provider: 'minimax' }),
+      ];
+
+      const result = supplementWithKnownModels(raw, 'minimax');
+
+      expect(result.map((m) => m.id)).toContain('MiniMax-M2.1');
+      expect(result.map((m) => m.id)).toContain('MiniMax-M2');
+      expect(result.map((m) => m.id)).not.toContain('MiniMax-M2.5');
     });
   });
 });

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
@@ -126,7 +126,7 @@ describe('ModelDiscoveryService', () => {
 
       expect(mockGetSecret).toHaveBeenCalled();
       expect(mockDecrypt).toHaveBeenCalledWith('encrypted-key', expect.any(String));
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'decrypted-key', 'api_key');
+      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'decrypted-key', 'api_key', undefined);
       expect(result).toHaveLength(1);
       expect(provider.cached_models).toEqual(result);
       expect(provider.models_fetched_at).toBeDefined();
@@ -150,7 +150,7 @@ describe('ModelDiscoveryService', () => {
       await service.discoverModels(provider);
 
       expect(mockDecrypt).not.toHaveBeenCalled();
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', '', 'api_key');
+      expect(fetcher.fetch).toHaveBeenCalledWith('openai', '', 'api_key', undefined);
     });
 
     it('should enrich models with openRouter pricing when available', async () => {
@@ -742,7 +742,12 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Should pass the unwrapped access token, not the JSON blob
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'access-token-123', 'subscription');
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'openai',
+        'access-token-123',
+        'subscription',
+        undefined,
+      );
     });
 
     it('should use raw key when OpenAI subscription blob has no t field', async () => {
@@ -760,7 +765,7 @@ describe('ModelDiscoveryService', () => {
       );
 
       // No `t` field — should use the raw JSON string
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', blob, 'subscription');
+      expect(fetcher.fetch).toHaveBeenCalledWith('openai', blob, 'subscription', undefined);
     });
 
     it('should use raw key when OpenAI subscription value is not JSON', async () => {
@@ -776,7 +781,12 @@ describe('ModelDiscoveryService', () => {
         }),
       );
 
-      expect(fetcher.fetch).toHaveBeenCalledWith('openai', 'plain-token-value', 'subscription');
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'openai',
+        'plain-token-value',
+        'subscription',
+        undefined,
+      );
     });
 
     it('should not unwrap blob for non-OpenAI subscription providers', async () => {
@@ -794,7 +804,34 @@ describe('ModelDiscoveryService', () => {
       );
 
       // Should pass the raw JSON string for Anthropic (no unwrapping)
-      expect(fetcher.fetch).toHaveBeenCalledWith('anthropic', blob, 'subscription');
+      expect(fetcher.fetch).toHaveBeenCalledWith('anthropic', blob, 'subscription', undefined);
+    });
+
+    it('should unwrap MiniMax OAuth blob and forward resource URL for subscription discovery', async () => {
+      const blob = JSON.stringify({
+        t: 'minimax-access',
+        r: 'minimax-refresh',
+        e: Date.now() + 60000,
+        u: 'https://api.minimax.io/anthropic',
+      });
+      mockDecrypt.mockReturnValue(blob);
+
+      fetcher.fetch.mockResolvedValue([]);
+
+      await service.discoverModels(
+        makeProvider({
+          provider: 'minimax',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted-blob',
+        }),
+      );
+
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'minimax',
+        'minimax-access',
+        'subscription',
+        'https://api.minimax.io/anthropic',
+      );
     });
 
     it('should fall back to subscription fallback when OpenAI token fetch returns empty', async () => {

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.ts
@@ -8,6 +8,7 @@ import { DiscoveredModel } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
 import { computeQualityScore } from '../../database/quality-score.util';
 import { PricingSyncService } from '../../database/pricing-sync.service';
+import { parseOAuthTokenBlob } from '../openai-oauth.types';
 import {
   findOpenRouterPrefix,
   lookupWithVariants,
@@ -36,6 +37,7 @@ export class ModelDiscoveryService {
 
   async discoverModels(provider: UserProvider): Promise<DiscoveredModel[]> {
     let apiKey = '';
+    let endpointOverride: string | undefined;
     if (provider.api_key_encrypted) {
       try {
         apiKey = decrypt(provider.api_key_encrypted, getEncryptionSecret());
@@ -45,20 +47,18 @@ export class ModelDiscoveryService {
       }
     }
 
-    // For OpenAI subscription, the stored "key" is a JSON blob with access/refresh tokens.
-    // Unwrap it to get the actual Bearer token for the models API.
-    if (
-      provider.auth_type === 'subscription' &&
-      provider.provider.toLowerCase() === 'openai' &&
-      apiKey
-    ) {
-      try {
-        const blob = JSON.parse(apiKey) as { t?: string };
-        if (blob.t) {
+    // OAuth-backed subscription providers store an encrypted token blob.
+    // Unwrap it so model discovery can call the provider-native /models endpoint.
+    if (provider.auth_type === 'subscription' && apiKey) {
+      const lowerProvider = provider.provider.toLowerCase();
+      if (lowerProvider === 'openai' || lowerProvider === 'minimax') {
+        const blob = parseOAuthTokenBlob(apiKey);
+        if (blob?.t) {
           apiKey = blob.t;
+          if (lowerProvider === 'minimax' && blob.u) {
+            endpointOverride = blob.u;
+          }
         }
-      } catch {
-        // Not a JSON blob — use as-is
       }
     }
 
@@ -73,7 +73,12 @@ export class ModelDiscoveryService {
         );
       }
     } else {
-      raw = await this.fetcher.fetch(provider.provider, apiKey, provider.auth_type);
+      raw = await this.fetcher.fetch(
+        provider.provider,
+        apiKey,
+        provider.auth_type,
+        endpointOverride,
+      );
 
       // If native API returned no models, fall back to OpenRouter + manual pricing
       if (raw.length === 0) {

--- a/packages/backend/src/routing/model-discovery/model-fallback.ts
+++ b/packages/backend/src/routing/model-discovery/model-fallback.ts
@@ -130,6 +130,7 @@ export function buildSubscriptionFallbackModels(
 ): DiscoveredModel[] {
   const knownPrefixes = getSubscriptionKnownModels(providerId);
   if (!knownPrefixes) return [];
+  const normalizedKnownPrefixes = knownPrefixes.map((modelId) => modelId.toLowerCase());
 
   const capabilities = getSubscriptionCapabilities(providerId);
   const models: DiscoveredModel[] = [];
@@ -141,7 +142,9 @@ export function buildSubscriptionFallbackModels(
     for (const [fullId, entry] of pricingSync.getAll()) {
       if (!fullId.startsWith(`${orPrefix}/`)) continue;
       const modelId = fullId.substring(orPrefix.length + 1);
-      if (!knownPrefixes.some((p: string) => modelId.startsWith(p))) continue;
+      if (!normalizedKnownPrefixes.some((p: string) => modelId.toLowerCase().startsWith(p))) {
+        continue;
+      }
       if (seen.has(modelId)) continue;
       seen.add(modelId);
 
@@ -169,7 +172,11 @@ export function buildSubscriptionFallbackModels(
   // (e.g., "claude-opus-4" is covered by "claude-opus-4-20260301").
   const defaultCtx = capabilities?.maxContextWindow ?? 200000;
   for (const modelId of knownPrefixes) {
-    const covered = models.some((m) => m.id === modelId || m.id.startsWith(`${modelId}-`));
+    const lowerModelId = modelId.toLowerCase();
+    const covered = models.some((m) => {
+      const lowerDiscovered = m.id.toLowerCase();
+      return lowerDiscovered === lowerModelId || lowerDiscovered.startsWith(`${lowerModelId}-`);
+    });
     if (covered) continue;
     models.push({
       id: modelId,
@@ -203,8 +210,12 @@ export function supplementWithKnownModels(
   const defaultCtx = capabilities?.maxContextWindow ?? 200000;
 
   for (const modelId of knownModels) {
+    const lowerModelId = modelId.toLowerCase();
     // Skip if this model or a more specific version (e.g., with date suffix) already exists
-    const covered = raw.some((m) => m.id === modelId || m.id.startsWith(`${modelId}-`));
+    const covered = raw.some((m) => {
+      const lowerDiscovered = m.id.toLowerCase();
+      return lowerDiscovered === lowerModelId || lowerDiscovered.startsWith(`${lowerModelId}-`);
+    });
     if (covered) continue;
     raw.push({
       id: modelId,

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.spec.ts
@@ -202,6 +202,25 @@ describe('ProviderModelFetcherService', () => {
     );
   });
 
+  it('should ignore invalid endpoint overrides for MiniMax subscription discovery', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.fetch('minimax', 'sk-test', 'subscription', 'http://127.0.0.1:8080/anthropic');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.minimax.io/anthropic/v1/models?limit=100',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer sk-test',
+          'anthropic-version': '2023-06-01',
+        },
+      }),
+    );
+  });
+
   /* ── Anthropic provider ── */
 
   describe('parseAnthropic (via anthropic provider)', () => {

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.spec.ts
@@ -15,7 +15,7 @@ describe('ProviderModelFetcherService', () => {
 
   /* ── PROVIDER_CONFIGS sanity ── */
 
-  it('should have configs for all providers including openai-subscription', () => {
+  it('should have configs for all providers including subscription variants', () => {
     const expected = [
       'openai',
       'openai-subscription',
@@ -24,6 +24,7 @@ describe('ProviderModelFetcherService', () => {
       'moonshot',
       'xai',
       'minimax',
+      'minimax-subscription',
       'qwen',
       'zai',
       'anthropic',
@@ -178,6 +179,25 @@ describe('ProviderModelFetcherService', () => {
       'https://api.openai.com/v1/models',
       expect.objectContaining({
         headers: { Authorization: 'Bearer sk-abc' },
+      }),
+    );
+  });
+
+  it('should use the endpoint override for MiniMax subscription discovery', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.fetch('minimax', 'sk-test', 'subscription', 'https://api.minimaxi.com/anthropic');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.minimaxi.com/anthropic/v1/models?limit=100',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer sk-test',
+          'anthropic-version': '2023-06-01',
+        },
       }),
     );
   });

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DiscoveredModel, FetcherConfig } from './model-fetcher';
 import { OLLAMA_HOST } from '../../common/constants/ollama';
+import { normalizeProviderBaseUrl } from '../provider-base-url';
 
 const FETCH_TIMEOUT_MS = 5000;
 const DEFAULT_CONTEXT_WINDOW = 128000;
@@ -42,10 +43,6 @@ function parseOpenAI(body: unknown, provider: string): DiscoveredModel[] {
 
 function bearerHeaders(key: string): Record<string, string> {
   return { Authorization: `Bearer ${key}` };
-}
-
-function normalizeProviderBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
 }
 
 /* ── Provider-specific parsers ── */

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
@@ -6,6 +6,7 @@ const FETCH_TIMEOUT_MS = 5000;
 const DEFAULT_CONTEXT_WINDOW = 128000;
 const ANTHROPIC_DEFAULT_CONTEXT = 200000;
 const GEMINI_DEFAULT_CONTEXT = 1000000;
+const MINIMAX_SUBSCRIPTION_MODELS_URL = 'https://api.minimax.io/anthropic/v1/models?limit=100';
 
 /* ── Shared OpenAI-compatible parser ── */
 
@@ -41,6 +42,10 @@ function parseOpenAI(body: unknown, provider: string): DiscoveredModel[] {
 
 function bearerHeaders(key: string): Record<string, string> {
   return { Authorization: `Bearer ${key}` };
+}
+
+function normalizeProviderBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
 }
 
 /* ── Provider-specific parsers ── */
@@ -253,6 +258,14 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     buildHeaders: bearerHeaders,
     parse: parseOpenAI,
   },
+  'minimax-subscription': {
+    endpoint: MINIMAX_SUBSCRIPTION_MODELS_URL,
+    buildHeaders: (key: string) => ({
+      Authorization: `Bearer ${key}`,
+      'anthropic-version': '2023-06-01',
+    }),
+    parse: parseAnthropic,
+  },
   qwen: {
     endpoint: 'https://dashscope.aliyuncs.com/compatible-mode/v1/models',
     buildHeaders: bearerHeaders,
@@ -301,11 +314,18 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
 export class ProviderModelFetcherService {
   private readonly logger = new Logger(ProviderModelFetcherService.name);
 
-  async fetch(providerId: string, apiKey: string, authType?: string): Promise<DiscoveredModel[]> {
+  async fetch(
+    providerId: string,
+    apiKey: string,
+    authType?: string,
+    endpointOverride?: string,
+  ): Promise<DiscoveredModel[]> {
     let configKey = providerId.toLowerCase();
     // OpenAI subscription tokens use a different models endpoint
     if (configKey === 'openai' && authType === 'subscription') {
       configKey = 'openai-subscription';
+    } else if (configKey === 'minimax' && authType === 'subscription') {
+      configKey = 'minimax-subscription';
     }
     const config = PROVIDER_CONFIGS[configKey];
     if (!config) {
@@ -313,7 +333,10 @@ export class ProviderModelFetcherService {
       return [];
     }
 
-    const url = typeof config.endpoint === 'function' ? config.endpoint(apiKey) : config.endpoint;
+    let url = typeof config.endpoint === 'function' ? config.endpoint(apiKey) : config.endpoint;
+    if (endpointOverride && configKey === 'minimax-subscription') {
+      url = `${normalizeProviderBaseUrl(endpointOverride)}/v1/models?limit=100`;
+    }
 
     const headers = config.buildHeaders(apiKey, authType);
 

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { DiscoveredModel, FetcherConfig } from './model-fetcher';
 import { OLLAMA_HOST } from '../../common/constants/ollama';
-import { normalizeProviderBaseUrl } from '../provider-base-url';
+import { normalizeMinimaxSubscriptionBaseUrl } from '../provider-base-url';
 
 const FETCH_TIMEOUT_MS = 5000;
 const DEFAULT_CONTEXT_WINDOW = 128000;
@@ -332,7 +332,12 @@ export class ProviderModelFetcherService {
 
     let url = typeof config.endpoint === 'function' ? config.endpoint(apiKey) : config.endpoint;
     if (endpointOverride && configKey === 'minimax-subscription') {
-      url = `${normalizeProviderBaseUrl(endpointOverride)}/v1/models?limit=100`;
+      const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(endpointOverride);
+      if (minimaxBaseUrl) {
+        url = `${minimaxBaseUrl}/v1/models?limit=100`;
+      } else {
+        this.logger.warn('Ignoring invalid MiniMax subscription endpoint override');
+      }
     }
 
     const headers = config.buildHeaders(apiKey, authType);

--- a/packages/backend/src/routing/openai-oauth.types.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.types.spec.ts
@@ -1,19 +1,27 @@
-import { oauthDoneHtml } from './openai-oauth.types';
+import { parseOAuthTokenBlob } from './openai-oauth.types';
 
-describe('oauthDoneHtml', () => {
-  it('returns success HTML with manifest-oauth-success message', () => {
-    const html = oauthDoneHtml(true);
-    expect(html).toContain('manifest-oauth-success');
-    expect(html).toContain('Login successful!');
-    expect(html).toContain('BroadcastChannel');
-    expect(html).toContain('window.location.origin');
+describe('parseOAuthTokenBlob', () => {
+  it('returns null when the optional resource URL is not a string', () => {
+    expect(parseOAuthTokenBlob(JSON.stringify({ t: 'token', r: 'refresh', e: 123, u: 42 }))).toBe(
+      null,
+    );
   });
 
-  it('returns error HTML with manifest-oauth-error message', () => {
-    const html = oauthDoneHtml(false);
-    expect(html).toContain('manifest-oauth-error');
-    expect(html).toContain('Login failed');
-    expect(html).toContain('BroadcastChannel');
-    expect(html).toContain('window.location.origin');
+  it('returns the parsed blob when the optional resource URL is a string', () => {
+    expect(
+      parseOAuthTokenBlob(
+        JSON.stringify({
+          t: 'token',
+          r: 'refresh',
+          e: 123,
+          u: 'https://api.minimax.io/anthropic',
+        }),
+      ),
+    ).toEqual({
+      t: 'token',
+      r: 'refresh',
+      e: 123,
+      u: 'https://api.minimax.io/anthropic',
+    });
   });
 });

--- a/packages/backend/src/routing/openai-oauth.types.ts
+++ b/packages/backend/src/routing/openai-oauth.types.ts
@@ -13,6 +13,24 @@ export interface OAuthTokenBlob {
   r: string;
   /** expires at (epoch ms) */
   e: number;
+  /** provider-specific resource URL / base URL */
+  u?: string;
+}
+
+export function parseOAuthTokenBlob(rawValue: string): OAuthTokenBlob | null {
+  try {
+    const parsed = JSON.parse(rawValue) as Partial<OAuthTokenBlob>;
+    if (
+      typeof parsed?.t !== 'string' ||
+      typeof parsed?.r !== 'string' ||
+      typeof parsed?.e !== 'number'
+    ) {
+      return null;
+    }
+    return parsed as OAuthTokenBlob;
+  } catch {
+    return null;
+  }
 }
 
 export function oauthDoneHtml(success: boolean): string {

--- a/packages/backend/src/routing/openai-oauth.types.ts
+++ b/packages/backend/src/routing/openai-oauth.types.ts
@@ -23,11 +23,17 @@ export function parseOAuthTokenBlob(rawValue: string): OAuthTokenBlob | null {
     if (
       typeof parsed?.t !== 'string' ||
       typeof parsed?.r !== 'string' ||
-      typeof parsed?.e !== 'number'
+      typeof parsed?.e !== 'number' ||
+      (parsed.u !== undefined && typeof parsed.u !== 'string')
     ) {
       return null;
     }
-    return parsed as OAuthTokenBlob;
+    return {
+      t: parsed.t,
+      r: parsed.r,
+      e: parsed.e,
+      ...(parsed.u !== undefined ? { u: parsed.u } : {}),
+    };
   } catch {
     return null;
   }

--- a/packages/backend/src/routing/provider-base-url.ts
+++ b/packages/backend/src/routing/provider-base-url.ts
@@ -1,0 +1,3 @@
+export function normalizeProviderBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
+}

--- a/packages/backend/src/routing/provider-base-url.ts
+++ b/packages/backend/src/routing/provider-base-url.ts
@@ -1,3 +1,22 @@
 export function normalizeProviderBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
 }
+
+const MINIMAX_SUBSCRIPTION_BASE_URLS = new Set([
+  'https://api.minimax.io/anthropic',
+  'https://api.minimaxi.com/anthropic',
+]);
+
+export function normalizeMinimaxSubscriptionBaseUrl(baseUrl: string): string | null {
+  try {
+    const url = new URL(baseUrl);
+    if (url.protocol !== 'https:' || url.username || url.password) {
+      return null;
+    }
+
+    const normalized = normalizeProviderBaseUrl(`${url.origin}${url.pathname}`);
+    return MINIMAX_SUBSCRIPTION_BASE_URLS.has(normalized) ? normalized : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -2005,5 +2005,50 @@ describe('ProxyService', () => {
         'subscription',
       );
     });
+
+    it('ignores invalid MiniMax resource URLs when forwarding subscription requests', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'MiniMax-M2.5',
+        provider: 'minimax',
+        confidence: 1.0,
+        score: 0.5,
+        reason: 'scored',
+        auth_type: 'subscription',
+      });
+      const tokenBlob = JSON.stringify({
+        t: 'minimax-access',
+        r: 'minimax-refresh',
+        e: Date.now() + 60000,
+        u: 'https://evil.example/anthropic',
+      });
+      routingService.getProviderApiKey.mockResolvedValue(tokenBlob);
+      minimaxOauth.unwrapToken.mockResolvedValue({
+        t: 'minimax-access',
+        r: 'minimax-refresh',
+        e: Date.now() + 60000,
+        u: 'https://evil.example/anthropic',
+      });
+      providerClient.forward.mockResolvedValue({
+        response: new Response('ok', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+
+      await service.proxyRequest('agent-1', 'user-1', body, 'sess');
+
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        'minimax',
+        'minimax-access',
+        'MiniMax-M2.5',
+        expect.any(Object),
+        false,
+        undefined,
+        undefined,
+        undefined,
+        'subscription',
+      );
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -4,6 +4,7 @@ import { ResolveService } from '../../resolve.service';
 import { RoutingService } from '../../routing.service';
 import { CustomProviderService } from '../../custom-provider.service';
 import { OpenaiOauthService } from '../../openai-oauth.service';
+import { MinimaxOauthService } from '../../minimax-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { SessionMomentumService } from '../session-momentum.service';
 import { LimitCheckService } from '../../../notifications/services/limit-check.service';
@@ -16,6 +17,7 @@ describe('ProxyService', () => {
   let routingService: jest.Mocked<RoutingService>;
   let customProviderService: jest.Mocked<CustomProviderService>;
   let openaiOauth: jest.Mocked<OpenaiOauthService>;
+  let minimaxOauth: jest.Mocked<MinimaxOauthService>;
   let providerClient: jest.Mocked<ProviderClient>;
   let momentum: SessionMomentumService;
   let limitCheck: jest.Mocked<LimitCheckService>;
@@ -55,6 +57,13 @@ describe('ProxyService', () => {
       refreshAccessToken: jest.fn(),
     } as unknown as jest.Mocked<OpenaiOauthService>;
 
+    minimaxOauth = {
+      unwrapToken: jest.fn().mockResolvedValue(null),
+      startAuthorization: jest.fn(),
+      pollAuthorization: jest.fn(),
+      refreshAccessToken: jest.fn(),
+    } as unknown as jest.Mocked<MinimaxOauthService>;
+
     pricingCache = {
       getByModel: jest.fn().mockReturnValue(null),
       getAll: jest.fn().mockReturnValue([]),
@@ -65,6 +74,7 @@ describe('ProxyService', () => {
       routingService,
       customProviderService,
       openaiOauth,
+      minimaxOauth,
       providerClient,
       momentum,
       limitCheck,
@@ -1872,6 +1882,7 @@ describe('ProxyService', () => {
       await service.proxyRequest('agent-1', 'user-1', body, 'sess');
 
       expect(openaiOauth.unwrapToken).not.toHaveBeenCalled();
+      expect(minimaxOauth.unwrapToken).not.toHaveBeenCalled();
     });
 
     it('skips unwrap for OpenAI api_key auth', async () => {
@@ -1944,6 +1955,55 @@ describe('ProxyService', () => {
         'user-1',
       );
       expect(result.meta.model).toBe('gpt-4o');
+    });
+
+    it('unwraps JSON token blob for MiniMax subscription and forwards resource URL', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'MiniMax-M2.5',
+        provider: 'minimax',
+        confidence: 1.0,
+        score: 0.5,
+        reason: 'scored',
+        auth_type: 'subscription',
+      });
+      const tokenBlob = JSON.stringify({
+        t: 'minimax-access',
+        r: 'minimax-refresh',
+        e: Date.now() + 60000,
+        u: 'https://api.minimax.io/anthropic',
+      });
+      routingService.getProviderApiKey.mockResolvedValue(tokenBlob);
+      minimaxOauth.unwrapToken.mockResolvedValue({
+        t: 'minimax-access',
+        r: 'minimax-refresh',
+        e: Date.now() + 60000,
+        u: 'https://api.minimax.io/anthropic',
+      });
+      providerClient.forward.mockResolvedValue({
+        response: new Response('ok', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+
+      await service.proxyRequest('agent-1', 'user-1', body, 'sess');
+
+      expect(minimaxOauth.unwrapToken).toHaveBeenCalledWith(tokenBlob, 'agent-1', 'user-1');
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        'minimax',
+        'minimax-access',
+        'MiniMax-M2.5',
+        expect.any(Object),
+        false,
+        undefined,
+        undefined,
+        expect.objectContaining({
+          baseUrl: 'https://api.minimax.io/anthropic',
+          format: 'anthropic',
+        }),
+        'subscription',
+      );
     });
   });
 });

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -142,6 +142,8 @@ export class ProviderClient {
       // ChatGPT subscription tokens use a different backend endpoint
       if (resolved === 'openai' && authType === 'subscription') {
         resolved = 'openai-subscription';
+      } else if (resolved === 'minimax' && authType === 'subscription') {
+        resolved = 'minimax-subscription';
       }
       endpointKey = resolved;
       endpoint = PROVIDER_ENDPOINTS[endpointKey];

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -8,6 +8,10 @@ export interface ProviderEndpoint {
   format: 'openai' | 'google' | 'anthropic' | 'chatgpt';
 }
 
+function normalizeProviderBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
+}
+
 const openaiHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
@@ -29,6 +33,12 @@ const anthropicHeaders = (apiKey: string, authType?: string): Record<string, str
   return headers;
 };
 
+const anthropicBearerHeaders = (apiKey: string): Record<string, string> => ({
+  Authorization: `Bearer ${apiKey}`,
+  'Content-Type': 'application/json',
+  'anthropic-version': '2023-06-01',
+});
+
 /**
  * ChatGPT subscription OAuth tokens use the Codex backend,
  * which requires specific headers to avoid 403 responses.
@@ -36,6 +46,7 @@ const anthropicHeaders = (apiKey: string, authType?: string): Record<string, str
  * endpoint to accept requests, but may break if OpenAI changes validation.
  */
 const CHATGPT_SUBSCRIPTION_BASE = 'https://chatgpt.com/backend-api';
+const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
 const chatgptSubscriptionHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
@@ -86,6 +97,12 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: openaiPath,
     format: 'openai',
   },
+  'minimax-subscription': {
+    baseUrl: MINIMAX_SUBSCRIPTION_BASE,
+    buildHeaders: anthropicBearerHeaders,
+    buildPath: () => '/v1/messages',
+    format: 'anthropic',
+  },
   moonshot: {
     baseUrl: 'https://api.moonshot.cn',
     buildHeaders: openaiHeaders,
@@ -121,12 +138,23 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
 /** Build a ProviderEndpoint for a custom provider with the given base URL. */
 export function buildCustomEndpoint(baseUrl: string): ProviderEndpoint {
   // Strip trailing /v1 (or /v1/) since openaiPath already includes /v1
-  const normalized = baseUrl.replace(/\/v1\/?$/, '');
+  const normalized = normalizeProviderBaseUrl(baseUrl);
   return {
     baseUrl: normalized,
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+  };
+}
+
+export function buildEndpointOverride(baseUrl: string, templateKey: string): ProviderEndpoint {
+  const template = PROVIDER_ENDPOINTS[templateKey];
+  if (!template) {
+    throw new Error(`No provider endpoint template configured for: ${templateKey}`);
+  }
+  return {
+    ...template,
+    baseUrl: normalizeProviderBaseUrl(baseUrl),
   };
 }
 

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -1,15 +1,12 @@
 import { OLLAMA_HOST } from '../../common/constants/ollama';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
+import { normalizeProviderBaseUrl } from '../provider-base-url';
 
 export interface ProviderEndpoint {
   baseUrl: string;
   buildHeaders: (apiKey: string, authType?: string) => Record<string, string>;
   buildPath: (model: string) => string;
   format: 'openai' | 'google' | 'anthropic' | 'chatgpt';
-}
-
-function normalizeProviderBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, '').replace(/\/v1$/, '');
 }
 
 const openaiHeaders = (apiKey: string) => ({

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -12,6 +12,7 @@ import { LimitCheckService } from '../../notifications/services/limit-check.serv
 import { shouldTriggerFallback, FALLBACK_EXHAUSTED_STATUS } from './fallback-status-codes';
 import { inferProviderFromModelName } from '../provider-aliases';
 import { Tier, ScorerMessage } from '../scorer/types';
+import { normalizeMinimaxSubscriptionBaseUrl } from '../provider-base-url';
 
 /**
  * Roles excluded from scoring. OpenClaw (and similar tools) inject a large,
@@ -414,7 +415,12 @@ export class ProxyService {
       provider.toLowerCase() === 'minimax' &&
       resourceUrl
     ) {
-      customEndpoint = buildEndpointOverride(resourceUrl, 'minimax-subscription');
+      const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(resourceUrl);
+      if (minimaxBaseUrl) {
+        customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
+      } else {
+        this.logger.warn('Ignoring invalid MiniMax subscription resource URL');
+      }
     }
 
     return this.providerClient.forward(

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -3,9 +3,10 @@ import { ResolveService } from '../resolve.service';
 import { RoutingService } from '../routing.service';
 import { CustomProviderService } from '../custom-provider.service';
 import { OpenaiOauthService } from '../openai-oauth.service';
+import { MinimaxOauthService } from '../minimax-oauth.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ProviderClient, ForwardResult } from './provider-client';
-import { buildCustomEndpoint, ProviderEndpoint } from './provider-endpoints';
+import { buildCustomEndpoint, buildEndpointOverride, ProviderEndpoint } from './provider-endpoints';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
 import { shouldTriggerFallback, FALLBACK_EXHAUSTED_STATUS } from './fallback-status-codes';
@@ -57,6 +58,7 @@ export class ProxyService {
     private readonly routingService: RoutingService,
     private readonly customProviderService: CustomProviderService,
     private readonly openaiOauth: OpenaiOauthService,
+    private readonly minimaxOauth: MinimaxOauthService,
     private readonly providerClient: ProviderClient,
     private readonly momentum: SessionMomentumService,
     private readonly limitCheck: LimitCheckService,
@@ -116,7 +118,7 @@ export class ProxyService {
       );
     }
 
-    apiKey = await this.resolveApiKey(
+    const resolvedCredentials = await this.resolveApiKey(
       resolved.provider,
       apiKey,
       resolved.auth_type,
@@ -131,13 +133,14 @@ export class ProxyService {
     const stream = body.stream === true;
     const forward = await this.forwardToProvider(
       resolved.provider,
-      apiKey,
+      resolvedCredentials.apiKey,
       resolved.model,
       body,
       stream,
       sessionKey,
       signal,
       resolved.auth_type,
+      resolvedCredentials.resourceUrl,
     );
 
     if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {
@@ -274,7 +277,13 @@ export class ProxyService {
         continue;
       }
 
-      apiKey = await this.resolveApiKey(provider, apiKey, authType, agentId, userId);
+      const resolvedCredentials = await this.resolveApiKey(
+        provider,
+        apiKey,
+        authType,
+        agentId,
+        userId,
+      );
 
       this.logger.log(
         `Fallback ${i}: trying model=${model} provider=${provider} auth_type=${authType} (primary=${primaryModel})`,
@@ -282,13 +291,14 @@ export class ProxyService {
 
       const forward = await this.forwardToProvider(
         provider,
-        apiKey,
+        resolvedCredentials.apiKey,
         model,
         body,
         stream,
         sessionKey,
         signal,
         authType,
+        resolvedCredentials.resourceUrl,
       );
 
       if (forward.response.ok) {
@@ -314,12 +324,19 @@ export class ProxyService {
     authType: string | undefined,
     agentId: string,
     userId: string,
-  ): Promise<string> {
-    if (authType === 'subscription' && provider.toLowerCase() === 'openai') {
-      const unwrapped = await this.openaiOauth.unwrapToken(apiKey, agentId, userId);
-      if (unwrapped) return unwrapped;
+  ): Promise<{ apiKey: string; resourceUrl?: string }> {
+    if (authType === 'subscription') {
+      const lower = provider.toLowerCase();
+      if (lower === 'openai') {
+        const unwrapped = await this.openaiOauth.unwrapToken(apiKey, agentId, userId);
+        if (unwrapped) return { apiKey: unwrapped };
+      }
+      if (lower === 'minimax') {
+        const unwrapped = await this.minimaxOauth.unwrapToken(apiKey, agentId, userId);
+        if (unwrapped) return { apiKey: unwrapped.t, resourceUrl: unwrapped.u };
+      }
     }
-    return apiKey;
+    return { apiKey };
   }
 
   private async enforceLimits(tenantId?: string, agentName?: string): Promise<void> {
@@ -374,6 +391,7 @@ export class ProxyService {
     sessionKey: string,
     signal?: AbortSignal,
     authType?: string,
+    resourceUrl?: string,
   ): Promise<ForwardResult> {
     const extraHeaders: Record<string, string> = {};
     if (provider === 'xai') {
@@ -391,6 +409,12 @@ export class ProxyService {
         customEndpoint = buildCustomEndpoint(cp.base_url);
         forwardModel = CustomProviderService.rawModelName(model);
       }
+    } else if (
+      authType === 'subscription' &&
+      provider.toLowerCase() === 'minimax' &&
+      resourceUrl
+    ) {
+      customEndpoint = buildEndpointOverride(resourceUrl, 'minimax-subscription');
     }
 
     return this.providerClient.forward(

--- a/packages/backend/src/routing/routing.module.ts
+++ b/packages/backend/src/routing/routing.module.ts
@@ -30,6 +30,8 @@ import { OllamaSyncService } from '../database/ollama-sync.service';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { OpenaiOauthService } from './openai-oauth.service';
 import { OpenaiOauthController } from './openai-oauth.controller';
+import { MinimaxOauthService } from './minimax-oauth.service';
+import { MinimaxOauthController } from './minimax-oauth.controller';
 
 @Module({
   imports: [
@@ -52,6 +54,7 @@ import { OpenaiOauthController } from './openai-oauth.controller';
     ResolveController,
     ProxyController,
     OpenaiOauthController,
+    MinimaxOauthController,
   ],
   providers: [
     RoutingService,
@@ -69,6 +72,7 @@ import { OpenaiOauthController } from './openai-oauth.controller';
     SessionMomentumService,
     OllamaSyncService,
     OpenaiOauthService,
+    MinimaxOauthService,
   ],
   exports: [
     RoutingService,
@@ -77,6 +81,7 @@ import { OpenaiOauthController } from './openai-oauth.controller';
     TierAutoAssignService,
     ResolveAgentService,
     OpenaiOauthService,
+    MinimaxOauthService,
   ],
 })
 export class RoutingModule {}

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -47,6 +47,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
   let pollTimer: number | undefined;
   let isDisposed = false;
+  let activeFlowGeneration = 0;
 
   const clearPollTimer = () => {
     if (pollTimer !== undefined) {
@@ -55,12 +56,12 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     }
   };
 
-  const schedulePoll = (delayMs: number) => {
+  const schedulePoll = (delayMs: number, flowGeneration = activeFlowGeneration) => {
     clearPollTimer();
-    if (isDisposed) return;
+    if (isDisposed || flowGeneration !== activeFlowGeneration) return;
     pollTimer = window.setTimeout(() => {
-      if (isDisposed) return;
-      void runPoll();
+      if (isDisposed || flowGeneration !== activeFlowGeneration) return;
+      void runPoll(flowGeneration);
     }, delayMs);
   };
 
@@ -92,8 +93,8 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     }
   };
 
-  const runPoll = async () => {
-    if (isDisposed) return;
+  const runPoll = async (flowGeneration = activeFlowGeneration) => {
+    if (isDisposed || flowGeneration !== activeFlowGeneration) return;
     const current = flow();
     if (!current) return;
 
@@ -106,7 +107,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
     try {
       const result = await pollMinimaxOAuth(current.flowId);
-      if (isDisposed) return;
+      if (isDisposed || flowGeneration !== activeFlowGeneration) return;
       const latest = flow();
       if (!latest || latest.flowId !== current.flowId) {
         return;
@@ -129,9 +130,12 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
       setFlowError(null);
       setStatusMessage(result.message ?? 'Waiting for approval…');
-      schedulePoll(result.pollIntervalMs ?? latest.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+      schedulePoll(
+        result.pollIntervalMs ?? latest.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+        flowGeneration,
+      );
     } catch {
-      if (isDisposed) return;
+      if (isDisposed || flowGeneration !== activeFlowGeneration) return;
       if (flow()?.flowId !== current.flowId) {
         return;
       }
@@ -143,26 +147,28 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
   const handleStart = async () => {
     props.setBusy(true);
+    const flowGeneration = ++activeFlowGeneration;
     clearPollTimer();
     setFlowError(null);
     setStatusMessage(null);
     try {
       const nextFlow = await startMinimaxOAuth(props.agentName, selectedRegion());
-      if (isDisposed) return;
+      if (isDisposed || flowGeneration !== activeFlowGeneration) return;
       setFlow(nextFlow);
       window.open(nextFlow.verificationUri, '_blank', 'noopener,noreferrer');
-      schedulePoll(nextFlow.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+      schedulePoll(nextFlow.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS, flowGeneration);
     } catch {
-      if (isDisposed) return;
+      if (isDisposed || flowGeneration !== activeFlowGeneration) return;
       setFlow(null);
     } finally {
-      if (isDisposed) return;
+      if (isDisposed || flowGeneration !== activeFlowGeneration) return;
       props.setBusy(false);
     }
   };
 
   onCleanup(() => {
     isDisposed = true;
+    activeFlowGeneration += 1;
     clearPollTimer();
   });
 

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -1,10 +1,18 @@
-import { createSignal, onCleanup, Show, type Accessor, type Component, type Setter } from 'solid-js';
+import {
+  createSignal,
+  onCleanup,
+  Show,
+  type Accessor,
+  type Component,
+  type Setter,
+} from 'solid-js';
 import type { ProviderDef } from '../services/providers.js';
 import {
   disconnectProvider,
   pollMinimaxOAuth,
   startMinimaxOAuth,
   type AuthType,
+  type MinimaxOAuthRegion,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import { CopyButton } from './SetupStepInstall.js';
@@ -36,6 +44,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [flow, setFlow] = createSignal<DeviceCodeFlow | null>(null);
   const [statusMessage, setStatusMessage] = createSignal<string | null>(null);
   const [flowError, setFlowError] = createSignal<string | null>(null);
+  const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
   let pollTimer: number | undefined;
 
   const clearPollTimer = () => {
@@ -125,10 +134,10 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     setFlowError(null);
     setStatusMessage(null);
     try {
-      const nextFlow = await startMinimaxOAuth(props.agentName);
+      const nextFlow = await startMinimaxOAuth(props.agentName, selectedRegion());
       setFlow(nextFlow);
       window.open(nextFlow.verificationUri, '_blank', 'noopener,noreferrer');
-      schedulePoll(0);
+      schedulePoll(nextFlow.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
     } catch {
       setFlow(null);
     } finally {
@@ -146,11 +155,27 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
           fallback={
             <>
               <p class="provider-detail__hint">
-                Open the verification page, enter a one-time code, and we will finish the
-                connection automatically.
+                Choose your MiniMax region, then open the authorization page in your browser to sign
+                in and approve access.
               </p>
+              <div class="provider-detail__field" style="margin-top: 12px;">
+                <label class="provider-detail__label" for="minimax-region">
+                  Region
+                </label>
+                <select
+                  id="minimax-region"
+                  class="provider-detail__input"
+                  value={selectedRegion()}
+                  disabled={props.busy()}
+                  onChange={(e) => setSelectedRegion(e.currentTarget.value as MinimaxOAuthRegion)}
+                >
+                  <option value="global">Global (api.minimax.io)</option>
+                  <option value="cn">China Mainland (api.minimaxi.com)</option>
+                </select>
+              </div>
               <button
                 class="btn btn--primary provider-detail__action"
+                style="margin-top: 12px;"
                 disabled={props.busy()}
                 onClick={handleStart}
               >
@@ -164,7 +189,8 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
           {(activeFlow) => (
             <>
               <p class="provider-detail__hint">
-                Enter this code at the MiniMax verification page to approve access.
+                Your browser should open to the MiniMax authorization page. If MiniMax asks for a
+                one-time code, enter the code shown below.
               </p>
               <div class="provider-detail__field" style="margin-top: 12px;">
                 <label class="provider-detail__label">Verification Code</label>

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -102,6 +102,10 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
     try {
       const result = await pollMinimaxOAuth(current.flowId);
+      const latest = flow();
+      if (!latest || latest.flowId !== current.flowId) {
+        return;
+      }
 
       if (result.status === 'success') {
         clearPollTimer();
@@ -120,8 +124,11 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
       setFlowError(null);
       setStatusMessage(result.message ?? 'Waiting for approval…');
-      schedulePoll(result.pollIntervalMs ?? current.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+      schedulePoll(result.pollIntervalMs ?? latest.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
     } catch {
+      if (flow()?.flowId !== current.flowId) {
+        return;
+      }
       clearPollTimer();
       setFlowError('Failed to check approval status. Start again to retry.');
       setStatusMessage(null);

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -46,6 +46,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [flowError, setFlowError] = createSignal<string | null>(null);
   const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
   let pollTimer: number | undefined;
+  let isDisposed = false;
 
   const clearPollTimer = () => {
     if (pollTimer !== undefined) {
@@ -56,7 +57,9 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
   const schedulePoll = (delayMs: number) => {
     clearPollTimer();
+    if (isDisposed) return;
     pollTimer = window.setTimeout(() => {
+      if (isDisposed) return;
       void runPoll();
     }, delayMs);
   };
@@ -90,6 +93,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   };
 
   const runPoll = async () => {
+    if (isDisposed) return;
     const current = flow();
     if (!current) return;
 
@@ -102,6 +106,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
     try {
       const result = await pollMinimaxOAuth(current.flowId);
+      if (isDisposed) return;
       const latest = flow();
       if (!latest || latest.flowId !== current.flowId) {
         return;
@@ -126,6 +131,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
       setStatusMessage(result.message ?? 'Waiting for approval…');
       schedulePoll(result.pollIntervalMs ?? latest.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
     } catch {
+      if (isDisposed) return;
       if (flow()?.flowId !== current.flowId) {
         return;
       }
@@ -142,17 +148,23 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     setStatusMessage(null);
     try {
       const nextFlow = await startMinimaxOAuth(props.agentName, selectedRegion());
+      if (isDisposed) return;
       setFlow(nextFlow);
       window.open(nextFlow.verificationUri, '_blank', 'noopener,noreferrer');
       schedulePoll(nextFlow.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
     } catch {
+      if (isDisposed) return;
       setFlow(null);
     } finally {
+      if (isDisposed) return;
       props.setBusy(false);
     }
   };
 
-  onCleanup(() => clearPollTimer());
+  onCleanup(() => {
+    isDisposed = true;
+    clearPollTimer();
+  });
 
   return (
     <>

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -1,0 +1,242 @@
+import { createSignal, onCleanup, Show, type Accessor, type Component, type Setter } from 'solid-js';
+import type { ProviderDef } from '../services/providers.js';
+import {
+  disconnectProvider,
+  pollMinimaxOAuth,
+  startMinimaxOAuth,
+  type AuthType,
+} from '../services/api.js';
+import { toast } from '../services/toast-store.js';
+import { CopyButton } from './SetupStepInstall.js';
+
+interface Props {
+  provDef: ProviderDef;
+  provId: string;
+  agentName: string;
+  connected: Accessor<boolean>;
+  selectedAuthType: Accessor<AuthType>;
+  busy: Accessor<boolean>;
+  setBusy: Setter<boolean>;
+  onBack: () => void;
+  onUpdate: () => void;
+  onClose: () => void;
+}
+
+interface DeviceCodeFlow {
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+  pollIntervalMs: number;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+
+const DeviceCodeDetailView: Component<Props> = (props) => {
+  const [flow, setFlow] = createSignal<DeviceCodeFlow | null>(null);
+  const [statusMessage, setStatusMessage] = createSignal<string | null>(null);
+  const [flowError, setFlowError] = createSignal<string | null>(null);
+  let pollTimer: number | undefined;
+
+  const clearPollTimer = () => {
+    if (pollTimer !== undefined) {
+      window.clearTimeout(pollTimer);
+      pollTimer = undefined;
+    }
+  };
+
+  const schedulePoll = (delayMs: number) => {
+    clearPollTimer();
+    pollTimer = window.setTimeout(() => {
+      void runPoll();
+    }, delayMs);
+  };
+
+  const openVerificationPage = () => {
+    const current = flow();
+    if (!current) return;
+    window.open(current.verificationUri, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleDisconnect = async () => {
+    props.setBusy(true);
+    try {
+      const result = await disconnectProvider(
+        props.agentName,
+        props.provId,
+        props.selectedAuthType(),
+      );
+      if (result?.notifications?.length) {
+        for (const msg of result.notifications) {
+          toast.error(msg);
+        }
+      }
+      props.onBack();
+      props.onUpdate();
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const runPoll = async () => {
+    const current = flow();
+    if (!current) return;
+
+    if (Date.now() >= current.expiresAt) {
+      setFlowError('This verification code expired. Start again to generate a new one.');
+      setStatusMessage(null);
+      clearPollTimer();
+      return;
+    }
+
+    try {
+      const result = await pollMinimaxOAuth(current.flowId);
+
+      if (result.status === 'success') {
+        clearPollTimer();
+        toast.success(`${props.provDef.name} subscription connected`);
+        props.onUpdate();
+        props.onClose();
+        return;
+      }
+
+      if (result.status === 'error') {
+        clearPollTimer();
+        setFlowError(result.message ?? 'MiniMax login failed. Start again to retry.');
+        setStatusMessage(null);
+        return;
+      }
+
+      setFlowError(null);
+      setStatusMessage(result.message ?? 'Waiting for approval…');
+      schedulePoll(result.pollIntervalMs ?? current.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    } catch {
+      clearPollTimer();
+      setFlowError('Failed to check approval status. Start again to retry.');
+      setStatusMessage(null);
+    }
+  };
+
+  const handleStart = async () => {
+    props.setBusy(true);
+    clearPollTimer();
+    setFlowError(null);
+    setStatusMessage(null);
+    try {
+      const nextFlow = await startMinimaxOAuth(props.agentName);
+      setFlow(nextFlow);
+      window.open(nextFlow.verificationUri, '_blank', 'noopener,noreferrer');
+      schedulePoll(0);
+    } catch {
+      setFlow(null);
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  onCleanup(() => clearPollTimer());
+
+  return (
+    <>
+      <Show when={!props.connected()}>
+        <Show
+          when={flow()}
+          fallback={
+            <>
+              <p class="provider-detail__hint">
+                Open the verification page, enter a one-time code, and we will finish the
+                connection automatically.
+              </p>
+              <button
+                class="btn btn--primary provider-detail__action"
+                disabled={props.busy()}
+                onClick={handleStart}
+              >
+                <Show when={!props.busy()} fallback={<span class="spinner" />}>
+                  Connect with {props.provDef.name}
+                </Show>
+              </button>
+            </>
+          }
+        >
+          {(activeFlow) => (
+            <>
+              <p class="provider-detail__hint">
+                Enter this code at the MiniMax verification page to approve access.
+              </p>
+              <div class="provider-detail__field" style="margin-top: 12px;">
+                <label class="provider-detail__label">Verification Code</label>
+                <div class="provider-detail__key-row">
+                  <input
+                    class="provider-detail__input provider-detail__input--disabled"
+                    type="text"
+                    value={activeFlow().userCode}
+                    readonly
+                    aria-label={`${props.provDef.name} verification code`}
+                  />
+                  <CopyButton text={activeFlow().userCode} />
+                </div>
+              </div>
+              <div class="provider-detail__field" style="margin-top: 12px;">
+                <label class="provider-detail__label">Verification Link</label>
+                <div class="provider-detail__key-row">
+                  <input
+                    class="provider-detail__input provider-detail__input--disabled"
+                    type="text"
+                    value={activeFlow().verificationUri}
+                    readonly
+                    aria-label={`${props.provDef.name} verification link`}
+                  />
+                  <CopyButton text={activeFlow().verificationUri} />
+                </div>
+              </div>
+              <div class="provider-detail__field" style="margin-top: 12px;">
+                <button class="btn btn--outline btn--sm" onClick={openVerificationPage}>
+                  Open verification page
+                </button>
+                <button
+                  class="btn btn--ghost btn--sm"
+                  style="margin-left: 8px;"
+                  disabled={props.busy()}
+                  onClick={handleStart}
+                >
+                  Start over
+                </button>
+              </div>
+              <Show when={statusMessage()}>
+                <p class="provider-detail__hint" style="margin-top: 12px;">
+                  {statusMessage()}
+                </p>
+              </Show>
+              <Show when={flowError()}>
+                <div class="provider-detail__error" style="margin-top: 12px;">
+                  {flowError()}
+                </div>
+              </Show>
+            </>
+          )}
+        </Show>
+      </Show>
+      <Show when={props.connected()}>
+        <div class="provider-detail__field">
+          <span class="provider-detail__no-key">
+            Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+          </span>
+        </div>
+        <button
+          class="btn btn--outline provider-detail__action provider-detail__disconnect"
+          disabled={props.busy()}
+          onClick={handleDisconnect}
+        >
+          <Show when={!props.busy()} fallback={<span class="spinner" />}>
+            Disconnect
+          </Show>
+        </button>
+      </Show>
+    </>
+  );
+};
+
+export default DeviceCodeDetailView;

--- a/packages/frontend/src/components/ProviderDetailView.tsx
+++ b/packages/frontend/src/components/ProviderDetailView.tsx
@@ -71,6 +71,7 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
     (provDef.subscriptionKeyPlaceholder ? 'token' : undefined);
   const isPopupOAuthFlow = () => isSubMode() && subscriptionAuthMode() === 'popup_oauth';
   const isDeviceCodeFlow = () => isSubMode() && subscriptionAuthMode() === 'device_code';
+  const shouldRevokeOpenaiOAuth = () => props.provId === 'openai' && isPopupOAuthFlow();
   const isCommandOnly = () =>
     isSubMode() &&
     !!provDef.subscriptionCommand &&
@@ -106,7 +107,7 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      if (isPopupOAuthFlow()) {
+      if (shouldRevokeOpenaiOAuth()) {
         await revokeOpenaiOAuth(props.agentName).catch(() => {});
       }
       const result = await disconnectProvider(

--- a/packages/frontend/src/components/ProviderDetailView.tsx
+++ b/packages/frontend/src/components/ProviderDetailView.tsx
@@ -12,6 +12,7 @@ import { toast } from '../services/toast-store.js';
 import { CopyButton } from './SetupStepInstall.js';
 import ProviderKeyForm from './ProviderKeyForm.js';
 import OAuthDetailView from './OAuthDetailView.js';
+import DeviceCodeDetailView from './DeviceCodeDetailView.js';
 
 export interface ProviderDetailViewProps {
   provId: string;
@@ -64,17 +65,24 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
   };
 
   const isSubMode = () => props.selectedAuthType() === 'subscription';
-  const isOAuthFlow = () => isSubMode() && !!provDef.subscriptionOAuth;
+  const subscriptionAuthMode = () =>
+    provDef.subscriptionAuthMode ??
+    (provDef.subscriptionOAuth ? 'popup_oauth' : undefined) ??
+    (provDef.subscriptionKeyPlaceholder ? 'token' : undefined);
+  const isPopupOAuthFlow = () => isSubMode() && subscriptionAuthMode() === 'popup_oauth';
+  const isDeviceCodeFlow = () => isSubMode() && subscriptionAuthMode() === 'device_code';
   const isCommandOnly = () =>
     isSubMode() &&
     !!provDef.subscriptionCommand &&
     !provDef.subscriptionKeyPlaceholder &&
-    !provDef.subscriptionOAuth;
+    !subscriptionAuthMode();
   const connected = () =>
     isSubMode()
       ? isCommandOnly()
         ? isSubscriptionConnected()
-        : isSubscriptionWithToken()
+        : subscriptionAuthMode() === 'token'
+          ? isSubscriptionWithToken()
+          : isSubscriptionConnected()
       : isConnectedApiKey() || isNoKeyConnected();
   const isOllama = provDef.noKeyRequired;
 
@@ -98,7 +106,7 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      if (provDef.subscriptionOAuth && props.selectedAuthType() === 'subscription') {
+      if (isPopupOAuthFlow()) {
         await revokeOpenaiOAuth(props.agentName).catch(() => {});
       }
       const result = await disconnectProvider(
@@ -145,8 +153,10 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
           <div class="routing-modal__title">Connect providers</div>
           <div class="routing-modal__subtitle">
             {isSubMode()
-              ? isOAuthFlow()
+              ? isPopupOAuthFlow()
                 ? 'Log in to connect your subscription'
+                : isDeviceCodeFlow()
+                  ? 'Verify your account to connect your subscription'
                 : isCommandOnly()
                   ? 'Log in via your browser to connect your subscription'
                   : 'Paste your setup-token to enable routing'
@@ -230,8 +240,24 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
       </Show>
 
       {/* OAuth subscription */}
-      <Show when={isOAuthFlow()}>
+      <Show when={isPopupOAuthFlow()}>
         <OAuthDetailView
+          provDef={provDef}
+          provId={props.provId}
+          agentName={props.agentName}
+          connected={connected}
+          selectedAuthType={props.selectedAuthType}
+          busy={props.busy}
+          setBusy={props.setBusy}
+          onBack={props.onBack}
+          onUpdate={props.onUpdate}
+          onClose={props.onClose}
+        />
+      </Show>
+
+      {/* Device-code subscription */}
+      <Show when={isDeviceCodeFlow()}>
+        <DeviceCodeDetailView
           provDef={provDef}
           provId={props.provId}
           agentName={props.agentName}
@@ -275,7 +301,7 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
       </Show>
 
       {/* API key / subscription token form (non-Ollama, non-command-only, non-OAuth) */}
-      <Show when={!isOllama && !isCommandOnly() && !isOAuthFlow()}>
+      <Show when={!isOllama && !isCommandOnly() && !isPopupOAuthFlow() && !isDeviceCodeFlow()}>
         <ProviderKeyForm
           provDef={provDef}
           provId={props.provId}

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -33,6 +33,10 @@ export interface ProviderKeyFormProps {
 const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   const isPopupOAuth = () =>
     props.provDef.subscriptionAuthMode === 'popup_oauth' || !!props.provDef.subscriptionOAuth;
+  const shouldRevokeOpenaiOAuth = () =>
+    props.provId === 'openai' &&
+    isPopupOAuth() &&
+    props.selectedAuthType() === 'subscription';
   const fieldLabel = () => (props.isSubMode() ? 'Setup Token' : 'API Key');
   const placeholder = () =>
     props.isSubMode()
@@ -102,7 +106,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      if (isPopupOAuth() && props.selectedAuthType() === 'subscription') {
+      if (shouldRevokeOpenaiOAuth()) {
         await revokeOpenaiOAuth(props.agentName).catch(() => {});
       }
       const result = await disconnectProvider(

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -31,6 +31,8 @@ export interface ProviderKeyFormProps {
 }
 
 const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
+  const isPopupOAuth = () =>
+    props.provDef.subscriptionAuthMode === 'popup_oauth' || !!props.provDef.subscriptionOAuth;
   const fieldLabel = () => (props.isSubMode() ? 'Setup Token' : 'API Key');
   const placeholder = () =>
     props.isSubMode()
@@ -100,7 +102,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      if (props.provDef.subscriptionOAuth && props.selectedAuthType() === 'subscription') {
+      if (isPopupOAuth() && props.selectedAuthType() === 'subscription') {
         await revokeOpenaiOAuth(props.agentName).catch(() => {});
       }
       const result = await disconnectProvider(

--- a/packages/frontend/src/components/ProviderSubscriptionTab.tsx
+++ b/packages/frontend/src/components/ProviderSubscriptionTab.tsx
@@ -13,6 +13,11 @@ interface Props {
 }
 
 const ProviderSubscriptionTab: Component<Props> = (props) => {
+  const getSubscriptionAuthMode = (prov: ProviderDef) =>
+    prov.subscriptionAuthMode ??
+    (prov.subscriptionOAuth ? 'popup_oauth' : undefined) ??
+    (prov.subscriptionKeyPlaceholder ? 'token' : undefined);
+
   return (
     <>
       <div class="provider-modal__tab-hint">
@@ -25,9 +30,10 @@ const ProviderSubscriptionTab: Component<Props> = (props) => {
             const hasDetailView = () =>
               !!prov.subscriptionKeyPlaceholder ||
               !!prov.subscriptionCommand ||
-              !!prov.subscriptionOAuth;
+              !!getSubscriptionAuthMode(prov);
+            const requiresStoredToken = () => getSubscriptionAuthMode(prov) === 'token';
             const connected = () =>
-              prov.subscriptionKeyPlaceholder || prov.subscriptionOAuth
+              requiresStoredToken()
                 ? props.isSubscriptionWithToken(prov.id)
                 : props.isSubscriptionConnected(prov.id);
 

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -382,6 +382,7 @@ export function getRoutingStatus(agentName: string) {
 /* -- Routing: Providers -- */
 
 export type AuthType = 'api_key' | 'subscription';
+export type MinimaxOAuthRegion = 'global' | 'cn';
 
 export interface RoutingProvider {
   id: string;
@@ -453,9 +454,9 @@ export function revokeOpenaiOAuth(agentName: string) {
   );
 }
 
-export function startMinimaxOAuth(agentName: string) {
+export function startMinimaxOAuth(agentName: string, region: MinimaxOAuthRegion = 'global') {
   return fetchMutate<MinimaxOAuthStartResponse>(
-    `${BASE_URL}/oauth/minimax/start?agentName=${encodeURIComponent(agentName)}`,
+    `${BASE_URL}/oauth/minimax/start?agentName=${encodeURIComponent(agentName)}&region=${encodeURIComponent(region)}`,
     { method: 'POST' },
   );
 }

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -393,6 +393,20 @@ export interface RoutingProvider {
   connected_at: string;
 }
 
+export interface MinimaxOAuthStartResponse {
+  flowId: string;
+  userCode: string;
+  verificationUri: string;
+  expiresAt: number;
+  pollIntervalMs: number;
+}
+
+export interface MinimaxOAuthPollResponse {
+  status: 'pending' | 'success' | 'error';
+  message?: string;
+  pollIntervalMs?: number;
+}
+
 export function getProviders(agentName: string) {
   return fetchJson<RoutingProvider[]>(`/routing/${encodeURIComponent(agentName)}/providers`);
 }
@@ -437,6 +451,19 @@ export function revokeOpenaiOAuth(agentName: string) {
     `${BASE_URL}/oauth/openai/revoke?agentName=${encodeURIComponent(agentName)}`,
     { method: 'POST' },
   );
+}
+
+export function startMinimaxOAuth(agentName: string) {
+  return fetchMutate<MinimaxOAuthStartResponse>(
+    `${BASE_URL}/oauth/minimax/start?agentName=${encodeURIComponent(agentName)}`,
+    { method: 'POST' },
+  );
+}
+
+export function pollMinimaxOAuth(flowId: string) {
+  return fetchJson<MinimaxOAuthPollResponse>(`/oauth/minimax/poll`, {
+    flowId,
+  });
 }
 
 export function disconnectProvider(agentName: string, provider: string, authType?: AuthType) {

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -20,7 +20,9 @@ export interface ProviderDef {
   subscriptionKeyPlaceholder?: string;
   /** Instructions text shown in the subscription detail view. */
   subscriptionCommand?: string;
-  /** Provider uses browser-based OAuth flow (popup window). */
+  /** UI auth mode for subscription flows. */
+  subscriptionAuthMode?: 'popup_oauth' | 'device_code' | 'token';
+  /** Deprecated compatibility flag for popup OAuth providers. */
   subscriptionOAuth?: boolean;
 }
 
@@ -47,6 +49,7 @@ export const PROVIDERS: ProviderDef[] = [
     keyPlaceholder: 'sk-ant-...',
     supportsSubscription: true,
     subscriptionLabel: 'Claude Max / Pro subscription',
+    subscriptionAuthMode: 'token',
     subscriptionKeyPlaceholder: 'Paste your setup-token',
     subscriptionCommand: 'claude setup-token',
     models: [],
@@ -82,6 +85,9 @@ export const PROVIDERS: ProviderDef[] = [
     keyPrefix: 'sk-api-',
     minKeyLength: 30,
     keyPlaceholder: 'sk-api-...',
+    supportsSubscription: true,
+    subscriptionLabel: 'MiniMax Coding Plan',
+    subscriptionAuthMode: 'device_code',
     models: [],
   },
   {
@@ -130,7 +136,7 @@ export const PROVIDERS: ProviderDef[] = [
     keyPlaceholder: 'sk-...',
     supportsSubscription: true,
     subscriptionLabel: 'ChatGPT Plus/Pro/Team',
-    subscriptionOAuth: true,
+    subscriptionAuthMode: 'popup_oauth',
     models: [
       { label: 'GPT-4o', value: 'gpt-4o' },
       { label: 'GPT-4o Mini', value: 'gpt-4o-mini' },

--- a/packages/frontend/tests/components/ProviderSelectModal-commandonly.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal-commandonly.test.tsx
@@ -4,12 +4,16 @@ import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockPollMinimaxOAuth = vi.fn();
+const mockStartMinimaxOAuth = vi.fn();
 
 vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: () => Promise.resolve({ ok: true }),
+  startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({
@@ -63,6 +67,14 @@ describe("ProviderSelectModal -- command-only subscription detail view", () => {
     onClose = vi.fn();
     onUpdate = vi.fn();
     mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    mockPollMinimaxOAuth.mockResolvedValue({ status: "pending", pollIntervalMs: 2000 });
+    mockStartMinimaxOAuth.mockResolvedValue({
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: Date.now() + 60_000,
+      pollIntervalMs: 2000,
+    });
   });
 
   it("shows command-only subtitle and hint text when not connected", () => {

--- a/packages/frontend/tests/components/ProviderSelectModal-subscription.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal-subscription.test.tsx
@@ -4,12 +4,16 @@ import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockPollMinimaxOAuth = vi.fn();
+const mockStartMinimaxOAuth = vi.fn();
 
 vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: () => Promise.resolve({ ok: true }),
+  startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({
@@ -62,6 +66,14 @@ describe("ProviderSelectModal — subscription toggle (no subscriptionKeyPlaceho
     onUpdate = vi.fn();
     mockConnectProvider.mockResolvedValue({});
     mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    mockPollMinimaxOAuth.mockResolvedValue({ status: "pending", pollIntervalMs: 2000 });
+    mockStartMinimaxOAuth.mockResolvedValue({
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: Date.now() + 60_000,
+      pollIntervalMs: 2000,
+    });
   });
 
   it("connects a subscription provider via toggle when not connected", async () => {

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1517,11 +1517,22 @@ describe("ProviderSelectModal", () => {
       expect(mockRevokeOpenaiOAuth).not.toHaveBeenCalled();
     });
 
-    it("ignores stale MiniMax poll results after starting over", async () => {
+    it("ignores stale MiniMax poll results while a replacement flow is still starting", async () => {
       vi.useFakeTimers();
-      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+      const openSpy = vi
+        .spyOn(window, "open")
+        .mockReturnValue({ closed: false } as unknown as Window);
 
       let resolveFirstPoll: ((value: { status: string; message?: string; pollIntervalMs?: number }) => void) | undefined;
+      let resolveSecondStart:
+        | ((value: {
+            flowId: string;
+            userCode: string;
+            verificationUri: string;
+            expiresAt: number;
+            pollIntervalMs: number;
+          }) => void)
+        | undefined;
       mockStartMinimaxOAuth
         .mockResolvedValueOnce({
           flowId: "flow-1",
@@ -1530,13 +1541,12 @@ describe("ProviderSelectModal", () => {
           expiresAt: Date.now() + 60_000,
           pollIntervalMs: 2000,
         })
-        .mockResolvedValueOnce({
-          flowId: "flow-2",
-          userCode: "WXYZ-9876",
-          verificationUri: "https://www.minimax.io/verify-2",
-          expiresAt: Date.now() + 60_000,
-          pollIntervalMs: 2000,
-        });
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveSecondStart = resolve;
+            }),
+        );
       mockPollMinimaxOAuth.mockImplementationOnce(
         () =>
           new Promise((resolve) => {
@@ -1563,7 +1573,7 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("Start over"));
 
       await waitFor(() => {
-        expect(screen.getByDisplayValue("WXYZ-9876")).toBeDefined();
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledTimes(2);
       });
 
       resolveFirstPoll?.({ status: "success" });
@@ -1572,10 +1582,22 @@ describe("ProviderSelectModal", () => {
 
       expect(onClose).not.toHaveBeenCalled();
       expect(onUpdate).not.toHaveBeenCalled();
-      expect(screen.getByDisplayValue("WXYZ-9876")).toBeDefined();
+      expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+
+      resolveSecondStart?.({
+        flowId: "flow-2",
+        userCode: "WXYZ-9876",
+        verificationUri: "https://www.minimax.io/verify-2",
+        expiresAt: Date.now() + 60_000,
+        pollIntervalMs: 2000,
+      });
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("WXYZ-9876")).toBeDefined();
+      });
 
       vi.useRealTimers();
-      vi.restoreAllMocks();
+      openSpy.mockRestore();
     });
 
     it("stops MiniMax polling after the modal unmounts", async () => {

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1258,6 +1258,183 @@ describe("ProviderSelectModal", () => {
       vi.restoreAllMocks();
     });
 
+    it("shows MiniMax pending status and can reopen the verification page", async () => {
+      vi.useFakeTimers();
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+      mockPollMinimaxOAuth.mockResolvedValueOnce({
+        status: "pending",
+        message: "Waiting for MiniMax approval…",
+        pollIntervalMs: 2500,
+      });
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await waitFor(() => {
+        expect(mockPollMinimaxOAuth).toHaveBeenCalledWith("flow-1");
+        expect(screen.getByText("Waiting for MiniMax approval…")).toBeDefined();
+      });
+
+      fireEvent.click(screen.getByText("Open verification page"));
+
+      expect(window.open).toHaveBeenLastCalledWith(
+        "https://www.minimax.io/verify",
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    it("closes the modal when MiniMax approval succeeds", async () => {
+      vi.useFakeTimers();
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+      mockPollMinimaxOAuth.mockResolvedValueOnce({ status: "success" });
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith("MiniMax subscription connected");
+        expect(onUpdate).toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalled();
+      });
+
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    it("shows MiniMax poll errors inline", async () => {
+      vi.useFakeTimers();
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+      mockPollMinimaxOAuth.mockResolvedValueOnce({
+        status: "error",
+        message: "MiniMax rejected the login",
+      });
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await waitFor(() => {
+        expect(screen.getByText("MiniMax rejected the login")).toBeDefined();
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    it("shows a retry message when MiniMax polling throws", async () => {
+      vi.useFakeTimers();
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+      mockPollMinimaxOAuth.mockRejectedValueOnce(new Error("network error"));
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Failed to check approval status. Start again to retry."),
+        ).toBeDefined();
+      });
+
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    it("shows an expiry message instead of polling expired MiniMax codes", async () => {
+      vi.useFakeTimers();
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+      mockStartMinimaxOAuth.mockResolvedValueOnce({
+        flowId: "expired-flow",
+        userCode: "EXPIRED-1234",
+        verificationUri: "https://www.minimax.io/verify",
+        expiresAt: Date.now() - 1,
+        pollIntervalMs: 1,
+      });
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("EXPIRED-1234")).toBeDefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(1);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("This verification code expired. Start again to generate a new one."),
+        ).toBeDefined();
+      });
+      expect(mockPollMinimaxOAuth).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    it("keeps MiniMax in setup mode when starting the device-code flow fails", async () => {
+      mockStartMinimaxOAuth.mockRejectedValueOnce(new Error("MiniMax unavailable"));
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith("test-agent", "global");
+      });
+      expect(screen.queryByDisplayValue("ABCD-1234")).toBeNull();
+      expect(screen.getByText("Connect with MiniMax")).toBeDefined();
+    });
+
     it("shows Disconnect button for connected MiniMax subscription", () => {
       const subProvider: RoutingProvider = {
         id: "p-minimax-sub",
@@ -1305,6 +1482,37 @@ describe("ProviderSelectModal", () => {
 
       await waitFor(() => {
         expect(mockDisconnectProvider).toHaveBeenCalledWith("test-agent", "minimax", "subscription");
+      });
+      expect(mockRevokeOpenaiOAuth).not.toHaveBeenCalled();
+    });
+
+    it("shows MiniMax disconnect notifications as error toasts", async () => {
+      mockDisconnectProvider.mockResolvedValueOnce({
+        notifications: ["MiniMax tiers were recalculated."],
+      });
+      const subProvider: RoutingProvider = {
+        id: "p-minimax-sub",
+        provider: "minimax",
+        is_active: true,
+        has_api_key: true,
+        key_prefix: '{"t":"mm',
+        connected_at: "2025-01-01",
+        auth_type: "subscription",
+      };
+      render(() => (
+        <ProviderSelectModal
+          providers={[subProvider]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Disconnect"));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("MiniMax tiers were recalculated.");
       });
       expect(mockRevokeOpenaiOAuth).not.toHaveBeenCalled();
     });

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1578,6 +1578,48 @@ describe("ProviderSelectModal", () => {
       vi.restoreAllMocks();
     });
 
+    it("stops MiniMax polling after the modal unmounts", async () => {
+      vi.useFakeTimers();
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+
+      let resolveFirstPoll:
+        | ((value: { status: string; message?: string; pollIntervalMs?: number }) => void)
+        | undefined;
+      mockPollMinimaxOAuth.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstPoll = resolve;
+          }),
+      );
+
+      const view = render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(2000);
+      await waitFor(() => {
+        expect(mockPollMinimaxOAuth).toHaveBeenCalledTimes(1);
+      });
+
+      view.unmount();
+      resolveFirstPoll?.({ status: "pending", pollIntervalMs: 2000 });
+      await Promise.resolve();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(4000);
+
+      expect(mockPollMinimaxOAuth).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
     it("does not show paste field for OAuth provider", () => {
       render(() => (
         <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1215,6 +1215,7 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("MiniMax"));
       expect(screen.getByText("Verify your account to connect your subscription")).toBeDefined();
       expect(screen.getByText("Connect with MiniMax")).toBeDefined();
+      expect(screen.getByLabelText("Region")).toBeDefined();
     });
 
     it("starts MiniMax device-code flow and shows code details", async () => {
@@ -1227,7 +1228,7 @@ describe("ProviderSelectModal", () => {
       fireEvent.click(screen.getByText("Connect with MiniMax"));
 
       await waitFor(() => {
-        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith("test-agent");
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith("test-agent", "global");
       });
       expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
       expect(screen.getByDisplayValue("https://www.minimax.io/verify")).toBeDefined();
@@ -1236,6 +1237,23 @@ describe("ProviderSelectModal", () => {
         "_blank",
         "noopener,noreferrer",
       );
+
+      vi.restoreAllMocks();
+    });
+
+    it("starts MiniMax device-code flow with the selected region", async () => {
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.change(screen.getByLabelText("Region"), { target: { value: "cn" } });
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith("test-agent", "cn");
+      });
 
       vi.restoreAllMocks();
     });

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1,10 +1,40 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 
+const broadcastChannelRegistry = new Map<string, Set<MockBroadcastChannel>>();
+
+class MockBroadcastChannel {
+  name: string;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+
+  constructor(name: string) {
+    this.name = name;
+    if (!broadcastChannelRegistry.has(name)) {
+      broadcastChannelRegistry.set(name, new Set());
+    }
+    broadcastChannelRegistry.get(name)!.add(this);
+  }
+
+  postMessage(data: unknown) {
+    const listeners = broadcastChannelRegistry.get(this.name);
+    if (!listeners) return;
+    for (const channel of listeners) {
+      if (channel === this) continue;
+      channel.onmessage?.({ data });
+    }
+  }
+
+  close() {
+    broadcastChannelRegistry.get(this.name)?.delete(this);
+  }
+}
+
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockPollMinimaxOAuth = vi.fn();
 const mockRevokeOpenaiOAuth = vi.fn();
+const mockStartMinimaxOAuth = vi.fn();
 const mockCreateCustomProvider = vi.fn();
 const mockUpdateCustomProvider = vi.fn();
 const mockDeleteCustomProvider = vi.fn();
@@ -13,7 +43,9 @@ vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
+  startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
   createCustomProvider: (...args: unknown[]) => mockCreateCustomProvider(...args),
   updateCustomProvider: (...args: unknown[]) => mockUpdateCustomProvider(...args),
   deleteCustomProvider: (...args: unknown[]) => mockDeleteCustomProvider(...args),
@@ -67,13 +99,27 @@ describe("ProviderSelectModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    broadcastChannelRegistry.clear();
+    vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
     mockLocalMode = false;
     onClose = vi.fn();
     onUpdate = vi.fn();
     mockConnectProvider.mockResolvedValue({});
     mockDisconnectProvider.mockResolvedValue({ notifications: [] });
     mockGetOpenaiOAuthUrl.mockResolvedValue({ url: "https://auth.openai.com/oauth/authorize?test=1" });
+    mockPollMinimaxOAuth.mockResolvedValue({
+      status: "pending",
+      message: "Waiting for MiniMax approval…",
+      pollIntervalMs: 2000,
+    });
     mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
+    mockStartMinimaxOAuth.mockResolvedValue({
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: Date.now() + 60_000,
+      pollIntervalMs: 2000,
+    });
   });
 
   it("renders modal with title", () => {
@@ -1153,6 +1199,68 @@ describe("ProviderSelectModal", () => {
         <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
       ));
       expect(screen.getByText("ChatGPT Plus/Pro/Team")).toBeDefined();
+    });
+
+    it("shows MiniMax subscription label in list", () => {
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+      expect(screen.getByText("MiniMax Coding Plan")).toBeDefined();
+    });
+
+    it("opens MiniMax device-code detail view", () => {
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+      fireEvent.click(screen.getByText("MiniMax"));
+      expect(screen.getByText("Verify your account to connect your subscription")).toBeDefined();
+      expect(screen.getByText("Connect with MiniMax")).toBeDefined();
+    });
+
+    it("starts MiniMax device-code flow and shows code details", async () => {
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith("test-agent");
+      });
+      expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+      expect(screen.getByDisplayValue("https://www.minimax.io/verify")).toBeDefined();
+      expect(window.open).toHaveBeenCalledWith(
+        "https://www.minimax.io/verify",
+        "_blank",
+        "noopener,noreferrer",
+      );
+
+      vi.restoreAllMocks();
+    });
+
+    it("shows Disconnect button for connected MiniMax subscription", () => {
+      const subProvider: RoutingProvider = {
+        id: "p-minimax-sub",
+        provider: "minimax",
+        is_active: true,
+        has_api_key: true,
+        key_prefix: '{"t":"mm',
+        connected_at: "2025-01-01",
+        auth_type: "subscription",
+      };
+      render(() => (
+        <ProviderSelectModal
+          providers={[subProvider]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
+      ));
+      fireEvent.click(screen.getByText("MiniMax"));
+      expect(screen.getByText("Disconnect")).toBeDefined();
+      expect(screen.getByText(/Connected via MiniMax Coding Plan/)).toBeDefined();
     });
 
     it("does not show paste field for OAuth provider", () => {

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1281,6 +1281,95 @@ describe("ProviderSelectModal", () => {
       expect(screen.getByText(/Connected via MiniMax Coding Plan/)).toBeDefined();
     });
 
+    it("disconnects MiniMax without revoking OpenAI OAuth", async () => {
+      const subProvider: RoutingProvider = {
+        id: "p-minimax-sub",
+        provider: "minimax",
+        is_active: true,
+        has_api_key: true,
+        key_prefix: '{"t":"mm',
+        connected_at: "2025-01-01",
+        auth_type: "subscription",
+      };
+      render(() => (
+        <ProviderSelectModal
+          providers={[subProvider]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Disconnect"));
+
+      await waitFor(() => {
+        expect(mockDisconnectProvider).toHaveBeenCalledWith("test-agent", "minimax", "subscription");
+      });
+      expect(mockRevokeOpenaiOAuth).not.toHaveBeenCalled();
+    });
+
+    it("ignores stale MiniMax poll results after starting over", async () => {
+      vi.useFakeTimers();
+      vi.spyOn(window, "open").mockReturnValue({ closed: false } as unknown as Window);
+
+      let resolveFirstPoll: ((value: { status: string; message?: string; pollIntervalMs?: number }) => void) | undefined;
+      mockStartMinimaxOAuth
+        .mockResolvedValueOnce({
+          flowId: "flow-1",
+          userCode: "ABCD-1234",
+          verificationUri: "https://www.minimax.io/verify",
+          expiresAt: Date.now() + 60_000,
+          pollIntervalMs: 2000,
+        })
+        .mockResolvedValueOnce({
+          flowId: "flow-2",
+          userCode: "WXYZ-9876",
+          verificationUri: "https://www.minimax.io/verify-2",
+          expiresAt: Date.now() + 60_000,
+          pollIntervalMs: 2000,
+        });
+      mockPollMinimaxOAuth.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirstPoll = resolve;
+          }),
+      );
+
+      render(() => (
+        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      ));
+
+      fireEvent.click(screen.getByText("MiniMax"));
+      fireEvent.click(screen.getByText("Connect with MiniMax"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("ABCD-1234")).toBeDefined();
+      });
+
+      await vi.advanceTimersByTimeAsync(2000);
+      await waitFor(() => {
+        expect(mockPollMinimaxOAuth).toHaveBeenCalledWith("flow-1");
+      });
+
+      fireEvent.click(screen.getByText("Start over"));
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue("WXYZ-9876")).toBeDefined();
+      });
+
+      resolveFirstPoll?.({ status: "success" });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onClose).not.toHaveBeenCalled();
+      expect(onUpdate).not.toHaveBeenCalled();
+      expect(screen.getByDisplayValue("WXYZ-9876")).toBeDefined();
+
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
     it("does not show paste field for OAuth provider", () => {
       render(() => (
         <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -566,7 +566,7 @@ describe("revokeOpenaiOAuth", () => {
 });
 
 describe("startMinimaxOAuth", () => {
-  it("sends POST to /oauth/minimax/start with agentName param", async () => {
+  it("sends POST to /oauth/minimax/start with agentName and default region params", async () => {
     const payload = {
       flowId: "flow-1",
       userCode: "ABCD-1234",
@@ -579,7 +579,25 @@ describe("startMinimaxOAuth", () => {
     const result = await startMinimaxOAuth("my-agent");
     expect(result).toEqual(payload);
     expect(mockFetch).toHaveBeenCalledWith(
-      "/api/v1/oauth/minimax/start?agentName=my-agent",
+      "/api/v1/oauth/minimax/start?agentName=my-agent&region=global",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
+  });
+
+  it("sends POST to /oauth/minimax/start with the selected region", async () => {
+    const payload = {
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: 1760000000000,
+      pollIntervalMs: 2000,
+    };
+    mockMutateOk(payload);
+
+    const result = await startMinimaxOAuth("my-agent", "cn");
+    expect(result).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/oauth/minimax/start?agentName=my-agent&region=cn",
       expect.objectContaining({ method: "POST", credentials: "include" }),
     );
   });

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -18,7 +18,9 @@ import {
   deactivateAllProviders,
   disconnectProvider,
   getOpenaiOAuthUrl,
+  pollMinimaxOAuth,
   revokeOpenaiOAuth,
+  startMinimaxOAuth,
   getTierAssignments,
   overrideTier,
   resetTier,
@@ -560,6 +562,39 @@ describe("revokeOpenaiOAuth", () => {
       "/api/v1/oauth/openai/revoke?agentName=my-agent",
       expect.objectContaining({ method: "POST", credentials: "include" }),
     );
+  });
+});
+
+describe("startMinimaxOAuth", () => {
+  it("sends POST to /oauth/minimax/start with agentName param", async () => {
+    const payload = {
+      flowId: "flow-1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://www.minimax.io/verify",
+      expiresAt: 1760000000000,
+      pollIntervalMs: 2000,
+    };
+    mockMutateOk(payload);
+
+    const result = await startMinimaxOAuth("my-agent");
+    expect(result).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/oauth/minimax/start?agentName=my-agent",
+      expect.objectContaining({ method: "POST", credentials: "include" }),
+    );
+  });
+});
+
+describe("pollMinimaxOAuth", () => {
+  it("fetches /oauth/minimax/poll with flowId param", async () => {
+    const payload = { status: "pending", message: "Waiting", pollIntervalMs: 2000 };
+    mockOk(payload);
+
+    const result = await pollMinimaxOAuth("flow-1");
+    expect(result).toEqual(payload);
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/api/v1/oauth/minimax/poll");
+    expect(url).toContain("flowId=flow-1");
   });
 });
 

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -279,13 +279,21 @@ describe("PROVIDERS", () => {
     expect(openai.subscriptionLabel).toBe("ChatGPT Plus/Pro/Team");
     expect(openai.subscriptionKeyPlaceholder).toBeUndefined();
     expect(openai.subscriptionCommand).toBeUndefined();
-    expect(openai.subscriptionOAuth).toBe(true);
+    expect(openai.subscriptionAuthMode).toBe("popup_oauth");
   });
 
   it("Anthropic supports subscription", () => {
     const anthropic = PROVIDERS.find((p) => p.id === "anthropic")!;
     expect(anthropic.supportsSubscription).toBe(true);
     expect(anthropic.subscriptionLabel).toBe("Claude Max / Pro subscription");
+    expect(anthropic.subscriptionAuthMode).toBe("token");
+  });
+
+  it("MiniMax supports subscription with device-code flow", () => {
+    const minimax = PROVIDERS.find((p) => p.id === "minimax")!;
+    expect(minimax.supportsSubscription).toBe(true);
+    expect(minimax.subscriptionLabel).toBe("MiniMax Coding Plan");
+    expect(minimax.subscriptionAuthMode).toBe("device_code");
   });
 
   it("requires an API key URL for every provider that needs one", () => {

--- a/packages/openclaw-plugin/__tests__/subscription-capabilities.test.ts
+++ b/packages/openclaw-plugin/__tests__/subscription-capabilities.test.ts
@@ -1,0 +1,33 @@
+describe("subscription capability manifests", () => {
+  const pluginCapabilities = require("../subscription-capabilities");
+  const sharedCapabilities = require("../../subscription-capabilities");
+
+  it("publishes MiniMax device-code metadata in both manifests", () => {
+    for (const capabilities of [pluginCapabilities, sharedCapabilities]) {
+      expect(capabilities.supportsSubscriptionProvider("minimax")).toBe(true);
+      expect(capabilities.getSubscriptionProviderConfig("minimax")).toMatchObject({
+        supportsSubscription: true,
+        subscriptionLabel: "MiniMax Coding Plan",
+        subscriptionAuthMode: "device_code",
+      });
+      expect(capabilities.getSubscriptionKnownModels("minimax")).toContain("MiniMax-M2.5");
+      expect(capabilities.getSubscriptionCapabilities("minimax")).toMatchObject({
+        maxContextWindow: 200000,
+        supportsPromptCaching: false,
+        supportsBatching: false,
+      });
+    }
+  });
+
+  it("keeps existing auth-mode metadata for Anthropic and OpenAI", () => {
+    for (const capabilities of [pluginCapabilities, sharedCapabilities]) {
+      expect(capabilities.getSubscriptionProviderConfig("anthropic")).toMatchObject({
+        subscriptionAuthMode: "token",
+      });
+      expect(capabilities.getSubscriptionProviderConfig("openai")).toMatchObject({
+        subscriptionAuthMode: "popup_oauth",
+        subscriptionOAuth: true,
+      });
+    }
+  });
+});

--- a/packages/openclaw-plugin/__tests__/subscription.test.ts
+++ b/packages/openclaw-plugin/__tests__/subscription.test.ts
@@ -204,6 +204,7 @@ describe("discoverSubscriptionProviders", () => {
           c: { type: "oauth", provider: "qwen-portal" },
           d: { type: "oauth", provider: "kimi" },
           e: { type: "oauth", provider: "minimax" },
+          f: { type: "oauth", provider: "minimax-portal" },
         },
       }),
     );
@@ -212,6 +213,7 @@ describe("discoverSubscriptionProviders", () => {
     expect(result).toEqual([
       { openclawId: "anthropic", manifestId: "anthropic", authType: "oauth" },
       { openclawId: "github-copilot", manifestId: "openai", authType: "oauth" },
+      { openclawId: "minimax", manifestId: "minimax", authType: "oauth" },
     ]);
   });
 });

--- a/packages/openclaw-plugin/__tests__/subscription.test.ts
+++ b/packages/openclaw-plugin/__tests__/subscription.test.ts
@@ -234,6 +234,17 @@ describe("registerSubscriptionProviders", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("logs debug when global fetch is unavailable", async () => {
+    const globalWithFetch = globalThis as typeof globalThis & { fetch?: typeof mockFetch };
+    Reflect.deleteProperty(globalWithFetch, "fetch");
+
+    await registerSubscriptionProviders(mockProviders, "http://localhost/otlp", "key", mockLogger);
+
+    expect(mockLogger.debug).toHaveBeenCalledWith(
+      "[manifest] Global fetch is not available",
+    );
+  });
+
   it("posts providers to the subscription endpoint", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/packages/openclaw-plugin/__tests__/subscription.test.ts
+++ b/packages/openclaw-plugin/__tests__/subscription.test.ts
@@ -225,7 +225,8 @@ describe("registerSubscriptionProviders", () => {
 
   const mockFetch = jest.fn();
   beforeEach(() => {
-    global.fetch = mockFetch;
+    const globalWithFetch = globalThis as typeof globalThis & { fetch: typeof mockFetch };
+    globalWithFetch.fetch = mockFetch;
   });
 
   it("does nothing when providers array is empty", async () => {

--- a/packages/openclaw-plugin/__tests__/subscription.test.ts
+++ b/packages/openclaw-plugin/__tests__/subscription.test.ts
@@ -355,4 +355,39 @@ describe("registerSubscriptionProviders", () => {
       "[manifest] Error registering subscription providers: timeout",
     );
   });
+
+  it("tolerates runtimes without AbortSignal.timeout", async () => {
+    const abortSignalDescriptor = Object.getOwnPropertyDescriptor(globalThis, "AbortSignal");
+    Object.defineProperty(globalThis, "AbortSignal", {
+      configurable: true,
+      value: {},
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ registered: 1 }),
+    });
+
+    try {
+      await registerSubscriptionProviders(
+        mockProviders,
+        "http://localhost/otlp",
+        "key",
+        mockLogger,
+      );
+    } finally {
+      if (abortSignalDescriptor) {
+        Object.defineProperty(globalThis, "AbortSignal", abortSignalDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, "AbortSignal");
+      }
+    }
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost/api/v1/routing/subscription-providers",
+      expect.objectContaining({
+        signal: undefined,
+      }),
+    );
+  });
 });

--- a/packages/openclaw-plugin/src/subscription.ts
+++ b/packages/openclaw-plugin/src/subscription.ts
@@ -42,6 +42,7 @@ const OPENCLAW_TO_MANIFEST: Record<string, string> = {
   moonshot: 'moonshot',
   kimi: 'moonshot',
   minimax: 'minimax',
+  'minimax-portal': 'minimax',
 };
 
 /**

--- a/packages/openclaw-plugin/src/subscription.ts
+++ b/packages/openclaw-plugin/src/subscription.ts
@@ -23,6 +23,34 @@ export interface SubscriptionProvider {
   authType: string;
 }
 
+interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: unknown;
+  },
+) => Promise<FetchResponseLike>;
+
+function getFetch(): FetchLike | null {
+  return (globalThis as typeof globalThis & { fetch?: FetchLike }).fetch ?? null;
+}
+
+function getAbortSignalTimeout(ms: number): unknown {
+  return (
+    globalThis as typeof globalThis & {
+      AbortSignal?: { timeout: (timeoutMs: number) => unknown };
+    }
+  ).AbortSignal?.timeout(ms);
+}
+
 /**
  * Map OpenClaw provider names from auth-profiles to Manifest provider IDs.
  * OpenClaw uses names like "openai-codex", "google-gemini", "github-copilot"
@@ -131,6 +159,12 @@ export async function registerSubscriptionProviders(
   const url = `${baseUrl}/api/v1/routing/subscription-providers`;
 
   try {
+    const fetchImpl = getFetch();
+    if (!fetchImpl) {
+      logger.debug('[manifest] Global fetch is not available');
+      return;
+    }
+
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
@@ -138,13 +172,13 @@ export async function registerSubscriptionProviders(
       headers['Authorization'] = `Bearer ${apiKey}`;
     }
 
-    const res = await fetch(url, {
+    const res = await fetchImpl(url, {
       method: 'POST',
       headers,
       body: JSON.stringify({
         providers: providers.map((p) => ({ provider: p.manifestId })),
       }),
-      signal: AbortSignal.timeout(5000),
+      signal: getAbortSignalTimeout(5000),
     });
 
     if (res.ok) {

--- a/packages/openclaw-plugin/src/subscription.ts
+++ b/packages/openclaw-plugin/src/subscription.ts
@@ -48,7 +48,7 @@ function getAbortSignalTimeout(ms: number): unknown {
     globalThis as typeof globalThis & {
       AbortSignal?: { timeout: (timeoutMs: number) => unknown };
     }
-  ).AbortSignal?.timeout(ms);
+  ).AbortSignal?.timeout?.(ms);
 }
 
 /**

--- a/packages/openclaw-plugin/subscription-capabilities/index.d.ts
+++ b/packages/openclaw-plugin/subscription-capabilities/index.d.ts
@@ -9,6 +9,7 @@ export interface SubscriptionProviderConfig {
   subscriptionLabel: string;
   subscriptionKeyPlaceholder?: string;
   subscriptionCommand?: string;
+  subscriptionAuthMode?: 'popup_oauth' | 'device_code' | 'token';
   subscriptionTokenPrefix?: string;
   subscriptionOAuth?: boolean;
   knownModels?: readonly string[];

--- a/packages/openclaw-plugin/subscription-capabilities/index.js
+++ b/packages/openclaw-plugin/subscription-capabilities/index.js
@@ -33,7 +33,13 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
   minimax: Object.freeze({
     supportsSubscription: true,
     subscriptionLabel: 'MiniMax Coding Plan',
-    knownModels: Object.freeze(['minimax-m2.1', 'minimax-m2.5']),
+    knownModels: Object.freeze([
+      'MiniMax-M2.5',
+      'MiniMax-M2.5-highspeed',
+      'MiniMax-M2.1',
+      'MiniMax-M2.1-highspeed',
+      'MiniMax-M2',
+    ]),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
       supportsPromptCaching: false,

--- a/packages/openclaw-plugin/subscription-capabilities/index.js
+++ b/packages/openclaw-plugin/subscription-capabilities/index.js
@@ -30,6 +30,16 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
       supportsBatching: false,
     }),
   }),
+  minimax: Object.freeze({
+    supportsSubscription: true,
+    subscriptionLabel: 'MiniMax Coding Plan',
+    knownModels: Object.freeze(['minimax-m2.1', 'minimax-m2.5']),
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
 });
 
 const SUPPORTED_SUBSCRIPTION_PROVIDER_IDS = Object.freeze(

--- a/packages/openclaw-plugin/subscription-capabilities/index.js
+++ b/packages/openclaw-plugin/subscription-capabilities/index.js
@@ -2,6 +2,7 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
   anthropic: Object.freeze({
     supportsSubscription: true,
     subscriptionLabel: 'Claude Max / Pro subscription',
+    subscriptionAuthMode: 'token',
     subscriptionKeyPlaceholder: 'Paste your setup-token',
     subscriptionCommand: 'claude setup-token',
     subscriptionTokenPrefix: 'sk-ant-oat',
@@ -15,6 +16,7 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
   openai: Object.freeze({
     supportsSubscription: true,
     subscriptionLabel: 'ChatGPT Plus/Pro/Team',
+    subscriptionAuthMode: 'popup_oauth',
     subscriptionOAuth: true,
     knownModels: Object.freeze([
       'gpt-5.4',
@@ -33,6 +35,7 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
   minimax: Object.freeze({
     supportsSubscription: true,
     subscriptionLabel: 'MiniMax Coding Plan',
+    subscriptionAuthMode: 'device_code',
     knownModels: Object.freeze([
       'MiniMax-M2.5',
       'MiniMax-M2.5-highspeed',

--- a/packages/subscription-capabilities/index.d.ts
+++ b/packages/subscription-capabilities/index.d.ts
@@ -9,6 +9,7 @@ export interface SubscriptionProviderConfig {
   subscriptionLabel: string;
   subscriptionKeyPlaceholder?: string;
   subscriptionCommand?: string;
+  subscriptionAuthMode?: 'popup_oauth' | 'device_code' | 'token';
   subscriptionTokenPrefix?: string;
   subscriptionOAuth?: boolean;
   knownModels?: readonly string[];

--- a/packages/subscription-capabilities/index.js
+++ b/packages/subscription-capabilities/index.js
@@ -33,7 +33,13 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
   minimax: Object.freeze({
     supportsSubscription: true,
     subscriptionLabel: 'MiniMax Coding Plan',
-    knownModels: Object.freeze(['minimax-m2.1', 'minimax-m2.5']),
+    knownModels: Object.freeze([
+      'MiniMax-M2.5',
+      'MiniMax-M2.5-highspeed',
+      'MiniMax-M2.1',
+      'MiniMax-M2.1-highspeed',
+      'MiniMax-M2',
+    ]),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,
       supportsPromptCaching: false,

--- a/packages/subscription-capabilities/index.js
+++ b/packages/subscription-capabilities/index.js
@@ -30,6 +30,16 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
       supportsBatching: false,
     }),
   }),
+  minimax: Object.freeze({
+    supportsSubscription: true,
+    subscriptionLabel: 'MiniMax Coding Plan',
+    knownModels: Object.freeze(['minimax-m2.1', 'minimax-m2.5']),
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 200000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
 });
 
 const SUPPORTED_SUBSCRIPTION_PROVIDER_IDS = Object.freeze(

--- a/packages/subscription-capabilities/index.js
+++ b/packages/subscription-capabilities/index.js
@@ -2,6 +2,7 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
   anthropic: Object.freeze({
     supportsSubscription: true,
     subscriptionLabel: 'Claude Max / Pro subscription',
+    subscriptionAuthMode: 'token',
     subscriptionKeyPlaceholder: 'Paste your setup-token',
     subscriptionCommand: 'claude setup-token',
     subscriptionTokenPrefix: 'sk-ant-oat',
@@ -15,6 +16,7 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
   openai: Object.freeze({
     supportsSubscription: true,
     subscriptionLabel: 'ChatGPT Plus/Pro/Team',
+    subscriptionAuthMode: 'popup_oauth',
     subscriptionOAuth: true,
     knownModels: Object.freeze([
       'gpt-5.4',
@@ -33,6 +35,7 @@ const SUBSCRIPTION_PROVIDER_CONFIGS = Object.freeze({
   minimax: Object.freeze({
     supportsSubscription: true,
     subscriptionLabel: 'MiniMax Coding Plan',
+    subscriptionAuthMode: 'device_code',
     knownModels: Object.freeze([
       'MiniMax-M2.5',
       'MiniMax-M2.5-highspeed',


### PR DESCRIPTION
## Summary

This PR adds MiniMax as a first-class subscription provider using its device-code OAuth flow, and wires the resulting credentials through model discovery, proxy forwarding, and the OpenClaw subscription registration path.

At a high level, the branch does four things:

1. Adds a backend MiniMax OAuth device-code flow (`start` + `poll`) that stores refreshable subscription credentials.
2. Extends discovery/proxy plumbing so MiniMax subscription credentials can be used against the correct provider-native base URL after login.
3. Adds a dedicated frontend subscription UI for device-code auth, including region selection, verification code display, and polling.
4. Registers MiniMax in shared subscription capability metadata and the OpenClaw plugin so it is detected and surfaced like other subscription providers.

## Why this is structured this way

MiniMax does not fit either of the existing subscription UX patterns:

- Anthropic uses a pasted setup token.
- OpenAI uses popup OAuth.
- MiniMax uses a device-code style flow with a verification page, a one-time code, server-side polling, and region-specific hosts.

Because of that, this PR intentionally introduces a separate `device_code` subscription mode instead of trying to shoehorn MiniMax into the existing token or popup flows.

On the backend, MiniMax also differs from OpenAI because the OAuth response can include a provider-specific `resource_url`, and subsequent model discovery / inference requests need to use that resolved base URL rather than a single global default.

## Design Overview

### Backend OAuth flow

New service/controller:
- `packages/backend/src/routing/minimax-oauth.service.ts`
- `packages/backend/src/routing/minimax-oauth.controller.ts`

Flow:
- `POST /api/v1/oauth/minimax/start?agentName=...&region=global|cn`
  - starts the MiniMax device-code flow
  - validates region
  - requests the user code + verification URI from MiniMax
  - stores an in-memory pending flow with verifier, expiry, poll interval, region base URL, and default resource URL
- `GET /api/v1/oauth/minimax/poll?flowId=...`
  - polls the token endpoint
  - returns `pending | success | error`
  - on success, stores an encrypted OAuth blob in the same provider table used by other subscription providers
  - triggers model discovery and tier recalculation

The stored OAuth blob extends the existing shape with an optional `u` field:
- `t`: access token
- `r`: refresh token
- `e`: absolute expiry timestamp
- `u`: provider resource/base URL when supplied by MiniMax

### Discovery and runtime forwarding

Key files:
- `packages/backend/src/routing/model-discovery/model-discovery.service.ts`
- `packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts`
- `packages/backend/src/routing/proxy/proxy.service.ts`
- `packages/backend/src/routing/proxy/provider-client.ts`
- `packages/backend/src/routing/proxy/provider-endpoints.ts`
- `packages/backend/src/routing/provider-base-url.ts`

Design choices:
- OpenAI and MiniMax subscription credentials are both stored as OAuth blobs, so discovery now uses a shared parser instead of OpenAI-only JSON unwrapping.
- The unwrapping remains explicitly gated to `openai` and `minimax`; Anthropic/token-based subscriptions are left untouched.
- MiniMax alone can forward a `resource_url` / endpoint override into discovery and runtime proxying.
- A small shared `normalizeProviderBaseUrl()` helper keeps custom endpoint cleanup and MiniMax endpoint override cleanup consistent.

This means:
- OpenAI subscription discovery still uses the Codex models endpoint.
- MiniMax subscription discovery uses the MiniMax/Anthropic-compatible models endpoint, optionally overridden by the returned resource URL.
- Runtime MiniMax subscription requests are forwarded to the resolved resource URL rather than the static provider host.

### Frontend UX

Key files:
- `packages/frontend/src/components/DeviceCodeDetailView.tsx`
- `packages/frontend/src/components/ProviderDetailView.tsx`
- `packages/frontend/src/services/api.ts`
- `packages/frontend/src/services/providers.ts`

A dedicated device-code view was added because MiniMax needs UI state that the existing popup OAuth view does not support:
- region selection (`global` vs `cn`)
- start flow action
- display of verification code + verification URI
- polling loop with provider-defined interval
- expiry handling / start-over flow

This keeps the existing OpenAI popup OAuth flow isolated and prevents `ProviderDetailView` from absorbing a large amount of MiniMax-specific state management.

### Shared provider metadata and plugin detection

Key files:
- `packages/subscription-capabilities/index.js`
- `packages/openclaw-plugin/subscription-capabilities/index.js`
- `packages/openclaw-plugin/src/subscription.ts`

MiniMax is added to the shared subscription capability registry and to the OpenClaw provider mapping so that:
- Manifest can surface MiniMax in the subscription UI
- the plugin can detect MiniMax device-login auth profiles and register MiniMax as a subscription provider automatically
- known MiniMax subscription models are available for fallback/supplement when live discovery is incomplete

## Critical Paths For Review

If you only want to inspect the risky paths, I would focus on these:

1. **Device-code auth lifecycle**
   - `minimax-oauth.service.ts`
   - start flow, pending flow storage, poll flow, success/error handling, refresh behavior

2. **Region/resource URL propagation**
   - `minimax-oauth.service.ts`
   - `model-discovery.service.ts`
   - `provider-model-fetcher.service.ts`
   - `proxy.service.ts`
   - `provider-endpoints.ts`
   
   This is the most important design change in the PR. MiniMax auth, discovery, and runtime forwarding need to stay on the same resolved host.

3. **Non-regression for existing subscription providers**
   - `openai-oauth.types.ts`
   - `model-discovery.service.ts`
   - `proxy.service.ts`
   - relevant specs
   
   The shared blob parser and subscription unwrapping are intentionally narrow, but this is the part worth sanity-checking for OpenAI/Anthropic behavior.

4. **Frontend flow split**
   - `ProviderDetailView.tsx`
   - `DeviceCodeDetailView.tsx`
   
   This is the main UI design change in the PR.

## Follow-ups / intentionally not in scope

- This PR does **not** change routing/tier-selection heuristics.
- Mixed-case MiniMax model ID pricing enrichment is tracked separately in [#1167](https://github.com/mnfst/manifest/issues/1167) and is not addressed here.

## Test Coverage

Backend:
- `minimax-oauth.service.spec.ts`
- `minimax-oauth.controller.spec.ts`
- `model-discovery.service.spec.ts`
- `provider-model-fetcher.service.spec.ts`
- `proxy.service.spec.ts`
- `openai-oauth.types.spec.ts`

Frontend:
- `ProviderSelectModal.test.tsx`
- `ProviderSelectModal-subscription.test.tsx`
- `ProviderSelectModal-commandonly.test.tsx`
- `api.test.ts`
- `providers.test.ts`

Plugin:
- `packages/openclaw-plugin/__tests__/subscription.test.ts`

The branch also already went through the full GitHub checks and Cubic review/follow-ups on the fork PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MiniMax device-code OAuth for subscriptions with region selection and a dedicated device-code UI. Stores refreshable tokens (with optional resource URL) and routes discovery and runtime requests through the resolved MiniMax host.

- **New Features**
  - Backend device-code flow (start + poll) with `global`/`cn` endpoints; stores OAuth blob `{t, r, e, u}` and triggers discovery + tier recalculation.
  - Discovery/proxy use a MiniMax resource URL for both `/models` and inference; adds `minimax-subscription` config, endpoint override with Anthropic headers, and normalized base URLs.
  - Frontend adds `DeviceCodeDetailView` with region select, code + verification URI, polling, and expiry; standardizes `subscriptionAuthMode` (`popup_oauth`/`device_code`/`token`) and scopes OpenAI revoke to popup OAuth; API adds `startMinimaxOAuth`/`pollMinimaxOAuth`.
  - Shared capabilities and `openclaw-plugin` publish MiniMax device-code metadata and known models; plugin detects MiniMax OAuth profiles and uses safe `fetch` with timeout.

- **Bug Fixes**
  - Normalize device-code timing (ms poll interval, absolute expiry) and MiniMax base URL handling; validate and normalize resource URLs via `parseOAuthTokenBlob` and `normalizeMinimaxSubscriptionBaseUrl`.
  - Case-insensitive matching for MiniMax known model IDs in fallback/supplement logic.

<sup>Written for commit 938407f1fce219c591f98f6205a57122a5d15e97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

