### PR TITLE
Fix: filter phantom OpenRouter models using provider-native API registry

### DIFF
--- a/.changeset/provider-model-registry.md
+++ b/.changeset/provider-model-registry.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Filter phantom models from OpenRouter fallback using provider-native API data

--- a/packages/backend/src/model-prices/model-prices.module.ts
+++ b/packages/backend/src/model-prices/model-prices.module.ts
@@ -1,12 +1,21 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ModelPricesController } from './model-prices.controller';
 import { ModelPricesService } from './model-prices.service';
 import { ModelPricingCacheService } from './model-pricing-cache.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
+import { ProviderModelRegistryService } from '../routing/model-discovery/provider-model-registry.service';
+import { UserProvider } from '../entities/user-provider.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([UserProvider])],
   controllers: [ModelPricesController],
-  providers: [ModelPricesService, ModelPricingCacheService, PricingSyncService],
-  exports: [ModelPricingCacheService, PricingSyncService],
+  providers: [
+    ModelPricesService,
+    ModelPricingCacheService,
+    PricingSyncService,
+    ProviderModelRegistryService,
+  ],
+  exports: [ModelPricingCacheService, PricingSyncService, ProviderModelRegistryService],
 })
 export class ModelPricesModule {}

--- a/packages/backend/src/model-prices/model-prices.service.spec.ts
+++ b/packages/backend/src/model-prices/model-prices.service.spec.ts
@@ -140,6 +140,37 @@ describe('ModelPricesService', () => {
       expect(result.models[0].model_name).toBe('claude-opus-4-6');
       expect(result.models[1].model_name).toBe('gpt-4o');
     });
+
+    it('should pass through validated flag', async () => {
+      mockPricingCache.getAll.mockReturnValue([
+        {
+          model_name: 'gpt-4o',
+          provider: 'OpenAI',
+          input_price_per_token: 0.0000025,
+          output_price_per_token: 0.00001,
+          validated: true,
+        },
+        {
+          model_name: 'phantom-model',
+          provider: 'Qwen',
+          input_price_per_token: 0.001,
+          output_price_per_token: 0.002,
+          validated: false,
+        },
+        {
+          model_name: 'unknown',
+          provider: 'OpenRouter',
+          input_price_per_token: 0.001,
+          output_price_per_token: 0.002,
+        },
+      ]);
+
+      const result = await service.getAll();
+
+      expect(result.models[0].validated).toBe(true);
+      expect(result.models[1].validated).toBe(false);
+      expect(result.models[2].validated).toBeUndefined();
+    });
   });
 
   describe('triggerSync', () => {

--- a/packages/backend/src/model-prices/model-prices.service.ts
+++ b/packages/backend/src/model-prices/model-prices.service.ts
@@ -22,6 +22,7 @@ export class ModelPricesService {
         output_price_per_million:
           r.output_price_per_token != null ? Number(r.output_price_per_token) * 1_000_000 : null,
         display_name: r.display_name || null,
+        validated: r.validated,
       })),
       lastSyncedAt,
     };

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -1,18 +1,32 @@
 import { ModelPricingCacheService } from './model-pricing-cache.service';
 import { PricingSyncService, OpenRouterPricingEntry } from '../database/pricing-sync.service';
+import { ProviderModelRegistryService } from '../routing/model-discovery/provider-model-registry.service';
 
 function makeEntry(input: number, output: number): OpenRouterPricingEntry {
   return { input, output };
 }
 
