### PR TITLE
chore(docker): harden image and compose without breaking upgrades

### DIFF
--- a/.changeset/docker-security-hardening.md
+++ b/.changeset/docker-security-hardening.md
@@ -1,0 +1,12 @@
+---
+"manifest": patch
+---
+
+Harden the published Docker image and compose stack without changing the upgrade path:
+
+- Pin `node:22-alpine` and `postgres:16-alpine` base images by multi-arch digest
+- Fix HEALTHCHECK to use `127.0.0.1` instead of `localhost` (IPv6 resolution was causing spurious unhealthy status)
+- Add container hardening to `docker-compose.yml`: read-only root filesystem with tmpfs for `/tmp`, dropped all Linux capabilities, `no-new-privileges`, 1 GB memory limit, 256 pids limit
+- Isolate Postgres on an `internal: true` network with no egress; expose only Manifest on the `frontend` network
+- Sign published images with cosign keyless signing (Sigstore); verification command documented in `docker/DOCKER_README.md`
+- Add Dependabot config for weekly Docker base image updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,9 @@ jobs:
     name: Build & Publish
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -72,6 +75,7 @@ jobs:
             type=sha
 
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           file: docker/Dockerfile
@@ -83,3 +87,14 @@ jobs:
           cache-to: type=gha,mode=max
           sbom: true
           provenance: mode=max
+
+      - uses: sigstore/cosign-installer@v3
+
+      - name: Sign published image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          for tag in ${TAGS}; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -105,6 +105,16 @@ docker run -d \
 
 Local mode skips the login page. The dashboard is accessible directly.
 
+### Verifying the image signature
+
+Published images are signed with cosign keyless signing (Sigstore). Verify before pulling:
+
+```bash
+cosign verify manifestdotbuild/manifest:<version> \
+  --certificate-identity-regexp="^https://github.com/mnfst/manifest/" \
+  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+
 ### Custom port
 
 If port 3001 is taken, change both the mapping and `BETTER_AUTH_URL`:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 # Stage 1: Install dependencies
-FROM node:22-alpine AS deps
+# Base image pinned by digest (multi-arch manifest list). Updated via Dependabot.
+FROM node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3 AS deps
 WORKDIR /app
 COPY package.json package-lock.json turbo.json ./
 COPY packages/shared/package.json packages/shared/
@@ -17,7 +18,7 @@ COPY packages/backend packages/backend
 RUN npx turbo build --filter=manifest-backend --filter=manifest-frontend --filter=manifest-shared
 
 # Stage 3: Production dependencies only
-FROM node:22-alpine AS prod-deps
+FROM node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3 AS prod-deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 COPY packages/shared/package.json packages/shared/
@@ -47,7 +48,7 @@ RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev --ignore-scripts && \
     true
 
 # Stage 4: Production runtime
-FROM node:22-alpine AS runtime
+FROM node:22-alpine@sha256:4d64b49e6c891c8fc821007cb1cdc6c0db7773110ac2c34bf2e6960adef62ed3 AS runtime
 WORKDIR /app
 
 LABEL org.opencontainers.image.title="Manifest" \
@@ -77,7 +78,7 @@ RUN mkdir -p /home/node/.openclaw/manifest && chown -R node:node /home/node/.ope
 EXPOSE 3001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -qO- http://localhost:3001/api/v1/health || exit 1
+  CMD wget -qO- http://127.0.0.1:3001/api/v1/health || exit 1
 
 USER node
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,9 +13,21 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    mem_limit: 1g
+    pids_limit: 256
+    networks:
+      - internal
+      - frontend
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416
     environment:
       - POSTGRES_USER=manifest
       - POSTGRES_PASSWORD=manifest
@@ -27,6 +39,17 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    security_opt:
+      - no-new-privileges:true
+    networks:
+      - internal
+
+networks:
+  internal:
+    driver: bridge
+    internal: true
+  frontend:
+    driver: bridge
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Closes security audit findings on the published Docker image and `docker/docker-compose.yml` without introducing any upgrade friction for existing users. The documented quickstart (`curl docker-compose.yml && docker compose up -d`) still works byte-for-byte, existing `pgdata` volumes keep working, no new env vars are required, no encrypted data breaks.

## What ships

- **Base image digest pinning.** `node:22-alpine` pinned by multi-arch manifest digest in all three stages of `docker/Dockerfile`; `postgres:16-alpine` pinned the same way in `docker/docker-compose.yml`. Updates tracked by a new Dependabot config.
- **HEALTHCHECK fix.** `docker/Dockerfile` was using `http://localhost:3001` but the container's `/etc/hosts` resolves `localhost` to `::1` first while the app binds only to `0.0.0.0`, so BusyBox `wget` got `Connection refused` and the container was reported unhealthy. Switched to `http://127.0.0.1:3001` — after the fix the container reports healthy within seconds.
- **Container hardening on the Manifest service** (layered on top of the existing compose, no env changes): `read_only: true` + `tmpfs: /tmp`, `cap_drop: [ALL]`, `security_opt: [no-new-privileges:true]`, `mem_limit: 1g`, `pids_limit: 256`.
- **Network isolation.** Two named networks: `internal` (with `internal: true`, no egress) shared by Postgres and Manifest, and `frontend` (bridge) for the host-exposed Manifest port. Postgres is unreachable from outside the compose project and cannot make outbound connections.
- **`no-new-privileges`** also applied to Postgres.
- **Image signing.** `.github/workflows/docker.yml` publish job now signs every published tag via cosign keyless (Sigstore) — `id-token: write` scoped to the `publish` job only. Verification command added to `docker/DOCKER_README.md`.
- **Dependabot.** Weekly Docker ecosystem updates scoped to `/docker`.

