### PR TITLE
fix: prevent Chrome password save prompt on provider key inputs

### DIFF
--- a/.changeset/disable-store-password.md
+++ b/.changeset/disable-store-password.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Prevent Chrome password save prompt on provider API key inputs by using text-security CSS masking instead of type=password.

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -133,9 +133,10 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
         <div class="provider-detail__field">
           <label class="provider-detail__label">{fieldLabel()}</label>
           <input
-            class="provider-detail__input"
+            class="provider-detail__input provider-detail__input--masked"
             classList={{ 'provider-detail__input--error': !!props.validationError() }}
-            type="password"
+            type="text"
+            autocomplete="off"
             placeholder={placeholder()}
             aria-label={inputAriaLabel()}
             value={props.keyInput()}
@@ -228,9 +229,10 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
           </Show>
           <Show when={props.editing()}>
             <input
-              class="provider-detail__input"
+              class="provider-detail__input provider-detail__input--masked"
               classList={{ 'provider-detail__input--error': !!props.validationError() }}
-              type="password"
+              type="text"
+              autocomplete="off"
               placeholder={placeholder()}
               aria-label={editAriaLabel()}
               value={props.keyInput()}

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1947,7 +1947,7 @@ describe('ProviderSelectModal', () => {
       ));
       fireEvent.click(screen.getByText('OpenAI'));
       // Should not have a setup token input field
-      const inputs = document.querySelectorAll("input[type='password']");
+      const inputs = document.querySelectorAll(".provider-detail__input--masked");
       expect(inputs.length).toBe(0);
     });
 


### PR DESCRIPTION
## Summary

- Replace `type="password"` with `type="text"` + `autocomplete="off"` + CSS `text-security: disc` masking on `ProviderKeyForm` inputs
- Prevents Chrome from detecting API key fields as password fields and offering to save credentials
- Follows the same pattern already used by `CustomProviderForm` and `EmailProviderModal`

## Test plan

- [ ] Open Routing page, click a provider to connect
- [ ] Enter an API key — text should be visually masked (dots) but Chrome should NOT offer to save password
- [ ] Click "Change" on a connected provider — same behavior on the edit input
- [ ] Frontend tests pass (`npm test --workspace=packages/frontend`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop Chrome from offering to save passwords on provider API key fields by switching `ProviderKeyForm` inputs to masked text with autocomplete disabled. Keys stay visually masked and this now matches `CustomProviderForm` and `EmailProviderModal`.

- **Bug Fixes**
  - Replaced password inputs with type="text" + autocomplete="off" and CSS masking via `.provider-detail__input--masked` in `ProviderKeyForm`.
  - Updated tests to target the masked input class instead of password type.

<sup>Written for commit 559107a97b4dceb2d47653c541f54cebb1f0e9fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

