### PR TITLE
fix: fallback chain tries alternate auth type for same provider

### DIFF
--- a/.changeset/fix-fallback-auth-type.md
+++ b/.changeset/fix-fallback-auth-type.md
@@ -1,0 +1,7 @@
+---
+"manifest": patch
+---
+
+fix: fallback chain now tries alternate auth type for same provider (#1272)
+
+When both subscription and API key credentials exist for the same provider, the fallback chain previously reused the same (failing) auth type instead of trying the alternate credential. This resulted in 424 errors even when a valid API key was available as fallback.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -415,6 +415,131 @@ describe('ProxyFallbackService', () => {
       expect(result.success!.provider).toBe('custom:cp-1');
     });
 
+    it('tries alternate auth_type for same provider when primary failed (#1272)', async () => {
+      providerKeyService.getAuthType.mockImplementation(
+        async (_agentId: string, _provider: string, exclude?: Set<string>) => {
+          if (exclude && exclude.has('subscription')) return 'api_key';
+          return 'subscription';
+        },
+      );
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-api-key');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+      pricingCache.getByModel.mockReturnValue({ provider: 'Anthropic' } as never);
+
+      const result = await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['claude-sonnet-4'],
+        body,
+        false,
+        'sess-1',
+        'gpt-4o',
+        undefined,
+        'anthropic',
+        'subscription',
+      );
+
+      expect(result.success).not.toBeNull();
+      // getAuthType should have been called with the exclusion set
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith(
+        'agent-1',
+        'Anthropic',
+        new Set(['subscription']),
+      );
+      // getProviderApiKey should use the alternate auth type
+      expect(providerKeyService.getProviderApiKey).toHaveBeenCalledWith(
+        'agent-1',
+        'Anthropic',
+        'api_key',
+      );
+    });
+
+    it('does not exclude auth types for different provider', async () => {
+      providerKeyService.getAuthType.mockResolvedValue('api_key');
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      pricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' } as never);
+
+      await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['gpt-4o'],
+        body,
+        false,
+        'sess-1',
+        'claude-sonnet-4',
+        undefined,
+        'anthropic',
+        'subscription',
+      );
+
+      // OpenAI is a different provider, so no exclusion set should be passed
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith(
+        'agent-1',
+        'OpenAI',
+        undefined,
+      );
+    });
+
+    it('accumulates failed auth types across same-provider fallbacks', async () => {
+      providerKeyService.getAuthType
+        .mockResolvedValueOnce('api_key')
+        .mockResolvedValueOnce('api_key');
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('error', { status: 401 }),
+          isGoogle: false,
+          isAnthropic: true,
+          isChatGpt: false,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('error', { status: 401 }),
+          isGoogle: false,
+          isAnthropic: true,
+          isChatGpt: false,
+        });
+      pricingCache.getByModel.mockReturnValue({ provider: 'Anthropic' } as never);
+
+      await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['claude-sonnet-4', 'claude-haiku-3.5'],
+        body,
+        false,
+        'sess-1',
+        'gpt-4o',
+        undefined,
+        'anthropic',
+        'subscription',
+      );
+
+      // First call: exclusion contains 'subscription' (from primary)
+      expect(providerKeyService.getAuthType).toHaveBeenNthCalledWith(
+        1,
+        'agent-1',
+        'Anthropic',
+        new Set(['subscription']),
+      );
+      // Second call: exclusion now also contains 'api_key' (from first fallback failure)
+      expect(providerKeyService.getAuthType).toHaveBeenNthCalledWith(
+        2,
+        'agent-1',
+        'Anthropic',
+        new Set(['subscription', 'api_key']),
+      );
+    });
+
     it('stops chain on non-retriable status (424)', async () => {
       providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -2211,8 +2211,8 @@ describe('ProxyService', () => {
         stream: false,
         authType: 'subscription',
       });
-      // getAuthType was called for the fallback provider
-      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'Anthropic');
+      // getAuthType was called for the fallback provider (different provider, no exclusions)
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'Anthropic', undefined);
       // getProviderApiKey was called with subscription for the fallback
       expect(providerKeyService.getProviderApiKey).toHaveBeenNthCalledWith(
         2,
@@ -2442,9 +2442,9 @@ describe('ProxyService', () => {
       // forward called twice: primary + second fallback (first was skipped)
       expect(providerClient.forward).toHaveBeenCalledTimes(2);
       expect(result.failedFallbacks).toHaveLength(0);
-      // Verify getAuthType was called for both fallback providers
-      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'Anthropic');
-      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'DeepSeek');
+      // Verify getAuthType was called for both fallback providers (different from primary, no exclusions)
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'Anthropic', undefined);
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'DeepSeek', undefined);
     });
 
     it('resolves fallback provider via findProviderForModel when pricing and name inference fail', async () => {
@@ -2637,6 +2637,57 @@ describe('ProxyService', () => {
       expect(result.forward.response.status).toBe(424);
       expect(shouldTriggerFallback(result.forward.response.status)).toBe(false);
       expect(result.failedFallbacks).toHaveLength(2);
+    });
+  });
+
+  describe('auth type fallback for same provider (#1272)', () => {
+    it('passes primary provider and auth_type to tryFallbacks', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'claude-sonnet-4',
+        provider: 'anthropic',
+        confidence: 0.9,
+        score: 0.5,
+        reason: 'scored',
+        auth_type: 'subscription',
+      });
+      providerKeyService.getProviderApiKey.mockResolvedValue('sub-token');
+
+      // Primary fails
+      providerClient.forward.mockResolvedValueOnce({
+        response: new Response('error', { status: 401 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+
+      tierService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: ['claude-haiku-3.5'] },
+      ] as never);
+
+      // Fallback also fails so we get 424
+      providerKeyService.getAuthType.mockResolvedValue('api_key');
+      providerClient.forward.mockResolvedValueOnce({
+        response: new Response('also error', { status: 500 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+      pricingCache.getByModel.mockReturnValue({ provider: 'Anthropic' } as never);
+
+      await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body,
+        sessionKey: 'default',
+      });
+
+      // Verify tryFallbacks receives primary context so it can exclude auth_type
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith(
+        'agent-1',
+        'Anthropic',
+        new Set(['subscription']),
+      );
     });
   });
 

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -58,6 +58,8 @@ export class ProxyFallbackService {
     sessionKey: string,
     primaryModel: string,
     signal?: AbortSignal,
+    primaryProvider?: string,
+    primaryAuthType?: string,
   ): Promise<{
     success: {
       forward: ForwardResult;
@@ -68,6 +70,14 @@ export class ProxyFallbackService {
     failures: FailedFallback[];
   }> {
     const failures: FailedFallback[] = [];
+
+    // Track auth types that already failed per provider so fallbacks for the
+    // same provider try a different credential (fixes #1272).
+    const failedAuthByProvider = new Map<string, Set<string>>();
+    if (primaryProvider && primaryAuthType) {
+      failedAuthByProvider.set(primaryProvider.toLowerCase(), new Set([primaryAuthType]));
+    }
+
     for (let i = 0; i < fallbackModels.length; i++) {
       const requestedModel = fallbackModels[i];
       const pricing = this.pricingCache.getByModel(requestedModel);
@@ -89,7 +99,8 @@ export class ProxyFallbackService {
         continue;
       }
       const model = normalizeProviderModel(provider, requestedModel);
-      const authType = await this.providerKeyService.getAuthType(agentId, provider);
+      const excludeAuth = failedAuthByProvider.get(provider.toLowerCase());
+      const authType = await this.providerKeyService.getAuthType(agentId, provider, excludeAuth);
       let apiKey = await this.providerKeyService.getProviderApiKey(agentId, provider, authType);
       if (apiKey === null) {
         this.logger.debug(
@@ -142,6 +153,15 @@ export class ProxyFallbackService {
         status: forward.response.status,
         errorBody,
       });
+
+      // Record this auth type as failed for the provider so subsequent
+      // fallback models from the same provider try a different credential.
+      // Create a new Set to avoid mutating the reference passed to getAuthType.
+      const existing = failedAuthByProvider.get(provider.toLowerCase());
+      const updated = new Set(existing);
+      updated.add(authType);
+      failedAuthByProvider.set(provider.toLowerCase(), updated);
+
       if (!shouldTriggerFallback(forward.response.status)) break;
     }
     return { success: null, failures };

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -159,6 +159,8 @@ export class ProxyService {
           sessionKey,
           primaryModel,
           signal,
+          resolved.provider ?? undefined,
+          resolved.auth_type,
         );
 
         if (success) {

--- a/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
@@ -315,6 +315,67 @@ describe('ProviderKeyService', () => {
 
       expect(result).toBe('api_key');
     });
+
+    it('should return api_key when subscription is excluded and both exist', async () => {
+      providerService.getProviders.mockResolvedValue([
+        makeProvider({ id: 'p1', auth_type: 'subscription', api_key_encrypted: 'enc-sub' }),
+        makeProvider({ id: 'p2', auth_type: 'api_key', api_key_encrypted: 'enc-api' }),
+      ]);
+
+      const result = await service.getAuthType('agent-1', 'openai', new Set(['subscription']));
+
+      expect(result).toBe('api_key');
+    });
+
+    it('should return subscription when api_key is excluded and both exist', async () => {
+      providerService.getProviders.mockResolvedValue([
+        makeProvider({ id: 'p1', auth_type: 'subscription', api_key_encrypted: 'enc-sub' }),
+        makeProvider({ id: 'p2', auth_type: 'api_key', api_key_encrypted: 'enc-api' }),
+      ]);
+
+      const result = await service.getAuthType('agent-1', 'openai', new Set(['api_key']));
+
+      expect(result).toBe('subscription');
+    });
+
+    it('should fall through to default when all auth types excluded', async () => {
+      providerService.getProviders.mockResolvedValue([
+        makeProvider({ id: 'p1', auth_type: 'subscription', api_key_encrypted: 'enc-sub' }),
+        makeProvider({ id: 'p2', auth_type: 'api_key', api_key_encrypted: 'enc-api' }),
+      ]);
+
+      const result = await service.getAuthType(
+        'agent-1',
+        'openai',
+        new Set(['subscription', 'api_key']),
+      );
+
+      // Falls through because filtered set is empty — original logic applies
+      expect(result).toBe('subscription');
+    });
+
+    it('should ignore exclusions when only one auth type exists', async () => {
+      providerService.getProviders.mockResolvedValue([
+        makeProvider({ id: 'p1', auth_type: 'api_key', api_key_encrypted: 'enc-api' }),
+      ]);
+
+      const result = await service.getAuthType('agent-1', 'openai', new Set(['api_key']));
+
+      // Falls through because filtering leaves empty set
+      expect(result).toBe('api_key');
+    });
+
+    it('should behave the same with empty exclusion set', async () => {
+      providerService.getProviders.mockResolvedValue([
+        makeProvider({ id: 'p1', auth_type: 'subscription', api_key_encrypted: 'enc-sub' }),
+        makeProvider({ id: 'p2', auth_type: 'api_key', api_key_encrypted: 'enc-api' }),
+      ]);
+
+      const result = await service.getAuthType('agent-1', 'openai', new Set());
+
+      // Empty set has size 0, so exclusion logic is skipped — defaults to subscription
+      expect(result).toBe('subscription');
+    });
   });
 
   /* ── findProviderForModel ── */

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -43,10 +43,20 @@ export class ProviderKeyService {
     return result;
   }
 
-  async getAuthType(agentId: string, provider: string): Promise<'api_key' | 'subscription'> {
+  async getAuthType(
+    agentId: string,
+    provider: string,
+    excludeAuthTypes?: Set<string>,
+  ): Promise<'api_key' | 'subscription'> {
     const names = expandProviderNames([provider]);
     const records = await this.providerService.getProviders(agentId);
-    const matches = records.filter((r) => r.is_active && names.has(r.provider.toLowerCase()));
+    let matches = records.filter((r) => r.is_active && names.has(r.provider.toLowerCase()));
+    // When the caller knows certain auth types already failed (e.g. during
+    // fallback retries), filter them out so the alternate type is preferred.
+    if (excludeAuthTypes && excludeAuthTypes.size > 0) {
+      const filtered = matches.filter((r) => !excludeAuthTypes.has(r.auth_type));
+      if (filtered.length > 0) matches = filtered;
+    }
     // Prefer subscription if both exist and the subscription record has a usable key
     const subMatch = matches.find((r) => r.auth_type === 'subscription' && r.api_key_encrypted);
     if (subMatch) return 'subscription';


### PR DESCRIPTION
## Summary

Fixes #1272

- When both subscription and API key credentials exist for the same provider (e.g. Anthropic), the fallback chain now tries the alternate auth type instead of retrying with the same failing credential
- `getAuthType()` accepts an optional `excludeAuthTypes` parameter to filter out auth types that already failed
- `tryFallbacks()` tracks failed auth types per provider and passes exclusions to `getAuthType()` for each fallback attempt
- If all auth types are excluded (both failed), falls through to original logic gracefully

## Test plan

- [x] `getAuthType` returns alternate auth type when primary is excluded
- [x] `getAuthType` falls through when all types excluded (no crash)
- [x] Fallback chain passes primary provider/auth_type context
- [x] Same-provider fallbacks try different credential
- [x] Cross-provider fallbacks are unaffected (no exclusions applied)
- [x] Auth type failures accumulate across the fallback chain
- [x] All 3010 backend unit tests pass
- [x] All 96 e2e tests pass
- [x] All 1700 frontend tests pass
- [x] TypeScript compiles cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1272 by making the fallback chain try a different auth type for the same provider instead of retrying the failing credential. This prevents 424s when a valid API key or subscription exists.

- **Bug Fixes**
  - `getAuthType(agentId, provider, excludeAuthTypes?)` now accepts optional exclusions to avoid known-bad auth types.
  - `tryFallbacks()` tracks failed auth types per provider and passes exclusions to `getAuthType`, so same-provider fallbacks switch credentials; cross-provider behavior is unchanged.
  - If both auth types fail, logic falls through gracefully without crashes.
  - `ProxyService` now provides the primary provider and auth_type to the fallback chain.
  - Tests added for exclusion logic and accumulation across same-provider fallbacks.

<sup>Written for commit 8b02fdce21019f513998b5b690880e4c6e52f07e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

