### PR TITLE
fix(proxy): preserve Codex subscription instructions

### DIFF
--- a/.changeset/fix-codex-subscription-instructions.md
+++ b/.changeset/fix-codex-subscription-instructions.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Preserve Codex subscription instructions in proxied OpenAI requests so Codex backend calls do not fail with "Instructions are required".

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-adapter.spec.ts
@@ -6,7 +6,7 @@ import {
 
 describe('ChatGPT Adapter', () => {
   describe('toResponsesRequest', () => {
-    it('converts string content to input_text parts', () => {
+    it('converts string content to input_text parts and sets default instructions', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hello world' }],
       };
@@ -18,7 +18,7 @@ describe('ChatGPT Adapter', () => {
       ]);
       expect(result.stream).toBe(true);
       expect(result.store).toBe(false);
-      expect(result.instructions).toBeUndefined();
+      expect(result.instructions).toBe('You are a helpful assistant.');
     });
 
     it('extracts system message as instructions', () => {
@@ -34,6 +34,34 @@ describe('ChatGPT Adapter', () => {
       expect(result.input).toEqual([
         { role: 'user', content: [{ type: 'input_text', text: 'Hi' }] },
       ]);
+    });
+
+    it('extracts developer message as instructions', () => {
+      const body = {
+        messages: [
+          { role: 'developer', content: 'Follow the house style.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5.3-codex');
+
+      expect(result.instructions).toBe('Follow the house style.');
+      expect(result.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'Hi' }] },
+      ]);
+    });
+
+    it('combines system and developer text blocks into instructions', () => {
+      const body = {
+        messages: [
+          { role: 'system', content: [{ type: 'text', text: 'Be helpful.' }] },
+          { role: 'developer', content: [{ type: 'text', text: 'Prefer concise answers.' }] },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5.3-codex');
+
+      expect(result.instructions).toBe('Be helpful.\n\nPrefer concise answers.');
     });
 
     it('remaps multipart "text" type to "input_text" for user messages', () => {
@@ -100,10 +128,11 @@ describe('ChatGPT Adapter', () => {
       expect(input[0].content[1].type).toBe('image_url');
     });
 
-    it('filters system messages from input array', () => {
+    it('filters system and developer messages from input array', () => {
       const body = {
         messages: [
           { role: 'system', content: 'Be concise.' },
+          { role: 'developer', content: 'Use markdown.' },
           { role: 'user', content: 'Question' },
           { role: 'assistant', content: 'Answer' },
           { role: 'user', content: 'Follow-up' },
@@ -113,17 +142,17 @@ describe('ChatGPT Adapter', () => {
       const input = result.input as { role: string }[];
 
       expect(input).toHaveLength(3);
-      expect(input.every((m) => m.role !== 'system')).toBe(true);
+      expect(input.every((m) => m.role !== 'system' && m.role !== 'developer')).toBe(true);
     });
 
     it('handles missing messages gracefully', () => {
       const result = toResponsesRequest({}, 'gpt-5');
 
       expect(result.input).toEqual([]);
-      expect(result.instructions).toBeUndefined();
+      expect(result.instructions).toBe('You are a helpful assistant.');
     });
 
-    it('ignores non-string system content', () => {
+    it('extracts text parts from multipart system content', () => {
       const body = {
         messages: [
           { role: 'system', content: [{ type: 'text', text: 'parts' }] },
@@ -132,7 +161,19 @@ describe('ChatGPT Adapter', () => {
       };
       const result = toResponsesRequest(body, 'gpt-5');
 
-      expect(result.instructions).toBeUndefined();
+      expect(result.instructions).toBe('parts');
+    });
+
+    it('falls back to default instructions when system content has no text', () => {
+      const body = {
+        messages: [
+          { role: 'system', content: [{ type: 'image_url', image_url: { url: 'http://x.test' } }] },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      const result = toResponsesRequest(body, 'gpt-5');
+
+      expect(result.instructions).toBe('You are a helpful assistant.');
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -282,6 +282,25 @@ describe('ProviderClient', () => {
       expect(sentBody.store).toBe(false);
     });
 
+    it('sends default instructions when no system or developer prompt is present', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward(
+        'openai',
+        'token',
+        'gpt-5.1-codex-mini',
+        { messages: [{ role: 'user', content: 'Hello' }] },
+        false,
+        undefined,
+        undefined,
+        undefined,
+        'subscription',
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.instructions).toBe('You are a helpful assistant.');
+    });
+
     it('sets isChatGpt=false for regular OpenAI api_key auth', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1169,6 +1169,73 @@ describe('ProxyService', () => {
       expect(result.meta.model).toBe('claude-sonnet-4');
     });
 
+    it('tries fallback model when primary returns 400', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'simple',
+        model: 'gpt-5.1-codex-mini',
+        provider: 'OpenAI',
+        confidence: 0.7,
+        score: 0.1,
+        reason: 'scored',
+        auth_type: 'subscription',
+      });
+      routingService.getProviderApiKey
+        .mockResolvedValueOnce('skst-openai')
+        .mockResolvedValueOnce('sk-deepseek');
+      routingService.getAuthType.mockResolvedValueOnce('api_key');
+      openaiOauth.unwrapToken.mockResolvedValueOnce('oauth-openai');
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('{"detail":"Instructions are required"}', { status: 400 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: true,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        });
+      routingService.getTiers.mockResolvedValue([
+        { tier: 'simple', fallback_models: ['deepseek-chat'] },
+      ] as never);
+      pricingCache.getByModel.mockReturnValue({ provider: 'DeepSeek' } as never);
+
+      const result = await service.proxyRequest('agent-1', 'user-1', body, 'default');
+
+      expect(result.meta.fallbackFromModel).toBe('gpt-5.1-codex-mini');
+      expect(result.meta.fallbackIndex).toBe(0);
+      expect(result.meta.primaryErrorStatus).toBe(400);
+      expect(result.meta.primaryErrorBody).toBe('{"detail":"Instructions are required"}');
+      expect(result.meta.model).toBe('deepseek-chat');
+      expect(result.meta.provider).toBe('DeepSeek');
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        1,
+        'OpenAI',
+        'oauth-openai',
+        'gpt-5.1-codex-mini',
+        body,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        'subscription',
+      );
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        2,
+        'DeepSeek',
+        'sk-deepseek',
+        'deepseek-chat',
+        body,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        'api_key',
+      );
+    });
+
     it('returns original error when no fallback models configured', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -7,18 +7,23 @@
 
 import { randomUUID } from 'crypto';
 
+const DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
+
+interface OpenAiMessage {
+  role: string;
+  content: unknown;
+}
+
 /* ── Request conversion ── */
 
 export function toResponsesRequest(
   body: Record<string, unknown>,
   model: string,
 ): Record<string, unknown> {
-  const messages = (body.messages ?? []) as { role: string; content: unknown }[];
+  const messages = (body.messages ?? []) as OpenAiMessage[];
 
-  // Extract system message as instructions
-  const systemMsg = messages.find((m) => m.role === 'system');
   const input = messages
-    .filter((m) => m.role !== 'system')
+    .filter((m) => m.role !== 'system' && m.role !== 'developer')
     .map((m) => ({ role: m.role, content: convertContent(m.content, m.role) }));
 
   const request: Record<string, unknown> = {
@@ -26,11 +31,8 @@ export function toResponsesRequest(
     input,
     stream: body.stream !== false,
     store: false,
+    instructions: extractInstructions(messages),
   };
-
-  if (systemMsg && typeof systemMsg.content === 'string') {
-    request.instructions = systemMsg.content;
-  }
 
   return request;
 }
@@ -161,6 +163,31 @@ function convertContent(content: unknown, role: string): unknown {
     if (part.type === 'text') return { ...part, type: partType };
     return part;
   });
+}
+
+function extractInstructions(messages: OpenAiMessage[]): string {
+  const parts: string[] = [];
+
+  for (const message of messages) {
+    if (message.role !== 'system' && message.role !== 'developer') continue;
+    parts.push(...extractTextParts(message.content));
+  }
+
+  const instructions = parts
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .join('\n\n');
+
+  return instructions || DEFAULT_INSTRUCTIONS;
+}
+
+function extractTextParts(content: unknown): string[] {
+  if (typeof content === 'string') return [content];
+  if (!Array.isArray(content)) return [];
+
+  return (content as Array<Record<string, unknown>>)
+    .filter((part) => part.type === 'text' && typeof part.text === 'string')
+    .map((part) => part.text as string);
 }
 
 function safeParse(str: string): Record<string, unknown> | null {


### PR DESCRIPTION
## Summary

- preserve `instructions` for OpenAI subscription requests sent to the Codex backend
- treat `developer` prompt text like `system` prompt text when building Codex `instructions`
- add regressions for the exact 400 failure (`{"detail":"Instructions are required"}`) and fallback behavior

## Testing

- `npm test --workspace=packages/backend -- routing/proxy/__tests__/chatgpt-adapter.spec.ts routing/proxy/__tests__/provider-client.spec.ts routing/proxy/__tests__/proxy.service.spec.ts`

Closes #1169

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Codex subscription requests by always sending `instructions`, preventing 400 "Instructions are required" errors. `developer` and `system` prompts are merged into `instructions`, with a safe default when none are provided.

- **Bug Fixes**
  - Build `instructions` from `system` + `developer` text (supports multipart; combines blocks).
  - Default to "You are a helpful assistant." when no text instructions exist or messages are missing.
  - Remove `system`/`developer` messages from input; keep user text as `input_text`.
  - Add regression tests for the exact 400 error and verified fallback to the next model.

<sup>Written for commit 3536bc8a6a54c158899c7fe84df82734e3f80460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

