### PR TITLE
chore(proxy): humanize friendly error messages

### DIFF
--- a/.changeset/humanize-proxy-messages.md
+++ b/.changeset/humanize-proxy-messages.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Rewrite the `[🦚 Manifest] …` friendly error messages the proxy sends back as chat completions so they read less like a system alert and more like a note from a person. Em dashes are gone, "connected successfully" is gone, "this API key wasn't recognized" becomes "I don't recognize this key", limit messages lead with "You hit your ${metric} limit" instead of the clinical "Usage limit hit:", and the auth-header hint now tells users the exact `Bearer mnfst_<your-key>` format to paste. No behavioural change — same triggers, same URLs, same branching; just different copy.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-exception.filter.spec.ts
@@ -51,7 +51,7 @@ describe('ProxyExceptionFilter', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: expect.stringContaining('Missing API key'),
+                content: expect.stringContaining('Missing the Authorization header'),
               }),
             }),
           ]),
@@ -94,7 +94,7 @@ describe('ProxyExceptionFilter', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       const content = res.json.mock.calls[0][0].choices[0].message.content;
-      expect(content).toContain("wasn't recognized");
+      expect(content).toContain("I don't recognize this key");
     });
 
     it('includes dashboard URL in auth error messages', () => {
@@ -164,7 +164,7 @@ describe('ProxyExceptionFilter', () => {
 
       expect(res.status).toHaveBeenCalledWith(200);
       const content = res.json.mock.calls[0][0].choices[0].message.content;
-      expect(content).toBe('[🦚 Manifest] Something broke on our end. Try again shortly.');
+      expect(content).toBe('[🦚 Manifest] Something broke on our end. Try again in a moment.');
     });
 
     it('converts unknown auth message to friendly message', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -641,7 +641,7 @@ describe('ProxyController', () => {
         choices: expect.arrayContaining([
           expect.objectContaining({
             message: expect.objectContaining({
-              content: '[🦚 Manifest] Something broke on our end. Try again shortly.',
+              content: '[🦚 Manifest] Something broke on our end. Try again in a moment.',
             }),
           }),
         ]),
@@ -1395,7 +1395,7 @@ describe('ProxyController', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: '[🦚 Manifest] Something broke on our end. Try again shortly.',
+                content: '[🦚 Manifest] Something broke on our end. Try again in a moment.',
               }),
             }),
           ]),
