### PR TITLE
fix: normalize DeepSeek max_tokens before forwarding

### DIFF
--- a/.changeset/deepseek-max-tokens.md
+++ b/.changeset/deepseek-max-tokens.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Normalize DeepSeek `max_tokens` before forwarding requests so out-of-range values do not hard-fail upstream.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -683,6 +683,51 @@ describe('ProviderClient', () => {
       expect(sentBody.service_tier).toBeUndefined();
     });
 
+    it('caps DeepSeek max_tokens at the provider limit', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward(
+        'deepseek',
+        'sk-ds',
+        'deepseek-chat',
+        { ...bodyWithOpenAiFields, max_tokens: 12000 },
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.max_tokens).toBe(8192);
+    });
+
+    it('drops non-positive DeepSeek max_tokens values', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward(
+        'deepseek',
+        'sk-ds',
+        'deepseek-chat',
+        { ...bodyWithOpenAiFields, max_tokens: 0 },
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.max_tokens).toBeUndefined();
+    });
+
+    it('normalizes string DeepSeek max_tokens values', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward(
+        'deepseek',
+        'sk-ds',
+        'deepseek-chat',
+        { ...bodyWithOpenAiFields, max_tokens: '9000' as unknown as number },
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.max_tokens).toBe(8192);
+    });
+
     it('strips reasoning_content for Mistral assistant messages without mutating the input', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       const bodyWithReasoningContent = makeBodyWithReasoningContent();

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -34,6 +34,7 @@ const OPENAI_ONLY_FIELDS = new Set([
  * Nested message fields may still need target-aware cleanup.
  */
 const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
+const DEEPSEEK_MAX_TOKENS_LIMIT = 8192;
 
 function supportsReasoningContent(endpointKey: string, model: string): boolean {
   if (endpointKey === 'deepseek') return true;
@@ -87,7 +88,28 @@ function sanitizeOpenAiBody(
     }
     cleaned[key] = value;
   }
+  if (endpointKey === 'deepseek') normalizeDeepSeekMaxTokens(cleaned);
   return cleaned;
+}
+
+function normalizeDeepSeekMaxTokens(body: Record<string, unknown>): void {
+  if (!('max_tokens' in body)) return;
+
+  const raw = body.max_tokens;
+  const parsed =
+    typeof raw === 'number'
+      ? raw
+      : typeof raw === 'string'
+        ? Number(raw)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    delete body.max_tokens;
+    return;
+  }
+
+  body.max_tokens = Math.min(Math.trunc(parsed), DEEPSEEK_MAX_TOKENS_LIMIT);
+  if ((body.max_tokens as number) < 1) delete body.max_tokens;
 }
 
 export interface ForwardResult {


### PR DESCRIPTION
## Summary
- normalize DeepSeek `max_tokens` before forwarding OpenAI-compatible requests
- cap oversized values at the provider limit and drop invalid non-positive inputs
- add focused regression coverage for oversized, zero, and string-valued inputs

## Testing
- npm test --workspace=packages/backend -- provider-client.spec.ts

Fixes #1177

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize DeepSeek `max_tokens` before forwarding OpenAI-compatible requests to prevent provider errors and enforce the 8192 limit. Fixes #1177.

- **Bug Fixes**
  - Apply normalization only for DeepSeek in the provider client, truncate decimals, and add a changeset for a `manifest` patch release.
  - Add focused tests for oversized, zero, and string `max_tokens` inputs.

<sup>Written for commit 1a94edbfd7e535f0a65e46203500219dcd35cb3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

