### PR TITLE
fix: correct Ollama model grouping in routing model picker

### DIFF
--- a/.changeset/fix-ollama-model-grouping.md
+++ b/.changeset/fix-ollama-model-grouping.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: prevent OpenRouter colon-variant models from being mis-grouped under Ollama and ensure all Ollama models appear in the routing model picker

--- a/packages/backend/src/common/utils/provider-inference.spec.ts
+++ b/packages/backend/src/common/utils/provider-inference.spec.ts
@@ -71,6 +71,13 @@ describe('inferProviderFromModel', () => {
     expect(inferProviderFromModel('stepfun/step-3.5-flash:free')).toBe('openrouter');
   });
 
+  it('does not treat vendor/model:variant as ollama', () => {
+    expect(inferProviderFromModel('anthropic/claude-sonnet-4:thinking')).toBe('openrouter');
+    expect(inferProviderFromModel('nvidia/llama-3.1-nemotron-70b-instruct:extended')).toBe(
+      'openrouter',
+    );
+  });
+
   it('returns undefined for unrecognized models', () => {
     expect(inferProviderFromModel('whisper-large')).toBeUndefined();
     expect(inferProviderFromModel('unknown-model')).toBeUndefined();

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -103,9 +103,11 @@ const ModelPickerModal: Component<Props> = (props) => {
       // Prefer prefix-inferred provider (e.g. "anthropic" from "anthropic/claude-sonnet-4")
       // over the DB provider (e.g. "openrouter" when all models come from OpenRouter)
       const provId =
-        prefixProvId && PROVIDERS.find((p) => p.id === prefixProvId)
-          ? prefixProvId
-          : (dbProvId ?? prefixProvId);
+        dbProvId === 'ollama'
+          ? 'ollama'
+          : prefixProvId && PROVIDERS.find((p) => p.id === prefixProvId)
+            ? prefixProvId
+            : (dbProvId ?? prefixProvId);
       if (!provId) continue;
       if (allowedProviders && !allowedProviders.has(provId)) continue;
       if (!groupMap.has(provId)) {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -8,12 +8,13 @@ vi.mock("../../src/components/ProviderIcon.js", () => ({
 vi.mock("../../src/services/routing-utils.js", () => ({
   pricePerM: (v: number) => `$${(v * 1_000_000).toFixed(2)}`,
   resolveProviderId: (provider: string) => {
-    const map: Record<string, string> = { OpenAI: "openai", Anthropic: "anthropic", Google: "google" };
+    const map: Record<string, string> = { OpenAI: "openai", Anthropic: "anthropic", Google: "google", Ollama: "ollama" };
     return map[provider] ?? null;
   },
   inferProviderFromModel: (modelName: string) => {
     const slash = modelName.indexOf("/");
     if (slash !== -1) return modelName.substring(0, slash).toLowerCase();
+    if (modelName.startsWith("mistral-")) return "mistral";
     return null;
   },
 }));
@@ -434,6 +435,27 @@ describe("ModelPickerModal", () => {
     ));
     // The model should render with its raw name as label (no label in PROVIDERS for this model)
     expect(container.textContent).toContain("my-custom-thing");
+  });
+
+  it("groups tagless Ollama models under Ollama even when prefix matches another provider", () => {
+    const models = [
+      { model_name: "mistral-small", provider: "Ollama", display_name: "Mistral Small", input_price_per_token: 0, output_price_per_token: 0, context_window: 32000, capability_reasoning: false, capability_code: true },
+    ];
+    const providers = [
+      { id: "p1", provider: "Ollama", is_active: true, has_api_key: false, auth_type: "api_key" as const, connected_at: "2025-01-01" },
+    ];
+    render(() => (
+      <ModelPickerModal
+        tierId="simple"
+        models={models}
+        tiers={baseTiers}
+        connectedProviders={providers}
+        onSelect={onSelect}
+        onClose={onClose}
+      />
+    ));
+    expect(screen.getByText("Ollama")).toBeDefined();
+    expect(screen.queryByText("Mistral")).toBeNull();
   });
 
   it("resets showFreeOnly when switching to subscription tab", () => {

--- a/packages/frontend/tests/services/routing-utils.test.ts
+++ b/packages/frontend/tests/services/routing-utils.test.ts
@@ -167,6 +167,11 @@ describe("inferProviderFromModel", () => {
     expect(inferProviderFromModel("meta-llama/llama-4-maverick")).toBe("openrouter");
   });
 
+  it("does not misclassify OpenRouter colon-variant models as Ollama", () => {
+    expect(inferProviderFromModel("anthropic/claude-sonnet-4:thinking")).toBe("openrouter");
+    expect(inferProviderFromModel("nvidia/llama-3.1-nemotron-70b-instruct:extended")).toBe("openrouter");
+  });
+
   it("returns undefined for unrecognized models", () => {
     expect(inferProviderFromModel("some-random-model")).toBeUndefined();
   });

--- a/packages/shared/__tests__/provider-inference.spec.ts
+++ b/packages/shared/__tests__/provider-inference.spec.ts
@@ -51,6 +51,12 @@ describe('inferProviderFromModel', () => {
     expect(inferProviderFromModel('llama3:latest')).toBe('ollama');
   });
 
+  it('does not treat OpenRouter vendor/model:variant as ollama', () => {
+    expect(inferProviderFromModel('anthropic/claude-sonnet-4:thinking')).toBe('openrouter');
+    expect(inferProviderFromModel('nvidia/llama-3.1-nemotron-70b-instruct:extended')).toBe('openrouter');
+    expect(inferProviderFromModel('meta-llama/llama-4-scout:free')).toBe('openrouter');
+  });
+
   it('does not treat :free suffix as ollama', () => {
     expect(inferProviderFromModel('openrouter/model:free')).not.toBe('ollama');
   });

--- a/packages/shared/src/provider-inference.ts
+++ b/packages/shared/src/provider-inference.ts
@@ -22,7 +22,7 @@ export { MODEL_PREFIX_MAP };
 
 export function inferProviderFromModel(model: string): string | undefined {
   if (model.startsWith('custom:')) return 'custom';
-  if (/:/.test(model) && !model.endsWith(':free')) return 'ollama';
+  if (!model.includes('/') && /:/.test(model) && !model.endsWith(':free')) return 'ollama';
   const lower = model.toLowerCase();
   for (const [re, id] of MODEL_PREFIX_MAP) {
     if (re.test(lower)) return id;


### PR DESCRIPTION
## Summary

Fixes two bugs in the routing model picker that caused incorrect model grouping:

- **OpenRouter models mis-grouped under Ollama**: Models with colon variants (e.g. `anthropic/claude-sonnet-4:thinking`) were classified as Ollama because the `:` heuristic didn't distinguish `vendor/model:variant` (OpenRouter) from `name:tag` (Ollama). Added a `/` check to only apply the colon heuristic to slash-less names.

- **Ollama models missing from picker**: When an Ollama model's name matched a known provider prefix (e.g. `mistral-small` → Mistral, `qwen2.5` → Qwen), the prefix inference overrode the API-provided provider, causing the model to be grouped under a provider the user hadn't connected. Now when the API says `provider: "ollama"`, the picker always groups it under Ollama.

Closes #1391

## Test plan

- [x] Shared package tests pass (60/60)
- [x] Backend unit tests pass (3203/3203)
- [x] Frontend tests pass (1705/1705)
- [x] TypeScript compilation clean (backend + frontend)
- [x] Tested locally with Ollama (4 models: `qwen2.5:0.5b`, `qwen2.5`, `gpt-oss`, `gemma3`) — all correctly grouped under Ollama
- [x] Verified OpenRouter colon-variant models (`anthropic/claude-sonnet-4:thinking`, etc.) resolve to `openrouter`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes model grouping in the routing model picker so OpenRouter and Ollama models appear under the correct providers.

- **Bug Fixes**
  - Only treat colon tags as Ollama when the name has no slash, preventing `vendor/model:variant` (e.g., `anthropic/claude-sonnet-4:thinking`) from being misclassified.
  - When the API says a model’s provider is `ollama`, always group it under Ollama, even if the name matches another provider’s prefix (e.g., `mistral-small`).

<sup>Written for commit 315a08b06fd051a56973b31a0d865c7eb454122e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

