### PR TITLE
fix: openclaw onboard setup improvements

### DIFF
--- a/.changeset/fix-setup-onboard.md
+++ b/.changeset/fix-setup-onboard.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix openclaw onboard verification by returning a synthetic 200 response when no providers are configured, remove non-existent copilot model, add Endpoint ID to interactive wizard instructions, and fix settings page margin.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -137,7 +137,7 @@ describe('ProxyService', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
-  it('throws when no model is resolved', async () => {
+  it('returns synthetic response when no model is resolved', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'simple',
       model: null,
@@ -147,9 +147,53 @@ describe('ProxyService', () => {
       reason: 'ambiguous',
     });
 
-    await expect(
-      service.proxyRequest({ agentId: 'agent-1', userId: 'user-1', body, sessionKey: 'default' }),
-    ).rejects.toThrow('No model available');
+    const result = await service.proxyRequest({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      body,
+      sessionKey: 'default',
+    });
+
+    expect(result.forward.response.ok).toBe(true);
+    const json = (await result.forward.response.json()) as Record<string, unknown>;
+    expect((json.id as string).startsWith('chatcmpl-manifest-')).toBe(true);
+    expect(json.object).toBe('chat.completion');
+    expect(json.model).toBe('manifest');
+    const choices = json.choices as { message: { content: string } }[];
+    expect(choices[0].message.content).toContain('Manifest is connected successfully');
+    expect(result.meta).toEqual({
+      tier: 'simple',
+      model: 'manifest',
+      provider: 'manifest',
+      confidence: 1,
+      reason: 'no_provider',
+    });
+  });
+
+  it('returns synthetic streaming response when no model is resolved', async () => {
+    resolveService.resolve.mockResolvedValue({
+      tier: 'simple',
+      model: null,
+      provider: null,
+      confidence: 0.5,
+      score: -0.1,
+      reason: 'ambiguous',
+    });
+
+    const result = await service.proxyRequest({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      body: { ...body, stream: true },
+      sessionKey: 'default',
+    });
+
+    expect(result.forward.response.ok).toBe(true);
+    const text = await result.forward.response.text();
+    expect(text).toContain('data: {');
+    expect(text).toContain('chat.completion.chunk');
+    expect(text).toContain('Manifest is connected successfully');
+    expect(text).toContain('data: [DONE]');
+    expect(result.meta.reason).toBe('no_provider');
   });
 
   it('throws when no API key found for provider', async () => {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Injectable, Logger, BadRequestException, HttpException } from '@nestjs/common';
 import { ResolveService } from '../resolve/resolve.service';
 import { ProviderKeyService } from '../routing-core/provider-key.service';
@@ -93,9 +94,7 @@ export class ProxyService {
           `tier=${resolved.tier} model=${resolved.model} provider=${resolved.provider} ` +
           `confidence=${resolved.confidence} reason=${resolved.reason}`,
       );
-      throw new BadRequestException(
-        'No model available. Connect a provider in the Manifest dashboard.',
-      );
+      return this.buildNoProviderResult(body.stream === true);
     }
 
     let apiKey = await this.providerKeyService.getProviderApiKey(
@@ -270,5 +269,78 @@ export class ProxyService {
       );
     }
     return false;
+  }
+
+  private buildNoProviderResult(stream: boolean): ProxyResult {
+    const id = `chatcmpl-manifest-${randomUUID()}`;
+    const created = Math.floor(Date.now() / 1000);
+    const content =
+      'Manifest is connected successfully. To start routing requests, connect a model provider in your Manifest dashboard.';
+
+    const meta: RoutingMeta = {
+      tier: 'simple' as Tier,
+      model: 'manifest',
+      provider: 'manifest',
+      confidence: 1,
+      reason: 'no_provider',
+    };
+
+    if (stream) {
+      const chunk = {
+        id,
+        object: 'chat.completion.chunk',
+        created,
+        model: 'manifest',
+        choices: [{ index: 0, delta: { role: 'assistant', content }, finish_reason: 'stop' }],
+      };
+      const ssePayload = `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`;
+      const encoder = new TextEncoder();
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(ssePayload));
+          controller.close();
+        },
+      });
+      return {
+        forward: {
+          response: new Response(body, {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        },
+        meta,
+      };
+    }
+
+    const responseBody = {
+      id,
+      object: 'chat.completion',
+      created,
+      model: 'manifest',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    };
+
+    return {
+      forward: {
+        response: new Response(JSON.stringify(responseBody), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      },
+      meta,
+    };
   }
 }

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -128,6 +128,13 @@ openclaw gateway restart`;
                   <CopyButton text="auto" />
                 </span>
               </div>
+              <div class="setup-onboard-fields__row">
+                <span class="setup-onboard-fields__label">Endpoint ID</span>
+                <span class="setup-onboard-fields__value">
+                  manifest
+                  <CopyButton text="manifest" />
+                </span>
+              </div>
             </div>
           </Show>
         </div>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -264,7 +264,7 @@ const Settings: Component = () => {
                 baseUrl={baseUrl()}
               />
               <Show when={!routingEnabled()}>
-                <div style="margin-top: var(--gap-lg); padding-top: var(--gap-lg); border-top: 1px solid hsl(var(--border)); display: flex; align-items: center; justify-content: space-between;">
+                <div style="margin-top: 0; padding-top: var(--gap-lg); border-top: 1px solid hsl(var(--border)); display: flex; align-items: center; justify-content: space-between;">
                   <p style="margin: 0; font-size: var(--font-size-sm); color: hsl(var(--muted-foreground)); line-height: 1.5;">
                     Add at least one LLM provider so Manifest knows where to route requests.
                   </p>

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -85,7 +85,6 @@ export const PROVIDERS: ProviderDef[] = [
     subscriptionOnly: true,
     models: [
       { label: 'Claude Opus 4.6', value: 'copilot/claude-opus-4.6' },
-      { label: 'Claude Opus 4.6 (fast)', value: 'copilot/claude-opus-4.6-fast' },
       { label: 'Claude Sonnet 4.6', value: 'copilot/claude-sonnet-4.6' },
       { label: 'Claude Haiku 4.5', value: 'copilot/claude-haiku-4.5' },
       { label: 'GPT-5.4', value: 'copilot/gpt-5.4' },

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -127,6 +127,8 @@ describe("SetupStepAddProvider", () => {
     expect(container.textContent).toContain("Endpoint compatibility");
     expect(container.textContent).toContain("OpenAI-compatible");
     expect(container.textContent).toContain("Model ID");
+    expect(container.textContent).toContain("Endpoint ID");
+    expect(container.textContent).toContain("manifest");
   });
 
   it("has copy buttons for base URL and model", () => {

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -59,7 +59,6 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionAuthMode: 'device_code' as const,
     knownModels: Object.freeze([
       'copilot/claude-opus-4.6',
-      'copilot/claude-opus-4.6-fast',
       'copilot/claude-sonnet-4.6',
       'copilot/claude-haiku-4.5',
       'copilot/gpt-5.4',


### PR DESCRIPTION
## Summary

- Return a synthetic OpenAI-compatible 200 response when no providers are configured, so `openclaw onboard` verification passes for new agents
- Remove non-existent `copilot/claude-opus-4.6-fast` model from knownModels (causes 400 upstream errors)
- Add "Endpoint ID" field to the interactive wizard instructions in the setup modal
- Fix excess margin above routing CTA in settings page

## Test plan

- [ ] Run `openclaw onboard` with a fresh agent (no providers) — verification should pass
- [ ] Verify Copilot provider no longer auto-assigns `claude-opus-4.6-fast`
- [ ] Check setup modal "Interactive wizard" tab shows Endpoint ID field
- [ ] Verify settings page routing CTA spacing is correct

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `openclaw onboard` succeed for fresh agents by returning a synthetic OpenAI‑compatible 200 when no providers are configured, and polish the setup flow.

- **Bug Fixes**
  - Return a synthetic 200 response (including streaming) when no model/provider is resolved so `openclaw onboard` verification passes.
  - Remove non-existent `copilot/claude-opus-4.6-fast` from `knownModels` and provider list to prevent upstream 400s.
  - Fix extra top margin above the routing CTA on the settings page.

- **New Features**
  - Add an "Endpoint ID" field to the setup modal’s Interactive wizard with copy support for `manifest`.

<sup>Written for commit b6a038cc9394a62d5134bc533d27971839a160cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

