### PR TITLE
fix: skip changeset check for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
   changeset-check:
     name: Changeset status
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Skip the `changeset-check` CI job when the PR author is `dependabot[bot]`
- Dependabot PRs only bump dependency versions in `package.json` / `package-lock.json` — they don't need a changeset since the version bump is handled by the dependency update itself

## Test plan

- [x] Verify the `if` condition syntax is valid for GitHub Actions
- [ ] Merge this PR, then re-run CI on the open dependabot PR to confirm it passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the changeset-check job for Dependabot PRs to reduce noise and avoid unnecessary failures. Dependabot only bumps versions in `package.json` and `package-lock.json`, so a changeset isn’t needed.

<sup>Written for commit ceea03cb07ede35ce181c684415e82e2a9d3bb42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

