### PR TITLE
Fix SKILL.md scanner contradictions

### DIFF
--- a/.changeset/fix-skill-scanner.md
+++ b/.changeset/fix-skill-scanner.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix SKILL.md scanner contradictions: qualify "Not collected" statement to clarify OTLP vs routing data, remove MANIFEST_API_KEY from required env metadata since local mode doesn't need it.

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: manifest
 description: Smart LLM Router for OpenClaw. Save up to 70% by routing every request to the right model. No coding required.
-metadata: {"openclaw":{"requires":{"bins":["openclaw"],"env":["MANIFEST_API_KEY"],"config":["plugins.entries.manifest.config.apiKey"]},"primaryEnv":"MANIFEST_API_KEY","homepage":"https://github.com/mnfst/manifest"}}
+metadata: {"openclaw":{"requires":{"bins":["openclaw"]},"primaryEnv":"MANIFEST_API_KEY","homepage":"https://github.com/mnfst/manifest"}}
 ---
 
 # Manifest — LLM Router & Observability for OpenClaw
@@ -45,7 +45,7 @@ Exhaustive list of attributes sent per span:
 - `manifest.routing.reason` — routing reason (if routed)
 - Error status: agent errors truncated to 500 chars; tool errors include `event.error.message` untruncated
 
-**Not collected**: user prompts, assistant responses, tool input/output arguments, file contents, or any message body.
+**Not collected by OTLP telemetry**: user prompts, assistant responses, tool input/output arguments, file contents, or any message body. Note: when `manifest/auto` routing is active, the last 10 non-system messages (`{role, content}` only) are sent to the routing endpoint for tier scoring — see Routing Data below. To avoid this, set a fixed model instead of `manifest/auto`.
 
 ### Routing Data
 


### PR DESCRIPTION
## Summary

- Qualify "Not collected" to "Not collected by OTLP telemetry" with explicit note about routing sending `{role, content}` when `manifest/auto` is active — resolves the privacy claim contradiction flagged by the OpenClaw scanner
- Remove `MANIFEST_API_KEY` and `config` path from `requires` in metadata since local mode doesn't need them — keeps `primaryEnv` for cloud mode discovery

## Test plan

- [ ] SKILL.md reads consistently — no contradiction between "not collected" and routing data section
- [ ] Local mode install works without API key (metadata no longer requires it)
- [ ] Re-upload to ClawHub and verify scanner no longer flags privacy contradiction

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies privacy language in Manifest SKILL to resolve OpenClaw scanner contradictions and simplifies metadata for local installs. Specifies OTLP vs routing data and removes unnecessary requirements for local mode.

- **Bug Fixes**
  - Updated privacy statement to “Not collected by OTLP telemetry”; added note that when `manifest/auto` is enabled, the last 10 non-system messages (`{role, content}` only) are sent to the routing endpoint and how to avoid it.
  - Adjusted SKILL metadata: removed `MANIFEST_API_KEY` and config path from `requires` for local mode; retained `primaryEnv` for cloud discovery.

<sup>Written for commit f72e8a36758c05b11b81619ccd91551190ecf1ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

