### PR TITLE
fix(routing): route short greetings to simple tier when tools attached

### DIFF
--- a/.changeset/short-greeting-with-tools.md
+++ b/.changeset/short-greeting-with-tools.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Route short greetings to the `simple` tier even when the agent attaches tools. The scorer's short-message fast path was gated on `!hasTools`, so personal AI agents like OpenClaw (which always send a `tools` array) skipped it entirely and fell into full scoring, where session momentum could pull a one-word `hi` up to `complex`. Dropping the gate lets short, non-technical prompts short-circuit to `simple` before momentum kicks in. Short technical prompts like `Debug this function` still fall through to full scoring.

--- a/packages/backend/src/routing/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve.service.spec.ts
@@ -394,9 +394,16 @@ describe('ResolveService', () => {
     mockProviderKeyService.getEffectiveModel.mockResolvedValue('gpt-4o');
     mockPricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' });
 
+    // Message is long enough to bypass the short-message fast path so the
+    // tools-floor branch in applyTierFloors is exercised.
     const result = await service.resolve(
       'agent-1',
-      [{ role: 'user', content: 'hi' }],
+      [
+        {
+          role: 'user',
+          content: 'Please list the items you know about and summarise what they do.',
+        },
+      ],
       [{ name: 'search' }],
       'auto',
     );

--- a/packages/backend/src/scoring/__tests__/score-request-advanced.spec.ts
+++ b/packages/backend/src/scoring/__tests__/score-request-advanced.spec.ts
@@ -74,6 +74,20 @@ describe('scoreRequest — estimateTotalTokens branches', () => {
   });
 });
 
