### PR TITLE
fix: remove credential harvesting warning on plugin install

### DIFF
--- a/.changeset/remove-warning-local-install.md
+++ b/.changeset/remove-warning-local-install.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: remove process.env access in OpenAI OAuth service to eliminate false "credential harvesting" warning during plugin install

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -25,6 +25,7 @@ export class OpenaiOauthService {
   private callbackServer: Server | null = null;
   private serverReady: Promise<void> | null = null;
   private readonly clientId: string;
+  private readonly useCallbackServer: boolean;
 
   constructor(
     private readonly providerService: ProviderService,
@@ -32,6 +33,7 @@ export class OpenaiOauthService {
     private readonly discoveryService: ModelDiscoveryService,
   ) {
     this.clientId = this.configService.get<string>('OPENAI_OAUTH_CLIENT_ID') ?? DEFAULT_CLIENT_ID;
+    this.useCallbackServer = this.configService.get<string>('MANIFEST_MODE') !== 'cloud';
   }
 
   async generateAuthorizationUrl(
@@ -50,8 +52,7 @@ export class OpenaiOauthService {
       backendUrl: backendUrl ?? '',
       expiresAt: Date.now() + STATE_TTL_MS,
     });
-    // Skip the ephemeral callback server in cloud mode — frontend handles the paste-URL fallback.
-    if (process.env['MANIFEST_MODE'] !== 'cloud') {
+    if (this.useCallbackServer) {
       await this.ensureCallbackServer();
     }
     const params = new URLSearchParams({

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -360,6 +360,21 @@ describe('OpenaiOauthService', () => {
       expect(createServerMock).toHaveBeenCalled();
     });
 
+    it('skips callback server in cloud mode', async () => {
+      const cloudConfig = {
+        get: jest.fn((key: string) => (key === 'MANIFEST_MODE' ? 'cloud' : undefined)),
+      } as unknown as jest.Mocked<ConfigService>;
+      const cloudService = new OpenaiOauthService(
+        providerService,
+        cloudConfig,
+        discoveryService as never,
+      );
+
+      createServerMock.mockClear();
+      await cloudService.generateAuthorizationUrl('agent-1', 'user-1');
+      expect(createServerMock).not.toHaveBeenCalled();
+    });
+
     it('does not start a second server when one is already running', async () => {
       await service.generateAuthorizationUrl('agent-1', 'user-1');
       const callCount = createServerMock.mock.calls.length;


### PR DESCRIPTION
## Summary

- Replace direct `process.env['MANIFEST_MODE']` access with a `useCallbackServer` field derived from `ConfigService` in `OpenaiOauthService`
- Eliminates the `process.env` + `fetch()` pattern that OpenClaw's security scanner flags as "possible credential harvesting" during `openclaw plugins install manifest`
- Add test coverage for cloud mode path (callback server not started)

The warning was a false positive — the service reads a mode flag, not credentials — but the fix is also better practice: using ConfigService is idiomatic NestJS and the service already had it injected for other config.

## Test plan

- [x] All 2798 backend unit tests pass
- [x] New test verifies callback server is skipped in cloud mode
- [x] TypeScript compiles clean
- [ ] Verify `openclaw plugins install manifest` no longer shows the warning after next publish

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the false “credential harvesting” warning during plugin install by replacing direct env access in the OpenAI OAuth service. Manifest mode is read via `ConfigService`, and the local callback server only runs outside cloud mode.

- **Bug Fixes**
  - Read manifest mode from `ConfigService` at construction and drop `process.env['MANIFEST_MODE']`, eliminating the scanner warning during `openclaw plugins install manifest`.
  - Gate `ensureCallbackServer()` with a `useCallbackServer` flag; add a unit test to verify the server is skipped in cloud mode.

<sup>Written for commit dd6bdd09e9c9b0d032d6774b282d3f04f9227ec3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

