### PR TITLE
fix: deduplicate OpenAI dated model snapshots and add dashboard URL to no-provider message

### DIFF
--- a/.changeset/fix-doubled-models.md
+++ b/.changeset/fix-doubled-models.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: deduplicate OpenAI dated model snapshots and add dashboard URL to no-provider message

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -227,6 +227,25 @@ describe('ProviderModelFetcherService', () => {
       const result = await service.fetch('openai', 'sk-test');
       expect(result.map((m) => m.id)).toEqual(['codex-mini-latest']);
     });
+
+    it('should deduplicate dated snapshots when alias exists', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'gpt-4o-mini' },
+            { id: 'gpt-4o-mini-2024-07-18' },
+            { id: 'gpt-4o' },
+            { id: 'gpt-4o-2024-08-06' },
+            { id: 'o3-mini-2025-01-31' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openai', 'sk-test');
+      // Dated snapshots removed when alias exists; o3-mini-2025-01-31 kept (no alias)
+      expect(result.map((m) => m.id)).toEqual(['gpt-4o-mini', 'gpt-4o', 'o3-mini-2025-01-31']);
+    });
   });
 
   /* ── Mistral-specific filter ── */

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -76,6 +76,9 @@ const parseOpenAI = createModelParser<OpenAIModelEntry>({
 const OPENAI_NON_CHAT_RE =
   /(?:embed|tts|whisper|dall-e|moderation|davinci|babbage|^text-|audio|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct)/i;
 
+/** Date-suffixed snapshots returned by OpenAI (e.g. gpt-4o-mini-2024-07-18). */
+const OPENAI_DATE_SUFFIX_RE = /-\d{4}-\d{2}-\d{2}$/;
+
 /**
  * OpenAI models only supported in v1/responses (not v1/chat/completions).
  * Codex models (except codex-mini-latest) and -pro variants of GPT-5+.
@@ -83,9 +86,18 @@ const OPENAI_NON_CHAT_RE =
 const OPENAI_RESPONSES_ONLY_RE = /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$))/i;
 
 function parseOpenAIChatOnly(body: unknown, provider: string): DiscoveredModel[] {
-  return parseOpenAI(body, provider).filter(
+  const filtered = parseOpenAI(body, provider).filter(
     (m) => !OPENAI_NON_CHAT_RE.test(m.id) && !OPENAI_RESPONSES_ONLY_RE.test(m.id),
   );
+
+  // Deduplicate: if both an alias (gpt-4o-mini) and a dated snapshot
+  // (gpt-4o-mini-2024-07-18) exist, keep only the alias.
+  const ids = new Set(filtered.map((m) => m.id));
+  return filtered.filter((m) => {
+    if (!OPENAI_DATE_SUFFIX_RE.test(m.id)) return true;
+    const alias = m.id.replace(OPENAI_DATE_SUFFIX_RE, '');
+    return !ids.has(alias);
+  });
 }
 
 /**

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, HttpException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Repository } from 'typeorm';
 import { ProxyService } from '../proxy.service';
 import { ProxyFallbackService } from '../proxy-fallback.service';
@@ -28,6 +29,7 @@ describe('ProxyService', () => {
   let copilotToken: jest.Mocked<CopilotTokenService>;
   let limitCheck: jest.Mocked<LimitCheckService>;
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
+  let configService: jest.Mocked<ConfigService>;
   let fallbackService: ProxyFallbackService;
 
   beforeEach(() => {
@@ -84,6 +86,14 @@ describe('ProxyService', () => {
       getAll: jest.fn().mockReturnValue([]),
     } as unknown as jest.Mocked<ModelPricingCacheService>;
 
+    configService = {
+      get: jest.fn((key: string, fallback?: unknown) => {
+        if (key === 'app.betterAuthUrl') return 'http://localhost:3001';
+        if (key === 'app.port') return 3001;
+        return fallback;
+      }),
+    } as unknown as jest.Mocked<ConfigService>;
+
     fallbackService = new ProxyFallbackService(
       providerKeyService,
       customProviderRepo,
@@ -103,6 +113,7 @@ describe('ProxyService', () => {
       momentum,
       limitCheck,
       fallbackService,
+      configService,
     );
   });
 
@@ -281,6 +292,29 @@ describe('ProxyService', () => {
       confidence: 1,
       reason: 'no_provider',
     });
+  });
+
+  it('includes dashboard URL with agent name in no-provider response', async () => {
+    resolveService.resolve.mockResolvedValue({
+      tier: 'simple',
+      model: null,
+      provider: null,
+      confidence: 0.5,
+      score: -0.1,
+      reason: 'ambiguous',
+    });
+
+    const result = await service.proxyRequest({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      body,
+      sessionKey: 'default',
+      agentName: 'my-agent',
+    });
+
+    const json = (await result.forward.response.json()) as Record<string, unknown>;
+    const choices = json.choices as { message: { content: string } }[];
+    expect(choices[0].message.content).toContain('http://localhost:3001/routing/my-agent');
   });
 
   it('returns synthetic streaming response when no model is resolved', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -317,6 +317,58 @@ describe('ProxyService', () => {
     expect(choices[0].message.content).toContain('http://localhost:3001/routing/my-agent');
   });
 
+  it('uses /routing path when agentName is not provided', async () => {
+    resolveService.resolve.mockResolvedValue({
+      tier: 'simple',
+      model: null,
+      provider: null,
+      confidence: 0.5,
+      score: -0.1,
+      reason: 'ambiguous',
+    });
+
+    const result = await service.proxyRequest({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      body,
+      sessionKey: 'default',
+    });
+
+    const json = (await result.forward.response.json()) as Record<string, unknown>;
+    const choices = json.choices as { message: { content: string } }[];
+    expect(choices[0].message.content).toContain('http://localhost:3001/routing');
+    expect(choices[0].message.content).not.toContain('/routing/');
+  });
+
+  it('falls back to localhost URL when betterAuthUrl is empty', async () => {
+    configService.get.mockImplementation((key: string, fallback?: unknown) => {
+      if (key === 'app.betterAuthUrl') return '';
+      if (key === 'app.port') return 4000;
+      return fallback;
+    });
+
+    resolveService.resolve.mockResolvedValue({
+      tier: 'simple',
+      model: null,
+      provider: null,
+      confidence: 0.5,
+      score: -0.1,
+      reason: 'ambiguous',
+    });
+
+    const result = await service.proxyRequest({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      body,
+      sessionKey: 'default',
+      agentName: 'test-agent',
+    });
+
+    const json = (await result.forward.response.json()) as Record<string, unknown>;
+    const choices = json.choices as { message: { content: string } }[];
+    expect(choices[0].message.content).toContain('http://localhost:4000/routing/test-agent');
+  });
+
   it('returns synthetic streaming response when no model is resolved', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'simple',

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -274,7 +274,7 @@ export class ProxyService {
     return false;
   }
 
-  private getDashboardUrl(agentName?: string): string | null {
+  private getDashboardUrl(agentName?: string): string {
     const baseUrl =
       this.config.get<string>('app.betterAuthUrl') ||
       `http://localhost:${this.config.get<number>('app.port', 3001)}`;
@@ -286,9 +286,7 @@ export class ProxyService {
     const id = `chatcmpl-manifest-${randomUUID()}`;
     const created = Math.floor(Date.now() / 1000);
     const dashboardUrl = this.getDashboardUrl(agentName);
-    const content = dashboardUrl
-      ? `Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`
-      : 'Manifest is connected successfully. To start routing requests, connect a model provider in your Manifest dashboard.';
+    const content = `Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`;
 
     const meta: RoutingMeta = {
       tier: 'simple' as Tier,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto';
 import { Injectable, Logger, BadRequestException, HttpException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ResolveService } from '../resolve/resolve.service';
 import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { TierService } from '../routing-core/tier.service';
@@ -61,6 +62,7 @@ export class ProxyService {
     private readonly momentum: SessionMomentumService,
     private readonly limitCheck: LimitCheckService,
     private readonly fallbackService: ProxyFallbackService,
+    private readonly config: ConfigService,
   ) {}
 
   async proxyRequest(opts: ProxyRequestOptions): Promise<ProxyResult> {
@@ -95,7 +97,7 @@ export class ProxyService {
           `tier=${resolved.tier} model=${resolved.model} provider=${resolved.provider} ` +
           `confidence=${resolved.confidence} reason=${resolved.reason}`,
       );
-      return this.buildNoProviderResult(body.stream === true);
+      return this.buildNoProviderResult(body.stream === true, agentName);
     }
 
     let apiKey = await this.providerKeyService.getProviderApiKey(
@@ -272,11 +274,21 @@ export class ProxyService {
     return false;
   }
 
-  private buildNoProviderResult(stream: boolean): ProxyResult {
+  private getDashboardUrl(agentName?: string): string | null {
+    const baseUrl =
+      this.config.get<string>('app.betterAuthUrl') ||
+      `http://localhost:${this.config.get<number>('app.port', 3001)}`;
+    const path = agentName ? `/routing/${encodeURIComponent(agentName)}` : '/routing';
+    return `${baseUrl}${path}`;
+  }
+
+  private buildNoProviderResult(stream: boolean, agentName?: string): ProxyResult {
     const id = `chatcmpl-manifest-${randomUUID()}`;
     const created = Math.floor(Date.now() / 1000);
-    const content =
-      'Manifest is connected successfully. To start routing requests, connect a model provider in your Manifest dashboard.';
+    const dashboardUrl = this.getDashboardUrl(agentName);
+    const content = dashboardUrl
+      ? `Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`
+      : 'Manifest is connected successfully. To start routing requests, connect a model provider in your Manifest dashboard.';
 
     const meta: RoutingMeta = {
       tier: 'simple' as Tier,


### PR DESCRIPTION
## Summary

- **Deduplicate OpenAI models**: OpenAI's `/v1/models` API returns both aliases (`gpt-4o-mini`) and dated snapshots (`gpt-4o-mini-2024-07-18`). During enrichment both get the same display name from OpenRouter, appearing as duplicates in the model picker. Added deduplication to `parseOpenAIChatOnly` that filters out dated snapshots when the alias exists — mirroring the existing Gemini version-suffix dedup logic.
- **Dashboard URL in no-provider message**: The proxy response when no providers are connected now includes a direct URL to the agent's routing page (e.g. `http://localhost:3001/routing/my-agent`) so users can navigate directly to connect a provider.

Closes #1375

## Test plan

- [ ] Backend unit tests pass (157 suites, 3003 tests)
- [ ] TypeScript compiles with no errors
- [ ] Connect OpenAI via API key and verify no duplicate models in the model picker
- [ ] Send a proxy request with no providers connected and verify the response includes the dashboard URL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes duplicate OpenAI models by filtering dated snapshots when an alias exists, and adds a direct dashboard routing URL to the “no providers connected” proxy response with sensible fallbacks.

- **Bug Fixes**
  - OpenAI model parsing drops date-suffixed snapshots when the alias exists (e.g., keep gpt-4o-mini, drop gpt-4o-mini-2024-07-18).

- **New Features**
  - “No provider” responses include the routing dashboard URL using `app.betterAuthUrl` or fall back to `http://localhost:<app.port>`.
  - Includes the agent path when available (e.g., http://localhost:3001/routing/my-agent) or defaults to /routing when not provided.

<sup>Written for commit 6dd72e16de51dfc225254213c662113781f8b2fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

