### PR TITLE
fix: probe Anthropic subscription model access at discovery time

### DIFF
--- a/.changeset/anthropic-subscription-probe.md
+++ b/.changeset/anthropic-subscription-probe.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Probe Anthropic subscription token access at discovery time to filter out inaccessible model families. Separate model lists by auth type so subscription and API key tabs show independent results.

--- a/packages/backend/src/model-discovery/anthropic-subscription-probe.spec.ts
+++ b/packages/backend/src/model-discovery/anthropic-subscription-probe.spec.ts
@@ -32,6 +32,18 @@ describe('extractFamily', () => {
     expect(extractFamily('claude-3-haiku-20240307')).toBe('haiku');
   });
 
+  it('extracts "sonnet" from claude-3-5-sonnet-20241022 (multi-digit version prefix)', () => {
+    expect(extractFamily('claude-3-5-sonnet-20241022')).toBe('sonnet');
+  });
+
+  it('extracts "haiku" from claude-3-5-haiku-20241022', () => {
+    expect(extractFamily('claude-3-5-haiku-20241022')).toBe('haiku');
+  });
+
+  it('extracts "sonnet" from claude-3-7-sonnet-20250219', () => {
+    expect(extractFamily('claude-3-7-sonnet-20250219')).toBe('sonnet');
+  });
+
   it('extracts "opus" from claude-opus-4-5-20251101', () => {
     expect(extractFamily('claude-opus-4-5-20251101')).toBe('opus');
   });

