### PR TITLE
fix: resolve HTTP 400 errors from Anthropic API via routing proxy

### DIFF
--- a/.changeset/fix-anthropic-400-errors.md
+++ b/.changeset/fix-anthropic-400-errors.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix HTTP 400 errors from Anthropic API via routing proxy: remove redundant top-level cache_control field and filter empty text content blocks in assistant messages with tool_calls. Surface actual upstream error messages in development mode.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -73,12 +73,12 @@ describe('Anthropic Adapter', () => {
       expect(system[1].cache_control).toEqual({ type: 'ephemeral' });
     });
 
-    it('includes top-level cache_control for automatic caching', () => {
+    it('does not include top-level cache_control', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hello' }],
       };
       const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
-      expect(result.cache_control).toEqual({ type: 'ephemeral' });
+      expect(result.cache_control).toBeUndefined();
     });
 
     it('defaults max_tokens to 4096 when absent', () => {
@@ -257,6 +257,45 @@ describe('Anthropic Adapter', () => {
       expect(messages).toHaveLength(2);
     });
 
+    it('filters empty string content on assistant messages with tool_calls', () => {
+      const body = {
+        messages: [
+          { role: 'user', content: 'Hello' },
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              { id: 'tc1', type: 'function', function: { name: 'search', arguments: '{}' } },
+            ],
+          },
+          { role: 'tool', content: 'result', tool_call_id: 'tc1' },
+          { role: 'user', content: 'Thanks' },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+
+      const messages = result.messages as Array<{ role: string; content: Array<{ type: string }> }>;
+      const assistant = messages.find((m) => m.role === 'assistant');
+      expect(assistant).toBeDefined();
+      expect(assistant!.content).toHaveLength(1);
+      expect(assistant!.content[0].type).toBe('tool_use');
+    });
+
+    it('omits assistant message with empty string content and no tool_calls', () => {
+      const body = {
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: '' },
+          { role: 'user', content: 'Bye' },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+
+      const messages = result.messages as Array<{ role: string }>;
+      expect(messages).toHaveLength(2);
+      expect(messages.every((m) => m.role === 'user')).toBe(true);
+    });
+
     it('omits system key when no system messages exist', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],
@@ -392,7 +431,7 @@ describe('Anthropic Adapter', () => {
       expect(tools[1].cache_control).toBeUndefined();
     });
 
-    it('injects cache_control by default when options is undefined', () => {
+    it('injects cache_control on system blocks and tools by default', () => {
       const body = {
         messages: [
           { role: 'system', content: 'You are helpful.' },
@@ -401,7 +440,7 @@ describe('Anthropic Adapter', () => {
         tools: [{ type: 'function', function: { name: 'a', description: 'tool a' } }],
       };
       const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
-      expect(result.cache_control).toEqual({ type: 'ephemeral' });
+      expect(result.cache_control).toBeUndefined();
       const system = result.system as Array<{ cache_control?: unknown }>;
       expect(system[system.length - 1].cache_control).toEqual({ type: 'ephemeral' });
       const tools = result.tools as Array<{ cache_control?: unknown }>;

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -220,7 +220,7 @@ describe('ProviderClient', () => {
       expect(headers['anthropic-beta']).toBeUndefined();
     });
 
-    it('includes top-level cache_control in Anthropic request body', async () => {
+    it('does not include top-level cache_control in Anthropic request body', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       await client.forward({
@@ -232,7 +232,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.cache_control).toEqual({ type: 'ephemeral' });
+      expect(sentBody.cache_control).toBeUndefined();
     });
 
     it('converts request body to Anthropic format with model', async () => {
@@ -312,7 +312,7 @@ describe('ProviderClient', () => {
       expect(tools[0].cache_control).toBeUndefined();
     });
 
-    it('includes cache_control for regular Anthropic API key auth', async () => {
+    it('includes block-level cache_control for regular Anthropic API key auth', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       const bodyWithSystem = {
@@ -332,7 +332,7 @@ describe('ProviderClient', () => {
       });
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.cache_control).toEqual({ type: 'ephemeral' });
+      expect(sentBody.cache_control).toBeUndefined();
       const system = sentBody.system as Array<{ cache_control?: unknown }>;
       expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
       const tools = sentBody.tools as Array<{ cache_control?: unknown }>;

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -250,6 +250,36 @@ describe('proxy-response-handler', () => {
 
       expect(res.status).toHaveBeenCalledWith(500);
     });
+
+    it('should surface actual error message in development mode', async () => {
+      const originalEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      try {
+        const { res } = mockResponse();
+        const recorder = mockRecorder();
+        const meta = makeMeta();
+        const metaHeaders = buildMetaHeaders(meta);
+
+        await handleProviderError(
+          res as any,
+          testCtx,
+          meta,
+          metaHeaders,
+          400,
+          JSON.stringify({ error: { message: 'Invalid model' } }),
+          undefined,
+          recorder as any,
+        );
+
+        expect(res.json).toHaveBeenCalledWith(
+          expect.objectContaining({
+            error: expect.objectContaining({ message: 'Invalid model' }),
+          }),
+        );
+      } finally {
+        process.env.NODE_ENV = originalEnv;
+      }
+    });
   });
 
   /* ── recordFallbackFailures ── */

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -277,7 +277,11 @@ describe('proxy-response-handler', () => {
           }),
         );
       } finally {
-        process.env.NODE_ENV = originalEnv;
+        if (originalEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = originalEnv;
+        }
       }
     });
   });

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -55,7 +55,7 @@ function extractSystemBlocks(messages: OpenAIMessage[]): ContentBlock[] {
 }
 
 function toContentBlocks(content: unknown): ContentBlock[] {
-  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  if (typeof content === 'string') return content ? [{ type: 'text', text: content }] : [];
   if (Array.isArray(content)) {
     return (content as Array<Record<string, unknown>>)
       .filter((b) => b.type === 'text' && typeof b.text === 'string')
@@ -138,8 +138,6 @@ export function toAnthropicRequest(
     messages: converted,
     max_tokens: (body.max_tokens as number) || 4096,
   };
-  if (shouldCache) result.cache_control = { type: 'ephemeral' };
-
   if (systemBlocks.length > 0) result.system = systemBlocks;
 
   const tools = convertTools(body.tools as Array<Record<string, unknown>> | undefined);

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -75,7 +75,7 @@ export async function handleProviderError(
   setHeaders(res, metaHeaders);
   res.json({
     error: {
-      message: sanitizeProviderError(errorStatus, errorBody),
+      message: sanitizeProviderError(errorStatus, errorBody, process.env.NODE_ENV),
       type: 'upstream_error',
       status: errorStatus,
     },
@@ -115,7 +115,7 @@ function handleFallbackExhausted(
   res.setHeader('X-Manifest-Fallback-Exhausted', 'true');
   res.json({
     error: {
-      message: sanitizeProviderError(errorStatus, errorBody),
+      message: sanitizeProviderError(errorStatus, errorBody, process.env.NODE_ENV),
       type: 'fallback_exhausted',
       status: errorStatus,
       primary_model: meta.model,


### PR DESCRIPTION
## Summary

- Remove redundant top-level `cache_control` field from Anthropic request body — block-level injection on system blocks and tools already provides full prompt caching
- Filter empty text content blocks produced when `sanitizeNullContent` converts `null` to empty string on assistant messages with tool_calls
- Surface actual upstream error messages in development mode (`NODE_ENV=development`) for easier debugging

## Test plan

- [x] Unit tests pass (180 tests across anthropic-adapter, provider-client, proxy-response-handler)
- [x] TypeScript compilation clean (no errors in modified files)
- [x] Manual verification: Anthropic subscription auth → 200 OK
- [x] Manual verification: Anthropic API key auth → 200 OK
- [x] Manual verification: Complex request with system prompt + null content + tool calls → 200 OK

Fixes #1374

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes HTTP 400 errors from the Anthropic API when requests go through the routing proxy by aligning the request shape and surfacing clearer errors in development.

- **Bug Fixes**
  - Removed top-level `cache_control`; keep caching hints only on system blocks and tools.
  - Filtered empty text blocks: for assistant with `tool_calls`, keep only `tool_use`; if assistant is empty with no `tool_calls`, drop the message.
  - In `NODE_ENV=development`, return the upstream provider error message to aid debugging.

<sup>Written for commit 783958ca89495c7686962862e8b7826a7f2d1646. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

