### PR TITLE
docs: restructure supported providers table

### DIFF
--- a/.changeset/readme-providers-table.md
+++ b/.changeset/readme-providers-table.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs: restructure supported providers table in README to show API key and subscription support per provider.

--- a/README.md
+++ b/README.md
@@ -74,24 +74,24 @@ All routing data (tokens, costs, model, duration) is recorded automatically. You
 
 ## Supported providers
 
-Works with 300+ models across these providers:
+Works with 300+ models across these providers. Connect with an API key, or reuse an existing paid subscription where supported:
 
-| Provider                                                                       | Models                                                               |
-| ------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
-| [OpenAI](https://platform.openai.com/)                                         | `gpt-5.3`, `gpt-4.1`, `o3`, `o4-mini` + 54 more                      |
-| [Anthropic](https://www.anthropic.com/)                                        | `claude-opus-4-6`, `claude-sonnet-4.5`, `claude-haiku-4.5` + 14 more |
-| [Google Gemini](https://ai.google.dev/)                                        | `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-3-pro` + 19 more       |
-| [DeepSeek](https://www.deepseek.com/)                                          | `deepseek-chat`, `deepseek-reasoner` + 11 more                       |
-| [xAI](https://x.ai/)                                                           | `grok-4`, `grok-3`, `grok-3-mini` + 8 more                           |
-| [Mistral AI](https://mistral.ai/)                                              | `mistral-large`, `codestral`, `devstral` + 26 more                   |
-| [Qwen (Alibaba)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) | `qwen3-235b`, `qwen3-coder`, `qwq-32b` + 42 more                     |
-| [MiniMax](https://www.minimax.io/)                                             | `minimax-m2.5`, `minimax-m1`, `minimax-m2` + 5 more                  |
-| [Kimi (Moonshot)](https://kimi.ai/)                                            | `kimi-k2`, `kimi-k2.5` + 3 more                                      |
-| [Amazon Nova](https://aws.amazon.com/ai/nova/)                                 | `nova-pro`, `nova-lite`, `nova-micro` + 5 more                       |
-| [Z.ai (Zhipu)](https://z.ai/)                                                  | `glm-5`, `glm-4.7`, `glm-4.5` + 5 more                               |
-| [OpenRouter](https://openrouter.ai/)                                           | 300+ models from all providers                                       |
-| [Ollama](https://ollama.com/)                                                  | Run any model locally (Llama, Gemma, Mistral, ...)                   |
-| Custom providers                                                               | Any provider with an OpenAI-compatible API endpoint                  |
+| Provider                                                                       | API key | Subscription               |
+| ------------------------------------------------------------------------------ | :-----: | :------------------------- |
+| [OpenAI](https://platform.openai.com/)                                         |   ✅    | ✅ ChatGPT Plus / Pro / Team |
+| [Anthropic](https://www.anthropic.com/)                                        |   ✅    | ✅ Claude Max / Pro          |
+| [Google Gemini](https://ai.google.dev/)                                        |   ✅    |                            |
+| [DeepSeek](https://www.deepseek.com/)                                          |   ✅    |                            |
+| [xAI](https://x.ai/)                                                           |   ✅    |                            |
+| [Mistral AI](https://mistral.ai/)                                              |   ✅    |                            |
+| [Qwen (Alibaba)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) |   ✅    |                            |
+| [MiniMax](https://www.minimax.io/)                                             |   ✅    | ✅ MiniMax Coding Plan       |
+| [Kimi (Moonshot)](https://kimi.ai/)                                            |   ✅    |                            |
+| [Z.ai (Zhipu)](https://z.ai/)                                                  |   ✅    | ✅ GLM Coding Plan           |
+| [GitHub Copilot](https://github.com/features/copilot)                          |         | ✅ Copilot subscription      |
+| [OpenRouter](https://openrouter.ai/)                                           |   ✅    |                            |
+| [Ollama](https://ollama.com/)                                                  |   ✅ Local   | ✅ Ollama Cloud              |
+| Custom providers (OpenAI-compatible)                                           |   ✅    |                            |
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Restructures the Supported providers table in the README to make auth options visible at a glance:

- Replaces the **Models** column with two columns: **API key** and **Subscription**, marked with ✅ where covered.
- Subscription column names the plan (e.g. Claude Max / Pro, GLM Coding Plan).
- Adds **GitHub Copilot** and **Ollama Cloud** (subscription-only providers that were missing).
- Merges Ollama local + Ollama Cloud into a single row (local API key, cloud subscription).
- Removes **Amazon Nova** (not in `PROVIDER_REGISTRY`).
- Clarifies custom providers as OpenAI-compatible.

Subscription coverage sourced from `packages/shared/src/subscription/configs.ts`.

## Test plan

- [x] README renders correctly on GitHub

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restructures the Supported providers table to show at-a-glance auth options (API key vs subscription) and adds missing providers. This makes it clearer how to connect and which plans are supported.

- **New Features**
  - Replace the Models column with API key and Subscription columns; include plan names where relevant.
  - Add GitHub Copilot and Ollama Cloud; merge Ollama local/cloud into one row.
  - Remove Amazon Nova (not in `PROVIDER_REGISTRY`).
  - Clarify that custom providers use an OpenAI-compatible endpoint.

<sup>Written for commit 187b2614c9533939dcf4a5581362a473eaed9e74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

