### PR TITLE
feat: add peacock emoji to Manifest branding prefix

### DIFF
--- a/.changeset/message-branding.md
+++ b/.changeset/message-branding.md
@@ -1,5 +1,5 @@
 ---
-'manifest': patch
+"manifest": patch
 ---
 
 Update branding prefix to include peacock emoji in plugin startup logs and proxy error messages

--- a/.changeset/message-branding.md
+++ b/.changeset/message-branding.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Update branding prefix to include peacock emoji in plugin startup logs and proxy error messages

--- a/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
@@ -163,7 +163,7 @@ describe('ProxyExceptionFilter', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       const content = res.json.mock.calls[0][0].choices[0].message.content;
-      expect(content).toBe('[Manifest] Something broke on our end. Try again shortly.');
+      expect(content).toBe('[🦚 Manifest] Something broke on our end. Try again shortly.');
     });
 
     it('converts unknown auth message to friendly message', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -637,7 +637,7 @@ describe('ProxyController', () => {
         choices: expect.arrayContaining([
           expect.objectContaining({
             message: expect.objectContaining({
-              content: '[Manifest] Something broke on our end. Try again shortly.',
+              content: '[🦚 Manifest] Something broke on our end. Try again shortly.',
             }),
           }),
         ]),
@@ -1391,7 +1391,7 @@ describe('ProxyController', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: '[Manifest] Something broke on our end. Try again shortly.',
+                content: '[🦚 Manifest] Something broke on our end. Try again shortly.',
               }),
             }),
           ]),
@@ -1438,7 +1438,7 @@ describe('ProxyController', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: '[Manifest] Something broke on our end. Try again shortly.',
+                content: '[🦚 Manifest] Something broke on our end. Try again shortly.',
               }),
             }),
           ]),

--- a/packages/backend/src/routing/proxy/proxy-exception.filter.ts
+++ b/packages/backend/src/routing/proxy/proxy-exception.filter.ts
@@ -7,15 +7,15 @@ import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interf
 /** Guard-thrown messages that should become friendly chat responses. */
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
   'Authorization header required':
-    '[Manifest] Missing API key. Set your Manifest key (starts with mnfst_) as the Bearer token.',
+    '[🦚 Manifest] Missing API key. Set your Manifest key (starts with mnfst_) as the Bearer token.',
   'Empty token':
-    '[Manifest] Bearer token is empty — paste your Manifest API key into the authorization field.',
+    '[🦚 Manifest] Bearer token is empty — paste your Manifest API key into the authorization field.',
   'Invalid API key format':
-    '[Manifest] That doesn\'t look like a Manifest key. They start with "mnfst_" — check your dashboard.',
+    '[🦚 Manifest] That doesn\'t look like a Manifest key. They start with "mnfst_" — check your dashboard.',
   'API key expired':
-    '[Manifest] This API key expired. Generate a new one from your Manifest dashboard',
+    '[🦚 Manifest] This API key expired. Generate a new one from your Manifest dashboard',
   'Invalid API key':
-    "[Manifest] This API key wasn't recognized — it may have been rotated or deleted. Check your dashboard for the current key.",
+    "[🦚 Manifest] This API key wasn't recognized — it may have been rotated or deleted. Check your dashboard for the current key.",
 };
 
 /** Status codes that should pass through as normal HTTP errors. */
