### PR TITLE
chore: single canonical version, auto-wire docker release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["manifest-frontend", "manifest-shared"]
 }

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to publish (e.g. 5.38.1)"
-        required: true
+        description: "Optional version override (e.g. 5.38.1). Leave blank to use the current version from packages/backend/package.json."
+        required: false
         type: string
   pull_request:
     branches: [main]
@@ -55,6 +55,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Resolve version
+        id: version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+            echo "Using version from workflow input: $VERSION"
+          else
+            VERSION=$(jq -r .version packages/backend/package.json)
+            echo "Using version from packages/backend/package.json: $VERSION"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
@@ -69,9 +81,9 @@ jobs:
         with:
           images: manifestdotbuild/manifest
           tags: |
-            type=semver,pattern={{version}},value=${{ inputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
-            type=semver,pattern={{major}},value=${{ inputs.version }}
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}},value=${{ steps.version.outputs.version }}
             type=sha
 
       - uses: docker/build-push-action@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,13 +481,47 @@ All pricing comes from a single source:
 
 ## Releases
 
-There are **no publishable npm packages** in this repo anymore. `packages/backend`, `packages/frontend`, and `packages/shared` are all `private: true`. Manifest ships exclusively as the Docker image at `manifestdotbuild/manifest` (built from `docker/Dockerfile`).
+There are **no publishable npm packages** in this repo. `packages/backend`, `packages/frontend`, and `packages/shared` are all `private: true`. Manifest ships exclusively as the Docker image at `manifestdotbuild/manifest` (built from `docker/Dockerfile`).
 
-Changesets are still installed and wired into the release workflow for internal `CHANGELOG.md` bookkeeping on private packages — they are **not** required on every PR. Use `npx changeset add --empty` if you want to record a changelog entry for a private-package change, otherwise skip it.
+### Single canonical version
 
-The Docker image is built and published via `.github/workflows/docker.yml`:
-- **PR**: validates the Docker build on changes to `docker/`, `.dockerignore`, `packages/backend/`, `packages/frontend/`, `packages/shared/`, or root `package.json`/`turbo.json`.
-- **Manual publish**: `workflow_dispatch` with a `version` input, run by a maintainer when a new image tag should be pushed.
+The **version of Manifest as a whole** lives in `packages/backend/package.json`. This is the version that:
+
+- Changesets bumps when you add a changeset
+- The Docker workflow reads automatically when cutting a release
+- Drives `CHANGELOG.md` at `packages/backend/CHANGELOG.md`
+
+`manifest-frontend` and `manifest-shared` are **ignored by changesets** (`ignore` list in `.changeset/config.json`). Always target `manifest-backend` when running `npx changeset`, regardless of which files you actually changed — a backend-scoped changeset is the canonical "Manifest release" signal.
+
+### Adding a changeset
+
+```bash
+npx changeset
+# → select "manifest-backend"
+# → choose patch / minor / major
+# → write a one-line summary (this becomes the CHANGELOG entry)
+```
+
+Commit the generated `.changeset/*.md` file alongside your code. On merge to `main`, `release.yml` runs `changesets/action`, which opens (or updates) a `chore: version packages` PR bumping `packages/backend/package.json` and appending to `packages/backend/CHANGELOG.md`.
+
+Changesets are **not** required on every PR — they're optional and only meaningful for changes you want in the changelog. Use `npx changeset add --empty` for purely internal work if you want an explicit "no release" marker.
+
+### Cutting a Docker release
+
+1. Merge the pending `chore: version packages` PR to land the version bump in `packages/backend/package.json`.
+2. Go to **GitHub Actions → Docker → Run workflow**, leave the `version` input blank, click Run.
+3. The `publish` job reads `packages/backend/package.json`, resolves the version automatically, and pushes `manifestdotbuild/manifest:{version}` + `{major}.{minor}` + `{major}` + `sha-<short>` to Docker Hub. The image is multi-arch (amd64 + arm64) and cosign-signed.
+
+To retag an older commit or publish a hotfix version that doesn't match the current `package.json`, pass a semver string in the `version` input and it'll override the package.json lookup.
+
+### Summary of what CI does on each trigger
+
+| Trigger | What happens |
+|---------|--------------|
+| PR opened/updated | `ci.yml` runs tests, lint, typecheck, coverage. `docker.yml` validates the Docker build (no push). `changeset-check` warns if no changeset is present (soft — PR still mergeable). |
+| Merge to `main` | `release.yml` runs `changesets/action` to open or update the `chore: version packages` PR. **No auto-publish** — neither npm nor Docker. |
+| Merge of `chore: version packages` PR | `release.yml` runs again. Version bumps and `CHANGELOG.md` land on `main`. Still no publish. |
+| Manual `workflow_dispatch` on `Docker` workflow | Reads the current version and pushes a new image tag to Docker Hub. This is the **only** path that publishes anything. |
 
 ## Code Coverage (Codecov)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,18 @@ The backend runs standalone and OpenClaw talks to it as a regular OpenAI-compati
 1. Create a branch from `main` for your change
 2. Make your changes in the relevant package(s)
 3. Write or update tests as needed
