### PR TITLE
Add provider plugin metadata for ClawHub listing

### DIFF
--- a/.changeset/clawhub-provider-metadata.md
+++ b/.changeset/clawhub-provider-metadata.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add provider plugin metadata to openclaw.plugin.json and package.json for ClawHub listing

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,11 +1,27 @@
 {
   "id": "manifest",
-  "kind": "observability",
   "name": "Manifest — Agent Observability",
   "version": "5.28.2",
   "description": "Traces, metrics, and cost tracking for your OpenClaw agent. Zero-config local dashboard included.",
   "author": "MNFST Inc.",
   "homepage": "https://manifest.build",
+  "providers": ["manifest"],
+  "providerAuthEnvVars": {
+    "manifest": ["MANIFEST_API_KEY"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "manifest",
+      "method": "api-key",
+      "choiceId": "manifest-api-key",
+      "choiceLabel": "Manifest API Key",
+      "groupId": "manifest",
+      "groupLabel": "Manifest",
+      "cliFlag": "--manifest-key",
+      "cliOption": "--manifest-key <key>",
+      "cliDescription": "Manifest API key (starts with mnfst_)"
+    }
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -34,6 +34,9 @@
   "openclaw": {
     "extensions": [
       "./dist/index.js"
+    ],
+    "providers": [
+      "manifest"
     ]
   },
   "engines": {


### PR DESCRIPTION
## Summary

- Declare manifest as a provider plugin in `openclaw.plugin.json` and `package.json` so ClawHub categorizes it correctly
- Remove invalid `kind: "observability"` field (not a valid value per OpenClaw plugin manifest schema)
- Add `providers`, `providerAuthEnvVars`, and `providerAuthChoices` fields for proper provider plugin discovery

## Context

ClawHub now has a plugin directory at clawhub.ai/plugins. The manifest plugin already registers itself as an OpenAI-compatible provider (`manifest/auto`) via `api.registerProvider()`, but the metadata files didn't declare it as a provider plugin. This update aligns the metadata with the actual plugin behavior so ClawHub lists it in the correct category.

## Test plan

- [x] Plugin unit tests pass (328/328)
- [x] TypeScript compiles cleanly
- [ ] `openclaw.plugin.json` included in build output
- [ ] Plugin installs and registers correctly in OpenClaw

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the Manifest plugin as a provider in `openclaw.plugin.json` and `package.json` so ClawHub lists it under Providers. Adds provider auth metadata (`providers`, `providerAuthEnvVars` with `MANIFEST_API_KEY`, and `providerAuthChoices` with `--manifest-key`) and removes the invalid `kind: "observability"` field to match the manifest schema.

<sup>Written for commit 1494199a0af2afd2f2b5df66d3172ab0782b71bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

