### PR TITLE
feat: replace default admin seed with first-run setup wizard

### DIFF
--- a/.changeset/first-run-setup-wizard.md
+++ b/.changeset/first-run-setup-wizard.md
@@ -1,0 +1,6 @@
+---
+---
+
+Replace the hardcoded `admin@manifest.build` / `manifest` seed credentials with a first-run setup wizard. On fresh installs, visiting any route redirects to `/setup`, where the operator creates the first admin account with their own email and password. The wizard is backed by `POST /api/v1/setup/admin` which uses a Postgres advisory lock to prevent race-creation of multiple admins, marks the new user as `emailVerified = true` so it can log in immediately regardless of email configuration, and 409s once any user exists.
+
+Self-hosted Docker Compose now ships with `NODE_ENV=production` and `SEED_DATA=false`, so the setup wizard is the only supported onboarding path. The dev/test seeder (`SEED_DATA=true` under `NODE_ENV=development|test`) still seeds `admin@manifest.build` for `/serve` and E2E fixtures. In production, `SEED_DATA=true` is explicitly ignored with a warning log directing operators to the setup wizard.

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -59,11 +59,9 @@ curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker/docker-comp
 docker compose up -d
 ```
 
-3. Open [http://localhost:3001](http://localhost:3001) and log in:
-   - Email: `admin@manifest.build`
-   - Password: `manifest`
+3. Open [http://localhost:3001](http://localhost:3001). The **setup wizard** walks you through creating the first admin account — pick your own email and password (min 8 chars). No hardcoded credentials.
 
-Connect a provider on the Routing page and you're set.
+4. Connect a provider on the Routing page and you're set.
 
 To stop:
 
@@ -82,12 +80,11 @@ docker run -d \
   -e DATABASE_URL=postgresql://user:pass@host:5432/manifest \
   -e BETTER_AUTH_SECRET=$(openssl rand -hex 32) \
   -e BETTER_AUTH_URL=http://localhost:3001 \
-  -e NODE_ENV=development \
-  -e MANIFEST_TRUST_LAN=true \
+  -e AUTO_MIGRATE=true \
   manifestdotbuild/manifest
 ```
 
-`NODE_ENV=development` makes migrations run on startup. Without it you'd need to run them manually.
+`AUTO_MIGRATE=true` runs TypeORM migrations on first boot. Then visit http://localhost:3001 and complete the setup wizard to create your admin account.
 
 ### Verifying the image signature
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,15 @@
-# This compose file is intended for local testing only. Before exposing
-# this instance beyond localhost:
+# First boot: `docker compose up -d` starts the stack. Visit
+# http://localhost:3001 and the app walks you through creating the first
+# admin account via the setup wizard at /setup. No hardcoded credentials.
+#
+# Before exposing this instance beyond localhost:
 #   - Replace BETTER_AUTH_SECRET below with a real secret. Generate one
 #     with: openssl rand -hex 32
-#   - Set SEED_DATA=false to stop seeding the demo agent on every boot.
-#   - Change the seeded admin password (admin@manifest.build / manifest).
-#   - Set NODE_ENV=production to enable trust proxy, error sanitization,
-#     and strict Better Auth verification.
+#   - Confirm your admin password is strong (the setup wizard enforces
+#     at least 8 characters).
+#   - If you enable email verification (set EMAIL_PROVIDER / EMAIL_API_KEY),
+#     set BETTER_AUTH_URL to a reachable public URL so the verification
+#     links resolve.
 
 services:
   manifest:
@@ -17,8 +21,8 @@ services:
       # ⚠  Placeholder. Replace before any non-localhost use (see top of file).
       - BETTER_AUTH_SECRET=change-me-to-a-random-32-char-string!!
       - BETTER_AUTH_URL=http://localhost:3001
-      - SEED_DATA=true
-      - NODE_ENV=development
+      - SEED_DATA=false
+      - NODE_ENV=production
       - AUTO_MIGRATE=true
       # Email provider (optional). Covers both login/verification emails
       # and threshold alert notifications. Set one provider block — see

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -23,6 +23,7 @@ import { CommonModule } from './common/common.module';
 import { SseModule } from './sse/sse.module';
 import { GithubModule } from './github/github.module';
 import { PublicStatsModule } from './public-stats/public-stats.module';
+import { SetupModule } from './setup/setup.module';
 
 const frontendPath = resolveFrontendDir();
 const ONE_YEAR_S = 365 * 24 * 60 * 60;
@@ -70,6 +71,7 @@ const serveStaticImports = frontendPath
     SseModule,
     GithubModule,
     PublicStatsModule,
+    SetupModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: SessionGuard },

--- a/packages/backend/src/database/database-seeder.service.spec.ts
+++ b/packages/backend/src/database/database-seeder.service.spec.ts
@@ -99,20 +99,20 @@ describe('DatabaseSeederService', () => {
       });
     });
 
