### PR TITLE
chore(compose): flag default compose file as local-testing only

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,10 @@
+# This compose file is intended for local testing only. Before exposing
+# this instance beyond localhost:
+#   - Replace BETTER_AUTH_SECRET below with a real secret. Generate one
+#     with: openssl rand -hex 32
+#   - Set SEED_DATA=false to stop seeding the demo agent on every boot.
+#   - Change the seeded admin password (admin@manifest.build / manifest).
+
 services:
   manifest:
     image: manifestdotbuild/manifest:latest
@@ -5,6 +12,7 @@ services:
       - "3001:3001"
     environment:
       - DATABASE_URL=postgresql://manifest:manifest@postgres:5432/manifest
+      # ⚠  Placeholder. Replace before any non-localhost use (see top of file).
       - BETTER_AUTH_SECRET=change-me-to-a-random-32-char-string!!
       - BETTER_AUTH_URL=http://localhost:3001
       - SEED_DATA=true


### PR DESCRIPTION
## Summary

Closes #1531.

The default `docker/docker-compose.yml` ships with three things that are fine for a localhost quick-start but become a footgun the moment anyone exposes the instance beyond localhost:

1. A hardcoded placeholder `BETTER_AUTH_SECRET=change-me-to-a-random-32-char-string!!`. It's 37 chars (so it passes the 32-char minimum), but it's a well-known public value.
2. `SEED_DATA=true`, which seeds a fake `demo-agent` with sample token usage on every boot.
3. The well-known `admin@manifest.build` / `manifest` credentials.

The docs site now calls this out (mnfst/docs#21), but the compose file doesn't self-advertise the constraint — a user can copy it verbatim and run with a publicly-known auth secret without ever reading the docs.

## Change

Two comments, no functional change:

- A header block at the top of the file listing the three defaults to change before non-local use.
- An inline comment on the `BETTER_AUTH_SECRET` line pointing back to the header, so the warning is visible at the exact line it applies to.

The compose file still boots unchanged for first-time readers following the Docker Hub / docs Quick Start.

## Test plan

- [x] Diff is scoped to comments in \`docker/docker-compose.yml\`; no YAML keys touched
- [ ] CI passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flagged the default `docker/docker-compose.yml` as local-testing only with a header warning and an inline note on `BETTER_AUTH_SECRET` to prevent unsafe non-local use. No functional changes; quick-start still works as before.

The comments call out three defaults to change before exposing beyond localhost: `BETTER_AUTH_SECRET`, `SEED_DATA`, and the seeded admin credentials.

<sup>Written for commit 9c2f64b7b11fef8929e0a0ad5a3d8facb78fce5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

