### PR TITLE
feat: improve onboarding wizard UX with accordion layout

### DIFF
--- a/.changeset/wizard-ux-improvements.md
+++ b/.changeset/wizard-ux-improvements.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Improve onboarding wizard UX: lead with environment variable setup (easiest method), add openclaw onboard command, replace tabbed terminal with stacked accordion, extract shared CopyButton and ApiKeyDisplay components, add local mode ready state, improve copy and accessibility

--- a/packages/frontend/src/components/ApiKeyDisplay.tsx
+++ b/packages/frontend/src/components/ApiKeyDisplay.tsx
@@ -1,0 +1,34 @@
+import { Show, type Component } from 'solid-js';
+import CopyButton from './CopyButton.jsx';
+
+interface Props {
+  apiKey: string | null;
+  keyPrefix: string | null;
+}
+
+const ApiKeyDisplay: Component<Props> = (props) => {
+  const hasFullKey = () => !!props.apiKey;
+
+  return (
+    <>
+      <Show when={hasFullKey()}>
+        <div class="api-key-display__warning">
+          Save your API key -- you won't see it again after closing this dialog.
+        </div>
+        <div class="api-key-display__value">
+          {props.apiKey}
+          <CopyButton text={props.apiKey!} />
+        </div>
+      </Show>
+
+      <Show when={!hasFullKey() && props.keyPrefix}>
+        <div class="api-key-display__prefix">
+          Replace <code class="api-key-display__code">{props.keyPrefix}...</code> below with your
+          full API key.
+        </div>
+      </Show>
+    </>
+  );
+};
+
+export default ApiKeyDisplay;

