### PR TITLE
fix: filter non-working models from provider discovery

### DIFF
--- a/.changeset/filter-broken-models.md
+++ b/.changeset/filter-broken-models.md
@@ -1,0 +1,11 @@
+---
+"manifest": patch
+---
+
+Filter non-working models from provider discovery results
+
+- Add Mistral-specific parser with metadata filtering (deprecation, capabilities.completion_chat)
+- Filter Mistral labs-prefixed models (require admin opt-in)
+- Filter xAI multi-agent models (not chat-compatible)
+- Filter deprecated Gemini models (gemini-2.0-flash-lite, flash-lite-preview snapshots)
+- Add per-provider exact-ID blocklist for models with no pattern (voxtral-mini-2602)

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -2,6 +2,7 @@ import {
   filterNonChatModels,
   UNIVERSAL_NON_CHAT_RE,
   PROVIDER_NON_CHAT,
+  PROVIDER_BLOCKLIST,
 } from './provider-model-fetcher.service';
 import { DiscoveredModel } from './model-fetcher';
 
@@ -159,6 +160,28 @@ describe('filterNonChatModels', () => {
       expect(result.map((m) => m.id)).toEqual(['gemini-2.5-pro']);
     });
 
+    it('filters deprecated gemini-2.0-flash-lite', () => {
+      const models = [makeModel('gemini-2.0-flash-lite'), makeModel('gemini-2.5-flash')];
+      const result = filterNonChatModels(models, 'gemini');
+      expect(result.map((m) => m.id)).toEqual(['gemini-2.5-flash']);
+    });
+
+    it('filters flash-lite-preview deprecated snapshots', () => {
+      const models = [
+        makeModel('gemini-2.5-flash-lite-preview-09-2025'),
+        makeModel('gemini-3.0-flash-lite-preview-01-2026'),
+        makeModel('gemini-2.5-flash'),
+      ];
+      const result = filterNonChatModels(models, 'gemini');
+      expect(result.map((m) => m.id)).toEqual(['gemini-2.5-flash']);
+    });
+
+    it('keeps non-preview flash-lite models', () => {
+      const models = [makeModel('gemini-2.5-flash-lite'), makeModel('gemini-3.0-flash-lite')];
+      const result = filterNonChatModels(models, 'gemini');
+      expect(result).toHaveLength(2);
+    });
+
     it('keeps gemini-image and gemini-robotics models', () => {
       const models = [
         makeModel('gemini-2.5-flash-image'),
@@ -215,6 +238,34 @@ describe('filterNonChatModels', () => {
       const result = filterNonChatModels(models, 'mistral');
       expect(result).toHaveLength(2);
     });
+
+    it('filters labs-prefixed models', () => {
+      const models = [makeModel('labs-leanstral-2603'), makeModel('mistral-large-latest')];
+      const result = filterNonChatModels(models, 'mistral');
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
+    });
+
+    it('filters any future labs-* model', () => {
+      const models = [makeModel('labs-future-model-2707'), makeModel('codestral-latest')];
+      const result = filterNonChatModels(models, 'mistral');
+      expect(result.map((m) => m.id)).toEqual(['codestral-latest']);
+    });
+
+    it('filters blocklisted model voxtral-mini-2602', () => {
+      const models = [makeModel('voxtral-mini-2602'), makeModel('mistral-large-latest')];
+      const result = filterNonChatModels(models, 'mistral');
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
+    });
+
+    it('filters all labs- prefixed models including labs-devstral', () => {
+      const models = [
+        makeModel('labs-devstral-small-2512'),
+        makeModel('labs-mistral-small-creative'),
+        makeModel('mistral-large-latest'),
+      ];
+      const result = filterNonChatModels(models, 'mistral');
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
+    });
   });
 
   describe('xAI-specific patterns', () => {
@@ -230,6 +281,18 @@ describe('filterNonChatModels', () => {
       const models = [makeModel('grok-3'), makeModel('grok-3-mini')];
       const result = filterNonChatModels(models, 'xai');
       expect(result).toHaveLength(2);
+    });
+
+    it('filters multi-agent models', () => {
+      const models = [makeModel('grok-4.20-multi-agent-0309'), makeModel('grok-3')];
+      const result = filterNonChatModels(models, 'xai');
+      expect(result.map((m) => m.id)).toEqual(['grok-3']);
+    });
+
+    it('filters any future multi-agent model', () => {
+      const models = [makeModel('grok-5-multi-agent-0612'), makeModel('grok-3')];
+      const result = filterNonChatModels(models, 'xai');
+      expect(result.map((m) => m.id)).toEqual(['grok-3']);
     });
   });
 
@@ -254,6 +317,18 @@ describe('filterNonChatModels', () => {
       expect(PROVIDER_NON_CHAT).toHaveProperty('gemini');
       expect(PROVIDER_NON_CHAT).toHaveProperty('mistral');
       expect(PROVIDER_NON_CHAT).toHaveProperty('xai');
+    });
+  });
+
+  describe('PROVIDER_BLOCKLIST', () => {
+    it('has blocklist entry for mistral voxtral-mini-2602', () => {
+      expect(PROVIDER_BLOCKLIST).toHaveProperty('mistral');
+      expect(PROVIDER_BLOCKLIST.mistral.has('voxtral-mini-2602')).toBe(true);
+    });
+
+    it('does not blocklist valid voxtral models', () => {
+      expect(PROVIDER_BLOCKLIST.mistral.has('voxtral-mini-latest')).toBe(false);
+      expect(PROVIDER_BLOCKLIST.mistral.has('voxtral-mini-2507')).toBe(false);
     });
   });
 });

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -292,6 +292,89 @@ describe('ProviderModelFetcherService', () => {
     });
   });
 
