### PR TITLE
revert: drop docker hub description sync job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,11 +7,6 @@ on:
         description: "Optional version override (e.g. 5.38.1). Leave blank to use the current version from packages/manifest/package.json."
         required: false
         type: string
-  push:
-    branches: [main]
-    paths:
-      - "docker/DOCKER_README.md"
-      - ".github/workflows/docker.yml"
   pull_request:
     branches: [main]
     paths:
@@ -114,32 +109,3 @@ jobs:
           for tag in ${TAGS}; do
             cosign sign --yes "${tag}@${DIGEST}"
           done
-
-  sync-description:
-    name: Sync Docker Hub description
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Push README to Docker Hub
-        env:
-          DOCKER_USER: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKER_PASS: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          # Pinned to immutable digest for supply-chain safety.
-          # The underlying tool is chko/docker-pushrm:1. When bumping the tag,
-          # fetch the current digest with:
-          #   TOKEN=$(curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:chko/docker-pushrm:pull" | jq -r .token)
-          #   curl -sI -H "Authorization: Bearer $TOKEN" \
-          #     -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
-          #     https://registry-1.docker.io/v2/chko/docker-pushrm/manifests/1 | grep -i docker-content-digest
-          docker run --rm \
-            -v "$GITHUB_WORKSPACE/docker/DOCKER_README.md:/data/README.md:ro" \
-            -e DOCKER_USER \
-            -e DOCKER_PASS \
-            chko/docker-pushrm@sha256:812a950e5be7dca26cef33b61eb2076bfcfb6c2a8ec96c126371fc049c3b6608 \
-            --file /data/README.md \
-            --short "Smart LLM router for personal AI agents. Cut costs up to 70%." \
-            --debug \
-            manifestdotbuild/manifest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,24 +506,19 @@ Changesets are **not** required on every PR — they're optional and only meanin
 
 1. Merge the pending `chore: version packages` PR to land the version bump in `packages/manifest/package.json`.
 2. Go to **GitHub Actions → Docker → Run workflow**, leave the `version` input blank, click Run.
-3. The `publish` job reads `packages/manifest/package.json`, resolves the version automatically, and pushes `manifestdotbuild/manifest:{version}` + `{major}.{minor}` + `{major}` + `sha-<short>` to Docker Hub. The image is multi-arch (amd64 + arm64) and cosign-signed. The `sync-description` job also runs in the same workflow_dispatch and pushes the latest `docker/DOCKER_README.md` to the Docker Hub repo description.
+3. The `publish` job reads `packages/manifest/package.json`, resolves the version automatically, and pushes `manifestdotbuild/manifest:{version}` + `{major}.{minor}` + `{major}` + `sha-<short>` to Docker Hub. The image is multi-arch (amd64 + arm64) and cosign-signed.
+4. **Manually update the Docker Hub description** on hub.docker.com by copy-pasting the current contents of `docker/DOCKER_README.md`. (Automating this sync hit a wall because `docker-pushrm` and the Docker Hub web API need a personal-user PAT and the existing secrets are scoped to the org — tracked as a follow-up, not blocking releases.)
 
 To retag an older commit or publish a hotfix version that doesn't match the current `package.json`, pass a semver string in the `version` input and it overrides the package.json lookup.
