### PR TITLE
Rewrite SKILL.md TL;DR to eliminate privacy contradiction

### DIFF
--- a/.changeset/fix-tldr-contradiction.md
+++ b/.changeset/fix-tldr-contradiction.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Rewrite SKILL.md TL;DR to remove blanket "not collected" claim that contradicted routing behavior. Now precisely states what each data path does.

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -16,7 +16,7 @@ Source: [github.com/mnfst/manifest](https://github.com/mnfst/manifest) — MIT l
 
 ## Security & Privacy
 
-> **TL;DR** — No user prompts or assistant responses are stored or collected by Manifest's telemetry pipeline. No file contents are transmitted. The API key (`mnfst_*`) authenticates your telemetry — it is not exfiltration. When `manifest/auto` routing is active, the last 10 non-system messages (`{role, content}` only) are sent to the routing endpoint for scoring — disable this by setting a fixed model. In local mode, all Manifest data stays on your machine.
+> **TL;DR** — OTLP telemetry collects only metadata (model, tokens, latency, tool names) — never prompt or response text. When `manifest/auto` routing is active, the last 10 non-system messages are sent to the routing endpoint for tier scoring; set a fixed model to avoid this. The API key (`mnfst_*`) authenticates your telemetry — it is not exfiltration. In local mode, all data stays on your machine.
 
 ### External Endpoints
 


### PR DESCRIPTION
## Summary

- Replace blanket "No user prompts or assistant responses are stored or collected" with precise "OTLP telemetry collects only metadata (model, tokens, latency, tool names) — never prompt or response text"
- Eliminates the contradiction that ClawHub's OpenClaw scanner flags between the privacy claim and the routing behavior that sends `{role, content}` for `manifest/auto` scoring

The previous wording used "not collected" which scanners interpret as encompassing any transmission, conflicting with the routing section. The new wording states exactly what each data path does without blanket claims.

## Test plan

- [ ] SKILL.md TL;DR no longer contains "not collected" / "not stored" claims that contradict routing behavior
- [ ] Re-upload to ClawHub and verify scanner no longer flags privacy contradiction

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the TL;DR in `skills/manifest/SKILL.md` to replace the blanket “not collected” claim with a clear explanation of what is sent, eliminating the privacy contradiction flagged by scanners. OTLP telemetry sends only metadata (model, tokens, latency, tool names), never prompt/response text; when `manifest/auto` is enabled, the last 10 non‑system messages are sent for scoring, and setting a fixed model disables this.

<sup>Written for commit c3fd8c2c01006e201675ad0aba706e4804d47e59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