--- a/packages/frontend/src/components/CopyButton.tsx
+++ b/packages/frontend/src/components/CopyButton.tsx
@@ -1,0 +1,51 @@
+import { createSignal, type Component } from 'solid-js';
+
+const CopyButton: Component<{ text: string }> = (props) => {
+  const [copied, setCopied] = createSignal(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(props.text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: select text for manual copy (e.g. non-HTTPS contexts)
+    }
+  };
+
+  return (
+    <button
+      class="modal-terminal__copy"
+      onClick={handleCopy}
+      title="Copy"
+      aria-label={copied() ? 'Copied' : 'Copy to clipboard'}
+    >
+      {copied() ? (
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+};
+
+export default CopyButton;

--- a/packages/frontend/src/components/CopyButton.tsx
+++ b/packages/frontend/src/components/CopyButton.tsx
@@ -2,6 +2,7 @@ import { createSignal, type Component } from 'solid-js';
 
 const CopyButton: Component<{ text: string }> = (props) => {
   const [copied, setCopied] = createSignal(false);
+  const [failed, setFailed] = createSignal(false);
 
   const handleCopy = async () => {
     try {
@@ -9,7 +10,8 @@ const CopyButton: Component<{ text: string }> = (props) => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Fallback: select text for manual copy (e.g. non-HTTPS contexts)
+      setFailed(true);
+      setTimeout(() => setFailed(false), 2000);
     }
   };
 
@@ -18,7 +20,7 @@ const CopyButton: Component<{ text: string }> = (props) => {
       class="modal-terminal__copy"
       onClick={handleCopy}
       title="Copy"
-      aria-label={copied() ? 'Copied' : 'Copy to clipboard'}
+      aria-label={copied() ? 'Copied' : failed() ? 'Copy failed' : 'Copy to clipboard'}
     >
       {copied() ? (
         <svg

--- a/packages/frontend/src/components/SetupModal.tsx
+++ b/packages/frontend/src/components/SetupModal.tsx
@@ -1,5 +1,7 @@
 import { createResource, Show, type Component } from 'solid-js';
 import SetupStepAddProvider from './SetupStepAddProvider.jsx';
+import SetupStepLocalReady from './SetupStepLocalReady.jsx';
+import ErrorState from './ErrorState.jsx';
 import { getAgentKey, getHealth } from '../services/api.js';
 
 const SetupModal: Component<{
@@ -14,9 +16,10 @@ const SetupModal: Component<{
     () => props.open,
     (open) => (open ? getHealth() : null),
   );
+  // Health check failure defaults to cloud mode
   const isLocal = () => (healthData() as { mode?: string })?.mode === 'local';
 
-  const [apiKeyData] = createResource(
+  const [apiKeyData, { refetch: refetchKey }] = createResource(
     () => (props.open ? props.agentName : null),
     (n) => (n ? getAgentKey(n) : null),
   );
@@ -54,15 +57,11 @@ const SetupModal: Component<{
           aria-modal="true"
           aria-labelledby="setup-modal-title"
         >
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-sm);">
+          <div class="setup-modal__header">
             <div class="modal-card__title" id="setup-modal-title">
-              Set up your agent
+              Set up {props.agentName}
             </div>
-            <button
-              style="background: none; border: none; cursor: pointer; color: hsl(var(--muted-foreground)); padding: 4px; min-width: 44px; min-height: 44px; display: inline-flex; align-items: center; justify-content: center;"
-              onClick={() => props.onClose()}
-              aria-label="Close"
-            >
+            <button class="modal__close" onClick={() => props.onClose()} aria-label="Close">
               <svg
                 width="16"
                 height="16"
@@ -79,14 +78,42 @@ const SetupModal: Component<{
             </button>
           </div>
           <p class="modal-card__desc">
-            Add Manifest as a model provider, then connect at least one LLM so routing works.
+            <Show
+              when={isLocal()}
+              fallback="Add Manifest as a model provider, then connect at least one LLM so routing works."
+            >
+              Your local agent is pre-configured. Connect an LLM provider to enable routing.
+            </Show>
           </p>
 
-          <SetupStepAddProvider
-            apiKey={props.apiKey ?? null}
-            keyPrefix={apiKeyData()?.keyPrefix ?? null}
-            baseUrl={baseUrl()}
-          />
+          <Show
+            when={!apiKeyData.error}
+            fallback={
+              <ErrorState
+                error={apiKeyData.error}
+                title="Could not load API key"
+                message="Failed to fetch your agent's API key. Please try again."
+                onRetry={refetchKey}
+              />
+            }
+          >
+            <Show
+              when={!isLocal()}
+              fallback={
+                <SetupStepLocalReady
+                  apiKey={props.apiKey ?? null}
+                  keyPrefix={apiKeyData()?.keyPrefix ?? null}
+                  baseUrl={baseUrl()}
+                />
+              }
+            >
+              <SetupStepAddProvider
+                apiKey={props.apiKey ?? null}
+                keyPrefix={apiKeyData()?.keyPrefix ?? null}
+                baseUrl={baseUrl()}
+              />
+            </Show>
+          </Show>
 
           <div class="setup-modal__nav">
             <span />

--- a/packages/frontend/src/components/SetupModal.tsx
+++ b/packages/frontend/src/components/SetupModal.tsx
@@ -87,7 +87,7 @@ const SetupModal: Component<{
           </p>
 
           <Show
-            when={!apiKeyData.error}
+            when={!apiKeyData.error || !!props.apiKey}
             fallback={
               <ErrorState
                 error={apiKeyData.error}

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -2,7 +2,7 @@ import { createSignal, Show, type Component } from 'solid-js';
 import CopyButton from './CopyButton.jsx';
 import ApiKeyDisplay from './ApiKeyDisplay.jsx';
 
-type MethodId = 'env' | 'onboard' | 'cli';
+type MethodId = 'cli' | 'onboard' | 'env';
 
 interface Props {
   apiKey: string | null;
@@ -27,7 +27,7 @@ function ChevronIcon(props: { open: boolean }) {
 }
 
 const SetupStepAddProvider: Component<Props> = (props) => {
-  const [openMethod, setOpenMethod] = createSignal<MethodId>('env');
+  const [openMethod, setOpenMethod] = createSignal<MethodId>('cli');
 
   const displayKey = () =>
     props.apiKey ?? (props.keyPrefix ? `${props.keyPrefix}...` : 'mnfst_YOUR_KEY');
@@ -35,20 +35,6 @@ const SetupStepAddProvider: Component<Props> = (props) => {
   const toggle = (id: MethodId) => {
     setOpenMethod((cur) => (cur === id ? (null as unknown as MethodId) : id));
   };
-
-  const envSnippet = () => {
-    const lines = [`export MANIFEST_API_KEY="${displayKey()}"`];
-    if (props.baseUrl && !props.baseUrl.includes('app.manifest.build')) {
-      lines.push(`export MANIFEST_ENDPOINT="${props.baseUrl}"`);
-    }
-    return lines.join('\n');
-  };
-
-  const onboardSnippet = () =>
-    `openclaw onboard \\
-  --auth-choice manifest-api-key \\
-  --manifest-api-key "${displayKey()}" \\
-  --non-interactive`;
 
   const cliSnippet = () => {
     const providerJson = JSON.stringify({
@@ -60,6 +46,16 @@ const SetupStepAddProvider: Component<Props> = (props) => {
     return `openclaw config set models.providers.manifest '${providerJson}'
 openclaw config set agents.defaults.model.primary manifest/auto
 openclaw gateway restart`;
+  };
+
+  const onboardSnippet = () => `openclaw onboard`;
+
+  const envSnippet = () => {
+    const lines = [`export MANIFEST_API_KEY="${displayKey()}"`];
+    if (props.baseUrl && !props.baseUrl.includes('app.manifest.build')) {
+      lines.push(`export MANIFEST_ENDPOINT="${props.baseUrl}"`);
+    }
+    return lines.join('\n');
   };
 
   return (
@@ -90,16 +86,95 @@ openclaw gateway restart`;
         </div>
       </div>
 
-      {/* Method 1: Environment variable (recommended) */}
-      <div class={`setup-method${openMethod() === 'env' ? ' setup-method--recommended' : ''}`}>
+      {/* Method 1: Manual CLI configuration */}
+      <div class="setup-method">
+        <button
+          class="setup-method__header"
+          onClick={() => toggle('cli')}
+          aria-expanded={openMethod() === 'cli'}
+          aria-controls="method-cli"
+        >
+          CLI configuration
+          <ChevronIcon open={openMethod() === 'cli'} />
+        </button>
+        <Show when={openMethod() === 'cli'}>
+          <div class="setup-method__body" id="method-cli">
+            <p class="setup-method__hint">
+              Set the provider config and default model directly via CLI commands.
+            </p>
+            <div class="setup-method__code">
+              <CopyButton text={cliSnippet()} />
+              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
+                {cliSnippet()}
+              </pre>
+            </div>
+          </div>
+        </Show>
+      </div>
+
+      {/* Method 2: Interactive onboarding wizard */}
+      <div class="setup-method">
+        <button
+          class="setup-method__header"
+          onClick={() => toggle('onboard')}
+          aria-expanded={openMethod() === 'onboard'}
+          aria-controls="method-onboard"
+        >
+          Interactive wizard
+          <ChevronIcon open={openMethod() === 'onboard'} />
+        </button>
+        <Show when={openMethod() === 'onboard'}>
+          <div class="setup-method__body" id="method-onboard">
+            <p class="setup-method__hint">
+              Run the onboarding wizard and select <strong>Custom Provider</strong> when prompted.
+              Then enter the following values:
+            </p>
+            <div class="setup-method__code" style="margin-bottom: 12px;">
+              <CopyButton text={onboardSnippet()} />
+              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
+                {onboardSnippet()}
+              </pre>
+            </div>
+            <div class="setup-onboard-fields">
+              <div class="setup-onboard-fields__row">
+                <span class="setup-onboard-fields__label">API Base URL</span>
+                <span class="setup-onboard-fields__value">
+                  {props.baseUrl}
+                  <CopyButton text={props.baseUrl} />
+                </span>
+              </div>
+              <div class="setup-onboard-fields__row">
+                <span class="setup-onboard-fields__label">API Key</span>
+                <span class="setup-onboard-fields__value">
+                  {displayKey()}
+                  <CopyButton text={displayKey()} />
+                </span>
+              </div>
+              <div class="setup-onboard-fields__row">
+                <span class="setup-onboard-fields__label">Endpoint compatibility</span>
+                <span class="setup-onboard-fields__value">OpenAI-compatible</span>
+              </div>
+              <div class="setup-onboard-fields__row">
+                <span class="setup-onboard-fields__label">Model ID</span>
+                <span class="setup-onboard-fields__value">
+                  auto
+                  <CopyButton text="auto" />
+                </span>
+              </div>
+            </div>
+          </div>
+        </Show>
+      </div>
+
+      {/* Method 3: Environment variable */}
+      <div class="setup-method">
         <button
           class="setup-method__header"
           onClick={() => toggle('env')}
           aria-expanded={openMethod() === 'env'}
           aria-controls="method-env"
         >
-          Set an environment variable
-          <span class="setup-method__badge">Recommended</span>
+          Environment variable
           <ChevronIcon open={openMethod() === 'env'} />
         </button>
         <Show when={openMethod() === 'env'}>
@@ -112,58 +187,6 @@ openclaw gateway restart`;
               <CopyButton text={envSnippet()} />
               <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
                 {envSnippet()}
-              </pre>
-            </div>
-          </div>
-        </Show>
-      </div>
-
-      {/* Method 2: One-command setup */}
-      <div class="setup-method">
-        <button
-          class="setup-method__header"
-          onClick={() => toggle('onboard')}
-          aria-expanded={openMethod() === 'onboard'}
-          aria-controls="method-onboard"
-        >
-          One-command setup
-          <ChevronIcon open={openMethod() === 'onboard'} />
-        </button>
-        <Show when={openMethod() === 'onboard'}>
-          <div class="setup-method__body" id="method-onboard">
-            <p class="setup-method__hint">
-              Runs the OpenClaw onboarding wizard non-interactively with your API key.
-            </p>
-            <div class="setup-method__code">
-              <CopyButton text={onboardSnippet()} />
-              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
-                {onboardSnippet()}
-              </pre>
-            </div>
-          </div>
-        </Show>
-      </div>
-
-      {/* Method 3: Manual CLI */}
-      <div class="setup-method">
-        <button
-          class="setup-method__header"
-          onClick={() => toggle('cli')}
-          aria-expanded={openMethod() === 'cli'}
-          aria-controls="method-cli"
-        >
-          Manual CLI configuration
-          <ChevronIcon open={openMethod() === 'cli'} />
-        </button>
-        <Show when={openMethod() === 'cli'}>
-          <div class="setup-method__body" id="method-cli">
-            <p class="setup-method__hint">
-              Set the provider config and default model directly via CLI commands.
-            </p>
-            <div class="setup-method__code">
-              <CopyButton text={cliSnippet()} />
-              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
-                {cliSnippet()}
               </pre>
             </div>
           </div>

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -1,7 +1,8 @@
 import { createSignal, Show, type Component } from 'solid-js';
-import { CopyButton } from './SetupStepInstall.jsx';
+import CopyButton from './CopyButton.jsx';
+import ApiKeyDisplay from './ApiKeyDisplay.jsx';
 
-type ConfigTab = 'openclaw' | 'sdk' | 'curl';
+type MethodId = 'env' | 'onboard' | 'cli';
 
 interface Props {
   apiKey: string | null;
@@ -9,14 +10,47 @@ interface Props {
   baseUrl: string;
 }
 
-const SetupStepAddProvider: Component<Props> = (props) => {
-  const [tab, setTab] = createSignal<ConfigTab>('openclaw');
+function ChevronIcon(props: { open: boolean }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      class={`setup-method__chevron${props.open ? ' setup-method__chevron--open' : ''}`}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
 
-  const hasFullKey = () => !!props.apiKey;
+const SetupStepAddProvider: Component<Props> = (props) => {
+  const [openMethod, setOpenMethod] = createSignal<MethodId>('env');
+
   const displayKey = () =>
     props.apiKey ?? (props.keyPrefix ? `${props.keyPrefix}...` : 'mnfst_YOUR_KEY');
 
-  const openclawSnippet = () => {
+  const toggle = (id: MethodId) => {
+    setOpenMethod((cur) => (cur === id ? (null as unknown as MethodId) : id));
+  };
+
+  const envSnippet = () => {
+    const lines = [`export MANIFEST_API_KEY="${displayKey()}"`];
+    if (props.baseUrl && !props.baseUrl.includes('app.manifest.build')) {
+      lines.push(`export MANIFEST_ENDPOINT="${props.baseUrl}"`);
+    }
+    return lines.join('\n');
+  };
+
+  const onboardSnippet = () =>
+    `openclaw onboard \\
+  --auth-choice manifest-api-key \\
+  --manifest-api-key "${displayKey()}" \\
+  --non-interactive`;
+
+  const cliSnippet = () => {
     const providerJson = JSON.stringify({
       baseUrl: props.baseUrl,
       api: 'openai-completions',
@@ -28,133 +62,112 @@ openclaw config set agents.defaults.model.primary manifest/auto
 openclaw gateway restart`;
   };
 
-  const sdkSnippet = () =>
-    `from openai import OpenAI
-
-client = OpenAI(
-    base_url="${props.baseUrl}",
-    api_key="${displayKey()}",
-)
-
-response = client.chat.completions.create(
-    model="manifest/auto",
-    messages=[{"role": "user", "content": "Hello"}],
-)`;
-
-  const curlSnippet = () =>
-    `curl ${props.baseUrl}/chat/completions \\
-  -H "Authorization: Bearer ${displayKey()}" \\
-  -H "Content-Type: application/json" \\
-  -d '{
-    "model": "manifest/auto",
-    "messages": [{"role": "user", "content": "Hello"}]
-  }'`;
-
-  const snippetFor = (t: ConfigTab) => {
-    if (t === 'openclaw') return openclawSnippet();
-    if (t === 'sdk') return sdkSnippet();
-    return curlSnippet();
-  };
-
   return (
     <div>
-      <h3 style="margin: 0 0 4px; font-size: var(--font-size-base); font-weight: 600;">
-        Add Manifest as a provider
-      </h3>
-      <p style="margin: 0 0 16px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-        Run these commands to register Manifest in your OpenClaw config. Use{' '}
-        <code style="font-family: var(--font-mono); font-size: var(--font-size-sm); background: hsl(var(--muted)); padding: 2px 6px; border-radius: 4px;">
-          manifest/auto
-        </code>{' '}
-        as the model -- it routes each request to the best provider for the job.
+      <h3 class="setup-step__heading">Add Manifest as a provider</h3>
+      <p class="setup-step__desc">
+        Register Manifest in your OpenClaw config, then use{' '}
+        <code class="api-key-display__code">manifest/auto</code> as the model to route each request
+        to the best provider.
       </p>
 
-      <Show when={hasFullKey()}>
-        <div style="background: hsl(var(--chart-5) / 0.1); border: 1px solid hsl(var(--chart-5) / 0.3); border-radius: var(--radius); padding: 10px 14px; margin-bottom: 12px; font-size: var(--font-size-sm); color: hsl(var(--foreground));">
-          Save this API key somewhere safe. You won't see it again.
-        </div>
-        <div style="display: flex; align-items: center; gap: 8px; background: hsl(var(--muted)); border-radius: var(--radius); padding: 10px 14px; margin-bottom: 16px; font-family: var(--font-mono); font-size: var(--font-size-sm); word-break: break-all;">
-          {props.apiKey}
-          <CopyButton text={props.apiKey!} />
-        </div>
-      </Show>
+      <ApiKeyDisplay apiKey={props.apiKey} keyPrefix={props.keyPrefix} />
 
-      <Show when={!hasFullKey() && props.keyPrefix}>
-        <div style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); padding: 10px 14px; background: hsl(var(--muted)); border-radius: var(--radius); margin-bottom: 16px;">
-          Replace{' '}
-          <code style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
-            {props.keyPrefix}...
-          </code>{' '}
-          below with your full API key.
-        </div>
-      </Show>
-
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 16px; font-size: var(--font-size-sm);">
-        <div style="background: hsl(var(--muted)); border-radius: var(--radius); padding: 10px 14px;">
-          <div style="color: hsl(var(--muted-foreground)); margin-bottom: 4px;">Base URL</div>
-          <div style="font-family: var(--font-mono); font-size: var(--font-size-xs); word-break: break-all; display: flex; align-items: center; gap: 6px;">
+      <div class="setup-info-grid">
+        <div class="setup-info-grid__card">
+          <div class="setup-info-grid__label">Base URL</div>
+          <div class="setup-info-grid__value">
             <span>{props.baseUrl}</span>
             <CopyButton text={props.baseUrl} />
           </div>
         </div>
-        <div style="background: hsl(var(--muted)); border-radius: var(--radius); padding: 10px 14px;">
-          <div style="color: hsl(var(--muted-foreground)); margin-bottom: 4px;">Model</div>
-          <div style="font-family: var(--font-mono); font-size: var(--font-size-xs); display: flex; align-items: center; gap: 6px;">
+        <div class="setup-info-grid__card">
+          <div class="setup-info-grid__label">Model</div>
+          <div class="setup-info-grid__value">
             <span>manifest/auto</span>
             <CopyButton text="manifest/auto" />
           </div>
         </div>
       </div>
 
-      <div class="modal-terminal">
-        <div class="modal-terminal__header">
-          <div class="modal-terminal__dots">
-            <span class="modal-terminal__dot modal-terminal__dot--red" />
-            <span class="modal-terminal__dot modal-terminal__dot--yellow" />
-            <span class="modal-terminal__dot modal-terminal__dot--green" />
+      {/* Method 1: Environment variable (recommended) */}
+      <div class={`setup-method${openMethod() === 'env' ? ' setup-method--recommended' : ''}`}>
+        <button
+          class="setup-method__header"
+          onClick={() => toggle('env')}
+          aria-expanded={openMethod() === 'env'}
+          aria-controls="method-env"
+        >
+          Set an environment variable
+          <span class="setup-method__badge">Recommended</span>
+          <ChevronIcon open={openMethod() === 'env'} />
+        </button>
+        <Show when={openMethod() === 'env'}>
+          <div class="setup-method__body" id="method-env">
+            <p class="setup-method__hint">
+              OpenClaw detects this automatically. Add to your shell profile or{' '}
+              <code class="api-key-display__code">~/.openclaw/.env</code> for persistence.
+            </p>
+            <div class="setup-method__code">
+              <CopyButton text={envSnippet()} />
+              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
+                {envSnippet()}
+              </pre>
+            </div>
           </div>
-          <div class="modal-terminal__tabs" role="tablist" aria-label="Code example">
-            <button
-              class="modal-terminal__tab"
-              classList={{ 'modal-terminal__tab--active': tab() === 'openclaw' }}
-              onClick={() => setTab('openclaw')}
-              role="tab"
-              aria-selected={tab() === 'openclaw'}
-            >
-              OpenClaw
-            </button>
-            <span class="modal-terminal__tab-sep" aria-hidden="true">
-              |
-            </span>
-            <button
-              class="modal-terminal__tab"
-              classList={{ 'modal-terminal__tab--active': tab() === 'sdk' }}
-              onClick={() => setTab('sdk')}
-              role="tab"
-              aria-selected={tab() === 'sdk'}
-            >
-              Python SDK
-            </button>
-            <span class="modal-terminal__tab-sep" aria-hidden="true">
-              |
-            </span>
-            <button
-              class="modal-terminal__tab"
-              classList={{ 'modal-terminal__tab--active': tab() === 'curl' }}
-              onClick={() => setTab('curl')}
-              role="tab"
-              aria-selected={tab() === 'curl'}
-            >
-              cURL
-            </button>
+        </Show>
+      </div>
+
+      {/* Method 2: One-command setup */}
+      <div class="setup-method">
+        <button
+          class="setup-method__header"
+          onClick={() => toggle('onboard')}
+          aria-expanded={openMethod() === 'onboard'}
+          aria-controls="method-onboard"
+        >
+          One-command setup
+          <ChevronIcon open={openMethod() === 'onboard'} />
+        </button>
+        <Show when={openMethod() === 'onboard'}>
+          <div class="setup-method__body" id="method-onboard">
+            <p class="setup-method__hint">
+              Runs the OpenClaw onboarding wizard non-interactively with your API key.
+            </p>
+            <div class="setup-method__code">
+              <CopyButton text={onboardSnippet()} />
+              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
+                {onboardSnippet()}
+              </pre>
+            </div>
           </div>
-        </div>
-        <div class="modal-terminal__body">
-          <CopyButton text={snippetFor(tab())} />
-          <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
-            <code class="modal-terminal__code">{snippetFor(tab())}</code>
-          </pre>
-        </div>
+        </Show>
+      </div>
+
+      {/* Method 3: Manual CLI */}
+      <div class="setup-method">
+        <button
+          class="setup-method__header"
+          onClick={() => toggle('cli')}
+          aria-expanded={openMethod() === 'cli'}
+          aria-controls="method-cli"
+        >
+          Manual CLI configuration
+          <ChevronIcon open={openMethod() === 'cli'} />
+        </button>
+        <Show when={openMethod() === 'cli'}>
+          <div class="setup-method__body" id="method-cli">
+            <p class="setup-method__hint">
+              Set the provider config and default model directly via CLI commands.
+            </p>
+            <div class="setup-method__code">
+              <CopyButton text={cliSnippet()} />
+              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
+                {cliSnippet()}
+              </pre>
+            </div>
+          </div>
+        </Show>
       </div>
     </div>
   );

--- a/packages/frontend/src/components/SetupStepInstall.tsx
+++ b/packages/frontend/src/components/SetupStepInstall.tsx
@@ -1,44 +1,16 @@
-import { createSignal, type Component } from "solid-js";
+import { type Component } from 'solid-js';
+import CopyButton from './CopyButton.jsx';
 
-function CopyButton(props: { text: string }) {
-  const [copied, setCopied] = createSignal(false);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(props.text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Fallback: select text for manual copy (e.g. non-HTTPS contexts)
-    }
-  };
-
-  return (
-    <button class="modal-terminal__copy" onClick={handleCopy} title="Copy" aria-label={copied() ? "Copied" : "Copy to clipboard"}>
-      {copied() ? (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <polyline points="20 6 9 17 4 12" />
-        </svg>
-      ) : (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-        </svg>
-      )}
-    </button>
-  );
-}
-
-const INSTALL_CMD = "openclaw plugins install manifest";
+const INSTALL_CMD = 'openclaw plugins install manifest';
 
 const SetupStepInstall: Component<{ stepNumber?: number }> = (props) => {
   return (
     <div>
-      <h3 style="margin: 0 0 4px; font-size: var(--font-size-base); font-weight: 600;">
-        {props.stepNumber ? `${props.stepNumber}. ` : ''}Install the plugin
+      <h3 class="setup-step__heading">
+        {props.stepNumber ? `${props.stepNumber}. ` : ''}Install the Manifest plugin
       </h3>
-      <p style="margin: 0 0 16px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-        Install the Manifest plugin for OpenClaw so your agent's activity is tracked automatically.
+      <p class="setup-step__desc">
+        Install the Manifest plugin for OpenClaw to enable smart routing and observability.
       </p>
 
       <div class="modal-terminal">

--- a/packages/frontend/src/components/SetupStepLocalReady.tsx
+++ b/packages/frontend/src/components/SetupStepLocalReady.tsx
@@ -1,0 +1,69 @@
+import { Show, type Component } from 'solid-js';
+import ApiKeyDisplay from './ApiKeyDisplay.jsx';
+
+interface Props {
+  apiKey: string | null;
+  keyPrefix: string | null;
+  baseUrl: string;
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="hsl(var(--chart-4))"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+const SetupStepLocalReady: Component<Props> = (props) => {
+  return (
+    <div>
+      <h3 class="setup-step__heading">Your agent is ready</h3>
+      <p class="setup-step__desc">
+        Your local server is running and your agent is pre-configured. Use{' '}
+        <code class="api-key-display__code">manifest/auto</code> as your model to route requests
+        through Manifest.
+      </p>
+
+      <ApiKeyDisplay apiKey={props.apiKey} keyPrefix={props.keyPrefix} />
+
+      <div class="setup-checklist">
+        <div class="setup-checklist__item">
+          <CheckIcon />
+          <span>Plugin installed and configured</span>
+        </div>
+        <div class="setup-checklist__item">
+          <CheckIcon />
+          <span>API key auto-generated</span>
+        </div>
+        <div class="setup-checklist__item">
+          <CheckIcon />
+          <span>
+            Base URL:{' '}
+            <code class="api-key-display__code" style="font-size: var(--font-size-xs);">
+              {props.baseUrl}
+            </code>
+          </span>
+        </div>
+      </div>
+
+      <Show when={!props.apiKey}>
+        <p class="setup-step__desc" style="margin-top: 16px; margin-bottom: 0;">
+          Set <strong>manifest/auto</strong> as your model, send a message, and activity will appear
+          on the dashboard within a few seconds.
+        </p>
+      </Show>
+    </div>
+  );
+};
+
+export default SetupStepLocalReady;

--- a/packages/frontend/src/components/SetupStepProviders.tsx
+++ b/packages/frontend/src/components/SetupStepProviders.tsx
@@ -3,31 +3,37 @@ import { type Component } from 'solid-js';
 interface Props {
   agentName: string;
   onGoToRouting: () => void;
+  onSkip?: () => void;
 }
 
 const SetupStepProviders: Component<Props> = (props) => {
   return (
     <div>
-      <h3 style="margin: 0 0 4px; font-size: var(--font-size-base); font-weight: 600;">
-        Connect your models
-      </h3>
-      <p style="margin: 0 0 12px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-        Manifest needs at least one LLM provider to route requests. Add your API keys so it can pick
-        the right model for each request -- cheaper models handle simple tasks, expensive ones kick
-        in when needed.
+      <h3 class="setup-step__heading">Connect your LLM providers</h3>
+      <p class="setup-step__desc">
+        Manifest routes each request to the best model for the job. Connect at least one provider so{' '}
+        <code class="api-key-display__code">manifest/auto</code> can resolve requests.
       </p>
 
-      <div style="background: hsl(var(--chart-5) / 0.1); border: 1px solid hsl(var(--chart-5) / 0.3); border-radius: var(--radius); padding: 10px 14px; margin-bottom: 16px; font-size: var(--font-size-sm); color: hsl(var(--foreground)); line-height: 1.5;">
+      <div class="api-key-display__warning" style="margin-bottom: 16px;">
         Without a connected provider, requests to{' '}
-        <code style="font-family: var(--font-mono); font-size: var(--font-size-sm); background: hsl(var(--muted)); padding: 2px 6px; border-radius: 4px;">
-          manifest/auto
-        </code>{' '}
-        will fail.
+        <code class="api-key-display__code">manifest/auto</code> will return an error.
       </div>
 
-      <button class="btn btn--primary btn--sm" onClick={() => props.onGoToRouting()}>
-        Go to routing
-      </button>
+      <div style="display: flex; align-items: center; gap: 12px;">
+        <button class="btn btn--primary btn--sm" onClick={() => props.onGoToRouting()}>
+          Connect a provider
+        </button>
+        {props.onSkip && (
+          <button
+            class="btn btn--ghost btn--sm"
+            onClick={() => props.onSkip!()}
+            style="color: hsl(var(--muted-foreground));"
+          >
+            I'll do this later
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/frontend/src/styles/overview.css
+++ b/packages/frontend/src/styles/overview.css
@@ -8,6 +8,14 @@
   background: rgb(0 0 0 / 0.7);
 }
 
+/* ── Setup Modal header ──────────────────────────── */
+.setup-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--gap-sm);
+}
+
 /* ── Setup Modal nav ─────────────────────────────── */
 .setup-modal__nav {
   display: flex;

--- a/packages/frontend/src/styles/wizard.css
+++ b/packages/frontend/src/styles/wizard.css
@@ -26,9 +26,15 @@
   border-radius: 50%;
 }
 
-.modal-terminal__dot--red { background: #ff5f57; }
-.modal-terminal__dot--yellow { background: #febc2e; }
-.modal-terminal__dot--green { background: #28c840; }
+.modal-terminal__dot--red {
+  background: #ff5f57;
+}
+.modal-terminal__dot--yellow {
+  background: #febc2e;
+}
+.modal-terminal__dot--green {
+  background: #28c840;
+}
 
 .modal-terminal__tabs {
   display: flex;
@@ -205,22 +211,227 @@
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 /* ── Animations ────────────────────────────────────── */
 @keyframes fadeInUp {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .cards-grid > * {
   animation: fadeInUp 300ms ease-out both;
 }
-.cards-grid > *:nth-child(1) { animation-delay: 0ms; }
-.cards-grid > *:nth-child(2) { animation-delay: 50ms; }
-.cards-grid > *:nth-child(3) { animation-delay: 100ms; }
-.cards-grid > *:nth-child(4) { animation-delay: 150ms; }
+.cards-grid > *:nth-child(1) {
+  animation-delay: 0ms;
+}
+.cards-grid > *:nth-child(2) {
+  animation-delay: 50ms;
+}
+.cards-grid > *:nth-child(3) {
+  animation-delay: 100ms;
+}
+.cards-grid > *:nth-child(4) {
+  animation-delay: 150ms;
+}
 
-.panel { animation: fadeInUp 300ms ease-out both; }
+.panel {
+  animation: fadeInUp 300ms ease-out both;
+}
+
+/* ── Setup step shared ─────────────────────────────── */
+.setup-step__heading {
+  margin: 0 0 4px;
+  font-size: var(--font-size-base);
+  font-weight: 600;
+}
+
+.setup-step__desc {
+  margin: 0 0 16px;
+  font-size: var(--font-size-sm);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.5;
+}
+
+/* ── API key display ───────────────────────────────── */
+.api-key-display__warning {
+  background: hsl(var(--chart-5) / 0.1);
+  border: 1px solid hsl(var(--chart-5) / 0.3);
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  font-size: var(--font-size-sm);
+  color: hsl(var(--foreground));
+}
+
+.api-key-display__value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: hsl(var(--muted));
+  border-radius: var(--radius);
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  word-break: break-all;
+}
+
+.api-key-display__prefix {
+  font-size: var(--font-size-sm);
+  color: hsl(var(--muted-foreground));
+  padding: 10px 14px;
+  background: hsl(var(--muted));
+  border-radius: var(--radius);
+  margin-bottom: 16px;
+}
+
+.api-key-display__code {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+/* ── Setup method accordion ────────────────────────── */
+.setup-method {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.setup-method--recommended {
+  border-color: hsl(var(--chart-1) / 0.4);
+}
+
+.setup-method__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: hsl(var(--muted));
+  cursor: pointer;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.setup-method__header:hover {
+  background: hsl(var(--accent));
+}
+
+.setup-method__header:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: -2px;
+}
+
+.setup-method__badge {
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 99px;
+  background: hsl(var(--chart-1) / 0.15);
+  color: hsl(var(--chart-1));
+}
+
+.setup-method__chevron {
+  margin-left: auto;
+  transition: transform var(--transition-fast);
+  color: hsl(var(--muted-foreground));
+}
+
+.setup-method__chevron--open {
+  transform: rotate(180deg);
+}
+
+.setup-method__body {
+  padding: 12px 14px;
+  border-top: 1px solid hsl(var(--border));
+}
+
+.setup-method__hint {
+  margin: 0 0 10px;
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.5;
+}
+
+.setup-method__code {
+  position: relative;
+  background: hsl(var(--background));
+  border-radius: var(--radius);
+  padding: 12px 14px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.7;
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
+.dark .setup-method__code {
+  background: hsl(222 47% 6%);
+  color: hsl(178 75% 50%);
+}
+
+/* ── Info grid (base URL + model) ──────────────────── */
+.setup-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-bottom: 16px;
+  font-size: var(--font-size-sm);
+}
+
+.setup-info-grid__card {
+  background: hsl(var(--muted));
+  border-radius: var(--radius);
+  padding: 10px 14px;
+}
+
+.setup-info-grid__label {
+  color: hsl(var(--muted-foreground));
+  margin-bottom: 4px;
+}
+
+.setup-info-grid__value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  word-break: break-all;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* ── Local ready checklist ─────────────────────────── */
+.setup-checklist {
+  background: hsl(var(--muted));
+  border-radius: var(--radius);
+  padding: 14px;
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+}
+
+.setup-checklist__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.setup-checklist__item + .setup-checklist__item {
+  margin-top: 8px;
+}

--- a/packages/frontend/src/styles/wizard.css
+++ b/packages/frontend/src/styles/wizard.css
@@ -435,3 +435,39 @@
 .setup-checklist__item + .setup-checklist__item {
   margin-top: 8px;
 }
+
+/* ── Onboard wizard fields ─────────────────────────── */
+.setup-onboard-fields {
+  font-size: var(--font-size-sm);
+}
+
+.setup-onboard-fields__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.setup-onboard-fields__row:last-child {
+  border-bottom: none;
+}
+
+.setup-onboard-fields__label {
+  color: hsl(var(--muted-foreground));
+  font-weight: 500;
+}
+
+.setup-onboard-fields__value {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  word-break: break-all;
+}
+
+.setup-onboard-fields__value .modal-terminal__copy {
+  position: static;
+  flex-shrink: 0;
+}

--- a/packages/frontend/tests/components/ApiKeyDisplay.test.tsx
+++ b/packages/frontend/tests/components/ApiKeyDisplay.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+
+vi.stubGlobal("navigator", {
+  clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+});
+
+import ApiKeyDisplay from "../../src/components/ApiKeyDisplay";
+
+describe("ApiKeyDisplay", () => {
+  it("renders nothing when apiKey and keyPrefix are both null", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey={null} keyPrefix={null} />
+    ));
+    expect(container.textContent).toBe("");
+  });
+
+  it("shows warning message when apiKey is provided", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey="mnfst_full_key_123" keyPrefix={null} />
+    ));
+    expect(container.textContent).toContain(
+      "Save your API key -- you won't see it again after closing this dialog."
+    );
+  });
+
+  it("shows the full API key value when apiKey is provided", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey="mnfst_full_key_123" keyPrefix={null} />
+    ));
+    expect(container.textContent).toContain("mnfst_full_key_123");
+  });
+
+  it("renders CopyButton alongside the API key", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey="mnfst_full_key_123" keyPrefix={null} />
+    ));
+    const copyBtn = container.querySelector(".modal-terminal__copy");
+    expect(copyBtn).not.toBeNull();
+  });
+
+  it("shows prefix hint when only keyPrefix is provided", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey={null} keyPrefix="mnfst_abc" />
+    ));
+    expect(container.textContent).toContain("Replace");
+    expect(container.textContent).toContain("mnfst_abc...");
+    expect(container.textContent).toContain("below with your full API key.");
+  });
+
+  it("does not show prefix hint when full key is provided", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey="mnfst_full_key" keyPrefix="mnfst_abc" />
+    ));
+    expect(container.textContent).not.toContain("Replace");
+    expect(container.textContent).not.toContain("below with your full API key.");
+  });
+
+  it("does not show warning when only keyPrefix is provided", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey={null} keyPrefix="mnfst_abc" />
+    ));
+    expect(container.textContent).not.toContain(
+      "Save your API key -- you won't see it again"
+    );
+  });
+
+  it("renders api-key-display__warning class when apiKey is provided", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey="mnfst_key" keyPrefix={null} />
+    ));
+    expect(container.querySelector(".api-key-display__warning")).not.toBeNull();
+  });
+
+  it("renders api-key-display__value class when apiKey is provided", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey="mnfst_key" keyPrefix={null} />
+    ));
+    expect(container.querySelector(".api-key-display__value")).not.toBeNull();
+  });
+
+  it("renders api-key-display__prefix class when only keyPrefix is provided", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey={null} keyPrefix="mnfst_pre" />
+    ));
+    expect(container.querySelector(".api-key-display__prefix")).not.toBeNull();
+  });
+
+  it("renders prefix inside a code element", () => {
+    const { container } = render(() => (
+      <ApiKeyDisplay apiKey={null} keyPrefix="mnfst_pre" />
+    ));
+    const code = container.querySelector("code.api-key-display__code");
+    expect(code).not.toBeNull();
+    expect(code!.textContent).toBe("mnfst_pre...");
+  });
+});

--- a/packages/frontend/tests/components/CopyButton.test.tsx
+++ b/packages/frontend/tests/components/CopyButton.test.tsx
@@ -77,11 +77,21 @@ describe("CopyButton", () => {
     expect(container.querySelector("svg polyline")).toBeNull();
   });
 
-  it("handles clipboard failure gracefully without changing state", async () => {
+  it("shows 'Copy failed' aria-label on clipboard failure", async () => {
     writeTextMock.mockRejectedValueOnce(new Error("clipboard denied"));
     render(() => <CopyButton text="hello" />);
     const btn = screen.getByRole("button");
     await fireEvent.click(btn);
+    expect(btn.getAttribute("aria-label")).toBe("Copy failed");
+  });
+
+  it("reverts 'Copy failed' back to 'Copy to clipboard' after 2000ms", async () => {
+    writeTextMock.mockRejectedValueOnce(new Error("clipboard denied"));
+    render(() => <CopyButton text="hello" />);
+    const btn = screen.getByRole("button");
+    await fireEvent.click(btn);
+    expect(btn.getAttribute("aria-label")).toBe("Copy failed");
+    vi.advanceTimersByTime(2000);
     expect(btn.getAttribute("aria-label")).toBe("Copy to clipboard");
   });
 

--- a/packages/frontend/tests/components/CopyButton.test.tsx
+++ b/packages/frontend/tests/components/CopyButton.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+vi.stubGlobal("navigator", {
+  clipboard: { writeText: writeTextMock },
+});
+
+import CopyButton from "../../src/components/CopyButton";
+
+describe("CopyButton", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    writeTextMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders a button with Copy title", () => {
+    const { container } = render(() => <CopyButton text="hello" />);
+    const btn = container.querySelector("button");
+    expect(btn).not.toBeNull();
+    expect(btn!.getAttribute("title")).toBe("Copy");
+  });
+
+  it("has aria-label 'Copy to clipboard' initially", () => {
+    render(() => <CopyButton text="hello" />);
+    const btn = screen.getByRole("button");
+    expect(btn.getAttribute("aria-label")).toBe("Copy to clipboard");
+  });
+
+  it("renders copy icon SVG with rect element initially", () => {
+    const { container } = render(() => <CopyButton text="hello" />);
+    expect(container.querySelector("svg rect")).not.toBeNull();
+    expect(container.querySelector("svg polyline")).toBeNull();
+  });
+
+  it("calls navigator.clipboard.writeText with the text prop on click", async () => {
+    render(() => <CopyButton text="test-text-123" />);
+    const btn = screen.getByRole("button");
+    await fireEvent.click(btn);
+    expect(writeTextMock).toHaveBeenCalledWith("test-text-123");
+  });
+
+  it("changes aria-label to 'Copied' after successful copy", async () => {
+    render(() => <CopyButton text="hello" />);
+    const btn = screen.getByRole("button");
+    await fireEvent.click(btn);
+    expect(btn.getAttribute("aria-label")).toBe("Copied");
+  });
+
+  it("shows check icon SVG after successful copy", async () => {
+    const { container } = render(() => <CopyButton text="hello" />);
+    await fireEvent.click(screen.getByRole("button"));
+    expect(container.querySelector("svg polyline")).not.toBeNull();
+    expect(container.querySelector("svg rect")).toBeNull();
+  });
+
+  it("reverts aria-label to 'Copy to clipboard' after 2000ms timeout", async () => {
+    render(() => <CopyButton text="hello" />);
+    const btn = screen.getByRole("button");
+    await fireEvent.click(btn);
+    expect(btn.getAttribute("aria-label")).toBe("Copied");
+    vi.advanceTimersByTime(2000);
+    expect(btn.getAttribute("aria-label")).toBe("Copy to clipboard");
+  });
+
+  it("reverts to copy icon after 2000ms timeout", async () => {
+    const { container } = render(() => <CopyButton text="hello" />);
+    await fireEvent.click(screen.getByRole("button"));
+    expect(container.querySelector("svg polyline")).not.toBeNull();
+    vi.advanceTimersByTime(2000);
+    expect(container.querySelector("svg rect")).not.toBeNull();
+    expect(container.querySelector("svg polyline")).toBeNull();
+  });
+
+  it("handles clipboard failure gracefully without changing state", async () => {
+    writeTextMock.mockRejectedValueOnce(new Error("clipboard denied"));
+    render(() => <CopyButton text="hello" />);
+    const btn = screen.getByRole("button");
+    await fireEvent.click(btn);
+    expect(btn.getAttribute("aria-label")).toBe("Copy to clipboard");
+  });
+
+  it("has modal-terminal__copy class", () => {
+    const { container } = render(() => <CopyButton text="hello" />);
+    expect(container.querySelector(".modal-terminal__copy")).not.toBeNull();
+  });
+});

--- a/packages/frontend/tests/components/SetupModal.test.tsx
+++ b/packages/frontend/tests/components/SetupModal.test.tsx
@@ -196,6 +196,19 @@ describe("SetupModal", () => {
     });
   });
 
