### PR TITLE
feat: add 30d/previous-7d token data and provider-tokens public endpoint

### DIFF
--- a/.changeset/public-stats-enhancements.md
+++ b/.changeset/public-stats-enhancements.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add 30-day and previous-7-day token data to public usage endpoint, and new provider-tokens endpoint with daily breakdown per provider and model

--- a/packages/backend/src/public-stats/public-stats.controller.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.spec.ts
@@ -1,8 +1,14 @@
-import type { PublicStatsService, UsageStats, FreeModel } from './public-stats.service';
+import type {
+  PublicStatsService,
+  UsageStats,
+  FreeModel,
+  ProviderDailyTokens,
+} from './public-stats.service';
 
 const mockService: Record<string, jest.Mock> = {
   getUsageStats: jest.fn(),
   getFreeModels: jest.fn(),
+  getProviderDailyTokens: jest.fn(),
 };
 
 jest.mock('./public-stats.service', () => ({
@@ -16,6 +22,8 @@ const STATS_FIXTURE: UsageStats = {
       model: 'gpt-4o',
       provider: 'OpenAI',
       tokens_7d: 5000000,
+      tokens_previous_7d: 4500000,
+      tokens_30d: 18000000,
       input_price_per_million: 2.5,
       output_price_per_million: 10,
       usage_rank: 1,
@@ -133,6 +141,114 @@ describe('PublicStatsController', () => {
 
       expect(result.models).toEqual([]);
       expect(result.total_models).toBe(0);
+    });
+  });
+
+  describe('getProviderTokens', () => {
+    const PROVIDER_FIXTURE: ProviderDailyTokens[] = [
+      {
+        provider: 'OpenAI',
+        total_tokens: 1100000,
+        models: [
+          {
+            model: 'gpt-4o',
+            total_tokens: 1100000,
+            daily: [
+              { date: '2026-04-06', tokens: 500000 },
+              { date: '2026-04-07', tokens: 600000 },
+            ],
+          },
+        ],
+      },
+    ];
+
+    it('fetches provider tokens on first call', async () => {
+      mockService.getProviderDailyTokens.mockResolvedValue(PROVIDER_FIXTURE);
+
+      const result = await controller.getProviderTokens();
+
+      expect(result.providers).toHaveLength(1);
+      expect(result.providers[0].provider).toBe('OpenAI');
+      expect(result.cached_at).toBeDefined();
+      expect(mockService.getProviderDailyTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns cached within TTL', async () => {
+      mockService.getProviderDailyTokens.mockResolvedValue(PROVIDER_FIXTURE);
+      await controller.getProviderTokens();
+
+      const result = await controller.getProviderTokens();
+
+      expect(result.providers).toHaveLength(1);
+      expect(mockService.getProviderDailyTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-fetches after TTL expires', async () => {
+      mockService.getProviderDailyTokens.mockResolvedValue(PROVIDER_FIXTURE);
+      await controller.getProviderTokens();
+
+      const realDateNow = Date.now;
+      Date.now = () => realDateNow() + 86_400_001;
+
+      const updated: ProviderDailyTokens[] = [];
+      mockService.getProviderDailyTokens.mockResolvedValue(updated);
+
+      const result = await controller.getProviderTokens();
+
+      expect(result.providers).toEqual([]);
+      Date.now = realDateNow;
+    });
+
+    it('returns fallback when service fails on first call', async () => {
+      mockService.getProviderDailyTokens.mockRejectedValue(new Error('fail'));
+
+      const result = await controller.getProviderTokens();
+
+      expect(result.providers).toEqual([]);
+    });
+
+    it('returns stale cache on error after previous success', async () => {
+      mockService.getProviderDailyTokens.mockResolvedValue(PROVIDER_FIXTURE);
+      await controller.getProviderTokens();
+
+      const realDateNow = Date.now;
+      Date.now = () => realDateNow() + 86_400_001;
+      mockService.getProviderDailyTokens.mockRejectedValue(new Error('fail'));
+
+      const result = await controller.getProviderTokens();
+
+      expect(result.providers).toHaveLength(1);
+      Date.now = realDateNow;
+    });
+
+    it('deduplicates concurrent requests', async () => {
+      let resolve!: (v: ProviderDailyTokens[]) => void;
+      mockService.getProviderDailyTokens.mockReturnValue(
+        new Promise<ProviderDailyTokens[]>((r) => {
+          resolve = r;
+        }),
+      );
+
+      const p1 = controller.getProviderTokens();
+      const p2 = controller.getProviderTokens();
+
+      resolve(PROVIDER_FIXTURE);
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      expect(r1.providers).toHaveLength(1);
+      expect(r2.providers).toHaveLength(1);
+      expect(mockService.getProviderDailyTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears inflight lock after error', async () => {
+      mockService.getProviderDailyTokens.mockRejectedValueOnce(new Error('fail'));
+      await controller.getProviderTokens();
+
+      mockService.getProviderDailyTokens.mockResolvedValue(PROVIDER_FIXTURE);
+      const result = await controller.getProviderTokens();
+
+      expect(result.providers).toHaveLength(1);
+      expect(mockService.getProviderDailyTokens).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/backend/src/public-stats/public-stats.controller.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.ts
@@ -1,7 +1,12 @@
 import { Controller, Get, Logger } from '@nestjs/common';
 import { Public } from '../common/decorators/public.decorator';
 import { PUBLIC_STATS_CACHE_TTL_MS } from '../common/constants/cache.constants';
-import { PublicStatsService, TopModel, FreeModel } from './public-stats.service';
+import {
+  PublicStatsService,
+  TopModel,
+  FreeModel,
+  ProviderDailyTokens,
+} from './public-stats.service';
 
 interface UsageResponse {
   total_messages: number;
@@ -15,6 +20,11 @@ interface FreeModelsResponse {
   cached_at: string;
 }
 
+interface ProviderTokensResponse {
+  providers: ProviderDailyTokens[];
+  cached_at: string;
+}
+
 let cachedUsage: UsageResponse | null = null;
 let usageTimestamp = 0;
 let usageInflight: Promise<UsageResponse> | null = null;
@@ -22,6 +32,10 @@ let usageInflight: Promise<UsageResponse> | null = null;
 let cachedFree: FreeModelsResponse | null = null;
 let freeTimestamp = 0;
 let freeInflight: Promise<FreeModelsResponse> | null = null;
+
+let cachedProviderTokens: ProviderTokensResponse | null = null;
+let providerTokensTimestamp = 0;
+let providerTokensInflight: Promise<ProviderTokensResponse> | null = null;
 
 @Controller('api/v1/public')
 export class PublicStatsController {
@@ -61,6 +75,22 @@ export class PublicStatsController {
     return freeInflight;
   }
 
+  @Public()
+  @Get('provider-tokens')
+  async getProviderTokens(): Promise<ProviderTokensResponse> {
+    if (cachedProviderTokens && Date.now() - providerTokensTimestamp < PUBLIC_STATS_CACHE_TTL_MS) {
+      return cachedProviderTokens;
+    }
+
+    if (!providerTokensInflight) {
+      providerTokensInflight = this.refreshProviderTokens().finally(() => {
+        providerTokensInflight = null;
+      });
+    }
+
+    return providerTokensInflight;
+  }
+
   private async refreshUsage(): Promise<UsageResponse> {
     try {
       const stats = await this.service.getUsageStats();
@@ -96,5 +126,21 @@ export class PublicStatsController {
     }
 
     return cachedFree ?? { models: [], total_models: 0, cached_at: new Date().toISOString() };
+  }
+
+  private async refreshProviderTokens(): Promise<ProviderTokensResponse> {
+    try {
+      const providers = await this.service.getProviderDailyTokens();
+      cachedProviderTokens = {
+        providers,
+        cached_at: new Date().toISOString(),
+      };
+      providerTokensTimestamp = Date.now();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Failed to fetch provider tokens: ${msg}`);
+    }
+
+    return cachedProviderTokens ?? { providers: [], cached_at: new Date().toISOString() };
   }
 }

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -29,6 +29,8 @@ function makePricingEntry(overrides: Partial<PricingEntry> = {}): PricingEntry {
   };
 }
 
+const mockDataSource = { options: { type: 'postgres' } };
+
 describe('PublicStatsService', () => {
   let service: PublicStatsService;
   let mockRepo: { createQueryBuilder: jest.Mock };
@@ -43,14 +45,23 @@ describe('PublicStatsService', () => {
     service = new PublicStatsService(
       mockRepo as never,
       mockPricingCache as unknown as ModelPricingCacheService,
+      mockDataSource as never,
     );
   });
 
-  function setupQueries(count: unknown, top: unknown, tokens: unknown) {
+  function setupQueries(
+    count: unknown,
+    top: unknown,
+    tokens7d: unknown,
+    tokensPrev7d: unknown = [],
+    tokens30d: unknown = [],
+  ) {
     mockRepo.createQueryBuilder
       .mockReturnValueOnce(mockQueryBuilder(count))
       .mockReturnValueOnce(mockQueryBuilder(top))
-      .mockReturnValueOnce(mockQueryBuilder(tokens));
+      .mockReturnValueOnce(mockQueryBuilder(tokens7d))
+      .mockReturnValueOnce(mockQueryBuilder(tokensPrev7d))
+      .mockReturnValueOnce(mockQueryBuilder(tokens30d));
   }
 
   describe('getUsageStats', () => {
@@ -65,6 +76,14 @@ describe('PublicStatsService', () => {
           { model: 'gpt-4o', tokens: '1000000' },
           { model: 'claude-opus', tokens: '5000000' },
         ],
+        [
+          { model: 'gpt-4o', tokens: '900000' },
+          { model: 'claude-opus', tokens: '4500000' },
+        ],
+        [
+          { model: 'gpt-4o', tokens: '3500000' },
+          { model: 'claude-opus', tokens: '18000000' },
+        ],
       );
       mockPricingCache.getByModel.mockImplementation((name: string) => {
         if (name === 'gpt-4o') return makePricingEntry({ provider: 'OpenAI' });
@@ -77,8 +96,12 @@ describe('PublicStatsService', () => {
       expect(result.total_messages).toBe(42);
       expect(result.top_models[0].model).toBe('claude-opus');
       expect(result.top_models[0].tokens_7d).toBe(5000000);
+      expect(result.top_models[0].tokens_previous_7d).toBe(4500000);
+      expect(result.top_models[0].tokens_30d).toBe(18000000);
       expect(result.top_models[0].usage_rank).toBe(1);
       expect(result.top_models[1].model).toBe('gpt-4o');
+      expect(result.top_models[1].tokens_previous_7d).toBe(900000);
+      expect(result.top_models[1].tokens_30d).toBe(3500000);
       expect(result.top_models[1].usage_rank).toBe(2);
     });
 
@@ -156,10 +179,14 @@ describe('PublicStatsService', () => {
 
     it('applies 7-day cutoff to token query', async () => {
       const tokenQb = mockQueryBuilder([]);
+      const prev7dQb = mockQueryBuilder([]);
+      const thirtyDayQb = mockQueryBuilder([]);
       mockRepo.createQueryBuilder
         .mockReturnValueOnce(mockQueryBuilder({ total: '0' }))
         .mockReturnValueOnce(mockQueryBuilder([]))
-        .mockReturnValueOnce(tokenQb);
+        .mockReturnValueOnce(tokenQb)
+        .mockReturnValueOnce(prev7dQb)
+        .mockReturnValueOnce(thirtyDayQb);
 
       await service.getUsageStats();
 
@@ -167,6 +194,60 @@ describe('PublicStatsService', () => {
         'at.timestamp >= :cutoff',
         expect.objectContaining({ cutoff: expect.any(String) }),
       );
+    });
+
+    it('applies correct cutoffs to previous-7d query', async () => {
+      const prev7dQb = mockQueryBuilder([]);
+      mockRepo.createQueryBuilder
+        .mockReturnValueOnce(mockQueryBuilder({ total: '0' }))
+        .mockReturnValueOnce(mockQueryBuilder([]))
+        .mockReturnValueOnce(mockQueryBuilder([]))
+        .mockReturnValueOnce(prev7dQb)
+        .mockReturnValueOnce(mockQueryBuilder([]));
+
+      await service.getUsageStats();
+
+      expect(prev7dQb.andWhere).toHaveBeenCalledWith(
+        'at.timestamp >= :cutoff14d',
+        expect.objectContaining({ cutoff14d: expect.any(String) }),
+      );
+      expect(prev7dQb.andWhere).toHaveBeenCalledWith(
+        'at.timestamp < :cutoff7d',
+        expect.objectContaining({ cutoff7d: expect.any(String) }),
+      );
+    });
+
+    it('applies correct cutoff to 30d query', async () => {
+      const thirtyDayQb = mockQueryBuilder([]);
+      mockRepo.createQueryBuilder
+        .mockReturnValueOnce(mockQueryBuilder({ total: '0' }))
+        .mockReturnValueOnce(mockQueryBuilder([]))
+        .mockReturnValueOnce(mockQueryBuilder([]))
+        .mockReturnValueOnce(mockQueryBuilder([]))
+        .mockReturnValueOnce(thirtyDayQb);
+
+      await service.getUsageStats();
+
+      expect(thirtyDayQb.andWhere).toHaveBeenCalledWith(
+        'at.timestamp >= :cutoff30d',
+        expect.objectContaining({ cutoff30d: expect.any(String) }),
+      );
+    });
+
+    it('defaults tokens_previous_7d and tokens_30d to zero when no data', async () => {
+      setupQueries(
+        { total: '1' },
+        [{ model: 'gpt-4o', usage_count: '1' }],
+        [{ model: 'gpt-4o', tokens: '1000' }],
+        [],
+        [],
+      );
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models[0].tokens_previous_7d).toBe(0);
+      expect(result.top_models[0].tokens_30d).toBe(0);
     });
   });
 
@@ -290,6 +371,151 @@ describe('PublicStatsService', () => {
       const result = service.getFreeModels(new Map([['n', 500]]));
 
       expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('getProviderDailyTokens', () => {
+    function setupProviderQuery(rows: unknown) {
+      const qb = mockQueryBuilder(rows);
+      qb.addGroupBy = jest.fn().mockReturnValue(qb);
+      mockRepo.createQueryBuilder.mockReturnValueOnce(qb);
+      return qb;
+    }
+
+    it('groups tokens by provider and model with daily breakdown', async () => {
+      setupProviderQuery([
+        { model: 'gpt-4o', date: '2026-04-06', tokens: '500000' },
+        { model: 'gpt-4o', date: '2026-04-07', tokens: '600000' },
+        { model: 'claude-opus', date: '2026-04-07', tokens: '1000000' },
+      ]);
+      mockPricingCache.getByModel.mockImplementation((name: string) => {
+        if (name === 'gpt-4o') return makePricingEntry({ provider: 'OpenAI' });
+        if (name === 'claude-opus') return makePricingEntry({ provider: 'Anthropic' });
+        return null;
+      });
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].provider).toBe('OpenAI');
+      expect(result[0].total_tokens).toBe(1100000);
+      expect(result[0].models).toHaveLength(1);
+      expect(result[0].models[0].model).toBe('gpt-4o');
+      expect(result[0].models[0].daily).toEqual([
+        { date: '2026-04-06', tokens: 500000 },
+        { date: '2026-04-07', tokens: 600000 },
+      ]);
+      expect(result[1].provider).toBe('Anthropic');
+      expect(result[1].total_tokens).toBe(1000000);
+    });
+
+    it('sorts providers by total tokens descending', async () => {
+      setupProviderQuery([
+        { model: 'gpt-4o', date: '2026-04-07', tokens: '100' },
+        { model: 'claude-opus', date: '2026-04-07', tokens: '9999' },
+      ]);
+      mockPricingCache.getByModel.mockImplementation((name: string) => {
+        if (name === 'gpt-4o') return makePricingEntry({ provider: 'OpenAI' });
+        if (name === 'claude-opus') return makePricingEntry({ provider: 'Anthropic' });
+        return null;
+      });
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result[0].provider).toBe('Anthropic');
+      expect(result[1].provider).toBe('OpenAI');
+    });
+
+    it('sorts models within a provider by total tokens descending', async () => {
+      setupProviderQuery([
+        { model: 'gpt-4o', date: '2026-04-07', tokens: '100' },
+        { model: 'gpt-4o-mini', date: '2026-04-07', tokens: '9000' },
+      ]);
+      mockPricingCache.getByModel.mockImplementation(() =>
+        makePricingEntry({ provider: 'OpenAI' }),
+      );
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result[0].models[0].model).toBe('gpt-4o-mini');
+      expect(result[0].models[1].model).toBe('gpt-4o');
+    });
+
+    it('returns empty array when no data', async () => {
+      setupProviderQuery([]);
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('excludes custom models', async () => {
+      setupProviderQuery([{ model: 'custom:abc/gpt-4o', date: '2026-04-07', tokens: '1000' }]);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('excludes Unknown provider models', async () => {
+      setupProviderQuery([{ model: 'mystery-model', date: '2026-04-07', tokens: '1000' }]);
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('handles null tokens', async () => {
+      setupProviderQuery([{ model: 'gpt-4o', date: '2026-04-07', tokens: null }]);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result[0].total_tokens).toBe(0);
+      expect(result[0].models[0].daily[0].tokens).toBe(0);
+    });
+
+    it('sorts daily entries chronologically', async () => {
+      setupProviderQuery([
+        { model: 'gpt-4o', date: '2026-04-07', tokens: '200' },
+        { model: 'gpt-4o', date: '2026-04-05', tokens: '100' },
+        { model: 'gpt-4o', date: '2026-04-06', tokens: '150' },
+      ]);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
+
+      const result = await service.getProviderDailyTokens();
+
+      const dates = result[0].models[0].daily.map((d) => d.date);
+      expect(dates).toEqual(['2026-04-05', '2026-04-06', '2026-04-07']);
+    });
+
+    it('applies 30-day cutoff', async () => {
+      const qb = mockQueryBuilder([]);
+      qb.addGroupBy = jest.fn().mockReturnValue(qb);
+      mockRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+      await service.getProviderDailyTokens();
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'at.timestamp >= :cutoff30d',
+        expect.objectContaining({ cutoff30d: expect.any(String) }),
+      );
+    });
+
+    it('aggregates multiple models under the same provider', async () => {
+      setupProviderQuery([
+        { model: 'gpt-4o', date: '2026-04-07', tokens: '500' },
+        { model: 'gpt-4o-mini', date: '2026-04-07', tokens: '300' },
+      ]);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('OpenAI');
+      expect(result[0].total_tokens).toBe(800);
+      expect(result[0].models).toHaveLength(2);
     });
   });
 });

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -1,9 +1,14 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
-import { computeCutoff } from '../common/utils/sql-dialect';
+import {
+  DbDialect,
+  detectDialect,
+  computeCutoff,
+  sqlDateBucket,
+} from '../common/utils/sql-dialect';
 
 const MAX_RESULTS = 10;
 const EXCLUDED_PROVIDERS = new Set(['Unknown']);
@@ -12,6 +17,8 @@ export interface TopModel {
   model: string;
   provider: string;
   tokens_7d: number;
+  tokens_previous_7d: number;
+  tokens_30d: number;
   input_price_per_million: number | null;
   output_price_per_million: number | null;
   usage_rank: number;
@@ -29,22 +36,46 @@ export interface FreeModel {
   tokens_7d: number;
 }
 
+export interface DailyModelTokens {
+  date: string;
+  tokens: number;
+}
+
+export interface ModelBreakdown {
+  model: string;
+  total_tokens: number;
+  daily: DailyModelTokens[];
+}
+
+export interface ProviderDailyTokens {
+  provider: string;
+  total_tokens: number;
+  models: ModelBreakdown[];
+}
+
 function isCustomModel(model: string): boolean {
   return model.startsWith('custom:');
 }
 
 @Injectable()
 export class PublicStatsService {
+  private readonly dialect: DbDialect;
+
   constructor(
     @InjectRepository(AgentMessage)
     private readonly messageRepo: Repository<AgentMessage>,
     private readonly pricingCache: ModelPricingCacheService,
-  ) {}
+    private readonly dataSource: DataSource,
+  ) {
+    this.dialect = detectDialect(this.dataSource.options.type as string);
+  }
 
   async getUsageStats(): Promise<UsageStats> {
-    const cutoff = computeCutoff('7 days');
+    const cutoff7d = computeCutoff('7 days');
+    const cutoff14d = computeCutoff('14 days');
+    const cutoff30d = computeCutoff('30 days');
 
-    const [countRow, topRows, tokenRows] = await Promise.all([
+    const [countRow, topRows, tokenRows, tokenRowsPrev7d, tokenRows30d] = await Promise.all([
       this.messageRepo.createQueryBuilder('at').select('COUNT(*)', 'total').getRawOne(),
       this.messageRepo
         .createQueryBuilder('at')
@@ -59,7 +90,24 @@ export class PublicStatsService {
         .select('at.model', 'model')
         .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
         .where('at.model IS NOT NULL')
-        .andWhere('at.timestamp >= :cutoff', { cutoff })
+        .andWhere('at.timestamp >= :cutoff', { cutoff: cutoff7d })
+        .groupBy('at.model')
+        .getRawMany(),
+      this.messageRepo
+        .createQueryBuilder('at')
+        .select('at.model', 'model')
+        .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+        .where('at.model IS NOT NULL')
+        .andWhere('at.timestamp >= :cutoff14d', { cutoff14d })
+        .andWhere('at.timestamp < :cutoff7d', { cutoff7d })
+        .groupBy('at.model')
+        .getRawMany(),
+      this.messageRepo
+        .createQueryBuilder('at')
+        .select('at.model', 'model')
+        .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+        .where('at.model IS NOT NULL')
+        .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
         .groupBy('at.model')
         .getRawMany(),
     ]);
@@ -67,6 +115,16 @@ export class PublicStatsService {
     const tokenMap = new Map<string, number>();
     for (const r of tokenRows) {
       tokenMap.set(r.model as string, Number(r.tokens ?? 0));
+    }
+
+    const tokenMapPrev7d = new Map<string, number>();
+    for (const r of tokenRowsPrev7d) {
+      tokenMapPrev7d.set(r.model as string, Number(r.tokens ?? 0));
+    }
+
+    const tokenMap30d = new Map<string, number>();
+    for (const r of tokenRows30d) {
+      tokenMap30d.set(r.model as string, Number(r.tokens ?? 0));
     }
 
     const eligible: TopModel[] = [];
@@ -81,6 +139,8 @@ export class PublicStatsService {
         model: modelName,
         provider,
         tokens_7d: tokenMap.get(modelName) ?? 0,
+        tokens_previous_7d: tokenMapPrev7d.get(modelName) ?? 0,
+        tokens_30d: tokenMap30d.get(modelName) ?? 0,
         input_price_per_million:
           pricing?.input_price_per_token != null
             ? Number(pricing.input_price_per_token) * 1_000_000
@@ -102,6 +162,71 @@ export class PublicStatsService {
       top_models: topModels,
       token_map: tokenMap,
     };
+  }
+
+  async getProviderDailyTokens(): Promise<ProviderDailyTokens[]> {
+    const cutoff30d = computeCutoff('30 days');
+    const dateBucket = sqlDateBucket('at.timestamp', this.dialect);
+
+    const rows: { model: string; date: string; tokens: string }[] = await this.messageRepo
+      .createQueryBuilder('at')
+      .select('at.model', 'model')
+      .addSelect(dateBucket, 'date')
+      .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+      .where('at.model IS NOT NULL')
+      .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
+      .groupBy('at.model')
+      .addGroupBy('date')
+      .orderBy('date', 'ASC')
+      .getRawMany();
+
+    const modelMap = new Map<
+      string,
+      { provider: string; total: number; daily: Map<string, number> }
+    >();
+
+    for (const r of rows) {
+      const modelName = r.model;
+      if (isCustomModel(modelName)) continue;
+      const pricing = this.pricingCache.getByModel(modelName);
+      const provider = pricing?.provider || 'Unknown';
+      if (EXCLUDED_PROVIDERS.has(provider)) continue;
+
+      let entry = modelMap.get(modelName);
+      if (!entry) {
+        entry = { provider, total: 0, daily: new Map() };
+        modelMap.set(modelName, entry);
+      }
+      const tokens = Number(r.tokens ?? 0);
+      entry.total += tokens;
+      entry.daily.set(r.date, tokens);
+    }
+
+    const providerMap = new Map<string, { total: number; models: ModelBreakdown[] }>();
+
+    for (const [modelName, entry] of modelMap) {
+      let prov = providerMap.get(entry.provider);
+      if (!prov) {
+        prov = { total: 0, models: [] };
+        providerMap.set(entry.provider, prov);
+      }
+      prov.total += entry.total;
+      prov.models.push({
+        model: modelName,
+        total_tokens: entry.total,
+        daily: Array.from(entry.daily.entries())
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([date, tokens]) => ({ date, tokens })),
+      });
+    }
+
+    return Array.from(providerMap.entries())
+      .sort(([, a], [, b]) => b.total - a.total)
+      .map(([provider, data]) => ({
+        provider,
+        total_tokens: data.total,
+        models: data.models.sort((a, b) => b.total_tokens - a.total_tokens),
+      }));
   }
 
   getFreeModels(tokenMap: Map<string, number>): FreeModel[] {


### PR DESCRIPTION
## Summary

- Extend `GET /api/v1/public/usage` with `tokens_previous_7d` and `tokens_30d` fields on each top model, enabling week-over-week trend calculation on the website
- Add new `GET /api/v1/public/provider-tokens` endpoint returning daily token breakdown per provider and model over the last 30 days
- Both endpoints are public (no auth), cached 24h with stampede prevention

## Test plan

- [ ] `curl /api/v1/public/usage` returns `tokens_previous_7d` and `tokens_30d` on each model
- [ ] `curl /api/v1/public/provider-tokens` returns providers with nested models and daily arrays
- [ ] Providers sorted by total tokens desc, models within provider sorted by total tokens desc
- [ ] Daily entries sorted chronologically
- [ ] Custom models and Unknown provider excluded from both endpoints
- [ ] Cache returns same response within 24h TTL
- [ ] Backend unit tests pass with 100% line coverage on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds week-over-week and 30‑day token metrics to public usage stats and adds a new public endpoint with a 30‑day provider/model token breakdown. Both endpoints are cached for 24h with stampede prevention.

- New Features
  - `GET /api/v1/public/usage`: adds `tokens_previous_7d` and `tokens_30d` per top model for trend insights.
  - `GET /api/v1/public/provider-tokens`: returns providers → models → daily `[date, tokens]` for the last 30 days.
  - Sorting: providers and models by total tokens (desc); daily entries chronological.
  - Exclusions: custom models and `Unknown` provider are filtered out.
  - Responses include `cached_at`; 24h TTL with request de‑dup and stale cache on errors.

<sup>Written for commit 00693f69a83b6b5aa11a9f361c7fde7ed59b56af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