@@ -1442,7 +1442,7 @@ describe('ProxyController', () => {
           choices: expect.arrayContaining([
             expect.objectContaining({
               message: expect.objectContaining({
-                content: '[🦚 Manifest] Something broke on our end. Try again shortly.',
+                content: '[🦚 Manifest] Something broke on our end. Try again in a moment.',
               }),
             }),
           ]),

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -303,7 +303,8 @@ describe('ProxyService', () => {
     expect(json.object).toBe('chat.completion');
     expect(json.model).toBe('manifest');
     const choices = json.choices as { message: { content: string } }[];
-    expect(choices[0].message.content).toContain('Manifest is connected successfully');
+    expect(choices[0].message.content).toContain("You're connected");
+    expect(choices[0].message.content).toContain('no providers are set up yet');
     expect(result.meta).toEqual({
       tier: 'simple',
       model: 'manifest',
@@ -410,7 +411,7 @@ describe('ProxyService', () => {
     const text = await result.forward.response.text();
     expect(text).toContain('data: {');
     expect(text).toContain('chat.completion.chunk');
-    expect(text).toContain('Manifest is connected successfully');
+    expect(text).toContain("You're connected");
     expect(text).toContain('data: [DONE]');
     expect(result.meta.reason).toBe('no_provider');
   });
@@ -438,7 +439,7 @@ describe('ProxyService', () => {
     const json = (await result.forward.response.json()) as {
       choices: { message: { content: string } }[];
     };
-    expect(json.choices[0].message.content).toContain('No API key set for OpenAI');
+    expect(json.choices[0].message.content).toContain('No OpenAI API key yet');
     expect(json.choices[0].message.content).toContain('/agents/my-agent/routing');
     expect(result.meta.reason).toBe('no_provider_key');
   });
@@ -1137,8 +1138,7 @@ describe('ProxyService', () => {
       const json = (await result.forward.response.json()) as {
         choices: { message: { content: string } }[];
       };
-      expect(json.choices[0].message.content).toContain('Usage limit hit');
-      expect(json.choices[0].message.content).toContain('tokens');
+      expect(json.choices[0].message.content).toContain('You hit your tokens limit');
       expect(json.choices[0].message.content).toContain(
         'http://localhost:3001/agents/my-agent/limits',
       );
@@ -1726,7 +1726,7 @@ describe('ProxyService', () => {
       const json = (await result.forward.response.json()) as {
         choices: { message: { content: string } }[];
       };
-      expect(json.choices[0].message.content).toContain('No API key set for Anthropic');
+      expect(json.choices[0].message.content).toContain('No Anthropic API key yet');
       expect(result.meta.reason).toBe('no_provider_key');
     });
   });

--- a/packages/backend/src/routing/proxy/proxy-exception.filter.ts
+++ b/packages/backend/src/routing/proxy/proxy-exception.filter.ts
@@ -6,15 +6,13 @@ import { getDashboardUrl, sendFriendlyResponse } from './proxy-friendly-response
 /** Guard-thrown messages that should become friendly chat responses. */
 const AUTH_ERROR_MESSAGES: Record<string, string> = {
   'Authorization header required':
-    '[🦚 Manifest] Missing API key. Set your Manifest key (starts with mnfst_) as the Bearer token.',
-  'Empty token':
-    '[🦚 Manifest] Bearer token is empty — paste your Manifest API key into the authorization field.',
+    '[🦚 Manifest] Missing the Authorization header. Set it to "Bearer mnfst_<your-key>".',
+  'Empty token': '[🦚 Manifest] The Bearer token is empty. Paste your Manifest key into it.',
   'Invalid API key format':
-    '[🦚 Manifest] That doesn\'t look like a Manifest key. They start with "mnfst_" — check your dashboard.',
-  'API key expired':
-    '[🦚 Manifest] This API key expired. Generate a new one from your Manifest dashboard',
+    '[🦚 Manifest] That doesn\'t look right. Manifest keys start with "mnfst_". Grab yours from the dashboard.',
+  'API key expired': '[🦚 Manifest] This key has expired. Generate a new one here',
   'Invalid API key':
-    "[🦚 Manifest] This API key wasn't recognized — it may have been rotated or deleted. Check your dashboard for the current key.",
+    "[🦚 Manifest] I don't recognize this key. It might have been rotated or deleted. Grab the current one from the dashboard.",
 };
 
 /** Status codes that should pass through as normal HTTP errors. */
@@ -61,7 +59,7 @@ export class ProxyExceptionFilter implements ExceptionFilter {
 
     // Other errors (400 bad request, 500, etc.) — send as friendly chat message
     const content =
-      status >= 500 ? '[🦚 Manifest] Something broke on our end. Try again shortly.' : message;
+      status >= 500 ? '[🦚 Manifest] Something broke on our end. Try again in a moment.' : message;
     sendFriendlyResponse(res, content, isStream);
   }
 }

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -189,7 +189,9 @@ export class ProxyController {
 
       const isStream = (req.body as Record<string, unknown>)?.stream === true;
       const clientMessage =
-        status >= 500 ? '[🦚 Manifest] Something broke on our end. Try again shortly.' : message;
+        status >= 500
+          ? '[🦚 Manifest] Something broke on our end. Try again in a moment.'
+          : message;
       sendFriendlyResponse(res, clientMessage, isStream);
     } finally {
       if (slotAcquired) this.rateLimiter.releaseSlot(userId);

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -130,7 +130,7 @@ export class ProxyService {
     );
     if (apiKey === null) {
       const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
-      const content = `[🦚 Manifest] No API key set for ${resolved.provider} yet. Add one here: ${dashboardUrl}`;
+      const content = `[🦚 Manifest] No ${resolved.provider} API key yet. Add one here: ${dashboardUrl}`;
       return buildFriendlyResponse(content, body.stream === true, 'no_provider_key');
     }
 
@@ -283,7 +283,7 @@ export class ProxyService {
         ? `$${Number(exceeded.threshold).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
         : Number(exceeded.threshold).toLocaleString(undefined, { maximumFractionDigits: 0 });
     const dashboardUrl = getDashboardUrl(this.config, agentName, 'limits');
-    return `[🦚 Manifest] Usage limit hit: ${exceeded.metricType} is at ${fmt} (limit: ${threshFmt}/${exceeded.period}). You can adjust it here: ${dashboardUrl}`;
+    return `[🦚 Manifest] You hit your ${exceeded.metricType} limit: ${fmt} used, ${threshFmt}/${exceeded.period} allowed. Adjust it here: ${dashboardUrl}`;
   }
 
   private filterScoringMessages(messages: ScorerMessage[]): ScorerMessage[] {
@@ -306,7 +306,7 @@ export class ProxyService {
 
   private buildNoProviderResult(stream: boolean, agentName?: string): ProxyResult {
     const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
-    const content = `[🦚 Manifest] Manifest is connected successfully. To start routing requests, connect a model provider: ${dashboardUrl}`;
+    const content = `[🦚 Manifest] You're connected, but no providers are set up yet. Add one here: ${dashboardUrl}`;
     return buildFriendlyResponse(content, stream, 'no_provider');
   }
 }

--- a/packages/backend/test/proxy.e2e-spec.ts
+++ b/packages/backend/test/proxy.e2e-spec.ts
@@ -76,7 +76,7 @@ describe('Proxy E2E — /v1/chat/completions', () => {
       .expect(200);
 
     // Auth errors are returned as friendly chat completion messages
-    expect(res.body.choices[0].message.content).toContain('Missing API key');
+    expect(res.body.choices[0].message.content).toContain('Missing the Authorization header');
   });
 
   it('returns friendly message when messages are missing', async () => {

--- a/packages/backend/test/smoke-test.e2e-spec.ts
+++ b/packages/backend/test/smoke-test.e2e-spec.ts
@@ -298,7 +298,7 @@ describe('ST-08: Hard limit blocks', () => {
       .expect(200);
 
     // Limit exceeded returns a friendly chat completion message
-    expect(res.body.choices[0].message.content).toContain('Usage limit hit');
+    expect(res.body.choices[0].message.content).toContain('You hit your tokens limit');
     // Mock server should NOT have been called — blocked before forwarding
     expect(mockCallLog.length).toBe(0);
   });


### PR DESCRIPTION
## Summary

Rewrites the `[🦚 Manifest] …` chat-completion messages the OpenAI-compatible proxy returns on auth errors, limit breaches, and missing-provider cases so they read less like a sterile system alert and more like a note from an operator. No behavioural change — same triggers, same URLs, same branching.

### Before → after

| Trigger | Before | After |
|---|---|---|
| No auth header | `Missing API key. Set your Manifest key (starts with mnfst_) as the Bearer token.` | `Missing the Authorization header. Set it to "Bearer mnfst_<your-key>".` |
| Empty bearer | `Bearer token is empty — paste your Manifest API key into the authorization field.` | `The Bearer token is empty. Paste your Manifest key into it.` |
| Wrong prefix | `That doesn't look like a Manifest key. They start with "mnfst_" — check your dashboard.` | `That doesn't look right. Manifest keys start with "mnfst_". Grab yours from the dashboard.` |
| Expired key | `This API key expired. Generate a new one from your Manifest dashboard` | `This key has expired. Generate a new one here` |
| Unknown key | `This API key wasn't recognized — it may have been rotated or deleted. Check your dashboard for the current key.` | `I don't recognize this key. It might have been rotated or deleted. Grab the current one from the dashboard.` |
| 500 | `Something broke on our end. Try again shortly.` | `Something broke on our end. Try again in a moment.` |
| No provider key | `No API key set for ${provider} yet. Add one here: …` | `No ${provider} API key yet. Add one here: …` |
| Limit hit | `Usage limit hit: ${metric} is at ${fmt} (limit: ${thresh}/${period}). You can adjust it here: …` | `You hit your ${metric} limit: ${fmt} used, ${thresh}/${period} allowed. Adjust it here: …` |
| No providers configured | `Manifest is connected successfully. To start routing requests, connect a model provider: …` | `You're connected, but no providers are set up yet. Add one here: …` |

### What got fixed and why

- Dropped em dashes across all five auth-error strings — per the `humanizer` skill guide, em-dash overuse is one of the loudest "obviously AI-generated" tells.
- Dropped `Manifest is connected successfully` — "successfully" is classic sterile-system-message language, and saying "Manifest is..." immediately after the `[🦚 Manifest]` prefix is redundant self-reference.
- Dropped passive voice (`wasn't recognized` → `I don't recognize this key`).
- Dropped `Usage limit hit:` (clinical) in favor of `You hit your ${metric} limit` (direct).
- `Missing API key` was re-describing the Bearer-token hint right next to it; the new version leads with the header name and shows the exact `Bearer mnfst_<your-key>` format to paste.

## Test plan

- [x] `npm test --workspace=packages/backend` — 3533 unit tests passing
- [x] `npm run test:e2e --workspace=packages/backend` — 107 e2e tests passing (fixed two stale `.toContain('Missing API key')` / `.toContain('Usage limit hit')` assertions)
- [x] `npm test --workspace=packages/frontend` — 2110 tests passing
- [x] `cd packages/shared && npx jest` — 67 tests passing
- [x] `npx tsc --noEmit` clean in `packages/backend` and `packages/frontend`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Humanize the `[🦚 Manifest]` chat-completion messages in the proxy for auth failures, limit breaches, and missing-provider cases. No behavior change—same triggers and URLs; clearer copy only.

- **Refactors**
  - Auth errors: lead with header name and show exact `Bearer mnfst_<your-key>`; simpler tone (e.g., “I don't recognize this key”, “This key has expired”).
  - Provider/setup: “No ${provider} API key yet” and “You're connected, but no providers are set up yet…” replace older phrasing.
  - Limits: “You hit your ${metric} limit: ${fmt} used, ${thresh}/${period} allowed.”
  - 500s: now say “Try again in a moment.” Updated unit and e2e tests to match.

<sup>Written for commit 97dbe29b1a11c1f37a88c9f607f8217dd6a8cce3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