-
-### Docker Hub description
-
-`docker/DOCKER_README.md` is the source of truth for the Docker Hub repo description at [`manifestdotbuild/manifest`](https://hub.docker.com/r/manifestdotbuild/manifest). The `sync-description` job in `docker.yml` pushes it to Docker Hub via the [`chko/docker-pushrm`](https://github.com/christian-korneck/docker-pushrm) container image (standalone `docker run`, no third-party GitHub Action). It uses the same `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets as the publish job — the Docker Hub PAT needs write access to the repo, which the existing token already has for image pushes. Edits to `docker/DOCKER_README.md` are treated as doc-only: they do **not** trigger the PR validate job (no point rebuilding multi-arch images for content changes), and they auto-sync to Docker Hub on merge to main via a dedicated `push:` trigger with a narrow paths filter. The `chko/docker-pushrm` image is pinned to an immutable digest in the workflow — when bumping, re-fetch the digest via `docker manifest inspect chko/docker-pushrm:1` or the registry API (see the inline comment in `docker.yml`).
 
 ### Summary of what CI does on each trigger
 
 | Trigger | What happens |
 |---------|--------------|
 | PR opened/updated (runtime files) | `ci.yml` runs tests, lint, typecheck, coverage. `docker.yml` validates the Docker build (no push). `changeset-check` warns softly if no changeset is present. |
-| PR opened/updated (`docker/DOCKER_README.md` only) | No Docker CI runs — content-only change, nothing to validate. |
 | Merge to `main` | `release.yml` runs `changesets/action` to open or update the `chore: version packages` PR. **No auto-publish** — neither npm nor Docker. |
 | Merge of `chore: version packages` PR | `release.yml` runs again. Version bump in `packages/manifest/package.json` and the CHANGELOG update land on `main`. Still no image publish. |
-| Merge of a PR that touched `docker/DOCKER_README.md` | `docker.yml` `sync-description` job runs, pushing the new README to Docker Hub via `chko/docker-pushrm`. No image rebuild. |
-| Manual `workflow_dispatch` on `Docker` workflow | `publish` job reads `packages/manifest/package.json` and pushes a new image tag to Docker Hub. `sync-description` also runs in parallel and re-syncs the Docker Hub description. This is the **only** path that publishes image artifacts. |
+| Manual `workflow_dispatch` on `Docker` workflow | Reads `packages/manifest/package.json` and pushes a new image tag to Docker Hub. This is the **only** path that publishes anything. |
 
 ## Code Coverage (Codecov)
 


### PR DESCRIPTION
## Summary

The \`sync-description\` job added in #1544 fails in CI because `DOCKERHUB_USERNAME` is set to `manifestdotbuild` (the org name). That works for `docker/login-action` (registry API accepts org names for authentication) but is rejected by `docker-pushrm` because Docker Hub's web API login endpoint (`/v2/users/login/`) only accepts real user accounts — you can't "log in" as an org, you have to log in as a user who has access to the org.

Confirmed from the failed CI log:

```
Using target: docker.io/***/manifest:latest
namespace: ***
...
retrieve Dockerhub jwt token, status code: 401
error retrieving Dockerhub jwt token
```

(The `***` is the GitHub Actions log redaction for `manifestdotbuild`, which tells us `DOCKERHUB_USERNAME` holds that string.)

Fixing this properly would mean either rotating `DOCKERHUB_USERNAME` to a personal user's login (and making sure that user has write access to the org repo and owns the PAT), or adding a second set of secrets (`DOCKERHUB_DESC_USERNAME` / `DOCKERHUB_DESC_TOKEN`) scoped only to the sync job. Per the maintainer: not worth the secret-rotation overhead — Docker Hub description updates will continue to happen by hand.

## What's reverted

- `sync-description` job removed from `.github/workflows/docker.yml`
- `push: main` trigger removed from `docker.yml` (it existed only to fire the sync job)
- `chko/docker-pushrm` digest pin removed (no longer referenced)
- "Docker Hub description" subsection removed from `CLAUDE.md` Releases section
- "Merge of a PR that touched `docker/DOCKER_README.md`" row removed from the CI triggers table
- The step 3 in "Cutting a Docker release" no longer mentions sync-description running in parallel
- Added a new step 4 to the release checklist as a reminder: **"Manually update the Docker Hub description on hub.docker.com by copy-pasting the current contents of `docker/DOCKER_README.md`"**

## What's intentionally NOT reverted

- **`docker/DOCKER_README.md` content refresh** — dropping the deprecated npm badge, adding the Docker pulls badge, updating "for OpenClaw" → "for personal AI agents like OpenClaw or Hermes", adding the Image tags section, adding Z.ai to the provider list, swapping the brittle user-attachments hero image URL for a stable `.github/assets/` path. All orthogonal to the sync job and still worth having.
- **`docker/DOCKER_README.md` removal from the `pull_request` paths filter**. This is a separate optimization: README-only PRs shouldn't trigger a 7-minute multi-arch Docker rebuild since content doesn't affect the built image.

## Test plan

- [x] `.github/workflows/docker.yml` diff reverts exactly the sync additions from #1544
- [x] `CLAUDE.md` diff matches the pre-#1544 Releases section structure with step 4 added
- [ ] After merge: next `workflow_dispatch` on Docker workflow runs cleanly with just `validate` (on PRs) and `publish` (on dispatch) jobs, no `sync-description`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `sync-description` job from the Docker workflow to stop CI failures caused by org-scoped Docker Hub creds. Description updates are now manual; related triggers and docs were cleaned up.

- **Bug Fixes**
  - Remove `sync-description` job and its `push: main` trigger from `.github/workflows/docker.yml`.
  - Drop the `chko/docker-pushrm` reference; add a release step to manually copy `docker/DOCKER_README.md` to Docker Hub.
  - Keep the `docker/DOCKER_README.md` content refresh and its exclusion from `pull_request` paths (README-only PRs still skip image builds).

<sup>Written for commit 05cb0e69e5542c2acaf8273f1ea07ec3e57c8be0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

