### PR TITLE
fix: improve signup UX for existing emails

### DIFF
--- a/.changeset/fix-signup-existing-email.md
+++ b/.changeset/fix-signup-existing-email.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Improve signup UX: show actionable error when email already exists, auto-redirect when email verification is not required, and skip email verification when no email provider is configured

--- a/packages/backend/src/auth/auth.instance.spec.ts
+++ b/packages/backend/src/auth/auth.instance.spec.ts
@@ -105,13 +105,26 @@ describe('auth.instance', () => {
     expect(config.emailAndPassword.requireEmailVerification).toBe(false);
   });
 
-  it('requires email verification in production', () => {
+  it('requires email verification in production when email provider is configured', () => {
     process.env['NODE_ENV'] = 'production';
     process.env['BETTER_AUTH_SECRET'] = 'a]3kF9!xLm2@pQzR7^wYu4&vN6*cE0hT';
+    process.env['MAILGUN_API_KEY'] = 'key-test';
+    process.env['MAILGUN_DOMAIN'] = 'mg.example.com';
     loadModule();
 
     const config = mockBetterAuth.mock.calls[0][0];
     expect(config.emailAndPassword.requireEmailVerification).toBe(true);
+  });
+
+  it('does not require email verification in production when no email provider is configured', () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['BETTER_AUTH_SECRET'] = 'a]3kF9!xLm2@pQzR7^wYu4&vN6*cE0hT';
+    delete process.env['MAILGUN_API_KEY'];
+    delete process.env['MAILGUN_DOMAIN'];
+    loadModule();
+
+    const config = mockBetterAuth.mock.calls[0][0];
+    expect(config.emailAndPassword.requireEmailVerification).toBe(false);
   });
 
   it('does not require email verification in development', () => {
@@ -333,12 +346,24 @@ describe('auth.instance', () => {
       });
     });
 
-    it('sends verification email on sign-up in cloud mode', () => {
+    it('sends verification email on sign-up in cloud mode when email provider is configured', () => {
       delete process.env['MANIFEST_MODE'];
+      process.env['MAILGUN_API_KEY'] = 'key-test';
+      process.env['MAILGUN_DOMAIN'] = 'mg.example.com';
       loadModule();
 
       const config = mockBetterAuth.mock.calls[0][0];
       expect(config.emailVerification.sendOnSignUp).toBe(true);
+    });
+
+    it('does not send verification email on sign-up when no email provider is configured', () => {
+      delete process.env['MANIFEST_MODE'];
+      delete process.env['MAILGUN_API_KEY'];
+      delete process.env['MAILGUN_DOMAIN'];
+      loadModule();
+
+      const config = mockBetterAuth.mock.calls[0][0];
+      expect(config.emailVerification.sendOnSignUp).toBe(false);
     });
 
     it('enables autoSignInAfterVerification', () => {

--- a/packages/backend/src/auth/auth.instance.ts
+++ b/packages/backend/src/auth/auth.instance.ts
@@ -8,6 +8,7 @@ import { getLocalAuthSecret } from '../common/constants/local-mode.constants';
 const isLocalMode = process.env['MANIFEST_MODE'] === 'local';
 const port = process.env['PORT'] ?? '3001';
 const isDev = (process.env['NODE_ENV'] ?? '') !== 'production';
+const hasEmailProvider = !!(process.env['MAILGUN_API_KEY'] && process.env['MAILGUN_DOMAIN']);
 
 function createDatabaseConnection() {
   if (isLocalMode) {
@@ -70,7 +71,7 @@ const authInstance = isLocalMode
       emailAndPassword: {
         enabled: true,
         minPasswordLength: 8,
-        requireEmailVerification: !isDev && !isLocalMode,
+        requireEmailVerification: !isDev && !isLocalMode && hasEmailProvider,
         sendResetPassword: async ({ user, url }) => {
           const element = ResetPasswordEmail({
             userName: user.name,
@@ -87,7 +88,7 @@ const authInstance = isLocalMode
         },
       },
       emailVerification: {
-        sendOnSignUp: !isLocalMode,
+        sendOnSignUp: !isLocalMode && hasEmailProvider,
         autoSignInAfterVerification: true,
         sendVerificationEmail: async ({ user, url }) => {
           const element = VerifyEmailEmail({

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -51,7 +51,7 @@ const Register: Component = () => {
     }
     setAlreadyExists(false);
 
-    if (data?.session) {
+    if (data?.token) {
       window.location.href = '/';
       return;
     }

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -13,6 +13,7 @@ const Register: Component = () => {
   const [error, setError] = createSignal('');
   const [loading, setLoading] = createSignal(false);
   const [emailSent, setEmailSent] = createSignal(false);
+  const [alreadyExists, setAlreadyExists] = createSignal(false);
   const [resendCooldown, setResendCooldown] = createSignal(0);
 
   const startCooldown = () => {
@@ -33,7 +34,7 @@ const Register: Component = () => {
     setError('');
     setLoading(true);
 
-    const { error: authError } = await authClient.signUp.email({
+    const { data, error: authError } = await authClient.signUp.email({
       name: name(),
       email: email(),
       password: password(),
@@ -42,7 +43,16 @@ const Register: Component = () => {
     setLoading(false);
 
     if (authError) {
+      if (authError.code === 'USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL') {
+        setAlreadyExists(true);
+      }
       setError(authError.message ?? 'Registration failed');
+      return;
+    }
+    setAlreadyExists(false);
+
+    if (data?.session) {
+      window.location.href = '/';
       return;
     }
 
@@ -89,7 +99,22 @@ const Register: Component = () => {
             </div>
 
             <form class="auth-form" onSubmit={handleSubmit}>
-              {error() && <div class="auth-form__error">{error()}</div>}
+              <Show when={alreadyExists()}>
+                <div class="auth-form__error">
+                  An account with this email already exists.{' '}
+                  <A href="/login" class="auth-form__error-link">
+                    Sign in
+                  </A>{' '}
+                  or{' '}
+                  <A href="/reset-password" class="auth-form__error-link">
+                    reset your password
+                  </A>
+                  .
+                </div>
+              </Show>
+              <Show when={error() && !alreadyExists()}>
+                <div class="auth-form__error">{error()}</div>
+              </Show>
               <label class="auth-form__label">
                 Name
                 <input

--- a/packages/frontend/src/styles/auth.css
+++ b/packages/frontend/src/styles/auth.css
@@ -157,6 +157,12 @@
   font-size: var(--font-size-xs);
 }
 
+.auth-form__error-link {
+  color: hsl(var(--destructive));
+  font-weight: 600;
+  text-decoration: underline;
+}
+
 .auth-form__success {
   padding: var(--gap-sm) var(--gap-md);
   background: hsl(142 71% 45% / 0.1);

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -85,15 +85,57 @@ describe("Register", () => {
   });
 
   it("shows error on failed registration", async () => {
-    mockSignUpEmail.mockResolvedValue({ error: { message: "Email already exists" } });
+    mockSignUpEmail.mockResolvedValue({ error: { message: "Something went wrong" } });
     const { container } = render(() => <Register />);
     fireEvent.input(container.querySelector('input[type="text"]')!, { target: { value: "Test" } });
     fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "exists@test.com" } });
     fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass123" } });
     fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Email already exists");
+      expect(container.textContent).toContain("Something went wrong");
     });
+    // Should NOT show the "already exists" variant
+    expect(container.textContent).not.toContain("An account with this email already exists");
+  });
+
+  it("shows already-exists error with sign-in and reset links", async () => {
+    mockSignUpEmail.mockResolvedValue({
+      error: { code: "USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL", message: "User already exists" },
+    });
+    const { container } = render(() => <Register />);
+    fireEvent.input(container.querySelector('input[type="text"]')!, { target: { value: "Test" } });
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "exists@test.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass123" } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("An account with this email already exists");
+    });
+    expect(container.querySelector('a[href="/login"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/reset-password"]')).not.toBeNull();
+  });
+
+  it("redirects to home when signup returns a session", async () => {
+    const locationSpy = vi.spyOn(window, "location", "get").mockReturnValue({
+      ...window.location,
+      href: "",
+    });
+    const hrefSetter = vi.fn();
+    Object.defineProperty(window.location, "href", { set: hrefSetter, configurable: true });
+
+    mockSignUpEmail.mockResolvedValue({
+      data: { session: { token: "tok" }, user: { id: "u1" } },
+      error: null,
+    });
+    const { container } = render(() => <Register />);
+    fireEvent.input(container.querySelector('input[type="text"]')!, { target: { value: "Test" } });
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "new@test.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass12345" } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(hrefSetter).toHaveBeenCalledWith("/");
+    });
+
+    locationSpy.mockRestore();
   });
 
   it("shows loading state during submission", async () => {

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -114,7 +114,7 @@ describe("Register", () => {
     expect(container.querySelector('a[href="/reset-password"]')).not.toBeNull();
   });
 
-  it("redirects to home when signup returns a session", async () => {
+  it("redirects to home when signup returns a token", async () => {
     const locationSpy = vi.spyOn(window, "location", "get").mockReturnValue({
       ...window.location,
       href: "",
@@ -123,7 +123,7 @@ describe("Register", () => {
     Object.defineProperty(window.location, "href", { set: hrefSetter, configurable: true });
 
     mockSignUpEmail.mockResolvedValue({
-      data: { session: { token: "tok" }, user: { id: "u1" } },
+      data: { token: "tok", user: { id: "u1" } },
       error: null,
     });
     const { container } = render(() => <Register />);


### PR DESCRIPTION
## Summary

- When signing up with an email that already exists, the form now shows a clear error: "An account with this email already exists" with links to **Sign in** or **reset your password**
- When email verification is not required (dev mode or no email provider), signup auto-redirects to the app instead of showing the "Check your email" screen
- `requireEmailVerification` and `sendOnSignUp` now also check for `hasEmailProvider` — prevents permanent user lockout on self-hosted instances without Mailgun configured

Closes #1398 

## Test plan

- [ ] Sign up with an existing email → verify error message with links appears
- [ ] Sign up with a new email (dev mode, no Mailgun) → verify auto-redirect to app
- [ ] Sign up with a new email (prod mode, Mailgun configured) → verify "Check your email" screen
- [ ] Run backend tests: `npx jest src/auth/auth.instance.spec.ts`
- [ ] Run frontend tests: `npx vitest run tests/pages/Register.test.tsx`

Closes #1398