### PR TITLE
chore: add changeset for Docker local mode

### DIFF
--- a/.changeset/docker-local-mode.md
+++ b/.changeset/docker-local-mode.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Improve local/Docker mode: hide social login buttons when OAuth is not configured, fix per-user data isolation, add optional Ollama via Docker Compose profile, and expose mode/Ollama status in setup endpoint.


### PR DESCRIPTION
## Summary

Adds the missing changeset for PR #1576 (Docker local mode improvements) so the release pipeline can bump the version and publish a new Docker image.

## Test plan

- No code changes — changeset only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a missing changeset to publish Docker local mode improvements as a patch for `manifest`. This unblocks the version bump and Docker image release.

- **New Features**
  - Hide social login buttons when OAuth is not configured.
  - Fix per-user data isolation in local mode.
  - Add optional Ollama via a Docker Compose profile.
  - Expose mode and Ollama status in the setup endpoint.

<sup>Written for commit 77a7cdd169dc9fc615747aa2fda938d4af236022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

