### PR TITLE
fix: preserve provider query param in /connect-provider redirect

### DIFF
--- a/.changeset/fix-connect-provider-redirect.md
+++ b/.changeset/fix-connect-provider-redirect.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix: preserve provider query param in /connect-provider redirect

--- a/packages/frontend/src/pages/ConnectProvider.tsx
+++ b/packages/frontend/src/pages/ConnectProvider.tsx
@@ -22,7 +22,8 @@ const ConnectProvider: Component = () => {
 
   const buildTarget = (agentName: string) => {
     const qp = new URLSearchParams();
-    qp.set('provider', 'custom');
+    const provider = str(searchParams.provider) || 'custom';
+    qp.set('provider', provider);
     const name = str(searchParams.name);
     const baseUrl = str(searchParams.baseUrl);
     const apiKey = str(searchParams.apiKey);

--- a/packages/frontend/tests/pages/ConnectProvider.test.tsx
+++ b/packages/frontend/tests/pages/ConnectProvider.test.tsx
@@ -174,3 +174,30 @@ describe('ConnectProvider', () => {
     });
   });
 });
+
+describe('ConnectProvider with provider deep-link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('preserves provider param in redirect URL', async () => {
+    // Re-mock useSearchParams with a provider param
+    const routerMock = await import('@solidjs/router');
+    (routerMock as Record<string, unknown>).useSearchParams = () => [{ provider: 'anthropic' }];
+
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: 'my-agent' }] });
+
+    render(() => <ConnectProvider />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.stringContaining('/agents/my-agent/routing?'),
+        { replace: true },
+      );
+    });
+
+    const url = mockNavigate.mock.calls[0][0] as string;
+    expect(url).toContain('provider=anthropic');
+    expect(url).not.toContain('provider=custom');
+  });
+});


### PR DESCRIPTION
## Summary
- `/connect-provider?provider=anthropic` was always redirecting to `routing?provider=custom` because `buildTarget()` hardcoded `provider=custom`
- Now reads the `provider` param from the URL, falling back to `custom` only when absent
- Added test verifying the provider param is preserved through the redirect

## Test plan
- [ ] Navigate to `/connect-provider?provider=anthropic` — should open Anthropic detail view
- [ ] Navigate to `/connect-provider?provider=custom&name=Test` — should open custom provider form
- [ ] Navigate to `/connect-provider?name=Test` (no provider param) — should default to custom provider form

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the provider query param when redirecting from /connect-provider to the routing page, so deep links open the correct provider view. Falls back to custom only when the param is missing.

<sup>Written for commit ef84724d358013e073fd3956055a6cde166dffba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

