### PR TITLE
fix: unblock plugin install on OpenClaw 2026.3.22+

### DIFF
--- a/.changeset/fix-clawhub-skill-shadow.md
+++ b/.changeset/fix-clawhub-skill-shadow.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: unblock plugin install on OpenClaw 2026.3.22+ by removing ClawHub skill that shadowed the npm package, add install workaround to READMEs, and improve plugin startup log formatting

--- a/.changeset/fix-clawhub-skill-shadow.md
+++ b/.changeset/fix-clawhub-skill-shadow.md
@@ -1,5 +1,6 @@
 ---
 "manifest": patch
+"manifest-model-router": patch
 ---
 
 fix: unblock plugin install on OpenClaw 2026.3.22+ by removing ClawHub skill that shadowed the npm package, add install workaround to READMEs, and improve plugin startup log formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,12 +101,9 @@ jobs:
               --source-commit "$GITHUB_SHA" || echo "ClawHub plugin publish failed (non-fatal)"
           fi
 
-          # Publish skill when manifest or manifest-model-router is released
-          if [ "$HAS_MANIFEST" -gt 0 ] || [ "$HAS_PROVIDER" -gt 0 ]; then
-            SKILL_VERSION="${MANIFEST_VERSION:-$PROVIDER_VERSION}"
-            echo "Publishing manifest-build skill@${SKILL_VERSION} to ClawHub..."
-            npx clawhub@latest publish skills/manifest \
-              --slug manifest-build \
-              --version "$SKILL_VERSION" \
-              --changelog "Release ${SKILL_VERSION}" || echo "ClawHub skill publish failed (non-fatal)"
-          fi
+          # Skill publish disabled: the "manifest" ClawHub skill was deleted to
+          # unblock `openclaw plugins install manifest` on OpenClaw 2026.3.22+
+          # (ClawHub skills shadow npm plugins in the new resolver).
+          # Re-enable once `clawhub package publish` supports plugins in the CLI,
+          # or once OpenClaw fixes the skill-shadows-plugin resolution bug
+          # (openclaw/openclaw#52831, openclaw/openclaw#53241).

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ openclaw plugins install manifest
 openclaw gateway restart
 ```
 
+> **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
+> ```bash
+> openclaw plugins install "$(npm pack manifest --pack-destination /tmp | tail -1)"
+> ```
+
 Dashboard opens at **http://127.0.0.1:2099**. The plugin starts an embedded server, runs the dashboard locally, and registers itself as a provider automatically. No account or API key needed.
 
 ### Cloud vs local

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ openclaw gateway restart
 
 > **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
 > ```bash
-> openclaw plugins install "$(npm pack manifest --pack-destination /tmp | tail -1)"
+> openclaw plugins install "/tmp/$(npm pack manifest --pack-destination /tmp | tail -1)"
 > ```
 
 Dashboard opens at **http://127.0.0.1:2099**. The plugin starts an embedded server, runs the dashboard locally, and registers itself as a provider automatically. No account or API key needed.

--- a/packages/openclaw-plugins/manifest-model-router/README.md
+++ b/packages/openclaw-plugins/manifest-model-router/README.md
@@ -31,6 +31,11 @@ For a self-hosted server with SQLite and a local dashboard, install the full pac
 openclaw plugins install manifest
 ```
 
