### PR TITLE
fix: prefix Manifest error messages with [Manifest]

### DIFF
--- a/.changeset/manifest-error-prefix.md
+++ b/.changeset/manifest-error-prefix.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Prefix all Manifest-originated error messages with [Manifest] to distinguish them from upstream provider errors

--- a/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
@@ -163,7 +163,7 @@ describe('ProxyExceptionFilter', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       const content = res.json.mock.calls[0][0].choices[0].message.content;
-      expect(content).toBe('Something broke on our end. Try again shortly.');
+      expect(content).toBe('[Manifest] Something broke on our end. Try again shortly.');
     });
 
     it('converts unknown auth message to friendly message', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -637,7 +637,7 @@ describe('ProxyController', () => {
         choices: expect.arrayContaining([
           expect.objectContaining({
             message: expect.objectContaining({
-              content: 'Something broke on our end. Try again shortly.',
+              content: '[Manifest] Something broke on our end. Try again shortly.',
             }),
           }),
         ]),
@@ -1391,7 +1391,7 @@ describe('ProxyController', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: 'Something broke on our end. Try again shortly.',
+                content: '[Manifest] Something broke on our end. Try again shortly.',
               }),
             }),
           ]),
@@ -1438,7 +1438,7 @@ describe('ProxyController', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: 'Something broke on our end. Try again shortly.',
+                content: '[Manifest] Something broke on our end. Try again shortly.',
               }),
             }),
           ]),

--- a/packages/backend/src/routing/proxy/proxy-exception.filter.ts
+++ b/packages/backend/src/routing/proxy/proxy-exception.filter.ts
@@ -7,14 +7,15 @@ import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interf
 /** Guard-thrown messages that should become friendly chat responses. */
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
   'Authorization header required':
-    'Missing API key. Set your Manifest key (starts with mnfst_) as the Bearer token.',
+    '[Manifest] Missing API key. Set your Manifest key (starts with mnfst_) as the Bearer token.',
   'Empty token':
-    'Bearer token is empty — paste your Manifest API key into the authorization field.',
+    '[Manifest] Bearer token is empty — paste your Manifest API key into the authorization field.',
   'Invalid API key format':
-    'That doesn\'t look like a Manifest key. They start with "mnfst_" — check your dashboard.',
-  'API key expired': 'This API key expired. Generate a new one from your Manifest dashboard',
+    '[Manifest] That doesn\'t look like a Manifest key. They start with "mnfst_" — check your dashboard.',
+  'API key expired':
+    '[Manifest] This API key expired. Generate a new one from your Manifest dashboard',
   'Invalid API key':
-    "This API key wasn't recognized — it may have been rotated or deleted. Check your dashboard for the current key.",
+    "[Manifest] This API key wasn't recognized — it may have been rotated or deleted. Check your dashboard for the current key.",
 };
 
 /** Status codes that should pass through as normal HTTP errors. */
@@ -63,7 +64,8 @@ export class ProxyExceptionFilter implements ExceptionFilter {
     }
 
     // Other errors (400 bad request, 500, etc.) — send as friendly chat message
-    const content = status >= 500 ? 'Something broke on our end. Try again shortly.' : message;
+    const content =
+      status >= 500 ? '[Manifest] Something broke on our end. Try again shortly.' : message;
     sendFriendlyResponse(res, content, isStream);
   }
 }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -177,7 +177,7 @@ export class ProxyController {
 
       const isStream = (req.body as Record<string, unknown>)?.stream === true;
       const clientMessage =
-        status >= 500 ? 'Something broke on our end. Try again shortly.' : message;
+        status >= 500 ? '[Manifest] Something broke on our end. Try again shortly.' : message;
       sendFriendlyResponse(res, clientMessage, isStream);
     } finally {
       if (slotAcquired) this.rateLimiter.releaseSlot(userId);

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -112,7 +112,7 @@ export class ProxyService {
     );
     if (apiKey === null) {
       const dashboardUrl = getDashboardUrl(this.config, agentName);
-      const content = `No API key set for ${resolved.provider} yet. Add one here: ${dashboardUrl}`;
+      const content = `[Manifest] No API key set for ${resolved.provider} yet. Add one here: ${dashboardUrl}`;
       return buildFriendlyResponse(content, body.stream === true, 'no_provider_key');
     }
 
@@ -256,7 +256,7 @@ export class ProxyService {
         ? `$${Number(exceeded.threshold).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
         : Number(exceeded.threshold).toLocaleString(undefined, { maximumFractionDigits: 0 });
     const dashboardUrl = getDashboardUrl(this.config, agentName);
-    return `Usage limit hit: ${exceeded.metricType} is at ${fmt} (limit: ${threshFmt}/${exceeded.period}). You can adjust it here: ${dashboardUrl}`;
+    return `[Manifest] Usage limit hit: ${exceeded.metricType} is at ${fmt} (limit: ${threshFmt}/${exceeded.period}). You can adjust it here: ${dashboardUrl}`;
   }
 
   private filterScoringMessages(messages: ScorerMessage[]): ScorerMessage[] {
@@ -279,7 +279,7 @@ export class ProxyService {
 
   private buildNoProviderResult(stream: boolean, agentName?: string): ProxyResult {
     const dashboardUrl = getDashboardUrl(this.config, agentName);
-    const content = `Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`;
+    const content = `[Manifest] Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`;
     return buildFriendlyResponse(content, stream, 'no_provider');
   }
 }


### PR DESCRIPTION
## Summary

- Prefixes all Manifest-originated error messages with `[Manifest]` so users can distinguish them from upstream provider errors
- Covers auth errors, routing errors (no provider, no API key), limit exceeded, and 5xx catch-alls
- Upstream provider errors (proxy-error-sanitizer) are unchanged since they already say "upstream provider"

## Example

Before: `Something broke on our end. Try again shortly.`
After: `[Manifest] Something broke on our end. Try again shortly.`

Before: `No API key set for OpenAI yet. Add one here: ...`
After: `[Manifest] No API key set for OpenAI yet. Add one here: ...`

## Test plan

- [x] All 3244 backend unit tests pass
- [x] TypeScript compiles with no errors
- [x] Lint passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefix all Manifest-originated error messages with [Manifest] so users can tell them apart from upstream provider errors. Applies to auth failures, routing issues (no provider or API key), usage limit exceeded, and 5xx catch-alls; upstream provider errors are unchanged.

<sup>Written for commit 8f11d570f7932909c18c455f8d508684eb958e59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

