### PR TITLE
feat: reframe Manifest as a router for any personal AI agent

### DIFF
--- a/.changeset/personal-agent-rebrand.md
+++ b/.changeset/personal-agent-rebrand.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Rebrand Manifest as a smart model router for any personal AI agent (OpenClaw, Hermes, OpenAI SDK, Vercel AI SDK, LangChain, cURL) rather than OpenClaw-only. Login subtitle, default platform selection in the Connect Agent modal, and backend comments now reflect the broader positioning. CLAUDE.md and CONTRIBUTING.md updated with the new framing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,12 @@
 # Manifest Development Guidelines
 
-Last updated: 2026-04-09
+Last updated: 2026-04-12
+
+## What Manifest Is
+
+Manifest is a smart model router for **personal AI agents**. It sits between an agent and its LLM providers, scores each request, and routes it to the cheapest model that can handle it. The dashboard tracks costs, tokens, and messages across any agent that speaks OpenAI-compatible HTTP.
+
+**Supported agents** (configured in `packages/shared/src/agent-type.ts`): OpenClaw, Hermes, OpenAI SDK, Vercel AI SDK, LangChain, cURL, and a generic `other` slot. OpenClaw remains the deepest integration — we ship two first-party plugins for it under `packages/openclaw-plugins/` — but no new code or copy should frame Manifest as OpenClaw-only. When adding examples, prefer "personal AI agent" as the noun and pick OpenClaw as the worked example rather than the sole target.
 
 ## IMPORTANT: Cloud Mode Always
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,11 @@ The frontend runs on `http://localhost:3000` and proxies API requests to the bac
 
 4. With `SEED_DATA=true`, you can log in with `admin@manifest.build` / `manifest`.
 
-## Testing with OpenClaw
+## Testing Routing with a Personal AI Agent
+
+Manifest is a smart router for any personal AI agent that speaks OpenAI-compatible HTTP. The list of supported agents lives in `packages/shared/src/agent-type.ts` — OpenClaw, Hermes, OpenAI SDK, Vercel AI SDK, LangChain, and cURL are all first-class. The dashboard's "Connect Agent" flow generates the right setup snippet for whichever platform you pick.
+
+This section walks through **OpenClaw** because it's the deepest integration and the easiest to wire up end-to-end. The same backend also handles all other agents — just follow the dashboard instructions after creating the agent, or grab the snippet shown by the setup modal.
 
 To test routing against your local backend, add Manifest as a model provider in your OpenClaw config:
 
