### PR TITLE
feat: universal model compatibility filter and thought signature cache

### DIFF
--- a/.changeset/model-compatibility-filter.md
+++ b/.changeset/model-compatibility-filter.md
@@ -1,0 +1,11 @@
+---
+"manifest": minor
+---
+
+Add universal non-chat model filter, tool support filter, and thought signature cache
+
+- Filter non-chat models (TTS, embedding, image-gen) across all providers at discovery time
+- Filter models without tool calling support when models.dev confirms toolCall: false
+- Prefer tool-capable models in tier auto-assignment for standard/complex/reasoning tiers
+- Relax output modality check from "text-only" to "includes text" for multimodal models
+- Add ThoughtSignatureCache to re-inject thought_signature values stripped by clients during Google Gemini round-trips

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -507,7 +507,7 @@ describe('ModelsDevSyncService', () => {
       expect(service.lookupModel('openai', 'image-model')).toBeNull();
     });
 
-    it('should exclude models with mixed text+image output', async () => {
+    it('should include models with mixed text+image output (includes text)', async () => {
       const response = {
         openai: {
           id: 'openai',
@@ -526,7 +526,7 @@ describe('ModelsDevSyncService', () => {
 
       await service.refreshCache();
 
-      expect(service.lookupModel('openai', 'mixed-output')).toBeNull();
+      expect(service.lookupModel('openai', 'mixed-output')).not.toBeNull();
     });
 
     it('should exclude models with audio-only input', async () => {

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -246,7 +246,11 @@ export class ModelsDevSyncService implements OnModuleInit {
     };
   }
 
-  /** Filter to text-in / text-out models only (same logic as PricingSyncService). */
+  /**
+   * Filter to models that accept text input and can produce text output.
+   * Uses "includes text" (not "text-only") so multimodal models that
+   * also produce text (e.g. GPT-4o) pass through.
+   */
   private isChatCompatible(model: RawModelsDevModel): boolean {
     const inputMods = model.modalities?.input?.map((m) => m.toLowerCase());
     if (inputMods && inputMods.length > 0 && !inputMods.includes('text')) {
@@ -254,7 +258,7 @@ export class ModelsDevSyncService implements OnModuleInit {
     }
     const outputMods = model.modalities?.output?.map((m) => m.toLowerCase());
     if (outputMods && outputMods.length > 0) {
-      return outputMods.every((m) => m === 'text');
+      return outputMods.includes('text');
     }
     return true;
   }

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -197,7 +197,7 @@ describe('PricingSyncService', () => {
       expect(count).toBe(0);
     });
 
-    it('skips non-chat-compatible models', async () => {
+    it('skips non-chat-compatible models (output-only image)', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -206,7 +206,7 @@ describe('PricingSyncService', () => {
               id: 'google/image-gen',
               architecture: {
                 input_modalities: ['text', 'image'],
-                output_modalities: ['text', 'image'],
+                output_modalities: ['image'],
               },
               pricing: { prompt: '0.0000005', completion: '0.000003' },
             },
@@ -476,13 +476,25 @@ describe('PricingSyncService', () => {
       ).toBe(true);
     });
 
-    it('returns false for non-text output modalities', () => {
+    it('returns true for multimodal output that includes text', () => {
       expect(
         service.isChatCompatible({
           id: 'test',
           architecture: {
             input_modalities: ['text', 'image'],
             output_modalities: ['text', 'image'],
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false for output without text', () => {
+      expect(
+        service.isChatCompatible({
+          id: 'test',
+          architecture: {
+            input_modalities: ['text'],
+            output_modalities: ['image', 'audio'],
           },
         }),
       ).toBe(false);

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -116,6 +116,11 @@ export class PricingSyncService implements OnModuleInit {
     return model.name;
   }
 
+  /**
+   * Filter to models that accept text input and can produce text output.
+   * Uses "includes text" (not "text-only") so multimodal models that
+   * also produce text (e.g. GPT-4o) pass through.
+   */
   isChatCompatible(model: OpenRouterModel): boolean {
     const inputModalities = model.architecture?.input_modalities?.map((m) => m.toLowerCase());
     if (inputModalities && inputModalities.length > 0 && !inputModalities.includes('text')) {
@@ -124,7 +129,7 @@ export class PricingSyncService implements OnModuleInit {
 
     const outputModalities = model.architecture?.output_modalities?.map((m) => m.toLowerCase());
     if (outputModalities && outputModalities.length > 0) {
-      return outputModalities.every((m) => m === 'text');
+      return outputModalities.includes('text');
     }
 
     return true;

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -1,0 +1,155 @@
+import {
+  filterNonChatModels,
+  UNIVERSAL_NON_CHAT_RE,
+  PROVIDER_NON_CHAT,
+} from './provider-model-fetcher.service';
+import { DiscoveredModel } from './model-fetcher';
+
+function makeModel(id: string, provider = 'test'): DiscoveredModel {
+  return {
+    id,
+    displayName: id,
+    provider,
+    contextWindow: 128000,
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 3,
+  };
+}
+
+describe('filterNonChatModels', () => {
+  describe('universal non-chat patterns', () => {
+    const nonChatIds = [
+      'text-embedding-ada-002',
+      'text-embedding-3-large',
+      'tts-1',
+      'tts-1-hd',
+      'whisper-1',
+      'dall-e-3',
+      'dall-e-2',
+      'imagen-3.0-generate-002',
+      'cogview-3-plus',
+      'wanx-v1',
+      'sambert-v1',
+      'paraformer-v2',
+      'speech-to-text-model',
+      'voice-alloy',
+      'audio-turbo-v1',
+    ];
+
+    it.each(nonChatIds)('filters out "%s" for any provider', (modelId) => {
+      const models = [makeModel(modelId), makeModel('gpt-4o')];
+      const result = filterNonChatModels(models, 'unknown-provider');
+      expect(result.map((m) => m.id)).toEqual(['gpt-4o']);
+    });
+
+    it('keeps chat-compatible models through universal filter', () => {
+      const chatModels = [
+        makeModel('gpt-4o'),
+        makeModel('claude-sonnet-4'),
+        makeModel('gemini-2.5-flash'),
+        makeModel('deepseek-chat'),
+      ];
+      const result = filterNonChatModels(chatModels, 'unknown-provider');
+      expect(result).toHaveLength(4);
+    });
+  });
+
+  describe('universal regex', () => {
+    it('matches embed case-insensitively', () => {
+      expect(UNIVERSAL_NON_CHAT_RE.test('text-EMBEDDING-large')).toBe(true);
+    });
+
+    it('does not match partial words that happen to contain "embed"', () => {
+      // "embed" substring in the middle still matches by design
+      expect(UNIVERSAL_NON_CHAT_RE.test('some-embed-model')).toBe(true);
+    });
+  });
+
+  describe('OpenAI-specific patterns', () => {
+    const openaiNonChat = [
+      'text-moderation-latest',
+      'davinci-002',
+      'babbage-002',
+      'text-davinci-003',
+      'gpt-4o-mini-realtime-preview',
+      'gpt-4o-transcribe',
+      'sora-v1',
+      'gpt-3.5-turbo-instruct',
+      'gpt-4o-audio-preview',
+    ];
+
+    it.each(openaiNonChat)('filters out "%s" for openai config key', (modelId) => {
+      const models = [makeModel(modelId), makeModel('gpt-4o')];
+      const result = filterNonChatModels(models, 'openai');
+      expect(result.map((m) => m.id)).toEqual(['gpt-4o']);
+    });
+
+    it('keeps chat models for openai', () => {
+      const models = [makeModel('gpt-4o'), makeModel('gpt-4o-mini')];
+      const result = filterNonChatModels(models, 'openai');
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('OpenAI subscription patterns', () => {
+    it('filters moderation models for openai-subscription', () => {
+      const models = [makeModel('text-moderation-latest'), makeModel('gpt-4o')];
+      const result = filterNonChatModels(models, 'openai-subscription');
+      expect(result.map((m) => m.id)).toEqual(['gpt-4o']);
+    });
+
+    it('filters audio models for openai-subscription', () => {
+      const models = [makeModel('gpt-4o-audio-preview'), makeModel('gpt-4o')];
+      const result = filterNonChatModels(models, 'openai-subscription');
+      expect(result.map((m) => m.id)).toEqual(['gpt-4o']);
+    });
+  });
+
+  describe('Gemini-specific patterns', () => {
+    it('filters aqs- prefixed models', () => {
+      const models = [makeModel('aqs-gemini-model'), makeModel('gemini-2.5-flash')];
+      const result = filterNonChatModels(models, 'gemini');
+      expect(result.map((m) => m.id)).toEqual(['gemini-2.5-flash']);
+    });
+
+    it('filters nano-banana models', () => {
+      const models = [makeModel('nano-banana'), makeModel('gemini-2.5-pro')];
+      const result = filterNonChatModels(models, 'gemini');
+      expect(result.map((m) => m.id)).toEqual(['gemini-2.5-pro']);
+    });
+  });
+
+  describe('Mistral-specific patterns', () => {
+    it('filters mistral-ocr model', () => {
+      const models = [makeModel('mistral-ocr'), makeModel('mistral-large-latest')];
+      const result = filterNonChatModels(models, 'mistral');
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
+    });
+  });
+
+  describe('providers without specific filters', () => {
+    it('only applies universal filter for unknown config keys', () => {
+      const models = [makeModel('some-chat-model'), makeModel('text-embedding-ada')];
+      const result = filterNonChatModels(models, 'anthropic');
+      expect(result.map((m) => m.id)).toEqual(['some-chat-model']);
+    });
+  });
+
+  describe('empty input', () => {
+    it('returns empty array when given empty input', () => {
+      expect(filterNonChatModels([], 'openai')).toEqual([]);
+    });
+  });
+
+  describe('PROVIDER_NON_CHAT registry', () => {
+    it('has entries for openai, openai-subscription, gemini, and mistral', () => {
+      expect(PROVIDER_NON_CHAT).toHaveProperty('openai');
+      expect(PROVIDER_NON_CHAT).toHaveProperty('openai-subscription');
+      expect(PROVIDER_NON_CHAT).toHaveProperty('gemini');
+      expect(PROVIDER_NON_CHAT).toHaveProperty('mistral');
+    });
+  });
+});

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1911,7 +1911,7 @@ describe('ModelDiscoveryService', () => {
         inputPricePerToken: 0.003, // should NOT be used
         outputPricePerToken: 0.006,
         reasoning: true,
-        toolCall: false,
+        toolCall: true,
       });
 
       const models = [
@@ -1920,7 +1920,7 @@ describe('ModelDiscoveryService', () => {
           inputPricePerToken: 0,
           outputPricePerToken: 0,
           capabilityReasoning: false,
-          capabilityCode: true,
+          capabilityCode: false,
         }),
       ];
       fetcher.fetch.mockResolvedValue(models);
@@ -1932,7 +1932,7 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].outputPricePerToken).toBe(0);
       // Capabilities updated from models.dev
       expect(result[0].capabilityReasoning).toBe(true);
-      expect(result[0].capabilityCode).toBe(false);
+      expect(result[0].capabilityCode).toBe(true);
     });
   });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -153,14 +153,24 @@ export class ModelDiscoveryService {
       authType: authType as 'api_key' | 'subscription',
     }));
 
-    provider.cached_models = enriched;
+    // Filter out models confirmed to lack tool support (models.dev toolCall === false).
+    // In the OpenClaw context every request includes tools, so models without
+    // tool calling are unusable. Only filter when models.dev has data — if no
+    // entry exists we keep the model (we don't know its capabilities).
+    const filtered = enriched.filter((model) => {
+      const mdEntry = this.modelsDevSync?.lookupModel(provider.provider, model.id);
+      if (mdEntry && mdEntry.toolCall === false) return false;
+      return true;
+    });
+
+    provider.cached_models = filtered;
     provider.models_fetched_at = new Date().toISOString();
     await this.providerRepo.save(provider);
 
     this.logger.log(
-      `Discovered ${enriched.length} models for provider ${provider.provider} (agent ${provider.agent_id})`,
+      `Discovered ${filtered.length} models for provider ${provider.provider} (agent ${provider.agent_id})`,
     );
-    return enriched;
+    return filtered;
   }
 
   async discoverAllForAgent(agentId: string): Promise<void> {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -66,15 +66,7 @@ const parseOpenAI = createModelParser<OpenAIModelEntry>({
   getDisplayName: (_entry, id) => id,
 });
 
-/* ── OpenAI-specific chat model filter ── */
-
-/**
- * Non-chat models returned by OpenAI's /v1/models that don't work with
- * /v1/chat/completions. Includes embeddings, TTS, image, audio, moderation,
- * legacy instruct models, and video models.
- */
-const OPENAI_NON_CHAT_RE =
-  /(?:embed|tts|whisper|dall-e|moderation|davinci|babbage|^text-|audio|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct)/i;
+/* ── OpenAI-specific structural filters (not non-chat) ── */
 
 /** Date-suffixed snapshots returned by OpenAI (e.g. gpt-4o-mini-2024-07-18). */
 const OPENAI_DATE_SUFFIX_RE = /-\d{4}-\d{2}-\d{2}$/;
@@ -85,10 +77,8 @@ const OPENAI_DATE_SUFFIX_RE = /-\d{4}-\d{2}-\d{2}$/;
  */
 const OPENAI_RESPONSES_ONLY_RE = /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$))/i;
 
-function parseOpenAIChatOnly(body: unknown, provider: string): DiscoveredModel[] {
-  const filtered = parseOpenAI(body, provider).filter(
-    (m) => !OPENAI_NON_CHAT_RE.test(m.id) && !OPENAI_RESPONSES_ONLY_RE.test(m.id),
-  );
+function parseOpenAIDeduped(body: unknown, provider: string): DiscoveredModel[] {
+  const filtered = parseOpenAI(body, provider).filter((m) => !OPENAI_RESPONSES_ONLY_RE.test(m.id));
 
   // Deduplicate: if both an alias (gpt-4o-mini) and a dated snapshot
   // (gpt-4o-mini-2024-07-18) exist, keep only the alias.
@@ -100,14 +90,39 @@ function parseOpenAIChatOnly(body: unknown, provider: string): DiscoveredModel[]
   });
 }
 
-/**
- * Non-chat Mistral models that fail with 400 on /v1/chat/completions.
- * OCR models require document input, not chat messages.
- */
-const MISTRAL_NON_CHAT_RE = /(?:^mistral-ocr|embed)/i;
+/* ── Universal non-chat model filter ── */
 
-function parseMistralChatOnly(body: unknown, provider: string): DiscoveredModel[] {
-  return parseOpenAI(body, provider).filter((m) => !MISTRAL_NON_CHAT_RE.test(m.id));
+/**
+ * Non-chat patterns common across ALL providers. Models matching these
+ * are not compatible with /v1/chat/completions and must be filtered out.
+ * Covers: embeddings, TTS, speech recognition, image generation, audio.
+ */
+export const UNIVERSAL_NON_CHAT_RE =
+  /(?:embed|tts|whisper|dall-e|imagen|cogview|wanx|sambert|paraformer|text-embedding|speech-to|voice-|audio-turbo)/i;
+
+/**
+ * Provider-specific non-chat patterns that supplement the universal filter.
+ * Keyed by the config key used in PROVIDER_CONFIGS.
+ */
+export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
+  openai:
+    /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio)/i,
+  'openai-subscription': /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|audio)/i,
+  gemini: /(?:^aqs-|nano-banana)/i,
+  mistral: /(?:^mistral-ocr)/i,
+};
+
+/** Filter models that are not compatible with chat completions. */
+export function filterNonChatModels(
+  models: DiscoveredModel[],
+  configKey: string,
+): DiscoveredModel[] {
+  const providerFilter = PROVIDER_NON_CHAT[configKey];
+  return models.filter((m) => {
+    if (UNIVERSAL_NON_CHAT_RE.test(m.id)) return false;
+    if (providerFilter && providerFilter.test(m.id)) return false;
+    return true;
+  });
 }
 
 function bearerHeaders(key: string): Record<string, string> {
@@ -268,7 +283,7 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
   openai: {
     endpoint: 'https://api.openai.com/v1/models',
     buildHeaders: bearerHeaders,
-    parse: parseOpenAIChatOnly,
+    parse: parseOpenAIDeduped,
   },
   'openai-subscription': {
     endpoint: 'https://chatgpt.com/backend-api/codex/models?client_version=0.99.0',
@@ -288,7 +303,7 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
   mistral: {
     endpoint: 'https://api.mistral.ai/v1/models',
     buildHeaders: bearerHeaders,
-    parse: parseMistralChatOnly,
+    parse: parseOpenAI,
   },
   moonshot: {
     endpoint: 'https://api.moonshot.ai/v1/models',
@@ -428,7 +443,7 @@ export class ProviderModelFetcherService {
       }
 
       const body = await res.json();
-      return config.parse(body, providerId);
+      return filterNonChatModels(config.parse(body, providerId), configKey);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.logger.warn(`Failed to fetch models from ${providerId}: ${message}`);

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -3,6 +3,7 @@ import { ProxyController } from '../proxy.controller';
 import { ProxyMessageRecorder } from '../proxy-message-recorder';
 import { ProxyMessageDedup } from '../proxy-message-dedup';
 import { IngestEventBusService } from '../../../common/services/ingest-event-bus.service';
+import { ThoughtSignatureCache } from '../thought-signature-cache';
 
 function mockResponse(): {
   res: Record<string, jest.Mock | boolean | number>;
@@ -132,6 +133,7 @@ describe('ProxyController', () => {
       rateLimiter as never,
       providerClient as never,
       recorder,
+      new ThoughtSignatureCache(),
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -15,6 +15,7 @@ import { CopilotTokenService } from '../copilot-token.service';
 import { LimitCheckService } from '../../../notifications/services/limit-check.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import { shouldTriggerFallback } from '../fallback-status-codes';
+import { ThoughtSignatureCache } from '../thought-signature-cache';
 
 describe('ProxyService', () => {
   let service: ProxyService;
@@ -115,6 +116,7 @@ describe('ProxyService', () => {
       limitCheck,
       fallbackService,
       configService,
+      new ThoughtSignatureCache(),
     );
   });
 
@@ -450,13 +452,15 @@ describe('ProxyService', () => {
     expect(momentum.getRecentTiers('sess-1')).toEqual(['standard']);
 
     // Verify forward was called correctly (signal is undefined when not provided)
-    expect(providerClient.forward).toHaveBeenCalledWith({
-      provider: 'OpenAI',
-      apiKey: 'sk-test',
-      model: 'gpt-4o',
-      body,
-      stream: false,
-    });
+    expect(providerClient.forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'OpenAI',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+      }),
+    );
   });
 
   it('applies the stored Qwen region when resolver returns the Alibaba alias', async () => {
@@ -549,14 +553,16 @@ describe('ProxyService', () => {
     });
 
     expect(result.meta.model).toBe('claude-sonnet-4-6');
-    expect(providerClient.forward).toHaveBeenCalledWith({
-      provider: 'Anthropic',
-      apiKey: 'sk-ant-oat',
-      model: 'claude-sonnet-4-6',
-      body,
-      stream: false,
-      authType: 'subscription',
-    });
+    expect(providerClient.forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'Anthropic',
+        apiKey: 'sk-ant-oat',
+        model: 'claude-sonnet-4-6',
+        body,
+        stream: false,
+        authType: 'subscription',
+      }),
+    );
   });
 
   it('passes tools and tool_choice to the resolver', async () => {
@@ -601,13 +607,15 @@ describe('ProxyService', () => {
     );
 
     // But the full body (with tools) should be forwarded to the provider
-    expect(providerClient.forward).toHaveBeenCalledWith({
-      provider: 'OpenAI',
-      apiKey: 'sk-test',
-      model: 'gpt-4o',
-      body: bodyWithTools,
-      stream: false,
-    });
+    expect(providerClient.forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'OpenAI',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: bodyWithTools,
+        stream: false,
+      }),
+    );
   });
 
   it('passes AbortSignal through to providerClient.forward', async () => {
@@ -638,14 +646,16 @@ describe('ProxyService', () => {
       signal: abortController.signal,
     });
 
-    expect(providerClient.forward).toHaveBeenCalledWith({
-      provider: 'OpenAI',
-      apiKey: 'sk-test',
-      model: 'gpt-4o',
-      body,
-      stream: false,
-      signal: abortController.signal,
-    });
+    expect(providerClient.forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'OpenAI',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        signal: abortController.signal,
+      }),
+    );
   });
 
   describe('heartbeat detection', () => {
@@ -714,13 +724,15 @@ describe('ProxyService', () => {
         sessionKey: 'sess-1',
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'OpenAI',
-        apiKey: 'sk-test',
-        model: 'gpt-4o-mini',
-        body: heartbeatBody,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'OpenAI',
+          apiKey: 'sk-test',
+          model: 'gpt-4o-mini',
+          body: heartbeatBody,
+          stream: false,
+        }),
+      );
     });
 
     it('does NOT detect heartbeat when HEARTBEAT_OK is only in an earlier user message', async () => {
@@ -1015,13 +1027,15 @@ describe('ProxyService', () => {
       });
 
       // Provider should get the FULL body including system messages
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'OpenAI',
-        apiKey: 'sk-test',
-        model: 'gpt-4o-mini',
-        body: bodyWithSystem,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'OpenAI',
+          apiKey: 'sk-test',
+          model: 'gpt-4o-mini',
+          body: bodyWithSystem,
+          stream: false,
+        }),
+      );
     });
 
     it('limits scoring to last 10 non-system messages', async () => {
@@ -1292,14 +1306,16 @@ describe('ProxyService', () => {
         sessionKey: 'my-session',
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'xai',
-        apiKey: 'sk-xai-test',
-        model: 'grok-2',
-        body,
-        stream: false,
-        extraHeaders: { 'x-grok-conv-id': 'my-session' },
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'xai',
+          apiKey: 'sk-xai-test',
+          model: 'grok-2',
+          body,
+          stream: false,
+          extraHeaders: { 'x-grok-conv-id': 'my-session' },
+        }),
+      );
     });
   });
 
@@ -1379,13 +1395,15 @@ describe('ProxyService', () => {
       expect(scoredMessages).toEqual([]);
 
       // But the full body is forwarded to the provider
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'OpenAI',
-        apiKey: 'sk-test',
-        model: 'gpt-4o-mini',
-        body: bodyWithOnlySystem,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'OpenAI',
+          apiKey: 'sk-test',
+          model: 'gpt-4o-mini',
+          body: bodyWithOnlySystem,
+          stream: false,
+        }),
+      );
     });
   });
 
@@ -1425,17 +1443,19 @@ describe('ProxyService', () => {
 
       expect(customProviderRepo.findOne).toHaveBeenCalledWith({ where: { id: 'cp-uuid' } });
       // Forward should use the raw model name (without custom prefix)
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'custom:cp-uuid',
-        apiKey: 'gsk_test',
-        model: 'llama-3.1-70b',
-        body,
-        stream: false,
-        customEndpoint: expect.objectContaining({
-          baseUrl: 'https://api.groq.com/openai',
-          format: 'openai',
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'custom:cp-uuid',
+          apiKey: 'gsk_test',
+          model: 'llama-3.1-70b',
+          body,
+          stream: false,
+          customEndpoint: expect.objectContaining({
+            baseUrl: 'https://api.groq.com/openai',
+            format: 'openai',
+          }),
         }),
-      });
+      );
       expect(result.meta.provider).toBe('custom:cp-uuid');
     });
 
