### PR TITLE
fix: agent setup tab not rendering when API key fetch fails

### DIFF
--- a/.changeset/fix-agent-setup-tab.md
+++ b/.changeset/fix-agent-setup-tab.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix Agent setup tab on Settings page not rendering content when API key fetch fails

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createResource, Show, For, type Component } from 'solid-js';
+import { createSignal, createResource, Show, For, ErrorBoundary, type Component } from 'solid-js';
 import { useParams, useNavigate, useLocation } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
 import ErrorState from '../components/ErrorState.jsx';
@@ -41,8 +41,10 @@ const Settings: Component = () => {
   const [routingStatus] = createResource(() => agentName(), getRoutingStatus);
   const routingEnabled = () => routingStatus()?.enabled ?? false;
 
+  const keyData = () => (apiKeyData.error ? undefined : apiKeyData());
+
   const baseUrl = () => {
-    const custom = apiKeyData()?.pluginEndpoint;
+    const custom = keyData()?.pluginEndpoint;
     if (custom) return custom;
     const host = window.location.hostname;
     if (host === 'app.manifest.build') return 'https://app.manifest.build/v1';
@@ -193,74 +195,83 @@ const Settings: Component = () => {
 
       {/* -- Tab: Agent setup ------------------------- */}
       <Show when={tab() === 'Agent setup'}>
-        <h3 class="settings-section__title">API Key</h3>
-
-        <div class="settings-card">
-          <div class="settings-card__row">
-            <div class="settings-card__label">
-              <span class="settings-card__label-title">Agent API key</span>
-              <span class="settings-card__label-desc">
-                This key authenticates your agent's requests to Manifest. Rotating it generates a
-                new key and immediately invalidates the current one.
-              </span>
-            </div>
-            <div
-              class="settings-card__control"
-              style="display: flex; align-items: center; gap: 8px;"
-            >
-              <code style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground));">
-                {apiKeyData()?.keyPrefix ?? '...'}...
-              </code>
-              <button class="btn btn--outline btn--sm" onClick={handleRotate} disabled={rotating()}>
-                {rotating() ? (
-                  <>
-                    <span class="spinner" />
-                    <span class="sr-only">Rotating…</span>
-                  </>
-                ) : (
-                  'Rotate key'
-                )}
-              </button>
-            </div>
-          </div>
-          <Show when={rotatedKey()}>
-            <div style="padding: 0 var(--gap-md) var(--gap-md);">
-              <div style="background: hsl(var(--chart-5) / 0.1); border: 1px solid hsl(var(--chart-5) / 0.3); border-radius: var(--radius); padding: 10px 14px; margin-bottom: 12px; font-size: var(--font-size-sm); color: hsl(var(--foreground));">
-                Save this key somewhere safe. You won't see it again.
-              </div>
-              <div style="display: flex; align-items: center; gap: 8px; background: hsl(var(--muted)); border-radius: var(--radius); padding: 10px 14px; font-family: var(--font-mono); font-size: var(--font-size-sm); word-break: break-all;">
-                {rotatedKey()}
-                <CopyButton text={rotatedKey()!} />
-              </div>
-            </div>
-          </Show>
-        </div>
-
-        <h3 class="settings-section__title">Setup</h3>
-
-        <Show
-          when={!apiKeyData.loading}
-          fallback={
-            <div class="setup-steps">
-              <div class="skeleton skeleton--rect" style="width: 100%; height: 200px;" />
-            </div>
-          }
+        <ErrorBoundary
+          fallback={(err, reset) => (
+            <ErrorState
+              error={err}
+              title="Something went wrong"
+              message="An error occurred while rendering setup instructions."
+              onRetry={reset}
+            />
+          )}
         >
+          <h3 class="settings-section__title">API Key</h3>
+
+          <div class="settings-card">
+            <div class="settings-card__row">
+              <div class="settings-card__label">
+                <span class="settings-card__label-title">Agent API key</span>
+                <span class="settings-card__label-desc">
+                  This key authenticates your agent's requests to Manifest. Rotating it generates a
+                  new key and immediately invalidates the current one.
+                </span>
+              </div>
+              <div
+                class="settings-card__control"
+                style="display: flex; align-items: center; gap: 8px;"
+              >
+                <code style="font-size: var(--font-size-sm); color: hsl(var(--muted-foreground));">
+                  {keyData()?.keyPrefix ?? '...'}...
+                </code>
+                <button
+                  class="btn btn--outline btn--sm"
+                  onClick={handleRotate}
+                  disabled={rotating()}
+                >
+                  {rotating() ? (
+                    <>
+                      <span class="spinner" />
+                      <span class="sr-only">Rotating…</span>
+                    </>
+                  ) : (
+                    'Rotate key'
+                  )}
+                </button>
+              </div>
+            </div>
+            <Show when={rotatedKey()}>
+              <div style="padding: 0 var(--gap-md) var(--gap-md);">
+                <div style="background: hsl(var(--chart-5) / 0.1); border: 1px solid hsl(var(--chart-5) / 0.3); border-radius: var(--radius); padding: 10px 14px; margin-bottom: 12px; font-size: var(--font-size-sm); color: hsl(var(--foreground));">
+                  Save this key somewhere safe. You won't see it again.
+                </div>
+                <div style="display: flex; align-items: center; gap: 8px; background: hsl(var(--muted)); border-radius: var(--radius); padding: 10px 14px; font-family: var(--font-mono); font-size: var(--font-size-sm); word-break: break-all;">
+                  {rotatedKey()}
+                  <CopyButton text={rotatedKey()!} />
+                </div>
+              </div>
+            </Show>
+          </div>
+
+          <h3 class="settings-section__title">Setup</h3>
+
           <Show
-            when={!apiKeyData.error}
+            when={!apiKeyData.loading}
             fallback={
-              <ErrorState
-                error={apiKeyData.error}
-                title="Could not load API key"
-                message="Failed to fetch your agent's API key. Please try again."
-                onRetry={refetchKey}
-              />
+              <div class="setup-steps">
+                <div class="skeleton skeleton--rect" style="width: 100%; height: 200px;" />
+              </div>
             }
           >
+            <Show when={apiKeyData.error}>
+              <div style="background: hsl(var(--chart-5) / 0.1); border: 1px solid hsl(var(--chart-5) / 0.3); border-radius: var(--radius); padding: 10px 14px; margin-bottom: var(--gap-md); font-size: var(--font-size-sm); color: hsl(var(--foreground));">
+                Could not load your API key. Use <strong>Rotate key</strong> above to generate a new
+                one, or follow the setup instructions below with a placeholder key.
+              </div>
+            </Show>
             <div class="settings-card" style="padding: var(--gap-lg);">
               <SetupStepAddProvider
                 apiKey={rotatedKey() ?? null}
-                keyPrefix={apiKeyData()?.keyPrefix ?? null}
+                keyPrefix={keyData()?.keyPrefix ?? null}
                 baseUrl={baseUrl()}
               />
               <Show when={!routingEnabled()}>
@@ -283,7 +294,7 @@ const Settings: Component = () => {
               </Show>
             </div>
           </Show>
-        </Show>
+        </ErrorBoundary>
       </Show>
 
       {/* -- Delete Agent Modal ----------------------- */}

--- a/packages/frontend/src/services/api/core.ts
+++ b/packages/frontend/src/services/api/core.ts
@@ -19,7 +19,7 @@ export async function fetchJson<T>(
     if (window.location.pathname !== '/login') {
       window.location.href = '/login';
     }
-    return new Promise<T>(() => {}); // hang forever, page is redirecting
+    throw new Error('Session expired');
   }
   if (!res.ok) {
     const body = await res.text().catch(() => '');

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -361,7 +361,7 @@ describe("Settings", () => {
     });
   });
 
-  it("shows ErrorState when getAgentKey fails", { retry: 0 } as any, async () => {
+  it("shows warning banner when getAgentKey fails", { retry: 0 } as any, async () => {
     // SolidJS createResource re-throws internally; suppress at both levels
     const suppress = (e: PromiseRejectionEvent) => { e.preventDefault(); e.stopImmediatePropagation(); };
     window.addEventListener("unhandledrejection", suppress, true);
@@ -371,7 +371,7 @@ describe("Settings", () => {
     const { container } = render(() => <Settings />);
     fireEvent.click(screen.getByText("Agent setup"));
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Could not load API key");
+      expect(container.textContent).toContain("Could not load your API key");
     });
     await new Promise((r) => setTimeout(r, 100));
     window.removeEventListener("unhandledrejection", suppress, true);

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -44,10 +44,14 @@ vi.mock("../../src/components/SetupStepInstall.jsx", () => ({
   CopyButton: () => <button>Copy</button>,
 }));
 
+let mockSetupThrows = false;
 vi.mock("../../src/components/SetupStepAddProvider.jsx", () => ({
-  default: (props: any) => (
-    <div data-testid="setup-add-provider" data-base-url={props.baseUrl ?? ""} data-key={props.apiKey ?? ""} data-prefix={props.keyPrefix ?? ""} />
-  ),
+  default: (props: any) => {
+    if (mockSetupThrows) throw new Error("render crash");
+    return (
+      <div data-testid="setup-add-provider" data-base-url={props.baseUrl ?? ""} data-key={props.apiKey ?? ""} data-prefix={props.keyPrefix ?? ""} />
+    );
+  },
 }));
 
 vi.mock("../../src/components/SetupStepLocalConfigure.jsx", () => ({
@@ -376,6 +380,19 @@ describe("Settings", () => {
     await new Promise((r) => setTimeout(r, 100));
     window.removeEventListener("unhandledrejection", suppress, true);
     process.removeListener("unhandledRejection", processSup);
+  });
+
+  it("shows ErrorBoundary fallback when child component crashes", async () => {
+    mockSetupThrows = true;
+    const suppress = (e: ErrorEvent) => { e.preventDefault(); e.stopImmediatePropagation(); };
+    window.addEventListener("error", suppress, true);
+    const { container } = render(() => <Settings />);
+    fireEvent.click(screen.getByText("Agent setup"));
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Something went wrong");
+    });
+    window.removeEventListener("error", suppress, true);
+    mockSetupThrows = false;
   });
 
   it("uses custom pluginEndpoint when available", async () => {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -386,13 +386,16 @@ describe("Settings", () => {
     mockSetupThrows = true;
     const suppress = (e: ErrorEvent) => { e.preventDefault(); e.stopImmediatePropagation(); };
     window.addEventListener("error", suppress, true);
-    const { container } = render(() => <Settings />);
-    fireEvent.click(screen.getByText("Agent setup"));
-    await vi.waitFor(() => {
-      expect(container.textContent).toContain("Something went wrong");
-    });
-    window.removeEventListener("error", suppress, true);
-    mockSetupThrows = false;
+    try {
+      const { container } = render(() => <Settings />);
+      fireEvent.click(screen.getByText("Agent setup"));
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("Something went wrong");
+      });
+    } finally {
+      window.removeEventListener("error", suppress, true);
+      mockSetupThrows = false;
+    }
   });
 
   it("uses custom pluginEndpoint when available", async () => {

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -1213,28 +1213,21 @@ describe('copilotPollToken', () => {
 });
 
 describe('fetchJson 401 redirect', () => {
-  it('redirects to /login on 401 response', async () => {
+  it('redirects to /login on 401 response and throws', async () => {
     const loc = { origin: 'http://localhost:3000', pathname: '/overview', href: '' };
     vi.stubGlobal('location', loc);
     mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
 
-    // fetchJson returns a never-resolving promise on 401, so race with a timeout
-    const result = await Promise.race([
-      getHealth().then(() => 'resolved'),
-      new Promise<string>((r) => setTimeout(() => r('pending'), 50)),
-    ]);
-
-    expect(result).toBe('pending');
+    await expect(getHealth()).rejects.toThrow('Session expired');
     expect(loc.href).toBe('/login');
   });
 
-  it('does not redirect if already on /login', async () => {
+  it('does not redirect if already on /login but still throws', async () => {
     const loc = { origin: 'http://localhost:3000', pathname: '/login', href: '' };
     vi.stubGlobal('location', loc);
     mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
 
-    await Promise.race([getHealth(), new Promise<string>((r) => setTimeout(() => r('done'), 50))]);
-
+    await expect(getHealth()).rejects.toThrow('Session expired');
     expect(loc.href).toBe('');
   });
 });


### PR DESCRIPTION
## Summary

- Fix the "Agent setup" tab on the Settings page not working when the API key fetch fails (404 or session expiry)
- Replace never-resolving promise in `fetchJson` 401 handler with a thrown error so `createResource` transitions to error state instead of hanging forever
- Add `ErrorBoundary` around tab content and safe `keyData()` accessor to prevent SolidJS resource error re-throws from crashing the component tree
- Show an inline warning banner instead of a blocking ErrorState when the API key can't be loaded, keeping setup instructions visible with placeholder values

## Test plan

- [ ] Verify "Agent setup" tab works for agents with a valid API key (shows setup instructions with key prefix)
- [ ] Verify "Agent setup" tab works for agents without an active API key (shows warning banner + setup instructions with placeholder)
- [ ] Verify session expiry (401) redirects to login instead of infinite skeleton
- [ ] Verify "Rotate key" button still works on the Agent setup tab
- [ ] Frontend tests pass (1429/1429)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings > Agent setup tab so it still renders when the API key fetch fails, and stops infinite loading on expired sessions by throwing on 401 and redirecting to login.

- **Bug Fixes**
  - `fetchJson`: throw "Session expired" on 401 and redirect to `/login` instead of hanging.
  - Wrap Agent setup tab in `ErrorBoundary` and use safe `keyData()` to avoid SolidJS re-throws.
  - Show an inline warning banner when the API key can’t be loaded; keep setup steps visible with placeholders; “Rotate key” still works.
  - Use `keyData()?.pluginEndpoint` for `baseUrl`; add tests for 401 throw-and-redirect and `ErrorBoundary` fallback; stabilize the fallback test with try/finally cleanup.

<sup>Written for commit 63a2ad2db431a14a8f027ca8a7015106b9745786. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

