### PR TITLE
fix: short prompts with technical keywords bypass scorer

### DIFF
--- a/.changeset/fix-short-prompt-scoring.md
+++ b/.changeset/fix-short-prompt-scoring.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix short prompts bypassing scorer: technical prompts under 50 chars now run full keyword scoring instead of always routing to simple tier

--- a/packages/backend/src/scoring/__tests__/score-request.spec.ts
+++ b/packages/backend/src/scoring/__tests__/score-request.spec.ts
@@ -118,6 +118,29 @@ describe('scoreRequest — hard overrides', () => {
     expect(result.tier).toBe('simple');
     expect(result.reason).toBe('short_message');
   });
+
+  it('does NOT return short_message for short technical prompts with keywords', () => {
+    const technicalPrompts = [
+      'Implement OAuth PKCE flow in Next.js',
+      'Fix a race condition in a Redis lock',
+      'Debug a flaky Playwright login test',
+      'Write SQL to detect duplicate invoices',
+      'Implement JWT refresh token rotation',
+    ];
+    for (const prompt of technicalPrompts) {
+      const result = scoreRequest({
+        messages: [{ role: 'user', content: prompt }],
+      });
+      expect(result.reason).not.toBe('short_message');
+    }
+  });
+
+  it('routes short technical prompts to standard or higher', () => {
+    const result = scoreRequest({
+      messages: [{ role: 'user', content: 'Implement OAuth PKCE flow in Next.js' }],
+    });
+    expect(result.tier).not.toBe('simple');
+  });
 });
 
 describe('scoreRequest — full pipeline', () => {

--- a/packages/backend/src/scoring/index.ts
+++ b/packages/backend/src/scoring/index.ts
@@ -188,21 +188,15 @@ export function scoreRequest(
   const hasTools = tools && tools.length > 0;
   const hasMomentum = momentum?.recentTiers && momentum.recentTiers.length > 0;
   if (lastUserText.length > 0 && lastUserText.length < 50 && !hasTools) {
-    if (!hasMomentum) {
-      return {
-        tier: 'simple',
-        score: -0.3,
-        confidence: 0.9,
-        reason: 'short_message',
-        dimensions: emptyDimensions(config),
-        momentum: null,
-      };
-    }
-    // With momentum: still bypass if the message matches a simple indicator.
-    // This prevents momentum from pulling clearly simple messages (greetings,
-    // factual questions like "where is Paris?") up to higher tiers.
     const lastMatches = trie.scan(lastUserText);
-    if (lastMatches.some((m) => m.dimension === 'simpleIndicators')) {
+    const hasSimpleIndicator = lastMatches.some((m) => m.dimension === 'simpleIndicators');
+    const hasComplexSignal = lastMatches.some(
+      (m) => m.dimension !== 'simpleIndicators' && m.dimension !== 'relay',
+    );
+
+    // Short message with complex keywords → fall through to full scoring
+    // Short message with NO complex keywords → simple (greetings, factual questions)
+    if (!hasComplexSignal && (!hasMomentum || hasSimpleIndicator)) {
       return {
         tier: 'simple',
         score: -0.3,


### PR DESCRIPTION
## Summary

- Fix the scorer fast-path that blindly returned `tier: simple` for all messages under 50 chars without tools
- Now scans the keyword trie before the fast exit — if technical keywords match (codeGeneration, technicalTerms, codeReview, etc.), the full scoring pipeline runs
- Greetings, factual questions, and acknowledgements still get the fast simple exit

## Before/After

| Prompt | Before | After |
|--------|--------|-------|
| "Implement OAuth PKCE flow in Next.js" | simple | complex |
| "Fix a race condition in a Redis lock" | simple | complex |
| "Debug a flaky Playwright login test" | simple | standard |
| "Write SQL to detect duplicate invoices" | simple | standard |
| "hi" | simple | simple |
| "thanks" | simple | simple |
| "What is the capital of France?" | simple | simple |

Fixes #1172

## Test plan

- [ ] All 214 scoring tests pass (9 suites)
- [ ] New tests verify short technical prompts bypass the fast-path
- [ ] Existing tests for greetings/factual questions still pass unchanged
- [ ] TypeScript compiles cleanly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes (#1172) short‑prompt scoring so technical requests no longer bypass and get `simple`. We now scan the keyword trie first; technical signals trigger the full pipeline, while greetings and factual questions still return `simple`.

- **Bug Fixes**
  - For messages under 50 chars without tools, scan the trie; if non-`simpleIndicators` keywords appear, skip the fast-path and run full scoring.
  - Added tests to cover short technical prompts routing to `standard`/`complex` and to keep greetings/factual questions on `simple`.

<sup>Written for commit 3d9afa25022bc6691b353b45063d14e9b7a2ed96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