+  it("still shows setup content when apiKey prop is provided even if fetch fails", async () => {
+    const { getAgentKey } = await import("../../src/services/api.js");
+    (getAgentKey as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("Fetch failed"));
+    const { container } = render(() => (
+      <SetupModal open={true} agentName="fail-agent" apiKey="mnfst_provided" onClose={onClose} />
+    ));
+    await vi.waitFor(() => {
+      const step = container.querySelector('[data-testid="step-add-provider"]');
+      expect(step).not.toBeNull();
+      expect(step!.getAttribute("data-key")).toBe("mnfst_provided");
+    });
+  });
+
   describe("local mode", () => {
     beforeEach(() => {
       mockGetHealth.mockResolvedValue({ mode: "local" });

--- a/packages/frontend/tests/components/SetupModal.test.tsx
+++ b/packages/frontend/tests/components/SetupModal.test.tsx
@@ -15,10 +15,19 @@ vi.mock("../../src/components/SetupStepAddProvider.jsx", () => ({
   ),
 }));
 
-vi.mock("../../src/components/SetupStepLocalConfigure.jsx", () => ({
+vi.mock("../../src/components/SetupStepLocalReady.jsx", () => ({
   default: (props: any) => (
-    <div data-testid="step-local-configure" data-base-url={props.baseUrl ?? ""} data-key={props.apiKey ?? ""} data-prefix={props.keyPrefix ?? ""}>
-      Local Configure Step
+    <div data-testid="step-local-ready" data-base-url={props.baseUrl ?? ""} data-key={props.apiKey ?? ""} data-prefix={props.keyPrefix ?? ""}>
+      Local Ready Step
+    </div>
+  ),
+}));
+
+vi.mock("../../src/components/ErrorState.jsx", () => ({
+  default: (props: any) => (
+    <div data-testid="error-state">
+      {props.title}
+      <button data-testid="retry-btn" onClick={() => props.onRetry?.()}>Retry</button>
     </div>
   ),
 }));
@@ -42,14 +51,14 @@ describe("SetupModal", () => {
     expect(container.querySelector(".modal-overlay")).toBeNull();
   });
 
-  it("renders modal title when open", () => {
+  it("renders modal title with agent name when open", () => {
     render(() => (
-      <SetupModal open={true} agentName="test-agent" onClose={onClose} />
+      <SetupModal open={true} agentName="my-agent" onClose={onClose} />
     ));
-    expect(screen.getByText("Set up your agent")).toBeDefined();
+    expect(screen.getByText("Set up my-agent")).toBeDefined();
   });
 
-  it("shows close button", () => {
+  it("shows close button with aria-label", () => {
     const { container } = render(() => (
       <SetupModal open={true} agentName="test-agent" onClose={onClose} />
     ));
@@ -96,7 +105,7 @@ describe("SetupModal", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("shows description text", () => {
+  it("shows cloud description text", () => {
     const { container } = render(() => (
       <SetupModal open={true} agentName="test-agent" onClose={onClose} />
     ));
@@ -158,17 +167,55 @@ describe("SetupModal", () => {
     });
   });
 
+  it("has role dialog and aria-modal", () => {
+    const { container } = render(() => (
+      <SetupModal open={true} agentName="test-agent" onClose={onClose} />
+    ));
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("has aria-labelledby pointing to title", () => {
+    const { container } = render(() => (
+      <SetupModal open={true} agentName="test-agent" onClose={onClose} />
+    ));
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog!.getAttribute("aria-labelledby")).toBe("setup-modal-title");
+    expect(container.querySelector("#setup-modal-title")).not.toBeNull();
+  });
+
+  it("shows error state when API key fetch fails", async () => {
+    const { getAgentKey } = await import("../../src/services/api.js");
+    (getAgentKey as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("Fetch failed"));
+    const { container } = render(() => (
+      <SetupModal open={true} agentName="fail-agent" onClose={onClose} />
+    ));
+    await vi.waitFor(() => {
+      expect(container.querySelector('[data-testid="error-state"]')).not.toBeNull();
+    });
+  });
+
   describe("local mode", () => {
     beforeEach(() => {
       mockGetHealth.mockResolvedValue({ mode: "local" });
     });
 
-    it("shows same AddProvider step as cloud mode", async () => {
+    it("shows Local Ready step", async () => {
       const { container } = render(() => (
         <SetupModal open={true} agentName="local-agent" onClose={onClose} />
       ));
       await vi.waitFor(() => {
-        expect(container.querySelector('[data-testid="step-add-provider"]')).not.toBeNull();
+        expect(container.querySelector('[data-testid="step-local-ready"]')).not.toBeNull();
+      });
+    });
+
+    it("shows local description text", async () => {
+      const { container } = render(() => (
+        <SetupModal open={true} agentName="local-agent" onClose={onClose} />
+      ));
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("pre-configured");
       });
     });
 
@@ -186,9 +233,8 @@ describe("SetupModal", () => {
         <SetupModal open={true} agentName="local-agent" onClose={onClose} />
       ));
       await vi.waitFor(() => {
-        const step = container.querySelector('[data-testid="step-add-provider"]');
+        const step = container.querySelector('[data-testid="step-local-ready"]');
         expect(step).not.toBeNull();
-        // Local mode uses window.location.origin + /v1
         expect(step?.getAttribute("data-base-url")).toContain("/v1");
       });
     });

--- a/packages/frontend/tests/components/SetupModal.test.tsx
+++ b/packages/frontend/tests/components/SetupModal.test.tsx
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+// SolidJS createResource leaks rejected promises as unhandled rejections
+// when error gate is bypassed (e.g. props.apiKey provided)
+const noop = () => {};
+beforeAll(() => process.on("unhandledRejection", noop));
+afterAll(() => process.off("unhandledRejection", noop));
 
 const mockGetHealth = vi.fn().mockResolvedValue({ mode: "cloud" });
 vi.mock("../../src/services/api.js", () => ({

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -5,6 +5,14 @@ vi.stubGlobal("navigator", {
   clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
 });
 
+vi.mock("../../src/components/ApiKeyDisplay.jsx", () => ({
+  default: (props: any) => (
+    <div data-testid="api-key-display" data-key={props.apiKey ?? ""} data-prefix={props.keyPrefix ?? ""}>
+      ApiKeyDisplay
+    </div>
+  ),
+}));
+
 import SetupStepAddProvider from "../../src/components/SetupStepAddProvider";
 
 describe("SetupStepAddProvider", () => {
@@ -22,7 +30,7 @@ describe("SetupStepAddProvider", () => {
   it("shows description with manifest/auto model", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
     expect(container.textContent).toContain("manifest/auto");
-    expect(container.textContent).toContain("routes each request");
+    expect(container.textContent).toContain("route each request");
   });
 
   it("shows base URL in the info grid", () => {
@@ -36,96 +44,146 @@ describe("SetupStepAddProvider", () => {
     expect(container.textContent).toContain("Model");
   });
 
-  it("shows OpenClaw tab by default", () => {
-    render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(screen.getByText("OpenClaw")).toBeDefined();
-  });
-
-  it("shows OpenClaw snippet with direct models.providers config as single JSON", () => {
+  it("renders ApiKeyDisplay component", () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_test_key" />
     ));
-    expect(container.textContent).toContain("models.providers.manifest");
-    expect(container.textContent).toContain("openai-completions");
-    expect(container.textContent).toContain("mnfst_test_key");
-    expect(container.textContent).toContain("agents.defaults.model.primary");
-    expect(container.textContent).toContain("openclaw gateway restart");
+    const display = container.querySelector('[data-testid="api-key-display"]');
+    expect(display).not.toBeNull();
+    expect(display!.getAttribute("data-key")).toBe("mnfst_test_key");
   });
 
-  it("includes full baseUrl in OpenClaw snippet JSON", () => {
-    const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} baseUrl="https://app.manifest.build/v1" />
-    ));
-    const snippet = container.querySelector(".modal-terminal__code")!;
-    expect(snippet.textContent).toContain("app.manifest.build/v1");
-  });
-
-  it("switches to Python SDK tab", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    fireEvent.click(screen.getByText("Python SDK"));
-    expect(container.textContent).toContain('base_url="http://localhost:3001/v1"');
-    expect(container.textContent).toContain('model="manifest/auto"');
-  });
-
-  it("switches to cURL tab", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    fireEvent.click(screen.getByText("cURL"));
-    expect(container.textContent).toContain("curl http://localhost:3001/v1/chat/completions");
-  });
-
-  it("shows full API key with warning when provided", () => {
-    const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_full_key_123" />
-    ));
-    expect(container.textContent).toContain("mnfst_full_key_123");
-    expect(container.textContent).toContain("won't see it again");
-  });
-
-  it("shows key prefix hint when no full key", () => {
+  it("passes keyPrefix to ApiKeyDisplay", () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} keyPrefix="mnfst_abc" />
     ));
-    expect(container.textContent).toContain("mnfst_abc...");
-    expect(container.textContent).toContain("Replace");
+    const display = container.querySelector('[data-testid="api-key-display"]');
+    expect(display!.getAttribute("data-prefix")).toBe("mnfst_abc");
   });
 
-  it("uses placeholder key when no apiKey or keyPrefix", () => {
+  // Accordion: env var method is expanded by default
+  it("shows env var method expanded by default", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("mnfst_YOUR_KEY");
+    expect(container.textContent).toContain("Set an environment variable");
+    expect(container.textContent).toContain("Recommended");
+    expect(container.textContent).toContain("MANIFEST_API_KEY");
   });
 
-  it("includes apiKey in SDK snippet when provided", () => {
+  it("shows env var snippet with placeholder key", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.textContent).toContain('MANIFEST_API_KEY="mnfst_YOUR_KEY"');
+  });
+
+  it("shows env var snippet with full key when provided", () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_real_key" />
     ));
-    fireEvent.click(screen.getByText("Python SDK"));
-    expect(container.textContent).toContain('api_key="mnfst_real_key"');
+    expect(container.textContent).toContain('MANIFEST_API_KEY="mnfst_real_key"');
   });
 
-  it("includes apiKey in cURL snippet when provided", () => {
+  it("includes MANIFEST_ENDPOINT in env snippet for non-production baseUrl", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.textContent).toContain("MANIFEST_ENDPOINT");
+  });
+
+  it("omits MANIFEST_ENDPOINT for app.manifest.build baseUrl", () => {
     const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_real_key" />
+      <SetupStepAddProvider {...defaultProps} baseUrl="https://app.manifest.build/v1" />
     ));
-    fireEvent.click(screen.getByText("cURL"));
-    expect(container.textContent).toContain("Bearer mnfst_real_key");
+    // env method is open by default — should not have MANIFEST_ENDPOINT
+    expect(container.querySelector("#method-env")?.textContent).not.toContain("MANIFEST_ENDPOINT");
+  });
+
+  it("shows env var key prefix snippet when only prefix provided", () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} keyPrefix="mnfst_abc" />
+    ));
+    expect(container.textContent).toContain('MANIFEST_API_KEY="mnfst_abc..."');
+  });
+
+  // Accordion: onboard method (collapsed by default)
+  it("shows one-command setup section (collapsed)", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.textContent).toContain("One-command setup");
+    // body should not be rendered
+    expect(container.querySelector("#method-onboard")).toBeNull();
+  });
+
+  it("expands onboard method and collapses env on click", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    // Click onboard header
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[1]); // second method = onboard
+    expect(container.querySelector("#method-onboard")).not.toBeNull();
+    expect(container.textContent).toContain("openclaw onboard");
+    // env should be collapsed
+    expect(container.querySelector("#method-env")).toBeNull();
+  });
+
+  // Accordion: CLI method (collapsed by default)
+  it("shows manual CLI section (collapsed)", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.textContent).toContain("Manual CLI configuration");
+    expect(container.querySelector("#method-cli")).toBeNull();
+  });
+
+  it("expands CLI method on click", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[2]); // third method = cli
+    expect(container.querySelector("#method-cli")).not.toBeNull();
+    expect(container.textContent).toContain("models.providers.manifest");
+    expect(container.textContent).toContain("openai-completions");
+    expect(container.textContent).toContain("openclaw gateway restart");
+  });
+
+  it("CLI snippet includes apiKey when provided", () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_test_key" />
+    ));
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[2]);
+    expect(container.textContent).toContain("mnfst_test_key");
+  });
+
+  it("CLI snippet includes baseUrl", () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} baseUrl="https://app.manifest.build/v1" />
+    ));
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[2]);
+    expect(container.textContent).toContain("app.manifest.build/v1");
+  });
+
+  it("collapses open method when clicking its header again", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    // env is open by default, click it to close
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[0]);
+    expect(container.querySelector("#method-env")).toBeNull();
+  });
+
+  it("has aria-expanded on method headers", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    expect(headers[0].getAttribute("aria-expanded")).toBe("true");
+    expect(headers[1].getAttribute("aria-expanded")).toBe("false");
+    expect(headers[2].getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("has aria-controls on method headers", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    expect(headers[0].getAttribute("aria-controls")).toBe("method-env");
+    expect(headers[1].getAttribute("aria-controls")).toBe("method-onboard");
+    expect(headers[2].getAttribute("aria-controls")).toBe("method-cli");
   });
 
   it("has copy buttons for base URL and model", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
     const copyButtons = container.querySelectorAll(".modal-terminal__copy");
-    // At least one for base URL, one for model, and one for code snippet
+    // At least: base URL copy, model copy, env snippet copy
     expect(copyButtons.length).toBeGreaterThanOrEqual(3);
-  });
-
-  it("shows terminal UI", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.querySelector(".modal-terminal")).not.toBeNull();
-  });
-
-  it("has tab role on all three tab buttons", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const tabs = container.querySelectorAll('[role="tab"]');
-    expect(tabs.length).toBe(3);
   });
 
   it("renders custom baseUrl correctly", () => {
@@ -133,5 +191,46 @@ describe("SetupStepAddProvider", () => {
       <SetupStepAddProvider {...defaultProps} baseUrl="https://custom.example.com/v1" />
     ));
     expect(container.textContent).toContain("https://custom.example.com/v1");
+  });
+
+  it("uses setup-step__heading class", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.querySelector(".setup-step__heading")).not.toBeNull();
+  });
+
+  it("uses setup-info-grid class for info cards", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.querySelector(".setup-info-grid")).not.toBeNull();
+  });
+
+  it("applies recommended class to env method when open", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const methods = container.querySelectorAll(".setup-method");
+    expect(methods[0].classList.contains("setup-method--recommended")).toBe(true);
+  });
+
+  it("removes recommended class from env method when closed", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    // Close env by clicking onboard
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[1]);
+    const methods = container.querySelectorAll(".setup-method");
+    expect(methods[0].classList.contains("setup-method--recommended")).toBe(false);
+  });
+
+  it("onboard snippet includes --non-interactive flag", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[1]);
+    expect(container.textContent).toContain("--non-interactive");
+  });
+
+  it("onboard snippet includes the API key", () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_key_123" />
+    ));
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[1]);
+    expect(container.textContent).toContain("mnfst_key_123");
   });
 });

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -61,76 +61,9 @@ describe("SetupStepAddProvider", () => {
     expect(display!.getAttribute("data-prefix")).toBe("mnfst_abc");
   });
 
