### PR TITLE
fix: remove install workaround, fix README claim, update description

### DIFF
--- a/.changeset/remove-install-workaround.md
+++ b/.changeset/remove-install-workaround.md
@@ -1,0 +1,6 @@
+---
+"manifest": patch
+"manifest-model-router": patch
+---
+
+chore: remove obsolete OpenClaw 2026.3.22+ install workaround from READMEs

--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ openclaw plugins install manifest
 openclaw gateway restart
 ```
 
-> **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
-> ```bash
-> openclaw plugins install "/tmp/$(npm pack manifest --pack-destination /tmp | tail -1)"
-> ```
-
 Dashboard opens at **http://127.0.0.1:2099**. The plugin starts an embedded server, runs the dashboard locally, and registers itself as a provider automatically. No account or API key needed.
 
 ### Cloud vs local

--- a/packages/openclaw-plugins/manifest-model-router/README.md
+++ b/packages/openclaw-plugins/manifest-model-router/README.md
@@ -31,11 +31,6 @@ For a self-hosted server with SQLite and a local dashboard, install the full pac
 openclaw plugins install manifest
 ```
 
-> **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
-> ```bash
-> openclaw plugins install "/tmp/$(npm pack manifest --pack-destination /tmp | tail -1)"
-> ```
-
 See the [manifest](https://www.npmjs.com/package/manifest) package.
 
 ## Contributing

--- a/packages/openclaw-plugins/manifest/README.md
+++ b/packages/openclaw-plugins/manifest/README.md
@@ -9,11 +9,6 @@ openclaw plugins install manifest
 openclaw gateway restart
 ```
 
-> **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
-> ```bash
-> openclaw plugins install "/tmp/$(npm pack manifest --pack-destination /tmp | tail -1)"
-> ```
-
 Dashboard opens at **http://127.0.0.1:2099**. The plugin auto-generates an API key, starts the embedded server, and registers `manifest/auto` as a model. No configuration needed.
 
 ## How it works

--- a/skills/manifest/SKILL.md
+++ b/skills/manifest/SKILL.md
@@ -73,11 +73,6 @@ openclaw plugins install manifest
 openclaw gateway restart
 ```
 
-> **OpenClaw 2026.3.22+:** If you see `"manifest" is a skill`, install from npm directly:
-> ```bash
-> openclaw plugins install "/tmp/$(npm pack manifest --pack-destination /tmp | tail -1)"
-> ```
-
 Dashboard opens at **http://127.0.0.1:2099**. Data stored locally in `~/.openclaw/manifest/manifest.db`. No account or API key needed.
 
 To expose over Tailscale (requires Tailscale on both devices, only accessible within your Tailnet): `tailscale serve --bg 2099`


### PR DESCRIPTION
## Summary

- Removes the obsolete OpenClaw 2026.3.22+ `npm pack` workaround from all READMEs and SKILL.md (no longer needed since ClawHub skill was deleted in #1355)
- Fixes inaccurate claim in `manifest/README.md` that plugin "registers manifest/auto as a model" — it only starts the embedded server
- Updates root `package.json` description from stale "observability for AI agents" to "LLM router for OpenClaw"

## Test plan

- [x] `openclaw plugins install manifest` works without the workaround
- [ ] CI passes