-4. Run the test suite to make sure everything passes:
+4. Add a changeset if your change should appear in the release notes:
+
+```bash
+npx changeset
+# → select "manifest-backend"
+# → choose patch / minor / major
+# → write a one-line summary
+```
+
+Always target `manifest-backend` — it's the canonical version for the Manifest Docker image. `manifest-frontend` and `manifest-shared` are ignored by changesets regardless of what you pick, so even frontend-only or shared-only changes should go under `manifest-backend`. Commit the generated `.changeset/*.md` alongside your code. Changesets are optional for internal/tooling changes; skip this step if the change doesn't need a CHANGELOG entry.
+
+5. Run the test suite to make sure everything passes:
 
 ```bash
 npm test --workspace=packages/shared
@@ -159,13 +170,23 @@ npm run test:e2e --workspace=packages/backend
 npm test --workspace=packages/frontend
 ```
 
-5. Verify the production build works:
+6. Verify the production build works:
 
 ```bash
 npm run build
 ```
 
-6. Open a pull request against `main`
+7. Open a pull request against `main`
+
+### Cutting a Docker release
+
+Manifest ships as the Docker image at [`manifestdotbuild/manifest`](https://hub.docker.com/r/manifestdotbuild/manifest). Releases are manual:
+
+1. After merging PRs with changesets, a `chore: version packages` PR will be open on `main` — merge it to land the version bump in `packages/backend/package.json` and update `packages/backend/CHANGELOG.md`.
+2. Go to **GitHub Actions → Docker → Run workflow**, leave the `version` input blank, click Run.
+3. The workflow reads the version from `packages/backend/package.json` and pushes `manifestdotbuild/manifest:{version}` (plus `{major}.{minor}`, `{major}`, and a `sha-<short>` rollback tag).
+
+If you need to retag an older commit or publish a version that doesn't match the current `package.json`, pass a semver string in the `version` input and it overrides the auto-detected value.
 
 ### Commit Messages
 


### PR DESCRIPTION
## Summary

Solves the "one version number, docker follows it" question by:

1. **Making `manifest-backend` the canonical version** for the Manifest Docker image. `manifest-frontend` and `manifest-shared` are added to `.changeset/config.json`'s `ignore` list, so when a contributor runs `npx changeset`, only `manifest-backend` is a bump target. The version lives in `packages/backend/package.json`, the CHANGELOG at `packages/backend/CHANGELOG.md`.
2. **Auto-wiring `docker.yml`** to read that version. The `version` input on `workflow_dispatch` is now optional — a new `Resolve version` step uses the input if provided, otherwise `jq -r .version packages/backend/package.json`. Maintainers click "Run workflow" with a blank form and the workflow figures out what to tag the image with.

## Why `manifest-backend` and not a new synthetic package

I first tried versioning the root `package.json` (which is already `"name": "manifest"`). Changesets refuses to see it — `@manypkg/get-packages` only surfaces workspace members, not the workspace root, and setting a `version` field on the root doesn't change that. The alternatives were all worse:

- **Rename `manifest-backend` → `manifest`**: collides with the root package name. Fixable but intrusive.
- **New synthetic `packages/manifest/`**: cleanest semantically, but adds a directory that exists only to hold `package.json` + `CHANGELOG.md`. Contributors would wonder what it's for.
- **`manifest-backend` as canonical**: zero new files, zero renames, one config line. Downside: the name in the changeset picker is "manifest-backend", not "manifest". Docs explain why.

I went with the last option because it's the smallest change that works and the convention is easy to document.

## Verified locally

```bash
# With a changeset targeting manifest-backend:
$ npx changeset status --verbose
🦋  info Packages to be bumped at patch
🦋  - manifest-backend 0.1.1
🦋    - .changeset/_test.md

# With a changeset targeting manifest-frontend (ignored):
$ npx changeset status --verbose
🦋  info Running release would release NO packages as a patch
```

Behavior is correct in both cases. `manifest-frontend` and `manifest-shared` changesets are silently ignored — worth a note in the contributor docs (included).

## Test plan

- [x] `npm run build --workspace=packages/shared` — clean
- [x] `npx tsc --noEmit` in backend and frontend — clean
- [x] `npx changeset status` with a backend-targeted changeset — bumps correctly
- [x] `npx changeset status` with a frontend-targeted changeset — silently ignored
- [ ] After merge: verify `chore: version packages` PR still opens correctly with future changesets
- [ ] After merge: dry-run `docker.yml` via \`workflow_dispatch\` with blank version — should tag \`manifestdotbuild/manifest:0.1.0\` (current `manifest-backend` version) plus derived tags

## Follow-up (optional, not in this PR)

The current `manifest-backend` version is `0.1.0`. If you want the Docker image to launch with a more meaningful starting version (e.g. `1.0.0` for the first post-plugin release), we can either:
- Bump it manually in a small follow-up PR, or
- Add a major-bump changeset in this repo's next real PR.

Not doing it here because I don't want to make a versioning decision for you.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `manifest-backend` the single source of truth for the app version, and auto-tag Docker releases from that version. This removes manual version entry and prevents fragmented versions.

- **Refactors**
  - Set `manifest-backend` as the canonical version; added `manifest-frontend` and `manifest-shared` to `.changeset/config.json` ignore. Version and `CHANGELOG.md` live under `packages/backend/`.
  - Auto-wire `.github/workflows/docker.yml`: `version` input is optional; when blank, reads from `packages/backend/package.json` and applies semver + `sha` tags to `manifestdotbuild/manifest`.
  - Updated `CLAUDE.md` and `CONTRIBUTING.md` with the new versioning and release flow.

<sup>Written for commit f3672525355939e1ccf8165fd25d23b46951dd23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

