### PR TITLE
feat: add models.dev as primary pricing source for model discovery

### DIFF
--- a/.changeset/models-dev-pricing.md
+++ b/.changeset/models-dev-pricing.md
@@ -1,0 +1,15 @@
+---
+"manifest": minor
+---
+
+Add models.dev as primary pricing source for model discovery
+
+- New ModelsDevSyncService fetches curated model data from models.dev/api.json
+- models.dev uses native provider model IDs (no normalization needed)
+- Enrichment priority: models.dev first, OpenRouter fallback
+- Smart lookupModel with 7 fallback strategies for variant model names
+- Capability flags (reasoning, toolCall) flow from models.dev to quality scoring
+- OpenAI max_tokens → max_completion_tokens conversion for GPT-5+/o-series
+- Filter non-chat models from OpenAI (embed, TTS, sora, codex) and Mistral (OCR)
+- Gemini alias/versioned model deduplication
+- Price=0 subscription models no longer overwritten by enrichment

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1,0 +1,852 @@
+import { ModelsDevSyncService } from './models-dev-sync.service';
+
+const MOCK_API_RESPONSE = {
+  anthropic: {
+    id: 'anthropic',
+    name: 'Anthropic',
+    models: {
+      'claude-opus-4-6': {
+        id: 'claude-opus-4-6',
+        name: 'Claude Opus 4.6',
+        family: 'claude-opus',
+        reasoning: true,
+        tool_call: true,
+        structured_output: false,
+        cost: { input: 5.0, output: 25.0, cache_read: 0.5, cache_write: 6.25 },
+        limit: { context: 1000000, output: 128000 },
+        modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+      },
+      'claude-sonnet-4-6': {
+        id: 'claude-sonnet-4-6',
+        name: 'Claude Sonnet 4.6',
+        family: 'claude-sonnet',
+        cost: { input: 3.0, output: 15.0 },
+        limit: { context: 200000, output: 8192 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
+  google: {
+    id: 'google',
+    name: 'Google',
+    models: {
+      'gemini-2.5-pro': {
+        id: 'gemini-2.5-pro',
+        name: 'Gemini 2.5 Pro',
+        cost: { input: 1.25, output: 10.0 },
+        limit: { context: 1048576, output: 65536 },
+        modalities: { input: ['text', 'image'], output: ['text'] },
+      },
+      'gemini-live-2.5-flash': {
+        id: 'gemini-live-2.5-flash',
+        name: 'Gemini Live 2.5 Flash',
+        modalities: { input: ['audio'], output: ['audio'] },
+        cost: { input: 0.5, output: 2.0 },
+        limit: { context: 100000 },
+      },
+    },
+  },
+  openai: {
+    id: 'openai',
+    name: 'OpenAI',
+    models: {
+      'gpt-4o': {
+        id: 'gpt-4o',
+        name: 'GPT-4o',
+        cost: { input: 2.5, output: 10.0 },
+        limit: { context: 128000, output: 16384 },
+        modalities: { input: ['text', 'image'], output: ['text'] },
+      },
+    },
+  },
+  deepseek: {
+    id: 'deepseek',
+    name: 'DeepSeek',
+    models: {
+      'deepseek-chat': {
+        id: 'deepseek-chat',
+        name: 'DeepSeek Chat',
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
+  mistral: {
+    id: 'mistral',
+    name: 'Mistral',
+    models: {
+      'mistral-medium-latest': {
+        id: 'mistral-medium-latest',
+        name: 'Mistral Medium',
+        cost: { input: 0.4, output: 2.0 },
+        limit: { context: 128000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'mistral-small-latest': {
+        id: 'mistral-small-latest',
+        name: 'Mistral Small',
+        cost: { input: 0.1, output: 0.3 },
+        limit: { context: 128000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'mistral-large-latest': {
+        id: 'mistral-large-latest',
+        name: 'Mistral Large',
+        cost: { input: 0.5, output: 1.5 },
+        limit: { context: 128000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
+  xai: {
+    id: 'xai',
+    name: 'xAI',
+    models: {
+      'grok-4': {
+        id: 'grok-4',
+        name: 'Grok 4',
+        reasoning: true,
+        tool_call: true,
+        cost: { input: 3.0, output: 15.0 },
+        limit: { context: 256000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'grok-4-1-fast': {
+        id: 'grok-4-1-fast',
+        name: 'Grok 4.1 Fast',
+        reasoning: true,
+        tool_call: true,
+        cost: { input: 0.2, output: 0.5 },
+        limit: { context: 2000000 },
+        modalities: { input: ['text', 'image'], output: ['text'] },
+      },
+      'grok-4-fast': {
+        id: 'grok-4-fast',
+        name: 'Grok 4 Fast',
+        cost: { input: 0.2, output: 0.5 },
+        limit: { context: 2000000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
+  'unknown-provider': {
+    id: 'unknown-provider',
+    name: 'Unknown',
+    models: { 'some-model': { id: 'some-model', name: 'Some Model' } },
+  },
+};
+
+describe('ModelsDevSyncService', () => {
+  let service: ModelsDevSyncService;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    service = new ModelsDevSyncService();
+    fetchSpy = jest.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('refreshCache', () => {
+    it('should fetch, parse, and cache models from api.json', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+
+      const count = await service.refreshCache();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://models.dev/api.json',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      // anthropic: 2, google: 1 (audio excluded), openai: 1, deepseek: 1, mistral: 3, xai: 3 = 11
+      expect(count).toBe(11);
+    });
+
+    it('should filter out non-text-output models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+
+      await service.refreshCache();
+
+      // gemini-live-2.5-flash has audio-only output, should be filtered
+      expect(service.lookupModel('gemini', 'gemini-live-2.5-flash')).toBeNull();
+      expect(service.lookupModel('gemini', 'gemini-2.5-pro')).not.toBeNull();
+    });
+
+    it('should return 0 when fetch fails', async () => {
+      fetchSpy.mockRejectedValue(new Error('Network error'));
+
+      const count = await service.refreshCache();
+
+      expect(count).toBe(0);
+    });
+
+    it('should return 0 when API returns non-ok status', async () => {
+      fetchSpy.mockResolvedValue({ ok: false, status: 500 });
+
+      const count = await service.refreshCache();
+
+      expect(count).toBe(0);
+    });
+
+    it('should only include providers from PROVIDER_ID_MAP', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+
+      await service.refreshCache();
+
+      // 'unknown-provider' is not in our map, should not appear
+      expect(service.getModelsForProvider('unknown-provider')).toEqual([]);
+    });
+  });
+
+  describe('lookupModel', () => {
+    beforeEach(async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+    });
+
+    it('should find Anthropic models by our provider ID', () => {
+      const model = service.lookupModel('anthropic', 'claude-opus-4-6');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Claude Opus 4.6');
+      expect(model!.inputPricePerToken).toBe(5.0 / 1_000_000);
+      expect(model!.outputPricePerToken).toBe(25.0 / 1_000_000);
+      expect(model!.contextWindow).toBe(1000000);
+      expect(model!.maxOutputTokens).toBe(128000);
+      expect(model!.reasoning).toBe(true);
+      expect(model!.toolCall).toBe(true);
+    });
+
+    it('should find Google/Gemini models via our "gemini" provider ID', () => {
+      const model = service.lookupModel('gemini', 'gemini-2.5-pro');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Gemini 2.5 Pro');
+      expect(model!.inputPricePerToken).toBe(1.25 / 1_000_000);
+    });
+
+    it('should return null for unknown model', () => {
+      expect(service.lookupModel('anthropic', 'nonexistent')).toBeNull();
+    });
+
+    it('should return null for unmapped provider', () => {
+      expect(service.lookupModel('nonexistent', 'some-model')).toBeNull();
+    });
+
+    it('should handle case-insensitive provider lookup', () => {
+      const model = service.lookupModel('ANTHROPIC', 'claude-opus-4-6');
+      expect(model).not.toBeNull();
+    });
+
+    it('should set null pricing for models without cost', () => {
+      const model = service.lookupModel('deepseek', 'deepseek-chat');
+      expect(model).not.toBeNull();
+      expect(model!.inputPricePerToken).toBeNull();
+      expect(model!.outputPricePerToken).toBeNull();
+    });
+
+    it('should convert cache pricing to per-token', () => {
+      const model = service.lookupModel('anthropic', 'claude-opus-4-6');
+      expect(model!.cacheReadPricePerToken).toBe(0.5 / 1_000_000);
+      expect(model!.cacheWritePricePerToken).toBe(6.25 / 1_000_000);
+    });
+
+    it('should match model by stripping version suffix (-001)', () => {
+      // Google API returns gemini-2.5-pro-001, models.dev has gemini-2.5-pro
+      const model = service.lookupModel('gemini', 'gemini-2.5-pro-001');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Gemini 2.5 Pro');
+    });
+
+    it('should not strip suffix that is not a 3-digit version', () => {
+      // -09-2025 is not a version suffix
+      expect(service.lookupModel('gemini', 'gemini-2.5-flash-lite-preview-09-2025')).toBeNull();
+    });
+
+    it('should prefer exact match over version-stripped match', () => {
+      const model = service.lookupModel('gemini', 'gemini-2.5-pro');
+      expect(model).not.toBeNull();
+      expect(model!.id).toBe('gemini-2.5-pro');
+    });
+
+    it('should strip date suffix to find base model (OpenAI convention)', () => {
+      // OpenAI returns gpt-4o-2024-08-06, models.dev has gpt-4o
+      const model = service.lookupModel('openai', 'gpt-4o-20240806');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('GPT-4o');
+    });
+
+    it('should strip hyphenated date suffix', () => {
+      // Some APIs return dates with hyphens: gpt-4.1-2025-04-14
+      const model = service.lookupModel('openai', 'gpt-4o-2024-08-06');
+      expect(model).not.toBeNull();
+    });
+
+    it('should append -latest to match alias models (Mistral convention)', () => {
+      // Mistral API returns mistral-medium, models.dev has mistral-medium-latest
+      const model = service.lookupModel('mistral', 'mistral-medium');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral Medium');
+      expect(model!.inputPricePerToken).toBe(0.4 / 1_000_000);
+    });
+
+    it('should strip date then append -latest (Mistral dated variant)', () => {
+      // Mistral returns mistral-small-2603, models.dev has mistral-small-latest
+      const model = service.lookupModel('mistral', 'mistral-small-20250603');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral Small');
+    });
+
+    it('should not append -latest when model already ends with -latest', () => {
+      const model = service.lookupModel('mistral', 'mistral-large-latest');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral Large');
+    });
+
+    it('should strip -reasoning suffix (xAI convention)', () => {
+      // xAI returns grok-4-1-fast-reasoning, models.dev has grok-4-1-fast
+      const model = service.lookupModel('xai', 'grok-4-1-fast-reasoning');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Grok 4.1 Fast');
+      expect(model!.inputPricePerToken).toBe(0.2 / 1_000_000);
+    });
+
+    it('should strip -non-reasoning suffix (xAI convention)', () => {
+      const model = service.lookupModel('xai', 'grok-4-fast-non-reasoning');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Grok 4 Fast');
+    });
+
+    it('should strip 4-digit short date suffix (xAI: grok-4-0709)', () => {
+      // xAI returns grok-4-0709 (July 9 release), models.dev has grok-4
+      const model = service.lookupModel('xai', 'grok-4-0709');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Grok 4');
+      expect(model!.inputPricePerToken).toBe(3.0 / 1_000_000);
+    });
+  });
+
+  describe('getModelsForProvider', () => {
+    beforeEach(async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+    });
+
+    it('should return all models for a provider', () => {
+      const models = service.getModelsForProvider('anthropic');
+      expect(models).toHaveLength(2);
+      const ids = models.map((m) => m.id);
+      expect(ids).toContain('claude-opus-4-6');
+      expect(ids).toContain('claude-sonnet-4-6');
+    });
+
+    it('should return empty array for unmapped provider', () => {
+      expect(service.getModelsForProvider('nonexistent')).toEqual([]);
+    });
+  });
+
+  describe('isProviderSupported', () => {
+    it('should return true for mapped providers', () => {
+      expect(service.isProviderSupported('anthropic')).toBe(true);
+      expect(service.isProviderSupported('gemini')).toBe(true);
+      expect(service.isProviderSupported('qwen')).toBe(true);
+    });
+
+    it('should return false for unmapped providers', () => {
+      expect(service.isProviderSupported('unknown')).toBe(false);
+      expect(service.isProviderSupported('ollama')).toBe(false);
+    });
+  });
+
+  describe('getLastFetchedAt', () => {
+    it('should return null before first fetch', () => {
+      expect(service.getLastFetchedAt()).toBeNull();
+    });
+
+    it('should return a date after successful fetch', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+      expect(service.getLastFetchedAt()).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('onModuleInit', () => {
+    it('should call refreshCache on module init', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      await service.onModuleInit();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not throw when fetch fails during init', async () => {
+      fetchSpy.mockRejectedValue(new Error('Network error'));
+
+      await expect(service.onModuleInit()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('isChatCompatible edge cases', () => {
+    it('should include models with no modalities at all', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'no-modalities-model': {
+              id: 'no-modalities-model',
+              name: 'No Modalities',
+              cost: { input: 1.0, output: 2.0 },
+              // No modalities field
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'no-modalities-model')).not.toBeNull();
+    });
+
+    it('should include models with empty modalities', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'empty-mod': {
+              id: 'empty-mod',
+              name: 'Empty Modalities',
+              modalities: {},
+              cost: { input: 1.0, output: 2.0 },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'empty-mod')).not.toBeNull();
+    });
+
+    it('should include models with empty input and output arrays', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'empty-arrays': {
+              id: 'empty-arrays',
+              name: 'Empty Arrays',
+              modalities: { input: [], output: [] },
+              cost: { input: 1.0, output: 2.0 },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'empty-arrays')).not.toBeNull();
+    });
+
+    it('should exclude models with non-text-only output (e.g. image)', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'image-model': {
+              id: 'image-model',
+              name: 'Image Model',
+              modalities: { input: ['text'], output: ['image'] },
+              cost: { input: 1.0, output: 2.0 },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'image-model')).toBeNull();
+    });
+
+    it('should exclude models with mixed text+image output', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'mixed-output': {
+              id: 'mixed-output',
+              name: 'Mixed Output',
+              modalities: { input: ['text'], output: ['text', 'image'] },
+              cost: { input: 1.0, output: 2.0 },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'mixed-output')).toBeNull();
+    });
+
+    it('should exclude models with audio-only input', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'audio-in': {
+              id: 'audio-in',
+              name: 'Audio Input',
+              modalities: { input: ['audio'], output: ['text'] },
+              cost: { input: 1.0, output: 2.0 },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'audio-in')).toBeNull();
+    });
+
+    it('should handle case-insensitive modality checking', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'caps-text': {
+              id: 'caps-text',
+              name: 'Upper Case Text',
+              modalities: { input: ['Text', 'Image'], output: ['TEXT'] },
+              cost: { input: 1.0, output: 2.0 },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'caps-text')).not.toBeNull();
+    });
+  });
+
+  describe('parseModel edge cases', () => {
+    it('should handle partial cache pricing (only cache_read)', async () => {
+      const response = {
+        anthropic: {
+          id: 'anthropic',
+          name: 'Anthropic',
+          models: {
+            'partial-cache': {
+              id: 'partial-cache',
+              name: 'Partial Cache',
+              cost: { input: 1.0, output: 2.0, cache_read: 0.5 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const model = service.lookupModel('anthropic', 'partial-cache');
+      expect(model).not.toBeNull();
+      expect(model!.cacheReadPricePerToken).toBe(0.5 / 1_000_000);
+      expect(model!.cacheWritePricePerToken).toBeNull();
+    });
+
+    it('should use model id as name when name field is empty', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'unnamed-model': {
+              id: 'unnamed-model',
+              name: '',
+              cost: { input: 1.0, output: 2.0 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const model = service.lookupModel('openai', 'unnamed-model');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('unnamed-model');
+    });
+
+    it('should parse structuredOutput flag', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'structured-model': {
+              id: 'structured-model',
+              name: 'Structured',
+              structured_output: true,
+              cost: { input: 1.0, output: 2.0 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const model = service.lookupModel('openai', 'structured-model');
+      expect(model).not.toBeNull();
+      expect(model!.structuredOutput).toBe(true);
+    });
+
+    it('should default structuredOutput to false when not provided', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'no-so-flag': {
+              id: 'no-so-flag',
+              name: 'No Structured Output Flag',
+              cost: { input: 1.0, output: 2.0 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      await service.refreshCache();
+
+      const model = service.lookupModel('openai', 'no-so-flag');
+      expect(model).not.toBeNull();
+      expect(model!.structuredOutput).toBe(false);
+    });
+  });
+
+  describe('refreshCache edge cases', () => {
+    it('should skip providers with no models key', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          // No models field
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      const count = await service.refreshCache();
+
+      expect(count).toBe(0);
+      expect(service.getModelsForProvider('openai')).toEqual([]);
+    });
+
+    it('should not create provider entry when all models are filtered out', async () => {
+      const response = {
+        openai: {
+          id: 'openai',
+          name: 'OpenAI',
+          models: {
+            'audio-only': {
+              id: 'audio-only',
+              name: 'Audio Only',
+              modalities: { input: ['audio'], output: ['audio'] },
+              cost: { input: 1.0, output: 2.0 },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+
+      const count = await service.refreshCache();
+
+      expect(count).toBe(0);
+      expect(service.getModelsForProvider('openai')).toEqual([]);
+    });
+
+    it('should replace old cache on subsequent refresh', async () => {
+      // First refresh
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          openai: {
+            id: 'openai',
+            name: 'OpenAI',
+            models: {
+              'old-model': {
+                id: 'old-model',
+                name: 'Old Model',
+                cost: { input: 1.0, output: 2.0 },
+                modalities: { input: ['text'], output: ['text'] },
+              },
+            },
+          },
+        }),
+      });
+      await service.refreshCache();
+      expect(service.lookupModel('openai', 'old-model')).not.toBeNull();
+
+      // Second refresh with different models
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          openai: {
+            id: 'openai',
+            name: 'OpenAI',
+            models: {
+              'new-model': {
+                id: 'new-model',
+                name: 'New Model',
+                cost: { input: 3.0, output: 4.0 },
+                modalities: { input: ['text'], output: ['text'] },
+              },
+            },
+          },
+        }),
+      });
+      await service.refreshCache();
+
+      expect(service.lookupModel('openai', 'old-model')).toBeNull();
+      expect(service.lookupModel('openai', 'new-model')).not.toBeNull();
+    });
+  });
+
+  describe('lookupModel fallback priority', () => {
+    it('should not apply short date fallback when it matches version suffix', async () => {
+      // grok-4-0001 should match version suffix (strategy 2), not short date (strategy 7)
+      const response = {
+        xai: {
+          id: 'xai',
+          name: 'xAI',
+          models: {
+            'grok-4': {
+              id: 'grok-4',
+              name: 'Grok 4',
+              cost: { input: 3.0, output: 15.0 },
+              modalities: { input: ['text'], output: ['text'] },
+            },
+          },
+        },
+      };
+      fetchSpy.mockResolvedValue({ ok: true, json: async () => response });
+      await service.refreshCache();
+
+      // -001 matches VERSION_SUFFIX_RE (/\d{3}$/), strategy 2 strips it to 'grok-4'
+      const model = service.lookupModel('xai', 'grok-4-001');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Grok 4');
+    });
+
+    it('should return null when no fallback strategy matches', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+
+      // 'totally-different' won't match any strategy
+      expect(service.lookupModel('openai', 'totally-different')).toBeNull();
+    });
+
+    it('should not strip -latest when the model already ends with -latest', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+
+      // mistral-large-latest already ends with -latest, so step 4 is skipped
+      // It should still be found via exact match (step 1)
+      const model = service.lookupModel('mistral', 'mistral-large-latest');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral Large');
+    });
+
+    it('should handle model that matches date suffix but no base model exists', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+
+      // nonexistent-model-20250514 strips to nonexistent-model which doesn't exist
+      expect(service.lookupModel('openai', 'nonexistent-model-20250514')).toBeNull();
+    });
+
+    it('should try step 5 (date+latest) when no date match or latest match', async () => {
+      // Mistral: mistral-small-20250103 -> strip date -> mistral-small -> try +latest -> mistral-small-latest
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+
+      const model = service.lookupModel('mistral', 'mistral-large-20250603');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral Large');
+    });
+
+    it('should not apply reasoning suffix to non-matching models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+
+      // 'grok-4-fast-turbo' does not end with -reasoning or -non-reasoning
+      expect(service.lookupModel('xai', 'grok-4-fast-turbo')).toBeNull();
+    });
+  });
+
+  describe('getModelsForProvider case sensitivity', () => {
+    it('should be case-insensitive for provider lookup', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+
+      const lower = service.getModelsForProvider('anthropic');
+      const upper = service.getModelsForProvider('ANTHROPIC');
+      expect(lower).toEqual(upper);
+      expect(lower.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
+import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 
 /**
  * Mapping from our internal provider IDs to models.dev provider directory names.
@@ -20,6 +21,14 @@ const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
 };
 
 const SUPPORTED_PROVIDERS = new Set(Object.keys(PROVIDER_ID_MAP));
+
+/** Resolve a provider ID or alias to our canonical internal ID (e.g., 'alibaba' → 'qwen'). */
+function resolveProviderId(providerId: string): string {
+  const lower = providerId.toLowerCase();
+  if (SUPPORTED_PROVIDERS.has(lower)) return lower;
+  const entry = PROVIDER_BY_ID_OR_ALIAS.get(lower);
+  return entry?.id ?? lower;
+}
 
 export interface ModelsDevModelEntry {
   id: string;
@@ -129,7 +138,7 @@ export class ModelsDevSyncService implements OnModuleInit {
    *   7. Strip 4-digit short date suffix (-0709 MMDD format)
    */
   lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null {
-    const providerModels = this.cache.get(providerId.toLowerCase());
+    const providerModels = this.cache.get(resolveProviderId(providerId));
     if (!providerModels) return null;
 
     // 1. Exact match
@@ -174,6 +183,11 @@ export class ModelsDevSyncService implements OnModuleInit {
     if (noShortDate !== modelId) {
       const found = providerModels.get(noShortDate);
       if (found) return found;
+      // 8. Strip short date then append -latest (mistral-small-2603 → mistral-small-latest)
+      if (!noShortDate.endsWith(LATEST_SUFFIX)) {
+        const withLatest = providerModels.get(noShortDate + LATEST_SUFFIX);
+        if (withLatest) return withLatest;
+      }
     }
 
     return null;
@@ -184,14 +198,14 @@ export class ModelsDevSyncService implements OnModuleInit {
    * Returns an empty array if the provider is not found.
    */
   getModelsForProvider(providerId: string): ModelsDevModelEntry[] {
-    const providerModels = this.cache.get(providerId.toLowerCase());
+    const providerModels = this.cache.get(resolveProviderId(providerId));
     if (!providerModels) return [];
     return [...providerModels.values()];
   }
 
   /** Whether a provider ID is mapped for models.dev lookups. */
   isProviderSupported(providerId: string): boolean {
-    return SUPPORTED_PROVIDERS.has(providerId.toLowerCase());
+    return SUPPORTED_PROVIDERS.has(resolveProviderId(providerId));
   }
 
   getLastFetchedAt(): Date | null {

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -1,0 +1,255 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+/**
+ * Mapping from our internal provider IDs to models.dev provider directory names.
+ * models.dev uses its own naming convention for provider directories.
+ */
+const PROVIDER_ID_MAP: Readonly<Record<string, string>> = {
+  anthropic: 'anthropic',
+  openai: 'openai',
+  gemini: 'google',
+  deepseek: 'deepseek',
+  mistral: 'mistral',
+  xai: 'xai',
+  minimax: 'minimax',
+  moonshot: 'moonshotai',
+  qwen: 'alibaba',
+  zai: 'zai',
+  copilot: 'github-copilot',
+};
+
+const SUPPORTED_PROVIDERS = new Set(Object.keys(PROVIDER_ID_MAP));
+
+export interface ModelsDevModelEntry {
+  id: string;
+  name: string;
+  family?: string;
+  reasoning?: boolean;
+  toolCall?: boolean;
+  structuredOutput?: boolean;
+  contextWindow?: number;
+  maxOutputTokens?: number;
+  inputPricePerToken: number | null;
+  outputPricePerToken: number | null;
+  cacheReadPricePerToken?: number | null;
+  cacheWritePricePerToken?: number | null;
+}
+
+interface RawModelsDevModel {
+  id: string;
+  name?: string;
+  family?: string;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  structured_output?: boolean;
+  cost?: { input?: number; output?: number; cache_read?: number; cache_write?: number };
+  limit?: { context?: number; output?: number };
+  modalities?: { input?: string[]; output?: string[] };
+}
+
+interface RawModelsDevProvider {
+  id: string;
+  name?: string;
+  models?: Record<string, RawModelsDevModel>;
+}
+
+type RawModelsDevResponse = Record<string, RawModelsDevProvider>;
+
+const MODELS_DEV_API = 'https://models.dev/api.json';
+const FETCH_TIMEOUT_MS = 10000;
+/** Matches trailing version suffixes like -001, -002 (Google API convention). */
+const VERSION_SUFFIX_RE = /-\d{3}$/;
+/** Matches trailing date suffixes like -20250514, -2025-04-14. */
+const DATE_SUFFIX_RE = /-\d{4}-?\d{2}-?\d{2}$/;
+/** Matches short date suffixes like -0709 (MMDD format, used by xAI). */
+const SHORT_DATE_SUFFIX_RE = /-\d{4}$/;
+/** Common suffix aliases: try appending -latest when the base name is not found. */
+const LATEST_SUFFIX = '-latest';
+/** xAI reasoning/non-reasoning mode suffixes. */
+const REASONING_SUFFIX_RE = /-(reasoning|non-reasoning)$/;
+
+@Injectable()
+export class ModelsDevSyncService implements OnModuleInit {
+  private readonly logger = new Logger(ModelsDevSyncService.name);
+  /** Map: our provider ID → Map<model ID (native), entry> */
+  private cache = new Map<string, Map<string, ModelsDevModelEntry>>();
+  private lastFetchedAt: Date | null = null;
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.refreshCache();
+    } catch (err) {
+      this.logger.error(`Startup models.dev cache refresh failed: ${err}`);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async refreshCache(): Promise<number> {
+    this.logger.log('Refreshing models.dev cache...');
+    const raw = await this.fetchModelsDevData();
+    if (!raw) return 0;
+
+    const newCache = new Map<string, Map<string, ModelsDevModelEntry>>();
+    let totalModels = 0;
+
+    for (const [ourId, modelsDevId] of Object.entries(PROVIDER_ID_MAP)) {
+      const provider = raw[modelsDevId];
+      if (!provider?.models) continue;
+
+      const modelMap = new Map<string, ModelsDevModelEntry>();
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        if (!this.isChatCompatible(model)) continue;
+        const entry = this.parseModel(modelId, model);
+        modelMap.set(modelId, entry);
+        totalModels++;
+      }
+
+      if (modelMap.size > 0) {
+        newCache.set(ourId, modelMap);
+      }
+    }
+
+    this.cache = newCache;
+    this.lastFetchedAt = new Date();
+    this.logger.log(`models.dev cache loaded: ${newCache.size} providers, ${totalModels} models`);
+
+    return totalModels;
+  }
+
+  /**
+   * Look up a single model by our provider ID and native model ID.
+   * Tries multiple fallback strategies for variant model names:
+   *   1. Exact match
+   *   2. Strip 3-digit version suffix (-001)
+   *   3. Strip date suffix (-20250514 or -2025-04-14)
+   *   4. Append -latest (mistral-medium → mistral-medium-latest)
+   *   5. Strip date then append -latest
+   *   6. Strip -reasoning / -non-reasoning suffix (xAI convention)
+   *   7. Strip 4-digit short date suffix (-0709 MMDD format)
+   */
+  lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null {
+    const providerModels = this.cache.get(providerId.toLowerCase());
+    if (!providerModels) return null;
+
+    // 1. Exact match
+    const exact = providerModels.get(modelId);
+    if (exact) return exact;
+
+    // 2. Strip 3-digit version suffix (e.g., gemini-2.0-flash-001 → gemini-2.0-flash)
+    const noVersion = modelId.replace(VERSION_SUFFIX_RE, '');
+    if (noVersion !== modelId) {
+      const found = providerModels.get(noVersion);
+      if (found) return found;
+    }
+
+    // 3. Strip date suffix (e.g., gpt-4.1-2025-04-14 → gpt-4.1)
+    const noDate = modelId.replace(DATE_SUFFIX_RE, '');
+    if (noDate !== modelId) {
+      const found = providerModels.get(noDate);
+      if (found) return found;
+    }
+
+    // 4. Append -latest (e.g., mistral-medium → mistral-medium-latest)
+    if (!modelId.endsWith(LATEST_SUFFIX)) {
+      const withLatest = providerModels.get(modelId + LATEST_SUFFIX);
+      if (withLatest) return withLatest;
+    }
+
+    // 5. Strip date then append -latest (e.g., mistral-small-2603 → mistral-small-latest)
+    if (noDate !== modelId && !noDate.endsWith(LATEST_SUFFIX)) {
+      const found = providerModels.get(noDate + LATEST_SUFFIX);
+      if (found) return found;
+    }
+
+    // 6. Strip -reasoning / -non-reasoning suffix (xAI: grok-4-1-fast-reasoning → grok-4-1-fast)
+    const noReasoning = modelId.replace(REASONING_SUFFIX_RE, '');
+    if (noReasoning !== modelId) {
+      const found = providerModels.get(noReasoning);
+      if (found) return found;
+    }
+
+    // 7. Strip 4-digit short date suffix (xAI: grok-4-0709 → grok-4)
+    const noShortDate = modelId.replace(SHORT_DATE_SUFFIX_RE, '');
+    if (noShortDate !== modelId) {
+      const found = providerModels.get(noShortDate);
+      if (found) return found;
+    }
+
+    return null;
+  }
+
+  /**
+   * Get all models for a provider (by our internal provider ID).
+   * Returns an empty array if the provider is not found.
+   */
+  getModelsForProvider(providerId: string): ModelsDevModelEntry[] {
+    const providerModels = this.cache.get(providerId.toLowerCase());
+    if (!providerModels) return [];
+    return [...providerModels.values()];
+  }
+
+  /** Whether a provider ID is mapped for models.dev lookups. */
+  isProviderSupported(providerId: string): boolean {
+    return SUPPORTED_PROVIDERS.has(providerId.toLowerCase());
+  }
+
+  getLastFetchedAt(): Date | null {
+    return this.lastFetchedAt;
+  }
+
+  private parseModel(modelId: string, raw: RawModelsDevModel): ModelsDevModelEntry {
+    const inputPerMillion = raw.cost?.input ?? null;
+    const outputPerMillion = raw.cost?.output ?? null;
+    const cacheReadPerMillion = raw.cost?.cache_read ?? null;
+    const cacheWritePerMillion = raw.cost?.cache_write ?? null;
+
+    return {
+      id: modelId,
+      name: raw.name || modelId,
+      family: raw.family,
+      reasoning: raw.reasoning ?? false,
+      toolCall: raw.tool_call ?? false,
+      structuredOutput: raw.structured_output ?? false,
+      contextWindow: raw.limit?.context,
+      maxOutputTokens: raw.limit?.output,
+      inputPricePerToken: inputPerMillion !== null ? inputPerMillion / 1_000_000 : null,
+      outputPricePerToken: outputPerMillion !== null ? outputPerMillion / 1_000_000 : null,
+      cacheReadPricePerToken: cacheReadPerMillion !== null ? cacheReadPerMillion / 1_000_000 : null,
+      cacheWritePricePerToken:
+        cacheWritePerMillion !== null ? cacheWritePerMillion / 1_000_000 : null,
+    };
+  }
+
+  /** Filter to text-in / text-out models only (same logic as PricingSyncService). */
+  private isChatCompatible(model: RawModelsDevModel): boolean {
+    const inputMods = model.modalities?.input?.map((m) => m.toLowerCase());
+    if (inputMods && inputMods.length > 0 && !inputMods.includes('text')) {
+      return false;
+    }
+    const outputMods = model.modalities?.output?.map((m) => m.toLowerCase());
+    if (outputMods && outputMods.length > 0) {
+      return outputMods.every((m) => m === 'text');
+    }
+    return true;
+  }
+
+  private async fetchModelsDevData(): Promise<RawModelsDevResponse | null> {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+      const res = await fetch(MODELS_DEV_API, { signal: controller.signal });
+      clearTimeout(timeout);
+
+      if (!res.ok) {
+        this.logger.error(`models.dev API returned ${res.status}`);
+        return null;
+      }
+      return (await res.json()) as RawModelsDevResponse;
+    } catch (err) {
+      this.logger.error(`Failed to fetch models.dev data: ${err}`);
+      return null;
+    }
+  }
+}

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -93,6 +93,7 @@ describe('ModelDiscoveryService', () => {
     registerModels: jest.Mock;
     getConfirmedModels: jest.Mock;
   };
+  let mockModelsDevSync: { lookupModel: jest.Mock; getModelsForProvider: jest.Mock };
   let mockCopilotTokenService: { getCopilotToken: jest.Mock };
 
   beforeEach(() => {
@@ -102,6 +103,10 @@ describe('ModelDiscoveryService', () => {
     mockPricingSync = {
       lookupPricing: jest.fn().mockReturnValue(null),
       getAll: jest.fn().mockReturnValue(new Map()),
+    };
+    mockModelsDevSync = {
+      lookupModel: jest.fn().mockReturnValue(null),
+      getModelsForProvider: jest.fn().mockReturnValue([]),
     };
     mockModelRegistry = {
       registerModels: jest.fn(),
@@ -120,6 +125,7 @@ describe('ModelDiscoveryService', () => {
       customProviderRepo as never,
       fetcher as unknown as ProviderModelFetcherService,
       mockPricingSync as never,
+      mockModelsDevSync as never,
       mockModelRegistry as unknown as ProviderModelRegistryService,
       mockCopilotTokenService as never,
     );
@@ -241,6 +247,7 @@ describe('ModelDiscoveryService', () => {
         null,
         null,
         null,
+        null,
       );
 
       const models = [makeModel({ id: 'some-model' })];
@@ -335,6 +342,7 @@ describe('ModelDiscoveryService', () => {
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
         mockPricingSync as never,
+        mockModelsDevSync as never,
         null,
         null,
       );
@@ -552,8 +560,8 @@ describe('ModelDiscoveryService', () => {
   /* ── enrichModel edge cases via discoverModels ── */
 
   describe('enrichModel (via discoverModels)', () => {
-    it('should use pricingSync lookup when fetcher provided zero pricing', async () => {
-      // inputPricePerToken is 0, which is not > 0, so enrichModel continues to lookup
+    it('should preserve zero pricing from fetcher (free/subscription models)', async () => {
+      // inputPricePerToken is 0 (free/subscription), enrichment should NOT override
       mockPricingSync.lookupPricing.mockImplementation((key: string) => {
         if (key === 'openai/free-model') {
           return { input: 0.001, output: 0.002 };
@@ -567,9 +575,46 @@ describe('ModelDiscoveryService', () => {
       fetcher.fetch.mockResolvedValue(models);
 
       const result = await service.discoverModels(makeProvider());
-      // Should have gone through pricingSync lookup since 0 is not > 0
-      expect(mockPricingSync.lookupPricing).toHaveBeenCalled();
-      expect(result[0].inputPricePerToken).toBe(0.001);
+      // Price=0 means "free/included" — should not be overwritten
+      expect(result[0].inputPricePerToken).toBe(0);
+      expect(result[0].outputPricePerToken).toBe(0);
+    });
+
+    it('should apply capabilities from models.dev even when pricing is already set', async () => {
+      // Copilot/subscription model has price=0 but needs capability flags for scoring
+      mockModelsDevSync.lookupModel.mockImplementation((providerId: string, modelId: string) => {
+        if (modelId === 'copilot-model') {
+          return {
+            id: 'copilot-model',
+            name: 'Copilot Model',
+            inputPricePerToken: 0.000005, // pricing should NOT be applied
+            outputPricePerToken: 0.000025,
+            reasoning: true,
+            toolCall: true,
+          };
+        }
+        return null;
+      });
+
+      const models = [
+        makeModel({
+          id: 'copilot-model',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityReasoning: false,
+          capabilityCode: false,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      // Pricing preserved as 0 (not overwritten)
+      expect(result[0].inputPricePerToken).toBe(0);
+      expect(result[0].outputPricePerToken).toBe(0);
+      // Capabilities applied from models.dev
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].capabilityCode).toBe(true);
     });
 
     it('should fall back to exact model ID lookup when prefix lookup misses', async () => {
@@ -612,6 +657,77 @@ describe('ModelDiscoveryService', () => {
       expect(mockPricingSync.lookupPricing).toHaveBeenCalledWith('mistralai/mistral-large');
       expect(result[0].inputPricePerToken).toBe(0.00002);
       expect(result[0].outputPricePerToken).toBe(0.00006);
+    });
+
+    it('should use models.dev pricing before OpenRouter when available', async () => {
+      mockModelsDevSync.lookupModel.mockImplementation((providerId: string, modelId: string) => {
+        if (providerId === 'openai' && modelId === 'gpt-4o') {
+          return {
+            id: 'gpt-4o',
+            name: 'GPT-4o',
+            inputPricePerToken: 0.0000025,
+            outputPricePerToken: 0.00001,
+            contextWindow: 128000,
+            reasoning: false,
+          };
+        }
+        return null;
+      });
+      // OpenRouter also has pricing but should NOT be used
+      mockPricingSync.lookupPricing.mockReturnValue({
+        input: 0.99,
+        output: 0.99,
+        displayName: 'Wrong',
+      });
+
+      const models = [makeModel({ id: 'gpt-4o' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputPricePerToken).toBe(0.0000025);
+      expect(result[0].outputPricePerToken).toBe(0.00001);
+      expect(result[0].displayName).toBe('GPT-4o');
+    });
+
+    it('should propagate capabilities from models.dev to quality scoring', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'claude-opus-4-6',
+        name: 'Claude Opus 4.6',
+        inputPricePerToken: 0.000005,
+        outputPricePerToken: 0.000025,
+        contextWindow: 1000000,
+        reasoning: true,
+        toolCall: true,
+      });
+
+      const models = [
+        makeModel({ id: 'claude-opus-4-6', capabilityReasoning: false, capabilityCode: false }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider({ provider: 'anthropic' }));
+
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].capabilityCode).toBe(true);
+    });
+
+    it('should fall through to OpenRouter when models.dev has no match', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue(null);
+      mockPricingSync.lookupPricing.mockImplementation((key: string) => {
+        if (key === 'openai/new-model') {
+          return { input: 0.001, output: 0.002, displayName: 'New Model' };
+        }
+        return null;
+      });
+
+      const models = [makeModel({ id: 'new-model' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputPricePerToken).toBe(0.001);
+      expect(result[0].displayName).toBe('New Model');
     });
 
     it('should skip prefix lookup when provider has no OpenRouter prefix', async () => {
@@ -1189,6 +1305,7 @@ describe('ModelDiscoveryService', () => {
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
         mockPricingSync as never,
+        mockModelsDevSync as never,
         mockModelRegistry as unknown as ProviderModelRegistryService,
         null,
       );
@@ -1218,6 +1335,7 @@ describe('ModelDiscoveryService', () => {
         providerRepo as never,
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
+        null,
         null,
         null,
         null,
@@ -1620,6 +1738,267 @@ describe('ModelDiscoveryService', () => {
       expect(result.map((m) => m.id)).toContain('MiniMax-M2.1');
       expect(result.map((m) => m.id)).toContain('MiniMax-M2');
       expect(result.map((m) => m.id)).not.toContain('MiniMax-M2.5');
+    });
+  });
+
+  /* ── applyCapabilities edge cases ── */
+
+  describe('applyCapabilities (via enrichModel)', () => {
+    it('should not apply capabilities when modelsDevSync is null', async () => {
+      const serviceNoMd = new ModelDiscoveryService(
+        providerRepo as never,
+        customProviderRepo as never,
+        fetcher as unknown as ProviderModelFetcherService,
+        mockPricingSync as never,
+        null, // no models.dev sync
+        mockModelRegistry as unknown as ProviderModelRegistryService,
+        null,
+      );
+
+      const models = [
+        makeModel({
+          id: 'free-model',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityReasoning: false,
+          capabilityCode: false,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await serviceNoMd.discoverModels(makeProvider());
+
+      expect(result[0].capabilityReasoning).toBe(false);
+      expect(result[0].capabilityCode).toBe(false);
+    });
+
+    it('should preserve existing capabilities when models.dev has no match', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue(null);
+
+      const models = [
+        makeModel({
+          id: 'custom-model',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityReasoning: true,
+          capabilityCode: true,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].capabilityCode).toBe(true);
+    });
+
+    it('should apply capabilities for OpenRouter-sourced models with positive pricing', async () => {
+      // Model has pricing > 0, so enrichModel skips pricing but applies capabilities
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'gpt-4o',
+        name: 'GPT-4o',
+        inputPricePerToken: 0.0000025,
+        outputPricePerToken: 0.00001,
+        reasoning: true,
+        toolCall: true,
+      });
+
+      const models = [
+        makeModel({
+          id: 'gpt-4o',
+          inputPricePerToken: 0.0000025, // positive pricing, already set
+          outputPricePerToken: 0.00001,
+          capabilityReasoning: false,
+          capabilityCode: false,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      // Pricing should be preserved (not overwritten from models.dev)
+      expect(result[0].inputPricePerToken).toBe(0.0000025);
+      expect(result[0].outputPricePerToken).toBe(0.00001);
+      // Capabilities should be applied from models.dev
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].capabilityCode).toBe(true);
+    });
+
+    it('should use model default capabilities when models.dev entry has undefined flags', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'model-no-flags',
+        name: 'Model No Flags',
+        inputPricePerToken: 0.001,
+        outputPricePerToken: 0.002,
+        // reasoning and toolCall are undefined
+      });
+
+      const models = [
+        makeModel({
+          id: 'model-no-flags',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityReasoning: true,
+          capabilityCode: true,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      // undefined ?? true = true (model defaults preserved)
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].capabilityCode).toBe(true);
+    });
+  });
+
+  /* ── enrichModel pricing boundary conditions ── */
+
+  describe('enrichModel pricing boundary conditions', () => {
+    it('should trigger pricing enrichment when inputPricePerToken is negative', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'neg-model',
+        name: 'Negative Price Model',
+        inputPricePerToken: 0.001,
+        outputPricePerToken: 0.002,
+        contextWindow: 128000,
+      });
+
+      const models = [
+        makeModel({
+          id: 'neg-model',
+          inputPricePerToken: -1,
+          outputPricePerToken: null,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      // Negative price is < 0, so the >= 0 guard fails, enrichment kicks in
+      expect(result[0].inputPricePerToken).toBe(0.001);
+      expect(result[0].outputPricePerToken).toBe(0.002);
+    });
+
+    it('should trigger pricing enrichment when inputPricePerToken is null', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'null-price',
+        name: 'Null Price',
+        inputPricePerToken: 0.005,
+        outputPricePerToken: 0.01,
+        contextWindow: 64000,
+      });
+
+      const models = [
+        makeModel({
+          id: 'null-price',
+          inputPricePerToken: null,
+          outputPricePerToken: null,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputPricePerToken).toBe(0.005);
+      expect(result[0].outputPricePerToken).toBe(0.01);
+    });
+
+    it('should skip pricing enrichment but apply capabilities for price=0 models', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'zero-price',
+        name: 'Zero Price Enhanced',
+        inputPricePerToken: 0.003, // should NOT be used
+        outputPricePerToken: 0.006,
+        reasoning: true,
+        toolCall: false,
+      });
+
+      const models = [
+        makeModel({
+          id: 'zero-price',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityReasoning: false,
+          capabilityCode: true,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      // Pricing preserved
+      expect(result[0].inputPricePerToken).toBe(0);
+      expect(result[0].outputPricePerToken).toBe(0);
+      // Capabilities updated from models.dev
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].capabilityCode).toBe(false);
+    });
+  });
+
+  /* ── models.dev fallback in discoverModels ── */
+
+  describe('models.dev fallback in discoverModels', () => {
+    it('should try models.dev before OpenRouter when native API returns empty', async () => {
+      fetcher.fetch.mockResolvedValue([]);
+      mockModelsDevSync.getModelsForProvider.mockReturnValue([
+        {
+          id: 'md-model',
+          name: 'MD Model',
+          contextWindow: 128000,
+          inputPricePerToken: 0.001,
+          outputPricePerToken: 0.002,
+          reasoning: true,
+          toolCall: false,
+        },
+      ]);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(mockModelsDevSync.getModelsForProvider).toHaveBeenCalledWith('openai');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('md-model');
+      expect(result[0].capabilityReasoning).toBe(true);
+      // OpenRouter fallback should NOT be called when models.dev has data
+      expect(mockPricingSync.getAll).not.toHaveBeenCalled();
+    });
+
+    it('should fall through to OpenRouter when both native API and models.dev return empty', async () => {
+      fetcher.fetch.mockResolvedValue([]);
+      mockModelsDevSync.getModelsForProvider.mockReturnValue([]);
+      mockPricingSync.getAll.mockReturnValue(
+        new Map([['openai/gpt-4o', { input: 0.01, output: 0.02, displayName: 'GPT-4o' }]]),
+      );
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(mockModelsDevSync.getModelsForProvider).toHaveBeenCalledWith('openai');
+      expect(mockPricingSync.getAll).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gpt-4o');
+    });
+
+    it('should skip models.dev fallback when modelsDevSync is null', async () => {
+      const serviceNoMd = new ModelDiscoveryService(
+        providerRepo as never,
+        customProviderRepo as never,
+        fetcher as unknown as ProviderModelFetcherService,
+        mockPricingSync as never,
+        null,
+        mockModelRegistry as unknown as ProviderModelRegistryService,
+        null,
+      );
+
+      fetcher.fetch.mockResolvedValue([]);
+      mockPricingSync.getAll.mockReturnValue(
+        new Map([['openai/gpt-4o', { input: 0.01, output: 0.02, displayName: 'GPT-4o' }]]),
+      );
+
+      const result = await serviceNoMd.discoverModels(makeProvider());
+
+      // Should go straight to OpenRouter fallback
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gpt-4o');
     });
   });
 });

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -9,6 +9,7 @@ import { DiscoveredModel } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
 import { computeQualityScore } from '../database/quality-score.util';
 import { PricingSyncService } from '../database/pricing-sync.service';
+import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { parseOAuthTokenBlob } from '../routing/oauth/openai-oauth.types';
 import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../routing/qwen-region';
 import { CopilotTokenService } from '../routing/proxy/copilot-token.service';
@@ -16,6 +17,7 @@ import {
   findOpenRouterPrefix,
   lookupWithVariants,
   buildFallbackModels,
+  buildModelsDevFallback,
   buildSubscriptionFallbackModels,
   supplementWithKnownModels,
 } from './model-fallback';
@@ -41,6 +43,9 @@ export class ModelDiscoveryService {
     @Optional()
     @Inject(PricingSyncService)
     private readonly pricingSync: PricingSyncService | null,
+    @Optional()
+    @Inject(ModelsDevSyncService)
+    private readonly modelsDevSync: ModelsDevSyncService | null,
     @Optional()
     @Inject(ProviderModelRegistryService)
     private readonly modelRegistry: ProviderModelRegistryService | null,
@@ -114,14 +119,23 @@ export class ModelDiscoveryService {
         );
       }
 
-      // If native API returned no models, fall back to OpenRouter filtered by confirmed models
+      // If native API returned no models, try models.dev first (native IDs), then OpenRouter
+      if (raw.length === 0) {
+        raw = buildModelsDevFallback(this.modelsDevSync, provider.provider);
+        if (raw.length > 0) {
+          this.logger.log(
+            `Native API returned 0 models for ${provider.provider} — using ${raw.length} models from models.dev`,
+          );
+        }
+      }
+      // If models.dev also had nothing, fall back to OpenRouter filtered by confirmed models.
       // Qwen is excluded because OpenRouter/pricing ids can diverge from DashScope ids.
       if (raw.length === 0 && !isQwenProvider(provider.provider)) {
         const confirmed = this.modelRegistry?.getConfirmedModels(provider.provider) ?? null;
         raw = buildFallbackModels(this.pricingSync, provider.provider, confirmed);
         if (raw.length > 0) {
           this.logger.log(
-            `Native API returned 0 models for ${provider.provider} — using ${raw.length} models from pricing data`,
+            `No models.dev data for ${provider.provider} — using ${raw.length} models from OpenRouter`,
           );
         }
       }
@@ -233,10 +247,29 @@ export class ModelDiscoveryService {
   }
 
   private enrichModel(model: DiscoveredModel, providerId: string): DiscoveredModel {
-    if (model.inputPricePerToken !== null && model.inputPricePerToken > 0) {
-      return this.computeScore(model);
+    // Skip pricing enrichment when pricing is already set (price=0 for free/subscription)
+    // but still apply capability flags from models.dev for better scoring
+    if (model.inputPricePerToken !== null && model.inputPricePerToken >= 0) {
+      return this.computeScore(this.applyCapabilities(model, providerId));
     }
 
+    // Priority 1: models.dev — uses native provider IDs, no normalization needed
+    if (this.modelsDevSync) {
+      const mdEntry = this.modelsDevSync.lookupModel(providerId, model.id);
+      if (mdEntry && mdEntry.inputPricePerToken !== null) {
+        return this.computeScore({
+          ...model,
+          inputPricePerToken: mdEntry.inputPricePerToken,
+          outputPricePerToken: mdEntry.outputPricePerToken,
+          contextWindow: mdEntry.contextWindow ?? model.contextWindow,
+          displayName: mdEntry.name || model.displayName,
+          capabilityReasoning: mdEntry.reasoning ?? model.capabilityReasoning,
+          capabilityCode: mdEntry.toolCall ?? model.capabilityCode,
+        });
+      }
+    }
+
+    // Priority 2: OpenRouter cache — broader coverage, needs prefix + variant matching
     if (this.pricingSync) {
       const orPrefix = findOpenRouterPrefix(providerId);
       if (orPrefix) {
@@ -264,6 +297,18 @@ export class ModelDiscoveryService {
     }
 
     return this.computeScore(model);
+  }
+
+  /** Merge capability flags from models.dev without touching pricing or display name. */
+  private applyCapabilities(model: DiscoveredModel, providerId: string): DiscoveredModel {
+    if (!this.modelsDevSync) return model;
+    const mdEntry = this.modelsDevSync.lookupModel(providerId, model.id);
+    if (!mdEntry) return model;
+    return {
+      ...model,
+      capabilityReasoning: mdEntry.reasoning ?? model.capabilityReasoning,
+      capabilityCode: mdEntry.toolCall ?? model.capabilityCode,
+    };
   }
 
   private computeScore(model: DiscoveredModel): DiscoveredModel {

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildFallbackModels,
+  buildModelsDevFallback,
   buildSubscriptionFallbackModels,
   supplementWithKnownModels,
   findOpenRouterPrefix,
@@ -209,6 +210,14 @@ describe('lookupWithVariants', () => {
     expect(result).toEqual({ input: 0.01, output: 0.02 });
   });
 
+  it('should try :free suffix variant', () => {
+    const cache = new Map([['google/gemma-3n-e2b-it:free', { input: 0, output: 0 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'google', 'gemma-3n-e2b-it');
+
+    expect(result).toEqual({ input: 0, output: 0 });
+  });
+
   it('should return null when no match found', () => {
     const cache = new Map<string, { input: number; output: number }>();
 
@@ -285,5 +294,199 @@ describe('supplementWithKnownModels', () => {
 
     const opusEntries = result.filter((m) => m.id.startsWith('claude-opus-4'));
     expect(opusEntries).toHaveLength(1);
+  });
+});
+
+describe('buildModelsDevFallback', () => {
+  it('should return models from models.dev sync for a provider', () => {
+    const mockSync = {
+      getModelsForProvider: jest.fn().mockReturnValue([
+        {
+          id: 'claude-opus-4-6',
+          name: 'Claude Opus 4.6',
+          contextWindow: 1000000,
+          inputPricePerToken: 0.000005,
+          outputPricePerToken: 0.000025,
+          reasoning: true,
+          toolCall: true,
+        },
+        {
+          id: 'claude-sonnet-4-6',
+          name: 'Claude Sonnet 4.6',
+          contextWindow: 200000,
+          inputPricePerToken: 0.000003,
+          outputPricePerToken: 0.000015,
+          reasoning: false,
+        },
+      ]),
+    };
+
+    const result = buildModelsDevFallback(mockSync, 'anthropic');
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('claude-opus-4-6');
+    expect(result[0].displayName).toBe('Claude Opus 4.6');
+    expect(result[0].provider).toBe('anthropic');
+    expect(result[0].inputPricePerToken).toBe(0.000005);
+    expect(result[0].contextWindow).toBe(1000000);
+    expect(result[0].capabilityReasoning).toBe(true);
+    expect(result[1].capabilityReasoning).toBe(false);
+  });
+
+  it('should return empty when sync is null', () => {
+    expect(buildModelsDevFallback(null, 'anthropic')).toEqual([]);
+  });
+
+  it('should return empty when provider has no models', () => {
+    const mockSync = {
+      getModelsForProvider: jest.fn().mockReturnValue([]),
+    };
+    expect(buildModelsDevFallback(mockSync, 'unknown')).toEqual([]);
+  });
+
+  it('should use default context window when not provided', () => {
+    const mockSync = {
+      getModelsForProvider: jest
+        .fn()
+        .mockReturnValue([
+          { id: 'test-model', name: 'Test', inputPricePerToken: 0.01, outputPricePerToken: 0.02 },
+        ]),
+    };
+
+    const result = buildModelsDevFallback(mockSync, 'openai');
+
+    expect(result[0].contextWindow).toBe(128000);
+  });
+
+  it('should use model id as displayName when name is empty', () => {
+    const mockSync = {
+      getModelsForProvider: jest
+        .fn()
+        .mockReturnValue([
+          { id: 'unnamed-model', name: '', inputPricePerToken: 0.01, outputPricePerToken: 0.02 },
+        ]),
+    };
+
+    const result = buildModelsDevFallback(mockSync, 'openai');
+
+    expect(result[0].displayName).toBe('unnamed-model');
+  });
+
+  it('should propagate toolCall as capabilityCode', () => {
+    const mockSync = {
+      getModelsForProvider: jest.fn().mockReturnValue([
+        {
+          id: 'tool-model',
+          name: 'Tool Model',
+          inputPricePerToken: 0.01,
+          outputPricePerToken: 0.02,
+          reasoning: false,
+          toolCall: true,
+        },
+      ]),
+    };
+
+    const result = buildModelsDevFallback(mockSync, 'openai');
+
+    expect(result[0].capabilityCode).toBe(true);
+    expect(result[0].capabilityReasoning).toBe(false);
+  });
+
+  it('should default reasoning to false when not provided', () => {
+    const mockSync = {
+      getModelsForProvider: jest.fn().mockReturnValue([
+        {
+          id: 'no-caps',
+          name: 'No Caps',
+          inputPricePerToken: 0.01,
+          outputPricePerToken: 0.02,
+          // no reasoning or toolCall
+        },
+      ]),
+    };
+
+    const result = buildModelsDevFallback(mockSync, 'openai');
+
+    expect(result[0].capabilityReasoning).toBe(false);
+    expect(result[0].capabilityCode).toBe(false);
+  });
+
+  it('should include models with null pricing', () => {
+    const mockSync = {
+      getModelsForProvider: jest.fn().mockReturnValue([
+        {
+          id: 'null-price',
+          name: 'Null Price',
+          inputPricePerToken: null,
+          outputPricePerToken: null,
+        },
+      ]),
+    };
+
+    const result = buildModelsDevFallback(mockSync, 'openai');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].inputPricePerToken).toBeNull();
+    expect(result[0].outputPricePerToken).toBeNull();
+  });
+
+  it('should set qualityScore to 3 for all models', () => {
+    const mockSync = {
+      getModelsForProvider: jest.fn().mockReturnValue([
+        { id: 'model-1', name: 'Model 1', inputPricePerToken: 0.01, outputPricePerToken: 0.02 },
+        { id: 'model-2', name: 'Model 2', inputPricePerToken: 0.05, outputPricePerToken: 0.1 },
+      ]),
+    };
+
+    const result = buildModelsDevFallback(mockSync, 'anthropic');
+
+    for (const m of result) {
+      expect(m.qualityScore).toBe(3);
+    }
+  });
+});
+
+describe('lookupWithVariants edge cases', () => {
+  it('should not double-apply dot variant when model already uses dots', () => {
+    const cache = new Map([['openai/gpt-4.1', { input: 0.01, output: 0.02 }]]);
+
+    // Already has a dot, so -(\d+)-(\d) pattern won't match
+    const result = lookupWithVariants(makePricingSync(cache), 'openai', 'gpt-4.1');
+
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
+  it('should prefer exact match over :free suffix', () => {
+    const cache = new Map([
+      ['google/gemma-3n-e2b-it', { input: 0.01, output: 0.02 }],
+      ['google/gemma-3n-e2b-it:free', { input: 0, output: 0 }],
+    ]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'google', 'gemma-3n-e2b-it');
+
+    // Should return exact match, not :free variant
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
+  it('should handle model names with multiple dashes and digits', () => {
+    const cache = new Map([['anthropic/claude-sonnet-4.5', { input: 0.01, output: 0.02 }]]);
+
+    // claude-sonnet-4-5 -> dot variant: claude-sonnet-4.5
+    const result = lookupWithVariants(makePricingSync(cache), 'anthropic', 'claude-sonnet-4-5');
+
+    expect(result).toEqual({ input: 0.01, output: 0.02 });
+  });
+
+  it('should try date-stripped + dot variant as last resort', () => {
+    const cache = new Map([['anthropic/claude-opus-4.6', { input: 0.015, output: 0.075 }]]);
+
+    // claude-opus-4-6-20260301 -> strip date -> claude-opus-4-6 -> dot variant -> claude-opus-4.6
+    const result = lookupWithVariants(
+      makePricingSync(cache),
+      'anthropic',
+      'claude-opus-4-6-20260301',
+    );
+
+    expect(result).toEqual({ input: 0.015, output: 0.075 });
   });
 });

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -5,6 +5,7 @@ import {
 } from '../common/constants/providers';
 import { getSubscriptionKnownModels, getSubscriptionCapabilities } from 'manifest-shared';
 import { normalizeAnthropicShortModelId } from '../common/utils/anthropic-model-id';
+import type { ModelsDevSyncService } from '../database/models-dev-sync.service';
 
 interface PricingLookup {
   lookupPricing(key: string): {
@@ -83,7 +84,46 @@ export function lookupWithVariants(
     }
   }
 
+  // Try :free suffix (OpenRouter lists some models as "provider/model:free")
+  const freeResult = pricingSync.lookupPricing(`${prefix}/${modelId}:free`);
+  if (freeResult) return freeResult;
+
   return null;
+}
+
+/**
+ * Build a fallback model list from models.dev cache.
+ * Uses native provider model IDs — no prefix stripping or variant matching needed.
+ */
+export function buildModelsDevFallback(
+  modelsDevSync: {
+    getModelsForProvider(
+      id: string,
+    ): {
+      id: string;
+      name: string;
+      contextWindow?: number;
+      inputPricePerToken: number | null;
+      outputPricePerToken: number | null;
+      reasoning?: boolean;
+      toolCall?: boolean;
+    }[];
+  } | null,
+  providerId: string,
+): DiscoveredModel[] {
+  if (!modelsDevSync) return [];
+  const entries = modelsDevSync.getModelsForProvider(providerId);
+  return entries.map((e) => ({
+    id: e.id,
+    displayName: e.name || e.id,
+    provider: providerId,
+    contextWindow: e.contextWindow ?? 128000,
+    inputPricePerToken: e.inputPricePerToken,
+    outputPricePerToken: e.outputPricePerToken,
+    capabilityReasoning: e.reasoning ?? false,
+    capabilityCode: e.toolCall ?? false,
+    qualityScore: 3,
+  }));
 }
 
 /**

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1231,17 +1231,17 @@ describe('ProviderModelFetcherService', () => {
     });
 
     it('should keep model with "ocr" in the middle of the name but not at start', async () => {
-      // The regex is /^mistral-ocr|embed/i -- so "some-ocr-model" should pass
+      // The regex is /^mistral-ocr|embed/i — only filters "mistral-ocr-*" prefix, not "ocr" mid-name
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({
-          data: [{ id: 'pixtral-large-latest' }],
+          data: [{ id: 'pixtral-large-latest' }, { id: 'some-ocr-model' }],
         }),
       });
 
       const result = await service.fetch('mistral', 'key');
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('pixtral-large-latest');
+      // Both pass: pixtral has no "mistral-ocr" prefix, "some-ocr-model" has "ocr" mid-name not prefix
+      expect(result).toHaveLength(2);
     });
   });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -151,6 +151,121 @@ describe('ProviderModelFetcherService', () => {
       const result = await service.fetch('openai', 'sk-test');
       expect(result).toEqual([]);
     });
+
+    it('should filter out non-chat OpenAI models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-4o' },
+            { id: 'gpt-4.1' },
+            { id: 'text-embedding-3-small' },
+            { id: 'tts-1' },
+            { id: 'tts-1-hd' },
+            { id: 'whisper-1' },
+            { id: 'dall-e-3' },
+            { id: 'text-moderation-latest' },
+            { id: 'gpt-3.5-turbo-instruct' },
+            { id: 'davinci-002' },
+            { id: 'babbage-002' },
+            { id: 'sora-2' },
+            { id: 'sora-2-pro' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result.map((m) => m.id)).toEqual(['gpt-4o', 'gpt-4.1']);
+    });
+
+    it('should filter out v1/responses-only models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-5-chat-latest' },
+            { id: 'gpt-5-codex' },
+            { id: 'gpt-5-pro' },
+            { id: 'gpt-5.1-codex' },
+            { id: 'gpt-5.1-codex-mini' },
+            { id: 'gpt-5.2-codex' },
+            { id: 'gpt-5.2-pro' },
+            { id: 'gpt-5.4-pro' },
+            { id: 'gpt-5.3-codex' },
+            { id: 'codex-mini-latest' },
+            { id: 'o3' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      // chat-latest, codex-mini-latest, and o3 should pass; codex and pro should be filtered
+      expect(result.map((m) => m.id)).toEqual(['gpt-5-chat-latest', 'codex-mini-latest', 'o3']);
+    });
+
+    it('should not filter non-OpenAI providers with similar model names', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'deepseek-chat' }, { id: 'deepseek-reasoner' }],
+        }),
+      });
+
+      // DeepSeek uses the generic parseOpenAI (no filtering)
+      const result = await service.fetch('deepseek', 'sk-test');
+      expect(result).toHaveLength(2);
+    });
+
+    it('should keep codex-mini-latest (chat-compatible codex model)', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'codex-mini-latest' }, { id: 'gpt-5-codex' }],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result.map((m) => m.id)).toEqual(['codex-mini-latest']);
+    });
+  });
+
+  /* ── Mistral-specific filter ── */
+
+  describe('parseMistralChatOnly (via mistral provider)', () => {
+    it('should filter out OCR models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mistral-large-latest' },
+            { id: 'mistral-ocr-2512' },
+            { id: 'mistral-ocr-latest' },
+            { id: 'mistral-ocr-2503' },
+            { id: 'codestral-latest' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest', 'codestral-latest']);
+    });
+
+    it('should keep all regular Mistral chat models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mistral-medium-latest' },
+            { id: 'magistral-small-latest' },
+            { id: 'devstral-medium-2507' },
+            { id: 'voxtral-small-latest' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(4);
+    });
   });
 
   /* ── OpenAI-compatible providers use same parser ── */
@@ -438,6 +553,55 @@ describe('ProviderModelFetcherService', () => {
 
       const result = await service.fetch('gemini', 'key');
       expect(result).toEqual([]);
+    });
+
+    it('should deduplicate versioned models when alias exists', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          models: [
+            {
+              name: 'models/gemini-2.0-flash',
+              displayName: 'Gemini 2.0 Flash',
+              supportedGenerationMethods: ['generateContent'],
+            },
+            {
+              name: 'models/gemini-2.0-flash-001',
+              displayName: 'Gemini 2.0 Flash 001',
+              supportedGenerationMethods: ['generateContent'],
+            },
+            {
+              name: 'models/gemini-2.5-pro',
+              displayName: 'Gemini 2.5 Pro',
+              supportedGenerationMethods: ['generateContent'],
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('gemini', 'key');
+      // gemini-2.0-flash-001 should be dropped because gemini-2.0-flash exists
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(['gemini-2.0-flash', 'gemini-2.5-pro']);
+    });
+
+    it('should keep versioned model when alias does not exist', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          models: [
+            {
+              name: 'models/gemini-2.0-flash-001',
+              displayName: 'Gemini 2.0 Flash 001',
+              supportedGenerationMethods: ['generateContent'],
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('gemini', 'key');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gemini-2.0-flash-001');
     });
 
     it('should embed key in URL and send no headers', async () => {
@@ -988,5 +1152,316 @@ describe('ProviderModelFetcherService', () => {
 
     const result = await service.fetch('gemini', 'secret-key');
     expect(result).toEqual([]);
+  });
+
+  /* ── Mistral-specific filter: edge cases ── */
+
+  describe('parseMistralChatOnly edge cases', () => {
+    it('should preserve voxtral models (speech-capable chat models)', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'voxtral-small-latest' }, { id: 'voxtral-medium-2507' }],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(['voxtral-small-latest', 'voxtral-medium-2507']);
+    });
+
+    it('should preserve magistral models (reasoning chat models)', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'magistral-small-latest' }, { id: 'magistral-medium-latest' }],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual([
+        'magistral-small-latest',
+        'magistral-medium-latest',
+      ]);
+    });
+
+    it('should preserve devstral models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'devstral-medium-2507' }],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('devstral-medium-2507');
+    });
+
+    it('should filter out embed models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'mistral-embed' }, { id: 'mistral-large-latest' }],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('mistral-large-latest');
+    });
+
+    it('should filter out all OCR variants', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mistral-ocr-2512' },
+            { id: 'mistral-ocr-latest' },
+            { id: 'mistral-ocr-2503' },
+            { id: 'codestral-latest' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('codestral-latest');
+    });
+
+    it('should keep model with "ocr" in the middle of the name but not at start', async () => {
+      // The regex is /^mistral-ocr|embed/i -- so "some-ocr-model" should pass
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'pixtral-large-latest' }],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('pixtral-large-latest');
+    });
+  });
+
+  /* ── OpenAI parseOpenAIChatOnly edge cases ── */
+
+  describe('parseOpenAIChatOnly edge cases', () => {
+    it('should filter out realtime models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'gpt-4o-realtime-preview' }, { id: 'gpt-4o' }],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gpt-4o');
+    });
+
+    it('should filter out transcribe models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-4o-audio-transcribe' },
+            { id: 'gpt-4o-mini-audio-transcribe' },
+            { id: 'gpt-4o' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gpt-4o');
+    });
+
+    it('should filter out sora models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'sora-2' }, { id: 'sora-2-pro' }, { id: 'o3' }],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('o3');
+    });
+
+    it('should keep codex-mini-latest but filter other codex models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'codex-mini-latest' },
+            { id: 'gpt-5-codex' },
+            { id: 'gpt-5.1-codex' },
+            { id: 'gpt-5.2-codex' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result.map((m) => m.id)).toEqual(['codex-mini-latest']);
+    });
+
+    it('should filter out gpt-5-pro but keep gpt-5-chat-latest', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-5-pro' },
+            { id: 'gpt-5.2-pro' },
+            { id: 'gpt-5-chat-latest' },
+            { id: 'gpt-5' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result.map((m) => m.id)).toEqual(['gpt-5-chat-latest', 'gpt-5']);
+    });
+
+    it('should filter out audio models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-4o-audio-preview' },
+            { id: 'gpt-4o-mini-audio-preview' },
+            { id: 'gpt-4o' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gpt-4o');
+    });
+
+    it('should filter out text-moderation models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'text-moderation-latest' },
+            { id: 'text-moderation-stable' },
+            { id: 'gpt-4o' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      // text-moderation-* matches both the moderation pattern and the text- prefix pattern
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gpt-4o');
+    });
+  });
+
+  /* ── Gemini dedup edge cases ── */
+
+  describe('parseGemini dedup edge cases', () => {
+    it('should keep multiple versioned models when no alias exists for any', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          models: [
+            {
+              name: 'models/gemini-2.0-flash-001',
+              displayName: 'Flash 001',
+              supportedGenerationMethods: ['generateContent'],
+            },
+            {
+              name: 'models/gemini-2.0-flash-002',
+              displayName: 'Flash 002',
+              supportedGenerationMethods: ['generateContent'],
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('gemini', 'key');
+      // Neither has an alias without -NNN suffix, so both should be kept
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(['gemini-2.0-flash-001', 'gemini-2.0-flash-002']);
+    });
+
+    it('should keep non-versioned model even when versioned variant exists', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          models: [
+            {
+              name: 'models/gemini-2.5-flash',
+              displayName: 'Flash',
+              supportedGenerationMethods: ['generateContent'],
+            },
+            {
+              name: 'models/gemini-2.5-flash-001',
+              displayName: 'Flash 001',
+              supportedGenerationMethods: ['generateContent'],
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('gemini', 'key');
+      // gemini-2.5-flash-001 has alias gemini-2.5-flash, so it's dropped
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gemini-2.5-flash');
+    });
+
+    it('should not treat non-3-digit suffixes as version suffixes', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          models: [
+            {
+              name: 'models/gemini-2.5-pro-preview-03-25',
+              displayName: 'Preview',
+              supportedGenerationMethods: ['generateContent'],
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('gemini', 'key');
+      // -03-25 is not a 3-digit version suffix, so the model stays
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('gemini-2.5-pro-preview-03-25');
+    });
+  });
+
+  /* ── MiniMax subscription routing ── */
+
+  it('should route minimax+subscription to minimax-subscription config', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.fetch('minimax', 'token', 'subscription');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('api.minimax.io'),
+      expect.anything(),
+    );
+  });
+
+  it('should use regular minimax config when authType is not subscription', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.fetch('minimax', 'api-key', 'api_key');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('api.minimaxi.chat'),
+      expect.anything(),
+    );
   });
 });

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -42,6 +42,38 @@ function parseOpenAI(body: unknown, provider: string): DiscoveredModel[] {
     });
 }
 
+/* ── OpenAI-specific chat model filter ── */
+
+/**
+ * Non-chat models returned by OpenAI's /v1/models that don't work with
+ * /v1/chat/completions. Includes embeddings, TTS, image, audio, moderation,
+ * legacy instruct models, and video models.
+ */
+const OPENAI_NON_CHAT_RE =
+  /(?:embed|tts|whisper|dall-e|moderation|davinci|babbage|^text-|audio|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct)/i;
+
+/**
+ * OpenAI models only supported in v1/responses (not v1/chat/completions).
+ * Codex models (except codex-mini-latest) and -pro variants of GPT-5+.
+ */
+const OPENAI_RESPONSES_ONLY_RE = /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$))/i;
+
+function parseOpenAIChatOnly(body: unknown, provider: string): DiscoveredModel[] {
+  return parseOpenAI(body, provider).filter(
+    (m) => !OPENAI_NON_CHAT_RE.test(m.id) && !OPENAI_RESPONSES_ONLY_RE.test(m.id),
+  );
+}
+
+/**
+ * Non-chat Mistral models that fail with 400 on /v1/chat/completions.
+ * OCR models require document input, not chat messages.
+ */
+const MISTRAL_NON_CHAT_RE = /(?:^mistral-ocr|embed)/i;
+
+function parseMistralChatOnly(body: unknown, provider: string): DiscoveredModel[] {
+  return parseOpenAI(body, provider).filter((m) => !MISTRAL_NON_CHAT_RE.test(m.id));
+}
+
 function bearerHeaders(key: string): Record<string, string> {
   return { Authorization: `Bearer ${key}` };
 }
@@ -85,10 +117,12 @@ interface GeminiModelEntry {
   inputTokenLimit?: number;
 }
 
+const GEMINI_VERSION_SUFFIX_RE = /-\d{3}$/;
+
 function parseGemini(body: unknown, provider: string): DiscoveredModel[] {
   const models = (body as { models?: unknown[] })?.models;
   if (!Array.isArray(models)) return [];
-  return models
+  const parsed = models
     .filter((m: unknown) => {
       const entry = m as GeminiModelEntry;
       if (typeof entry.name !== 'string') return false;
@@ -111,6 +145,15 @@ function parseGemini(body: unknown, provider: string): DiscoveredModel[] {
         qualityScore: 3,
       };
     });
+
+  // Deduplicate: if both an alias (gemini-2.0-flash) and a versioned
+  // variant (gemini-2.0-flash-001) exist, keep only the alias.
+  const ids = new Set(parsed.map((m) => m.id));
+  return parsed.filter((m) => {
+    if (!GEMINI_VERSION_SUFFIX_RE.test(m.id)) return true;
+    const alias = m.id.replace(GEMINI_VERSION_SUFFIX_RE, '');
+    return !ids.has(alias);
+  });
 }
 
 interface OpenRouterModelEntry {
@@ -247,7 +290,7 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
   openai: {
     endpoint: 'https://api.openai.com/v1/models',
     buildHeaders: bearerHeaders,
-    parse: parseOpenAI,
+    parse: parseOpenAIChatOnly,
   },
   'openai-subscription': {
     endpoint: 'https://chatgpt.com/backend-api/codex/models?client_version=0.99.0',
@@ -267,7 +310,7 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
   mistral: {
     endpoint: 'https://api.mistral.ai/v1/models',
     buildHeaders: bearerHeaders,
-    parse: parseOpenAI,
+    parse: parseMistralChatOnly,
   },
   moonshot: {
     endpoint: 'https://api.moonshot.ai/v1/models',

--- a/packages/backend/src/model-prices/model-prices.module.ts
+++ b/packages/backend/src/model-prices/model-prices.module.ts
@@ -4,6 +4,7 @@ import { ModelPricesController } from './model-prices.controller';
 import { ModelPricesService } from './model-prices.service';
 import { ModelPricingCacheService } from './model-pricing-cache.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
+import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
 import { UserProvider } from '../entities/user-provider.entity';
 
@@ -14,8 +15,14 @@ import { UserProvider } from '../entities/user-provider.entity';
     ModelPricesService,
     ModelPricingCacheService,
     PricingSyncService,
+    ModelsDevSyncService,
     ProviderModelRegistryService,
   ],
-  exports: [ModelPricingCacheService, PricingSyncService, ProviderModelRegistryService],
+  exports: [
+    ModelPricingCacheService,
+    PricingSyncService,
+    ModelsDevSyncService,
+    ProviderModelRegistryService,
+  ],
 })
 export class ModelPricesModule {}

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -1,5 +1,6 @@
 import { ModelPricingCacheService } from './model-pricing-cache.service';
 import { PricingSyncService, OpenRouterPricingEntry } from '../database/pricing-sync.service';
+import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
 
 function makeEntry(input: number, output: number): OpenRouterPricingEntry {
@@ -14,17 +15,28 @@ function makeMockRegistry() {
   };
 }
 
+function makeMockModelsDevSync() {
+  return {
+    lookupModel: jest.fn().mockReturnValue(null),
+    getModelsForProvider: jest.fn().mockReturnValue([]),
+    isProviderSupported: jest.fn().mockReturnValue(false),
+  };
+}
+
 describe('ModelPricingCacheService', () => {
   let service: ModelPricingCacheService;
   let mockGetAll: jest.Mock;
   let mockRegistry: ReturnType<typeof makeMockRegistry>;
+  let mockModelsDevSync: ReturnType<typeof makeMockModelsDevSync>;
 
   beforeEach(() => {
     mockGetAll = jest.fn().mockReturnValue(new Map<string, OpenRouterPricingEntry>());
     const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
+    mockModelsDevSync = makeMockModelsDevSync();
     mockRegistry = makeMockRegistry();
     service = new ModelPricingCacheService(
       mockSync,
+      mockModelsDevSync as unknown as ModelsDevSyncService,
       mockRegistry as unknown as ProviderModelRegistryService,
     );
   });
@@ -258,7 +270,7 @@ describe('ModelPricingCacheService', () => {
 
     it('should work without registry (null)', async () => {
       const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
-      const serviceNoRegistry = new ModelPricingCacheService(mockSync, null);
+      const serviceNoRegistry = new ModelPricingCacheService(mockSync, null, null);
       mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.01, 0.02)]]));
       await serviceNoRegistry.reload();
 
@@ -287,6 +299,257 @@ describe('ModelPricingCacheService', () => {
       const entry = service.getByModel('google/gemini-2.5-pro');
       expect(entry!.validated).toBe(true);
       expect(mockRegistry.isModelConfirmed).toHaveBeenCalledWith('gemini', 'gemini-2.5-pro');
+    });
+  });
+
+  describe('models.dev overlay', () => {
+    it('should override OpenRouter entries with models.dev data', async () => {
+      // OpenRouter has slightly different pricing
+      mockGetAll.mockReturnValue(
+        new Map([['anthropic/claude-opus-4-6', makeEntry(0.000015, 0.000075)]]),
+      );
+      // models.dev has correct native-ID pricing
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'anthropic') {
+          return [
+            {
+              id: 'claude-opus-4-6',
+              name: 'Claude Opus 4.6',
+              inputPricePerToken: 0.000005,
+              outputPricePerToken: 0.000025,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      // Bare model name should resolve to models.dev data
+      const entry = service.getByModel('claude-opus-4-6');
+      expect(entry).toBeDefined();
+      expect(entry!.source).toBe('models.dev');
+      expect(entry!.input_price_per_token).toBe(0.000005);
+      expect(entry!.provider).toBe('Anthropic');
+    });
+
+    it('should set source to openrouter for non-overlaid entries', async () => {
+      mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.0025, 0.01)]]));
+      mockModelsDevSync.getModelsForProvider.mockReturnValue([]);
+
+      await service.reload();
+
+      const entry = service.getByModel('openai/gpt-4o');
+      expect(entry!.source).toBe('openrouter');
+    });
+
+    it('should skip models.dev entries without pricing', async () => {
+      mockGetAll.mockReturnValue(new Map([['deepseek/deepseek-chat', makeEntry(0.001, 0.002)]]));
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'deepseek') {
+          return [
+            {
+              id: 'deepseek-chat',
+              name: 'DeepSeek Chat',
+              inputPricePerToken: null,
+              outputPricePerToken: null,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      // OpenRouter entry should remain since models.dev has null pricing
+      const entry = service.getByModel('deepseek-chat');
+      expect(entry!.source).toBe('openrouter');
+    });
+
+    it('should work when modelsDevSync is null', async () => {
+      const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
+      const serviceNoModelsDev = new ModelPricingCacheService(
+        mockSync,
+        null,
+        mockRegistry as unknown as ProviderModelRegistryService,
+      );
+      mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.01, 0.02)]]));
+
+      await serviceNoModelsDev.reload();
+
+      expect(serviceNoModelsDev.getByModel('openai/gpt-4o')).toBeDefined();
+    });
+
+    it('should set display_name from models.dev entries', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'openai') {
+          return [
+            {
+              id: 'gpt-4o',
+              name: 'GPT-4o Enhanced',
+              inputPricePerToken: 0.0000025,
+              outputPricePerToken: 0.00001,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('gpt-4o');
+      expect(entry).toBeDefined();
+      expect(entry!.display_name).toBe('GPT-4o Enhanced');
+      expect(entry!.source).toBe('models.dev');
+    });
+
+    it('should set display_name to null when models.dev entry has no name', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'anthropic') {
+          return [
+            {
+              id: 'claude-test',
+              name: '',
+              inputPricePerToken: 0.001,
+              outputPricePerToken: 0.002,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('claude-test');
+      expect(entry).toBeDefined();
+      expect(entry!.display_name).toBeNull();
+    });
+
+    it('should use resolveValidatedForModelsDev for models.dev entries', async () => {
+      mockRegistry.isModelConfirmed.mockImplementation((providerId: string, modelId: string) => {
+        if (providerId === 'openai' && modelId === 'gpt-4o') return true;
+        return null;
+      });
+
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'openai') {
+          return [
+            {
+              id: 'gpt-4o',
+              name: 'GPT-4o',
+              inputPricePerToken: 0.0000025,
+              outputPricePerToken: 0.00001,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('gpt-4o');
+      expect(entry).toBeDefined();
+      expect(entry!.validated).toBe(true);
+      expect(mockRegistry.isModelConfirmed).toHaveBeenCalledWith('openai', 'gpt-4o');
+    });
+
+    it('should handle models.dev overlay for multiple providers', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'openai') {
+          return [
+            { id: 'gpt-4o', name: 'GPT-4o', inputPricePerToken: 0.001, outputPricePerToken: 0.002 },
+          ];
+        }
+        if (providerId === 'anthropic') {
+          return [
+            {
+              id: 'claude-opus-4-6',
+              name: 'Claude Opus',
+              inputPricePerToken: 0.005,
+              outputPricePerToken: 0.025,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const openai = service.getByModel('gpt-4o');
+      const anthropic = service.getByModel('claude-opus-4-6');
+      expect(openai).toBeDefined();
+      expect(openai!.provider).toBe('OpenAI');
+      expect(anthropic).toBeDefined();
+      expect(anthropic!.provider).toBe('Anthropic');
+    });
+
+    it('should not log overlay message when no models.dev entries have pricing', async () => {
+      mockGetAll.mockReturnValue(new Map([['openai/gpt-4o', makeEntry(0.0025, 0.01)]]));
+      mockModelsDevSync.getModelsForProvider.mockReturnValue([
+        { id: 'no-price', name: 'No Price', inputPricePerToken: null, outputPricePerToken: null },
+      ]);
+
+      await service.reload();
+
+      // The entry should be OpenRouter-sourced since models.dev had null pricing
+      const entry = service.getByModel('gpt-4o');
+      expect(entry!.source).toBe('openrouter');
+    });
+  });
+
+  describe('resolveValidatedForModelsDev', () => {
+    it('should return undefined when registry is null', async () => {
+      const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
+      const serviceNoRegistry = new ModelPricingCacheService(
+        mockSync,
+        mockModelsDevSync as unknown as ModelsDevSyncService,
+        null,
+      );
+
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'openai') {
+          return [
+            { id: 'gpt-4o', name: 'GPT-4o', inputPricePerToken: 0.001, outputPricePerToken: 0.002 },
+          ];
+        }
+        return [];
+      });
+
+      await serviceNoRegistry.reload();
+
+      const entry = serviceNoRegistry.getByModel('gpt-4o');
+      expect(entry).toBeDefined();
+      expect(entry!.validated).toBeUndefined();
+    });
+
+    it('should resolve false for unconfirmed models.dev entries', async () => {
+      mockRegistry.isModelConfirmed.mockReturnValue(false);
+
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'anthropic') {
+          return [
+            {
+              id: 'claude-test',
+              name: 'Test',
+              inputPricePerToken: 0.001,
+              outputPricePerToken: 0.002,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('claude-test');
+      expect(entry).toBeDefined();
+      expect(entry!.validated).toBe(false);
     });
   });
 });

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -1,15 +1,17 @@
 import { Injectable, Logger, OnApplicationBootstrap, Inject, Optional } from '@nestjs/common';
 import { buildAliasMap, resolveModelName } from './model-name-normalizer';
 import { PricingSyncService } from '../database/pricing-sync.service';
+import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import {
   OPENROUTER_PREFIX_TO_PROVIDER,
+  PROVIDER_BY_ID,
   PROVIDER_BY_ID_OR_ALIAS,
 } from '../common/constants/providers';
 import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
 
 /**
  * Lightweight pricing entry used for cost calculation and provider detection.
- * No longer backed by a database table — reads from OpenRouter cache + manual ref.
+ * Reads from models.dev (preferred) and OpenRouter cache (fallback).
  */
 export interface PricingEntry {
   model_name: string;
@@ -19,6 +21,8 @@ export interface PricingEntry {
   display_name: string | null;
   /** True if confirmed via provider-native API, false if unverified, undefined if no data. */
   validated?: boolean;
+  /** Data source: models.dev (curated, native IDs) or openrouter (broad coverage). */
+  source?: 'models.dev' | 'openrouter';
 }
 
 @Injectable()
@@ -29,6 +33,9 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
 
   constructor(
     private readonly pricingSync: PricingSyncService,
+    @Optional()
+    @Inject(ModelsDevSyncService)
+    private readonly modelsDevSync: ModelsDevSyncService | null,
     @Optional()
     @Inject(ProviderModelRegistryService)
     private readonly modelRegistry: ProviderModelRegistryService | null,
@@ -41,6 +48,7 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
   async reload(): Promise<void> {
     this.cache.clear();
 
+    // Load OpenRouter data first (broad coverage, will be overridden by models.dev)
     const orCache = this.pricingSync.getAll();
     for (const [fullId, entry] of orCache) {
       const { provider, canonical, providerId } = this.resolveProviderAndName(fullId);
@@ -52,6 +60,7 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
         output_price_per_token: entry.output,
         display_name: entry.displayName ?? null,
         validated: this.resolveValidated(providerId, canonical),
+        source: 'openrouter',
       };
 
       // Store under full OpenRouter ID (e.g. "anthropic/claude-opus-4-6")
@@ -63,6 +72,9 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
         this.cache.set(canonical, pricingEntry);
       }
     }
+
+    // Overlay models.dev entries (curated, native IDs — preferred source)
+    this.loadModelsDevEntries();
 
     this.aliasMap = buildAliasMap([...this.cache.keys()]);
     this.logger.log(`Loaded ${this.cache.size} pricing entries`);
@@ -125,12 +137,53 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
     return { provider: 'OpenRouter', canonical: openRouterId, providerId: null };
   }
 
+  /**
+   * Load models.dev entries into the cache, overriding OpenRouter entries
+   * for the same model. models.dev uses native provider IDs so bare model
+   * names match directly without prefix stripping.
+   */
+  private loadModelsDevEntries(): void {
+    if (!this.modelsDevSync) return;
+
+    let count = 0;
+    for (const [providerId, registryEntry] of PROVIDER_BY_ID) {
+      const models = this.modelsDevSync.getModelsForProvider(providerId);
+      for (const model of models) {
+        if (model.inputPricePerToken === null) continue;
+
+        const pricingEntry: PricingEntry = {
+          model_name: model.id,
+          provider: registryEntry.displayName,
+          input_price_per_token: model.inputPricePerToken,
+          output_price_per_token: model.outputPricePerToken,
+          display_name: model.name || null,
+          validated: this.resolveValidatedForModelsDev(providerId, model.id),
+          source: 'models.dev',
+        };
+
+        // Override any existing entry for this bare model name
+        this.cache.set(model.id, pricingEntry);
+        count++;
+      }
+    }
+
+    if (count > 0) {
+      this.logger.log(`Overlaid ${count} models.dev pricing entries`);
+    }
+  }
+
   private resolveValidated(providerId: string | null, canonical: string): boolean | undefined {
     if (!this.modelRegistry || !providerId) return undefined;
     // Resolve OpenRouter prefix to canonical provider ID (e.g., "google" → "gemini")
     const entry = PROVIDER_BY_ID_OR_ALIAS.get(providerId);
     const canonicalProviderId = entry?.id ?? providerId;
     const result = this.modelRegistry.isModelConfirmed(canonicalProviderId, canonical);
+    return result ?? undefined;
+  }
+
+  private resolveValidatedForModelsDev(providerId: string, modelId: string): boolean | undefined {
+    if (!this.modelRegistry) return undefined;
+    const result = this.modelRegistry.isModelConfirmed(providerId, modelId);
     return result ?? undefined;
   }
 }

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -161,8 +161,15 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
           source: 'models.dev',
         };
 
-        // Override any existing entry for this bare model name
+        // Override both bare and prefixed keys so getAll() dedup works
         this.cache.set(model.id, pricingEntry);
+        // Also update the OpenRouter-prefixed key if it exists
+        for (const prefix of registryEntry.openRouterPrefixes) {
+          const prefixedKey = `${prefix}/${model.id}`;
+          if (this.cache.has(prefixedKey)) {
+            this.cache.set(prefixedKey, { ...pricingEntry, model_name: prefixedKey });
+          }
+        }
         count++;
       }
     }

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -382,5 +382,245 @@ describe('provider-client-converters', () => {
       expect(messages[1].tool_call_id).toBe(messages[2].tool_call_id);
       expect(messages[1].tool_call_id).toBe(messages[0].tool_calls[0].id);
     });
+
+    /* ── max_tokens → max_completion_tokens for newer OpenAI models ── */
+
+    it('should convert max_tokens to max_completion_tokens for GPT-5 models', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'gpt-5',
+        max_tokens: 4096,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should convert max_tokens for o-series models', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'o3',
+        max_tokens: 2048,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'o3');
+
+      expect(result).toHaveProperty('max_completion_tokens', 2048);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should keep max_tokens for older OpenAI models (GPT-4)', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'gpt-4o',
+        max_tokens: 4096,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-4o');
+
+      expect(result).toHaveProperty('max_tokens', 4096);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should not convert when max_completion_tokens already present', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'gpt-5.2',
+        max_tokens: 1000,
+        max_completion_tokens: 2000,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5.2');
+
+      expect(result).toHaveProperty('max_completion_tokens', 2000);
+      expect(result).toHaveProperty('max_tokens', 1000);
+    });
+
+    it('should not convert max_tokens for non-OpenAI providers', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'mistral-large',
+        max_tokens: 4096,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large');
+
+      expect(result).toHaveProperty('max_tokens', 4096);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    /* ── max_tokens → max_completion_tokens: extended edge cases ── */
+
+    it('should convert max_tokens for o1 model', () => {
+      const body = { messages: [], max_tokens: 2048 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'o1');
+
+      expect(result).toHaveProperty('max_completion_tokens', 2048);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should convert max_tokens for o1-mini model', () => {
+      const body = { messages: [], max_tokens: 1024 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'o1-mini');
+
+      expect(result).toHaveProperty('max_completion_tokens', 1024);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should convert max_tokens for o3-mini model', () => {
+      const body = { messages: [], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'o3-mini');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should convert max_tokens for o4-mini model', () => {
+      const body = { messages: [], max_tokens: 8192 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'o4-mini');
+
+      expect(result).toHaveProperty('max_completion_tokens', 8192);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should convert max_tokens for gpt-5.4 model', () => {
+      const body = { messages: [], max_tokens: 16384 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5.4');
+
+      expect(result).toHaveProperty('max_completion_tokens', 16384);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should convert max_tokens for gpt-5-chat-latest model', () => {
+      const body = { messages: [], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5-chat-latest');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should NOT convert max_tokens for gpt-4.1 model', () => {
+      const body = { messages: [], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-4.1');
+
+      expect(result).toHaveProperty('max_tokens', 4096);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should NOT convert max_tokens for gpt-4o-mini model', () => {
+      const body = { messages: [], max_tokens: 2048 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-4o-mini');
+
+      expect(result).toHaveProperty('max_tokens', 2048);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should NOT convert for OpenRouter even when model is o3', () => {
+      // OpenRouter is a passthrough provider, but it handles max_tokens itself
+      // The conversion should only happen for endpointKey=openai
+      const body = { messages: [], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'openrouter', 'o3');
+
+      // OpenRouter is passthrough, so max_tokens stays as-is (no conversion)
+      expect(result).toHaveProperty('max_tokens', 4096);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should handle case insensitivity for o-series regex', () => {
+      const body = { messages: [], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'O3');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should handle case insensitivity for GPT-5 regex', () => {
+      const body = { messages: [], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'GPT-5');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should NOT convert when body has no max_tokens', () => {
+      const body = { messages: [], model: 'gpt-5' };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'gpt-5');
+
+      expect(result).not.toHaveProperty('max_tokens');
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should NOT match model names like "operative" that start with "o"', () => {
+      const body = { messages: [], max_tokens: 4096 };
+
+      // "operative" starts with "o" but the regex is /^(o[134]|gpt-5)/i
+      // So "operative" won't match since it's o + non-[134] char
+      const result = sanitizeOpenAiBody(body, 'openai', 'operative');
+
+      expect(result).toHaveProperty('max_tokens', 4096);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should match o1-preview model', () => {
+      const body = { messages: [], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'openai', 'o1-preview');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    /* ── Non-passthrough provider: max_completion_tokens conversion ── */
+
+    it('should convert max_completion_tokens to max_tokens for anthropic', () => {
+      const body = {
+        messages: [],
+        max_completion_tokens: 4096,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'anthropic', 'claude-opus-4-6');
+
+      expect(result).toHaveProperty('max_tokens', 4096);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should convert max_completion_tokens to max_tokens for gemini', () => {
+      const body = {
+        messages: [],
+        max_completion_tokens: 8192,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'gemini', 'gemini-2.5-pro');
+
+      expect(result).toHaveProperty('max_tokens', 8192);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should not convert max_completion_tokens when max_tokens already exists for non-passthrough', () => {
+      const body = {
+        messages: [],
+        max_tokens: 2048,
+        max_completion_tokens: 4096,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'anthropic', 'claude-opus-4-6');
+
+      expect(result).toHaveProperty('max_tokens', 2048);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -211,10 +211,12 @@ export function sanitizeOpenAiBody(
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
-  // For OpenAI models that require max_completion_tokens, convert before passthrough
+  // For OpenAI models that require max_completion_tokens, convert before passthrough.
+  // Strip vendor prefix (e.g., "openai/gpt-5" → "gpt-5") before matching.
+  const bareForRegex = model.includes('/') ? model.substring(model.indexOf('/') + 1) : model;
   const convertMaxTokens =
     endpointKey === 'openai' &&
-    OPENAI_MAX_COMPLETION_TOKENS_RE.test(model) &&
+    OPENAI_MAX_COMPLETION_TOKENS_RE.test(bareForRegex) &&
     'max_tokens' in body &&
     !('max_completion_tokens' in body);
 

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -87,7 +87,7 @@ const DEEPSEEK_MAX_TOKENS_LIMIT = 8192;
  * OpenAI models that require `max_completion_tokens` instead of `max_tokens`.
  * All o-series reasoning models and GPT-5+ models use the new parameter.
  */
-const OPENAI_MAX_COMPLETION_TOKENS_RE = /^(o[134]|gpt-5)/i;
+const OPENAI_MAX_COMPLETION_TOKENS_RE = /^(o\d|gpt-5)/i;
 
 function supportsReasoningContent(endpointKey: string, model: string): boolean {
   if (endpointKey === 'deepseek') return true;

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -83,6 +83,12 @@ const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
 const MISTRAL_TOOL_CALL_ID_REGEX = /^[A-Za-z0-9]{9}$/;
 const DEEPSEEK_MAX_TOKENS_LIMIT = 8192;
 
+/**
+ * OpenAI models that require `max_completion_tokens` instead of `max_tokens`.
+ * All o-series reasoning models and GPT-5+ models use the new parameter.
+ */
+const OPENAI_MAX_COMPLETION_TOKENS_RE = /^(o[134]|gpt-5)/i;
+
 function supportsReasoningContent(endpointKey: string, model: string): boolean {
   if (endpointKey === 'deepseek') return true;
   if (endpointKey === 'openrouter') return model.toLowerCase().startsWith('deepseek/');
@@ -205,6 +211,13 @@ export function sanitizeOpenAiBody(
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
+  // For OpenAI models that require max_completion_tokens, convert before passthrough
+  const convertMaxTokens =
+    endpointKey === 'openai' &&
+    OPENAI_MAX_COMPLETION_TOKENS_RE.test(model) &&
+    'max_tokens' in body &&
+    !('max_completion_tokens' in body);
+
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
     if (key === 'messages') {
@@ -212,6 +225,11 @@ export function sanitizeOpenAiBody(
       continue;
     }
     if (passthroughTopLevel) {
+      // Convert max_tokens → max_completion_tokens for newer OpenAI models
+      if (convertMaxTokens && key === 'max_tokens') {
+        cleaned['max_completion_tokens'] = value;
+        continue;
+      }
       cleaned[key] = value;
       continue;
     }


### PR DESCRIPTION
## Summary

- Adds `ModelsDevSyncService` that fetches curated model data from [models.dev](https://models.dev) (by SST/OpenCode) as the first-choice pricing and capability source, with OpenRouter as fallback
- Smart `lookupModel()` with 7 fallback strategies for variant model names (version suffix `-001`, date suffix, `-latest` alias, `-reasoning` suffix, short date `-0709`)
- Capability flags (`reasoning`, `toolCall`) from models.dev flow to the quality scorer for better tier assignment
- OpenAI `max_tokens` → `max_completion_tokens` conversion for GPT-5+ and o-series models
- Filters non-chat models: OpenAI (embed, TTS, sora, codex, pro), Mistral (OCR)
- Gemini alias/versioned model deduplication
- Price=0 subscription models protected from enrichment override
- `:free` suffix variant in OpenRouter lookup

## Why

OpenRouter model IDs don't always match native provider IDs (e.g., `anthropic/claude-opus-4.6` vs native `claude-opus-4-6`), requiring extensive normalization. models.dev uses **native provider IDs** as-is, eliminating most normalization. It also provides richer data (capabilities, cache pricing, output limits) that OpenRouter lacks.

The priority chain is now: native API → models.dev → OpenRouter.

## Test plan

- [ ] 2947 backend tests pass with 100% line coverage
- [ ] 1697 frontend tests pass
- [ ] Verify models.dev enrichment: connect Anthropic provider, check `claude-opus-4-6` shows $5/$25 pricing from models.dev
- [ ] Verify OpenAI GPT-5 models work (no `max_tokens` rejection)
- [ ] Verify Gemini shows no `-001` duplicates
- [ ] Verify Mistral OCR models are filtered
- [ ] Verify subscription models (price=0) keep their pricing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set models.dev as the primary source for model pricing and capabilities in discovery, with OpenRouter as fallback. Improves ID matching, pricing accuracy, and OpenAI request compatibility.

- **New Features**
  - Added `ModelsDevSyncService` and integrated it into discovery, pricing cache, and fallbacks (native API → models.dev → OpenRouter).
  - Smarter ID matching for variants (version/date, -latest/-reasoning, short date) and OpenRouter `:free`; capability flags feed into quality scoring.
  - Convert OpenAI `max_tokens` to `max_completion_tokens` for GPT-5+ and o-series.
  - Filter non-chat models (OpenAI embeddings/TTS/image/audio/moderation/codex; Mistral OCR), dedupe Gemini aliases/versions, and preserve price=0 subscription pricing.

- **Bug Fixes**
  - Handle vendor-prefixed model IDs when converting `max_tokens`; update prefixed OpenRouter keys in the models.dev overlay to prevent stale duplicates.
  - Improve lookups by resolving provider aliases (`alibaba` → `qwen`, `google` → `gemini`) and adding a short-date + latest fallback (e.g., `mistral-small-2603` → `mistral-small-latest`).
  - Future-proof o-series detection by matching any `o`-digit model when converting to `max_completion_tokens`.

<sup>Written for commit 597daa5debd10be27296aeabb8271b5b54cbe752. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

