### PR TITLE
fix(proxy): capture streaming token usage for Ollama providers

### DIFF
--- a/.changeset/fix-ollama-token-count.md
+++ b/.changeset/fix-ollama-token-count.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+fix(proxy): capture streaming token usage for Ollama and Ollama Cloud providers

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1414,6 +1414,34 @@ describe('ProviderClient', () => {
       expect(sentBody.stream_options).toEqual({ include_usage: true });
     });
 
+    it('injects stream_options.include_usage for Ollama streaming requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'ollama',
+        apiKey: '',
+        model: 'llama3',
+        body: { messages: [{ role: 'user', content: 'Hello' }] },
+        stream: true,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
+    });
+
+    it('injects stream_options.include_usage for Ollama Cloud streaming requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'ollama-cloud',
+        apiKey: 'ollama-key',
+        model: 'llama3',
+        body: { messages: [{ role: 'user', content: 'Hello' }] },
+        stream: true,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
+    });
+
     it('does not inject stream_options for non-streaming OpenAI requests', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -123,7 +123,13 @@ export class ProviderClient {
       // Inject stream_options.include_usage so providers always send token
       // usage in streaming responses — needed for both DB logging and
       // downstream clients (e.g. OpenClaw context management).
-      if (stream && (endpointKey === 'openai' || endpointKey === 'openrouter')) {
+      if (
+        stream &&
+        (endpointKey === 'openai' ||
+          endpointKey === 'openrouter' ||
+          endpointKey === 'ollama' ||
+          endpointKey === 'ollama-cloud')
+      ) {
         const existing =
           typeof sanitized.stream_options === 'object' && sanitized.stream_options !== null
             ? (sanitized.stream_options as Record<string, unknown>)


### PR DESCRIPTION
## Summary

- Inject `stream_options.include_usage: true` for `ollama` and `ollama-cloud` endpoints in streaming requests, matching the existing behavior for `openai` and `openrouter`
- Without this flag, Ollama servers omit token usage data from the final SSE chunk, resulting in 0 tokens and $0.00 costs in the dashboard
- Add test coverage for both Ollama variants

Closes #1585

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix missing token usage in streaming responses from `ollama` and `ollama-cloud` by injecting stream_options.include_usage, matching `openai`/`openrouter`. Restores accurate token counts and costs in the dashboard. Closes #1585.

- **Bug Fixes**
  - Inject `stream_options.include_usage: true` for streaming requests to `ollama` and `ollama-cloud`.
  - Added tests to assert the injection for both providers.

<sup>Written for commit aa004e384b91073654f2aa873a7a2762a457ab18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

