### PR TITLE
fix: resolve missing model prices for 22 models across 4 providers

### DIFF
--- a/.changeset/fix-missing-model-prices.md
+++ b/.changeset/fix-missing-model-prices.md
@@ -1,0 +1,11 @@
+---
+"manifest": patch
+---
+
+Fix missing model prices for 22 models across Mistral, Moonshot, Gemini, and OpenAI providers
+
+- Filter non-chat models from discovery: gemini-robotics, gpt-5-search-api, mistral-vibe-cli
+- Add -latest suffix stripping to pricing lookups in both models.dev and OpenRouter paths
+- Add legacy Mistral name aliases: open-mistral-nemo to mistral-nemo, mistral-tiny to open-mistral-7b
+- Add OpenRouter name aliases for provider API mismatches (voxtral-small to voxtral-small-24b)
+- Add hardcoded fallback prices for moonshot-v1-* legacy models, gemma-3-1b-it, and gemini-pro-latest

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -95,6 +95,27 @@ const MOCK_API_RESPONSE = {
         limit: { context: 128000 },
         modalities: { input: ['text'], output: ['text'] },
       },
+      'mistral-nemo': {
+        id: 'mistral-nemo',
+        name: 'Mistral Nemo',
+        cost: { input: 0.15, output: 0.15 },
+        limit: { context: 128000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'open-mistral-7b': {
+        id: 'open-mistral-7b',
+        name: 'Mistral 7B',
+        cost: { input: 0.25, output: 0.25 },
+        limit: { context: 32000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      'devstral-2512': {
+        id: 'devstral-2512',
+        name: 'Devstral',
+        cost: { input: 0.4, output: 2.0 },
+        limit: { context: 256000 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
     },
   },
   xai: {
@@ -161,8 +182,8 @@ describe('ModelsDevSyncService', () => {
         'https://models.dev/api.json',
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
-      // anthropic: 2, google: 1 (audio excluded), openai: 1, deepseek: 1, mistral: 3, xai: 3 = 11
-      expect(count).toBe(11);
+      // anthropic: 2, google: 1 (audio excluded), openai: 1, deepseek: 1, mistral: 6, xai: 3 = 14
+      expect(count).toBe(14);
     });
 
     it('should filter out non-text-output models', async () => {
@@ -346,6 +367,46 @@ describe('ModelsDevSyncService', () => {
       expect(model).not.toBeNull();
       expect(model!.name).toBe('Grok 4');
       expect(model!.inputPricePerToken).toBe(3.0 / 1_000_000);
+    });
+
+    it('should strip -latest and find dated variant (devstral-latest → devstral-2512)', () => {
+      const model = service.lookupModel('mistral', 'devstral-latest');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Devstral');
+      expect(model!.inputPricePerToken).toBe(0.4 / 1_000_000);
+    });
+
+    it('should strip -latest and find base name when no dated variant exists', () => {
+      // mistral-nemo has no -latest sibling but base name matches
+      // This tests the baseMatch path in step 10
+      const model = service.lookupModel('mistral', 'mistral-nemo-latest');
+      // models.dev has mistral-nemo as a key (step 10 base match)
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral Nemo');
+    });
+
+    it('should resolve legacy alias open-mistral-nemo → mistral-nemo', () => {
+      const model = service.lookupModel('mistral', 'open-mistral-nemo');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral Nemo');
+    });
+
+    it('should resolve legacy alias open-mistral-nemo-2407 → mistral-nemo', () => {
+      const model = service.lookupModel('mistral', 'open-mistral-nemo-2407');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral Nemo');
+    });
+
+    it('should resolve legacy alias mistral-tiny-2407 → open-mistral-7b', () => {
+      const model = service.lookupModel('mistral', 'mistral-tiny-2407');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral 7B');
+    });
+
+    it('should resolve legacy alias mistral-tiny-latest → open-mistral-7b', () => {
+      const model = service.lookupModel('mistral', 'mistral-tiny-latest');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('Mistral 7B');
     });
   });
 

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -79,6 +79,15 @@ const LATEST_SUFFIX = '-latest';
 const GOOGLE_VARIANT_RE = /-(?:preview(?:-\d{2,4}){1,3}|exp-\d{4}|latest)$/;
 /** xAI reasoning/non-reasoning mode suffixes. */
 const REASONING_SUFFIX_RE = /-(reasoning|non-reasoning)$/;
+/**
+ * Legacy model names that providers still return in their native API
+ * but which are listed under a different canonical name in pricing databases.
+ * Maps legacy base name (without dated suffix) → canonical name.
+ */
+const LEGACY_NAME_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['open-mistral-nemo', 'mistral-nemo'], // Mistral renamed open-mistral-nemo → mistral-nemo
+  ['mistral-tiny', 'open-mistral-7b'], // mistral-tiny was the internal codename for Mistral 7B
+]);
 
 @Injectable()
 export class ModelsDevSyncService implements OnModuleInit {
@@ -148,6 +157,21 @@ export class ModelsDevSyncService implements OnModuleInit {
     const exact = providerModels.get(modelId);
     if (exact) return exact;
 
+    // 1b. Legacy name alias (e.g., open-mistral-nemo → mistral-nemo)
+    //     Strip date, short-date, and -latest suffixes to find the base name for alias lookup.
+    const aliasBase = modelId
+      .replace(DATE_SUFFIX_RE, '')
+      .replace(SHORT_DATE_SUFFIX_RE, '')
+      .replace(/-latest$/, '');
+    const aliasTarget =
+      LEGACY_NAME_ALIASES.get(aliasBase) ??
+      LEGACY_NAME_ALIASES.get(modelId) ??
+      LEGACY_NAME_ALIASES.get(modelId.replace(/-latest$/, ''));
+    if (aliasTarget) {
+      const found = providerModels.get(aliasTarget);
+      if (found) return found;
+    }
+
     // 2. Strip 3-digit version suffix (e.g., gemini-2.0-flash-001 → gemini-2.0-flash)
     const noVersion = modelId.replace(VERSION_SUFFIX_RE, '');
     if (noVersion !== modelId) {
@@ -199,6 +223,20 @@ export class ModelsDevSyncService implements OnModuleInit {
         const withLatest = providerModels.get(noShortDate + LATEST_SUFFIX);
         if (withLatest) return withLatest;
       }
+    }
+
+    // 10. Strip -latest and search for any dated variant of the base name
+    //     (e.g. devstral-latest → devstral-2512, ministral-14b-latest → ministral-14b-2512)
+    if (modelId.endsWith(LATEST_SUFFIX)) {
+      const base = modelId.slice(0, -LATEST_SUFFIX.length);
+      const prefix = `${base}-`;
+      for (const [key, entry] of providerModels) {
+        if (key.startsWith(prefix) && key !== modelId) return entry;
+      }
+      // Also try exact base name (e.g. gemini-pro-latest → gemini-pro is unlikely
+      // but handles edge cases where models.dev stores the bare name)
+      const baseMatch = providerModels.get(base);
+      if (baseMatch) return baseMatch;
     }
 
     return null;

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -96,10 +96,10 @@ describe('filterNonChatModels', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('keeps search models for openai', () => {
+    it('filters search-api models for openai', () => {
       const models = [makeModel('gpt-5-search-api'), makeModel('gpt-4o-search-preview')];
       const result = filterNonChatModels(models, 'openai');
-      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(['gpt-4o-search-preview']);
     });
   });
 
@@ -182,14 +182,17 @@ describe('filterNonChatModels', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('keeps gemini-image and gemini-robotics models', () => {
+    it('keeps gemini-image models but filters robotics models', () => {
       const models = [
         makeModel('gemini-2.5-flash-image'),
         makeModel('gemini-3-pro-image-preview'),
         makeModel('gemini-robotics-er-1.5-preview'),
       ];
       const result = filterNonChatModels(models, 'gemini');
-      expect(result).toHaveLength(3);
+      expect(result.map((m) => m.id)).toEqual([
+        'gemini-2.5-flash-image',
+        'gemini-3-pro-image-preview',
+      ]);
     });
   });
 
@@ -233,10 +236,15 @@ describe('filterNonChatModels', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('keeps mistral-vibe-cli models', () => {
-      const models = [makeModel('mistral-vibe-cli-latest'), makeModel('mistral-vibe-cli-fast')];
+    it('filters mistral-vibe-cli models', () => {
+      const models = [
+        makeModel('mistral-vibe-cli-latest'),
+        makeModel('mistral-vibe-cli-fast'),
+        makeModel('mistral-vibe-cli-with-tools'),
+        makeModel('mistral-large-latest'),
+      ];
       const result = filterNonChatModels(models, 'mistral');
-      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(['mistral-large-latest']);
     });
 
     it('filters labs-prefixed models', () => {

--- a/packages/backend/src/model-discovery/known-model-prices.spec.ts
+++ b/packages/backend/src/model-discovery/known-model-prices.spec.ts
@@ -1,0 +1,52 @@
+import { lookupKnownPrice } from './known-model-prices';
+
+describe('lookupKnownPrice', () => {
+  it('should return pricing for moonshot-v1-8k', () => {
+    const result = lookupKnownPrice('moonshot-v1-8k');
+    expect(result).not.toBeNull();
+    expect(result!.input).toBeCloseTo(1.66 / 1_000_000, 12);
+    expect(result!.output).toBeCloseTo(1.66 / 1_000_000, 12);
+  });
+
+  it('should return pricing for moonshot-v1-32k', () => {
+    const result = lookupKnownPrice('moonshot-v1-32k');
+    expect(result).not.toBeNull();
+  });
+
+  it('should return pricing for moonshot-v1-128k', () => {
+    const result = lookupKnownPrice('moonshot-v1-128k');
+    expect(result).not.toBeNull();
+  });
+
+  it('should return pricing for moonshot-v1-128k-vision-preview', () => {
+    const result = lookupKnownPrice('moonshot-v1-128k-vision-preview');
+    expect(result).not.toBeNull();
+  });
+
+  it('should return pricing for moonshot-v1-auto', () => {
+    const result = lookupKnownPrice('moonshot-v1-auto');
+    expect(result).not.toBeNull();
+  });
+
+  it('should return zero pricing for gemma-3-1b-it', () => {
+    const result = lookupKnownPrice('gemma-3-1b-it');
+    expect(result).not.toBeNull();
+    expect(result!.input).toBe(0);
+    expect(result!.output).toBe(0);
+  });
+
+  it('should return pricing for gemini-pro-latest', () => {
+    const result = lookupKnownPrice('gemini-pro-latest');
+    expect(result).not.toBeNull();
+    expect(result!.input).toBeCloseTo(1.25 / 1_000_000, 12);
+    expect(result!.output).toBeCloseTo(10.0 / 1_000_000, 12);
+  });
+
+  it('should return null for unknown model', () => {
+    expect(lookupKnownPrice('gpt-4o')).toBeNull();
+  });
+
+  it('should return null for partial prefix mismatch', () => {
+    expect(lookupKnownPrice('moonshot-v2-8k')).toBeNull();
+  });
+});

--- a/packages/backend/src/model-discovery/known-model-prices.ts
+++ b/packages/backend/src/model-discovery/known-model-prices.ts
@@ -1,0 +1,38 @@
+/**
+ * Last-resort hardcoded pricing for models that no external pricing source covers.
+ *
+ * This is used ONLY when both models.dev and OpenRouter have no data for a model.
+ * Keep this list minimal — prefer upstream sources. Prices are per-token (not per-million).
+ *
+ * Sources:
+ *  - Moonshot v1: https://platform.moonshot.cn/docs/pricing (¥12/1M ≈ $1.66/1M at 2025 rates)
+ *  - gemma-3-1b-it: Free on Google AI Studio
+ */
+
+interface KnownPrice {
+  input: number;
+  output: number;
+}
+
+const PER_MILLION = 1_000_000;
+
+/**
+ * Map of model ID prefixes → per-token pricing.
+ * Prefix matching allows one entry to cover multiple context-window variants
+ * (e.g. "moonshot-v1-" covers moonshot-v1-8k, moonshot-v1-32k, moonshot-v1-128k).
+ */
+const KNOWN_PRICES: ReadonlyArray<{ prefix: string; price: KnownPrice }> = [
+  { prefix: 'moonshot-v1-', price: { input: 1.66 / PER_MILLION, output: 1.66 / PER_MILLION } },
+  { prefix: 'gemma-3-1b-it', price: { input: 0, output: 0 } },
+  // gemini-pro-latest is Google's alias for the current Gemini Pro (2.5 Pro)
+  { prefix: 'gemini-pro-latest', price: { input: 1.25 / PER_MILLION, output: 10.0 / PER_MILLION } },
+];
+
+export function lookupKnownPrice(modelId: string): KnownPrice | null {
+  for (const entry of KNOWN_PRICES) {
+    if (modelId.startsWith(entry.prefix) || modelId === entry.prefix) {
+      return entry.price;
+    }
+  }
+  return null;
+}

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -2015,6 +2015,44 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].capabilityReasoning).toBe(true);
       expect(result[0].capabilityCode).toBe(true);
     });
+
+    it('should fall back to known-model-prices when models.dev and OpenRouter have no data', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue(null);
+      mockPricingSync.lookupPricing.mockReturnValue(null);
+
+      const models = [
+        makeModel({
+          id: 'moonshot-v1-128k',
+          inputPricePerToken: null,
+          outputPricePerToken: null,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+      expect(result[0].outputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+    });
+
+    it('should return model without pricing when no source has data', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue(null);
+      mockPricingSync.lookupPricing.mockReturnValue(null);
+
+      const models = [
+        makeModel({
+          id: 'totally-unknown-model',
+          inputPricePerToken: null,
+          outputPricePerToken: null,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputPricePerToken).toBeNull();
+      expect(result[0].outputPricePerToken).toBeNull();
+    });
   });
 
   /* ── models.dev fallback in discoverModels ── */

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -22,6 +22,7 @@ import {
   buildSubscriptionFallbackModels,
   supplementWithKnownModels,
 } from './model-fallback';
+import { lookupKnownPrice } from './known-model-prices';
 // Import static helpers directly to avoid circular dependency with RoutingModule
 const customProviderKey = (id: string) => `custom:${id}`;
 const customModelKey = (id: string, modelName: string) => `custom:${id}/${modelName}`;
@@ -310,6 +311,16 @@ export class ModelDiscoveryService {
           displayName: exactPricing.displayName || model.displayName,
         });
       }
+    }
+
+    // Priority 3: hardcoded known prices — last resort for models no external source covers
+    const known = lookupKnownPrice(model.id);
+    if (known) {
+      return this.computeScore({
+        ...model,
+        inputPricePerToken: known.input,
+        outputPricePerToken: known.output,
+      });
     }
 
     return this.computeScore(model);

--- a/packages/backend/src/model-discovery/model-fallback.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.spec.ts
@@ -474,6 +474,56 @@ describe('buildModelsDevFallback', () => {
   });
 });
 
+describe('lookupWithVariants OpenRouter name aliases', () => {
+  it('should resolve voxtral-small-2507 to voxtral-small-24b-2507', () => {
+    const cache = new Map([
+      ['mistralai/voxtral-small-24b-2507', { input: 0.0000001, output: 0.0000003 }],
+    ]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'mistralai', 'voxtral-small-2507');
+
+    expect(result).toEqual({ input: 0.0000001, output: 0.0000003 });
+  });
+
+  it('should resolve voxtral-small-latest via alias then -latest stripping', () => {
+    const cache = new Map([
+      ['mistralai/voxtral-small-24b-2507', { input: 0.0000001, output: 0.0000003 }],
+    ]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'mistralai', 'voxtral-small-latest');
+
+    expect(result).toEqual({ input: 0.0000001, output: 0.0000003 });
+  });
+
+  it('should resolve open-mistral-nemo to mistral-nemo via alias', () => {
+    const cache = new Map([['mistralai/mistral-nemo', { input: 0.00000015, output: 0.00000015 }]]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'mistralai', 'open-mistral-nemo');
+
+    expect(result).toEqual({ input: 0.00000015, output: 0.00000015 });
+  });
+});
+
+describe('lookupWithVariants -latest stripping', () => {
+  it('should strip -latest and find dated variant in cache', () => {
+    const cache = new Map([
+      ['mistralai/ministral-14b-2512', { input: 0.0000002, output: 0.0000002 }],
+    ]);
+
+    const result = lookupWithVariants(makePricingSync(cache), 'mistralai', 'ministral-14b-latest');
+
+    expect(result).toEqual({ input: 0.0000002, output: 0.0000002 });
+  });
+
+  it('should not strip -latest when model does not end with it', () => {
+    const cache = new Map<string, { input: number; output: number }>();
+
+    const result = lookupWithVariants(makePricingSync(cache), 'mistralai', 'mistral-medium-2508');
+
+    expect(result).toBeNull();
+  });
+});
+
 describe('lookupWithVariants edge cases', () => {
   it('should not double-apply dot variant when model already uses dots', () => {
     const cache = new Map([['openai/gpt-4.1', { input: 0.01, output: 0.02 }]]);

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -49,6 +49,16 @@ export function findOpenRouterPrefix(providerId: string): string | null {
 }
 
 /**
+ * Provider-native model names that differ from OpenRouter naming.
+ * Maps the name fragment from the provider API → the OpenRouter equivalent.
+ */
+const OPENROUTER_NAME_ALIASES: ReadonlyMap<string, string> = new Map([
+  ['voxtral-small', 'voxtral-small-24b'], // Mistral API omits the 24b size indicator
+  ['open-mistral-nemo', 'mistral-nemo'], // Mistral renamed open-mistral-nemo → mistral-nemo
+  ['mistral-tiny', 'open-mistral-7b'], // mistral-tiny was internal codename for Mistral 7B
+]);
+
+/**
  * Look up pricing with name normalization variants.
  * Providers use different conventions: Anthropic uses dashes (claude-sonnet-4-6),
  * OpenRouter uses dots (claude-sonnet-4.6). Try both.
@@ -60,6 +70,15 @@ export function lookupWithVariants(
 ): { input: number; output: number; contextWindow?: number; displayName?: string } | null {
   const exact = pricingSync.lookupPricing(`${prefix}/${modelId}`);
   if (exact) return exact;
+
+  // Try OpenRouter name aliases (e.g., voxtral-small-2507 → voxtral-small-24b-2507)
+  for (const [from, to] of OPENROUTER_NAME_ALIASES) {
+    if (modelId.includes(from)) {
+      const aliased = modelId.replace(from, to);
+      const aliasResult = pricingSync.lookupPricing(`${prefix}/${aliased}`);
+      if (aliasResult) return aliasResult;
+    }
+  }
 
   const dotVariant = modelId.replace(/-(\d+)-(\d)/g, '-$1.$2');
   if (dotVariant !== modelId) {
@@ -94,6 +113,19 @@ export function lookupWithVariants(
   if (noGoogleVariant !== modelId) {
     const result = pricingSync.lookupPricing(`${prefix}/${noGoogleVariant}`);
     if (result) return result;
+  }
+
+  // Strip -latest and search for dated variants in the cache
+  // (e.g. ministral-14b-latest → mistralai/ministral-14b-2512)
+  if (modelId.endsWith('-latest')) {
+    const base = modelId.slice(0, -'-latest'.length);
+    const scanPrefix = `${prefix}/${base}-`;
+    for (const [key] of pricingSync.getAll()) {
+      if (key.startsWith(scanPrefix)) {
+        const found = pricingSync.lookupPricing(key);
+        if (found) return found;
+      }
+    }
   }
 
   return null;

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -108,12 +108,13 @@ export const UNIVERSAL_NON_CHAT_RE =
  */
 export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
   openai:
-    /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio|^chatgpt-image)/i,
+    /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio|^chatgpt-image|search-api)/i,
   'openai-subscription':
     /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|audio|^chatgpt-image)/i,
   gemini:
-    /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview)/i,
-  mistral: /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime)|^labs-)/i,
+    /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview|robotics)/i,
+  mistral:
+    /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime)|^labs-|^mistral-vibe-cli)/i,
   xai: /(?:imagine|multi-agent)/i,
 };
 


