### PR TITLE
Add clawcon image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+
+<a href="https://luma.com/clawcondfw">
+<img width="1543" height="256" alt="Capture d’écran 2026-03-18 à 16 13 34" src="https://github.com/user-attachments/assets/11294f94-76c4-47bb-9c75-5ccc6b28fbdb" />
+</a>
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/mnfst/manifest/HEAD/.github/assets/logo-white.svg" />


### PR DESCRIPTION
Add images and links for better visual representation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a clickable ClawCon banner at the top of the README to improve visual presentation and highlight the event. Clicking the image opens https://luma.com/clawcondfw.

<sup>Written for commit 4f3c31b289bda44a417324e559ad10db0b58f67e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

