### PR TITLE
fix: local-mode fallback for mnfst_ key auth failures

### DIFF
--- a/.changeset/fix-local-auth-fallback.md
+++ b/.changeset/fix-local-auth-fallback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: add local-mode fallback for mnfst_ key auth failures in AgentKeyAuthGuard

--- a/packages/backend/src/config/app.config.spec.ts
+++ b/packages/backend/src/config/app.config.spec.ts
@@ -46,10 +46,26 @@ describe('appConfig', () => {
     expect(config.dbPath).toMatch(/db\.sqlite$/);
   });
 
-  it('returns empty string for empty MANIFEST_DB_PATH', async () => {
+  it('returns empty string for empty MANIFEST_DB_PATH in cloud mode', async () => {
     delete process.env['MANIFEST_DB_PATH'];
+    delete process.env['MANIFEST_MODE'];
     const config = await loadConfig();
     expect(config.dbPath).toBe('');
+  });
+
+  it('defaults dbPath to persistent file in local mode', async () => {
+    delete process.env['MANIFEST_DB_PATH'];
+    process.env['MANIFEST_MODE'] = 'local';
+    const config = await loadConfig();
+    expect(config.dbPath).toMatch(/manifest\.db$/);
+    expect(config.dbPath).toContain('.openclaw');
+  });
+
+  it('uses explicit MANIFEST_DB_PATH over default in local mode', async () => {
+    process.env['MANIFEST_DB_PATH'] = '/tmp/custom.db';
+    process.env['MANIFEST_MODE'] = 'local';
+    const config = await loadConfig();
+    expect(config.dbPath).toBe('/tmp/custom.db');
   });
 
   it('defaults bindAddress to 127.0.0.1', async () => {

--- a/packages/backend/src/config/app.config.ts
+++ b/packages/backend/src/config/app.config.ts
@@ -1,9 +1,18 @@
 import { registerAs } from '@nestjs/config';
-import { resolve } from 'path';
+import { resolve, join } from 'path';
+import { homedir } from 'os';
 
 function sanitizeDbPath(raw: string): string {
   if (!raw) return '';
   return resolve(raw);
+}
+
+function resolveLocalDbPath(): string {
+  const explicit = process.env['MANIFEST_DB_PATH'];
+  if (explicit) return sanitizeDbPath(explicit);
+  if (process.env['MANIFEST_MODE'] !== 'local') return '';
+  // Default to persistent file so keys survive dev-server restarts
+  return join(homedir(), '.openclaw', 'manifest', 'manifest.db');
 }
 
 function resolveDatabaseUrl(): string {
@@ -20,7 +29,7 @@ export const appConfig = registerAs('app', () => ({
   nodeEnv: process.env['NODE_ENV'] ?? 'development',
   databaseUrl: resolveDatabaseUrl(),
   manifestMode: process.env['MANIFEST_MODE'] ?? 'cloud',
-  dbPath: sanitizeDbPath(process.env['MANIFEST_DB_PATH'] ?? ''),
+  dbPath: resolveLocalDbPath(),
 
   corsOrigin: process.env['CORS_ORIGIN'] ?? 'http://localhost:3000',
   betterAuthUrl: process.env['BETTER_AUTH_URL'] ?? '',

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
+import { mkdirSync } from 'fs';
+import { dirname } from 'path';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { LlmCall } from '../entities/llm-call.entity';
 import { ToolExecution } from '../entities/tool-execution.entity';
@@ -139,6 +141,9 @@ function buildModeServices() {
       useFactory: (config: ConfigService) => {
         if (isLocalMode) {
           const dbPath = config.get<string>('app.dbPath') || ':memory:';
+          if (dbPath !== ':memory:') {
+            mkdirSync(dirname(dbPath), { recursive: true, mode: 0o700 });
+          }
           return {
             type: 'sqljs' as const,
             location: dbPath === ':memory:' ? undefined : dbPath,

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -326,6 +326,59 @@ describe('AgentKeyAuthGuard', () => {
       const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '8.8.8.8');
       await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
     });
+
+    it('falls back to first active agent when mnfst_ key is not found in local mode', async () => {
+      mockGetMany.mockResolvedValue([]); // no matching key in DB
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'fb-tenant',
+        agent_id: 'fb-agent',
+        agent: { name: 'my-agent' },
+        tenant: { name: 'local-user-001' },
+      });
+
+      const { ctx, req } = makeContext(
+        { authorization: 'Bearer mnfst_stale-or-unknown-key' },
+        '127.0.0.1',
+      );
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(req.ingestionContext).toEqual({
+        tenantId: 'fb-tenant',
+        agentId: 'fb-agent',
+        agentName: 'my-agent',
+        userId: 'local-user-001',
+      });
+    });
+
+    it('falls back to LOCAL constants when mnfst_ key not found and no active agents in local mode', async () => {
+      mockGetMany.mockResolvedValue([]);
+      mockFindOne.mockResolvedValue(null);
+
+      const { ctx, req } = makeContext(
+        { authorization: 'Bearer mnfst_stale-or-unknown-key' },
+        '127.0.0.1',
+      );
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(req.ingestionContext).toEqual({
+        tenantId: 'local-tenant-001',
+        agentId: 'local-agent-001',
+        agentName: 'local-agent',
+        userId: 'local-user-001',
+      });
+    });
+
+    it('still rejects unknown mnfst_ key from public IP in local mode', async () => {
+      mockGetMany.mockResolvedValue([]);
+
+      const { ctx } = makeContext(
+        { authorization: 'Bearer mnfst_stale-or-unknown-key' },
+        '8.8.8.8',
+      );
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key');
+    });
   });
 
   it('still requires auth for loopback IPs when not in local mode', async () => {

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -327,14 +327,18 @@ describe('AgentKeyAuthGuard', () => {
       await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
     });
 
-    it('falls back to first active agent when mnfst_ key is not found in local mode', async () => {
-      mockGetMany.mockResolvedValue([]); // no matching key in DB
-      mockFindOne.mockResolvedValue({
-        tenant_id: 'fb-tenant',
-        agent_id: 'fb-agent',
-        agent: { name: 'my-agent' },
-        tenant: { name: 'local-user-001' },
-      });
+    it('uses prefix-matched agent when mnfst_ key hash fails in local mode', async () => {
+      // Prefix matches a candidate but hash doesn't verify (rotated key)
+      mockGetMany.mockResolvedValue([
+        {
+          id: 'key-stale',
+          tenant_id: 'my-tenant',
+          agent_id: 'my-agent-id',
+          key_hash: 'wrong-hash',
+          agent: { name: 'my-agent' },
+          tenant: { name: 'local-user-001' },
+        },
+      ]);
 
       const { ctx, req } = makeContext(
         { authorization: 'Bearer mnfst_stale-or-unknown-key' },
@@ -344,14 +348,40 @@ describe('AgentKeyAuthGuard', () => {
 
       expect(result).toBe(true);
       expect(req.ingestionContext).toEqual({
+        tenantId: 'my-tenant',
+        agentId: 'my-agent-id',
+        agentName: 'my-agent',
+        userId: 'local-user-001',
+      });
+      // Should NOT call resolveDevContext since prefix matched
+      expect(mockFindOne).not.toHaveBeenCalled();
+    });
+
+    it('falls back to first active agent when no prefix match in local mode', async () => {
+      mockGetMany.mockResolvedValue([]); // no prefix match at all
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'fb-tenant',
+        agent_id: 'fb-agent',
+        agent: { name: 'fallback-agent' },
+        tenant: { name: 'local-user-001' },
+      });
+
+      const { ctx, req } = makeContext(
+        { authorization: 'Bearer mnfst_totally-unknown-key' },
+        '127.0.0.1',
+      );
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(req.ingestionContext).toEqual({
         tenantId: 'fb-tenant',
         agentId: 'fb-agent',
-        agentName: 'my-agent',
+        agentName: 'fallback-agent',
         userId: 'local-user-001',
       });
     });
 
-    it('falls back to LOCAL constants when mnfst_ key not found and no active agents in local mode', async () => {
+    it('falls back to LOCAL constants when no prefix match and no active agents in local mode', async () => {
       mockGetMany.mockResolvedValue([]);
       mockFindOne.mockResolvedValue(null);
 

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -152,10 +152,25 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
     const keyRecord = candidates.find((c) => verifyKey(token, c.key_hash));
 
     if (!keyRecord) {
-      // In local mode, fall back to the first active agent instead of rejecting.
+      // In local mode, gracefully fall back instead of rejecting.
       // This handles stale keys after gateway restarts, race conditions during
       // startup, or keys created on a different server instance.
       if (isLocal) {
+        // If the prefix matched a candidate, we know which agent the caller
+        // intended — use that agent even though the hash didn't verify
+        // (the key was likely rotated).
+        if (candidates.length > 0) {
+          const best = candidates[0];
+          (request as Request & { ingestionContext: IngestionContext }).ingestionContext = {
+            tenantId: best.tenant_id,
+            agentId: best.agent_id,
+            agentName: best.agent.name,
+            userId: best.tenant.name,
+          };
+          return true;
+        }
+        // No prefix match — key is from a different server instance.
+        // Try the first active agent, then fall back to LOCAL constants.
         const fallback = await this.resolveDevContext();
         if (fallback) {
           (request as Request & { ingestionContext: IngestionContext }).ingestionContext = fallback;

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -152,6 +152,23 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleDestroy {
     const keyRecord = candidates.find((c) => verifyKey(token, c.key_hash));
 
     if (!keyRecord) {
+      // In local mode, fall back to the first active agent instead of rejecting.
+      // This handles stale keys after gateway restarts, race conditions during
+      // startup, or keys created on a different server instance.
+      if (isLocal) {
+        const fallback = await this.resolveDevContext();
+        if (fallback) {
+          (request as Request & { ingestionContext: IngestionContext }).ingestionContext = fallback;
+          return true;
+        }
+        (request as Request & { ingestionContext: IngestionContext }).ingestionContext = {
+          tenantId: LOCAL_TENANT_ID,
+          agentId: LOCAL_AGENT_ID,
+          agentName: LOCAL_AGENT_NAME,
+          userId: LOCAL_USER_ID,
+        };
+        return true;
+      }
       this.logger.warn(`Rejected unknown agent key: ${token.substring(0, 8)}...`);
       throw new UnauthorizedException('Invalid API key');
     }


### PR DESCRIPTION
## Summary

- **Root cause fix**: Local mode defaulted to in-memory SQLite (`:memory:`), which wiped all agent keys on every dev-server restart. Now defaults to `~/.openclaw/manifest/manifest.db` (same path the plugin uses) so both share one persistent database.
- **Guard fallback** (safety net): Adds a local-mode fallback in `AgentKeyAuthGuard` when a `mnfst_` token fails DB lookup from a loopback IP. If the prefix matches a DB candidate but the hash fails (rotated key), uses that candidate's agent context. Falls back to first active agent or LOCAL constants only when there's no prefix match at all.

## Root cause

When the dev server runs with `MANIFEST_MODE=local` without `MANIFEST_DB_PATH`, the database defaults to `:memory:`. Every restart (including `--watch` restarts) wipes all data. The `mnfst_` key the user copied into OpenClaw config no longer exists in the database, causing 401 on every request.

## Test plan

- [x] New test: local mode defaults dbPath to persistent file
- [x] New test: explicit MANIFEST_DB_PATH overrides default in local mode
- [x] New test: uses prefix-matched agent when mnfst_ key hash fails in local mode
- [x] New test: falls back to first active agent when no prefix match in local mode
- [x] New test: falls back to LOCAL constants when no prefix match and no active agents
- [x] New test: still rejects unknown mnfst_ key from public IPs (security preserved)
- [x] All 2804 backend unit tests pass
- [x] All 96 backend e2e tests pass
- [x] All 1697 frontend tests pass
- [x] TypeScript compilation clean