### PR TITLE
fix(frontend): resolve 404 pages after creating a new agent

### DIFF
--- a/.changeset/fix-404-agent-creation.md
+++ b/.changeset/fix-404-agent-creation.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix 404 pages after creating a new agent in cloud mode

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -3,8 +3,9 @@ jest.mock('../../common/constants/local-mode.constants', () => ({
 }));
 
 import { Test, TestingModule } from '@nestjs/testing';
-import { CacheModule } from '@nestjs/cache-manager';
+import { CACHE_MANAGER, CacheModule } from '@nestjs/cache-manager';
 import { ConfigService } from '@nestjs/config';
+import type { Cache } from 'cache-manager';
 import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
 import { AgentsController } from './agents.controller';
@@ -18,6 +19,7 @@ const mockReadLocalApiKey = readLocalApiKey as jest.MockedFunction<typeof readLo
 
 describe('AgentsController', () => {
   let controller: AgentsController;
+  let cacheManager: Cache;
   let mockGetAgentList: jest.Mock;
   let mockGetKeyForAgent: jest.Mock;
   let mockRotateKey: jest.Mock;
@@ -77,6 +79,8 @@ describe('AgentsController', () => {
     }).compile();
 
     controller = module.get<AgentsController>(AgentsController);
+    cacheManager = module.get<Cache>(CACHE_MANAGER);
+    jest.spyOn(cacheManager, 'del').mockResolvedValue(true);
   });
 
   it('returns agent list wrapped in agents property', async () => {
@@ -152,6 +156,7 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ renamed: true, name: 'bot-renamed', display_name: 'Bot Renamed' });
     expect(mockRenameAgent).toHaveBeenCalledWith('u1', 'bot-1', 'bot-renamed', 'Bot Renamed');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
   });
 
   it('rejects rename with empty slug', async () => {
@@ -167,6 +172,7 @@ describe('AgentsController', () => {
 
     expect(result).toEqual({ deleted: true });
     expect(mockDeleteAgent).toHaveBeenCalledWith('u1', 'bot-1');
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
   });
 
   it('throws ForbiddenException when deleting in local mode', async () => {
@@ -178,6 +184,40 @@ describe('AgentsController', () => {
       ForbiddenException,
     );
     expect(mockDeleteAgent).not.toHaveBeenCalled();
+  });
+
+  it('invalidates agent list cache after successful createAgent', async () => {
+    const mockOnboard = jest.fn().mockResolvedValue({
+      tenantId: 't1',
+      agentId: 'a1',
+      apiKey: 'mnfst_key',
+    });
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [CacheModule.register()],
+      controllers: [AgentsController],
+      providers: [
+        { provide: TimeseriesQueriesService, useValue: { getAgentList: jest.fn() } },
+        {
+          provide: AggregationService,
+          useValue: { deleteAgent: jest.fn(), renameAgent: jest.fn() },
+        },
+        {
+          provide: ApiKeyGeneratorService,
+          useValue: { onboardAgent: mockOnboard, getKeyForAgent: jest.fn(), rotateKey: jest.fn() },
+        },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: TenantCacheService, useValue: { resolve: jest.fn().mockResolvedValue(null) } },
+      ],
+    }).compile();
+
+    const ctrl = module.get<AgentsController>(AgentsController);
+    const cm = module.get<Cache>(CACHE_MANAGER);
+    const delSpy = jest.spyOn(cm, 'del').mockResolvedValue(true);
+    const user = { id: 'user-123', email: 'test@example.com' };
+    const result = await ctrl.createAgent(user as never, { name: 'My Agent' } as never);
+
+    expect(result.agent.name).toBe('my-agent');
+    expect(delSpy).toHaveBeenCalledWith('user-123:/api/v1/agents');
   });
 
   it('rejects createAgent with empty slug', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -6,13 +6,15 @@ import {
   Delete,
   ForbiddenException,
   Get,
+  Inject,
   Param,
   Patch,
   Post,
   UseInterceptors,
 } from '@nestjs/common';
 import { QueryFailedError } from 'typeorm';
-import { CacheTTL } from '@nestjs/cache-manager';
+import { CACHE_MANAGER, CacheTTL } from '@nestjs/cache-manager';
+import type { Cache } from 'cache-manager';
 import { ConfigService } from '@nestjs/config';
 import { TimeseriesQueriesService } from '../services/timeseries-queries.service';
 import { AggregationService } from '../services/aggregation.service';
@@ -35,7 +37,12 @@ export class AgentsController {
     private readonly apiKeyGenerator: ApiKeyGeneratorService,
     private readonly config: ConfigService,
     private readonly tenantCache: TenantCacheService,
+    @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
+
+  private agentListCacheKey(userId: string): string {
+    return `${userId}:/api/v1/agents`;
+  }
 
   @Get('agents')
   @UseInterceptors(UserCacheInterceptor)
@@ -67,6 +74,7 @@ export class AgentsController {
       }
       throw error;
     }
+    await this.cacheManager.del(this.agentListCacheKey(user.id));
     return {
       agent: { id: result.agentId, name: slug, display_name: displayName },
       apiKey: result.apiKey,
@@ -104,6 +112,7 @@ export class AgentsController {
     }
     const displayName = body.name.trim();
     await this.aggregation.renameAgent(user.id, agentName, slug, displayName);
+    await this.cacheManager.del(this.agentListCacheKey(user.id));
     return { renamed: true, name: slug, display_name: displayName };
   }
 
@@ -113,6 +122,7 @@ export class AgentsController {
       throw new ForbiddenException('Cannot delete agents in local mode');
     }
     await this.aggregation.deleteAgent(user.id, agentName);
+    await this.cacheManager.del(this.agentListCacheKey(user.id));
     return { deleted: true };
   }
 }

