### PR TITLE
fix: Product Hunt badge image blocked by CSP and extra styling

### DIFF
--- a/.changeset/fix-ph-modal-badge.md
+++ b/.changeset/fix-ph-modal-badge.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix Product Hunt badge image blocked by CSP and remove extra border/padding from badge container

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -25,7 +25,7 @@ export async function bootstrap() {
           defaultSrc: ["'self'"],
           scriptSrc: ["'self'"],
           styleSrc: ["'self'", "'unsafe-inline'"],
-          imgSrc: ["'self'", 'data:'],
+          imgSrc: ["'self'", 'data:', 'https://api.producthunt.com'],
           connectSrc: ["'self'"],
           fontSrc: ["'self'"],
           objectSrc: ["'none'"],

--- a/packages/frontend/src/styles/product-hunt.css
+++ b/packages/frontend/src/styles/product-hunt.css
@@ -98,30 +98,22 @@
   z-index: 1;
   display: inline-flex;
   margin-top: 14px;
-  border: 1px solid rgb(39 20 7 / 0.08);
+  border: none;
   border-radius: 14px;
-  background: rgb(255 255 255 / 0.72);
+  background: none;
   text-decoration: none;
   color: inherit;
   transition:
     transform var(--transition-fast),
-    border-color var(--transition-fast),
     box-shadow var(--transition-fast);
 }
 
 .product-hunt-modal__featured-badge:hover {
   transform: translateY(-1px);
-  border-color: rgb(255 97 0 / 0.22);
   box-shadow: 0 10px 20px rgb(39 20 7 / 0.08);
 }
 
-.dark .product-hunt-modal__featured-badge {
-  border-color: rgb(255 255 255 / 0.08);
-  background: rgb(255 255 255 / 0.03);
-}
-
 .dark .product-hunt-modal__featured-badge:hover {
-  border-color: rgb(255 97 0 / 0.28);
   box-shadow: 0 12px 24px rgb(0 0 0 / 0.18);
 }
 
@@ -131,7 +123,7 @@
   justify-content: center;
   min-height: 62px;
   min-width: 250px;
-  padding: 8px 10px;
+  padding: 0;
   border-radius: 12px;
   background: rgb(255 255 255 / 0.88);
 }


### PR DESCRIPTION
## Summary
- Add `https://api.producthunt.com` to the Content Security Policy `img-src` directive so the Product Hunt featured badge SVG loads correctly
- Remove the border and extra padding around the badge container in the modal for a cleaner look

## Test plan
- [ ] Open the dashboard and verify the Product Hunt modal shows the badge image
- [ ] Verify no CSP errors in browser console
- [ ] Confirm the badge has no border or extra padding around it

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Product Hunt badge in the modal by allowing its SVG origin in the CSP and simplifying the badge container styling for a cleaner look. Users now see the badge without CSP console errors.

<sup>Written for commit 8fe30e65ce3d28d9be23bc89703708f88c480238. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

