### PR TITLE
fix: harden auth guards, rate limiting, and input sanitization

### DIFF
--- a/.changeset/owasp-security-hardening.md
+++ b/.changeset/owasp-security-hardening.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Harden auth guards, rate limiting, and input sanitization (OWASP audit)

--- a/packages/backend/src/auth/session.guard.spec.ts
+++ b/packages/backend/src/auth/session.guard.spec.ts
@@ -83,6 +83,7 @@ describe('SessionGuard', () => {
     expect(result).toBe(true);
     expect(request['user']).toEqual(mockSession.user);
     expect(request['session']).toEqual(mockSession.session);
+    expect(request['authMethod']).toBe('session');
   });
 
   it('returns true even when no session found', async () => {
@@ -94,6 +95,7 @@ describe('SessionGuard', () => {
 
     expect(result).toBe(true);
     expect(request['user']).toBeUndefined();
+    expect(request['authMethod']).toBeUndefined();
   });
 
   it('returns true and leaves user undefined when getSession throws', async () => {
@@ -105,5 +107,6 @@ describe('SessionGuard', () => {
 
     expect(result).toBe(true);
     expect(request['user']).toBeUndefined();
+    expect(request['authMethod']).toBeUndefined();
   });
 });

--- a/packages/backend/src/auth/session.guard.ts
+++ b/packages/backend/src/auth/session.guard.ts
@@ -34,6 +34,7 @@ export class SessionGuard implements CanActivate {
       if (session) {
         (request as Request & { user: unknown }).user = session.user;
         (request as Request & { session: unknown }).session = session.session;
+        (request as Request & { authMethod: string }).authMethod = 'session';
       }
     } catch (err) {
       this.logger.warn(`Session lookup failed: ${(err as Error).message}`);

--- a/packages/backend/src/common/guards/api-key.guard.spec.ts
+++ b/packages/backend/src/common/guards/api-key.guard.spec.ts
@@ -169,7 +169,25 @@ describe('ApiKeyGuard', () => {
     expect(mockFind).not.toHaveBeenCalled();
   });
 
-  it('skips API key validation when request.user is already set', async () => {
+  it('skips API key validation when authMethod is session', async () => {
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: {},
+          ip: '127.0.0.1',
+          authMethod: 'session',
+        }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    const result = await guard.canActivate(ctx);
+    expect(result).toBe(true);
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  it('does not skip API key validation when user is set but authMethod is missing', async () => {
     const ctx = {
       switchToHttp: () => ({
         getRequest: () => ({
@@ -182,8 +200,6 @@ describe('ApiKeyGuard', () => {
       getClass: () => ({}),
     } as unknown as ExecutionContext;
 
-    const result = await guard.canActivate(ctx);
-    expect(result).toBe(true);
-    expect(mockFind).not.toHaveBeenCalled();
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
 });

--- a/packages/backend/src/common/guards/api-key.guard.ts
+++ b/packages/backend/src/common/guards/api-key.guard.ts
@@ -35,8 +35,8 @@ export class ApiKeyGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest<Request>();
 
-    // Skip if already authenticated via session
-    if ((request as Request & { user?: unknown }).user) return true;
+    // Skip if already authenticated via session (explicit flag prevents accidental bypass)
+    if ((request as Request & { authMethod?: string }).authMethod === 'session') return true;
 
     const apiKey = request.headers['x-api-key'];
 

--- a/packages/backend/src/common/middleware/http-error-logger.middleware.spec.ts
+++ b/packages/backend/src/common/middleware/http-error-logger.middleware.spec.ts
@@ -247,4 +247,49 @@ describe('httpErrorLogger', () => {
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('strips control characters from user-agent', () => {
+    const req = mockReq({
+      headers: { 'user-agent': 'evil\x00bot\x1f/1.0' },
+    });
+    const res = mockRes(400);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    const logMessage = warnSpy.mock.calls[0][0] as string;
+    expect(logMessage).toContain('ua=evilbot/1.0');
+    expect(logMessage).not.toMatch(/[\x00-\x1f\x7f]/);
+  });
+
+  it('strips control characters from forwarded IP', () => {
+    const req = mockReq({
+      headers: { 'user-agent': 'ua', 'x-forwarded-for': '1.2.3.4\x0d\x0a' },
+    });
+    const res = mockRes(400);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    const logMessage = warnSpy.mock.calls[0][0] as string;
+    expect(logMessage).toContain('ip=1.2.3.4');
+    expect(logMessage).not.toMatch(/[\x00-\x1f\x7f]/);
+  });
+
+  it('strips control characters from array x-forwarded-for', () => {
+    const req = mockReq({
+      headers: { 'user-agent': 'ua', 'x-forwarded-for': ['5.6\x007.8', '9.0.1.2'] },
+    });
+    const res = mockRes(400);
+    const next = jest.fn();
+
+    httpErrorLogger(req, res, next);
+    (res as unknown as EventEmitter).emit('finish');
+
+    const logMessage = warnSpy.mock.calls[0][0] as string;
+    expect(logMessage).toContain('ip=5.67.8');
+    expect(logMessage).not.toMatch(/[\x00-\x1f\x7f]/);
+  });
 });

--- a/packages/backend/src/common/middleware/http-error-logger.middleware.ts
+++ b/packages/backend/src/common/middleware/http-error-logger.middleware.ts
@@ -18,6 +18,10 @@ function isSuppressed(url: string, status: number): boolean {
   return false;
 }
 
+function stripControlChars(str: string): string {
+  return str.replace(/[\x00-\x1f\x7f]/g, '');
+}
+
 export function httpErrorLogger(req: Request, res: Response, next: NextFunction): void {
   const start = Date.now();
 
@@ -26,9 +30,9 @@ export function httpErrorLogger(req: Request, res: Response, next: NextFunction)
     if (isSuppressed(req.originalUrl, res.statusCode)) return;
 
     const elapsed = Date.now() - start;
-    const ua = (req.headers['user-agent'] ?? '').slice(0, 120);
+    const ua = stripControlChars((req.headers['user-agent'] ?? '').slice(0, 120));
     const ip = req.headers['x-forwarded-for'] ?? req.ip ?? '';
-    const forwardedIp = Array.isArray(ip) ? ip[0] : ip;
+    const forwardedIp = stripControlChars(Array.isArray(ip) ? ip[0] : ip);
 
     logger.warn(
       `${res.statusCode} ${req.method} ${req.originalUrl} ${elapsed}ms ip=${forwardedIp} ua=${ua}`,

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -31,7 +31,10 @@ export async function bootstrap() {
           fontSrc: ["'self'"],
           objectSrc: ["'none'"],
           frameAncestors: process.env['FRAME_ANCESTORS']
-            ? process.env['FRAME_ANCESTORS'].split(',')
+            ? process.env['FRAME_ANCESTORS']
+                .split(',')
+                .map((v) => v.trim())
+                .filter((v) => v !== '*')
             : ["'none'"],
         },
       },
@@ -106,6 +109,14 @@ export async function bootstrap() {
   const host = process.env['BIND_ADDRESS'] ?? '127.0.0.1';
   await app.listen(port, host);
   logger.log(`Server running on http://${host}:${port}`);
+
+  if (isDev && host !== '127.0.0.1' && host !== 'localhost' && host !== '::1') {
+    logger.warn(
+      `Development mode with BIND_ADDRESS=${host} — auth guards are relaxed for loopback IPs. ` +
+        'Ensure this server is not exposed to untrusted networks.',
+    );
+  }
+
   return app;
 }
 

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -167,8 +167,8 @@ export class OpenaiOauthService {
       this.logger.log(`OpenAI OAuth token refreshed for agent=${agentId}`);
       return refreshed.t;
     } catch (err) {
-      this.logger.error(`Failed to refresh OpenAI token: ${err}`);
-      return blob.t;
+      this.logger.error(`Failed to refresh OpenAI token for agent=${agentId}: ${err}`);
+      return null;
     }
   }
 
@@ -259,8 +259,18 @@ export class OpenaiOauthService {
       });
   }
 
+  private isAllowedRedirectOrigin(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      const hostname = parsed.hostname;
+      return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    } catch {
+      return false;
+    }
+  }
+
   private sendDoneResponse(res: ServerResponse, success: boolean, appUrl: string): void {
-    if (appUrl) {
+    if (appUrl && this.isAllowedRedirectOrigin(appUrl)) {
       const ok = success ? '1' : '0';
       res.writeHead(302, { Location: `${appUrl}/api/v1/oauth/openai/done?ok=${ok}` });
       res.end();

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -309,7 +309,7 @@ describe('OpenaiOauthService', () => {
       expect(result).toBe('fresh-access');
     });
 
-    it('returns existing token when refresh fails', async () => {
+    it('returns null when refresh fails', async () => {
       const blob: OAuthTokenBlob = {
         t: 'stale-access',
         r: 'bad-refresh',
@@ -322,7 +322,7 @@ describe('OpenaiOauthService', () => {
       });
 
       const result = await service.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
-      expect(result).toBe('stale-access');
+      expect(result).toBeNull();
     });
   });
 
@@ -636,6 +636,125 @@ describe('OpenaiOauthService', () => {
       // No backendUrl → inline error HTML, not a redirect
       expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
       expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
+    });
+
+    it('redirects to localhost backendUrl on success', async () => {
+      let requestHandler: (req: unknown, res: unknown) => void;
+      createServerMock.mockImplementationOnce((handler: (req: unknown, res: unknown) => void) => {
+        requestHandler = handler;
+        return {
+          listen: jest.fn((_p: number, _h: string, cb?: () => void) => cb?.()),
+          close: jest.fn(),
+          on: jest.fn(),
+          unref: jest.fn(),
+        };
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).callbackServer = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).serverReady = null;
+      const url = await service.generateAuthorizationUrl(
+        'agent-1',
+        'user-1',
+        'http://localhost:3001',
+      );
+      const state = new URL(url).searchParams.get('state')!;
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'tok',
+          refresh_token: 'ref',
+          expires_in: 3600,
+        }),
+      });
+
+      const res = { writeHead: jest.fn(), end: jest.fn() };
+      requestHandler!({ url: `/auth/callback?code=the-code&state=${state}` }, res);
+
+      await new Promise((r) => setTimeout(r, 50));
+      expect(res.writeHead).toHaveBeenCalledWith(302, {
+        Location: 'http://localhost:3001/api/v1/oauth/openai/done?ok=1',
+      });
+    });
+
+    it('falls back to HTML when backendUrl is an external origin', async () => {
+      let requestHandler: (req: unknown, res: unknown) => void;
+      createServerMock.mockImplementationOnce((handler: (req: unknown, res: unknown) => void) => {
+        requestHandler = handler;
+        return {
+          listen: jest.fn((_p: number, _h: string, cb?: () => void) => cb?.()),
+          close: jest.fn(),
+          on: jest.fn(),
+          unref: jest.fn(),
+        };
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).callbackServer = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).serverReady = null;
+      const url = await service.generateAuthorizationUrl(
+        'agent-1',
+        'user-1',
+        'https://evil.example.com',
+      );
+      const state = new URL(url).searchParams.get('state')!;
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'tok',
+          refresh_token: 'ref',
+          expires_in: 3600,
+        }),
+      });
+
+      const res = { writeHead: jest.fn(), end: jest.fn() };
+      requestHandler!({ url: `/auth/callback?code=the-code&state=${state}` }, res);
+
+      await new Promise((r) => setTimeout(r, 50));
+      // Should NOT redirect to external URL — falls back to HTML
+      expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+      expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-success'));
+    });
+
+    it('falls back to HTML when backendUrl is an invalid URL', async () => {
+      let requestHandler: (req: unknown, res: unknown) => void;
+      createServerMock.mockImplementationOnce((handler: (req: unknown, res: unknown) => void) => {
+        requestHandler = handler;
+        return {
+          listen: jest.fn((_p: number, _h: string, cb?: () => void) => cb?.()),
+          close: jest.fn(),
+          on: jest.fn(),
+          unref: jest.fn(),
+        };
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).callbackServer = null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).serverReady = null;
+      const url = await service.generateAuthorizationUrl('agent-1', 'user-1', 'not-a-valid-url');
+      const state = new URL(url).searchParams.get('state')!;
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'tok',
+          refresh_token: 'ref',
+          expires_in: 3600,
+        }),
+      });
+
+      const res = { writeHead: jest.fn(), end: jest.fn() };
+      requestHandler!({ url: `/auth/callback?code=the-code&state=${state}` }, res);
+
+      await new Promise((r) => setTimeout(r, 50));
+      // Invalid URL → falls back to HTML
+      expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+      expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-success'));
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1440,5 +1440,48 @@ describe('ProviderClient', () => {
         }),
       ).rejects.toThrow('Network error');
     });