+> **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
+> ```bash
+> openclaw plugins install "$(npm pack manifest --pack-destination /tmp | tail -1)"
+> ```
+
 See the [manifest](https://www.npmjs.com/package/manifest) package.
 
 ## Contributing

--- a/packages/openclaw-plugins/manifest-model-router/README.md
+++ b/packages/openclaw-plugins/manifest-model-router/README.md
@@ -33,7 +33,7 @@ openclaw plugins install manifest
 
 > **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
 > ```bash
-> openclaw plugins install "$(npm pack manifest --pack-destination /tmp | tail -1)"
+> openclaw plugins install "/tmp/$(npm pack manifest --pack-destination /tmp | tail -1)"
 > ```
 
 See the [manifest](https://www.npmjs.com/package/manifest) package.

--- a/packages/openclaw-plugins/manifest/README.md
+++ b/packages/openclaw-plugins/manifest/README.md
@@ -9,6 +9,11 @@ openclaw plugins install manifest
 openclaw gateway restart
 ```
 
+> **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
+> ```bash
+> openclaw plugins install "$(npm pack manifest --pack-destination /tmp | tail -1)"
+> ```
+
 Dashboard opens at **http://127.0.0.1:2099**. The plugin auto-generates an API key, starts the embedded server, and registers `manifest/auto` as a model. No configuration needed.
 
 ## How it works

--- a/packages/openclaw-plugins/manifest/README.md
+++ b/packages/openclaw-plugins/manifest/README.md
@@ -11,7 +11,7 @@ openclaw gateway restart
 
 > **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
 > ```bash
-> openclaw plugins install "$(npm pack manifest --pack-destination /tmp | tail -1)"
+> openclaw plugins install "/tmp/$(npm pack manifest --pack-destination /tmp | tail -1)"
 > ```
 
 Dashboard opens at **http://127.0.0.1:2099**. The plugin auto-generates an API key, starts the embedded server, and registers `manifest/auto` as a model. No configuration needed.

--- a/packages/openclaw-plugins/manifest/src/index.ts
+++ b/packages/openclaw-plugins/manifest/src/index.ts
@@ -24,9 +24,9 @@ module.exports = {
     const host = typeof inner.host === 'string' && inner.host.length > 0 ? inner.host : '127.0.0.1';
 
     logger.info(
-      `[manifest] Dashboard: http://${host}:${port}\n` +
-        '  The plugin starts an embedded server and registers manifest/auto as a model.\n' +
-        '  Open the dashboard to connect a provider and start routing.',
+      `[manifest] 🦚 Dashboard: http://${host}:${port}\n` +
+        '[manifest] 🦚 The plugin starts an embedded server.\n' +
+        '[manifest] 🦚 Open the dashboard to connect a provider and start routing.',
     );
 
     registerLocalMode(api, port, host, logger);

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -75,7 +75,7 @@ openclaw gateway restart
 
 > **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
 > ```bash
-> openclaw plugins install "$(npm pack manifest --pack-destination /tmp | tail -1)"
+> openclaw plugins install "/tmp/$(npm pack manifest --pack-destination /tmp | tail -1)"
 > ```
 
 Dashboard opens at **http://127.0.0.1:2099**. Data stored locally in `~/.openclaw/manifest/manifest.db`. No account or API key needed.

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -73,6 +73,11 @@ openclaw plugins install manifest
 openclaw gateway restart
 ```
 
+> **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
+> ```bash
+> openclaw plugins install "$(npm pack manifest --pack-destination /tmp | tail -1)"
+> ```
+
 Dashboard opens at **http://127.0.0.1:2099**. Data stored locally in `~/.openclaw/manifest/manifest.db`. No account or API key needed.
 
 To expose over Tailscale (requires Tailscale on both devices, only accessible within your Tailnet): `tailscale serve --bg 2099`


### PR DESCRIPTION
## Summary

- **ClawHub skill deleted**: The `manifest` ClawHub skill was shadowing `openclaw plugins install manifest` on OpenClaw 2026.3.22+ (ClawHub is now checked before npm). Transferred the slug from `@sebconejo`, then deleted the skill so the resolver falls through to npm.
- **CI updated**: Disabled ClawHub skill publishing in `release.yml` until `clawhub package publish` ships in the CLI or OpenClaw fixes the resolver bug (openclaw/openclaw#52831, openclaw/openclaw#53241).
- **README workaround**: Added `npm pack` fallback instructions to all READMEs and SKILL.md for users who still hit the issue.
- **Plugin log cleanup**: Removed inaccurate "registers manifest/auto as a model" claim from startup message, added peacock emoji branding.

## Test plan

- [x] `openclaw plugins install manifest` resolves to npm and installs successfully
- [x] All plugin tests pass
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes plugin install on OpenClaw 2026.3.22+ by deleting the `manifest` ClawHub skill that shadowed the npm plugin. Also disables CI skill publishing, documents an `npm pack` fallback, and cleans up startup logs.

- **Bug Fixes**
  - Removed the `manifest` ClawHub skill so `openclaw plugins install manifest` resolves to the npm package on 2026.3.22+.

- **Refactors**
  - Disabled skill publishing in `release.yml` until the resolver/CLI supports plugins.
  - Added `npm pack` install fallback to READMEs and `SKILL.md`.
  - Added patch changesets for `manifest` and `manifest-model-router`.
  - Simplified startup logs and added branding.

<sup>Written for commit 31a4d4b3678c19b69521636f2ac25ffc984e7273. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

