### PR TITLE
fix: use space-separated timestamps to match SQLite storage format

### DIFF
--- a/.changeset/fix-timestamp-timezone.md
+++ b/.changeset/fix-timestamp-timezone.md
@@ -1,0 +1,14 @@
+---
+"manifest": patch
+---
+
+fix: use space-separated local-time timestamps to match SQLite storage format
+
+Two issues caused the "Last 24 hours" overview to show no data for non-UTC users:
+
+1. Messages were inserted with `new Date().toISOString()` (UTC) but query cutoffs used
+   `formatLocalIso()` (local time), creating a timezone offset mismatch.
+2. `formatLocalIso()` used 'T' as the date-time separator, but SQLite stores timestamps
+   with a space separator. Since space (0x20) < 'T' (0x54), all same-day cutoff
+   comparisons failed — the "Last 7 days" range worked only because the date portion
+   difference masked the separator mismatch.

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -180,7 +180,7 @@ describe('MessagesQueryService', () => {
     });
 
     expect(result.next_cursor).not.toBeNull();
-    expect(result.next_cursor).toContain('2026-02-16T09:30:00');
+    expect(result.next_cursor).toContain('2026-02-16 09:30:00');
     expect(result.next_cursor).toContain('|msg-1');
   });
 

--- a/packages/backend/src/analytics/services/query-helpers.spec.ts
+++ b/packages/backend/src/analytics/services/query-helpers.spec.ts
@@ -89,25 +89,25 @@ describe('formatTimestamp', () => {
   it('formats a Date as a PG-compatible timestamp string', () => {
     const d = new Date(2026, 1, 16, 10, 5, 3, 42);
     const result = formatTimestamp(d);
-    expect(result).toBe('2026-02-16T10:05:03.042');
+    expect(result).toBe('2026-02-16 10:05:03.042');
   });
 
   it('zero-pads single-digit months, days, hours, minutes, seconds', () => {
     const d = new Date(2026, 0, 2, 3, 4, 5, 7);
     const result = formatTimestamp(d);
-    expect(result).toBe('2026-01-02T03:04:05.007');
+    expect(result).toBe('2026-01-02 03:04:05.007');
   });
 
   it('handles midnight (all-zero time components)', () => {
     const d = new Date(2026, 5, 15, 0, 0, 0, 0);
     const result = formatTimestamp(d);
-    expect(result).toBe('2026-06-15T00:00:00.000');
+    expect(result).toBe('2026-06-15 00:00:00.000');
   });
 
   it('handles end-of-day timestamp', () => {
     const d = new Date(2026, 11, 31, 23, 59, 59, 999);
     const result = formatTimestamp(d);
-    expect(result).toBe('2026-12-31T23:59:59.999');
+    expect(result).toBe('2026-12-31 23:59:59.999');
   });
 });
 

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -6,10 +6,11 @@ export interface MetricWithTrend {
   sub_values?: Record<string, number>;
 }
 
-/** Format a Date as a timestamp string using local time (matches `timestamp without time zone` storage). */
+/** Format a Date as a timestamp string using local time (matches `timestamp without time zone` storage).
+ *  Uses space separator to match SQLite's datetime storage format. */
 export function formatTimestamp(d: Date): string {
   const p = (n: number, len = 2) => String(n).padStart(len, '0');
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`;
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}.${p(d.getMilliseconds(), 3)}`;
 }
 
 /**

--- a/packages/backend/src/common/utils/sql-dialect.spec.ts
+++ b/packages/backend/src/common/utils/sql-dialect.spec.ts
@@ -84,7 +84,7 @@ describe('sql-dialect', () => {
       const after = Date.now();
       // No trailing 'Z' — local time format
       expect(cutoff).not.toContain('Z');
-      expect(cutoff).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+      expect(cutoff).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
       const parsed = new Date(cutoff).getTime();
       // formatLocalIso truncates milliseconds, so allow up to 1s tolerance
       expect(parsed).toBeGreaterThanOrEqual(before - 24 * 3600_000 - 1000);
@@ -135,7 +135,7 @@ describe('sql-dialect', () => {
       const result = sqlNow();
       const after = Date.now();
       expect(result).not.toContain('Z');
-      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/);
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
       const parsed = new Date(result).getTime();
       expect(parsed).toBeGreaterThanOrEqual(before - 1000);
       expect(parsed).toBeLessThanOrEqual(after + 1000);

--- a/packages/backend/src/common/utils/sql-dialect.ts
+++ b/packages/backend/src/common/utils/sql-dialect.ts
@@ -97,14 +97,16 @@ export function sqlCastInterval(paramName: string, dialect: DbDialect): string {
 }
 
 /**
- * Format a Date as a local-time ISO-8601 string without timezone suffix.
- * Matches the format PostgreSQL stores for `timestamp without time zone`
- * when the pg driver serialises JS Dates in the Node process's local TZ.
+ * Format a Date as a local-time timestamp string without timezone suffix.
+ * Uses space separator (not 'T') so the string sorts correctly in both
+ * PostgreSQL (`timestamp without time zone`) and SQLite (`datetime`)
+ * comparisons. SQLite stores timestamps with a space separator; using 'T'
+ * breaks string ordering because space (0x20) < 'T' (0x54).
  */