-    it('should seed demo data in production when SEED_DATA=true (self-hosted first boot)', async () => {
+    it('should NOT seed demo data in production even with SEED_DATA=true (use setup wizard instead)', async () => {
       configValues['app.nodeEnv'] = 'production';
       configValues['SEED_DATA'] = 'true';
 
       await service.onModuleInit();
 
-      // Seeding is now gated purely on SEED_DATA, so production + SEED_DATA=true seeds.
-      // The existing security warning log in the service makes misuse visible.
-      expect(mockApiKeyRepo.count).toHaveBeenCalledWith({
-        where: { id: 'seed-api-key-001' },
-      });
-      expect(mockTenantRepo.count).toHaveBeenCalledWith({
-        where: { id: 'seed-tenant-001' },
-      });
+      // Production first-run uses the /setup wizard to create the admin;
+      // demo data is dev/test only. See database-seeder.service.ts.
+      expect(mockApiKeyRepo.count).not.toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'seed-api-key-001' } }),
+      );
+      expect(mockTenantRepo.count).not.toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'seed-tenant-001' } }),
+      );
     });
 
     it('should not seed demo data when SEED_DATA is not true', async () => {

--- a/packages/backend/src/database/database-seeder.service.ts
+++ b/packages/backend/src/database/database-seeder.service.ts
@@ -34,16 +34,27 @@ export class DatabaseSeederService implements OnModuleInit {
     await this.runBetterAuthMigrations();
 
     const seedData = this.configService.get<string>('SEED_DATA');
-    if (seedData === 'true') {
-      await this.seedAdminUser();
-      await this.seedApiKey();
-      await this.seedTenantAndAgent();
-      await this.seedAgentMessages();
-      this.logger.log('Seeded demo data (SEED_DATA=true)');
+    if (seedData !== 'true') return;
+
+    const nodeEnv = this.configService.get<string>('app.nodeEnv', 'development');
+    if (nodeEnv === 'production') {
       this.logger.warn(
-        'SECURITY: Default seed credentials are active (admin@manifest.build). Do NOT use in production.',
+        'SEED_DATA=true is ignored in production — use the first-run setup wizard at /setup to create the admin account. Demo data is not seeded in production.',
       );
+      return;
     }
+
+    // Dev/test workflow: seed the well-known admin + demo data in one shot
+    // so `/serve` and E2E tests get a non-empty dashboard without going
+    // through the setup wizard on every run.
+    await this.seedAdminUser();
+    await this.seedApiKey();
+    await this.seedTenantAndAgent();
+    await this.seedAgentMessages();
+    this.logger.log('Seeded demo data (SEED_DATA=true, dev/test only)');
+    this.logger.warn(
+      'SECURITY: Default seed credentials are active (admin@manifest.build). Do NOT use in production.',
+    );
   }
 
   private async runBetterAuthMigrations() {

--- a/packages/backend/src/setup/dto/create-admin.dto.ts
+++ b/packages/backend/src/setup/dto/create-admin.dto.ts
@@ -1,0 +1,18 @@
+import { IsEmail, IsNotEmpty, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class CreateAdminDto {
+  @IsEmail()
+  @MaxLength(254)
+  email!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MinLength(2)
+  @MaxLength(100)
+  name!: string;
+
+  @IsString()
+  @MinLength(8)
+  @MaxLength(128)
+  password!: string;
+}

--- a/packages/backend/src/setup/setup.controller.spec.ts
+++ b/packages/backend/src/setup/setup.controller.spec.ts
@@ -1,0 +1,68 @@
+jest.mock('../auth/auth.instance', () => ({
+  auth: { api: { signUpEmail: jest.fn() } },
+}));
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { SetupController } from './setup.controller';
+import { SetupService } from './setup.service';
+
+describe('SetupController', () => {
+  let controller: SetupController;
+  let mockNeedsSetup: jest.Mock;
+  let mockCreateFirstAdmin: jest.Mock;
+
+  beforeEach(async () => {
+    mockNeedsSetup = jest.fn();
+    mockCreateFirstAdmin = jest.fn();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SetupController],
+      providers: [
+        {
+          provide: SetupService,
+          useValue: {
+            needsSetup: mockNeedsSetup,
+            createFirstAdmin: mockCreateFirstAdmin,
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SetupController>(SetupController);
+  });
+
+  describe('getStatus', () => {
+    it('returns needsSetup=true when service says so', async () => {
+      mockNeedsSetup.mockResolvedValue(true);
+      const result = await controller.getStatus();
+      expect(result).toEqual({ needsSetup: true });
+    });
+
+    it('returns needsSetup=false when an admin already exists', async () => {
+      mockNeedsSetup.mockResolvedValue(false);
+      const result = await controller.getStatus();
+      expect(result).toEqual({ needsSetup: false });
+    });
+  });
+
+  describe('createAdmin', () => {
+    const dto = {
+      email: 'founder@example.com',
+      name: 'Founder',
+      password: 'secret-password',
+    };
+
+    it('delegates to service and returns ok', async () => {
+      mockCreateFirstAdmin.mockResolvedValue(undefined);
+      const result = await controller.createAdmin(dto);
+
+      expect(result).toEqual({ ok: true });
+      expect(mockCreateFirstAdmin).toHaveBeenCalledWith(dto);
+    });
+
+    it('propagates service errors', async () => {
+      mockCreateFirstAdmin.mockRejectedValue(new Error('already exists'));
+      await expect(controller.createAdmin(dto)).rejects.toThrow('already exists');
+    });
+  });
+});

--- a/packages/backend/src/setup/setup.controller.ts
+++ b/packages/backend/src/setup/setup.controller.ts
@@ -1,0 +1,23 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { Public } from '../common/decorators/public.decorator';
+import { CreateAdminDto } from './dto/create-admin.dto';
+import { SetupService } from './setup.service';
+
+@Controller('api/v1/setup')
+export class SetupController {
+  constructor(private readonly setupService: SetupService) {}
+
+  @Public()
+  @Get('status')
+  async getStatus(): Promise<{ needsSetup: boolean }> {
+    return { needsSetup: await this.setupService.needsSetup() };
+  }
+
+  @Public()
+  @Post('admin')
+  @HttpCode(HttpStatus.CREATED)
+  async createAdmin(@Body() dto: CreateAdminDto): Promise<{ ok: true }> {
+    await this.setupService.createFirstAdmin(dto);
+    return { ok: true };
+  }
+}

--- a/packages/backend/src/setup/setup.module.ts
+++ b/packages/backend/src/setup/setup.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SetupController } from './setup.controller';
+import { SetupService } from './setup.service';
+
+@Module({
+  controllers: [SetupController],
+  providers: [SetupService],
+})
+export class SetupModule {}

--- a/packages/backend/src/setup/setup.service.spec.ts
+++ b/packages/backend/src/setup/setup.service.spec.ts
@@ -1,0 +1,142 @@
+import { ConflictException } from '@nestjs/common';
+
+jest.mock('../auth/auth.instance', () => ({
+  auth: {
+    api: {
+      signUpEmail: jest.fn(),
+    },
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { auth } = require('../auth/auth.instance');
+
+import { SetupService } from './setup.service';
+
+interface MockManager {
+  query: jest.Mock;
+}
+
+function buildMockDataSource(managerQuery: jest.Mock) {
+  const manager: MockManager = { query: managerQuery };
+  return {
+    query: jest.fn(),
+    transaction: jest.fn(async (fn: (m: MockManager) => Promise<void>) => {
+      await fn(manager);
+    }),
+  };
+}
+
+describe('SetupService', () => {
+  let mockManagerQuery: jest.Mock;
+  let ds: ReturnType<typeof buildMockDataSource>;
+  let service: SetupService;
+
+  beforeEach(() => {
+    mockManagerQuery = jest.fn();
+    ds = buildMockDataSource(mockManagerQuery);
+    service = new SetupService(ds as never);
+    jest.clearAllMocks();
+  });
+
+  describe('needsSetup', () => {
+    it('returns true when user table is empty', async () => {
+      ds.query.mockResolvedValueOnce([{ count: '0' }]);
+      expect(await service.needsSetup()).toBe(true);
+      expect(ds.query).toHaveBeenCalledWith(expect.stringContaining('COUNT(*)'));
+    });
+
+    it('returns false when at least one user exists', async () => {
+      ds.query.mockResolvedValueOnce([{ count: '1' }]);
+      expect(await service.needsSetup()).toBe(false);
+    });
+
+    it('handles multi-user count', async () => {
+      ds.query.mockResolvedValueOnce([{ count: '42' }]);
+      expect(await service.needsSetup()).toBe(false);
+    });
+
+    it('treats missing count row as empty', async () => {
+      ds.query.mockResolvedValueOnce([]);
+      expect(await service.needsSetup()).toBe(true);
+    });
+  });
+
+  describe('createFirstAdmin', () => {
+    const dto = { email: 'founder@example.com', name: 'Founder', password: 'secret-password' };
+
+    it('acquires an advisory lock before checking user count', async () => {
+      mockManagerQuery
+        .mockResolvedValueOnce(undefined) // advisory lock
+        .mockResolvedValueOnce([{ count: '0' }]) // count check
+        .mockResolvedValueOnce(undefined); // emailVerified update
+      (auth.api.signUpEmail as jest.Mock).mockResolvedValueOnce({});
+
+      await service.createFirstAdmin(dto);
+
+      expect(mockManagerQuery.mock.calls[0][0]).toContain('pg_advisory_xact_lock');
+      expect(mockManagerQuery.mock.calls[1][0]).toContain('COUNT(*)');
+    });
+
+    it('calls Better Auth signUpEmail with the DTO', async () => {
+      mockManagerQuery
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([{ count: '0' }])
+        .mockResolvedValueOnce(undefined);
+      (auth.api.signUpEmail as jest.Mock).mockResolvedValueOnce({});
+
+      await service.createFirstAdmin(dto);
+
+      expect(auth.api.signUpEmail).toHaveBeenCalledWith({
+        body: {
+          email: 'founder@example.com',
+          password: 'secret-password',
+          name: 'Founder',
+        },
+      });
+    });
+
+    it('marks the new user as emailVerified', async () => {
+      mockManagerQuery
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([{ count: '0' }])
+        .mockResolvedValueOnce(undefined);
+      (auth.api.signUpEmail as jest.Mock).mockResolvedValueOnce({});
+
+      await service.createFirstAdmin(dto);
+
+      const lastCall = mockManagerQuery.mock.calls[mockManagerQuery.mock.calls.length - 1];
+      expect(lastCall[0]).toContain('UPDATE "user"');
+      expect(lastCall[0]).toContain('"emailVerified" = true');
+      expect(lastCall[1]).toEqual(['founder@example.com']);
+    });
+
+    it('throws ConflictException when a user already exists', async () => {
+      mockManagerQuery
+        .mockResolvedValueOnce(undefined) // advisory lock
+        .mockResolvedValueOnce([{ count: '1' }]); // count check
+
+      await expect(service.createFirstAdmin(dto)).rejects.toThrow(ConflictException);
+      expect(auth.api.signUpEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not call signUpEmail when conflict is detected', async () => {
+      mockManagerQuery.mockResolvedValueOnce(undefined).mockResolvedValueOnce([{ count: '3' }]);
+
+      await expect(service.createFirstAdmin(dto)).rejects.toThrow('already completed');
+      expect(auth.api.signUpEmail).not.toHaveBeenCalled();
+    });
+
+    it('wraps the whole operation in a transaction', async () => {
+      mockManagerQuery
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([{ count: '0' }])
+        .mockResolvedValueOnce(undefined);
+      (auth.api.signUpEmail as jest.Mock).mockResolvedValueOnce({});
+
+      await service.createFirstAdmin(dto);
+
+      expect(ds.transaction).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/backend/src/setup/setup.service.spec.ts
+++ b/packages/backend/src/setup/setup.service.spec.ts
@@ -13,28 +13,33 @@ const { auth } = require('../auth/auth.instance');
 
 import { SetupService } from './setup.service';
 
-interface MockManager {
+interface MockQueryRunner {
+  connect: jest.Mock;
+  release: jest.Mock;
   query: jest.Mock;
 }
 
-function buildMockDataSource(managerQuery: jest.Mock) {
-  const manager: MockManager = { query: managerQuery };
+function buildMockDataSource(runnerQuery: jest.Mock) {
+  const queryRunner: MockQueryRunner = {
+    connect: jest.fn().mockResolvedValue(undefined),
+    release: jest.fn().mockResolvedValue(undefined),
+    query: runnerQuery,
+  };
   return {
     query: jest.fn(),
-    transaction: jest.fn(async (fn: (m: MockManager) => Promise<void>) => {
-      await fn(manager);
-    }),
+    createQueryRunner: jest.fn(() => queryRunner),
+    _queryRunner: queryRunner,
   };
 }
 
 describe('SetupService', () => {
-  let mockManagerQuery: jest.Mock;
+  let runnerQuery: jest.Mock;
   let ds: ReturnType<typeof buildMockDataSource>;
   let service: SetupService;
 
   beforeEach(() => {
-    mockManagerQuery = jest.fn();
-    ds = buildMockDataSource(mockManagerQuery);
+    runnerQuery = jest.fn();
+    ds = buildMockDataSource(runnerQuery);
     service = new SetupService(ds as never);
     jest.clearAllMocks();
   });
@@ -65,24 +70,34 @@ describe('SetupService', () => {
   describe('createFirstAdmin', () => {
     const dto = { email: 'founder@example.com', name: 'Founder', password: 'secret-password' };
 
-    it('acquires an advisory lock before checking user count', async () => {
-      mockManagerQuery
-        .mockResolvedValueOnce(undefined) // advisory lock
+    function mockHappyPath(): void {
+      runnerQuery
+        .mockResolvedValueOnce(undefined) // pg_advisory_lock
         .mockResolvedValueOnce([{ count: '0' }]) // count check
-        .mockResolvedValueOnce(undefined); // emailVerified update
+        .mockResolvedValueOnce(undefined) // UPDATE emailVerified
+        .mockResolvedValueOnce(undefined); // pg_advisory_unlock
+    }
+
+    it('acquires and releases a session-level advisory lock around the flow', async () => {
+      mockHappyPath();
       (auth.api.signUpEmail as jest.Mock).mockResolvedValueOnce({});
 
       await service.createFirstAdmin(dto);
 
-      expect(mockManagerQuery.mock.calls[0][0]).toContain('pg_advisory_xact_lock');
-      expect(mockManagerQuery.mock.calls[1][0]).toContain('COUNT(*)');
+      const lockCall = runnerQuery.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('pg_advisory_lock'),
+      );
+      const unlockCall = runnerQuery.mock.calls.find(
+        (c) => typeof c[0] === 'string' && c[0].includes('pg_advisory_unlock'),
+      );
+      expect(lockCall).toBeDefined();
+      expect(unlockCall).toBeDefined();
+      expect(ds._queryRunner.connect).toHaveBeenCalledTimes(1);
+      expect(ds._queryRunner.release).toHaveBeenCalledTimes(1);
     });
 
     it('calls Better Auth signUpEmail with the DTO', async () => {
-      mockManagerQuery
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce([{ count: '0' }])
-        .mockResolvedValueOnce(undefined);
+      mockHappyPath();
       (auth.api.signUpEmail as jest.Mock).mockResolvedValueOnce({});
 
       await service.createFirstAdmin(dto);
@@ -97,46 +112,113 @@ describe('SetupService', () => {
     });
 
     it('marks the new user as emailVerified', async () => {
-      mockManagerQuery
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce([{ count: '0' }])
-        .mockResolvedValueOnce(undefined);
+      mockHappyPath();
       (auth.api.signUpEmail as jest.Mock).mockResolvedValueOnce({});
 
       await service.createFirstAdmin(dto);
 
-      const lastCall = mockManagerQuery.mock.calls[mockManagerQuery.mock.calls.length - 1];
-      expect(lastCall[0]).toContain('UPDATE "user"');
-      expect(lastCall[0]).toContain('"emailVerified" = true');
-      expect(lastCall[1]).toEqual(['founder@example.com']);
+      const updateCall = runnerQuery.mock.calls.find(
+        (c) =>
+          typeof c[0] === 'string' &&
+          c[0].includes('UPDATE "user"') &&
+          c[0].includes('emailVerified'),
+      );
+      expect(updateCall).toBeDefined();
+      expect(updateCall?.[1]).toEqual(['founder@example.com']);
     });
 
-    it('throws ConflictException when a user already exists', async () => {
-      mockManagerQuery
-        .mockResolvedValueOnce(undefined) // advisory lock
-        .mockResolvedValueOnce([{ count: '1' }]); // count check
+    it('throws ConflictException when a user already exists and is verified', async () => {
+      runnerQuery
+        .mockResolvedValueOnce(undefined) // lock
+        .mockResolvedValueOnce([{ count: '1' }]) // count
+        .mockResolvedValueOnce([]) // unverified check returns none
+        .mockResolvedValueOnce(undefined); // unlock
 
       await expect(service.createFirstAdmin(dto)).rejects.toThrow(ConflictException);
       expect(auth.api.signUpEmail).not.toHaveBeenCalled();
     });
 
-    it('does not call signUpEmail when conflict is detected', async () => {
-      mockManagerQuery.mockResolvedValueOnce(undefined).mockResolvedValueOnce([{ count: '3' }]);
+    it('throws ConflictException when multiple users already exist', async () => {
+      runnerQuery
+        .mockResolvedValueOnce(undefined) // lock
+        .mockResolvedValueOnce([{ count: '3' }]) // count
+        .mockResolvedValueOnce(undefined); // unlock
 
       await expect(service.createFirstAdmin(dto)).rejects.toThrow('already completed');
       expect(auth.api.signUpEmail).not.toHaveBeenCalled();
     });
 
-    it('wraps the whole operation in a transaction', async () => {
-      mockManagerQuery
-        .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce([{ count: '0' }])
-        .mockResolvedValueOnce(undefined);
+    it('releases the advisory lock even when the flow throws', async () => {
+      runnerQuery
+        .mockResolvedValueOnce(undefined) // lock
+        .mockResolvedValueOnce([{ count: '5' }]) // count — triggers 409
+        .mockResolvedValueOnce(undefined); // unlock
+
+      await expect(service.createFirstAdmin(dto)).rejects.toThrow(ConflictException);
+
+      const unlockCalls = runnerQuery.mock.calls.filter(
+        (c) => typeof c[0] === 'string' && c[0].includes('pg_advisory_unlock'),
+      );
+      expect(unlockCalls).toHaveLength(1);
+      expect(ds._queryRunner.release).toHaveBeenCalledTimes(1);
+    });
+
+    describe('recovery branch', () => {
+      it('completes verification when the only existing user is unverified and matches the DTO email', async () => {
+        runnerQuery
+          .mockResolvedValueOnce(undefined) // lock
+          .mockResolvedValueOnce([{ count: '1' }]) // count = 1
+          .mockResolvedValueOnce([{ email: 'founder@example.com' }]) // unverified match
+          .mockResolvedValueOnce(undefined) // UPDATE emailVerified
+          .mockResolvedValueOnce(undefined); // unlock
+
+        await service.createFirstAdmin(dto);
+
+        expect(auth.api.signUpEmail).not.toHaveBeenCalled();
+        const updateCall = runnerQuery.mock.calls.find(
+          (c) =>
+            typeof c[0] === 'string' &&
+            c[0].includes('UPDATE "user"') &&
+            c[0].includes('emailVerified'),
+        );
+        expect(updateCall).toBeDefined();
+        expect(updateCall?.[1]).toEqual(['founder@example.com']);
+      });
+
+      it('throws ConflictException when count=1 but the existing user is already verified', async () => {
+        runnerQuery
+          .mockResolvedValueOnce(undefined) // lock
+          .mockResolvedValueOnce([{ count: '1' }]) // count = 1
+          .mockResolvedValueOnce([]) // no unverified users
+          .mockResolvedValueOnce(undefined); // unlock
+
+        await expect(service.createFirstAdmin(dto)).rejects.toThrow(ConflictException);
+        expect(auth.api.signUpEmail).not.toHaveBeenCalled();
+      });
+
+      it('throws ConflictException when count=1 but email does not match', async () => {
+        runnerQuery
+          .mockResolvedValueOnce(undefined) // lock
+          .mockResolvedValueOnce([{ count: '1' }]) // count = 1
+          .mockResolvedValueOnce([]) // unverified query with matching email returns none
+          .mockResolvedValueOnce(undefined); // unlock
+
+        await expect(service.createFirstAdmin(dto)).rejects.toThrow(ConflictException);
+        expect(auth.api.signUpEmail).not.toHaveBeenCalled();
+      });
+    });
+
+    it('does not wrap the flow in a TypeORM transaction', async () => {
+      // If we ever revert to this.dataSource.transaction(), a rollback
+      // would leave the Better Auth user insert committed on its own
+      // pool while the emailVerified update gets reverted. The current
+      // implementation uses a session-level advisory lock instead.
+      mockHappyPath();
       (auth.api.signUpEmail as jest.Mock).mockResolvedValueOnce({});
 
       await service.createFirstAdmin(dto);
 
-      expect(ds.transaction).toHaveBeenCalledTimes(1);
+      expect(ds.createQueryRunner).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/backend/src/setup/setup.service.ts
+++ b/packages/backend/src/setup/setup.service.ts
@@ -1,0 +1,66 @@
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { CreateAdminDto } from './dto/create-admin.dto';
+
+/**
+ * Postgres advisory lock key reserved for the first-run setup wizard.
+ * A random-ish constant — collisions only matter if another call site
+ * uses the same key, which we control.
+ */
+const SETUP_ADVISORY_LOCK_KEY = 9001;
+
+@Injectable()
+export class SetupService {
+  private readonly logger = new Logger(SetupService.name);
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  /**
+   * Returns true when no Better Auth user exists yet. The login flow uses
+   * this to redirect visitors to the setup wizard instead of showing the
+   * login form on a fresh install.
+   */
+  async needsSetup(): Promise<boolean> {
+    const rows = await this.dataSource.query<{ count: string }[]>(
+      `SELECT COUNT(*) AS count FROM "user"`,
+    );
+    const count = Number(rows[0]?.count ?? 0);
+    return count === 0;
+  }
+
+  /**
+   * Creates the first admin user via Better Auth, wrapped in a Postgres
+   * transaction with an advisory lock so concurrent POSTs can't both
+   * succeed. The created user is marked `emailVerified = true` so they
+   * can log in immediately without configuring an email provider.
+   */
+  async createFirstAdmin(dto: CreateAdminDto): Promise<void> {
+    await this.dataSource.transaction(async (manager) => {
+      // Serialize concurrent setup attempts. The lock is released when
+      // the transaction ends (commit or rollback).
+      await manager.query(`SELECT pg_advisory_xact_lock($1)`, [SETUP_ADVISORY_LOCK_KEY]);
+
+      const rows = await manager.query<{ count: string }[]>(`SELECT COUNT(*) AS count FROM "user"`);
+      const count = Number(rows[0]?.count ?? 0);
+      if (count > 0) {
+        throw new ConflictException('Setup already completed — an admin user exists');
+      }
+
+      // Lazy-require so jest unit and e2e tests that don't exercise this
+      // path don't have to load Better Auth's ESM bundle.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { auth } = require('../auth/auth.instance');
+      await auth.api.signUpEmail({
+        body: {
+          email: dto.email,
+          password: dto.password,
+          name: dto.name,
+        },
+      });
+
+      await manager.query(`UPDATE "user" SET "emailVerified" = true WHERE email = $1`, [dto.email]);
+
+      this.logger.log(`First-run setup complete — admin user created: ${dto.email}`);
+    });
+  }
+}

--- a/packages/backend/src/setup/setup.service.ts
+++ b/packages/backend/src/setup/setup.service.ts
@@ -29,38 +29,76 @@ export class SetupService {
   }
 
   /**
-   * Creates the first admin user via Better Auth, wrapped in a Postgres
-   * transaction with an advisory lock so concurrent POSTs can't both
-   * succeed. The created user is marked `emailVerified = true` so they
-   * can log in immediately without configuring an email provider.
+   * Creates the first admin user via Better Auth and marks them
+   * `emailVerified = true` so they can log in immediately without an
+   * email provider.
+   *
+   * Why not wrap this in `this.dataSource.transaction(...)`:
+   * `auth.api.signUpEmail()` runs against Better Auth's own `pg.Pool`,
+   * not the TypeORM connection. A TypeORM rollback after signUpEmail
+   * succeeds would NOT undo the user insert, leaving the account
+   * created but unverified and blocking subsequent retries with a 409.
+   *
+   * Instead we hold a session-level Postgres advisory lock (not
+   * transaction-level) across the whole sequence so concurrent setup
+   * attempts serialize, and we add a recovery branch: if the only
+   * existing user is unverified and matches the DTO email, we treat the
+   * previous attempt as partial and complete the verification step.
    */
   async createFirstAdmin(dto: CreateAdminDto): Promise<void> {
-    await this.dataSource.transaction(async (manager) => {
-      // Serialize concurrent setup attempts. The lock is released when
-      // the transaction ends (commit or rollback).
-      await manager.query(`SELECT pg_advisory_xact_lock($1)`, [SETUP_ADVISORY_LOCK_KEY]);
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    try {
+      await queryRunner.query(`SELECT pg_advisory_lock($1)`, [SETUP_ADVISORY_LOCK_KEY]);
+      try {
+        const rows = (await queryRunner.query(`SELECT COUNT(*) AS count FROM "user"`)) as Array<{
+          count: string;
+        }>;
+        const count = Number(rows[0]?.count ?? 0);
 
-      const rows = await manager.query<{ count: string }[]>(`SELECT COUNT(*) AS count FROM "user"`);
-      const count = Number(rows[0]?.count ?? 0);
-      if (count > 0) {
-        throw new ConflictException('Setup already completed — an admin user exists');
+        if (count > 0) {
+          // Recovery branch: a previous attempt may have created the user
+          // but crashed before setting emailVerified. If there's exactly
+          // one user, it's unverified, and its email matches the DTO,
+          // finish the verification step instead of returning 409.
+          if (count === 1) {
+            const unverified = (await queryRunner.query(
+              `SELECT email FROM "user" WHERE "emailVerified" = false AND email = $1`,
+              [dto.email],
+            )) as Array<{ email: string }>;
+            if (unverified.length === 1) {
+              await queryRunner.query(`UPDATE "user" SET "emailVerified" = true WHERE email = $1`, [
+                dto.email,
+              ]);
+              this.logger.log(`First-run setup recovery — completed verification for ${dto.email}`);
+              return;
+            }
+          }
+          throw new ConflictException('Setup already completed — an admin user exists');
+        }
+
+        // Lazy-require so jest unit and e2e tests that don't exercise
+        // this path don't have to load Better Auth's ESM bundle.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { auth } = require('../auth/auth.instance');
+        await auth.api.signUpEmail({
+          body: {
+            email: dto.email,
+            password: dto.password,
+            name: dto.name,
+          },
+        });
+
+        await queryRunner.query(`UPDATE "user" SET "emailVerified" = true WHERE email = $1`, [
+          dto.email,
+        ]);
+
+        this.logger.log(`First-run setup complete — admin user created: ${dto.email}`);
+      } finally {
+        await queryRunner.query(`SELECT pg_advisory_unlock($1)`, [SETUP_ADVISORY_LOCK_KEY]);
       }
-
-      // Lazy-require so jest unit and e2e tests that don't exercise this
-      // path don't have to load Better Auth's ESM bundle.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { auth } = require('../auth/auth.instance');
-      await auth.api.signUpEmail({
-        body: {
-          email: dto.email,
-          password: dto.password,
-          name: dto.name,
-        },
-      });
-
-      await manager.query(`UPDATE "user" SET "emailVerified" = true WHERE email = $1`, [dto.email]);
-
-      this.logger.log(`First-run setup complete — admin user created: ${dto.email}`);
-    });
+    } finally {
+      await queryRunner.release();
+    }
   }
 }

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -35,6 +35,7 @@ import { ModelPricingCacheService } from '../src/model-prices/model-pricing-cach
 import { RoutingModule } from '../src/routing/routing.module';
 import { CommonModule } from '../src/common/common.module';
 import { PublicStatsModule } from '../src/public-stats/public-stats.module';
+import { SetupModule } from '../src/setup/setup.module';
 
 export const TEST_USER_ID = 'test-user-001';
 export const TEST_API_KEY = 'test-api-key-001';
@@ -159,6 +160,7 @@ export async function createTestApp(): Promise<INestApplication> {
         ModelPricesModule,
         RoutingModule,
         PublicStatsModule,
+        SetupModule,
       ],
       providers: [
         { provide: APP_GUARD, useClass: MockSessionGuard },

--- a/packages/backend/test/setup.e2e-spec.ts
+++ b/packages/backend/test/setup.e2e-spec.ts
@@ -1,0 +1,110 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { createTestApp } from './helpers';
+
+let app: INestApplication;
+
+beforeAll(async () => {
+  app = await createTestApp();
+
+  // Better Auth migrations don't run in these E2E tests, so the "user"
+  // table doesn't exist by default. Create a minimal stub so SetupService
+  // queries resolve. The happy path (real Better Auth signUpEmail) is
+  // covered by the unit tests in setup.service.spec.ts.
+  const ds = app.get(DataSource);
+  await ds.query(
+    `CREATE TABLE IF NOT EXISTS "user" (
+       id VARCHAR PRIMARY KEY,
+       email VARCHAR,
+       "emailVerified" BOOLEAN
+     )`,
+  );
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(async () => {
+  // Reset the user table between tests so needsSetup swings back to true.
+  const ds = app.get(DataSource);
+  await ds.query(`DELETE FROM "user"`);
+});
+
+describe('First-run setup wizard', () => {
+  describe('GET /api/v1/setup/status', () => {
+    it('returns needsSetup=true when user table is empty', async () => {
+      const res = await request(app.getHttpServer()).get('/api/v1/setup/status').expect(200);
+      expect(res.body).toEqual({ needsSetup: true });
+    });
+
+    it('returns needsSetup=false after a user has been inserted', async () => {
+      const ds = app.get(DataSource);
+      await ds.query(
+        `INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`,
+        ['test-user-id', 'founder@example.com'],
+      );
+
+      const res = await request(app.getHttpServer()).get('/api/v1/setup/status').expect(200);
+      expect(res.body).toEqual({ needsSetup: false });
+    });
+
+    it('is a public endpoint (no auth required)', async () => {
+      const res = await request(app.getHttpServer()).get('/api/v1/setup/status');
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('POST /api/v1/setup/admin', () => {
+    it('rejects with 409 when a user already exists', async () => {
+      const ds = app.get(DataSource);
+      await ds.query(
+        `INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`,
+        ['existing-admin', 'admin@example.com'],
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({
+          email: 'founder@example.com',
+          name: 'Founder',
+          password: 'secret-password',
+        });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('rejects when email is missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({ name: 'Founder', password: 'secret-password' })
+        .expect(400);
+      expect(res.body.message).toBeDefined();
+    });
+
+    it('rejects when password is too short', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({ email: 'founder@example.com', name: 'Founder', password: 'short' })
+        .expect(400);
+      expect(res.body.message).toBeDefined();
+    });
+
+    it('rejects when email is not a valid email', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({ email: 'not-an-email', name: 'Founder', password: 'secret-password' })
+        .expect(400);
+      expect(res.body.message).toBeDefined();
+    });
+
+    it('rejects when name is missing', async () => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({ email: 'founder@example.com', password: 'secret-password' })
+        .expect(400);
+      expect(res.body.message).toBeDefined();
+    });
+  });
+});

--- a/packages/frontend/src/components/GuestGuard.tsx
+++ b/packages/frontend/src/components/GuestGuard.tsx
@@ -1,20 +1,31 @@
-import { useNavigate } from "@solidjs/router";
-import { Show, createEffect, type ParentComponent } from "solid-js";
-import { authClient } from "../services/auth-client.js";
+import { useNavigate } from '@solidjs/router';
+import { Show, createEffect, createSignal, onMount, type ParentComponent } from 'solid-js';
+import { authClient } from '../services/auth-client.js';
+import { checkNeedsSetup } from '../services/setup-status.js';
 
 const GuestGuard: ParentComponent = (props) => {
   const session = authClient.useSession();
   const navigate = useNavigate();
+  const [setupChecked, setSetupChecked] = createSignal(false);
+
+  onMount(async () => {
+    const needsSetup = await checkNeedsSetup();
+    if (needsSetup) {
+      navigate('/setup', { replace: true });
+      return;
+    }
+    setSetupChecked(true);
+  });
 
   createEffect(() => {
     const s = session();
     if (!s.isPending && s.data) {
-      navigate("/", { replace: true });
+      navigate('/', { replace: true });
     }
   });
 
   return (
-    <Show when={!session().isPending && !session().data} fallback={null}>
+    <Show when={setupChecked() && !session().isPending && !session().data} fallback={null}>
       {props.children}
     </Show>
   );

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -22,6 +22,7 @@ const Account = lazy(() => import('./pages/Account.jsx'));
 const Login = lazy(() => import('./pages/Login.jsx'));
 const Register = lazy(() => import('./pages/Register.jsx'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword.jsx'));
+const Setup = lazy(() => import('./pages/Setup.jsx'));
 const ModelPrices = lazy(() => import('./pages/ModelPrices.jsx'));
 const Help = lazy(() => import('./pages/Help.jsx'));
 const FreeModels = lazy(() => import('./pages/FreeModels.jsx'));
@@ -72,6 +73,9 @@ render(
           <Route path="/login" component={Login} />
           <Route path="/register" component={Register} />
           <Route path="/reset-password" component={ResetPassword} />
+        </Route>
+        <Route path="/setup" component={AuthLayout}>
+          <Route path="/" component={Setup} />
         </Route>
         <Route path="*404" component={NotFound} />
       </Router>

--- a/packages/frontend/src/pages/Setup.tsx
+++ b/packages/frontend/src/pages/Setup.tsx
@@ -1,0 +1,135 @@
+import { useNavigate } from '@solidjs/router';
+import { Title, Meta } from '@solidjs/meta';
+import { type Component, createSignal, onMount, Show } from 'solid-js';
+import { authClient } from '../services/auth-client.js';
+import { checkNeedsSetup, createFirstAdmin } from '../services/setup-status.js';
+
+const Setup: Component = () => {
+  const navigate = useNavigate();
+  const [email, setEmail] = createSignal('');
+  const [name, setName] = createSignal('');
+  const [password, setPassword] = createSignal('');
+  const [confirmPassword, setConfirmPassword] = createSignal('');
+  const [error, setError] = createSignal('');
+  const [loading, setLoading] = createSignal(false);
+  const [checking, setChecking] = createSignal(true);
+
+  onMount(async () => {
+    const needsSetup = await checkNeedsSetup();
+    if (!needsSetup) {
+      navigate('/login', { replace: true });
+      return;
+    }
+    setChecking(false);
+  });
+
+  const handleSubmit = async (e: Event) => {
+    e.preventDefault();
+    setError('');
+
+    if (password() !== confirmPassword()) {
+      setError('Passwords do not match');
+      return;
+    }
+    if (password().length < 8) {
+      setError('Password must be at least 8 characters');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await createFirstAdmin({ email: email(), name: name(), password: password() });
+
+      // Auto sign-in with the credentials just created.
+      const { error: authError } = await authClient.signIn.email({
+        email: email(),
+        password: password(),
+      });
+      if (authError) {
+        // Creation succeeded but sign-in failed — send them to login.
+        navigate('/login', { replace: true });
+        return;
+      }
+      window.location.href = '/';
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Setup failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Title>Set up Manifest</Title>
+      <Meta name="description" content="Create the admin account for your Manifest instance." />
+      <Show when={!checking()} fallback={<div class="auth-header__subtitle">Loading...</div>}>
+        <div class="auth-header">
+          <h1 class="auth-header__title">Welcome to Manifest</h1>
+          <p class="auth-header__subtitle">Create the admin account for your instance</p>
+        </div>
+        <form class="auth-form" onSubmit={handleSubmit}>
+          {error() && (
+            <div class="auth-form__error" role="alert">
+              {error()}
+            </div>
+          )}
+          <label class="auth-form__label">
+            Name
+            <input
+              class="auth-form__input"
+              type="text"
+              placeholder="Your name"
+              value={name()}
+              onInput={(e) => setName(e.currentTarget.value)}
+              required
+              minLength={2}
+              maxLength={100}
+            />
+          </label>
+          <label class="auth-form__label">
+            Email
+            <input
+              class="auth-form__input"
+              type="email"
+              placeholder="you@example.com"
+              value={email()}
+              onInput={(e) => setEmail(e.currentTarget.value)}
+              required
+            />
+          </label>
+          <label class="auth-form__label">
+            Password
+            <input
+              class="auth-form__input"
+              type="password"
+              placeholder="At least 8 characters"
+              value={password()}
+              onInput={(e) => setPassword(e.currentTarget.value)}
+              required
+              minLength={8}
+              maxLength={128}
+            />
+          </label>
+          <label class="auth-form__label">
+            Confirm password
+            <input
+              class="auth-form__input"
+              type="password"
+              placeholder="Re-enter password"
+              value={confirmPassword()}
+              onInput={(e) => setConfirmPassword(e.currentTarget.value)}
+              required
+              minLength={8}
+              maxLength={128}
+            />
+          </label>
+          <button class="auth-form__submit" type="submit" disabled={loading()}>
+            {loading() ? <span class="spinner" /> : 'Create admin account'}
+          </button>
+        </form>
+      </Show>
+    </>
+  );
+};
+
+export default Setup;

--- a/packages/frontend/src/services/setup-status.ts
+++ b/packages/frontend/src/services/setup-status.ts
@@ -1,0 +1,62 @@
+/**
+ * First-run setup status check. Cached per page load so the login page,
+ * setup page, and any guards can all ask without spamming the endpoint.
+ */
+let cachedPromise: Promise<boolean> | null = null;
+
+interface SetupStatusResponse {
+  needsSetup: boolean;
+}
+
+async function fetchSetupStatus(): Promise<boolean> {
+  try {
+    const res = await fetch('/api/v1/setup/status', {
+      credentials: 'include',
+      cache: 'no-store',
+    });
+    if (!res.ok) return false;
+    const data = (await res.json()) as SetupStatusResponse;
+    return data.needsSetup === true;
+  } catch {
+    return false;
+  }
+}
+
+export function checkNeedsSetup(): Promise<boolean> {
+  if (!cachedPromise) {
+    cachedPromise = fetchSetupStatus();
+  }
+  return cachedPromise;
+}
+
+/** Invalidate the cached status. Call this after a successful setup. */
+export function resetSetupStatus(): void {
+  cachedPromise = null;
+}
+
+export interface CreateAdminInput {
+  email: string;
+  name: string;
+  password: string;
+}
+
+export async function createFirstAdmin(input: CreateAdminInput): Promise<void> {
+  const res = await fetch('/api/v1/setup/admin', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    let message = `Setup failed (${res.status})`;
+    try {
+      const body = (await res.json()) as { message?: string | string[] };
+      if (typeof body.message === 'string') message = body.message;
+      else if (Array.isArray(body.message)) message = body.message.join(', ');
+    } catch {
+      // not JSON — use default
+    }
+    throw new Error(message);
+  }
+  resetSetupStatus();
+}

--- a/packages/frontend/tests/components/GuestGuard.test.tsx
+++ b/packages/frontend/tests/components/GuestGuard.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@solidjs/testing-library";
 
 const mockNavigate = vi.fn();
+const mockCheckNeedsSetup = vi.fn();
 let mockSessionData: any = { data: null, isPending: false };
 
 vi.mock("@solidjs/router", () => ({
@@ -14,21 +15,28 @@ vi.mock("../../src/services/auth-client.js", () => ({
   },
 }));
 
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkNeedsSetup: (...args: unknown[]) => mockCheckNeedsSetup(...args),
+}));
+
 import GuestGuard from "../../src/components/GuestGuard";
 
 describe("GuestGuard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSessionData = { data: null, isPending: false };
+    mockCheckNeedsSetup.mockResolvedValue(false);
   });
 
-  it("renders children when no session", () => {
+  it("renders children when no session and setup is complete", async () => {
     render(() => (
       <GuestGuard>
         <span>Guest content</span>
       </GuestGuard>
     ));
-    expect(screen.getByText("Guest content")).toBeDefined();
+    await vi.waitFor(() => {
+      expect(screen.queryByText("Guest content")).toBeDefined();
+    });
   });
 
   it("redirects to home when session exists", async () => {
@@ -44,5 +52,28 @@ describe("GuestGuard", () => {
     await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
     });
+  });
+
+  it("redirects to /setup when setup is incomplete", async () => {
+    mockCheckNeedsSetup.mockResolvedValue(true);
+    render(() => (
+      <GuestGuard>
+        <span>Guest content</span>
+      </GuestGuard>
+    ));
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/setup", { replace: true });
+    });
+  });
+
+  it("does not render children while setup check is pending", () => {
+    // checkNeedsSetup hangs — we should see no content rendered yet
+    mockCheckNeedsSetup.mockReturnValue(new Promise(() => undefined));
+    const { container } = render(() => (
+      <GuestGuard>
+        <span>Guest content</span>
+      </GuestGuard>
+    ));
+    expect(container.textContent).not.toContain("Guest content");
   });
 });

--- a/packages/frontend/tests/components/GuestGuard.test.tsx
+++ b/packages/frontend/tests/components/GuestGuard.test.tsx
@@ -35,7 +35,7 @@ describe("GuestGuard", () => {
       </GuestGuard>
     ));
     await vi.waitFor(() => {
-      expect(screen.queryByText("Guest content")).toBeDefined();
+      expect(screen.getByText("Guest content")).not.toBeNull();
     });
   });
 

--- a/packages/frontend/tests/pages/Setup.test.tsx
+++ b/packages/frontend/tests/pages/Setup.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
+
+const mockNavigate = vi.fn();
+const mockSignInEmail = vi.fn().mockResolvedValue({});
+const mockCheckNeedsSetup = vi.fn();
+const mockCreateFirstAdmin = vi.fn();
+
+vi.mock('@solidjs/router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@solidjs/meta', () => ({
+  Title: (props: { children: unknown }) => <title>{props.children as string}</title>,
+  Meta: () => null,
+}));
+
+vi.mock('../../src/services/auth-client.js', () => ({
+  authClient: {
+    signIn: {
+      email: (...args: unknown[]) => mockSignInEmail(...args),
+    },
+  },
+}));
+
+vi.mock('../../src/services/setup-status.js', () => ({
+  checkNeedsSetup: (...args: unknown[]) => mockCheckNeedsSetup(...args),
+  createFirstAdmin: (...args: unknown[]) => mockCreateFirstAdmin(...args),
+}));
+
+import Setup from '../../src/pages/Setup';
+
+describe('Setup page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckNeedsSetup.mockResolvedValue(true);
+    mockCreateFirstAdmin.mockResolvedValue(undefined);
+    mockSignInEmail.mockResolvedValue({});
+
+    // Stub window.location.href for the final navigation
+    Object.defineProperty(window, 'location', {
+      value: { href: '', replace: vi.fn() },
+      writable: true,
+    });
+  });
+
+  async function renderSetup() {
+    const result = render(() => <Setup />);
+    await waitFor(() => {
+      expect(screen.queryByText('Welcome to Manifest')).toBeDefined();
+    });
+    return result;
+  }
+
+  it('redirects to /login when setup is already complete', async () => {
+    mockCheckNeedsSetup.mockResolvedValue(false);
+    render(() => <Setup />);
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
+    });
+  });
+
+  it('renders the welcome headline and form after status check', async () => {
+    await renderSetup();
+    expect(screen.getByText('Welcome to Manifest')).toBeDefined();
+    expect(screen.getByPlaceholderText('Your name')).toBeDefined();
+    expect(screen.getByPlaceholderText('you@example.com')).toBeDefined();
+    expect(screen.getByPlaceholderText('At least 8 characters')).toBeDefined();
+    expect(screen.getByPlaceholderText('Re-enter password')).toBeDefined();
+  });
+
+  it('shows an error when passwords do not match', async () => {
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: 'different' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Passwords do not match')).toBeDefined();
+    });
+    expect(mockCreateFirstAdmin).not.toHaveBeenCalled();
+  });
+
+  it('calls createFirstAdmin with form values on valid submit', async () => {
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockCreateFirstAdmin).toHaveBeenCalledWith({
+        email: 'founder@example.com',
+        name: 'Founder',
+        password: 'secretpassword',
+      });
+    });
+  });
+
+  it('auto-signs-in after successful setup', async () => {
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockSignInEmail).toHaveBeenCalledWith({
+        email: 'founder@example.com',
+        password: 'secretpassword',
+      });
+    });
+  });
+
+  it('surfaces server errors from createFirstAdmin', async () => {
+    mockCreateFirstAdmin.mockRejectedValue(new Error('already exists'));
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(screen.queryByText('already exists')).toBeDefined();
+    });
+  });
+
+  it('falls back to /login if auto-sign-in fails after setup', async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: 'session failed' } });
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/login', { replace: true });
+    });
+  });
+
+  it('rejects short passwords (< 8 chars)', async () => {
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    // Use a 7-char password — must bypass native minLength validation
+    const passwordInput = screen.getByPlaceholderText('At least 8 characters') as HTMLInputElement;
+    const confirmInput = screen.getByPlaceholderText('Re-enter password') as HTMLInputElement;
+    passwordInput.removeAttribute('minLength');
+    confirmInput.removeAttribute('minLength');
+    fireEvent.input(passwordInput, { target: { value: 'short77' } });
+    fireEvent.input(confirmInput, { target: { value: 'short77' } });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Password must be at least 8 characters')).toBeDefined();
+    });
+    expect(mockCreateFirstAdmin).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/tests/services/setup-status.test.ts
+++ b/packages/frontend/tests/services/setup-status.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  checkNeedsSetup,
+  resetSetupStatus,
+  createFirstAdmin,
+} from '../../src/services/setup-status';
+
+describe('setup-status service', () => {
+  beforeEach(() => {
+    resetSetupStatus();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('checkNeedsSetup', () => {
+    it('returns true when backend reports needsSetup=true', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ needsSetup: true }),
+        }),
+      );
+      expect(await checkNeedsSetup()).toBe(true);
+    });
+
+    it('returns false when backend reports needsSetup=false', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ needsSetup: false }),
+        }),
+      );
+      expect(await checkNeedsSetup()).toBe(false);
+    });
+
+    it('returns false on HTTP error', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          json: async () => ({}),
+        }),
+      );
+      expect(await checkNeedsSetup()).toBe(false);
+    });
+
+    it('returns false on network failure', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+      expect(await checkNeedsSetup()).toBe(false);
+    });
+
+    it('caches the result across calls', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ needsSetup: true }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await checkNeedsSetup();
+      await checkNeedsSetup();
+      await checkNeedsSetup();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-fetches after resetSetupStatus()', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ needsSetup: true }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await checkNeedsSetup();
+      resetSetupStatus();
+      await checkNeedsSetup();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('createFirstAdmin', () => {
+    it('POSTs the admin payload as JSON', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await createFirstAdmin({
+        email: 'founder@example.com',
+        name: 'Founder',
+        password: 'secretpassword',
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/v1/setup/admin',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body).toEqual({
+        email: 'founder@example.com',
+        name: 'Founder',
+        password: 'secretpassword',
+      });
+    });
+
+    it('throws with server message when request fails with JSON body', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 409,
+          json: async () => ({ message: 'Setup already completed' }),
+        }),
+      );
+      await expect(
+        createFirstAdmin({ email: 'a@b.com', name: 'X', password: '12345678' }),
+      ).rejects.toThrow('Setup already completed');
+    });
+
+    it('flattens array error messages', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 400,
+          json: async () => ({ message: ['email must be valid', 'name is required'] }),
+        }),
+      );
+      await expect(
+        createFirstAdmin({ email: 'bad', name: '', password: '12345678' }),
+      ).rejects.toThrow('email must be valid, name is required');
+    });
+
+    it('falls back to generic error when body is not JSON', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          json: async () => {
+            throw new Error('not json');
+          },
+        }),
+      );
+      await expect(
+        createFirstAdmin({ email: 'a@b.com', name: 'X', password: '12345678' }),
+      ).rejects.toThrow('Setup failed (500)');
+    });
+
+    it('resets cached setup status after success', async () => {
+      // Prime the cache
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({ needsSetup: true }),
+        }),
+      );
+      await checkNeedsSetup();
+
+      // Swap fetch mock for create
+      const createMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ ok: true }) });
+      vi.stubGlobal('fetch', createMock);
+
+      await createFirstAdmin({ email: 'a@b.com', name: 'X', password: '12345678' });
+
+      // Next check should re-fetch
+      const statusMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ needsSetup: false }),
+      });
+      vi.stubGlobal('fetch', statusMock);
+
+      expect(await checkNeedsSetup()).toBe(false);
+      expect(statusMock).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the hardcoded `admin@manifest.build` / `manifest` seed credentials with a WordPress-style first-run setup wizard. On fresh installs, visiting any route redirects to `/setup` where the operator creates the first admin with their own email and password. Eliminates the universal known credentials that every Docker instance previously shipped with.

