### PR TITLE
fix: honor specific-tier fallbacks in proxy path

### DIFF
--- a/packages/backend/src/routing/dto/resolve-response.ts
+++ b/packages/backend/src/routing/dto/resolve-response.ts
@@ -12,4 +12,5 @@ export interface ResolveResponse {
   reason: ScoringReason;
   auth_type?: AuthType;
   specificity_category?: SpecificityCategory;
+  fallback_models?: string[] | null;
 }

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -1761,6 +1761,52 @@ describe('ProxyService', () => {
       expect(result.meta.fallbackIndex).toBeUndefined();
     });
 
+    it('tries specificity fallback models before tier fallbacks when a specific-tier route fails', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        model: 'gpt-5.4',
+        provider: 'OpenAI',
+        confidence: 0.95,
+        score: 0,
+        reason: 'specificity',
+        specificity_category: 'coding',
+        fallback_models: ['claude-sonnet-4'],
+      });
+      providerKeyService.getProviderApiKey
+        .mockResolvedValueOnce('sk-openai')
+        .mockResolvedValueOnce('sk-ant');
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('error', { status: 429 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: false,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: true,
+          isChatGpt: false,
+        });
+      tierService.getTiers.mockResolvedValue([
+        { tier: 'standard', fallback_models: null },
+      ] as never);
+      pricingCache.getByModel.mockReturnValue({ provider: 'Anthropic' } as never);
+
+      const result = await service.proxyRequest({
+        agentId: 'agent-1',
+        userId: 'user-1',
+        body,
+        sessionKey: 'default',
+      });
+
+      expect(result.meta.fallbackFromModel).toBe('gpt-5.4');
+      expect(result.meta.fallbackIndex).toBe(0);
+      expect(result.meta.primaryErrorStatus).toBe(429);
+      expect(result.meta.model).toBe('claude-sonnet-4');
+      expect(result.meta.specificity_category).toBe('coding');
+    });
+
     it('tries fallback model when primary returns 429', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -177,7 +177,7 @@ export class ProxyService {
     if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {
       const tiers = await this.tierService.getTiers(agentId);
       const assignment = tiers.find((t) => t.tier === resolved.tier);
-      const fallbackModels = assignment?.fallback_models;
+      const fallbackModels = resolved.fallback_models ?? assignment?.fallback_models;
 
       if (fallbackModels && fallbackModels.length > 0) {
         const primaryStatus = forward.response.status;

--- a/packages/backend/src/routing/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve.service.spec.ts
@@ -421,6 +421,7 @@ describe('ResolveService', () => {
           override_provider: 'anthropic',
           override_auth_type: null,
           auto_assigned_model: null,
+          fallback_models: ['gpt-4o', 'deepseek-chat'],
         },
       ]);
       mockProviderKeyService.hasActiveProvider.mockResolvedValue(true);
@@ -434,6 +435,7 @@ describe('ResolveService', () => {
       expect(result.provider).toBe('anthropic');
       expect(result.reason).toBe('specificity');
       expect(result.specificity_category).toBe('coding');
+      expect(result.fallback_models).toEqual(['gpt-4o', 'deepseek-chat']);
     });
 
     it('should return null when no active assignments exist', async () => {

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -162,6 +162,7 @@ export class ResolveService {
       reason: 'specificity',
       auth_type: authType,
       specificity_category: detected.category,
+      fallback_models: assignment.fallback_models ?? null,
     };
   }
 

--- a/packages/backend/src/routing/routing-core/tier.service.ts
+++ b/packages/backend/src/routing/routing-core/tier.service.ts
@@ -8,7 +8,7 @@ import { RoutingCacheService } from './routing-cache.service';
 import { ProviderService } from './provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { randomUUID } from 'crypto';
-import { TIERS } from '../../scoring/types';
+import { TIERS, Tier } from '../../scoring/types';
 import { isManifestUsableProvider } from '../../common/utils/subscription-support';
 
 @Injectable()
@@ -39,7 +39,7 @@ export class TierService {
 
     if (rows.length === 0) {
       // Batch tier inserts — create all 4 tier rows in one query
-      const created: TierAssignment[] = TIERS.map((tier) =>
+      const created: TierAssignment[] = TIERS.map((tier: Tier) =>
         Object.assign(new TierAssignment(), {
           id: randomUUID(),
           user_id: userId ?? '',


### PR DESCRIPTION
Summary
- propagate `fallback_models` from specificity resolution
- prefer those fallbacks in the proxy when a specificity-routed primary fails
- add regression coverage for both resolve and proxy behavior

Why
Specific-tier fallbacks were persisted and configurable, but the runtime proxy path ignored them and only consulted general tier fallbacks.

What changed
1. `packages/backend/src/routing/dto/resolve-response.ts`
- add optional `fallback_models?: string[] | null`

2. `packages/backend/src/routing/resolve/resolve.service.ts`
- include `assignment.fallback_models ?? null` in `resolveSpecificity(...)`

3. `packages/backend/src/routing/proxy/proxy.service.ts`
- prefer `resolved.fallback_models` before general tier fallbacks

4. tests
- `packages/backend/src/routing/resolve.service.spec.ts`
  - assert specificity resolution propagates fallback models
- `packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts`
  - assert a specificity-routed request uses its own fallback chain even when the general tier fallback list is null

Test plan
- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/backend -- --runInBand src/routing/resolve.service.spec.ts src/routing/proxy/__tests__/proxy.service.spec.ts`

Additional note
To run the targeted tests in this environment, I also had to fix a pre-existing strict-typing compile issue in `packages/backend/src/routing/routing-core/tier.service.ts` by annotating the `TIERS.map(...)` callback parameter as `Tier`. If you'd prefer, I can split that into a separate cleanup PR.

Closes #1586


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure specificity-routed requests use their own fallback chain when the primary model fails. Propagates per-assignment `fallback_models` through resolve and prefers them in the proxy, fixing incorrect tier fallback behavior.

- **Bug Fixes**
  - Expose `fallback_models` on `ResolveResponse` and propagate from `resolveSpecificity`.
  - Proxy now prefers `resolved.fallback_models` before tier-level fallbacks.
  - Add regression tests for resolve and proxy fallback behavior.
  - Fix strict typing in `tier.service.ts` (`TIERS.map` callback typed as `Tier`).

<sup>Written for commit 4f91ccdebbe0c1e44a5c36ec51c45559119e56fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

