### PR TITLE
fix: remove legacy mode from manifest-provider and fix config paths

### DIFF
--- a/.changeset/sharp-apples-enter.md
+++ b/.changeset/sharp-apples-enter.md
@@ -1,0 +1,5 @@
+---
+"manifest-provider": patch
+---
+
+Fix wrong plugin name in config instructions and remove legacy mode concept

--- a/packages/openclaw-plugins/manifest-provider/__tests__/command.test.ts
+++ b/packages/openclaw-plugins/manifest-provider/__tests__/command.test.ts
@@ -15,7 +15,6 @@ const mockLogger = {
 };
 
 const config: ManifestConfig = {
-  mode: "cloud",
   devMode: true,
   apiKey: "",
   endpoint: "http://localhost:38238/otlp",
@@ -61,7 +60,7 @@ describe("registerCommand", () => {
     const cmd = api.registerCommand.mock.calls[0][0];
     const result = await cmd.handler();
 
-    expect(result).toContain("Mode: cloud");
+    expect(result).toContain("Dev mode:");
     expect(result).toContain("Endpoint reachable: yes");
     expect(result).toContain("Auth valid: yes");
     expect(result).toContain("Agent: test-agent");
@@ -100,10 +99,10 @@ describe("registerCommand", () => {
     const cmd = api.registerCommand.mock.calls[0][0];
     const result = await cmd.execute();
 
-    expect(result.text).toContain("Mode: cloud");
+    expect(result.text).toContain("Dev mode:");
     expect(result.text).toContain("Agent: test-agent");
     expect(result.content).toEqual([
-      { type: "text", text: expect.stringContaining("Mode: cloud") },
+      { type: "text", text: expect.stringContaining("Dev mode:") },
     ]);
   });
 
@@ -178,7 +177,7 @@ describe("registerCommand", () => {
     const cmd = api.registerCommand.mock.calls[0][0];
     const result = await cmd.handler();
 
-    expect(result).toContain("Mode: cloud");
+    expect(result).toContain("Dev mode:");
     expect(result).toContain("Endpoint reachable: yes");
     expect(result).not.toContain("Agent:");
   });

--- a/packages/openclaw-plugins/manifest-provider/__tests__/config.test.ts
+++ b/packages/openclaw-plugins/manifest-provider/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { parseConfig, parseConfigWithDeprecation, validateConfig } from "../src/config";
+import { parseConfig, validateConfig } from "../src/config";
 import { API_KEY_PREFIX, DEFAULTS, ENV } from "../src/constants";
 
 describe("API_KEY_PREFIX constant", () => {
@@ -58,62 +58,44 @@ describe("parseConfig", () => {
     expect(result.endpoint).toBe(DEFAULTS.ENDPOINT);
   });
 
-  it("defaults mode to cloud", () => {
-    const result = parseConfig({ apiKey: "mnfst_abc" });
-    expect(result.mode).toBe("cloud");
-  });
-
-  it("parses explicit mode: cloud", () => {
-    const result = parseConfig({ mode: "cloud", apiKey: "mnfst_abc" });
-    expect(result.mode).toBe("cloud");
-  });
-
-  it("parses explicit mode: local", () => {
-    const result = parseConfig({ mode: "local" });
-    expect(result.mode).toBe("local");
-  });
-
-  it("maps mode: dev to mode: cloud with devMode: true", () => {
+  it("enables devMode for legacy mode: dev", () => {
     const result = parseConfig({ mode: "dev", endpoint: "http://localhost:38238/otlp" });
-    expect(result.mode).toBe("cloud");
     expect(result.devMode).toBe(true);
   });
 
-  it("preserves mode: dev backward compat through nested config wrapper", () => {
+  it("preserves legacy mode: dev through nested config wrapper", () => {
     const result = parseConfig({
       enabled: true,
       config: { mode: "dev", endpoint: "http://localhost:38238/otlp" },
     });
-    expect(result.mode).toBe("cloud");
     expect(result.devMode).toBe(true);
   });
 
-  it("falls back to cloud for unknown mode string", () => {
+  it("ignores unknown mode values", () => {
     const result = parseConfig({ mode: "hybrid" });
-    expect(result.mode).toBe("cloud");
+    expect(result.devMode).toBe(false);
   });
 
-  it("falls back to cloud when mode is a non-string value", () => {
+  it("ignores non-string mode values", () => {
     const result = parseConfig({ mode: 42 });
-    expect(result.mode).toBe("cloud");
+    expect(result.devMode).toBe(false);
   });
 
-  it("defaults to cloud with zero config (empty object)", () => {
+  it("ignores legacy mode: local silently", () => {
+    const result = parseConfig({ mode: "local" });
+    expect(result.devMode).toBe(false);
+  });
+
+  it("works with empty object", () => {
     const result = parseConfig({});
-    expect(result.mode).toBe("cloud");
+    expect(result.devMode).toBe(false);
+    expect(result.endpoint).toBe(DEFAULTS.ENDPOINT);
   });
 
-  it("defaults to cloud with null input", () => {
+  it("works with null input", () => {
     const result = parseConfig(null);
-    expect(result.mode).toBe("cloud");
-  });
-
-  it("preserves mode: cloud through nested config wrapper", () => {
-    const result = parseConfig({
-      enabled: true,
-      config: { mode: "cloud", apiKey: "mnfst_abc" },
-    });
-    expect(result.mode).toBe("cloud");
+    expect(result.devMode).toBe(false);
+    expect(result.endpoint).toBe(DEFAULTS.ENDPOINT);
   });
 
   it("defaults port and host", () => {
@@ -252,43 +234,8 @@ describe("parseConfig — devMode", () => {
   });
 });
 
-describe("parseConfigWithDeprecation", () => {
-  it("sets _deprecatedDevMode when mode is dev", () => {
-    const { _deprecatedDevMode } = parseConfigWithDeprecation({
-      mode: "dev",
-      endpoint: "http://localhost:38238/otlp",
-    });
-    expect(_deprecatedDevMode).toBe(true);
-  });
-
-  it("does not set _deprecatedDevMode for cloud mode", () => {
-    const { _deprecatedDevMode } = parseConfigWithDeprecation({
-      mode: "cloud",
-      apiKey: "mnfst_abc",
-    });
-    expect(_deprecatedDevMode).toBe(false);
-  });
-
-  it("does not set _deprecatedDevMode for local mode", () => {
-    const { _deprecatedDevMode } = parseConfigWithDeprecation({
-      mode: "local",
-    });
-    expect(_deprecatedDevMode).toBe(false);
-  });
-
-  it("does not set _deprecatedDevMode when using devMode: true directly", () => {
-    const { _deprecatedDevMode } = parseConfigWithDeprecation({
-      mode: "cloud",
-      devMode: true,
-      endpoint: "http://localhost:38238/otlp",
-    });
-    expect(_deprecatedDevMode).toBe(false);
-  });
-});
-
 describe("validateConfig", () => {
   const validConfig = {
-    mode: "cloud" as const,
     devMode: false,
     apiKey: "mnfst_abc",
     endpoint: "https://app.manifest.build/otlp",
@@ -298,11 +245,6 @@ describe("validateConfig", () => {
 
   it("accepts valid config", () => {
     expect(validateConfig(validConfig)).toBeNull();
-  });
-
-  it("skips validation in local mode (no apiKey required)", () => {
-    const config = { ...validConfig, mode: "local" as const, apiKey: "" };
-    expect(validateConfig(config)).toBeNull();
   });
 
   it("accepts devMode with valid http endpoint (no apiKey required)", () => {
@@ -337,6 +279,17 @@ describe("validateConfig", () => {
     expect(err).toContain("http://localhost:<PORT>");
   });
 
+  it("uses correct plugin name in devMode endpoint error", () => {
+    const config = {
+      ...validConfig,
+      devMode: true,
+      apiKey: "",
+      endpoint: "not-a-url",
+    };
+    const err = validateConfig(config)!;
+    expect(err).toContain("manifest-provider.config.endpoint");
+  });
+
   it("rejects missing apiKey with actionable fix command", () => {
     const config = { ...validConfig, apiKey: "" };
     const err = validateConfig(config)!;
@@ -345,11 +298,23 @@ describe("validateConfig", () => {
     expect(err).toContain("MANIFEST_API_KEY");
   });
 
+  it("uses correct plugin name in missing apiKey error", () => {
+    const config = { ...validConfig, apiKey: "" };
+    const err = validateConfig(config)!;
+    expect(err).toContain("manifest-provider.config.apiKey");
+  });
+
   it("rejects invalid apiKey prefix with actionable fix command", () => {
     const config = { ...validConfig, apiKey: "wrong_prefix" };
     const err = validateConfig(config)!;
     expect(err).toContain("mnfst_");
     expect(err).toContain("openclaw config set");
+  });
+
+  it("uses correct plugin name in invalid apiKey error", () => {
+    const config = { ...validConfig, apiKey: "wrong_prefix" };
+    const err = validateConfig(config)!;
+    expect(err).toContain("manifest-provider.config.apiKey");
   });
 
   it("rejects keys with old osk_ prefix", () => {
@@ -364,6 +329,12 @@ describe("validateConfig", () => {
     const err = validateConfig(config)!;
     expect(err).toContain("Invalid endpoint URL");
     expect(err).toContain("openclaw config set");
+  });
+
+  it("uses correct plugin name in invalid endpoint error", () => {
+    const config = { ...validConfig, endpoint: "not-a-url" };
+    const err = validateConfig(config)!;
+    expect(err).toContain("manifest-provider.config.endpoint");
   });
 
   it("accepts http endpoint", () => {

--- a/packages/openclaw-plugins/manifest-provider/__tests__/register.test.ts
+++ b/packages/openclaw-plugins/manifest-provider/__tests__/register.test.ts
@@ -1,6 +1,5 @@
 jest.mock("../src/config", () => ({
   parseConfig: jest.fn(),
-  parseConfigWithDeprecation: jest.fn(),
   validateConfig: jest.fn(),
 }));
 jest.mock("../src/tools", () => ({
@@ -25,7 +24,7 @@ jest.mock("../src/command", () => ({
   registerCommand: jest.fn(),
 }));
 
-import { parseConfigWithDeprecation, validateConfig } from "../src/config";
+import { parseConfig, validateConfig } from "../src/config";
 import { injectProviderConfig, injectAuthProfile } from "../src/provider-inject";
 import { registerTools } from "../src/tools";
 import { registerCommand } from "../src/command";
@@ -54,57 +53,8 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe("register — mode routing", () => {
-  it("logs manifest plugin message when mode is explicitly local", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "local",
-        devMode: false,
-        apiKey: "",
-        endpoint: "",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
-    });
-
-    const api = makeApi();
-    plugin.register(api);
-
-    expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("manifest plugin"),
-    );
-  });
-
-  it("does NOT log manifest plugin message for cloud mode", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "cloud",
-        devMode: false,
-        apiKey: "mnfst_abc",
-        endpoint: "https://app.manifest.build",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
-    });
-    (validateConfig as jest.Mock).mockReturnValue(null);
-
-    const api = makeApi();
-    plugin.register(api);
-
-    const infoCalls = api.logger.info.mock.calls;
-    const localModeCalls = infoCalls.filter(
-      (call: string[]) => typeof call[0] === "string" && call[0].includes("manifest plugin"),
-    );
-    expect(localModeCalls).toHaveLength(0);
-  });
-
-});
-
-describe("register — cloud mode with devMode", () => {
+describe("register — devMode path", () => {
   const devConfig = {
-    mode: "cloud" as const,
     devMode: true,
     apiKey: "",
     endpoint: "http://localhost:38238",
@@ -112,28 +62,8 @@ describe("register — cloud mode with devMode", () => {
     host: "127.0.0.1",
   };
 
-  it("does NOT log manifest plugin message", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
-    (validateConfig as jest.Mock).mockReturnValue(null);
-
-    const api = makeApi();
-    plugin.register(api);
-
-    const infoCalls = api.logger.info.mock.calls;
-    const localModeCalls = infoCalls.filter(
-      (call: string[]) => typeof call[0] === "string" && call[0].includes("manifest plugin"),
-    );
-    expect(localModeCalls).toHaveLength(0);
-  });
-
   it("calls injectProviderConfig and injectAuthProfile with dev-no-auth", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -146,10 +76,7 @@ describe("register — cloud mode with devMode", () => {
   });
 
   it("registers provider with auth onboarding", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -167,10 +94,7 @@ describe("register — cloud mode with devMode", () => {
   });
 
   it("registers tools when registerTool is available", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -180,10 +104,7 @@ describe("register — cloud mode with devMode", () => {
   });
 
   it("registers a manifest-routing service", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -195,10 +116,7 @@ describe("register — cloud mode with devMode", () => {
   });
 
   it("logs dashboard URL", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -211,10 +129,7 @@ describe("register — cloud mode with devMode", () => {
 
   it("derives port 443 for https endpoints without explicit port", () => {
     const httpsConfig = { ...devConfig, endpoint: "https://dev.example.com" };
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: httpsConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(httpsConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -226,10 +141,7 @@ describe("register — cloud mode with devMode", () => {
   });
 
   it("service start invokes verifyConnection", async () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockResolvedValue({ error: null, agentName: "test-agent" });
 
@@ -247,10 +159,7 @@ describe("register — cloud mode with devMode", () => {
   });
 
   it("service start logs warning on verify error", async () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockResolvedValue({
       error: "Cannot reach endpoint",
@@ -270,10 +179,7 @@ describe("register — cloud mode with devMode", () => {
   });
 
   it("service start handles verify rejection", async () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockRejectedValue(new Error("boom"));
 
@@ -292,10 +198,7 @@ describe("register — cloud mode with devMode", () => {
 
   it("logs error message for validation errors in devMode", () => {
     const badDevConfig = { ...devConfig, endpoint: "not-a-url" };
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: badDevConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(badDevConfig);
     (validateConfig as jest.Mock).mockReturnValue("Invalid endpoint URL");
 
     const api = makeApi();
@@ -307,57 +210,8 @@ describe("register — cloud mode with devMode", () => {
   });
 });
 
-describe("register — deprecation warning", () => {
-  it("logs deprecation warning when _deprecatedDevMode is true", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "cloud",
-        devMode: true,
-        apiKey: "",
-        endpoint: "http://localhost:38238",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: true,
-    });
-    (validateConfig as jest.Mock).mockReturnValue(null);
-
-    const api = makeApi();
-    plugin.register(api);
-
-    expect(api.logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining("deprecated"),
-    );
-  });
-
-  it("does not log deprecation warning when _deprecatedDevMode is false", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "cloud",
-        devMode: true,
-        apiKey: "",
-        endpoint: "http://localhost:38238",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
-    });
-    (validateConfig as jest.Mock).mockReturnValue(null);
-
-    const api = makeApi();
-    plugin.register(api);
-
-    const warnCalls = api.logger.warn.mock.calls;
-    const deprecationCalls = warnCalls.filter(
-      (call: string[]) => typeof call[0] === "string" && call[0].includes("deprecated"),
-    );
-    expect(deprecationCalls).toHaveLength(0);
-  });
-});
-
-describe("register — cloud mode full path", () => {
+describe("register — cloud path", () => {
   const cloudConfig = {
-    mode: "cloud" as const,
     devMode: false,
     apiKey: "mnfst_abc",
     endpoint: "https://app.manifest.build",
@@ -365,11 +219,8 @@ describe("register — cloud mode full path", () => {
     host: "127.0.0.1",
   };
 
-  it("initializes routing, tools, and command in cloud mode", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: cloudConfig,
-      _deprecatedDevMode: false,
-    });
+  it("initializes routing, tools, and command", () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -380,11 +231,8 @@ describe("register — cloud mode full path", () => {
     expect(registerCommand).toHaveBeenCalledWith(api, cloudConfig, api.logger);
   });
 
-  it("calls injectProviderConfig and injectAuthProfile in cloud mode", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: cloudConfig,
-      _deprecatedDevMode: false,
-    });
+  it("calls injectProviderConfig and injectAuthProfile", () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -396,11 +244,8 @@ describe("register — cloud mode full path", () => {
     expect(injectAuthProfile).toHaveBeenCalledWith("mnfst_abc", api.logger);
   });
 
-  it("registers manifest-routing service in cloud mode", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: cloudConfig,
-      _deprecatedDevMode: false,
-    });
+  it("registers manifest-routing service", () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -411,11 +256,8 @@ describe("register — cloud mode full path", () => {
     );
   });
 
-  it("cloud service start invokes verifyConnection and logs success", async () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: cloudConfig,
-      _deprecatedDevMode: false,
-    });
+  it("service start invokes verifyConnection and logs success", async () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockResolvedValue({
       error: null,
@@ -435,11 +277,8 @@ describe("register — cloud mode full path", () => {
     );
   });
 
-  it("cloud service start logs warning on verify error", async () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: cloudConfig,
-      _deprecatedDevMode: false,
-    });
+  it("service start logs warning on verify error", async () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockResolvedValue({
       error: "Cannot reach endpoint",
@@ -458,11 +297,8 @@ describe("register — cloud mode full path", () => {
     );
   });
 
-  it("cloud service start handles verify rejection silently", async () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: cloudConfig,
-      _deprecatedDevMode: false,
-    });
+  it("service start handles verify rejection silently", async () => {
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
     (verifyConnection as jest.Mock).mockRejectedValue(new Error("boom"));
 
@@ -480,10 +316,7 @@ describe("register — cloud mode full path", () => {
   });
 
   it("skips registerTools when registerTool is not a function", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: cloudConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -499,17 +332,14 @@ describe("register — cloud mode full path", () => {
 
 describe("register — fallback logger", () => {
   it("uses console-based logger when api.logger is not provided", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "local",
-        devMode: false,
-        apiKey: "",
-        endpoint: "",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: false,
+      apiKey: "",
+      endpoint: "https://app.manifest.build",
+      port: 2099,
+      host: "127.0.0.1",
     });
+    (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
 
     const api = {
       pluginConfig: {},
@@ -518,30 +348,25 @@ describe("register — fallback logger", () => {
       registerTool: jest.fn(),
       registerProvider: jest.fn(),
     };
-    // No logger property
 
     const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     plugin.register(api);
 
-    // Should not throw — fallback logger.info delegates to console.log
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("manifest plugin"),
+      expect.stringContaining("Manifest requires an API key"),
     );
     consoleSpy.mockRestore();
   });
 
   it("fallback logger.info delegates to console.log", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "local",
-        devMode: false,
-        apiKey: "",
-        endpoint: "",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: false,
+      apiKey: "",
+      endpoint: "https://app.manifest.build",
+      port: 2099,
+      host: "127.0.0.1",
     });
+    (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
 
     const api = {
       pluginConfig: {},
@@ -554,24 +379,19 @@ describe("register — fallback logger", () => {
     const consoleSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     plugin.register(api);
 
-    // The local-mode branch calls logger.info(...) which delegates to console.log
     expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("manifest plugin"),
+      expect.stringContaining("Manifest requires an API key"),
     );
     consoleSpy.mockRestore();
   });
 
   it("fallback logger.error delegates to console.error", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "cloud",
-        devMode: true,
-        apiKey: "",
-        endpoint: "http://localhost:38238",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: true,
+      apiKey: "",
+      endpoint: "http://localhost:38238",
+      port: 2099,
+      host: "127.0.0.1",
     });
     (validateConfig as jest.Mock).mockReturnValue("Invalid endpoint URL");
 
@@ -587,7 +407,6 @@ describe("register — fallback logger", () => {
     const consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     plugin.register(api);
 
-    // The validation error branch calls logger.error which delegates to console.error
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining("Invalid endpoint URL"),
     );
@@ -595,52 +414,15 @@ describe("register — fallback logger", () => {
     consoleLogSpy.mockRestore();
   });
 
-  it("fallback logger.warn delegates to console.warn", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "cloud",
-        devMode: true,
-        apiKey: "",
-        endpoint: "http://localhost:38238",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: true,
-    });
-    (validateConfig as jest.Mock).mockReturnValue(null);
-
-    const api = {
-      pluginConfig: {},
-      config: { plugins: { entries: {} } },
-      registerService: jest.fn(),
-      registerTool: jest.fn(),
-      registerProvider: jest.fn(),
-    };
-
-    const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    const consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-    plugin.register(api);
-
-    // The deprecation branch calls logger.warn which delegates to console.warn
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining("deprecated"),
-    );
-    consoleSpy.mockRestore();
-    consoleLogSpy.mockRestore();
-  });
-
   it("fallback logger.debug is a no-op", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "local",
-        devMode: false,
-        apiKey: "",
-        endpoint: "",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: false,
+      apiKey: "",
+      endpoint: "https://app.manifest.build",
+      port: 2099,
+      host: "127.0.0.1",
     });
+    (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
 
     const api = {
       pluginConfig: {},
@@ -660,17 +442,13 @@ describe("register — fallback logger", () => {
 describe("register — registerCommand wiring", () => {
   it("calls registerCommand in devMode", () => {
     const devConfig = {
-      mode: "cloud" as const,
       devMode: true,
       apiKey: "",
       endpoint: "http://localhost:38238",
       port: 2099,
       host: "127.0.0.1",
     };
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: devConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(devConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -679,19 +457,15 @@ describe("register — registerCommand wiring", () => {
     expect(registerCommand).toHaveBeenCalledWith(api, devConfig, api.logger);
   });
 
-  it("calls registerCommand in cloud mode", () => {
+  it("calls registerCommand with valid config", () => {
     const cloudConfig = {
-      mode: "cloud" as const,
       devMode: false,
       apiKey: "mnfst_abc",
       endpoint: "https://app.manifest.build",
       port: 2099,
       host: "127.0.0.1",
     };
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: cloudConfig,
-      _deprecatedDevMode: false,
-    });
+    (parseConfig as jest.Mock).mockReturnValue(cloudConfig);
     (validateConfig as jest.Mock).mockReturnValue(null);
 
     const api = makeApi();
@@ -701,18 +475,14 @@ describe("register — registerCommand wiring", () => {
   });
 });
 
-describe("register — cloud mode missing API key", () => {
-  it("logs cloud mode requires API key message", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "cloud",
-        devMode: false,
-        apiKey: "",
-        endpoint: "https://app.manifest.build",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
+describe("register — missing API key", () => {
+  it("logs API key required message", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: false,
+      apiKey: "",
+      endpoint: "https://app.manifest.build",
+      port: 2099,
+      host: "127.0.0.1",
     });
     (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
 
@@ -720,21 +490,17 @@ describe("register — cloud mode missing API key", () => {
     plugin.register(api);
 
     expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("Cloud mode requires an API key"),
+      expect.stringContaining("Manifest requires an API key"),
     );
   });
 
   it("includes setup wizard instructions in the message", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "cloud",
-        devMode: false,
-        apiKey: "",
-        endpoint: "https://app.manifest.build",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: false,
+      apiKey: "",
+      endpoint: "https://app.manifest.build",
+      port: 2099,
+      host: "127.0.0.1",
     });
     (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
 
@@ -745,43 +511,54 @@ describe("register — cloud mode missing API key", () => {
       expect.stringContaining("openclaw providers setup manifest"),
     );
   });
+
+  it("uses correct plugin name in config path", () => {
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: false,
+      apiKey: "",
+      endpoint: "https://app.manifest.build",
+      port: 2099,
+      host: "127.0.0.1",
+    });
+    (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
+
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("manifest-provider.config.apiKey"),
+    );
+  });
 });
 
 describe("register — registerProvider behavior", () => {
   it("skips provider registration when api.registerProvider is not a function", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "local",
-        devMode: false,
-        apiKey: "",
-        endpoint: "",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: false,
+      apiKey: "",
+      endpoint: "https://app.manifest.build",
+      port: 2099,
+      host: "127.0.0.1",
     });
+    (validateConfig as jest.Mock).mockReturnValue("Missing apiKey");
 
     const api = makeApi();
     delete (api as any).registerProvider;
     plugin.register(api);
 
-    // Should not throw — just skips provider registration and logs manifest message
+    // Should not throw — just skips provider registration
     expect(api.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("manifest plugin"),
+      expect.stringContaining("Manifest requires an API key"),
     );
   });
 
   it("handles registerProvider error gracefully", () => {
-    (parseConfigWithDeprecation as jest.Mock).mockReturnValue({
-      config: {
-        mode: "cloud",
-        devMode: false,
-        apiKey: "mnfst_abc",
-        endpoint: "https://app.manifest.build",
-        port: 2099,
-        host: "127.0.0.1",
-      },
-      _deprecatedDevMode: false,
+    (parseConfig as jest.Mock).mockReturnValue({
+      devMode: false,
+      apiKey: "mnfst_abc",
+      endpoint: "https://app.manifest.build",
+      port: 2099,
+      host: "127.0.0.1",
     });
     (validateConfig as jest.Mock).mockReturnValue(null);
 

--- a/packages/openclaw-plugins/manifest-provider/__tests__/tools.test.ts
+++ b/packages/openclaw-plugins/manifest-provider/__tests__/tools.test.ts
@@ -12,7 +12,6 @@ const mockLogger = {
 };
 
 const config: ManifestConfig = {
-  mode: "cloud",
   devMode: false,
   apiKey: "mnfst_test_key",
   endpoint: "http://localhost:3001/otlp",
@@ -394,7 +393,6 @@ describe("registerTools", () => {
 
 describe("registerTools — no apiKey (devMode)", () => {
   const devConfig: ManifestConfig = {
-    mode: "cloud",
     devMode: true,
     apiKey: "",
     endpoint: "http://localhost:38238/otlp",

--- a/packages/openclaw-plugins/manifest-provider/__tests__/verify.test.ts
+++ b/packages/openclaw-plugins/manifest-provider/__tests__/verify.test.ts
@@ -2,7 +2,6 @@ import { verifyConnection, VerifyResult } from "../src/verify";
 import { ManifestConfig } from "../src/config";
 
 const baseConfig: ManifestConfig = {
-  mode: "cloud",
   devMode: false,
   apiKey: "mnfst_test123",
   endpoint: "http://localhost:3001/otlp",

--- a/packages/openclaw-plugins/manifest-provider/src/command.ts
+++ b/packages/openclaw-plugins/manifest-provider/src/command.ts
@@ -13,7 +13,6 @@ export function registerCommand(api: any, config: ManifestConfig, logger: Plugin
     try {
       const check = await verifyConnection(config);
       const lines = [
-        `Mode: ${config.mode}`,
         `Dev mode: ${config.devMode ? 'yes' : 'no'}`,
         `Endpoint reachable: ${check.endpointReachable ? 'yes' : 'no'}`,
         `Auth valid: ${check.authValid ? 'yes' : 'no'}`,

--- a/packages/openclaw-plugins/manifest-provider/src/compat.ts
+++ b/packages/openclaw-plugins/manifest-provider/src/compat.ts
@@ -11,7 +11,7 @@ export function stripOtlpSuffix(endpoint: string, logger: PluginLogger): string 
       `[manifest] Endpoint "${endpoint}" contains a deprecated /otlp suffix.\n` +
         `  The endpoint should now be the base URL (e.g. "${cleaned}").\n` +
         `  Update your config:\n` +
-        `    openclaw config set plugins.entries.manifest.config.endpoint ${cleaned}`,
+        `    openclaw config set plugins.entries.manifest-provider.config.endpoint ${cleaned}`,
     );
   }
   return cleaned;

--- a/packages/openclaw-plugins/manifest-provider/src/config.ts
+++ b/packages/openclaw-plugins/manifest-provider/src/config.ts
@@ -1,17 +1,11 @@
 import { API_KEY_PREFIX, DEFAULTS, ENV } from './constants';
 
 export interface ManifestConfig {
-  mode: 'cloud' | 'local';
   devMode: boolean;
   apiKey: string;
   endpoint: string;
   port: number;
   host: string;
-}
-
-export interface ParseResult {
-  config: ManifestConfig;
-  _deprecatedDevMode: boolean;
 }
 
 function isLoopback(endpoint: string): boolean {
@@ -25,10 +19,6 @@ function isLoopback(endpoint: string): boolean {
 }
 
 export function parseConfig(raw: unknown): ManifestConfig {
-  return parseConfigWithDeprecation(raw).config;
-}
-
-export function parseConfigWithDeprecation(raw: unknown): ParseResult {
   // OpenClaw may pass the full plugin entry { enabled, config: {...} }
   // or just the inner config object. Handle both.
   let obj: Record<string, unknown> =
@@ -36,18 +26,6 @@ export function parseConfigWithDeprecation(raw: unknown): ParseResult {
 
   if (obj.config && typeof obj.config === 'object' && !Array.isArray(obj.config)) {
     obj = obj.config as Record<string, unknown>;
-  }
-
-  // Backward compat: mode: "dev" → mode: "cloud" + devMode: true
-  let _deprecatedDevMode = false;
-  let mode: 'cloud' | 'local';
-  if (obj.mode === 'local') {
-    mode = 'local';
-  } else if (obj.mode === 'dev') {
-    mode = 'cloud';
-    _deprecatedDevMode = true;
-  } else {
-    mode = 'cloud';
   }
 
   const apiKey =
@@ -68,34 +46,29 @@ export function parseConfigWithDeprecation(raw: unknown): ParseResult {
 
   const host = typeof obj.host === 'string' && obj.host.length > 0 ? obj.host : '127.0.0.1';
 
-  // Determine devMode: explicit > deprecated mode: "dev" > auto-detect
+  // Determine devMode: explicit > legacy mode: "dev" > auto-detect
   let devMode: boolean;
   if (typeof obj.devMode === 'boolean') {
     devMode = obj.devMode;
-  } else if (_deprecatedDevMode) {
+  } else if (obj.mode === 'dev') {
+    // Backward compat: legacy mode: "dev" silently enables devMode
     devMode = true;
   } else {
     // Auto-detect: loopback endpoint + no mnfst_ API key
     devMode = isLoopback(endpoint) && !apiKey.startsWith(API_KEY_PREFIX);
   }
 
-  return {
-    config: { mode, devMode, apiKey, endpoint, port, host },
-    _deprecatedDevMode,
-  };
+  return { devMode, apiKey, endpoint, port, host };
 }
 
 export function validateConfig(config: ManifestConfig): string | null {
-  // In local mode, API key is auto-generated — skip validation
-  if (config.mode === 'local') return null;
-
   // devMode requires an endpoint but no API key
   if (config.devMode) {
     if (!config.endpoint.startsWith('http')) {
       return (
         `Invalid endpoint URL '${config.endpoint}'. ` +
         'Must start with http:// or https://. Fix it via:\n' +
-        '  openclaw config set plugins.entries.manifest.config.endpoint http://localhost:<PORT>'
+        '  openclaw config set plugins.entries.manifest-provider.config.endpoint http://localhost:<PORT>'
       );
     }
     return null;
@@ -104,7 +77,7 @@ export function validateConfig(config: ManifestConfig): string | null {
   if (!config.apiKey) {
     return (
       'Missing apiKey. Set it via:\n' +
-      `  openclaw config set plugins.entries.manifest.config.apiKey ${API_KEY_PREFIX}YOUR_KEY\n` +
+      `  openclaw config set plugins.entries.manifest-provider.config.apiKey ${API_KEY_PREFIX}YOUR_KEY\n` +
       `  or export MANIFEST_API_KEY=${API_KEY_PREFIX}YOUR_KEY`
     );
   }
@@ -112,14 +85,14 @@ export function validateConfig(config: ManifestConfig): string | null {
     return (
       'Invalid apiKey format. ' +
       `Keys must start with '${API_KEY_PREFIX}'. Fix it via:\n` +
-      `  openclaw config set plugins.entries.manifest.config.apiKey ${API_KEY_PREFIX}YOUR_KEY`
+      `  openclaw config set plugins.entries.manifest-provider.config.apiKey ${API_KEY_PREFIX}YOUR_KEY`
     );
   }
   if (!config.endpoint.startsWith('http')) {
     return (
       `Invalid endpoint URL '${config.endpoint}'. ` +
       'Must start with http:// or https://. Fix it via:\n' +
-      '  openclaw config set plugins.entries.manifest.config.endpoint https://app.manifest.build\n\n' +
+      '  openclaw config set plugins.entries.manifest-provider.config.endpoint https://app.manifest.build\n\n' +
       'Or run the setup wizard:\n' +
       '  openclaw providers setup manifest'
     );

--- a/packages/openclaw-plugins/manifest-provider/src/index.ts
+++ b/packages/openclaw-plugins/manifest-provider/src/index.ts
@@ -1,4 +1,4 @@
-import { parseConfigWithDeprecation, validateConfig } from './config';
+import { parseConfig, validateConfig } from './config';
 import { PluginLogger } from './types';
 import { registerTools } from './tools';
 import { registerCommand } from './command';
@@ -21,37 +21,20 @@ module.exports = {
       warn: (...args: unknown[]) => console.warn(...args),
     };
 
-    const { config, _deprecatedDevMode } = parseConfigWithDeprecation(api.pluginConfig);
-
-    if (_deprecatedDevMode) {
-      logger.warn?.(
-        '[manifest] mode: "dev" is deprecated. Use mode: "cloud" with devMode: true instead.\n' +
-          '  openclaw config set plugins.entries.manifest.config.mode cloud\n' +
-          '  openclaw config set plugins.entries.manifest.config.devMode true',
-      );
-    }
+    const config = parseConfig(api.pluginConfig);
 
     // Register as a provider plugin with auth onboarding
     registerProvider(api, config.endpoint, logger);
 
-    if (config.mode === 'local') {
-      logger.info(
-        '[manifest-provider] Local mode requires the manifest plugin.\n' +
-          '  Install it with: openclaw plugins install manifest\n' +
-          '  Then restart: openclaw gateway restart',
-      );
-      return;
-    }
-
     const error = validateConfig(config);
     if (error) {
-      if (!config.devMode && config.mode === 'cloud' && !config.apiKey) {
+      if (!config.devMode && !config.apiKey) {
         logger.info(
-          '[manifest] Cloud mode requires an API key.\n\n' +
+          '[manifest] Manifest requires an API key to route requests.\n\n' +
             'Run the setup wizard:\n' +
             '  openclaw providers setup manifest\n\n' +
             'Or set your key manually:\n' +
-            '  openclaw config set plugins.entries.manifest.config.apiKey mnfst_YOUR_KEY\n' +
+            '  openclaw config set plugins.entries.manifest-provider.config.apiKey mnfst_YOUR_KEY\n' +
             '  openclaw gateway restart',
         );
       } else {


### PR DESCRIPTION
## Summary

**manifest-provider plugin:**
- Remove the legacy `mode` field (`cloud` | `local`) — the plugin is cloud-only, the `manifest` plugin handles local
- Fix all config path references from `plugins.entries.manifest.config.*` to `plugins.entries.manifest-provider.config.*`
- Change "Cloud mode requires an API key" to "Manifest requires an API key to route requests"
- Remove the `mode: "dev"` deprecation warning (backward compat preserved: silently enables `devMode`)
- Remove `Mode:` line from `/manifest` status command output

**manifest plugin (embedded server):**
- Set `NODE_ENV=production` instead of `development` — removes the DEV badge from the dashboard
- Skip seed messages when running as embedded plugin (`MANIFEST_EMBEDDED=1`) — fresh installs show an empty dashboard
- Add dashboard URL info message during plugin registration

## Test plan

- [ ] 173 manifest-provider tests pass with 100% line coverage
- [ ] 62 manifest plugin tests pass with 100% line coverage
- [ ] 22 local-bootstrap tests pass (2 new for MANIFEST_EMBEDDED check)
- [ ] TypeScript compiles clean
- [ ] `openclaw plugins install manifest` shows LOCAL badge only (no DEV badge)
- [ ] Fresh install shows empty dashboard (no seed messages)