### PR TITLE
ci: auto-publish Docker image on version-packages merge

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,12 @@ on:
         description: "Optional version override (e.g. 5.38.1). Leave blank to use the current version from packages/manifest/package.json."
         required: false
         type: string
+  workflow_call:
+    inputs:
+      version:
+        description: "Optional version override. Leave blank to use the current version from packages/manifest/package.json."
+        required: false
+        type: string
   pull_request:
     branches: [main]
     paths:
@@ -56,7 +62,7 @@ jobs:
 
   build:
     name: Build (${{ matrix.platform.arch }})
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: true
       matrix:
@@ -111,7 +117,7 @@ jobs:
 
   merge:
     name: Merge & Publish
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -41,15 +41,26 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Detect version bump
         id: detect
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          PREV=$(git show HEAD~1:packages/manifest/package.json 2>/dev/null | jq -r .version 2>/dev/null || echo "")
-          CURR=$(jq -r .version packages/manifest/package.json)
-          if [ -n "$PREV" ] && [ "$PREV" != "$CURR" ]; then
+          # Read CURR from HEAD (not the working tree) because
+          # changesets/action runs `npm run version-packages` in place and
+          # may have mutated packages/manifest/package.json on disk.
+          CURR=$(git show HEAD:packages/manifest/package.json 2>/dev/null | jq -r .version 2>/dev/null || echo "")
+          # Compare against the push base so multi-commit pushes are handled
+          # correctly. On first push to a branch, BEFORE_SHA is all zeros.
+          if [ -n "$BEFORE_SHA" ] && [ "$BEFORE_SHA" != "0000000000000000000000000000000000000000" ]; then
+            PREV=$(git show "${BEFORE_SHA}:packages/manifest/package.json" 2>/dev/null | jq -r .version 2>/dev/null || echo "")
+          else
+            PREV=""
+          fi
+          if [ -n "$PREV" ] && [ -n "$CURR" ] && [ "$PREV" != "$CURR" ]; then
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
             echo "Version bumped: $PREV -> $CURR"
           else
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "No version change ($CURR)"
+            echo "No version change (PREV=${PREV:-<none>} CURR=${CURR:-<none>})"
           fi
 
   publish-docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.detect.outputs.should_publish }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -21,6 +23,8 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -35,3 +39,24 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Detect version bump
+        id: detect
+        run: |
+          PREV=$(git show HEAD~1:packages/manifest/package.json 2>/dev/null | jq -r .version 2>/dev/null || echo "")
+          CURR=$(jq -r .version packages/manifest/package.json)
+          if [ -n "$PREV" ] && [ "$PREV" != "$CURR" ]; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+            echo "Version bumped: $PREV -> $CURR"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "No version change ($CURR)"
+          fi
+
+  publish-docker:
+    needs: release
+    if: needs.release.outputs.should_publish == 'true'
+    uses: ./.github/workflows/docker.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -504,21 +504,22 @@ Changesets are **not** required on every PR — they're optional and only meanin
 
 ### Cutting a Docker release
 
-1. Merge the pending `chore: version packages` PR to land the version bump in `packages/manifest/package.json`.
-2. Go to **GitHub Actions → Docker → Run workflow**, leave the `version` input blank, click Run.
-3. The `publish` job reads `packages/manifest/package.json`, resolves the version automatically, and pushes `manifestdotbuild/manifest:{version}` + `{major}.{minor}` + `{major}` + `sha-<short>` to Docker Hub. The image is multi-arch (amd64 + arm64) and cosign-signed.
-4. **Manually update the Docker Hub description** on hub.docker.com by copy-pasting the current contents of `docker/DOCKER_README.md`. (Automating this sync hit a wall because `docker-pushrm` and the Docker Hub web API need a personal-user PAT and the existing secrets are scoped to the org — tracked as a follow-up, not blocking releases.)
+Merging the `chore: version packages` PR to `main` automatically publishes a new Docker image — no manual step required.
 
-To retag an older commit or publish a hotfix version that doesn't match the current `package.json`, pass a semver string in the `version` input and it overrides the package.json lookup.
+1. Merge the pending `chore: version packages` PR. `release.yml` detects the version bump in `packages/manifest/package.json` (by diffing `HEAD~1` against `HEAD`) and calls `docker.yml` as a reusable workflow.
+2. The `publish` job reads `packages/manifest/package.json`, resolves the version automatically, and pushes `manifestdotbuild/manifest:{version}` + `{major}.{minor}` + `{major}` + `sha-<short>` to Docker Hub. The image is multi-arch (amd64 + arm64) and cosign-signed.
+3. **Manually update the Docker Hub description** on hub.docker.com by copy-pasting the current contents of `docker/DOCKER_README.md`. (Automating this sync hit a wall because `docker-pushrm` and the Docker Hub web API need a personal-user PAT and the existing secrets are scoped to the org — tracked as a follow-up, not blocking releases.)
+
+**Manual override:** `workflow_dispatch` on `Docker → Run workflow` still works for hotfixes and retags. Leave the `version` input blank to use `packages/manifest/package.json`, or pass a semver string to retag an older commit / publish a hotfix version.
 
 ### Summary of what CI does on each trigger
 
 | Trigger | What happens |
 |---------|--------------|
 | PR opened/updated (runtime files) | `ci.yml` runs tests, lint, typecheck, coverage. `docker.yml` validates the Docker build (no push). `changeset-check` warns softly if no changeset is present. |
