### PR TITLE
fix: plugin only starts server, no config injection or auto-setup

### DIFF
--- a/.changeset/public-bears-sin.md
+++ b/.changeset/public-bears-sin.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Plugin only starts embedded server — no config injection, no auto agent/tenant creation. Users create agents and connect providers through the dashboard wizard, same as cloud mode.

--- a/packages/backend/src/database/local-bootstrap.service.spec.ts
+++ b/packages/backend/src/database/local-bootstrap.service.spec.ts
@@ -9,7 +9,6 @@ jest.mock('@nestjs/typeorm', () => ({
   InjectRepository: () => () => undefined,
 }));
 
-// Mock fs for config reading (includes writeFileSync/mkdirSync used by local-mode.constants)
 jest.mock('fs', () => ({
   existsSync: jest.fn().mockReturnValue(false),
   readFileSync: jest.fn(),
@@ -36,7 +35,6 @@ jest.mock('../model-discovery/model-discovery.service', () => ({
 }));
 
 import { LocalBootstrapService } from './local-bootstrap.service';
-import { existsSync, readFileSync } from 'fs';
 
 function makeMockRepo() {
   return {
@@ -44,6 +42,7 @@ function makeMockRepo() {
     insert: jest.fn().mockResolvedValue({}),
     upsert: jest.fn().mockResolvedValue({}),
     find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn().mockResolvedValue(null),
     save: jest.fn().mockResolvedValue({}),
     delete: jest.fn().mockResolvedValue({}),
   };
@@ -95,180 +94,57 @@ describe('LocalBootstrapService', () => {
   });
 
   describe('onModuleInit', () => {
-    it('runs full bootstrap sequence', async () => {
+    it('runs bootstrap without creating tenant or agent', async () => {
       await service.onModuleInit();
-      // Wait for background discovery to complete
       await new Promise((r) => setTimeout(r, 10));
-
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { LOCAL_USER_ID } = require('../common/constants/local-mode.constants');
-      const tenantInsertArg = mockTenantRepo.insert.mock.calls[0][0];
-      expect(tenantInsertArg.name).toBe(LOCAL_USER_ID);
-
-      expect(mockTenantRepo.insert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'local-tenant-001',
-          name: 'local-user-001',
-        }),
-      );
-      expect(mockAgentRepo.insert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'local-agent-001',
-          name: 'local-agent',
-          tenant_id: 'local-tenant-001',
-        }),
-      );
-    });
-
-    it('skips tenant/agent when tenant already exists', async () => {
-      mockTenantRepo.count.mockResolvedValue(1);
-
-      await service.onModuleInit();
 
       expect(mockTenantRepo.insert).not.toHaveBeenCalled();
       expect(mockAgentRepo.insert).not.toHaveBeenCalled();
     });
-  });
 
-  describe('config reading', () => {
-    it('does not register API key when config file missing', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { existsSync } = require('fs');
-      (existsSync as jest.Mock).mockReturnValue(false);
-
+    it('does not seed messages', async () => {
       await service.onModuleInit();
 
-      expect(mockAgentKeyRepo.upsert).not.toHaveBeenCalled();
-    });
-
-    it('returns null when readFileSync throws (catches error in readApiKeyFromConfig)', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { existsSync, readFileSync } = require('fs');
-      (existsSync as jest.Mock).mockReturnValue(true);
-      (readFileSync as jest.Mock).mockImplementation(() => {
-        throw new Error('EACCES: permission denied');
-      });
-
-      await service.onModuleInit();
-
-      // readApiKeyFromConfig returns null on error, so no key registration
-      expect(mockAgentKeyRepo.insert).not.toHaveBeenCalled();
-    });
-
-    it('registers API key when config file exists with apiKey', async () => {
-      (existsSync as jest.Mock).mockReturnValue(true);
-      (readFileSync as jest.Mock).mockReturnValue(
-        JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
-      );
-
-      await service.onModuleInit();
-
-      expect(mockAgentKeyRepo.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'local-otlp-key-001',
-          label: 'Local OTLP ingest key',
-          tenant_id: 'local-tenant-001',
-          agent_id: 'local-agent-001',
-          is_active: true,
-        }),
-        ['id'],
-      );
-    });
-
-    it('skips API key registration when key hash already exists', async () => {
-      (existsSync as jest.Mock).mockReturnValue(true);
-      (readFileSync as jest.Mock).mockReturnValue(
-        JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
-      );
-      // Return a candidate whose hash verifies against the API key
-      const { hashKey } =
-        // eslint-disable-next-line @typescript-eslint/no-require-imports
-        require('../common/utils/hash.util') as typeof import('../common/utils/hash.util');
-      mockAgentKeyRepo.find.mockResolvedValue([
-        { key_hash: hashKey('mnfst_test_key_12345'), key_prefix: 'mnfst_test_k' },
-      ]);
-
-      await service.onModuleInit();
-
-      expect(mockAgentKeyRepo.upsert).not.toHaveBeenCalled();
-    });
-
-    it('does not register when apiKey is not a string', async () => {
-      (existsSync as jest.Mock).mockReturnValue(true);
-      (readFileSync as jest.Mock).mockReturnValue(JSON.stringify({ apiKey: 12345 }));
-
-      await service.onModuleInit();
-
-      expect(mockAgentKeyRepo.upsert).not.toHaveBeenCalled();
-    });
-
-    it('reconciles API key even when tenant already exists', async () => {
-      (existsSync as jest.Mock).mockReturnValue(true);
-      (readFileSync as jest.Mock).mockReturnValue(
-        JSON.stringify({ apiKey: 'mnfst_test_key_12345' }),
-      );
-      mockTenantRepo.count.mockResolvedValue(1);
-
-      await service.onModuleInit();
-
-      expect(mockTenantRepo.insert).not.toHaveBeenCalled();
-      expect(mockAgentKeyRepo.upsert).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: 'local-otlp-key-001',
-          tenant_id: 'local-tenant-001',
-          agent_id: 'local-agent-001',
-        }),
-        ['id'],
-      );
+      expect(mockMessageRepo.insert).not.toHaveBeenCalled();
     });
   });
 
   describe('fixupRoutingAgentIds', () => {
-    it('updates orphaned provider rows to LOCAL_AGENT_ID', async () => {
+    it('skips fixup when no active agents exist', async () => {
+      mockAgentRepo.findOne.mockResolvedValue(null);
+
+      await service.onModuleInit();
+
+      expect(mockProviderRepo.save).not.toHaveBeenCalled();
+      expect(mockTierRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('updates orphaned provider rows to first active agent', async () => {
       const orphanedProvider = { id: 'p1', provider: 'openai', agent_id: null };
+      mockAgentRepo.findOne.mockResolvedValue({ id: 'user-agent-1', is_active: true });
       mockProviderRepo.find.mockResolvedValue([orphanedProvider]);
       mockTierRepo.find.mockResolvedValue([]);
 
       await service.onModuleInit();
 
-      expect(mockProviderRepo.find).toHaveBeenCalledWith({
-        where: { agent_id: expect.anything() },
-      });
-      expect(orphanedProvider.agent_id).toBe('local-agent-001');
+      expect(orphanedProvider.agent_id).toBe('user-agent-1');
       expect(mockProviderRepo.save).toHaveBeenCalledWith(orphanedProvider);
     });
 
-    it('updates orphaned tier rows to LOCAL_AGENT_ID', async () => {
+    it('updates orphaned tier rows to first active agent', async () => {
       const orphanedTier = { id: 't1', tier: 'simple', agent_id: null };
+      mockAgentRepo.findOne.mockResolvedValue({ id: 'user-agent-1', is_active: true });
       mockProviderRepo.find.mockResolvedValue([]);
       mockTierRepo.find.mockResolvedValue([orphanedTier]);
 
       await service.onModuleInit();
 
-      expect(mockTierRepo.find).toHaveBeenCalledWith({
-        where: { agent_id: expect.anything() },
-      });
-      expect(orphanedTier.agent_id).toBe('local-agent-001');
+      expect(orphanedTier.agent_id).toBe('user-agent-1');
       expect(mockTierRepo.save).toHaveBeenCalledWith(orphanedTier);
     });
 
-    it('updates both orphaned providers and tiers', async () => {
-      const provider1 = { id: 'p1', provider: 'openai', agent_id: null };
-      const provider2 = { id: 'p2', provider: 'anthropic', agent_id: null };
-      const tier1 = { id: 't1', tier: 'simple', agent_id: null };
-      mockProviderRepo.find.mockResolvedValue([provider1, provider2]);
-      mockTierRepo.find.mockResolvedValue([tier1]);
-
-      await service.onModuleInit();
-
-      expect(provider1.agent_id).toBe('local-agent-001');
-      expect(provider2.agent_id).toBe('local-agent-001');
-      expect(tier1.agent_id).toBe('local-agent-001');
-      expect(mockProviderRepo.save).toHaveBeenCalledTimes(2);
-      expect(mockTierRepo.save).toHaveBeenCalledTimes(1);
-    });
-
     it('does nothing when no orphaned rows exist', async () => {
+      mockAgentRepo.findOne.mockResolvedValue({ id: 'user-agent-1', is_active: true });
       mockProviderRepo.find.mockResolvedValue([]);
       mockTierRepo.find.mockResolvedValue([]);
 
@@ -280,16 +156,25 @@ describe('LocalBootstrapService', () => {
   });
 
   describe('recalculateTiersIfNeeded', () => {
-    it('recalculates tiers when active providers exist on startup', async () => {
+    it('skips when no active agents exist', async () => {
+      mockAgentRepo.findOne.mockResolvedValue(null);
+
+      await service.onModuleInit();
+
+      expect(mockRecalculate).not.toHaveBeenCalled();
+    });
+
+    it('recalculates tiers when active providers exist', async () => {
+      mockAgentRepo.findOne.mockResolvedValue({ id: 'user-agent-1', is_active: true });
       mockProviderRepo.count.mockResolvedValue(2);
 
       await service.onModuleInit();
 
-      expect(mockModuleRef.get).toHaveBeenCalled();
-      expect(mockRecalculate).toHaveBeenCalledWith('local-agent-001');
+      expect(mockRecalculate).toHaveBeenCalledWith('user-agent-1');
     });
 
-    it('skips tier recalculation when no active providers', async () => {
+    it('skips when no active providers', async () => {
+      mockAgentRepo.findOne.mockResolvedValue({ id: 'user-agent-1', is_active: true });
       mockProviderRepo.count.mockResolvedValue(0);
 
       await service.onModuleInit();
@@ -297,7 +182,8 @@ describe('LocalBootstrapService', () => {
       expect(mockRecalculate).not.toHaveBeenCalled();
     });
 
-    it('handles tier recalculation failure gracefully', async () => {
+    it('handles failure gracefully', async () => {
+      mockAgentRepo.findOne.mockResolvedValue({ id: 'user-agent-1', is_active: true });
       mockProviderRepo.count.mockResolvedValue(1);
       mockModuleRef.get.mockImplementation((token) => {
         const name = typeof token === 'function' ? token.name : String(token);
@@ -314,62 +200,39 @@ describe('LocalBootstrapService', () => {
     });
   });
 
-  describe('seed messages', () => {
-    const originalEmbedded = process.env['MANIFEST_EMBEDDED'];
-
-    afterEach(() => {
-      if (originalEmbedded !== undefined) {
-        process.env['MANIFEST_EMBEDDED'] = originalEmbedded;
-      } else {
-        delete process.env['MANIFEST_EMBEDDED'];
-      }
-    });
-
-    it('seeds messages when MANIFEST_EMBEDDED is not set', async () => {
-      delete process.env['MANIFEST_EMBEDDED'];
-      await service.onModuleInit();
-
-      // seedAgentMessages calls messageRepo.count then insert
-      expect(mockMessageRepo.insert).toHaveBeenCalled();
-    });
-
-    it('skips seed messages when MANIFEST_EMBEDDED is set', async () => {
-      process.env['MANIFEST_EMBEDDED'] = '1';
-      await service.onModuleInit();
-
-      // seedAgentMessages should not be called, so no insert on messageRepo
-      expect(mockMessageRepo.insert).not.toHaveBeenCalled();
-    });
-  });
-
   describe('background model discovery', () => {
-    it('calls discoverAllForAgent in background after bootstrap', async () => {
+    it('discovers models for active agents', async () => {
+      mockAgentRepo.find.mockResolvedValue([
+        { id: 'agent-1', is_active: true },
+        { id: 'agent-2', is_active: true },
+      ]);
+
       await service.onModuleInit();
-      // Wait for background promise to resolve
       await new Promise((r) => setTimeout(r, 10));
 
-      expect(mockDiscoverAllForAgent).toHaveBeenCalledWith('local-agent-001');
+      expect(mockDiscoverAllForAgent).toHaveBeenCalledWith('agent-1');
+      expect(mockDiscoverAllForAgent).toHaveBeenCalledWith('agent-2');
     });
 
-    it('handles background discovery failure gracefully', async () => {
+    it('skips discovery when no active agents', async () => {
+      mockAgentRepo.find.mockResolvedValue([]);
+
+      await service.onModuleInit();
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockDiscoverAllForAgent).not.toHaveBeenCalled();
+    });
+
+    it('handles discovery failure gracefully', async () => {
+      mockAgentRepo.find.mockResolvedValue([{ id: 'agent-1', is_active: true }]);
       mockDiscoverAllForAgent.mockRejectedValue(new Error('network error'));
 
       await expect(service.onModuleInit()).resolves.not.toThrow();
-      // Wait for background promise to settle
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    it('recalculates tiers after successful discovery', async () => {
-      mockProviderRepo.count.mockResolvedValue(1);
-
-      await service.onModuleInit();
-      await new Promise((r) => setTimeout(r, 10));
-
-      // recalculate should be called: once in onModuleInit and once after discovery
-      expect(mockRecalculate).toHaveBeenCalledWith('local-agent-001');
-    });
-
-    it('handles moduleRef.get failure for ModelDiscoveryService gracefully', async () => {
+    it('handles moduleRef.get failure gracefully', async () => {
+      mockAgentRepo.find.mockResolvedValue([{ id: 'agent-1', is_active: true }]);
       mockModuleRef.get.mockImplementation((token) => {
         const name = typeof token === 'function' ? token.name : String(token);
         if (name === 'ModelDiscoveryService') {
@@ -385,9 +248,7 @@ describe('LocalBootstrapService', () => {
       await new Promise((r) => setTimeout(r, 10));
     });
 
-    it('handles outer .catch when discoverModelsInBackground rejects unexpectedly', async () => {
-      // Override the private method to reject, triggering the outer .catch on line 52
-
+    it('handles outer .catch when discoverModelsInBackground rejects', async () => {
       jest
         .spyOn(service as any, 'discoverModelsInBackground')
         .mockRejectedValue(new Error('unexpected rejection'));

--- a/packages/backend/src/database/local-bootstrap.service.ts
+++ b/packages/backend/src/database/local-bootstrap.service.ts
@@ -2,24 +2,12 @@ import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { InjectRepository } from '@nestjs/typeorm';
 import { IsNull, Repository } from 'typeorm';
-import { readFileSync, existsSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
 import { Tenant } from '../entities/tenant.entity';
 import { Agent } from '../entities/agent.entity';
 import { AgentApiKey } from '../entities/agent-api-key.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { UserProvider } from '../entities/user-provider.entity';
 import { TierAssignment } from '../entities/tier-assignment.entity';
-import { hashKey, keyPrefix, verifyKey } from '../common/utils/hash.util';
-import {
-  LOCAL_USER_ID,
-  LOCAL_EMAIL,
-  LOCAL_TENANT_ID,
-  LOCAL_AGENT_ID,
-  LOCAL_AGENT_NAME,
-} from '../common/constants/local-mode.constants';
-import { seedAgentMessages } from './seed-messages';
 
 @Injectable()
 export class LocalBootstrapService implements OnModuleInit {
@@ -36,103 +24,40 @@ export class LocalBootstrapService implements OnModuleInit {
   ) {}
 
   async onModuleInit() {
-    await this.ensureTenantAndAgent();
     await this.fixupRoutingAgentIds();
     await this.recalculateTiersIfNeeded();
-    // Only seed demo messages for local dev (not embedded plugin installs)
-    if (!process.env['MANIFEST_EMBEDDED']) {
-      await seedAgentMessages(this.messageRepo, LOCAL_USER_ID, this.logger, {
-        tenantId: LOCAL_TENANT_ID,
-        agentId: LOCAL_AGENT_ID,
-        agentName: LOCAL_AGENT_NAME,
-      });
-    }
     this.logger.log('Local mode bootstrap complete');
 
-    // Discover models for all active providers in the background
     this.discoverModelsInBackground().catch((err) => {
       this.logger.warn(`Background model discovery failed: ${err}`);
     });
   }
 
   private async discoverModelsInBackground(): Promise<void> {
+    const agents = await this.agentRepo.find({ where: { is_active: true } });
+    if (agents.length === 0) return;
+
     try {
       const { ModelDiscoveryService } = await import('../model-discovery/model-discovery.service');
       const discovery = this.moduleRef.get(ModelDiscoveryService, { strict: false });
-      await discovery.discoverAllForAgent(LOCAL_AGENT_ID);
+      for (const agent of agents) {
+        await discovery.discoverAllForAgent(agent.id);
+      }
       await this.recalculateTiersIfNeeded();
     } catch (err) {
       this.logger.warn(`Model discovery failed: ${err}`);
     }
   }
 
-  private async ensureTenantAndAgent() {
-    const count = await this.tenantRepo.count({ where: { id: LOCAL_TENANT_ID } });
-    if (count === 0) {
-      await this.tenantRepo.insert({
-        id: LOCAL_TENANT_ID,
-        name: LOCAL_USER_ID,
-        organization_name: 'Local',
-        email: LOCAL_EMAIL,
-        is_active: true,
-      });
-
-      await this.agentRepo.insert({
-        id: LOCAL_AGENT_ID,
-        name: LOCAL_AGENT_NAME,
-        description: 'Default local agent',
-        is_active: true,
-        tenant_id: LOCAL_TENANT_ID,
-      });
-      this.logger.log(`Created tenant/agent for local mode`);
-    }
-
-    const apiKey = this.readApiKeyFromConfig();
-    if (apiKey) {
-      await this.registerApiKey(apiKey);
-    }
-  }
-
-  private readApiKeyFromConfig(): string | null {
-    try {
-      const configPath = join(homedir(), '.openclaw', 'manifest', 'config.json');
-      if (!existsSync(configPath)) return null;
-      const data = JSON.parse(readFileSync(configPath, 'utf-8'));
-      return typeof data.apiKey === 'string' ? data.apiKey : null;
-    } catch {
-      return null;
-    }
-  }
-
-  private async registerApiKey(apiKey: string) {
-    const prefix = keyPrefix(apiKey);
-    const candidates = await this.agentKeyRepo.find({ where: { key_prefix: prefix } });
-    const alreadyExists = candidates.some((c) => verifyKey(apiKey, c.key_hash));
-    if (alreadyExists) return;
-
-    const hash = hashKey(apiKey);
-
-    await this.agentKeyRepo.upsert(
-      {
-        id: 'local-otlp-key-001',
-        key: null,
-        key_hash: hash,
-        key_prefix: keyPrefix(apiKey),
-        label: 'Local OTLP ingest key',
-        tenant_id: LOCAL_TENANT_ID,
-        agent_id: LOCAL_AGENT_ID,
-        is_active: true,
-      },
-      ['id'],
-    );
-  }
-
   private async fixupRoutingAgentIds() {
     const orphanedProviders = await this.providerRepo.find({
       where: { agent_id: IsNull() as unknown as string },
     });
+    const firstAgent = await this.agentRepo.findOne({ where: { is_active: true } });
+    if (!firstAgent) return;
+
     for (const row of orphanedProviders) {
-      row.agent_id = LOCAL_AGENT_ID;
+      row.agent_id = firstAgent.id;
       await this.providerRepo.save(row);
     }
 
@@ -140,7 +65,7 @@ export class LocalBootstrapService implements OnModuleInit {
       where: { agent_id: IsNull() as unknown as string },
     });
     for (const row of orphanedTiers) {
-      row.agent_id = LOCAL_AGENT_ID;
+      row.agent_id = firstAgent.id;
       await this.tierRepo.save(row);
     }
 
@@ -152,8 +77,11 @@ export class LocalBootstrapService implements OnModuleInit {
   }
 
   private async recalculateTiersIfNeeded() {
+    const firstAgent = await this.agentRepo.findOne({ where: { is_active: true } });
+    if (!firstAgent) return;
+
     const activeProviders = await this.providerRepo.count({
-      where: { agent_id: LOCAL_AGENT_ID, is_active: true },
+      where: { agent_id: firstAgent.id, is_active: true },
     });
     if (activeProviders === 0) return;
 
@@ -161,7 +89,7 @@ export class LocalBootstrapService implements OnModuleInit {
       const { TierAutoAssignService } =
         await import('../routing/routing-core/tier-auto-assign.service');
       const autoAssign = this.moduleRef.get(TierAutoAssignService, { strict: false });
-      await autoAssign.recalculate(LOCAL_AGENT_ID);
+      await autoAssign.recalculate(firstAgent.id);
       this.logger.log('Recalculated tier assignments on startup');
     } catch (err) {
       this.logger.warn(`Failed to recalculate tiers: ${err}`);

--- a/packages/openclaw-plugins/manifest/__tests__/local-mode.test.ts
+++ b/packages/openclaw-plugins/manifest/__tests__/local-mode.test.ts
@@ -2,27 +2,11 @@ const mockServerStart = jest.fn();
 
 jest.mock("fs", () => ({
   existsSync: jest.fn(),
-  writeFileSync: jest.fn(),
   mkdirSync: jest.fn(),
-  readdirSync: jest.fn(),
-  renameSync: jest.fn(),
-  openSync: jest.fn(),
-  closeSync: jest.fn(),
-  unlinkSync: jest.fn(),
 }));
 
 jest.mock("os", () => ({
   homedir: () => "/mock-home",
-}));
-
-jest.mock("crypto", () => ({
-  randomBytes: jest.fn(() => ({
-    toString: () => "aabbccdd11223344aabbccdd11223344aabbccdd11223344",
-  })),
-}));
-
-jest.mock("../src/json-file", () => ({
-  loadJsonFile: jest.fn(() => ({})),
 }));
 
 jest.mock("../src/server", () => ({
@@ -30,25 +14,11 @@ jest.mock("../src/server", () => ({
   version: "1.0.0",
 }));
 
-import { existsSync, writeFileSync, mkdirSync, readdirSync, renameSync, openSync, closeSync, unlinkSync } from "fs";
-import { loadJsonFile } from "../src/json-file";
-import {
-  loadOrGenerateApiKey,
-  injectProviderConfig,
-  injectAuthProfile,
-  checkExistingServer,
-  registerLocalMode,
-} from "../src/local-mode";
+import { existsSync, mkdirSync } from "fs";
+import { checkExistingServer, registerLocalMode } from "../src/local-mode";
 
 const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
-const mockWriteFileSync = writeFileSync as jest.MockedFunction<typeof writeFileSync>;
 const mockMkdirSync = mkdirSync as jest.MockedFunction<typeof mkdirSync>;
-const mockReaddirSync = readdirSync as jest.MockedFunction<typeof readdirSync>;
-const mockRenameSync = renameSync as jest.MockedFunction<typeof renameSync>;
-const mockOpenSync = openSync as jest.MockedFunction<typeof openSync>;
-const mockCloseSync = closeSync as jest.MockedFunction<typeof closeSync>;
-const mockUnlinkSync = unlinkSync as jest.MockedFunction<typeof unlinkSync>;
-const mockLoadJsonFile = loadJsonFile as jest.MockedFunction<typeof loadJsonFile>;
 
 function makeLogger() {
   return {
@@ -59,648 +29,11 @@ function makeLogger() {
   };
 }
 
-const CONFIG_DIR = "/mock-home/.openclaw/manifest";
-const CONFIG_FILE = "/mock-home/.openclaw/manifest/config.json";
-const OPENCLAW_CONFIG = "/mock-home/.openclaw/openclaw.json";
-const OPENCLAW_DIR = "/mock-home/.openclaw";
-
 beforeEach(() => {
   jest.clearAllMocks();
   mockExistsSync.mockReturnValue(false);
-  mockLoadJsonFile.mockReturnValue({});
-  // By default, openSync throws (lock can't be acquired) so existing tests
-  // exercise the fallback path. Tests for the lock-acquired path override this.
-  mockOpenSync.mockImplementation(() => {
-    throw new Error("EEXIST");
-  });
 });
 
-// ---------------------------------------------------------------------------
-// loadOrGenerateApiKey
-// ---------------------------------------------------------------------------
-describe("loadOrGenerateApiKey", () => {
-  it("creates config dir when it does not exist", () => {
-    mockExistsSync.mockReturnValue(false);
-
-    loadOrGenerateApiKey();
-
-    expect(mockMkdirSync).toHaveBeenCalledWith(CONFIG_DIR, {
-      recursive: true,
-      mode: 0o700,
-    });
-  });
-
-  it("does not create config dir when it already exists", () => {
-    mockExistsSync.mockImplementation((p) => String(p) === CONFIG_DIR);
-
-    loadOrGenerateApiKey();
-
-    expect(mockMkdirSync).not.toHaveBeenCalled();
-  });
-
-  it("returns existing key from config file when valid", () => {
-    mockExistsSync.mockReturnValue(true);
-    mockLoadJsonFile.mockReturnValue({ apiKey: "mnfst_existing_key_123" });
-
-    const key = loadOrGenerateApiKey();
-
-    expect(key).toBe("mnfst_existing_key_123");
-    expect(mockWriteFileSync).not.toHaveBeenCalled();
-  });
-
-  it("generates new key when config file exists but key has wrong prefix", () => {
-    mockExistsSync.mockReturnValue(true);
-    mockLoadJsonFile
-      .mockReturnValueOnce({ apiKey: "wrong_prefix_key" })
-      .mockReturnValueOnce({ apiKey: "wrong_prefix_key" });
-
-    const key = loadOrGenerateApiKey();
-
-    expect(key).toBe(
-      "mnfst_local_aabbccdd11223344aabbccdd11223344aabbccdd11223344",
-    );
-    expect(mockWriteFileSync).toHaveBeenCalledWith(
-      CONFIG_FILE,
-      expect.stringContaining("mnfst_local_"),
-      { mode: 0o600 },
-    );
-  });
-
-  it("generates new key when config file exists but apiKey is missing", () => {
-    mockExistsSync.mockReturnValue(true);
-    mockLoadJsonFile.mockReturnValue({});
-
-    const key = loadOrGenerateApiKey();
-
-    expect(key).toMatch(/^mnfst_local_/);
-    expect(mockWriteFileSync).toHaveBeenCalled();
-  });
-
-  it("generates new key when config file does not exist", () => {
-    mockExistsSync.mockImplementation((p) => String(p) === CONFIG_DIR);
-    mockLoadJsonFile.mockReturnValue({});
-
-    const key = loadOrGenerateApiKey();
-
-    expect(key).toMatch(/^mnfst_local_/);
-  });
-
-  it("acquires file lock and cleans up on success", () => {
-    mockOpenSync.mockReturnValue(42);
-    mockExistsSync.mockReturnValue(true);
-    mockLoadJsonFile.mockReturnValue({ apiKey: "mnfst_existing_key_123" });
-
-    const key = loadOrGenerateApiKey();
-
-    expect(key).toBe("mnfst_existing_key_123");
-    expect(mockCloseSync).toHaveBeenCalledWith(42);
-    expect(mockUnlinkSync).toHaveBeenCalled();
-  });
-
-  it("cleans up lock even when unlinkSync throws", () => {
-    mockOpenSync.mockReturnValue(42);
-    mockUnlinkSync.mockImplementation(() => {
-      throw new Error("ENOENT");
-    });
-    mockExistsSync.mockReturnValue(true);
-    mockLoadJsonFile.mockReturnValue({ apiKey: "mnfst_existing_key_123" });
-
-    const key = loadOrGenerateApiKey();
-
-    expect(key).toBe("mnfst_existing_key_123");
-    expect(mockCloseSync).toHaveBeenCalledWith(42);
-  });
-
-  it("merges new key with existing config data", () => {
-    mockExistsSync.mockImplementation((p) => String(p) === CONFIG_DIR);
-    mockLoadJsonFile.mockReturnValue({ otherSetting: true });
-
-    loadOrGenerateApiKey();
-
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(written.otherSetting).toBe(true);
-    expect(written.apiKey).toMatch(/^mnfst_local_/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// injectProviderConfig
-// ---------------------------------------------------------------------------
-describe("injectProviderConfig", () => {
-  const baseUrl = "http://127.0.0.1:2099/v1";
-  const apiKey = "mnfst_test_key";
-
-  it("writes provider config to openclaw.json", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    mockLoadJsonFile.mockReturnValue({});
-    mockExistsSync.mockImplementation((p) => {
-      if (String(p) === OPENCLAW_DIR) return true;
-      return false;
-    });
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(mockRenameSync).toHaveBeenCalled();
-    const tmpPath = mockWriteFileSync.mock.calls[0][0] as string;
-    expect(tmpPath).toMatch(/openclaw\.json\.tmp\./);
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(written.models.providers.manifest.baseUrl).toBe(baseUrl);
-    expect(written.models.providers.manifest.apiKey).toBe(apiKey);
-    expect(written.models.providers.manifest.models).toEqual([
-      { id: "auto", name: "auto" },
-    ]);
-    expect(logger.debug).toHaveBeenCalledWith(
-      "[manifest] Wrote provider config to openclaw.json",
-    );
-  });
-
-  it("adds manifest/auto to agents.defaults.models when it is an object", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    mockLoadJsonFile.mockReturnValue({
-      agents: { defaults: { models: { "gpt-4": {} } } },
-    });
-    mockExistsSync.mockReturnValue(true);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(written.agents.defaults.models["manifest/auto"]).toEqual({});
-    expect(written.agents.defaults.models["gpt-4"]).toEqual({});
-  });
-
-  it("does not duplicate manifest/auto when already present in object", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    mockLoadJsonFile.mockReturnValue({
-      agents: {
-        defaults: { models: { "manifest/auto": { existing: true } } },
-      },
-    });
-    mockExistsSync.mockReturnValue(true);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(written.agents.defaults.models["manifest/auto"]).toEqual({
-      existing: true,
-    });
-  });
-
-  it("adds manifest/auto to agents.defaults.models when it is an array", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    mockLoadJsonFile.mockReturnValue({
-      agents: { defaults: { models: ["gpt-4"] } },
-    });
-    mockExistsSync.mockReturnValue(true);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(written.agents.defaults.models).toContain("manifest/auto");
-    expect(written.agents.defaults.models).toContain("gpt-4");
-  });
-
-  it("does not duplicate manifest/auto when already present in array", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    mockLoadJsonFile.mockReturnValue({
-      agents: { defaults: { models: ["manifest/auto"] } },
-    });
-    mockExistsSync.mockReturnValue(true);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    const count = written.agents.defaults.models.filter(
-      (m: string) => m === "manifest/auto",
-    ).length;
-    expect(count).toBe(1);
-  });
-
-  it("logs debug message when writeFileSync throws", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    mockLoadJsonFile.mockReturnValue({});
-    mockWriteFileSync.mockImplementationOnce(() => {
-      throw new Error("EACCES: permission denied");
-    });
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining("Could not write openclaw.json"),
-    );
-  });
-
-  it("logs debug with stringified error when error is not an Error instance", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    mockLoadJsonFile.mockImplementation(() => {
-      throw "string error";
-    });
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining("string error"),
-    );
-  });
-
-  it("cleans stale manifest entries from agent models.json files", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    const agentsDir = `${OPENCLAW_DIR}/agents`;
-
-    let callCount = 0;
-    mockLoadJsonFile.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) return {}; // openclaw.json
-      return { providers: { manifest: { old: true } } }; // models.json
-    });
-
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === agentsDir) return true;
-      if (path.endsWith("models.json")) return true;
-      if (path === OPENCLAW_DIR) return true;
-      return false;
-    });
-
-    mockReaddirSync.mockReturnValue([
-      { name: "agent1", isDirectory: () => true },
-    ] as any);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    // Two writes: one for openclaw.json, one for models.json
-    expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
-    const modelsWritten = JSON.parse(
-      mockWriteFileSync.mock.calls[1][1] as string,
-    );
-    expect(modelsWritten.providers.manifest).toBeUndefined();
-  });
-
-  it("skips agent models.json that does not exist", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    const agentsDir = `${OPENCLAW_DIR}/agents`;
-
-    mockLoadJsonFile.mockReturnValueOnce({}); // openclaw.json
-
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === agentsDir) return true;
-      if (path === OPENCLAW_DIR) return true;
-      if (path.endsWith("models.json")) return false;
-      return false;
-    });
-
-    mockReaddirSync.mockReturnValue([
-      { name: "agent1", isDirectory: () => true },
-    ] as any);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    // Only one write for openclaw.json, not for models.json
-    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips agent models.json that has no manifest provider", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    const agentsDir = `${OPENCLAW_DIR}/agents`;
-
-    let callCount = 0;
-    mockLoadJsonFile.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) return {}; // openclaw.json
-      return { providers: { openai: {} } }; // models.json
-    });
-
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === agentsDir) return true;
-      if (path === OPENCLAW_DIR) return true;
-      if (path.endsWith("models.json")) return true;
-      return false;
-    });
-
-    mockReaddirSync.mockReturnValue([
-      { name: "agent1", isDirectory: () => true },
-    ] as any);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    // Only openclaw.json write
-    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips stale cleanup when agents dir does not exist", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-
-    mockLoadJsonFile.mockReturnValue({});
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === OPENCLAW_DIR) return true;
-      return false;
-    });
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(mockReaddirSync).not.toHaveBeenCalled();
-  });
-
-  it("silently handles error during stale cleanup", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    const agentsDir = `${OPENCLAW_DIR}/agents`;
-
-    mockLoadJsonFile.mockReturnValueOnce({}); // openclaw.json
-
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === agentsDir) return true;
-      if (path === OPENCLAW_DIR) return true;
-      return false;
-    });
-
-    mockReaddirSync.mockImplementation(() => {
-      throw new Error("read error");
-    });
-
-    // Should not throw
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-  });
-
-  it("sets runtime config on api.config", () => {
-    const logger = makeLogger();
-    const api = { config: {} as any };
-    mockLoadJsonFile.mockReturnValue({});
-    mockExistsSync.mockReturnValue(true);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(api.config.models.providers.manifest.baseUrl).toBe(baseUrl);
-    expect(api.config.agents.defaults.models["manifest/auto"]).toEqual({});
-  });
-
-  it("adds manifest/auto to runtime config models when it is an array", () => {
-    const logger = makeLogger();
-    const api = {
-      config: {
-        agents: { defaults: { models: ["gpt-4"] } },
-      } as any,
-    };
-    mockLoadJsonFile.mockReturnValue({});
-    mockExistsSync.mockReturnValue(true);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(api.config.agents.defaults.models).toContain("manifest/auto");
-  });
-
-  it("does not duplicate manifest/auto in runtime config array", () => {
-    const logger = makeLogger();
-    const api = {
-      config: {
-        agents: { defaults: { models: ["manifest/auto"] } },
-      } as any,
-    };
-    mockLoadJsonFile.mockReturnValue({});
-    mockExistsSync.mockReturnValue(true);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(api.config.agents.defaults.models.length).toBe(1);
-  });
-
-  it("does not duplicate manifest/auto in runtime config object", () => {
-    const logger = makeLogger();
-    const api = {
-      config: {
-        agents: {
-          defaults: { models: { "manifest/auto": { x: 1 } } },
-        },
-      } as any,
-    };
-    mockLoadJsonFile.mockReturnValue({});
-    mockExistsSync.mockReturnValue(true);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(api.config.agents.defaults.models["manifest/auto"]).toEqual({
-      x: 1,
-    });
-  });
-
-  it("handles api.config being null/undefined gracefully", () => {
-    const logger = makeLogger();
-    const api = { config: null };
-    mockLoadJsonFile.mockReturnValue({});
-    mockExistsSync.mockReturnValue(true);
-
-    // Should not throw
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-  });
-
-  it("silently handles error during runtime config injection", () => {
-    const logger = makeLogger();
-    const api = {
-      get config(): any {
-        throw new Error("config error");
-      },
-    };
-    mockLoadJsonFile.mockReturnValue({});
-    mockExistsSync.mockReturnValue(true);
-
-    // Should not throw
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-  });
-
-  it("creates dir in atomicWriteJson when dir does not exist", () => {
-    const logger = makeLogger();
-    const api = { config: {} };
-    mockLoadJsonFile.mockReturnValue({});
-    // OPENCLAW_DIR does not exist => atomicWriteJson creates it
-    mockExistsSync.mockReturnValue(false);
-
-    injectProviderConfig(api, baseUrl, apiKey, logger);
-
-    expect(mockMkdirSync).toHaveBeenCalledWith(OPENCLAW_DIR, {
-      recursive: true,
-      mode: 0o700,
-    });
-  });
-});
-
-// ---------------------------------------------------------------------------
-// injectAuthProfile
-// ---------------------------------------------------------------------------
-describe("injectAuthProfile", () => {
-  const apiKey = "mnfst_test_key";
-  const agentsDir = `${OPENCLAW_DIR}/agents`;
-
-  it("skips if agents directory does not exist", () => {
-    const logger = makeLogger();
-    mockExistsSync.mockReturnValue(false);
-
-    injectAuthProfile(apiKey, logger);
-
-    expect(mockReaddirSync).not.toHaveBeenCalled();
-  });
-
-  it("injects profile into agent auth-profiles.json", () => {
-    const logger = makeLogger();
-    const agentPath = `${agentsDir}/agent1/agent`;
-
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === agentsDir) return true;
-      if (path === agentPath) return true;
-      return true;
-    });
-
-    mockReaddirSync.mockReturnValue([
-      { name: "agent1", isDirectory: () => true },
-    ] as any);
-
-    mockLoadJsonFile.mockReturnValue({});
-
-    injectAuthProfile(apiKey, logger);
-
-    expect(mockWriteFileSync).toHaveBeenCalled();
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(written.version).toBe(1);
-    expect(written.profiles["manifest:default"]).toEqual({
-      type: "api_key",
-      provider: "manifest",
-      key: apiKey,
-    });
-  });
-
-  it("preserves existing version in auth-profiles.json", () => {
-    const logger = makeLogger();
-
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValue([
-      { name: "agent1", isDirectory: () => true },
-    ] as any);
-    mockLoadJsonFile.mockReturnValue({ version: 2, profiles: {} });
-
-    injectAuthProfile(apiKey, logger);
-
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(written.version).toBe(2);
-  });
-
-  it("skips agents that already have the same key", () => {
-    const logger = makeLogger();
-
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValue([
-      { name: "agent1", isDirectory: () => true },
-    ] as any);
-    mockLoadJsonFile.mockReturnValue({
-      version: 1,
-      profiles: {
-        "manifest:default": {
-          type: "api_key",
-          provider: "manifest",
-          key: apiKey,
-        },
-      },
-    });
-
-    injectAuthProfile(apiKey, logger);
-
-    expect(mockWriteFileSync).not.toHaveBeenCalled();
-  });
-
-  it("updates profile when key is different", () => {
-    const logger = makeLogger();
-
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockReturnValue([
-      { name: "agent1", isDirectory: () => true },
-    ] as any);
-    mockLoadJsonFile.mockReturnValue({
-      version: 1,
-      profiles: {
-        "manifest:default": {
-          type: "api_key",
-          provider: "manifest",
-          key: "mnfst_old_key",
-        },
-      },
-    });
-
-    injectAuthProfile(apiKey, logger);
-
-    expect(mockWriteFileSync).toHaveBeenCalled();
-    const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-    expect(written.profiles["manifest:default"].key).toBe(apiKey);
-  });
-
-  it("skips agent dir when agent subdir does not exist", () => {
-    const logger = makeLogger();
-
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === agentsDir) return true;
-      // dirname(profilePath) = agentsDir/agent1/agent => does not exist
-      return false;
-    });
-
-    mockReaddirSync.mockReturnValue([
-      { name: "agent1", isDirectory: () => true },
-    ] as any);
-
-    injectAuthProfile(apiKey, logger);
-
-    expect(mockWriteFileSync).not.toHaveBeenCalled();
-  });
-
-  it("handles errors gracefully and logs debug", () => {
-    const logger = makeLogger();
-
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockImplementation(() => {
-      throw new Error("permission denied");
-    });
-
-    injectAuthProfile(apiKey, logger);
-
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining("Auth profile injection error"),
-    );
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining("permission denied"),
-    );
-  });
-
-  it("logs stringified error when error is not an Error instance", () => {
-    const logger = makeLogger();
-
-    mockExistsSync.mockReturnValue(true);
-    mockReaddirSync.mockImplementation(() => {
-      throw "string error";
-    });
-
-    injectAuthProfile(apiKey, logger);
-
-    expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining("string error"),
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// checkExistingServer
-// ---------------------------------------------------------------------------
 describe("checkExistingServer", () => {
   const originalFetch = global.fetch;
 
@@ -708,353 +41,286 @@ describe("checkExistingServer", () => {
     global.fetch = originalFetch;
   });
 
-  it("returns true when server responds with healthy status", async () => {
+  it("returns true when server responds healthy", async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ status: "healthy" }),
     });
 
     const result = await checkExistingServer("127.0.0.1", 2099);
-
     expect(result).toBe(true);
-    expect(global.fetch).toHaveBeenCalledWith(
-      "http://127.0.0.1:2099/api/v1/health",
-      { signal: expect.any(AbortSignal) },
-    );
   });
 
-  it("returns false when response is ok but not a Manifest server", async () => {
+  it("returns false when server responds not ok", async () => {
     global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ message: "some other service" }),
+      ok: false,
     });
 
     const result = await checkExistingServer("127.0.0.1", 2099);
-
     expect(result).toBe(false);
   });
 
-  it("returns false when server responds with non-ok status", async () => {
-    global.fetch = jest.fn().mockResolvedValue({ ok: false });
+  it("returns false when server responds with non-healthy status", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: "unhealthy" }),
+    });
 
     const result = await checkExistingServer("127.0.0.1", 2099);
-
     expect(result).toBe(false);
   });
 
-  it("returns false when fetch throws (connection refused)", async () => {
+  it("returns false on network error", async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
 
     const result = await checkExistingServer("127.0.0.1", 2099);
-
     expect(result).toBe(false);
   });
 
-  it("returns false when fetch throws (timeout)", async () => {
-    global.fetch = jest.fn().mockRejectedValue(new Error("AbortError"));
+  it("returns false when response body is null", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(null),
+    });
 
-    const result = await checkExistingServer("localhost", 3000);
-
+    const result = await checkExistingServer("127.0.0.1", 2099);
     expect(result).toBe(false);
   });
 });
 
-// ---------------------------------------------------------------------------
-// registerLocalMode
-// ---------------------------------------------------------------------------
 describe("registerLocalMode", () => {
-  const host = "127.0.0.1";
-  const port = 2099;
   const originalFetch = global.fetch;
-
-  beforeEach(() => {
-    // For loadOrGenerateApiKey — config dir exists, config file has a key
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === CONFIG_DIR) return true;
-      if (path === CONFIG_FILE) return true;
-      if (path === OPENCLAW_DIR) return true;
-      return false;
-    });
-
-    mockLoadJsonFile.mockImplementation((p) => {
-      if (String(p) === CONFIG_FILE) {
-        return { apiKey: "mnfst_test_key_abc123" };
-      }
-      return {};
-    });
-  });
 
   afterEach(() => {
     global.fetch = originalFetch;
   });
 
-  it("generates API key and injects config", () => {
+  it("creates config dir if it does not exist", () => {
     const logger = makeLogger();
-    const api = { config: {}, registerService: jest.fn() };
+    const api = { registerService: jest.fn() };
+    mockExistsSync.mockReturnValue(false);
 
-    registerLocalMode(api, port, host, logger);
+    registerLocalMode(api, 2099, "127.0.0.1", logger);
 
-    expect(logger.debug).toHaveBeenCalledWith(
-      "[manifest] Starting embedded server...",
+    expect(mockMkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining("manifest"),
+      expect.objectContaining({ recursive: true }),
     );
-    // Dashboard log now appears in start() callback, not synchronously
-    expect(api.registerService).toHaveBeenCalledWith({
-      id: "manifest",
-      start: expect.any(Function),
-    });
+  });
+
+  it("registers service with api", () => {
+    const logger = makeLogger();
+    const api = { registerService: jest.fn() };
+
+    registerLocalMode(api, 2099, "127.0.0.1", logger);
+
+    expect(api.registerService).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "manifest" }),
+    );
+  });
+
+  it("does not touch api.config", () => {
+    const logger = makeLogger();
+    const api = { registerService: jest.fn(), config: { models: {} } };
+
+    registerLocalMode(api, 2099, "127.0.0.1", logger);
+
+    // Plugin should not inject provider config into api.config
+    expect(api.config.models).toEqual({});
   });
 
   describe("service start callback", () => {
-    let startCallback: () => Promise<void>;
-    let logger: ReturnType<typeof makeLogger>;
-
-    beforeEach(() => {
-      logger = makeLogger();
-      const api = { config: {}, registerService: jest.fn() };
-
-      registerLocalMode(api, port, host, logger);
-
-      startCallback = api.registerService.mock.calls[0][0].start;
-    });
-
     it("reuses existing server when health check passes", async () => {
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ status: "healthy" }),
       });
 
-      await startCallback();
+      const logger = makeLogger();
+      const api = { registerService: jest.fn() };
 
-      expect(logger.info).toHaveBeenCalledWith(
-        `[manifest] Reusing existing server at http://${host}:${port}`,
-      );
+      registerLocalMode(api, 2099, "127.0.0.1", logger);
+
+      const serviceCall = api.registerService.mock.calls[0][0];
+      await serviceCall.start();
+
       expect(mockServerStart).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Reusing existing server"),
+      );
     });
 
-    it("starts server when no existing server is running", async () => {
-      global.fetch = jest
-        .fn()
-        .mockRejectedValueOnce(new Error("ECONNREFUSED")) // checkExistingServer (pre)
-        .mockResolvedValueOnce({
+    it("starts server and logs dashboard URL on success", async () => {
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(new Error("ECONNREFUSED"));
+        return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({ status: "healthy" }),
-        }); // checkExistingServer (post-start verification)
-
-      await startCallback();
-
-      expect(mockServerStart).toHaveBeenCalledWith({
-        port,
-        host,
-        dbPath: `${CONFIG_DIR}/manifest.db`,
-        quiet: true,
+        });
       });
-      expect(logger.info).toHaveBeenCalledWith(
-        `[manifest] Dashboard -> http://${host}:${port}`,
+
+      const logger = makeLogger();
+      const api = { registerService: jest.fn() };
+
+      registerLocalMode(api, 2099, "127.0.0.1", logger);
+
+      const serviceCall = api.registerService.mock.calls[0][0];
+      await serviceCall.start();
+
+      expect(mockServerStart).toHaveBeenCalledWith(
+        expect.objectContaining({ port: 2099, host: "127.0.0.1" }),
       );
       expect(logger.info).toHaveBeenCalledWith(
-        `[manifest]   DB: ${CONFIG_DIR}/manifest.db`,
+        expect.stringContaining("Dashboard ->"),
       );
     });
 
-    it("warns when server starts but verification fails", async () => {
+    it("logs warning when server starts but health check fails", async () => {
       global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
 
-      await startCallback();
+      const logger = makeLogger();
+      const api = { registerService: jest.fn() };
 
-      expect(mockServerStart).toHaveBeenCalled();
+      registerLocalMode(api, 2099, "127.0.0.1", logger);
+
+      const serviceCall = api.registerService.mock.calls[0][0];
+      await serviceCall.start();
+
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Server started but health check failed"),
+        expect.stringContaining("health check failed"),
       );
     });
 
-    it("falls back to logger.info when warn is undefined on verification failure", async () => {
+    it("uses logger.info as fallback when logger.warn is undefined", async () => {
       global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
 
-      // Create a logger without warn
-      const noWarnLogger = {
+      const logger = {
         info: jest.fn(),
         debug: jest.fn(),
         error: jest.fn(),
+        warn: undefined,
       };
-      const api = { config: {}, registerService: jest.fn() };
-      registerLocalMode(api, port, host, noWarnLogger);
-      const cb = api.registerService.mock.calls[0][0].start;
+      const api = { registerService: jest.fn() };
 
-      await cb();
+      registerLocalMode(api, 2099, "127.0.0.1", logger as any);
 
-      expect(noWarnLogger.info).toHaveBeenCalledWith(
-        expect.stringContaining("Server started but health check failed"),
-      );
-    });
-
-    it("reuses server on EADDRINUSE when health check passes", async () => {
-      global.fetch = jest
-        .fn()
-        .mockRejectedValueOnce(new Error("ECONNREFUSED")) // pre-start check
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: "healthy" }),
-        }); // EADDRINUSE recovery check
-
-      mockServerStart.mockRejectedValue(
-        new Error("listen EADDRINUSE: address already in use :::2099"),
-      );
-
-      await startCallback();
+      const serviceCall = api.registerService.mock.calls[0][0];
+      await serviceCall.start();
 
       expect(logger.info).toHaveBeenCalledWith(
-        `[manifest] Reusing existing server at http://${host}:${port}`,
+        expect.stringContaining("health check failed"),
       );
     });
 
-    it("logs port-in-use error on EADDRINUSE when health check fails", async () => {
-      global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    it("handles EADDRINUSE with existing manifest server", async () => {
+      mockServerStart.mockRejectedValue(new Error("listen EADDRINUSE: address already in use"));
 
-      mockServerStart.mockRejectedValue(
-        new Error("listen EADDRINUSE: address already in use :::2099"),
-      );
+      let callCount = 0;
+      global.fetch = jest.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return Promise.reject(new Error("ECONNREFUSED"));
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ status: "healthy" }),
+        });
+      });
 
-      await startCallback();
+      const logger = makeLogger();
+      const api = { registerService: jest.fn() };
 
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining(`Port ${port} is already in use`),
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining(`${port + 1}`),
+      registerLocalMode(api, 2099, "127.0.0.1", logger);
+
+      const serviceCall = api.registerService.mock.calls[0][0];
+      await serviceCall.start();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining("Reusing existing server"),
       );
     });
 
-    it("logs generic error for non-EADDRINUSE server start failures", async () => {
+    it("handles EADDRINUSE with non-manifest process", async () => {
+      mockServerStart.mockRejectedValue(new Error("listen EADDRINUSE: address already in use"));
       global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
 
-      mockServerStart.mockRejectedValue(new Error("Database corruption"));
+      const logger = makeLogger();
+      const api = { registerService: jest.fn() };
 
-      await startCallback();
+      registerLocalMode(api, 2099, "127.0.0.1", logger);
+
+      const serviceCall = api.registerService.mock.calls[0][0];
+      await serviceCall.start();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("already in use by another process"),
+      );
+    });
+
+    it("handles generic server start error", async () => {
+      mockServerStart.mockRejectedValue(new Error("ENOMEM"));
+      global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const logger = makeLogger();
+      const api = { registerService: jest.fn() };
+
+      registerLocalMode(api, 2099, "127.0.0.1", logger);
+
+      const serviceCall = api.registerService.mock.calls[0][0];
+      await serviceCall.start();
 
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining("Failed to start local server"),
-      );
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("Database corruption"),
-      );
-    });
-
-    it("handles non-Error throws during server start", async () => {
-      global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
-
-      mockServerStart.mockRejectedValue("unknown failure");
-
-      await startCallback();
-
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining("unknown failure"),
-      );
-    });
-
-    it("handles 'address already in use' variant of EADDRINUSE", async () => {
-      global.fetch = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
-
-      mockServerStart.mockRejectedValue(
-        new Error("address already in use 127.0.0.1:2099"),
-      );
-
-      await startCallback();
-
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining(`Port ${port} is already in use`),
       );
     });
   });
 });
 