-  // Accordion: env var method is expanded by default
-  it("shows env var method expanded by default", () => {
+  // Accordion order: CLI (expanded), Interactive wizard, Environment variable
+  it("shows CLI method expanded by default", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("Set an environment variable");
-    expect(container.textContent).toContain("Recommended");
-    expect(container.textContent).toContain("MANIFEST_API_KEY");
-  });
-
-  it("shows env var snippet with placeholder key", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain('MANIFEST_API_KEY="mnfst_YOUR_KEY"');
-  });
-
-  it("shows env var snippet with full key when provided", () => {
-    const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_real_key" />
-    ));
-    expect(container.textContent).toContain('MANIFEST_API_KEY="mnfst_real_key"');
-  });
-
-  it("includes MANIFEST_ENDPOINT in env snippet for non-production baseUrl", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("MANIFEST_ENDPOINT");
-  });
-
-  it("omits MANIFEST_ENDPOINT for app.manifest.build baseUrl", () => {
-    const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} baseUrl="https://app.manifest.build/v1" />
-    ));
-    // env method is open by default — should not have MANIFEST_ENDPOINT
-    expect(container.querySelector("#method-env")?.textContent).not.toContain("MANIFEST_ENDPOINT");
-  });
-
-  it("shows env var key prefix snippet when only prefix provided", () => {
-    const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} keyPrefix="mnfst_abc" />
-    ));
-    expect(container.textContent).toContain('MANIFEST_API_KEY="mnfst_abc..."');
-  });
-
-  // Accordion: onboard method (collapsed by default)
-  it("shows one-command setup section (collapsed)", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("One-command setup");
-    // body should not be rendered
-    expect(container.querySelector("#method-onboard")).toBeNull();
-  });
-
-  it("expands onboard method and collapses env on click", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    // Click onboard header
-    const headers = container.querySelectorAll(".setup-method__header");
-    fireEvent.click(headers[1]); // second method = onboard
-    expect(container.querySelector("#method-onboard")).not.toBeNull();
-    expect(container.textContent).toContain("openclaw onboard");
-    // env should be collapsed
-    expect(container.querySelector("#method-env")).toBeNull();
-  });
-
-  // Accordion: CLI method (collapsed by default)
-  it("shows manual CLI section (collapsed)", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    expect(container.textContent).toContain("Manual CLI configuration");
-    expect(container.querySelector("#method-cli")).toBeNull();
-  });
-
-  it("expands CLI method on click", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const headers = container.querySelectorAll(".setup-method__header");
-    fireEvent.click(headers[2]); // third method = cli
     expect(container.querySelector("#method-cli")).not.toBeNull();
     expect(container.textContent).toContain("models.providers.manifest");
     expect(container.textContent).toContain("openai-completions");
@@ -141,8 +74,6 @@ describe("SetupStepAddProvider", () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_test_key" />
     ));
