### PR TITLE
fix: handle non-streaming responses from ChatGPT subscription proxy

### DIFF
--- a/.changeset/fix-chatgpt-non-streaming.md
+++ b/.changeset/fix-chatgpt-non-streaming.md
@@ -1,0 +1,9 @@
+---
+"manifest": patch
+---
+
+Fix non-streaming responses for ChatGPT subscription (Codex) models
+
+The Codex Responses API always returns SSE even when stream: false is requested.
+The proxy now collects the SSE events and builds a proper non-streaming OpenAI
+Chat Completion response instead of failing with a JSON parse error.

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-response.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-response.spec.ts
@@ -184,6 +184,30 @@ describe('ChatGPT Adapter – collectChatGptSseResponse', () => {
     expect(choices[0].message.tool_calls[0].function.arguments).toBe('{"city":"Paris"}');
   });
 
+  it('handles function calls at non-zero output_index (mixed output items)', () => {
+    const sse = [
+      'event: response.output_text.delta\ndata: {"delta":"Let me check."}',
+      'event: response.output_item.added\ndata: {"item":{"type":"function_call","call_id":"call_2","name":"search"},"output_index":1}',
+      'event: response.function_call_arguments.delta\ndata: {"delta":"{\\"q\\":\\"test\\"}","output_index":1}',
+      'event: response.completed\ndata: {"response":{"output":[{"type":"message"},{"type":"function_call"}],"usage":{"input_tokens":8,"output_tokens":4,"total_tokens":12}}}',
+    ].join('\n\n');
+
+    const result = collectChatGptSseResponse(sse, 'gpt-5');
+    const choices = result.choices as {
+      message: {
+        content: string;
+        tool_calls: { id: string; function: { name: string; arguments: string } }[];
+      };
+      finish_reason: string;
+    }[];
+
+    expect(choices[0].message.content).toBe('Let me check.');
+    expect(choices[0].message.tool_calls).toHaveLength(1);
+    expect(choices[0].message.tool_calls[0].id).toBe('call_2');
+    expect(choices[0].message.tool_calls[0].function.arguments).toBe('{"q":"test"}');
+    expect(choices[0].finish_reason).toBe('tool_calls');
+  });
+
   it('handles empty SSE text', () => {
     const result = collectChatGptSseResponse('', 'gpt-5');
     const choices = result.choices as { message: { content: string | null } }[];

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-response.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-response.spec.ts
@@ -1,4 +1,4 @@
-import { fromResponsesResponse } from '../chatgpt-adapter';
+import { fromResponsesResponse, collectChatGptSseResponse } from '../chatgpt-adapter';
 
 describe('ChatGPT Adapter – fromResponsesResponse', () => {
   it('converts Responses API output to OpenAI chat completion format', () => {
@@ -139,5 +139,55 @@ describe('ChatGPT Adapter – fromResponsesResponse', () => {
     const usage = result.usage as Record<string, number>;
 
     expect(usage.cache_read_tokens).toBe(42);
+  });
+});
+
+describe('ChatGPT Adapter – collectChatGptSseResponse', () => {
+  it('collects text deltas into a non-streaming response', () => {
+    const sse = [
+      'event: response.output_text.delta\ndata: {"delta":"Hello"}',
+      'event: response.output_text.delta\ndata: {"delta":" world"}',
+      'event: response.completed\ndata: {"response":{"usage":{"input_tokens":10,"output_tokens":2,"total_tokens":12},"output":[{"type":"message"}]}}',
+    ].join('\n\n');
+
+    const result = collectChatGptSseResponse(sse, 'gpt-5');
+    const choices = result.choices as { message: { content: string }; finish_reason: string }[];
+
+    expect(result.object).toBe('chat.completion');
+    expect(result.model).toBe('gpt-5');
+    expect(choices[0].message.content).toBe('Hello world');
+    expect(choices[0].finish_reason).toBe('stop');
+
+    const usage = result.usage as Record<string, number>;
+    expect(usage.prompt_tokens).toBe(10);
+    expect(usage.completion_tokens).toBe(2);
+  });
+
+  it('collects function calls from SSE events', () => {
+    const sse = [
+      'event: response.output_item.added\ndata: {"item":{"type":"function_call","call_id":"call_1","name":"get_weather"},"output_index":0}',
+      'event: response.function_call_arguments.delta\ndata: {"delta":"{\\"city\\":","output_index":0}',
+      'event: response.function_call_arguments.delta\ndata: {"delta":"\\"Paris\\"}","output_index":0}',
+      'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}],"usage":{"input_tokens":5,"output_tokens":3,"total_tokens":8}}}',
+    ].join('\n\n');
+
+    const result = collectChatGptSseResponse(sse, 'gpt-5');
+    const choices = result.choices as {
+      message: { tool_calls: { id: string; function: { name: string; arguments: string } }[] };
+      finish_reason: string;
+    }[];
+
+    expect(choices[0].finish_reason).toBe('tool_calls');
+    expect(choices[0].message.tool_calls).toHaveLength(1);
+    expect(choices[0].message.tool_calls[0].id).toBe('call_1');
+    expect(choices[0].message.tool_calls[0].function.name).toBe('get_weather');
+    expect(choices[0].message.tool_calls[0].function.arguments).toBe('{"city":"Paris"}');
+  });
+
+  it('handles empty SSE text', () => {
+    const result = collectChatGptSseResponse('', 'gpt-5');
+    const choices = result.choices as { message: { content: string | null } }[];
+
+    expect(choices[0].message.content).toBeNull();
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -465,6 +465,7 @@ describe('proxy-response-handler', () => {
         convertGoogleResponse: jest.fn().mockReturnValue({ id: 'google-converted' }),
         convertAnthropicResponse: jest.fn().mockReturnValue({ id: 'anthropic-converted' }),
         convertChatGptResponse: jest.fn().mockReturnValue({ id: 'chatgpt-converted' }),
+        collectChatGptSseResponse: jest.fn().mockReturnValue({ id: 'chatgpt-collected' }),
       };
     }
 
@@ -473,7 +474,10 @@ describe('proxy-response-handler', () => {
       flags: { isGoogle?: boolean; isAnthropic?: boolean; isChatGpt?: boolean } = {},
     ) {
       return {
-        response: { json: jest.fn().mockResolvedValue(body) },
+        response: {
+          json: jest.fn().mockResolvedValue(body),
+          text: jest.fn().mockResolvedValue(typeof body === 'string' ? body : JSON.stringify(body)),
+        },
         isGoogle: flags.isGoogle ?? false,
         isAnthropic: flags.isAnthropic ?? false,
         isChatGpt: flags.isChatGpt ?? false,
@@ -526,15 +530,17 @@ describe('proxy-response-handler', () => {
       expect(usage).toBeNull();
     });
 
-    it('should convert ChatGPT response', async () => {
+    it('should collect ChatGPT SSE response for non-streaming requests', async () => {
       const { res } = mockResponse();
       const client = mockProviderClient();
-      const forward = mockForward({}, { isChatGpt: true });
+      const sseText = 'event: response.output_text.delta\ndata: {"delta":"Hi"}\n\n';
+      const forward = mockForward(sseText, { isChatGpt: true });
       const meta = makeMeta();
 
       await handleNonStreamResponse(res as any, forward as any, meta, {}, client as any);
 
-      expect(client.convertChatGptResponse).toHaveBeenCalled();
+      expect(client.collectChatGptSseResponse).toHaveBeenCalledWith(sseText, meta.model);
+      expect(forward.response.text).toHaveBeenCalled();
     });
 
     it('should pass through standard OpenAI response', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -248,19 +248,18 @@ describe('ProxyController', () => {
     expect(res.json).toHaveBeenCalledWith(convertedBody);
   });
 
-  it('should convert ChatGPT response for non-streaming', async () => {
-    const chatgptBody = {
-      output: [{ type: 'message', content: [{ type: 'output_text', text: 'hi' }] }],
-      usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
-    };
-    const convertedBody = {
+  it('should collect ChatGPT SSE response for non-streaming', async () => {
+    const sseText =
+      'event: response.output_text.delta\ndata: {"delta":"hi"}\n\n' +
+      'event: response.completed\ndata: {"response":{"usage":{"input_tokens":5,"output_tokens":3,"total_tokens":8},"output":[{"type":"message"}]}}\n\n';
+    const collectedBody = {
       choices: [{ message: { content: 'hi' } }],
       usage: { prompt_tokens: 5, completion_tokens: 3 },
     };
 
-    const mockProviderResp = new Response(JSON.stringify(chatgptBody), {
+    const mockProviderResp = new Response(sseText, {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'text/event-stream' },
     });
 
     proxyService.proxyRequest.mockResolvedValue({
@@ -273,9 +272,9 @@ describe('ProxyController', () => {
         reason: 'scored',
       },
     });
-    (providerClient as Record<string, jest.Mock>).convertChatGptResponse = jest
+    (providerClient as Record<string, jest.Mock>).collectChatGptSseResponse = jest
       .fn()
-      .mockReturnValue(convertedBody);
+      .mockReturnValue(collectedBody);
 
     const req = mockRequest({ messages: [{ role: 'user', content: 'test' }] });
     const { res } = mockResponse();
@@ -283,9 +282,9 @@ describe('ProxyController', () => {
     await controller.chatCompletions(req as never, res as never);
 
     expect(
-      (providerClient as Record<string, jest.Mock>).convertChatGptResponse,
-    ).toHaveBeenCalledWith(chatgptBody, 'gpt-5.3-codex');
-    expect(res.json).toHaveBeenCalledWith(convertedBody);
+      (providerClient as Record<string, jest.Mock>).collectChatGptSseResponse,
+    ).toHaveBeenCalledWith(sseText, 'gpt-5.3-codex');
+    expect(res.json).toHaveBeenCalledWith(collectedBody);
   });
 
   it('should not record success message for non-fallback responses (OTLP pipeline records them)', async () => {

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -259,8 +259,14 @@ export function collectChatGptSseResponse(
   model: string,
 ): Record<string, unknown> {
   let text = '';
-  const toolCalls: { id: string; type: string; function: { name: string; arguments: string } }[] =
-    [];
+  // Map output_index → tool call to handle mixed output items correctly.
+  // The output_index from the API refers to position in the full output array
+  // (which can include non-function items like messages), so we cannot use a
+  // plain array indexed by push order.
+  const toolCallMap = new Map<
+    number,
+    { id: string; type: string; function: { name: string; arguments: string } }
+  >();
   let usage: Record<string, unknown> | undefined;
   let hasFunctionCalls = false;
 
@@ -283,7 +289,8 @@ export function collectChatGptSseResponse(
     } else if (eventType === 'response.output_item.added') {
       const item = isObjectRecord(data.item) ? data.item : undefined;
       if (item?.type === 'function_call') {
-        toolCalls.push({
+        const idx = typeof data.output_index === 'number' ? data.output_index : toolCallMap.size;
+        toolCallMap.set(idx, {
           id: (item.call_id as string) ?? '',
           type: 'function',
           function: { name: (item.name as string) ?? '', arguments: '' },
@@ -291,8 +298,9 @@ export function collectChatGptSseResponse(
       }
     } else if (eventType === 'response.function_call_arguments.delta') {
       const idx = typeof data.output_index === 'number' ? data.output_index : 0;
-      if (toolCalls[idx]) {
-        toolCalls[idx].function.arguments += typeof data.delta === 'string' ? data.delta : '';
+      const tc = toolCallMap.get(idx);
+      if (tc) {
+        tc.function.arguments += typeof data.delta === 'string' ? data.delta : '';
       }
     } else if (eventType === 'response.completed') {
       const response = isObjectRecord(data.response) ? data.response : undefined;
@@ -314,6 +322,7 @@ export function collectChatGptSseResponse(
     }
   }
 
+  const toolCalls = [...toolCallMap.values()];
   const message: Record<string, unknown> = { role: 'assistant', content: text || null };
   if (toolCalls.length > 0) message.tool_calls = toolCalls;
 

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -246,3 +246,89 @@ function handleCompletedEvent(dataStr: string, model: string): string {
   );
   return `${finish}\ndata: [DONE]\n\n`;
 }
+
+/* ── Non-streaming SSE collection ── */
+
+/**
+ * The Codex Responses API always returns SSE even when `stream: false`.
+ * This function consumes the SSE text and builds a non-streaming
+ * OpenAI Chat Completion response from the collected events.
+ */
+export function collectChatGptSseResponse(
+  sseText: string,
+  model: string,
+): Record<string, unknown> {
+  let text = '';
+  const toolCalls: { id: string; type: string; function: { name: string; arguments: string } }[] =
+    [];
+  let usage: Record<string, unknown> | undefined;
+  let hasFunctionCalls = false;
+
+  const events = sseText.split('\n\n');
+  for (const event of events) {
+    const lines = event.split('\n');
+    let eventType = '';
+    let dataStr = '';
+    for (const line of lines) {
+      if (line.startsWith('event: ')) eventType = line.slice(7).trim();
+      else if (line.startsWith('data: ')) dataStr = line.slice(6);
+    }
+    if (!eventType || !dataStr) continue;
+
+    const data = safeParse(dataStr);
+    if (!data) continue;
+
+    if (eventType === 'response.output_text.delta') {
+      text += typeof data.delta === 'string' ? data.delta : '';
+    } else if (eventType === 'response.output_item.added') {
+      const item = isObjectRecord(data.item) ? data.item : undefined;
+      if (item?.type === 'function_call') {
+        toolCalls.push({
+          id: (item.call_id as string) ?? '',
+          type: 'function',
+          function: { name: (item.name as string) ?? '', arguments: '' },
+        });
+      }
+    } else if (eventType === 'response.function_call_arguments.delta') {
+      const idx = typeof data.output_index === 'number' ? data.output_index : 0;
+      if (toolCalls[idx]) {
+        toolCalls[idx].function.arguments += typeof data.delta === 'string' ? data.delta : '';
+      }
+    } else if (eventType === 'response.completed') {
+      const response = isObjectRecord(data.response) ? data.response : undefined;
+      const respUsage = response?.usage as Record<string, unknown> | undefined;
+      if (respUsage) {
+        const inputDetails = respUsage.input_tokens_details as Record<string, number> | undefined;
+        usage = {
+          prompt_tokens: (respUsage.input_tokens as number) ?? 0,
+          completion_tokens: (respUsage.output_tokens as number) ?? 0,
+          total_tokens: (respUsage.total_tokens as number) ?? 0,
+          cache_read_tokens: inputDetails?.cached_tokens ?? 0,
+          cache_creation_tokens: 0,
+        };
+      }
+      const output = Array.isArray(response?.output)
+        ? (response.output as Array<{ type?: string }>)
+        : [];
+      hasFunctionCalls = output.some((item) => item.type === 'function_call');
+    }
+  }
+
+  const message: Record<string, unknown> = { role: 'assistant', content: text || null };
+  if (toolCalls.length > 0) message.tool_calls = toolCalls;
+
+  return {
+    id: `chatcmpl-${randomUUID().replace(/-/g, '').slice(0, 29)}`,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: hasFunctionCalls || toolCalls.length > 0 ? 'tool_calls' : 'stop',
+      },
+    ],
+    usage: usage ?? { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  };
+}

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -9,6 +9,7 @@ import {
   toResponsesRequest,
   fromResponsesResponse,
   transformResponsesStreamChunk,
+  collectChatGptSseResponse,
 } from './chatgpt-adapter';
 
 /** Convert a ChatGPT Responses API response to OpenAI format. */
@@ -56,7 +57,7 @@ export function createAnthropicTransformer(model: string): (chunk: string) => st
 }
 
 // Re-export adapter functions used by ProviderClient.forward()
-export { toGoogleRequest, toAnthropicRequest, toResponsesRequest };
+export { toGoogleRequest, toAnthropicRequest, toResponsesRequest, collectChatGptSseResponse };
 export type { ExtractedSignature } from './google-adapter';
 export type { SignatureLookup } from './proxy-types';
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -6,6 +6,7 @@ import {
   toAnthropicRequest,
   toResponsesRequest,
   sanitizeOpenAiBody,
+  collectChatGptSseResponse as chatGptSseCollector,
   convertChatGptResponse as chatGptResponseConverter,
   convertChatGptStreamChunk as chatGptStreamChunkConverter,
   convertGoogleResponse as googleResponseConverter,
@@ -174,5 +175,10 @@ export class ProviderClient {
   /** Create a stateful Anthropic stream transformer that tracks usage across events. */
   createAnthropicStreamTransformer(model: string): (chunk: string) => string | null {
     return createAnthropicTransformer(model);
+  }
+
+  /** Collect a ChatGPT SSE stream into a non-streaming OpenAI response. */
+  collectChatGptSseResponse(sseText: string, model: string): Record<string, unknown> {
+    return chatGptSseCollector(sseText, model);
   }
 }

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -242,8 +242,10 @@ export async function handleNonStreamResponse(
     const anthropicData = (await forward.response.json()) as Record<string, unknown>;
     responseBody = providerClient.convertAnthropicResponse(anthropicData, meta.model);
   } else if (forward.isChatGpt) {
-    const chatgptData = (await forward.response.json()) as Record<string, unknown>;
-    responseBody = providerClient.convertChatGptResponse(chatgptData, meta.model);
+    // The Codex Responses API always returns SSE even when stream: false.
+    // Consume the SSE text and build a non-streaming response.
+    const sseText = await forward.response.text();
+    responseBody = providerClient.collectChatGptSseResponse(sseText, meta.model);
   } else {
     responseBody = await forward.response.json();
   }


### PR DESCRIPTION
## Summary

- The Codex Responses API (`chatgpt.com/backend-api/codex/responses`) always returns SSE even when `stream: false` is sent
- Previously, non-streaming requests to OpenAI subscription models failed with `Unexpected token 'e', "event: res"... is not valid JSON` because the proxy tried to parse the SSE response as JSON
- Added `collectChatGptSseResponse()` that consumes SSE events and builds a proper non-streaming OpenAI Chat Completion response
- Wired it into `handleNonStreamResponse` so ChatGPT format responses use `.text()` instead of `.json()`

## Test plan

- [x] New unit tests for `collectChatGptSseResponse` (text deltas, function calls, empty input)
- [x] Updated `proxy-response-handler` test to verify SSE collection path
- [x] All 267 proxy tests pass
- [x] Verified streaming requests still work (unchanged path)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-streaming ChatGPT subscription (Codex) responses by collecting SSE events and returning a valid OpenAI chat completion instead of failing on JSON parse. Streaming behavior is unchanged.

- **Bug Fixes**
  - Added `collectChatGptSseResponse()` to build non-stream responses from SSE; handles text deltas, tool calls, usage (incl. cache reads), and non-zero `output_index` via a Map.
  - Routed non-stream ChatGPT requests through `response.text()` and `ProviderClient.collectChatGptSseResponse()`.
  - Updated tests for the collector (text, tool calls, mixed items), proxy handler, and `ProxyController` to cover SSE collection.

<sup>Written for commit c6f76b6d029467f71e640671ae8a112ae41ba4f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