--- a/packages/backend/src/model-discovery/anthropic-subscription-probe.spec.ts
+++ b/packages/backend/src/model-discovery/anthropic-subscription-probe.spec.ts
@@ -1,0 +1,213 @@
+import { extractFamily, filterBySubscriptionAccess } from './anthropic-subscription-probe';
+import { DiscoveredModel } from './model-fetcher';
+
+function makeModel(id: string): DiscoveredModel {
+  return {
+    id,
+    displayName: id,
+    provider: 'anthropic',
+    contextWindow: 200000,
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 3,
+  };
+}
+
+describe('extractFamily', () => {
+  it('extracts "sonnet" from claude-sonnet-4-6', () => {
+    expect(extractFamily('claude-sonnet-4-6')).toBe('sonnet');
+  });
+
+  it('extracts "opus" from claude-opus-4-6', () => {
+    expect(extractFamily('claude-opus-4-6')).toBe('opus');
+  });
+
+  it('extracts "haiku" from claude-haiku-4-5-20251001', () => {
+    expect(extractFamily('claude-haiku-4-5-20251001')).toBe('haiku');
+  });
+
+  it('extracts "haiku" from claude-3-haiku-20240307 (legacy naming)', () => {
+    expect(extractFamily('claude-3-haiku-20240307')).toBe('haiku');
+  });
+
+  it('extracts "opus" from claude-opus-4-5-20251101', () => {
+    expect(extractFamily('claude-opus-4-5-20251101')).toBe('opus');
+  });
+
+  it('extracts "sonnet" from claude-sonnet-4-20250514', () => {
+    expect(extractFamily('claude-sonnet-4-20250514')).toBe('sonnet');
+  });
+
+  it('returns null for non-Claude model IDs', () => {
+    expect(extractFamily('gpt-4o')).toBeNull();
+    expect(extractFamily('gemini-2.5-flash')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractFamily('')).toBeNull();
+  });
+});
+
+describe('filterBySubscriptionAccess', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  function mockFetchResponses(accessMap: Record<string, boolean>): void {
+    global.fetch = jest.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string);
+      const model = body.model as string;
+      const family = extractFamily(model);
+      const accessible = family ? (accessMap[family] ?? true) : true;
+
+      if (accessible) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              type: 'message',
+              content: [{ type: 'text', text: '.' }],
+            }),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 400,
+        json: () =>
+          Promise.resolve({
+            type: 'error',
+            error: { type: 'invalid_request_error', message: 'Error' },
+          }),
+      });
+    });
+  }
+
+  it('keeps all models when all families are accessible', async () => {
+    mockFetchResponses({ haiku: true, sonnet: true, opus: true });
+
+    const models = [
+      makeModel('claude-haiku-4-5-20251001'),
+      makeModel('claude-sonnet-4-6'),
+      makeModel('claude-opus-4-6'),
+    ];
+    const result = await filterBySubscriptionAccess(models, 'test-key');
+    expect(result.map((m) => m.id)).toEqual([
+      'claude-haiku-4-5-20251001',
+      'claude-sonnet-4-6',
+      'claude-opus-4-6',
+    ]);
+  });
+
+  it('removes sonnet and opus when only haiku is accessible (Pro plan)', async () => {
+    mockFetchResponses({ haiku: true, sonnet: false, opus: false });
+
+    const models = [
+      makeModel('claude-haiku-4-5-20251001'),
+      makeModel('claude-3-haiku-20240307'),
+      makeModel('claude-sonnet-4-6'),
+      makeModel('claude-sonnet-4-5-20250929'),
+      makeModel('claude-opus-4-6'),
+      makeModel('claude-opus-4-5-20251101'),
+    ];
+    const result = await filterBySubscriptionAccess(models, 'test-key');
+    expect(result.map((m) => m.id)).toEqual([
+      'claude-haiku-4-5-20251001',
+      'claude-3-haiku-20240307',
+    ]);
+  });
+
+  it('removes only opus when haiku and sonnet are accessible (Team plan)', async () => {
+    mockFetchResponses({ haiku: true, sonnet: true, opus: false });
+
+    const models = [
+      makeModel('claude-haiku-4-5-20251001'),
+      makeModel('claude-sonnet-4-6'),
+      makeModel('claude-opus-4-6'),
+    ];
+    const result = await filterBySubscriptionAccess(models, 'test-key');
+    expect(result.map((m) => m.id)).toEqual(['claude-haiku-4-5-20251001', 'claude-sonnet-4-6']);
+  });
+
+  it('probes exactly one model per family', async () => {
+    mockFetchResponses({ haiku: true, sonnet: true, opus: true });
+
+    const models = [
+      makeModel('claude-haiku-4-5-20251001'),
+      makeModel('claude-3-haiku-20240307'),
+      makeModel('claude-sonnet-4-6'),
+      makeModel('claude-sonnet-4-5-20250929'),
+      makeModel('claude-opus-4-6'),
+      makeModel('claude-opus-4-5-20251101'),
+    ];
+    await filterBySubscriptionAccess(models, 'test-key');
+    // 3 families = 3 probe calls
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps models with no extractable family', async () => {
+    mockFetchResponses({ haiku: true });
+
+    const models = [makeModel('claude-haiku-4-5-20251001'), makeModel('some-unknown-model')];
+    const result = await filterBySubscriptionAccess(models, 'test-key');
+    expect(result.map((m) => m.id)).toEqual(['claude-haiku-4-5-20251001', 'some-unknown-model']);
+  });
+
+  it('keeps models on network/timeout errors (non-deterministic failures)', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network error'));
+
+    const models = [makeModel('claude-sonnet-4-6'), makeModel('claude-opus-4-6')];
+    const result = await filterBySubscriptionAccess(models, 'test-key');
+    expect(result).toHaveLength(2);
+  });
+
+  it('keeps models on non-400 errors like 429 rate limit', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+    });
+
+    const models = [makeModel('claude-sonnet-4-6'), makeModel('claude-opus-4-6')];
+    const result = await filterBySubscriptionAccess(models, 'test-key');
+    expect(result).toHaveLength(2);
+  });
+
+  it('sends correct headers for subscription auth', async () => {
+    mockFetchResponses({ haiku: true });
+
+    await filterBySubscriptionAccess([makeModel('claude-haiku-4-5-20251001')], 'my-token');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/messages',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-token',
+          'anthropic-version': '2023-06-01',
+          'anthropic-beta': 'oauth-2025-04-20',
+        }),
+      }),
+    );
+  });
+
+  it('sends max_tokens: 1 to minimize cost', async () => {
+    mockFetchResponses({ haiku: true });
+
+    await filterBySubscriptionAccess([makeModel('claude-haiku-4-5-20251001')], 'my-token');
+
+    const callBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(callBody.max_tokens).toBe(1);
+  });
+
+  it('returns empty array for empty input', async () => {
+    const spy = jest.fn();
+    global.fetch = spy;
+    const result = await filterBySubscriptionAccess([], 'test-key');
+    expect(result).toEqual([]);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/model-discovery/anthropic-subscription-probe.ts
+++ b/packages/backend/src/model-discovery/anthropic-subscription-probe.ts
@@ -7,7 +7,7 @@ const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
 const PROBE_TIMEOUT_MS = 5000;
 
 /** Extract the model family from an Anthropic model ID (e.g. "claude-sonnet-4-6" → "sonnet"). */
-const FAMILY_RE = /^claude-(?:\d+-)?(\w+)/;
+const FAMILY_RE = /^claude-(?:\d+(?:-\d+)*-)?([a-z]+)/i;
 
 export function extractFamily(modelId: string): string | null {
   const match = FAMILY_RE.exec(modelId);

--- a/packages/backend/src/model-discovery/anthropic-subscription-probe.ts
+++ b/packages/backend/src/model-discovery/anthropic-subscription-probe.ts
@@ -1,0 +1,116 @@
+import { Logger } from '@nestjs/common';
+import { DiscoveredModel } from './model-fetcher';
+
+const logger = new Logger('AnthropicSubscriptionProbe');
+
+const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+const PROBE_TIMEOUT_MS = 5000;
+
+/** Extract the model family from an Anthropic model ID (e.g. "claude-sonnet-4-6" → "sonnet"). */
+const FAMILY_RE = /^claude-(?:\d+-)?(\w+)/;
+
+export function extractFamily(modelId: string): string | null {
+  const match = FAMILY_RE.exec(modelId);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Probe a single model with a minimal request to check subscription access.
+ * Returns true if the model is accessible, false if Anthropic rejects it.
+ */
+async function probeModel(apiKey: string, modelId: string): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+
+    const res = await fetch(ANTHROPIC_MESSAGES_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'oauth-2025-04-20',
+      },
+      body: JSON.stringify({
+        model: modelId,
+        max_tokens: 1,
+        messages: [{ role: 'user', content: '.' }],
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeout);
+
+    if (res.ok) return true;
+
+    // Anthropic returns 400 with opaque "Error" for subscription tier restrictions
+    if (res.status === 400) return false;
+
+    // Other errors (429 rate limit, 500 server error) — don't exclude the model,
+    // it might work later. Only subscription tier rejections are deterministic.
+    return true;
+  } catch {
+    // Network/timeout error — keep the model (don't penalize for transient failures)
+    return true;
+  }
+}
+
+/**
+ * Filter Anthropic subscription models by probing one model per family.
+ *
+ * Groups models by family (haiku, sonnet, opus), probes one representative
+ * from each family, and removes all models from families the subscription
+ * cannot access. Only called for Anthropic subscription auth — API key
+ * providers are never probed.
+ */
+export async function filterBySubscriptionAccess(
+  models: DiscoveredModel[],
+  apiKey: string,
+): Promise<DiscoveredModel[]> {
+  // Group models by family
+  const familyMap = new Map<string, DiscoveredModel[]>();
+  const noFamily: DiscoveredModel[] = [];
+
+  for (const model of models) {
+    const family = extractFamily(model.id);
+    if (!family) {
+      noFamily.push(model);
+      continue;
+    }
+    const group = familyMap.get(family) ?? [];
+    group.push(model);
+    familyMap.set(family, group);
+  }
+
+  // Probe one model per family in parallel
+  const families = [...familyMap.keys()];
+  const probeResults = await Promise.all(
+    families.map(async (family) => {
+      const representative = familyMap.get(family)![0];
+      const accessible = await probeModel(apiKey, representative.id);
+      if (!accessible) {
+        logger.log(
+          `Anthropic subscription: ${family} models not accessible (probed ${representative.id})`,
+        );
+      }
+      return { family, accessible };
+    }),
+  );
+
+  const accessibleFamilies = new Set(probeResults.filter((r) => r.accessible).map((r) => r.family));
+  const blockedFamilies = families.filter((f) => !accessibleFamilies.has(f));
+
+  if (blockedFamilies.length > 0) {
+    logger.log(
+      `Anthropic subscription: accessible families=[${[...accessibleFamilies].join(', ')}], ` +
+        `blocked families=[${blockedFamilies.join(', ')}]`,
+    );
+  }
+
+  const filtered = models.filter((model) => {
+    const family = extractFamily(model.id);
+    if (!family) return true;
+    return accessibleFamilies.has(family);
+  });
+
+  return filtered;
+}

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -15,7 +15,12 @@ jest.mock('../database/quality-score.util', () => ({
   computeQualityScore: jest.fn().mockReturnValue(3),
 }));
 
+jest.mock('./anthropic-subscription-probe', () => ({
+  filterBySubscriptionAccess: jest.fn().mockImplementation((models: unknown[]) => models),
+}));
+
 import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
+import { filterBySubscriptionAccess } from './anthropic-subscription-probe';
 import { computeQualityScore } from '../database/quality-score.util';
 
 const mockDecrypt = decrypt as jest.MockedFunction<typeof decrypt>;
@@ -998,6 +1003,79 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).toHaveBeenCalledWith('anthropic', blob, 'subscription', undefined);
     });
 
