### PR TITLE
fix: resolve $0.00 cost tracking for Google Gemini models

### DIFF
--- a/.changeset/fix-gemini-cost-tracking.md
+++ b/.changeset/fix-gemini-cost-tracking.md
@@ -1,0 +1,9 @@
+---
+"manifest": patch
+---
+
+fix: resolve $0.00 cost tracking for Google Gemini models
+
+Fixes an issue where Gemini 2.5 Pro showed $0.00 costs despite active token usage.
+Root cause: GitHub Copilot's zero-pricing models.dev entries overwrote Google's real pricing
+in the pricing cache. Also adds daily cache reload and Google variant model name normalization.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -313,6 +313,19 @@ describe('ModelsDevSyncService', () => {
       expect(model!.name).toBe('Mistral Large');
     });
 
+    it('should strip Google preview variant suffix', () => {
+      // Google API returns gemini-2.5-pro-preview-03-25, models.dev has gemini-2.5-pro
+      const model = service.lookupModel('gemini', 'gemini-2.5-pro-preview-03-25');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Gemini 2.5 Pro');
+    });
+
+    it('should strip Google exp variant suffix', () => {
+      const model = service.lookupModel('gemini', 'gemini-2.5-pro-exp-0325');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Gemini 2.5 Pro');
+    });
+
     it('should strip -reasoning suffix (xAI convention)', () => {
       // xAI returns grok-4-1-fast-reasoning, models.dev has grok-4-1-fast
       const model = service.lookupModel('xai', 'grok-4-1-fast-reasoning');

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -75,6 +75,8 @@ const DATE_SUFFIX_RE = /-\d{4}-?\d{2}-?\d{2}$/;
 const SHORT_DATE_SUFFIX_RE = /-\d{4}$/;
 /** Common suffix aliases: try appending -latest when the base name is not found. */
 const LATEST_SUFFIX = '-latest';
+/** Google variant suffixes: -preview-MM-DD, -preview-YYYY-MM-DD, -exp-MMDD, -latest. */
+const GOOGLE_VARIANT_RE = /-(?:preview(?:-\d{2,4}){1,3}|exp-\d{4}|latest)$/;
 /** xAI reasoning/non-reasoning mode suffixes. */
 const REASONING_SUFFIX_RE = /-(reasoning|non-reasoning)$/;
 
@@ -134,8 +136,9 @@ export class ModelsDevSyncService implements OnModuleInit {
    *   3. Strip date suffix (-20250514 or -2025-04-14)
    *   4. Append -latest (mistral-medium → mistral-medium-latest)
    *   5. Strip date then append -latest
-   *   6. Strip -reasoning / -non-reasoning suffix (xAI convention)
-   *   7. Strip 4-digit short date suffix (-0709 MMDD format)
+   *   6. Strip Google variant suffix (-preview-MM-DD, -exp-MMDD, -latest)
+   *   7. Strip -reasoning / -non-reasoning suffix (xAI convention)
+   *   8. Strip 4-digit short date suffix (-0709 MMDD format)
    */
   lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null {
     const providerModels = this.cache.get(resolveProviderId(providerId));
@@ -171,19 +174,27 @@ export class ModelsDevSyncService implements OnModuleInit {
       if (found) return found;
     }
 
-    // 6. Strip -reasoning / -non-reasoning suffix (xAI: grok-4-1-fast-reasoning → grok-4-1-fast)
+    // 6. Strip Google variant suffixes: -preview-MM-DD, -exp-MMDD, -latest
+    //    (e.g., gemini-2.5-pro-preview-03-25 → gemini-2.5-pro)
+    const noGoogleVariant = modelId.replace(GOOGLE_VARIANT_RE, '');
+    if (noGoogleVariant !== modelId) {
+      const found = providerModels.get(noGoogleVariant);
+      if (found) return found;
+    }
+
+    // 7. Strip -reasoning / -non-reasoning suffix (xAI: grok-4-1-fast-reasoning → grok-4-1-fast)
     const noReasoning = modelId.replace(REASONING_SUFFIX_RE, '');
     if (noReasoning !== modelId) {
       const found = providerModels.get(noReasoning);
       if (found) return found;
     }
 
-    // 7. Strip 4-digit short date suffix (xAI: grok-4-0709 → grok-4)
+    // 8. Strip 4-digit short date suffix (xAI: grok-4-0709 → grok-4)
     const noShortDate = modelId.replace(SHORT_DATE_SUFFIX_RE, '');
     if (noShortDate !== modelId) {
       const found = providerModels.get(noShortDate);
       if (found) return found;
-      // 8. Strip short date then append -latest (mistral-small-2603 → mistral-small-latest)
+      // 9. Strip short date then append -latest (mistral-small-2603 → mistral-small-latest)
       if (!noShortDate.endsWith(LATEST_SUFFIX)) {
         const withLatest = providerModels.get(noShortDate + LATEST_SUFFIX);
         if (withLatest) return withLatest;

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -225,6 +225,34 @@ describe('lookupWithVariants', () => {
 
     expect(result).toBeNull();
   });
+
+  it('should strip Google preview variant suffix', () => {
+    const cache = new Map([['google/gemini-2.5-pro', { input: 0.00000125, output: 0.00001 }]]);
+
+    const result = lookupWithVariants(
+      makePricingSync(cache),
+      'google',
+      'gemini-2.5-pro-preview-03-25',
+    );
+
+    expect(result).toEqual({ input: 0.00000125, output: 0.00001 });
+  });
+
+  it('should strip Google exp variant suffix', () => {
+    const cache = new Map([['google/gemini-2.5-pro', { input: 0.00000125, output: 0.00001 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'google', 'gemini-2.5-pro-exp-0325');
+
+    expect(result).toEqual({ input: 0.00000125, output: 0.00001 });
+  });
+
+  it('should strip Google latest variant suffix', () => {
+    const cache = new Map([['google/gemini-2.5-flash', { input: 0.0000003, output: 0.0000025 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'google', 'gemini-2.5-flash-latest');
+
+    expect(result).toEqual({ input: 0.0000003, output: 0.0000025 });
+  });
 });
 
 describe('buildSubscriptionFallbackModels', () => {

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -5,6 +5,7 @@ import {
 } from '../common/constants/providers';
 import { getSubscriptionKnownModels, getSubscriptionCapabilities } from 'manifest-shared';
 import { normalizeAnthropicShortModelId } from '../common/utils/anthropic-model-id';
+import { GOOGLE_VARIANT_RE } from '../model-prices/model-name-normalizer';
 import type { ModelsDevSyncService } from '../database/models-dev-sync.service';
 
 interface PricingLookup {
@@ -87,6 +88,13 @@ export function lookupWithVariants(
   // Try :free suffix (OpenRouter lists some models as "provider/model:free")
   const freeResult = pricingSync.lookupPricing(`${prefix}/${modelId}:free`);
   if (freeResult) return freeResult;
+
+  // Strip Google variant suffixes: -preview-MM-DD, -exp-MMDD, -latest
+  const noGoogleVariant = modelId.replace(GOOGLE_VARIANT_RE, '');
+  if (noGoogleVariant !== modelId) {
+    const result = pricingSync.lookupPricing(`${prefix}/${noGoogleVariant}`);
+    if (result) return result;
+  }
 
   return null;
 }

--- a/packages/backend/src/model-prices/model-name-normalizer.spec.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.spec.ts
@@ -4,6 +4,7 @@ import {
   buildAliasMap,
   resolveModelName,
   normalizeDots,
+  stripGoogleVariant,
 } from './model-name-normalizer';
 
 describe('model-name-normalizer', () => {
@@ -79,6 +80,32 @@ describe('model-name-normalizer', () => {
     });
   });
 
+  describe('stripGoogleVariant', () => {
+    it('strips -preview-MM-DD suffix', () => {
+      expect(stripGoogleVariant('gemini-2.5-pro-preview-03-25')).toBe('gemini-2.5-pro');
+    });
+
+    it('strips -preview-YYYY-MM-DD suffix', () => {
+      expect(stripGoogleVariant('gemini-2.5-pro-preview-2025-03-25')).toBe('gemini-2.5-pro');
+    });
+
+    it('strips -exp-MMDD suffix', () => {
+      expect(stripGoogleVariant('gemini-2.5-pro-exp-0325')).toBe('gemini-2.5-pro');
+    });
+
+    it('strips -latest suffix', () => {
+      expect(stripGoogleVariant('gemini-2.5-pro-latest')).toBe('gemini-2.5-pro');
+    });
+
+    it('returns name unchanged for non-Google models', () => {
+      expect(stripGoogleVariant('gpt-4o')).toBe('gpt-4o');
+    });
+
+    it('returns name unchanged for models without variant suffix', () => {
+      expect(stripGoogleVariant('gemini-2.5-pro')).toBe('gemini-2.5-pro');
+    });
+  });
+
   describe('buildAliasMap', () => {
     it('maps canonical names to themselves', () => {
       const map = buildAliasMap(['gpt-4o', 'claude-opus-4-6']);
@@ -123,6 +150,21 @@ describe('model-name-normalizer', () => {
       const map = buildAliasMap(['google/gemini-001']);
       // gemini-001 bare → gemini (suffix stripped), but gemini-001 should also exist
       expect(map.get('gemini-001')).toBe('google/gemini-001');
+    });
+
+    it('indexes short name for canonical names with Google variant suffix', () => {
+      const map = buildAliasMap(['gemini-2.5-pro-preview-03-25']);
+      expect(map.get('gemini-2.5-pro')).toBe('gemini-2.5-pro-preview-03-25');
+    });
+
+    it('indexes short name for vendor-prefixed Google variant', () => {
+      const map = buildAliasMap(['google/gemini-2.5-pro-exp-0325']);
+      expect(map.get('gemini-2.5-pro')).toBe('google/gemini-2.5-pro-exp-0325');
+    });
+
+    it('does not overwrite existing entry when stripping Google variant', () => {
+      const map = buildAliasMap(['gemini-2.5-pro', 'gemini-2.5-pro-preview-03-25']);
+      expect(map.get('gemini-2.5-pro')).toBe('gemini-2.5-pro');
     });
   });
 
@@ -230,6 +272,32 @@ describe('model-name-normalizer', () => {
     it('resolves Anthropic dash variant when canonical name uses dots', () => {
       const map = buildAliasMap(['anthropic/claude-opus-4.6']);
       expect(resolveModelName('claude-opus-4-6', map)).toBe('anthropic/claude-opus-4.6');
+    });
+
+    it('resolves Google preview variant to canonical', () => {
+      expect(resolveModelName('gemini-2.5-pro-preview-03-25', aliasMap)).toBeUndefined();
+      const map = buildAliasMap(['gemini-2.5-pro']);
+      expect(resolveModelName('gemini-2.5-pro-preview-03-25', map)).toBe('gemini-2.5-pro');
+    });
+
+    it('resolves Google exp variant to canonical', () => {
+      const map = buildAliasMap(['gemini-2.5-pro']);
+      expect(resolveModelName('gemini-2.5-pro-exp-0325', map)).toBe('gemini-2.5-pro');
+    });
+
+    it('resolves Google latest variant to canonical', () => {
+      const map = buildAliasMap(['gemini-2.5-pro']);
+      expect(resolveModelName('gemini-2.5-pro-latest', map)).toBe('gemini-2.5-pro');
+    });
+
+    it('resolves prefixed Google preview variant', () => {
+      const map = buildAliasMap(['gemini-2.5-pro']);
+      expect(resolveModelName('google/gemini-2.5-pro-preview-03-25', map)).toBe('gemini-2.5-pro');
+    });
+
+    it('resolves short name when pricing has Google variant canonical', () => {
+      const map = buildAliasMap(['gemini-2.5-pro-preview-03-25']);
+      expect(resolveModelName('gemini-2.5-pro', map)).toBe('gemini-2.5-pro-preview-03-25');
     });
   });
 });

--- a/packages/backend/src/model-prices/model-name-normalizer.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.ts
@@ -10,8 +10,9 @@ import { OPENROUTER_PREFIX_TO_PROVIDER } from '../common/constants/providers';
  *  3. Strip provider prefix (e.g. "anthropic/claude-opus-4-6" → "claude-opus-4-6")
  *  4. Strip date suffix (e.g. "gpt-4.1-2025-04-14" → "gpt-4.1")
  *  5. Strip both prefix and date suffix
- *  6. Dot-to-dash normalization (e.g. "claude-opus-4.6" → "claude-opus-4-6")
- *  7. Dot-to-dash + strip date suffix
+ *  6. Strip Google variant suffix (e.g. "gemini-2.5-pro-preview-03-25" → "gemini-2.5-pro")
+ *  7. Dot-to-dash normalization (e.g. "claude-opus-4.6" → "claude-opus-4-6")
+ *  8. Dot-to-dash + strip date suffix
  */
 
 const KNOWN_ALIASES: ReadonlyArray<readonly [string, string]> = [
@@ -53,6 +54,13 @@ const PROVIDER_PREFIXES: readonly string[] = [
 const DATE_SUFFIX_RE = /-\d{4}-?\d{2}-?\d{2}$/;
 const VERSION_SUFFIX_RE = /-\d{3}$/;
 
+/** Matches Google-style variant suffixes: -preview-MM-DD, -preview-YYYY-MM-DD, -exp-MMDD, -latest */
+export const GOOGLE_VARIANT_RE = /-(?:preview(?:-\d{2,4}){1,3}|exp-\d{4}|latest)$/;
+
+export function stripGoogleVariant(name: string): string {
+  return name.replace(GOOGLE_VARIANT_RE, '');
+}
+
 export function stripProviderPrefix(name: string): string {
   for (const prefix of PROVIDER_PREFIXES) {
     if (name.startsWith(prefix)) {
@@ -86,6 +94,12 @@ export function buildAliasMap(canonicalNames: ReadonlyArray<string>): Map<string
     const bareNoVersion = bare.replace(VERSION_SUFFIX_RE, '');
     if (bareNoVersion !== bare && !map.has(bareNoVersion)) {
       map.set(bareNoVersion, name);
+    }
+    // Index by bare name without Google variant suffix
+    // (e.g. "gemini-2.5-pro-preview-03-25" → "gemini-2.5-pro")
+    const bareNoVariant = stripGoogleVariant(bare);
+    if (bareNoVariant !== bare && !map.has(bareNoVariant)) {
+      map.set(bareNoVariant, name);
     }
     for (const variant of buildAnthropicShortModelIdVariants(bare)) {
       if (!map.has(variant)) {
@@ -121,6 +135,12 @@ export function resolveModelName(name: string, aliasMap: Map<string, string>): s
   if (noDate !== stripped) {
     const fromNoDate = aliasMap.get(noDate);
     if (fromNoDate) return fromNoDate;
+  }
+
+  const noVariant = stripGoogleVariant(stripped);
+  if (noVariant !== stripped) {
+    const fromNoVariant = aliasMap.get(noVariant);
+    if (fromNoVariant) return fromNoVariant;
   }
 
   const dotNorm = normalizeDots(stripped);

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -49,6 +49,14 @@ describe('ModelPricingCacheService', () => {
     });
   });
 
+  describe('scheduledReload', () => {
+    it('should call reload()', async () => {
+      const spy = jest.spyOn(service, 'reload').mockResolvedValue();
+      await service.scheduledReload();
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('reload', () => {
     it('should attribute supported providers from OpenRouter data', async () => {
       const orMap = new Map<string, OpenRouterPricingEntry>([
@@ -525,6 +533,66 @@ describe('ModelPricingCacheService', () => {
       const entry = serviceNoRegistry.getByModel('gpt-4o');
       expect(entry).toBeDefined();
       expect(entry!.validated).toBeUndefined();
+    });
+
+    it('should not overwrite real pricing with zero-pricing entry from later provider', async () => {
+      // Gemini provider sets gemini-2.5-pro with real pricing,
+      // then Copilot provider tries to overwrite with $0 pricing.
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'gemini') {
+          return [
+            {
+              id: 'gemini-2.5-pro',
+              name: 'Gemini 2.5 Pro',
+              inputPricePerToken: 0.00000125,
+              outputPricePerToken: 0.00001,
+            },
+          ];
+        }
+        if (providerId === 'copilot') {
+          return [
+            {
+              id: 'gemini-2.5-pro',
+              name: 'Gemini 2.5 Pro',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('gemini-2.5-pro');
+      expect(entry).toBeDefined();
+      expect(entry!.provider).toBe('Google');
+      expect(entry!.input_price_per_token).toBe(0.00000125);
+    });
+
+    it('should allow zero-pricing entry when no existing entry', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'copilot') {
+          return [
+            {
+              id: 'copilot-only-model',
+              name: 'Copilot Model',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('copilot-only-model');
+      expect(entry).toBeDefined();
+      expect(entry!.provider).toBe('GitHub Copilot');
+      expect(entry!.input_price_per_token).toBe(0);
     });
 
     it('should resolve false for unconfirmed models.dev entries', async () => {

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, OnApplicationBootstrap, Inject, Optional } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
 import { buildAliasMap, resolveModelName } from './model-name-normalizer';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
@@ -42,6 +43,12 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
   ) {}
 
   async onApplicationBootstrap(): Promise<void> {
+    await this.reload();
+  }
+
+  /** Rebuild the pricing cache after sync services refresh their data. */
+  @Cron('0 5 * * *')
+  async scheduledReload(): Promise<void> {
     await this.reload();
   }
 
@@ -161,8 +168,17 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
           source: 'models.dev',
         };
 
-        // Override both bare and prefixed keys so getAll() dedup works
-        this.cache.set(model.id, pricingEntry);
+        // Override both bare and prefixed keys so getAll() dedup works.
+        // Don't overwrite real pricing with zero-pricing entries (e.g. Copilot
+        // lists models like gemini-2.5-pro as free, which would erase Google's
+        // actual pricing that was set by an earlier provider in the loop).
+        const existing = this.cache.get(model.id);
+        const hasRealPricing = existing && (existing.input_price_per_token ?? 0) > 0;
+        const isZeroPricing =
+          (model.inputPricePerToken ?? 0) === 0 && (model.outputPricePerToken ?? 0) === 0;
+        if (!hasRealPricing || !isZeroPricing) {
+          this.cache.set(model.id, pricingEntry);
+        }
         // Also update the OpenRouter-prefixed key if it exists
         for (const prefix of registryEntry.openRouterPrefixes) {
           const prefixedKey = `${prefix}/${model.id}`;


### PR DESCRIPTION
## Summary

Fixes #1372 — Gemini 2.5 Pro showed $0.00 costs despite active token usage (560k+ tokens).

**Root cause:** In `ModelPricingCacheService.loadModelsDevEntries()`, providers are processed in registry order. The `gemini` provider correctly sets `gemini-2.5-pro` with real pricing ($1.25/$10 per million tokens), but the `copilot` provider (processed later) overwrites it with $0/$0 pricing because GitHub Copilot lists the same model as a free subscription model. Additionally, OpenRouter has removed all Gemini 2.x models from their API, so models.dev is the only pricing source for these models.

**Changes:**
- **Prevent zero-pricing overwrites** — `loadModelsDevEntries()` now skips bare model name writes when an entry with real pricing already exists and the new entry has zero pricing
- **Add daily pricing cache reload** — `@Cron('0 5 * * *')` on `ModelPricingCacheService` rebuilds the cache after `PricingSyncService` (3AM) and `ModelsDevSyncService` (4AM) refresh, recovering from any startup failures
- **Google variant suffix normalization** — Handles preview/experimental model names (`-preview-MM-DD`, `-exp-MMDD`, `-latest`) across all three pricing lookup sites (model-name-normalizer, model-fallback, models-dev-sync)

## Test plan

- [ ] Verified costs stored correctly in PostgreSQL for Gemini 2.5 Pro messages via proxy
- [ ] All 3039 backend unit tests pass
- [ ] TypeScript compiles cleanly
- [ ] Pre-commit hooks (ESLint + Prettier) pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes $0.00 cost tracking for Google Gemini models by preventing zero-pricing overwrites and normalizing Google variant IDs. Adds a daily pricing cache reload to keep Gemini pricing accurate after nightly syncs.

- **Bug Fixes**
  - Prevent zero-pricing overwrites in `ModelPricingCacheService` when loading from `models.dev`, so Gemini 2.5 Pro keeps Google’s real pricing instead of Copilot’s free listing.
  - Normalize Google variant suffixes (-preview-…, -exp-…, -latest) across lookups, and add a 5:00 AM cron in `@nestjs/schedule` to rebuild the cache after nightly syncs.

<sup>Written for commit 9e21d33c12499aa022db7f84735acd1a1aa365c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

