### PR TITLE
fix: resolve SPA deep-route refresh 404 in local/embedded mode

### DIFF
--- a/.changeset/fix-spa-deep-route-refresh.md
+++ b/.changeset/fix-spa-deep-route-refresh.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix SPA deep-route refresh returning 404 in local/embedded mode by disabling @nestjs/serve-static's broken render handler and hardening the SPA fallback filter to use cached index.html content instead of res.sendFile()

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -35,6 +35,7 @@ const serveStaticImports = frontendPath
   ? [
       ServeStaticModule.forRoot({
         rootPath: frontendPath,
+        renderPath: '/__serve_static_never_match',
         exclude: ['/api/{*path}', '/otlp/{*path}', '/v1/{*path}'],
         serveStaticOptions: {
           maxAge: ONE_YEAR_S * 1000,

--- a/packages/backend/src/common/filters/spa-fallback.filter.spec.ts
+++ b/packages/backend/src/common/filters/spa-fallback.filter.spec.ts
@@ -4,15 +4,21 @@ jest.mock('../utils/frontend-path', () => ({
   resolveFrontendDir: jest.fn(),
 }));
 
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  readFileSync: jest.fn().mockReturnValue('<html><body>SPA</body></html>'),
+}));
+
 import { resolveFrontendDir } from '../utils/frontend-path';
 
 const mockResolveFrontendDir = resolveFrontendDir as jest.MockedFunction<typeof resolveFrontendDir>;
 
 function createMockHost(method: string, url: string) {
   const json = jest.fn();
-  const status = jest.fn().mockReturnValue({ json });
-  const sendFile = jest.fn();
-  const res = { status, json, sendFile };
+  const send = jest.fn();
+  const setHeader = jest.fn();
+  const status = jest.fn().mockReturnValue({ json, send });
+  const res = { status, json, send, setHeader };
   const req = { method, originalUrl: url };
 
   return {
@@ -37,6 +43,10 @@ describe('SpaFallbackFilter', () => {
     jest.mock('../utils/frontend-path', () => ({
       resolveFrontendDir: mockResolveFrontendDir,
     }));
+    jest.mock('fs', () => ({
+      ...jest.requireActual('fs'),
+      readFileSync: jest.fn().mockReturnValue('<html><body>SPA</body></html>'),
+    }));
     const { SpaFallbackFilter } =
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       require('./spa-fallback.filter') as typeof import('./spa-fallback.filter');
@@ -51,38 +61,40 @@ describe('SpaFallbackFilter', () => {
       filter = loadFilter();
     });
 
-    it('serves index.html for GET to a deep SPA route', () => {
+    it('serves cached index.html content for GET to a deep SPA route', () => {
       const { host, res } = createMockHost('GET', '/agents/foo/routing');
       filter.catch(exception, host);
-      expect(res.sendFile).toHaveBeenCalledWith('/mock/frontend/index.html');
-      expect(res.status).not.toHaveBeenCalled();
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith('<html><body>SPA</body></html>');
     });
 
     it('returns JSON 404 for GET to /api/ routes', () => {
       const { host, res } = createMockHost('GET', '/api/v1/nonexistent');
       filter.catch(exception, host);
-      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.send).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(404);
     });
 
     it('returns JSON 404 for GET to /otlp/ routes', () => {
       const { host, res } = createMockHost('GET', '/otlp/v1/unknown');
       filter.catch(exception, host);
-      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.send).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(404);
     });
 
     it('returns JSON 404 for GET to /v1/ routes', () => {
       const { host, res } = createMockHost('GET', '/v1/something');
       filter.catch(exception, host);
-      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.send).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(404);
     });
 
     it('returns JSON 404 for non-GET requests', () => {
       const { host, res } = createMockHost('POST', '/agents/foo');
       filter.catch(exception, host);
-      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.send).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(404);
     });
   });
@@ -98,7 +110,7 @@ describe('SpaFallbackFilter', () => {
     it('returns JSON 404 even for GET to a deep SPA route', () => {
       const { host, res } = createMockHost('GET', '/agents/foo/routing');
       filter.catch(exception, host);
-      expect(res.sendFile).not.toHaveBeenCalled();
+      expect(res.send).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(404);
     });
   });

--- a/packages/backend/src/common/filters/spa-fallback.filter.ts
+++ b/packages/backend/src/common/filters/spa-fallback.filter.ts
@@ -1,17 +1,18 @@
 import { ExceptionFilter, Catch, NotFoundException, ArgumentsHost } from '@nestjs/common';
 import { Response, Request } from 'express';
 import { join } from 'path';
+import { readFileSync } from 'fs';
 import { resolveFrontendDir } from '../utils/frontend-path';
 
 const API_PREFIXES = ['/api/', '/otlp/', '/v1/'];
 
 @Catch(NotFoundException)
 export class SpaFallbackFilter implements ExceptionFilter {
-  private readonly indexPath: string | null;
+  private readonly indexContent: string | null;
 
   constructor() {
     const frontendDir = resolveFrontendDir();
-    this.indexPath = frontendDir ? join(frontendDir, 'index.html') : null;
+    this.indexContent = frontendDir ? readFileSync(join(frontendDir, 'index.html'), 'utf-8') : null;
   }
 
   catch(exception: NotFoundException, host: ArgumentsHost) {
@@ -21,7 +22,7 @@ export class SpaFallbackFilter implements ExceptionFilter {
 
     if (
       req.method !== 'GET' ||
-      !this.indexPath ||
+      !this.indexContent ||
       API_PREFIXES.some((p) => req.originalUrl.startsWith(p))
     ) {
       const response = exception.getResponse();
@@ -30,6 +31,8 @@ export class SpaFallbackFilter implements ExceptionFilter {
       return;
     }
 
-    res.sendFile(this.indexPath);
+    res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.status(200).send(this.indexContent);
   }
 }

--- a/packages/openclaw-plugin/scripts/copy-assets.js
+++ b/packages/openclaw-plugin/scripts/copy-assets.js
@@ -11,7 +11,9 @@ if (existsSync(frontendDist)) {
   });
   console.log('Copied frontend assets to public/');
 } else {
-  console.warn('Frontend dist not found — skipping asset copy. Build frontend first.');
+  console.error('ERROR: Frontend dist not found at', frontendDist);
+  console.error('Run "npm run build" from the monorepo root first.');
+  process.exit(1);
 }
 
 const backendDist = join(__dirname, '..', '..', 'backend', 'dist');
@@ -32,7 +34,9 @@ if (existsSync(backendDist)) {
   }
   console.log('Copied backend dist to dist/backend/');
 } else {
-  console.warn('Backend dist not found — skipping backend copy. Build backend first.');
+  console.error('ERROR: Backend dist not found at', backendDist);
+  console.error('Run "npm run build" from the monorepo root first.');
+  process.exit(1);
 }
 
 const subCaps = join(__dirname, '..', '..', 'subscription-capabilities');