+
+    it('sanitizes Google API key from fetch error messages', async () => {
+      mockFetch.mockRejectedValue(
+        new Error('getaddrinfo ENOTFOUND generativelanguage.googleapis.com key=AIzaSySecret123'),
+      );
+
+      await expect(
+        client.forward({
+          provider: 'google',
+          apiKey: 'AIzaSySecret123',
+          model: 'gemini-2.0-flash',
+          body,
+          stream: false,
+        }),
+      ).rejects.toThrow('key=***');
+
+      // Verify the secret key is NOT in the error
+      try {
+        await client.forward({
+          provider: 'google',
+          apiKey: 'AIzaSySecret123',
+          model: 'gemini-2.0-flash',
+          body,
+          stream: false,
+        });
+      } catch (err) {
+        expect((err as Error).message).not.toContain('AIzaSySecret123');
+      }
+    });
+
+    it('sanitizes non-Error fetch exceptions', async () => {
+      mockFetch.mockRejectedValue('key=LEAKED_SECRET fetch failed');
+
+      await expect(
+        client.forward({
+          provider: 'google',
+          apiKey: 'LEAKED_SECRET',
+          model: 'gemini-2.0-flash',
+          body,
+          stream: false,
+        }),
+      ).rejects.toThrow('key=***');
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-rate-limiter.spec.ts
@@ -182,6 +182,84 @@ describe('ProxyRateLimiter', () => {
     });
   });
 