### PR DESCRIPTION
## Summary

- Fixes model pricing coverage from 82% (99/121) to **100% (116/116)** across all 9 providers
- Addresses 4 categories of pricing lookup failures in the discovery pipeline
- Filters 5 non-chat models that shouldn't appear in routing (robotics, search-api, vibe-cli)

## Changes

**Filter non-chat models** (`provider-model-fetcher.service.ts`):
- `gpt-5-search-api` (OpenAI) — search-only endpoint, not chat completions
- `gemini-robotics-er-1.5-preview` (Gemini) — robotics model, not text chat
- `mistral-vibe-cli-*` (Mistral) — CLI-specific models with no published pricing

**Add `-latest` suffix stripping** (`models-dev-sync.service.ts`, `model-fallback.ts`):
- Resolves `devstral-latest` → `devstral-2512`, `ministral-14b-latest` → `ministral-14b-2512`
- Scans both models.dev and OpenRouter caches for dated variants when a `-latest` alias has no direct match

**Add legacy Mistral name aliases** (`models-dev-sync.service.ts`, `model-fallback.ts`):
- `open-mistral-nemo` → `mistral-nemo` (Mistral renamed this model)
- `mistral-tiny` → `open-mistral-7b` (internal codename for Mistral 7B)
- `voxtral-small` → `voxtral-small-24b` (Mistral API omits size indicator that OpenRouter includes)