--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -1,10 +1,11 @@
-import { useParams, useLocation } from '@solidjs/router';
+import { useParams } from '@solidjs/router';
 import { createResource, createMemo, Show, onCleanup, type ParentComponent } from 'solid-js';
 import ErrorState from './ErrorState.jsx';
 import NotFound from '../pages/NotFound.jsx';
 import { getAgents } from '../services/api.js';
 import { isLocalMode, checkLocalMode } from '../services/local-mode.js';
 import { setAgentDisplayName } from '../services/agent-display-name.js';
+import { isRecentlyCreated, clearRecentAgent } from '../services/recent-agents.js';
 
 interface Agent {
   agent_name: string;
@@ -17,7 +18,6 @@ interface AgentsData {
 
 const AgentGuard: ParentComponent = (props) => {
   const params = useParams<{ agentName: string }>();
-  const location = useLocation<{ newAgent?: boolean }>();
 
   // Wait for the mode check to resolve before deciding what to do.
   // checkLocalMode() is already called by AuthGuard, so this just awaits
@@ -36,11 +36,13 @@ const AgentGuard: ParentComponent = (props) => {
       setAgentDisplayName(null);
       return true;
     }
-    if (location.state?.newAgent) return true;
+    const decoded = decodeURIComponent(params.agentName);
+    if (isRecentlyCreated(decoded)) return true;
     const list = data()?.agents;
     if (!list) return true; // still loading or no data yet — don't block
-    const agent = list.find((a) => a.agent_name === decodeURIComponent(params.agentName));
+    const agent = list.find((a) => a.agent_name === decoded);
     if (agent) {
+      clearRecentAgent(agent.agent_name);
       setAgentDisplayName(agent.display_name ?? agent.agent_name);
     }
     return !!agent;

--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -37,7 +37,7 @@ const AgentGuard: ParentComponent = (props) => {
       return true;
     }
     const decoded = decodeURIComponent(params.agentName);
-    if (isRecentlyCreated(decoded)) return true;
+    const recent = isRecentlyCreated(decoded);
     const list = data()?.agents;
     if (!list) return true; // still loading or no data yet — don't block
     const agent = list.find((a) => a.agent_name === decoded);
@@ -45,7 +45,7 @@ const AgentGuard: ParentComponent = (props) => {
       clearRecentAgent(agent.agent_name);
       setAgentDisplayName(agent.display_name ?? agent.agent_name);
     }
-    return !!agent;
+    return recent || !!agent;
   });
 
   onCleanup(() => setAgentDisplayName(null));

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -1,5 +1,6 @@
 import { Meta, Title } from '@solidjs/meta';
 import { A, useLocation, useParams } from '@solidjs/router';
+import { isRecentlyCreated } from '../services/recent-agents.js';
 import { createEffect, createResource, createSignal, For, Show, type Component } from 'solid-js';
 import CostChart from '../components/CostChart.jsx';
 import ErrorState from '../components/ErrorState.jsx';
@@ -74,7 +75,7 @@ type ActiveView = 'cost' | 'tokens' | 'messages';
 
 const Overview: Component = () => {
   const params = useParams<{ agentName: string }>();
-  const location = useLocation<{ newAgent?: boolean; newApiKey?: string }>();
+  const location = useLocation<{ newApiKey?: string }>();
   preloadModelDisplayNames();
   const RANGE_STORAGE_KEY = 'manifest_chart_range';
   const VALID_RANGES = new Set(['24h', '7d', '30d']);
@@ -91,7 +92,7 @@ const Overview: Component = () => {
   };
   const [activeView, setActiveView] = createSignal<ActiveView>('cost');
   const [setupOpen, setSetupOpen] = createSignal(
-    !!(location.state as { newAgent?: boolean } | undefined)?.newAgent,
+    isRecentlyCreated(decodeURIComponent(params.agentName)),
   );
   const [setupCompleted, setSetupCompleted] = createSignal(
     !!localStorage.getItem(`setup_completed_${params.agentName}`),

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import SetupStepVerify from '../components/SetupStepVerify.jsx';
 import { CopyButton } from '../components/SetupStepInstall.jsx';
 import { getAgentKey, deleteAgent, renameAgent, rotateAgentKey } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
+import { markAgentCreated } from '../services/recent-agents.js';
 import { isLocalMode } from '../services/local-mode.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 
@@ -49,9 +50,9 @@ const Settings: Component = () => {
     try {
       const result = await renameAgent(agentName(), newName);
       const slug = result?.name ?? newName;
+      markAgentCreated(slug);
       navigate(`/agents/${encodeURIComponent(slug)}/settings`, {
         replace: true,
-        state: { newAgent: true },
       });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -4,6 +4,7 @@ import { Title, Meta } from '@solidjs/meta';
 import ErrorState from '../components/ErrorState.jsx';
 import { getAgents, createAgent } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
+import { markAgentCreated } from '../services/recent-agents.js';
 import { formatNumber, formatCost } from '../services/formatters.js';
 import Sparkline from '../components/Sparkline.jsx';
 import { checkLocalMode } from '../services/local-mode.js';
@@ -38,8 +39,9 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
       props.onClose();
       setName('');
       const slug = result?.agent?.name ?? agentName;
+      markAgentCreated(slug);
       const url = `/agents/${encodeURIComponent(slug)}`;
-      navigate(url, { state: { newAgent: true, newApiKey: result?.apiKey } });
+      navigate(url, { state: { newApiKey: result?.apiKey } });
     } catch {
       // error toast already shown by fetchMutate
     } finally {

--- a/packages/frontend/src/services/recent-agents.ts
+++ b/packages/frontend/src/services/recent-agents.ts
@@ -1,0 +1,13 @@
+const recentlyCreated = new Set<string>();
+
+export function markAgentCreated(slug: string): void {
+  recentlyCreated.add(slug);
+}
+
+export function isRecentlyCreated(slug: string): boolean {
+  return recentlyCreated.has(slug);
+}
+
+export function clearRecentAgent(slug: string): void {
+  recentlyCreated.delete(slug);
+}

--- a/packages/frontend/tests/components/AgentGuard.test.tsx
+++ b/packages/frontend/tests/components/AgentGuard.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from "@solidjs/testing-library";
 
 vi.mock("@solidjs/router", () => ({
   useParams: () => ({ agentName: "test-agent" }),
-  useLocation: () => ({ pathname: "/agents/test-agent", state: null }),
   A: (props: any) => <a href={props.href}>{props.children}</a>,
 }));
 
@@ -22,6 +21,13 @@ vi.mock("../../src/services/local-mode.js", () => ({
 const mockSetAgentDisplayName = vi.fn();
 vi.mock("../../src/services/agent-display-name.js", () => ({
   setAgentDisplayName: (...args: unknown[]) => mockSetAgentDisplayName(...args),
+}));
+
+const mockIsRecentlyCreated = vi.fn(() => false);
+const mockClearRecentAgent = vi.fn();
+vi.mock("../../src/services/recent-agents.js", () => ({
+  isRecentlyCreated: (...args: unknown[]) => mockIsRecentlyCreated(...args),
+  clearRecentAgent: (...args: unknown[]) => mockClearRecentAgent(...args),
 }));
 
 vi.mock("../../src/components/ErrorState.jsx", () => ({
@@ -45,6 +51,8 @@ describe("AgentGuard", () => {
     mockIsLocalMode.mockReturnValue(false);
     mockCheckLocalMode.mockResolvedValue(false);
     mockSetAgentDisplayName.mockClear();
+    mockIsRecentlyCreated.mockReturnValue(false);
+    mockClearRecentAgent.mockClear();
   });
 
   it("renders children when agent exists", async () => {
@@ -113,6 +121,32 @@ describe("AgentGuard", () => {
     ));
     await vi.waitFor(() => {
       expect(mockGetAgents).toHaveBeenCalled();
+    });
+  });
+
+  it("renders children when isRecentlyCreated returns true even if agent not in list", async () => {
+    mockIsRecentlyCreated.mockReturnValue(true);
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "other-agent" }] });
+    render(() => (
+      <AgentGuard>
+        <div data-testid="child">Child content</div>
+      </AgentGuard>
+    ));
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("child")).toBeDefined();
+    });
+    expect(mockIsRecentlyCreated).toHaveBeenCalledWith("test-agent");
+  });
+
+  it("calls clearRecentAgent when agent is found in the fetched list", async () => {
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "test-agent", display_name: "Test Agent" }] });
+    render(() => (
+      <AgentGuard>
+        <div data-testid="child">Child</div>
+      </AgentGuard>
+    ));
+    await vi.waitFor(() => {
+      expect(mockClearRecentAgent).toHaveBeenCalledWith("test-agent");
     });
   });
 });