## Why

Universal known credentials on every self-hosted install are a textbook insecure default:
- Anyone who reads the docs can try them against exposed instances
- No forced password change — "change it immediately" was just a docs sentence
- The seed email `admin@manifest.build` isn't reachable, so password reset was a no-op
- The `SECURITY:` warning in container logs scrolled past and nobody saw it

WordPress, Ghost, Gitea, Grafana, and Supabase all use a first-run wizard for this reason. Now we do too.

## How it works

1. `GET /api/v1/setup/status` returns `{ needsSetup: true }` when the `user` table is empty.
2. `GuestGuard` (wrapping `/login`, `/register`, `/reset-password`) checks status on mount and redirects to `/setup` when `needsSetup=true`.
3. `/setup` page shows a form: name, email, password (min 8), confirm password. On submit, POSTs to `/api/v1/setup/admin`.
4. `POST /api/v1/setup/admin` wraps creation in a Postgres transaction with `pg_advisory_xact_lock(9001)` to serialize concurrent POSTs. Counts users inside the lock and throws `ConflictException` if one already exists. Otherwise calls Better Auth's `signUpEmail` and marks the new user `emailVerified = true` so they can log in immediately without email setup.
5. After success, the Setup page auto-signs-in via `authClient.signIn.email` and navigates to `/`.

