### PR TITLE
fix: improve Settings page API key display and rename UX

### DIFF
--- a/.changeset/improve-settings-ux.md
+++ b/.changeset/improve-settings-ux.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Improve Settings page UX: reload page after agent rename, update API key warning text, and show API key display contextually based on key availability

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -13,6 +13,7 @@ interface Props {
   apiKey: string | null;
   keyPrefix: string | null;
   baseUrl: string;
+  hideFullKey?: boolean;
 }
 
 const SetupStepAddProvider: Component<Props> = (props) => {
@@ -44,7 +45,10 @@ openclaw gateway restart`;
         to the best provider.
       </p>
 
-      <ApiKeyDisplay apiKey={props.apiKey} keyPrefix={props.keyPrefix} />
+      <ApiKeyDisplay
+        apiKey={props.hideFullKey ? null : props.apiKey}
+        keyPrefix={props.apiKey ? null : props.keyPrefix}
+      />
 
       <div class="setup-info-grid">
         <div class="setup-info-grid__card">

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,20 +1,20 @@
-import { createSignal, createResource, Show, For, ErrorBoundary, type Component } from 'solid-js';
-import { useParams, useNavigate, useLocation } from '@solidjs/router';
-import { Title, Meta } from '@solidjs/meta';
+import { Meta, Title } from '@solidjs/meta';
+import { useLocation, useNavigate, useParams } from '@solidjs/router';
+import { createResource, createSignal, ErrorBoundary, For, Show, type Component } from 'solid-js';
 import ErrorState from '../components/ErrorState.jsx';
 import SetupStepAddProvider from '../components/SetupStepAddProvider.jsx';
 import { CopyButton } from '../components/SetupStepInstall.jsx';
+import { agentDisplayName } from '../services/agent-display-name.js';
 import {
-  getAgentKey,
   deleteAgent,
+  getAgentKey,
+  getRoutingStatus,
   renameAgent,
   rotateAgentKey,
-  getRoutingStatus,
 } from '../services/api.js';
-import { toast } from '../services/toast-store.js';
-import { markAgentCreated } from '../services/recent-agents.js';
 import { isLocalMode } from '../services/local-mode.js';
-import { agentDisplayName } from '../services/agent-display-name.js';
+import { markAgentCreated } from '../services/recent-agents.js';
+import { toast } from '../services/toast-store.js';
 
 const Settings: Component = () => {
   const params = useParams<{ agentName: string }>();
@@ -235,9 +235,9 @@ const Settings: Component = () => {
               </div>
             </div>
             <Show when={rotatedKey()}>
-              <div style="padding: 0 var(--gap-md) var(--gap-md);">
+              <div style="padding: 0 var(--gap-md) var(--gap-md); margin-top: var(--gap-md);">
                 <div style="background: hsl(var(--chart-5) / 0.1); border: 1px solid hsl(var(--chart-5) / 0.3); border-radius: var(--radius); padding: 10px 14px; margin-bottom: 12px; font-size: var(--font-size-sm); color: hsl(var(--foreground));">
-                  Save this key somewhere safe. You won't see it again.
+                  Save your API key. You won't see it again after closing this dialog.
                 </div>
                 <div style="display: flex; align-items: center; gap: 8px; background: hsl(var(--muted)); border-radius: var(--radius); padding: 10px 14px; font-family: var(--font-mono); font-size: var(--font-size-sm); word-break: break-all;">
                   {rotatedKey()}
@@ -268,6 +268,7 @@ const Settings: Component = () => {
                 apiKey={rotatedKey() ?? null}
                 keyPrefix={keyData()?.keyPrefix ?? null}
                 baseUrl={baseUrl()}
+                hideFullKey
               />
               <Show when={!routingEnabled()}>
                 <div style="margin-top: 0; padding-top: var(--gap-lg); border-top: 1px solid hsl(var(--border)); display: flex; align-items: center; justify-content: space-between;">

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -60,14 +60,9 @@ const Settings: Component = () => {
       const result = await renameAgent(agentName(), newName);
       const slug = result?.name ?? newName;
       markAgentCreated(slug);
-      navigate(`/agents/${encodeURIComponent(slug)}/settings`, {
-        replace: true,
-      });
-      setSaved(true);
-      setTimeout(() => setSaved(false), 2000);
+      window.location.replace(`/agents/${encodeURIComponent(slug)}/settings`);
     } catch {
       setName(agentName());
-    } finally {
       setSaving(false);
     }
   };

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -44,20 +44,32 @@ describe("SetupStepAddProvider", () => {
     expect(container.textContent).toContain("Model");
   });
 
-  it("renders ApiKeyDisplay component", () => {
+  it("shows full API key in ApiKeyDisplay by default", () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} apiKey="mnfst_test_key" />
     ));
     const display = container.querySelector('[data-testid="api-key-display"]');
     expect(display).not.toBeNull();
     expect(display!.getAttribute("data-key")).toBe("mnfst_test_key");
+    expect(display!.getAttribute("data-prefix")).toBe("");
   });
 
-  it("passes keyPrefix to ApiKeyDisplay", () => {
+  it("hides both key and prefix when hideFullKey is set with apiKey", () => {
+    const { container } = render(() => (
+      <SetupStepAddProvider {...defaultProps} apiKey="mnfst_test_key" keyPrefix="mnfst_abc" hideFullKey />
+    ));
+    const display = container.querySelector('[data-testid="api-key-display"]');
+    expect(display).not.toBeNull();
+    expect(display!.getAttribute("data-key")).toBe("");
+    expect(display!.getAttribute("data-prefix")).toBe("");
+  });
+
+  it("shows ApiKeyDisplay with keyPrefix when no full key", () => {
     const { container } = render(() => (
       <SetupStepAddProvider {...defaultProps} keyPrefix="mnfst_abc" />
     ));
     const display = container.querySelector('[data-testid="api-key-display"]');
+    expect(display).not.toBeNull();
     expect(display!.getAttribute("data-prefix")).toBe("mnfst_abc");
   });
 

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -169,7 +169,14 @@ describe("Settings", () => {
     expect(saveBtn.disabled).toBe(false);
   });
 
-  it("clicking Save calls renameAgent API then shows Saved", async () => {
+  it("clicking Save calls renameAgent API then reloads to new slug", async () => {
+    const replaceFn = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, replace: replaceFn },
+      writable: true,
+      configurable: true,
+    });
     const { container } = render(() => <Settings />);
     const input = screen.getByLabelText("Agent name") as HTMLInputElement;
     fireEvent.input(input, { target: { value: "new-name" } });
@@ -184,7 +191,12 @@ describe("Settings", () => {
       expect(mockMarkAgentCreated).toHaveBeenCalledWith("new-name");
     });
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Saved");
+      expect(replaceFn).toHaveBeenCalledWith("/agents/new-name/settings");
+    });
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
     });
   });
 


### PR DESCRIPTION
## Summary

- Reload page after agent rename so URL, breadcrumb, and data reflect the new slug (fixes #1255)
- Update API key warning text for clarity and add margin-top to the rotated key banner
- Show full API key display contextually: visible in SetupModal (agent creation), hidden in Settings Setup section when already shown in the API Key section above
- Hide "Replace mnfst_... with your full API key" hint when the full key is available (after rotate or in SetupModal)

## Test plan

- [ ] Rename an agent on the Settings page — verify page reloads with new slug in URL, breadcrumb, and data
- [ ] Rotate API key — verify the warning banner has proper spacing and updated text
- [ ] After rotating, check Setup section — "Replace..." hint should not appear
- [ ] Revisit Settings later (no rotated key) — "Replace..." hint should appear in Setup section
- [ ] Create a new agent — SetupModal should show the full API key with "Save your API key" warning

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reloads the Settings page after agent rename so the new slug updates everywhere, and simplifies API key display/warnings for a clearer setup flow. Prevents stale UI and hides redundant hints in Settings while still showing the full key in the Setup modal.

- **Bug Fixes**
  - Use window.location.replace after rename to refresh URL, breadcrumb, and data.
  - Tweak API key banner: clearer warning text and added top margin.
  - Contextual API key display:
    - Show full key in SetupModal (agent creation).
    - In Settings Setup section, hide full key when already shown above and hide the “Replace mnfst_...” hint when the full key is available.

<sup>Written for commit a4975447d45b5d6f33cf11726521d140d906ffb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

