### PR TITLE
fix: remove manifest-shared from plugin dependencies

### DIFF
--- a/.changeset/fancy-loops-guess.md
+++ b/.changeset/fancy-loops-guess.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Remove manifest-shared from dependencies to fix plugin install failure

--- a/package-lock.json
+++ b/package-lock.json
@@ -15012,7 +15012,7 @@
       }
     },
     "packages/openclaw-plugins/manifest": {
-      "version": "5.33.6",
+      "version": "5.33.7",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",
@@ -15033,7 +15033,6 @@
         "compression": "^1.8.1",
         "express-rate-limit": "^8.3.1",
         "helmet": "^8.1.0",
-        "manifest-shared": "*",
         "pg": "^8.13.0",
         "protobufjs": "^8.0.0",
         "react": "^19.2.4",
@@ -15057,11 +15056,8 @@
       }
     },
     "packages/openclaw-plugins/manifest-provider": {
-      "version": "5.33.1",
+      "version": "5.33.2",
       "license": "MIT",
-      "dependencies": {
-        "manifest-shared": "*"
-      },
       "devDependencies": {
         "@types/jest": "^29.5.0",
         "esbuild": "^0.25.0",

--- a/packages/openclaw-plugins/manifest/package.json
+++ b/packages/openclaw-plugins/manifest/package.json
@@ -31,9 +31,6 @@
       "./dist/index.js"
     ]
   },
-  "bundleDependencies": [
-    "manifest-shared"
-  ],
   "engines": {
     "node": ">=20.0.0"
   },
@@ -57,7 +54,6 @@
     "embedded-server"
   ],
   "dependencies": {
-    "manifest-shared": "*",
     "@nestjs/cache-manager": "^3.1.0",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.0",


### PR DESCRIPTION
## Summary

- Remove `manifest-shared` from `dependencies` in the manifest plugin's `package.json`
- Remove now-unnecessary `bundleDependencies` field (added in #1316)

## Why

`manifest-shared` is a private workspace package never published to npm. The build script (`copy-assets.js`) already bundles it into `dist/node_modules/manifest-shared/` where Node module resolution finds it at runtime.

Having it in `dependencies` causes `npm install` to fail with `E404` when OpenClaw installs the plugin. The `bundleDependencies` fix from #1316 didn't work because OpenClaw's installer extracts the tarball manually and runs `npm install` separately, bypassing npm's bundled deps mechanism.

## Test plan

- [ ] Plugin tests pass (60/60)
- [ ] `openclaw plugins install manifest` succeeds
- [ ] Dashboard loads at http://127.0.0.1:2099
- [ ] `openclaw models list` shows `manifest/auto`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin install failures by removing `manifest-shared` from the `manifest` plugin’s dependencies and dropping `bundleDependencies`. `manifest-shared` is already bundled into `dist/node_modules/manifest-shared/`, so runtime behavior is unchanged.

- **Bug Fixes**
  - Remove `manifest-shared` from `packages/openclaw-plugins/manifest` dependencies.
  - Delete `bundleDependencies` (OpenClaw’s installer bypasses bundled deps).
  - Prevents `E404` during `openclaw plugins install manifest`.

<sup>Written for commit c43481d92e6a7802c979631df20ea244d2d81fb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

