### PR TITLE
Fix token count for ollama cloud

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -623,4 +623,57 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
   });
+
+  describe('ollama', () => {
+    it('should inject stream_options.include_usage when not present', () => {
+      const body = {
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'hello' }],
+        stream: true,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'ollama', 'qwen2.5:7b');
+
+      expect(result).toHaveProperty('stream_options');
+      expect(result['stream_options']).toEqual({ include_usage: true });
+    });
+
+    it('should inject stream_options.include_usage for ollama-cloud', () => {
+      const body = {
+        model: 'llama3',
+        messages: [{ role: 'user', content: 'hello' }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'ollama-cloud', 'llama3');
+
+      expect(result).toHaveProperty('stream_options');
+      expect(result['stream_options']).toEqual({ include_usage: true });
+    });
+
+    it('should overwrite stream_options.include_usage to true regardless of user value', () => {
+      const body = {
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'hello' }],
+        stream_options: { include_usage: false },
+      };
+
+      const result = sanitizeOpenAiBody(body, 'ollama', 'qwen2.5:7b');
+
+      expect(result['stream_options']).toEqual({ include_usage: true });
+    });
+
+    it('should pass through messages and model fields', () => {
+      const body = {
+        model: 'qwen2.5:7b',
+        messages: [{ role: 'user', content: 'hello' }],
+        temperature: 0.7,
+      };
+
+      const result = sanitizeOpenAiBody(body, 'ollama', 'qwen2.5:7b');
+
+      expect(result).toHaveProperty('model', 'qwen2.5:7b');
+      expect(result).toHaveProperty('messages');
+      expect(result).toHaveProperty('temperature', 0.7);
+    });
+  });
 });

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -454,6 +454,20 @@ describe('pipeStream', () => {
     });
   });
 
+  it('should capture usage from leftover passthroughBuffer without trailing newline', async () => {
+    const { res } = mockResponse();
+    const contentChunk = `data: ${JSON.stringify({ choices: [{ delta: { content: 'hi' } }] })}\n\n`;
+    const usageChunk = `data: ${JSON.stringify({
+      choices: [],
+      usage: { prompt_tokens: 99, completion_tokens: 42 },
+    })}`;
+    const stream = createReadableStream([contentChunk, usageChunk]);
+
+    const usage = await pipeStream(stream, res as never);
+
+    expect(usage).toEqual({ prompt_tokens: 99, completion_tokens: 42 });
+  });
+
   it('should return null usage when stream has no usage data', async () => {
     const { res } = mockResponse();
     const stream = createReadableStream([

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -260,5 +260,8 @@ export function sanitizeOpenAiBody(
     cleaned[key] = value;
   }
   if (endpointKey === 'deepseek') normalizeDeepSeekMaxTokens(cleaned);
+  if (endpointKey === 'ollama' || endpointKey === 'ollama-cloud') {
+    cleaned['stream_options'] = { include_usage: true };
+  }
   return cleaned;
 }

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -144,6 +144,30 @@ export async function pipeStream(
       }
     }
 
+    if (passthroughBuffer.trim()) {
+      const payload = passthroughBuffer
+        .trim()
+        .split('\n')
+        .map((line) => (line.startsWith('data: ') ? line.slice(6) : line))
+        .join('\n')
+        .trim();
+      if (payload && payload !== '[DONE]') {
+        try {
+          const obj = JSON.parse(payload);
+          if (obj.usage && typeof obj.usage.prompt_tokens === 'number') {
+            capturedUsage = {
+              prompt_tokens: obj.usage.prompt_tokens,
+              completion_tokens: obj.usage.completion_tokens ?? 0,
+              cache_read_tokens: obj.usage.cache_read_tokens,
+              cache_creation_tokens: obj.usage.cache_creation_tokens,
+            };
+          }
+        } catch {
+          /* ignore non-JSON */
+        }
+      }
+    }
+
     // Flush any remaining buffer content through the transform
     if (transform && sseBuffer.trim()) {
       const payload = sseBuffer


### PR DESCRIPTION
Related to #1502 


1. Added include_usage to stream_options.
2. Capture usage when stream is done.
3. Added Test Cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect token usage reporting for streaming responses from `ollama` and `ollama-cloud`. Always requests usage in streams and captures final usage even if the SSE stream ends without a trailing newline.

- **Bug Fixes**
  - Force `stream_options.include_usage: true` for `ollama` and `ollama-cloud` in `sanitizeOpenAiBody`.
  - Capture usage from the leftover SSE buffer at stream end (handles missing trailing newline) in `pipeStream`.
  - Added tests for converter injection and end-of-stream usage parsing.

<sup>Written for commit 6ec04565814fa0893313501768fb78721566f359. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

