### PR TITLE
feat: improve routing UX with auto-show instructions and autofocus

### DIFF
--- a/.changeset/routing-ux-improvements.md
+++ b/.changeset/routing-ux-improvements.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Auto-show routing setup instructions modal when re-enabling routing after disable, and autofocus API key input in provider detail view

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -1,4 +1,4 @@
-import { Show, type Component, type Accessor, type Setter } from 'solid-js';
+import { Show, onMount, type Component, type Accessor, type Setter } from 'solid-js';
 import type { ProviderDef } from '../services/providers.js';
 import { validateApiKey, validateSubscriptionKey } from '../services/provider-utils.js';
 import {
@@ -126,6 +126,13 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
     }
   };
 
+  let connectInputRef: HTMLInputElement | undefined;
+  onMount(() => {
+    if (connectInputRef && !props.connected()) {
+      connectInputRef.focus();
+    }
+  });
+
   return (
     <>
       {/* Not yet connected */}
@@ -133,6 +140,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
         <div class="provider-detail__field">
           <label class="provider-detail__label">{fieldLabel()}</label>
           <input
+            ref={connectInputRef}
             class="provider-detail__input provider-detail__input--masked"
             classList={{ 'provider-detail__input--error': !!props.validationError() }}
             type="text"

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -49,6 +49,8 @@ const Routing: Component = () => {
   const [instructionProvider, setInstructionProvider] = createSignal<string | null>(null);
   const [fallbackPickerTier, setFallbackPickerTier] = createSignal<string | null>(null);
   const [refreshingModels, setRefreshingModels] = createSignal(false);
+  const [wasEnabledBeforeModal, setWasEnabledBeforeModal] = createSignal(false);
+  const [hadProvidersBeforeModal, setHadProvidersBeforeModal] = createSignal(false);
 
   const refetchAll = async () => {
     await Promise.all([
@@ -83,6 +85,19 @@ const Routing: Component = () => {
   const hadRouting = () => (connectedProviders()?.length ?? 0) > 0 && !isEnabled();
   const activeProviders = () => connectedProviders()?.filter((p) => p.is_active) ?? [];
   const hasOverrides = () => tiers()?.some((t) => t.override_model !== null) ?? false;
+
+  const openProviderModal = () => {
+    setWasEnabledBeforeModal(isEnabled());
+    setHadProvidersBeforeModal((connectedProviders()?.length ?? 0) > 0);
+    setShowProviderModal(true);
+  };
+
+  const closeProviderModal = () => {
+    setShowProviderModal(false);
+    if (!wasEnabledBeforeModal() && isEnabled() && hadProvidersBeforeModal()) {
+      setInstructionModal('enable');
+    }
+  };
 
   const handleProviderUpdate = async () => {
     await refetchAll();
@@ -125,7 +140,7 @@ const Routing: Component = () => {
             >
               {refreshingModels() ? 'Refreshing...' : 'Refresh models'}
             </button>
-            <button class="btn btn--primary btn--sm" onClick={() => setShowProviderModal(true)}>
+            <button class="btn btn--primary btn--sm" onClick={openProviderModal}>
               Connect providers
             </button>
           </div>
@@ -144,7 +159,12 @@ const Routing: Component = () => {
                 class="panel"
                 style="display: flex; align-items: center; justify-content: center; min-height: 260px;"
               >
-                <span class="spinner" style="width: 24px; height: 24px;" role="status" aria-label="Loading" />
+                <span
+                  class="spinner"
+                  style="width: 24px; height: 24px;"
+                  role="status"
+                  aria-label="Loading"
+                />
               </div>
             }
           >
@@ -152,10 +172,7 @@ const Routing: Component = () => {
           </Show>
         }
       >
-        <Show
-          when={isEnabled()}
-          fallback={<EnableRoutingCard onEnable={() => setShowProviderModal(true)} />}
-        >
+        <Show when={isEnabled()} fallback={<EnableRoutingCard onEnable={openProviderModal} />}>
           <ActiveProviderIcons
             activeProviders={activeProviders}
             customProviders={() => customProviders() ?? []}
@@ -219,7 +236,7 @@ const Routing: Component = () => {
         fallbackPickerTier={fallbackPickerTier}
         onFallbackPickerClose={() => setFallbackPickerTier(null)}
         showProviderModal={showProviderModal}
-        onProviderModalClose={() => setShowProviderModal(false)}
+        onProviderModalClose={closeProviderModal}
         instructionModal={instructionModal}
         instructionProvider={instructionProvider}
         onInstructionClose={() => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -869,6 +869,75 @@ describe("Routing — handleProviderUpdate", () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(screen.queryByText("Activate routing")).toBeNull();
   });
+
+  it("does not show instruction modal on first-ever enable (fresh agent)", async () => {
+    mockGetProviders.mockResolvedValue([]);
+    mockDeactivateAllProviders.mockResolvedValue({ ok: true });
+
+    render(() => <Routing />);
+    const enableBtn = await screen.findByText("Enable Routing");
+    fireEvent.click(enableBtn);
+
+    // Simulate provider connected via update
+    mockGetProviders.mockResolvedValue([
+      { id: "p1", provider: "openai", auth_type: "api_key" as const, is_active: true, has_api_key: true, connected_at: "2025-01-01" },
+    ]);
+    const updateBtn = screen.getByTestId("trigger-update");
+    fireEvent.click(updateBtn);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Click Done — no modal because this is the first-ever enable (no prior providers)
+    const doneBtn = screen.getByText("Done");
+    fireEvent.click(doneBtn);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.queryByText("Activate routing")).toBeNull();
+  });
+
+  it("shows instruction modal when re-enabling routing after disable", async () => {
+    // Start with inactive providers (routing was previously disabled)
+    mockGetProviders.mockResolvedValue([
+      { id: "p1", provider: "openai", auth_type: "api_key" as const, is_active: false, has_api_key: true, connected_at: "2025-01-01" },
+    ]);
+    mockDeactivateAllProviders.mockResolvedValue({ ok: true });
+
+    render(() => <Routing />);
+    const enableBtn = await screen.findByText("Enable Routing");
+    fireEvent.click(enableBtn);
+
+    // Simulate provider re-activated via update
+    mockGetProviders.mockResolvedValue([
+      { id: "p1", provider: "openai", auth_type: "api_key" as const, is_active: true, has_api_key: true, connected_at: "2025-01-01" },
+    ]);
+    const updateBtn = screen.getByTestId("trigger-update");
+    fireEvent.click(updateBtn);
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Click Done — modal appears because routing was previously configured
+    const doneBtn = screen.getByText("Done");
+    fireEvent.click(doneBtn);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.queryByText("Activate routing")).toBeDefined();
+  });
+
+  it("does not show instruction modal when Done is clicked and routing was already enabled", async () => {
+    mockGetProviders.mockResolvedValue([
+      { id: "p1", provider: "openai", auth_type: "api_key" as const, is_active: true, has_api_key: true, connected_at: "2025-01-01" },
+    ]);
+    mockDeactivateAllProviders.mockResolvedValue({ ok: true });
+
+    render(() => <Routing />);
+    const provBtn = await screen.findByText("Connect providers");
+    fireEvent.click(provBtn);
+
+    // Click Done without any transition
+    const doneBtn = screen.getByText("Done");
+    fireEvent.click(doneBtn);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.queryByText("Activate routing")).toBeNull();
+  });
 });
 
 describe("Routing — fallback management", () => {


### PR DESCRIPTION
## Summary

- Auto-show the routing setup instructions modal when re-enabling routing after a disable (skipped on first-ever enable since the user already completed setup during agent creation)
- Autofocus the API key input field when navigating to the provider detail view, so users can immediately type or paste their key

## Test plan

- [ ] Fresh agent: Enable routing → connect provider → Done → no instruction modal
- [ ] Disable routing → re-enable → connect provider → Done → instruction modal appears
- [ ] Already enabled: Connect providers → Done → no instruction modal
- [ ] Click provider toggle → API key input is auto-focused
- [ ] Frontend tests pass (`npx vitest run`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves routing UX by auto-showing setup instructions only when routing is re-enabled after a disable (not on first-ever enable or when already enabled) and by auto-focusing the API key input in the provider detail view. This guides users on re-enable and speeds up key entry.

<sup>Written for commit b61dce5c53bcaa48c5295dbf5fce2ec75feafd66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

