### PR TITLE
Update Google Gemini API key validation parameters

### DIFF
--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -109,9 +109,9 @@ export const PROVIDERS: ProviderDef[] = [
     color: '#4285f4',
     initial: 'G',
     subtitle: 'Gemini 2.5, Gemini 2.0 Flash',
-    keyPrefix: 'AIza',
-    minKeyLength: 39,
-    keyPlaceholder: 'AIza...',
+    keyPrefix: '',
+    minKeyLength: 30,
+    keyPlaceholder: 'API key',
     models: [],
   },
   {


### PR DESCRIPTION
## Summary
Updated the API key validation configuration for Google Gemini provider to be more flexible and less restrictive.

## Key Changes
- Removed the specific `AIza` key prefix requirement, allowing any API key format
- Reduced minimum key length from 39 to 30 characters
- Changed key placeholder text from `AIza...` to generic `API key` for better UX

## Implementation Details
These changes make the Google Gemini provider configuration more accommodating to different API key formats that Google may use, while maintaining a reasonable minimum length validation to catch obviously invalid keys.

https://claude.ai/code/session_01JA1bi4mmwBEm8A2WAFCid4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Google Gemini provider validation in `packages/frontend` to accept new API key formats. Removed the `AIza` prefix check, lowered minimum length to 30, and changed the placeholder to "API key" so non-`AIza` keys (e.g., AQ...) work.

<sup>Written for commit 5eb24f66008905362814f443a2377715b60791bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

