### PR TITLE
fix: widen key_hash column to fit salted hash format

### DIFF
--- a/.changeset/widen-key-hash.md
+++ b/.changeset/widen-key-hash.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: widen key_hash column to accommodate salted hash format

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -60,6 +60,7 @@ import { AddProviderRegion1773650000000 } from './migrations/1773650000000-AddPr
 import { DropSecurityEventTable1773700000000 } from './migrations/1773700000000-DropSecurityEventTable';
 import { FixNegativeCosts1773800000000 } from './migrations/1773800000000-FixNegativeCosts';
 import { AddKeyPrefixIndex1773900000000 } from './migrations/1773900000000-AddKeyPrefixIndex';
+import { WidenKeyHashColumn1774000000000 } from './migrations/1774000000000-WidenKeyHashColumn';
 
 const entities = [
   AgentMessage,
@@ -120,6 +121,7 @@ const migrations = [
   DropSecurityEventTable1773700000000,
   FixNegativeCosts1773800000000,
   AddKeyPrefixIndex1773900000000,
+  WidenKeyHashColumn1774000000000,
 ];
 
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';

--- a/packages/backend/src/database/migrations/1774000000000-WidenKeyHashColumn.spec.ts
+++ b/packages/backend/src/database/migrations/1774000000000-WidenKeyHashColumn.spec.ts
@@ -1,0 +1,36 @@
+import { WidenKeyHashColumn1774000000000 } from './1774000000000-WidenKeyHashColumn';
+
+describe('WidenKeyHashColumn1774000000000', () => {
+  const migration = new WidenKeyHashColumn1774000000000();
+  let queries: string[];
+
+  const mockQueryRunner = {
+    query: jest.fn().mockImplementation((sql: string) => {
+      queries.push(sql);
+      return Promise.resolve();
+    }),
+  } as never;
+
+  beforeEach(() => {
+    queries = [];
+    jest.clearAllMocks();
+  });
+
+  it('widens key_hash columns to varchar(128)', async () => {
+    await migration.up(mockQueryRunner);
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain('agent_api_keys');
+    expect(queries[0]).toContain('varchar(128)');
+    expect(queries[1]).toContain('api_keys');
+    expect(queries[1]).toContain('varchar(128)');
+  });
+
+  it('reverts key_hash columns to varchar(64)', async () => {
+    await migration.down(mockQueryRunner);
+    expect(queries).toHaveLength(2);
+    expect(queries[0]).toContain('agent_api_keys');
+    expect(queries[0]).toContain('varchar(64)');
+    expect(queries[1]).toContain('api_keys');
+    expect(queries[1]).toContain('varchar(64)');
+  });
+});

--- a/packages/backend/src/database/migrations/1774000000000-WidenKeyHashColumn.spec.ts
+++ b/packages/backend/src/database/migrations/1774000000000-WidenKeyHashColumn.spec.ts
@@ -25,12 +25,14 @@ describe('WidenKeyHashColumn1774000000000', () => {
     expect(queries[1]).toContain('varchar(128)');
   });
 
-  it('reverts key_hash columns to varchar(64)', async () => {
+  it('reverts key_hash columns to varchar(64) with truncation', async () => {
     await migration.down(mockQueryRunner);
     expect(queries).toHaveLength(2);
     expect(queries[0]).toContain('agent_api_keys');
     expect(queries[0]).toContain('varchar(64)');
+    expect(queries[0]).toContain('USING left');
     expect(queries[1]).toContain('api_keys');
     expect(queries[1]).toContain('varchar(64)');
+    expect(queries[1]).toContain('USING left');
   });
 });

--- a/packages/backend/src/database/migrations/1774000000000-WidenKeyHashColumn.ts
+++ b/packages/backend/src/database/migrations/1774000000000-WidenKeyHashColumn.ts
@@ -10,8 +10,10 @@ export class WidenKeyHashColumn1774000000000 implements MigrationInterface {
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "agent_api_keys" ALTER COLUMN "key_hash" TYPE varchar(64)`,
+      `ALTER TABLE "agent_api_keys" ALTER COLUMN "key_hash" TYPE varchar(64) USING left("key_hash", 64)`,
     );
-    await queryRunner.query(`ALTER TABLE "api_keys" ALTER COLUMN "key_hash" TYPE varchar(64)`);
+    await queryRunner.query(
+      `ALTER TABLE "api_keys" ALTER COLUMN "key_hash" TYPE varchar(64) USING left("key_hash", 64)`,
+    );
   }
 }

--- a/packages/backend/src/database/migrations/1774000000000-WidenKeyHashColumn.ts
+++ b/packages/backend/src/database/migrations/1774000000000-WidenKeyHashColumn.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class WidenKeyHashColumn1774000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent_api_keys" ALTER COLUMN "key_hash" TYPE varchar(128)`,
+    );
+    await queryRunner.query(`ALTER TABLE "api_keys" ALTER COLUMN "key_hash" TYPE varchar(128)`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent_api_keys" ALTER COLUMN "key_hash" TYPE varchar(64)`,
+    );
+    await queryRunner.query(`ALTER TABLE "api_keys" ALTER COLUMN "key_hash" TYPE varchar(64)`);
+  }
+}

--- a/packages/backend/src/entities/agent-api-key.entity.ts
+++ b/packages/backend/src/entities/agent-api-key.entity.ts
@@ -1,12 +1,4 @@
-import {
-  Entity,
-  Column,
-  PrimaryColumn,
-  ManyToOne,
-  OneToOne,
-  JoinColumn,
-  Index,
-} from 'typeorm';
+import { Entity, Column, PrimaryColumn, ManyToOne, OneToOne, JoinColumn, Index } from 'typeorm';
 import { Tenant } from './tenant.entity';
 import { Agent } from './agent.entity';
 import { timestampType, timestampDefault } from '../common/utils/sql-dialect';
@@ -20,7 +12,7 @@ export class AgentApiKey {
   key!: string | null;
 
   @Index({ unique: true })
-  @Column('varchar', { length: 64 })
+  @Column('varchar', { length: 128 })
   key_hash!: string;
 
   @Column('varchar', { length: 12 })

--- a/packages/backend/src/entities/api-key.entity.ts
+++ b/packages/backend/src/entities/api-key.entity.ts
@@ -10,7 +10,7 @@ export class ApiKey {
   key!: string | null;
 
   @Index({ unique: true })
-  @Column('varchar', { length: 64 })
+  @Column('varchar', { length: 128 })
   key_hash!: string;
 
   @Column('varchar', { length: 12 })


### PR DESCRIPTION
## Summary

- The `key_hash` column was `varchar(64)` but `hashKey()` now produces 97-char salted hashes (`salt_hex:hash_hex` format: 32 + 1 + 64 = 97 chars)
- PostgreSQL rejects the oversized value on insert, causing 500 errors on key rotation and new agent creation
- Widens `key_hash` to `varchar(128)` on both `agent_api_keys` and `api_keys` tables via migration

## Test plan

- [x] Migration test covers up/down paths
- [x] Entity annotations updated to match new column width
- [x] All existing unit tests pass (no regressions)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened `key_hash` to `varchar(128)` on `agent_api_keys` and `api_keys` to fit 97‑char salted hashes (`salt_hex:hash_hex`), with entities updated to match. Added a reversible migration (down truncates to 64) to fix Postgres insert errors and stop 500s on key rotation and new agent creation.

<sup>Written for commit 90e142c056522afef8d0d26c79a1d7517bd9ad0e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