@@ -98,7 +102,7 @@ openclaw config set agents.defaults.model.primary manifest/auto
 openclaw gateway restart
 ```
 
-No plugin needed for this. The backend runs standalone and OpenClaw talks to it as a regular model provider.
+No plugin needed for this. The backend runs standalone and OpenClaw talks to it as a regular model provider. For other agents (OpenAI SDK, Vercel AI SDK, LangChain, cURL, …) follow the corresponding tab in the dashboard's "Connect Agent" modal — the underlying endpoint and auth are identical.
 
 **When to use this:**
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 <p align="center">
-    Take control of your OpenClaw costs
+    Affordable Personal AI
 </p>
 
 ![manifest-gh](https://github.com/user-attachments/assets/7dd74fc2-f7d6-4558-a95a-014ed754a125)
@@ -37,7 +37,7 @@
 
 ## What is Manifest?
 
-Manifest is a smart model router for OpenClaw. It sits between your agent and your LLM providers, scores each request, and routes it to the cheapest model that can handle it. Simple questions go to fast, cheap models. Hard problems go to expensive ones. You save money without thinking about it.
+Manifest is a smart model router for Personal AI Agents like OpenClaw or Hermes. It sits between your agent and your LLM providers, scores each request, and routes it to the cheapest model that can handle it. Simple questions go to fast, cheap models. Hard problems go to expensive ones. You save money without thinking about it.
 
 - Route requests to the right model: Cut costs up to 70%
 - Automatic fallbacks: If a model fails, the next one picks up
@@ -49,24 +49,12 @@ Manifest is a smart model router for OpenClaw. It sits between your agent and yo
 
 Go to [app.manifest.build](https://app.manifest.build) and follow the guide.
 
-### Local version
-
-```bash
-openclaw plugins install manifest
-openclaw gateway restart
-```
-
-Dashboard opens at **http://127.0.0.1:2099**. The plugin starts an embedded server, runs the dashboard locally, and registers itself as a provider automatically. No account or API key needed.
-
-### Docker
+### Self-hosted (Docker)
 
 Our <a href="https://hub.docker.com/r/manifestdotbuild/manifest">Manifest Docker Image</a> allows you to self-host Manifest router in your own infrastructure.
 
-### Which version choose?
-
-Pick cloud version for quick setup and multi-device access. Pick local version for keeping all your data on your machine or for using local models like Ollama. Pick Docker for self-hosting on your own infrastructure.
-
-Not sure which one to choose? Start with cloud.
+> [!WARNING]
+> Our [OpenClaw plugin](https://www.npmjs.com/package/manifest) is deprecated, for self-hosting we suggest using Docker instead.
 
 ## How it works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14108,7 +14108,7 @@
       }
     },
     "packages/openclaw-plugins/manifest": {
-      "version": "5.45.1",
+      "version": "5.46.0",
       "license": "MIT",
       "dependencies": {
         "@nestjs/cache-manager": "^3.1.0",

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -163,9 +163,10 @@ export class ModelDiscoveryService {
     }));
 
     // Filter out models confirmed to lack tool support (models.dev toolCall === false).
-    // In the OpenClaw context every request includes tools, so models without
-    // tool calling are unusable. Only filter when models.dev has data — if no
-    // entry exists we keep the model (we don't know its capabilities).
+    // Personal AI agents (OpenClaw, Hermes, SDK-based agents) almost always
+    // include tools in every request, so models without tool calling are
+    // unusable. Only filter when models.dev has data — if no entry exists we
+    // keep the model (we don't know its capabilities).
     const filtered = enriched.filter((model) => {
       const mdEntry = this.modelsDevSync?.lookupModel(provider.provider, model.id);
       if (mdEntry && mdEntry.toolCall === false) return false;

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -24,10 +24,11 @@ import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-respons
 export { FailedFallback } from './proxy-fallback.service';
 
 /**
- * Roles excluded from scoring. OpenClaw (and similar tools) inject a large,
- * keyword-rich system prompt with every request. Scoring it inflates every
- * request to the most expensive tier. We strip these before the scorer sees
- * them, but forward the full unmodified body to the real provider.
+ * Roles excluded from scoring. Personal AI agents (OpenClaw, Hermes, and
+ * similar tools) inject a large, keyword-rich system prompt with every
+ * request. Scoring it inflates every request to the most expensive tier.
+ * We strip these before the scorer sees them, but forward the full
+ * unmodified body to the real provider.
  */
 const SCORING_EXCLUDED_ROLES = new Set(['system', 'developer']);
 const SCORING_RECENT_MESSAGES = 10;

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -111,7 +111,7 @@ const Login: Component = () => {
       <Show when={!localRedirecting()}>
         <div class="auth-header">
           <h1 class="auth-header__title">Welcome back</h1>
-          <p class="auth-header__subtitle">Take control of your OpenClaw costs</p>
+          <p class="auth-header__subtitle">Take control of your AI agent costs</p>
         </div>
 
         <SocialButtons />
@@ -121,7 +121,11 @@ const Login: Component = () => {
         </div>
 
         <form class="auth-form" onSubmit={handleSubmit}>
-          {error() && <div class="auth-form__error" role="alert">{error()}</div>}
+          {error() && (
+            <div class="auth-form__error" role="alert">
+              {error()}
+            </div>
+          )}
           <Show when={needsVerification()}>
             <button
               type="button"

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -36,7 +36,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
   const navigate = useNavigate();
   const [name, setName] = createSignal('');
   const [category, setCategory] = createSignal<AgentCategory | null>('personal');
-  const [platform, setPlatform] = createSignal<AgentPlatform | null>('openclaw');
+  const [platform, setPlatform] = createSignal<AgentPlatform | null>(null);
   const [creating, setCreating] = createSignal(false);
 
   const handleCategoryChange = (c: AgentCategory) => {
@@ -72,7 +72,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
   const resetForm = () => {
     setName('');
     setCategory('personal');
-    setPlatform('openclaw');
+    setPlatform(null);
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -12,7 +12,7 @@ export interface ProviderDef {
   keyPlaceholder: string;
   noKeyRequired?: boolean;
   localOnly?: boolean;
-  /** Provider supports OpenClaw OAuth/subscription auth (setup-token, OAuth, device-login). */
+  /** Provider supports agent-side OAuth/subscription auth (setup-token, OAuth, device-login). */
   supportsSubscription?: boolean;
   /** Label shown in the subscription tab for this provider. */
   subscriptionLabel?: string;


### PR DESCRIPTION
## Summary

- Shifts positioning from "smart router for OpenClaw" to "smart router for any personal AI agent" (OpenClaw, Hermes, OpenAI SDK, Vercel AI SDK, LangChain, cURL).
- Frontend: Login hero subtitle reworded; the Connect Agent modal no longer preselects OpenClaw as the default platform (users pick from the existing multi-platform picker).
- Backend: two comments reworded so they don't assume OpenClaw is the only caller. No behaviour change.
- Docs: README updated by the product owner (new tagline, removed the OpenClaw-plugin install snippet, added a deprecation note for the `manifest` plugin). CLAUDE.md gains a "What Manifest Is" section. CONTRIBUTING.md renames its testing section and frames OpenClaw as the worked example rather than the sole target.
- Changeset: patch bump on `manifest`.

## Test plan

- [x] `cd packages/frontend && npx tsc --noEmit`
- [x] `cd packages/backend && npx tsc --noEmit`
- [x] `cd packages/frontend && npx vitest run tests/pages/Login.test.tsx tests/pages/Workspace.test.tsx` — 50/50
- [x] `cd packages/backend && npx jest` — 3689/3689 across 186 suites
- [ ] Visual check in dev: `/login` subtitle reads "Take control of your AI agent costs"; `/workspace` → "Connect Agent" modal opens with no platform preselected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reframes Manifest as a smart model router for any personal AI agent, not just OpenClaw. Updates UI copy, broadens docs, and deprecates the `manifest` OpenClaw plugin; no backend behavior changes.

- **Refactors**
  - Positioning: supports OpenClaw, Hermes, OpenAI SDK, Vercel AI SDK, LangChain, and cURL.
  - Frontend: login subtitle now “Take control of your AI agent costs”; Connect Agent modal no longer preselects a platform.
  - Backend: comment wording generalized; behavior unchanged.
  - Docs: README tagline updated and `manifest` plugin marked deprecated (recommend Docker); added “What Manifest Is” to CLAUDE.md; CONTRIBUTING focuses on “personal AI agent” with OpenClaw as the example; patch bump to `manifest`.

<sup>Written for commit 2651f388fd78058ce41c14a645ad94680f566cba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

