### PR TITLE
fix(frontend): hide GitHub Copilot from API Keys tab

### DIFF
--- a/.changeset/sunny-eggs-guess.md
+++ b/.changeset/sunny-eggs-guess.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Hide GitHub Copilot from API Keys tab since it only supports subscription auth

--- a/.changeset/sunny-eggs-guess.md
+++ b/.changeset/sunny-eggs-guess.md
@@ -1,5 +1,5 @@
 ---
-'manifest': patch
+"manifest": patch
 ---
 
 Hide GitHub Copilot from API Keys tab since it only supports subscription auth

--- a/packages/frontend/src/components/ProviderSelectModal.tsx
+++ b/packages/frontend/src/components/ProviderSelectModal.tsx
@@ -37,10 +37,12 @@ const ProviderSelectModal: Component<Props> = (props) => {
   const [validationError, setValidationError] = createSignal<string | null>(null);
   const [direction, setDirection] = createSignal<'forward' | 'back' | null>(null);
   const subscriptionProviders = () => PROVIDERS.filter((p) => p.supportsSubscription);
-  const apiKeyProviders = () =>
-    isLocalMode()
-      ? PROVIDERS
-      : [...PROVIDERS].sort((a, b) => (a.localOnly ? 1 : 0) - (b.localOnly ? 1 : 0));
+  const apiKeyProviders = () => {
+    const filtered = PROVIDERS.filter((p) => !p.subscriptionOnly);
+    return isLocalMode()
+      ? filtered
+      : [...filtered].sort((a, b) => (a.localOnly ? 1 : 0) - (b.localOnly ? 1 : 0));
+  };
 
   const getProviderByAuth = (provId: string, authType: AuthType) =>
     props.providers.find((p) => p.provider === provId && p.auth_type === authType);

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -26,6 +26,8 @@ export interface ProviderDef {
   subscriptionAuthMode?: 'popup_oauth' | 'device_code' | 'token';
   /** Deprecated compatibility flag for popup OAuth providers. */
   subscriptionOAuth?: boolean;
+  /** Provider is subscription-only and should not appear in the API Keys tab. */
+  subscriptionOnly?: boolean;
 }
 
 export const PROVIDERS: ProviderDef[] = [
@@ -80,6 +82,7 @@ export const PROVIDERS: ProviderDef[] = [
     subscriptionLabel: 'GitHub Copilot subscription',
     subscriptionAuthMode: 'device_code',
     deviceLogin: true,
+    subscriptionOnly: true,
     models: [
       { label: 'Claude Opus 4', value: 'copilot/claude-opus-4' },
       { label: 'Claude Sonnet 4.5', value: 'copilot/claude-sonnet-4.5' },

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -148,6 +148,14 @@ describe("ProviderSelectModal", () => {
     expect(screen.getByText("OpenRouter")).toBeDefined();
   });
 
+  it("does not show subscription-only providers in the API Keys tab", () => {
+    render(() => (
+      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+    ));
+    fireEvent.click(screen.getByText("API Keys"));
+    expect(screen.queryByText("GitHub Copilot")).toBeNull();
+  });
+
   it("shows toggle switch in 'on' state for connected providers", () => {
     const { container } = render(() => (
       <ProviderSelectModal

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -289,6 +289,14 @@ describe("PROVIDERS", () => {
     expect(anthropic.subscriptionAuthMode).toBe("token");
   });
 
+  it("GitHub Copilot is subscription-only", () => {
+    const copilot = PROVIDERS.find((p) => p.id === "copilot")!;
+    expect(copilot.supportsSubscription).toBe(true);
+    expect(copilot.subscriptionOnly).toBe(true);
+    expect(copilot.deviceLogin).toBe(true);
+    expect(copilot.subscriptionAuthMode).toBe("device_code");
+  });
+
   it("MiniMax supports subscription with device-code flow", () => {
     const minimax = PROVIDERS.find((p) => p.id === "minimax")!;
     expect(minimax.supportsSubscription).toBe(true);


### PR DESCRIPTION
## Summary

- GitHub Copilot only supports subscription authentication (device code flow), not API keys
- Added `subscriptionOnly` flag to `ProviderDef` interface
- Filtered subscription-only providers from the API Keys tab in the provider selection modal

## Test plan

- [x] Frontend TypeScript compiles cleanly
- [x] All 1626 frontend tests pass (including 2 new tests)
- [x] All 2804 backend tests pass
- [x] New test verifies Copilot does not appear in API Keys tab
- [x] New test verifies Copilot has `subscriptionOnly: true` flag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide GitHub Copilot from the API Keys tab since it only supports subscription auth via device code. Adds a `subscriptionOnly` flag and filters the API Keys provider list to prevent invalid setup paths.

- **Bug Fixes**
  - Added `subscriptionOnly` to `ProviderDef` and set it on Copilot; filtered subscription-only providers from the API Keys tab while keeping local-mode sorting.
  - Fixed changeset frontmatter to use double quotes for CI compatibility.

<sup>Written for commit 84c3e1d800d8f3b32f76803759f640c0b61d70b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

