### PR TITLE
fix: improve local plugin startup reliability

### DIFF
--- a/.changeset/fix-local-plugin-startup.md
+++ b/.changeset/fix-local-plugin-startup.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix local plugin startup diagnostics: validate health response is from Manifest before reusing server, move dashboard URL log to after actual startup, add post-start self-verification

--- a/packages/openclaw-plugins/manifest/__tests__/local-mode.test.ts
+++ b/packages/openclaw-plugins/manifest/__tests__/local-mode.test.ts
@@ -671,8 +671,11 @@ describe("checkExistingServer", () => {
     global.fetch = originalFetch;
   });
 
-  it("returns true when server responds with ok status", async () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  it("returns true when server responds with healthy status", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: "healthy" }),
+    });
 
     const result = await checkExistingServer("127.0.0.1", 2099);
 
@@ -681,6 +684,17 @@ describe("checkExistingServer", () => {
       "http://127.0.0.1:2099/api/v1/health",
       { signal: expect.any(AbortSignal) },
     );
+  });
+
+  it("returns false when response is ok but not a Manifest server", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ message: "some other service" }),
+    });
+
+    const result = await checkExistingServer("127.0.0.1", 2099);
+
+    expect(result).toBe(false);
   });
 
   it("returns false when server responds with non-ok status", async () => {
@@ -747,9 +761,7 @@ describe("registerLocalMode", () => {
     expect(logger.debug).toHaveBeenCalledWith(
       "[manifest] Starting embedded server...",
     );
-    expect(logger.info).toHaveBeenCalledWith(
-      `[manifest] Dashboard -> http://${host}:${port}`,
-    );
+    // Dashboard log now appears in start() callback, not synchronously
     expect(api.registerService).toHaveBeenCalledWith({
       id: "manifest",
       start: expect.any(Function),
@@ -770,7 +782,10 @@ describe("registerLocalMode", () => {
     });
 
     it("reuses existing server when health check passes", async () => {
-      global.fetch = jest.fn().mockResolvedValue({ ok: true });
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: "healthy" }),
+      });
 
       await startCallback();
 
@@ -781,7 +796,13 @@ describe("registerLocalMode", () => {
     });
 
     it("starts server when no existing server is running", async () => {
-      global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+      global.fetch = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("ECONNREFUSED")) // checkExistingServer (pre)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ status: "healthy" }),
+        }); // checkExistingServer (post-start verification)
 
       await startCallback();
 
@@ -792,18 +813,52 @@ describe("registerLocalMode", () => {
         quiet: true,
       });
       expect(logger.info).toHaveBeenCalledWith(
-        `[manifest] Server running on http://${host}:${port}`,
+        `[manifest] Dashboard -> http://${host}:${port}`,
       );
       expect(logger.info).toHaveBeenCalledWith(
         `[manifest]   DB: ${CONFIG_DIR}/manifest.db`,
       );
     });
 
+    it("warns when server starts but verification fails", async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+      await startCallback();
+
+      expect(mockServerStart).toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Server started but health check failed"),
+      );
+    });
+
+    it("falls back to logger.info when warn is undefined on verification failure", async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+      // Create a logger without warn
+      const noWarnLogger = {
+        info: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+      };
+      const api = { config: {}, registerService: jest.fn() };
+      registerLocalMode(api, port, host, noWarnLogger);
+      const cb = api.registerService.mock.calls[0][0].start;
+
+      await cb();
+
+      expect(noWarnLogger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Server started but health check failed"),
+      );
+    });
+
     it("reuses server on EADDRINUSE when health check passes", async () => {
       global.fetch = jest
         .fn()
-        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
-        .mockResolvedValueOnce({ ok: true });
+        .mockRejectedValueOnce(new Error("ECONNREFUSED")) // pre-start check
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ status: "healthy" }),
+        }); // EADDRINUSE recovery check
 
       mockServerStart.mockRejectedValue(
         new Error("listen EADDRINUSE: address already in use :::2099"),

--- a/packages/openclaw-plugins/manifest/src/local-mode.ts
+++ b/packages/openclaw-plugins/manifest/src/local-mode.ts
@@ -167,7 +167,14 @@ export async function checkExistingServer(host: string, port: number): Promise<b
     const res = await fetch(`http://${host}:${port}/api/v1/health`, {
       signal: AbortSignal.timeout(HEALTH_TIMEOUT_MS),
     });
-    return res.ok;
+    if (!res.ok) return false;
+    const body: unknown = await res.json();
+    return (
+      body !== null &&
+      typeof body === 'object' &&
+      'status' in body &&
+      (body as Record<string, unknown>).status === 'healthy'
+    );
   } catch {
     return false;
   }
@@ -198,11 +205,10 @@ export function registerLocalMode(api: any, port: number, host: string, logger: 
     return;
   }
 
-  logger.info(`[manifest] Dashboard -> http://${host}:${port}`);
-
   api.registerService({
     id: 'manifest',
     start: async () => {
+      logger.debug('[manifest] Service start callback invoked');
       const alreadyRunning = await checkExistingServer(host, port);
       if (alreadyRunning) {
         logger.info(`[manifest] Reusing existing server at http://${host}:${port}`);
@@ -211,8 +217,18 @@ export function registerLocalMode(api: any, port: number, host: string, logger: 
 
       try {
         await serverModule.start({ port, host, dbPath, quiet: true });
-        logger.info(`[manifest] Server running on http://${host}:${port}`);
-        logger.info(`[manifest]   DB: ${dbPath}`);
+
+        const verified = await checkExistingServer(host, port);
+        if (verified) {
+          logger.info(`[manifest] Dashboard -> http://${host}:${port}`);
+          logger.info(`[manifest]   DB: ${dbPath}`);
+        } else {
+          const warnFn = logger.warn ?? logger.info;
+          warnFn(
+            `[manifest] Server started but health check failed.\n` +
+              `  The dashboard may not be accessible at http://${host}:${port}`,
+          );
+        }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
         if (msg.includes('EADDRINUSE') || msg.includes('address already in use')) {


### PR DESCRIPTION
## Summary
- Validate health response body (`{ status: "healthy" }`) before reusing an existing server on port 2099, preventing false positives from other services
- Move "Dashboard ->" log to after server actually starts and passes self-verification — previously logged before `start()` was called
- Add post-start self-health-check to surface silent startup failures with a clear warning

## Context
When installing the `manifest` plugin locally, users reported seeing nothing on port 2099. Investigation confirmed the server code works correctly when run directly (npm package is complete, NestJS boots, static files serve). The issue was poor diagnostic visibility:
1. The dashboard URL logged before the server started, misleading users
2. `checkExistingServer` accepted any HTTP 200 on `/api/v1/health`, so another service on port 2099 would cause the plugin to skip starting
3. No verification after startup — if the server started but failed to respond, there was no indication

## Test plan
- [x] All 63 plugin tests pass
- [x] 100% line, branch, function, and statement coverage on `local-mode.ts`
- [x] TypeScript compiles cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves local startup reliability for the `manifest` plugin. Validates health checks to avoid reusing other services on port 2099, moves the dashboard log to after verified startup, and warns when post-start health verification fails.

- **Bug Fixes**
  - Only reuse an existing server when health response is `{ status: "healthy" }`.
  - Log "Dashboard ->" after the server starts and passes verification.
  - Add a post-start health check and warn if the server is up but unhealthy.

<sup>Written for commit 8458afa1b11bd20de90847035875b9f085545f4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