@@ -1465,13 +1485,15 @@ describe('ProxyService', () => {
       });
 
       // No custom endpoint — forward without it
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'custom:cp-missing',
-        apiKey: 'key',
-        model: 'custom:cp-missing/model',
-        body,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'custom:cp-missing',
+          apiKey: 'key',
+          model: 'custom:cp-missing/model',
+          body,
+          stream: false,
+        }),
+      );
     });
   });
 
@@ -1501,13 +1523,15 @@ describe('ProxyService', () => {
       });
 
       expect(copilotToken.getCopilotToken).toHaveBeenCalledWith('ghu_github_oauth_token');
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'copilot',
-        apiKey: 'tid=copilot-session-token',
-        model: 'claude-sonnet-4.6',
-        body,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'copilot',
+          apiKey: 'tid=copilot-session-token',
+          model: 'claude-sonnet-4.6',
+          body,
+          stream: false,
+        }),
+      );
     });
 
     it('does not strip prefix for copilot models without copilot/ prefix', async () => {
@@ -1534,13 +1558,15 @@ describe('ProxyService', () => {
         sessionKey: 'sess-1',
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'copilot',
-        apiKey: 'tid=copilot-session-token',
-        model: 'gpt-4o',
-        body,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'copilot',
+          apiKey: 'tid=copilot-session-token',
+          model: 'gpt-4o',
+          body,
+          stream: false,
+        }),
+      );
     });
 
     it('does not exchange token for non-copilot providers', async () => {
@@ -1568,13 +1594,15 @@ describe('ProxyService', () => {
       });
 
       expect(copilotToken.getCopilotToken).not.toHaveBeenCalled();
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'openai',
-        apiKey: 'sk-openai-key',
-        model: 'gpt-4o',
-        body,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai',
+          apiKey: 'sk-openai-key',
+          model: 'gpt-4o',
+          body,
+          stream: false,
+        }),
+      );
     });
   });
 
