### PR TITLE
fix: preserve thought_signature in Google Gemini proxy

### DIFF
--- a/.changeset/fix-gemini-thought-signature.md
+++ b/.changeset/fix-gemini-thought-signature.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix Google Gemini proxy failing with "missing thought_signature" error on newer models (e.g. Gemini 3 Flash Preview) by preserving the thought_signature field through the OpenAI-compatible format conversion round-trip.

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -419,6 +419,54 @@ describe('Google Adapter', () => {
         args: { query: 'cats' },
       });
     });
+
+    it('passes through thought_signature in tool_calls to functionCall parts', () => {
+      const body = {
+        messages: [
+          { role: 'user', content: 'Read my file' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'read_file', arguments: '{"path":"a.txt"}' },
+                thought_signature: 'sig_abc123',
+              },
+            ],
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-3-flash-preview');
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(contents[1].parts[0].functionCall).toEqual({
+        name: 'read_file',
+        args: { path: 'a.txt' },
+        thought_signature: 'sig_abc123',
+      });
+    });
+
+    it('omits thought_signature when not present in tool_calls', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'noop', arguments: '{}' },
+              },
+            ],
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.0-flash');
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(contents[0].parts[0].functionCall).toEqual({ name: 'noop', args: {} });
+    });
   });
 
   describe('fromGoogleResponse', () => {
@@ -744,6 +792,51 @@ describe('Google Adapter', () => {
       expect(usage.cache_read_tokens).toBe(0);
     });
 
+    it('preserves thought_signature on function call response', () => {
+      const google = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'read_file',
+                    args: { path: 'a.txt' },
+                    thought_signature: 'sig_xyz789',
+                  },
+                },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      };
+
+      const result = fromGoogleResponse(google, 'gemini-3-flash-preview');
+      const choices = result.choices as Array<{ message: Record<string, unknown> }>;
+      const toolCalls = choices[0].message.tool_calls as Array<Record<string, unknown>>;
+      expect(toolCalls).toHaveLength(1);
+      expect(toolCalls[0].thought_signature).toBe('sig_xyz789');
+    });
+
+    it('omits thought_signature when not in function call response', () => {
+      const google = {
+        candidates: [
+          {
+            content: {
+              parts: [{ functionCall: { name: 'search', args: { q: 'cats' } } }],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      };
+
+      const result = fromGoogleResponse(google, 'gemini-2.0-flash');
+      const choices = result.choices as Array<{ message: Record<string, unknown> }>;
+      const toolCalls = choices[0].message.tool_calls as Array<Record<string, unknown>>;
+      expect(toolCalls[0].thought_signature).toBeUndefined();
+    });
+
     it('handles multiple function calls in response', () => {
       const google = {
         candidates: [
@@ -912,6 +1005,29 @@ describe('Google Adapter', () => {
       expect(data.choices[0].delta.tool_calls[0].function.name).toBe('tool_a');
       expect(data.choices[0].delta.tool_calls[1].index).toBe(1);
       expect(data.choices[0].delta.tool_calls[1].function.name).toBe('tool_b');
+    });
+
+    it('preserves thought_signature on streaming functionCall', () => {
+      const chunk = JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: {
+                    name: 'read_file',
+                    args: { path: 'a.txt' },
+                    thought_signature: 'sig_stream_456',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-3-flash-preview');
+      const data = JSON.parse(result!.split('\n\n')[0].replace('data: ', ''));
+      expect(data.choices[0].delta.tool_calls[0].thought_signature).toBe('sig_stream_456');
     });
 
     it('handles functionCall with null args', () => {

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -15,7 +15,7 @@ interface GeminiContent {
 
 interface GeminiPart {
   text?: string;
-  functionCall?: { name: string; args: Record<string, unknown> };
+  functionCall?: { name: string; args: Record<string, unknown>; [key: string]: unknown };
   functionResponse?: { name: string; response: Record<string, unknown> };
 }
 
@@ -102,12 +102,13 @@ function messageToContent(msg: OpenAIMessage): GeminiContent | null {
   // Handle tool calls from assistant
   if (Array.isArray(msg.tool_calls)) {
     for (const tc of msg.tool_calls) {
-      parts.push({
-        functionCall: {
-          name: tc.function.name,
-          args: safeParseArgs(tc.function.arguments),
-        },
-      });
+      const functionCall: GeminiPart['functionCall'] = {
+        name: tc.function.name,
+        args: safeParseArgs(tc.function.arguments),
+      };
+      const sig = (tc as Record<string, unknown>).thought_signature;
+      if (sig) functionCall!.thought_signature = sig;
+      parts.push({ functionCall });
     }
   }
 
@@ -220,12 +221,18 @@ export function fromGoogleResponse(
   for (const part of parts) {
     if (part.text) textContent += part.text;
     if (part.functionCall) {
-      const fc = part.functionCall as { name: string; args: Record<string, unknown> };
-      toolCalls.push({
+      const fc = part.functionCall as {
+        name: string;
+        args: Record<string, unknown>;
+        thought_signature?: string;
+      };
+      const toolCall: Record<string, unknown> = {
         id: `call_${randomUUID()}`,
         type: 'function',
         function: { name: fc.name, arguments: JSON.stringify(fc.args) },
-      });
+      };
+      if (fc.thought_signature) toolCall.thought_signature = fc.thought_signature;
+      toolCalls.push(toolCall);
     }
   }
 
@@ -289,13 +296,19 @@ export function transformGoogleStreamChunk(chunk: string, model: string): string
   const toolCalls: Record<string, unknown>[] = [];
   for (const part of parts) {
     if (part.functionCall) {
-      const fc = part.functionCall as { name: string; args?: Record<string, unknown> };
-      toolCalls.push({
+      const fc = part.functionCall as {
+        name: string;
+        args?: Record<string, unknown>;
+        thought_signature?: string;
+      };
+      const toolCall: Record<string, unknown> = {
         index: toolCalls.length,
         id: `call_${randomUUID()}`,
         type: 'function',
         function: { name: fc.name, arguments: JSON.stringify(fc.args ?? {}) },
-      });
+      };
+      if (fc.thought_signature) toolCall.thought_signature = fc.thought_signature;
+      toolCalls.push(toolCall);
     }
   }
 


### PR DESCRIPTION
## Summary

- Newer Gemini models (e.g. Gemini 3 Flash Preview) return a `thought_signature` field in `functionCall` parts and require it in subsequent requests
- The proxy was dropping this field during OpenAI-format conversion, causing 400 errors: "Function call is missing a thought_signature in functionCall parts"
- Preserve `thought_signature` through the round-trip in all three code paths: non-streaming response, streaming response, and request conversion
- Backwards-compatible: models that don't use `thought_signature` are unaffected

## Test plan

- [x] Unit tests for `toGoogleRequest` — thought_signature round-trips through request conversion
- [x] Unit tests for `fromGoogleResponse` — thought_signature preserved in non-streaming responses
- [x] Unit tests for `transformGoogleStreamChunk` — thought_signature preserved in streaming responses
- [x] Verified existing tests still pass (61 total)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400 errors from newer Gemini models by preserving the `thought_signature` field in the Google Gemini proxy during OpenAI-format conversions. Works for both streaming and non-streaming flows and remains backward compatible.

- **Bug Fixes**
  - Preserve `thought_signature` in request conversion (`toGoogleRequest`).
  - Preserve `thought_signature` in non-streaming responses (`fromGoogleResponse`).
  - Preserve `thought_signature` in streaming responses (`transformGoogleStreamChunk`).
  - No-op for models that don’t use `thought_signature`.

<sup>Written for commit 7d8862ffeecbd779f0610ef85db67b817ee22ff3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