-| Merge to `main` | `release.yml` runs `changesets/action` to open or update the `chore: version packages` PR. **No auto-publish** — neither npm nor Docker. |
-| Merge of `chore: version packages` PR | `release.yml` runs again. Version bump in `packages/manifest/package.json` and the CHANGELOG update land on `main`. Still no image publish. |
-| Manual `workflow_dispatch` on `Docker` workflow | Reads `packages/manifest/package.json` and pushes a new image tag to Docker Hub. This is the **only** path that publishes anything. |
+| Merge to `main` | `release.yml` runs `changesets/action` to open or update the `chore: version packages` PR. No publish — the version on `main` hasn't changed yet. |
+| Merge of `chore: version packages` PR | `release.yml` runs again, detects the version bump in `packages/manifest/package.json`, and calls `docker.yml` as a reusable workflow. This pushes a new image tag to Docker Hub automatically. |
+| Manual `workflow_dispatch` on `Docker` workflow | Reads `packages/manifest/package.json` (or the `version` input override) and pushes a new image tag to Docker Hub. Used for hotfixes and retags. |
 
 ## Code Coverage (Codecov)
 


### PR DESCRIPTION
## Summary

- Make `.github/workflows/docker.yml` a reusable workflow and have `.github/workflows/release.yml` call it whenever `packages/manifest/package.json`'s version actually changes on `main`.
- Removes the manual **GitHub Actions → Docker → Run workflow** step after each `chore: version packages` PR. The image now publishes automatically as soon as the version bump lands.

## Why

Today `docker.yml`'s publish job is gated by `if: github.event_name == 'workflow_dispatch'`, and `release.yml` only runs `changesets/action` — nothing wires the two together. As a result, merging a `chore: version packages` PR bumps `packages/manifest/package.json` but never produces a Docker image (you can see the `Build & Publish — 0s, skipped` entry on that PR's run).

## What changed

**`.github/workflows/docker.yml`**
- New `workflow_call` trigger with an optional `version` input, alongside the existing `workflow_dispatch` and `pull_request` triggers.
- Publish job gate relaxed from `== 'workflow_dispatch'` to `!= 'pull_request'`, so it runs on manual dispatch **and** when called from `release.yml`. `validate` stays PR-only.

**`.github/workflows/release.yml`**
- `actions/checkout@v4` now uses `fetch-depth: 2` so we can diff against the previous commit on `main`.
- New `Detect version bump` step compares `git show HEAD~1:packages/manifest/package.json` to the current file and sets `should_publish=true` iff the version changed.
- `release` job now exposes `should_publish` as a job output.
- New `publish-docker` job that `needs: release`, gates on `should_publish == 'true'`, and invokes `./.github/workflows/docker.yml` as a reusable workflow with `secrets: inherit` and `id-token: write` so cosign keyless signing still works.

**`CLAUDE.md`**
- Updated the *Releases → Cutting a Docker release* section and the *What CI does on each trigger* table to document the new automatic path. Manual `workflow_dispatch` stays as a hotfix / retag override.

## Edge cases

- **Empty / non-version pushes to main** → detect step returns `false`, `publish-docker` is skipped.
- **Manual version bumps outside changesets** → still fire (the version on `main` is the source of truth, regardless of who bumped it).
- **First run with no `HEAD~1`** → `git show` falls back to empty, `PREV` is empty, publish is skipped.
- **Hotfix retags** → `workflow_dispatch` with an explicit `version` input still works exactly as before.

## Test plan

- [x] `npx @action-validator/cli .github/workflows/docker.yml` — passes (only a glob-validation warning, unrelated).
- [x] `npx @action-validator/cli .github/workflows/release.yml` — passes.
- [x] Dry-run of the detect step locally against the current `main` HEAD (which bumps `5.46.0 → 5.46.1`):
  ```
  PREV=5.46.0
  CURR=5.46.1
  should_publish=true
  ```
- [ ] CI passes on this PR.
- [ ] End-to-end: merge a real `chore: version packages` PR after this lands and confirm a new `manifestdotbuild/manifest:{version}` tag appears on Docker Hub.
- [ ] Manual override still works: run `Docker → Run workflow` from the UI with a blank `version` input and confirm it still publishes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-publish the Docker image when a `chore: version packages` bump lands on `main`. Detection reads the version from `git show HEAD:…` and compares against `github.event.before` to avoid false positives and handle multi-commit pushes; manual hotfix/retag overrides still work.

- **New Features**
  - Made `.github/workflows/docker.yml` reusable via `workflow_call`; publish runs on non-PR events, PRs only validate.
  - In `release.yml`: `actions/checkout@v4` with `fetch-depth: 0`; detect version change using `git show HEAD:…` vs `github.event.before`; expose `should_publish`; when true, call `docker.yml` with `id-token: write` for cosign.
  - Defaults to the version in `packages/manifest/package.json`; optional `version` input remains for retags/hotfixes.

<sup>Written for commit 184fa795b9f8a32c8a22b6b6285ec4de239fbeaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

