### PR TITLE
fix(frontend): bundle Product Hunt popup badge

### DIFF
--- a/.changeset/product-hunt-badge-fix.md
+++ b/.changeset/product-hunt-badge-fix.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Bundle the Product Hunt popup badge locally so it renders reliably in browsers.

--- a/packages/frontend/src/assets/product-hunt-featured.svg
+++ b/packages/frontend/src/assets/product-hunt-featured.svg
@@ -1,0 +1,27 @@
+<svg width="250" height="54" viewBox="0 0 250 54" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g transform="translate(-130 -73)">
+      <g transform="translate(130 73)">
+        <rect stroke="#FF6154" stroke-width="1" fill="#FFFFFF" x="0.5" y="0.5" width="249" height="53" rx="10" />
+        <text font-family="Helvetica-Bold, Helvetica" font-size="9" font-weight="bold" fill="#FF6154">
+          <tspan x="53" y="20">FIND US ON</tspan>
+        </text>
+        <text font-family="Helvetica-Bold, Helvetica" font-size="21" font-weight="bold" fill="#FF6154">
+          <tspan x="52" y="40">Product Hunt</tspan>
+        </text>
+        <g transform="translate(201 13)" fill="#FF6154">
+          <g>
+            <polygon points="26.0024997 10 15 10 20.5012498 0" />
+            <text font-family="Helvetica-Bold, Helvetica" font-size="13" font-weight="bold" line-spacing="20">
+              <tspan x="15.7" y="27">4</tspan>
+            </text>
+          </g>
+        </g>
+        <g transform="translate(11 12)">
+          <path d="M31,15.5 C31,24.0603917 24.0603917,31 15.5,31 C6.93960833,31 0,24.0603917 0,15.5 C0,6.93960833 6.93960833,0 15.5,0 C24.0603917,0 31,6.93960833 31,15.5" fill="#FF6154" />
+          <path d="M17.4329412,15.9558824 L17.4329412,15.9560115 L13.0929412,15.9560115 L13.0929412,11.3060115 L17.4329412,11.3060115 L17.4329412,11.3058824 C18.7018806,11.3058824 19.7305882,12.3468365 19.7305882,13.6308824 C19.7305882,14.9149282 18.7018806,15.9558824 17.4329412,15.9558824 M17.4329412,8.20588235 L17.4329412,8.20601152 L10.0294118,8.20588235 L10.0294118,23.7058824 L13.0929412,23.7058824 L13.0929412,19.0560115 L17.4329412,19.0560115 L17.4329412,19.0558824 C20.3938424,19.0558824 22.7941176,16.6270324 22.7941176,13.6308824 C22.7941176,10.6347324 20.3938424,8.20588235 17.4329412,8.20588235" fill="#FFFFFF" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/packages/frontend/src/components/ProductHuntUpvoteModal.tsx
+++ b/packages/frontend/src/components/ProductHuntUpvoteModal.tsx
@@ -1,4 +1,5 @@
 import { createEffect, createSignal, onCleanup, Show, type Component } from 'solid-js';
+import productHuntFeaturedBadge from '../assets/product-hunt-featured.svg';
 import { isLocalMode } from '../services/local-mode.js';
 
 export const PRODUCT_HUNT_UPVOTE_KEY = 'mnfst_product_hunt_upvote_2026_03_23';
@@ -8,8 +9,6 @@ export const PRODUCT_HUNT_FALLBACK_URL =
 const PRODUCT_HUNT_URL =
   (import.meta.env.VITE_PRODUCT_HUNT_URL as string | undefined) ?? PRODUCT_HUNT_FALLBACK_URL;
 const PRODUCT_HUNT_ALT = 'Manifest - Open Source LLM Router for OpenClaw | Product Hunt';
-const PRODUCT_HUNT_FEATURED_BADGE =
-  'https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1104032&theme=light';
 
 const hasAcknowledgedPrompt = (): boolean => {
   try {
@@ -111,7 +110,7 @@ const ProductHuntUpvoteModal: Component = () => {
           >
             <div class="product-hunt-modal__featured-frame">
               <img
-                src={PRODUCT_HUNT_FEATURED_BADGE}
+                src={productHuntFeaturedBadge}
                 alt={PRODUCT_HUNT_ALT}
                 width="250"
                 height="54"

--- a/packages/frontend/tests/components/ProductHuntUpvoteModal.test.tsx
+++ b/packages/frontend/tests/components/ProductHuntUpvoteModal.test.tsx
@@ -22,9 +22,13 @@ describe('ProductHuntUpvoteModal', () => {
     const { container } = render(() => <ProductHuntUpvoteModal />);
 
     expect(screen.getByText('Manifest on Product Hunt')).toBeDefined();
+    const badgeImage = screen.getByAltText(
+      'Manifest - Open Source LLM Router for OpenClaw | Product Hunt',
+    ) as HTMLImageElement;
     const link = container.querySelector(
       '.product-hunt-modal__featured-badge',
     ) as HTMLAnchorElement;
+    expect(badgeImage.getAttribute('src')).not.toContain('api.producthunt.com');
     expect(link).toBeDefined();
     expect(link.getAttribute('href')).toBe(PRODUCT_HUNT_FALLBACK_URL);
   });


### PR DESCRIPTION
## Summary
- bundle the Product Hunt featured badge locally in the frontend
- stop depending on the live Product Hunt widget URL inside the popup modal
- keep the popup CTA link unchanged while making the badge render reliably in browsers
- add a focused test assertion for the local badge asset and a matching manifest changeset

## Validation
- `npm test --workspace=packages/frontend -- ProductHuntUpvoteModal`
- `npx vite build` in `packages/frontend`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bundles the Product Hunt "Featured" badge SVG locally and removes the external widget load in the upvote modal so the badge renders reliably. The popup CTA link remains unchanged.

- **Bug Fixes**
  - Replaced the external widget URL with a local `product-hunt-featured.svg` in `ProductHuntUpvoteModal`.
  - Added a test to ensure the badge uses the local asset and the CTA still points to the fallback URL.
  - Added a manifest changeset to reflect the asset bundling.

<sup>Written for commit 92e0a774459a1389721f9cb1f76bcec4f42475be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