-    const headers = container.querySelectorAll(".setup-method__header");
-    fireEvent.click(headers[2]);
     expect(container.textContent).toContain("mnfst_test_key");
   });
 
@@ -150,39 +81,124 @@ describe("SetupStepAddProvider", () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} baseUrl="https://app.manifest.build/v1" />
     ));
-    const headers = container.querySelectorAll(".setup-method__header");
-    fireEvent.click(headers[2]);
     expect(container.textContent).toContain("app.manifest.build/v1");
   });
 
+  it("CLI snippet uses placeholder key when no apiKey or keyPrefix", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.textContent).toContain("mnfst_YOUR_KEY");
+  });
+
+  it("CLI snippet uses key prefix when only prefix provided", () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} keyPrefix="mnfst_abc" />
+    ));
+    expect(container.textContent).toContain("mnfst_abc...");
+  });
+
+  // Accordion: interactive wizard (collapsed by default)
+  it("shows interactive wizard section (collapsed)", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.textContent).toContain("Interactive wizard");
+    expect(container.querySelector("#method-onboard")).toBeNull();
+  });
+
+  it("expands onboard method and collapses CLI on click", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[1]); // second = onboard
+    expect(container.querySelector("#method-onboard")).not.toBeNull();
+    expect(container.textContent).toContain("openclaw onboard");
+    // CLI should be collapsed
+    expect(container.querySelector("#method-cli")).toBeNull();
+  });
+
+  it("onboard section mentions Custom Provider", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[1]);
+    expect(container.textContent).toContain("Custom Provider");
+  });
+
+  it("onboard section shows field values to copy", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[1]);
+    expect(container.textContent).toContain("API Base URL");
+    expect(container.textContent).toContain("http://localhost:3001/v1");
+    expect(container.textContent).toContain("API Key");
+    expect(container.textContent).toContain("Endpoint compatibility");
+    expect(container.textContent).toContain("OpenAI-compatible");
+    expect(container.textContent).toContain("Model ID");
+  });
+
+  // Accordion: env var (collapsed by default)
+  it("shows env var section (collapsed)", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    expect(container.textContent).toContain("Environment variable");
+    expect(container.querySelector("#method-env")).toBeNull();
+  });
+
+  it("expands env var method on click", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[2]); // third = env
+    expect(container.querySelector("#method-env")).not.toBeNull();
+    expect(container.textContent).toContain("MANIFEST_API_KEY");
+  });
+
+  it("env snippet with full key when provided", () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_real_key" />
+    ));
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[2]);
+    expect(container.textContent).toContain('MANIFEST_API_KEY="mnfst_real_key"');
+  });
+
+  it("includes MANIFEST_ENDPOINT in env snippet for non-production baseUrl", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[2]);
+    expect(container.textContent).toContain("MANIFEST_ENDPOINT");
+  });
+
+  it("omits MANIFEST_ENDPOINT for app.manifest.build baseUrl", () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} baseUrl="https://app.manifest.build/v1" />
+    ));
+    const headers = container.querySelectorAll(".setup-method__header");
+    fireEvent.click(headers[2]);
+    expect(container.querySelector("#method-env")?.textContent).not.toContain("MANIFEST_ENDPOINT");
+  });
+
+  // General accordion behavior
   it("collapses open method when clicking its header again", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    // env is open by default, click it to close
     const headers = container.querySelectorAll(".setup-method__header");
-    fireEvent.click(headers[0]);
-    expect(container.querySelector("#method-env")).toBeNull();
+    fireEvent.click(headers[0]); // CLI is open, click to close
+    expect(container.querySelector("#method-cli")).toBeNull();
   });
 
   it("has aria-expanded on method headers", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
     const headers = container.querySelectorAll(".setup-method__header");
-    expect(headers[0].getAttribute("aria-expanded")).toBe("true");
-    expect(headers[1].getAttribute("aria-expanded")).toBe("false");
-    expect(headers[2].getAttribute("aria-expanded")).toBe("false");
+    expect(headers[0].getAttribute("aria-expanded")).toBe("true");  // CLI expanded
+    expect(headers[1].getAttribute("aria-expanded")).toBe("false"); // onboard collapsed
+    expect(headers[2].getAttribute("aria-expanded")).toBe("false"); // env collapsed
   });
 
   it("has aria-controls on method headers", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
     const headers = container.querySelectorAll(".setup-method__header");
-    expect(headers[0].getAttribute("aria-controls")).toBe("method-env");
+    expect(headers[0].getAttribute("aria-controls")).toBe("method-cli");
     expect(headers[1].getAttribute("aria-controls")).toBe("method-onboard");
-    expect(headers[2].getAttribute("aria-controls")).toBe("method-cli");
+    expect(headers[2].getAttribute("aria-controls")).toBe("method-env");
   });
 
   it("has copy buttons for base URL and model", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
     const copyButtons = container.querySelectorAll(".modal-terminal__copy");
-    // At least: base URL copy, model copy, env snippet copy
     expect(copyButtons.length).toBeGreaterThanOrEqual(3);
   });
 
