### PR TITLE
feat: configurable CSP frame-ancestors for iframe embedding

### DIFF
--- a/.changeset/frame-ancestors.md
+++ b/.changeset/frame-ancestors.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Allow configuring CSP frame-ancestors via FRAME_ANCESTORS env var

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -29,7 +29,9 @@ export async function bootstrap() {
           connectSrc: ["'self'"],
           fontSrc: ["'self'"],
           objectSrc: ["'none'"],
-          frameAncestors: ["'none'"],
+          frameAncestors: process.env['FRAME_ANCESTORS']
+            ? process.env['FRAME_ANCESTORS'].split(',')
+            : ["'none'"],
         },
       },
     }),


### PR DESCRIPTION
## Summary

Make Helmet's `frameAncestors` CSP directive configurable via `FRAME_ANCESTORS` env var.

This allows embedding Manifest in iframes, which is needed for Hugging Face Spaces (live demo). Without this, HF Spaces shows "refused to connect" because `frame-ancestors: 'none'` blocks all iframe embedding.

Usage:
```env
FRAME_ANCESTORS=https://huggingface.co
```

Comma-separated for multiple origins:
```env
FRAME_ANCESTORS=https://huggingface.co,https://example.com
```

Defaults to `'none'` when unset (no change in behavior).

## Test plan

- [ ] Without `FRAME_ANCESTORS`: dashboard loads normally, cannot be iframed
- [ ] With `FRAME_ANCESTORS=https://huggingface.co`: HF Space embeds the dashboard
- [ ] Backend unit tests pass
- [ ] E2E tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the CSP frame-ancestors directive configurable via the `FRAME_ANCESTORS` env var to allow embedding the app in iframes (e.g., Hugging Face Spaces). Defaults to 'none' when unset, so existing deployments are unchanged.

- **Migration**
  - Set `FRAME_ANCESTORS` to allowed origins (comma-separated), e.g. `https://huggingface.co` or `https://a.com,https://b.com`.

<sup>Written for commit ae0b429abd3b81ed30cfc34dee7273290b591e4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

