### PR TITLE
fix: block Z.AI glm-5.1 from model discovery

### DIFF
--- a/.changeset/block-zai-glm51.md
+++ b/.changeset/block-zai-glm51.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Block glm-5.1 from Z.AI model discovery (subscription-only model returns 403 on standard API)

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -330,10 +330,7 @@ describe('ProviderModelFetcherService', () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({
-          data: [
-            { id: 'mistral-large-latest' },
-            { id: 'codestral-latest' },
-          ],
+          data: [{ id: 'mistral-large-latest' }, { id: 'codestral-latest' }],
         }),
       });
 
@@ -347,7 +344,10 @@ describe('ProviderModelFetcherService', () => {
         json: async () => ({
           data: [
             { id: 'mistral-large-latest', capabilities: { completion_chat: true } },
-            { id: 'codestral-latest', capabilities: { completion_chat: true, completion_fim: true } },
+            {
+              id: 'codestral-latest',
+              capabilities: { completion_chat: true, completion_fim: true },
+            },
           ],
         }),
       });
@@ -362,7 +362,11 @@ describe('ProviderModelFetcherService', () => {
         json: async () => ({
           data: [
             { id: 'mistral-large-latest', capabilities: { completion_chat: true } },
-            { id: 'deprecated-model', capabilities: { completion_chat: true }, deprecation: '2025-06-01' },
+            {
+              id: 'deprecated-model',
+              capabilities: { completion_chat: true },
+              deprecation: '2025-06-01',
+            },
             { id: 'labs-experimental', capabilities: { completion_chat: true } },
             { id: 'voxtral-mini-2602', capabilities: { completion_chat: true } },
           ],
@@ -373,6 +377,20 @@ describe('ProviderModelFetcherService', () => {
       // deprecated-model filtered by metadata, labs-experimental by regex, voxtral-mini-2602 by blocklist
       expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
     });
+  });
+
+  /* ── Z.AI blocklist ── */
+
+  it('should filter glm-5.1 from zai models via blocklist', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'glm-4.5' }, { id: 'glm-5' }, { id: 'glm-5.1' }],
+      }),
+    });
+
+    const result = await service.fetch('zai', 'key');
+    expect(result.map((m) => m.id)).toEqual(['glm-4.5', 'glm-5']);
   });
 
   /* ── OpenAI-compatible providers use same parser ── */

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -111,7 +111,8 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
     /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio|^chatgpt-image)/i,
   'openai-subscription':
     /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|audio|^chatgpt-image)/i,
-  gemini: /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview)/i,
+  gemini:
+    /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview)/i,
   mistral: /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime)|^labs-)/i,
   xai: /(?:imagine|multi-agent)/i,
 };
@@ -123,6 +124,9 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
 export const PROVIDER_BLOCKLIST: Record<string, ReadonlySet<string>> = {
   mistral: new Set([
     'voxtral-mini-2602', // Invalid model returned by API; not a real chat endpoint
+  ]),
+  zai: new Set([
+    'glm-5.1', // Requires Coding Plan subscription + different endpoint; 403 on standard API
   ]),
 };
 


### PR DESCRIPTION
## Summary

- Add `glm-5.1` to `PROVIDER_BLOCKLIST` for Z.AI provider
- `glm-5.1` requires a Coding Plan subscription and uses a different API endpoint (`/api/coding/paas/v4/...`). The standard models API lists it but chat completions returns 403.
- Prevents users from seeing a model that always errors when routed through our proxy

## Test plan

- [x] New unit test: `should filter glm-5.1 from zai models via blocklist`
- [ ] Verify all other Z.AI models (glm-4.5, glm-4.5-air, glm-4.6, glm-4.7, glm-5, glm-5-turbo) still appear after discovery
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocked Z.AI `glm-5.1` from model discovery to avoid surfacing a model that 403s on chat completions via the standard API. This model is subscription-only and uses a different endpoint (`/api/coding/paas/v4/...`).

- **Bug Fixes**
  - Added `glm-5.1` to `PROVIDER_BLOCKLIST` for `zai`.
  - Added a unit test to ensure `glm-5.1` is filtered from discovery.

<sup>Written for commit 5b0af4447a8396605b6e4d76d48eb6e98260bab7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

