### PR TITLE
fix(docker): harden Docker release and routing correctness

### DIFF
--- a/.changeset/docker-hardening-phase-1-2.md
+++ b/.changeset/docker-hardening-phase-1-2.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Docker release hardening pass: parameterize POSTGRES_PASSWORD and wire `.env.example` through `install.sh`; bind port 3001 to `127.0.0.1` by default; drop stale `MANIFEST_TRUST_LAN` from docs; replace OpenClaw-specific meta tags in the SPA with agent-neutral copy. `/api/v1/routing/:agent/status` now returns a structured `{ enabled, reason }` shape and only claims `enabled: true` when at least one tier resolves to a real model (`reason: no_provider | no_routable_models | pricing_cache_empty`). Provider connect rejects unknown providers and normalises casing. Tier override rejects unknown models with a helpful list. New `GET /api/v1/routing/pricing-health` and `POST /api/v1/routing/pricing/refresh` endpoints plus a Routing-page banner when the OpenRouter pricing cache is empty. Workspace-card and per-agent message counts now exclude error and fallback-error rows.

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -13,8 +13,11 @@ BETTER_AUTH_SECRET=
 
 # ─── Database ──────────────────────────────────────────────────────────────
 
-# Override the bundled Postgres password for hardening.
+# To harden the bundled Postgres password, set BOTH of the variables below.
+# They must agree. Special characters in the password must be percent-encoded
+# in DATABASE_URL (e.g. `@` → `%40`, `:` → `%3A`, `/` → `%2F`).
 # POSTGRES_PASSWORD=change-me
