### PR TITLE
ci(docker): self-trigger on workflow file changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".github/workflows/docker.yml"
       - "docker/Dockerfile"
       - ".dockerignore"
       - "docker/docker-compose.yml"


### PR DESCRIPTION
## Summary

Tiny follow-up to #1549. The Docker workflow's `pull_request` path filter didn't include `.github/workflows/docker.yml` itself, so PRs that only touch the workflow — like #1549 did — don't actually exercise the Docker `validate` job. I only caught this after #1549 merged and realised the new amd64/arm64 matrix had never been run against a real PR.

Adding the workflow file to its own path filter is standard practice and makes future workflow edits self-validate.

## Test plan

- [x] YAML still parses
- [ ] This very PR should now show `Build (validate, amd64)` and `Build (validate, arm64)` in the checks — that's the first real signal that the native-runner matrix shape from #1549 actually works. If either check fails, that's the signal to iterate on #1549's shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include `.github/workflows/docker.yml` in the Docker workflow’s `pull_request.paths` so edits to the workflow trigger the Docker `validate` job (amd64/arm64). This ensures workflow changes self-validate instead of silently skipping the matrix.

<sup>Written for commit 06aef89ae737c2b7193513fca6d2d17514c479f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