+    it('should call filterBySubscriptionAccess for Anthropic subscription providers', async () => {
+      const token = 'sk-ant-oat01-test-token';
+      mockDecrypt.mockReturnValue(token);
+
+      const models = [
+        makeModel({ id: 'claude-haiku-4-5-20251001', provider: 'anthropic' }),
+        makeModel({ id: 'claude-sonnet-4-6', provider: 'anthropic' }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const mockFilter = filterBySubscriptionAccess as jest.MockedFunction<
+        typeof filterBySubscriptionAccess
+      >;
+      mockFilter.mockResolvedValue([models[0]]);
+
+      const result = await service.discoverModels(
+        makeProvider({
+          provider: 'anthropic',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted',
+        }),
+      );
+
+      expect(mockFilter).toHaveBeenCalledWith(models, token);
+      expect(result.map((m) => m.id)).toEqual(['claude-haiku-4-5-20251001']);
+    });
+
+    it('should NOT call filterBySubscriptionAccess for Anthropic API key providers', async () => {
+      mockDecrypt.mockReturnValue('sk-ant-api03-test-key');
+
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ id: 'claude-sonnet-4-6', provider: 'anthropic' }),
+      ]);
+
+      const mockFilter = filterBySubscriptionAccess as jest.MockedFunction<
+        typeof filterBySubscriptionAccess
+      >;
+      mockFilter.mockClear();
+
+      await service.discoverModels(
+        makeProvider({
+          provider: 'anthropic',
+          auth_type: 'api_key',
+          api_key_encrypted: 'encrypted',
+        }),
+      );
+
+      expect(mockFilter).not.toHaveBeenCalled();
+    });
+
+    it('should NOT call filterBySubscriptionAccess for non-Anthropic subscription providers', async () => {
+      mockDecrypt.mockReturnValue(
+        JSON.stringify({ t: 'token', r: 'refresh', e: Date.now() + 60000 }),
+      );
+
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'gpt-4o', provider: 'openai' })]);
+
+      const mockFilter = filterBySubscriptionAccess as jest.MockedFunction<
+        typeof filterBySubscriptionAccess
+      >;
+      mockFilter.mockClear();
+
+      await service.discoverModels(
+        makeProvider({
+          provider: 'openai',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted',
+        }),
+      );
+
+      expect(mockFilter).not.toHaveBeenCalled();
+    });
+
     it('should unwrap MiniMax OAuth blob and forward resource URL for subscription discovery', async () => {
       const blob = JSON.stringify({
         t: 'minimax-access',
@@ -1365,7 +1443,7 @@ describe('ModelDiscoveryService', () => {
   /* ── getModelsForAgent auth-type deduplication ── */
 
   describe('getModelsForAgent (auth-type dedup)', () => {
-    it('should prefer subscription model over api_key duplicate', async () => {
+    it('should keep both auth types as separate entries for the same model', async () => {
       const providers = [
         makeProvider({
           id: 'p1',
@@ -1392,13 +1470,15 @@ describe('ModelDiscoveryService', () => {
 
       const result = await service.getModelsForAgent('agent-1');
 
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('claude-sonnet-4');
-      expect(result[0].authType).toBe('subscription');
-      expect(result[0].contextWindow).toBe(200000);
+      expect(result).toHaveLength(2);
+      const apiKeyEntry = result.find((m) => m.authType === 'api_key');
+      const subEntry = result.find((m) => m.authType === 'subscription');
+      expect(apiKeyEntry).toBeDefined();
+      expect(subEntry).toBeDefined();
+      expect(subEntry!.contextWindow).toBe(200000);
     });
 
-    it('should not replace subscription with api_key duplicate', async () => {
+    it('should deduplicate same model + same auth type from multiple providers', async () => {
       const providers = [
         makeProvider({
           id: 'p1',
@@ -1415,7 +1495,7 @@ describe('ModelDiscoveryService', () => {
           id: 'p2',
           provider: 'anthropic',
           cached_models: [
-            makeModel({ id: 'claude-sonnet-4', provider: 'anthropic', authType: 'api_key' }),
+            makeModel({ id: 'claude-sonnet-4', provider: 'anthropic', authType: 'subscription' }),
           ],
         }),
       ];
@@ -1452,8 +1532,9 @@ describe('ModelDiscoveryService', () => {
 
       const result = await service.getModelsForAgent('agent-1');
 
-      expect(result).toHaveLength(1);
-      // Legacy model from subscription provider should replace the api_key one
+      // Both entries kept — one with inferred api_key, one with inferred subscription
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.authType).sort()).toEqual(['api_key', 'subscription']);
     });
   });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -13,6 +13,7 @@ import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { parseOAuthTokenBlob } from '../routing/oauth/openai-oauth.types';
 import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../routing/qwen-region';
 import { CopilotTokenService } from '../routing/proxy/copilot-token.service';
+import { filterBySubscriptionAccess } from './anthropic-subscription-probe';
 import {
   findOpenRouterPrefix,
   lookupWithVariants,
@@ -147,6 +148,13 @@ export class ModelDiscoveryService {
       raw = supplementWithKnownModels(raw, provider.provider);
     }
 
+    // Anthropic subscription tokens may only access certain model families
+    // (e.g. Pro = haiku only, Team = haiku + sonnet). Probe one model per
+    // family to filter out inaccessible models before showing them to the user.
+    if (lowerProvider === 'anthropic' && provider.auth_type === 'subscription' && apiKey) {
+      raw = await filterBySubscriptionAccess(raw, apiKey);
+    }
+
     const authType = provider.auth_type === 'subscription' ? 'subscription' : 'api_key';
     const enriched = raw.map((model) => ({
       ...this.enrichModel(model, provider.provider),
@@ -203,14 +211,12 @@ export class ModelDiscoveryService {
       const providerAuthType = p.auth_type === 'subscription' ? 'subscription' : 'api_key';
       for (const m of cached) {
         const effectiveAuthType = m.authType ?? providerAuthType;
-        if (!seen.has(m.id)) {
-          seen.set(m.id, models.length);
-          models.push(m);
-        } else if (
-          effectiveAuthType === 'subscription' &&
-          models[seen.get(m.id)!]?.authType !== 'subscription'
-        ) {
-          models[seen.get(m.id)!] = m;
+        // Deduplicate by model ID + auth type so subscription and API key
+        // versions of the same model are kept as independent entries.
+        const dedupeKey = `${m.id}::${effectiveAuthType}`;
+        if (!seen.has(dedupeKey)) {
+          seen.set(dedupeKey, models.length);
+          models.push({ ...m, authType: effectiveAuthType });
         }
       }
     }

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -97,6 +97,11 @@ const ModelPickerModal: Component<Props> = (props) => {
     const allowedProviders = hasConnectedProviders ? providerIdsForTab(tab) : undefined;
 
     for (const m of props.models) {
+      // Filter by the model's own auth_type to prevent subscription models
+      // from leaking into the API Keys tab and vice versa (e.g. when the
+      // same provider is connected with both auth types and they have
+      // different model access levels).
+      if (showTabs() && m.auth_type && m.auth_type !== tab) continue;
       if (freeOnly && !isFreeModel(m)) continue;
       const dbProvId = resolveProviderId(m.provider);
       const prefixProvId = inferProviderFromModel(m.model_name);


### PR DESCRIPTION
## Summary

- Probe one model per Anthropic family (haiku, sonnet, opus) at discovery time to detect subscription tier restrictions. Only show models the token can actually use.
- Fix model picker tab separation: deduplicate by `(modelId, authType)` instead of `modelId` alone, and filter by model's own `auth_type` so Subscription and API Keys tabs are independent.
- Addresses #1396: subscription tokens that only support haiku no longer show sonnet/opus models

## Test plan

- [x] 18 new probe tests pass (family extraction, access filtering, error handling, headers)
- [x] 94 model-discovery tests pass (3 updated for new dedup behavior)
- [x] 1703 frontend tests pass
- [x] 3240 backend tests pass (167 suites)
- [x] TypeScript compiles cleanly
- [x] Manual test: subscription tab shows only haiku, API keys tab shows all models
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect Anthropic subscription model access at discovery and show only models the token can use. Also separate model lists by auth type so Subscription and API Keys tabs are independent. Fixes #1396.

- **Bug Fixes**
  - Probe one Anthropic model per family (`haiku`, `sonnet`, `opus`) during discovery and hide families the subscription token can’t access; API key providers are not probed.
  - Handle multi-segment version prefixes when extracting the family (e.g., `claude-3-5-sonnet-20241022`).
  - Send correct Anthropic headers and `max_tokens: 1` for the probe; non-400 errors don’t filter models.
  - Deduplicate available models by `(modelId, authType)` and filter the picker by a model’s own `auth_type` to keep tabs independent.

<sup>Written for commit d792d45465a00bf584da182e2f5cabd483c4db6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

