### PR TITLE
fix: record messages even when provider omits usage data

### DIFF
--- a/.changeset/fix-record-messages-without-usage.md
+++ b/.changeset/fix-record-messages-without-usage.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix messages silently dropped when provider doesn't report usage data in streaming or non-streaming responses

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -334,13 +334,18 @@ describe('ProxyMessageRecorder', () => {
       expect(emitMock).toHaveBeenCalledWith('user-1');
     });
 
-    it('does not insert or emit when tokens are zero', async () => {
+    it('records message even when tokens are zero', async () => {
       await recorder.recordSuccessMessage(ctx, 'gpt-4o', 'standard', 'scored', {
         prompt_tokens: 0,
         completion_tokens: 0,
       });
-      expect(insertMock).not.toHaveBeenCalled();
-      expect(emitMock).not.toHaveBeenCalled();
+      expect(insertMock).toHaveBeenCalledTimes(1);
+      expect(insertMock.mock.calls[0][0]).toMatchObject({
+        input_tokens: 0,
+        output_tokens: 0,
+        status: 'ok',
+      });
+      expect(emitMock).toHaveBeenCalledWith('user-1');
     });
 
     it('updates existing zero-token message and emits SSE event', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -662,14 +662,21 @@ describe('proxy-response-handler', () => {
       );
     });
 
-    it('should not record anything when no fallback and no usage', () => {
+    it('should record with zero-value usage when no fallback and no usage data', () => {
       const recorder = mockRecorder();
       const meta = makeMeta();
 
       recordSuccess(testCtx, meta, null, undefined, recorder as any);
 
       expect(recorder.recordFallbackSuccess).not.toHaveBeenCalled();
-      expect(recorder.recordSuccessMessage).not.toHaveBeenCalled();
+      expect(recorder.recordSuccessMessage).toHaveBeenCalledWith(
+        testCtx,
+        meta.model,
+        meta.tier,
+        meta.reason,
+        { prompt_tokens: 0, completion_tokens: 0 },
+        expect.objectContaining({ authType: meta.auth_type }),
+      );
     });
 
     it('should not record fallback success when fallbackFromModel but no timestamp', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -376,7 +376,7 @@ describe('ProxyController', () => {
     expect(mockMessageRepo.insert).toHaveBeenCalledTimes(1);
   });
 
-  it('should skip recording when response has zero tokens', async () => {
+  it('should record message with zero tokens when response reports zero usage', async () => {
     const responseBody = {
       choices: [{ message: { content: 'hello' } }],
       usage: { prompt_tokens: 0, completion_tokens: 0 },
@@ -408,11 +408,12 @@ describe('ProxyController', () => {
     await controller.chatCompletions(req as never, res as never);
     await new Promise((r) => setTimeout(r, 10));
 
-    // recordSuccessMessage returns early when both tokens are 0
-    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+    expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ input_tokens: 0, output_tokens: 0, status: 'ok' }),
+    );
   });
 
-  it('should not record success message when response has no usage', async () => {
+  it('should record message with zero tokens when response has no usage', async () => {
     const responseBody = { choices: [{ message: { content: 'hello' } }] };
     const mockProviderResp = new Response(JSON.stringify(responseBody), {
       status: 200,
@@ -441,7 +442,9 @@ describe('ProxyController', () => {
     await controller.chatCompletions(req as never, res as never);
     await new Promise((r) => setTimeout(r, 10));
 
-    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+    expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ input_tokens: 0, output_tokens: 0, status: 'ok', model: 'gpt-4o' }),
+    );
   });
 
   it('should record usage data on fallback success', async () => {
@@ -2120,7 +2123,7 @@ describe('ProxyController', () => {
       );
     });
 
-    it('should not pre-record message when no fallback was used', async () => {
+    it('should record message with zero tokens when response has no usage data', async () => {
       const responseBody = { choices: [{ message: { content: 'hello' } }] };
       const mockProviderResp = new Response(JSON.stringify(responseBody), {
         status: 200,
@@ -2149,7 +2152,14 @@ describe('ProxyController', () => {
       await controller.chatCompletions(req as never, res as never);
       await new Promise((r) => setTimeout(r, 10));
 
-      expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+      expect(mockMessageRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input_tokens: 0,
+          output_tokens: 0,
+          status: 'ok',
+          model: 'gpt-4o',
+        }),
+      );
     });
 
     it('should include fallback fields in error recording when fallback was used', async () => {

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -240,8 +240,6 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
   ): Promise<void> {
     const { traceId, authType, sessionKey, durationMs } = opts ?? {};
 
-    if (usage.prompt_tokens === 0 && usage.completion_tokens === 0) return;
-
     const costUsd = computeTokenCost({
       inputTokens: usage.prompt_tokens,
       outputTokens: usage.completion_tokens,

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -261,10 +261,11 @@ export function recordSuccess(
         usage: streamUsage ?? undefined,
       })
       .catch((e) => logger.warn(`Failed to record fallback success: ${e}`));
-  } else if (streamUsage) {
+  } else {
+    const usage = streamUsage ?? { prompt_tokens: 0, completion_tokens: 0 };
     const durationMs = startTime ? Date.now() - startTime : undefined;
     recorder
-      .recordSuccessMessage(ctx, meta.model, meta.tier, meta.reason, streamUsage, {
+      .recordSuccessMessage(ctx, meta.model, meta.tier, meta.reason, usage, {
         traceId,
         authType: meta.auth_type,
         sessionKey,


### PR DESCRIPTION
## Summary

- **Messages were silently dropped** when a provider didn't include token usage in the response (streaming or non-streaming)
- `recordSuccess` in `proxy-response-handler.ts` had `else if (streamUsage)` which skipped recording when `streamUsage` was null
- `recordSuccessMessage` in `proxy-message-recorder.ts` had an early return when both `prompt_tokens` and `completion_tokens` were 0
- Now always records with zero-value usage as fallback — every LLM call appears in the dashboard

## Affected providers

Any provider that omits `usage` from responses, including some OpenRouter models, Ollama, and custom providers. Streaming responses from providers that don't include usage in the SSE stream were also affected.

## Test plan

- [x] All 2847 backend tests pass
- [x] TypeScript compiles clean
- [x] Hot-patched running plugin on port 2099 and verified:
  - Gemini, Deepseek, OpenAI, Anthropic (API key + subscription), Mistral, xAI all record messages with correct tokens and costs
  - Streaming responses record correctly
  - Dashboard overview shows all models, token counts, and costs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records all LLM messages even when a provider omits usage data by falling back to zero tokens for streaming and non-streaming responses. Fixes dropped messages so the dashboard shows every call.

- **Bug Fixes**
  - In `recordSuccess`, always record; default to `{ prompt_tokens: 0, completion_tokens: 0 }` when usage is missing.
  - In `recordSuccessMessage`, removed early return when both token counts are zero.
  - Updated tests for zero-usage and no-usage scenarios.
  - Affects providers that omit usage (e.g., some OpenRouter models, Ollama, custom providers).

<sup>Written for commit 27e1608fba2bea9c3e6d1417be6a911d31bce7e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

