### PR TITLE
Improve Add Provider modal UX

### DIFF
--- a/.changeset/bumpy-toes-try.md
+++ b/.changeset/bumpy-toes-try.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Improve Add Provider modal: merge custom providers alphabetically with standard providers, add experimental disclaimer for subscription tab, use pill-style action chips for "Add custom provider" and "Request new subscription model"

--- a/packages/frontend/src/components/ProviderApiKeyTab.tsx
+++ b/packages/frontend/src/components/ProviderApiKeyTab.tsx
@@ -1,8 +1,13 @@
 import { For, Show, type Component } from 'solid-js';
+import type { AuthType, CustomProviderData } from '../services/api.js';
+import { customProviderColor } from '../services/formatters.js';
+import { isLocalMode } from '../services/local-mode.js';
 import type { ProviderDef } from '../services/providers.js';
 import { providerIcon } from './ProviderIcon.js';
-import type { CustomProviderData, AuthType } from '../services/api.js';
-import { isLocalMode } from '../services/local-mode.js';
+
+type ListItem =
+  | { kind: 'standard'; prov: ProviderDef }
+  | { kind: 'custom'; cp: CustomProviderData };
 
 interface Props {
   apiKeyProviders: ProviderDef[];
@@ -15,12 +20,48 @@ interface Props {
 }
 
 const ProviderApiKeyTab: Component<Props> = (props) => {
+  const mergedProviders = (): ListItem[] => {
+    const standards: ListItem[] = props.apiKeyProviders.map((prov) => ({ kind: 'standard', prov }));
+    const customs: ListItem[] = (props.customProviders ?? []).map((cp) => ({ kind: 'custom', cp }));
+    return [...standards, ...customs].sort((a, b) => {
+      const nameA = a.kind === 'standard' ? a.prov.name : a.cp.name;
+      const nameB = b.kind === 'standard' ? b.prov.name : b.cp.name;
+      return nameA.localeCompare(nameB);
+    });
+  };
+
   return (
     <>
       <div class="provider-modal__tab-hint">Connect providers using your own API keys (BYOK).</div>
       <div class="provider-modal__list">
-        <For each={props.apiKeyProviders}>
-          {(prov) => {
+        <For each={mergedProviders()}>
+          {(item) => {
+            if (item.kind === 'custom') {
+              const cp = item.cp;
+              return (
+                <button class="provider-toggle" onClick={() => props.onEditCustom(cp)}>
+                  <span class="provider-toggle__icon">
+                    <span
+                      class="provider-card__logo-letter"
+                      style={{ background: customProviderColor(cp.name) }}
+                    >
+                      {cp.name.charAt(0).toUpperCase()}
+                    </span>
+                  </span>
+                  <span class="provider-toggle__info">
+                    <span class="provider-toggle__name">
+                      {cp.name}
+                      <span class="provider-toggle__tag">Custom</span>
+                    </span>
+                  </span>
+                  <span class="provider-toggle__switch provider-toggle__switch--on">
+                    <span class="provider-toggle__switch-thumb" />
+                  </span>
+                </button>
+              );
+            }
+
+            const prov = item.prov;
             const connected = () => props.isConnected(prov.id) || props.isNoKeyConnected(prov.id);
             const disabled = () => !!prov.localOnly && !isLocalMode();
 
@@ -57,64 +98,14 @@ const ProviderApiKeyTab: Component<Props> = (props) => {
             );
           }}
         </For>
-        <a
-          class="provider-modal__request-link"
-          href="https://github.com/mnfst/manifest/discussions/973"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Request new model
-        </a>
-      </div>
-
-      <div class="custom-provider-section">
-        <div class="custom-provider-section__header">Custom providers</div>
-        <For each={props.customProviders}>
-          {(cp) => (
-            <button class="provider-toggle" onClick={() => props.onEditCustom(cp)}>
-              <span class="provider-toggle__icon">
-                <span
-                  class="provider-card__logo-letter"
-                  style={{ background: 'var(--custom-provider-color)' }}
-                >
-                  {cp.name.charAt(0).toUpperCase()}
-                </span>
-              </span>
-              <span class="provider-toggle__info">
-                <span class="provider-toggle__name">
-                  {cp.name}
-                  <span class="provider-toggle__tag">Custom</span>
-                </span>
-              </span>
-            </button>
-          )}
-        </For>
-        <button
-          class="provider-toggle"
-          onClick={props.onOpenCustomForm}
-          style="color: hsl(var(--primary));"
-        >
-          <span class="provider-toggle__icon" style="color: hsl(var(--primary));">
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              aria-hidden="true"
-            >
-              <circle cx="12" cy="12" r="10" />
-              <path d="M12 8v8" />
-              <path d="M8 12h8" />
+        <div class="provider-modal__add-custom">
+          <button class="provider-modal__add-custom-chip" onClick={props.onOpenCustomForm}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M8.46 11h7.08a1.755 1.755 0 0 0 1.43-2.77l-3.54-4.96c-.66-.92-2.19-.92-2.85 0L7.04 8.23A1.755 1.755 0 0 0 8.47 11ZM12 4.72 15.06 9H8.95l3.06-4.28ZM17.5 13c-2.48 0-4.5 2.02-4.5 4.5s2.02 4.5 4.5 4.5 4.5-2.02 4.5-4.5-2.02-4.5-4.5-4.5m0 7a2.5 2.5 0 0 1 0-5 2.5 2.5 0 0 1 0 5M3.75 22h5.5c.96 0 1.75-.79 1.75-1.75v-5.5c0-.96-.79-1.75-1.75-1.75h-5.5C2.79 13 2 13.79 2 14.75v5.5c0 .96.79 1.75 1.75 1.75M4 15h5v5H4z" />
             </svg>
-          </span>
-          <span class="provider-toggle__info">
-            <span class="provider-toggle__name">Add custom provider</span>
-          </span>
-        </button>
+            Add custom provider
+          </button>
+        </div>
       </div>
     </>
   );

--- a/packages/frontend/src/components/ProviderSubscriptionTab.tsx
+++ b/packages/frontend/src/components/ProviderSubscriptionTab.tsx
@@ -1,7 +1,7 @@
-import { For, type Component, type Accessor } from 'solid-js';
+import { For, type Accessor, type Component } from 'solid-js';
+import type { AuthType } from '../services/api.js';
 import type { ProviderDef } from '../services/providers.js';
 import { providerIcon } from './ProviderIcon.js';
-import type { AuthType } from '../services/api.js';
 
 interface Props {
   subscriptionProviders: ProviderDef[];
@@ -18,6 +18,11 @@ const ProviderSubscriptionTab: Component<Props> = (props) => {
       <div class="provider-modal__tab-hint">
         Use your existing subscription instead of an API key. Connect via OpenClaw or paste a
         setup-token.
+      </div>
+      <div class="provider-modal__disclaimer">
+        <span class="provider-modal__disclaimer-label">Experimental</span>
+        Using OAuth from certain providers with AI agents may lead to account restrictions or bans.
+        Use at your own risk.
       </div>
       <div class="provider-modal__list">
         <For each={props.subscriptionProviders}>
@@ -64,14 +69,20 @@ const ProviderSubscriptionTab: Component<Props> = (props) => {
             );
           }}
         </For>
-        <a
-          class="provider-modal__request-link"
-          href="https://github.com/mnfst/manifest/discussions/973"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Request new subscription model
-        </a>
+        <div class="provider-modal__add-custom">
+          <a
+            class="provider-modal__add-custom-chip"
+            href="https://github.com/mnfst/manifest/discussions/973"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="m9,13h2v2c0,.55.45,1,1,1s1-.45,1-1v-2h2c.55,0,1-.45,1-1s-.45-1-1-1h-2v-2c0-.55-.45-1-1-1s-1,.45-1,1v2h-2c-.55,0-1,.45-1,1s.45,1,1,1Z" />
+              <path d="m2.72,19.65c-.32.46-.35,1.05-.1,1.55.26.5.77.8,1.33.8h8.05c4.35,0,8.26-2.81,9.51-6.82,1.06-3.41.4-6.9-1.81-9.56-2.18-2.62-5.51-3.95-8.9-3.54C6.07,2.63,2.3,6.63,2.02,11.39c-.14,2.34.55,4.66,1.91,6.51l-1.21,1.75Zm1.29-8.14c.23-3.81,3.24-7.01,7.01-7.45h0c2.73-.32,5.39.74,7.13,2.83,1.77,2.13,2.3,4.94,1.44,7.69-.99,3.19-4.12,5.42-7.6,5.42h-7.09l.67-.96c.49-.7.48-1.63-.01-2.3-1.12-1.52-1.66-3.33-1.55-5.23Z" />
+            </svg>
+            Request new subscription model
+          </a>
+        </div>
       </div>
     </>
   );

--- a/packages/frontend/src/components/ProviderSubscriptionTab.tsx
+++ b/packages/frontend/src/components/ProviderSubscriptionTab.tsx
@@ -21,8 +21,10 @@ const ProviderSubscriptionTab: Component<Props> = (props) => {
       </div>
       <div class="provider-modal__disclaimer">
         <span class="provider-modal__disclaimer-label">Experimental</span>
-        Using OAuth from certain providers with AI agents may lead to account restrictions or bans.
-        Use at your own risk.
+        <span>
+          Using OAuth from certain providers with AI agents may lead to account restrictions or
+          bans. Use at your own risk.
+        </span>
       </div>
       <div class="provider-modal__list">
         <For each={props.subscriptionProviders}>

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -51,28 +51,28 @@
 
 /* ── Disclaimer banner ───────────────────────────────── */
 .provider-modal__disclaimer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   margin: 4px 24px 0;
-  padding: 8px 12px;
+  padding: 10px 12px;
   font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));
-  line-height: 1.45;
+  line-height: 1.5;
   background: #fbf9f3;
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
 }
 
 .provider-modal__disclaimer-label {
-  display: inline-block;
-  font-size: 10px;
+  align-self: flex-start;
+  font-size: var(--font-size-xs);
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
   color: hsl(var(--foreground));
-  border: 1px solid hsl(var(--foreground) / 0.4);
+  border: 1px solid hsl(var(--foreground) / 0.35);
   border-radius: 9999px;
-  padding: 1px 7px;
-  margin-right: 6px;
-  vertical-align: middle;
+  padding: 2px 10px;
+  line-height: 1.4;
 }
 
 .provider-modal__footer {

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -33,18 +33,46 @@
   position: relative;
 }
 
-.provider-modal__request-link {
-  display: block;
-  text-align: center;
-  padding: 10px 24px 2px;
-  font-size: var(--font-size-sm);
-  color: hsl(var(--muted-foreground));
+/* ── Action row (last item in subscription list: "Request new…") ── */
+.provider-toggle--action {
   text-decoration: none;
+  color: hsl(var(--muted-foreground));
+  border-top: 1px solid hsl(var(--border) / 0.5);
 }
 
-.provider-modal__request-link:hover {
+.provider-toggle__name--action {
+  color: hsl(var(--muted-foreground));
+  font-weight: 400;
+}
+
+.provider-toggle--action:hover .provider-toggle__name--action {
   color: hsl(var(--foreground));
-  text-decoration: underline;
+}
+
+/* ── Disclaimer banner ───────────────────────────────── */
+.provider-modal__disclaimer {
+  margin: 4px 24px 0;
+  padding: 8px 12px;
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.45;
+  background: #fbf9f3;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+}
+
+.provider-modal__disclaimer-label {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--foreground) / 0.4);
+  border-radius: 9999px;
+  padding: 1px 7px;
+  margin-right: 6px;
+  vertical-align: middle;
 }
 
 .provider-modal__footer {
@@ -567,13 +595,41 @@
 }
 
 .provider-modal__add-custom {
-  padding: 8px 24px 4px;
-  display: flex;
-  justify-content: flex-end;
+  padding: 4px 24px 8px;
 }
 
-.provider-modal__add-custom-btn {
+.provider-modal__add-custom-chip {
+  display: inline-flex;
+  align-items: center;
   gap: 6px;
+  padding: 6px 14px;
+  text-decoration: none;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  font-family: var(--font-family);
+  color: hsl(var(--foreground));
+  background: none;
+  border: 1px solid hsl(var(--border));
+  border-radius: 9999px;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.provider-modal__add-custom-chip:hover {
+  background: hsl(var(--muted) / 0.5);
+  border-color: hsl(var(--foreground) / 0.3);
+}
+
+.provider-modal__add-custom-chip:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+}
+
+.provider-modal__add-custom-chip svg {
+  flex-shrink: 0;
+  color: hsl(var(--muted-foreground));
 }
 
 .custom-provider-item {


### PR DESCRIPTION
## Summary

- Merge custom providers alphabetically with standard providers in the API Keys tab (no more separate section)
- Add colored avatar with initial letter for custom providers, using a hash-based 10-color palette
- Show toggle switch on custom providers (always on, opens edit form on click)
- Add experimental disclaimer banner on Subscription tab warning about potential ToS violations
- Replace inline links with pill-style action chips for "Add custom provider" and "Request new subscription model", placed inside the scrollable list as last items

## Test plan

- [ ] Open the Connect Providers modal on the Routing page
- [ ] Verify API Keys tab shows custom providers mixed alphabetically with standard ones
- [ ] Verify custom providers have colored avatar (rounded square + initial letter) and toggle switch
- [ ] Click a custom provider — should open edit form
- [ ] Verify "Add custom provider" chip appears at bottom of the list (scrolls with it)
- [ ] Switch to Subscription tab — verify experimental disclaimer banner appears with proper layout
- [ ] Verify "Request new subscription model" chip appears at bottom of subscription list
- [ ] Click "Request new subscription model" — should open GitHub discussion in new tab

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Add Provider modal to make providers easier to find and manage. Custom providers are merged into the main list with clear visuals, and the Subscription tab now shows an experimental disclaimer.

- **New Features**
  - Merge custom providers alphabetically with standard providers in the API Keys tab.
  - Show a colored avatar with the initial letter for custom providers (hash-based 10-color palette).
  - Add a toggle switch on custom providers (always on). Clicking opens the edit form.
  - Add an experimental disclaimer banner on the Subscription tab about potential ToS risks.
  - Replace inline links with pill-style chips: “Add custom provider” and “Request new subscription model,” placed at the end of the scrollable lists.

<sup>Written for commit 2a26d4585eee29cb990a2d7d6b1e88b2df1be7bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