@@ -1605,13 +1633,15 @@ describe('ProxyService', () => {
       });
 
       expect(result.meta.provider).toBe('Ollama');
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'Ollama',
-        apiKey: '',
-        model: 'llama3',
-        body,
-        stream: false,
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'Ollama',
+          apiKey: '',
+          model: 'llama3',
+          body,
+          stream: false,
+        }),
+      );
     });
   });
 
@@ -1642,14 +1672,16 @@ describe('ProxyService', () => {
       });
 
       expect(result.meta.provider).toBe('Anthropic');
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'Anthropic',
-        apiKey: 'skst-token-123',
-        model: 'claude-sonnet-4',
-        body,
-        stream: false,
-        authType: 'subscription',
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'Anthropic',
+          apiKey: 'skst-token-123',
+          model: 'claude-sonnet-4',
+          body,
+          stream: false,
+          authType: 'subscription',
+        }),
+      );
     });
 
     it('rejects subscription provider without stored token', async () => {
@@ -1864,22 +1896,28 @@ describe('ProxyService', () => {
       expect(result.meta.primaryErrorBody).toBe('{"detail":"Instructions are required"}');
       expect(result.meta.model).toBe('deepseek-chat');
       expect(result.meta.provider).toBe('DeepSeek');
-      expect(providerClient.forward).toHaveBeenNthCalledWith(1, {
-        provider: 'OpenAI',
-        apiKey: 'oauth-openai',
-        model: 'gpt-5.1-codex-mini',
-        body,
-        stream: false,
-        authType: 'subscription',
-      });
-      expect(providerClient.forward).toHaveBeenNthCalledWith(2, {
-        provider: 'DeepSeek',
-        apiKey: 'sk-deepseek',
-        model: 'deepseek-chat',
-        body,
-        stream: false,
-        authType: 'api_key',
-      });
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          provider: 'OpenAI',
+          apiKey: 'oauth-openai',
+          model: 'gpt-5.1-codex-mini',
+          body,
+          stream: false,
+          authType: 'subscription',
+        }),
+      );
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          provider: 'DeepSeek',
+          apiKey: 'sk-deepseek',
+          model: 'deepseek-chat',
+          body,
+          stream: false,
+          authType: 'api_key',
+        }),
+      );
     });
 
     it('returns original error when no fallback models configured', async () => {
@@ -2281,23 +2319,29 @@ describe('ProxyService', () => {
       expect(result.meta.provider).toBe('Anthropic');
       expect(result.meta.primaryErrorStatus).toBe(429);
       // Primary was called with api_key auth_type
-      expect(providerClient.forward).toHaveBeenNthCalledWith(1, {
-        provider: 'OpenAI',
-        apiKey: 'sk-openai',
-        model: 'gpt-4o',
-        body,
-        stream: false,
-        authType: 'api_key',
-      });
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          provider: 'OpenAI',
+          apiKey: 'sk-openai',
+          model: 'gpt-4o',
+          body,
+          stream: false,
+          authType: 'api_key',
+        }),
+      );
       // Fallback resolves auth_type via getAuthType and passes subscription
-      expect(providerClient.forward).toHaveBeenNthCalledWith(2, {
-        provider: 'Anthropic',
-        apiKey: 'skst-anthropic-token',
-        model: 'claude-sonnet-4',
-        body,
-        stream: false,
-        authType: 'subscription',
-      });
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          provider: 'Anthropic',
+          apiKey: 'skst-anthropic-token',
+          model: 'claude-sonnet-4',
+          body,
+          stream: false,
+          authType: 'subscription',
+        }),
+      );
       // getAuthType was called for the fallback provider (different provider, no exclusions)
       expect(providerKeyService.getAuthType).toHaveBeenCalledWith(
         'agent-1',
@@ -2353,14 +2397,17 @@ describe('ProxyService', () => {
       });
 
       expect(result.meta.model).toBe('claude-sonnet-4-6');
-      expect(providerClient.forward).toHaveBeenNthCalledWith(2, {
-        provider: 'Anthropic',
-        apiKey: 'skst-anthropic-token',
-        model: 'claude-sonnet-4-6',
-        body,
-        stream: false,
-        authType: 'subscription',
-      });
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          provider: 'Anthropic',
+          apiKey: 'skst-anthropic-token',
+          model: 'claude-sonnet-4-6',
+          body,
+          stream: false,
+          authType: 'subscription',
+        }),
+      );
     });
 
     it('falls back from subscription primary to api_key fallback model', async () => {
@@ -2407,23 +2454,29 @@ describe('ProxyService', () => {
       expect(result.meta.model).toBe('gpt-4o');
       expect(result.meta.provider).toBe('OpenAI');
       // Primary forwarded with subscription auth_type
-      expect(providerClient.forward).toHaveBeenNthCalledWith(1, {
-        provider: 'Anthropic',
-        apiKey: 'skst-token',
-        model: 'claude-sonnet-4',
-        body,
-        stream: false,
-        authType: 'subscription',
-      });
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          provider: 'Anthropic',
+          apiKey: 'skst-token',
+          model: 'claude-sonnet-4',
+          body,
+          stream: false,
+          authType: 'subscription',
+        }),
+      );
       // Fallback forwarded with api_key auth_type
-      expect(providerClient.forward).toHaveBeenNthCalledWith(2, {
-        provider: 'OpenAI',
-        apiKey: 'sk-openai',
-        model: 'gpt-4o',
-        body,
-        stream: false,
-        authType: 'api_key',
-      });
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          provider: 'OpenAI',
+          apiKey: 'sk-openai',
+          model: 'gpt-4o',
+          body,
+          stream: false,
+          authType: 'api_key',
+        }),
+      );
     });
 
     it('falls back between two subscription providers', async () => {
@@ -2471,14 +2524,17 @@ describe('ProxyService', () => {
       expect(result.meta.provider).toBe('Google');
       expect(result.meta.fallbackIndex).toBe(0);
       // Fallback forwarded with subscription auth_type
-      expect(providerClient.forward).toHaveBeenNthCalledWith(2, {
-        provider: 'Google',
-        apiKey: 'skst-google',
-        model: 'gemini-2.5-flash',
-        body,
-        stream: false,
-        authType: 'subscription',
-      });
+      expect(providerClient.forward).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          provider: 'Google',
+          apiKey: 'skst-google',
+          model: 'gemini-2.5-flash',
+          body,
+          stream: false,
+          authType: 'subscription',
+        }),
+      );
     });
 
     it('skips fallback model with subscription auth but no stored token', async () => {
@@ -2819,14 +2875,16 @@ describe('ProxyService', () => {
       });
 
       expect(openaiOauth.unwrapToken).toHaveBeenCalledWith(tokenBlob, 'agent-1', 'user-1');
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'openai',
-        apiKey: 'access-tok',
-        model: 'gpt-4o',
-        body: expect.any(Object),
-        stream: false,
-        authType: 'subscription',
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai',
+          apiKey: 'access-tok',
+          model: 'gpt-4o',
+          body: expect.any(Object),
+          stream: false,
+          authType: 'subscription',
+        }),
+      );
     });
 
     it('skips unwrap for non-OpenAI subscription providers', async () => {
@@ -2978,18 +3036,20 @@ describe('ProxyService', () => {
       });
 
       expect(minimaxOauth.unwrapToken).toHaveBeenCalledWith(tokenBlob, 'agent-1', 'user-1');
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'minimax',
-        apiKey: 'minimax-access',
-        model: 'MiniMax-M2.5',
-        body: expect.any(Object),
-        stream: false,
-        customEndpoint: expect.objectContaining({
-          baseUrl: 'https://api.minimax.io/anthropic',
-          format: 'anthropic',
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'minimax',
+          apiKey: 'minimax-access',
+          model: 'MiniMax-M2.5',
+          body: expect.any(Object),
+          stream: false,
+          customEndpoint: expect.objectContaining({
+            baseUrl: 'https://api.minimax.io/anthropic',
+            format: 'anthropic',
+          }),
+          authType: 'subscription',
         }),
-        authType: 'subscription',
-      });
+      );
     });
 
     it('ignores invalid MiniMax resource URLs when forwarding subscription requests', async () => {
@@ -3029,14 +3089,16 @@ describe('ProxyService', () => {
         sessionKey: 'sess',
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'minimax',
-        apiKey: 'minimax-access',
-        model: 'MiniMax-M2.5',
-        body: expect.any(Object),
-        stream: false,
-        authType: 'subscription',
-      });
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'minimax',
+          apiKey: 'minimax-access',
+          model: 'MiniMax-M2.5',
+          body: expect.any(Object),
+          stream: false,
+          authType: 'subscription',
+        }),
+      );
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/thought-signature-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/thought-signature-cache.spec.ts
@@ -1,0 +1,133 @@
+import { ThoughtSignatureCache } from '../thought-signature-cache';
+
+describe('ThoughtSignatureCache', () => {
+  let cache: ThoughtSignatureCache;
+
+  beforeEach(() => {
+    cache = new ThoughtSignatureCache();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('stores and retrieves a signature', () => {
+    cache.store('session-1', 'tc-1', 'sig-abc');
+    expect(cache.retrieve('session-1', 'tc-1')).toBe('sig-abc');
+  });
+
+  it('returns null for a non-existent key', () => {
+    expect(cache.retrieve('no-session', 'no-tool')).toBeNull();
+  });
+
+  it('returns null for an expired entry', () => {
+    const realNow = Date.now;
+    const baseTime = 1000000000000;
+
+    // Store at baseTime
+    Date.now = () => baseTime;
+    cache.store('session-1', 'tc-1', 'sig-expired');
+
+    // Retrieve 31 minutes later (TTL is 30 minutes)
+    Date.now = () => baseTime + 31 * 60 * 1000;
+    expect(cache.retrieve('session-1', 'tc-1')).toBeNull();
+
+    Date.now = realNow;
+  });
+
+  it('returns the signature when it has not yet expired', () => {
+    const realNow = Date.now;
+    const baseTime = 1000000000000;
+
+    Date.now = () => baseTime;
+    cache.store('session-1', 'tc-1', 'sig-valid');
+
+    // Retrieve 29 minutes later (still within 30 min TTL)
+    Date.now = () => baseTime + 29 * 60 * 1000;
+    expect(cache.retrieve('session-1', 'tc-1')).toBe('sig-valid');
+
+    Date.now = realNow;
+  });
+
+  it('clearSession removes all entries for a given session', () => {
+    cache.store('session-A', 'tc-1', 'sig-1');
+    cache.store('session-A', 'tc-2', 'sig-2');
+    cache.store('session-B', 'tc-1', 'sig-3');
+
+    cache.clearSession('session-A');
+
+    expect(cache.retrieve('session-A', 'tc-1')).toBeNull();
+    expect(cache.retrieve('session-A', 'tc-2')).toBeNull();
+    expect(cache.retrieve('session-B', 'tc-1')).toBe('sig-3');
+  });
+
+  it('clearSession does not throw for a non-existent session', () => {
+    expect(() => cache.clearSession('unknown')).not.toThrow();
+  });
+
+  it('stores entries for multiple sessions independently', () => {
+    cache.store('s1', 'tc-1', 'a');
+    cache.store('s2', 'tc-1', 'b');
+    cache.store('s3', 'tc-2', 'c');
+
+    expect(cache.retrieve('s1', 'tc-1')).toBe('a');
+    expect(cache.retrieve('s2', 'tc-1')).toBe('b');
+    expect(cache.retrieve('s3', 'tc-2')).toBe('c');
+  });
+
+  it('overwrites existing entry for the same session and tool call', () => {
+    cache.store('session-1', 'tc-1', 'old-sig');
+    cache.store('session-1', 'tc-1', 'new-sig');
+
+    expect(cache.retrieve('session-1', 'tc-1')).toBe('new-sig');
+  });
+
+  describe('maybeCleanup (lazy eviction)', () => {
+    it('evicts expired entries when cleanup interval has elapsed', () => {
+      const realNow = Date.now;
+      const baseTime = 1000000000000;
+
+      // Create a fresh cache with mocked Date.now so lastCleanup is baseTime
+      Date.now = () => baseTime;
+      const localCache = new ThoughtSignatureCache();
+
+      // Store an entry at baseTime
+      localCache.store('s1', 'tc-1', 'sig-1');
+
+      // Advance past TTL (30 min) AND cleanup interval (5 min)
+      Date.now = () => baseTime + 31 * 60 * 1000;
+
+      // Store a new entry - this triggers maybeCleanup because
+      // now - lastCleanup > 5 min, and sig-1 is expired
+      localCache.store('s2', 'tc-2', 'sig-2');
+
+      // The expired entry should have been cleaned up during the store call
+      expect(localCache.retrieve('s1', 'tc-1')).toBeNull();
+      // The new entry is still valid
+      expect(localCache.retrieve('s2', 'tc-2')).toBe('sig-2');
+
+      Date.now = realNow;
+    });
+
+    it('does not evict entries when cleanup interval has not elapsed', () => {
+      const realNow = Date.now;
+      const baseTime = 1000000000000;
+
+      Date.now = () => baseTime;
+      const localCache = new ThoughtSignatureCache();
+
+      localCache.store('s1', 'tc-1', 'sig-1');
+
+      // Advance only 2 minutes (less than 5 min cleanup interval)
+      Date.now = () => baseTime + 2 * 60 * 1000;
+      localCache.store('s2', 'tc-2', 'sig-2');
+
+      // sig-1 has not expired (only 2 min passed, TTL is 30 min)
+      expect(localCache.retrieve('s1', 'tc-1')).toBe('sig-1');
+      expect(localCache.retrieve('s2', 'tc-2')).toBe('sig-2');
+
+      Date.now = realNow;
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -6,7 +6,7 @@
 
 import { randomUUID } from 'crypto';
 
-import { OpenAIMessage } from './proxy-types';
+import { OpenAIMessage, SignatureLookup } from './proxy-types';
 
 interface GeminiContent {
   role: string;
@@ -86,7 +86,10 @@ function mapRole(role: string): string {
   return 'user';
 }
 
-function messageToContent(msg: OpenAIMessage): GeminiContent | null {
+function messageToContent(
+  msg: OpenAIMessage,
+  signatureLookup?: SignatureLookup,
+): GeminiContent | null {
   const parts: GeminiPart[] = [];
 
   if (typeof msg.content === 'string') {
@@ -106,8 +109,14 @@ function messageToContent(msg: OpenAIMessage): GeminiContent | null {
         name: tc.function.name,
         args: safeParseArgs(tc.function.arguments),
       };
+      // Preserve thought_signature from the client, or re-inject from cache
       const sig = (tc as Record<string, unknown>).thought_signature;
-      if (sig) functionCall!.thought_signature = sig;
+      if (sig) {
+        functionCall!.thought_signature = sig;
+      } else if (signatureLookup) {
+        const cached = signatureLookup(tc.id);
+        if (cached) functionCall!.thought_signature = cached;
+      }
       parts.push({ functionCall });
     }
   }
@@ -152,9 +161,16 @@ function convertTools(tools?: Record<string, unknown>[]): Record<string, unknown
   return [{ functionDeclarations: declarations }];
 }
 
+/** Extracted thought_signature entries from a Gemini response. */
+export interface ExtractedSignature {
+  toolCallId: string;
+  signature: string;
+}
+
 export function toGoogleRequest(
   body: Record<string, unknown>,
   _model: string,
+  signatureLookup?: SignatureLookup,
 ): Record<string, unknown> {
   const messages = (body.messages as OpenAIMessage[]) || [];
   const contents: GeminiContent[] = [];
@@ -168,7 +184,7 @@ export function toGoogleRequest(
 
   for (const msg of messages) {
     if (msg.role === 'system') continue;
-    const content = messageToContent(msg);
+    const content = messageToContent(msg, signatureLookup);
     if (content) contents.push(content);
   }
 
@@ -198,7 +214,7 @@ export function toGoogleRequest(
 export function fromGoogleResponse(
   googleResp: Record<string, unknown>,
   model: string,
-): Record<string, unknown> {
+): Record<string, unknown> & { _extractedSignatures?: ExtractedSignature[] } {
   const candidates = (googleResp.candidates as Array<Record<string, unknown>>) || [];
   const candidate = candidates[0];
 
@@ -239,6 +255,17 @@ export function fromGoogleResponse(
   const message: Record<string, unknown> = { role: 'assistant', content: textContent || null };
   if (toolCalls.length > 0) message.tool_calls = toolCalls;
 
+  // Extract thought_signatures for caching
+  const extractedSignatures: ExtractedSignature[] = [];
+  for (const tc of toolCalls) {
+    if (tc.thought_signature && typeof tc.id === 'string') {
+      extractedSignatures.push({
+        toolCallId: tc.id as string,
+        signature: tc.thought_signature as string,
+      });
+    }
+  }
+
   const usage = googleResp.usageMetadata as Record<string, number> | undefined;
 
   return {
@@ -259,6 +286,7 @@ export function fromGoogleResponse(
           cache_creation_tokens: 0,
         }
       : undefined,
+    ...(extractedSignatures.length > 0 ? { _extractedSignatures: extractedSignatures } : {}),
   };
 }
 

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -57,6 +57,8 @@ export function createAnthropicTransformer(model: string): (chunk: string) => st
 
 // Re-export adapter functions used by ProviderClient.forward()
 export { toGoogleRequest, toAnthropicRequest, toResponsesRequest };
+export type { ExtractedSignature } from './google-adapter';
+export type { SignatureLookup } from './proxy-types';
 
 // ─── OpenAI body sanitization (used by ProviderClient.forward) ───────────────
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -54,6 +54,7 @@ export class ProviderClient {
       extraHeaders,
       customEndpoint,
       authType,
+      signatureLookup,
     } = opts;
 
     let endpoint: ProviderEndpoint;
@@ -89,7 +90,7 @@ export class ProviderClient {
       url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}?key=${apiKey}`;
       if (stream) url += '&alt=sse';
       headers = endpoint.buildHeaders(apiKey, authType);
-      requestBody = toGoogleRequest(body, bareModel);
+      requestBody = toGoogleRequest(body, bareModel, signatureLookup);
     } else if (isAnthropic) {
       url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`;
       headers = endpoint.buildHeaders(apiKey, authType);

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -61,6 +61,7 @@ export class ProxyFallbackService {
     signal?: AbortSignal,
     primaryProvider?: string,
     primaryAuthType?: string,
+    signatureLookup?: SignatureLookup,
   ): Promise<{
     success: {
       forward: ForwardResult;
@@ -143,6 +144,7 @@ export class ProxyFallbackService {
         authType,
         resourceUrl: resolvedCredentials.resourceUrl,
         providerRegion,
+        signatureLookup,
       });
 
       if (forward.response.ok) {

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -25,6 +25,7 @@ import {
   buildTransportErrorResponse,
   describeTransportError,
 } from './proxy-transport';
+import type { SignatureLookup } from './proxy-types';
 
 export interface FailedFallback {
   model: string;
@@ -181,6 +182,7 @@ export class ProxyFallbackService {
     authType?: string;
     resourceUrl?: string;
     providerRegion?: string | null;
+    signatureLookup?: SignatureLookup;
   }): Promise<ForwardResult> {
     try {
       return await this.forwardToProvider(opts);
@@ -214,8 +216,18 @@ export class ProxyFallbackService {
     authType?: string;
     resourceUrl?: string;
     providerRegion?: string | null;
+    signatureLookup?: SignatureLookup;
   }): Promise<ForwardResult> {
-    const { provider, body, stream, signal, authType, resourceUrl, providerRegion } = opts;
+    const {
+      provider,
+      body,
+      stream,
+      signal,
+      authType,
+      resourceUrl,
+      providerRegion,
+      signatureLookup,
+    } = opts;
 
     const extraHeaders: Record<string, string> = {};
     if (provider === 'xai') {
@@ -265,6 +277,7 @@ export class ProxyFallbackService {
       extraHeaders: hasExtraHeaders ? extraHeaders : undefined,
       customEndpoint,
       authType,
+      signatureLookup,
     });
   }
 }

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -177,13 +177,26 @@ export async function handleStreamResponse(
   meta: RoutingMeta,
   metaHeaders: Record<string, string>,
   providerClient: ProviderClient,
+  signatureCache?: ThoughtSignatureCache,
+  sessionKey?: string,
 ): Promise<StreamUsage | null> {
   initSseHeaders(res, metaHeaders);
 
   if (forward.isGoogle) {
-    return pipeStream(forward.response.body!, res, (chunk) =>
-      providerClient.convertGoogleStreamChunk(chunk, meta.model),
-    );
+    return pipeStream(forward.response.body!, res, (chunk) => {
+      const result = providerClient.convertGoogleStreamChunk(chunk, meta.model);
+      // Cache thought_signatures from streamed tool calls
+      if (signatureCache && sessionKey && result) {
+        const sigRe = /"thought_signature"\s*:\s*"([^"]+)"/g;
+        const idRe = /"id"\s*:\s*"([^"]+)"/g;
+        const ids = [...result.matchAll(idRe)].map((m) => m[1]);
+        const sigs = [...result.matchAll(sigRe)].map((m) => m[1]);
+        for (let i = 0; i < Math.min(ids.length, sigs.length); i++) {
+          signatureCache.store(sessionKey, ids[i], sigs[i]);
+        }
+      }
+      return result;
+    });
   }
   if (forward.isAnthropic) {
     return pipeStream(

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -7,6 +7,8 @@ import { ProxyMessageRecorder } from './proxy-message-recorder';
 import { ProviderClient } from './provider-client';
 import { initSseHeaders, pipeStream, StreamUsage } from './stream-writer';
 import { sanitizeProviderError } from './proxy-error-sanitizer';
+import type { ThoughtSignatureCache } from './thought-signature-cache';
+import type { ExtractedSignature } from './google-adapter';
 
 const logger = new Logger('ProxyResponseHandler');
 
@@ -205,12 +207,24 @@ export async function handleNonStreamResponse(
   meta: RoutingMeta,
   metaHeaders: Record<string, string>,
   providerClient: ProviderClient,
+  signatureCache?: ThoughtSignatureCache,
+  sessionKey?: string,
 ): Promise<StreamUsage | null> {
   let responseBody: unknown;
 
   if (forward.isGoogle) {
     const googleData = (await forward.response.json()) as Record<string, unknown>;
     responseBody = providerClient.convertGoogleResponse(googleData, meta.model);
+    // Cache extracted thought_signatures for re-injection on subsequent requests
+    if (signatureCache && sessionKey) {
+      const sigs = (responseBody as Record<string, unknown>)?._extractedSignatures as
+        | ExtractedSignature[]
+        | undefined;
+      if (sigs) {
+        for (const s of sigs) signatureCache.store(sessionKey, s.toolCallId, s.signature);
+        delete (responseBody as Record<string, unknown>)._extractedSignatures;
+      }
+    }
   } else if (forward.isAnthropic) {
     const anthropicData = (await forward.response.json()) as Record<string, unknown>;
     responseBody = providerClient.convertAnthropicResponse(anthropicData, meta.model);

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -1,5 +1,12 @@
 import { ProviderEndpoint } from './provider-endpoints';
 
+/**
+ * Optional lookup to re-inject cached thought_signature values that were
+ * stripped by the client. Called with a tool_call id; returns the cached
+ * signature or null.
+ */
+export type SignatureLookup = (toolCallId: string) => string | null;
+
 export interface OpenAIMessage {
   role: string;
   content?: unknown;
@@ -23,6 +30,8 @@ export interface ForwardOptions {
   extraHeaders?: Record<string, string>;
   customEndpoint?: ProviderEndpoint;
   authType?: string;
+  /** Lookup for re-injecting cached thought_signature values (Google only). */
+  signatureLookup?: SignatureLookup;
 }
 
 /** Options for ProxyService.proxyRequest. */

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -106,6 +106,8 @@ export class ProxyController {
           meta,
           metaHeaders,
           this.providerClient,
+          this.signatureCache,
+          sessionKey,
         );
       } else {
         streamUsage = await handleNonStreamResponse(

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -8,6 +8,7 @@ import { ProxyService } from './proxy.service';
 import { ProxyRateLimiter } from './proxy-rate-limiter';
 import { ProviderClient } from './provider-client';
 import { ProxyMessageRecorder } from './proxy-message-recorder';
+import { ThoughtSignatureCache } from './thought-signature-cache';
 import {
   buildMetaHeaders,
   handleProviderError,
@@ -33,6 +34,7 @@ export class ProxyController {
     private readonly rateLimiter: ProxyRateLimiter,
     private readonly providerClient: ProviderClient,
     private readonly recorder: ProxyMessageRecorder,
+    private readonly signatureCache: ThoughtSignatureCache,
   ) {}
 
   @Post('chat/completions')
@@ -112,6 +114,8 @@ export class ProxyController {
           meta,
           metaHeaders,
           this.providerClient,
+          this.signatureCache,
+          sessionKey,
         );
       }
 

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -18,6 +18,7 @@ import { ProxyMessageRecorder } from './proxy-message-recorder';
 import { ProxyMessageDedup } from './proxy-message-dedup';
 import { SessionMomentumService } from './session-momentum.service';
 import { CopilotTokenService } from './copilot-token.service';
+import { ThoughtSignatureCache } from './thought-signature-cache';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { CopilotTokenService } from './copilot-token.service';
     ProxyMessageDedup,
     SessionMomentumService,
     CopilotTokenService,
+    ThoughtSignatureCache,
   ],
 })
 export class ProxyModule {}

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -18,6 +18,7 @@ import {
   resolveApiKey,
 } from './proxy-fallback.service';
 import { ProxyRequestOptions } from './proxy-types';
+import { ThoughtSignatureCache } from './thought-signature-cache';
 
 export { FailedFallback } from './proxy-fallback.service';
 
@@ -63,6 +64,7 @@ export class ProxyService {
     private readonly limitCheck: LimitCheckService,
     private readonly fallbackService: ProxyFallbackService,
     private readonly config: ConfigService,
+    private readonly signatureCache: ThoughtSignatureCache,
   ) {}
 
   async proxyRequest(opts: ProxyRequestOptions): Promise<ProxyResult> {
@@ -132,6 +134,8 @@ export class ProxyService {
     );
 
     const stream = body.stream === true;
+    const signatureLookup = (toolCallId: string) =>
+      this.signatureCache.retrieve(sessionKey, toolCallId);
     const forward = await this.fallbackService.tryForwardToProvider({
       provider: resolved.provider,
       apiKey: resolvedCredentials.apiKey,
@@ -143,6 +147,7 @@ export class ProxyService {
       authType: resolved.auth_type,
       resourceUrl: resolvedCredentials.resourceUrl,
       providerRegion,
+      signatureLookup,
     });
 
     if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -168,6 +168,7 @@ export class ProxyService {
           signal,
           resolved.provider ?? undefined,
           resolved.auth_type,
+          signatureLookup,
         );
 
         if (success) {

--- a/packages/backend/src/routing/proxy/thought-signature-cache.ts
+++ b/packages/backend/src/routing/proxy/thought-signature-cache.ts
@@ -1,0 +1,62 @@
+interface CachedSignature {
+  signature: string;
+  expiresAt: number;
+}
+
+const TTL_MS = 30 * 60 * 1000; // 30 minutes
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * In-memory cache for Google Gemini thought_signature values.
+ *
+ * Newer Gemini thinking models include a `thought_signature` on functionCall
+ * parts. Google requires this signature to round-trip: when the client sends
+ * the next request including the assistant's tool calls, the signature must
+ * be present. However, many clients strip unknown fields from the OpenAI
+ * format. This cache stores signatures from Gemini responses so they can be
+ * re-injected when missing from subsequent requests.
+ *
+ * Keyed by `${sessionKey}:${toolCallId}`.
+ */
+export class ThoughtSignatureCache {
+  private cache = new Map<string, CachedSignature>();
+  private lastCleanup = Date.now();
+
+  /** Store a thought_signature for a tool call in a session. */
+  store(sessionKey: string, toolCallId: string, signature: string): void {
+    this.maybeCleanup();
+    this.cache.set(`${sessionKey}:${toolCallId}`, {
+      signature,
+      expiresAt: Date.now() + TTL_MS,
+    });
+  }
+
+  /** Retrieve a cached thought_signature, or null if not found/expired. */
+  retrieve(sessionKey: string, toolCallId: string): string | null {
+    const entry = this.cache.get(`${sessionKey}:${toolCallId}`);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(`${sessionKey}:${toolCallId}`);
+      return null;
+    }
+    return entry.signature;
+  }
+
+  /** Clear all cached signatures for a session. */
+  clearSession(sessionKey: string): void {
+    const prefix = `${sessionKey}:`;
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(prefix)) this.cache.delete(key);
+    }
+  }
+
+  /** Lazily evict expired entries to avoid unbounded growth. */
+  private maybeCleanup(): void {
+    const now = Date.now();
+    if (now - this.lastCleanup < CLEANUP_INTERVAL_MS) return;
+    this.lastCleanup = now;
+    for (const [key, entry] of this.cache) {
+      if (now > entry.expiresAt) this.cache.delete(key);
+    }
+  }
+}

--- a/packages/backend/src/routing/routing-core/tier-auto-assign.service.ts
+++ b/packages/backend/src/routing/routing-core/tier-auto-assign.service.ts
@@ -126,13 +126,16 @@ export class TierAutoAssignService {
 
       case 'standard': {
         const eligible = byPrice.filter((m) => quality(m) >= 2);
-        picked = eligible.length > 0 ? eligible[0] : byPrice[0];
+        const pool = eligible.length > 0 ? eligible : byPrice;
+        const toolCapable = pool.filter((m) => m.capabilityCode);
+        picked = toolCapable.length > 0 ? toolCapable[0] : pool[0];
         break;
       }
 
       case 'complex': {
         const byQuality = [...byPrice].sort((a, b) => quality(b) - quality(a));
-        picked = byQuality[0];
+        const toolCapable = byQuality.filter((m) => m.capabilityCode);
+        picked = toolCapable.length > 0 ? toolCapable[0] : byQuality[0];
         break;
       }
 
@@ -140,10 +143,12 @@ export class TierAutoAssignService {
         const reasoningModels = byPrice.filter((m) => m.capabilityReasoning);
         if (reasoningModels.length > 0) {
           const byQuality = [...reasoningModels].sort((a, b) => quality(b) - quality(a));
-          picked = byQuality[0];
+          const toolCapable = byQuality.filter((m) => m.capabilityCode);
+          picked = toolCapable.length > 0 ? toolCapable[0] : byQuality[0];
         } else {
           const byQuality = [...byPrice].sort((a, b) => quality(b) - quality(a));
-          picked = byQuality[0];
+          const toolCapable = byQuality.filter((m) => m.capabilityCode);
+          picked = toolCapable.length > 0 ? toolCapable[0] : byQuality[0];
         }
         break;
       }


### PR DESCRIPTION
## Summary

- **Universal non-chat model filter**: Centralized regex filter in `ProviderModelFetcherService.fetch()` applied to ALL providers after parsing. Catches TTS, embedding, image generation, speech recognition, and other non-chat models. Provider-specific patterns supplement the universal filter (OpenAI: moderation/davinci/sora/audio, Gemini: aqs/nano-banana, Mistral: OCR).
- **Tool support filter**: Models where models.dev confirms `toolCall: false` are filtered at discovery time. In the OpenClaw context, every request includes tools — models without tool calling will always fail.
- **Tool-aware tier assignment**: `TierAutoAssignService.pickBest()` now prefers tool-capable models for standard, complex, and reasoning tiers.
- **Relaxed modality check**: Output modality check changed from "text-only" to "includes text", allowing multimodal models that can produce text (e.g., GPT-4o) to pass through.
- **Thought signature cache**: New `ThoughtSignatureCache` stores `thought_signature` values from Google Gemini thinking model responses and re-injects them when clients strip them during round-trips, preventing 400 errors with newer Gemini models.

## Test plan

- [x] All 3178 backend unit tests pass
- [x] New test file `filter-non-chat-models.spec.ts` covers universal and provider-specific filters (36 tests)
- [x] New test file `thought-signature-cache.spec.ts` covers store/retrieve/clear/expiry (10 tests)
- [x] Updated existing tests for relaxed modality checks and tool support filter
- [ ] CI passes
- [ ] Manual: Connect Google API key → verify TTS/embedding/Imagen models not shown
- [ ] Manual: Verify standard Gemini models (2.5 Flash, 2.5 Pro) still appear

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a universal non-chat model filter and a Gemini thought signature cache to keep tool calls working and prevent 400s.

- **New Features**
  - Centralized non-chat filter applied to all providers after parsing, with provider-specific patterns for `openai`, `openai-subscription`, `gemini`, and `mistral`; OpenAI models are de‑duped to prefer aliases over dated snapshots.
  - Model discovery skips models where `models.dev` reports `toolCall: false`, and the modality check now requires output that includes text (multimodal allowed).
  - Tier auto-assignment prefers tool-capable models for standard, complex, and reasoning tiers.
  - Added `ThoughtSignatureCache` to store and re-inject `thought_signature` in the Google adapter (per session/tool call, 30‑min TTL); signatures are extracted from both streaming and non-streaming responses and the lookup is passed through fallback and streaming paths.

<sup>Written for commit 7774ef90e310dbdc16321ddb8f3ff6abf3bf0669. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

