### PR TITLE
fix: update Hermes setup instructions to use model section

### DIFF
--- a/.changeset/fix-hermes-setup.md
+++ b/.changeset/fix-hermes-setup.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix Hermes setup instructions to use top-level model section instead of custom_providers

--- a/packages/frontend/src/components/HermesSetup.tsx
+++ b/packages/frontend/src/components/HermesSetup.tsx
@@ -62,9 +62,9 @@ const HermesSetup: Component<Props> = (props) => {
   const copyKey = () => props.apiKey ?? masked();
 
   const yamlConfig = () =>
-    `custom_providers:\n  - name: Manifest\n    base_url: ${props.baseUrl}\n    api_key: ${displayKey()}\n    model: auto`;
+    `model:\n  provider: custom\n  base_url: ${props.baseUrl}\n  api_key: ${displayKey()}\n  default: auto`;
   const yamlConfigCopy = () =>
-    `custom_providers:\n  - name: Manifest\n    base_url: ${props.baseUrl}\n    api_key: ${copyKey()}\n    model: auto`;
+    `model:\n  provider: custom\n  base_url: ${props.baseUrl}\n  api_key: ${copyKey()}\n  default: auto`;
 
   return (
     <div class="setup-agents-card">
@@ -76,7 +76,8 @@ const HermesSetup: Component<Props> = (props) => {
       <CodeBlock code="hermes config edit" language="bash" />
 
       <p class="setup-method__hint" style="margin-top: 12px;">
-        Add the following to your <code class="setup-model-hint__code">config.yaml</code>:
+        Add the following <code class="setup-model-hint__code">model:</code> section to your{' '}
+        <code class="setup-model-hint__code">config.yaml</code>:
       </p>
       <div class="setup-cli-block">
         <div class="setup-cli-block__actions">
@@ -100,7 +101,6 @@ const HermesSetup: Component<Props> = (props) => {
       </div>
 
       <div class="setup-onboard-fields" role="list" aria-label="Configuration values">
-        <OnboardField label="Name" value="Manifest" />
         <OnboardField label="Base URL" value={props.baseUrl} copyable />
         <div class="setup-onboard-fields__row" role="listitem">
           <span class="setup-onboard-fields__label">API Key</span>
@@ -121,11 +121,6 @@ const HermesSetup: Component<Props> = (props) => {
         </div>
         <OnboardField label="Model" value="auto" copyable />
       </div>
-
-      <p class="setup-method__hint" style="margin-top: 12px;">
-        Then verify the configuration:
-      </p>
-      <CodeBlock code='hermes chat -q "Hello"' language="bash" />
     </div>
   );
 };

--- a/packages/frontend/tests/components/HermesSetup.test.tsx
+++ b/packages/frontend/tests/components/HermesSetup.test.tsx
@@ -28,25 +28,20 @@ describe("HermesSetup", () => {
     expect(container.textContent).toContain("hermes config edit");
   });
 
-  it("shows config.yaml code block with YAML format", () => {
+  it("shows config.yaml code block with model section only", () => {
     const { container } = render(() => <HermesSetup {...defaultProps} />);
     expect(container.textContent).toContain("http://localhost:3001/v1");
-    expect(container.textContent).toContain("custom_providers:");
-    expect(container.textContent).toContain("name: Manifest");
-    expect(container.textContent).toContain("model: auto");
+    expect(container.textContent).toContain("model:");
+    expect(container.textContent).toContain("provider: custom");
+    expect(container.textContent).toContain("default: auto");
+    expect(container.textContent).not.toContain("custom_providers:");
   });
 
-  it("shows verify command", () => {
-    const { container } = render(() => <HermesSetup {...defaultProps} />);
-    expect(container.textContent).toContain('hermes chat -q "Hello"');
-  });
 
   it("shows onboard fields", () => {
     const { container } = render(() => <HermesSetup {...defaultProps} />);
     const fields = container.querySelectorAll('[role="listitem"]');
-    expect(fields.length).toBeGreaterThanOrEqual(3);
-    expect(container.textContent).toContain("Name");
-    expect(container.textContent).toContain("Manifest");
+    expect(fields.length).toBeGreaterThanOrEqual(2);
     expect(container.textContent).toContain("Model");
     expect(container.textContent).toContain("auto");
     expect(container.textContent).toContain("Base URL");

--- a/packages/frontend/tests/components/HermesSetup.test.tsx
+++ b/packages/frontend/tests/components/HermesSetup.test.tsx
@@ -109,6 +109,19 @@ describe("HermesSetup", () => {
     expect(copyBtns.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("copies yaml config when copy button in code block is clicked", () => {
+    const { container } = render(() => (
+      <HermesSetup {...defaultProps} apiKey="mnfst_test_key" keyPrefix="mnfst_te" />
+    ));
+    const codeBlock = container.querySelector(".setup-cli-block");
+    const copyBtn = codeBlock?.querySelector('[aria-label="Copy to clipboard"]');
+    expect(copyBtn).not.toBeNull();
+    fireEvent.click(copyBtn!);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("provider: custom")
+    );
+  });
+
   it("uses custom base URL in code block and fields", () => {
     const { container } = render(() => (
       <HermesSetup {...defaultProps} baseUrl="https://example.com/v1" />


### PR DESCRIPTION
## Summary

- Replaced the `custom_providers` YAML snippet with a top-level `model:` section in the Hermes setup instructions
- The previous instructions only registered Manifest as a provider but didn't activate it — Hermes requires the `model:` block to route requests
- Removed the "Name" onboard field and verify command for a cleaner setup flow

Closes #1572

## Test plan

- [ ] Open the Hermes setup tab in the agent setup modal and verify the YAML shows only the `model:` section
- [ ] Copy the snippet and confirm it works in a Hermes `config.yaml`
- [ ] Verify `custom_providers:` is no longer shown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Hermes setup to a top-level `model:` block to activate Manifest as the default provider and correctly route requests. Closes #1572.

- **Bug Fixes**
  - Replaced the YAML example with only `model:` (provider: custom, base_url, api_key, default: auto); removed `custom_providers:`.
  - Simplified the setup UI by removing the "Name" field and the verify command.
  - Updated tests to assert the new YAML and UI, and added coverage for the YAML copy button.

<sup>Written for commit 821b43b0981fcfd0be3e5ba08d9e5265ac63ba4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

