### PR TITLE
fix: skip prompt caching for Anthropic subscription auth

### DIFF
--- a/.changeset/fix-anthropic-subscription-caching.md
+++ b/.changeset/fix-anthropic-subscription-caching.md
@@ -1,0 +1,5 @@
+---
+manifest: patch
+---
+
+Skip prompt caching injection for Anthropic subscription (OAuth) requests. Fixes HTTP 400 errors when using Sonnet and Opus models with Claude Max/Pro subscription tokens.

--- a/.changeset/fix-anthropic-subscription-caching.md
+++ b/.changeset/fix-anthropic-subscription-caching.md
@@ -1,5 +1,5 @@
 ---
-manifest: patch
+"manifest": patch
 ---
 
 Skip prompt caching injection for Anthropic subscription (OAuth) requests. Fixes HTTP 400 errors when using Sonnet and Opus models with Claude Max/Pro subscription tokens.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -349,6 +349,64 @@ describe('Anthropic Adapter', () => {
       const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
       expect(result.tools).toBeUndefined();
     });
+
+    it('omits cache_control from system blocks when injectCacheControl is false', () => {
+      const body = {
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514', {
+        injectCacheControl: false,
+      });
+      const system = result.system as Array<{ cache_control?: unknown }>;
+      expect(system).toHaveLength(1);
+      expect(system[0].cache_control).toBeUndefined();
+    });
+
+    it('omits top-level cache_control when injectCacheControl is false', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514', {
+        injectCacheControl: false,
+      });
+      expect(result.cache_control).toBeUndefined();
+    });
+
+    it('omits cache_control from tools when injectCacheControl is false', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        tools: [
+          { type: 'function', function: { name: 'a', description: 'tool a' } },
+          { type: 'function', function: { name: 'b', description: 'tool b' } },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514', {
+        injectCacheControl: false,
+      });
+      const tools = result.tools as Array<{ cache_control?: unknown }>;
+      expect(tools).toHaveLength(2);
+      expect(tools[0].cache_control).toBeUndefined();
+      expect(tools[1].cache_control).toBeUndefined();
+    });
+
+    it('injects cache_control by default when options is undefined', () => {
+      const body = {
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hi' },
+        ],
+        tools: [{ type: 'function', function: { name: 'a', description: 'tool a' } }],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+      expect(result.cache_control).toEqual({ type: 'ephemeral' });
+      const system = result.system as Array<{ cache_control?: unknown }>;
+      expect(system[system.length - 1].cache_control).toEqual({ type: 'ephemeral' });
+      const tools = result.tools as Array<{ cache_control?: unknown }>;
+      expect(tools[tools.length - 1].cache_control).toEqual({ type: 'ephemeral' });
+    });
   });
 
   describe('fromAnthropicResponse', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -185,6 +185,64 @@ describe('ProviderClient', () => {
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.stream).toBeUndefined();
     });
