### PR TITLE
fix: remove environment variable setup option from agent setup UI

### DIFF
--- a/.changeset/remove-env-setup-tab.md
+++ b/.changeset/remove-env-setup-tab.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Remove environment variable setup option from agent setup UI, keeping only CLI and interactive wizard methods

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -2,12 +2,11 @@ import { createSignal, For, Show, type Component } from 'solid-js';
 import CopyButton from './CopyButton.jsx';
 import ApiKeyDisplay from './ApiKeyDisplay.jsx';
 
-type MethodId = 'cli' | 'onboard' | 'env';
+type MethodId = 'cli' | 'onboard';
 
 const METHOD_TABS: { id: MethodId; label: string }[] = [
   { id: 'cli', label: 'CLI configuration' },
   { id: 'onboard', label: 'Interactive wizard' },
-  { id: 'env', label: 'Environment variable' },
 ];
 
 interface Props {
@@ -35,14 +34,6 @@ openclaw gateway restart`;
   };
 
   const onboardSnippet = () => `openclaw onboard`;
-
-  const envSnippet = () => {
-    const lines = [`export MANIFEST_API_KEY="${displayKey()}"`];
-    if (props.baseUrl && !props.baseUrl.includes('app.manifest.build')) {
-      lines.push(`export MANIFEST_ENDPOINT="${props.baseUrl}"`);
-    }
-    return lines.join('\n');
-  };
 
   return (
     <div>
@@ -137,19 +128,6 @@ openclaw gateway restart`;
                   <CopyButton text="auto" />
                 </span>
               </div>
-            </div>
-          </Show>
-
-          <Show when={activeTab() === 'env'}>
-            <p class="setup-method__hint">
-              OpenClaw detects this automatically. Add to your shell profile or{' '}
-              <code class="api-key-display__code">~/.openclaw/.env</code> for persistence.
-            </p>
-            <div class="setup-method__code">
-              <CopyButton text={envSnippet()} />
-              <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
-                {envSnippet()}
-              </pre>
             </div>
           </Show>
         </div>

--- a/packages/frontend/src/components/SetupStepConfigure.tsx
+++ b/packages/frontend/src/components/SetupStepConfigure.tsx
@@ -1,7 +1,5 @@
-import { createSignal, Show, type Component } from "solid-js";
-import { CopyButton } from "./SetupStepInstall.jsx";
-
-type ConfigTab = "cli" | "env";
+import { Show, type Component } from 'solid-js';
+import { CopyButton } from './SetupStepInstall.jsx';
 
 interface Props {
   apiKey: string | null;
@@ -12,25 +10,18 @@ interface Props {
 }
 
 const SetupStepConfigure: Component<Props> = (props) => {
-  const [tab, setTab] = createSignal<ConfigTab>("cli");
-
   const hasFullKey = () => !!props.apiKey;
-  const displayKey = () => props.apiKey ?? (props.keyPrefix ? `${props.keyPrefix}...` : "mnfst_YOUR_KEY");
+  const displayKey = () =>
+    props.apiKey ?? (props.keyPrefix ? `${props.keyPrefix}...` : 'mnfst_YOUR_KEY');
 
   const cliCommand = () => {
     const lines = [`openclaw config set plugins.entries.manifest.config.apiKey "${displayKey()}"`];
     if (props.endpoint) {
-      lines.push(`openclaw config set plugins.entries.manifest.config.endpoint "${props.endpoint}"`);
+      lines.push(
+        `openclaw config set plugins.entries.manifest.config.endpoint "${props.endpoint}"`,
+      );
     }
-    return lines.join("\n");
-  };
-
-  const envCommand = () => {
-    const lines = [`export MANIFEST_API_KEY="${displayKey()}"`];
-    if (props.endpoint) {
-      lines.push(`export MANIFEST_ENDPOINT="${props.endpoint}"`);
-    }
-    return lines.join("\n");
+    return lines.join('\n');
   };
 
   return (
@@ -39,7 +30,7 @@ const SetupStepConfigure: Component<Props> = (props) => {
         {props.stepNumber ? `${props.stepNumber}. ` : ''}Configure your agent
       </h3>
       <p style="margin: 0 0 16px; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
-        Run one of these commands to connect your agent to Manifest.
+        Run this command to connect your agent to Manifest.
       </p>
 
       <Show when={hasFullKey()}>
@@ -54,7 +45,11 @@ const SetupStepConfigure: Component<Props> = (props) => {
 
       <Show when={!hasFullKey() && props.keyPrefix}>
         <div style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); padding: 10px 14px; background: hsl(var(--muted)); border-radius: var(--radius); margin-bottom: 16px;">
-          Replace <code style="font-family: var(--font-mono); font-size: var(--font-size-sm);">{props.keyPrefix}...</code> below with your full API key.
+          Replace{' '}
+          <code style="font-family: var(--font-mono); font-size: var(--font-size-sm);">
+            {props.keyPrefix}...
+          </code>{' '}
+          below with your full API key.
         </div>
       </Show>
 
@@ -65,34 +60,12 @@ const SetupStepConfigure: Component<Props> = (props) => {
             <span class="modal-terminal__dot modal-terminal__dot--yellow" />
             <span class="modal-terminal__dot modal-terminal__dot--green" />
           </div>
-          <div class="modal-terminal__tabs" role="tablist" aria-label="Configuration method">
-            <button
-              class="modal-terminal__tab"
-              classList={{ "modal-terminal__tab--active": tab() === "cli" }}
-              onClick={() => setTab("cli")}
-              role="tab"
-              aria-selected={tab() === "cli"}
-            >
-              OpenClaw CLI
-            </button>
-            <span class="modal-terminal__tab-sep" aria-hidden="true">|</span>
-            <button
-              class="modal-terminal__tab"
-              classList={{ "modal-terminal__tab--active": tab() === "env" }}
-              onClick={() => setTab("env")}
-              role="tab"
-              aria-selected={tab() === "env"}
-            >
-              Environment
-            </button>
-          </div>
+          <span class="modal-terminal__title">OpenClaw CLI</span>
         </div>
         <div class="modal-terminal__body">
-          <CopyButton text={tab() === "cli" ? cliCommand() : envCommand()} />
+          <CopyButton text={cliCommand()} />
           <pre style="margin: 0; white-space: pre-wrap; word-break: break-all;">
-            <code class="modal-terminal__code">
-              {tab() === "cli" ? cliCommand() : envCommand()}
-            </code>
+            <code class="modal-terminal__code">{cliCommand()}</code>
           </pre>
         </div>
       </div>

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -101,13 +101,12 @@ describe("SetupStepAddProvider", () => {
     expect(container.textContent).toContain("mnfst_abc...");
   });
 
-  it("shows all three tab buttons", () => {
+  it("shows both tab buttons", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
     const tabs = container.querySelectorAll(".panel__tab");
-    expect(tabs.length).toBe(3);
+    expect(tabs.length).toBe(2);
     expect(tabs[0].textContent).toBe("CLI configuration");
     expect(tabs[1].textContent).toBe("Interactive wizard");
-    expect(tabs[2].textContent).toBe("Environment variable");
   });
 
   it("switches to Interactive wizard tab on click", () => {
@@ -128,38 +127,6 @@ describe("SetupStepAddProvider", () => {
     expect(container.textContent).toContain("Endpoint compatibility");
     expect(container.textContent).toContain("OpenAI-compatible");
     expect(container.textContent).toContain("Model ID");
-  });
-
-  it("switches to Environment variable tab on click", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const tabs = container.querySelectorAll(".panel__tab");
-    fireEvent.click(tabs[2]);
-    expect(container.textContent).toContain("MANIFEST_API_KEY");
-  });
-
-  it("env snippet with full key when provided", () => {
-    const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_real_key" />
-    ));
-    const tabs = container.querySelectorAll(".panel__tab");
-    fireEvent.click(tabs[2]);
-    expect(container.textContent).toContain('MANIFEST_API_KEY="mnfst_real_key"');
-  });
-
-  it("includes MANIFEST_ENDPOINT in env snippet for non-production baseUrl", () => {
-    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
-    const tabs = container.querySelectorAll(".panel__tab");
-    fireEvent.click(tabs[2]);
-    expect(container.textContent).toContain("MANIFEST_ENDPOINT");
-  });
-
-  it("omits MANIFEST_ENDPOINT for app.manifest.build baseUrl", () => {
-    const { container } = render(() => (
-      <SetupStepAddProvider {...defaultProps} baseUrl="https://app.manifest.build/v1" />
-    ));
-    const tabs = container.querySelectorAll(".panel__tab");
-    fireEvent.click(tabs[2]);
-    expect(container.textContent).not.toContain("MANIFEST_ENDPOINT");
   });
 
   it("has copy buttons for base URL and model", () => {

--- a/packages/frontend/tests/components/SetupStepConfigure.test.tsx
+++ b/packages/frontend/tests/components/SetupStepConfigure.test.tsx
@@ -15,24 +15,17 @@ describe("SetupStepConfigure", () => {
 
   it("shows description", () => {
     const { container } = render(() => <SetupStepConfigure apiKey={null} keyPrefix={null} agentName="test-agent" endpoint={null} />);
-    expect(container.textContent).toContain("Run one of these commands");
+    expect(container.textContent).toContain("Run this command");
   });
 
-  it("shows CLI tab and Environment tab", () => {
-    render(() => <SetupStepConfigure apiKey={null} keyPrefix={null} agentName="test-agent" endpoint={null} />);
-    expect(screen.getByText("OpenClaw CLI")).toBeDefined();
-    expect(screen.getByText("Environment")).toBeDefined();
+  it("shows OpenClaw CLI title", () => {
+    const { container } = render(() => <SetupStepConfigure apiKey={null} keyPrefix={null} agentName="test-agent" endpoint={null} />);
+    expect(container.textContent).toContain("OpenClaw CLI");
   });
 
   it("shows CLI command by default", () => {
     const { container } = render(() => <SetupStepConfigure apiKey={null} keyPrefix={null} agentName="test-agent" endpoint={null} />);
     expect(container.textContent).toContain("openclaw config set");
-  });
-
-  it("shows env command when Environment tab clicked", () => {
-    const { container } = render(() => <SetupStepConfigure apiKey={null} keyPrefix={null} agentName="test-agent" endpoint={null} />);
-    fireEvent.click(screen.getByText("Environment"));
-    expect(container.textContent).toContain("export MANIFEST_API_KEY");
   });
 
   it("shows full API key with warning when provided", () => {
@@ -56,10 +49,4 @@ describe("SetupStepConfigure", () => {
     expect(container.textContent).toContain("2. Configure your agent");
   });
 
-  it("includes endpoint in env command when provided", () => {
-    const { container } = render(() => <SetupStepConfigure apiKey={null} keyPrefix={null} agentName="test-agent" endpoint="http://localhost:3001/otlp" />);
-    fireEvent.click(screen.getByText("Environment"));
-    expect(container.textContent).toContain("MANIFEST_ENDPOINT");
-    expect(container.textContent).toContain("http://localhost:3001/otlp");
-  });
 });


### PR DESCRIPTION
## Summary

- Remove the "Environment variable" tab from the agent setup modal (`SetupStepAddProvider`), keeping only **CLI configuration** and **Interactive wizard** methods
- Remove the "Environment" tab from `SetupStepConfigure`, keeping only the CLI command
- Update tests accordingly

## Test plan

- [ ] Open the setup modal for a new agent and verify only CLI and Interactive wizard tabs are shown
- [ ] Verify CLI configuration tab shows correct commands
- [ ] Verify Interactive wizard tab shows correct `openclaw onboard` instructions
- [ ] Verify the configure step in the setup wizard shows only CLI command (no env tab)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the environment variable setup option from the agent setup UI to simplify onboarding. Users now choose between CLI configuration and the interactive wizard; the configure step shows a single CLI command.

- **Refactors**
  - Removed the "Environment variable" tab from `SetupStepAddProvider.tsx`.
  - Removed the "Environment" tab from `SetupStepConfigure.tsx` and show a single "OpenClaw CLI" command.
  - Updated tests to reflect the two-method flow and adjusted copy; added a changeset entry.

<sup>Written for commit c294fd8b0bb17f62a7d2c04413a74b999554306e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

