### PR TITLE
fix: validate inferred provider prefix against active providers

### DIFF
--- a/.changeset/fix-provider-prefix-routing.md
+++ b/.changeset/fix-provider-prefix-routing.md
@@ -1,0 +1,7 @@
+---
+"manifest": patch
+---
+
+fix: validate inferred provider prefix against active providers before routing (#1383)
+
+Models from proxy providers (e.g. OpenRouter) carry vendor prefixes like `anthropic/claude-sonnet-4`. The router previously inferred the provider from this prefix without checking if that provider was active, causing requests to fail when the native provider was disabled.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -28,6 +28,7 @@ describe('ProxyFallbackService', () => {
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       findProviderForModel: jest.fn().mockResolvedValue(undefined),
       getProviderRegion: jest.fn().mockResolvedValue(null),
+      hasActiveProvider: jest.fn().mockResolvedValue(true),
     } as unknown as jest.Mocked<ProviderKeyService>;
 
     customProviderRepo = {
@@ -570,6 +571,35 @@ describe('ProxyFallbackService', () => {
       expect(result.success).toBeNull();
       expect(result.failures).toHaveLength(1);
       expect(providerClient.forward).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to findProviderForModel when inferred prefix provider is inactive (#1383)', async () => {
+      // Model has 'anthropic/' prefix but Anthropic is disabled
+      providerKeyService.hasActiveProvider.mockResolvedValue(false);
+      // findProviderForModel correctly maps to OpenRouter
+      providerKeyService.findProviderForModel.mockResolvedValue('openrouter');
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-or');
+      pricingCache.getByModel.mockReturnValue(null as never);
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      const result = await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['anthropic/claude-sonnet-4'],
+        body,
+        false,
+        'sess-1',
+        'gpt-4o',
+      );
+
+      expect(result.success).not.toBeNull();
+      expect(result.success!.provider).toBe('openrouter');
+      expect(providerKeyService.hasActiveProvider).toHaveBeenCalledWith('agent-1', 'anthropic');
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -42,6 +42,7 @@ describe('ProxyService', () => {
       getProviderRegion: jest.fn().mockResolvedValue(null),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       findProviderForModel: jest.fn().mockResolvedValue(undefined),
+      hasActiveProvider: jest.fn().mockResolvedValue(true),
     } as unknown as jest.Mocked<ProviderKeyService>;
 
     tierService = {

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -88,8 +88,11 @@ export class ProxyFallbackService {
         const slashIdx = requestedModel.indexOf('/');
         provider = slashIdx > 0 ? requestedModel.substring(0, slashIdx) : requestedModel;
       } else {
+        const prefix = inferProviderFromModelName(requestedModel);
         provider =
-          inferProviderFromModelName(requestedModel) ??
+          (prefix && (await this.providerKeyService.hasActiveProvider(agentId, prefix))
+            ? prefix
+            : undefined) ??
           pricing?.provider ??
           (await this.providerKeyService.findProviderForModel(agentId, requestedModel));
       }

--- a/packages/backend/src/routing/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve.service.spec.ts
@@ -23,6 +23,7 @@ describe('ResolveService', () => {
     mockProviderKeyService = {
       getEffectiveModel: jest.fn(),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
+      hasActiveProvider: jest.fn().mockResolvedValue(true),
     };
     mockPricingCache = {
       getByModel: jest.fn(),
@@ -345,6 +346,44 @@ describe('ResolveService', () => {
 
       expect(result.auth_type).toBeUndefined();
       expect(mockProviderKeyService.getAuthType).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('provider prefix validation (#1383)', () => {
+    it('should fall through to discovered models when inferred prefix provider is inactive', async () => {
+      mockTierService.getTiers.mockResolvedValue([
+        { tier: 'simple', override_model: null, auto_assigned_model: 'anthropic/claude-sonnet-4' },
+      ]);
+      mockProviderKeyService.getEffectiveModel.mockResolvedValue('anthropic/claude-sonnet-4');
+      // Anthropic is disabled — hasActiveProvider returns false
+      mockProviderKeyService.hasActiveProvider.mockResolvedValue(false);
+      // Discovery correctly maps the model to OpenRouter
+      mockDiscoveryService.getModelForAgent.mockResolvedValue({
+        id: 'anthropic/claude-sonnet-4',
+        provider: 'openrouter',
+      });
+
+      const result = await service.resolveForTier('agent-1', 'simple');
+
+      expect(result.provider).toBe('openrouter');
+      expect(mockProviderKeyService.hasActiveProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'anthropic',
+      );
+    });
+
+    it('should use prefix when inferred provider is active', async () => {
+      mockTierService.getTiers.mockResolvedValue([
+        { tier: 'simple', override_model: null, auto_assigned_model: 'anthropic/claude-sonnet-4' },
+      ]);
+      mockProviderKeyService.getEffectiveModel.mockResolvedValue('anthropic/claude-sonnet-4');
+      mockProviderKeyService.hasActiveProvider.mockResolvedValue(true);
+
+      const result = await service.resolveForTier('agent-1', 'simple');
+
+      expect(result.provider).toBe('anthropic');
+      // Discovery should not be called — fast path used
+      expect(mockDiscoveryService.getModelForAgent).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -126,9 +126,14 @@ export class ResolveService {
       return assignment.override_provider;
     }
 
-    // 1. Infer from slash prefix
+    // 1. Infer from slash prefix — but only if that provider is actually connected.
+    //    Models from proxy providers (e.g. OpenRouter) carry vendor prefixes
+    //    like "anthropic/claude-sonnet-4" which would incorrectly resolve to
+    //    the native provider when that provider is disabled (#1383).
     const prefix = inferProviderFromModelName(model);
-    if (prefix) return prefix;
+    if (prefix && (await this.providerKeyService.hasActiveProvider(agentId, prefix))) {
+      return prefix;
+    }
 
     // 2. Check discovered models
     const discovered = await this.discoveryService.getModelForAgent(agentId, model);

--- a/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.spec.ts
@@ -378,6 +378,40 @@ describe('ProviderKeyService', () => {
     });
   });
 
+  /* ── hasActiveProvider ── */
+
+  describe('hasActiveProvider', () => {
+    it('should return true when active provider exists', async () => {
+      providerService.getProviders.mockResolvedValue([
+        makeProvider({ provider: 'anthropic', is_active: true }),
+      ]);
+
+      expect(await service.hasActiveProvider('agent-1', 'anthropic')).toBe(true);
+    });
+
+    it('should return false when provider is inactive', async () => {
+      providerService.getProviders.mockResolvedValue([
+        makeProvider({ provider: 'anthropic', is_active: false }),
+      ]);
+
+      expect(await service.hasActiveProvider('agent-1', 'anthropic')).toBe(false);
+    });
+
+    it('should return false when provider does not exist', async () => {
+      providerService.getProviders.mockResolvedValue([]);
+
+      expect(await service.hasActiveProvider('agent-1', 'anthropic')).toBe(false);
+    });
+
+    it('should handle provider aliases (gemini/google)', async () => {
+      providerService.getProviders.mockResolvedValue([
+        makeProvider({ provider: 'google', is_active: true }),
+      ]);
+
+      expect(await service.hasActiveProvider('agent-1', 'gemini')).toBe(true);
+    });
+  });
+
   /* ── findProviderForModel ── */
 
   describe('findProviderForModel', () => {

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -66,6 +66,12 @@ export class ProviderKeyService {
     return withKey?.auth_type ?? matches[0]?.auth_type ?? 'api_key';
   }
 
+  async hasActiveProvider(agentId: string, provider: string): Promise<boolean> {
+    const names = expandProviderNames([provider]);
+    const records = await this.providerService.getProviders(agentId);
+    return records.some((r) => r.is_active && names.has(r.provider.toLowerCase()));
+  }
+
   async getProviderRegion(
     agentId: string,
     provider: string,


### PR DESCRIPTION
## Summary

Closes #1383
Related: [Discussion #1359](https://github.com/mnfst/manifest/discussions/1359)

- `resolveProvider()` previously inferred the provider from model name prefixes (e.g. `anthropic/claude-sonnet-4` → `anthropic`) without checking if that provider was active
- Models from proxy providers like OpenRouter carry vendor prefixes, so disabling the native provider (Anthropic) still routed requests to it instead of through OpenRouter
- Added `hasActiveProvider()` to `ProviderKeyService` and guarded prefix inference in both `resolveProvider()` and the fallback chain
- When the inferred provider is inactive, falls through to discovered models which correctly map to the actual provider

## Test plan

- [x] `hasActiveProvider` returns true/false correctly, handles aliases
- [x] `resolveProvider` falls through to discovered models when prefix provider is inactive
- [x] `resolveProvider` uses prefix fast path when provider is active (no regression)
- [x] Fallback chain resolves correct provider when prefix provider is inactive
- [x] All 3024 backend unit tests pass
- [x] All 96 e2e tests pass
- [x] TypeScript compiles cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider resolution to only use model-name prefixes when that provider is active. Prevents misrouting with proxy providers like OpenRouter, and correctly falls back to discovered models when the native provider is disabled.

- **Bug Fixes**
  - Added hasActiveProvider to ProviderKeyService and guarded prefix inference in resolve and proxy fallback paths.
  - When the inferred provider is inactive, fall through to discovered models and pricing to pick the actual provider (e.g., OpenRouter).
  - Covered cases with unit tests, including provider aliases (gemini/google).

<sup>Written for commit 9681acd656798984cd89584e165bb2aea9b67023. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