--- a/packages/frontend/tests/pages/Overview-limits.test.tsx
+++ b/packages/frontend/tests/pages/Overview-limits.test.tsx
@@ -59,6 +59,10 @@ vi.mock("../../src/components/Select.jsx", () => ({
   ),
 }));
 
+vi.mock("../../src/services/recent-agents.js", () => ({
+  isRecentlyCreated: () => false,
+}));
+
 import Overview from "../../src/pages/Overview";
 
 const overviewData = {

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -77,6 +77,11 @@ vi.mock("../../src/components/Select.jsx", () => ({
   ),
 }));
 
+const mockIsRecentlyCreated = vi.fn(() => false);
+vi.mock("../../src/services/recent-agents.js", () => ({
+  isRecentlyCreated: (...args: unknown[]) => mockIsRecentlyCreated(...args),
+}));
+
 import Overview from "../../src/pages/Overview";
 
 const overviewData = {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -49,6 +49,11 @@ vi.mock("../../src/services/local-mode.js", () => ({
   isLocalMode: () => mockIsLocalMode,
 }));
 
+const mockMarkAgentCreated = vi.fn();
+vi.mock("../../src/services/recent-agents.js", () => ({
+  markAgentCreated: (...args: unknown[]) => mockMarkAgentCreated(...args),
+}));
+
 import Settings from "../../src/pages/Settings";
 
 describe("Settings", () => {
@@ -157,6 +162,9 @@ describe("Settings", () => {
     fireEvent.click(saveBtn);
     await vi.waitFor(() => {
       expect(mockRenameAgent).toHaveBeenCalledWith("test-agent", "new-name");
+    });
+    await vi.waitFor(() => {
+      expect(mockMarkAgentCreated).toHaveBeenCalledWith("new-name");
     });
     await vi.waitFor(() => {
       expect(container.textContent).toContain("Saved");

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -41,6 +41,11 @@ vi.mock("../../src/services/sse.js", () => ({
   pingCount: () => 0,
 }));
 
+const mockMarkAgentCreated = vi.fn();
+vi.mock("../../src/services/recent-agents.js", () => ({
+  markAgentCreated: (...args: unknown[]) => mockMarkAgentCreated(...args),
+}));
+
 import Workspace from "../../src/pages/Workspace";
 
 describe("Workspace", () => {
@@ -127,7 +132,7 @@ describe("Workspace", () => {
   });
 
   it("creates agent when form submitted", async () => {
-    mockCreateAgent.mockResolvedValue({ apiKey: "test-key" });
+    mockCreateAgent.mockResolvedValue({ agent: { name: "new-agent" }, apiKey: "test-key" });
     const { container } = render(() => <Workspace />);
     const btn = screen.getAllByText("Connect Agent")[0];
     fireEvent.click(btn);
@@ -137,6 +142,9 @@ describe("Workspace", () => {
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockCreateAgent).toHaveBeenCalledWith("new-agent");
+    });
+    await vi.waitFor(() => {
+      expect(mockMarkAgentCreated).toHaveBeenCalledWith("new-agent");
     });
   });
 

--- a/packages/frontend/tests/services/recent-agents.test.ts
+++ b/packages/frontend/tests/services/recent-agents.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { markAgentCreated, isRecentlyCreated, clearRecentAgent } from '../../src/services/recent-agents';
+
+describe('recent-agents', () => {
+  beforeEach(() => {
+    clearRecentAgent('test-slug');
+    clearRecentAgent('another-slug');
+  });
+
+  it('returns false for unknown slug', () => {
+    expect(isRecentlyCreated('unknown')).toBe(false);
+  });
+
+  it('returns true after marking a slug as created', () => {
+    markAgentCreated('test-slug');
+    expect(isRecentlyCreated('test-slug')).toBe(true);
+  });
+
+  it('returns false after clearing a slug', () => {
+    markAgentCreated('test-slug');
+    clearRecentAgent('test-slug');
+    expect(isRecentlyCreated('test-slug')).toBe(false);
+  });
+
+  it('tracks multiple slugs independently', () => {
+    markAgentCreated('test-slug');
+    markAgentCreated('another-slug');
+    expect(isRecentlyCreated('test-slug')).toBe(true);
+    expect(isRecentlyCreated('another-slug')).toBe(true);
+    clearRecentAgent('test-slug');
+    expect(isRecentlyCreated('test-slug')).toBe(false);
+    expect(isRecentlyCreated('another-slug')).toBe(true);
+  });
+
+  it('clearRecentAgent is safe to call on non-existent slug', () => {
+    expect(() => clearRecentAgent('never-added')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Invalidate the backend agent list cache (`UserCacheInterceptor`, 60s TTL) when creating, renaming, or deleting an agent so the next `GET /api/v1/agents` returns fresh data
- Replace the ephemeral `location.state.newAgent` flag with a persistent module-level `Set` (`recent-agents.ts`) that survives sub-route navigations within the same session
- The combination of both fixes eliminates the race condition where AgentGuard would show 404 because the stale cached list didn't include the newly created agent

## Test plan

- [x] Backend unit tests pass (2805 tests, including new cache invalidation tests)
- [x] Backend E2E tests pass (121 tests)
- [x] Frontend tests pass (1639 tests, including new recent-agents tests and updated AgentGuard/Workspace/Settings tests)
- [x] TypeScript compiles with no errors in both backend and frontend
- [ ] Manual: create a new agent, click sidebar links (Routing, Messages, etc.) — no more 404

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404s after creating or renaming an agent by invalidating the backend agent list cache and persisting a “recently created” flag across routes. This removes the race where the guard sees stale data.

- Bug Fixes
  - Backend: invalidate `GET /api/v1/agents` cache on create/rename/delete via `CACHE_MANAGER` from `@nestjs/cache-manager` (key: `${userId}:/api/v1/agents`); added unit tests.
  - Frontend: replace `location.state.newAgent` with a session-scoped `recent-agents` service; `AgentGuard` allows access if `isRecentlyCreated()` and clears with `clearRecentAgent()` once the agent appears (safe to call even if not set); `Workspace`/`Settings` call `markAgentCreated()`; `Overview` uses the flag to open setup; tests updated.

<sup>Written for commit 44ba5788924d9cc911f3cee29d070fe9de283ea7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

