### PR TITLE
revert: undo skip changeset check for dependabot (wrong repo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
   changeset-check:
     name: Changeset status
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main' && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Reverts #1507 — the changeset skip was meant for the peacock repo, not manifest

## Test plan

- [x] CI should require changesets for all PRs again (including dependabot)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the CI condition that skipped the changeset check for Dependabot PRs, restoring the requirement for changesets on all PRs. The skip was intended for the peacock repo, not this one.

<sup>Written for commit 1955d0643273bf8ca6b454bb6a75352bb90352ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

