### PR TITLE
fix(routing): round-trip Gemini thoughtSignature correctly

### DIFF
--- a/.changeset/fix-gemini-thought-signature.md
+++ b/.changeset/fix-gemini-thought-signature.md
@@ -1,0 +1,12 @@
+---
+"manifest": patch
+---
+
+Fix Gemini 3 tool calling by round-tripping `thoughtSignature` correctly.
+
+The Google adapter was reading and writing `thought_signature` (snake_case, inside the `functionCall` object), but Google's actual wire format is `thoughtSignature` (camelCase, at the Part level, as a sibling of `functionCall`). Signatures were therefore never extracted from Gemini responses and never re-injected into follow-up requests. Gemini 3 made these signatures mandatory for tool-use follow-ups, surfacing the bug as `HTTP 400: Function call is missing a thought_signature in functionCall parts`. Gemini 2.5 Pro and 2.5 Flash were silently affected too, losing reasoning context across tool-call turns.
+
+- Parse `thoughtSignature` from the Part level in both streaming and non-streaming Google responses
+- Re-inject cached signatures as a Part-level `thoughtSignature` field when building follow-up requests
+- Drop `thought: true` reasoning-summary text parts from assistant content (previously leaked into replies)
+- Replace the regex-on-transformed-output signature extraction in the stream handler with a structured return value from the adapter

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -1,4 +1,17 @@
-import { toGoogleRequest, fromGoogleResponse, transformGoogleStreamChunk } from '../google-adapter';
+import {
+  toGoogleRequest,
+  fromGoogleResponse,
+  transformGoogleStreamChunk as transformGoogleStreamChunkRaw,
+} from '../google-adapter';
+
+/**
+ * Test helper: most tests below only care about the SSE chunk string produced
+ * by the transform, not the signature side-channel. This wrapper keeps the
+ * old string-returning shape so those tests don't need to destructure.
+ */
+function transformGoogleStreamChunk(chunk: string, model: string): string | null {
+  return transformGoogleStreamChunkRaw(chunk, model).chunk;
+}
 
 describe('Google Adapter', () => {
   describe('toGoogleRequest', () => {
@@ -420,7 +433,7 @@ describe('Google Adapter', () => {
       });
     });
 
-    it('passes through thought_signature in tool_calls to functionCall parts', () => {
+    it('passes through thought_signature as Part-level thoughtSignature', () => {
       const body = {
         messages: [
           { role: 'user', content: 'Read my file' },
@@ -438,16 +451,67 @@ describe('Google Adapter', () => {
           },
         ],
       };
-      const result = toGoogleRequest(body, 'gemini-3-flash-preview');
+      const result = toGoogleRequest(body, 'gemini-3-pro-preview');
       const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
-      expect(contents[1].parts[0].functionCall).toEqual({
-        name: 'read_file',
-        args: { path: 'a.txt' },
-        thought_signature: 'sig_abc123',
+      // The signature MUST be a sibling of functionCall on the Part, not
+      // nested inside functionCall — Gemini 3 rejects the nested form.
+      expect(contents[1].parts[0]).toEqual({
+        functionCall: { name: 'read_file', args: { path: 'a.txt' } },
+        thoughtSignature: 'sig_abc123',
       });
+      expect(
+        (contents[1].parts[0].functionCall as Record<string, unknown>).thoughtSignature,
+      ).toBeUndefined();
     });
 
-    it('omits thought_signature when not present in tool_calls', () => {
+    it('re-injects cached signatures via signatureLookup', () => {
+      const body = {
+        messages: [
+          { role: 'user', content: 'Read my file' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'read_file', arguments: '{}' },
+              },
+            ],
+          },
+        ],
+      };
+      const lookup = jest.fn().mockReturnValue('cached_sig');
+      const result = toGoogleRequest(body, 'gemini-3-pro-preview', lookup);
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(lookup).toHaveBeenCalledWith('call_1');
+      expect(contents[1].parts[0].thoughtSignature).toBe('cached_sig');
+    });
+
+    it('prefers client-echoed signature over cache when both exist', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'noop', arguments: '{}' },
+                thought_signature: 'from_client',
+              },
+            ],
+          },
+        ],
+      };
+      const lookup = jest.fn().mockReturnValue('from_cache');
+      const result = toGoogleRequest(body, 'gemini-3-pro-preview', lookup);
+      const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
+      expect(contents[0].parts[0].thoughtSignature).toBe('from_client');
+    });
+
+    it('omits thoughtSignature when neither client nor cache provides one', () => {
       const body = {
         messages: [
           {
@@ -465,7 +529,8 @@ describe('Google Adapter', () => {
       };
       const result = toGoogleRequest(body, 'gemini-2.0-flash');
       const contents = result.contents as Array<{ parts: Array<Record<string, unknown>> }>;
-      expect(contents[0].parts[0].functionCall).toEqual({ name: 'noop', args: {} });
+      expect(contents[0].parts[0]).toEqual({ functionCall: { name: 'noop', args: {} } });
+      expect(contents[0].parts[0].thoughtSignature).toBeUndefined();
     });
   });
 
@@ -792,18 +857,15 @@ describe('Google Adapter', () => {
       expect(usage.cache_read_tokens).toBe(0);
     });
 
-    it('preserves thought_signature on function call response', () => {
+    it('extracts Part-level thoughtSignature from functionCall response', () => {
       const google = {
         candidates: [
           {
             content: {
               parts: [
                 {
-                  functionCall: {
-                    name: 'read_file',
-                    args: { path: 'a.txt' },
-                    thought_signature: 'sig_xyz789',
-                  },
+                  functionCall: { name: 'read_file', args: { path: 'a.txt' } },
+                  thoughtSignature: 'sig_xyz789',
                 },
               ],
             },
@@ -812,14 +874,43 @@ describe('Google Adapter', () => {
         ],
       };
 
-      const result = fromGoogleResponse(google, 'gemini-3-flash-preview');
+      const result = fromGoogleResponse(google, 'gemini-3-pro-preview');
       const choices = result.choices as Array<{ message: Record<string, unknown> }>;
       const toolCalls = choices[0].message.tool_calls as Array<Record<string, unknown>>;
       expect(toolCalls).toHaveLength(1);
       expect(toolCalls[0].thought_signature).toBe('sig_xyz789');
+
+      // The extracted signature is also surfaced via _extractedSignatures so
+      // the response handler can cache it for the next turn.
+      const extracted = (result as Record<string, unknown>)._extractedSignatures as Array<{
+        toolCallId: string;
+        signature: string;
+      }>;
+      expect(extracted).toHaveLength(1);
+      expect(extracted[0].signature).toBe('sig_xyz789');
+      expect(extracted[0].toolCallId).toBe(toolCalls[0].id);
     });
 
-    it('omits thought_signature when not in function call response', () => {
+    it('drops thought text parts from assistant content', () => {
+      const google = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: 'Internal reasoning...', thought: true },
+                { text: 'User-facing answer.' },
+              ],
+            },
+            finishReason: 'STOP',
+          },
+        ],
+      };
+      const result = fromGoogleResponse(google, 'gemini-3-pro-preview');
+      const choices = result.choices as Array<{ message: Record<string, unknown> }>;
+      expect(choices[0].message.content).toBe('User-facing answer.');
+    });
+
+    it('omits thought_signature when the Part has no signature', () => {
       const google = {
         candidates: [
           {
@@ -1007,27 +1098,56 @@ describe('Google Adapter', () => {
       expect(data.choices[0].delta.tool_calls[1].function.name).toBe('tool_b');
     });
 
-    it('preserves thought_signature on streaming functionCall', () => {
+    it('preserves Part-level thoughtSignature on streaming functionCall', () => {
       const chunk = JSON.stringify({
         candidates: [
           {
             content: {
               parts: [
                 {
-                  functionCall: {
-                    name: 'read_file',
-                    args: { path: 'a.txt' },
-                    thought_signature: 'sig_stream_456',
-                  },
+                  functionCall: { name: 'read_file', args: { path: 'a.txt' } },
+                  thoughtSignature: 'sig_stream_456',
                 },
               ],
             },
           },
         ],
       });
-      const result = transformGoogleStreamChunk(chunk, 'gemini-3-flash-preview');
+      const { chunk: result, signatures } = transformGoogleStreamChunkRaw(
+        chunk,
+        'gemini-3-pro-preview',
+      );
       const data = JSON.parse(result!.split('\n\n')[0].replace('data: ', ''));
       expect(data.choices[0].delta.tool_calls[0].thought_signature).toBe('sig_stream_456');
+      expect(signatures).toHaveLength(1);
+      expect(signatures[0].signature).toBe('sig_stream_456');
+      expect(signatures[0].toolCallId).toBe(data.choices[0].delta.tool_calls[0].id);
+    });
+
+    it('returns empty signatures array when stream chunk has no thoughtSignature', () => {
+      const chunk = JSON.stringify({
+        candidates: [{ content: { parts: [{ text: 'hi' }] } }],
+      });
+      const { signatures } = transformGoogleStreamChunkRaw(chunk, 'gemini-2.0-flash');
+      expect(signatures).toEqual([]);
+    });
+
+    it('drops thought text parts from streaming content', () => {
+      const chunk = JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: 'thinking', thought: true },
+                { text: 'answer' },
+              ],
+            },
+          },
+        ],
+      });
+      const result = transformGoogleStreamChunk(chunk, 'gemini-3-pro-preview');
+      const data = JSON.parse(result!.split('\n\n')[0].replace('data: ', ''));
+      expect(data.choices[0].delta.content).toBe('answer');
     });
 
     it('handles functionCall with null args', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -747,13 +747,35 @@ describe('ProviderClient', () => {
       });
       const result = client.convertGoogleStreamChunk(chunk, 'gemini-2.0-flash');
 
-      expect(result).toContain('data: ');
-      expect(result).toContain('"chat.completion.chunk"');
+      expect(result.chunk).toContain('data: ');
+      expect(result.chunk).toContain('"chat.completion.chunk"');
+      expect(result.signatures).toEqual([]);
     });
 
-    it('returns null for empty chunk', () => {
+    it('returns null chunk for empty input', () => {
       const result = client.convertGoogleStreamChunk('', 'gemini-2.0-flash');
-      expect(result).toBeNull();
+      expect(result.chunk).toBeNull();
+      expect(result.signatures).toEqual([]);
+    });
+
+    it('surfaces extracted signatures from functionCall parts', () => {
+      const chunk = JSON.stringify({
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  functionCall: { name: 'fn', args: {} },
+                  thoughtSignature: 'sig_abc',
+                },
+              ],
+            },
+          },
+        ],
+      });
+      const result = client.convertGoogleStreamChunk(chunk, 'gemini-3-pro-preview');
+      expect(result.signatures).toHaveLength(1);
+      expect(result.signatures[0].signature).toBe('sig_abc');
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -480,7 +480,6 @@ describe('proxy-response-handler', () => {
       const sessionKey = 'sess-123';
 
       // The transformer is captured by pipeStream — we need to invoke it manually.
-      // Capture the transform function passed to pipeStream.
       let capturedTransform: ((chunk: string) => string | null) | undefined;
       pipeStreamSpy.mockImplementation(
         async (_body: unknown, _res: unknown, transform?: (chunk: string) => string | null) => {
@@ -489,7 +488,15 @@ describe('proxy-response-handler', () => {
         },
       );
 
-      client.convertGoogleStreamChunk.mockImplementation((chunk: string) => chunk);
+      // convertGoogleStreamChunk now returns structured { chunk, signatures }
+      // so the handler can cache signatures without scraping the output.
+      client.convertGoogleStreamChunk.mockReturnValue({
+        chunk: 'data: {}\n\n',
+        signatures: [
+          { toolCallId: 'call_abc', signature: 'sig_xyz' },
+          { toolCallId: 'call_def', signature: 'sig_uvw' },
+        ],
+      });
 
       await handleStreamResponse(
         res as any,
@@ -502,12 +509,36 @@ describe('proxy-response-handler', () => {
       );
 
       expect(capturedTransform).toBeDefined();
+      const out = capturedTransform!('{}');
+      expect(out).toBe('data: {}\n\n');
 
-      // Simulate a chunk with thought_signature and id fields
-      const chunk = '{"id":"call_abc","thought_signature":"sig_xyz"}';
-      capturedTransform!(chunk);
-
+      expect(signatureCache.store).toHaveBeenCalledTimes(2);
       expect(signatureCache.store).toHaveBeenCalledWith('sess-123', 'call_abc', 'sig_xyz');
+      expect(signatureCache.store).toHaveBeenCalledWith('sess-123', 'call_def', 'sig_uvw');
+    });
+
+    it('should not cache when signatureCache is absent', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward({ isGoogle: true });
+      const client = mockProviderClient();
+      const meta = makeMeta();
+
+      let capturedTransform: ((chunk: string) => string | null) | undefined;
+      pipeStreamSpy.mockImplementation(
+        async (_body: unknown, _res: unknown, transform?: (chunk: string) => string | null) => {
+          capturedTransform = transform;
+          return null;
+        },
+      );
+      client.convertGoogleStreamChunk.mockReturnValue({
+        chunk: 'data: {}\n\n',
+        signatures: [{ toolCallId: 'call_abc', signature: 'sig_xyz' }],
+      });
+
+      await handleStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      // Should not throw — just drops the signatures silently.
+      expect(() => capturedTransform!('{}')).not.toThrow();
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -1892,9 +1892,10 @@ describe('ProxyController', () => {
         },
       });
 
-      providerClient.convertGoogleStreamChunk.mockReturnValue(
-        'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
-      );
+      providerClient.convertGoogleStreamChunk.mockReturnValue({
+        chunk: 'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+        signatures: [],
+      });
 
       const req = mockRequest({
         messages: [{ role: 'user', content: 'test' }],

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -15,8 +15,12 @@ interface GeminiContent {
 
 interface GeminiPart {
   text?: string;
-  functionCall?: { name: string; args: Record<string, unknown>; [key: string]: unknown };
+  functionCall?: { name: string; args: Record<string, unknown> };
   functionResponse?: { name: string; response: Record<string, unknown> };
+  // Google attaches thoughtSignature at the Part level (sibling of functionCall),
+  // not inside the functionCall object. Gemini 3 rejects tool-use follow-ups
+  // that don't round-trip this field.
+  thoughtSignature?: string;
 }
 
 /**
@@ -109,15 +113,15 @@ function messageToContent(
         name: tc.function.name,
         args: safeParseArgs(tc.function.arguments),
       };
-      // Preserve thought_signature from the client, or re-inject from cache
-      const sig = (tc as Record<string, unknown>).thought_signature;
-      if (sig) {
-        functionCall!.thought_signature = sig;
-      } else if (signatureLookup) {
-        const cached = signatureLookup(tc.id);
-        if (cached) functionCall!.thought_signature = cached;
-      }
-      parts.push({ functionCall });
+      const part: GeminiPart = { functionCall };
+      // Preserve thought_signature from the client (if it echoed it back), or
+      // re-inject it from the cache. On the Google wire, the field lives at
+      // the Part level as `thoughtSignature`, not inside functionCall.
+      const echoed = (tc as Record<string, unknown>).thought_signature;
+      const cached = signatureLookup ? signatureLookup(tc.id) : null;
+      const signature = typeof echoed === 'string' ? echoed : cached;
+      if (signature) part.thoughtSignature = signature;
+      parts.push(part);
     }
   }
 
@@ -233,38 +237,32 @@ export function fromGoogleResponse(
 
   let textContent = '';
   const toolCalls: Record<string, unknown>[] = [];
+  const extractedSignatures: ExtractedSignature[] = [];
 
   for (const part of parts) {
-    if (part.text) textContent += part.text;
+    // Thinking summaries come back as text parts with `thought: true`. Skip
+    // them — the OpenAI-compat surface doesn't expose them, and including
+    // them in `content` would leak chain-of-thought into the assistant reply.
+    if (part.text && !part.thought) textContent += part.text;
     if (part.functionCall) {
-      const fc = part.functionCall as {
-        name: string;
-        args: Record<string, unknown>;
-        thought_signature?: string;
-      };
+      const fc = part.functionCall as { name: string; args: Record<string, unknown> };
+      const toolCallId = `call_${randomUUID()}`;
       const toolCall: Record<string, unknown> = {
-        id: `call_${randomUUID()}`,
+        id: toolCallId,
         type: 'function',
         function: { name: fc.name, arguments: JSON.stringify(fc.args) },
       };
-      if (fc.thought_signature) toolCall.thought_signature = fc.thought_signature;
+      const sig = part.thoughtSignature;
+      if (typeof sig === 'string' && sig) {
+        toolCall.thought_signature = sig;
+        extractedSignatures.push({ toolCallId, signature: sig });
+      }
       toolCalls.push(toolCall);
     }
   }
 
   const message: Record<string, unknown> = { role: 'assistant', content: textContent || null };
   if (toolCalls.length > 0) message.tool_calls = toolCalls;
-
-  // Extract thought_signatures for caching
-  const extractedSignatures: ExtractedSignature[] = [];
-  for (const tc of toolCalls) {
-    if (tc.thought_signature && typeof tc.id === 'string') {
-      extractedSignatures.push({
-        toolCallId: tc.id as string,
-        signature: tc.thought_signature as string,
-      });
-    }
-  }
 
   const usage = googleResp.usageMetadata as Record<string, number> | undefined;
 
@@ -305,37 +303,58 @@ function mapFinishReason(candidate: Record<string, unknown>, hasToolCalls = fals
 
 /* ── Stream chunk conversion ── */
 
-export function transformGoogleStreamChunk(chunk: string, model: string): string | null {
-  if (!chunk.trim()) return null;
+/**
+ * Result of transforming one Google SSE chunk. `chunk` is the OpenAI-formatted
+ * SSE text to forward to the client (null when the input chunk produced no
+ * output). `signatures` lists any thoughtSignature values extracted from
+ * functionCall parts in this chunk, which the caller should cache so they can
+ * be re-injected on the next turn (Gemini 3 requires this).
+ */
+export interface GoogleStreamChunkResult {
+  chunk: string | null;
+  signatures: ExtractedSignature[];
+}
+
+export function transformGoogleStreamChunk(
+  chunk: string,
+  model: string,
+): GoogleStreamChunkResult {
+  const empty: GoogleStreamChunkResult = { chunk: null, signatures: [] };
+  if (!chunk.trim()) return empty;
 
   let data: Record<string, unknown>;
   try {
     data = JSON.parse(chunk);
   } catch {
-    return null;
+    return empty;
   }
 
   const candidates = (data.candidates as Array<Record<string, unknown>>) || [];
   const candidate = candidates[0];
   const content = candidate?.content as { parts?: Array<Record<string, unknown>> } | undefined;
   const parts = content?.parts || [];
-  const text = parts.map((p) => p.text || '').join('');
+  const text = parts
+    .filter((p) => !p.thought)
+    .map((p) => p.text || '')
+    .join('');
 
   const toolCalls: Record<string, unknown>[] = [];
+  const signatures: ExtractedSignature[] = [];
   for (const part of parts) {
     if (part.functionCall) {
-      const fc = part.functionCall as {
-        name: string;
-        args?: Record<string, unknown>;
-        thought_signature?: string;
-      };
+      const fc = part.functionCall as { name: string; args?: Record<string, unknown> };
+      const toolCallId = `call_${randomUUID()}`;
       const toolCall: Record<string, unknown> = {
         index: toolCalls.length,
-        id: `call_${randomUUID()}`,
+        id: toolCallId,
         type: 'function',
         function: { name: fc.name, arguments: JSON.stringify(fc.args ?? {}) },
       };
-      if (fc.thought_signature) toolCall.thought_signature = fc.thought_signature;
+      const sig = part.thoughtSignature;
+      if (typeof sig === 'string' && sig) {
+        toolCall.thought_signature = sig;
+        signatures.push({ toolCallId, signature: sig });
+      }
       toolCalls.push(toolCall);
     }
   }
@@ -382,5 +401,5 @@ export function transformGoogleStreamChunk(chunk: string, model: string): string
     })}\n\n`;
   }
 
-  return result || null;
+  return { chunk: result || null, signatures };
 }

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -1,4 +1,9 @@
-import { toGoogleRequest, fromGoogleResponse, transformGoogleStreamChunk } from './google-adapter';
+import {
+  toGoogleRequest,
+  fromGoogleResponse,
+  transformGoogleStreamChunk,
+  type GoogleStreamChunkResult,
+} from './google-adapter';
 import {
   toAnthropicRequest,
   fromAnthropicResponse,
@@ -34,7 +39,10 @@ export function convertGoogleResponse(
 }
 
 /** Convert a Google SSE chunk to OpenAI SSE format. */
-export function convertGoogleStreamChunk(chunk: string, model: string): string | null {
+export function convertGoogleStreamChunk(
+  chunk: string,
+  model: string,
+): GoogleStreamChunkResult {
   return transformGoogleStreamChunk(chunk, model);
 }
 
@@ -58,7 +66,7 @@ export function createAnthropicTransformer(model: string): (chunk: string) => st
 
 // Re-export adapter functions used by ProviderClient.forward()
 export { toGoogleRequest, toAnthropicRequest, toResponsesRequest, collectChatGptSseResponse };
-export type { ExtractedSignature } from './google-adapter';
+export type { ExtractedSignature, GoogleStreamChunkResult } from './google-adapter';
 export type { SignatureLookup } from './proxy-types';
 
 // ─── OpenAI body sanitization (used by ProviderClient.forward) ───────────────

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -14,6 +14,7 @@ import {
   convertAnthropicResponse as anthropicResponseConverter,
   convertAnthropicStreamChunk as anthropicStreamChunkConverter,
   createAnthropicTransformer,
+  type GoogleStreamChunkResult,
 } from './provider-client-converters';
 import { ForwardOptions } from './proxy-types';
 
@@ -166,7 +167,7 @@ export class ProviderClient {
   }
 
   /** Convert a Google SSE chunk to OpenAI SSE format. */
-  convertGoogleStreamChunk(chunk: string, model: string): string | null {
+  convertGoogleStreamChunk(chunk: string, model: string): GoogleStreamChunkResult {
     return googleStreamChunkConverter(chunk, model);
   }
 

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -190,18 +190,16 @@ export async function handleStreamResponse(
 
   if (forward.isGoogle) {
     return pipeStream(forward.response.body!, res, (chunk) => {
-      const result = providerClient.convertGoogleStreamChunk(chunk, meta.model);
-      // Cache thought_signatures from streamed tool calls
-      if (signatureCache && sessionKey && result) {
-        const sigRe = /"thought_signature"\s*:\s*"([^"]+)"/g;
-        const idRe = /"id"\s*:\s*"([^"]+)"/g;
-        const ids = [...result.matchAll(idRe)].map((m) => m[1]);
-        const sigs = [...result.matchAll(sigRe)].map((m) => m[1]);
-        for (let i = 0; i < Math.min(ids.length, sigs.length); i++) {
-          signatureCache.store(sessionKey, ids[i], sigs[i]);
+      const { chunk: out, signatures } = providerClient.convertGoogleStreamChunk(
+        chunk,
+        meta.model,
+      );
+      if (signatureCache && sessionKey) {
+        for (const s of signatures) {
+          signatureCache.store(sessionKey, s.toolCallId, s.signature);
         }
       }
-      return result;
+      return out;
     });
   }
   if (forward.isAnthropic) {


### PR DESCRIPTION
## Summary

Fixes tool calling for Gemini 3 Pro Preview and silently improves Gemini 2.5 Pro / 2.5 Flash.

The Google adapter was reading and writing `thought_signature` (snake_case, nested inside the `functionCall` object), but Google's wire format is `thoughtSignature` (camelCase, at the Part level, as a sibling of `functionCall`). Signatures were therefore never extracted from Gemini responses and never re-injected into follow-up requests. Gemini 3 made signatures mandatory for tool-use follow-ups, surfacing the bug as:

> HTTP 400: Function call is missing a thought_signature in functionCall parts. This is required for tools to work correctly…

Gemini 2.5 Pro and 2.5 Flash were silently affected too — Google's own error text warns that missing signatures on those models "may lead to degraded model performance" across tool-call turns. Gemini 3 just turned what was previously a silent no-op into a hard failure.

## Changes

- `google-adapter.ts`: parse `thoughtSignature` from the Part level in both streaming and non-streaming paths; write it at the Part level (sibling of `functionCall`) on outbound requests; drop `thought: true` reasoning-summary text parts so chain-of-thought doesn't leak into assistant content.
- Replaced the regex-on-transformed-output signature extraction in `proxy-response-handler.ts` with a structured `{ chunk, signatures }` return from the stream adapter. The old regex matched the top-level `chatcmpl-...` id before the tool call id and was functionally broken.
- Updated `provider-client-converters.ts`, `provider-client.ts`, and all affected tests for the new return shape.
- Added unit tests for cache re-injection, client-echo precedence, thought-text stripping, and the empty-signatures path.

## Verification

- Backend unit tests: 3550 passing across 181 suites
- Backend e2e tests: 99 passing across 14 suites
- TypeScript: clean
- Line coverage on changed files: new code is fully covered; the few remaining uncovered lines (`safeParseArgs` catch, minimax subscription branch, etc.) are pre-existing gaps unrelated to this PR
- **Live end-to-end against Gemini 3 Pro Preview**: sent a tool-call request, fed the real response through `fromGoogleResponse`, rebuilt the follow-up turn with `toGoogleRequest` using the cached signature, and posted it back to Google — HTTP 200 with the expected answer. The exact scenario that was 400-ing before now succeeds.

## Scope of impact

| Model | Emits signatures | Hard-fails without them | Status |
|---|---|---|---|
| `gemini-3-pro-preview` | yes | **yes (400)** | fixed |
| `gemini-2.5-pro` | yes | no (degrades silently) | fixed |
| `gemini-2.5-flash` | yes | no (degrades silently) | fixed |
| `gemini-2.5-flash-lite` | no | n/a | unaffected |
| `gemini-2.0-flash` | no | n/a | unaffected |

## Known follow-ups (separate PRs)

Noticed while in this code but intentionally out of scope:

1. `messageToContent` passes `tool_call_id` as `functionResponse.name` — should be the function name. Gemini has been lenient about it; not the reported bug.
2. The adapter drops Google's `functionCall.id`, which matters for parallel tool calls on Gemini 3.
3. The Anthropic adapter has zero handling for extended-thinking `signature` round-tripping. Claude 4.x with thinking + tools is likely broken in the same way.

## Test plan

- [x] Unit tests (`npm test --workspace=packages/backend`)
- [x] E2E tests against a throwaway Postgres database (`npm run test:e2e --workspace=packages/backend`)
- [x] TypeScript compile (`npx tsc --noEmit -p packages/backend`)
- [x] Live reproduction of the 400 error against Gemini 3 Pro Preview
- [x] Live verification that the fix shape is accepted by Gemini 3 Pro Preview end-to-end

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Gemini tool calling by correctly round-tripping `thoughtSignature` and removing leaked thought text. Follow-up turns on `gemini-3-pro-preview` now return 200; 2.5 models keep reasoning context across tool calls.

- **Bug Fixes**
  - Read Part-level `thoughtSignature` from Google responses (streaming and non-streaming) and write it back as a sibling of `functionCall`; re-inject from cache and prefer client-echo when both exist.
  - Stream adapter now returns `{ chunk, signatures }` so the response handler can cache signatures without regex scraping.
  - Strip `thought: true` text parts so chain-of-thought does not appear in assistant content.

<sup>Written for commit 312ea5c6f8a679d1c215d9c443ef5835a17bb131. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