+  /* ── Mistral metadata filtering ── */
+
+  describe('parseMistral metadata filtering', () => {
+    it('should filter out models with deprecation set', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mistral-large-latest', capabilities: { completion_chat: true } },
+            { id: 'old-model', capabilities: { completion_chat: true }, deprecation: '2025-12-01' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
+    });
+
+    it('should filter out models without completion_chat capability', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mistral-large-latest', capabilities: { completion_chat: true } },
+            { id: 'mistral-ocr-2503', capabilities: { completion_chat: false } },
+            { id: 'labs-leanstral-2603', capabilities: { completion_chat: false } },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
+    });
+
+    it('should keep models when capabilities field is absent', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mistral-large-latest' },
+            { id: 'codestral-latest' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(2);
+    });
+
+    it('should keep models when completion_chat is true', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mistral-large-latest', capabilities: { completion_chat: true } },
+            { id: 'codestral-latest', capabilities: { completion_chat: true, completion_fim: true } },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      expect(result).toHaveLength(2);
+    });
+
+    it('should filter by both metadata and regex patterns', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'mistral-large-latest', capabilities: { completion_chat: true } },
+            { id: 'deprecated-model', capabilities: { completion_chat: true }, deprecation: '2025-06-01' },
+            { id: 'labs-experimental', capabilities: { completion_chat: true } },
+            { id: 'voxtral-mini-2602', capabilities: { completion_chat: true } },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('mistral', 'key');
+      // deprecated-model filtered by metadata, labs-experimental by regex, voxtral-mini-2602 by blocklist
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
+    });
+  });
+
   /* ── OpenAI-compatible providers use same parser ── */
 
   it('should work for deepseek provider', async () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -111,9 +111,19 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
     /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio|^chatgpt-image)/i,
   'openai-subscription':
     /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|audio|^chatgpt-image)/i,
-  gemini: /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria)/i,
-  mistral: /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime))/i,
-  xai: /(?:imagine)/i,
+  gemini: /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview)/i,
+  mistral: /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime)|^labs-)/i,
+  xai: /(?:imagine|multi-agent)/i,
+};
+
+/**
+ * Exact model IDs to block per provider. Use ONLY when no regex pattern
+ * or metadata field can catch the model. Document WHY each entry exists.
+ */
+export const PROVIDER_BLOCKLIST: Record<string, ReadonlySet<string>> = {
+  mistral: new Set([
+    'voxtral-mini-2602', // Invalid model returned by API; not a real chat endpoint
+  ]),
 };
 
 /** Filter models that are not compatible with chat completions. */
