### PR TITLE
fix: OWASP security hardening across backend

### DIFF
--- a/.changeset/security-hardening-owasp.md
+++ b/.changeset/security-hardening-owasp.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: OWASP security hardening - timing-safe legacy hash, email DTO validation, nonce CSP, SSRF bypass tightening, error sanitization

--- a/packages/backend/src/common/utils/hash.util.spec.ts
+++ b/packages/backend/src/common/utils/hash.util.spec.ts
@@ -37,6 +37,16 @@ describe('verifyKey', () => {
     expect(verifyKey('test', 'abcd:0011')).toBe(false);
   });
 
+  it('returns false for legacy hash with trailing junk', () => {
+    // 64 hex chars + extra characters should be rejected
+    const validHex = 'a'.repeat(64);
+    expect(verifyKey('test', validHex + 'JUNK')).toBe(false);
+  });
+
+  it('returns false for legacy hash with non-hex characters', () => {
+    expect(verifyKey('test', 'g'.repeat(64))).toBe(false);
+  });
+
   it('verifies legacy format (64-char hex without colon)', () => {
     // Legacy format: scrypt with static salt 'manifest-api-key-salt'
     // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/packages/backend/src/common/utils/hash.util.ts
+++ b/packages/backend/src/common/utils/hash.util.ts
@@ -27,9 +27,10 @@ export function verifyKey(input: string, storedHash: string): boolean {
     const actual = scryptSync(input, salt, KEY_LENGTH);
     return expected.length === KEY_LENGTH && timingSafeEqual(actual, expected);
   }
-  // Legacy: static salt, 64-char hex hash
-  const legacyHash = scryptSync(input, LEGACY_SALT, KEY_LENGTH).toString('hex');
-  return legacyHash === storedHash;
+  // Legacy: static salt, 64-char hex hash — use timing-safe comparison
+  const legacyHashBuf = scryptSync(input, LEGACY_SALT, KEY_LENGTH);
+  const storedBuf = Buffer.from(storedHash, 'hex');
+  return storedBuf.length === KEY_LENGTH && timingSafeEqual(legacyHashBuf, storedBuf);
 }
 
 export function keyPrefix(key: string): string {

--- a/packages/backend/src/common/utils/hash.util.ts
+++ b/packages/backend/src/common/utils/hash.util.ts
@@ -28,9 +28,10 @@ export function verifyKey(input: string, storedHash: string): boolean {
     return expected.length === KEY_LENGTH && timingSafeEqual(actual, expected);
   }
   // Legacy: static salt, 64-char hex hash — use timing-safe comparison
+  if (!/^[0-9a-fA-F]{64}$/.test(storedHash)) return false;
   const legacyHashBuf = scryptSync(input, LEGACY_SALT, KEY_LENGTH);
   const storedBuf = Buffer.from(storedHash, 'hex');
-  return storedBuf.length === KEY_LENGTH && timingSafeEqual(legacyHashBuf, storedBuf);
+  return timingSafeEqual(legacyHashBuf, storedBuf);
 }
 
 export function keyPrefix(key: string): string {

--- a/packages/backend/src/common/utils/url-validation.spec.ts
+++ b/packages/backend/src/common/utils/url-validation.spec.ts
@@ -146,6 +146,13 @@ describe('validatePublicUrl', () => {
     await expect(validatePublicUrl('http://127.0.0.1:8080')).resolves.toBeUndefined();
   });
 
+  it('enforces validation in test mode when SKIP_SSRF_VALIDATION=false', async () => {
+    process.env['NODE_ENV'] = 'test';
+    process.env['SKIP_SSRF_VALIDATION'] = 'false';
+    await expect(validatePublicUrl('http://127.0.0.1:8080')).rejects.toThrow('private or internal');
+    delete process.env['SKIP_SSRF_VALIDATION'];
+  });
+
   it('allows private IPs in local mode', async () => {
     process.env['MANIFEST_MODE'] = 'local';
     await expect(validatePublicUrl('http://127.0.0.1:8080')).resolves.toBeUndefined();
@@ -241,5 +248,10 @@ describe('validatePublicUrl', () => {
   it('accepts http scheme', async () => {
     mockLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
     await expect(validatePublicUrl('http://example.com/api')).resolves.toBeUndefined();
+  });
+
+  it('handles non-array lookup result (single object)', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 } as never);
+    await expect(validatePublicUrl('https://single.example.com')).resolves.toBeUndefined();
   });
 });

--- a/packages/backend/src/common/utils/url-validation.spec.ts
+++ b/packages/backend/src/common/utils/url-validation.spec.ts
@@ -149,8 +149,13 @@ describe('validatePublicUrl', () => {
   it('enforces validation in test mode when SKIP_SSRF_VALIDATION=false', async () => {
     process.env['NODE_ENV'] = 'test';
     process.env['SKIP_SSRF_VALIDATION'] = 'false';
-    await expect(validatePublicUrl('http://127.0.0.1:8080')).rejects.toThrow('private or internal');
-    delete process.env['SKIP_SSRF_VALIDATION'];
+    try {
+      await expect(validatePublicUrl('http://127.0.0.1:8080')).rejects.toThrow(
+        'private or internal',
+      );
+    } finally {
+      delete process.env['SKIP_SSRF_VALIDATION'];
+    }
   });
 
   it('allows private IPs in local mode', async () => {

--- a/packages/backend/src/common/utils/url-validation.ts
+++ b/packages/backend/src/common/utils/url-validation.ts
@@ -67,8 +67,8 @@ export function isCloudMetadataIp(ip: string): boolean {
 }
 
 export async function validatePublicUrl(url: string): Promise<void> {
-  // Skip SSRF validation in test mode
-  if (process.env['NODE_ENV'] === 'test') return;
+  // Skip SSRF validation in test mode (set SKIP_SSRF_VALIDATION=false to force validation)
+  if (process.env['NODE_ENV'] === 'test' && process.env['SKIP_SSRF_VALIDATION'] !== 'false') return;
 
   let parsed: URL;
   try {

--- a/packages/backend/src/database/database-seeder.service.ts
+++ b/packages/backend/src/database/database-seeder.service.ts
@@ -45,6 +45,9 @@ export class DatabaseSeederService implements OnModuleInit {
       await this.seedTenantAndAgent();
       await this.seedAgentMessages();
       this.logger.log('Seeded demo data (dev/test only, SEED_DATA=true)');
+      this.logger.warn(
+        'SECURITY: Default seed credentials are active (admin@manifest.build). Do NOT use in production.',
+      );
     }
   }
 

--- a/packages/backend/src/notifications/dto/set-notification-email.dto.spec.ts
+++ b/packages/backend/src/notifications/dto/set-notification-email.dto.spec.ts
@@ -1,0 +1,47 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { SetNotificationEmailDto } from './set-notification-email.dto';
+
+describe('SetNotificationEmailDto', () => {
+  function create(data: Record<string, unknown>): SetNotificationEmailDto {
+    return plainToInstance(SetNotificationEmailDto, data);
+  }
+
+  it('should accept a valid email', async () => {
+    const dto = create({ email: 'user@example.com' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject an invalid email', async () => {
+    const dto = create({ email: 'not-an-email' });
+    const errors = await validate(dto);
+    const emailError = errors.find((e) => e.property === 'email');
+    expect(emailError).toBeDefined();
+  });
+
+  it('should reject a missing email', async () => {
+    const dto = create({});
+    const errors = await validate(dto);
+    const emailError = errors.find((e) => e.property === 'email');
+    expect(emailError).toBeDefined();
+  });
+
+  it('should reject an empty string email', async () => {
+    const dto = create({ email: '' });
+    const errors = await validate(dto);
+    const emailError = errors.find((e) => e.property === 'email');
+    expect(emailError).toBeDefined();
+  });
+
+  it('should trim and lowercase the email via Transform', () => {
+    const dto = create({ email: '  User@Example.COM  ' });
+    expect(dto.email).toBe('user@example.com');
+  });
+
+  it('should pass through non-string email without transforming', () => {
+    const dto = create({ email: 42 });
+    expect(dto.email).toBe(42);
+  });
+});

--- a/packages/backend/src/notifications/dto/set-notification-email.dto.ts
+++ b/packages/backend/src/notifications/dto/set-notification-email.dto.ts
@@ -1,0 +1,8 @@
+import { IsEmail } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class SetNotificationEmailDto {
+  @IsEmail()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+  email!: string;
+}

--- a/packages/backend/src/notifications/notifications.controller.ts
+++ b/packages/backend/src/notifications/notifications.controller.ts
@@ -12,6 +12,7 @@ import {
   TestEmailProviderDto,
   TestSavedEmailProviderDto,
 } from './dto/set-email-provider.dto';
+import { SetNotificationEmailDto } from './dto/set-notification-email.dto';
 
 @Controller('api/v1/notifications')
 export class NotificationsController {
@@ -65,7 +66,7 @@ export class NotificationsController {
   }
 
   @Post('notification-email')
-  async setNotificationEmail(@CurrentUser() user: AuthUser, @Body() body: { email: string }) {
+  async setNotificationEmail(@CurrentUser() user: AuthUser, @Body() body: SetNotificationEmailDto) {
     await this.emailProviderConfigService.setNotificationEmail(user.id, body.email);
     return { saved: true };
   }

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
+import { randomBytes } from 'crypto';
 import { Request, Response } from 'express';
 import { Public } from '../../common/decorators/public.decorator';
 import { CurrentUser } from '../../auth/current-user.decorator';
@@ -120,9 +121,9 @@ export class OpenaiOauthController {
   done(@Query('ok') ok: string, @Res() res: Response) {
     const success = ok === '1';
 
+    const nonce = randomBytes(16).toString('base64');
     res.setHeader('Content-Type', 'text/html');
-    // Override Helmet's CSP to allow the inline script on this page
-    res.setHeader('Content-Security-Policy', "default-src 'none'; script-src 'unsafe-inline'");
-    res.send(oauthDoneHtml(success));
+    res.setHeader('Content-Security-Policy', `default-src 'none'; script-src 'nonce-${nonce}'`);
+    res.send(oauthDoneHtml(success, nonce));
   }
 }

--- a/packages/backend/src/routing/oauth/openai-oauth.types.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.types.ts
@@ -39,11 +39,12 @@ export function parseOAuthTokenBlob(rawValue: string): OAuthTokenBlob | null {
   }
 }
 
-export function oauthDoneHtml(success: boolean): string {
+export function oauthDoneHtml(success: boolean, nonce?: string): string {
   const message = success ? 'manifest-oauth-success' : 'manifest-oauth-error';
   const text = success
     ? 'Login successful!'
     : 'Login failed. Please close this window and try again.';
+  const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
 
   return `<!DOCTYPE html>
 <html>
@@ -51,7 +52,7 @@ export function oauthDoneHtml(success: boolean): string {
 <body style="font-family:system-ui;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;margin:0;background:#111;color:#eee;">
 <p>${text}</p>
 <p id="hint" style="font-size:13px;color:#888;display:none;">You can close this window.</p>
-<script>
+<script${nonceAttr}>
 try{var bc=new BroadcastChannel('manifest-oauth');bc.postMessage({type:'${message}'});bc.close();}catch(e){}
 if(window.opener){window.opener.postMessage({type:'${message}'},window.location.origin);}
 setTimeout(function(){window.close();document.getElementById('hint').style.display='block';},1500);

--- a/packages/backend/src/routing/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.spec.ts
@@ -97,6 +97,20 @@ describe('OpenaiOauthController', () => {
         controller.authorize('my-agent', { id: 'user-1' } as never, req),
       ).rejects.toThrow(HttpException);
     });
+
+    it('throws 503 with generic message when non-Error is thrown', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+      oauthService.generateAuthorizationUrl.mockRejectedValue('string-error');
+
+      const req = {
+        protocol: 'http',
+        get: jest.fn().mockReturnValue('localhost:3001'),
+      } as unknown as Request;
+
+      await expect(
+        controller.authorize('my-agent', { id: 'user-1' } as never, req),
+      ).rejects.toThrow('Failed to start OAuth callback server');
+    });
   });
 
   describe('revoke', () => {
@@ -194,6 +208,14 @@ describe('OpenaiOauthController', () => {
         controller.callback('auth-code', 'bad-state', { id: 'user-1' } as never),
       ).rejects.toThrow(HttpException);
     });
+
+    it('throws 400 with generic message when exchange throws non-Error', async () => {
+      oauthService.exchangeCode = jest.fn().mockRejectedValue('string-error');
+
+      await expect(
+        controller.callback('auth-code', 'bad-state', { id: 'user-1' } as never),
+      ).rejects.toThrow('Token exchange failed');
+    });
   });
 
   describe('done', () => {
@@ -206,27 +228,28 @@ describe('OpenaiOauthController', () => {
       } as unknown as jest.Mocked<Response>;
     });
 
-    it('returns success HTML when ok=1', () => {
+    it('returns success HTML when ok=1 with nonce-based CSP', () => {
       controller.done('1', res);
 
       expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
-      expect(res.setHeader).toHaveBeenCalledWith(
-        'Content-Security-Policy',
-        "default-src 'none'; script-src 'unsafe-inline'",
-      );
+      const cspCall = res.setHeader.mock.calls.find((c) => c[0] === 'Content-Security-Policy');
+      expect(cspCall).toBeDefined();
+      expect(cspCall![1]).toMatch(/^default-src 'none'; script-src 'nonce-[A-Za-z0-9+/=]+'$/);
       expect(res.send).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-success'));
       expect(res.send).toHaveBeenCalledWith(expect.stringContaining('Login successful'));
       expect(res.send).toHaveBeenCalledWith(expect.stringContaining('BroadcastChannel'));
+      // Script tag should include the nonce
+      const html = res.send.mock.calls[0][0] as string;
+      expect(html).toMatch(/nonce="[A-Za-z0-9+/=]+"/);
     });
 
-    it('returns error HTML when ok=0', () => {
+    it('returns error HTML when ok=0 with nonce-based CSP', () => {
       controller.done('0', res);
 
       expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
-      expect(res.setHeader).toHaveBeenCalledWith(
-        'Content-Security-Policy',
-        "default-src 'none'; script-src 'unsafe-inline'",
-      );
+      const cspCall = res.setHeader.mock.calls.find((c) => c[0] === 'Content-Security-Policy');
+      expect(cspCall).toBeDefined();
+      expect(cspCall![1]).toMatch(/^default-src 'none'; script-src 'nonce-[A-Za-z0-9+/=]+'$/);
       expect(res.send).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
       expect(res.send).toHaveBeenCalledWith(expect.stringContaining('Login failed'));
       expect(res.send).toHaveBeenCalledWith(expect.stringContaining('BroadcastChannel'));

--- a/packages/backend/src/routing/openai-oauth.types.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.types.spec.ts
@@ -1,4 +1,4 @@
-import { parseOAuthTokenBlob } from './oauth/openai-oauth.types';
+import { parseOAuthTokenBlob, oauthDoneHtml } from './oauth/openai-oauth.types';
 
 describe('parseOAuthTokenBlob', () => {
   it('returns null when the optional resource URL is not a string', () => {
@@ -23,5 +23,38 @@ describe('parseOAuthTokenBlob', () => {
       e: 123,
       u: 'https://api.minimax.io/anthropic',
     });
+  });
+
+  it('returns parsed blob without u field when u is undefined', () => {
+    expect(parseOAuthTokenBlob(JSON.stringify({ t: 'tok', r: 'ref', e: 999 }))).toEqual({
+      t: 'tok',
+      r: 'ref',
+      e: 999,
+    });
+  });
+
+  it('returns null when input is not valid JSON', () => {
+    expect(parseOAuthTokenBlob('not-json')).toBe(null);
+  });
+});
+
+describe('oauthDoneHtml', () => {
+  it('includes nonce attribute on script tag when provided', () => {
+    const html = oauthDoneHtml(true, 'test-nonce-123');
+    expect(html).toContain('nonce="test-nonce-123"');
+    expect(html).toContain('manifest-oauth-success');
+  });
+
+  it('omits nonce attribute when not provided', () => {
+    const html = oauthDoneHtml(true);
+    expect(html).not.toContain('nonce=');
+    expect(html).toContain('<script>');
+  });
+
+  it('renders error message when success is false', () => {
+    const html = oauthDoneHtml(false, 'nonce-abc');
+    expect(html).toContain('manifest-oauth-error');
+    expect(html).toContain('Login failed');
+    expect(html).toContain('nonce="nonce-abc"');
   });
 });

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -88,6 +88,9 @@ export class ProviderClient {
     let requestBody: Record<string, unknown>;
 
     if (isGoogle) {
+      // Google Gemini API requires the key as a URL parameter (not a header).
+      // The key is sanitized from debug logs below but may be visible to
+      // intermediate proxies between Manifest and Google's API.
       url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}?key=${apiKey}`;
       if (stream) url += '&alt=sse';
       headers = endpoint.buildHeaders(apiKey, authType);

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -100,6 +100,15 @@ describe('sanitizeProviderError', () => {
       expect(result).toContain('Bearer ***');
     });
 
+    it('redacts lowercase bearer tokens from error messages', () => {
+      const body = JSON.stringify({
+        error: { message: 'Header was: bearer eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp' },
+      });
+      const result = sanitizeProviderError(401, body, 'development');
+      expect(result).not.toContain('eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp');
+      expect(result).toContain('Bearer ***');
+    });
+
     it('does not redact patterns in production mode', () => {
       const key = 'sk-proj-abcdefghijklmnopqrstuvwxyz';
       const body = JSON.stringify({ error: { message: `Invalid key: ${key}` } });

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.spec.ts
@@ -64,4 +64,47 @@ describe('sanitizeProviderError', () => {
     const body = JSON.stringify({ error: { message: 'Should not leak' } });
     expect(sanitizeProviderError(500, body)).toBe('Upstream provider internal error');
   });
+
+  describe('sensitive pattern sanitization in non-production', () => {
+    it('redacts OpenAI API keys from error messages', () => {
+      const key = 'sk-proj-abcdefghijklmnopqrstuvwxyz';
+      const body = JSON.stringify({ error: { message: `Invalid key: ${key}` } });
+      const result = sanitizeProviderError(401, body, 'development');
+      expect(result).not.toContain(key);
+      expect(result).toContain('sk-***');
+    });
+
+    it('redacts Anthropic API keys from error messages', () => {
+      const key = 'sk-ant-api03-abcdefghijklmnopqrstuvwxyz';
+      const body = JSON.stringify({ error: { message: `Auth failed: ${key}` } });
+      const result = sanitizeProviderError(401, body, 'development');
+      expect(result).not.toContain(key);
+      expect(result).toContain('sk-ant-***');
+    });
+
+    it('redacts key= query parameters from error messages', () => {
+      const body = JSON.stringify({
+        error: { message: 'Failed at url?key=AIzaSyAbcdef123456789' },
+      });
+      const result = sanitizeProviderError(400, body, 'development');
+      expect(result).not.toContain('AIzaSyAbcdef123456789');
+      expect(result).toContain('key=***');
+    });
+
+    it('redacts Bearer tokens from error messages', () => {
+      const body = JSON.stringify({
+        error: { message: 'Header was: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp' },
+      });
+      const result = sanitizeProviderError(401, body, 'development');
+      expect(result).not.toContain('eyJhbGciOiJSUzI1NiIsInR5cCI6Ikp');
+      expect(result).toContain('Bearer ***');
+    });
+
+    it('does not redact patterns in production mode', () => {
+      const key = 'sk-proj-abcdefghijklmnopqrstuvwxyz';
+      const body = JSON.stringify({ error: { message: `Invalid key: ${key}` } });
+      const result = sanitizeProviderError(401, body, 'production');
+      expect(result).toBe('Authentication failed with upstream provider');
+    });
+  });
 });

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -17,7 +17,7 @@ function sanitizeSensitivePatterns(msg: string): string {
     .replace(/sk-ant-[a-zA-Z0-9_-]{20,}/g, 'sk-ant-***')
     .replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***')
     .replace(/key=[^&\s"]+/g, 'key=***')
-    .replace(/Bearer\s+[^\s"]+/g, 'Bearer ***');
+    .replace(/Bearer\s+[^\s"]+/gi, 'Bearer ***');
 }
 
 export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?: string): string {
@@ -31,7 +31,7 @@ export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?:
     const error = parsed.error as Record<string, unknown> | undefined;
     const message = error?.message ?? parsed.message;
     if (typeof message === 'string' && message.length > 0) {
-      return sanitizeSensitivePatterns(message.slice(0, 500));
+      return sanitizeSensitivePatterns(message).slice(0, 500);
     }
   } catch {
     // Not JSON — fall through to generic message

--- a/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
+++ b/packages/backend/src/routing/proxy/proxy-error-sanitizer.ts
@@ -12,6 +12,14 @@ const KNOWN_ERROR_MESSAGES: Record<number, string> = {
   504: 'Upstream provider gateway timeout',
 };
 
+function sanitizeSensitivePatterns(msg: string): string {
+  return msg
+    .replace(/sk-ant-[a-zA-Z0-9_-]{20,}/g, 'sk-ant-***')
+    .replace(/sk-[a-zA-Z0-9_-]{20,}/g, 'sk-***')
+    .replace(/key=[^&\s"]+/g, 'key=***')
+    .replace(/Bearer\s+[^\s"]+/g, 'Bearer ***');
+}
+
 export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?: string): string {
   const generic = KNOWN_ERROR_MESSAGES[status] ?? `Upstream provider returned HTTP ${status}`;
 
@@ -23,7 +31,7 @@ export function sanitizeProviderError(status: number, rawBody: string, nodeEnv?:
     const error = parsed.error as Record<string, unknown> | undefined;
     const message = error?.message ?? parsed.message;
     if (typeof message === 'string' && message.length > 0) {
-      return message.slice(0, 500);
+      return sanitizeSensitivePatterns(message.slice(0, 500));
     }
   } catch {
     // Not JSON — fall through to generic message


### PR DESCRIPTION
## Summary

- **Critical:** Fix timing-safe comparison for legacy API key hash verification (`hash.util.ts`)
- **High:** Add `SetNotificationEmailDto` with `@IsEmail()` validation for notification email endpoint
- **High:** Replace `script-src 'unsafe-inline'` with nonce-based CSP on OAuth done page
- **Medium:** Tighten SSRF test bypass to support `SKIP_SSRF_VALIDATION=false` override
- **Medium:** Sanitize API keys, Bearer tokens, and `key=` params from non-production error messages
- **Medium:** Add security warning log when seed credentials are active
- **Info:** Document Google Gemini API key-in-URL as a known provider limitation

## Test plan

- [x] All 3325 backend unit tests pass
- [x] TypeScript compiles with no errors
- [x] Lint passes (pre-commit hook)
- [x] 100% line coverage on all new/modified source files
- [x] Changeset included for `manifest` package

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens backend security to align with OWASP: fixes timing attack and adds input validation in legacy hash verification, adds email validation, switches OAuth done page to nonce-based CSP, tightens SSRF controls, and redacts secrets in error messages. Also warns on active seed credentials and documents a Google Gemini limitation.

- **Bug Fixes**
  - Use timing-safe comparison for legacy API key hashes and require valid 64-hex format.
  - Validate notification email via `SetNotificationEmailDto` with `@IsEmail()` and trim/lowercase transform.
  - Replace `script-src 'unsafe-inline'` with a per-request nonce-based CSP on the OAuth “done” page.
  - Allow forcing SSRF validation in tests with `SKIP_SSRF_VALIDATION=false`; handle single-object DNS lookups.
  - Redact API keys, `key=` query params, and Bearer tokens from non-production error messages.
  - Log a security warning when default seed credentials are active.
  - Note Google Gemini’s API key-in-URL requirement in provider client (sanitized in logs).

<sup>Written for commit 8bc5b69ff883b3f98bfb759849b04a45db56eb85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

