### PR TITLE
fix: harden pricing enrichment and OpenRouter parser

### DIFF
--- a/.changeset/fix-pricing-enrichment-robustness.md
+++ b/.changeset/fix-pricing-enrichment-robustness.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: check both input and output prices before skipping enrichment, filter negative OpenRouter prices

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1985,6 +1985,31 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].outputPricePerToken).toBe(0.01);
     });
 
+    it('should trigger pricing enrichment when inputPricePerToken is set but outputPricePerToken is null', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'partial-price',
+        name: 'Partial Price',
+        inputPricePerToken: 0.005,
+        outputPricePerToken: 0.01,
+        contextWindow: 64000,
+      });
+
+      const models = [
+        makeModel({
+          id: 'partial-price',
+          inputPricePerToken: 0.001,
+          outputPricePerToken: null,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      // Output is null so enrichment should run — both prices come from models.dev
+      expect(result[0].inputPricePerToken).toBe(0.005);
+      expect(result[0].outputPricePerToken).toBe(0.01);
+    });
+
     it('should skip pricing enrichment but apply capabilities for price=0 models', async () => {
       mockModelsDevSync.lookupModel.mockReturnValue({
         id: 'zero-price',

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -263,9 +263,14 @@ export class ModelDiscoveryService {
   }
 
   private enrichModel(model: DiscoveredModel, providerId: string): DiscoveredModel {
-    // Skip pricing enrichment when pricing is already set (price=0 for free/subscription)
+    // Skip pricing enrichment when both prices are already set (price=0 for free/subscription)
     // but still apply capability flags from models.dev for better scoring
-    if (model.inputPricePerToken !== null && model.inputPricePerToken >= 0) {
+    if (
+      model.inputPricePerToken !== null &&
+      model.inputPricePerToken >= 0 &&
+      model.outputPricePerToken !== null &&
+      model.outputPricePerToken >= 0
+    ) {
       return this.computeScore(this.applyCapabilities(model, providerId));
     }
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -863,6 +863,24 @@ describe('ProviderModelFetcherService', () => {
       expect(result[0].outputPricePerToken).toBeNull();
     });
 
+    it('should treat negative pricing as null', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 'neg-pricing',
+              pricing: { prompt: '-0.001', completion: '-0.002' },
+            },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('openrouter', '');
+      expect(result[0].inputPricePerToken).toBeNull();
+      expect(result[0].outputPricePerToken).toBeNull();
+    });
+
     it('should use id as displayName when name is missing', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -263,8 +263,10 @@ function parseOpenRouter(body: unknown, provider: string): DiscoveredModel[] {
         displayName: entry.name || entry.id,
         provider,
         contextWindow: entry.context_length ?? 128000,
-        inputPricePerToken: prompt !== null && Number.isFinite(prompt) ? prompt : null,
-        outputPricePerToken: completion !== null && Number.isFinite(completion) ? completion : null,
+        inputPricePerToken:
+          prompt !== null && Number.isFinite(prompt) && prompt >= 0 ? prompt : null,
+        outputPricePerToken:
+          completion !== null && Number.isFinite(completion) && completion >= 0 ? completion : null,
         capabilityReasoning: false,
         capabilityCode: false,
         qualityScore: 3,


### PR DESCRIPTION
## Summary

- `enrichModel` now checks **both** `inputPricePerToken` and `outputPricePerToken` before skipping enrichment. Previously only input was checked, so a model with `input=0` but `output=null` would skip enrichment and keep the null output price.
- `parseOpenRouter` now filters negative prices (treats them as null), matching the existing guard in `PricingSyncService.refreshCache()`.

## Test plan

- [x] Added test: enrichment triggers when input is set but output is null
- [x] Added test: negative OpenRouter pricing treated as null
- [x] All 3306 backend unit tests pass
- [x] TypeScript compiles with no errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens pricing enrichment and the OpenRouter parser to prevent null output prices and ignore negative pricing values.

- **Bug Fixes**
  - `ModelDiscoveryService.enrichModel` now skips enrichment only when both `inputPricePerToken` and `outputPricePerToken` are set and non-negative.
  - `parseOpenRouter` treats negative `prompt`/`completion` prices as null, aligning with `PricingSyncService.refreshCache()`.

<sup>Written for commit 6eb597600d9e9e9d92bf526f6786247578519bf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

