### PR TITLE
refactor: improve public stats endpoints — URLs, filtering, limits

### DIFF
--- a/.changeset/public-stats-improvements.md
+++ b/.changeset/public-stats-improvements.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Improve public stats endpoints: better URLs, filtering, and 10-item limits

--- a/packages/backend/src/public-stats/public-stats.controller.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.spec.ts
@@ -20,22 +20,11 @@ const STATS_FIXTURE: UsageStats = {
       output_price_per_million: 10,
       usage_rank: 1,
     },
-    {
-      model: 'claude-opus-4-6',
-      provider: 'Anthropic',
-      tokens_7d: 3000000,
-      input_price_per_million: 15,
-      output_price_per_million: 75,
-      usage_rank: 2,
-    },
   ],
-  token_map: new Map([
-    ['gpt-4o', 5000000],
-    ['claude-opus-4-6', 3000000],
-  ]),
+  token_map: new Map([['gpt-4o', 5000000]]),
 };
 
-const FREE_MODELS_FIXTURE: FreeModel[] = [
+const FREE_FIXTURE: FreeModel[] = [
   { model_name: 'deepseek-chat', provider: 'DeepSeek', tokens_7d: 64000000 },
 ];
 
@@ -53,26 +42,23 @@ describe('PublicStatsController', () => {
     controller = await freshImport();
   });
 
-  // ── getStats ──────────────────────────────────────────────────
-
-  describe('getStats', () => {
-    it('fetches stats on first call', async () => {
+  describe('getUsage', () => {
+    it('fetches usage on first call', async () => {
       mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
 
-      const result = await controller.getStats();
+      const result = await controller.getUsage();
 
       expect(result.total_messages).toBe(100);
-      expect(result.top_models).toHaveLength(2);
-      expect(result.top_models[0].provider).toBe('OpenAI');
+      expect(result.top_models).toHaveLength(1);
       expect(result.cached_at).toBeDefined();
       expect(mockService.getUsageStats).toHaveBeenCalledTimes(1);
     });
 
-    it('returns cached stats within TTL', async () => {
+    it('returns cached within TTL', async () => {
       mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
+      await controller.getUsage();
 
-      await controller.getStats();
-      const result = await controller.getStats();
+      const result = await controller.getUsage();
 
       expect(result.total_messages).toBe(100);
       expect(mockService.getUsageStats).toHaveBeenCalledTimes(1);
@@ -80,7 +66,7 @@ describe('PublicStatsController', () => {
 
     it('re-fetches after TTL expires', async () => {
       mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
-      await controller.getStats();
+      await controller.getUsage();
 
       const realDateNow = Date.now;
       Date.now = () => realDateNow() + 86_400_001;
@@ -88,127 +74,70 @@ describe('PublicStatsController', () => {
       const updated: UsageStats = { total_messages: 200, top_models: [], token_map: new Map() };
       mockService.getUsageStats.mockResolvedValue(updated);
 
-      const result = await controller.getStats();
+      const result = await controller.getUsage();
 
       expect(result.total_messages).toBe(200);
-      expect(mockService.getUsageStats).toHaveBeenCalledTimes(2);
-
       Date.now = realDateNow;
     });
 
-    it('returns cached_at as valid ISO date string', async () => {
-      mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
-      const result = await controller.getStats();
-      expect(new Date(result.cached_at).toISOString()).toBe(result.cached_at);
-    });
-
     it('returns fallback when service fails on first call', async () => {
-      mockService.getUsageStats.mockRejectedValue(new Error('db error'));
+      mockService.getUsageStats.mockRejectedValue(new Error('fail'));
 
-      const result = await controller.getStats();
+      const result = await controller.getUsage();
 
       expect(result.total_messages).toBe(0);
       expect(result.top_models).toEqual([]);
-      expect(new Date(result.cached_at).toISOString()).toBe(result.cached_at);
     });
 
-    it('returns stale cache when service fails after previous success', async () => {
+    it('returns stale cache on error after previous success', async () => {
       mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
-      await controller.getStats();
+      await controller.getUsage();
 
       const realDateNow = Date.now;
       Date.now = () => realDateNow() + 86_400_001;
-      mockService.getUsageStats.mockRejectedValue(new Error('db error'));
+      mockService.getUsageStats.mockRejectedValue(new Error('fail'));
 
-      const result = await controller.getStats();
+      const result = await controller.getUsage();
 
       expect(result.total_messages).toBe(100);
       Date.now = realDateNow;
     });
   });
 
-  // ── getModelCatalog ───────────────────────────────────────────
-
-  describe('getModelCatalog', () => {
+  describe('getFreeModels', () => {
     beforeEach(() => {
       mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
-      mockService.getFreeModels.mockReturnValue(FREE_MODELS_FIXTURE);
+      mockService.getFreeModels.mockReturnValue(FREE_FIXTURE);
     });
 
     it('fetches free models on first call', async () => {
-      const result = await controller.getModelCatalog();
+      const result = await controller.getFreeModels();
 
       expect(result.models).toHaveLength(1);
-      expect(result.models[0].model_name).toBe('deepseek-chat');
       expect(result.total_models).toBe(1);
-      expect(result.cached_at).toBeDefined();
-    });
-
-    it('passes token_map to getFreeModels', async () => {
-      await controller.getModelCatalog();
-
       expect(mockService.getFreeModels).toHaveBeenCalledWith(STATS_FIXTURE.token_map);
     });
 
-    it('returns cached catalog within TTL', async () => {
-      await controller.getModelCatalog();
-      const result = await controller.getModelCatalog();
+    it('returns cached within TTL', async () => {
+      await controller.getFreeModels();
+      const result = await controller.getFreeModels();
 
       expect(result.models).toHaveLength(1);
       expect(mockService.getUsageStats).toHaveBeenCalledTimes(1);
     });
 
-    it('re-fetches after TTL expires', async () => {
-      await controller.getModelCatalog();
-
-      const realDateNow = Date.now;
-      Date.now = () => realDateNow() + 86_400_001;
-      mockService.getFreeModels.mockReturnValue([]);
-
-      const result = await controller.getModelCatalog();
-
-      expect(result.total_models).toBe(0);
-      Date.now = realDateNow;
-    });
-
     it('returns fallback when service fails on first call', async () => {
-      mockService.getUsageStats.mockRejectedValue(new Error('db error'));
+      mockService.getUsageStats.mockRejectedValue(new Error('fail'));
 
-      const result = await controller.getModelCatalog();
+      const result = await controller.getFreeModels();
 
       expect(result.models).toEqual([]);
       expect(result.total_models).toBe(0);
     });
-
-    it('returns stale cache when service fails after previous success', async () => {
-      await controller.getModelCatalog();
-
-      const realDateNow = Date.now;
-      Date.now = () => realDateNow() + 86_400_001;
-      mockService.getUsageStats.mockRejectedValue(new Error('db error'));
-
-      const result = await controller.getModelCatalog();
-
-      expect(result.models).toHaveLength(1);
-      Date.now = realDateNow;
-    });
   });
 
-  // ── Cache isolation & stampede ────────────────────────────────
-
-  describe('cache isolation', () => {
-    it('stats cache and catalog cache are independent', async () => {
-      mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
-      mockService.getFreeModels.mockReturnValue(FREE_MODELS_FIXTURE);
-
-      await controller.getStats();
-      expect(mockService.getUsageStats).toHaveBeenCalledTimes(1);
-
-      await controller.getModelCatalog();
-      expect(mockService.getUsageStats).toHaveBeenCalledTimes(2);
-    });
-
-    it('deduplicates concurrent stats requests', async () => {
+  describe('stampede prevention', () => {
+    it('deduplicates concurrent usage requests', async () => {
       let resolve!: (v: UsageStats) => void;
       mockService.getUsageStats.mockReturnValue(
         new Promise<UsageStats>((r) => {
@@ -216,8 +145,8 @@ describe('PublicStatsController', () => {
         }),
       );
 
-      const p1 = controller.getStats();
-      const p2 = controller.getStats();
+      const p1 = controller.getUsage();
+      const p2 = controller.getUsage();
 
       resolve(STATS_FIXTURE);
       const [r1, r2] = await Promise.all([p1, p2]);
@@ -227,32 +156,12 @@ describe('PublicStatsController', () => {
       expect(mockService.getUsageStats).toHaveBeenCalledTimes(1);
     });
 
-    it('deduplicates concurrent catalog requests', async () => {
-      let resolve!: (v: UsageStats) => void;
-      mockService.getUsageStats.mockReturnValue(
-        new Promise<UsageStats>((r) => {
-          resolve = r;
-        }),
-      );
-      mockService.getFreeModels.mockReturnValue(FREE_MODELS_FIXTURE);
-
-      const p1 = controller.getModelCatalog();
-      const p2 = controller.getModelCatalog();
-
-      resolve(STATS_FIXTURE);
-      const [r1, r2] = await Promise.all([p1, p2]);
-
-      expect(r1.models).toHaveLength(1);
-      expect(r2.models).toHaveLength(1);
-      expect(mockService.getUsageStats).toHaveBeenCalledTimes(1);
-    });
-
-    it('clears inflight lock after error so next request retries', async () => {
+    it('clears inflight lock after error', async () => {
       mockService.getUsageStats.mockRejectedValueOnce(new Error('fail'));
-      await controller.getStats();
+      await controller.getUsage();
 
       mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
-      const result = await controller.getStats();
+      const result = await controller.getUsage();
 
       expect(result.total_messages).toBe(100);
       expect(mockService.getUsageStats).toHaveBeenCalledTimes(2);

--- a/packages/backend/src/public-stats/public-stats.controller.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.ts
@@ -3,98 +3,98 @@ import { Public } from '../common/decorators/public.decorator';
 import { PUBLIC_STATS_CACHE_TTL_MS } from '../common/constants/cache.constants';
 import { PublicStatsService, TopModel, FreeModel } from './public-stats.service';
 
-interface StatsResponse {
+interface UsageResponse {
   total_messages: number;
   top_models: TopModel[];
   cached_at: string;
 }
 
-interface CatalogResponse {
+interface FreeModelsResponse {
   models: FreeModel[];
   total_models: number;
   cached_at: string;
 }
 
-let cachedStats: StatsResponse | null = null;
-let statsTimestamp = 0;
-let statsInflight: Promise<StatsResponse> | null = null;
+let cachedUsage: UsageResponse | null = null;
+let usageTimestamp = 0;
+let usageInflight: Promise<UsageResponse> | null = null;
 
-let cachedCatalog: CatalogResponse | null = null;
-let catalogTimestamp = 0;
-let catalogInflight: Promise<CatalogResponse> | null = null;
+let cachedFree: FreeModelsResponse | null = null;
+let freeTimestamp = 0;
+let freeInflight: Promise<FreeModelsResponse> | null = null;
 
-@Controller('api/v1')
+@Controller('api/v1/public')
 export class PublicStatsController {
   private readonly logger = new Logger(PublicStatsController.name);
 
   constructor(private readonly service: PublicStatsService) {}
 
   @Public()
-  @Get('public-stats')
-  async getStats(): Promise<StatsResponse> {
-    if (cachedStats && Date.now() - statsTimestamp < PUBLIC_STATS_CACHE_TTL_MS) {
-      return cachedStats;
+  @Get('usage')
+  async getUsage(): Promise<UsageResponse> {
+    if (cachedUsage && Date.now() - usageTimestamp < PUBLIC_STATS_CACHE_TTL_MS) {
+      return cachedUsage;
     }
 
-    if (!statsInflight) {
-      statsInflight = this.refreshStats().finally(() => {
-        statsInflight = null;
+    if (!usageInflight) {
+      usageInflight = this.refreshUsage().finally(() => {
+        usageInflight = null;
       });
     }
 
-    return statsInflight;
+    return usageInflight;
   }
 
   @Public()
-  @Get('public-stats/models')
-  async getModelCatalog(): Promise<CatalogResponse> {
-    if (cachedCatalog && Date.now() - catalogTimestamp < PUBLIC_STATS_CACHE_TTL_MS) {
-      return cachedCatalog;
+  @Get('free-models')
+  async getFreeModels(): Promise<FreeModelsResponse> {
+    if (cachedFree && Date.now() - freeTimestamp < PUBLIC_STATS_CACHE_TTL_MS) {
+      return cachedFree;
     }
 
-    if (!catalogInflight) {
-      catalogInflight = this.refreshCatalog().finally(() => {
-        catalogInflight = null;
+    if (!freeInflight) {
+      freeInflight = this.refreshFreeModels().finally(() => {
+        freeInflight = null;
       });
     }
 
-    return catalogInflight;
+    return freeInflight;
   }
 
-  private async refreshStats(): Promise<StatsResponse> {
+  private async refreshUsage(): Promise<UsageResponse> {
     try {
       const stats = await this.service.getUsageStats();
-      cachedStats = {
+      cachedUsage = {
         total_messages: stats.total_messages,
         top_models: stats.top_models,
         cached_at: new Date().toISOString(),
       };
-      statsTimestamp = Date.now();
+      usageTimestamp = Date.now();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.error(`Failed to fetch usage stats: ${msg}`);
     }
 
     return (
-      cachedStats ?? { total_messages: 0, top_models: [], cached_at: new Date().toISOString() }
+      cachedUsage ?? { total_messages: 0, top_models: [], cached_at: new Date().toISOString() }
     );
   }
 
-  private async refreshCatalog(): Promise<CatalogResponse> {
+  private async refreshFreeModels(): Promise<FreeModelsResponse> {
     try {
       const stats = await this.service.getUsageStats();
       const models = this.service.getFreeModels(stats.token_map);
-      cachedCatalog = {
+      cachedFree = {
         models,
         total_models: models.length,
         cached_at: new Date().toISOString(),
       };
-      catalogTimestamp = Date.now();
+      freeTimestamp = Date.now();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      this.logger.error(`Failed to fetch model catalog: ${msg}`);
+      this.logger.error(`Failed to fetch free models: ${msg}`);
     }
 
-    return cachedCatalog ?? { models: [], total_models: 0, cached_at: new Date().toISOString() };
+    return cachedFree ?? { models: [], total_models: 0, cached_at: new Date().toISOString() };
   }
 }

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -46,40 +46,40 @@ describe('PublicStatsService', () => {
     );
   });
 
-  describe('getUsageStats', () => {
-    function setupQueries(count: unknown, top: unknown, tokens: unknown) {
-      mockRepo.createQueryBuilder
-        .mockReturnValueOnce(mockQueryBuilder(count))
-        .mockReturnValueOnce(mockQueryBuilder(top))
-        .mockReturnValueOnce(mockQueryBuilder(tokens));
-    }
+  function setupQueries(count: unknown, top: unknown, tokens: unknown) {
+    mockRepo.createQueryBuilder
+      .mockReturnValueOnce(mockQueryBuilder(count))
+      .mockReturnValueOnce(mockQueryBuilder(top))
+      .mockReturnValueOnce(mockQueryBuilder(tokens));
+  }
 
-    it('returns enriched top models with pricing and tokens_7d', async () => {
+  describe('getUsageStats', () => {
+    it('returns enriched top models sorted by tokens_7d', async () => {
       setupQueries(
         { total: '42' },
-        [{ model: 'gpt-4o', usage_count: '20' }],
-        [{ model: 'gpt-4o', tokens: '5000000' }],
+        [
+          { model: 'gpt-4o', usage_count: '20' },
+          { model: 'claude-opus', usage_count: '15' },
+        ],
+        [
+          { model: 'gpt-4o', tokens: '1000000' },
+          { model: 'claude-opus', tokens: '5000000' },
+        ],
       );
-      mockPricingCache.getByModel.mockReturnValue(
-        makePricingEntry({
-          provider: 'OpenAI',
-          input_price_per_token: 0.0000025,
-          output_price_per_token: 0.00001,
-        }),
-      );
+      mockPricingCache.getByModel.mockImplementation((name: string) => {
+        if (name === 'gpt-4o') return makePricingEntry({ provider: 'OpenAI' });
+        if (name === 'claude-opus') return makePricingEntry({ provider: 'Anthropic' });
+        return null;
+      });
 
       const result = await service.getUsageStats();
 
       expect(result.total_messages).toBe(42);
-      expect(result.top_models[0]).toEqual({
-        model: 'gpt-4o',
-        provider: 'OpenAI',
-        tokens_7d: 5000000,
-        input_price_per_million: 2.5,
-        output_price_per_million: 10,
-        usage_rank: 1,
-      });
-      expect(result.token_map.get('gpt-4o')).toBe(5000000);
+      expect(result.top_models[0].model).toBe('claude-opus');
+      expect(result.top_models[0].tokens_7d).toBe(5000000);
+      expect(result.top_models[0].usage_rank).toBe(1);
+      expect(result.top_models[1].model).toBe('gpt-4o');
+      expect(result.top_models[1].usage_rank).toBe(2);
     });
 
     it('returns zeros when table is empty', async () => {
@@ -89,7 +89,6 @@ describe('PublicStatsService', () => {
 
       expect(result.total_messages).toBe(0);
       expect(result.top_models).toEqual([]);
-      expect(result.token_map.size).toBe(0);
     });
 
     it('handles null count result', async () => {
@@ -102,21 +101,42 @@ describe('PublicStatsService', () => {
       expect((await service.getUsageStats()).total_messages).toBe(0);
     });
 
-    it('uses Unknown provider when pricing has no match', async () => {
-      setupQueries({ total: '1' }, [{ model: 'x', usage_count: '1' }], []);
+    it('excludes custom models', async () => {
+      setupQueries({ total: '1' }, [{ model: 'custom:abc/gpt-4o', usage_count: '1' }], []);
 
       const result = await service.getUsageStats();
 
-      expect(result.top_models[0].provider).toBe('Unknown');
-      expect(result.top_models[0].input_price_per_million).toBeNull();
+      expect(result.top_models).toHaveLength(0);
     });
 
-    it('sets tokens_7d to 0 for models with no recent usage', async () => {
-      setupQueries({ total: '5' }, [{ model: 'old', usage_count: '5' }], []);
+    it('excludes Unknown provider models', async () => {
+      setupQueries({ total: '1' }, [{ model: 'unknown-model', usage_count: '1' }], []);
 
       const result = await service.getUsageStats();
 
-      expect(result.top_models[0].tokens_7d).toBe(0);
+      expect(result.top_models).toHaveLength(0);
+    });
+
+    it('excludes OpenRouter provider models', async () => {
+      setupQueries({ total: '1' }, [{ model: 'openrouter/free', usage_count: '1' }], []);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenRouter' }));
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(0);
+    });
+
+    it('limits to 10 results', async () => {
+      const rows = Array.from({ length: 15 }, (_, i) => ({
+        model: `model-${i}`,
+        usage_count: `${15 - i}`,
+      }));
+      setupQueries({ total: '100' }, rows, []);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'Anthropic' }));
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(10);
     });
 
     it('handles null tokens in token query', async () => {
@@ -125,6 +145,7 @@ describe('PublicStatsService', () => {
         [{ model: 'x', usage_count: '1' }],
         [{ model: 'x', tokens: null }],
       );
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
 
       const result = await service.getUsageStats();
 
@@ -145,32 +166,50 @@ describe('PublicStatsService', () => {
         expect.objectContaining({ cutoff: expect.any(String) }),
       );
     });
-
-    it('assigns sequential usage_rank', async () => {
-      setupQueries(
-        { total: '10' },
-        [
-          { model: 'a', usage_count: '7' },
-          { model: 'b', usage_count: '3' },
-        ],
-        [],
-      );
-
-      const result = await service.getUsageStats();
-
-      expect(result.top_models[0].usage_rank).toBe(1);
-      expect(result.top_models[1].usage_rank).toBe(2);
-    });
   });
 
   describe('getFreeModels', () => {
-    it('returns only free models with tokens_7d', () => {
+    it('returns free models with tokens_7d > 0, sorted desc', () => {
       mockPricingCache.getAll.mockReturnValue([
         makePricingEntry({
-          model_name: 'free',
+          model_name: 'a',
+          provider: 'Google',
           input_price_per_token: 0,
           output_price_per_token: 0,
         }),
+        makePricingEntry({
+          model_name: 'b',
+          provider: 'DeepSeek',
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+        }),
+      ]);
+      const tokenMap = new Map([
+        ['a', 1000],
+        ['b', 5000],
+      ]);
+
+      const result = service.getFreeModels(tokenMap);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ model_name: 'b', provider: 'DeepSeek', tokens_7d: 5000 });
+      expect(result[1]).toEqual({ model_name: 'a', provider: 'Google', tokens_7d: 1000 });
+    });
+
+    it('excludes models with zero tokens_7d', () => {
+      mockPricingCache.getAll.mockReturnValue([
+        makePricingEntry({
+          model_name: 'no-usage',
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+        }),
+      ]);
+
+      expect(service.getFreeModels(new Map())).toEqual([]);
+    });
+
+    it('excludes paid models', () => {
+      mockPricingCache.getAll.mockReturnValue([
         makePricingEntry({
           model_name: 'paid',
           input_price_per_token: 0.001,
@@ -178,45 +217,63 @@ describe('PublicStatsService', () => {
         }),
       ]);
 
-      const result = service.getFreeModels(new Map([['free', 1000]]));
+      expect(service.getFreeModels(new Map([['paid', 1000]]))).toEqual([]);
+    });
 
-      expect(result).toEqual([{ model_name: 'free', provider: 'TestProvider', tokens_7d: 1000 }]);
+    it('excludes Unknown and OpenRouter providers', () => {
+      mockPricingCache.getAll.mockReturnValue([
+        makePricingEntry({
+          model_name: 'a',
+          provider: 'Unknown',
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+        }),
+        makePricingEntry({
+          model_name: 'b',
+          provider: 'OpenRouter',
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+        }),
+      ]);
+
+      expect(
+        service.getFreeModels(
+          new Map([
+            ['a', 100],
+            ['b', 200],
+          ]),
+        ),
+      ).toEqual([]);
+    });
+
+    it('limits to 10 results', () => {
+      const entries = Array.from({ length: 15 }, (_, i) =>
+        makePricingEntry({
+          model_name: `m-${i}`,
+          provider: 'Google',
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+        }),
+      );
+      mockPricingCache.getAll.mockReturnValue(entries);
+      const tokenMap = new Map(entries.map((e, i) => [e.model_name, i + 1]));
+
+      expect(service.getFreeModels(tokenMap)).toHaveLength(10);
     });
 
     it('treats null prices as free', () => {
       mockPricingCache.getAll.mockReturnValue([
         makePricingEntry({
           model_name: 'n',
+          provider: 'Google',
           input_price_per_token: null,
           output_price_per_token: null,
         }),
       ]);
 
-      const result = service.getFreeModels(new Map());
+      const result = service.getFreeModels(new Map([['n', 500]]));
 
       expect(result).toHaveLength(1);
-      expect(result[0].tokens_7d).toBe(0);
-    });
-
-    it('excludes models with one non-zero price', () => {
-      mockPricingCache.getAll.mockReturnValue([
-        makePricingEntry({ input_price_per_token: 0, output_price_per_token: 0.001 }),
-      ]);
-      expect(service.getFreeModels(new Map())).toHaveLength(0);
-    });
-
-    it('returns empty when no free models', () => {
-      mockPricingCache.getAll.mockReturnValue([
-        makePricingEntry({ input_price_per_token: 0.001, output_price_per_token: 0.002 }),
-      ]);
-      expect(service.getFreeModels(new Map())).toEqual([]);
-    });
-
-    it('uses Unknown as provider fallback', () => {
-      mockPricingCache.getAll.mockReturnValue([
-        makePricingEntry({ provider: '', input_price_per_token: 0, output_price_per_token: 0 }),
-      ]);
-      expect(service.getFreeModels(new Map())[0].provider).toBe('Unknown');
     });
   });
 });

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -101,8 +101,9 @@ describe('PublicStatsService', () => {
       expect((await service.getUsageStats()).total_messages).toBe(0);
     });
 
-    it('excludes custom models', async () => {
+    it('excludes custom models even with known provider', async () => {
       setupQueries({ total: '1' }, [{ model: 'custom:abc/gpt-4o', usage_count: '1' }], []);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
 
       const result = await service.getUsageStats();
 
@@ -244,6 +245,18 @@ describe('PublicStatsService', () => {
           ]),
         ),
       ).toEqual([]);
+    });
+
+    it('excludes custom models', () => {
+      mockPricingCache.getAll.mockReturnValue([
+        makePricingEntry({
+          model_name: 'custom:abc/model',
+          provider: 'OpenAI',
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+        }),
+      ]);
+      expect(service.getFreeModels(new Map([['custom:abc/model', 500]]))).toEqual([]);
     });
 
     it('limits to 10 results', () => {

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -5,6 +5,9 @@ import { AgentMessage } from '../entities/agent-message.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { computeCutoff } from '../common/utils/sql-dialect';
 
+const MAX_RESULTS = 10;
+const EXCLUDED_PROVIDERS = new Set(['Unknown', 'OpenRouter']);
+
 export interface TopModel {
   model: string;
   provider: string;
@@ -24,6 +27,10 @@ export interface FreeModel {
   model_name: string;
   provider: string;
   tokens_7d: number;
+}
+
+function isCustomModel(model: string): boolean {
+  return model.startsWith('custom:');
 }
 
 @Injectable()
@@ -46,7 +53,6 @@ export class PublicStatsService {
         .where('at.model IS NOT NULL')
         .groupBy('at.model')
         .orderBy('usage_count', 'DESC')
-        .limit(20)
         .getRawMany(),
       this.messageRepo
         .createQueryBuilder('at')
@@ -63,12 +69,18 @@ export class PublicStatsService {
       tokenMap.set(r.model as string, Number(r.tokens ?? 0));
     }
 
-    const topModels: TopModel[] = topRows.map((r, i) => {
+    const enriched: TopModel[] = [];
+    for (const r of topRows) {
+      if (enriched.length >= MAX_RESULTS) break;
       const modelName = r.model as string;
+      if (isCustomModel(modelName)) continue;
       const pricing = this.pricingCache.getByModel(modelName);
-      return {
+      const provider = pricing?.provider || 'Unknown';
+      if (EXCLUDED_PROVIDERS.has(provider)) continue;
+
+      enriched.push({
         model: modelName,
-        provider: pricing?.provider || 'Unknown',
+        provider,
         tokens_7d: tokenMap.get(modelName) ?? 0,
         input_price_per_million:
           pricing?.input_price_per_token != null
@@ -78,13 +90,16 @@ export class PublicStatsService {
           pricing?.output_price_per_token != null
             ? Number(pricing.output_price_per_token) * 1_000_000
             : null,
-        usage_rank: i + 1,
-      };
-    });
+        usage_rank: enriched.length + 1,
+      });
+    }
+
+    enriched.sort((a, b) => b.tokens_7d - a.tokens_7d);
+    enriched.forEach((m, i) => (m.usage_rank = i + 1));
 
     return {
       total_messages: Number(countRow?.total ?? 0),
-      top_models: topModels,
+      top_models: enriched,
       token_map: tokenMap,
     };
   }
@@ -92,11 +107,19 @@ export class PublicStatsService {
   getFreeModels(tokenMap: Map<string, number>): FreeModel[] {
     return this.pricingCache
       .getAll()
-      .filter((e) => (e.input_price_per_token ?? 0) === 0 && (e.output_price_per_token ?? 0) === 0)
+      .filter((e) => {
+        if ((e.input_price_per_token ?? 0) !== 0 || (e.output_price_per_token ?? 0) !== 0)
+          return false;
+        const provider = e.provider || 'Unknown';
+        if (EXCLUDED_PROVIDERS.has(provider)) return false;
+        return (tokenMap.get(e.model_name) ?? 0) > 0;
+      })
       .map((e) => ({
         model_name: e.model_name,
         provider: e.provider || 'Unknown',
         tokens_7d: tokenMap.get(e.model_name) ?? 0,
-      }));
+      }))
+      .sort((a, b) => b.tokens_7d - a.tokens_7d)
+      .slice(0, MAX_RESULTS);
   }
 }

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -69,16 +69,15 @@ export class PublicStatsService {
       tokenMap.set(r.model as string, Number(r.tokens ?? 0));
     }
 
-    const enriched: TopModel[] = [];
+    const eligible: TopModel[] = [];
     for (const r of topRows) {
-      if (enriched.length >= MAX_RESULTS) break;
       const modelName = r.model as string;
       if (isCustomModel(modelName)) continue;
       const pricing = this.pricingCache.getByModel(modelName);
       const provider = pricing?.provider || 'Unknown';
       if (EXCLUDED_PROVIDERS.has(provider)) continue;
 
-      enriched.push({
+      eligible.push({
         model: modelName,
         provider,
         tokens_7d: tokenMap.get(modelName) ?? 0,
@@ -90,16 +89,17 @@ export class PublicStatsService {
           pricing?.output_price_per_token != null
             ? Number(pricing.output_price_per_token) * 1_000_000
             : null,
-        usage_rank: enriched.length + 1,
+        usage_rank: 0,
       });
     }
 
-    enriched.sort((a, b) => b.tokens_7d - a.tokens_7d);
-    enriched.forEach((m, i) => (m.usage_rank = i + 1));
+    eligible.sort((a, b) => b.tokens_7d - a.tokens_7d);
+    const topModels = eligible.slice(0, MAX_RESULTS);
+    topModels.forEach((m, i) => (m.usage_rank = i + 1));
 
     return {
       total_messages: Number(countRow?.total ?? 0),
-      top_models: enriched,
+      top_models: topModels,
       token_map: tokenMap,
     };
   }
@@ -110,6 +110,7 @@ export class PublicStatsService {
       .filter((e) => {
         if ((e.input_price_per_token ?? 0) !== 0 || (e.output_price_per_token ?? 0) !== 0)
           return false;
+        if (isCustomModel(e.model_name)) return false;
         const provider = e.provider || 'Unknown';
         if (EXCLUDED_PROVIDERS.has(provider)) return false;
         return (tokenMap.get(e.model_name) ?? 0) > 0;

--- a/packages/backend/test/public-stats.e2e-spec.ts
+++ b/packages/backend/test/public-stats.e2e-spec.ts
@@ -58,13 +58,12 @@ describe('GET /api/v1/public/usage', () => {
       .get('/api/v1/public/usage')
       .expect(200);
 
-    if (res.body.top_models.length > 0) {
-      const m = res.body.top_models[0];
-      expect(m).toHaveProperty('model');
-      expect(m).toHaveProperty('provider');
-      expect(m).toHaveProperty('tokens_7d');
-      expect(m).toHaveProperty('usage_rank');
-    }
+    expect(res.body.top_models.length).toBeGreaterThan(0);
+    const m = res.body.top_models[0];
+    expect(m).toHaveProperty('model');
+    expect(m).toHaveProperty('provider');
+    expect(m).toHaveProperty('tokens_7d');
+    expect(m).toHaveProperty('usage_rank');
   });
 });
 

--- a/packages/backend/test/public-stats.e2e-spec.ts
+++ b/packages/backend/test/public-stats.e2e-spec.ts
@@ -41,49 +41,42 @@ afterAll(async () => {
   await app.close();
 });
 
-describe('GET /api/v1/public-stats', () => {
-  it('returns total messages and enriched top models without auth', async () => {
+describe('GET /api/v1/public/usage', () => {
+  it('returns total messages and top models without auth', async () => {
     const res = await request(app.getHttpServer())
-      .get('/api/v1/public-stats')
+      .get('/api/v1/public/usage')
       .expect(200);
 
     expect(res.body).toHaveProperty('total_messages');
     expect(res.body.total_messages).toBeGreaterThanOrEqual(3);
     expect(res.body).toHaveProperty('top_models');
     expect(res.body).toHaveProperty('cached_at');
+  });
 
-    const topModels = res.body.top_models;
-    expect(topModels.length).toBeGreaterThan(0);
-    expect(topModels[0]).toHaveProperty('model');
-    expect(topModels[0]).toHaveProperty('provider');
-    expect(topModels[0]).toHaveProperty('tokens_7d');
-    expect(topModels[0]).toHaveProperty('usage_rank');
-    expect(typeof topModels[0].tokens_7d).toBe('number');
+  it('includes expected fields in top models', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/public/usage')
+      .expect(200);
+
+    if (res.body.top_models.length > 0) {
+      const m = res.body.top_models[0];
+      expect(m).toHaveProperty('model');
+      expect(m).toHaveProperty('provider');
+      expect(m).toHaveProperty('tokens_7d');
+      expect(m).toHaveProperty('usage_rank');
+    }
   });
 });
 
-describe('GET /api/v1/public-stats/models', () => {
-  it('returns free model catalog without auth', async () => {
+describe('GET /api/v1/public/free-models', () => {
+  it('returns free models without auth', async () => {
     const res = await request(app.getHttpServer())
-      .get('/api/v1/public-stats/models')
+      .get('/api/v1/public/free-models')
       .expect(200);
 
     expect(res.body).toHaveProperty('models');
     expect(Array.isArray(res.body.models)).toBe(true);
     expect(res.body).toHaveProperty('total_models');
     expect(res.body).toHaveProperty('cached_at');
-  });
-
-  it('includes expected fields in each free model', async () => {
-    const res = await request(app.getHttpServer())
-      .get('/api/v1/public-stats/models')
-      .expect(200);
-
-    if (res.body.models.length > 0) {
-      const model = res.body.models[0];
-      expect(model).toHaveProperty('model_name');
-      expect(model).toHaveProperty('provider');
-      expect(model).toHaveProperty('tokens_7d');
-    }
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #1421. Improves the public stats endpoints:

- **Better URLs**: `/api/v1/public/usage` and `/api/v1/public/free-models`
- **10 items max** per list, sorted by `tokens_7d` descending (most active first)
- **Filters out** custom providers (`custom:*`) and Unknown/OpenRouter providers
- **Free models** only shows models with `tokens_7d > 0` (actually being used)

## Test plan

- [x] 170/170 unit test suites pass
- [x] 14/14 E2E test suites pass
- [x] TypeScript compiles cleanly

Closes #1390

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the public stats API with new public endpoints, stricter filtering, and predictable outputs, addressing #1390. Endpoints are `/api/v1/public/usage` and `/api/v1/public/free-models`; both return up to 10 items sorted by `tokens_7d`, exclude `custom:*` models and `Unknown`/`OpenRouter` providers, and the free models list only includes entries with `tokens_7d > 0`.

<sup>Written for commit 8d384df54c24f243486821621743272e0d6cda44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

