### PR TITLE
fix(routing): prevent cross-auth credential fallback for explicit auth_type

### DIFF
--- a/.changeset/tough-planets-shake.md
+++ b/.changeset/tough-planets-shake.md
@@ -1,0 +1,5 @@
+"manifest-backend": patch
+---
+
+Stop cross-auth credential fallback when an auth type is explicitly requested.
+Requests that resolve to `auth_type: api_key` now only use API key credentials (and likewise for `subscription`) instead of silently decrypting another auth record.

--- a/.changeset/tough-planets-shake.md
+++ b/.changeset/tough-planets-shake.md
@@ -1,4 +1,5 @@
-"manifest-backend": patch
+---
+"manifest": patch
 ---
 
 Stop cross-auth credential fallback when an auth type is explicitly requested.

--- a/packages/backend/src/routing/routing.service.spec.ts
+++ b/packages/backend/src/routing/routing.service.spec.ts
@@ -1885,7 +1885,7 @@ describe('RoutingService', () => {
       expect(result).toBe('sk-api-key');
     });
 
-    it('should fall back to subscription when preferred api_key has no encrypted key', async () => {
+    it('should return null when preferred api_key has no encrypted key', async () => {
       const { encrypt, getEncryptionSecret } = await import('../common/utils/crypto.util');
       const secret = getEncryptionSecret();
       const subTokenEncrypted = encrypt('skst-fallback', secret);
@@ -1908,7 +1908,33 @@ describe('RoutingService', () => {
       ]);
 
       const result = await service.getProviderApiKey('a1', 'anthropic', 'api_key');
-      expect(result).toBe('skst-fallback');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when preferred subscription has no encrypted key', async () => {
+      const { encrypt, getEncryptionSecret } = await import('../common/utils/crypto.util');
+      const secret = getEncryptionSecret();
+      const apiKeyEncrypted = encrypt('sk-api-key', secret);
+
+      mockProviderRepo.find.mockResolvedValue([
+        {
+          agent_id: 'a1',
+          provider: 'anthropic',
+          is_active: true,
+          auth_type: 'subscription',
+          api_key_encrypted: null,
+        },
+        {
+          agent_id: 'a1',
+          provider: 'anthropic',
+          is_active: true,
+          auth_type: 'api_key',
+          api_key_encrypted: apiKeyEncrypted,
+        },
+      ]);
+
+      const result = await service.getProviderApiKey('a1', 'anthropic', 'subscription');
+      expect(result).toBeNull();
     });
 
     it('should return null for custom: provider when decrypt fails', async () => {

--- a/packages/backend/src/routing/routing.service.ts
+++ b/packages/backend/src/routing/routing.service.ts
@@ -491,15 +491,17 @@ export class RoutingService {
     );
     if (matches.length === 0) return null;
 
-    // Sort preferred auth type first (default: api_key for backward compat)
-    const preferred = preferredAuthType ?? 'api_key';
-    const sorted = [...matches].sort((a, b) => {
-      const aPref = a.auth_type === preferred ? 0 : 1;
-      const bPref = b.auth_type === preferred ? 0 : 1;
-      return aPref - bPref;
-    });
+    // When a caller explicitly requests an auth type, do not fall through
+    // to a different auth type record.
+    const candidates = preferredAuthType
+      ? matches.filter((m) => m.auth_type === preferredAuthType)
+      : [...matches].sort((a, b) => {
+          const aPref = a.auth_type === 'api_key' ? 0 : 1;
+          const bPref = b.auth_type === 'api_key' ? 0 : 1;
+          return aPref - bPref;
+        });
 
-    for (const match of sorted) {
+    for (const match of candidates) {
       if (!match.api_key_encrypted) continue;
       try {
         return decrypt(match.api_key_encrypted, getEncryptionSecret());


### PR DESCRIPTION
## Summary
- make `getProviderApiKey(..., preferredAuthType)` strict when `preferredAuthType` is provided
- prevent explicit `api_key` lookups from silently decrypting `subscription` credentials (and vice versa)
- update routing service tests to cover strict behavior and add a backend changeset

## Why
Requests resolved as `auth_type=api_key` could still fall through to a subscription credential record. For OpenAI this can forward blob-shaped subscription secrets on the API-key path.

Fixes #1183

## Validation
- npm test --workspace=packages/backend -- routing.service.spec.ts --runInBand
- npm test --workspace=packages/backend -- proxy.service.spec.ts --runInBand

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop cross-auth credential fallback when an auth type is explicitly requested. Prevents OpenAI subscription secrets from being used on API-key routes and vice versa.

- **Bug Fixes**
  - Make `getProviderApiKey(..., preferredAuthType)` strict; no cross-auth fallback. Default stays prefer `api_key` when no type is provided.
  - Return null when the preferred auth record has no encrypted key (for both `api_key` and `subscription`).
  - Update routing tests and add a backend changeset; fix `manifest` release metadata. Aligns with Linear issue 1183.

<sup>Written for commit 2c7085e8cba2068003c574d4707603928f5eff35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