--- a/turbo.json
+++ b/turbo.json
@@ -9,6 +9,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
+    "manifest#build": {
+      "dependsOn": ["manifest-frontend#build", "manifest-backend#build"],
+      "outputs": ["dist/**", "public/**", "subscription-capabilities/**", "skills/**"]
+    },
     "test": {
       "cache": false
     },


### PR DESCRIPTION
## Summary

- Disable `@nestjs/serve-static`'s render handler via `renderPath: '/__serve_static_never_match'` — its Express loader intercepts deep route errors before NestJS exception filters run, bypassing `SpaFallbackFilter` entirely
- Harden `SpaFallbackFilter` to cache `index.html` content at startup via `readFileSync` and serve it with `res.send()` instead of `res.sendFile()`, avoiding Express's `send` module error handling bypass
- Fix `turbo.json` build order: add explicit `manifest#build` task depending on `manifest-frontend#build` and `manifest-backend#build` with `public/**` in outputs
- Make `copy-assets.js` fail with exit code 1 when frontend or backend dist is missing (was silently warning)

Fixes #1211, #1190

## Root cause

`@nestjs/serve-static` v5's Express loader registers a render function that calls `res.sendFile(indexFilePath)`. When this fails on deep routes (e.g. `/agents/foo/routing`), the error callback returns a JSON 404 **directly at the Express level**, completely bypassing NestJS's exception pipeline. The `SpaFallbackFilter` (added in #837, improved in #1127) never gets a chance to run.

## Test plan

- [x] Backend unit tests pass (2704 tests, 143 suites)
- [x] Frontend tests pass (1587 tests, 76 suites)
- [x] Plugin tests pass (316 tests, 15 suites)
- [x] TypeScript compiles clean
- [x] Manually verified: local mode server on port 2099 — deep route refresh now returns SPA instead of 404
- [x] API routes (`/api/v1/health`) still return JSON correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SPA deep-route refresh returning 404 in local/embedded mode by bypassing `@nestjs/serve-static`’s render handler and serving cached `index.html` from `SpaFallbackFilter`. API routes are unaffected. Fixes #1211, #1190.

- Bug Fixes
  - Disabled `@nestjs/serve-static` render via `renderPath: '/__serve_static_never_match'` to prevent Express-level 404s from skipping Nest filters.
  - `SpaFallbackFilter` now caches `index.html` at startup (`readFileSync`) and serves it with `res.status(200).send(...)`, setting `Content-Type` and `Cache-Control`.

- Refactors
  - Added `manifest#build` in `turbo.json` with deps on `manifest-frontend#build` and `manifest-backend#build`, and included `public/**` in outputs.
  - Updated `copy-assets.js` to exit with code 1 when frontend or backend dist is missing.

<sup>Written for commit e37c31547308a58f92981b5a25b422d6c4643ae5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

