### PR TITLE
fix: remove quotes from changeset frontmatter to unblock releases

### DIFF
--- a/.changeset/fix-openrouter-provider-resolution.md
+++ b/.changeset/fix-openrouter-provider-resolution.md
@@ -1,5 +1,5 @@
 ---
-"manifest": patch
+manifest: patch
 ---
 
 Persist the selected provider for manual routing overrides so OpenRouter-sourced models resolve through the chosen provider instead of being re-inferred from the model name.

--- a/.changeset/fix-spa-deep-route-refresh.md
+++ b/.changeset/fix-spa-deep-route-refresh.md
@@ -1,5 +1,5 @@
 ---
-"manifest": patch
+manifest: patch
 ---
 
 Fix SPA deep-route refresh returning 404 in local/embedded mode by disabling @nestjs/serve-static's broken render handler and hardening the SPA fallback filter to use cached index.html content instead of res.sendFile()

--- a/.changeset/green-lamps-relax.md
+++ b/.changeset/green-lamps-relax.md
@@ -1,4 +1,5 @@
-"manifest": patch
+---
+manifest: patch
 ---
 
 Trigger proxy fallbacks when the primary provider fails at the transport layer before returning an HTTP response.

--- a/.changeset/short-anthropic-pricing.md
+++ b/.changeset/short-anthropic-pricing.md
@@ -1,5 +1,5 @@
 ---
-"manifest": patch
+manifest: patch
 ---
 
 Normalize Anthropic short model ids so pricing lookup resolves Claude 4.6 cost entries across dotted and dashed variants.


### PR DESCRIPTION
## Summary

- Remove quotes from `"manifest"` in changeset frontmatter YAML — the changesets parser rejects quoted keys, causing the release workflow to fail
- Fix missing opening `---` delimiter in `green-lamps-relax.md`
- Affects 4 changeset files that were blocking `changesets/action@v1` in the release workflow

## Test plan

- [x] `npx changeset status` parses all changesets successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed quotes from the `manifest` key in changeset frontmatter and added a missing opening `---` so the parser accepts all files. This unblocks the release workflow using `changesets/action@v1`.

<sup>Written for commit a14e094124b32ee39d6e4ad7cb836424df8fee22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