+# DATABASE_URL=postgresql://manifest:change-me@postgres:5432/manifest
 
 
 # ─── Email provider (optional) ─────────────────────────────────────────────

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -62,9 +62,11 @@ Works with 300+ models across OpenAI, Anthropic, Google Gemini, DeepSeek, xAI, M
 
 Three paths, ordered from fastest to most hands-on. All three end in the same place: a running stack that walks you through the **setup wizard** at [http://localhost:3001](http://localhost:3001) to create your admin account.
 
+> **Heads up on network binding.** The bundled compose file binds port 3001 to `127.0.0.1` only, so the dashboard is reachable on the host machine but not over the LAN. See [Custom port](#custom-port) to expose it beyond localhost.
+
 ### Option 1: Quickstart install script (recommended)
 
-One command. The script downloads `docker/docker-compose.yml`, generates a fresh `BETTER_AUTH_SECRET` and injects it into the compose file, brings up the stack, and waits for the healthcheck to go green.
+One command. The script downloads `docker/docker-compose.yml` and `docker/.env.example`, writes a fresh `BETTER_AUTH_SECRET` into `.env`, brings up the stack, and waits for the healthcheck to go green.
 
 ```bash
 bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh)
@@ -82,19 +84,23 @@ Flags: `--dir <path>` (install into a custom directory, defaults to `./manifest`
 
 ### Option 2: Docker Compose (manual)
 
-Same underlying flow as the install script, but you drive it yourself so you can edit the compose file before booting the stack.
+Same underlying flow as the install script, but you drive it yourself so you can edit the config before booting the stack.
 
-1. Download the compose file:
+1. Download the compose file and the env template into the same directory:
 
 ```bash
 curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker/docker-compose.yml
+curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker/.env.example
+cp .env.example .env
 ```
 
-2. Generate a secret and paste it over the `BETTER_AUTH_SECRET` placeholder in `docker-compose.yml`:
+2. Generate a secret and paste it into the `BETTER_AUTH_SECRET=` line in `.env`:
 
 ```bash
 openssl rand -hex 32
 ```
+
+(Optional: set `POSTGRES_PASSWORD=` in `.env` to use something other than the default `manifest` password. The compose file feeds the same value into both the Postgres container and `DATABASE_URL`, so changing it in `.env` is sufficient.)
 
 3. Start it:
 
@@ -191,12 +197,24 @@ Or in docker-compose.yml:
 
 ```yaml
 ports:
-  - "8080:3001"
-environment:
-  - BETTER_AUTH_URL=http://localhost:8080
+  - "127.0.0.1:8080:3001"
 ```
 
-If you see "Invalid origin" on the login page, `BETTER_AUTH_URL` doesn't match the port you're using.
+…and in `.env`:
+
+```env
+BETTER_AUTH_URL=http://localhost:8080
+```
+
+### Exposing on the LAN
+
+By default the compose file binds port 3001 to `127.0.0.1` only — the dashboard is reachable from the host but not from other machines on the network. To expose it on the LAN:
+
+1. Edit `docker-compose.yml` and change the `ports` line from `"127.0.0.1:3001:3001"` to `"3001:3001"`.
+2. In `.env`, set `BETTER_AUTH_URL` to the host you'll reach the dashboard on — e.g. `http://192.168.1.20:3001` or `https://manifest.mydomain.com`. This MUST match the URL in the browser or Better Auth will reject the login with "Invalid origin".
+3. `docker compose up -d` to apply.
+
+If you see "Invalid origin" on the login page, `BETTER_AUTH_URL` doesn't match the URL you're accessing the dashboard on. The host matters as much as the port.
 
 ## Image tags
 
@@ -256,7 +274,6 @@ docker compose down -v    # ⚠  destroys all data
 | `PORT` | No | `3001` | Internal server port |
 | `NODE_ENV` | No | `production` | Set `development` for auto-migrations |
 | `SEED_DATA` | No | `false` | Seed demo data on startup |
-| `MANIFEST_TRUST_LAN` | No | `false` | Trust private network IPs (needed in Docker) |
 
 Full env var reference: [github.com/mnfst/manifest](https://github.com/mnfst/manifest)
 

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -100,7 +100,7 @@ cp .env.example .env
 openssl rand -hex 32
 ```
 
-(Optional: set `POSTGRES_PASSWORD=` in `.env` to use something other than the default `manifest` password. The compose file feeds the same value into both the Postgres container and `DATABASE_URL`, so changing it in `.env` is sufficient.)
+(Optional: to use a stronger database password, set BOTH `POSTGRES_PASSWORD` and `DATABASE_URL` in `.env` — they must agree, and any special characters in the password need to be percent-encoded in the URL.)
 
 3. Start it:
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,25 +2,31 @@
 # http://localhost:3001 and the app walks you through creating the first
 # admin account via the setup wizard at /setup. No hardcoded credentials.
 #
+# Configuration comes from a `.env` file next to this compose file.
+# Copy `.env.example` to `.env` and set at least BETTER_AUTH_SECRET before
+# booting. The install script does this automatically.
+#
 # Before exposing this instance beyond localhost:
-#   - Replace BETTER_AUTH_SECRET below with a real secret. Generate one
-#     with: openssl rand -hex 32
+#   - Set a real BETTER_AUTH_SECRET in .env (openssl rand -hex 32).
+#   - Override POSTGRES_PASSWORD in .env for a stronger database password.
 #   - Confirm your admin password is strong (the setup wizard enforces
 #     at least 8 characters).
 #   - If you enable email verification (set EMAIL_PROVIDER / EMAIL_API_KEY),
 #     set BETTER_AUTH_URL to a reachable public URL so the verification
 #     links resolve.
+#   - The app port binds to 127.0.0.1 by default. To expose on the LAN,
+#     change `127.0.0.1:3001:3001` below to `3001:3001` AND update
+#     BETTER_AUTH_URL in .env to match the host you reach it on.
 
 services:
   manifest:
     image: manifestdotbuild/manifest:latest
     ports:
-      - "3001:3001"
+      - "127.0.0.1:3001:3001"
     environment:
-      - DATABASE_URL=postgresql://manifest:manifest@postgres:5432/manifest
-      # ⚠  Placeholder. Replace before any non-localhost use (see top of file).
-      - BETTER_AUTH_SECRET=change-me-to-a-random-32-char-string!!
-      - BETTER_AUTH_URL=http://localhost:3001
+      - DATABASE_URL=postgresql://manifest:${POSTGRES_PASSWORD:-manifest}@postgres:5432/manifest
+      - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set in .env}
+      - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3001}
       - SEED_DATA=false
       - NODE_ENV=production
       - AUTO_MIGRATE=true
@@ -64,7 +70,7 @@ services:
     image: postgres:16-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416
     environment:
       - POSTGRES_USER=manifest
-      - POSTGRES_PASSWORD=manifest
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-manifest}
       - POSTGRES_DB=manifest
     volumes:
       - pgdata:/var/lib/postgresql/data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,10 @@
 #
 # Before exposing this instance beyond localhost:
 #   - Set a real BETTER_AUTH_SECRET in .env (openssl rand -hex 32).
-#   - Override POSTGRES_PASSWORD in .env for a stronger database password.
+#   - To harden the database password, set BOTH `POSTGRES_PASSWORD` AND
+#     `DATABASE_URL` in .env. They must agree — the password in the URL
+#     must match POSTGRES_PASSWORD, and any special characters must be
+#     percent-encoded in the URL.
 #   - Confirm your admin password is strong (the setup wizard enforces
 #     at least 8 characters).
 #   - If you enable email verification (set EMAIL_PROVIDER / EMAIL_API_KEY),
@@ -24,7 +27,7 @@ services:
     ports:
       - "127.0.0.1:3001:3001"
     environment:
-      - DATABASE_URL=postgresql://manifest:${POSTGRES_PASSWORD:-manifest}@postgres:5432/manifest
+      - DATABASE_URL=${DATABASE_URL:-postgresql://manifest:manifest@postgres:5432/manifest}
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set in .env}
       - BETTER_AUTH_URL=${BETTER_AUTH_URL:-http://localhost:3001}
       - SEED_DATA=false

--- a/docker/install.sh
+++ b/docker/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Manifest — self-host quick install
 #
-# Downloads the Docker Compose file, generates a BETTER_AUTH_SECRET and
-# writes it into the compose file (replacing the placeholder), then brings
-# up the stack. Designed for first-time self-hosters who want a one-command
-# setup. After the stack is healthy, visit http://localhost:3001 — the
-# setup wizard walks you through creating the first admin account.
+# Downloads the Docker Compose file and the `.env.example` template,
+# generates a BETTER_AUTH_SECRET, writes it into a local `.env`, then
+# brings up the stack. Designed for first-time self-hosters who want a
+# one-command setup. After the stack is healthy, visit http://localhost:3001
+# — the setup wizard walks you through creating the first admin account.
 #
 # Usage:
 #   bash install.sh                  # install into ./manifest
@@ -97,6 +97,15 @@ else
     || die "Failed to download docker-compose.yml"
 fi
 
+log "Downloading .env.example"
+ENV_PATH="$INSTALL_DIR/.env"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  printf '    \033[2m$ curl -sSLf %s/.env.example -o %s\033[0m\n' "$REPO_RAW" "$ENV_PATH"
+else
+  curl -sSLf "$REPO_RAW/.env.example" -o "$ENV_PATH" \
+    || die "Failed to download .env.example"
+fi
+
 log "Generating BETTER_AUTH_SECRET"
 if [[ "$DRY_RUN" -eq 1 ]]; then
   SECRET="<generated-at-install-time>"
@@ -108,18 +117,25 @@ else
   esac
 fi
 
-log "Writing secret into docker-compose.yml"
-COMPOSE_PATH="$INSTALL_DIR/docker-compose.yml"
-PLACEHOLDER='BETTER_AUTH_SECRET=change-me-to-a-random-32-char-string!!'
+log "Writing secret into .env"
 if [[ "$DRY_RUN" -eq 1 ]]; then
-  printf '    \033[2m$ replace "%s" → BETTER_AUTH_SECRET=<generated> in %s\033[0m\n' "$PLACEHOLDER" "$COMPOSE_PATH"
+  printf '    \033[2m$ replace "BETTER_AUTH_SECRET=" → "BETTER_AUTH_SECRET=<generated>" in %s\033[0m\n' "$ENV_PATH"
 else
-  if ! grep -qF "$PLACEHOLDER" "$COMPOSE_PATH"; then
-    die "Placeholder BETTER_AUTH_SECRET not found in $COMPOSE_PATH — refusing to proceed."
+  if ! grep -qE '^BETTER_AUTH_SECRET=$' "$ENV_PATH"; then
+    die "Expected empty BETTER_AUTH_SECRET= line not found in $ENV_PATH — refusing to proceed."
   fi
-  # openssl rand -hex produces only [0-9a-f], so plain bash string replacement is safe.
-  compose_content=$(<"$COMPOSE_PATH")
-  printf '%s' "${compose_content//$PLACEHOLDER/BETTER_AUTH_SECRET=$SECRET}" > "$COMPOSE_PATH"
+  # Line-based rewrite — no sed, no quoting edge cases. openssl rand -hex
+  # produces only [0-9a-f], so interpolation into the line is safe.
+  new_content=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == "BETTER_AUTH_SECRET=" ]]; then
+      new_content+="BETTER_AUTH_SECRET=$SECRET"$'\n'
+    else
+      new_content+="$line"$'\n'
+    fi
+  done < "$ENV_PATH"
+  printf '%s' "$new_content" > "$ENV_PATH"
+  chmod 600 "$ENV_PATH"
 fi
 
 log "Starting the stack"
@@ -141,8 +157,14 @@ for _ in $(seq 1 24); do
     log "Manifest is up."
     cat <<EOF
 
-  Open:  http://localhost:3001
-  Setup: the first visit walks you through creating your admin account.
+  Open:   http://localhost:3001
+  Setup:  the first visit walks you through creating your admin account.
+  Config: $INSTALL_DIR/.env  (BETTER_AUTH_SECRET, OAuth keys, email provider)
+
+  Note:   Port 3001 is bound to 127.0.0.1 only. To expose on your LAN,
+          edit $INSTALL_DIR/docker-compose.yml and change the ports line
+          from "127.0.0.1:3001:3001" to "3001:3001", then update
+          BETTER_AUTH_URL in .env to match the host you'll access it on.
 
   Stop:  (cd $INSTALL_DIR && docker compose down)
   Wipe:  (cd $INSTALL_DIR && docker compose down -v)

--- a/packages/backend/src/analytics/services/agent-analytics.service.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.ts
@@ -2,10 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
-import {
-  rangeToInterval,
-  rangeToPreviousInterval,
-} from '../../common/utils/range.util';
+import { rangeToInterval, rangeToPreviousInterval } from '../../common/utils/range.util';
 import { computeTrend } from './query-helpers';
 import { computeCutoff } from '../../common/utils/sql-dialect';
 
@@ -50,7 +47,10 @@ export class AgentAnalyticsService {
         .select('COALESCE(SUM(at.input_tokens), 0)', 'input')
         .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'output')
         .addSelect('COALESCE(SUM(at.cache_read_tokens), 0)', 'cache_read')
-        .addSelect('COUNT(*)', 'messages')
+        .addSelect(
+          `COUNT(*) FILTER (WHERE at.status IS NULL OR at.status NOT IN ('error', 'fallback_error'))`,
+          'messages',
+        )
         .where('at.timestamp >= :cutoff', { cutoff })
         .andWhere('at.tenant_id = :tenantId', { tenantId: scope.tenantId })
         .andWhere('at.agent_id = :agentId', { agentId: scope.agentId })

--- a/packages/backend/src/analytics/services/timeseries-queries.service.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.ts
@@ -202,7 +202,10 @@ export class TimeseriesQueriesService {
     const statsQb = this.turnRepo
       .createQueryBuilder('at')
       .select('at.agent_name', 'agent_name')
-      .addSelect('COUNT(*)', 'message_count')
+      .addSelect(
+        `COUNT(*) FILTER (WHERE at.status IS NULL OR at.status NOT IN ('error', 'fallback_error'))`,
+        'message_count',
+      )
       .addSelect('MAX(at.timestamp)', 'last_active')
       .addSelect(`COALESCE(SUM(${costExpr}), 0)`, 'total_cost')
       .addSelect('COALESCE(SUM(at.input_tokens + at.output_tokens), 0)', 'total_tokens')

--- a/packages/backend/src/routing/dto/routing.dto.spec.ts
+++ b/packages/backend/src/routing/dto/routing.dto.spec.ts
@@ -1,7 +1,12 @@
 import 'reflect-metadata';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
-import { AgentNameParamDto, CopilotPollDto, SetFallbacksDto } from './routing.dto';
+import {
+  AgentNameParamDto,
+  ConnectProviderDto,
+  CopilotPollDto,
+  SetFallbacksDto,
+} from './routing.dto';
 
 function toDto(data: Record<string, unknown>): AgentNameParamDto {
   return plainToInstance(AgentNameParamDto, data);
@@ -66,6 +71,61 @@ describe('AgentNameParamDto', () => {
 
   it('should reject non-string agentName', async () => {
     const dto = toDto({ agentName: 123 });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ConnectProviderDto', () => {
+  function toConnectDto(data: Record<string, unknown>): ConnectProviderDto {
+    return plainToInstance(ConnectProviderDto, data);
+  }
+
+  it('accepts a known provider id', async () => {
+    const dto = toConnectDto({ provider: 'openai', apiKey: 'sk-abcdef' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.provider).toBe('openai');
+  });
+
+  it('normalizes provider casing to lowercase', async () => {
+    const dto = toConnectDto({ provider: 'OpenAI' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.provider).toBe('openai');
+  });
+
+  it('trims whitespace around the provider name', async () => {
+    const dto = toConnectDto({ provider: '  anthropic  ' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+    expect(dto.provider).toBe('anthropic');
+  });
+
+  it('accepts registered aliases (google -> gemini entry)', async () => {
+    const dto = toConnectDto({ provider: 'google' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects an unknown provider name', async () => {
+    const dto = toConnectDto({ provider: 'made-up-xyz' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    const flat = errors.flatMap((e) => Object.values(e.constraints ?? {}));
+    expect(flat.join('\n')).toMatch(/provider must be one of/);
+  });
+
+  it('rejects an empty provider', async () => {
+    const dto = toConnectDto({ provider: '' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('passes through a non-string provider value without transforming', async () => {
+    const dto = toConnectDto({ provider: 42 });
+    // Transform preserves non-strings so class-validator can reject via @IsString
+    expect(dto.provider).toBe(42 as unknown as string);
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
   });

--- a/packages/backend/src/routing/dto/routing.dto.ts
+++ b/packages/backend/src/routing/dto/routing.dto.ts
@@ -7,8 +7,12 @@ import {
   ArrayMaxSize,
   Matches,
 } from 'class-validator';
+import { Transform } from 'class-transformer';
 
 import { TIERS, AUTH_TYPES } from 'manifest-shared';
+import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
+
+const KNOWN_PROVIDER_IDS: readonly string[] = Array.from(PROVIDER_BY_ID_OR_ALIAS.keys());
 
 export class AgentNameParamDto {
   @IsString()
@@ -31,6 +35,10 @@ export class ProviderParamDto {
 export class ConnectProviderDto {
   @IsString()
   @IsNotEmpty()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim().toLowerCase() : value))
+  @IsIn(KNOWN_PROVIDER_IDS, {
+    message: `provider must be one of: ${KNOWN_PROVIDER_IDS.join(', ')}`,
+  })
   provider!: string;
 
   @IsOptional()

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -4,6 +4,7 @@ import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { CustomProviderService } from './custom-provider/custom-provider.service';
 import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
 import { OllamaSyncService } from '../database/ollama-sync.service';
+import { PricingSyncService } from '../database/pricing-sync.service';
 import { DiscoveredModel } from '../model-discovery/model-fetcher';
 import { Agent } from '../entities/agent.entity';
 
@@ -33,6 +34,7 @@ describe('ModelController', () => {
   let mockOllamaSync: Record<string, jest.Mock>;
   let mockResolveAgent: Record<string, jest.Mock>;
   let mockCustomProviderService: Record<string, jest.Mock>;
+  let mockPricingSync: Record<string, jest.Mock>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -52,6 +54,11 @@ describe('ModelController', () => {
     mockCustomProviderService = {
       list: jest.fn().mockResolvedValue([]),
     };
+    mockPricingSync = {
+      getAll: jest.fn().mockReturnValue(new Map([['gpt-4o', {}]])),
+      getLastFetchedAt: jest.fn().mockReturnValue(new Date('2026-04-13T00:00:00Z')),
+      refreshCache: jest.fn().mockResolvedValue(42),
+    };
 
     controller = new ModelController(
       mockProviderService as unknown as ProviderService,
@@ -59,7 +66,65 @@ describe('ModelController', () => {
       mockOllamaSync as unknown as OllamaSyncService,
       mockResolveAgent as unknown as ResolveAgentService,
       mockCustomProviderService as unknown as CustomProviderService,
+      mockPricingSync as unknown as PricingSyncService,
     );
+  });
+
+  /* ── pricingHealth ── */
+
+  describe('pricingHealth', () => {
+    it('returns cache size and last fetch timestamp', () => {
+      mockPricingSync.getAll.mockReturnValue(
+        new Map([
+          ['a', {}],
+          ['b', {}],
+        ]),
+      );
+      mockPricingSync.getLastFetchedAt.mockReturnValue(new Date('2026-04-12T10:00:00Z'));
+
+      const result = controller.pricingHealth();
+
+      expect(result).toEqual({
+        model_count: 2,
+        last_fetched_at: '2026-04-12T10:00:00.000Z',
+      });
+    });
+
+    it('returns null last_fetched_at when cache was never populated', () => {
+      mockPricingSync.getAll.mockReturnValue(new Map());
+      mockPricingSync.getLastFetchedAt.mockReturnValue(null);
+
+      const result = controller.pricingHealth();
+
+      expect(result).toEqual({ model_count: 0, last_fetched_at: null });
+    });
+  });
+
+  /* ── refreshPricing ── */
+
+  describe('refreshPricing', () => {
+    it('triggers a cache refresh and reports the new count', async () => {
+      mockPricingSync.refreshCache.mockResolvedValue(150);
+      mockPricingSync.getLastFetchedAt.mockReturnValue(new Date('2026-04-13T12:00:00Z'));
+
+      const result = await controller.refreshPricing();
+
+      expect(mockPricingSync.refreshCache).toHaveBeenCalled();
+      expect(result).toEqual({
+        ok: true,
+        model_count: 150,
+        last_fetched_at: '2026-04-13T12:00:00.000Z',
+      });
+    });
+
+    it('returns ok=false when refresh yields zero models', async () => {
+      mockPricingSync.refreshCache.mockResolvedValue(0);
+      mockPricingSync.getLastFetchedAt.mockReturnValue(null);
+
+      const result = await controller.refreshPricing();
+
+      expect(result).toEqual({ ok: false, model_count: 0, last_fetched_at: null });
+    });
   });
 
   /* ── syncOllama ── */

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -6,6 +6,7 @@ import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { CustomProviderService } from './custom-provider/custom-provider.service';
 import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
 import { OllamaSyncService } from '../database/ollama-sync.service';
+import { PricingSyncService } from '../database/pricing-sync.service';
 import { AgentNameParamDto } from './dto/routing.dto';
 
 @Controller('api/v1/routing')
@@ -16,7 +17,26 @@ export class ModelController {
     private readonly ollamaSync: OllamaSyncService,
     private readonly resolveAgentService: ResolveAgentService,
     private readonly customProviderService: CustomProviderService,
+    private readonly pricingSync: PricingSyncService,
   ) {}
+
+  @Get('pricing-health')
+  pricingHealth() {
+    return {
+      model_count: this.pricingSync.getAll().size,
+      last_fetched_at: this.pricingSync.getLastFetchedAt()?.toISOString() ?? null,
+    };
+  }
+
+  @Post('pricing/refresh')
+  async refreshPricing() {
+    const modelCount = await this.pricingSync.refreshCache();
+    return {
+      ok: modelCount > 0,
+      model_count: modelCount,
+      last_fetched_at: this.pricingSync.getLastFetchedAt()?.toISOString() ?? null,
+    };
+  }
 
   @Post(':agentName/refresh-models')
   async refreshModels(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -2,8 +2,10 @@ import { NotFoundException } from '@nestjs/common';
 import { ProviderController } from './provider.controller';
 import { ProviderService } from './routing-core/provider.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
+import { TierService } from './routing-core/tier.service';
 import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
 import { OllamaSyncService } from '../database/ollama-sync.service';
+import { PricingSyncService } from '../database/pricing-sync.service';
 import { Agent } from '../entities/agent.entity';
 
 const mockUser = { id: 'user-1' } as never;
@@ -16,6 +18,8 @@ describe('ProviderController', () => {
   let mockDiscoveryService: Record<string, jest.Mock>;
   let mockOllamaSync: Record<string, jest.Mock>;
   let mockResolveAgent: Record<string, jest.Mock>;
+  let mockTierService: Record<string, jest.Mock>;
+  let mockPricingSync: Record<string, jest.Mock>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -35,51 +39,84 @@ describe('ProviderController', () => {
     mockResolveAgent = {
       resolve: jest.fn().mockResolvedValue({ id: TEST_AGENT_ID, name: 'test-agent' } as Agent),
     };
+    mockTierService = {
+      hasRoutableTier: jest.fn().mockResolvedValue(true),
+    };
+    mockPricingSync = {
+      getAll: jest.fn().mockReturnValue(new Map([['model-1', {}]])),
+    };
 
     controller = new ProviderController(
       mockProviderService as unknown as ProviderService,
       mockDiscoveryService as unknown as ModelDiscoveryService,
       mockOllamaSync as unknown as OllamaSyncService,
       mockResolveAgent as unknown as ResolveAgentService,
+      mockTierService as unknown as TierService,
+      mockPricingSync as unknown as PricingSyncService,
     );
   });
 
   /* ── getStatus ── */
 
   describe('getStatus', () => {
-    it('returns enabled true when at least one provider is active', async () => {
+    it('returns enabled true when a provider is active and a tier is routable', async () => {
       mockProviderService.getProviders.mockResolvedValue([
         { id: 'p1', provider: 'openai', is_active: true },
       ]);
+      mockTierService.hasRoutableTier.mockResolvedValue(true);
 
       const result = await controller.getStatus(mockUser, mockAgentName);
-      expect(result).toEqual({ enabled: true });
+      expect(result).toEqual({ enabled: true, reason: null });
     });
 
-    it('returns enabled false when no providers are active', async () => {
+    it('returns no_provider when no providers are active', async () => {
       mockProviderService.getProviders.mockResolvedValue([
         { id: 'p1', provider: 'openai', is_active: false },
       ]);
 
       const result = await controller.getStatus(mockUser, mockAgentName);
-      expect(result).toEqual({ enabled: false });
+      expect(result).toEqual({ enabled: false, reason: 'no_provider' });
+      expect(mockTierService.hasRoutableTier).not.toHaveBeenCalled();
     });
 
-    it('returns enabled false when no providers exist', async () => {
+    it('returns no_provider when no providers exist', async () => {
       mockProviderService.getProviders.mockResolvedValue([]);
 
       const result = await controller.getStatus(mockUser, mockAgentName);
-      expect(result).toEqual({ enabled: false });
+      expect(result).toEqual({ enabled: false, reason: 'no_provider' });
     });
 
-    it('returns enabled true with mixed active/inactive providers', async () => {
+    it('considers mixed active/inactive providers as having an active one', async () => {
       mockProviderService.getProviders.mockResolvedValue([
         { id: 'p1', provider: 'openai', is_active: false },
         { id: 'p2', provider: 'anthropic', is_active: true },
       ]);
+      mockTierService.hasRoutableTier.mockResolvedValue(true);
 
       const result = await controller.getStatus(mockUser, mockAgentName);
-      expect(result).toEqual({ enabled: true });
+      expect(result).toEqual({ enabled: true, reason: null });
+    });
+
+    it('returns no_routable_models when provider is active but no tier resolves', async () => {
+      mockProviderService.getProviders.mockResolvedValue([
+        { id: 'p1', provider: 'openai', is_active: true },
+      ]);
+      mockTierService.hasRoutableTier.mockResolvedValue(false);
+      mockPricingSync.getAll.mockReturnValue(new Map([['gpt-4', {}]]));
+
+      const result = await controller.getStatus(mockUser, mockAgentName);
+      expect(result).toEqual({ enabled: false, reason: 'no_routable_models' });
+    });
+
+    it('returns pricing_cache_empty when tiers are empty and pricing cache is empty', async () => {
+      mockProviderService.getProviders.mockResolvedValue([
+        { id: 'p1', provider: 'openai', is_active: true },
+      ]);
+      mockTierService.hasRoutableTier.mockResolvedValue(false);
+      mockPricingSync.getAll.mockReturnValue(new Map());
+
+      const result = await controller.getStatus(mockUser, mockAgentName);
+      expect(result).toEqual({ enabled: false, reason: 'pricing_cache_empty' });
     });
   });
 

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -12,8 +12,10 @@ import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
 import { ProviderService } from './routing-core/provider.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
+import { TierService } from './routing-core/tier.service';
 import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
 import { OllamaSyncService } from '../database/ollama-sync.service';
+import { PricingSyncService } from '../database/pricing-sync.service';
 import {
   AgentNameParamDto,
   AgentProviderParamDto,
@@ -29,14 +31,34 @@ export class ProviderController {
     private readonly discoveryService: ModelDiscoveryService,
     private readonly ollamaSync: OllamaSyncService,
     private readonly resolveAgentService: ResolveAgentService,
+    private readonly tierService: TierService,
+    private readonly pricingSync: PricingSyncService,
   ) {}
 
   @Get(':agentName/status')
   async getStatus(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
     const providers = await this.providerService.getProviders(agent.id);
-    const enabled = providers.some((p) => p.is_active);
-    return { enabled };
+    const hasActiveProvider = providers.some((p) => p.is_active);
+
+    if (!hasActiveProvider) {
+      return { enabled: false, reason: 'no_provider' as const };
+    }
+
+    const hasRoutableTier = await this.tierService.hasRoutableTier(agent.id);
+    if (!hasRoutableTier) {
+      // No tier resolves to a model. If the OpenRouter pricing cache is empty
+      // (e.g. first-boot fetch failed), surface that as a more actionable hint.
+      const pricingCacheEmpty = this.pricingSync.getAll().size === 0;
+      return {
+        enabled: false,
+        reason: pricingCacheEmpty
+          ? ('pricing_cache_empty' as const)
+          : ('no_routable_models' as const),
+      };
+    }
+
+    return { enabled: true, reason: null };
   }
 
   @Get(':agentName/providers')

--- a/packages/backend/src/routing/routing-core/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/tier.service.spec.ts
@@ -1,9 +1,27 @@
+import { BadRequestException } from '@nestjs/common';
 import { TierService } from './tier.service';
 import { TierAutoAssignService } from './tier-auto-assign.service';
 import { RoutingCacheService } from './routing-cache.service';
 import { ProviderService } from './provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { DiscoveredModel } from '../../model-discovery/model-fetcher';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { UserProvider } from '../../entities/user-provider.entity';
+
+function makeDiscoveredModel(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
+  return {
+    id: 'gpt-4o',
+    displayName: 'GPT-4o',
+    provider: 'openai',
+    contextWindow: 128000,
+    inputPricePerToken: 0.000005,
+    outputPricePerToken: 0.000015,
+    capabilityReasoning: false,
+    capabilityCode: true,
+    qualityScore: 4,
+    ...overrides,
+  } as DiscoveredModel;
+}
 
 jest.mock('../../common/utils/subscription-support', () => ({
   isManifestUsableProvider: jest.fn((record: { auth_type?: string }) => {
@@ -50,6 +68,7 @@ describe('TierService', () => {
     setProviders: jest.Mock;
   };
   let providerService: { getProviders: jest.Mock };
+  let discoveryService: { getModelsForAgent: jest.Mock };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -64,6 +83,14 @@ describe('TierService', () => {
       setProviders: jest.fn(),
     };
     providerService = { getProviders: jest.fn().mockResolvedValue([]) };
+    discoveryService = {
+      getModelsForAgent: jest
+        .fn()
+        .mockResolvedValue([
+          makeDiscoveredModel({ id: 'gpt-4o', provider: 'openai' }),
+          makeDiscoveredModel({ id: 'claude-3-haiku', provider: 'anthropic' }),
+        ]),
+    };
 
     service = new TierService(
       providerRepo as unknown as any,
@@ -71,7 +98,50 @@ describe('TierService', () => {
       autoAssign as unknown as TierAutoAssignService,
       routingCache as unknown as RoutingCacheService,
       providerService as unknown as ProviderService,
+      discoveryService as unknown as ModelDiscoveryService,
     );
+  });
+
+  /* ── hasRoutableTier ── */
+
+  describe('hasRoutableTier', () => {
+    it('returns true when a tier has an auto_assigned_model', async () => {
+      tierRepo.find.mockResolvedValue([makeTier({ auto_assigned_model: 'gpt-4o' })]);
+
+      const result = await service.hasRoutableTier('agent-1');
+      expect(result).toBe(true);
+    });
+
+    it('returns true when a tier has an override_model', async () => {
+      tierRepo.find.mockResolvedValue([
+        makeTier({ auto_assigned_model: null, override_model: 'claude-sonnet' }),
+      ]);
+
+      const result = await service.hasRoutableTier('agent-1');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when all tier rows are null', async () => {
+      tierRepo.find.mockResolvedValue([
+        makeTier({ auto_assigned_model: null, override_model: null }),
+        makeTier({
+          id: 'tier-2',
+          tier: 'complex',
+          auto_assigned_model: null,
+          override_model: null,
+        }),
+      ]);
+
+      const result = await service.hasRoutableTier('agent-1');
+      expect(result).toBe(false);
+    });
+
+    it('returns false when no tier rows exist', async () => {
+      tierRepo.find.mockResolvedValue([]);
+
+      const result = await service.hasRoutableTier('agent-1');
+      expect(result).toBe(false);
+    });
   });
 
   /* ── getTiers ── */
@@ -241,6 +311,56 @@ describe('TierService', () => {
       await service.setOverride('agent-1', 'user-1', 'simple', 'gpt-4o');
 
       expect(existing.fallback_models).toBeNull();
+    });
+
+    it('should reject unknown model with BadRequestException', async () => {
+      await expect(
+        service.setOverride('agent-1', 'user-1', 'simple', 'gpt-does-not-exist'),
+      ).rejects.toThrow(BadRequestException);
+      expect(tierRepo.save).not.toHaveBeenCalled();
+      expect(tierRepo.insert).not.toHaveBeenCalled();
+    });
+
+    it('should include available models in the rejection message', async () => {
+      await expect(
+        service.setOverride('agent-1', 'user-1', 'simple', 'bogus-model'),
+      ).rejects.toThrow(/gpt-4o/);
+    });
+
+    it('should reject model when provider hint does not match the discovered entry', async () => {
+      await expect(
+        service.setOverride('agent-1', 'user-1', 'simple', 'gpt-4o', 'anthropic'),
+      ).rejects.toThrow(BadRequestException);
+      expect(tierRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('should accept model when provider hint matches', async () => {
+      const existing = makeTier();
+      tierRepo.findOne.mockResolvedValue(existing);
+
+      await service.setOverride('agent-1', 'user-1', 'simple', 'gpt-4o', 'openai');
+
+      expect(tierRepo.save).toHaveBeenCalled();
+    });
+
+    it('should accept model when provider hint matches case-insensitively', async () => {
+      const existing = makeTier();
+      tierRepo.findOne.mockResolvedValue(existing);
+
+      await service.setOverride('agent-1', 'user-1', 'simple', 'gpt-4o', 'OpenAI');
+
+      expect(tierRepo.save).toHaveBeenCalled();
+    });
+
+    it('should truncate options list when many models are available', async () => {
+      const many = Array.from({ length: 30 }, (_, i) =>
+        makeDiscoveredModel({ id: `model-${i}`, provider: 'openai' }),
+      );
+      discoveryService.getModelsForAgent.mockResolvedValue(many);
+
+      await expect(
+        service.setOverride('agent-1', 'user-1', 'simple', 'missing-model'),
+      ).rejects.toThrow(/…/);
     });
   });
 

--- a/packages/backend/src/routing/routing-core/tier.service.ts
+++ b/packages/backend/src/routing/routing-core/tier.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
@@ -6,6 +6,7 @@ import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { TierAutoAssignService } from './tier-auto-assign.service';
 import { RoutingCacheService } from './routing-cache.service';
 import { ProviderService } from './provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { randomUUID } from 'crypto';
 import { TIERS } from '../../scoring/types';
 import { isManifestUsableProvider } from '../../common/utils/subscription-support';
@@ -20,7 +21,13 @@ export class TierService {
     private readonly autoAssign: TierAutoAssignService,
     private readonly routingCache: RoutingCacheService,
     private readonly providerService: ProviderService,
+    private readonly discoveryService: ModelDiscoveryService,
   ) {}
+
+  async hasRoutableTier(agentId: string): Promise<boolean> {
+    const rows = await this.tierRepo.find({ where: { agent_id: agentId } });
+    return rows.some((r) => !!r.override_model || !!r.auto_assigned_model);
+  }
 
   async getTiers(agentId: string, userId?: string): Promise<TierAssignment[]> {
     const cached = this.routingCache.getTiers(agentId);
@@ -83,6 +90,29 @@ export class TierService {
     provider?: string,
     authType?: 'api_key' | 'subscription',
   ): Promise<TierAssignment> {
+    const available = await this.discoveryService.getModelsForAgent(agentId);
+    const matches = available.filter((m) => m.id === model);
+    if (matches.length === 0) {
+      const providerHint = provider ? ` (provider: ${provider})` : '';
+      const options = available.map((m) => m.id).slice(0, 20);
+      throw new BadRequestException(
+        `Model "${model}" is not in this agent's discovered model list${providerHint}. ` +
+          `Connect the appropriate provider first, or choose from: ${options.join(', ')}${
+            available.length > options.length ? ', …' : ''
+          }`,
+      );
+    }
+    // If provider is supplied, ensure it matches one of the available entries.
+    if (provider) {
+      const providerLower = provider.toLowerCase();
+      const providerMatches = matches.some((m) => m.provider.toLowerCase() === providerLower);
+      if (!providerMatches) {
+        throw new BadRequestException(
+          `Model "${model}" is not offered by provider "${provider}" for this agent.`,
+        );
+      }
+    }
+
     const existing = await this.tierRepo.findOne({
       where: { agent_id: agentId, tier },
     });

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -12,12 +12,12 @@
     <link href="/fonts/boxicons/boxicons-duotone.min.css" rel="stylesheet" />
     <meta
       name="description"
-      content="Monitor and control your OpenClaw costs."
+      content="Monitor and control your personal AI agent costs."
     />
     <meta property="og:title" content="Manifest" />
     <meta
       property="og:description"
-      content="Monitor and control your OpenClaw costs."
+      content="Monitor and control your personal AI agent costs."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://app.manifest.build" />
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="Manifest" />
     <meta
       name="twitter:description"
-      content="Monitor and control your OpenClaw costs."
+      content="Monitor and control your personal AI agent costs."
     />
     <meta name="twitter:image" content="https://app.manifest.build/og-image.png" />
     <script src="/theme-init.js"></script>

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -23,6 +23,8 @@ import {
   overrideSpecificity,
   resetSpecificity,
   refreshModels,
+  getPricingHealth,
+  refreshPricing,
 } from '../services/api.js';
 import {
   parseCustomProviderParams,
@@ -72,6 +74,9 @@ const Routing: Component = () => {
   const [instructionProvider, setInstructionProvider] = createSignal<string | null>(null);
   const [fallbackPickerTier, setFallbackPickerTier] = createSignal<string | null>(null);
   const [refreshingModels, setRefreshingModels] = createSignal(false);
+  const [pricingHealth, { refetch: refetchPricingHealth }] = createResource(getPricingHealth);
+  const [refreshingPricing, setRefreshingPricing] = createSignal(false);
+  const pricingCacheEmpty = () => (pricingHealth()?.model_count ?? 0) === 0;
   const [wasEnabledBeforeModal, setWasEnabledBeforeModal] = createSignal(false);
   const [hadProvidersBeforeModal, setHadProvidersBeforeModal] = createSignal(false);
 
@@ -202,6 +207,46 @@ const Routing: Component = () => {
           </div>
         </Show>
       </div>
+
+      <Show when={pricingHealth() && pricingCacheEmpty()}>
+        <div
+          class="panel"
+          role="alert"
+          style="display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 16px; border-left: 3px solid var(--color-warning, #d97706);"
+        >
+          <div>
+            <strong>Pricing catalog is empty.</strong>{' '}
+            <span>
+              Manifest couldn't reach openrouter.ai at startup, so no models will be auto-assigned
+              to tiers. Retry below, or check outbound network access to openrouter.ai.
+            </span>
+          </div>
+          <button
+            class="btn btn--outline btn--sm"
+            disabled={refreshingPricing()}
+            onClick={async () => {
+              setRefreshingPricing(true);
+              try {
+                const res = await refreshPricing();
+                await refetchPricingHealth();
+                if (res.ok) {
+                  toast.success(`Pricing catalog loaded (${res.model_count} models)`);
+                  await refetchModels();
+                  await refetchTiers();
+                } else {
+                  toast.error('Pricing refresh failed — check backend logs');
+                }
+              } catch {
+                toast.error('Pricing refresh failed');
+              } finally {
+                setRefreshingPricing(false);
+              }
+            }}
+          >
+            {refreshingPricing() ? 'Retrying...' : 'Retry pricing sync'}
+          </button>
+        </div>
+      </Show>
 
       <Show
         when={!connectedProviders.loading}

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -15,8 +15,19 @@ export interface RoutingProvider {
 
 /* -- Routing: Status -- */
 
+export type RoutingStatusReason =
+  | 'no_provider'
+  | 'no_routable_models'
+  | 'pricing_cache_empty'
+  | null;
+
+export interface RoutingStatus {
+  enabled: boolean;
+  reason: RoutingStatusReason;
+}
+
 export function getRoutingStatus(agentName: string) {
-  return fetchJson<{ enabled: boolean }>(`/routing/${encodeURIComponent(agentName)}/status`);
+  return fetchJson<RoutingStatus>(`/routing/${encodeURIComponent(agentName)}/status`);
 }
 
 /* -- Routing: Providers -- */
@@ -187,6 +198,24 @@ export function getAvailableModels(agentName: string) {
 export function refreshModels(agentName: string) {
   return fetchMutate<{ ok: boolean }>(
     `${BASE_URL}/routing/${encodeURIComponent(agentName)}/refresh-models`,
+    { method: 'POST' },
+  );
+}
+
+/* -- Routing: Pricing cache health -- */
+
+export interface PricingHealth {
+  model_count: number;
+  last_fetched_at: string | null;
+}
+
+export function getPricingHealth() {
+  return fetchJson<PricingHealth>('/routing/pricing-health');
+}
+
+export function refreshPricing() {
+  return fetchMutate<{ ok: boolean; model_count: number; last_fetched_at: string | null }>(
+    `${BASE_URL}/routing/pricing/refresh`,
     { method: 'POST' },
   );
 }

--- a/packages/frontend/tests/pages/Routing-deeplink.test.tsx
+++ b/packages/frontend/tests/pages/Routing-deeplink.test.tsx
@@ -72,6 +72,8 @@ vi.mock('../../src/services/api.js', () => ({
   refreshModels: vi.fn().mockResolvedValue([]),
   getSpecificityAssignments: vi.fn().mockResolvedValue([]),
   overrideSpecificity: vi.fn().mockResolvedValue({}),
+  getPricingHealth: vi.fn().mockResolvedValue({ model_count: 100, last_fetched_at: '2026-04-13T00:00:00.000Z' }),
+  refreshPricing: vi.fn().mockResolvedValue({ ok: true, model_count: 100, last_fetched_at: '2026-04-13T00:00:00.000Z' }),
 }));
 
 vi.mock('../../src/services/routing-utils.js', () => ({

--- a/packages/frontend/tests/pages/Routing-prefill.test.tsx
+++ b/packages/frontend/tests/pages/Routing-prefill.test.tsx
@@ -68,6 +68,8 @@ vi.mock('../../src/services/api.js', () => ({
   refreshModels: vi.fn().mockResolvedValue([]),
   getSpecificityAssignments: vi.fn().mockResolvedValue([]),
   overrideSpecificity: vi.fn().mockResolvedValue({}),
+  getPricingHealth: vi.fn().mockResolvedValue({ model_count: 100, last_fetched_at: '2026-04-13T00:00:00.000Z' }),
+  refreshPricing: vi.fn().mockResolvedValue({ ok: true, model_count: 100, last_fetched_at: '2026-04-13T00:00:00.000Z' }),
 }));
 
 vi.mock('../../src/services/routing-utils.js', () => ({

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -80,7 +80,7 @@ import ModelPickerModal from "../../src/components/ModelPickerModal";
 import { toast } from "../../src/services/toast-store.js";
 import type { AvailableModel, TierAssignment, CustomProviderData } from "../../src/services/api.js";
 
-const { overrideTier, resetTier, resetAllTiers, setFallbacks, overrideSpecificity, resetSpecificity, setSpecificityFallbacks, clearSpecificityFallbacks, getSpecificityAssignments } = await import("../../src/services/api.js");
+const { overrideTier, resetTier, resetAllTiers, setFallbacks, overrideSpecificity, resetSpecificity, setSpecificityFallbacks, clearSpecificityFallbacks, getSpecificityAssignments, getPricingHealth, refreshPricing } = await import("../../src/services/api.js");
 
 describe("Routing — enabled state (providers active)", () => {
   beforeEach(() => {
@@ -487,6 +487,63 @@ describe("Routing — enabled state (providers active)", () => {
       expect(resetTier).toHaveBeenCalled();
     });
     // Should not crash — error is handled silently (fetchMutate shows toast)
+  });
+});
+
+describe("Routing — pricing cache health banner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProviders.mockResolvedValue([
+      { id: "p1", provider: "openai", auth_type: "api_key" as const, is_active: true, has_api_key: true, connected_at: "2025-01-01" },
+    ]);
+    mockGetCustomProviders.mockResolvedValue([]);
+  });
+
+  it("does not show the banner when the pricing cache has models", async () => {
+    vi.mocked(getPricingHealth).mockResolvedValue({ model_count: 100, last_fetched_at: "2026-04-13T00:00:00.000Z" });
+    render(() => <Routing />);
+    await screen.findByText("Simple");
+    expect(screen.queryByText(/Pricing catalog is empty/)).toBeNull();
+  });
+
+  it("shows the banner when the pricing cache is empty", async () => {
+    vi.mocked(getPricingHealth).mockResolvedValue({ model_count: 0, last_fetched_at: null });
+    render(() => <Routing />);
+    expect(await screen.findByText(/Pricing catalog is empty/)).toBeDefined();
+    expect(screen.getByText("Retry pricing sync")).toBeDefined();
+  });
+
+  it("calls refreshPricing when the retry button is clicked", async () => {
+    vi.mocked(getPricingHealth).mockResolvedValue({ model_count: 0, last_fetched_at: null });
+    vi.mocked(refreshPricing).mockResolvedValue({ ok: true, model_count: 200, last_fetched_at: "2026-04-13T12:00:00.000Z" });
+    render(() => <Routing />);
+    const retryBtn = await screen.findByText("Retry pricing sync");
+    fireEvent.click(retryBtn);
+    await waitFor(() => {
+      expect(refreshPricing).toHaveBeenCalled();
+    });
+  });
+
+  it("shows an error toast when refreshPricing returns ok=false", async () => {
+    vi.mocked(getPricingHealth).mockResolvedValue({ model_count: 0, last_fetched_at: null });
+    vi.mocked(refreshPricing).mockResolvedValue({ ok: false, model_count: 0, last_fetched_at: null });
+    render(() => <Routing />);
+    const retryBtn = await screen.findByText("Retry pricing sync");
+    fireEvent.click(retryBtn);
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("Pricing refresh failed"));
+    });
+  });
+
+  it("shows an error toast when refreshPricing throws", async () => {
+    vi.mocked(getPricingHealth).mockResolvedValue({ model_count: 0, last_fetched_at: null });
+    vi.mocked(refreshPricing).mockRejectedValue(new Error("network error"));
+    render(() => <Routing />);
+    const retryBtn = await screen.findByText("Retry pricing sync");
+    fireEvent.click(retryBtn);
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -70,6 +70,9 @@ vi.mock("../../src/services/api.js", () => ({
   resetSpecificity: vi.fn().mockResolvedValue({}),
   setSpecificityFallbacks: vi.fn().mockResolvedValue({}),
   clearSpecificityFallbacks: vi.fn().mockResolvedValue({}),
+  refreshModels: vi.fn().mockResolvedValue({ ok: true }),
+  getPricingHealth: vi.fn().mockResolvedValue({ model_count: 100, last_fetched_at: "2026-04-13T00:00:00.000Z" }),
+  refreshPricing: vi.fn().mockResolvedValue({ ok: true, model_count: 100, last_fetched_at: "2026-04-13T00:00:00.000Z" }),
 }));
 
 import Routing from "../../src/pages/Routing";

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -44,6 +44,8 @@ import {
   getFallbacks,
   setFallbacks,
   clearFallbacks,
+  getPricingHealth,
+  refreshPricing,
 } from '../../src/services/api.js';
 
 vi.mock('../../src/services/toast-store.js', () => ({
@@ -1003,13 +1005,40 @@ describe('testSavedEmailProvider', () => {
 
 describe('getRoutingStatus', () => {
   it('fetches /routing/:agentName/status', async () => {
-    const payload = { enabled: true };
+    const payload = { enabled: true, reason: null };
     mockOk(payload);
 
     const result = await getRoutingStatus('my-agent');
     expect(result).toEqual(payload);
     const url = mockFetch.mock.calls[0]?.[0] as string;
     expect(url).toContain('/api/v1/routing/my-agent/status');
+  });
+});
+
+describe('getPricingHealth', () => {
+  it('fetches /routing/pricing-health', async () => {
+    const payload = { model_count: 348, last_fetched_at: '2026-04-13T00:00:00.000Z' };
+    mockOk(payload);
+
+    const result = await getPricingHealth();
+    expect(result).toEqual(payload);
+    const url = mockFetch.mock.calls[0]?.[0] as string;
+    expect(url).toContain('/api/v1/routing/pricing-health');
+  });
+});
+
+describe('refreshPricing', () => {
+  it('POSTs /routing/pricing/refresh', async () => {
+    const payload = { ok: true, model_count: 350, last_fetched_at: '2026-04-13T12:00:00.000Z' };
+    mockMutateOk(payload);
+
+    const result = await refreshPricing();
+    expect(result).toEqual(payload);
+    const call = mockFetch.mock.calls[0];
+    const url = call?.[0] as string;
+    const init = call?.[1] as RequestInit;
+    expect(url).toContain('/api/v1/routing/pricing/refresh');
+    expect(init.method).toBe('POST');
   });
 });
 


### PR DESCRIPTION
## Summary

Addresses audit findings that let self-hosters believe Docker deployments worked when they silently didn't. Implements Phase 1 + 2 of the hardening plan; Phase 3 is tracked in #1551.

### Docker config (fixes misleading/broken install paths)
- Parameterize `POSTGRES_PASSWORD` and `DATABASE_URL` in `docker-compose.yml` so overrides in `.env` actually take effect (previously hardcoded, so `.env.example`'s override instructions were a lie).
- Require `BETTER_AUTH_SECRET` via `${VAR:?…}` — fail loudly at boot instead of shipping the placeholder.
- Bind port 3001 to `127.0.0.1` by default. LAN access is now opt-in and documented in a dedicated README section.
- `install.sh` now downloads `.env.example` → `.env` and writes the generated secret there (line-based rewrite, `chmod 600`). Prints the config location on success.
- `DOCKER_README.md` references `.env` in every install path and drops the phantom `MANIFEST_TRUST_LAN` env var (already removed in the changelog but still documented as live).

### Routing honesty (stop telling users routing is "on" when it's broken)
- `GET /api/v1/routing/:agent/status` now returns `{ enabled, reason }` where `reason` ∈ `no_provider | no_routable_models | pricing_cache_empty | null`. Only claims `enabled: true` when at least one tier resolves to a real model. Previously, the endpoint returned `enabled: true` based on `provider.is_active` alone, while every request silently fell back to the friendly stub.
- `POST /api/v1/routing/:agent/providers` now whitelists against `PROVIDER_REGISTRY` and trim/lowercase-normalizes the provider name. Bogus providers like `made-up-xyz` are rejected with a 400 listing valid options; `OpenAI` and `openai` collapse to the same row.
- `PUT /api/v1/routing/:agent/tiers/:tier` rejects models that aren't in the agent's discovered list with a helpful 400 listing available options. A single typo in the override field previously disabled the tier silently.
- New `GET /api/v1/routing/pricing-health` and `POST /api/v1/routing/pricing/refresh` endpoints, wired to a banner on the Routing page when the OpenRouter pricing cache is empty (e.g. after a network blip on first boot).
- Workspace-card and per-agent `message_count` aggregations exclude `status IN ('error', 'fallback_error')` so diagnostic rows don't inflate user-facing counters.

### Frontend
- Replaced "Monitor and control your OpenClaw costs" meta tags in `index.html` with agent-neutral copy per `CLAUDE.md` guidance (no new code should frame Manifest as OpenClaw-only).

## Test plan

- [x] `npm test --workspace=packages/backend` — **3530/3530 passing**
- [x] `npm run test:e2e --workspace=packages/backend` — **107/107 passing**
- [x] `npm test --workspace=packages/frontend` — **2103/2103 passing**
- [x] `npx tsc --noEmit` clean on both backend and frontend workspaces
- [x] Coverage on modified files at or above baseline (tier.service 93.75% stmts, routing.dto.ts 100%, model.controller.ts 100%, provider.controller.ts 93.44% — uncovered lines pre-existing)
- [x] Manual smoke against `node dist/main.js` + Better Auth cookie: status endpoint returns `{enabled:false, reason:'no_provider'}` on fresh boot, flips to `{enabled:true, reason:null}` after provider connect. `POST /providers` rejects `made-up-xyz` with whitelist error; accepts `OpenAI` (normalized to lowercase). `PUT /tiers/simple` rejects `this-model-does-not-exist` with available-model list; accepts `gpt-5-nano`. `GET /pricing-health` returns `{model_count:348, last_fetched_at:...}`. `POST /pricing/refresh` triggers a refresh and reports the result.
- [x] `docker compose config` validation passes with new parameterized variables; override via `POSTGRES_PASSWORD=supersecret` flows through to both the Postgres service and `DATABASE_URL`; `:?` constraint fires when `BETTER_AUTH_SECRET` is unset
- [x] `bash install.sh --dry-run` emits the new `.env.example` download + secret injection steps

## Notes

- `packages/manifest` changeset is included (`patch` bump). The audit report's Phase 3 follow-ups (compose tmpfs size, pids_limit, healthcheck node-ification, HTTP status codes for non-chat callers, public-stats opt-in, Better Auth log level verification, `og:` tag parameterization, CI smoke test, Dockerfile `.md` cleanup narrowing) are tracked in #1551.
- This PR touches backend validation, which is why e2e tests were run in addition to unit tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Docker self‑hosting and makes routing status truthful. Requires a real `BETTER_AUTH_SECRET` in `.env`, binds the dashboard to localhost by default, and adds pricing cache health endpoints and UI.

- **Bug Fixes**
  - Docker: parameterized `POSTGRES_PASSWORD`/`DATABASE_URL`; `DATABASE_URL` no longer interpolates the Postgres password—set both vars and percent‑encode special characters; require `BETTER_AUTH_SECRET`; bind `3001` to `127.0.0.1`; `install.sh` writes `.env` with a generated secret; docs remove `MANIFEST_TRUST_LAN` and document LAN exposure and port/host matching.
  - Analytics: workspace and per‑agent message counts exclude `error`/`fallback_error` rows.

- **New Features**
  - Routing: `GET /api/v1/routing/:agent/status` returns `{ enabled, reason }` (`no_provider | no_routable_models | pricing_cache_empty | null`), only true when a tier resolves to a model.
  - Pricing: `GET /api/v1/routing/pricing-health` and `POST /api/v1/routing/pricing/refresh` added, with a Routing page banner to retry when the OpenRouter catalog is empty.
  - Validation: provider connect whitelists/normalizes against the registry; tier overrides reject unknown models with a helpful list.
  - Frontend copy: replace OpenClaw‑specific meta text with agent‑neutral wording.

<sup>Written for commit ad2adbfd7c77d7fae707a7efc7a6c82ea58f0ab0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

