### PR TITLE
fix: resolve ClawHub security scan metadata mismatch

### DIFF
--- a/.changeset/fix-clawhub-scan.md
+++ b/.changeset/fix-clawhub-scan.md
@@ -1,0 +1,5 @@
+---
+"manifest-provider": patch
+---
+
+Remove stale subscription discovery claim from README and declare MANIFEST_API_KEY in SKILL.md frontmatter to resolve ClawHub security scan metadata mismatch.

--- a/packages/openclaw-plugins/manifest-provider/README.md
+++ b/packages/openclaw-plugins/manifest-provider/README.md
@@ -22,7 +22,6 @@ You can also set the key via environment variable for CI/CD: `export MANIFEST_AP
 - Interactive auth onboarding via `openclaw providers setup manifest-provider`
 - Agent tools: `manifest_usage`, `manifest_costs`, `manifest_health`
 - `/manifest` status command
-- Subscription provider discovery (detects existing OAuth providers)
 
 ## Self-hosted / Local mode
 

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: manifest
 description: Model Router for OpenClaw. Save up to 70% by routing requests to the right model. Choose LLM fallback to avoid API rate limits, set thresholds and reduce token consumption.
-metadata: {"openclaw":{"requires":{"bins":["openclaw"]},"homepage":"https://github.com/mnfst/manifest"}}
+metadata: {"openclaw":{"requires":{"bins":["openclaw"],"env":["MANIFEST_API_KEY"]},"primaryEnv":"MANIFEST_API_KEY","homepage":"https://github.com/mnfst/manifest"}}
 ---
 
 # Manifest — LLM Router & Observability for OpenClaw


### PR DESCRIPTION
## Summary

- Remove stale "Subscription provider discovery" bullet from `manifest-provider` README — feature was removed in 5.33.0 but the README still claimed it
- Add `requires.env: [MANIFEST_API_KEY]` and `primaryEnv` to `skills/manifest/SKILL.md` frontmatter so the ClawHub scanner sees the env var declaration

These two mismatches caused the ClawHub security scan to flag `manifest-provider` as **Suspicious** (medium confidence). See openclaw/clawhub#522 for the upstream registry extraction bug.

## Test plan

- [ ] Verify ClawHub security scan clears after next publish
- [ ] Confirm `manifest-provider` README accurately reflects current features

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned `manifest-provider` docs and skill metadata to resolve a ClawHub security scan mismatch. Declared `MANIFEST_API_KEY` and removed a deprecated feature claim to prevent false “Suspicious” flags.

- **Bug Fixes**
  - Added `requires.env: ["MANIFEST_API_KEY"]` and `primaryEnv` to `skills/manifest/SKILL.md`.
  - Removed "Subscription provider discovery" from `manifest-provider` README (feature removed in 5.33.0).

<sup>Written for commit cb3b391833659263e5057f8893b8228ad4de8cbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

