### PR TITLE
feat: improve Model Prices page and add models.dev enrichment

### DIFF
--- a/.changeset/model-prices-improvements.md
+++ b/.changeset/model-prices-improvements.md
@@ -1,0 +1,9 @@
+---
+"manifest": patch
+---
+
+Improve Model Prices page and model enrichment
+
+- Split Model column into separate "Model" (display name) and "Model ID" columns
+- Add green "Free" badge for free models instead of "(free)" in parentheses
+- Add models.dev as primary pricing source for Gemini models (OpenRouter as fallback)

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1,0 +1,286 @@
+import { ModelsDevSyncService } from './models-dev-sync.service';
+
+let fetchSpy: jest.SpyInstance;
+
+const googleProvider = {
+  id: 'google',
+  models: {
+    'gemini-2.0-flash': {
+      id: 'gemini-2.0-flash',
+      name: 'Gemini 2.0 Flash',
+      reasoning: false,
+      cost: { input: 0.1, output: 0.4 },
+      limit: { context: 1048576, output: 8192 },
+    },
+    'gemini-2.5-pro': {
+      id: 'gemini-2.5-pro',
+      name: 'Gemini 2.5 Pro',
+      reasoning: true,
+      cost: { input: 1.25, output: 10 },
+      limit: { context: 1048576, output: 65536 },
+    },
+    'gemini-2.5-flash-preview-tts': {
+      id: 'gemini-2.5-flash-preview-tts',
+      name: 'Gemini 2.5 Flash Preview TTS',
+      reasoning: false,
+      cost: { input: 0.5, output: 10 },
+      limit: { context: 8000, output: 16000 },
+    },
+  },
+};
+
+function mockApiResponse(body: Record<string, unknown>) {
+  fetchSpy.mockResolvedValue({
+    ok: true,
+    json: async () => body,
+  });
+}
+
+describe('ModelsDevSyncService', () => {
+  let service: ModelsDevSyncService;
+
+  beforeEach(() => {
+    service = new ModelsDevSyncService();
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('onModuleInit', () => {
+    it('calls refreshCache on init', async () => {
+      mockApiResponse({ google: googleProvider });
+
+      await service.onModuleInit();
+      expect(fetchSpy).toHaveBeenCalledWith('https://models.dev/api.json');
+      expect(service.lookupPricing('gemini-2.0-flash')).not.toBeNull();
+    });
+
+    it('does not throw when refreshCache rejects', async () => {
+      jest.spyOn(service, 'refreshCache').mockRejectedValue(new Error('fail'));
+      await service.onModuleInit();
+    });
+  });
+
+  describe('refreshCache', () => {
+    it('populates cache from google provider', async () => {
+      mockApiResponse({ google: googleProvider });
+
+      const count = await service.refreshCache();
+      expect(count).toBe(3);
+
+      const flash = service.lookupPricing('gemini-2.0-flash');
+      expect(flash).not.toBeNull();
+      expect(flash!.input).toBeCloseTo(0.1 / 1_000_000);
+      expect(flash!.output).toBeCloseTo(0.4 / 1_000_000);
+      expect(flash!.displayName).toBe('Gemini 2.0 Flash');
+      expect(flash!.contextWindow).toBe(1048576);
+      expect(flash!.reasoning).toBe(false);
+
+      const pro = service.lookupPricing('gemini-2.5-pro');
+      expect(pro).not.toBeNull();
+      expect(pro!.reasoning).toBe(true);
+    });
+
+    it('replaces old cache on refresh', async () => {
+      mockApiResponse({ google: googleProvider });
+      await service.refreshCache();
+      expect(service.lookupPricing('gemini-2.0-flash')).not.toBeNull();
+
+      mockApiResponse({
+        google: {
+          id: 'google',
+          models: {
+            'gemini-new': {
+              id: 'gemini-new',
+              name: 'New Model',
+              cost: { input: 1, output: 2 },
+            },
+          },
+        },
+      });
+      await service.refreshCache();
+      expect(service.lookupPricing('gemini-2.0-flash')).toBeNull();
+      expect(service.lookupPricing('gemini-new')).not.toBeNull();
+    });
+
+    it('ignores providers not in SUPPORTED_PROVIDERS', async () => {
+      mockApiResponse({
+        google: googleProvider,
+        openai: {
+          id: 'openai',
+          models: {
+            'gpt-4o': { id: 'gpt-4o', name: 'GPT-4o', cost: { input: 2.5, output: 10 } },
+          },
+        },
+      });
+
+      await service.refreshCache();
+      expect(service.lookupPricing('gemini-2.0-flash')).not.toBeNull();
+      expect(service.lookupPricing('gpt-4o')).toBeNull();
+    });
+
+    it('skips models without cost field', async () => {
+      mockApiResponse({
+        google: {
+          id: 'google',
+          models: {
+            'no-cost-model': { id: 'no-cost-model', name: 'No Cost' },
+            'has-cost': { id: 'has-cost', name: 'Has Cost', cost: { input: 1, output: 2 } },
+          },
+        },
+      });
+
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
+      expect(service.lookupPricing('no-cost-model')).toBeNull();
+      expect(service.lookupPricing('has-cost')).not.toBeNull();
+    });
+
+    it('skips models with negative pricing', async () => {
+      mockApiResponse({
+        google: {
+          id: 'google',
+          models: {
+            bad: { id: 'bad', name: 'Bad', cost: { input: -1, output: 2 } },
+          },
+        },
+      });
+
+      const count = await service.refreshCache();
+      expect(count).toBe(0);
+    });
+
+    it('skips models with NaN pricing', async () => {
+      mockApiResponse({
+        google: {
+          id: 'google',
+          models: {
+            bad: { id: 'bad', name: 'Bad', cost: { input: 'abc', output: 2 } },
+          },
+        },
+      });
+
+      const count = await service.refreshCache();
+      expect(count).toBe(0);
+    });
+
+    it('handles free models with zero pricing', async () => {
+      mockApiResponse({
+        google: {
+          id: 'google',
+          models: {
+            'free-model': { id: 'free-model', name: 'Free', cost: { input: 0, output: 0 } },
+          },
+        },
+      });
+
+      const count = await service.refreshCache();
+      expect(count).toBe(1);
+      const entry = service.lookupPricing('free-model');
+      expect(entry!.input).toBe(0);
+      expect(entry!.output).toBe(0);
+    });
+
+    it('returns 0 when API returns non-OK status', async () => {
+      fetchSpy.mockResolvedValue({ ok: false, status: 500 });
+      const count = await service.refreshCache();
+      expect(count).toBe(0);
+    });
+
+    it('returns 0 when fetch throws', async () => {
+      fetchSpy.mockRejectedValue(new Error('network error'));
+      const count = await service.refreshCache();
+      expect(count).toBe(0);
+    });
+
+    it('returns 0 when API returns unexpected format (array)', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => [1, 2, 3],
+      });
+      const count = await service.refreshCache();
+      expect(count).toBe(0);
+    });
+
+    it('returns 0 when API returns null body', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => null,
+      });
+      const count = await service.refreshCache();
+      expect(count).toBe(0);
+    });
+
+    it('handles provider with no models field', async () => {
+      mockApiResponse({ google: { id: 'google' } });
+      const count = await service.refreshCache();
+      expect(count).toBe(0);
+    });
+
+    it('omits displayName when name is missing', async () => {
+      mockApiResponse({
+        google: {
+          id: 'google',
+          models: {
+            'no-name': { id: 'no-name', cost: { input: 1, output: 2 } },
+          },
+        },
+      });
+
+      await service.refreshCache();
+      const entry = service.lookupPricing('no-name');
+      expect(entry!.displayName).toBeUndefined();
+    });
+
+    it('omits contextWindow when limit is missing', async () => {
+      mockApiResponse({
+        google: {
+          id: 'google',
+          models: {
+            'no-limit': { id: 'no-limit', name: 'Test', cost: { input: 1, output: 2 } },
+          },
+        },
+      });
+
+      await service.refreshCache();
+      const entry = service.lookupPricing('no-limit');
+      expect(entry!.contextWindow).toBeUndefined();
+    });
+
+    it('omits reasoning when not provided', async () => {
+      mockApiResponse({
+        google: {
+          id: 'google',
+          models: {
+            'no-reasoning': { id: 'no-reasoning', name: 'Test', cost: { input: 1, output: 2 } },
+          },
+        },
+      });
+
+      await service.refreshCache();
+      const entry = service.lookupPricing('no-reasoning');
+      expect(entry!.reasoning).toBeUndefined();
+    });
+  });
+
+  describe('lookupPricing', () => {
+    it('returns null for unknown model', () => {
+      expect(service.lookupPricing('nonexistent')).toBeNull();
+    });
+
+    it('returns entry for known model', async () => {
+      mockApiResponse({ google: googleProvider });
+      await service.refreshCache();
+
+      const entry = service.lookupPricing('gemini-2.5-pro');
+      expect(entry).not.toBeNull();
+      expect(entry!.displayName).toBe('Gemini 2.5 Pro');
+    });
+
+    it('returns null for empty cache', () => {
+      expect(service.lookupPricing('gemini-2.0-flash')).toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+export interface ModelsDevPricingEntry {
+  /** Price per token (converted from per-million). */
+  input: number;
+  /** Price per token (converted from per-million). */
+  output: number;
+  contextWindow?: number;
+  displayName?: string;
+  reasoning?: boolean;
+}
+
+interface ModelsDevModel {
+  id: string;
+  name?: string;
+  reasoning?: boolean;
+  cost?: { input?: number; output?: number };
+  limit?: { context?: number; output?: number };
+}
+
+interface ModelsDevProvider {
+  id: string;
+  models?: Record<string, ModelsDevModel>;
+}
+
+const MODELS_DEV_API = 'https://models.dev/api.json';
+
+/** Providers to process from models.dev (extend as needed). */
+const SUPPORTED_PROVIDERS = ['google'];
+
+@Injectable()
+export class ModelsDevSyncService implements OnModuleInit {
+  private readonly logger = new Logger(ModelsDevSyncService.name);
+  private cache = new Map<string, ModelsDevPricingEntry>();
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.refreshCache();
+    } catch (err) {
+      this.logger.error(`Startup models.dev cache refresh failed: ${err}`);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async refreshCache(): Promise<number> {
+    this.logger.log('Refreshing models.dev pricing cache...');
+    const data = await this.fetchModelsDevData();
+    if (!data) return 0;
+
+    const newCache = new Map<string, ModelsDevPricingEntry>();
+    let count = 0;
+
+    for (const providerId of SUPPORTED_PROVIDERS) {
+      const provider = data[providerId] as ModelsDevProvider | undefined;
+      if (!provider?.models) continue;
+
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        if (!model.cost) continue;
+
+        const inputPerMillion = Number(model.cost.input ?? 0);
+        const outputPerMillion = Number(model.cost.output ?? 0);
+        if (!Number.isFinite(inputPerMillion) || !Number.isFinite(outputPerMillion)) continue;
+        if (inputPerMillion < 0 || outputPerMillion < 0) continue;
+
+        const entry: ModelsDevPricingEntry = {
+          input: inputPerMillion / 1_000_000,
+          output: outputPerMillion / 1_000_000,
+          contextWindow: model.limit?.context ?? undefined,
+          displayName: model.name || undefined,
+          reasoning: model.reasoning ?? undefined,
+        };
+
+        newCache.set(modelId, entry);
+        count++;
+      }
+    }
+
+    this.cache = newCache;
+    this.logger.log(`models.dev pricing cache loaded: ${count} models`);
+    return count;
+  }
+
+  lookupPricing(modelId: string): ModelsDevPricingEntry | null {
+    return this.cache.get(modelId) ?? null;
+  }
+
+  private async fetchModelsDevData(): Promise<Record<string, unknown> | null> {
+    try {
+      const res = await fetch(MODELS_DEV_API);
+      if (!res.ok) {
+        this.logger.error(`models.dev API returned ${res.status}`);
+        return null;
+      }
+      const body = await res.json();
+      if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+        this.logger.error('models.dev API returned unexpected format');
+        return null;
+      }
+      return body as Record<string, unknown>;
+    } catch (err) {
+      this.logger.error(`Failed to fetch models.dev data: ${err}`);
+      return null;
+    }
+  }
+}

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -94,6 +94,7 @@ describe('ModelDiscoveryService', () => {
     getConfirmedModels: jest.Mock;
   };
   let mockCopilotTokenService: { getCopilotToken: jest.Mock };
+  let mockModelsDevSync: { lookupPricing: jest.Mock };
 
   beforeEach(() => {
     providerRepo = makeMockRepo();
@@ -110,6 +111,9 @@ describe('ModelDiscoveryService', () => {
     mockCopilotTokenService = {
       getCopilotToken: jest.fn().mockResolvedValue('tid=exchanged-copilot-token'),
     };
+    mockModelsDevSync = {
+      lookupPricing: jest.fn().mockReturnValue(null),
+    };
 
     mockDecrypt.mockReturnValue('decrypted-key');
     mockGetSecret.mockReturnValue('secret-32-chars-long-xxxxxxxxxx');
@@ -122,6 +126,7 @@ describe('ModelDiscoveryService', () => {
       mockPricingSync as never,
       mockModelRegistry as unknown as ProviderModelRegistryService,
       mockCopilotTokenService as never,
+      mockModelsDevSync as never,
     );
   });
 
@@ -241,6 +246,7 @@ describe('ModelDiscoveryService', () => {
         null,
         null,
         null,
+        null,
       );
 
       const models = [makeModel({ id: 'some-model' })];
@@ -335,6 +341,7 @@ describe('ModelDiscoveryService', () => {
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
         mockPricingSync as never,
+        null,
         null,
         null,
       );
@@ -1191,6 +1198,7 @@ describe('ModelDiscoveryService', () => {
         mockPricingSync as never,
         mockModelRegistry as unknown as ProviderModelRegistryService,
         null,
+        null,
       );
 
       mockDecrypt.mockReturnValue('ghu_github_token');
@@ -1218,6 +1226,7 @@ describe('ModelDiscoveryService', () => {
         providerRepo as never,
         customProviderRepo as never,
         fetcher as unknown as ProviderModelFetcherService,
+        null,
         null,
         null,
         null,
@@ -1620,6 +1629,107 @@ describe('ModelDiscoveryService', () => {
       expect(result.map((m) => m.id)).toContain('MiniMax-M2.1');
       expect(result.map((m) => m.id)).toContain('MiniMax-M2');
       expect(result.map((m) => m.id)).not.toContain('MiniMax-M2.5');
+    });
+  });
+
+  /* ── models.dev enrichment ── */
+
+  describe('enrichModel with models.dev (via discoverModels)', () => {
+    it('should use models.dev pricing when available', async () => {
+      const models = [makeModel({ id: 'gemini-2.0-flash', provider: 'gemini' })];
+      fetcher.fetch.mockResolvedValue(models);
+      mockModelsDevSync.lookupPricing.mockReturnValue({
+        input: 0.1 / 1_000_000,
+        output: 0.4 / 1_000_000,
+        contextWindow: 1048576,
+        displayName: 'Gemini 2.0 Flash',
+        reasoning: false,
+      });
+
+      const provider = makeProvider({ provider: 'gemini' });
+      const result = await service.discoverModels(provider);
+
+      expect(result[0].inputPricePerToken).toBeCloseTo(0.1 / 1_000_000);
+      expect(result[0].outputPricePerToken).toBeCloseTo(0.4 / 1_000_000);
+      expect(result[0].displayName).toBe('Gemini 2.0 Flash');
+      expect(mockModelsDevSync.lookupPricing).toHaveBeenCalledWith('gemini-2.0-flash');
+    });
+
+    it('should try models.dev before OpenRouter', async () => {
+      const models = [makeModel({ id: 'gemini-2.0-flash', provider: 'gemini' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      // Both have pricing, but models.dev should win
+      mockModelsDevSync.lookupPricing.mockReturnValue({
+        input: 0.1 / 1_000_000,
+        output: 0.4 / 1_000_000,
+        displayName: 'From ModelsDevSync',
+      });
+      mockPricingSync.lookupPricing.mockReturnValue({
+        input: 0.2 / 1_000_000,
+        output: 0.8 / 1_000_000,
+        displayName: 'From OpenRouter',
+      });
+
+      const provider = makeProvider({ provider: 'gemini' });
+      const result = await service.discoverModels(provider);
+
+      expect(result[0].displayName).toBe('From ModelsDevSync');
+      expect(result[0].inputPricePerToken).toBeCloseTo(0.1 / 1_000_000);
+    });
+
+    it('should fall back to OpenRouter when models.dev has no match', async () => {
+      const models = [makeModel({ id: 'gemini-unknown', provider: 'gemini' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      mockModelsDevSync.lookupPricing.mockReturnValue(null);
+      mockPricingSync.lookupPricing.mockImplementation((key: string) => {
+        if (key === 'google/gemini-unknown') {
+          return {
+            input: 0.5 / 1_000_000,
+            output: 1.0 / 1_000_000,
+            displayName: 'From OpenRouter',
+          };
+        }
+        return null;
+      });
+
+      const provider = makeProvider({ provider: 'gemini' });
+      const result = await service.discoverModels(provider);
+
+      expect(result[0].displayName).toBe('From OpenRouter');
+    });
+
+    it('should apply reasoning capability from models.dev', async () => {
+      const models = [
+        makeModel({ id: 'gemini-2.5-pro', provider: 'gemini', capabilityReasoning: false }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+      mockModelsDevSync.lookupPricing.mockReturnValue({
+        input: 1.25 / 1_000_000,
+        output: 10 / 1_000_000,
+        displayName: 'Gemini 2.5 Pro',
+        reasoning: true,
+      });
+
+      const provider = makeProvider({ provider: 'gemini' });
+      const result = await service.discoverModels(provider);
+
+      expect(mockComputeScore).toHaveBeenCalledWith(
+        expect.objectContaining({ capability_reasoning: true }),
+      );
+    });
+
+    it('should keep null pricing when neither source has a match', async () => {
+      const models = [makeModel({ id: 'gemma-3-1b-it', provider: 'gemini' })];
+      fetcher.fetch.mockResolvedValue(models);
+      mockModelsDevSync.lookupPricing.mockReturnValue(null);
+      mockPricingSync.lookupPricing.mockReturnValue(null);
+
+      const provider = makeProvider({ provider: 'gemini' });
+      const result = await service.discoverModels(provider);
+
+      expect(result[0].inputPricePerToken).toBeNull();
     });
   });
 });

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -9,6 +9,7 @@ import { DiscoveredModel } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
 import { computeQualityScore } from '../database/quality-score.util';
 import { PricingSyncService } from '../database/pricing-sync.service';
+import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { parseOAuthTokenBlob } from '../routing/oauth/openai-oauth.types';
 import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../routing/qwen-region';
 import { CopilotTokenService } from '../routing/proxy/copilot-token.service';
@@ -47,6 +48,9 @@ export class ModelDiscoveryService {
     @Optional()
     @Inject(CopilotTokenService)
     private readonly copilotTokenService: CopilotTokenService | null,
+    @Optional()
+    @Inject(ModelsDevSyncService)
+    private readonly modelsDevSync: ModelsDevSyncService | null,
   ) {}
 
   async discoverModels(provider: UserProvider): Promise<DiscoveredModel[]> {
@@ -237,6 +241,22 @@ export class ModelDiscoveryService {
       return this.computeScore(model);
     }
 
+    // Primary: models.dev (exact model IDs matching provider-native APIs)
+    if (this.modelsDevSync) {
+      const mdsEntry = this.modelsDevSync.lookupPricing(model.id);
+      if (mdsEntry) {
+        return this.computeScore({
+          ...model,
+          inputPricePerToken: mdsEntry.input,
+          outputPricePerToken: mdsEntry.output,
+          contextWindow: mdsEntry.contextWindow ?? model.contextWindow,
+          displayName: mdsEntry.displayName || model.displayName,
+          capabilityReasoning: mdsEntry.reasoning ?? model.capabilityReasoning,
+        });
+      }
+    }
+
+    // Fallback: OpenRouter
     if (this.pricingSync) {
       const orPrefix = findOpenRouterPrefix(providerId);
       if (orPrefix) {

--- a/packages/backend/src/model-prices/model-prices.module.ts
+++ b/packages/backend/src/model-prices/model-prices.module.ts
@@ -4,6 +4,7 @@ import { ModelPricesController } from './model-prices.controller';
 import { ModelPricesService } from './model-prices.service';
 import { ModelPricingCacheService } from './model-pricing-cache.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
+import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
 import { UserProvider } from '../entities/user-provider.entity';
 
@@ -14,8 +15,14 @@ import { UserProvider } from '../entities/user-provider.entity';
     ModelPricesService,
     ModelPricingCacheService,
     PricingSyncService,
+    ModelsDevSyncService,
     ProviderModelRegistryService,
   ],
-  exports: [ModelPricingCacheService, PricingSyncService, ProviderModelRegistryService],
+  exports: [
+    ModelPricingCacheService,
+    PricingSyncService,
+    ModelsDevSyncService,
+    ProviderModelRegistryService,
+  ],
 })
 export class ModelPricesModule {}

--- a/packages/frontend/src/pages/ModelPrices.tsx
+++ b/packages/frontend/src/pages/ModelPrices.tsx
@@ -32,7 +32,12 @@ interface ModelPricesData {
   lastSyncedAt: string | null;
 }
 
-type SortKey = 'model_name' | 'provider' | 'input_price_per_million' | 'output_price_per_million';
+type SortKey =
+  | 'display_name'
+  | 'model_name'
+  | 'provider'
+  | 'input_price_per_million'
+  | 'output_price_per_million';
 type SortDir = 'asc' | 'desc';
 
 function formatPrice(price: number | null): string {
@@ -86,12 +91,20 @@ const ModelPrices: Component = () => {
     });
   });
 
+  const resolveDisplayName = (m: ModelPrice) =>
+    (m.display_name || getModelDisplayName(m.model_name)).replace(/\s*\(free\)/i, '');
+
   const sortedModels = createMemo(() => {
     const models = filteredModels();
     if (!models.length) return [];
     const key = sortKey();
     const dir = sortDir();
     return [...models].sort((a, b) => {
+      if (key === 'display_name') {
+        const av = resolveDisplayName(a);
+        const bv = resolveDisplayName(b);
+        return dir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
+      }
       const av = a[key];
       const bv = b[key];
       if (typeof av === 'string' && typeof bv === 'string') {
@@ -207,6 +220,7 @@ const ModelPrices: Component = () => {
               <thead>
                 <tr>
                   <th>Model</th>
+                  <th>Model ID</th>
                   <th>Provider</th>
                   <th>Cost to send / 1M tokens</th>
                   <th>Cost to receive / 1M tokens</th>
@@ -218,6 +232,9 @@ const ModelPrices: Component = () => {
                     <tr>
                       <td>
                         <div class="skeleton skeleton--text" style="width: 70%;" />
+                      </td>
+                      <td>
+                        <div class="skeleton skeleton--text" style="width: 60%;" />
                       </td>
                       <td>
                         <div class="skeleton skeleton--text" style="width: 60%;" />
@@ -269,8 +286,11 @@ const ModelPrices: Component = () => {
               <table class="data-table">
                 <thead>
                   <tr>
+                    <th class="data-table__sortable" onClick={() => handleSort('display_name')}>
+                      Model{indicator('display_name')}
+                    </th>
                     <th class="data-table__sortable" onClick={() => handleSort('model_name')}>
-                      Model{indicator('model_name')}
+                      Model ID{indicator('model_name')}
                     </th>
                     <th class="data-table__sortable" onClick={() => handleSort('provider')}>
                       Provider{indicator('provider')}
@@ -294,16 +314,22 @@ const ModelPrices: Component = () => {
                 <tbody>
                   <For each={pager.pageItems()}>
                     {(model) => {
-                      const displayName = () =>
+                      const rawName = () =>
                         model.display_name || getModelDisplayName(model.model_name);
+                      const isFree = () => /\(free\)/i.test(rawName());
+                      const displayName = () => rawName().replace(/\s*\(free\)/i, '');
                       const pid = () => resolveProviderId(model.provider);
                       return (
                         <tr>
-                          <td>
-                            <div style="font-size: var(--font-size-sm);">{displayName()}</div>
-                            <div style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                              {model.model_name}
-                            </div>
+                          <td style="font-size: var(--font-size-sm);">
+                            {displayName()}
+                            <Show when={isFree()}>
+                              {' '}
+                              <span class="free-tag">Free</span>
+                            </Show>
+                          </td>
+                          <td style="font-family: var(--font-mono); font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                            {model.model_name}
                           </td>
                           <td>
                             <span style="display: inline-flex; align-items: center; gap: 6px;">

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -495,6 +495,17 @@ h6 {
   color: hsl(var(--destructive));
 }
 
+.free-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: calc(var(--radius) - 4px);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  background: hsl(var(--success));
+  color: hsl(var(--background));
+}
+
 /* ── Security Events ─────────────────────────────── */
 .security-event {
   display: flex;

--- a/packages/frontend/tests/pages/ModelPrices.test.tsx
+++ b/packages/frontend/tests/pages/ModelPrices.test.tsx
@@ -65,7 +65,7 @@ const modelData = {
 async function renderAndWait() {
   const result = render(() => <ModelPrices />);
   await vi.waitFor(() => {
-    expect(result.container.querySelectorAll(".data-table__sortable").length).toBe(4);
+    expect(result.container.querySelectorAll(".data-table__sortable").length).toBe(5);
   });
   return result;
 }
@@ -129,7 +129,7 @@ describe("ModelPrices", () => {
     const { container } = render(() => <ModelPrices />);
     await vi.waitFor(() => {
       const headers = container.querySelectorAll(".data-table__sortable");
-      expect(headers.length).toBe(4);
+      expect(headers.length).toBe(5);
     });
   });
 
@@ -164,7 +164,7 @@ describe("ModelPrices", () => {
       expect(rows.length).toBe(3);
     });
     const headers = container.querySelectorAll(".data-table__sortable");
-    fireEvent.click(headers[2]); // input price column
+    fireEvent.click(headers[3]); // input price column
     await vi.waitFor(() => {
       const rows = container.querySelectorAll("tbody tr");
       const lastRow = rows[rows.length - 1];
@@ -204,6 +204,36 @@ describe("ModelPrices", () => {
     mockGetModelPrices.mockResolvedValue({ models: [], lastSyncedAt: null });
     render(() => <ModelPrices />);
     expect(await screen.findByText("0 models")).toBeDefined();
+  });
+
+  it("shows Free badge and strips (free) from display name", async () => {
+    const dataWithFree = {
+      models: [
+        { model_name: "nvidia/llama-3.1-nemotron-70b-instruct:free", provider: "OpenRouter", display_name: "Nemotron 3 Super (free)", input_price_per_million: 0, output_price_per_million: 0 },
+        { model_name: "gpt-4o", provider: "OpenAI", display_name: "GPT-4o", input_price_per_million: 2.5, output_price_per_million: 10 },
+      ],
+      lastSyncedAt: null,
+    };
+    mockGetModelPrices.mockResolvedValue(dataWithFree);
+    const { container } = render(() => <ModelPrices />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Nemotron 3 Super");
+      const badge = container.querySelector(".free-tag");
+      expect(badge).not.toBeNull();
+      expect(badge!.textContent).toBe("Free");
+      // "(free)" should not appear as raw text
+      const rows = container.querySelectorAll("tbody tr");
+      const firstRowText = rows[0].textContent!;
+      expect(firstRowText).not.toContain("(free)");
+    });
+  });
+
+  it("does not show Free badge for non-free models", async () => {
+    const { container } = render(() => <ModelPrices />);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("gpt-4o");
+      expect(container.querySelector(".free-tag")).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- **Model Prices page**: Split the single "Model" column into "Model" (display name) and "Model ID" (technical identifier) for clarity. Both columns are independently sortable.
- **Free badge**: Models with "(free)" in their name now show a green "Free" badge instead of raw parenthesized text.
- **models.dev integration**: Added `ModelsDevSyncService` as the primary pricing enrichment source for Gemini models. OpenRouter remains as fallback. This fixes pricing gaps caused by ID mismatches between Google's API and OpenRouter (e.g. `gemini-2.0-flash` vs `google/gemini-2.0-flash-001`).

### What models.dev fixes for Gemini

| Issue | Before | After |
|---|---|---|
| Alias models (gemini-2.0-flash) | No price | $0.10 / $0.40 |
| TTS models | No price | $0.50 / $10.00 |
| Latest aliases (gemini-flash-latest) | No price | $0.30 / $2.50 |
| Display names ("Nano Banana") | OpenRouter overrides | Official Google names |

## Test plan

- [ ] Backend tests pass (`npx jest --testPathPattern="models-dev-sync|model-discovery"`)
- [ ] Frontend tests pass (`npx vitest run tests/pages/ModelPrices.test.tsx`)
- [ ] Model Prices page shows 5 columns (Model, Model ID, Provider, Cost in, Cost out)
- [ ] Free models show green badge instead of "(free)" text
- [ ] Gemini models on Routing page show correct pricing after connecting a Google provider

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Model Prices page and enriches Gemini pricing using `models.dev`, fixing missing prices caused by Google/OpenRouter ID mismatches. Adds a clearer UI with a separate Model ID column and a "Free" badge.

- **New Features**
  - Split "Model" into "Model" (display name) and "Model ID" with independent sorting.
  - Replace "(free)" in names with a green "Free" badge.
  - Add `ModelsDevSyncService` to prioritize `models.dev` pricing for Gemini; `OpenRouter` remains as fallback.
  - Fix pricing for Gemini aliases, TTS, and latest alias models; use official Google display names.
  - Cache refresh scheduled nightly to keep `models.dev` data up to date.

<sup>Written for commit dec216843c846a9de0d23778f76aa6afe605c6dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

