### PR TITLE
fix: bump manifest/auto contextWindow from 200k to 2M

### DIFF
--- a/.changeset/raise-max-tokens.md
+++ b/.changeset/raise-max-tokens.md
@@ -2,4 +2,4 @@
 "manifest-model-router": patch
 ---
 
-Raise manifest/auto maxTokens from 16384 to 128000 to better reflect the output capabilities of models the router selects
+Raise manifest/auto contextWindow from 200k to 2M to match the optimistic upper bound of the routing pool, consistent with how OpenRouter declares its auto model

--- a/packages/openclaw-plugins/manifest-model-router/__tests__/auth.test.ts
+++ b/packages/openclaw-plugins/manifest-model-router/__tests__/auth.test.ts
@@ -209,9 +209,9 @@ describe("buildModelConfig", () => {
     expect(result.models[0].name).toBe("Auto Router");
   });
 
-  it("returns model with contextWindow 200000", () => {
+  it("returns model with contextWindow 2000000", () => {
     const result = buildModelConfig("https://example.com");
-    expect(result.models[0].contextWindow).toBe(200000);
+    expect(result.models[0].contextWindow).toBe(2000000);
   });
 
   it("returns model with maxTokens 128000", () => {

--- a/packages/openclaw-plugins/manifest-model-router/src/auth.ts
+++ b/packages/openclaw-plugins/manifest-model-router/src/auth.ts
@@ -7,7 +7,7 @@ const AUTO_MODEL = {
   reasoning: false,
   input: ['text'],
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-  contextWindow: 200000,
+  contextWindow: 2000000,
   maxTokens: 128000,
 };
 


### PR DESCRIPTION
## Summary

- Raises `contextWindow` for `manifest/auto` from 200,000 to 2,000,000 in the `manifest-model-router` plugin
- Follows OpenRouter's approach for router models: declare the optimistic upper bound (the largest model in the routing pool) rather than a conservative estimate
- Prevents OpenClaw from aggressively compacting sessions when the routed model likely supports a much larger context window
- The actual provider enforces its real context limit server-side

Follow-up to #1457 which raised `maxTokens` from 16k to 128k.

Ref #1450

## Test plan

- [x] Plugin unit tests pass (`manifest-model-router`)
- [x] TypeScript compiles cleanly
- [x] Changeset included for `manifest-model-router` patch release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumped the `contextWindow` for `manifest/auto` in `manifest-model-router` from 200k to 2M to match the largest model in the routing pool. This prevents OpenClaw from compacting sessions unnecessarily while providers still enforce real limits. Addresses Linear #1450.

- **Bug Fixes**
  - Declare an optimistic upper-bound context window for the Auto Router model (aligned with OpenRouter).
  - Update unit test to expect the new window and include a changeset for a `manifest-model-router` patch release.

<sup>Written for commit b5c95623dd76ceb2dee2aa22c2d3bf647701a122. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

