### PR TITLE
fix: remove manifest-shared dependency and rewrite README for local-first

### DIFF
--- a/.changeset/fix-manifest-shared-install.md
+++ b/.changeset/fix-manifest-shared-install.md
@@ -1,0 +1,10 @@
+---
+"manifest": patch
+---
+
+fix: remove manifest-shared from dependencies to fix plugin npm install failure
+
+The manifest-shared package is not published on npm but was listed as a dependency,
+causing `npm install` to fail with a 404 when installing the plugin. Since manifest-shared
+is already vendored in `dist/node_modules/manifest-shared/` by the build script, removing
+it from dependencies lets Node.js resolve it at runtime without npm intervention.

--- a/README.md
+++ b/README.md
@@ -35,38 +35,37 @@
 
 ## What is Manifest?
 
-Manifest is a smart model router for OpenClaw. It sits between your agent and your LLM providers, scores each request, and routes it to the cheapest model that can handle it. Simple questions go to fast, cheap models. Hard problems go to expensive ones. You save money without thinking about it.
+Manifest is an open-source LLM router for [OpenClaw](https://openclaw.com). It sits between your agent and your LLM providers, scores each request, and routes it to the cheapest model that can handle it. Simple questions go to fast, cheap models. Hard problems go to expensive ones. You save money without thinking about it.
 
 - Route requests to the right model: Cut costs up to 70%
 - Automatic fallbacks: If a model fails, the next one picks up
-- Set limits: Don't exceed your budget
+- Set limits: Get alerts when usage crosses a threshold
+- Full dashboard: Monitor token usage, costs, and model performance
+
+> Want to get started quickly without self-hosting? Use [Manifest Cloud](https://app.manifest.build) -- no setup needed.
 
 ## Quick start
-
-### Cloud version
-
-Go to [app.manifest.build](https://app.manifest.build) and follow the guide.
-
-### Local version
 
 ```bash
 openclaw plugins install manifest
 openclaw gateway restart
 ```
 
-Dashboard opens at **http://127.0.0.1:2099**. The plugin starts an embedded server, runs the dashboard locally, and registers itself as a provider automatically. No account or API key needed.
+That's it. The plugin starts an embedded server with a local SQLite database, runs the dashboard, and registers itself as a provider. No account, no API key, no external dependencies.
 
-### Cloud vs local
-
-Pick cloud version for quick setup and multi-device access. Pick local version for keeping all your data on your machine or for using local models like Ollama.
-
-Not sure which one to choose? Start with cloud.
+Dashboard opens at **http://127.0.0.1:2099**. Your agent can now use `manifest/auto` as a model.
 
 ## How it works
 
 Every request to `manifest/auto` goes through a 23-dimension scoring algorithm (runs in under 2ms). The scorer picks a tier (simple, standard, complex, or reasoning) and routes to the best model in that tier from your connected providers.
 
 All routing data (tokens, costs, model, duration) is recorded automatically. You see it in the dashboard. No extra setup.
+
+## Privacy
+
+**Local mode**: Everything stays on your machine. No data leaves your network.
+
+**Cloud mode**: Manifest proxies your request to the LLM provider. It records metadata (model name, token counts, latency, cost) but never stores prompt or response content. The proxy is blind to your data by design.
 
 ## Manifest vs OpenRouter
 

--- a/packages/backend/src/auth/auth.instance.ts
+++ b/packages/backend/src/auth/auth.instance.ts
@@ -1,4 +1,3 @@
-import { betterAuth } from 'better-auth';
 import { render } from '@react-email/render';
 import { VerifyEmailEmail } from '../notifications/emails/verify-email';
 import { ResetPasswordEmail } from '../notifications/emails/reset-password';
@@ -54,7 +53,8 @@ function buildTrustedOrigins(): string[] {
 // In local mode, skip Better Auth entirely — LocalAuthGuard handles auth
 const authInstance = isLocalMode
   ? null
-  : betterAuth({
+  : // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('better-auth').betterAuth({
       database: database!,
       baseURL: process.env['BETTER_AUTH_URL'] ?? `http://localhost:${port}`,
       basePath: '/api/auth',
@@ -71,7 +71,13 @@ const authInstance = isLocalMode
         enabled: true,
         minPasswordLength: 8,
         requireEmailVerification: !isDev && !isLocalMode,
-        sendResetPassword: async ({ user, url }) => {
+        sendResetPassword: async ({
+          user,
+          url,
+        }: {
+          user: { name: string; email: string };
+          url: string;
+        }) => {
           const element = ResetPasswordEmail({
             userName: user.name,
             resetUrl: url,
@@ -89,7 +95,13 @@ const authInstance = isLocalMode
       emailVerification: {
         sendOnSignUp: !isLocalMode,
         autoSignInAfterVerification: true,
-        sendVerificationEmail: async ({ user, url }) => {
+        sendVerificationEmail: async ({
+          user,
+          url,
+        }: {
+          user: { name: string; email: string };
+          url: string;
+        }) => {
           const element = VerifyEmailEmail({
             userName: user.name,
             verificationUrl: url,
@@ -125,8 +137,27 @@ const authInstance = isLocalMode
       },
       trustedOrigins: buildTrustedOrigins(),
     });
-export const auth = authInstance as ReturnType<typeof betterAuth> | null;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const auth = authInstance as any;
 
-type BetterAuthInstance = ReturnType<typeof betterAuth>;
-export type AuthSession = BetterAuthInstance['$Infer']['Session'];
-export type AuthUser = BetterAuthInstance['$Infer']['Session']['user'];
+export interface AuthUser {
+  id: string;
+  name: string;
+  email: string;
+  emailVerified: boolean;
+  image?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AuthSession {
+  session: {
+    id: string;
+    userId: string;
+    token: string;
+    expiresAt: Date;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  user: AuthUser;
+}

--- a/packages/backend/src/auth/session.guard.ts
+++ b/packages/backend/src/auth/session.guard.ts
@@ -1,7 +1,6 @@
 import { CanActivate, ExecutionContext, Injectable, Logger } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
-import { fromNodeHeaders } from 'better-auth/node';
 import { auth } from './auth.instance';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
 
@@ -27,6 +26,8 @@ export class SessionGuard implements CanActivate {
     if (!auth) return true;
 
     try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { fromNodeHeaders } = require('better-auth/node');
       const session = await auth.api.getSession({
         headers: fromNodeHeaders(request.headers),
       });


### PR DESCRIPTION
## Summary

- **Fix #1282**: Remove `manifest-shared` from plugin `dependencies`. The package isn't published on npm but was listed as a dependency, causing `npm install` to fail with a 404. It's already vendored in `dist/node_modules/` by the build script — Node.js resolves it at runtime.
- **README rewrite**: Local/self-hosted install is now the primary Quick Start. Cloud mode reduced to a single callout link.

## Test plan

- [ ] `cd packages/openclaw-plugins/manifest && npx jest` — 60/60 pass
- [ ] `npm run build` succeeds, `dist/node_modules/manifest-shared/` present in tarball
- [ ] `openclaw plugins install ./manifest-*.tgz` completes without npm install failure

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin install failures and a local-mode startup crash, and makes local/self-hosted the default Quick Start in the README. Cloud mode is now a single callout link.

- **Bug Fixes**
  - Removed `manifest-shared` from `manifest` dependencies; it’s already vendored in `dist/node_modules/`, fixing npm 404s during install.
  - Lazy-load `better-auth` and `better-auth/node` so they only run in cloud mode, avoiding a local crash caused by the hard `@opentelemetry/api` import.

<sup>Written for commit a758931e5cda1f757da3dcd7185f9171a63fbfec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

