### PR TITLE
Fix meta title regression by removing static title from DOM

### DIFF
--- a/.changeset/fix-meta-titles-regression.md
+++ b/.changeset/fix-meta-titles-regression.md
@@ -1,0 +1,12 @@
+---
+"manifest": patch
+---
+
+fix: remove static title from DOM so @solidjs/meta can manage document.title
+
+The static `<title>` in index.html (added for SEO/Lighthouse) conflicted with
+@solidjs/meta's dynamic title management. Browsers use the first `<title>`
+element in the document, so the static tag always won and page-specific titles
+never appeared in the browser tab. The static tag is now removed on app mount,
+preserving the SEO fallback for pre-JS crawlers while letting @solidjs/meta
+control the title during navigation.

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -31,6 +31,13 @@ const GuestLayout: ParentComponent = (props) => (
   </GuestGuard>
 );
 
+// Remove the static <title> from index.html so @solidjs/meta can manage
+// document.title via its own <title> elements. The static tag is kept in
+// index.html for SEO (pre-JS crawlers / Lighthouse) but must be removed
+// before MetaProvider renders, otherwise the browser always picks the first
+// <title> in the DOM and ignores the dynamic ones.
+document.head.querySelector('title')?.remove();
+
 const root = document.getElementById('root');
 
 if (!root) {


### PR DESCRIPTION
## Summary
Fixed a regression where the static `<title>` element in index.html was preventing @solidjs/meta from dynamically managing the document title during navigation.

## Changes
- Remove the static `<title>` tag from the DOM on app initialization before MetaProvider renders
- This allows @solidjs/meta to take control of document.title for page-specific titles
- The static title remains in index.html for SEO purposes (pre-JS crawlers and Lighthouse) but is stripped at runtime

## Implementation Details
The fix works by querying and removing the static `<title>` element early in the app initialization (before the root component mounts). This preserves the SEO benefits of having a title in the HTML source while ensuring the browser uses the dynamic title elements managed by @solidjs/meta during client-side navigation.

The browser always uses the first `<title>` element in the DOM, so the static tag was previously preventing any dynamic title updates from appearing in the browser tab.

https://claude.ai/code/session_01DVxTb4DNymBy9cGUdVq3e8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where the static <title> blocked `@solidjs/meta` from updating page titles during navigation. The static title stays in `index.html` for SEO, but is removed at runtime so dynamic titles work.

- **Bug Fixes**
  - Remove the first <title> from document.head before `MetaProvider` renders to allow `@solidjs/meta` to control document.title.

<sup>Written for commit 32422f4826b129183fac2d7dd2c886c27b01ef31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