+describe('scoreRequest — short greeting with tools and momentum', () => {
+  it('keeps a tool-bearing short greeting at SIMPLE under complex momentum', () => {
+    const tools = Array.from({ length: 10 }, (_, i) => ({
+      type: 'function' as const,
+      function: { name: `tool_${i}`, description: 'noop', parameters: { type: 'object' } },
+    }));
+    const result = scoreRequest({ messages: [{ role: 'user', content: 'hi' }], tools }, undefined, {
+      recentTiers: ['complex', 'complex', 'complex'],
+    });
+    expect(result.tier).toBe('simple');
+    expect(result.reason).toBe('short_message');
+  });
+});
+
 describe('scoreRequest — ambiguous fallback', () => {
   it('falls back to standard/ambiguous when confidence is low and reason is scored', () => {
     const result = scoreRequest(

--- a/packages/backend/src/scoring/__tests__/score-request.spec.ts
+++ b/packages/backend/src/scoring/__tests__/score-request.spec.ts
@@ -78,12 +78,29 @@ describe('scoreRequest — hard overrides', () => {
     expect(result.reason).not.toBe('short_message');
   });
 
-  it('does NOT return SIMPLE for short message with tools', () => {
+  it('returns SIMPLE for short greeting even with tools attached', () => {
+    const tools = Array.from({ length: 10 }, (_, i) => ({
+      type: 'function' as const,
+      function: { name: `tool_${i}`, description: 'noop', parameters: { type: 'object' } },
+    }));
     const result = scoreRequest({
       messages: [{ role: 'user', content: 'hi' }],
-      tools: [{}, {}, {}, {}, {}],
+      tools,
     });
-    expect(result.tier).not.toBe('simple');
+    expect(result.tier).toBe('simple');
+    expect(result.reason).toBe('short_message');
+  });
+
+  it('does NOT return SIMPLE for short technical prompt with tools', () => {
+    const tools = Array.from({ length: 10 }, (_, i) => ({
+      type: 'function' as const,
+      function: { name: `tool_${i}`, description: 'noop', parameters: { type: 'object' } },
+    }));
+    const result = scoreRequest({
+      messages: [{ role: 'user', content: 'Debug this function' }],
+      tools,
+    });
+    expect(result.reason).not.toBe('short_message');
   });
 
   it('does NOT return SIMPLE for short message with momentum (no simple indicator)', () => {

--- a/packages/backend/src/scoring/index.ts
+++ b/packages/backend/src/scoring/index.ts
@@ -190,7 +190,7 @@ export function scoreRequest(
 
   const hasTools = tools && tools.length > 0;
   const hasMomentum = momentum?.recentTiers && momentum.recentTiers.length > 0;
-  if (lastUserText.length > 0 && lastUserText.length < 50 && !hasTools) {
+  if (lastUserText.length > 0 && lastUserText.length < 50) {
     const lastMatches = trie.scan(lastUserText);
     const hasSimpleIndicator = lastMatches.some((m) => m.dimension === 'simpleIndicators');
     const hasComplexSignal = lastMatches.some(

--- a/packages/backend/test/routing-flow.e2e-spec.ts
+++ b/packages/backend/test/routing-flow.e2e-spec.ts
@@ -234,9 +234,16 @@ describe('Routing enabled → scorer routes by query complexity', () => {
   });
 
   it('tools floor query to at least standard tier', async () => {
+    // Long enough to bypass the short-message fast path so the tools-floor
+    // branch in applyTierFloors is the thing being exercised.
     const res = await bearer(api().post('/api/v1/routing/resolve'))
       .send({
-        messages: [{ role: 'user', content: 'search for cats' }],
+        messages: [
+          {
+            role: 'user',
+            content: 'Search the web for recent news about cats and summarise the top results.',
+          },
+        ],
         tools: [{ name: 'web_search' }],
         tool_choice: 'auto',
       })


### PR DESCRIPTION
## Summary

- The scorer's short-message fast path was gated on `!hasTools`, so personal AI agents like OpenClaw (which always send a `tools` array) skipped it entirely and fell into full scoring.
- Full scoring returns a tiny raw score for a one-word prompt, but `applyMomentum` assigns a very high weight to very short messages (`~0.56` for a 4-char prompt), so any session that recently saw complex traffic pulled `hi` / `hola` up to **complex**.
- Dropping the `!hasTools` gate lets short, non-technical prompts short-circuit to `simple` before momentum can inflate them. The `hasComplexSignal` check added in #1172 still forces full scoring for short technical prompts like `Debug this function`.

## Test plan

- [x] `npx jest src/scoring` — 268 passed
- [x] `npx jest` (full backend unit suite) — 3535 passed
- [x] `npx tsc --noEmit` (backend) — clean
- [x] `npm run test:e2e --workspace=packages/backend` — 107 passed (updated `routing-flow.e2e-spec.ts` tools-floor case to use a long message so it still exercises `applyTierFloors`)
- [x] `npm test --workspace=packages/frontend` — 2110 passed
- [x] `npx tsc --noEmit` (frontend) — clean
- [x] `scoring/index.ts` stays at 100% line and branch coverage
- [ ] Manual: send `hola` through OpenClaw in cloud mode, confirm the message log shows `simple` / `short_message` instead of `complex` / `momentum`

## Notes

- `packages/backend/src/routing/resolve.service.spec.ts` and `packages/backend/test/routing-flow.e2e-spec.ts` had tests that explicitly asserted tools force non-simple on a short message. Both were switched to a long message so they still exercise the `applyTierFloors` tools-floor branch instead of the fast path.
- Non-English greetings (`hola`, `bonjour`, etc.) are intentionally **not** added to `simpleIndicators` — the fix here is in the fast-path gate, not the keyword list.
- Broad `codeGeneration` / `technicalTerms` keyword lists are untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route short greetings to the simple tier even when tools are attached, preventing momentum from promoting one‑word prompts to complex. Short technical prompts still go through full scoring via the existing complex‑signal check.

- **Bug Fixes**
  - Removed the `!hasTools` gate from the short-message fast path in `scoreRequest`, so non-technical short prompts short-circuit to `simple`.
  - Updated unit/e2e tests to cover the new behavior and use longer messages when testing the tools-floor path.

<sup>Written for commit 43590adb5f2077989b00bc92251d03a209916e61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