Race protection: the advisory lock ensures only one concurrent setup request succeeds. If two requests arrive at the same time, the second sees `COUNT(*) > 0` inside the locked transaction and returns 409.

## Seeder changes

Dev/test workflows that rely on the well-known `admin@manifest.build` seed (`/serve`, E2E fixtures) are preserved. In production, `SEED_DATA=true` is now a no-op with a warning log directing operators to the setup wizard:

```ts
if (nodeEnv === 'production') {
  this.logger.warn('SEED_DATA=true is ignored in production — use /setup');
  return;
}
```

## Docker compose

Flipped to drive the setup wizard flow:
- `NODE_ENV=development` → `production` (activates `trust proxy`, error sanitization, proper auth guard semantics)
- `SEED_DATA=true` → `false` (no more hardcoded admin)
- Top comment rewritten to describe the wizard flow

DOCKER_README updated: "log in with admin@manifest.build / manifest" replaced with "complete the setup wizard at http://localhost:3001/setup".

## Test plan

- [x] Backend jest — 3503/3503 across 181 suites (14 new unit tests for SetupService + SetupController)
- [x] Backend E2E — 107/107 across 15 suites against fresh Postgres (8 new tests for setup status, duplicate rejection, DTO validation)
- [x] Frontend vitest — 2103/2103 across 105 suites (19 new tests: Setup page, setup-status service, GuestGuard redirect)
- [x] `tsc --noEmit` clean on backend + frontend
- [x] `npm run build` — full Turbo build clean
- [ ] Runtime smoke test: `docker compose up -d`, visit http://localhost:3001, complete setup wizard, verify login works
- [ ] Second-boot smoke test: restart container with existing DB, verify setup wizard is skipped and login page loads
- [ ] Concurrent-setup race test (manual): two curl requests in parallel to POST /api/v1/setup/admin, verify exactly one succeeds

