### PR TITLE
fix: add OpenRouter app attribution headers (closes #1389)

### DIFF
--- a/.changeset/openrouter-app-headers.md
+++ b/.changeset/openrouter-app-headers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add HTTP-Referer and X-Title headers to OpenRouter requests for app attribution and free trial model eligibility.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -154,6 +154,8 @@ describe('ProviderClient', () => {
           headers: {
             Authorization: 'Bearer sk-or-test',
             'Content-Type': 'application/json',
+            'HTTP-Referer': 'https://manifest.build',
+            'X-Title': 'Manifest',
           },
         }),
       );

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -139,7 +139,12 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   },
   openrouter: {
     baseUrl: 'https://openrouter.ai',
-    buildHeaders: openaiHeaders,
+    buildHeaders: (apiKey: string) => ({
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://manifest.build',
+      'X-Title': 'Manifest',
+    }),
     buildPath: () => '/api/v1/chat/completions',
     format: 'openai',
   },


### PR DESCRIPTION
## Summary

- Add `HTTP-Referer: https://manifest.build` and `X-Title: Manifest` headers to OpenRouter proxy requests
- Without these headers, OpenRouter shows the app as "unknown" and promotional free-trial pricing (e.g. Mimo V2 Pro for OpenClaw) doesn't apply
- Closes #1389

## Test plan

- [x] 72 provider-client tests pass (existing OpenRouter header test updated)
- [x] TypeScript compiles cleanly
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `HTTP-Referer: https://manifest.build` and `X-Title: Manifest` headers to OpenRouter requests so the app is attributed correctly and free-trial pricing applies. Updates the OpenRouter provider endpoint and its test; closes #1389.

<sup>Written for commit ca4697eb7565da204db3e806d94edfd8235a0542. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