@@ -203,34 +219,8 @@ describe("SetupStepAddProvider", () => {
     expect(container.querySelector(".setup-info-grid")).not.toBeNull();
   });
 
-  it("applies recommended class to env method when open", () => {
+  it("does not show recommended badge", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const methods = container.querySelectorAll(".setup-method");
-    expect(methods[0].classList.contains("setup-method--recommended")).toBe(true);
-  });
-
-  it("removes recommended class from env method when closed", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    // Close env by clicking onboard
-    const headers = container.querySelectorAll(".setup-method__header");
-    fireEvent.click(headers[1]);
-    const methods = container.querySelectorAll(".setup-method");
-    expect(methods[0].classList.contains("setup-method--recommended")).toBe(false);
-  });
-
-  it("onboard snippet includes --non-interactive flag", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const headers = container.querySelectorAll(".setup-method__header");
-    fireEvent.click(headers[1]);
-    expect(container.textContent).toContain("--non-interactive");
-  });
-
-  it("onboard snippet includes the API key", () => {
-    const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_key_123" />
-    ));
-    const headers = container.querySelectorAll(".setup-method__header");
-    fireEvent.click(headers[1]);
-    expect(container.textContent).toContain("mnfst_key_123");
+    expect(container.querySelector(".setup-method__badge")).toBeNull();
   });
 });

