### PR TITLE
chore: rename CI job to Plugin (manifest-model-router)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           fail_ci_if_error: false
 
   provider-plugin:
-    name: Plugin (manifest-provider)
+    name: Plugin (manifest-model-router)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Renames the CI job from `Plugin (manifest-provider)` to `Plugin (manifest-model-router)` to match the package rename in #1338

## Required action

Before merging, update the GitHub branch protection required check:

**Settings → Branches → main → Edit → Status checks**
- Remove: `Plugin (manifest-provider)`
- Add: `Plugin (manifest-model-router)`

## Test plan

- [ ] Branch protection updated to require `Plugin (manifest-model-router)` instead of `Plugin (manifest-provider)`
- [ ] CI passes after merge

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the CI job to `Plugin (manifest-model-router)` to match the package rename in #1338. This only changes the workflow job name so required checks align with the new package.

- **Migration**
  - Remove required check `Plugin (manifest-provider)` on main.
  - Add required check `Plugin (manifest-model-router)`.

<sup>Written for commit 072abb136d3cc5401acb25498f121e70a468965c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

