### PR TITLE
feat: sort models alphabetically in model picker

### DIFF
--- a/.changeset/sort-models-alphabetically.md
+++ b/.changeset/sort-models-alphabetically.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Sort models alphabetically by label within each provider group and sort provider groups alphabetically by name in the model picker modal

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -129,9 +129,11 @@ const ModelPickerModal: Component<Props> = (props) => {
 
     const groups: { provId: string; name: string; models: ModalModel[] }[] = [];
     for (const group of groupMap.values()) {
-      group.models.sort((a, b) =>
-        a.value === 'openrouter/free' ? -1 : b.value === 'openrouter/free' ? 1 : 0,
-      );
+      group.models.sort((a, b) => {
+        if (a.value === 'openrouter/free') return -1;
+        if (b.value === 'openrouter/free') return 1;
+        return a.label.localeCompare(b.label);
+      });
       if (q) {
         const nameMatch = group.name.toLowerCase().includes(q);
         const filtered = nameMatch
@@ -144,6 +146,7 @@ const ModelPickerModal: Component<Props> = (props) => {
         groups.push(group);
       }
     }
+    groups.sort((a, b) => a.name.localeCompare(b.name));
     return groups;
   };
 

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -178,6 +178,32 @@ describe("ModelPickerModal", () => {
     expect(firstModel?.textContent).toContain("Free Models Router");
   });
 
+  it("sorts models alphabetically by label within each group", () => {
+    const models = [
+      { model_name: "gpt-4o", provider: "OpenAI", display_name: "GPT-4o", input_price_per_token: 0.0000025, output_price_per_token: 0.00001, context_window: 128000, capability_reasoning: false, capability_code: true },
+      { model_name: "gpt-3.5-turbo", provider: "OpenAI", display_name: "GPT-3.5 Turbo", input_price_per_token: 0.0000005, output_price_per_token: 0.0000015, context_window: 16385, capability_reasoning: false, capability_code: true },
+      { model_name: "gpt-4o-mini", provider: "OpenAI", display_name: "GPT-4o Mini", input_price_per_token: 0.00000015, output_price_per_token: 0.0000006, context_window: 128000, capability_reasoning: false, capability_code: true },
+    ];
+    const { container } = render(() => (
+      <ModelPickerModal tierId="simple" models={models} tiers={baseTiers} onSelect={onSelect} onClose={onClose} />
+    ));
+    const group = container.querySelector(".routing-modal__group")!;
+    const labels = Array.from(group.querySelectorAll(".routing-modal__model-label")).map((el) => el.childNodes[0].textContent?.trim());
+    expect(labels).toEqual(["GPT-3.5 Turbo", "GPT-4o", "GPT-4o Mini"]);
+  });
+
+  it("sorts provider groups alphabetically by name", () => {
+    const models = [
+      { model_name: "gpt-4o-mini", provider: "OpenAI", display_name: "GPT-4o Mini", input_price_per_token: 0.00000015, output_price_per_token: 0.0000006, context_window: 128000, capability_reasoning: false, capability_code: true },
+      { model_name: "claude-opus-4-6", provider: "Anthropic", display_name: "Claude Opus 4.6", input_price_per_token: 0.000015, output_price_per_token: 0.000075, context_window: 200000, capability_reasoning: true, capability_code: true },
+    ];
+    const { container } = render(() => (
+      <ModelPickerModal tierId="simple" models={models} tiers={baseTiers} onSelect={onSelect} onClose={onClose} />
+    ));
+    const groupNames = Array.from(container.querySelectorAll(".routing-modal__group-name")).map((el) => el.textContent);
+    expect(groupNames).toEqual(["Anthropic", "OpenAI"]);
+  });
+
   it("resolves label for vendor-prefixed model names", () => {
     const modelsWithSlash = [
       { model_name: "anthropic/claude-opus-4-6", provider: "Anthropic", display_name: "Claude Opus 4.6", input_price_per_token: 0.000015, output_price_per_token: 0.000075, context_window: 200000, capability_reasoning: true, capability_code: true },


### PR DESCRIPTION
## Summary
- Sort models alphabetically by label within each provider group in the model picker modal
- Sort provider groups alphabetically by name
- `openrouter/free` remains pinned to the top of its group

## Test plan
- [x] Added test: models sorted alphabetically by label within each group
- [x] Added test: provider groups sorted alphabetically by name
- [x] Existing tests pass (31/31)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts models alphabetically by label within each provider group and sorts provider groups by name in the model picker modal for easier browsing. `openrouter/free` stays pinned at the top of its group.

<sup>Written for commit 2e0e8430fab84b027b80c699fa7a6f46910cfba1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

