### PR TITLE
fix: treat upstream HTTP 424 as retriable to trigger fallback chain

### DIFF
--- a/.changeset/fix-fallback-424.md
+++ b/.changeset/fix-fallback-424.md
@@ -1,0 +1,7 @@
+---
+"manifest": patch
+---
+
+fix: treat upstream HTTP 424 as retriable so the fallback chain is attempted
+
+Previously, HTTP 424 was reused as an internal sentinel for "all fallbacks exhausted," which meant a real 424 from an upstream provider would skip the fallback chain entirely. The sentinel is now removed — the system relies on the existing `X-Manifest-Fallback-Exhausted` header and `fallback_exhausted` error type instead, and the rebuilt response preserves the primary provider's actual HTTP status.

--- a/packages/backend/src/routing/proxy/__tests__/fallback-status-codes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/fallback-status-codes.spec.ts
@@ -1,7 +1,7 @@
-import { shouldTriggerFallback, FALLBACK_EXHAUSTED_STATUS } from '../fallback-status-codes';
+import { shouldTriggerFallback } from '../fallback-status-codes';
 
 describe('shouldTriggerFallback', () => {
-  it.each([400, 401, 403, 404, 405, 409, 422, 429, 500, 501, 502, 503, 504])(
+  it.each([400, 401, 403, 404, 405, 409, 422, 424, 429, 500, 501, 502, 503, 504])(
     'should return true for error status %d',
     (status) => {
       expect(shouldTriggerFallback(status)).toBe(true);
@@ -10,19 +10,5 @@ describe('shouldTriggerFallback', () => {
 
   it.each([200, 201, 204, 301, 302])('should return false for non-error status %d', (status) => {
     expect(shouldTriggerFallback(status)).toBe(false);
-  });
-
-  it('should return false for 424 (fallback exhausted)', () => {
-    expect(shouldTriggerFallback(424)).toBe(false);
-  });
-});
-
-describe('FALLBACK_EXHAUSTED_STATUS', () => {
-  it('should be 424', () => {
-    expect(FALLBACK_EXHAUSTED_STATUS).toBe(424);
-  });
-
-  it('should not trigger fallback', () => {
-    expect(shouldTriggerFallback(FALLBACK_EXHAUSTED_STATUS)).toBe(false);
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -485,11 +485,7 @@ describe('ProxyFallbackService', () => {
       );
 
       // OpenAI is a different provider, so no exclusion set should be passed
-      expect(providerKeyService.getAuthType).toHaveBeenCalledWith(
-        'agent-1',
-        'OpenAI',
-        undefined,
-      );
+      expect(providerKeyService.getAuthType).toHaveBeenCalledWith('agent-1', 'OpenAI', undefined);
     });
 
     it('accumulates failed auth types across same-provider fallbacks', async () => {
@@ -541,11 +537,11 @@ describe('ProxyFallbackService', () => {
       );
     });
 
-    it('stops chain on non-retriable status (424)', async () => {
+    it('continues chain when upstream returns 424 (no longer a sentinel)', async () => {
       providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
       providerClient.forward
         .mockResolvedValueOnce({
-          response: new Response('exhausted', { status: 424 }),
+          response: new Response('upstream 424', { status: 424 }),
           isGoogle: false,
           isAnthropic: false,
           isChatGpt: false,
@@ -568,9 +564,12 @@ describe('ProxyFallbackService', () => {
         'gpt-4o',
       );
 
-      expect(result.success).toBeNull();
+      expect(result.success).not.toBeNull();
+      expect(result.success!.model).toBe('model-b');
+      expect(result.success!.fallbackIndex).toBe(1);
       expect(result.failures).toHaveLength(1);
-      expect(providerClient.forward).toHaveBeenCalledTimes(1);
+      expect(result.failures[0].status).toBe(424);
+      expect(providerClient.forward).toHaveBeenCalledTimes(2);
     });
 
     it('falls through to findProviderForModel when inferred prefix provider is inactive (#1383)', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -2262,7 +2262,7 @@ describe('ProxyController', () => {
 
     it('should record failed fallback attempts as separate messages', async () => {
       const mockProviderResp = new Response('primary error', {
-        status: 424,
+        status: 502,
         headers: { 'Content-Type': 'text/plain' },
       });
 
@@ -2327,7 +2327,7 @@ describe('ProxyController', () => {
       mockMessageRepo.insert.mockRejectedValue(new Error('DB write failed'));
 
       const mockProviderResp = new Response('primary error', {
-        status: 424,
+        status: 502,
         headers: { 'Content-Type': 'text/plain' },
       });
 
@@ -2363,12 +2363,12 @@ describe('ProxyController', () => {
       await controller.chatCompletions(req as never, res as never);
       await new Promise((r) => setTimeout(r, 50));
 
-      expect(res.status).toHaveBeenCalledWith(424);
+      expect(res.status).toHaveBeenCalledWith(502);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
           error: expect.objectContaining({
             type: 'fallback_exhausted',
-            status: 424,
+            status: 502,
           }),
         }),
       );
@@ -2464,7 +2464,7 @@ describe('ProxyController', () => {
 
     it('should mark intermediate failures as handled when all fallbacks fail', async () => {
       const mockProviderResp = new Response('primary error', {
-        status: 424,
+        status: 502,
         headers: { 'Content-Type': 'text/plain' },
       });
 
@@ -2533,7 +2533,7 @@ describe('ProxyController', () => {
 
   it('should pass authType to recordFailedFallbacks when all fallbacks fail', async () => {
     const mockProviderResp = new Response('primary error', {
-      status: 424,
+      status: 502,
       headers: { 'Content-Type': 'text/plain' },
     });
 
@@ -2586,9 +2586,9 @@ describe('ProxyController', () => {
     );
   });
 
-  it('should return 424 with fallback_exhausted type and X-Manifest-Fallback-Exhausted header', async () => {
+  it('should return primary error status with fallback_exhausted type and X-Manifest-Fallback-Exhausted header', async () => {
     const mockProviderResp = new Response('primary error', {
-      status: 424,
+      status: 502,
       headers: { 'Content-Type': 'text/plain' },
     });
 
@@ -2624,12 +2624,12 @@ describe('ProxyController', () => {
 
     await controller.chatCompletions(req as never, res as never);
 
-    expect(res.status).toHaveBeenCalledWith(424);
+    expect(res.status).toHaveBeenCalledWith(502);
     expect(headers['X-Manifest-Fallback-Exhausted']).toBe('true');
     expect(res.json).toHaveBeenCalledWith({
       error: expect.objectContaining({
         type: 'fallback_exhausted',
-        status: 424,
+        status: 502,
         primary_model: 'gpt-4o',
         primary_provider: 'OpenAI',
         attempted_fallbacks: [

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -14,7 +14,6 @@ import { SessionMomentumService } from '../session-momentum.service';
 import { CopilotTokenService } from '../copilot-token.service';
 import { LimitCheckService } from '../../../notifications/services/limit-check.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
-import { shouldTriggerFallback } from '../fallback-status-codes';
 import { ThoughtSignatureCache } from '../thought-signature-cache';
 
 describe('ProxyService', () => {
@@ -2159,7 +2158,7 @@ describe('ProxyService', () => {
       expect(fallbackError.error?.message).toBe('Upstream provider request timed out');
     });
 
-    it('stops fallback chain on 424 (fallback exhausted)', async () => {
+    it('treats upstream 424 as retriable and continues fallback chain', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         model: 'gpt-4o',
@@ -2180,7 +2179,13 @@ describe('ProxyService', () => {
           isChatGpt: false,
         })
         .mockResolvedValueOnce({
-          response: new Response('exhausted', { status: 424 }),
+          response: new Response('upstream 424', { status: 424 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
           isGoogle: false,
           isAnthropic: false,
           isChatGpt: false,
@@ -2197,9 +2202,9 @@ describe('ProxyService', () => {
         sessionKey: 'default',
       });
 
-      // Chain stopped at model-a's 424, model-b never tried
-      expect(result.forward.response.ok).toBe(false);
-      expect(providerClient.forward).toHaveBeenCalledTimes(2);
+      // model-a returned 424, model-b was tried and succeeded
+      expect(result.forward.response.ok).toBe(true);
+      expect(providerClient.forward).toHaveBeenCalledTimes(3);
       expect(result.failedFallbacks).toHaveLength(1);
       expect(result.failedFallbacks![0].status).toBe(424);
     });
@@ -2738,7 +2743,7 @@ describe('ProxyService', () => {
       });
 
       expect(result.forward.response.ok).toBe(false);
-      expect(result.forward.response.status).toBe(424);
+      expect(result.forward.response.status).toBe(500);
       expect(result.failedFallbacks).toHaveLength(1);
       expect(result.failedFallbacks![0]).toEqual({
         model: 'deepseek-chat',
@@ -2749,7 +2754,7 @@ describe('ProxyService', () => {
       });
     });
 
-    it('returns non-retriable 424 status when all fallbacks are exhausted', async () => {
+    it('preserves primary provider status when all fallbacks are exhausted', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         model: 'gpt-4o',
@@ -2792,8 +2797,8 @@ describe('ProxyService', () => {
         sessionKey: 'default',
       });
 
-      expect(result.forward.response.status).toBe(424);
-      expect(shouldTriggerFallback(result.forward.response.status)).toBe(false);
+      // Status is the primary provider's actual error (429), not a synthetic 424
+      expect(result.forward.response.status).toBe(429);
       expect(result.failedFallbacks).toHaveLength(2);
     });
   });
@@ -2823,7 +2828,7 @@ describe('ProxyService', () => {
         { tier: 'standard', fallback_models: ['claude-haiku-3.5'] },
       ] as never);
 
-      // Fallback also fails so we get 424
+      // Fallback also fails so we get the primary's 401 status
       providerKeyService.getAuthType.mockResolvedValue('api_key');
       providerClient.forward.mockResolvedValueOnce({
         response: new Response('also error', { status: 500 }),
@@ -3057,6 +3062,55 @@ describe('ProxyService', () => {
           authType: 'subscription',
         }),
       );
+    });
+
+    it('passes signatureLookup that delegates to ThoughtSignatureCache.retrieve', async () => {
+      const cache = new ThoughtSignatureCache();
+      cache.store('sess-sig', 'tc-42', 'cached-sig-value');
+
+      const svcWithCache = new ProxyService(
+        resolveService,
+        providerKeyService,
+        tierService,
+        openaiOauth,
+        minimaxOauth,
+        momentum,
+        limitCheck,
+        fallbackService,
+        configService,
+        cache,
+      );
+
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.8,
+        score: 0.1,
+        reason: 'scored',
+      });
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await svcWithCache.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body,
+        sessionKey: 'sess-sig',
+      });
+
+      const callArgs = providerClient.forward.mock.calls[0][0] as unknown as Record<
+        string,
+        unknown
+      >;
+      const lookup = callArgs.signatureLookup as (id: string) => string | null;
+      expect(lookup('tc-42')).toBe('cached-sig-value');
+      expect(lookup('nonexistent')).toBeNull();
     });
 
     it('ignores invalid MiniMax resource URLs when forwarding subscription requests', async () => {

--- a/packages/backend/src/routing/proxy/fallback-status-codes.ts
+++ b/packages/backend/src/routing/proxy/fallback-status-codes.ts
@@ -1,6 +1,3 @@
-export const FALLBACK_EXHAUSTED_STATUS = 424;
-
 export function shouldTriggerFallback(status: number): boolean {
-  if (status === FALLBACK_EXHAUSTED_STATUS) return false;
   return status >= 400;
 }

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -8,7 +8,7 @@ import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
 import { ForwardResult } from './provider-client';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
-import { FALLBACK_EXHAUSTED_STATUS, shouldTriggerFallback } from './fallback-status-codes';
+import { shouldTriggerFallback } from './fallback-status-codes';
 import { Tier, ScorerMessage } from '../../scoring/types';
 import {
   ProxyFallbackService,
@@ -159,6 +159,7 @@ export class ProxyService {
       const fallbackModels = assignment?.fallback_models;
 
       if (fallbackModels && fallbackModels.length > 0) {
+        const primaryStatus = forward.response.status;
         const primaryErrorBody = await forward.response.text();
         const { success, failures } = await this.fallbackService.tryFallbacks(
           agentId,
@@ -187,23 +188,23 @@ export class ProxyService {
               auth_type: resolved.auth_type,
               fallbackFromModel: primaryModel,
               fallbackIndex: success.fallbackIndex,
-              primaryErrorStatus: forward.response.status,
+              primaryErrorStatus: primaryStatus,
               primaryErrorBody: primaryErrorBody,
             },
             failedFallbacks: failures,
           };
         }
 
-        // All fallbacks exhausted -- return non-retriable 424 so the gateway
-        // does not retry the entire chain in an infinite loop.
+        // All fallbacks exhausted — preserve the primary provider's real
+        // HTTP status. The gateway uses the X-Manifest-Fallback-Exhausted
+        // header (set by the response handler) to detect this case.
         const safeHeaders = new Headers(forward.response.headers);
         safeHeaders.delete('content-encoding');
         safeHeaders.delete('content-length');
         safeHeaders.delete('transfer-encoding');
 
         const rebuilt = new Response(primaryErrorBody, {
-          status: FALLBACK_EXHAUSTED_STATUS,
-          statusText: 'Failed Dependency',
+          status: primaryStatus,
           headers: safeHeaders,
         });
         this.momentum.recordTier(sessionKey, resolved.tier as Tier);


### PR DESCRIPTION
## Summary

Fixes #1407 — When an upstream provider (e.g., OpenAI) returns HTTP 424 (Failed Dependency), Manifest now correctly triggers the configured fallback model instead of passing the error through.

**Root cause**: HTTP 424 was reused as an internal sentinel (`FALLBACK_EXHAUSTED_STATUS`) meaning "all fallbacks exhausted." When a real upstream 424 arrived, `shouldTriggerFallback(424)` returned `false` and the fallback chain was skipped entirely.

**Fix**: Remove the sentinel. `shouldTriggerFallback` now returns `true` for all `status >= 400` (including 424). The "fallback exhausted" response preserves the primary provider's actual HTTP status. The gateway detects exhaustion via the existing `X-Manifest-Fallback-Exhausted` header and `type: 'fallback_exhausted'` JSON field.

## Changes

- `fallback-status-codes.ts` — removed `FALLBACK_EXHAUSTED_STATUS` constant, simplified `shouldTriggerFallback`
- `proxy.service.ts` — capture `primaryStatus` before body read, use it in rebuilt Response instead of synthetic 424
- Updated tests across 4 test files to verify 424 is now retriable and fallback-exhausted responses preserve real provider status

## Test plan

- [x] `fallback-status-codes.spec.ts` — 424 now in the "returns true" list
- [x] `proxy-fallback.service.spec.ts` — upstream 424 continues to next fallback (not stops)
- [x] `proxy.service.spec.ts` — 424 triggers fallback chain; exhausted response uses primary status (429)
- [x] `proxy.controller.spec.ts` — fallback-exhausted responses carry real provider status (502)
- [x] All 167 backend test suites pass (3243 tests)
- [x] TypeScript compiles cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make upstream HTTP 424 retriable so the fallback chain runs, and return the primary provider’s real status when all fallbacks fail. Fixes #1407.

- **Bug Fixes**
  - Removed the internal 424 sentinel and simplified `shouldTriggerFallback` to return true for all `status >= 400`.
  - In `proxy.service.ts`, preserved the primary provider status in the final response when fallbacks are exhausted; the gateway detects exhaustion via `X-Manifest-Fallback-Exhausted` and `type: 'fallback_exhausted'`.
  - Updated tests to verify 424 triggers fallbacks and exhausted responses keep the original upstream status.

<sup>Written for commit 12ede3c7dae25a76270ac68259b1dce747669742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

