### PR TITLE
fix: return friendly chat messages instead of raw HTTP errors on proxy

### DIFF
--- a/.changeset/better-proxy-error-messages.md
+++ b/.changeset/better-proxy-error-messages.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Return friendly chat completion messages instead of raw HTTP errors on the proxy endpoint. Invalid API keys, missing provider keys, and usage limits now appear as helpful assistant messages in the user's chat instead of cryptic "HTTP 401: Unauthorized" errors.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
@@ -1,0 +1,178 @@
+import { UnauthorizedException, BadRequestException, HttpException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ArgumentsHost } from '@nestjs/common';
+import { ProxyExceptionFilter } from '../proxy-exception.filter';
+
+function createMockHost(body: Record<string, unknown> = {}, ingestionCtx?: unknown) {
+  const req: Record<string, unknown> = { body };
+  if (ingestionCtx) req.ingestionContext = ingestionCtx;
+
+  const res = {
+    setHeader: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+    send: jest.fn(),
+  };
+
+  return {
+    host: {
+      switchToHttp: () => ({
+        getRequest: () => req,
+        getResponse: () => res,
+      }),
+    } as unknown as ArgumentsHost,
+    res,
+    req,
+  };
+}
+
+describe('ProxyExceptionFilter', () => {
+  let filter: ProxyExceptionFilter;
+  let config: jest.Mocked<ConfigService>;
+
+  beforeEach(() => {
+    config = {
+      get: jest.fn((key: string) => {
+        if (key === 'app.betterAuthUrl') return 'http://localhost:3001';
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    filter = new ProxyExceptionFilter(config);
+  });
+
+  describe('auth errors (401)', () => {
+    it('converts "Authorization header required" to friendly message', () => {
+      const { host, res } = createMockHost();
+      filter.catch(new UnauthorizedException('Authorization header required'), host);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          choices: expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.objectContaining({
+                content: expect.stringContaining('Missing API key'),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('converts "Empty token" to friendly message', () => {
+      const { host, res } = createMockHost();
+      filter.catch(new UnauthorizedException('Empty token'), host);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const content = res.json.mock.calls[0][0].choices[0].message.content;
+      expect(content).toContain('Bearer token is empty');
+    });
+
+    it('converts "Invalid API key format" to friendly message', () => {
+      const { host, res } = createMockHost();
+      filter.catch(new UnauthorizedException('Invalid API key format'), host);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const content = res.json.mock.calls[0][0].choices[0].message.content;
+      expect(content).toContain('mnfst_');
+    });
+
+    it('converts "API key expired" with dashboard URL', () => {
+      const { host, res } = createMockHost({}, { agentName: 'my-agent' });
+      filter.catch(new UnauthorizedException('API key expired'), host);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const content = res.json.mock.calls[0][0].choices[0].message.content;
+      expect(content).toContain('expired');
+      expect(content).toContain('http://localhost:3001/agents/my-agent');
+    });
+
+    it('converts "Invalid API key" to friendly message', () => {
+      const { host, res } = createMockHost();
+      filter.catch(new UnauthorizedException('Invalid API key'), host);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const content = res.json.mock.calls[0][0].choices[0].message.content;
+      expect(content).toContain("wasn't recognized");
+    });
+
+    it('includes dashboard URL in auth error messages', () => {
+      const { host, res } = createMockHost();
+      filter.catch(new UnauthorizedException('Invalid API key'), host);
+
+      const content = res.json.mock.calls[0][0].choices[0].message.content;
+      expect(content).toContain('Dashboard: http://localhost:3001/routing');
+    });
+  });
+
+  describe('streaming responses', () => {
+    it('returns SSE format when stream=true', () => {
+      const { host, res } = createMockHost({ stream: true });
+      filter.catch(new UnauthorizedException('Invalid API key'), host);
+
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+      expect(res.status).toHaveBeenCalledWith(200);
+      const payload = res.send.mock.calls[0][0] as string;
+      expect(payload).toContain('data: [DONE]');
+      expect(payload).toContain('chat.completion.chunk');
+    });
+  });
+
+  describe('429 passthrough', () => {
+    it('passes rate limit errors through as HTTP 429', () => {
+      const { host, res } = createMockHost();
+      filter.catch(
+        new HttpException('Too many requests — wait a few seconds and retry.', 429),
+        host,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: 'Too many requests — wait a few seconds and retry.',
+          }),
+        }),
+      );
+    });
+
+    it('passes structured 429 errors through unchanged', () => {
+      const errorBody = { error: { message: 'Rate limited', type: 'rate_limit' } };
+      const { host, res } = createMockHost();
+      filter.catch(new HttpException(errorBody, 429), host);
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(res.json).toHaveBeenCalledWith(errorBody);
+    });
+  });
+
+  describe('other errors', () => {
+    it('converts 400 errors to friendly chat message', () => {
+      const { host, res } = createMockHost();
+      filter.catch(new BadRequestException('messages array is required'), host);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const content = res.json.mock.calls[0][0].choices[0].message.content;
+      expect(content).toBe('messages array is required');
+    });
+
+    it('converts 500 errors to generic friendly message', () => {
+      const { host, res } = createMockHost();
+      filter.catch(new HttpException('Some internal error', 500), host);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const content = res.json.mock.calls[0][0].choices[0].message.content;
+      expect(content).toBe('Something broke on our end. Try again shortly.');
+    });
+
+    it('converts unknown auth message to friendly message', () => {
+      const { host, res } = createMockHost();
+      filter.catch(new UnauthorizedException('Some unknown auth error'), host);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const content = res.json.mock.calls[0][0].choices[0].message.content;
+      expect(content).toBe('Some unknown auth error');
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy-friendly-response.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-friendly-response.spec.ts
@@ -1,0 +1,142 @@
+import { ConfigService } from '@nestjs/config';
+import { Response as ExpressResponse } from 'express';
+import {
+  buildFriendlyResponse,
+  getDashboardUrl,
+  sendFriendlyResponse,
+} from '../proxy-friendly-response';
+
+describe('proxy-friendly-response', () => {
+  describe('getDashboardUrl', () => {
+    it('returns agent-specific URL when agentName provided', () => {
+      const config = {
+        get: jest.fn((key: string) => {
+          if (key === 'app.betterAuthUrl') return 'https://app.manifest.build';
+          return undefined;
+        }),
+      } as unknown as ConfigService;
+
+      expect(getDashboardUrl(config, 'my-agent')).toBe(
+        'https://app.manifest.build/agents/my-agent',
+      );
+    });
+
+    it('returns routing URL when no agentName', () => {
+      const config = {
+        get: jest.fn((key: string) => {
+          if (key === 'app.betterAuthUrl') return 'https://app.manifest.build';
+          return undefined;
+        }),
+      } as unknown as ConfigService;
+
+      expect(getDashboardUrl(config)).toBe('https://app.manifest.build/routing');
+    });
+
+    it('falls back to localhost when no betterAuthUrl configured', () => {
+      const config = {
+        get: jest.fn((key: string, fallback?: unknown) => {
+          if (key === 'app.betterAuthUrl') return undefined;
+          if (key === 'app.port') return 4000;
+          return fallback;
+        }),
+      } as unknown as ConfigService;
+
+      expect(getDashboardUrl(config, 'demo')).toBe('http://localhost:4000/agents/demo');
+    });
+
+    it('encodes special characters in agent name', () => {
+      const config = {
+        get: jest.fn((key: string) => {
+          if (key === 'app.betterAuthUrl') return 'http://localhost:3001';
+          return undefined;
+        }),
+      } as unknown as ConfigService;
+
+      expect(getDashboardUrl(config, 'my agent')).toBe('http://localhost:3001/agents/my%20agent');
+    });
+  });
+
+  describe('buildFriendlyResponse', () => {
+    it('returns non-streaming chat completion', async () => {
+      const result = buildFriendlyResponse('Hello world', false);
+
+      expect(result.forward.response.status).toBe(200);
+      expect(result.forward.isGoogle).toBe(false);
+      expect(result.forward.isAnthropic).toBe(false);
+      expect(result.forward.isChatGpt).toBe(false);
+      expect(result.meta.model).toBe('manifest');
+      expect(result.meta.provider).toBe('manifest');
+      expect(result.meta.confidence).toBe(1);
+      expect(result.meta.reason).toBe('friendly_error');
+
+      const json = (await result.forward.response.json()) as Record<string, unknown>;
+      expect(json.object).toBe('chat.completion');
+      expect((json.id as string).startsWith('chatcmpl-manifest-')).toBe(true);
+
+      const choices = json.choices as { message: { role: string; content: string } }[];
+      expect(choices[0].message.role).toBe('assistant');
+      expect(choices[0].message.content).toBe('Hello world');
+    });
+
+    it('returns streaming SSE response', async () => {
+      const result = buildFriendlyResponse('Stream test', true);
+
+      expect(result.forward.response.status).toBe(200);
+      expect(result.forward.response.headers.get('Content-Type')).toBe('text/event-stream');
+
+      const text = await result.forward.response.text();
+      expect(text).toContain('data: {');
+      expect(text).toContain('"Stream test"');
+      expect(text).toContain('chat.completion.chunk');
+      expect(text).toContain('data: [DONE]');
+    });
+
+    it('uses custom reason when provided', () => {
+      const result = buildFriendlyResponse('test', false, 'no_provider');
+      expect(result.meta.reason).toBe('no_provider');
+    });
+  });
+
+  describe('sendFriendlyResponse', () => {
+    let res: jest.Mocked<ExpressResponse>;
+
+    beforeEach(() => {
+      res = {
+        setHeader: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+        send: jest.fn(),
+      } as unknown as jest.Mocked<ExpressResponse>;
+    });
+
+    it('sends non-streaming JSON response', () => {
+      sendFriendlyResponse(res, 'Test message', false);
+
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          object: 'chat.completion',
+          choices: expect.arrayContaining([
+            expect.objectContaining({
+              message: { role: 'assistant', content: 'Test message' },
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('sends streaming SSE response', () => {
+      sendFriendlyResponse(res, 'Stream msg', true);
+
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-cache');
+      expect(res.setHeader).toHaveBeenCalledWith('Connection', 'keep-alive');
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      const payload = res.send.mock.calls[0][0] as string;
+      expect(payload).toContain('Stream msg');
+      expect(payload).toContain('data: [DONE]');
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
@@ -38,7 +38,9 @@ describe('ProxyRateLimiter', () => {
       } catch (err) {
         expect(err).toBeInstanceOf(HttpException);
         expect((err as HttpException).getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
-        expect((err as HttpException).message).toBe('Rate limit exceeded. Try again later.');
+        expect((err as HttpException).message).toBe(
+          'Too many requests — wait a few seconds and retry.',
+        );
       }
     });
 
@@ -207,7 +209,7 @@ describe('ProxyRateLimiter', () => {
         expect(err).toBeInstanceOf(HttpException);
         expect((err as HttpException).getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
         expect((err as HttpException).message).toBe(
-          'Too many concurrent requests. Try again later.',
+          'Too many concurrent requests. Give it a moment.',
         );
       }
     });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -620,7 +620,7 @@ describe('ProxyController', () => {
     });
   });
 
-  it('should handle 500 errors from proxyService', async () => {
+  it('should handle 500 errors from proxyService as friendly chat message', async () => {
     proxyService.proxyRequest.mockRejectedValue(new Error('Internal failure'));
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
@@ -628,13 +628,22 @@ describe('ProxyController', () => {
 
     await controller.chatCompletions(req as never, res as never);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith({
-      error: { message: 'Internal proxy error', type: 'proxy_error' },
-    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        object: 'chat.completion',
+        choices: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.objectContaining({
+              content: 'Something broke on our end. Try again shortly.',
+            }),
+          }),
+        ]),
+      }),
+    );
   });
 
-  it('should forward HttpException status and message', async () => {
+  it('should forward HttpException as friendly chat message', async () => {
     proxyService.proxyRequest.mockRejectedValue(
       new HttpException('Bad request: messages required', 400),
     );
@@ -644,18 +653,24 @@ describe('ProxyController', () => {
 
     await controller.chatCompletions(req as never, res as never);
 
-    expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith({
-      error: { message: 'Bad request: messages required', type: 'proxy_error' },
-    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        object: 'chat.completion',
+        choices: expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.objectContaining({
+              content: 'Bad request: messages required',
+            }),
+          }),
+        ]),
+      }),
+    );
   });
 
   it('should record rate_limited agent_message on 429', async () => {
     proxyService.proxyRequest.mockRejectedValue(
-      new HttpException(
-        { error: { message: 'Limit exceeded: tokens usage (52,000) exceeds 50,000 per day' } },
-        429,
-      ),
+      new HttpException('Too many requests — wait a few seconds and retry.', 429),
     );
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -842,6 +857,22 @@ describe('ProxyController', () => {
       expect(res.status).toHaveBeenCalledWith(429);
     });
 
+    it('should wrap string HttpException response in proxy_error envelope on 429', async () => {
+      rateLimiter.checkLimit.mockImplementation(() => {
+        throw new HttpException('Too many requests', 429);
+      });
+
+      const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
+      const { res } = mockResponse();
+
+      await controller.chatCompletions(req as never, res as never);
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(res.json).toHaveBeenCalledWith({
+        error: { message: 'Too many requests', type: 'proxy_error' },
+      });
+    });
+
     it('should NOT releaseSlot when checkLimit throws (slot never acquired)', async () => {
       rateLimiter.checkLimit.mockImplementation(() => {
         throw new HttpException('Rate limit exceeded', 429);
@@ -872,7 +903,7 @@ describe('ProxyController', () => {
 
     it('should record 429 when checkLimit throws with 429', async () => {
       rateLimiter.checkLimit.mockImplementation(() => {
-        throw new HttpException('Rate limit exceeded. Try again later.', 429);
+        throw new HttpException('Too many requests — wait a few seconds and retry.', 429);
       });
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -1343,7 +1374,7 @@ describe('ProxyController', () => {
   });
 
   describe('error handling edge cases', () => {
-    it('should mask error message for 500+ status codes', async () => {
+    it('should mask error message for 500+ status codes as friendly chat message', async () => {
       proxyService.proxyRequest.mockRejectedValue(new Error('Sensitive internal error details'));
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -1351,13 +1382,22 @@ describe('ProxyController', () => {
 
       await controller.chatCompletions(req as never, res as never);
 
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({
-        error: { message: 'Internal proxy error', type: 'proxy_error' },
-      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          object: 'chat.completion',
+          choices: expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.objectContaining({
+                content: 'Something broke on our end. Try again shortly.',
+              }),
+            }),
+          ]),
+        }),
+      );
     });
 
-    it('should expose original message for client errors (4xx)', async () => {
+    it('should expose original message for client errors as friendly chat message', async () => {
       proxyService.proxyRequest.mockRejectedValue(
         new HttpException('messages array is required', 400),
       );
@@ -1367,13 +1407,21 @@ describe('ProxyController', () => {
 
       await controller.chatCompletions(req as never, res as never);
 
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: { message: 'messages array is required', type: 'proxy_error' },
-      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          choices: expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.objectContaining({
+                content: 'messages array is required',
+              }),
+            }),
+          ]),
+        }),
+      );
     });
 
-    it('should handle non-Error throw as string', async () => {
+    it('should handle non-Error throw as friendly chat message', async () => {
       proxyService.proxyRequest.mockRejectedValue('string error');
 
       const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }] });
@@ -1381,10 +1429,19 @@ describe('ProxyController', () => {
 
       await controller.chatCompletions(req as never, res as never);
 
-      expect(res.status).toHaveBeenCalledWith(500);
-      expect(res.json).toHaveBeenCalledWith({
-        error: { message: 'Internal proxy error', type: 'proxy_error' },
-      });
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          object: 'chat.completion',
+          choices: expect.arrayContaining([
+            expect.objectContaining({
+              message: expect.objectContaining({
+                content: 'Something broke on our end. Try again shortly.',
+              }),
+            }),
+          ]),
+        }),
+      );
     });
 
     it('should forward provider error response and preserve content-type from provider', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, HttpException } from '@nestjs/common';
+import { BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Repository } from 'typeorm';
 import { ProxyService } from '../proxy.service';
@@ -396,7 +396,7 @@ describe('ProxyService', () => {
     expect(result.meta.reason).toBe('no_provider');
   });
 
-  it('throws when no API key found for provider', async () => {
+  it('returns friendly response when no API key found for provider', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'standard',
       model: 'gpt-4o',
@@ -407,9 +407,21 @@ describe('ProxyService', () => {
     });
     providerKeyService.getProviderApiKey.mockResolvedValue(null);
 
-    await expect(
-      service.proxyRequest({ agentId: 'agent-1', userId: 'user-1', body, sessionKey: 'default' }),
-    ).rejects.toThrow('No API key found');
+    const result = await service.proxyRequest({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      body,
+      sessionKey: 'default',
+      agentName: 'my-agent',
+    });
+
+    expect(result.forward.response.status).toBe(200);
+    const json = (await result.forward.response.json()) as {
+      choices: { message: { content: string } }[];
+    };
+    expect(json.choices[0].message.content).toContain('No API key set for OpenAI');
+    expect(json.choices[0].message.content).toContain('/agents/my-agent');
+    expect(result.meta.reason).toBe('no_provider_key');
   });
 
   it('resolves, forwards, and records momentum on success', async () => {
@@ -1070,7 +1082,7 @@ describe('ProxyService', () => {
       });
     };
 
-    it('throws 429 when limit is exceeded', async () => {
+    it('returns friendly response when limit is exceeded', async () => {
       limitCheck.checkLimits.mockResolvedValue({
         ruleId: 'r1',
         metricType: 'tokens',
@@ -1079,33 +1091,22 @@ describe('ProxyService', () => {
         period: 'day',
       });
 
-      await expect(
-        service.proxyRequest({
-          agentId: 'agent-1',
-          userId: 'user-1',
-          body,
-          sessionKey: 'default',
-          tenantId: 'tenant-1',
-          agentName: 'my-agent',
-        }),
-      ).rejects.toThrow(HttpException);
+      const result = await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body,
+        sessionKey: 'default',
+        tenantId: 'tenant-1',
+        agentName: 'my-agent',
+      });
 
-      try {
-        await service.proxyRequest({
-          agentId: 'agent-1',
-          userId: 'user-1',
-          body,
-          sessionKey: 'default',
-          tenantId: 'tenant-1',
-          agentName: 'my-agent',
-        });
-      } catch (err) {
-        expect((err as HttpException).getStatus()).toBe(429);
-        const response = (err as HttpException).getResponse() as Record<string, unknown>;
-        const error = response.error as Record<string, unknown>;
-        expect(error.code).toBe('limit_exceeded');
-        expect(error.type).toBe('rate_limit_exceeded');
-      }
+      expect(result.forward.response.status).toBe(200);
+      const json = (await result.forward.response.json()) as {
+        choices: { message: { content: string } }[];
+      };
+      expect(json.choices[0].message.content).toContain('Usage limit hit');
+      expect(json.choices[0].message.content).toContain('tokens');
+      expect(result.meta.reason).toBe('limit_exceeded');
     });
 
     it('does not check limits when tenantId/agentName are not provided', async () => {
@@ -1167,7 +1168,7 @@ describe('ProxyService', () => {
       expect(result.meta.model).toBe('gpt-4o');
     });
 
-    it('formats cost limit error with dollar sign and 2 decimal places', async () => {
+    it('formats cost limit with dollar sign and 2 decimal places', async () => {
       limitCheck.checkLimits.mockResolvedValue({
         ruleId: 'r2',
         metricType: 'cost',
@@ -1176,26 +1177,24 @@ describe('ProxyService', () => {
         period: 'month',
       });
 
-      try {
-        await service.proxyRequest({
-          agentId: 'agent-1',
-          userId: 'user-1',
-          body,
-          sessionKey: 'default',
-          tenantId: 'tenant-1',
-          agentName: 'my-agent',
-        });
-        fail('Expected HttpException');
-      } catch (err) {
-        const response = (err as HttpException).getResponse() as Record<string, unknown>;
-        const error = response.error as Record<string, unknown>;
-        expect(error.message).toContain('$12.50');
-        expect(error.message).toContain('$10.00');
-        expect(error.message).toContain('per month');
-      }
+      const result = await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body,
+        sessionKey: 'default',
+        tenantId: 'tenant-1',
+        agentName: 'my-agent',
+      });
+
+      const json = (await result.forward.response.json()) as {
+        choices: { message: { content: string } }[];
+      };
+      expect(json.choices[0].message.content).toContain('$12.50');
+      expect(json.choices[0].message.content).toContain('$10.00');
+      expect(json.choices[0].message.content).toContain('/month');
     });
 
-    it('formats token limit error with locale string', async () => {
+    it('formats token limit with locale string', async () => {
       limitCheck.checkLimits.mockResolvedValue({
         ruleId: 'r3',
         metricType: 'tokens',
@@ -1204,24 +1203,22 @@ describe('ProxyService', () => {
         period: 'day',
       });
 
-      try {
-        await service.proxyRequest({
-          agentId: 'agent-1',
-          userId: 'user-1',
-          body,
-          sessionKey: 'default',
-          tenantId: 'tenant-1',
-          agentName: 'my-agent',
-        });
-        fail('Expected HttpException');
-      } catch (err) {
-        const response = (err as HttpException).getResponse() as Record<string, unknown>;
-        const error = response.error as Record<string, unknown>;
-        // toLocaleString formats numbers with commas
-        expect(error.message).toContain('105,000');
-        expect(error.message).toContain('100,000');
-        expect(error.message).toContain('per day');
-      }
+      const result = await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body,
+        sessionKey: 'default',
+        tenantId: 'tenant-1',
+        agentName: 'my-agent',
+      });
+
+      const json = (await result.forward.response.json()) as {
+        choices: { message: { content: string } }[];
+      };
+      // toLocaleString formats numbers with commas
+      expect(json.choices[0].message.content).toContain('105,000');
+      expect(json.choices[0].message.content).toContain('100,000');
+      expect(json.choices[0].message.content).toContain('/day');
     });
   });
 
@@ -1652,7 +1649,7 @@ describe('ProxyService', () => {
       });
     });
 
-    it('rejects subscription provider without stored token', async () => {
+    it('returns friendly response for subscription provider without stored token', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         model: 'claude-sonnet-4',
@@ -1663,9 +1660,19 @@ describe('ProxyService', () => {
       });
       providerKeyService.getProviderApiKey.mockResolvedValue(null);
 
-      await expect(
-        service.proxyRequest({ agentId: 'agent-1', userId: 'user-1', body, sessionKey: 'sess-1' }),
-      ).rejects.toThrow('No API key found');
+      const result = await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body,
+        sessionKey: 'sess-1',
+      });
+
+      expect(result.forward.response.status).toBe(200);
+      const json = (await result.forward.response.json()) as {
+        choices: { message: { content: string } }[];
+      };
+      expect(json.choices[0].message.content).toContain('No API key set for Anthropic');
+      expect(result.meta.reason).toBe('no_provider_key');
     });
   });
 

--- a/packages/backend/src/routing/proxy/proxy-exception.filter.ts
+++ b/packages/backend/src/routing/proxy/proxy-exception.filter.ts
@@ -1,0 +1,69 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpException, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request, Response as ExpressResponse } from 'express';
+import { getDashboardUrl, sendFriendlyResponse } from './proxy-friendly-response';
+import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interface';
+
+/** Guard-thrown messages that should become friendly chat responses. */
+const AUTH_ERROR_MESSAGES: Record<string, string> = {
+  'Authorization header required':
+    'Missing API key. Set your Manifest key (starts with mnfst_) as the Bearer token.',
+  'Empty token':
+    'Bearer token is empty — paste your Manifest API key into the authorization field.',
+  'Invalid API key format':
+    'That doesn\'t look like a Manifest key. They start with "mnfst_" — check your dashboard.',
+  'API key expired': 'This API key expired. Generate a new one from your Manifest dashboard',
+  'Invalid API key':
+    "This API key wasn't recognized — it may have been rotated or deleted. Check your dashboard for the current key.",
+};
+
+/** Status codes that should pass through as normal HTTP errors. */
+const PASSTHROUGH_STATUSES = new Set([429]);
+
+@Injectable()
+@Catch(HttpException)
+export class ProxyExceptionFilter implements ExceptionFilter {
+  constructor(private readonly config: ConfigService) {}
+
+  catch(exception: HttpException, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const req = ctx.getRequest<Request>();
+    const res = ctx.getResponse<ExpressResponse>();
+
+    const status = exception.getStatus();
+    const message = exception.message;
+
+    // Rate limit errors should stay as HTTP 429 so clients can backoff
+    if (PASSTHROUGH_STATUSES.has(status)) {
+      const response = exception.getResponse();
+      res
+        .status(status)
+        .json(
+          typeof response === 'string'
+            ? { error: { message: response, type: 'proxy_error' } }
+            : response,
+        );
+      return;
+    }
+
+    const isStream = (req.body as Record<string, unknown>)?.stream === true;
+    const ingestionCtx = (req as Request & { ingestionContext?: IngestionContext })
+      .ingestionContext;
+    const agentName = ingestionCtx?.agentName;
+
+    const friendly = AUTH_ERROR_MESSAGES[message];
+    if (friendly) {
+      const dashboardUrl = getDashboardUrl(this.config, agentName);
+      const content =
+        message === 'API key expired'
+          ? `${friendly}: ${dashboardUrl}`
+          : `${friendly}\n\nDashboard: ${dashboardUrl}`;
+      sendFriendlyResponse(res, content, isStream);
+      return;
+    }
+
+    // Other errors (400 bad request, 500, etc.) — send as friendly chat message
+    const content = status >= 500 ? 'Something broke on our end. Try again shortly.' : message;
+    sendFriendlyResponse(res, content, isStream);
+  }
+}

--- a/packages/backend/src/routing/proxy/proxy-friendly-response.ts
+++ b/packages/backend/src/routing/proxy/proxy-friendly-response.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from 'crypto';
+import { ConfigService } from '@nestjs/config';
+import { Response as ExpressResponse } from 'express';
+import { Tier } from '../../scoring/types';
+
+export interface FriendlyForward {
+  response: Response;
+  isGoogle: false;
+  isAnthropic: false;
+  isChatGpt: false;
+}
+
+export interface FriendlyResult {
+  forward: FriendlyForward;
+  meta: {
+    tier: Tier;
+    model: string;
+    provider: string;
+    confidence: number;
+    reason: string;
+  };
+}
+
+export function getDashboardUrl(config: ConfigService, agentName?: string): string {
+  const baseUrl =
+    config.get<string>('app.betterAuthUrl') ||
+    `http://localhost:${config.get<number>('app.port', 3001)}`;
+  const path = agentName ? `/agents/${encodeURIComponent(agentName)}` : '/routing';
+  return `${baseUrl}${path}`;
+}
+
+export function buildFriendlyResponse(
+  content: string,
+  stream: boolean,
+  reason = 'friendly_error',
+): FriendlyResult {
+  const id = `chatcmpl-manifest-${randomUUID()}`;
+  const created = Math.floor(Date.now() / 1000);
+
+  const meta = {
+    tier: 'simple' as Tier,
+    model: 'manifest',
+    provider: 'manifest',
+    confidence: 1,
+    reason,
+  };
+
+  if (stream) {
+    const chunk = {
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: 'manifest',
+      choices: [{ index: 0, delta: { role: 'assistant', content }, finish_reason: 'stop' }],
+    };
+    const ssePayload = `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`;
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(ssePayload));
+        controller.close();
+      },
+    });
+    return {
+      forward: {
+        response: new Response(body, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      },
+      meta,
+    };
+  }
+
+  const responseBody = {
+    id,
+    object: 'chat.completion',
+    created,
+    model: 'manifest',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+
+  return {
+    forward: {
+      response: new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+    },
+    meta,
+  };
+}
+
+/**
+ * Sends a friendly chat completion response directly to the Express response.
+ * Used by the exception filter where we don't return a ProxyResult.
+ */
+export function sendFriendlyResponse(res: ExpressResponse, content: string, stream: boolean): void {
+  const id = `chatcmpl-manifest-${randomUUID()}`;
+  const created = Math.floor(Date.now() / 1000);
+
+  if (stream) {
+    const chunk = {
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: 'manifest',
+      choices: [{ index: 0, delta: { role: 'assistant', content }, finish_reason: 'stop' }],
+    };
+    const ssePayload = `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`;
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.status(200).send(ssePayload);
+  } else {
+    const responseBody = {
+      id,
+      object: 'chat.completion',
+      created,
+      model: 'manifest',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    };
+    res.setHeader('Content-Type', 'application/json');
+    res.status(200).json(responseBody);
+  }
+}

--- a/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
+++ b/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
@@ -42,7 +42,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
 
     if (entry.count >= RATE_MAX_REQUESTS) {
       throw new HttpException(
-        'Rate limit exceeded. Try again later.',
+        'Too many requests — wait a few seconds and retry.',
         HttpStatus.TOO_MANY_REQUESTS,
       );
     }
@@ -56,7 +56,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
     const current = this.concurrency.get(userId) ?? 0;
     if (current >= CONCURRENCY_MAX) {
       throw new HttpException(
-        'Too many concurrent requests. Try again later.',
+        'Too many concurrent requests. Give it a moment.',
         HttpStatus.TOO_MANY_REQUESTS,
       );
     }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Post, Req, Res, UseGuards, Logger, HttpException } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+  UseFilters,
+  Logger,
+  HttpException,
+} from '@nestjs/common';
 import { Request, Response as ExpressResponse } from 'express';
 import { SkipThrottle } from '@nestjs/throttler';
 import { Public } from '../../common/decorators/public.decorator';
@@ -16,6 +25,8 @@ import {
   handleNonStreamResponse,
   recordSuccess,
 } from './proxy-response-handler';
+import { ProxyExceptionFilter } from './proxy-exception.filter';
+import { sendFriendlyResponse } from './proxy-friendly-response';
 
 const MAX_SEEN_USERS = 10_000;
 const SEEN_USER_TTL_MS = 24 * 60 * 60 * 1000;
@@ -23,6 +34,7 @@ const SEEN_USER_TTL_MS = 24 * 60 * 60 * 1000;
 @Controller('v1')
 @Public()
 @UseGuards(AgentKeyAuthGuard)
+@UseFilters(ProxyExceptionFilter)
 @SkipThrottle()
 export class ProxyController {
   private readonly logger = new Logger(ProxyController.name);
@@ -144,10 +156,23 @@ export class ProxyController {
         return;
       }
 
-      const clientMessage = status >= 500 ? 'Internal proxy error' : message;
-      res.status(status).json({
-        error: { message: clientMessage, type: 'proxy_error' },
-      });
+      // Rate limit errors stay as HTTP 429 so clients can backoff
+      if (status === 429) {
+        const response = err instanceof HttpException ? err.getResponse() : message;
+        res
+          .status(429)
+          .json(
+            typeof response === 'string'
+              ? { error: { message: response, type: 'proxy_error' } }
+              : response,
+          );
+        return;
+      }
+
+      const isStream = (req.body as Record<string, unknown>)?.stream === true;
+      const clientMessage =
+        status >= 500 ? 'Something broke on our end. Try again shortly.' : message;
+      sendFriendlyResponse(res, clientMessage, isStream);
     } finally {
       if (slotAcquired) this.rateLimiter.releaseSlot(userId);
     }

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -18,6 +18,7 @@ import { ProxyMessageRecorder } from './proxy-message-recorder';
 import { ProxyMessageDedup } from './proxy-message-dedup';
 import { SessionMomentumService } from './session-momentum.service';
 import { CopilotTokenService } from './copilot-token.service';
+import { ProxyExceptionFilter } from './proxy-exception.filter';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { CopilotTokenService } from './copilot-token.service';
     ProxyMessageDedup,
     SessionMomentumService,
     CopilotTokenService,
+    ProxyExceptionFilter,
   ],
 })
 export class ProxyModule {}

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -1,5 +1,4 @@
-import { randomUUID } from 'crypto';
-import { Injectable, Logger, BadRequestException, HttpException } from '@nestjs/common';
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ResolveService } from '../resolve/resolve.service';
 import { ProviderKeyService } from '../routing-core/provider-key.service';
@@ -18,6 +17,7 @@ import {
   resolveApiKey,
 } from './proxy-fallback.service';
 import { ProxyRequestOptions } from './proxy-types';
+import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
 
 export { FailedFallback } from './proxy-fallback.service';
 
@@ -73,7 +73,10 @@ export class ProxyService {
     }
     sanitizeNullContent(messages as Record<string, unknown>[]);
 
-    await this.enforceLimits(tenantId, agentName);
+    const limitMessage = await this.enforceLimits(tenantId, agentName);
+    if (limitMessage) {
+      return buildFriendlyResponse(limitMessage, body.stream === true, 'limit_exceeded');
+    }
 
     const scoringMessages = this.filterScoringMessages(messages as ScorerMessage[]);
     const scoringTools = Array.isArray(body.tools) ? body.tools : undefined;
@@ -106,9 +109,9 @@ export class ProxyService {
       resolved.auth_type,
     );
     if (apiKey === null) {
-      throw new BadRequestException(
-        `No API key found for provider: ${resolved.provider}. Re-connect the provider with an API key.`,
-      );
+      const dashboardUrl = getDashboardUrl(this.config, agentName);
+      const content = `No API key set for ${resolved.provider} yet. Add one here: ${dashboardUrl}`;
+      return buildFriendlyResponse(content, body.stream === true, 'no_provider_key');
     }
 
     const resolvedCredentials = await resolveApiKey(
@@ -233,10 +236,10 @@ export class ProxyService {
     };
   }
 
-  private async enforceLimits(tenantId?: string, agentName?: string): Promise<void> {
-    if (!tenantId || !agentName) return;
+  private async enforceLimits(tenantId?: string, agentName?: string): Promise<string | null> {
+    if (!tenantId || !agentName) return null;
     const exceeded = await this.limitCheck.checkLimits(tenantId, agentName);
-    if (!exceeded) return;
+    if (!exceeded) return null;
 
     const fmt =
       exceeded.metricType === 'cost'
@@ -246,16 +249,8 @@ export class ProxyService {
       exceeded.metricType === 'cost'
         ? `$${Number(exceeded.threshold).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
         : Number(exceeded.threshold).toLocaleString(undefined, { maximumFractionDigits: 0 });
-    throw new HttpException(
-      {
-        error: {
-          message: `Limit exceeded: ${exceeded.metricType} usage (${fmt}) exceeds ${threshFmt} per ${exceeded.period}`,
-          type: 'rate_limit_exceeded',
-          code: 'limit_exceeded',
-        },
-      },
-      429,
-    );
+    const dashboardUrl = getDashboardUrl(this.config, agentName);
+    return `Usage limit hit: ${exceeded.metricType} is at ${fmt} (limit: ${threshFmt}/${exceeded.period}). You can adjust it here: ${dashboardUrl}`;
   }
 
   private filterScoringMessages(messages: ScorerMessage[]): ScorerMessage[] {
@@ -276,85 +271,10 @@ export class ProxyService {
     return false;
   }
 
-  private getDashboardUrl(agentName?: string): string {
-    const baseUrl =
-      this.config.get<string>('app.betterAuthUrl') ||
-      `http://localhost:${this.config.get<number>('app.port', 3001)}`;
-    const path = agentName ? `/agents/${encodeURIComponent(agentName)}` : '/routing';
-    return `${baseUrl}${path}`;
-  }
-
   private buildNoProviderResult(stream: boolean, agentName?: string): ProxyResult {
-    const id = `chatcmpl-manifest-${randomUUID()}`;
-    const created = Math.floor(Date.now() / 1000);
-    const dashboardUrl = this.getDashboardUrl(agentName);
+    const dashboardUrl = getDashboardUrl(this.config, agentName);
     const content = `Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`;
-
-    const meta: RoutingMeta = {
-      tier: 'simple' as Tier,
-      model: 'manifest',
-      provider: 'manifest',
-      confidence: 1,
-      reason: 'no_provider',
-    };
-
-    if (stream) {
-      const chunk = {
-        id,
-        object: 'chat.completion.chunk',
-        created,
-        model: 'manifest',
-        choices: [{ index: 0, delta: { role: 'assistant', content }, finish_reason: 'stop' }],
-      };
-      const ssePayload = `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`;
-      const encoder = new TextEncoder();
-      const body = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(encoder.encode(ssePayload));
-          controller.close();
-        },
-      });
-      return {
-        forward: {
-          response: new Response(body, {
-            status: 200,
-            headers: { 'Content-Type': 'text/event-stream' },
-          }),
-          isGoogle: false,
-          isAnthropic: false,
-          isChatGpt: false,
-        },
-        meta,
-      };
-    }
-
-    const responseBody = {
-      id,
-      object: 'chat.completion',
-      created,
-      model: 'manifest',
-      choices: [
-        {
-          index: 0,
-          message: { role: 'assistant', content },
-          finish_reason: 'stop',
-        },
-      ],
-      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
-    };
-
-    return {
-      forward: {
-        response: new Response(JSON.stringify(responseBody), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }),
-        isGoogle: false,
-        isAnthropic: false,
-        isChatGpt: false,
-      },
-      meta,
-    };
+    return buildFriendlyResponse(content, stream, 'no_provider');
   }
 }
 

--- a/packages/backend/test/proxy.e2e-spec.ts
+++ b/packages/backend/test/proxy.e2e-spec.ts
@@ -82,28 +82,29 @@ describe('Proxy E2E — /v1/chat/completions', () => {
         });
       return;
     }
-    await api()
+    const res = await api()
       .post('/v1/chat/completions')
       .send({ messages: [{ role: 'user', content: 'hello' }] })
-      .expect(401);
+      .expect(200);
+
+    // Auth errors are returned as friendly chat completion messages
+    expect(res.body.choices[0].message.content).toContain('Missing API key');
   });
 
-  it('returns 400 when messages are missing', async () => {
+  it('returns friendly message when messages are missing', async () => {
     const res = await bearer(api().post('/v1/chat/completions'))
       .send({})
-      .expect(400);
+      .expect(200);
 
-    expect(res.body.error).toBeDefined();
-    expect(res.body.error.message).toContain('messages');
+    expect(res.body.choices[0].message.content).toContain('messages');
   });
 
-  it('returns 400 when messages array is empty', async () => {
+  it('returns friendly message when messages array is empty', async () => {
     const res = await bearer(api().post('/v1/chat/completions'))
       .send({ messages: [] })
-      .expect(400);
+      .expect(200);
 
-    expect(res.body.error).toBeDefined();
-    expect(res.body.error.message).toContain('messages');
+    expect(res.body.choices[0].message.content).toContain('messages');
   });
 
   it('resolves and attempts to forward to provider', async () => {

--- a/packages/backend/test/smoke-test.e2e-spec.ts
+++ b/packages/backend/test/smoke-test.e2e-spec.ts
@@ -295,9 +295,10 @@ describe('ST-08: Hard limit blocks', () => {
 
     const res = await smokeBearer(api().post('/v1/chat/completions'))
       .send({ messages: [{ role: 'user', content: 'blocked?' }], stream: false })
-      .expect(429);
+      .expect(200);
 
-    expect(res.body.error).toBeDefined();
+    // Limit exceeded returns a friendly chat completion message
+    expect(res.body.choices[0].message.content).toContain('Usage limit hit');
     // Mock server should NOT have been called — blocked before forwarding
     expect(mockCallLog.length).toBe(0);
   });

--- a/packages/backend/test/smoke-test.e2e-spec.ts
+++ b/packages/backend/test/smoke-test.e2e-spec.ts
@@ -279,7 +279,7 @@ describe('ST-07: Soft limit notification', () => {
 /*  ST-08 · Hard limit blocks proxy requests                           */
 /* ------------------------------------------------------------------ */
 describe('ST-08: Hard limit blocks', () => {
-  it('returns 429 when block rule is exceeded', async () => {
+  it('returns friendly limit message when block rule is exceeded', async () => {
     const rule = await auth(api().post('/api/v1/notifications'))
       .send({
         agent_name: smokeAgentName,


### PR DESCRIPTION
## Summary

- When users configure a wrong API key (`mnfst_*`) in their coding agent, they saw `HTTP 401: "Unauthorized"` with no explanation. Now they see a helpful assistant message in their chat with the issue and a link to the dashboard.
- Auth errors (401), missing provider keys, and usage limits on `/v1/chat/completions` now return 200 OK chat completion responses with friendly messages, matching the existing `buildNoProviderResult()` pattern.
- Rate limit 429s still return HTTP 429 so clients can backoff correctly.
- Dashboard API routes are unaffected — they keep standard HTTP error responses.

## Changes

- **New**: `proxy-friendly-response.ts` — shared helpers for building friendly chat completion responses
- **New**: `proxy-exception.filter.ts` — controller-scoped exception filter that converts guard 401 errors into chat messages
- **Modified**: `proxy.service.ts` — missing provider key and usage limit now return friendly responses instead of throwing
- **Modified**: `proxy.controller.ts` — wired filter, catch block uses `sendFriendlyResponse` for non-429 errors
- **Modified**: `proxy-rate-limiter.ts` — improved message strings

## Test plan

- [ ] Unit tests: 3153 backend tests pass, 1701 frontend tests pass
- [ ] E2E tests: 96 tests pass (updated 3 that expected old HTTP error format)
- [ ] Coverage: 100% line coverage on all new/modified files
- [ ] Send a request with an invalid `mnfst_` key and verify a helpful chat message appears instead of "HTTP 401: Unauthorized"
- [ ] Send a request with valid key but no provider configured — verify existing friendly message still works
- [ ] Send rapid requests to hit rate limit — verify 429 is still returned (not 200)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns friendly assistant messages on `/v1/chat/completions` instead of raw HTTP errors for auth issues, bad requests, missing provider keys, and usage limits. HTTP 429s (rate limits) still return 429 so clients can back off correctly.

- **Bug Fixes**
  - Converts non-429 errors into 200 OK chat completions with clear guidance and dashboard links; supports SSE when `stream: true`.
  - Maps guard 401s (e.g., missing/empty/invalid/expired keys) to helpful copy, including per-agent dashboard URLs.
  - Returns friendly messages from `proxy.service.ts` for missing provider keys and usage limits (with reason metadata).
  - Preserves HTTP 429 for rate limits.

- **Refactors**
  - Added `proxy-exception.filter.ts` and `proxy-friendly-response.ts` to centralize friendly response building and streaming.
  - Simplified `proxy.controller.ts` and `proxy.service.ts` to use shared helpers; improved rate limiter copy.

<sup>Written for commit 625c06cca5fe0fa8e881442d51e6745ffb78b177. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

