### PR TITLE
fix: correct onboarding dashboard URL from /routing to /agents

### DIFF
--- a/.changeset/fix-onboarding-url.md
+++ b/.changeset/fix-onboarding-url.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix onboarding dashboard URL to point to /agents/:name instead of /routing/:name

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -315,7 +315,7 @@ describe('ProxyService', () => {
 
     const json = (await result.forward.response.json()) as Record<string, unknown>;
     const choices = json.choices as { message: { content: string } }[];
-    expect(choices[0].message.content).toContain('http://localhost:3001/routing/my-agent');
+    expect(choices[0].message.content).toContain('http://localhost:3001/agents/my-agent');
   });
 
   it('uses /routing path when agentName is not provided', async () => {
@@ -367,7 +367,7 @@ describe('ProxyService', () => {
 
     const json = (await result.forward.response.json()) as Record<string, unknown>;
     const choices = json.choices as { message: { content: string } }[];
-    expect(choices[0].message.content).toContain('http://localhost:4000/routing/test-agent');
+    expect(choices[0].message.content).toContain('http://localhost:4000/agents/test-agent');
   });
 
   it('returns synthetic streaming response when no model is resolved', async () => {
@@ -2299,7 +2299,11 @@ describe('ProxyService', () => {
         authType: 'subscription',
       });
       // getAuthType was called for the fallback provider (different provider, no exclusions)
-      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'Anthropic', undefined);
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith(
+        'agent-1',
+        'Anthropic',
+        undefined,
+      );
       // getProviderApiKey was called with subscription for the fallback
       expect(providerKeyService.getProviderApiKey).toHaveBeenNthCalledWith(
         2,
@@ -2530,7 +2534,11 @@ describe('ProxyService', () => {
       expect(providerClient.forward).toHaveBeenCalledTimes(2);
       expect(result.failedFallbacks).toHaveLength(0);
       // Verify getAuthType was called for both fallback providers (different from primary, no exclusions)
-      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'Anthropic', undefined);
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith(
+        'agent-1',
+        'Anthropic',
+        undefined,
+      );
       expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'DeepSeek', undefined);
     });
 

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -280,7 +280,7 @@ export class ProxyService {
     const baseUrl =
       this.config.get<string>('app.betterAuthUrl') ||
       `http://localhost:${this.config.get<number>('app.port', 3001)}`;
-    const path = agentName ? `/routing/${encodeURIComponent(agentName)}` : '/routing';
+    const path = agentName ? `/agents/${encodeURIComponent(agentName)}` : '/routing';
     return `${baseUrl}${path}`;
   }
 


### PR DESCRIPTION
## Summary

- The no-provider onboarding response pointed users to `/routing/:agentName` (e.g. `app.manifest.build/routing/nana-chan`) but the correct destination is `/agents/:agentName`
- Updated `getDashboardUrl()` in `ProxyService` and corresponding test expectations

## Test plan

- [x] Unit test expectations updated for new URL path
- [x] Existing tests pass
- [x] Changeset included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the onboarding dashboard link so users are sent to /agents/:agentName instead of /routing/:agentName. Updated `ProxyService.getDashboardUrl()` and unit tests; requests without an agent name still use /routing.

<sup>Written for commit f4a08d10af189feda3cfda0b46ae2b97ab8f2f10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