--- a/packages/frontend/tests/components/SetupStepInstall.test.tsx
+++ b/packages/frontend/tests/components/SetupStepInstall.test.tsx
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@solidjs/testing-library";
-import SetupStepInstall, { CopyButton } from "../../src/components/SetupStepInstall";
 
 vi.stubGlobal("navigator", {
   clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
 });
 
+import SetupStepInstall, { CopyButton } from "../../src/components/SetupStepInstall";
+
 describe("SetupStepInstall", () => {
   it("renders install heading", () => {
     render(() => <SetupStepInstall />);
-    expect(screen.getByText("Install the plugin")).toBeDefined();
+    expect(screen.getByText("Install the Manifest plugin")).toBeDefined();
   });
 
   it("shows install description", () => {
@@ -30,30 +31,33 @@ describe("SetupStepInstall", () => {
 
   it("shows step number when provided", () => {
     const { container } = render(() => <SetupStepInstall stepNumber={1} />);
-    expect(container.textContent).toContain("1. Install the plugin");
+    expect(container.textContent).toContain("1. Install the Manifest plugin");
   });
 
   it("has copy button", () => {
     const { container } = render(() => <SetupStepInstall />);
     expect(container.querySelector(".modal-terminal__copy")).not.toBeNull();
   });
+
+  it("uses setup-step__heading class", () => {
+    const { container } = render(() => <SetupStepInstall />);
+    expect(container.querySelector(".setup-step__heading")).not.toBeNull();
+  });
+
+  it("uses setup-step__desc class", () => {
+    const { container } = render(() => <SetupStepInstall />);
+    expect(container.querySelector(".setup-step__desc")).not.toBeNull();
+  });
 });
 
-describe("CopyButton", () => {
+describe("CopyButton re-export", () => {
+  it("re-exports CopyButton from SetupStepInstall", () => {
+    expect(CopyButton).toBeDefined();
+  });
+
   it("copies text to clipboard on click", () => {
     const { container } = render(() => <CopyButton text="test-copy" />);
     const btn = container.querySelector(".modal-terminal__copy")!;
-    fireEvent.click(btn);
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("test-copy");
-  });
-
-  it("handles clipboard write failure gracefully", () => {
-    vi.stubGlobal("navigator", {
-      clipboard: { writeText: vi.fn().mockRejectedValue(new Error("Not allowed")) },
-    });
-    const { container } = render(() => <CopyButton text="test-copy" />);
-    const btn = container.querySelector(".modal-terminal__copy")!;
-    // Should not throw
     fireEvent.click(btn);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("test-copy");
   });

--- a/packages/frontend/tests/components/SetupStepLocalReady.test.tsx
+++ b/packages/frontend/tests/components/SetupStepLocalReady.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+
+vi.mock("../../src/components/CopyButton.jsx", () => ({
+  default: (props: any) => (
+    <button data-testid="copy-button" data-text={props.text}>
+      CopyStub
+    </button>
+  ),
+}));
+
+vi.mock("../../src/components/ApiKeyDisplay.jsx", () => ({
+  default: (props: any) => (
+    <div
+      data-testid="api-key-display"
+      data-api-key={props.apiKey ?? ""}
+      data-key-prefix={props.keyPrefix ?? ""}
+    >
+      {props.apiKey ? `KEY:${props.apiKey}` : ""}
+      {!props.apiKey && props.keyPrefix ? `PREFIX:${props.keyPrefix}` : ""}
+    </div>
+  ),
+}));
+
+import SetupStepLocalReady from "../../src/components/SetupStepLocalReady";
+
+describe("SetupStepLocalReady", () => {
+  const defaultProps = {
+    apiKey: null as string | null,
+    keyPrefix: null as string | null,
+    baseUrl: "http://localhost:3001/v1",
+  };
+
+  it("renders the heading", () => {
+    render(() => <SetupStepLocalReady {...defaultProps} />);
+    expect(screen.getByText("Your agent is ready")).toBeDefined();
+  });
+
+  it("shows description about local server and routing", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} />
+    ));
+    expect(container.textContent).toContain("local server is running");
+    expect(container.textContent).toContain("manifest/auto");
+    expect(container.textContent).toContain("route requests through Manifest");
+  });
+
+  it("shows checklist item for plugin", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} />
+    ));
+    expect(container.textContent).toContain("Plugin installed and configured");
+  });
+
+  it("shows checklist item for API key", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} />
+    ));
+    expect(container.textContent).toContain("API key auto-generated");
+  });
+
+  it("shows base URL in checklist", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} />
+    ));
+    expect(container.textContent).toContain("Base URL:");
+    expect(container.textContent).toContain("http://localhost:3001/v1");
+  });
+
+  it("shows custom base URL", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady
+        {...defaultProps}
+        baseUrl="https://custom.example.com/v1"
+      />
+    ));
+    expect(container.textContent).toContain("https://custom.example.com/v1");
+  });
+
+  it("renders check icon SVGs in checklist items", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} />
+    ));
+    const checklistItems = container.querySelectorAll(".setup-checklist__item");
+    expect(checklistItems.length).toBe(3);
+    checklistItems.forEach((item) => {
+      expect(item.querySelector("svg")).not.toBeNull();
+    });
+  });
+
+  it("shows start-chatting hint when apiKey is null", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} />
+    ));
+    expect(container.textContent).toContain("manifest/auto");
+    expect(container.textContent).toContain("send a message");
+    expect(container.textContent).toContain(
+      "activity will appear on the dashboard"
+    );
+  });
+
+  it("hides start-chatting hint when apiKey is provided", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} apiKey="mnfst_full_key_123" />
+    ));
+    expect(container.textContent).not.toContain(
+      "activity will appear on the dashboard within a few seconds"
+    );
+  });
+
+  it("passes apiKey to ApiKeyDisplay", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} apiKey="mnfst_test_key" />
+    ));
+    const display = container.querySelector('[data-testid="api-key-display"]');
+    expect(display).not.toBeNull();
+    expect(display!.getAttribute("data-api-key")).toBe("mnfst_test_key");
+  });
+
+  it("passes keyPrefix to ApiKeyDisplay", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} keyPrefix="mnfst_pre" />
+    ));
+    const display = container.querySelector('[data-testid="api-key-display"]');
+    expect(display).not.toBeNull();
+    expect(display!.getAttribute("data-key-prefix")).toBe("mnfst_pre");
+  });
+
+  it("renders ApiKeyDisplay with empty attributes when no key or prefix", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} />
+    ));
+    const display = container.querySelector('[data-testid="api-key-display"]');
+    expect(display).not.toBeNull();
+    expect(display!.getAttribute("data-api-key")).toBe("");
+    expect(display!.getAttribute("data-key-prefix")).toBe("");
+  });
+
+  it("renders the heading as an h3", () => {
+    const { container } = render(() => (
+      <SetupStepLocalReady {...defaultProps} />
+    ));
+    const h3 = container.querySelector("h3.setup-step__heading");
+    expect(h3).not.toBeNull();
+    expect(h3!.textContent).toBe("Your agent is ready");
+  });
+});