+function makeMockRegistry() {
+  return {
+    isModelConfirmed: jest.fn().mockReturnValue(null),
+    getConfirmedModels: jest.fn().mockReturnValue(null),
+    registerModels: jest.fn(),
+  };
+}
+
 describe('ModelPricingCacheService', () => {
   let service: ModelPricingCacheService;
   let mockGetAll: jest.Mock;
+  let mockRegistry: ReturnType<typeof makeMockRegistry>;
 
   beforeEach(() => {
     mockGetAll = jest.fn().mockReturnValue(new Map<string, OpenRouterPricingEntry>());
     const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
-    service = new ModelPricingCacheService(mockSync);
+    mockRegistry = makeMockRegistry();
+    service = new ModelPricingCacheService(
+      mockSync,
+      mockRegistry as unknown as ProviderModelRegistryService,
+    );
   });
 
   describe('onModuleInit', () => {
@@ -199,6 +213,65 @@ describe('ModelPricingCacheService', () => {
       const b = service.getAll();
       expect(a).not.toBe(b);
       expect(a).toEqual(b);
+    });
+  });
+
+  describe('validated flag', () => {
+    it('should set validated=true for confirmed models', async () => {
+      mockRegistry.isModelConfirmed.mockImplementation((providerId: string, modelId: string) => {
+        if (providerId === 'openai' && modelId === 'gpt-4o') return true;
+        return null;
+      });
+      mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.01, 0.02)]]));
+      await service.reload();
+
+      const entry = service.getByModel('openai/gpt-4o');
+      expect(entry!.validated).toBe(true);
+    });
+
+    it('should set validated=false for unconfirmed models', async () => {
+      mockRegistry.isModelConfirmed.mockReturnValue(false);
+      mockGetAll.mockReturnValue(new Map([['qwen/phantom-model', makeEntry(0.01, 0.02)]]));
+      await service.reload();
+
+      const entry = service.getByModel('qwen/phantom-model');
+      expect(entry!.validated).toBe(false);
+    });
+
+    it('should set validated=undefined when registry has no data for provider', async () => {
+      mockRegistry.isModelConfirmed.mockReturnValue(null);
+      mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.01, 0.02)]]));
+      await service.reload();
+
+      const entry = service.getByModel('openai/gpt-4o');
+      expect(entry!.validated).toBeUndefined();
+    });
+
+    it('should set validated=undefined for unsupported vendors (no providerId)', async () => {
+      mockGetAll.mockReturnValue(new Map([['nousresearch/hermes-3', makeEntry(0.01, 0.02)]]));
+      await service.reload();
+
+      const entry = service.getByModel('nousresearch/hermes-3');
+      expect(entry!.validated).toBeUndefined();
+    });
+
+    it('should work without registry (null)', async () => {
+      const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
+      const serviceNoRegistry = new ModelPricingCacheService(mockSync, null);
+      mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.01, 0.02)]]));
+      await serviceNoRegistry.reload();
+
+      const entry = serviceNoRegistry.getByModel('openai/gpt-4o');
+      expect(entry!.validated).toBeUndefined();
+    });
+
+    it('should propagate validated to canonical alias', async () => {
+      mockRegistry.isModelConfirmed.mockReturnValue(true);
+      mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.01, 0.02)]]));
+      await service.reload();
+
+      const canonical = service.getByModel('gpt-4o');
+      expect(canonical!.validated).toBe(true);
     });
   });
 });

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -253,6 +253,7 @@ describe('ModelPricingCacheService', () => {
 
       const entry = service.getByModel('nousresearch/hermes-3');
       expect(entry!.validated).toBeUndefined();
+      expect(mockRegistry.isModelConfirmed).not.toHaveBeenCalled();
     });
 
     it('should work without registry (null)', async () => {
@@ -272,6 +273,20 @@ describe('ModelPricingCacheService', () => {
 
       const canonical = service.getByModel('gpt-4o');
       expect(canonical!.validated).toBe(true);
+    });
+
+    it('should resolve aliased provider prefix to canonical ID for validation', async () => {
+      // "google" is the OpenRouter prefix, but the registry stores under "gemini"
+      mockRegistry.isModelConfirmed.mockImplementation((providerId: string, modelId: string) => {
+        if (providerId === 'gemini' && modelId === 'gemini-2.5-pro') return true;
+        return null;
+      });
+      mockGetAll.mockReturnValue(new Map([['google/gemini-2.5-pro', makeEntry(0.003, 0.015)]]));
+      await service.reload();
+
+      const entry = service.getByModel('google/gemini-2.5-pro');
+      expect(entry!.validated).toBe(true);
+      expect(mockRegistry.isModelConfirmed).toHaveBeenCalledWith('gemini', 'gemini-2.5-pro');
     });
   });
 });

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap, Inject, Optional } from '@nestjs/common';
 import { buildAliasMap, resolveModelName } from './model-name-normalizer';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { OPENROUTER_PREFIX_TO_PROVIDER } from '../common/constants/providers';
+import { ProviderModelRegistryService } from '../routing/model-discovery/provider-model-registry.service';
 
 /**
  * Lightweight pricing entry used for cost calculation and provider detection.
@@ -13,6 +14,8 @@ export interface PricingEntry {
   input_price_per_token: number | null;
   output_price_per_token: number | null;
   display_name: string | null;
+  /** True if confirmed via provider-native API, false if unverified, undefined if no data. */
+  validated?: boolean;
 }
 
 @Injectable()
@@ -21,7 +24,12 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
   private readonly cache = new Map<string, PricingEntry>();
   private aliasMap = new Map<string, string>();
 
-  constructor(private readonly pricingSync: PricingSyncService) {}
+  constructor(
+    private readonly pricingSync: PricingSyncService,
+    @Optional()
+    @Inject(ProviderModelRegistryService)
+    private readonly modelRegistry: ProviderModelRegistryService | null,
+  ) {}
 
   async onApplicationBootstrap(): Promise<void> {
     await this.reload();
@@ -32,9 +40,10 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
 
     const orCache = this.pricingSync.getAll();
     for (const [fullId, entry] of orCache) {
-      const { provider, canonical } = this.resolveProviderAndName(fullId);
+      const { provider, canonical, providerId } = this.resolveProviderAndName(fullId);
 
       const displayName = entry.displayName ?? null;
+      const validated = this.resolveValidated(providerId, canonical);
 
       // Store under full OpenRouter ID (e.g. "anthropic/claude-opus-4-6")
       this.cache.set(fullId, {
@@ -43,6 +52,7 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
         input_price_per_token: entry.input,
         output_price_per_token: entry.output,
         display_name: displayName,
+        validated,
       });
 
       // For supported providers, also store under canonical name (e.g. "claude-opus-4-6")
@@ -54,6 +64,7 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
           input_price_per_token: entry.input,
           output_price_per_token: entry.output,
           display_name: displayName,
+          validated,
         });
       }
     }
@@ -90,18 +101,20 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
    * For supported routing providers (OpenAI, Anthropic, etc.), extract
    * the provider display name and canonical model name from the OpenRouter ID.
    * All other vendors stay under "OpenRouter" with the full ID as canonical.