+
+    it('omits cache_control from request body for subscription auth', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const bodyWithSystem = {
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hello' },
+        ],
+        tools: [{ type: 'function', function: { name: 'search', description: 'Search' } }],
+      };
+
+      await client.forward(
+        'anthropic',
+        'sk-ant-oat-token',
+        'claude-sonnet-4-20250514',
+        bodyWithSystem,
+        false,
+        undefined,
+        undefined,
+        undefined,
+        'subscription',
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.cache_control).toBeUndefined();
+      const system = sentBody.system as Array<{ cache_control?: unknown }>;
+      expect(system[0].cache_control).toBeUndefined();
+      const tools = sentBody.tools as Array<{ cache_control?: unknown }>;
+      expect(tools[0].cache_control).toBeUndefined();
+    });
+
+    it('includes cache_control for regular Anthropic API key auth', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const bodyWithSystem = {
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hello' },
+        ],
+        tools: [{ type: 'function', function: { name: 'search', description: 'Search' } }],
+      };
+
+      await client.forward(
+        'anthropic',
+        'sk-ant-key',
+        'claude-sonnet-4-20250514',
+        bodyWithSystem,
+        false,
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.cache_control).toEqual({ type: 'ephemeral' });
+      const system = sentBody.system as Array<{ cache_control?: unknown }>;
+      expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+      const tools = sentBody.tools as Array<{ cache_control?: unknown }>;
+      expect(tools[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
   });
 
   describe('Google provider', () => {

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -118,26 +118,35 @@ function convertTools(tools?: Array<Record<string, unknown>>): AnthropicTool[] |
 
 /* ── Request conversion ── */
 
+export interface AnthropicRequestOptions {
+  /** When false, cache_control fields are omitted from the request. Defaults to true. */
+  injectCacheControl?: boolean;
+}
+
 export function toAnthropicRequest(
   body: Record<string, unknown>,
   _model: string,
+  options?: AnthropicRequestOptions,
 ): Record<string, unknown> {
+  const shouldCache = options?.injectCacheControl !== false;
   const messages = (body.messages as OpenAIMessage[]) || [];
   const systemBlocks = extractSystemBlocks(messages);
-  if (systemBlocks.length > 0) systemBlocks[systemBlocks.length - 1].cache_control = CACHE;
+  if (systemBlocks.length > 0 && shouldCache) {
+    systemBlocks[systemBlocks.length - 1].cache_control = CACHE;
+  }
 
   const converted = messages.map(convertMessage).filter(Boolean);
   const result: Record<string, unknown> = {
     messages: converted,
     max_tokens: (body.max_tokens as number) || 4096,
-    cache_control: { type: 'ephemeral' },
   };
+  if (shouldCache) result.cache_control = { type: 'ephemeral' };
 
   if (systemBlocks.length > 0) result.system = systemBlocks;
 
   const tools = convertTools(body.tools as Array<Record<string, unknown>> | undefined);
   if (tools) {
-    tools[tools.length - 1].cache_control = CACHE;
+    if (shouldCache) tools[tools.length - 1].cache_control = CACHE;
     result.tools = tools;
   }
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -170,12 +170,7 @@ function normalizeDeepSeekMaxTokens(body: Record<string, unknown>): void {
   if (!('max_tokens' in body)) return;
 
   const raw = body.max_tokens;
-  const parsed =
-    typeof raw === 'number'
-      ? raw
-      : typeof raw === 'string'
-        ? Number(raw)
-        : Number.NaN;
+  const parsed = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : Number.NaN;
 
   if (!Number.isFinite(parsed) || parsed <= 0) {
     delete body.max_tokens;
@@ -261,7 +256,9 @@ export class ProviderClient {
     } else if (isAnthropic) {
       url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`;
       headers = endpoint.buildHeaders(apiKey, authType);
-      requestBody = toAnthropicRequest(body, bareModel);
+      requestBody = toAnthropicRequest(body, bareModel, {
+        injectCacheControl: authType !== 'subscription',
+      });
       requestBody.model = bareModel;
       if (stream) requestBody.stream = true;
     } else if (isChatGpt) {


### PR DESCRIPTION
## Summary

- Anthropic's OAuth API rejects requests containing `cache_control` fields for Sonnet and Opus models (HTTP 400 `invalid_request_error`). Haiku was unaffected.
- The `subscription-capabilities` package already declares `supportsPromptCaching: false` for Anthropic, but the proxy adapter was ignoring this and unconditionally injecting prompt caching directives.
- Added an `injectCacheControl` option to `toAnthropicRequest()` and set it to `false` when `authType === 'subscription'`. This gates all three cache injection sites (system blocks, top-level body, tools).

Fixes #1193

## Test plan

- [x] 4 new unit tests in `anthropic-adapter.spec.ts` covering `injectCacheControl: false` and regression guard
- [x] 2 new integration tests in `provider-client.spec.ts` for subscription vs API key auth
- [x] All 2766 backend tests pass
- [x] All 1587 frontend tests pass
- [x] TypeScript compiles cleanly (backend + frontend)
- [x] 100% line coverage on `anthropic-adapter.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip injecting `cache_control` for Anthropic subscription (OAuth) requests to avoid HTTP 400 errors on Sonnet and Opus. Fixes #1193.

- **Bug Fixes**
  - Added `injectCacheControl` option to `toAnthropicRequest`; set to false for `authType: 'subscription'` in the provider client.
  - When disabled, omits `cache_control` from system blocks, the top-level body, and tools; default (API key auth) still injects it.
  - Aligns the proxy with `subscription-capabilities` where `supportsPromptCaching: false`.

<sup>Written for commit 5c8aa62dca690baa9ae4f25a917829573daa9755. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

