### PR TITLE
fix: unlock sonnet/opus for Anthropic subscription OAuth tokens

### DIFF
--- a/.changeset/fix-anthropic-subscription-models.md
+++ b/.changeset/fix-anthropic-subscription-models.md
@@ -1,0 +1,7 @@
+---
+"manifest": patch
+---
+
+fix: unlock sonnet/opus for Anthropic subscription tokens
+
+Anthropic's subscription OAuth API requires a Claude Code agent identity system prompt to access sonnet and opus model families. Without it, only haiku is accessible. This injects the required system prompt for subscription auth, matching how we already spoof Editor-Version headers for GitHub Copilot.

--- a/packages/backend/src/model-discovery/anthropic-subscription-probe.spec.ts
+++ b/packages/backend/src/model-discovery/anthropic-subscription-probe.spec.ts
@@ -215,6 +215,21 @@ describe('filterBySubscriptionAccess', () => {
     expect(callBody.max_tokens).toBe(1);
   });
 
+  it('includes subscription identity system prompt in probe requests', async () => {
+    mockFetchResponses({ haiku: true });
+
+    await filterBySubscriptionAccess([makeModel('claude-haiku-4-5-20251001')], 'my-token');
+
+    const callBody = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(callBody.system).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('Claude agent'),
+        cache_control: { type: 'ephemeral' },
+      }),
+    ]);
+  });
+
   it('returns empty array for empty input', async () => {
     const spy = jest.fn();
     global.fetch = spy;

--- a/packages/backend/src/model-discovery/anthropic-subscription-probe.ts
+++ b/packages/backend/src/model-discovery/anthropic-subscription-probe.ts
@@ -34,6 +34,13 @@ async function probeModel(apiKey: string, modelId: string): Promise<boolean> {
       body: JSON.stringify({
         model: modelId,
         max_tokens: 1,
+        system: [
+          {
+            type: 'text',
+            text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
         messages: [{ role: 'user', content: '.' }],
       }),
       signal: controller.signal,

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -431,6 +431,51 @@ describe('Anthropic Adapter', () => {
       expect(tools[1].cache_control).toBeUndefined();
     });
 
+    it('prepends subscription identity block when injectSubscriptionIdentity is true', () => {
+      const body = {
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-6', {
+        injectCacheControl: false,
+        injectSubscriptionIdentity: true,
+      });
+      const system = result.system as Array<{ type: string; text: string; cache_control?: unknown }>;
+      expect(system).toHaveLength(2);
+      expect(system[0].text).toContain('Claude agent');
+      expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+      expect(system[1].text).toBe('You are helpful.');
+    });
+
+    it('adds subscription identity as sole system block when no user system prompt', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-6', {
+        injectSubscriptionIdentity: true,
+      });
+      const system = result.system as Array<{ type: string; text: string }>;
+      expect(system).toHaveLength(1);
+      expect(system[0].text).toContain('Claude agent');
+    });
+
+    it('does not inject subscription identity when option is false', () => {
+      const body = {
+        messages: [
+          { role: 'system', content: 'Custom prompt.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-6', {
+        injectSubscriptionIdentity: false,
+      });
+      const system = result.system as Array<{ type: string; text: string }>;
+      expect(system).toHaveLength(1);
+      expect(system[0].text).toBe('Custom prompt.');
+    });
+
     it('injects cache_control on system blocks and tools by default', () => {
       const body = {
         messages: [

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -308,8 +308,12 @@ describe('ProviderClient', () => {
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.cache_control).toBeUndefined();
-      const system = sentBody.system as Array<{ cache_control?: unknown }>;
-      expect(system[0].cache_control).toBeUndefined();
+      const system = sentBody.system as Array<{ text?: string; cache_control?: unknown }>;
+      // First system block is the subscription identity prompt
+      expect(system[0].text).toContain('Claude agent');
+      expect(system[0].cache_control).toEqual({ type: 'ephemeral' });
+      // User system block has no cache_control (subscription skips caching)
+      expect(system[1].cache_control).toBeUndefined();
       const tools = sentBody.tools as Array<{ cache_control?: unknown }>;
       expect(tools[0].cache_control).toBeUndefined();
     });

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -27,6 +27,18 @@ interface AnthropicTool {
 
 const CACHE = { type: 'ephemeral' } as const;
 
+/**
+ * System prompt required by Anthropic's subscription OAuth API to unlock
+ * sonnet/opus model families. Without it, subscription tokens can only
+ * access haiku. This mirrors how the Copilot integration spoofs
+ * Editor-Version headers to satisfy GitHub's API validation.
+ */
+const SUBSCRIPTION_IDENTITY_BLOCK: ContentBlock = {
+  type: 'text',
+  text: "You are a Claude agent, built on Anthropic's Claude Agent SDK.",
+  cache_control: { type: 'ephemeral' },
+};
+
 function safeParseArgs(args: string | undefined): unknown {
   try {
     return JSON.parse(args || '{}');
@@ -119,6 +131,8 @@ function convertTools(tools?: Array<Record<string, unknown>>): AnthropicTool[] |
 export interface AnthropicRequestOptions {
   /** When false, cache_control fields are omitted from the request. Defaults to true. */
   injectCacheControl?: boolean;
+  /** When true, prepends the Claude Code agent system prompt required for subscription OAuth tokens. */
+  injectSubscriptionIdentity?: boolean;
 }
 
 export function toAnthropicRequest(
@@ -131,6 +145,12 @@ export function toAnthropicRequest(
   const systemBlocks = extractSystemBlocks(messages);
   if (systemBlocks.length > 0 && shouldCache) {
     systemBlocks[systemBlocks.length - 1].cache_control = CACHE;
+  }
+
+  // Subscription OAuth tokens require the Claude Code agent identity as the
+  // first system block to access sonnet/opus models (haiku works without it).
+  if (options?.injectSubscriptionIdentity) {
+    systemBlocks.unshift({ ...SUBSCRIPTION_IDENTITY_BLOCK });
   }
 
   const converted = messages.map(convertMessage).filter(Boolean);

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -98,8 +98,10 @@ export class ProviderClient {
     } else if (isAnthropic) {
       url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`;
       headers = endpoint.buildHeaders(apiKey, authType);
+      const isSubscription = authType === 'subscription';
       requestBody = toAnthropicRequest(body, bareModel, {
-        injectCacheControl: authType !== 'subscription',
+        injectCacheControl: !isSubscription,
+        injectSubscriptionIdentity: isSubscription,
       });
       requestBody.model = bareModel;
       if (stream) requestBody.stream = true;


### PR DESCRIPTION
## Summary

- Anthropic subscription OAuth tokens (`sk-ant-oat`) can only access haiku through the Messages API — sonnet and opus return `400 invalid_request_error` with an opaque "Error" message
- The root cause is that Anthropic requires a Claude Code agent identity system prompt as the first system block to unlock higher model families for subscription auth
- This injects the required system prompt when `authType === 'subscription'`, matching how we already spoof `Editor-Version` headers for GitHub Copilot
- Also updates the subscription probe to include the same system prompt so model discovery correctly detects that sonnet/opus are accessible

## Test plan

- [x] Backend unit tests pass (3356 tests)
- [x] E2E tested with a real Max 200 subscription token — haiku, sonnet 4.6, and opus 4.6 all return 200 OK
- [ ] Verify subscription model picker shows all three families
- [ ] Verify routing to sonnet/opus works end-to-end through the proxy

Fixes #1448

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unlocks `claude-sonnet` and `claude-opus` for Anthropic subscription OAuth tokens by prepending the required Claude Code agent identity system prompt. Also updates model discovery so subscription tokens correctly show all accessible families.

- **Bug Fixes**
  - Prepend the Claude agent identity system block when `authType === 'subscription'` (in `toAnthropicRequest`), with `cache_control: { type: 'ephemeral' }`; omit cache_control on user system/tools for subscriptions.
  - Add the same identity block to the subscription probe so discovery includes sonnet/opus; add tests for adapter, provider client, and probe.

<sup>Written for commit c0ed41f3a6ec1151330b7f907401cf198ac39cbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