+   * Also returns the raw prefix as `providerId` for registry lookups.
    */
   private resolveProviderAndName(openRouterId: string): {
     provider: string;
     canonical: string;
+    providerId: string | null;
   } {
     if (openRouterId.startsWith('openrouter/')) {
-      return { provider: 'OpenRouter', canonical: openRouterId };
+      return { provider: 'OpenRouter', canonical: openRouterId, providerId: null };
     }
 
     const slashIdx = openRouterId.indexOf('/');
     if (slashIdx <= 0) {
-      return { provider: 'OpenRouter', canonical: openRouterId };
+      return { provider: 'OpenRouter', canonical: openRouterId, providerId: null };
     }
 
     const prefix = openRouterId.substring(0, slashIdx);
@@ -110,9 +123,16 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
       return {
         provider: displayName,
         canonical: openRouterId.substring(slashIdx + 1),
+        providerId: prefix,
       };
     }
 
-    return { provider: 'OpenRouter', canonical: openRouterId };
+    return { provider: 'OpenRouter', canonical: openRouterId, providerId: null };
+  }
+
+  private resolveValidated(providerId: string | null, canonical: string): boolean | undefined {
+    if (!this.modelRegistry || !providerId) return undefined;
+    const result = this.modelRegistry.isModelConfirmed(providerId, canonical);
+    return result ?? undefined;
   }
 }

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger, OnApplicationBootstrap, Inject, Optional } from '@nestjs/common';
 import { buildAliasMap, resolveModelName } from './model-name-normalizer';
 import { PricingSyncService } from '../database/pricing-sync.service';
