### PR TITLE
chore: update skills for routing-only architecture

### DIFF
--- a/.changeset/update-skills-routing.md
+++ b/.changeset/update-skills-routing.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Update all skills for routing-only architecture. Cloud users add Manifest as a direct model provider (no plugin). Remove OTLP and telemetry references.

--- a/skills/manifest-status/SKILL.md
+++ b/skills/manifest-status/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: manifest-status
-description: Show current Manifest plugin configuration as a diagnostic table. Use when the user says "/manifest-status", "manifest status", "show manifest config", "manifest settings", "is manifest installed", "check manifest plugin", or wants to see the current state of the Manifest OpenClaw plugin configuration. Outputs a table and nothing else.
+description: Show current Manifest configuration as a diagnostic table. Use when the user says "/manifest-status", "manifest status", "show manifest config", "manifest settings", "is manifest installed", "check manifest", or wants to see the current Manifest routing setup. Outputs a table and nothing else.
 ---
 
 # Manifest Status
 
-Print the current Manifest plugin configuration. No commentary — just the table.
+Print the current Manifest configuration. Shows both the direct model provider config (`models.providers.manifest`) and the plugin config if installed. No commentary -- just the table.
 
 ## Workflow
 
-Run the diagnostic script (path relative to repository root):
+Run the diagnostic script:
 
 ```bash
 bash skills/manifest-status/scripts/manifest_status.sh

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -46,7 +46,7 @@ To expose over Tailscale: `tailscale serve --bg 2099`
 
 ## Security & Privacy
 
-**Cloud mode**: Manifest proxies your request to the LLM provider. It records metadata (model name, token counts, latency, cost) but never stores prompt or response content. When `manifest/auto` routing is active, the last 10 non-system messages are scored for tier assignment; set a fixed model to skip this.
+**Cloud mode**: Manifest proxies your request to the LLM provider. It records metadata (model name, token counts, latency, cost) but never stores prompt or response content. When `manifest/auto` routing is active, the last 10 non-system messages (`{role, content}` only -- no tool args or file contents) are sent to the scoring endpoint for tier assignment; set a fixed model to skip this.
 
 **Local mode**: All data stays on your machine. No external calls.
 
@@ -57,7 +57,8 @@ To expose over Tailscale: `tailscale serve --bg 2099`
 
 ## Agent Tools
 
-Three read-only tools available in-conversation:
+Three read-only tools available when the plugin is installed (local mode). Cloud-only users without the plugin do not get these tools.
+
 
 | Tool | Trigger phrases | Returns |
 |------|----------------|---------|

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -4,89 +4,35 @@ description: Model Router for OpenClaw. Save up to 70% by routing requests to th
 metadata: {"openclaw":{"requires":{"bins":["openclaw"]},"homepage":"https://github.com/mnfst/manifest"}}
 ---
 
-# Manifest — LLM Router & Observability for OpenClaw
+# Manifest -- LLM Router for OpenClaw
 
-Manifest is an OpenClaw plugin that:
+Manifest sits between your agent and your LLM providers. It scores each request, picks the cheapest model that can handle it, and records everything in a dashboard.
 
-- **Routes every request** to the most cost-effective model via a 23-dimension scoring algorithm (<2ms latency)
+- **Routes every request** to the right model via a 23-dimension scoring algorithm (<2ms)
 - **Tracks costs and tokens** in a real-time dashboard
 - **Sets limits** with email alerts and hard spending caps
 
-Source: [github.com/mnfst/manifest](https://github.com/mnfst/manifest) — MIT licensed. Homepage: [manifest.build](https://manifest.build)
+Source: [github.com/mnfst/manifest](https://github.com/mnfst/manifest) -- MIT licensed
 
-## Security & Privacy
+## Setup (Cloud -- recommended)
 
-> **TL;DR** — OTLP telemetry collects only metadata (model, tokens, latency, tool names) — never prompt or response text. When `manifest/auto` routing is active, the last 10 non-system messages are sent to the routing endpoint for tier scoring; set a fixed model to avoid this. The API key (`mnfst_*`) authenticates your telemetry — it is not exfiltration. In local mode, all data stays on your machine.
+No plugin needed. Add Manifest as a model provider directly in your OpenClaw config.
 
-### External Endpoints
-
-| Endpoint                            | When                               | Data Sent                                                                                                 |
-| ----------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `{endpoint}/v1/traces`              | Every LLM call (batched 10-30s)    | OTLP spans (see fields below)                                                                             |
-| `{endpoint}/v1/metrics`             | Every 10-30s                       | Counters: request count, token totals, tool call counts — grouped by model/provider                       |
-| `{endpoint}/api/v1/routing/resolve` | Only when model is `manifest/auto` | Last 10 non-system/non-developer messages (`{role, content}` only)                                        |
-
-### OTLP Span Fields
-
-Exhaustive list of attributes sent per span:
-
-- `openclaw.session.key` — opaque session identifier
-- `openclaw.message.channel` — message channel name
-- `gen_ai.request.model` — model name (e.g. "claude-sonnet-4-20250514")
-- `gen_ai.system` — provider name (e.g. "anthropic")
-- `gen_ai.usage.input_tokens` — integer
-- `gen_ai.usage.output_tokens` — integer
-- `gen_ai.usage.cache_read_input_tokens` — integer
-- `gen_ai.usage.cache_creation_input_tokens` — integer
-- `openclaw.agent.name` — agent identifier
-- `tool.name` — tool name string
-- `tool.success` — boolean
-- `manifest.routing.tier` — routing tier (if routed)
-- `manifest.routing.reason` — routing reason (if routed)
-- Error status: agent errors truncated to 500 chars; tool errors include `event.error.message` untruncated
-
-**Not collected by OTLP telemetry**: user prompts, assistant responses, tool input/output arguments, file contents, or any message body. Note: when `manifest/auto` routing is active, the last 10 non-system messages (`{role, content}` only) are sent to the routing endpoint for tier scoring — see Routing Data below. To avoid this, set a fixed model instead of `manifest/auto`.
-
-### Routing Data
-
-- Only active when model is `manifest/auto`
-- Excludes messages with `role: "system"` or `role: "developer"`
-- Sends only `{role, content}` — all other message properties are stripped (`routing.ts:77`)
-- 3-second timeout, non-blocking
-- To avoid sending content: disable routing in the dashboard or set a fixed model
-
-### Credential Storage
-
-- **Cloud mode**: API key stored in `~/.openclaw/openclaw.json` under `plugins.entries.manifest.config.apiKey` (managed by OpenClaw's standard plugin config)
-- **Local mode**: auto-generated key stored in `~/.openclaw/manifest/config.json` with file mode `0600`
-
-### Local Mode
-
-All data stays on your machine. No external calls are made in local mode.
-
-## Install Provenance
-
-`openclaw plugins install manifest` installs the [`manifest`](https://www.npmjs.com/package/manifest) npm package.
-
-- **Source**: [github.com/mnfst/manifest](https://github.com/mnfst/manifest) (`packages/openclaw-plugin/`)
-- **License**: MIT
-- **Author**: MNFST Inc.
-
-Verify before installing:
+1. Sign up at [app.manifest.build](https://app.manifest.build), create an agent, copy the `mnfst_*` API key
+2. Run:
 
 ```bash
