### PR TITLE
fix: set embedded server to production mode and skip seed data

### DIFF
--- a/.changeset/pretty-eyes-clean.md
+++ b/.changeset/pretty-eyes-clean.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Set embedded server to production mode, skip seed data for plugin installs, and show dashboard URL on registration

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -308,6 +308,34 @@ describe('LocalBootstrapService', () => {
     });
   });
 
+  describe('seed messages', () => {
+    const originalEmbedded = process.env['MANIFEST_EMBEDDED'];
+
+    afterEach(() => {
+      if (originalEmbedded !== undefined) {
+        process.env['MANIFEST_EMBEDDED'] = originalEmbedded;
+      } else {
+        delete process.env['MANIFEST_EMBEDDED'];
+      }
+    });
+
+    it('seeds messages when MANIFEST_EMBEDDED is not set', async () => {
+      delete process.env['MANIFEST_EMBEDDED'];
+      await service.onModuleInit();
+
+      // seedAgentMessages calls messageRepo.count then insert
+      expect(mockMessageRepo.insert).toHaveBeenCalled();
+    });
+
+    it('skips seed messages when MANIFEST_EMBEDDED is set', async () => {
+      process.env['MANIFEST_EMBEDDED'] = '1';
+      await service.onModuleInit();
+
+      // seedAgentMessages should not be called, so no insert on messageRepo
+      expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+    });
+  });
+
   describe('background model discovery', () => {
     it('calls discoverAllForAgent in background after bootstrap', async () => {
       await service.onModuleInit();

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -39,11 +39,14 @@ export class LocalBootstrapService implements OnModuleInit {
     await this.ensureTenantAndAgent();
     await this.fixupRoutingAgentIds();
     await this.recalculateTiersIfNeeded();
-    await seedAgentMessages(this.messageRepo, LOCAL_USER_ID, this.logger, {
-      tenantId: LOCAL_TENANT_ID,
-      agentId: LOCAL_AGENT_ID,
-      agentName: LOCAL_AGENT_NAME,
-    });
+    // Only seed demo messages for local dev (not embedded plugin installs)
+    if (!process.env['MANIFEST_EMBEDDED']) {
+      await seedAgentMessages(this.messageRepo, LOCAL_USER_ID, this.logger, {
+        tenantId: LOCAL_TENANT_ID,
+        agentId: LOCAL_AGENT_ID,
+        agentName: LOCAL_AGENT_NAME,
+      });
+    }
     this.logger.log('Local mode bootstrap complete');
 
     // Discover models for all active providers in the background

--- a/packages/openclaw-plugins/manifest/__tests__/register.test.ts
+++ b/packages/openclaw-plugins/manifest/__tests__/register.test.ts
@@ -102,4 +102,22 @@ describe("manifest plugin registration", () => {
 
     expect(registerLocalMode).toHaveBeenCalledWith(api, 2099, "127.0.0.1", api.logger);
   });
+
+  it("logs dashboard URL before starting server", () => {
+    const api = makeApi();
+    plugin.register(api);
+
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("http://127.0.0.1:2099"),
+    );
+  });
+
+  it("logs dashboard URL with custom port and host", () => {
+    const api = makeApi({ port: 3099, host: "0.0.0.0" });
+    plugin.register(api);
+
+    expect(api.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("http://0.0.0.0:3099"),
+    );
+  });
 });

--- a/packages/openclaw-plugins/manifest/src/index.ts
+++ b/packages/openclaw-plugins/manifest/src/index.ts
@@ -23,6 +23,12 @@ module.exports = {
     const port = typeof inner.port === 'number' && inner.port > 0 ? inner.port : 2099;
     const host = typeof inner.host === 'string' && inner.host.length > 0 ? inner.host : '127.0.0.1';
 
+    logger.info(
+      `[manifest] Dashboard: http://${host}:${port}\n` +
+        '  The plugin starts an embedded server and registers manifest/auto as a model.\n' +
+        '  Open the dashboard to connect a provider and start routing.',
+    );
+
     registerLocalMode(api, port, host, logger);
   },
 };

--- a/packages/openclaw-plugins/manifest/src/server.ts
+++ b/packages/openclaw-plugins/manifest/src/server.ts
@@ -31,7 +31,7 @@ export async function start(options: StartOptions = {}): Promise<unknown> {
   process.env['PORT'] = String(port);
   process.env['BIND_ADDRESS'] = host;
   process.env['MANIFEST_DB_PATH'] = dbPath;
-  process.env['NODE_ENV'] = 'development';
+  process.env['NODE_ENV'] = 'production';
   process.env['MANIFEST_FRONTEND_DIR'] = join(__dirname, '..', 'public');
 
   // Generate a random persistent secret for local mode


### PR DESCRIPTION
## Summary

- Set `NODE_ENV=production` in the embedded server (`server.ts`) instead of `development` — removes the DEV badge from the dashboard, health endpoint returns `devMode: false`
- Skip seed messages when running as embedded plugin (`MANIFEST_EMBEDDED=1`) — fresh installs show an empty dashboard instead of 704 fake messages
- Add dashboard URL info message during plugin registration so users see where the dashboard is

## Test plan

- [ ] 65 manifest plugin tests pass (100% line coverage)
- [ ] 22 local-bootstrap tests pass (2 new for `MANIFEST_EMBEDDED` check)
- [ ] `openclaw plugins install manifest` → dashboard shows LOCAL badge only (no DEV)
- [ ] Fresh install shows empty dashboard (no seed data)
- [ ] Dashboard URL printed during install/gateway restart

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the `manifest` plugin’s embedded server to production and skip seed data when running embedded, so the dashboard shows only LOCAL (no DEV) and fresh installs start empty. Also logs the dashboard URL during registration so users can open it quickly.

<sup>Written for commit a40111d0a2a989f551344e963c7b41b9d7f707d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

