### PR TITLE
Remove fixed width from logo images in email templates

### DIFF
--- a/packages/backend/src/notifications/emails/reset-password.tsx
+++ b/packages/backend/src/notifications/emails/reset-password.tsx
@@ -30,7 +30,7 @@ export function ResetPasswordEmail(props: ResetPasswordEmailProps) {
         <Container style={container}>
           {/* Logo */}
           <Section style={logoSection}>
-            <Img src={logoUrl} alt="Manifest" width="140" height="32" style={logoImg} />
+            <Img src={logoUrl} alt="Manifest" height="32" style={logoImg} />
           </Section>
 
           {/* Main content */}

--- a/packages/backend/src/notifications/emails/test-email.tsx
+++ b/packages/backend/src/notifications/emails/test-email.tsx
@@ -26,7 +26,7 @@ export function TestEmail(props: TestEmailProps = {}) {
         <Container style={container}>
           {/* Logo */}
           <Section style={logoSection}>
-            <Img src={logoUrl} alt="Manifest" width="140" height="32" style={logoImg} />
+            <Img src={logoUrl} alt="Manifest" height="32" style={logoImg} />
           </Section>
 
           {/* Main content */}

--- a/packages/backend/src/notifications/emails/threshold-alert.tsx
+++ b/packages/backend/src/notifications/emails/threshold-alert.tsx
@@ -77,7 +77,7 @@ export function ThresholdAlertEmail(props: ThresholdAlertProps) {
         <Container style={container}>
           {/* Logo */}
           <Section style={logoSection}>
-            <Img src={logoUrl} alt="Manifest" width="140" height="32" style={logoImg} />
+            <Img src={logoUrl} alt="Manifest" height="32" style={logoImg} />
           </Section>
 
           {/* Main content */}

--- a/packages/backend/src/notifications/emails/verify-email.tsx
+++ b/packages/backend/src/notifications/emails/verify-email.tsx
@@ -34,7 +34,7 @@ export function VerifyEmailEmail(props: VerifyEmailProps) {
         <Container style={container}>
           {/* Logo */}
           <Section style={logoSection}>
-            <Img src={logoUrl} alt="Manifest" width="140" height="32" style={logoImg} />
+            <Img src={logoUrl} alt="Manifest" height="32" style={logoImg} />
           </Section>
 
           {/* Main content */}


### PR DESCRIPTION
## Summary
Removed the fixed `width="140"` attribute from logo images across all email notification templates to allow for responsive sizing based on the height constraint and CSS styling.

## Changes
- **reset-password.tsx**: Removed `width="140"` from logo `<Img>` component
- **test-email.tsx**: Removed `width="140"` from logo `<Img>` component
- **threshold-alert.tsx**: Removed `width="140"` from logo `<Img>` component
- **verify-email.tsx**: Removed `width="140"` from logo `<Img>` component

## Details
The logo images now rely solely on the `height="32"` attribute and the `logoImg` style object for sizing. This allows the aspect ratio to be maintained automatically while enabling more flexible responsive behavior across different email clients. The `alt="Manifest"` attribute and `src` remain unchanged for accessibility and functionality.

https://claude.ai/code/session_01NpmdLcjPdS2zQ23CWMxQSC

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the fixed width from email logo images so they scale by height and keep their aspect ratio, fixing stretching in some clients. Updated reset-password, verify-email, threshold-alert, and test-email templates; kept height="32" and existing styles.

<sup>Written for commit ec55548f4aa571d47a1ec37ea463b13b97564e43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

