### PR TITLE
fix: retarget orphan changeset from manifest-model-router to manifest

### DIFF
--- a/.changeset/remove-local-mode.md
+++ b/.changeset/remove-local-mode.md
@@ -1,5 +1,5 @@
 ---
-"manifest-model-router": patch
+"manifest": patch
 ---
 
 Remove local mode and harden the Docker deployment.
@@ -10,4 +10,4 @@ Docker deployments now default to `NODE_ENV=production`, with migrations control
 
 New unified `EMAIL_*` env var scheme (`EMAIL_PROVIDER`, `EMAIL_API_KEY`, `EMAIL_DOMAIN`, `EMAIL_FROM`) covers both Better Auth transactional emails (signup verification, password reset) and threshold alert notifications. Supports Resend (recommended for self-hosting — no domain setup), Mailgun, and SendGrid. Legacy `MAILGUN_*` env vars still work for backward compatibility.
 
-Breaking: `MANIFEST_MODE`, `MANIFEST_DB_PATH`, `MANIFEST_UPDATE_CHECK_OPTOUT`, `MANIFEST_TRUST_LAN` env vars are removed (no-op if set). The `manifest` npm package is deprecated. The `manifest-model-router` plugin is unaffected and remains the recommended way to route OpenClaw requests through Manifest.
+Breaking: `MANIFEST_MODE`, `MANIFEST_DB_PATH`, `MANIFEST_UPDATE_CHECK_OPTOUT`, `MANIFEST_TRUST_LAN` env vars are removed (no-op if set). Both the `manifest` and `manifest-model-router` npm packages are deprecated — OpenClaw users should configure Manifest as a generic OpenAI-compatible provider instead (see the setup modal in the dashboard).


### PR DESCRIPTION
## Problem

Release workflow failing on the merge of #1545:

\`\`\`
🦋 error Found changeset remove-local-mode for package manifest-model-router which is not in the workspace
\`\`\`

\`.changeset/remove-local-mode.md\` was added in #1539 (\`chore/remove-local-mode\`) but targets \`"manifest-model-router": patch\`. That package was deleted in #1528, so changesets fast-fails on the dangling reference. Same class of problem as #1534.

## Fix

Unlike #1534 where I deleted the orphans outright, this one has **genuinely useful changelog content** — it documents the local-mode removal, the Docker hardening, the new \`AUTO_MIGRATE\` env var, and the unified \`EMAIL_*\` scheme. Those are real user-facing changes and they belong in the \`manifest\` CHANGELOG.

So: retarget the changeset from \`manifest-model-router\` to \`manifest\` (the canonical version from #1541). Keep the \`patch\` bump type — if you want \`minor\` or \`major\` instead, that's a one-line follow-up, but I don't want to make that call for you.

Also dropped the final sentence of the body, which described \`manifest-model-router\` as "the recommended way to route OpenClaw requests through Manifest" — that package no longer exists. Replaced with a correct note pointing users at the dashboard's setup modal (generic OpenAI-compatible provider config).

## Verified locally

\`\`\`
$ npx changeset status --verbose
🦋 info Packages to be bumped at patch
🦋 - manifest 5.46.1
🦋   - .changeset/remove-local-mode.md
\`\`\`

Clean resolve. Release workflow should succeed on the merge.

## Test plan

- [x] \`npx changeset status\` — resolves cleanly, bumps manifest from 5.46.0 to 5.46.1
- [ ] After merge: release workflow opens a \`chore: version packages\` PR with the \`manifest@5.46.1\` bump + a new entry in \`packages/manifest/CHANGELOG.md\`

## Follow-up thought

After this lands and the version-packages PR is merged, it might be worth a quick audit to make sure no other PRs in flight have orphan changesets. The pattern is always the same: a PR branched off main before #1528 landed adds a changeset targeting a now-deleted package. A one-liner \`grep -rl '"manifest-model-router"\' .changeset/\` on any release-blocking branch would catch this early.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retargeted `.changeset/remove-local-mode.md` from `manifest-model-router` to `manifest` to unblock the release workflow and put the changelog in the right package. Updated the final note to remove the deleted plugin and direct OpenClaw users to configure Manifest as a generic OpenAI-compatible provider.

<sup>Written for commit 53445108aafa341b2b6cbca2009b87d519cdab3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

