### PR TITLE
fix: show costs for dual-auth providers (API key + subscription)

### DIFF
--- a/.changeset/fix-dual-auth-cost-display.md
+++ b/.changeset/fix-dual-auth-cost-display.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix cost display for dual-auth providers: when both API key and subscription are connected for the same provider, costs are now correctly calculated instead of being zeroed out.

--- a/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.spec.ts
@@ -451,6 +451,97 @@ describe('TraceIngestService', () => {
     expect(mockQb.setParameter).toHaveBeenCalledWith('cost', 0);
   });
 
+  it('calculates cost in rollup when provider has both subscription and api_key (dual-auth)', async () => {
+    mockProviderFind.mockResolvedValue([
+      { provider: 'anthropic', auth_type: 'subscription' },
+      { provider: 'anthropic', auth_type: 'api_key' },
+    ]);
+    mockPricingGetByModel.mockReturnValue({
+      provider: 'anthropic',
+      input_price_per_token: 0.003,
+      output_price_per_token: 0.015,
+    });
+
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-dual',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-dual',
+      parentSpanId: 'span-msg-dual',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'anthropic' } },
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-sonnet-4-20250514' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 200 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 100 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [parentSpan, llmSpan] }],
+        },
+      ],
+    };
+
+    const repoInstance = (service as any).turnRepo;
+    const mockQb = repoInstance.createQueryBuilder();
+
+    await service.ingest(request, testCtx);
+
+    // Dual-auth: API key takes precedence → cost is calculated (200*0.003 + 100*0.015 = 2.1)
+    expect(mockQb.setParameter).toHaveBeenCalledWith('cost', 2.1);
+  });
+
+  it('calculates cost in rollup for dual-auth regardless of record order (api_key first)', async () => {
+    mockProviderFind.mockResolvedValue([
+      { provider: 'anthropic', auth_type: 'api_key' },
+      { provider: 'anthropic', auth_type: 'subscription' },
+    ]);
+    mockPricingGetByModel.mockReturnValue({
+      provider: 'anthropic',
+      input_price_per_token: 0.003,
+      output_price_per_token: 0.015,
+    });
+
+    const parentSpan = makeSpan({
+      spanId: 'span-msg-order',
+      name: 'openclaw.agent.turn',
+      attributes: [],
+    });
+
+    const llmSpan = makeSpan({
+      spanId: 'span-llm-order',
+      parentSpanId: 'span-msg-order',
+      attributes: [
+        { key: 'gen_ai.system', value: { stringValue: 'anthropic' } },
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-sonnet-4-20250514' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 200 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 100 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [parentSpan, llmSpan] }],
+        },
+      ],
+    };
+
+    const repoInstance = (service as any).turnRepo;
+    const mockQb = repoInstance.createQueryBuilder();
+
+    await service.ingest(request, testCtx);
+
+    expect(mockQb.setParameter).toHaveBeenCalledWith('cost', 2.1);
+  });
+
   it('does not treat unsupported subscription providers as zero-cost', async () => {
     mockProviderFind.mockResolvedValue([{ provider: 'deepseek', auth_type: 'subscription' }]);
     mockPricingGetByModel.mockReturnValue({
@@ -1060,7 +1151,7 @@ describe('TraceIngestService', () => {
     ]);
   });
 
-  it('returns zero cost when provider has both subscription and api_key (dual-auth)', async () => {
+  it('returns calculated cost when provider has both subscription and api_key (dual-auth)', async () => {
     mockProviderFind.mockResolvedValue([
       { provider: 'anthropic', auth_type: 'subscription' },
       { provider: 'anthropic', auth_type: 'api_key' },
@@ -1090,9 +1181,147 @@ describe('TraceIngestService', () => {
     };
 
     await service.ingest(request, testCtx);
-    // Dual-auth providers treated as subscription (routing prefers subscription) → zero cost
+    // Dual-auth: API key takes precedence → cost is calculated, not zero
     expect(mockTurnInsert).toHaveBeenCalledWith([
+      expect.objectContaining({ cost_usd: 0.2, auth_type: 'api_key' }),
+    ]);
+  });
+
+  it('removes dual-auth provider from subscription set regardless of record order', async () => {
+    // api_key record listed BEFORE subscription record — order should not matter
+    mockProviderFind.mockResolvedValue([
+      { provider: 'anthropic', auth_type: 'api_key' },
+      { provider: 'anthropic', auth_type: 'subscription' },
+    ]);
+    mockPricingGetByModel.mockReturnValue({
+      provider: 'anthropic',
+      input_price_per_token: 0.001,
+      output_price_per_token: 0.002,
+    });
+
+    const span = makeSpan({
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-haiku-4.5' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledWith([
+      expect.objectContaining({ cost_usd: 0.2, auth_type: 'api_key' }),
+    ]);
+  });
+
+  it('handles mixed providers: dual-auth for one and subscription-only for another', async () => {
+    mockProviderFind.mockResolvedValue([
+      { provider: 'anthropic', auth_type: 'subscription' },
+      { provider: 'anthropic', auth_type: 'api_key' },
+      { provider: 'openai', auth_type: 'subscription' },
+    ]);
+
+    // First call for the Anthropic model span, second for the OpenAI model span
+    mockPricingGetByModel
+      .mockReturnValueOnce({
+        provider: 'anthropic',
+        input_price_per_token: 0.001,
+        output_price_per_token: 0.002,
+      })
+      .mockReturnValueOnce({
+        provider: 'anthropic',
+        input_price_per_token: 0.001,
+        output_price_per_token: 0.002,
+      })
+      .mockReturnValueOnce({
+        provider: 'openai',
+        input_price_per_token: 0.005,
+        output_price_per_token: 0.01,
+      })
+      .mockReturnValueOnce({
+        provider: 'openai',
+        input_price_per_token: 0.005,
+        output_price_per_token: 0.01,
+      });
+
+    const anthropicSpan = makeSpan({
+      spanId: 'span-anthro',
+      traceId: 'trace-anthro',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-haiku-4.5' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const openaiSpan = makeSpan({
+      spanId: 'span-oai',
+      traceId: 'trace-oai',
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'gpt-4o' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [anthropicSpan, openaiSpan] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+
+    // Anthropic is dual-auth → cost calculated; OpenAI is subscription-only → cost = 0
+    expect(mockTurnInsert).toHaveBeenCalledWith([
+      expect.objectContaining({ cost_usd: 0.2, auth_type: 'api_key' }),
       expect.objectContaining({ cost_usd: 0, auth_type: 'subscription' }),
+    ]);
+  });
+
+  it('calculates cost for api_key-only provider (no subscription record)', async () => {
+    mockProviderFind.mockResolvedValue([{ provider: 'anthropic', auth_type: 'api_key' }]);
+    mockPricingGetByModel.mockReturnValue({
+      provider: 'anthropic',
+      input_price_per_token: 0.001,
+      output_price_per_token: 0.002,
+    });
+
+    const span = makeSpan({
+      name: 'openclaw.agent.turn',
+      attributes: [
+        { key: 'gen_ai.request.model', value: { stringValue: 'claude-haiku-4.5' } },
+        { key: 'gen_ai.usage.input_tokens', value: { intValue: 100 } },
+        { key: 'gen_ai.usage.output_tokens', value: { intValue: 50 } },
+      ],
+    });
+
+    const request = {
+      resourceSpans: [
+        {
+          resource: { attributes: [] },
+          scopeSpans: [{ scope: { name: 'test' }, spans: [span] }],
+        },
+      ],
+    };
+
+    await service.ingest(request, testCtx);
+    expect(mockTurnInsert).toHaveBeenCalledWith([
+      expect.objectContaining({ cost_usd: 0.2, auth_type: 'api_key' }),
     ]);
   });
 

--- a/packages/backend/src/otlp/services/trace-ingest.service.ts
+++ b/packages/backend/src/otlp/services/trace-ingest.service.ts
@@ -676,12 +676,15 @@ export class TraceIngestService {
       select: ['provider', 'auth_type'],
     });
     const sub = new Set<string>();
+    const apiKey = new Set<string>();
     for (const r of records) {
       if (!isManifestUsableProvider(r)) continue;
       if (r.auth_type === 'subscription') sub.add(r.provider);
+      else if (r.auth_type === 'api_key') apiKey.add(r.provider);
     }
-    // Keep dual-auth providers in the set: the routing layer prefers subscription
-    // when both exist, so the OTLP heuristic should match (zero cost).
+    // When both subscription and API key exist for the same provider,
+    // remove from the subscription set: API key costs should always be shown.
+    for (const p of apiKey) sub.delete(p);
     return sub;
   }
 


### PR DESCRIPTION
## Summary

- When both an API key and subscription are connected for the same provider (e.g. Anthropic), the OTLP ingestion heuristic was marking all messages as subscription with zero cost
- Fixed `getSubscriptionProviders()` to exclude providers that also have an API key connection from the subscription set
- API key costs are now always shown; subscription-only providers still show zero cost

Fixes #1214

## Test plan

- [x] Updated existing dual-auth test to expect calculated cost and `auth_type: 'api_key'`
- [x] Added rollup path test for dual-auth cost calculation
- [x] Added record-order independence test (api_key before subscription)
- [x] Added mixed-provider test (Anthropic dual-auth + OpenAI subscription-only)
- [x] Added api_key-only provider test
- [x] All 2771 backend tests pass
- [x] TypeScript compiles with no errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cost display when a provider has both an API key and a subscription: API key costs are now calculated and shown instead of zeroed out. Fixes #1214.

- **Bug Fixes**
  - Updated `getSubscriptionProviders()` to exclude providers that also have `api_key`, so OTLP rollups classify them as `api_key` and compute cost.
  - Subscription-only providers still show zero cost.
  - Added tests for dual-auth, order independence, rollup path, mixed providers, and api_key-only scenarios.

<sup>Written for commit 06c2301eabc42acc896c83066a635ec8436bff2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