## What's deliberately NOT in this PR

- Password reset flow is unchanged — still no-ops without a configured email provider. Operators can recover via DB access.
- Self-serve user registration (invite others beyond the first admin) is still handled by the existing `/register` route through Better Auth. The setup wizard only creates the first admin.
- Changing the `BETTER_AUTH_SECRET` placeholder in the compose file is out of scope. That belongs in a separate hardening pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hardcoded `admin@manifest.build` / `manifest` seed with a first‑run setup wizard. Fresh installs redirect to `/setup` to create the first admin, removing known credentials and shipping secure defaults.

- **New Features**
  - Backend: `GET /api/v1/setup/status` returns `needsSetup`; `POST /api/v1/setup/admin` holds a session‑level `pg_advisory_lock(9001)` to serialize requests, adds a recovery path if a single unverified user matches the submitted email, and sets `emailVerified=true`; production seeder now ignores `SEED_DATA=true` and logs a warning.
  - Frontend: New `/setup` page (name, email, password, confirm) with auto sign‑in; `GuestGuard` redirects to `/setup` when `needsSetup=true`; the setup page redirects to `/login` if setup is already complete.
  - Docker/docs: Defaults switched to `NODE_ENV=production` and `SEED_DATA=false`; guides now point to the `/setup` wizard; single‑container instructions use `AUTO_MIGRATE=true`.

- **Migration**
  - New installs: boot the stack and visit `/setup` to create the admin.
  - Existing installs: no action needed; the wizard is skipped if any user exists.
  - Dev/test: `SEED_DATA=true` works only with `NODE_ENV=development|test`; in production it’s ignored.

<sup>Written for commit 033428a31841003903a28fecb96d316949fa1f29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