## What is intentionally NOT changed

To keep existing installs upgrading cleanly, these items from the original audit were explicitly left alone:

- `BETTER_AUTH_SECRET`, `POSTGRES_PASSWORD`, and the `manifestdotbuild/manifest:latest` image tag are unchanged — no `.env` requirement, no secret rotation on upgrade.
- `NODE_ENV=development` and `SEED_DATA=true` remain the default so the documented `admin@manifest.build` / `manifest` login still works.
- `MANIFEST_ENCRYPTION_KEY` is not referenced — existing deployments that stored encrypted provider API keys under `BETTER_AUTH_SECRET` (via the fallback in `packages/backend/src/common/utils/crypto.util.ts`) are not forced to rotate, which would have bricked their stored keys.
- No backend source changes: `packages/backend/src/database/database.module.ts` is unchanged from main.

## Test plan

- [x] `npm test --workspace=packages/backend` — 3543 passed (181 suites)
- [x] `npm run test:e2e --workspace=packages/backend` — 99 passed (14 suites) against a fresh isolated Postgres database
- [x] `npm test --workspace=packages/frontend` — 1929 passed (100 files)
- [x] `cd packages/backend && npx tsc --noEmit` — clean
- [x] `cd packages/frontend && npx tsc --noEmit` — clean
- [x] `docker build -f docker/Dockerfile -t manifest:test .` — builds clean
- [x] `docker compose up -d` from `docker/` — both containers report `(healthy)` within 20 seconds, `curl http://localhost:3001/api/v1/health` returns 200, seeder logs `admin@manifest.build` warning, the hardening probes all pass:
  - `touch /test` inside the Manifest container → `Read-only file system`
  - `touch /tmp/test` → works (tmpfs)
  - `docker inspect` → `CapDrop=[ALL]`, `ReadonlyRootfs=true`, `PidsLimit=256`, `Memory=1073741824`
  - `docker network inspect manifest_internal` → `Internal=true`
  - `wget http://icanhazip.com` from the Postgres container → hangs and SIGTERMed (no egress)
- [x] Stop/start cycle preserves `pgdata` volume (`SELECT COUNT(*) FROM tenants` returns 1 after restart), confirming no password mismatch for existing users

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Docker image and compose stack without breaking upgrades. Fixes the container HEALTHCHECK and adds network isolation and image signing; the quickstart and existing volumes are unchanged.

- **New Features**
  - Hardened compose: read-only rootfs with `tmpfs /tmp`, `cap_drop: [ALL]`, `security_opt: [no-new-privileges:true]`, 1 GB memory, 256 pids; `no-new-privileges` also on Postgres.
  - Network isolation: Postgres on `internal` (no egress, not exposed); app on `frontend`.
  - Image signing via cosign keyless; verification steps added to `docker/DOCKER_README.md`.

- **Dependencies**
  - Pin `node:22-alpine` and `postgres:16-alpine` by multi-arch digest; add weekly Docker updates via Dependabot in `/docker`.

<sup>Written for commit 06eb6f42f6f71c9c473fb88a1ecad94a41061f43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