-import { OPENROUTER_PREFIX_TO_PROVIDER } from '../common/constants/providers';
+import {
+  OPENROUTER_PREFIX_TO_PROVIDER,
+  PROVIDER_BY_ID_OR_ALIAS,
+} from '../common/constants/providers';
 import { ProviderModelRegistryService } from '../routing/model-discovery/provider-model-registry.service';
 
 /**
@@ -132,7 +135,10 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
 
   private resolveValidated(providerId: string | null, canonical: string): boolean | undefined {
     if (!this.modelRegistry || !providerId) return undefined;
-    const result = this.modelRegistry.isModelConfirmed(providerId, canonical);
+    // Resolve OpenRouter prefix to canonical provider ID (e.g., "google" → "gemini")
+    const entry = PROVIDER_BY_ID_OR_ALIAS.get(providerId);
+    const canonicalProviderId = entry?.id ?? providerId;
+    const result = this.modelRegistry.isModelConfirmed(canonicalProviderId, canonical);
     return result ?? undefined;
   }
 }

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.spec.ts
@@ -1,5 +1,6 @@
 import { ModelDiscoveryService } from './model-discovery.service';
 import { ProviderModelFetcherService } from './provider-model-fetcher.service';
+import { ProviderModelRegistryService } from './provider-model-registry.service';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { DiscoveredModel } from './model-fetcher';
@@ -88,6 +89,10 @@ describe('ModelDiscoveryService', () => {
   let customProviderRepo: ReturnType<typeof makeMockRepo>;
   let fetcher: { fetch: jest.Mock };
   let mockPricingSync: { lookupPricing: jest.Mock; getAll: jest.Mock };
+  let mockModelRegistry: {
+    registerModels: jest.Mock;
+    getConfirmedModels: jest.Mock;
+  };
 
   beforeEach(() => {
     providerRepo = makeMockRepo();
@@ -96,6 +101,10 @@ describe('ModelDiscoveryService', () => {
     mockPricingSync = {
       lookupPricing: jest.fn().mockReturnValue(null),
       getAll: jest.fn().mockReturnValue(new Map()),
+    };
+    mockModelRegistry = {
+      registerModels: jest.fn(),
+      getConfirmedModels: jest.fn().mockReturnValue(null),
     };
 
     mockDecrypt.mockReturnValue('decrypted-key');
@@ -107,6 +116,7 @@ describe('ModelDiscoveryService', () => {
       customProviderRepo as never,
       fetcher as unknown as ProviderModelFetcherService,
       mockPricingSync as never,
+      mockModelRegistry as unknown as ProviderModelRegistryService,
     );
   });
 
@@ -224,6 +234,7 @@ describe('ModelDiscoveryService', () => {
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
         null,
+        null,
       );
 
       const models = [makeModel({ id: 'some-model' })];
@@ -270,6 +281,63 @@ describe('ModelDiscoveryService', () => {
         expect.objectContaining({ model_name: 'gpt-4' }),
       );
       expect(result[0].qualityScore).toBe(5);
+    });
+
+    it('should register models in registry after successful native fetch', async () => {
+      const models = [makeModel({ id: 'gpt-4o' }), makeModel({ id: 'gpt-4-turbo' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      await service.discoverModels(makeProvider());
+
+      expect(mockModelRegistry.registerModels).toHaveBeenCalledWith('openai', [
+        'gpt-4o',
+        'gpt-4-turbo',
+      ]);
+    });
+
+    it('should not register models when native fetch returns empty', async () => {
+      fetcher.fetch.mockResolvedValue([]);
+
+      await service.discoverModels(makeProvider());
+
+      expect(mockModelRegistry.registerModels).not.toHaveBeenCalled();
+    });
+
+    it('should pass confirmed models to buildFallbackModels when native fetch fails', async () => {
+      fetcher.fetch.mockResolvedValue([]);
+      const confirmed = new Set(['gpt-4o']);
+      mockModelRegistry.getConfirmedModels.mockReturnValue(confirmed);
+
+      // Set up OpenRouter cache with matching models
+      const orMap = new Map([
+        ['openai/gpt-4o', { input: 0.01, output: 0.02, displayName: 'GPT-4o' }],
+        ['openai/phantom', { input: 0.01, output: 0.02, displayName: 'Phantom' }],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(mockModelRegistry.getConfirmedModels).toHaveBeenCalledWith('openai');
+      // Only confirmed model should be in fallback
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gpt-4o');
+    });
+
+    it('should not call registry when modelRegistry is null', async () => {
+      const serviceNoRegistry = new ModelDiscoveryService(
+        providerRepo as never,
+        customProviderRepo as never,
+        fetcher as unknown as ProviderModelFetcherService,
+        mockPricingSync as never,
+        null,
+      );
+
+      const models = [makeModel({ id: 'gpt-4o' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      await serviceNoRegistry.discoverModels(makeProvider());
+
+      expect(mockModelRegistry.registerModels).not.toHaveBeenCalled();
     });
   });
 
@@ -1038,6 +1106,7 @@ describe('ModelDiscoveryService', () => {
         providerRepo as never,
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
+        null,
         null,
       );
 

--- a/packages/backend/src/routing/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/routing/model-discovery/model-discovery.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { ProviderModelFetcherService } from './provider-model-fetcher.service';
+import { ProviderModelRegistryService } from './provider-model-registry.service';
 import { DiscoveredModel } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../../common/utils/crypto.util';
 import { computeQualityScore } from '../../database/quality-score.util';
@@ -33,6 +34,9 @@ export class ModelDiscoveryService {
     @Optional()
     @Inject(PricingSyncService)
     private readonly pricingSync: PricingSyncService | null,
+    @Optional()
+    @Inject(ProviderModelRegistryService)
+    private readonly modelRegistry: ProviderModelRegistryService | null,
   ) {}
 
   async discoverModels(provider: UserProvider): Promise<DiscoveredModel[]> {
@@ -80,9 +84,18 @@ export class ModelDiscoveryService {
         endpointOverride,
       );
 
-      // If native API returned no models, fall back to OpenRouter + manual pricing
+      // Register confirmed model IDs from native API for future fallback filtering
+      if (raw.length > 0 && this.modelRegistry) {
+        this.modelRegistry.registerModels(
+          provider.provider,
+          raw.map((m) => m.id),
+        );
+      }
+
+      // If native API returned no models, fall back to OpenRouter filtered by confirmed models
       if (raw.length === 0) {
-        raw = buildFallbackModels(this.pricingSync, provider.provider);
+        const confirmed = this.modelRegistry?.getConfirmedModels(provider.provider) ?? null;
+        raw = buildFallbackModels(this.pricingSync, provider.provider, confirmed);
         if (raw.length > 0) {
           this.logger.log(
             `Native API returned 0 models for ${provider.provider} — using ${raw.length} models from pricing data`,

--- a/packages/backend/src/routing/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-fallback.spec.ts
@@ -103,13 +103,15 @@ describe('buildFallbackModels', () => {
   });
 
   it('should deduplicate models by normalized ID', () => {
+    // Anthropic normalization: dashes and dots in version numbers normalize to the same ID
     const cache = new Map([
-      ['openai/gpt-4o', { input: 0.01, output: 0.02 }],
-      ['openai/gpt-4o', { input: 0.01, output: 0.02 }],
+      ['anthropic/claude-sonnet-4-5-20250929', { input: 0.01, output: 0.02 }],
+      ['anthropic/claude-sonnet-4.5-20250929', { input: 0.03, output: 0.04 }],
     ]);
 
-    const result = buildFallbackModels(makePricingSync(cache), 'openai');
+    const result = buildFallbackModels(makePricingSync(cache), 'anthropic');
 
+    // Both normalize to "claude-sonnet-4-5-20250929" via normalizeAnthropicShortModelId
     expect(result).toHaveLength(1);
   });
 

--- a/packages/backend/src/routing/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/routing/model-discovery/model-fallback.spec.ts
@@ -1,0 +1,287 @@
+import {
+  buildFallbackModels,
+  buildSubscriptionFallbackModels,
+  supplementWithKnownModels,
+  findOpenRouterPrefix,
+  lookupWithVariants,
+} from './model-fallback';
+
+function makePricingSync(
+  entries: Map<
+    string,
+    { input: number; output: number; contextWindow?: number; displayName?: string }
+  >,
+) {
+  return {
+    lookupPricing: jest.fn((key: string) => entries.get(key) ?? null),
+    getAll: jest.fn(() => entries),
+  };
+}
+
+describe('buildFallbackModels', () => {
+  it('should return models from OpenRouter cache for the given provider', () => {
+    const cache = new Map([
+      ['openai/gpt-4o', { input: 0.01, output: 0.02, displayName: 'GPT-4o' }],
+      ['openai/gpt-4-turbo', { input: 0.005, output: 0.01 }],
+      ['anthropic/claude-opus-4-6', { input: 0.015, output: 0.075 }],
+    ]);
+
+    const result = buildFallbackModels(makePricingSync(cache), 'openai');
+
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.id)).toEqual(['gpt-4o', 'gpt-4-turbo']);
+  });
+
+  it('should return empty when pricingSync is null', () => {
+    expect(buildFallbackModels(null, 'openai')).toEqual([]);
+  });
+
+  it('should return empty when no prefix found', () => {
+    const cache = new Map([['openai/gpt-4o', { input: 0.01, output: 0.02 }]]);
+
+    expect(buildFallbackModels(makePricingSync(cache), 'unknown-provider')).toEqual([]);
+  });
+
+  describe('with confirmedModels', () => {
+    it('should filter out models not in the confirmed set', () => {
+      const cache = new Map([
+        ['qwen/qwen3-32b', { input: 0.01, output: 0.02, displayName: 'Qwen3 32B' }],
+        ['qwen/qwen3.5-9b', { input: 0.005, output: 0.01, displayName: 'Qwen3.5 9B' }],
+        ['qwen/qwen2.5-72b-instruct', { input: 0.02, output: 0.04 }],
+      ]);
+      const confirmed = new Set(['qwen3-32b', 'qwen2.5-72b-instruct']);
+
+      const result = buildFallbackModels(makePricingSync(cache), 'qwen', confirmed);
+
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(['qwen3-32b', 'qwen2.5-72b-instruct']);
+    });
+
+    it('should return all models when confirmedModels is null', () => {
+      const cache = new Map([
+        ['qwen/qwen3-32b', { input: 0.01, output: 0.02 }],
+        ['qwen/phantom-model', { input: 0.005, output: 0.01 }],
+      ]);
+
+      const result = buildFallbackModels(makePricingSync(cache), 'qwen', null);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should return all models when confirmedModels is empty', () => {
+      const cache = new Map([
+        ['qwen/qwen3-32b', { input: 0.01, output: 0.02 }],
+        ['qwen/phantom-model', { input: 0.005, output: 0.01 }],
+      ]);
+      const confirmed = new Set<string>();
+
+      const result = buildFallbackModels(makePricingSync(cache), 'qwen', confirmed);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('should match confirmed models case-insensitively', () => {
+      const cache = new Map([['openai/GPT-4o', { input: 0.01, output: 0.02 }]]);
+      const confirmed = new Set(['gpt-4o']);
+
+      const result = buildFallbackModels(makePricingSync(cache), 'openai', confirmed);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('should return empty when no models match confirmed set', () => {
+      const cache = new Map([
+        ['qwen/phantom-1', { input: 0.01, output: 0.02 }],
+        ['qwen/phantom-2', { input: 0.005, output: 0.01 }],
+      ]);
+      const confirmed = new Set(['real-model']);
+
+      const result = buildFallbackModels(makePricingSync(cache), 'qwen', confirmed);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  it('should deduplicate models by normalized ID', () => {
+    const cache = new Map([
+      ['openai/gpt-4o', { input: 0.01, output: 0.02 }],
+      ['openai/gpt-4o', { input: 0.01, output: 0.02 }],
+    ]);
+
+    const result = buildFallbackModels(makePricingSync(cache), 'openai');
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('should use default context window when not provided', () => {
+    const cache = new Map([['openai/gpt-4o', { input: 0.01, output: 0.02 }]]);
+
+    const result = buildFallbackModels(makePricingSync(cache), 'openai');
+
+    expect(result[0].contextWindow).toBe(128000);
+  });
+
+  it('should use provided context window', () => {
+    const cache = new Map([
+      ['openai/gpt-4o', { input: 0.01, output: 0.02, contextWindow: 200000 }],
+    ]);
+
+    const result = buildFallbackModels(makePricingSync(cache), 'openai');
+
+    expect(result[0].contextWindow).toBe(200000);
+  });
+
+  it('should use model ID as displayName when none provided', () => {
+    const cache = new Map([['openai/gpt-4o', { input: 0.01, output: 0.02 }]]);
+
+    const result = buildFallbackModels(makePricingSync(cache), 'openai');
+
+    expect(result[0].displayName).toBe('gpt-4o');
+  });
+});
+
+describe('findOpenRouterPrefix', () => {
+  it('should return prefix for known provider', () => {
+    expect(findOpenRouterPrefix('openai')).toBe('openai');
+  });
+
+  it('should return prefix via alias', () => {
+    expect(findOpenRouterPrefix('google')).toBeTruthy();
+  });
+
+  it('should return null for unknown provider', () => {
+    expect(findOpenRouterPrefix('totally-unknown')).toBeNull();
+  });
+
+  it('should be case-insensitive', () => {
+    expect(findOpenRouterPrefix('OpenAI')).toBe('openai');
+  });
+
+  it('should resolve via display name', () => {
+    expect(findOpenRouterPrefix('Mistral')).toBeTruthy();
+  });
+});
+
+describe('lookupWithVariants', () => {
+  it('should return exact match', () => {
+    const cache = new Map([['openai/gpt-4o', { input: 0.01, output: 0.02 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'openai', 'gpt-4o');
+
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
+  it('should try dot variant', () => {
+    const cache = new Map([['anthropic/claude-sonnet-4.6', { input: 0.01, output: 0.02 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'anthropic', 'claude-sonnet-4-6');
+
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
+  it('should try dash variant', () => {
+    const cache = new Map([['anthropic/claude-sonnet-4-6', { input: 0.01, output: 0.02 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'anthropic', 'claude-sonnet-4.6');
+
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
+  it('should try stripping date suffix', () => {
+    const cache = new Map([['openai/gpt-4o', { input: 0.01, output: 0.02 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'openai', 'gpt-4o-20250301');
+
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
+  it('should try stripping date suffix with dot variant', () => {
+    const cache = new Map([['anthropic/claude-sonnet-4.5', { input: 0.01, output: 0.02 }]]);
+
+    const result = lookupWithVariants(
+      makePricingSync(cache),
+      'anthropic',
+      'claude-sonnet-4-5-20250929',
+    );
+
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
+  it('should return null when no match found', () => {
+    const cache = new Map<string, { input: number; output: number }>();
+
+    const result = lookupWithVariants(makePricingSync(cache), 'openai', 'nonexistent');
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('buildSubscriptionFallbackModels', () => {
+  it('should return empty for providers with no known models', () => {
+    const cache = new Map([['openai/gpt-4o', { input: 0.01, output: 0.02 }]]);
+
+    const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'unknown-provider');
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return models for known subscription providers', () => {
+    const cache = new Map([
+      ['anthropic/claude-opus-4-6', { input: 0.015, output: 0.075, displayName: 'Claude Opus' }],
+    ]);
+
+    const result = buildSubscriptionFallbackModels(makePricingSync(cache), 'anthropic');
+
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should handle null pricingSync', () => {
+    const result = buildSubscriptionFallbackModels(null, 'anthropic');
+
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('supplementWithKnownModels', () => {
+  it('should return raw list unchanged for providers with no known models', () => {
+    const raw = [
+      {
+        id: 'some-model',
+        displayName: 'Some Model',
+        provider: 'unknown',
+        contextWindow: 128000,
+        inputPricePerToken: 0.01,
+        outputPricePerToken: 0.02,
+        capabilityReasoning: false,
+        capabilityCode: false,
+        qualityScore: 3,
+      },
+    ];
+
+    const result = supplementWithKnownModels(raw, 'unknown-provider');
+
+    expect(result).toBe(raw);
+    expect(result).toHaveLength(1);
+  });
+
+  it('should not add known models that are already covered', () => {
+    const raw = [
+      {
+        id: 'claude-opus-4-6',
+        displayName: 'Claude Opus',
+        provider: 'anthropic',
+        contextWindow: 200000,
+        inputPricePerToken: 0.015,
+        outputPricePerToken: 0.075,
+        capabilityReasoning: false,
+        capabilityCode: false,
+        qualityScore: 3,
+      },
+    ];
+
+    const result = supplementWithKnownModels(raw, 'anthropic');
+
+    const opusEntries = result.filter((m) => m.id.startsWith('claude-opus-4'));
+    expect(opusEntries).toHaveLength(1);
+  });
+});

--- a/packages/backend/src/routing/model-discovery/model-fallback.ts
+++ b/packages/backend/src/routing/model-discovery/model-fallback.ts
@@ -92,14 +92,22 @@ export function lookupWithVariants(
 /**
  * Build a fallback model list from OpenRouter cache
  * for providers whose native /models API is unavailable.
+ *
+ * When `confirmedModels` is provided and non-empty, only models that exist
+ * in the confirmed set are included. This filters out phantom models that
+ * OpenRouter lists but the provider's native API doesn't actually serve.
+ * When null or empty, all OpenRouter models for the provider are returned
+ * (graceful degradation for fresh installs with no native data yet).
  */
 export function buildFallbackModels(
   pricingSync: PricingLookup | null,
   providerId: string,
+  confirmedModels?: ReadonlySet<string> | null,
 ): DiscoveredModel[] {
   if (!pricingSync) return [];
   const models: DiscoveredModel[] = [];
   const seen = new Set<string>();
+  const hasConfirmed = confirmedModels != null && confirmedModels.size > 0;
 
   const orPrefix = findOpenRouterPrefix(providerId);
   if (!orPrefix) return [];
@@ -108,6 +116,9 @@ export function buildFallbackModels(
     if (!fullId.startsWith(`${orPrefix}/`)) continue;
     const modelId = normalizeProviderModelId(providerId, fullId.substring(orPrefix.length + 1));
     if (seen.has(modelId)) continue;
+
+    if (hasConfirmed && !confirmedModels!.has(modelId.toLowerCase())) continue;
+
     seen.add(modelId);
     models.push({
       id: modelId,

--- a/packages/backend/src/routing/model-discovery/provider-model-registry.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-registry.service.spec.ts
@@ -1,0 +1,172 @@
+import { ProviderModelRegistryService } from './provider-model-registry.service';
+
+function makeMockRepo(providers: Array<{ provider: string; cached_models: unknown }> = []) {
+  return {
+    createQueryBuilder: jest.fn().mockReturnValue({
+      select: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(providers),
+    }),
+  };
+}
+
+describe('ProviderModelRegistryService', () => {
+  describe('registerModels', () => {
+    it('should register models for a provider', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('openai', ['gpt-4o', 'gpt-4-turbo']);
+
+      const confirmed = service.getConfirmedModels('openai');
+      expect(confirmed).not.toBeNull();
+      expect(confirmed!.has('gpt-4o')).toBe(true);
+      expect(confirmed!.has('gpt-4-turbo')).toBe(true);
+    });
+
+    it('should merge models when called multiple times for the same provider', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('openai', ['gpt-4o']);
+      service.registerModels('openai', ['gpt-4-turbo']);
+
+      const confirmed = service.getConfirmedModels('openai');
+      expect(confirmed!.has('gpt-4o')).toBe(true);
+      expect(confirmed!.has('gpt-4-turbo')).toBe(true);
+    });
+
+    it('should store model IDs in lowercase for case-insensitive matching', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('OpenAI', ['GPT-4o']);
+
+      const confirmed = service.getConfirmedModels('openai');
+      expect(confirmed).not.toBeNull();
+      expect(confirmed!.has('gpt-4o')).toBe(true);
+    });
+  });
+
+  describe('getConfirmedModels', () => {
+    it('should return null for unknown provider', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      expect(service.getConfirmedModels('unknown')).toBeNull();
+    });
+
+    it('should be case-insensitive on provider ID', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('Anthropic', ['claude-opus-4-6']);
+
+      expect(service.getConfirmedModels('anthropic')).not.toBeNull();
+      expect(service.getConfirmedModels('ANTHROPIC')).not.toBeNull();
+    });
+  });
+
+  describe('isModelConfirmed', () => {
+    it('should return true for confirmed model', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('openai', ['gpt-4o']);
+
+      expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
+    });
+
+    it('should return false for unconfirmed model', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('openai', ['gpt-4o']);
+
+      expect(service.isModelConfirmed('openai', 'phantom-model')).toBe(false);
+    });
+
+    it('should return null for unknown provider', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+
+      expect(service.isModelConfirmed('unknown', 'some-model')).toBeNull();
+    });
+
+    it('should be case-insensitive on both provider and model', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('OpenAI', ['GPT-4o']);
+
+      expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
+    });
+  });
+
+  describe('onApplicationBootstrap', () => {
+    it('should load models from cached user_providers data', async () => {
+      const providers = [
+        {
+          provider: 'openai',
+          cached_models: [
+            { id: 'gpt-4o', displayName: 'GPT-4o' },
+            { id: 'gpt-4-turbo', displayName: 'GPT-4 Turbo' },
+          ],
+        },
+        {
+          provider: 'anthropic',
+          cached_models: [{ id: 'claude-opus-4-6', displayName: 'Claude Opus' }],
+        },
+      ];
+      const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
+      expect(service.isModelConfirmed('openai', 'gpt-4-turbo')).toBe(true);
+      expect(service.isModelConfirmed('anthropic', 'claude-opus-4-6')).toBe(true);
+    });
+
+    it('should skip providers with non-array cached_models', async () => {
+      const providers = [{ provider: 'openai', cached_models: 'not-an-array' }];
+      const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(service.getConfirmedModels('openai')).toBeNull();
+    });
+
+    it('should handle empty cached_models array', async () => {
+      const providers = [{ provider: 'openai', cached_models: [] }];
+      const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(service.getConfirmedModels('openai')).toBeNull();
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const mockRepo = {
+        createQueryBuilder: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          where: jest.fn().mockReturnThis(),
+          getMany: jest.fn().mockRejectedValue(new Error('DB down')),
+        }),
+      };
+      const service = new ProviderModelRegistryService(mockRepo as never);
+
+      await expect(service.onApplicationBootstrap()).resolves.not.toThrow();
+      expect(service.getConfirmedModels('openai')).toBeNull();
+    });
+
+    it('should merge models from multiple providers with same provider ID', async () => {
+      const providers = [
+        {
+          provider: 'openai',
+          cached_models: [{ id: 'gpt-4o' }],
+        },
+        {
+          provider: 'openai',
+          cached_models: [{ id: 'gpt-4-turbo' }],
+        },
+      ];
+      const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
+      expect(service.isModelConfirmed('openai', 'gpt-4-turbo')).toBe(true);
+    });
+
+    it('should not register models when providers list is empty', async () => {
+      const service = new ProviderModelRegistryService(makeMockRepo([]) as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(service.getConfirmedModels('openai')).toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/routing/model-discovery/provider-model-registry.service.spec.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-registry.service.spec.ts
@@ -128,6 +128,28 @@ describe('ProviderModelRegistryService', () => {
       expect(service.getConfirmedModels('openai')).toBeNull();
     });
 
+    it('should filter out malformed entries with missing id', async () => {
+      const providers = [
+        {
+          provider: 'openai',
+          cached_models: [
+            { id: 'gpt-4o', displayName: 'GPT-4o' },
+            { displayName: 'Missing ID' },
+            { id: null },
+            { id: '' },
+          ],
+        },
+      ];
+      const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
+      // null, undefined, and empty string should all be filtered out
+      const confirmed = service.getConfirmedModels('openai');
+      expect(confirmed!.size).toBe(1);
+    });
+
     it('should handle database errors gracefully', async () => {
       const mockRepo = {
         createQueryBuilder: jest.fn().mockReturnValue({

--- a/packages/backend/src/routing/model-discovery/provider-model-registry.service.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-registry.service.ts
@@ -1,0 +1,91 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UserProvider } from '../../entities/user-provider.entity';
+
+/**
+ * Maintains an in-memory registry of model IDs confirmed to exist
+ * via provider-native APIs. Populated opportunistically when users
+ * connect providers and on startup from cached data.
+ *
+ * Used to filter out phantom models from OpenRouter fallback lists.
+ */
+@Injectable()
+export class ProviderModelRegistryService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(ProviderModelRegistryService.name);
+  private readonly registry = new Map<string, Set<string>>();
+
+  constructor(
+    @InjectRepository(UserProvider)
+    private readonly providerRepo: Repository<UserProvider>,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    await this.loadFromCache();
+  }
+
+  /**
+   * Register model IDs confirmed via a provider's native API.
+   * Merges with any existing confirmed models for that provider.
+   */
+  registerModels(providerId: string, modelIds: string[]): void {
+    const key = providerId.toLowerCase();
+    const existing = this.registry.get(key);
+    if (existing) {
+      for (const id of modelIds) existing.add(id.toLowerCase());
+    } else {
+      this.registry.set(key, new Set(modelIds.map((id) => id.toLowerCase())));
+    }
+  }
+
+  /**
+   * Get the set of confirmed model IDs for a provider.
+   * Returns null if no native data has ever been recorded for this provider.
+   */
+  getConfirmedModels(providerId: string): ReadonlySet<string> | null {
+    return this.registry.get(providerId.toLowerCase()) ?? null;
+  }
+
+  /**
+   * Check whether a specific model is confirmed for a provider.
+   * Returns true if confirmed, false if not, or null if no data exists.
+   */
+  isModelConfirmed(providerId: string, modelId: string): boolean | null {
+    const confirmed = this.registry.get(providerId.toLowerCase());
+    if (!confirmed) return null;
+    return confirmed.has(modelId.toLowerCase());
+  }
+
+  /**
+   * Populate the registry from existing user_providers.cached_models
+   * data that was previously fetched from native APIs.
+   */
+  private async loadFromCache(): Promise<void> {
+    try {
+      const providers = await this.providerRepo
+        .createQueryBuilder('p')
+        .select(['p.provider', 'p.cached_models'])
+        .where('p.cached_models IS NOT NULL')
+        .getMany();
+
+      let totalModels = 0;
+      for (const p of providers) {
+        if (!Array.isArray(p.cached_models)) continue;
+        const ids = p.cached_models.map((m) => m.id);
+        if (ids.length > 0) {
+          this.registerModels(p.provider, ids);
+          totalModels += ids.length;
+        }
+      }
+
+      const providerCount = this.registry.size;
+      if (providerCount > 0) {
+        this.logger.log(
+          `Provider model registry loaded: ${providerCount} providers, ${totalModels} model entries`,
+        );
+      }
+    } catch (err) {
+      this.logger.warn(`Failed to load provider model registry from cache: ${err}`);
+    }
+  }
+}

--- a/packages/backend/src/routing/model-discovery/provider-model-registry.service.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-registry.service.ts
@@ -71,7 +71,7 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
       let totalModels = 0;
       for (const p of providers) {
         if (!Array.isArray(p.cached_models)) continue;
-        const ids = p.cached_models.map((m) => m.id);
+        const ids = p.cached_models.map((m) => m.id).filter(Boolean);
         if (ids.length > 0) {
           this.registerModels(p.provider, ids);
           totalModels += ids.length;


### PR DESCRIPTION
## Summary

- Adds `ProviderModelRegistryService` that tracks model IDs confirmed via provider-native APIs
- Filters `buildFallbackModels()` against confirmed models so phantom OpenRouter entries (e.g., `qwen3.5-9b`) don't appear in routing fallback
- Adds `validated` flag to Model Prices API response so the frontend can distinguish verified models from unverified ones
- Registry populates on startup from existing `user_providers.cached_models` data and updates whenever a user connects a provider

Closes #1204

## Test plan

- [ ] Verify backend unit tests pass (`npm test --workspace=packages/backend`)
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Verify `GET /api/v1/model-prices` returns `validated` field on each model
- [ ] Connect a provider (e.g., OpenAI), then disconnect — fallback models should only include confirmed ones
- [ ] On fresh install with no connected providers, fallback behavior remains unchanged (graceful degradation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters phantom OpenRouter models from routing fallbacks using a provider-native model registry, and adds a `validated` flag to `GET /api/v1/model-prices` so the UI can mark verified models. Prevents bad fallbacks (e.g., `qwen3.5-9b`) and satisfies #1204.

- **Bug Fixes**
  - Filters `buildFallbackModels()` with confirmed IDs when native `/models` returns none; degrades gracefully when no registry data exists.
  - Resolves OpenRouter prefix aliases to canonical provider IDs during validation (e.g., `google` → `gemini`).
  - Guards against malformed cached model entries (missing IDs) and skips registry lookups for unsupported vendors.

- **New Features**
  - Adds `ProviderModelRegistryService` that loads on startup from `user_providers.cached_models` and records models after native fetches.
  - Adds `validated` on each model in `GET /api/v1/model-prices`, sourced from the registry.

<sup>Written for commit 983ae7944ead2a638f77a306290b8e224f6ce4eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