@@ -122,9 +132,11 @@ export function filterNonChatModels(
   configKey: string,
 ): DiscoveredModel[] {
   const providerFilter = PROVIDER_NON_CHAT[configKey];
+  const blocklist = PROVIDER_BLOCKLIST[configKey];
   return models.filter((m) => {
     if (UNIVERSAL_NON_CHAT_RE.test(m.id)) return false;
     if (providerFilter && providerFilter.test(m.id)) return false;
+    if (blocklist && blocklist.has(m.id)) return false;
     return true;
   });
 }
@@ -134,6 +146,28 @@ function bearerHeaders(key: string): Record<string, string> {
 }
 
 /* ── Provider-specific parsers ── */
+
+interface MistralModelEntry {
+  id: string;
+  object?: string;
+  owned_by?: string;
+  capabilities?: {
+    completion_chat?: boolean;
+  };
+  deprecation?: string | null;
+}
+
+const parseMistral = createModelParser<MistralModelEntry>({
+  arrayKey: 'data',
+  filter: (entry) => {
+    if (typeof entry.id !== 'string' || entry.id.length === 0) return false;
+    if (entry.deprecation != null) return false;
+    if (entry.capabilities && entry.capabilities.completion_chat === false) return false;
+    return true;
+  },
+  getId: (entry) => entry.id,
+  getDisplayName: (_entry, id) => id,
+});
 
 interface AnthropicModelEntry {
   id: string;
@@ -307,7 +341,7 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
   mistral: {
     endpoint: 'https://api.mistral.ai/v1/models',
     buildHeaders: bearerHeaders,
-    parse: parseOpenAI,
+    parse: parseMistral,
   },
   moonshot: {
     endpoint: 'https://api.moonshot.ai/v1/models',


### PR DESCRIPTION
## Summary

- Add three-tier filtering pipeline to remove models that appear in provider discovery but fail at chat completion time
- **Tier 1 (metadata):** New Mistral-specific parser that filters on `capabilities.completion_chat` and `deprecation` fields from the API response
- **Tier 2 (name patterns):** Regex filters for Mistral `labs-*` prefix (admin opt-in required), xAI `multi-agent` models (not chat-compatible), and deprecated Gemini `flash-lite` variants
- **Tier 3 (blocklist):** Per-provider exact-ID `PROVIDER_BLOCKLIST` as last resort for `voxtral-mini-2602` (invalid model returned by Mistral API)

## Models removed

| Provider | Model | Reason |
|----------|-------|--------|
| Mistral | `labs-leanstral-2603` | Labs-restricted, requires admin opt-in (Tier 1+2) |
| Mistral | `labs-devstral-small-2512` | Labs-restricted (Tier 2) |
| Mistral | `labs-mistral-small-creative` | Labs-restricted (Tier 2) |
| Mistral | `voxtral-mini-2602` | Invalid model, HTTP 400 (Tier 3 blocklist) |
| xAI | `grok-4.20-multi-agent-0309` | Multi-agent only, not chat-compatible (Tier 2) |
| Gemini | `gemini-2.0-flash-lite` | Deprecated, "no longer available to new users" (Tier 2) |
| Gemini | `gemini-2.5-flash-lite-preview-09-2025` | Deprecated preview snapshot (Tier 2) |

## Test plan

- [x] All existing model discovery tests pass (155 tests)
- [x] New tests for Mistral metadata filtering (deprecation, capabilities, graceful fallback)
- [x] New tests for all regex patterns (`labs-*`, `multi-agent`, `flash-lite-preview`)
- [x] New tests for `PROVIDER_BLOCKLIST` mechanism
- [x] Verified non-preview `flash-lite` models (e.g. `gemini-2.5-flash-lite`) are NOT filtered

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out non-chat and deprecated models from provider discovery to prevent chat-time errors. Adds provider-aware rules for Mistral, xAI, and Gemini with a small blocklist fallback.

- **Bug Fixes**
  - Mistral: new parser filters by `capabilities.completion_chat` and `deprecation`.
  - Regex filters: Mistral `labs-*`, xAI `*-multi-agent-*`, Gemini `gemini-2.0-flash-lite` and `*-flash-lite-preview-*`.
  - Blocklist: per-provider exact IDs; adds `mistral` model `voxtral-mini-2602`.
  - Keeps valid non-preview `flash-lite` models.

<sup>Written for commit fbad4180703f5c1ca18527ed40c670139fa274e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