-function formatLocalIso(d: Date): string {
+export function formatLocalIso(d: Date): string {
   const pad = (n: number) => String(n).padStart(2, '0');
   return (
     `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
-    `T${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+    ` ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
   );
 }

--- a/packages/backend/src/database/seed-messages.ts
+++ b/packages/backend/src/database/seed-messages.ts
@@ -1,6 +1,7 @@
 import { Repository } from 'typeorm';
 import { Logger } from '@nestjs/common';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { formatLocalIso } from '../common/utils/sql-dialect';
 
 interface SeedContext {
   tenantId: string;
@@ -52,7 +53,7 @@ export async function seedAgentMessages(
       idx++;
       const entry = models[idx % models.length]!;
       const rawTs = hourBase + Math.floor(seededRandom(idx) * 3500000);
-      const ts = new Date(Math.min(rawTs, now)).toISOString();
+      const ts = formatLocalIso(new Date(Math.min(rawTs, now)));
 
       // Input tokens 5-25x larger than output (realistic for LLM usage)
       const inputBase = 800 + Math.floor(seededRandom(idx * 3) * 14000);

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -3,6 +3,7 @@ import { ProxyMessageDedup } from '../proxy-message-dedup';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import { IngestEventBusService } from '../../../common/services/ingest-event-bus.service';
 import { IngestionContext } from '../../../otlp/interfaces/ingestion-context.interface';
+import { sqlNow } from '../../../common/utils/sql-dialect';
 
 const ctx: IngestionContext = {
   tenantId: 'tenant-1',
@@ -183,11 +184,11 @@ describe('ProxyMessageRecorder', () => {
     });
 
     it('uses current timestamp when timestamp is not provided', async () => {
-      const before = new Date().toISOString();
+      const before = sqlNow();
       await recorder.recordFallbackSuccess(ctx, 'gpt-4o', 'standard', {
         usage: { prompt_tokens: 10, completion_tokens: 5 },
       });
-      const after = new Date().toISOString();
+      const after = sqlNow();
       const inserted = insertMock.mock.calls[0][0];
       expect(inserted.timestamp >= before).toBe(true);
       expect(inserted.timestamp <= after).toBe(true);

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -10,6 +10,7 @@ import { FailedFallback } from './proxy-fallback.service';
 import { StreamUsage } from './stream-writer';
 import { ProxyMessageDedup } from './proxy-message-dedup';
 import { computeTokenCost } from '../../common/utils/cost-calculator';
+import { sqlNow, formatLocalIso } from '../../common/utils/sql-dialect';
 
 export interface ProviderErrorOpts {
   model?: string;
@@ -89,7 +90,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       tenant_id: ctx.tenantId,
       agent_id: ctx.agentId,
       trace_id: traceId ?? null,
-      timestamp: new Date().toISOString(),
+      timestamp: sqlNow(),
       status: messageStatus,
       error_message: errorMessage.slice(0, 2000),
       agent_name: ctx.agentName,
@@ -124,8 +125,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     for (let i = 0; i < failures.length; i++) {
       const f = failures[i];
       const ts = baseTimeMs
-        ? new Date(baseTimeMs + (failures.length - i) * 100).toISOString()
-        : new Date().toISOString();
+        ? formatLocalIso(new Date(baseTimeMs + (failures.length - i) * 100))
+        : sqlNow();
       const isLast = i === failures.length - 1;
       const useHandledStatus = markHandled && !(lastAsError && isLast);
       const status = useHandledStatus
@@ -212,7 +213,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
       tenant_id: ctx.tenantId,
       agent_id: ctx.agentId,
       trace_id: traceId ?? null,
-      timestamp: timestamp ?? new Date().toISOString(),
+      timestamp: timestamp ?? sqlNow(),
       status: 'ok',
       agent_name: ctx.agentName,
       model,
@@ -295,7 +296,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
             agent_id: ctx.agentId,
             trace_id: traceId ?? null,
             session_key: normalizedSessionKey,
-            timestamp: new Date().toISOString(),
+            timestamp: sqlNow(),
             status: 'ok',
             agent_name: ctx.agentName,
             model,

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -9,6 +9,7 @@ import { initSseHeaders, pipeStream, StreamUsage } from './stream-writer';
 import { sanitizeProviderError } from './proxy-error-sanitizer';
 import type { ThoughtSignatureCache } from './thought-signature-cache';
 import type { ExtractedSignature } from './google-adapter';
+import { formatLocalIso } from '../../common/utils/sql-dialect';
 
 const logger = new Logger('ProxyResponseHandler');
 
@@ -106,7 +107,7 @@ function handleFallbackExhausted(
     })
     .catch((e) => logger.warn(`Failed to record fallback errors: ${e}`));
 
-  const primaryTs = new Date(baseTime + (failedFallbacks.length + 1) * 100).toISOString();
+  const primaryTs = formatLocalIso(new Date(baseTime + (failedFallbacks.length + 1) * 100));
   recorder
     .recordPrimaryFailure(ctx, meta.tier, meta.model, errorBody, primaryTs, meta.auth_type)
     .catch((e) => logger.warn(`Failed to record primary failure: ${e}`));
@@ -152,7 +153,7 @@ export function recordFallbackFailures(
       meta.tier,
       meta.fallbackFromModel,
       meta.primaryErrorBody ?? `Provider returned HTTP ${meta.primaryErrorStatus ?? 500}`,
-      new Date(fallbackBaseTime).toISOString(),
+      formatLocalIso(new Date(fallbackBaseTime)),
       meta.auth_type,
     )
     .catch((e) => logger.warn(`Failed to record primary failure: ${e}`));
@@ -167,7 +168,7 @@ export function recordFallbackFailures(
       .catch((e) => logger.warn(`Failed to record fallback errors: ${e}`));
   }
 
-  return new Date(fallbackBaseTime + (failures.length + 1) * 100).toISOString();
+  return formatLocalIso(new Date(fallbackBaseTime + (failures.length + 1) * 100));
 }
 
 /** Pipes a streaming response, applying adapter transforms as needed. */


### PR DESCRIPTION
## Summary

- **"Last 24 hours" overview showed no data** for plugin (local mode) users because `formatLocalIso()` used `T` as the date-time separator, but SQLite stores timestamps with a space separator. Since space (0x20) < `T` (0x54) in ASCII, all same-day cutoff comparisons failed silently. The "Last 7 days" and "Last 30 days" ranges worked only because the date portion difference masked the separator mismatch.
- **Message timestamps were written in UTC** (`new Date().toISOString()`) while query cutoffs used local time (`formatLocalIso()`), creating a timezone offset mismatch that would exclude early-morning data for non-UTC users in PostgreSQL (cloud) mode.

## Changes

- `formatLocalIso()`: use space separator instead of `T`, export for reuse
- `formatTimestamp()`: use space separator for cursor pagination consistency  
- `proxy-message-recorder.ts`: use `sqlNow()`/`formatLocalIso()` instead of `toISOString()`
- `proxy-response-handler.ts`: use `formatLocalIso()` for fallback timestamps
- `seed-messages.ts`: use `formatLocalIso()` for seed data consistency

## Root cause

SQLite `datetime` columns store timestamps as strings with space separators (e.g. `2026-04-08 17:39:20.000`). The `computeCutoff()` function produced cutoff strings with `T` separators (e.g. `2026-04-08T01:42:31`). In SQLite string comparison, every stored timestamp sorted *before* the cutoff because `' ' < 'T'`, making the `WHERE timestamp >= :cutoff` filter exclude all same-day data.

## Test plan

- [x] All 172 backend test suites pass (3356 tests)
- [x] Verified fix locally with the OpenClaw manifest plugin (SQLite/local mode) — "Last 24 hours" overview now displays data correctly
- [ ] PostgreSQL (cloud mode) path: covered by unit tests; not e2e-verified in this PR

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing “Last 24 hours” data in SQLite/local mode by standardizing on space‑separated local-time timestamps across reads and writes. Also resolves UTC/local mismatches that excluded early‑morning data for non‑UTC users.

- **Bug Fixes**
  - Switch `formatLocalIso` and `formatTimestamp` to use a space separator; export `formatLocalIso` for reuse.
  - Replace `toISOString()` with `sqlNow()`/`formatLocalIso()` in proxy recording and response handling; unify fallback/primary failure timestamps.
  - Update seed data and tests to the new format, ensuring correct filtering and cursor pagination in SQLite and PostgreSQL.

<sup>Written for commit 5527e32125c944c07ae72352ce30c8091ac9afaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