-// ---------------------------------------------------------------------------
-// registerLocalMode — server module load failures
-// These tests use jest.resetModules() and must run in isolation.
-// ---------------------------------------------------------------------------
 describe("registerLocalMode server module load failures", () => {
-  const host = "127.0.0.1";
-  const port = 2099;
-
-  function doMockDeps(serverFactory: () => unknown) {
+  it("logs error when server module fails to load", () => {
     jest.resetModules();
-    jest.doMock("fs", () => ({
-      existsSync: mockExistsSync,
-      writeFileSync: mockWriteFileSync,
-      mkdirSync: mockMkdirSync,
-      readdirSync: mockReaddirSync,
-      renameSync: mockRenameSync,
-      openSync: mockOpenSync,
-      closeSync: mockCloseSync,
-      unlinkSync: mockUnlinkSync,
+
+    jest.mock("fs", () => ({
+      existsSync: jest.fn().mockReturnValue(false),
+      mkdirSync: jest.fn(),
     }));
-    jest.doMock("os", () => ({ homedir: () => "/mock-home" }));
-    jest.doMock("crypto", () => ({
-      randomBytes: jest.fn(() => ({
-        toString: () => "aabbccdd11223344aabbccdd11223344aabbccdd11223344",
-      })),
-    }));
-    jest.doMock("../src/json-file", () => ({
-      loadJsonFile: mockLoadJsonFile,
-    }));
-    jest.doMock("../src/server", serverFactory);
-  }
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockExistsSync.mockImplementation((p) => {
-      const path = String(p);
-      if (path === CONFIG_DIR) return true;
-      if (path === CONFIG_FILE) return true;
-      if (path === OPENCLAW_DIR) return true;
-      return false;
-    });
-    mockLoadJsonFile.mockImplementation((p) => {
-      if (String(p) === CONFIG_FILE) {
-        return { apiKey: "mnfst_test_key_abc123" };
-      }
-      return {};
-    });
-  });
-
-  afterEach(() => {
-    jest.resetModules();
-  });
-
-  it("logs error and returns when server module fails to load", () => {
-    const logger = makeLogger();
-    const api = { config: {}, registerService: jest.fn() };
-
-    doMockDeps(() => {
+    jest.mock("os", () => ({ homedir: () => "/mock-home" }));
+    jest.mock("../src/server", () => {
       throw new Error("Cannot find module");
     });
 
     const { registerLocalMode: freshRegister } = require("../src/local-mode");
-    freshRegister(api, port, host, logger);
+    const logger = makeLogger();
+    const api = { registerService: jest.fn() };
+
+    freshRegister(api, 2099, "127.0.0.1", logger);
 
     expect(logger.error).toHaveBeenCalledWith(
       expect.stringContaining("Failed to load embedded server"),
     );
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining("Cannot find module"),
-    );
     expect(api.registerService).not.toHaveBeenCalled();
   });
 
-  it("logs stringified value when server module throws non-Error", () => {
-    const logger = makeLogger();
-    const api = { config: {}, registerService: jest.fn() };
+  it("logs non-Error thrown value as string", () => {
+    jest.resetModules();
 
-    doMockDeps(() => {
-      throw "string load error";
+    jest.mock("fs", () => ({
+      existsSync: jest.fn().mockReturnValue(false),
+      mkdirSync: jest.fn(),
+    }));
+    jest.mock("os", () => ({ homedir: () => "/mock-home" }));
+    jest.mock("../src/server", () => {
+      throw "string error";
     });
 
     const { registerLocalMode: freshRegister } = require("../src/local-mode");
-    freshRegister(api, port, host, logger);
+    const logger = makeLogger();
+    const api = { registerService: jest.fn() };
+
+    freshRegister(api, 2099, "127.0.0.1", logger);
 
     expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining("string load error"),
+      expect.stringContaining("string error"),
     );
-    expect(api.registerService).not.toHaveBeenCalled();
   });
 });

--- a/packages/openclaw-plugins/manifest/src/local-mode.ts
+++ b/packages/openclaw-plugins/manifest/src/local-mode.ts
@@ -1,198 +1,13 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-import {
-  writeFileSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  renameSync,
-  openSync,
-  closeSync,
-  unlinkSync,
-} from 'fs';
-import { join, dirname } from 'path';
+import { existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
 import { homedir } from 'os';
-import { randomBytes } from 'crypto';
 import { PluginLogger } from './types';
-import { loadJsonFile } from './json-file';
 
-const API_KEY_PREFIX = 'mnfst_';
 const CONFIG_DIR = join(homedir(), '.openclaw', 'manifest');
-const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
-const LOCK_FILE = join(CONFIG_DIR, '.config.lock');
-const OPENCLAW_DIR = join(homedir(), '.openclaw');
-const OPENCLAW_CONFIG = join(OPENCLAW_DIR, 'openclaw.json');
 const HEALTH_TIMEOUT_MS = 3000;
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-function ensureConfigDir() {
-  if (!existsSync(CONFIG_DIR)) {
-    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
-  }
-}
-
-function withFileLock<T>(fn: () => T): T {
-  let fd: number | null = null;
-  try {
-    fd = openSync(LOCK_FILE, 'wx');
-  } catch {
-    // Lock exists or can't be acquired — proceed without lock (best-effort)
-    return fn();
-  }
-  try {
-    return fn();
-  } finally {
-    closeSync(fd);
-    try {
-      unlinkSync(LOCK_FILE);
-    } catch {
-      // Ignore cleanup errors
-    }
-  }
-}
-
-export function loadOrGenerateApiKey(): string {
-  ensureConfigDir();
-
-  return withFileLock(() => {
-    if (existsSync(CONFIG_FILE)) {
-      const data = loadJsonFile(CONFIG_FILE);
-      if (data.apiKey && data.apiKey.startsWith(API_KEY_PREFIX)) {
-        return data.apiKey;
-      }
-    }
-
-    const key = `${API_KEY_PREFIX}local_${randomBytes(24).toString('hex')}`;
-    const existing = loadJsonFile(CONFIG_FILE);
-    writeFileSync(CONFIG_FILE, JSON.stringify({ ...existing, apiKey: key }, null, 2), {
-      mode: 0o600,
-    });
-    return key;
-  });
-}
-
-function atomicWriteJson(path: string, data: unknown): void {
-  const dir = dirname(path);
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
-  const tmp = `${path}.tmp.${process.pid}`;
-  writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
-  renameSync(tmp, path);
-}
-
-export function injectProviderConfig(
-  api: any,
-  baseUrl: string,
-  apiKey: string,
-  logger: PluginLogger,
-): void {
-  const providerConfig = {
-    baseUrl,
-    api: 'openai-completions',
-    apiKey,
-    models: [{ id: 'auto', name: 'auto' }],
-  };
-
-  try {
-    const config = loadJsonFile(OPENCLAW_CONFIG);
-
-    if (!config.models) config.models = {};
-    if (!config.models.providers) config.models.providers = {};
-    config.models.providers.manifest = providerConfig;
-
-    if (!config.agents) config.agents = {};
-    if (!config.agents.defaults) config.agents.defaults = {};
-    if (!config.agents.defaults.models) config.agents.defaults.models = {};
-
-    const models = config.agents.defaults.models;
-    if (Array.isArray(models)) {
-      if (!models.includes('manifest/auto')) models.push('manifest/auto');
-    } else if (typeof models === 'object') {
-      if (!('manifest/auto' in models)) models['manifest/auto'] = {};
-    }
-
-    atomicWriteJson(OPENCLAW_CONFIG, config);
-    logger.debug('[manifest] Wrote provider config to openclaw.json');
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    logger.debug(`[manifest] Could not write openclaw.json: ${msg}`);
-  }
-
-  try {
-    const agentsDir = join(OPENCLAW_DIR, 'agents');
-    if (existsSync(agentsDir)) {
-      const agentDirs = readdirSync(agentsDir, { withFileTypes: true }).filter((d) =>
-        d.isDirectory(),
-      );
-
-      for (const dir of agentDirs) {
-        const modelsPath = join(agentsDir, dir.name, 'agent', 'models.json');
-        if (!existsSync(modelsPath)) continue;
-
-        const data = loadJsonFile(modelsPath);
-        if (!data.providers?.manifest) continue;
-
-        delete data.providers.manifest;
-        atomicWriteJson(modelsPath, data);
-      }
-    }
-  } catch {
-    // Stale model cleanup is best-effort
-  }
-
-  try {
-    if (api.config) {
-      if (!api.config.models) api.config.models = {};
-      if (!api.config.models.providers) api.config.models.providers = {};
-      api.config.models.providers.manifest = providerConfig;
-
-      if (!api.config.agents) api.config.agents = {};
-      if (!api.config.agents.defaults) api.config.agents.defaults = {};
-      if (!api.config.agents.defaults.models) api.config.agents.defaults.models = {};
-
-      const rtModels = api.config.agents.defaults.models;
-      if (Array.isArray(rtModels)) {
-        if (!rtModels.includes('manifest/auto')) rtModels.push('manifest/auto');
-      } else if (typeof rtModels === 'object') {
-        if (!('manifest/auto' in rtModels)) rtModels['manifest/auto'] = {};
-      }
-    }
-  } catch {
-    // Runtime config injection is best-effort
-  }
-}
-
-export function injectAuthProfile(apiKey: string, logger: PluginLogger): void {
-  const agentsDir = join(OPENCLAW_DIR, 'agents');
-  if (!existsSync(agentsDir)) return;
-
-  const profileEntry = { type: 'api_key', provider: 'manifest', key: apiKey };
-
-  try {
-    const agentDirs = readdirSync(agentsDir, { withFileTypes: true }).filter((d) =>
-      d.isDirectory(),
-    );
-
-    for (const dir of agentDirs) {
-      const profilePath = join(agentsDir, dir.name, 'agent', 'auth-profiles.json');
-      if (!existsSync(dirname(profilePath))) continue;
-
-      const data = loadJsonFile(profilePath);
-      if (!data.version) data.version = 1;
-      if (!data.profiles) data.profiles = {};
-
-      const existing = data.profiles['manifest:default'];
-      if (existing && existing.key === apiKey) continue;
-
-      data.profiles['manifest:default'] = profileEntry;
-      atomicWriteJson(profilePath, data);
-    }
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    logger.debug(`[manifest] Auth profile injection error: ${msg}`);
-  }
-}
 
 export async function checkExistingServer(host: string, port: number): Promise<boolean> {
   try {
@@ -213,13 +28,12 @@ export async function checkExistingServer(host: string, port: number): Promise<b
 }
 
 export function registerLocalMode(api: any, port: number, host: string, logger: PluginLogger) {
-  const apiKey = loadOrGenerateApiKey();
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+  }
   const dbPath = join(CONFIG_DIR, 'manifest.db');
 
   logger.debug('[manifest] Starting embedded server...');
-
-  injectProviderConfig(api, `http://${host}:${port}/v1`, apiKey, logger);
-  injectAuthProfile(apiKey, logger);
 
   let serverModule: {
     start: (opts: Record<string, unknown>) => Promise<unknown>;

--- a/packages/openclaw-plugins/manifest/src/server.ts
+++ b/packages/openclaw-plugins/manifest/src/server.ts
@@ -31,7 +31,7 @@ export async function start(options: StartOptions = {}): Promise<unknown> {
   process.env['PORT'] = String(port);
   process.env['BIND_ADDRESS'] = host;
   process.env['MANIFEST_DB_PATH'] = dbPath;
-  process.env['NODE_ENV'] = process.env['NODE_ENV'] || 'production';
+  process.env['NODE_ENV'] = 'production';
   process.env['MANIFEST_FRONTEND_DIR'] = join(__dirname, '..', 'public');
 
   // Generate a random persistent secret for local mode


### PR DESCRIPTION
## Summary

The manifest plugin now only starts the embedded server. Users go through the same onboarding as cloud mode: open the dashboard, create an agent, connect providers via the wizard.

**Removed from the plugin:**
- `injectProviderConfig` — no more writing to `openclaw.json` or runtime config injection
- `injectAuthProfile` — no more auth profile injection
- `loadOrGenerateApiKey` from registration path
- Default model setting

**Removed from `LocalBootstrapService`:**
- Auto tenant/agent creation (users create via the dashboard wizard)
- API key registration from config file
- Seed message generation

**Also:**
- `NODE_ENV` set to `production` in embedded server (removes DEV badge)
- Routing fixups and model discovery kept for existing agents

**Net: -1126 lines** (mostly removed config injection and tests for removed functions)

## Test plan

- [ ] 31 manifest plugin tests pass (100% line coverage)
- [ ] 15 local-bootstrap tests pass
- [ ] `openclaw plugins install manifest && openclaw gateway restart` starts server on :2099
- [ ] Dashboard shows empty workspace (no auto-created agent, no seed data, no DEV badge)
- [ ] User can create agent and connect provider through the dashboard wizard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The `manifest` plugin now only starts the embedded server and removes all config/auth injection or auto-setup. Users create agents and connect providers through the dashboard wizard, same as cloud.

- **Refactors**
  - Removed `injectProviderConfig`, `injectAuthProfile`, and API key generation from the plugin (no writes to `openclaw.json` or auth profiles; no default model).
  - Removed auto tenant/agent/API key creation and seed messages in `LocalBootstrapService`; keeps routing fixups and model discovery for existing agents; tier recalculation uses the first active agent.
  - Embedded server forces `NODE_ENV='production'` (no DEV badge).

- **Migration**
  - Install and restart as before; the server starts on :2099.
  - Open the dashboard, create an agent, and connect providers via the wizard.
  - Existing workspaces: orphaned providers/tiers auto-attach to the first active agent.

<sup>Written for commit b3e349188c25afec8dfa2371e8d4dc9e7e84f54f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

