### PR TITLE
feat: support multiple agents in local mode

### DIFF
--- a/.changeset/multi-agent-local.md
+++ b/.changeset/multi-agent-local.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Support multiple agents in local mode, matching cloud mode behavior

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('../../common/constants/local-mode.constants', () => ({
   readLocalApiKey: jest.fn().mockReturnValue(null),
+  LOCAL_AGENT_NAME: 'local-agent',
 }));
 
 import { Test, TestingModule } from '@nestjs/testing';
@@ -120,7 +121,18 @@ describe('AgentsController', () => {
     });
   });
 
-  it('returns full apiKey in local mode', async () => {
+  it('returns full apiKey in local mode for default agent', async () => {
+    mockReadLocalApiKey.mockReturnValue('mnfst_full_local_key');
+    mockConfigGet.mockImplementation((key: string, fallback?: string) =>
+      key === 'MANIFEST_MODE' ? 'local' : (fallback ?? ''),
+    );
+    const user = { id: 'u1' };
+    const result = await controller.getAgentKey(user as never, 'local-agent');
+
+    expect(result).toMatchObject({ keyPrefix: 'mnfst_test1234', apiKey: 'mnfst_full_local_key' });
+  });
+
+  it('does not return full apiKey in local mode for non-default agent', async () => {
     mockReadLocalApiKey.mockReturnValue('mnfst_full_local_key');
     mockConfigGet.mockImplementation((key: string, fallback?: string) =>
       key === 'MANIFEST_MODE' ? 'local' : (fallback ?? ''),
@@ -128,7 +140,8 @@ describe('AgentsController', () => {
     const user = { id: 'u1' };
     const result = await controller.getAgentKey(user as never, 'bot-1');
 
-    expect(result).toMatchObject({ keyPrefix: 'mnfst_test1234', apiKey: 'mnfst_full_local_key' });
+    expect(result).toMatchObject({ keyPrefix: 'mnfst_test1234' });
+    expect(result).not.toHaveProperty('apiKey');
   });
 
   it('returns empty agents array when no agents exist', async () => {
@@ -175,15 +188,25 @@ describe('AgentsController', () => {
     expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
   });
 
-  it('throws ForbiddenException when deleting in local mode', async () => {
+  it('throws ForbiddenException when deleting default agent in local mode', async () => {
     mockConfigGet.mockImplementation((key: string, fallback?: string) =>
       key === 'MANIFEST_MODE' ? 'local' : (fallback ?? ''),
     );
     const user = { id: 'u1' };
-    await expect(controller.deleteAgent(user as never, 'bot-1')).rejects.toThrow(
+    await expect(controller.deleteAgent(user as never, 'local-agent')).rejects.toThrow(
       ForbiddenException,
     );
     expect(mockDeleteAgent).not.toHaveBeenCalled();
+  });
+
+  it('allows deleting non-default agents in local mode', async () => {
+    mockConfigGet.mockImplementation((key: string, fallback?: string) =>
+      key === 'MANIFEST_MODE' ? 'local' : (fallback ?? ''),
+    );
+    const user = { id: 'u1' };
+    const result = await controller.deleteAgent(user as never, 'bot-1');
+    expect(result).toEqual({ deleted: true });
+    expect(mockDeleteAgent).toHaveBeenCalledWith('u1', 'bot-1');
   });
 
   it('invalidates agent list cache after successful createAgent', async () => {

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -25,7 +25,7 @@ import { CreateAgentDto } from '../../common/dto/create-agent.dto';
 import { RenameAgentDto } from '../../common/dto/rename-agent.dto';
 import { UserCacheInterceptor } from '../../common/interceptors/user-cache.interceptor';
 import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants';
-import { readLocalApiKey } from '../../common/constants/local-mode.constants';
+import { readLocalApiKey, LOCAL_AGENT_NAME } from '../../common/constants/local-mode.constants';
 import { slugify } from '../../common/utils/slugify';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 
@@ -86,7 +86,7 @@ export class AgentsController {
     const keyData = await this.apiKeyGenerator.getKeyForAgent(user.id, agentName);
     const customEndpoint = this.config.get<string>('app.pluginOtlpEndpoint', '');
     const isLocal = this.config.get<string>('MANIFEST_MODE') === 'local';
-    const fullKey = isLocal ? readLocalApiKey() : undefined;
+    const fullKey = isLocal && agentName === LOCAL_AGENT_NAME ? readLocalApiKey() : undefined;
     return {
       ...keyData,
       ...(fullKey ? { apiKey: fullKey } : {}),
@@ -118,8 +118,8 @@ export class AgentsController {
 
   @Delete('agents/:agentName')
   async deleteAgent(@CurrentUser() user: AuthUser, @Param('agentName') agentName: string) {
-    if (this.config.get<string>('MANIFEST_MODE') === 'local') {
-      throw new ForbiddenException('Cannot delete agents in local mode');
+    if (this.config.get<string>('MANIFEST_MODE') === 'local' && agentName === LOCAL_AGENT_NAME) {
+      throw new ForbiddenException('Cannot delete the default local agent');
     }
     await this.aggregation.deleteAgent(user.id, agentName);
     await this.cacheManager.del(this.agentListCacheKey(user.id));

--- a/packages/frontend/src/components/AgentGuard.tsx
+++ b/packages/frontend/src/components/AgentGuard.tsx
@@ -3,7 +3,7 @@ import { createResource, createMemo, Show, onCleanup, type ParentComponent } fro
 import ErrorState from './ErrorState.jsx';
 import NotFound from '../pages/NotFound.jsx';
 import { getAgents } from '../services/api.js';
-import { isLocalMode, checkLocalMode } from '../services/local-mode.js';
+import { checkLocalMode } from '../services/local-mode.js';
 import { setAgentDisplayName } from '../services/agent-display-name.js';
 import { isRecentlyCreated, clearRecentAgent } from '../services/recent-agents.js';
 
@@ -25,17 +25,11 @@ const AgentGuard: ParentComponent = (props) => {
   const [mode] = createResource(() => checkLocalMode());
 
   const [data, { refetch }] = createResource(
-    // Only fetch agents in cloud mode (mode resolved and not local)
-    () => (mode() === false ? true : false),
+    () => (mode() !== undefined ? true : false),
     () => getAgents() as Promise<AgentsData>,
   );
 
   const agentExists = createMemo(() => {
-    // Local mode: agent is guaranteed to exist (bootstrapped by LocalBootstrapService)
-    if (isLocalMode()) {
-      setAgentDisplayName(null);
-      return true;
-    }
     const decoded = decodeURIComponent(params.agentName);
     const recent = isRecentlyCreated(decoded);
     const list = data()?.agents;
@@ -52,21 +46,14 @@ const AgentGuard: ParentComponent = (props) => {
 
   return (
     <Show when={mode() !== undefined} fallback={null}>
-      <Show
-        when={isLocalMode()}
-        fallback={
-          <Show when={!data.loading} fallback={null}>
-            <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
-              <Show when={data()?.agents}>
-                <Show when={agentExists()} fallback={<NotFound />}>
-                  {props.children}
-                </Show>
-              </Show>
+      <Show when={!data.loading} fallback={null}>
+        <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
+          <Show when={data()?.agents}>
+            <Show when={agentExists()} fallback={<NotFound />}>
+              {props.children}
             </Show>
           </Show>
-        }
-      >
-        {props.children}
+        </Show>
       </Show>
     </Show>
   );

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -98,7 +98,7 @@ const Header: Component = () => {
   return (
     <header class="header">
       <div class="header__left">
-        <A href={isLocalMode() ? '/agents/local-agent' : '/'} class="header__logo">
+        <A href="/" class="header__logo">
           <img src="/logo.svg" alt="Manifest" class="header__logo-img header__logo-img--light" />
           <img
             src="/logo-white.svg"
@@ -113,12 +113,10 @@ const Header: Component = () => {
           <span class="header__mode-badge header__mode-badge--dev">Dev</span>
         </Show>
         <Show when={getAgentName()}>
-          <Show when={!isLocalMode()}>
-            <span class="header__separator">/</span>
-            <A href="/" class="header__breadcrumb-link">
-              Workspace
-            </A>
-          </Show>
+          <span class="header__separator">/</span>
+          <A href="/" class="header__breadcrumb-link">
+            Workspace
+          </A>
           <span class="header__separator">/</span>
           <span class="header__breadcrumb-current">{agentDisplayName() ?? getAgentName()}</span>
         </Show>

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { A, useLocation } from '@solidjs/router';
 import { Show, type Component } from 'solid-js';
 import { useAgentName, agentPath } from '../services/routing.js';
-import { isLocalMode } from '../services/local-mode.js';
 
 const Sidebar: Component = () => {
   const location = useLocation();
@@ -17,7 +16,7 @@ const Sidebar: Component = () => {
 
   return (
     <nav class="sidebar" aria-label="Agent navigation">
-      <Show when={!getAgentName() && !isLocalMode()}>
+      <Show when={!getAgentName()}>
         <A
           href="/"
           class="sidebar__link"

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -41,8 +41,7 @@ const MessageLog: Component = () => {
   const [costMax, setCostMax] = createSignal('');
   const [setupOpen, setSetupOpen] = createSignal(false);
   const [setupCompleted] = createSignal(
-    !!localStorage.getItem(`setup_completed_${params.agentName}`) ||
-      (isLocalMode() === true && params.agentName === 'local-agent'),
+    !!localStorage.getItem(`setup_completed_${params.agentName}`) || isLocalMode() === true,
   );
 
   const [customProviders] = createResource(
@@ -191,13 +190,7 @@ const MessageLog: Component = () => {
               />
             </div>
           </Show>
-          <Show
-            when={
-              isAgentEmpty() &&
-              !(isLocalMode() && params.agentName === 'local-agent') &&
-              !setupCompleted()
-            }
-          >
+          <Show when={isAgentEmpty() && !isLocalMode() && !setupCompleted()}>
             <button class="btn btn--primary btn--sm" onClick={() => setSetupOpen(true)}>
               Set up agent
             </button>
@@ -275,7 +268,7 @@ const MessageLog: Component = () => {
         <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
           <Show when={isAgentEmpty()}>
             <Show
-              when={(isLocalMode() && params.agentName === 'local-agent') || setupCompleted()}
+              when={isLocalMode() || setupCompleted()}
               fallback={
                 <div class="empty-state">
                   <div class="empty-state__title">No messages recorded</div>

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -120,7 +120,7 @@ const Overview: Component = () => {
   };
 
   createEffect(() => {
-    if (isLocalMode() === true && params.agentName === 'local-agent') {
+    if (isLocalMode() === true) {
       localStorage.setItem(`setup_completed_${params.agentName}`, '1');
       setSetupCompleted(true);
       return;
@@ -205,13 +205,7 @@ const Overview: Component = () => {
               ]}
             />
           </Show>
-          <Show
-            when={
-              isNewAgent() &&
-              !(isLocalMode() && params.agentName === 'local-agent') &&
-              !setupCompleted()
-            }
-          >
+          <Show when={isNewAgent() && !isLocalMode() && !setupCompleted()}>
             <button class="btn btn--primary btn--sm" onClick={() => setSetupOpen(true)}>
               Set up agent
             </button>
@@ -339,7 +333,7 @@ const Overview: Component = () => {
         <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
           <Show when={isNewAgent()}>
             <Show
-              when={(isLocalMode() && params.agentName === 'local-agent') || setupCompleted()}
+              when={isLocalMode() || setupCompleted()}
               fallback={
                 <div class="empty-state">
                   <div class="empty-state__title">No activity yet</div>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -77,7 +77,7 @@ const Settings: Component = () => {
     }
   };
 
-  const TABS = () => (isLocalMode() ? [] : (['General', 'Agent setup'] as const));
+  const TABS = () => ['General', 'Agent setup'] as const;
   type Tab = 'General' | 'Agent setup';
   const [tab, setTab] = createSignal<Tab>('General');
 
@@ -156,7 +156,7 @@ const Settings: Component = () => {
           </div>
         </div>
 
-        <Show when={!isLocalMode()}>
+        <Show when={!isLocalMode() || agentName() !== 'local-agent'}>
           <h3 class="settings-section__title settings-section__title--danger">Danger zone</h3>
 
           <div class="settings-card settings-card--danger">
@@ -185,7 +185,7 @@ const Settings: Component = () => {
       </Show>
 
       {/* -- Tab: Agent setup ------------------------- */}
-      <Show when={tab() === 'Agent setup' && !isLocalMode()}>
+      <Show when={tab() === 'Agent setup'}>
         <h3 class="settings-section__title">API Key</h3>
 
         <div class="settings-card">

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -1,4 +1,4 @@
-import { createResource, createSignal, onMount, Show, For, type Component } from 'solid-js';
+import { createResource, createSignal, Show, For, type Component } from 'solid-js';
 import { A, useNavigate } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
 import ErrorState from '../components/ErrorState.jsx';
@@ -7,7 +7,6 @@ import { toast } from '../services/toast-store.js';
 import { markAgentCreated } from '../services/recent-agents.js';
 import { formatNumber, formatCost } from '../services/formatters.js';
 import Sparkline from '../components/Sparkline.jsx';
-import { checkLocalMode } from '../services/local-mode.js';
 import { pingCount } from '../services/sse.js';
 
 interface Agent {
@@ -108,19 +107,11 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
 };
 
 const Workspace: Component = () => {
-  const navigate = useNavigate();
   const [data, { refetch }] = createResource(
     () => ({ _ping: pingCount() }),
     () => getAgents() as Promise<AgentsData>,
   );
   const [modalOpen, setModalOpen] = createSignal(false);
-
-  onMount(async () => {
-    const local = await checkLocalMode();
-    if (local) {
-      navigate('/agents/local-agent', { replace: true });
-    }
-  });
 
   return (
     <div class="container--md">

--- a/packages/frontend/tests/components/AgentGuard.test.tsx
+++ b/packages/frontend/tests/components/AgentGuard.test.tsx
@@ -98,9 +98,10 @@ describe("AgentGuard", () => {
     });
   });
 
-  it("renders children immediately in local mode without calling getAgents", async () => {
+  it("calls getAgents and renders children when agent exists in local mode", async () => {
     mockIsLocalMode.mockReturnValue(true);
     mockCheckLocalMode.mockResolvedValue(true);
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "test-agent" }] });
     render(() => (
       <AgentGuard>
         <div data-testid="child">Child content</div>
@@ -109,7 +110,22 @@ describe("AgentGuard", () => {
     await vi.waitFor(() => {
       expect(screen.getByTestId("child")).toBeDefined();
     });
-    expect(mockGetAgents).not.toHaveBeenCalled();
+    expect(mockGetAgents).toHaveBeenCalled();
+  });
+
+  it("shows NotFound when agent does not exist in local mode", async () => {
+    mockIsLocalMode.mockReturnValue(true);
+    mockCheckLocalMode.mockResolvedValue(true);
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "other-agent" }] });
+    const { container } = render(() => (
+      <AgentGuard>
+        <div data-testid="child">Child</div>
+      </AgentGuard>
+    ));
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Page not found");
+    });
+    expect(container.querySelector('[data-testid="child"]')).toBeNull();
   });
 
   it("calls getAgents (covers the fetcher path)", async () => {

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -257,11 +257,11 @@ describe("Header - GitHub star button", () => {
 });
 
 describe("Header - local mode", () => {
-  it("logo links to /agents/local-agent in local mode", () => {
+  it("logo links to / in local mode", () => {
     mockIsLocalMode = true;
     const { container } = render(() => <Header />);
     const logoLink = container.querySelector(".header__logo") as HTMLAnchorElement;
-    expect(logoLink.getAttribute("href")).toBe("/agents/local-agent");
+    expect(logoLink.getAttribute("href")).toBe("/");
   });
 
   it("logo links to / in cloud mode", () => {
@@ -304,11 +304,11 @@ describe("Header - local mode", () => {
     expect(screen.getByText("Dev")).toBeDefined();
   });
 
-  it("hides Workspace breadcrumb in local mode", () => {
+  it("shows Workspace breadcrumb in local mode", () => {
     mockIsLocalMode = true;
     mockAgentName = "my-agent";
     render(() => <Header />);
-    expect(screen.queryByText("Workspace")).toBeNull();
+    expect(screen.getByText("Workspace")).toBeDefined();
   });
 
   it("shows Workspace breadcrumb in cloud mode", () => {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -3,8 +3,6 @@ import { render, screen } from "@solidjs/testing-library";
 
 let mockAgentName: string | null = "test-agent";
 let mockPathname = "/agents/test-agent";
-let mockIsLocalMode: boolean | null = true;
-
 vi.mock("@solidjs/router", () => ({
   A: (props: any) => {
     // Access classList to trigger coverage of classList expressions
@@ -26,7 +24,7 @@ vi.mock("../../src/services/routing.js", () => ({
 }));
 
 vi.mock("../../src/services/local-mode.js", () => ({
-  isLocalMode: () => mockIsLocalMode,
+  isLocalMode: () => false,
 }));
 
 import Sidebar from "../../src/components/Sidebar";
@@ -63,11 +61,8 @@ describe("Sidebar with agent", () => {
   });
 
   it("renders Settings link in cloud mode", () => {
-    const prev = mockIsLocalMode;
-    mockIsLocalMode = false;
     render(() => <Sidebar />);
     expect(screen.getByText("Settings")).toBeDefined();
-    mockIsLocalMode = prev;
   });
 
   it("renders Limits link", () => {
@@ -101,8 +96,6 @@ describe("Sidebar with agent", () => {
   });
 
   it("has correct link hrefs for agent routes", () => {
-    const prev = mockIsLocalMode;
-    mockIsLocalMode = false;
     const { container } = render(() => <Sidebar />);
     expect(container.querySelector('a[href="/agents/test-agent"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/messages"]')).not.toBeNull();
@@ -110,7 +103,6 @@ describe("Sidebar with agent", () => {
     expect(container.querySelector('a[href="/agents/test-agent/limits"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/model-prices"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/help"]')).not.toBeNull();
-    mockIsLocalMode = prev;
   });
 
   it("marks current page link as active", () => {
@@ -144,7 +136,6 @@ describe("Sidebar without agent", () => {
   beforeAll(() => {
     mockAgentName = null;
     mockPathname = "/";
-    mockIsLocalMode = false;
   });
 
   it("renders Agents link when no agent selected", () => {
@@ -167,7 +158,6 @@ describe("Sidebar without agent", () => {
 describe("Sidebar active states for sub-paths", () => {
   beforeAll(() => {
     mockAgentName = "test-agent";
-    mockIsLocalMode = false;
   });
 
   it("marks routing link as active on routing path", () => {
@@ -217,11 +207,10 @@ describe("Sidebar in local mode", () => {
   beforeAll(() => {
     mockAgentName = null;
     mockPathname = "/";
-    mockIsLocalMode = true;
   });
 
-  it("hides Agents link in local mode", () => {
-    const { container } = render(() => <Sidebar />);
-    expect(container.textContent).not.toContain("Agents");
+  it("shows Agents link in local mode when no agent selected", () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText("Agents")).toBeDefined();
   });
 });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -511,7 +511,7 @@ describe("MessageLog", () => {
   });
 
   describe("local mode", () => {
-    it("should treat setup as completed for local-agent in local mode", async () => {
+    it("should treat setup as completed for any agent in local mode", async () => {
       mockAgentName = "local-agent";
       mockIsLocalMode = true;
       mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
@@ -521,8 +521,8 @@ describe("MessageLog", () => {
       });
     });
 
-    it("should not show Set up agent button for local-agent in local mode", async () => {
-      mockAgentName = "local-agent";
+    it("should not show Set up agent button for any agent in local mode", async () => {
+      mockAgentName = "other-agent";
       mockIsLocalMode = true;
       mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
       const { container } = render(() => <MessageLog />);
@@ -532,13 +532,13 @@ describe("MessageLog", () => {
       });
     });
 
-    it("should show Set up agent button for non-local-agent even in local mode", async () => {
+    it("should show waiting banner for non-default agent in local mode", async () => {
       mockAgentName = "other-agent";
       mockIsLocalMode = true;
       mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
       const { container } = render(() => <MessageLog />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("No messages recorded");
+        expect(container.textContent).toContain("Messages will show up");
       });
     });
 

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -464,8 +464,18 @@ describe("Overview", () => {
       });
     });
 
-    it("should not open setup modal for local-agent in local mode", async () => {
-      mockAgentName = "local-agent";
+    it("should auto-complete setup for any agent in local mode", async () => {
+      mockAgentName = "other-agent";
+      mockIsLocalMode = true;
+      mockGetOverview.mockResolvedValue({ ...overviewData, has_data: false, summary: null });
+      render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(localStorage.getItem("setup_completed_other-agent")).toBe("1");
+      });
+    });
+
+    it("should not open setup modal for any agent in local mode", async () => {
+      mockAgentName = "other-agent";
       mockIsLocalMode = true;
       mockGetOverview.mockResolvedValue({ ...overviewData, has_data: false, summary: null });
       const { container } = render(() => <Overview />);
@@ -475,24 +485,13 @@ describe("Overview", () => {
       });
     });
 
-    it("should show waiting banner instead of empty state for local-agent in local mode", async () => {
-      mockAgentName = "local-agent";
-      mockIsLocalMode = true;
-      mockGetOverview.mockResolvedValue({ ...overviewData, has_data: false, summary: null });
-      const { container } = render(() => <Overview />);
-      await vi.waitFor(() => {
-        expect(container.textContent).toContain("dashboard will update");
-      });
-    });
-
-    it("should still open setup modal for non-local-agent even in local mode", async () => {
+    it("should show waiting banner instead of empty state for any agent in local mode", async () => {
       mockAgentName = "other-agent";
       mockIsLocalMode = true;
       mockGetOverview.mockResolvedValue({ ...overviewData, has_data: false, summary: null });
       const { container } = render(() => <Overview />);
       await vi.waitFor(() => {
-        const modal = container.querySelector('[data-testid="setup-modal"]');
-        expect(modal?.getAttribute("data-open")).toBe("true");
+        expect(container.textContent).toContain("dashboard will update");
       });
     });
 

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -361,22 +361,30 @@ describe("Settings", () => {
       expect(screen.getByLabelText("Agent name")).toBeDefined();
     });
 
-    it("hides tabs in local mode", () => {
-      const { container } = render(() => <Settings />);
-      expect(container.querySelector(".panel__tabs")).toBeNull();
-      expect(screen.queryByText("Agent setup")).toBeNull();
-    });
-
-    it("still shows General content without tab switcher", () => {
+    it("shows tabs in local mode", () => {
       render(() => <Settings />);
-      expect(screen.getByLabelText("Agent name")).toBeDefined();
-      expect(screen.getByText("Save")).toBeDefined();
+      expect(screen.getByText("General")).toBeDefined();
+      expect(screen.getByText("Agent setup")).toBeDefined();
     });
 
-    it("hides Danger zone in local mode", () => {
+    it("shows Agent setup tab content in local mode", () => {
+      const { container } = render(() => <Settings />);
+      fireEvent.click(screen.getByText("Agent setup"));
+      expect(container.textContent).toContain("OTLP ingest key");
+    });
+
+    it("hides Danger zone for default local-agent", () => {
+      mockAgentName = "local-agent";
       const { container } = render(() => <Settings />);
       expect(container.textContent).not.toContain("Danger zone");
       expect(container.textContent).not.toContain("Delete agent");
+    });
+
+    it("shows Danger zone for non-default agent in local mode", () => {
+      mockAgentName = "custom-agent";
+      render(() => <Settings />);
+      expect(screen.getByText("Danger zone")).toBeDefined();
+      expect(screen.getByText("Delete agent")).toBeDefined();
     });
   });
 });

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -32,11 +32,6 @@ vi.mock("../../src/components/Sparkline.jsx", () => ({
   default: () => <div data-testid="sparkline" />,
 }));
 
-let mockCheckLocalMode = vi.fn().mockResolvedValue(false);
-vi.mock("../../src/services/local-mode.js", () => ({
-  checkLocalMode: (...args: unknown[]) => mockCheckLocalMode(...args),
-}));
-
 vi.mock("../../src/services/sse.js", () => ({
   pingCount: () => 0,
 }));
@@ -51,7 +46,6 @@ import Workspace from "../../src/pages/Workspace";
 describe("Workspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCheckLocalMode = vi.fn().mockResolvedValue(false);
     mockGetAgents.mockResolvedValue({
       agents: [
         { agent_name: "demo-agent", display_name: "Demo Agent", message_count: 42, last_active: "2024-01-01", total_cost: 5.5, total_tokens: 15000, sparkline: [1, 2, 3] },
@@ -255,22 +249,11 @@ describe("Workspace", () => {
     expect(container.querySelector(".modal-card__input")).toBeNull();
   });
 
-  describe("local mode", () => {
-    it("redirects to /agents/local-agent in local mode", async () => {
-      mockCheckLocalMode = vi.fn().mockResolvedValue(true);
-      render(() => <Workspace />);
-      await vi.waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith("/agents/local-agent", { replace: true });
-      });
+  it("does not redirect in any mode", async () => {
+    render(() => <Workspace />);
+    await vi.waitFor(() => {
+      expect(mockGetAgents).toHaveBeenCalled();
     });
-
-    it("does not redirect in cloud mode", async () => {
-      mockCheckLocalMode = vi.fn().mockResolvedValue(false);
-      render(() => <Workspace />);
-      await vi.waitFor(() => {
-        expect(mockCheckLocalMode).toHaveBeenCalled();
-      });
-      expect(mockNavigate).not.toHaveBeenCalled();
-    });
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Remove the single-agent restriction from local mode, bringing it to feature parity with cloud mode for agent management
- The default `local-agent` is still auto-created on boot and protected from deletion; keyless OTLP requests still route there for backward compatibility
- New agents get proper `mnfst_*` API keys and full CRUD support (create, rename, delete, key rotation)

### Backend
- Relaxed delete guard to only protect `local-agent` (non-default agents can now be deleted)
- Scoped full API key exposure to `local-agent` only; other agents follow cloud behavior

### Frontend
- Removed auto-redirect from Workspace to `/agents/local-agent`
- Show "Agents" link in Sidebar in local mode
- AgentGuard now validates agent existence via API in both modes
- Generalized setup auto-completion from `local-agent`-only to all agents in local mode (Overview, MessageLog)
- Unlocked Settings tabs, Agent setup tab, and Danger zone for non-default agents
- Fixed Header logo and breadcrumb to navigate to Workspace in local mode

## Test plan

- [ ] Backend agents controller tests pass (16 tests)
- [ ] Frontend tests pass (1633 tests across 78 files)
- [ ] Start in local mode, verify Workspace shows agent grid
- [ ] Create a second agent, verify it gets a `mnfst_*` key
- [ ] Navigate between agents via Workspace
- [ ] Delete a non-default agent from Settings
- [ ] Verify `local-agent` cannot be deleted
- [ ] Verify Settings tabs and Agent setup are visible for all agents
- [ ] Verify Header breadcrumb shows "/ Workspace / agent-name" in local mode

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full multi‑agent support in local mode, matching cloud behavior for agent management, navigation, and setup. `local-agent` remains the protected default for backward‑compatible keyless OTLP.

- **New Features**
  - Local mode now supports multiple agents; `local-agent` is auto-created and protected.
  - Non-default agents support full CRUD (create, rename, delete, key rotation).
  - API keys: only `local-agent` returns the full key in local mode; others return the `mnfst_*` key prefix only.
  - Navigation: removed Workspace redirect; show “Agents” in Sidebar in all modes; header logo and breadcrumbs link to Workspace.
  - AgentGuard validates agent existence via API in both modes.
  - Setup flow: auto-completes for all agents in local mode; Settings tabs and Agent setup visible for all agents; Danger zone shown for non-default agents only.

<sup>Written for commit 9fd49cc11041a9210cc03178712d32256a3f772b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

