### PR TITLE
fix: filter OpenAI responses-only models from discovery

### DIFF
--- a/.changeset/filter-openai-responses-only.md
+++ b/.changeset/filter-openai-responses-only.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Filter OpenAI responses-only models (gpt-image-*, o1-pro, o4-mini-deep-research) that fail on /v1/chat/completions.

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -193,13 +193,18 @@ describe('ProviderModelFetcherService', () => {
             { id: 'gpt-5.4-pro' },
             { id: 'gpt-5.3-codex' },
             { id: 'codex-mini-latest' },
+            { id: 'gpt-image-1' },
+            { id: 'gpt-image-1-mini' },
+            { id: 'gpt-image-1.5' },
+            { id: 'o1-pro' },
+            { id: 'o4-mini-deep-research' },
             { id: 'o3' },
           ],
         }),
       });
 
       const result = await service.fetch('openai', 'sk-test');
-      // chat-latest, codex-mini-latest, and o3 should pass; codex and pro should be filtered
+      // chat-latest, codex-mini-latest, and o3 should pass; codex, pro, image, and deep-research filtered
       expect(result.map((m) => m.id)).toEqual(['gpt-5-chat-latest', 'codex-mini-latest', 'o3']);
     });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -73,9 +73,11 @@ const OPENAI_DATE_SUFFIX_RE = /-\d{4}-\d{2}-\d{2}$/;
 
 /**
  * OpenAI models only supported in v1/responses (not v1/chat/completions).
- * Codex models (except codex-mini-latest) and -pro variants of GPT-5+.
+ * Codex models (except codex-mini-latest), -pro variants of GPT-5+,
+ * image generation models, o1-pro, and deep-research models.
  */
-const OPENAI_RESPONSES_ONLY_RE = /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$))/i;
+const OPENAI_RESPONSES_ONLY_RE =
+  /(?:-codex(?!-mini-latest)|^gpt-5[^/]*-pro(?:-|$)|^gpt-image-|^o1-pro|^o4-mini-deep-research)/i;
 
 function parseOpenAIDeduped(body: unknown, provider: string): DiscoveredModel[] {
   const filtered = parseOpenAI(body, provider).filter((m) => !OPENAI_RESPONSES_ONLY_RE.test(m.id));


### PR DESCRIPTION
## Summary

- Filter `gpt-image-*`, `o1-pro`, and `o4-mini-deep-research` from OpenAI model discovery — these only work on `/v1/responses` and fail on `/v1/chat/completions`
- Verified with real API calls: all three return "This model is only supported in v1/responses"

## Test plan

- [x] 86 provider-model-fetcher tests pass (existing responses-only test updated with new models)
- [x] TypeScript compiles cleanly
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filter out OpenAI responses-only models from chat completions discovery to prevent errors. Now excludes `gpt-image-*`, `o1-pro`, and `o4-mini-deep-research` (alongside existing Codex exclusions and GPT‑5 `-pro` variants).

- **Bug Fixes**
  - Updated regex to omit responses-only models during OpenAI discovery for `/v1/chat/completions`.
  - Expanded unit test to cover new IDs; expectations updated accordingly.
  - Added a patch changeset.

<sup>Written for commit bd5134d37ab0730a03b1aa36d59efa3e1359f984. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

