### PR TITLE
feat: add MiniMax-M2.7 and MiniMax-M2.7-highspeed model support

### DIFF
--- a/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.spec.ts
+++ b/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.spec.ts
@@ -47,7 +47,9 @@ describe('PurgeNonCuratedModels1772960000000', () => {
       expect(params).toContain('gpt-4o');
       expect(params).toContain('openrouter/auto');
       expect(params).toContain('glm-4-flash');
-      expect(params.length).toBe(68);
+      expect(params).toContain('minimax-m2.7');
+      expect(params).toContain('minimax-m2.7-highspeed');
+      expect(params.length).toBe(70);
     });
   });
 

--- a/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.ts
+++ b/packages/backend/src/database/migrations/1772960000000-PurgeNonCuratedModels.ts
@@ -51,6 +51,8 @@ const CURATED_MODELS = [
   'openrouter/free',
   'minimax/minimax-m2.5',
   'minimax/minimax-m1',
+  'minimax-m2.7',
+  'minimax-m2.7-highspeed',
   'minimax-m2.5',
   'minimax-m2.5-highspeed',
   'minimax-m2.1',

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1740,6 +1740,8 @@ describe('ModelDiscoveryService', () => {
       const result = buildSubscriptionFallbackModels(null as never, 'minimax');
 
       expect(result.map((m) => m.id)).toEqual([
+        'MiniMax-M2.7',
+        'MiniMax-M2.7-highspeed',
         'MiniMax-M2.5',
         'MiniMax-M2.5-highspeed',
         'MiniMax-M2.1',

--- a/packages/backend/src/model-prices/model-name-normalizer.spec.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.spec.ts
@@ -136,7 +136,9 @@ describe('model-name-normalizer', () => {
     });
 
     it('includes MiniMax mixed-case aliases', () => {
-      const map = buildAliasMap(['minimax-m2.5', 'minimax-m1']);
+      const map = buildAliasMap(['minimax-m2.7', 'minimax-m2.5', 'minimax-m1']);
+      expect(map.get('MiniMax-M2.7')).toBe('minimax-m2.7');
+      expect(map.get('MiniMax-M2.7-highspeed')).toBe('minimax-m2.7-highspeed');
       expect(map.get('MiniMax-M2.5')).toBe('minimax-m2.5');
       expect(map.get('MiniMax-M1')).toBe('minimax-m1');
     });
@@ -234,7 +236,9 @@ describe('model-name-normalizer', () => {
     });
 
     it('resolves MiniMax mixed-case alias', () => {
-      const map = buildAliasMap(['minimax-m2.5', 'minimax-m1']);
+      const map = buildAliasMap(['minimax-m2.7', 'minimax-m2.5', 'minimax-m1']);
+      expect(resolveModelName('MiniMax-M2.7', map)).toBe('minimax-m2.7');
+      expect(resolveModelName('MiniMax-M2.7-highspeed', map)).toBe('minimax-m2.7-highspeed');
       expect(resolveModelName('MiniMax-M2.5', map)).toBe('minimax-m2.5');
     });
 

--- a/packages/backend/src/model-prices/model-name-normalizer.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.ts
@@ -30,6 +30,8 @@ const KNOWN_ALIASES: ReadonlyArray<readonly [string, string]> = [
   ['deepseek-chat-v3-0324', 'deepseek-chat'],
   ['deepseek-r1', 'deepseek-reasoner'],
   // MiniMax mixed-case aliases
+  ['MiniMax-M2.7', 'minimax-m2.7'],
+  ['MiniMax-M2.7-highspeed', 'minimax-m2.7-highspeed'],
   ['MiniMax-M2.5', 'minimax-m2.5'],
   ['MiniMax-M2.5-highspeed', 'minimax-m2.5-highspeed'],
   ['MiniMax-M2.1', 'minimax-m2.1'],

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -119,7 +119,7 @@ export const PROVIDERS: ProviderDef[] = [
     name: 'MiniMax',
     color: '#E73562',
     initial: 'Mm',
-    subtitle: 'MiniMax M2.5, M1, M2',
+    subtitle: 'MiniMax M2.7, M2.5, M1',
     keyPrefix: 'sk-',
     minKeyLength: 30,
     keyPlaceholder: 'sk-...',

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -133,6 +133,13 @@ describe('getSubscriptionKnownModels', () => {
     expect(models).toContain('copilot/gpt-5.4');
   });
 
+  it('returns known models for minimax including M2.7', () => {
+    const models = getSubscriptionKnownModels('minimax');
+    expect(models).toContain('MiniMax-M2.7');
+    expect(models).toContain('MiniMax-M2.7-highspeed');
+    expect(models).toContain('MiniMax-M2.5');
+  });
+
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {
     const models = getSubscriptionKnownModels('ollama-cloud');
     expect(models).toBeNull();

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -41,6 +41,8 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionLabel: 'MiniMax Coding Plan',
     subscriptionAuthMode: 'device_code' as const,
     knownModels: Object.freeze([
+      'MiniMax-M2.7',
+      'MiniMax-M2.7-highspeed',
       'MiniMax-M2.5',
       'MiniMax-M2.5-highspeed',
       'MiniMax-M2.1',


### PR DESCRIPTION
## Summary

- Add `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` to `KNOWN_ALIASES` in `model-name-normalizer.ts` for mixed-case model name resolution
- Add both models to `minimax.knownModels` in `packages/shared/src/subscription/configs.ts` so they appear as known models for the MiniMax Coding Plan subscription
- Add `minimax-m2.7` and `minimax-m2.7-highspeed` to the curated model allowlist in `PurgeNonCuratedModels` migration so they survive the DB cleanup pass
- Update MiniMax provider subtitle in the frontend to reflect M2.7 as the latest model
- Extend existing tests to cover M2.7 alias resolution and known-models inclusion

MiniMax-M2.7 is MiniMax's newest flagship model (*Peak Performance. Ultimate Value. Master the Complex*). MiniMax-M2.7-highspeed is the faster variant. Without these entries the model names returned by the MiniMax API are not normalized correctly and would be filtered out by the curated-models migration.

## Test plan

- [ ] `npm test --workspace=packages/shared` — all tests pass (68 total)
- [ ] `npm test --workspace=packages/backend -- --testPathPattern="model-name-normalizer|PurgeNonCuratedModels"` — all tests pass (66 total)
- [ ] `npm test --workspace=packages/frontend -- providers.test.ts` — all tests pass (67 total)
- [ ] MiniMax-M2.7 resolves correctly when used as a routing model name
- [ ] MiniMax-M2.7-highspeed appears in the known-models list for the MiniMax Coding Plan subscription

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`. Models are normalized, appear in MiniMax subscription and fallbacks, survive the curated-models migration, and the provider subtitle now highlights M2.7.

- **New Features**
  - Added mixed-case aliases to `KNOWN_ALIASES` for `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`.
  - Included both models in MiniMax subscription `knownModels`.
  - Added `minimax-m2.7` and `minimax-m2.7-highspeed` to the curated allowlist in `PurgeNonCuratedModels`.
  - Updated MiniMax provider subtitle; extended tests for alias resolution and known-models.

- **Bug Fixes**
  - Updated subscription fallback test to expect `MiniMax-M2.7` and `MiniMax-M2.7-highspeed`.

<sup>Written for commit 4227122f49d4c88e15a98448c4073ce777b14423. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