@@ -65,7 +65,7 @@ export class ProxyExceptionFilter implements ExceptionFilter {
 
     // Other errors (400 bad request, 500, etc.) — send as friendly chat message
     const content =
-      status >= 500 ? '[Manifest] Something broke on our end. Try again shortly.' : message;
+      status >= 500 ? '[🦚 Manifest] Something broke on our end. Try again shortly.' : message;
     sendFriendlyResponse(res, content, isStream);
   }
 }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -177,7 +177,7 @@ export class ProxyController {
 
       const isStream = (req.body as Record<string, unknown>)?.stream === true;
       const clientMessage =
-        status >= 500 ? '[Manifest] Something broke on our end. Try again shortly.' : message;
+        status >= 500 ? '[🦚 Manifest] Something broke on our end. Try again shortly.' : message;
       sendFriendlyResponse(res, clientMessage, isStream);
     } finally {
       if (slotAcquired) this.rateLimiter.releaseSlot(userId);

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -112,7 +112,7 @@ export class ProxyService {
     );
     if (apiKey === null) {
       const dashboardUrl = getDashboardUrl(this.config, agentName);
-      const content = `[Manifest] No API key set for ${resolved.provider} yet. Add one here: ${dashboardUrl}`;
+      const content = `[🦚 Manifest] No API key set for ${resolved.provider} yet. Add one here: ${dashboardUrl}`;
       return buildFriendlyResponse(content, body.stream === true, 'no_provider_key');
     }
 
@@ -257,7 +257,7 @@ export class ProxyService {
         ? `$${Number(exceeded.threshold).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
         : Number(exceeded.threshold).toLocaleString(undefined, { maximumFractionDigits: 0 });
     const dashboardUrl = getDashboardUrl(this.config, agentName);
-    return `[Manifest] Usage limit hit: ${exceeded.metricType} is at ${fmt} (limit: ${threshFmt}/${exceeded.period}). You can adjust it here: ${dashboardUrl}`;
+    return `[🦚 Manifest] Usage limit hit: ${exceeded.metricType} is at ${fmt} (limit: ${threshFmt}/${exceeded.period}). You can adjust it here: ${dashboardUrl}`;
   }
 
   private filterScoringMessages(messages: ScorerMessage[]): ScorerMessage[] {
@@ -280,7 +280,7 @@ export class ProxyService {
 
   private buildNoProviderResult(stream: boolean, agentName?: string): ProxyResult {
     const dashboardUrl = getDashboardUrl(this.config, agentName);
-    const content = `[Manifest] Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`;
+    const content = `[🦚 Manifest] Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`;
     return buildFriendlyResponse(content, stream, 'no_provider');
   }
 }

--- a/packages/openclaw-plugins/manifest/src/index.ts
+++ b/packages/openclaw-plugins/manifest/src/index.ts
@@ -24,9 +24,9 @@ module.exports = {
     const host = typeof inner.host === 'string' && inner.host.length > 0 ? inner.host : '127.0.0.1';
 
     logger.info(
-      `[manifest] 🦚 Dashboard: http://${host}:${port}\n` +
-        '[manifest] 🦚 The plugin starts an embedded server.\n' +
-        '[manifest] 🦚 Open the dashboard to connect a provider and start routing.',
+      `\n[🦚 Manifest] Dashboard: http://${host}:${port}\n` +
+        '[🦚 Manifest] The plugin starts an embedded server.\n' +
+        '[🦚 Manifest] Open the dashboard to connect a provider and start routing.',
     );
 
     registerLocalMode(api, port, host, logger);


### PR DESCRIPTION
## Summary

- Update `[manifest] 🦚` prefix to `[🦚 Manifest]` in the self-hosted plugin startup banner (with leading newline for visual separation)
- Update `[Manifest]` prefix to `[🦚 Manifest]` in all proxy error and friendly chat messages (auth errors, usage limits, no provider, 500 fallbacks)
- Update corresponding test assertions

## Test plan

- [x] Backend unit tests pass (proxy-exception filter, proxy controller specs)
- [x] Manifest plugin tests pass (100% line coverage)
- [x] Manifest model-router plugin tests pass
- [x] Pre-commit hooks (ESLint + Prettier) pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the Manifest branding prefix to [🦚 Manifest] across plugin startup logs and all proxy error/friendly messages. Also adds a leading newline to the startup banner for clearer separation and updates tests.

- **Refactors**
  - Replaced `[manifest]`/`[Manifest]` with `[🦚 Manifest]` in self-hosted startup logs for the `manifest` plugin and in proxy messages (auth errors, usage limits, no provider, 500 fallbacks).
  - Added leading newline to the startup banner for visual separation.
  - Updated unit tests to reflect the new messages.

- **Bug Fixes**
  - Used double quotes in `.changeset/message-branding.md` for CI compatibility.

<sup>Written for commit d31f086e5a8147226028442fcbf4f2e76df5ceca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

