### PR TITLE
fix(routing): pass tool metadata into scorer

### DIFF
--- a/.changeset/fix-tool-aware-routing.md
+++ b/.changeset/fix-tool-aware-routing.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Pass request tools and tool_choice into routing resolution so tool-aware scoring uses the actual proxy request context.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -203,7 +203,7 @@ describe('ProxyService', () => {
     );
   });
 
-  it('does not pass tools or tool_choice to the resolver', async () => {
+  it('passes tools and tool_choice to the resolver', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'standard',
       model: 'gpt-4o',
@@ -229,12 +229,12 @@ describe('ProxyService', () => {
 
     await service.proxyRequest('agent-1', 'user-1', bodyWithTools, 'default');
 
-    // Resolver should receive undefined for tools and tool_choice
+    // Resolver should receive tools and tool_choice for scoring
     expect(resolveService.resolve).toHaveBeenCalledWith(
       'agent-1',
       expect.any(Array),
-      undefined,
-      undefined,
+      bodyWithTools.tools,
+      bodyWithTools.tool_choice,
       undefined,
       undefined,
     );

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -80,6 +80,7 @@ export class ProxyService {
     await this.enforceLimits(tenantId, agentName);
 
     const scoringMessages = this.filterScoringMessages(messages as ScorerMessage[]);
+    const scoringTools = Array.isArray(body.tools) ? body.tools : undefined;
     const isHeartbeat = this.detectHeartbeat(scoringMessages);
     const recentTiers = this.momentum.getRecentTiers(sessionKey);
 
@@ -88,8 +89,8 @@ export class ProxyService {
       : await this.resolveService.resolve(
           agentId,
           scoringMessages,
-          undefined,
-          undefined,
+          scoringTools,
+          body.tool_choice,
           body.max_tokens as number | undefined,
           recentTiers,
         );


### PR DESCRIPTION
## Summary
- pass request tools through the proxy into routing resolution
- pass tool_choice into routing resolution so tool-aware scoring sees the real request context
- update the proxy regression test to assert tool metadata is forwarded

## Testing
- npx jest --config packages/backend/package.json --runTestsByPath packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts

Closes #1171

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes tools and tool_choice from the proxy to the routing resolver so tool-aware scoring uses the real request context and routes correctly. Adds a patch changeset and updates the proxy regression test to assert these fields are forwarded (fixes #1171).

<sup>Written for commit 4b31e8241913eb355d2564b10b838796076c8498. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