--- a/packages/frontend/tests/components/SetupStepProviders.test.tsx
+++ b/packages/frontend/tests/components/SetupStepProviders.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { render, fireEvent } from "@solidjs/testing-library";
 
 import SetupStepProviders from "../../src/components/SetupStepProviders";
 
@@ -10,45 +10,78 @@ describe("SetupStepProviders", () => {
     const { container } = render(() => (
       <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
     ));
-    expect(container.querySelector("h3")?.textContent).toBe("Connect your models");
+    expect(container.querySelector("h3")?.textContent).toBe("Connect your LLM providers");
   });
 
-  it("renders description about needing a provider", () => {
+  it("renders description about routing", () => {
     const { container } = render(() => (
       <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
     ));
-    expect(container.textContent).toContain("at least one LLM provider");
+    expect(container.textContent).toContain("routes each request to the best model");
   });
 
   it("renders warning about requests failing without providers", () => {
     const { container } = render(() => (
       <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
     ));
-    expect(container.textContent).toContain("will fail");
+    expect(container.textContent).toContain("will return an error");
   });
 
-  it("mentions manifest/auto in the warning", () => {
+  it("mentions manifest/auto", () => {
     const { container } = render(() => (
       <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
     ));
     expect(container.textContent).toContain("manifest/auto");
   });
 
-  it("renders go to routing button", () => {
+  it("renders connect a provider button", () => {
     const { container } = render(() => (
       <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
     ));
-    const btn = container.querySelector(".btn");
+    const btn = container.querySelector(".btn--primary");
     expect(btn).not.toBeNull();
-    expect(btn?.textContent).toContain("Go to routing");
+    expect(btn?.textContent).toContain("Connect a provider");
   });
 
   it("calls onGoToRouting when button clicked", () => {
     const { container } = render(() => (
       <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
     ));
-    const btn = container.querySelector(".btn")!;
+    const btn = container.querySelector(".btn--primary")!;
     fireEvent.click(btn);
     expect(onGoToRouting).toHaveBeenCalled();
+  });
+
+  it("shows skip button when onSkip provided", () => {
+    const onSkip = vi.fn();
+    const { container } = render(() => (
+      <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} onSkip={onSkip} />
+    ));
+    const skipBtn = container.querySelector(".btn--ghost");
+    expect(skipBtn).not.toBeNull();
+    expect(skipBtn?.textContent).toContain("I'll do this later");
+  });
+
+  it("calls onSkip when skip button clicked", () => {
+    const onSkip = vi.fn();
+    const { container } = render(() => (
+      <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} onSkip={onSkip} />
+    ));
+    fireEvent.click(container.querySelector(".btn--ghost")!);
+    expect(onSkip).toHaveBeenCalled();
+  });
+
+  it("does not show skip button when onSkip not provided", () => {
+    const { container } = render(() => (
+      <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
+    ));
+    expect(container.querySelector(".btn--ghost")).toBeNull();
+  });
+
+  it("uses setup-step__heading class", () => {
+    const { container } = render(() => (
+      <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
+    ));
+    expect(container.querySelector(".setup-step__heading")).not.toBeNull();
   });
 });

--- a/packages/openclaw-plugin/public/index.html
+++ b/packages/openclaw-plugin/public/index.html
@@ -30,10 +30,10 @@
     />
     <meta name="twitter:image" content="https://app.manifest.build/og-image.png" />
     <script src="/theme-init.js"></script>
-    <script type="module" crossorigin src="/assets/index-esby_Amw.js"></script>
+    <script type="module" crossorigin src="/assets/index-fn4HLThn.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/vendor-K8fEFSq9.js">
     <link rel="modulepreload" crossorigin href="/assets/auth-C2bQ9WcQ.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-CbWrZHJK.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-DBDD7Bu4.css">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary

- Redesign setup wizard to lead with the easiest provider registration method (environment variable), replacing the tabbed terminal widget with a stacked accordion
- Add `openclaw onboard` one-command setup as a second option (new OpenClaw v2026.3.22+ capability)
- Remove Python SDK and cURL tabs from the wizard (post-setup concern, not onboarding)
- Extract shared `CopyButton` and `ApiKeyDisplay` components from inline duplicates
- Create `SetupStepLocalReady` merging local configure + verify steps
- Update `SetupModal` with error handling for API key fetch, local mode branch, personalized title
- Improve `SetupStepProviders` copy and add "skip for now" option
- Move inline styles to CSS classes (`wizard.css`, `overview.css`)

## Test plan

- [ ] All frontend tests pass (85 suites, 1702 tests)
- [ ] TypeScript compiles with no errors
- [ ] Cloud mode: wizard shows accordion with env var expanded, onboard collapsed, CLI collapsed
- [ ] Local mode: wizard shows "Your agent is ready" checklist + start chatting hint
- [ ] API key display shows warning + copy button when full key present
- [ ] API key display shows prefix hint when only prefix available
- [ ] Accordion toggles correctly: clicking one method closes others
- [ ] Copy buttons work for all code snippets, base URL, and model name
- [ ] Connect providers button navigates to routing page
- [ ] Skip button closes wizard without navigating
- [ ] Error state renders when API key fetch fails

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the onboarding wizard with an accordion that opens on CLI setup, adds an interactive `openclaw onboard` flow with copyable field values, and lists env var setup third. Local mode shows a ready checklist; the modal adds resilient API key/error handling and better copy feedback.

- **New Features**
  - Accordion methods: CLI (expanded), interactive `openclaw onboard` with Custom Provider instructions and copyable fields, and environment variable.
  - Local mode “Your agent is ready” step with checklist and guidance.
  - `SetupModal` updates: personalized title, cloud/local copy, API key error state with retry, and shows setup if `apiKey` is present even when fetch fails.
  - Provider step copy improved and adds “I’ll do this later” skip.

- **Refactors**
  - Removed Python SDK and cURL tabs from the wizard.
  - Extracted shared `CopyButton` and `ApiKeyDisplay` components; `CopyButton` adds a “Copy failed” aria-label on clipboard errors.
  - Moved inline styles to `wizard.css` and `overview.css` with new utility classes; polished onboarding UI (copy button placement in onboard fields, no “Recommended” badge).
  - Suppressed SolidJS `createResource` unhandled rejections in tests to avoid flaky failures.

<sup>Written for commit 259434506e962c9ee952aa0e906d842e352c32bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

