### PR TITLE
fix: default agent type to OpenClaw and fix self-hosted install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,15 @@ Go to [app.manifest.build](https://app.manifest.build) and follow the guide.
 
 ### Self-hosted (Docker)
 
-Manifest ships as a [Docker image](https://hub.docker.com/r/manifestdotbuild/manifest). Two commands:
+Manifest ships as a [Docker image](https://hub.docker.com/r/manifestdotbuild/manifest). One command:
 
 ```bash
-curl -O https://raw.githubusercontent.com/mnfst/manifest/main/docker/docker-compose.yml
-docker compose up -d
+bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/install.sh)
 ```
 
-Open [http://localhost:3001](http://localhost:3001) and the setup wizard walks you through creating your admin account. Full self-hosting guide: [docker/DOCKER_README.md](docker/DOCKER_README.md).
+The installer downloads the compose file, generates a secret, and brings up the stack. Give it about 30 seconds to boot.
+
+Open [http://localhost:3001](http://localhost:3001) and sign up. The first account you create becomes the admin. Full self-hosting guide: [docker/DOCKER_README.md](docker/DOCKER_README.md).
 
 > Docker is the only supported distribution. The legacy `manifest` npm package is deprecated and no longer published.
 

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -36,7 +36,9 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
   const navigate = useNavigate();
   const [name, setName] = createSignal('');
   const [category, setCategory] = createSignal<AgentCategory | null>('personal');
-  const [platform, setPlatform] = createSignal<AgentPlatform | null>(null);
+  const [platform, setPlatform] = createSignal<AgentPlatform | null>(
+    PLATFORMS_BY_CATEGORY['personal'][0] ?? null,
+  );
   const [creating, setCreating] = createSignal(false);
 
   const handleCategoryChange = (c: AgentCategory) => {
@@ -72,7 +74,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
   const resetForm = () => {
     setName('');
     setCategory('personal');
-    setPlatform(null);
+    setPlatform(PLATFORMS_BY_CATEGORY['personal'][0] ?? null);
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {


### PR DESCRIPTION
## Summary
- Default the platform dropdown to OpenClaw when creating a new agent (was `null`, forcing manual selection)
- Replace the broken 2-command Docker install in README with the install script one-liner that works out of the box

## Test plan
- [ ] Create a new agent — platform dropdown should show "OpenClaw" pre-selected
- [ ] Verify the install script URL in README points to the correct file
- [ ] Reset the form after creating an agent — platform should reset to OpenClaw

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the agent platform to OpenClaw in the new agent modal and replace the broken self‑hosted Docker instructions with a working one‑liner installer. This removes an extra step for users and fixes setup failures.

- **Bug Fixes**
  - Preselects OpenClaw when creating a new agent and after form reset, instead of leaving the platform empty.
  - Updates README to use the install script one‑liner that downloads compose, generates a secret, and brings up the stack.

<sup>Written for commit c2e92225ae33d1b7b03d0e7edfa2e5ca374fc9f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

