### PR TITLE
fix: treat null-priced models as unknown cost in tier auto-assignment

### DIFF
--- a/.changeset/fix-null-pricing-tier-assignment.md
+++ b/.changeset/fix-null-pricing-tier-assignment.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: null-priced models no longer treated as free in tier auto-assignment

--- a/packages/backend/src/routing/routing-core/tier-auto-assign.service.ts
+++ b/packages/backend/src/routing/routing-core/tier-auto-assign.service.ts
@@ -26,8 +26,10 @@ function filterSubModels(models: DiscoveredModel[]): DiscoveredModel[] {
   for (const providerModels of byProvider.values()) {
     const zeroCost = providerModels.filter(
       (m) =>
-        (m.inputPricePerToken == null || m.inputPricePerToken === 0) &&
-        (m.outputPricePerToken == null || m.outputPricePerToken === 0),
+        m.inputPricePerToken != null &&
+        m.outputPricePerToken != null &&
+        m.inputPricePerToken === 0 &&
+        m.outputPricePerToken === 0,
     );
     // If zero-cost models exist (e.g. OpenAI Codex), use only those
     result.push(...(zeroCost.length > 0 ? zeroCost : providerModels));
@@ -107,16 +109,17 @@ export class TierAutoAssignService {
   pickBest(models: DiscoveredModel[], tier: Tier): ScoredModel | null {
     if (models.length === 0) return null;
 
-    const totalPrice = (m: DiscoveredModel) =>
-      (m.inputPricePerToken != null ? Number(m.inputPricePerToken) : 0) +
-      (m.outputPricePerToken != null ? Number(m.outputPricePerToken) : 0);
+    const totalPrice = (m: DiscoveredModel) => {
+      if (m.inputPricePerToken == null || m.outputPricePerToken == null) return Infinity;
+      return Number(m.inputPricePerToken) + Number(m.outputPricePerToken);
+    };
 
     const quality = (m: DiscoveredModel) => m.qualityScore ?? 3;
 
     // Sort by price ascending (cheapest first, including free local models)
     const byPrice = [...models].sort((a, b) => totalPrice(a) - totalPrice(b));
 
-    let picked: DiscoveredModel;
+    let picked: DiscoveredModel = byPrice[0];
 
     switch (tier) {
       case 'simple': {

--- a/packages/backend/src/routing/tier-auto-assign.service.spec.ts
+++ b/packages/backend/src/routing/tier-auto-assign.service.spec.ts
@@ -334,7 +334,7 @@ describe('TierAutoAssignService', () => {
       expect(result!.score).toBe(3);
     });
 
-    it('should handle null inputPricePerToken as 0', () => {
+    it('should deprioritize null inputPricePerToken (unknown cost)', () => {
       const nullInput = makeModel({
         id: 'null-input',
         inputPricePerToken: null,
@@ -348,11 +348,11 @@ describe('TierAutoAssignService', () => {
         qualityScore: 3,
       });
 
-      // null input treated as 0 makes null-input cheaper
-      expect(service.pickBest([nullInput, priced], 'simple')!.model_name).toBe('null-input');
+      // null pricing = unknown cost, priced model wins cheapest-first
+      expect(service.pickBest([nullInput, priced], 'simple')!.model_name).toBe('priced');
     });
 
-    it('should handle null outputPricePerToken as 0', () => {
+    it('should deprioritize null outputPricePerToken (unknown cost)', () => {
       const nullOutput = makeModel({
         id: 'null-output',
         inputPricePerToken: 0.000001,
@@ -366,8 +366,37 @@ describe('TierAutoAssignService', () => {
         qualityScore: 3,
       });
 
-      // null output treated as 0 makes null-output cheaper
-      expect(service.pickBest([nullOutput, priced], 'simple')!.model_name).toBe('null-output');
+      // null pricing = unknown cost, priced model wins cheapest-first
+      expect(service.pickBest([nullOutput, priced], 'simple')!.model_name).toBe('priced');
+    });
+
+    it('should still pick null-priced model when it is the only option', () => {
+      const nullPriced = makeModel({
+        id: 'null-priced',
+        inputPricePerToken: null,
+        outputPricePerToken: null,
+        qualityScore: 3,
+      });
+
+      expect(service.pickBest([nullPriced], 'simple')!.model_name).toBe('null-priced');
+    });
+
+    it('should prefer priced model over null-priced for simple tier', () => {
+      const gemma = makeModel({
+        id: 'gemma-3-1b',
+        inputPricePerToken: null,
+        outputPricePerToken: null,
+        qualityScore: 2,
+      });
+      const flash = makeModel({
+        id: 'gemini-2.0-flash',
+        inputPricePerToken: 0.0000001,
+        outputPricePerToken: 0.0000004,
+        qualityScore: 2,
+        capabilityCode: true,
+      });
+
+      expect(service.pickBest([gemma, flash], 'simple')!.model_name).toBe('gemini-2.0-flash');
     });
   });
 
@@ -706,6 +735,39 @@ describe('TierAutoAssignService', () => {
       for (const record of inserted) {
         expect(record.auto_assigned_model).toBe('gpt-5.3-codex');
       }
+    });
+
+    it('should not treat null-priced subscription models as zero-cost', async () => {
+      const nullPricedModel = makeModel({
+        id: 'gemma-3-1b',
+        provider: 'Google',
+        inputPricePerToken: null,
+        outputPricePerToken: null,
+        qualityScore: 2,
+        authType: 'subscription',
+      });
+      const paidModel = makeModel({
+        id: 'gemini-2.5-flash',
+        provider: 'Google',
+        inputPricePerToken: 0.0000003,
+        outputPricePerToken: 0.0000025,
+        qualityScore: 2,
+        capabilityCode: true,
+        authType: 'subscription',
+      });
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([nullPricedModel, paidModel]);
+      mockTierRepo.find.mockResolvedValue([]);
+
+      await service.recalculate('agent-1');
+
+      expect(mockTierRepo.insert).toHaveBeenCalledTimes(1);
+      const inserted = mockTierRepo.insert.mock.calls[0][0] as {
+        tier: string;
+        auto_assigned_model: string;
+      }[];
+      // Simple tier should pick gemini-2.5-flash (known price), not gemma-3-1b (null price)
+      const simpleTier = inserted.find((t) => t.tier === 'simple');
+      expect(simpleTier!.auto_assigned_model).toBe('gemini-2.5-flash');
     });
 
     it('should keep all models for providers without zero-cost models (Anthropic)', async () => {


### PR DESCRIPTION
## Summary

- Models with null pricing (e.g. Gemma 3 1B from Gemini API) were treated as $0 (free) in `pickBest()`, causing them to be auto-assigned as "recommended" for the Simple tier
- Fixed `totalPrice` to return `Infinity` for null-priced models so they sort after priced alternatives
- Fixed `filterSubModels` to require explicit zero pricing (not null) when classifying subscription models as zero-cost

## Test plan

- [x] Updated existing null-pricing tests to verify new behavior (deprioritize instead of favor)
- [x] Added test: null-priced model still selectable when it's the only option
- [x] Added test: priced model wins over null-priced for simple tier
- [x] Added test: null-priced subscription models not treated as zero-cost
- [x] All 3304 backend unit tests pass
- [x] TypeScript compiles with no errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tier auto-assignment to treat null-priced models as unknown cost so they no longer get picked as the cheapest; priced models are now preferred for the Simple tier (e.g., Gemini/Gemma models).

- **Bug Fixes**
  - `totalPrice` now returns Infinity when input or output price is null, pushing unknown-cost models after priced ones.
  - `filterSubModels` only classifies explicit `0`/`0` pricing as zero-cost; `null` is not treated as free.
  - Tests added to verify deprioritization, single-option selection, and subscription models with null prices not counted as free.

<sup>Written for commit 4ce1b73e89c107cd7ae44bb51bc09f20dd795a6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

