### PR TITLE
chore: sync package-lock.json with current package.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11317,7 +11317,9 @@
     },
     "node_modules/sql.js": {
       "version": "1.14.1",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -13338,7 +13340,6 @@
         "react-dom": "^19.2.4",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.0",
-        "sql.js": "^1.12.0",
         "typeorm": "^0.3.0",
         "uuid": "^11.0.0"
       },
@@ -14042,7 +14043,7 @@
       }
     },
     "packages/manifest": {
-      "version": "0.1.0"
+      "version": "5.46.2"
     },
     "packages/shared": {
       "name": "manifest-shared",


### PR DESCRIPTION
## Summary

Regenerated the lockfile via \`npm install\` to bring it in line with current source tree state. Pure metadata sync — no behavior or source changes.

### What's in the diff (7 lines)

1. **\`packages/manifest\` version**: \`0.1.0\` → \`5.46.2\`. The \`0.1.0\` was a placeholder written when the canonical release package was first introduced. Subsequent changesets bumped \`packages/manifest/package.json\` (currently 5.46.2) but never touched the lockfile, so the two drifted.

2. **\`sql.js\` removed from \`packages/backend\`'s resolved deps**: leftover from the local-mode removal in \`fc7890fd\`, which dropped \`sql.js\` from \`packages/backend/package.json\` but the lockfile entry under \`packages/backend\` was never refreshed.

3. **\`node_modules/sql.js\` re-marked \`optional: true, peer: true\`**: same root cause — \`sql.js\` is no longer a direct dep of any workspace, so npm regenerates the metadata to reflect that it's only present transitively.

## Why now

Anyone running a fresh \`npm ci\` / \`npm install\` against the repo gets these same modifications spit out as working-tree drift, which is noisy when working on actual changes. Committing the regenerated lockfile makes the repo idempotent under \`npm install\`.

## Test plan

- [x] \`npm install\` produces an empty diff after committing
- [x] No source files touched, so no tests/typecheck/lint impact beyond CI's standard run
- [x] Branch cut from latest \`origin/main\`, no rebase needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated `package-lock.json` to match current workspace `package.json` files. Prevents working tree diffs after `npm install`/`npm ci`; no code or behavior changes.

- **Dependencies**
  - `packages/manifest` in lockfile: 0.1.0 → 5.46.2
  - Dropped `sql.js` from `packages/backend` resolved deps
  - `node_modules/sql.js` marked `optional: true` and `peer: true`

<sup>Written for commit 22b93f1515c2e5bd2a58506e2f582b2106189314. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