-npm view manifest repository.url
-npm view manifest dist.integrity
+openclaw config set models.providers.manifest '{"baseUrl":"https://app.manifest.build/v1","api":"openai-completions","apiKey":"mnfst_YOUR_KEY","models":[{"id":"auto","name":"Manifest Auto"}]}'
+openclaw config set agents.defaults.model.primary manifest/auto
+openclaw gateway restart
 ```
 
-The package is published with [npm provenance attestations](https://docs.npmjs.com/generating-provenance-statements). Verify with:
-```bash
-npm audit signatures
-```
+3. Connect at least one LLM provider in the dashboard (Routing page)
+4. Send a message -- it routes through Manifest and shows up in the dashboard
 
-## Setup (Local — recommended for evaluation)
+## Setup (Local)
 
-No account, no API key, no external calls.
+For a self-contained setup where everything stays on your machine. Install the plugin:
 
 ```bash
 openclaw plugins install manifest
@@ -94,132 +40,63 @@ openclaw config set plugins.entries.manifest.config.mode local
 openclaw gateway restart
 ```
 
-Dashboard opens at **http://127.0.0.1:2099**. Data stored locally in `~/.openclaw/manifest/manifest.db`. No account or API key needed.
+Dashboard at **http://127.0.0.1:2099**. Data stored in `~/.openclaw/manifest/manifest.db`. No account or API key needed.
 
-To expose over Tailscale (requires Tailscale on both devices, only accessible within your Tailnet): `tailscale serve --bg 2099`
+To expose over Tailscale: `tailscale serve --bg 2099`
 
-## Setup (Cloud)
+## Security & Privacy
 
-Three commands, no coding:
+**Cloud mode**: Manifest proxies your request to the LLM provider. It records metadata (model name, token counts, latency, cost) but never stores prompt or response content. When `manifest/auto` routing is active, the last 10 non-system messages are scored for tier assignment; set a fixed model to skip this.
 
-```bash
-openclaw plugins install manifest
-openclaw config set plugins.entries.manifest.config.apiKey "mnfst_YOUR_KEY"
-openclaw gateway restart
-```
+**Local mode**: All data stays on your machine. No external calls.
 
-Get the API key at [app.manifest.build](https://app.manifest.build) → create an account → create an agent → copy the `mnfst_*` key.
+### Credential storage
 
-After restart, the plugin auto-configures:
-
-- Adds `manifest/auto` to the model allowlist (does not change your current default)
-- Injects the `manifest` provider into `~/.openclaw/openclaw.json`
-- Starts exporting OTLP telemetry to `app.manifest.build`
-- Exposes three agent tools: `manifest_usage`, `manifest_costs`, `manifest_health`
-
-Dashboard at [app.manifest.build](https://app.manifest.build). Telemetry arrives within 10-30 seconds (batched OTLP export).
-
-### Verify connection
-
-```bash
-openclaw manifest
-```
-
-Shows: mode, endpoint reachability, auth validity, agent name.
-
-## Configuration Changes
-
-On plugin registration, Manifest writes to these files:
-
-| File                                            | Change                                                                                                      | Reversible                                  |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `~/.openclaw/openclaw.json`                     | Adds `models.providers.manifest` provider entry; adds `manifest/auto` to `agents.defaults.models` allowlist | Yes — `openclaw plugins uninstall manifest` |
-| `~/.openclaw/agents/*/agent/auth-profiles.json` | Adds `manifest:default` auth profile                                                                        | Yes — uninstall removes it                  |
-| `~/.openclaw/manifest/config.json`              | Stores auto-generated API key (local mode only, file mode 0600)                                             | Yes — delete `~/.openclaw/manifest/`        |
-| `~/.openclaw/manifest/manifest.db`              | SQLite database (local mode only)                                                                           | Yes — delete the file                       |
-
-No other files are modified. The plugin does not change your current default model.
-
-## What Manifest Answers
-
-Manifest answers these questions about your OpenClaw agents — via the dashboard or directly in-conversation via agent tools:
-
-**Spending & budget**
-
-- How much have I spent today / this week / this month?
-- What's my cost breakdown by model?
-- Which model consumes the biggest share of my budget?
-- Am I approaching my spending limit?
-
-**Token consumption**
-
-- How many tokens has my agent used (input vs. output)?
-- What's my token trend compared to the previous period?
-- How much cache am I reading vs. writing?
-
-**Activity & performance**
-
-- How many LLM calls has my agent made?
-- How long do LLM calls take (latency)?
-- Are there errors or rate limits occurring? What are the error messages?
-- Which skills/tools are running and how often?
-
-**Routing intelligence**
-
-- What routing tier (simple/standard/complex/reasoning) was each request assigned?
-- Why was a specific tier chosen?
-- What model pricing is available across all providers?
-
-**Connectivity**
-
-- Is Manifest connected and healthy?
-- Is telemetry flowing correctly?
+- **Cloud mode**: API key in OpenClaw config at `models.providers.manifest.apiKey`
+- **Local mode**: auto-generated key in `~/.openclaw/manifest/config.json` (file mode `0600`)
 
 ## Agent Tools
 
-Three tools are available to the agent in-conversation:
+Three read-only tools available in-conversation:
 
-| Tool              | Trigger phrases                                 | What it returns                                                             |
-| ----------------- | ----------------------------------------------- | --------------------------------------------------------------------------- |
-| `manifest_usage`  | "how many tokens", "token usage", "consumption" | Total, input, output, cache-read tokens + action count for today/week/month |
-| `manifest_costs`  | "how much spent", "costs", "money burned"       | Cost breakdown by model in USD for today/week/month                         |
-| `manifest_health` | "is monitoring working", "connectivity test"    | Endpoint reachable, auth valid, agent name, status                          |
+| Tool | Trigger phrases | Returns |
+|------|----------------|---------|
+| `manifest_usage` | "how many tokens", "token usage" | Total, input, output, cache tokens for today/week/month |
+| `manifest_costs` | "how much spent", "costs" | Cost breakdown by model in USD |
+| `manifest_health` | "is monitoring working" | Endpoint reachable, auth valid, agent name |
 
 Each accepts a `period` parameter: `"today"`, `"week"`, or `"month"`.
 
-All three tools are read-only — they query the agent's own usage data and never send message content.
-
 ## LLM Routing
 
-When the model is set to `manifest/auto`, the router scores each conversation across 23 dimensions and assigns one of 4 tiers:
+When model is `manifest/auto`, the router scores each conversation across 23 dimensions and assigns a tier:
 
-| Tier          | Use case                                | Examples                                                |
-| ------------- | --------------------------------------- | ------------------------------------------------------- |
-| **Simple**    | Greetings, confirmations, short lookups | "hi", "yes", "what time is it"                          |
-| **Standard**  | General tasks, balanced quality/cost    | "summarize this", "write a test"                        |
-| **Complex**   | Multi-step reasoning, nuanced analysis  | "compare these architectures", "debug this stack trace" |
-| **Reasoning** | Formal logic, proofs, critical planning | "prove this theorem", "design a migration strategy"     |
+| Tier | Use case | Examples |
+|------|----------|---------|
+| **Simple** | Greetings, short lookups | "hi", "what time is it" |
+| **Standard** | General tasks | "summarize this", "write a test" |
+| **Complex** | Multi-step reasoning | "compare these architectures" |
+| **Reasoning** | Formal logic, proofs | "prove this theorem" |
 
-Each tier maps to a model. Default models are auto-assigned per provider, but overridable in the dashboard under **Routing**.
+Default models are auto-assigned per provider, overridable in the dashboard under Routing.
 
 Short-circuit rules:
-
-- Messages <50 chars with no tools → **Simple**
-- Formal logic keywords → **Reasoning**
-- Tools present → floor at **Standard**
-- Context >50k tokens → floor at **Complex**
+- Messages <50 chars with no tools -> Simple
+- Formal logic keywords -> Reasoning
+- Tools present -> floor at Standard
+- Context >50k tokens -> floor at Complex
 
 ## Dashboard Pages
 
-| Page             | What it shows                                                                 |
-| ---------------- | ----------------------------------------------------------------------------- |
-| **Workspace**    | All connected agents as cards with sparkline activity charts                  |
-| **Overview**     | Per-agent cost, tokens, messages with trend badges and time-series charts     |
-| **Messages**     | Full paginated message log with filters (status, model, cost range)           |
-| **Routing**      | 4-tier model config, provider connections, enable/disable routing             |
-| **Limits**       | Email alerts and hard spending caps (tokens or cost, per hour/day/week/month) |
-| **Settings**     | Agent rename, delete, OTLP key management                                     |
-| **Model Prices** | Sortable table of 300+ model prices across all providers                      |
+| Page | What it shows |
+|------|--------------|
+| **Workspace** | All agents with sparkline activity charts |
+| **Overview** | Cost, tokens, messages with trend badges and charts |
+| **Messages** | Full paginated log with filters (status, model, cost range) |
+| **Routing** | 4-tier model config, provider connections |
+| **Limits** | Alerts and spending caps |
+| **Settings** | Agent rename, delete, API key management |
+| **Model Prices** | 300+ model prices across all providers |
 
 ## Supported Providers
 
@@ -227,21 +104,27 @@ Anthropic, OpenAI, Google Gemini, DeepSeek, xAI, Mistral AI, Qwen, MiniMax, Kimi
 
 ## Uninstall
 
+**Cloud users** (no plugin): Remove the provider from your OpenClaw config:
+
+```bash
+openclaw config set models.providers.manifest null
+openclaw config set agents.defaults.model.primary <your-preferred-model>
+openclaw gateway restart
+```
+
+**Local users** (plugin installed):
+
 ```bash
 openclaw plugins uninstall manifest
 openclaw gateway restart
 ```
 
-This removes the plugin, provider config, and auth profiles. After uninstalling, `manifest/auto` is no longer available. If any agent uses it, switch to another model.
-
 ## Troubleshooting
 
-**Telemetry not appearing**: The gateway batches OTLP data every 10-30 seconds. Wait, then check `openclaw manifest` for connection status.
+**401 errors**: Check that the API key in your OpenClaw config matches the key in the Manifest dashboard (Settings -> Agent setup). Keys start with `mnfst_`.
 
-**Auth errors in cloud mode**: Verify the API key starts with `mnfst_` and matches the key in the dashboard under Settings → Agent setup.
+**No messages in dashboard**: Make sure you have at least one provider connected in the Routing page. Without a provider, requests to `manifest/auto` fail with a 400 error.
 
-**Port conflict in local mode**: If port 2099 is busy, the plugin checks if the existing process is Manifest and reuses it. To change the port: `openclaw config set plugins.entries.manifest.config.port <PORT>`.
+**Port conflict in local mode**: If port 2099 is busy, change it: `openclaw config set plugins.entries.manifest.config.port <PORT>`.
 
-**Plugin conflicts**: Manifest conflicts with the built-in `diagnostics-otel` plugin. Disable it before enabling Manifest.
-
-**After backend restart**: Always restart the gateway too (`openclaw gateway restart`) — the OTLP pipeline doesn't auto-reconnect.
+**After backend restart**: Restart the gateway too (`openclaw gateway restart`).

--- a/skills/setup-manifest-plugin/SKILL.md
+++ b/skills/setup-manifest-plugin/SKILL.md
@@ -1,40 +1,40 @@
 ---
 name: setup-manifest-plugin
-description: Configure the Manifest OpenClaw plugin (OTLP endpoint + proxy baseUrl). Use when the user says "/setup-manifest-plugin", "setup manifest plugin", "connect manifest to port", "point openclaw to localhost", "switch to cloud mode", or wants to configure the OpenClaw gateway to route through Manifest (local dev or cloud at app.manifest.build). Accepts a port number (required for dev/local, optional for cloud) and optional mode. Resets routing, sets the OTLP endpoint and proxy baseUrl, and restarts the gateway.
+description: Configure Manifest as a model provider in OpenClaw. Use when the user says "/setup-manifest-plugin", "setup manifest", "connect manifest", "point openclaw to localhost", or wants to add Manifest as a model provider. For cloud users, sets up models.providers.manifest directly (no plugin). For local dev, configures the plugin. Accepts a port number and optional mode.
 ---
 
-# Setup Manifest Plugin
+# Setup Manifest
 
-Configure the OpenClaw gateway to route through Manifest — either a local dev server or cloud (`app.manifest.build`).
+Configure OpenClaw to route through Manifest -- either the cloud service or a local dev server.
+
+**Cloud users don't need the plugin.** This skill adds Manifest as a direct model provider in the OpenClaw config.
 
 ## Workflow
 
 ### 1. Determine parameters
 
-- **Port** (required for dev/local, optional for cloud): The port where the Manifest backend is running (e.g., `35166`). In cloud mode without a port, defaults to `https://app.manifest.build`.
+- **Port** (required for dev/local, optional for cloud): The port where the Manifest backend is running. In cloud mode without a port, defaults to `https://app.manifest.build`.
 - **Mode** (optional, default `dev`): `dev`, `local`, or `cloud`
-  - `dev` — Standard development mode, OTLP loopback bypass (no real API key needed)
-  - `local` — Local mode with SQLite, no PostgreSQL, useful for testing local-mode differences
-  - `cloud` — Cloud mode pointing to `app.manifest.build` (or localhost if port is provided for local cloud testing)
-- **Key** (optional): A `mnfst_*` OTLP API key. Required for cloud mode. If mode is `cloud` and no key is provided, use the seeded dev key `mnfst_dev-otlp-key-001`.
+  - `dev` -- Local development, connects to a backend you started manually
+  - `local` -- Installs the plugin with embedded server and SQLite
+  - `cloud` -- Connects to `app.manifest.build` (or localhost if port is provided)
+- **Key** (optional): A `mnfst_*` API key. Required for cloud mode.
 
-If the user doesn't specify a mode, default to `dev`. If the mode is dev/local and the user doesn't specify a port, ask them. For cloud mode without a port, the script defaults to `app.manifest.build`.
+If the user doesn't specify a mode, default to `dev`. If dev/local and no port, ask them.
 
 ### 2. Run the setup script
 
 ```bash
-# Dev/local (port required):
-bash skills/setup-manifest-plugin/scripts/setup_manifest.sh <PORT> --mode <MODE> [--key <KEY>]
+# Dev (port required):
+bash skills/setup-manifest-plugin/scripts/setup_manifest.sh <PORT> --mode dev [--key <KEY>]
 
-# Cloud (port optional — defaults to app.manifest.build):
+# Cloud (port optional):
 bash skills/setup-manifest-plugin/scripts/setup_manifest.sh --mode cloud --key <KEY>
 ```
 
-The script configures the OTLP endpoint, provider block, default model (`manifest/auto`), and restarts the gateway. Use `--dry-run` to preview changes without modifying anything.
+The script sets the provider config (`models.providers.manifest`), default model (`manifest/auto`), and restarts the gateway. Use `--dry-run` to preview.
 
 ### 3. Show status table
-
-After the script completes, run the diagnostic table:
 
 ```bash
 bash skills/manifest-status/scripts/manifest_status.sh

--- a/skills/setup-manifest-plugin/SKILL.md
+++ b/skills/setup-manifest-plugin/SKILL.md
@@ -16,7 +16,7 @@ Configure OpenClaw to route through Manifest -- either the cloud service or a lo
 - **Port** (required for dev/local, optional for cloud): The port where the Manifest backend is running. In cloud mode without a port, defaults to `https://app.manifest.build`.
 - **Mode** (optional, default `dev`): `dev`, `local`, or `cloud`
   - `dev` -- Local development, connects to a backend you started manually
-  - `local` -- Installs the plugin with embedded server and SQLite
+  - `local` -- Configures the plugin for embedded server with SQLite (plugin must be installed separately via `openclaw plugins install manifest`)
   - `cloud` -- Connects to `app.manifest.build` (or localhost if port is provided)
 - **Key** (optional): A `mnfst_*` API key. Required for cloud mode.
 

--- a/skills/setup-manifest-plugin/scripts/setup_manifest.sh
+++ b/skills/setup-manifest-plugin/scripts/setup_manifest.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Configure the Manifest OpenClaw plugin (OTLP endpoint + proxy baseUrl).
+# Configure Manifest as a model provider in OpenClaw.
+# Cloud users: sets models.providers.manifest directly (no plugin needed).
+# Dev/local users: also configures the plugin.
 # Usage: bash setup_manifest.sh [PORT] [--mode dev|local|cloud] [--key mnfst_*] [--dry-run]
-# PORT is required for dev/local modes. In cloud mode without PORT, defaults to app.manifest.build.
 set -euo pipefail
 
 OPENCLAW_DIR="${HOME}/.openclaw"
@@ -32,26 +33,24 @@ if [[ ! "$MODE" =~ ^(dev|local|cloud)$ ]]; then
   exit 1
 fi
 
-# Port is required for dev/local, optional for cloud (defaults to app.manifest.build)
+# Port is required for dev/local, optional for cloud
 if [[ -z "$PORT" && "$MODE" != "cloud" ]]; then
   echo "ERROR: Port is required for ${MODE} mode. Usage: bash setup_manifest.sh <PORT> [--mode dev|local|cloud] [--key mnfst_*]" >&2
   exit 1
 fi
 
-# Cloud mode requires an API key — use seeded dev key as fallback
+# Cloud mode requires an API key
 if [[ "$MODE" == "cloud" && -z "$API_KEY" ]]; then
   API_KEY="mnfst_dev-otlp-key-001"
   echo "[setup-manifest] No --key provided for cloud mode, using seeded dev key"
 fi
 
-# Compute base origin, OTLP endpoint, and proxy baseUrl
+# Compute base URL
 if [[ -n "$PORT" ]]; then
   BASE_ORIGIN="http://localhost:${PORT}"
 else
-  # Cloud mode without port → production
   BASE_ORIGIN="https://app.manifest.build"
 fi
-ENDPOINT="${BASE_ORIGIN}/otlp"
 BASE_URL="${BASE_ORIGIN}/v1"
 
 log() { echo "[setup-manifest] $*"; }
@@ -73,29 +72,29 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
   exit 1
 fi
 
-# --- Step 1: Set plugin mode ---
-log "Setting manifest plugin mode to '${MODE}'..."
-if $DRY_RUN; then
-  log "[dry-run] Would run: openclaw config set plugins.entries.manifest.config.mode ${MODE}"
-else
-  openclaw config set plugins.entries.manifest.config.mode "${MODE}"
-  log "Mode set to ${MODE}"
+# --- Step 1: Set plugin mode (only for local/dev — cloud users skip the plugin) ---
+if [[ "$MODE" != "cloud" ]]; then
+  log "Setting manifest plugin mode to '${MODE}'..."
+  if $DRY_RUN; then
+    log "[dry-run] Would run: openclaw config set plugins.entries.manifest.config.mode ${MODE}"
+  else
+    openclaw config set plugins.entries.manifest.config.mode "${MODE}"
+    log "Mode set to ${MODE}"
+  fi
+
+  # Set plugin endpoint for dev mode
+  if [[ "$MODE" == "dev" ]]; then
+    log "Setting plugin endpoint to ${BASE_ORIGIN}..."
+    if $DRY_RUN; then
+      log "[dry-run] Would run: openclaw config set plugins.entries.manifest.config.endpoint ${BASE_ORIGIN}"
+    else
+      openclaw config set plugins.entries.manifest.config.endpoint "${BASE_ORIGIN}"
+      log "Endpoint set to ${BASE_ORIGIN}"
+    fi
+  fi
 fi
 
-# --- Step 2: Set OTLP endpoint ---
-log "Setting OTLP endpoint to ${ENDPOINT}..."
-if $DRY_RUN; then
-  log "[dry-run] Would run: openclaw config set plugins.entries.manifest.config.endpoint ${ENDPOINT}"
-else
-  openclaw config set plugins.entries.manifest.config.endpoint "${ENDPOINT}"
-  log "Endpoint set to ${ENDPOINT}"
-fi
-
-# --- Step 3: Set provider config (baseUrl + apiKey + api type) ---
-# The gateway reads models.providers.manifest to route proxy requests.
-# injectProviderConfig (local/dev mode) writes these values, but switching
-# modes leaves stale values behind. We must overwrite the full provider
-# block so the gateway sends requests to the right host with the right key.
+# --- Step 2: Set provider config (models.providers.manifest) ---
 PROVIDER_KEY="${API_KEY:-dev-no-auth}"
 log "Setting provider config (baseUrl=${BASE_URL}, apiKey=${PROVIDER_KEY:0:10}***)..."
 if $DRY_RUN; then
@@ -109,7 +108,7 @@ else
       baseUrl: $url,
       api: "openai-completions",
       apiKey: $key,
-      models: [{ id: "auto", name: "auto" }]
+      models: [{ id: "auto", name: "Manifest Auto" }]
     }
   ' "$CONFIG_FILE" > "$TEMP_CONFIG"
   cp "$TEMP_CONFIG" "$CONFIG_FILE"
@@ -117,33 +116,18 @@ else
   log "Provider config set"
 fi
 
-# --- Step 4: Set API key (cloud mode) ---
-if [[ -n "$API_KEY" ]]; then
-  log "Setting API key..."
+# --- Step 3: Set API key for plugin (cloud mode) ---
+if [[ -n "$API_KEY" && "$MODE" != "cloud" ]]; then
+  log "Setting plugin API key..."
   if $DRY_RUN; then
     log "[dry-run] Would run: openclaw config set plugins.entries.manifest.config.apiKey ${API_KEY:0:10}***"
   else
     openclaw config set plugins.entries.manifest.config.apiKey "${API_KEY}"
-    log "API key set (${API_KEY:0:10}***)"
-  fi
-else
-  # Remove any stale apiKey for non-cloud modes
-  TEMP_CONFIG=$(mktemp)
-  trap 'rm -f "$TEMP_CONFIG"' EXIT
-  if jq -e '.plugins.entries.manifest.config.apiKey' "$CONFIG_FILE" &>/dev/null; then
-    log "Removing stale API key (not needed for ${MODE} mode)..."
-    if $DRY_RUN; then
-      log "[dry-run] Would remove plugins.entries.manifest.config.apiKey"
-    else
-      jq 'del(.plugins.entries.manifest.config.apiKey)' "$CONFIG_FILE" > "$TEMP_CONFIG"
-      cp "$TEMP_CONFIG" "$CONFIG_FILE"
-      chmod 600 "$CONFIG_FILE"
-      log "Stale API key removed"
-    fi
+    log "Plugin API key set (${API_KEY:0:10}***)"
   fi
 fi
 
-# --- Step 5: Set primary model to manifest/auto ---
+# --- Step 4: Set primary model to manifest/auto ---
 log "Setting default model to manifest/auto..."
 if $DRY_RUN; then
   log "[dry-run] Would update agents.defaults.model.primary = manifest/auto"
@@ -157,7 +141,7 @@ else
   log "Default model set to manifest/auto"
 fi
 
-# --- Step 6: Reset routing overrides ---
+# --- Step 5: Reset routing overrides ---
 log "Resetting routing overrides..."
 if $DRY_RUN; then
   log "[dry-run] Would clear agents.defaults.models"
@@ -179,21 +163,19 @@ else
   log "Routing overrides cleared"
 fi
 
-# --- Step 7: Restart gateway ---
+# --- Step 6: Restart gateway ---
 log "Restarting OpenClaw gateway..."
 if $DRY_RUN; then
   log "[dry-run] Would run: openclaw gateway restart"
 else
-  openclaw gateway restart 2>/dev/null && log "Gateway restarted" || warn "Gateway restart failed — restart manually with: openclaw gateway restart"
+  openclaw gateway restart 2>/dev/null && log "Gateway restarted" || warn "Gateway restart failed -- restart manually with: openclaw gateway restart"
 fi
 
 log ""
 log "=== Setup complete ==="
 log "  Mode:      ${MODE}"
-log "  OTLP:      ${ENDPOINT}"
 log "  Proxy:     ${BASE_URL}"
 log "  Provider:  ${PROVIDER_KEY:0:10}***"
 log "  Model:     manifest/auto"
 log ""
 log "The gateway is now routing through ${BASE_ORIGIN}"
-log "Telemetry will appear in the dashboard after a few seconds."

--- a/skills/uninstall-manifest-plugin/SKILL.md
+++ b/skills/uninstall-manifest-plugin/SKILL.md
@@ -1,30 +1,31 @@
 ---
 name: uninstall-manifest-plugin
-description: Uninstall the Manifest observability plugin from OpenClaw and reset to a local model provider. Use when the user says "/uninstall-manifest-plugin", "uninstall manifest", "remove manifest plugin", "reset openclaw to local", or wants to stop using Manifest routing and go back to direct provider access. Detects installed API keys and sets the best available model as default.
+description: Remove Manifest from OpenClaw and reset to a direct model provider. Use when the user says "/uninstall-manifest-plugin", "uninstall manifest", "remove manifest", "reset openclaw", or wants to stop using Manifest routing and go back to direct provider access. Works for both cloud users (provider config only) and local users (plugin + provider config).
 ---
 
-# Uninstall Manifest Plugin
+# Uninstall Manifest
 
-Reverse everything `openclaw plugins install manifest` did: remove the manifest provider, clean up auth profiles, delete local data, and set the default model to the best available provider.
+Remove Manifest from OpenClaw -- both the model provider config and the plugin (if installed). Resets the default model to the best available provider.
+
+**Cloud users** (no plugin): This removes `models.providers.manifest` from the config and resets the default model.
+
+**Local users** (plugin installed): This also removes the plugin, auth profiles, and local data.
 
 ## Workflow
 
 ### 1. Run the uninstall script
 
-Execute the bundled script to perform the full cleanup:
-
 ```bash
 bash skills/uninstall-manifest-plugin/scripts/uninstall_manifest.sh
 ```
 
-The script removes the plugin, provider config, auth profiles, and local data, then detects available providers and restarts the gateway. Use `--dry-run` to preview changes without modifying anything.
+The script removes the provider config, plugin (if installed), auth profiles, and local data, then detects available providers and restarts the gateway. Use `--dry-run` to preview.
 
 ### 2. Set the default model
 
-Read the script output for `OUTPUT_PROVIDER` and `OUTPUT_MODEL` lines. If a provider was detected, update both the primary model and the allowlist in `~/.openclaw/openclaw.json`:
+Read the script output for `OUTPUT_PROVIDER` and `OUTPUT_MODEL` lines. If a provider was detected, update the primary model:
 
 ```bash
-# Set detected model as primary and in the allowlist
 jq --arg model "<OUTPUT_MODEL>" '
   .agents.defaults.model.primary = $model
 ' ~/.openclaw/openclaw.json > /tmp/oc.json \
@@ -41,11 +42,9 @@ jq --arg model "<OUTPUT_MODEL>" '
 | DeepSeek | `DEEPSEEK_API_KEY` | `deepseek/deepseek-r1` |
 | Groq | `GROQ_API_KEY` | `groq/llama-4-scout-17b` |
 
-Config providers take precedence over env vars. If multiple exist, ask the user which to use as default.
+If multiple exist, ask the user which to use as default.
 
 ### 3. Show status table
-
-After running the script, show the diagnostic table:
 
 ```bash
 bash skills/manifest-status/scripts/manifest_status.sh


### PR DESCRIPTION
## Summary

- Rewrite `manifest/SKILL.md` to be cloud-first: lead with direct `models.providers.manifest` setup, no plugin needed for cloud users
- Update `setup-manifest-plugin` script to remove OTLP endpoint step; cloud mode skips plugin config entirely
- Update `manifest-status` and `uninstall-manifest-plugin` descriptions for both cloud and local users
- Remove all OTLP, telemetry, and observability references from skill files

## Test plan

- [ ] Verify `/manifest-status` still prints the diagnostic table
- [ ] Verify `/setup-manifest-plugin <port>` configures the provider correctly
- [ ] Verify `/uninstall-manifest-plugin` cleans up provider config
- [ ] Verify SKILL.md renders correctly on the skills registry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Manifest cloud-first by adding it as a direct model provider (`models.providers.manifest`) with no plugin for cloud users. Updates skills and setup/uninstall scripts for a routing-only architecture and removes OTLP/telemetry references.

- **Refactors**
  - Rewrote `skills/manifest/SKILL.md` to lead with cloud setup (direct provider), clarify local mode/security, and drop OTLP.
  - Updated setup flow: `setup-manifest-plugin` + `scripts/setup_manifest.sh` now configure `models.providers.manifest`, set `manifest/auto`, default to `--mode dev`, require `--key` in cloud, set plugin endpoint only in `dev`, support `--dry-run`, and restart the gateway.
  - Refreshed `manifest-status` to report both direct provider and plugin config; simplified triggers and instructions.
  - Revised `uninstall-manifest-plugin` to handle cloud-only (remove provider) and local (remove plugin + data); resets the primary model.
  - Added a patch changeset documenting the routing-only shift.

<sup>Written for commit fef4ed8e44776d7645a5253eda8f71afb7da1e84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

