### PR TITLE
fix: raise manifest/auto maxTokens from 16384 to 128000

### DIFF
--- a/.changeset/raise-max-tokens.md
+++ b/.changeset/raise-max-tokens.md
@@ -1,0 +1,5 @@
+---
+"manifest-model-router": patch
+---
+
+Raise manifest/auto maxTokens from 16384 to 128000 to better reflect the output capabilities of models the router selects

--- a/packages/openclaw-plugins/manifest-model-router/__tests__/auth.test.ts
+++ b/packages/openclaw-plugins/manifest-model-router/__tests__/auth.test.ts
@@ -214,9 +214,9 @@ describe("buildModelConfig", () => {
     expect(result.models[0].contextWindow).toBe(200000);
   });
 
-  it("returns model with maxTokens 16384", () => {
+  it("returns model with maxTokens 128000", () => {
     const result = buildModelConfig("https://example.com");
-    expect(result.models[0].maxTokens).toBe(16384);
+    expect(result.models[0].maxTokens).toBe(128000);
   });
 
   it("returns model with reasoning false", () => {

--- a/packages/openclaw-plugins/manifest-model-router/src/auth.ts
+++ b/packages/openclaw-plugins/manifest-model-router/src/auth.ts
@@ -8,7 +8,7 @@ const AUTO_MODEL = {
   input: ['text'],
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
   contextWindow: 200000,
-  maxTokens: 16384,
+  maxTokens: 128000,
 };
 
 /**


### PR DESCRIPTION
## Summary

- Raises the `maxTokens` declaration for `manifest/auto` from 16384 to 128000 in the `manifest-model-router` plugin
- The previous 16k cap was an overly conservative placeholder that caused OpenClaw to under-utilize models with larger output limits (Claude 32k, Gemini 65k+, GPT 128k)
- The actual provider enforces its own output token limit server-side, so this value is a safe upper bound

Closes #1450

## Test plan

- [x] Plugin unit tests pass (`manifest-model-router`)
- [x] TypeScript compiles cleanly
- [x] Changeset included for `manifest-model-router` patch release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised `maxTokens` for `manifest/auto` in `manifest-model-router` from 16384 to 128000 to align with larger model output limits. This prevents under-utilization of models with big output windows while relying on provider-side limits for safety.

<sup>Written for commit e2e38a2c62773ec1772a64e271994ce1196aefa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

