### PR TITLE
fix: keep OpenRouter models in public stats endpoints

### DIFF
--- a/.changeset/keep-openrouter.md
+++ b/.changeset/keep-openrouter.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Keep OpenRouter models in public stats endpoints, only exclude custom and unknown providers

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -118,13 +118,14 @@ describe('PublicStatsService', () => {
       expect(result.top_models).toHaveLength(0);
     });
 
-    it('excludes OpenRouter provider models', async () => {
+    it('includes OpenRouter provider models', async () => {
       setupQueries({ total: '1' }, [{ model: 'openrouter/free', usage_count: '1' }], []);
       mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenRouter' }));
 
       const result = await service.getUsageStats();
 
-      expect(result.top_models).toHaveLength(0);
+      expect(result.top_models).toHaveLength(1);
+      expect(result.top_models[0].provider).toBe('OpenRouter');
     });
 
     it('limits to 10 results', async () => {
@@ -221,7 +222,7 @@ describe('PublicStatsService', () => {
       expect(service.getFreeModels(new Map([['paid', 1000]]))).toEqual([]);
     });
 
-    it('excludes Unknown and OpenRouter providers', () => {
+    it('excludes Unknown provider', () => {
       mockPricingCache.getAll.mockReturnValue([
         makePricingEntry({
           model_name: 'a',
@@ -229,6 +230,13 @@ describe('PublicStatsService', () => {
           input_price_per_token: 0,
           output_price_per_token: 0,
         }),
+      ]);
+
+      expect(service.getFreeModels(new Map([['a', 100]]))).toEqual([]);
+    });
+
+    it('includes OpenRouter provider', () => {
+      mockPricingCache.getAll.mockReturnValue([
         makePricingEntry({
           model_name: 'b',
           provider: 'OpenRouter',
@@ -237,14 +245,9 @@ describe('PublicStatsService', () => {
         }),
       ]);
 
-      expect(
-        service.getFreeModels(
-          new Map([
-            ['a', 100],
-            ['b', 200],
-          ]),
-        ),
-      ).toEqual([]);
+      const result = service.getFreeModels(new Map([['b', 200]]));
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('OpenRouter');
     });
 
     it('excludes custom models', () => {

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -6,7 +6,7 @@ import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.se
 import { computeCutoff } from '../common/utils/sql-dialect';
 
 const MAX_RESULTS = 10;
-const EXCLUDED_PROVIDERS = new Set(['Unknown', 'OpenRouter']);
+const EXCLUDED_PROVIDERS = new Set(['Unknown']);
 
 export interface TopModel {
   model: string;


### PR DESCRIPTION
## Summary

- Stop filtering out OpenRouter provider from public stats endpoints
- Only exclude `custom:*` models and `Unknown` provider
- OpenRouter-attributed free models (nvidia, stepfun, etc.) now appear correctly

## Test plan

- [x] 170/170 unit test suites pass
- [x] 14/14 E2E test suites pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Public stats endpoints now keep OpenRouter models and only exclude `custom:*` and `Unknown` providers. This fixes missing free models attributed via OpenRouter (e.g., NVIDIA, StepFun) in top and free model lists.

- **Bug Fixes**
  - Removed OpenRouter from the excluded providers set in the public stats service.
  - Updated tests to assert inclusion of OpenRouter models in top and free lists.

<sup>Written for commit 3754fcb977fc4a33d850d0a473dff3a4fcb48ac5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

