### PR TITLE
fix: switch Moonshot/Kimi API endpoint from .cn to .ai TLD

### DIFF
--- a/.changeset/kimi-ai-tld.md
+++ b/.changeset/kimi-ai-tld.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Switch Moonshot/Kimi API endpoint from .cn to .ai TLD for international users

--- a/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/routing/model-discovery/provider-model-fetcher.service.ts
@@ -241,7 +241,7 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     parse: parseOpenAI,
   },
   moonshot: {
-    endpoint: 'https://api.moonshot.cn/v1/models',
+    endpoint: 'https://api.moonshot.ai/v1/models',
     buildHeaders: bearerHeaders,
     parse: parseOpenAI,
   },

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -66,7 +66,7 @@ describe('ProviderClient', () => {
       await client.forward('moonshot', 'sk-moon', 'kimi-k2', body, false);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://api.moonshot.cn/v1/chat/completions',
+        'https://api.moonshot.ai/v1/chat/completions',
         expect.any(Object),
       );
     });

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -101,7 +101,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     format: 'anthropic',
   },
   moonshot: {
-    baseUrl: 'https://api.moonshot.cn',
+    baseUrl: 'https://api.moonshot.ai',
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',


### PR DESCRIPTION
## Summary

- Switch Moonshot/Kimi API base URL from `api.moonshot.cn` to `api.moonshot.ai` for international users
- Moonshot AI officially provides both endpoints — `.ai` is the global/international one, `.cn` is China-specific
- Updated proxy endpoint, model fetcher, and test expectation

Closes #1213

## Test plan

- [x] All 2771 backend unit tests pass
- [x] TypeScript compiles with no errors
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Moonshot/Kimi API to the global `.ai` endpoint to route international traffic correctly and avoid the China-specific `.cn` domain.
Updated the provider base URL, model discovery endpoint, and unit test expectations to use `https://api.moonshot.ai`.

<sup>Written for commit 8f27bd79c23c3c04f3b6279b293c90ba6a057626. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