+  describe('checkIpLimit', () => {
+    it('allows requests within the IP limit', () => {
+      for (let i = 0; i < 500; i++) {
+        expect(() => limiter.checkIpLimit('192.168.1.1')).not.toThrow();
+      }
+    });
+
+    it('throws 429 when IP rate exceeded', () => {
+      for (let i = 0; i < 500; i++) {
+        limiter.checkIpLimit('192.168.1.1');
+      }
+
+      expect(() => limiter.checkIpLimit('192.168.1.1')).toThrow(HttpException);
+    });
+
+    it('throws with correct status and message on IP rate exceeded', () => {
+      for (let i = 0; i < 500; i++) {
+        limiter.checkIpLimit('192.168.1.1');
+      }
+
+      try {
+        limiter.checkIpLimit('192.168.1.1');
+        fail('Expected HttpException');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpException);
+        expect((err as HttpException).getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
+        expect((err as HttpException).message).toBe(
+          'Too many requests from this IP — wait a few seconds and retry.',
+        );
+      }
+    });
+
+    it('resets after window expires', () => {
+      jest.useFakeTimers();
+
+      for (let i = 0; i < 500; i++) {
+        limiter.checkIpLimit('192.168.1.1');
+      }
+      expect(() => limiter.checkIpLimit('192.168.1.1')).toThrow(HttpException);
+
+      jest.advanceTimersByTime(60_001);
+
+      expect(() => limiter.checkIpLimit('192.168.1.1')).not.toThrow();
+      jest.useRealTimers();
+    });
+
+    it('isolates different IPs', () => {
+      for (let i = 0; i < 500; i++) {
+        limiter.checkIpLimit('192.168.1.1');
+      }
+
+      expect(() => limiter.checkIpLimit('192.168.1.1')).toThrow(HttpException);
+      expect(() => limiter.checkIpLimit('10.0.0.1')).not.toThrow();
+    });
+  });
+
+  describe('evictExpired cleans ipRates', () => {
+    it('removes expired IP entries when evictExpired is called', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ipRates = (limiter as any).ipRates as Map<
+        string,
+        { count: number; windowStart: number }
+      >;
+
+      ipRates.set('old-ip', { count: 5, windowStart: Date.now() - 120_000 });
+      ipRates.set('fresh-ip', { count: 2, windowStart: Date.now() });
+
+      expect(ipRates.size).toBe(2);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (limiter as any).evictExpired();
+
+      expect(ipRates.has('old-ip')).toBe(false);
+      expect(ipRates.has('fresh-ip')).toBe(true);
+      expect(ipRates.size).toBe(1);
+    });
+  });
+
   describe('acquireSlot / releaseSlot', () => {
     it('allows up to 10 concurrent slots', () => {
       for (let i = 0; i < 10; i++) {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -56,6 +56,7 @@ function mockRequest(
     },
     body,
     headers,
+    ip: '127.0.0.1',
   };
 }
 
@@ -64,6 +65,7 @@ describe('ProxyController', () => {
   let proxyService: { proxyRequest: jest.Mock };
   let rateLimiter: {
     checkLimit: jest.Mock;
+    checkIpLimit: jest.Mock;
     recordSuccess: jest.Mock;
     acquireSlot: jest.Mock;
     releaseSlot: jest.Mock;
@@ -95,6 +97,7 @@ describe('ProxyController', () => {
     proxyService = { proxyRequest: jest.fn() };
     rateLimiter = {
       checkLimit: jest.fn(),
+      checkIpLimit: jest.fn(),
       recordSuccess: jest.fn(),
       acquireSlot: jest.fn(),
       releaseSlot: jest.fn(),

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -150,6 +150,21 @@ describe('ProxyService', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
+  it('throws BadRequestException when messages array exceeds 1000', async () => {
+    const messages = Array.from({ length: 1001 }, (_, i) => ({
+      role: 'user',
+      content: `msg-${i}`,
+    }));
+    await expect(
+      service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body: { messages },
+        sessionKey: 'default',
+      }),
+    ).rejects.toThrow('messages array exceeds maximum length of 1000');
+  });
+
   it('sanitizes null content fields before forwarding', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'simple',

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -131,12 +131,18 @@ export class ProviderClient {
     const timeoutSignal = AbortSignal.timeout(PROVIDER_TIMEOUT_MS);
     const fetchSignal = signal ? AbortSignal.any([timeoutSignal, signal]) : timeoutSignal;
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(requestBody),
-      signal: fetchSignal,
-    });
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(requestBody),
+        signal: fetchSignal,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(message.replace(/key=[^&\s]+/gi, 'key=***'));
+    }
 
     return { response, isGoogle, isAnthropic, isChatGpt };
   }

--- a/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
+++ b/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
@@ -75,6 +75,7 @@ export class ProxyRateLimiter implements OnModuleDestroy {
 
     entry.count++;
     this.ipRates.set(ip, entry);
+    this.evictIpLruIfNeeded();
   }
 
   acquireSlot(userId: string): void {
@@ -115,6 +116,13 @@ export class ProxyRateLimiter implements OnModuleDestroy {
     while (this.rates.size > MAX_RATE_ENTRIES) {
       const oldest = this.rates.keys().next().value as string;
       this.rates.delete(oldest);
+    }
+  }
+
+  private evictIpLruIfNeeded(): void {
+    while (this.ipRates.size > MAX_RATE_ENTRIES) {
+      const oldest = this.ipRates.keys().next().value as string;
+      this.ipRates.delete(oldest);
     }
   }
 }

--- a/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
+++ b/packages/backend/src/routing/proxy/proxy-rate-limiter.ts
@@ -2,6 +2,7 @@ import { Injectable, OnModuleDestroy, HttpException, HttpStatus } from '@nestjs/
 
 const RATE_WINDOW_MS = 60_000;
 const RATE_MAX_REQUESTS = 200;
+const IP_RATE_MAX_REQUESTS = 500;
 const MAX_RATE_ENTRIES = 50_000;
 const CONCURRENCY_MAX = 10;
 const CLEANUP_INTERVAL_MS = 60_000;
@@ -14,6 +15,7 @@ interface RateEntry {
 @Injectable()
 export class ProxyRateLimiter implements OnModuleDestroy {
   private readonly rates = new Map<string, RateEntry>();
+  private readonly ipRates = new Map<string, RateEntry>();
   private readonly concurrency = new Map<string, number>();
   private readonly cleanupTimer: ReturnType<typeof setInterval>;
 
@@ -52,6 +54,29 @@ export class ProxyRateLimiter implements OnModuleDestroy {
     this.evictLruIfNeeded();
   }
 
+  /**
+   * Check if the IP is over the per-IP rate limit and increment the counter.
+   * This catches abuse even when all requests share a userId (e.g. dev/local mode).
+   */
+  checkIpLimit(ip: string): void {
+    const now = Date.now();
+    let entry = this.ipRates.get(ip);
+
+    if (!entry || now - entry.windowStart >= RATE_WINDOW_MS) {
+      entry = { count: 0, windowStart: now };
+    }
+
+    if (entry.count >= IP_RATE_MAX_REQUESTS) {
+      throw new HttpException(
+        'Too many requests from this IP — wait a few seconds and retry.',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    entry.count++;
+    this.ipRates.set(ip, entry);
+  }
+
   acquireSlot(userId: string): void {
     const current = this.concurrency.get(userId) ?? 0;
     if (current >= CONCURRENCY_MAX) {
@@ -77,6 +102,11 @@ export class ProxyRateLimiter implements OnModuleDestroy {
     for (const [key, entry] of this.rates) {
       if (now - entry.windowStart >= RATE_WINDOW_MS) {
         this.rates.delete(key);
+      }
+    }
+    for (const [key, entry] of this.ipRates) {
+      if (now - entry.windowStart >= RATE_WINDOW_MS) {
+        this.ipRates.delete(key);
       }
     }
   }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -68,6 +68,7 @@ export class ProxyController {
 
     try {
       this.rateLimiter.checkLimit(userId);
+      this.rateLimiter.checkIpLimit(req.ip ?? '');
       this.rateLimiter.acquireSlot(userId);
       slotAcquired = true;
       const { forward, meta, failedFallbacks } = await this.proxyService.proxyRequest({

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -75,6 +75,11 @@ export class ProxyService {
     }
     sanitizeNullContent(messages as Record<string, unknown>[]);
 
+    // Basic payload size guard — reject absurdly large message arrays
+    if (messages.length > 1000) {
+      throw new BadRequestException('messages array exceeds maximum length of 1000');
+    }
+
     const limitMessage = await this.enforceLimits(tenantId, agentName);
     if (limitMessage) {
       return buildFriendlyResponse(limitMessage, body.stream === true, 'limit_exceeded');

--- a/packages/frontend/src/components/ToastContainer.tsx
+++ b/packages/frontend/src/components/ToastContainer.tsx
@@ -1,5 +1,5 @@
-import { For, onMount, onCleanup, type Component } from "solid-js";
-import { toasts, dismissToast, type Toast } from "../services/toast-store.js";
+import { For, onMount, onCleanup, type Component } from 'solid-js';
+import { toasts, dismissToast, type Toast } from '../services/toast-store.js';
 
 const icons: Record<string, string> = {
   error:
@@ -20,11 +20,7 @@ const ToastItem: Component<{ toast: Toast }> = (props) => {
   onCleanup(() => clearTimeout(timer));
 
   return (
-    <div
-      class={`toast toast--${props.toast.type}`}
-      role="alert"
-      aria-live="assertive"
-    >
+    <div class={`toast toast--${props.toast.type}`} role="alert" aria-live="assertive">
       <svg
         class="toast__icon"
         width="18"
@@ -36,7 +32,7 @@ const ToastItem: Component<{ toast: Toast }> = (props) => {
         stroke-linecap="round"
         stroke-linejoin="round"
         aria-hidden="true"
-        innerHTML={icons[props.toast.type]}
+        innerHTML={icons[props.toast.type] ?? ''}
       />
       <span class="toast__message">{props.toast.message}</span>
       <button
@@ -66,9 +62,7 @@ const ToastItem: Component<{ toast: Toast }> = (props) => {
 const ToastContainer: Component = () => {
   return (
     <div class="toast-container" aria-live="polite" aria-relevant="additions removals">
-      <For each={toasts()}>
-        {(t) => <ToastItem toast={t} />}
-      </For>
+      <For each={toasts()}>{(t) => <ToastItem toast={t} />}</For>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

OWASP security audit follow-up with fixes for 10 findings:

**High**
- **H2**: Replace fragile `request.user` presence check with explicit `authMethod='session'` flag in guard chain — prevents accidental auth bypass if middleware sets `request.user`
- **H3**: Add IP-based rate limiting (500/min) as fallback in ProxyRateLimiter — prevents abuse when all dev/local requests share a userId

**Medium**
- **M1**: Log warning at startup when dev mode binds to non-loopback address
- **M2**: Sanitize Google API key from fetch error messages in provider-client
- **M3**: Validate OAuth redirect URLs are localhost-only before issuing 302
- **M5**: Strip wildcard `*` from FRAME_ANCESTORS CSP env var
- **M6**: Add nullish fallback for `innerHTML` in ToastContainer

**Low**
- **L2**: Reject proxy requests with more than 1000 messages
- **L3**: Strip control characters from user-agent and IP in error logger
- **L4**: Return null instead of expired token when OAuth refresh fails

## Test plan

- [x] Backend unit tests pass (174 suites, 3429 tests)
- [x] Backend E2E tests pass (14 suites, 99 tests)
- [x] Frontend tests pass (100 suites, 1894 tests)
- [x] TypeScript compiles cleanly
- [x] New guard behavior tested (authMethod flag, user-without-authMethod rejection)
- [x] IP rate limiter tested (within limit, exceeded, window reset, IP isolation)
- [x] Google API key sanitization tested in error paths
- [x] OAuth redirect validation tested (localhost allowed, external blocked)
- [x] Message array length limit tested
- [x] Control character stripping tested in error logger

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened auth guards, rate limiting, and input sanitization to address OWASP findings. Prevents auth bypass, curbs abuse in dev/local, cleans logs/errors, and caps rate-limiter memory.

- **Bug Fixes**
  - Guard chain now requires `authMethod='session'`; `ApiKeyGuard` skips only when this flag is set.
  - Added IP-based rate limiting (500/min) in the proxy, with windowed cleanup and max-entry eviction to prevent unbounded memory growth.
  - Sanitized errors and logs: mask Google API keys in fetch errors; strip control chars from `user-agent` and `x-forwarded-for`.
  - OAuth hardening: only redirect to localhost origins; HTML fallback otherwise; return null if token refresh fails.
  - CSP fix: remove `*` from `FRAME_ANCESTORS` to avoid clickjacking misconfig.
  - Input hardening: reject requests with >1000 messages; safe fallback for toast icon `innerHTML`.
  - Dev warning at startup when binding to a non-loopback address in development.

<sup>Written for commit bdb76f711fe2fecfb43d10f9edf458067918595b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

