### PR TITLE
fix(proxy): point friendly error URLs at real frontend routes

### DIFF
--- a/.changeset/fix-proxy-dashboard-urls.md
+++ b/.changeset/fix-proxy-dashboard-urls.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix the "check your dashboard" links that Manifest embeds in `[🦚 Manifest] …` friendly error messages returned by the OpenAI-compatible proxy. Auth errors (missing / empty / invalid / expired / unrecognized key) used to emit `${baseUrl}/routing`, which 404'd — that path does not exist in the frontend router. They now point at the Workspace landing page. Agent-scoped errors used to drop the user on the agent Overview page; they now deep-link to the section that actually fixes the problem — "No API key set for X" and "Manifest is connected successfully, connect a provider" go to `/agents/:name/routing`, and "Usage limit hit" goes to `/agents/:name/limits`.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
@@ -3,9 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { ArgumentsHost } from '@nestjs/common';
 import { ProxyExceptionFilter } from '../proxy-exception.filter';
 
-function createMockHost(body: Record<string, unknown> = {}, ingestionCtx?: unknown) {
+function createMockHost(body: Record<string, unknown> = {}) {
   const req: Record<string, unknown> = { body };
-  if (ingestionCtx) req.ingestionContext = ingestionCtx;
 
   const res = {
     setHeader: jest.fn(),
@@ -79,13 +78,14 @@ describe('ProxyExceptionFilter', () => {
     });
 
     it('converts "API key expired" with dashboard URL', () => {
-      const { host, res } = createMockHost({}, { agentName: 'my-agent' });
+      const { host, res } = createMockHost();
       filter.catch(new UnauthorizedException('API key expired'), host);
 
       expect(res.status).toHaveBeenCalledWith(200);
       const content = res.json.mock.calls[0][0].choices[0].message.content;
       expect(content).toContain('expired');
-      expect(content).toContain('http://localhost:3001/agents/my-agent');
+      expect(content).toContain('http://localhost:3001');
+      expect(content).not.toContain('/routing');
     });
 
     it('converts "Invalid API key" to friendly message', () => {
@@ -102,7 +102,8 @@ describe('ProxyExceptionFilter', () => {
       filter.catch(new UnauthorizedException('Invalid API key'), host);
 
       const content = res.json.mock.calls[0][0].choices[0].message.content;
-      expect(content).toContain('Dashboard: http://localhost:3001/routing');
+      expect(content).toContain('Dashboard: http://localhost:3001');
+      expect(content).not.toContain('Dashboard: http://localhost:3001/routing');
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-friendly-response.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-friendly-response.spec.ts
@@ -8,28 +8,37 @@ import {
 
 describe('proxy-friendly-response', () => {
   describe('getDashboardUrl', () => {
-    it('returns agent-specific URL when agentName provided', () => {
-      const config = {
-        get: jest.fn((key: string) => {
-          if (key === 'app.betterAuthUrl') return 'https://app.manifest.build';
-          return undefined;
-        }),
-      } as unknown as ConfigService;
+    const prodConfig = {
+      get: jest.fn((key: string) => {
+        if (key === 'app.betterAuthUrl') return 'https://app.manifest.build';
+        return undefined;
+      }),
+    } as unknown as ConfigService;
 
-      expect(getDashboardUrl(config, 'my-agent')).toBe(
+    it('returns agent Overview URL when agentName provided without section', () => {
+      expect(getDashboardUrl(prodConfig, 'my-agent')).toBe(
         'https://app.manifest.build/agents/my-agent',
       );
     });
 
-    it('returns routing URL when no agentName', () => {
-      const config = {
-        get: jest.fn((key: string) => {
-          if (key === 'app.betterAuthUrl') return 'https://app.manifest.build';
-          return undefined;
-        }),
-      } as unknown as ConfigService;
+    it('returns agent Routing URL when section is "routing"', () => {
+      expect(getDashboardUrl(prodConfig, 'my-agent', 'routing')).toBe(
+        'https://app.manifest.build/agents/my-agent/routing',
+      );
+    });
 
-      expect(getDashboardUrl(config)).toBe('https://app.manifest.build/routing');
+    it('returns agent Limits URL when section is "limits"', () => {
+      expect(getDashboardUrl(prodConfig, 'my-agent', 'limits')).toBe(
+        'https://app.manifest.build/agents/my-agent/limits',
+      );
+    });
+
+    it('returns bare base URL (Workspace) when no agentName', () => {
+      expect(getDashboardUrl(prodConfig)).toBe('https://app.manifest.build');
+    });
+
+    it('ignores section when no agentName is supplied', () => {
+      expect(getDashboardUrl(prodConfig, undefined, 'routing')).toBe('https://app.manifest.build');
     });
 
     it('falls back to localhost when no betterAuthUrl configured', () => {
@@ -41,7 +50,9 @@ describe('proxy-friendly-response', () => {
         }),
       } as unknown as ConfigService;
 
-      expect(getDashboardUrl(config, 'demo')).toBe('http://localhost:4000/agents/demo');
+      expect(getDashboardUrl(config, 'demo', 'routing')).toBe(
+        'http://localhost:4000/agents/demo/routing',
+      );
     });
 
     it('encodes special characters in agent name', () => {
@@ -52,7 +63,9 @@ describe('proxy-friendly-response', () => {
         }),
       } as unknown as ConfigService;
 
-      expect(getDashboardUrl(config, 'my agent')).toBe('http://localhost:3001/agents/my%20agent');
+      expect(getDashboardUrl(config, 'my agent', 'limits')).toBe(
+        'http://localhost:3001/agents/my%20agent/limits',
+      );
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -313,7 +313,7 @@ describe('ProxyService', () => {
     });
   });
 
-  it('includes dashboard URL with agent name in no-provider response', async () => {
+  it('points no-provider response at the agent Routing page', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'simple',
       model: null,
@@ -333,10 +333,10 @@ describe('ProxyService', () => {
 
     const json = (await result.forward.response.json()) as Record<string, unknown>;
     const choices = json.choices as { message: { content: string } }[];
-    expect(choices[0].message.content).toContain('http://localhost:3001/agents/my-agent');
+    expect(choices[0].message.content).toContain('http://localhost:3001/agents/my-agent/routing');
   });
 
-  it('uses /routing path when agentName is not provided', async () => {
+  it('uses bare base URL in no-provider response when agentName is missing', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'simple',
       model: null,
@@ -355,8 +355,9 @@ describe('ProxyService', () => {
 
     const json = (await result.forward.response.json()) as Record<string, unknown>;
     const choices = json.choices as { message: { content: string } }[];
-    expect(choices[0].message.content).toContain('http://localhost:3001/routing');
-    expect(choices[0].message.content).not.toContain('/routing/');
+    expect(choices[0].message.content).toContain('http://localhost:3001');
+    expect(choices[0].message.content).not.toContain('/routing');
+    expect(choices[0].message.content).not.toContain('/agents/');
   });
 
   it('falls back to localhost URL when betterAuthUrl is empty', async () => {
@@ -385,7 +386,7 @@ describe('ProxyService', () => {
 
     const json = (await result.forward.response.json()) as Record<string, unknown>;
     const choices = json.choices as { message: { content: string } }[];
-    expect(choices[0].message.content).toContain('http://localhost:4000/agents/test-agent');
+    expect(choices[0].message.content).toContain('http://localhost:4000/agents/test-agent/routing');
   });
 
   it('returns synthetic streaming response when no model is resolved', async () => {
@@ -438,7 +439,7 @@ describe('ProxyService', () => {
       choices: { message: { content: string } }[];
     };
     expect(json.choices[0].message.content).toContain('No API key set for OpenAI');
-    expect(json.choices[0].message.content).toContain('/agents/my-agent');
+    expect(json.choices[0].message.content).toContain('/agents/my-agent/routing');
     expect(result.meta.reason).toBe('no_provider_key');
   });
 
@@ -1138,6 +1139,9 @@ describe('ProxyService', () => {
       };
       expect(json.choices[0].message.content).toContain('Usage limit hit');
       expect(json.choices[0].message.content).toContain('tokens');
+      expect(json.choices[0].message.content).toContain(
+        'http://localhost:3001/agents/my-agent/limits',
+      );
       expect(result.meta.reason).toBe('limit_exceeded');
     });
 

--- a/packages/backend/src/routing/proxy/proxy-exception.filter.ts
+++ b/packages/backend/src/routing/proxy/proxy-exception.filter.ts
@@ -2,7 +2,6 @@ import { ExceptionFilter, Catch, ArgumentsHost, HttpException, Injectable } from
 import { ConfigService } from '@nestjs/config';
 import { Request, Response as ExpressResponse } from 'express';
 import { getDashboardUrl, sendFriendlyResponse } from './proxy-friendly-response';
-import { IngestionContext } from '../../otlp/interfaces/ingestion-context.interface';
 
 /** Guard-thrown messages that should become friendly chat responses. */
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
@@ -48,13 +47,10 @@ export class ProxyExceptionFilter implements ExceptionFilter {
     }
 
     const isStream = (req.body as Record<string, unknown>)?.stream === true;
-    const ingestionCtx = (req as Request & { ingestionContext?: IngestionContext })
-      .ingestionContext;
-    const agentName = ingestionCtx?.agentName;
 
     const friendly = AUTH_ERROR_MESSAGES[message];
     if (friendly) {
-      const dashboardUrl = getDashboardUrl(this.config, agentName);
+      const dashboardUrl = getDashboardUrl(this.config);
       const content =
         message === 'API key expired'
           ? `${friendly}: ${dashboardUrl}`

--- a/packages/backend/src/routing/proxy/proxy-friendly-response.ts
+++ b/packages/backend/src/routing/proxy/proxy-friendly-response.ts
@@ -21,12 +21,19 @@ export interface FriendlyResult {
   };
 }
 
-export function getDashboardUrl(config: ConfigService, agentName?: string): string {
+export type DashboardSection = 'routing' | 'limits';
+
+export function getDashboardUrl(
+  config: ConfigService,
+  agentName?: string,
+  section?: DashboardSection,
+): string {
   const baseUrl =
     config.get<string>('app.betterAuthUrl') ||
     `http://localhost:${config.get<number>('app.port', 3001)}`;
-  const path = agentName ? `/agents/${encodeURIComponent(agentName)}` : '/routing';
-  return `${baseUrl}${path}`;
+  if (!agentName) return baseUrl;
+  const suffix = section ? `/${section}` : '';
+  return `${baseUrl}/agents/${encodeURIComponent(agentName)}${suffix}`;
 }
 
 export function buildFriendlyResponse(

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -129,7 +129,7 @@ export class ProxyService {
       resolved.auth_type,
     );
     if (apiKey === null) {
-      const dashboardUrl = getDashboardUrl(this.config, agentName);
+      const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
       const content = `[🦚 Manifest] No API key set for ${resolved.provider} yet. Add one here: ${dashboardUrl}`;
       return buildFriendlyResponse(content, body.stream === true, 'no_provider_key');
     }
@@ -282,7 +282,7 @@ export class ProxyService {
       exceeded.metricType === 'cost'
         ? `$${Number(exceeded.threshold).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
         : Number(exceeded.threshold).toLocaleString(undefined, { maximumFractionDigits: 0 });
-    const dashboardUrl = getDashboardUrl(this.config, agentName);
+    const dashboardUrl = getDashboardUrl(this.config, agentName, 'limits');
     return `[🦚 Manifest] Usage limit hit: ${exceeded.metricType} is at ${fmt} (limit: ${threshFmt}/${exceeded.period}). You can adjust it here: ${dashboardUrl}`;
   }
 
@@ -305,7 +305,7 @@ export class ProxyService {
   }
 
   private buildNoProviderResult(stream: boolean, agentName?: string): ProxyResult {
-    const dashboardUrl = getDashboardUrl(this.config, agentName);
+    const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
     const content = `[🦚 Manifest] Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`;
     return buildFriendlyResponse(content, stream, 'no_provider');
   }


### PR DESCRIPTION
## Summary

- Fix the "check your dashboard" links Manifest embeds in `[🦚 Manifest] …` friendly chat responses so they resolve to real frontend routes instead of the `*404` fallback or the wrong page.
- Auth errors (missing / empty / invalid / expired / unrecognized key) used to emit `${baseUrl}/routing`, which doesn't exist in the SolidJS router — routing is nested under `/agents/:agentName/routing`. They now point at the bare base URL (Workspace), which is always valid and lists every agent the user owns.
- Agent-scoped errors now deep-link to the section that actually fixes the problem:
  - `[🦚 Manifest] No API key set for X yet` → `/agents/:name/routing`
  - `[🦚 Manifest] Manifest is connected successfully. To start routing requests, connect a model provider` → `/agents/:name/routing`
  - `[🦚 Manifest] Usage limit hit` → `/agents/:name/limits`
- `getDashboardUrl` now takes an optional `section: 'routing' | 'limits'`.
- `ProxyExceptionFilter` no longer tries to recover an `agentName` from `request.ingestionContext` — the ingestion context is only set *after* `AgentKeyAuthGuard` validates the key, so for every auth-error branch the lookup was always `undefined`. Dead code is removed.

## Test plan

- [x] `npm test --workspace=packages/backend` — 3510 unit tests passing
- [x] `npm run test:e2e --workspace=packages/backend` — 107 e2e tests passing
- [x] `npm test --workspace=packages/frontend` — 2103 tests passing
- [x] `cd packages/shared && npx jest` — 67 tests passing
- [x] `npx tsc --noEmit` clean in `packages/backend` and `packages/frontend`
- [x] Touched-file line coverage 100% (`proxy-friendly-response.ts`, `proxy-exception.filter.ts`; `proxy.service.ts` stays at its pre-existing 99.02%).
- [x] Manual smoke against a fresh cloud-mode dev server: bad `mnfst_` key → message URL is the bare base, unknown-agent/no-provider → message URL is `/agents/:name/routing`, all of which resolve to real frontend routes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "check your dashboard" links in friendly proxy errors so they resolve to real frontend routes and the right page. Auth errors go to the Workspace root; agent-scoped errors deep-link to Routing or Limits.

- **Bug Fixes**
  - Auth errors now link to the base app URL instead of `/routing` (prevents 404s).
  - Agent errors deep-link to the right section:
    - No API key / connect a provider → `/agents/:name/routing`
    - Usage limit hit → `/agents/:name/limits`
  - Added optional `section` to `getDashboardUrl` to build section-specific URLs.
  - Removed dead `agentName` lookup from `ProxyExceptionFilter`.

<sup>Written for commit 68510a500202da6a670f03c646bc9840724c2f14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