**Add hardcoded fallback prices** (`known-model-prices.ts`):
- `moonshot-v1-*` (7 models) — legacy Moonshot models with Chinese-only pricing docs (~$1.66/1M tokens)
- `gemma-3-1b-it` — free model on Google AI Studio
- `gemini-pro-latest` — Google alias for current Gemini Pro (same pricing as gemini-2.5-pro)

## Test plan

- [x] All 3324 backend unit tests pass
- [x] TypeScript compiles with no errors
- [x] Verified 100% pricing coverage with live API keys for all 9 providers (116/116 models priced)
- [x] 5 non-chat models correctly filtered from discovery results

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing prices for 22 models across Mistral, Moonshot, Gemini, and OpenAI, and filters non-chat endpoints from discovery. Pricing coverage is now 100% (116/116) and routing only includes chat-capable models.

- **Bug Fixes**
  - Filtered non-chat models: `gemini-robotics-*`, `gpt-5-search-api`, `mistral-vibe-cli-*`.
  - Added `-latest` suffix handling for models.dev and OpenRouter lookups; scans for dated variants.
  - Added Mistral aliases: `open-mistral-nemo` → `mistral-nemo`, `mistral-tiny` → `open-mistral-7b`; OpenRouter alias `voxtral-small` → `voxtral-small-24b`.
  - Added fallback prices for `moonshot-v1-*`, `gemma-3-1b-it` (free), and `gemini-pro-latest`.
  - Discovery uses known prices only when upstream sources return no data.

<sup>Written for commit a07b9247e2baf8166eb31d3ded6b4aa3b08e8fb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

