### PR TITLE
fix(manifest-model-router): use AUTO_MODEL in injectProviderConfig

### DIFF
--- a/packages/openclaw-plugins/manifest-model-router/src/auth.ts
+++ b/packages/openclaw-plugins/manifest-model-router/src/auth.ts
@@ -1,7 +1,7 @@
 import { API_KEY_PREFIX, DEFAULTS } from './constants';
 import type { ProviderAuthContext, ProviderAuthResult } from './types';
 
-const AUTO_MODEL = {
+export const AUTO_MODEL = {
   id: 'auto',
   name: 'Auto Router',
   reasoning: false,

--- a/packages/openclaw-plugins/manifest-model-router/src/index.ts
+++ b/packages/openclaw-plugins/manifest-model-router/src/index.ts
@@ -5,7 +5,7 @@ import { registerCommand } from './command';
 import { verifyConnection } from './verify';
 import { injectProviderConfig, injectAuthProfile } from './provider-inject';
 import { stripOtlpSuffix } from './compat';
-import { runApiKeyAuth, buildModelConfig } from './auth';
+import { runApiKeyAuth, buildModelConfig, AUTO_MODEL } from './auth';
 import { ENV } from './constants';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -119,7 +119,7 @@ function registerProvider(api: any, endpoint: string, logger: PluginLogger): voi
           run: runApiKeyAuth,
         },
       ],
-      models: buildModelConfig(stripOtlpSuffix(endpoint, { info: () => {}, error: () => {}, debug: () => {} })),
+      ...buildModelConfig(stripOtlpSuffix(endpoint, { info: () => {}, error: () => {}, debug: () => {} })),
     });
 
     logger.info('[manifest] Registered as provider (model: manifest/auto)');

--- a/packages/openclaw-plugins/manifest-model-router/src/provider-inject.ts
+++ b/packages/openclaw-plugins/manifest-model-router/src/provider-inject.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { PluginLogger } from './types';
 import { loadJsonFile } from './json-file';
+import { AUTO_MODEL } from './auth';
 
 const OPENCLAW_DIR = join(homedir(), '.openclaw');
 const OPENCLAW_CONFIG = join(OPENCLAW_DIR, 'openclaw.json');
@@ -36,7 +37,7 @@ export function injectProviderConfig(
     baseUrl,
     api: 'openai-completions',
     apiKey,
-    models: [{ id: 'auto', name: 'auto' }],
+    models: [AUTO_MODEL],
   };
 
   // 1. Write to ~/.openclaw/openclaw.json (atomic write)


### PR DESCRIPTION
injectProviderConfig was writing a minimal model object {id:"auto", name:"auto"} missing the input, cost, contextWindow, and maxTokens fields. OpenClaw crashes with "Cannot read properties of undefined (reading 'input')" because the model catalog entry has no input field.

Export AUTO_MODEL from auth.ts and use it in provider-inject.ts so the injected config includes all required fields.

Fixes #1464

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an OpenClaw crash in the manifest model router by exporting and using the full `AUTO_MODEL` when injecting provider config, ensuring required fields are present. Also spreads `buildModelConfig(...)` during provider registration so `models` is a flat array, preventing a TypeError in provider resolution (fixes #1464).

<sup>Written for commit 120393491da635c8f564ca6e1a398588ff316330. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

