### PR TITLE
feat: add message feedback (thumbs up/down)

### DIFF
--- a/.changeset/message-feedback.md
+++ b/.changeset/message-feedback.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add per-message feedback (thumbs up/down) to Messages and Overview pages

--- a/packages/backend/src/analytics/analytics.module.ts
+++ b/packages/backend/src/analytics/analytics.module.ts
@@ -13,6 +13,7 @@ import { AgentLifecycleService } from './services/agent-lifecycle.service';
 import { TimeseriesQueriesService } from './services/timeseries-queries.service';
 import { MessagesQueryService } from './services/messages-query.service';
 import { MessageDetailsService } from './services/message-details.service';
+import { MessageFeedbackService } from './services/message-feedback.service';
 import { AgentAnalyticsService } from './services/agent-analytics.service';
 import { OverviewController } from './controllers/overview.controller';
 import { TokensController } from './controllers/tokens.controller';
@@ -41,6 +42,7 @@ import { AgentAnalyticsController } from './controllers/agent-analytics.controll
     TimeseriesQueriesService,
     MessagesQueryService,
     MessageDetailsService,
+    MessageFeedbackService,
     AgentAnalyticsService,
   ],
 })

--- a/packages/backend/src/analytics/controllers/messages.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.spec.ts
@@ -2,11 +2,14 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MessagesController } from './messages.controller';
 import { MessagesQueryService } from '../services/messages-query.service';
 import { MessageDetailsService } from '../services/message-details.service';
+import { MessageFeedbackService } from '../services/message-feedback.service';
 
 describe('MessagesController', () => {
   let controller: MessagesController;
   let mockGetMessages: jest.Mock;
   let mockGetDetails: jest.Mock;
+  let mockSetFeedback: jest.Mock;
+  let mockClearFeedback: jest.Mock;
 
   beforeEach(async () => {
     mockGetMessages = jest.fn().mockResolvedValue({
@@ -23,6 +26,9 @@ describe('MessagesController', () => {
       agent_logs: [],
     });
 
+    mockSetFeedback = jest.fn().mockResolvedValue(undefined);
+    mockClearFeedback = jest.fn().mockResolvedValue(undefined);
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MessagesController],
       providers: [
@@ -33,6 +39,10 @@ describe('MessagesController', () => {
         {
           provide: MessageDetailsService,
           useValue: { getDetails: mockGetDetails },
+        },
+        {
+          provide: MessageFeedbackService,
+          useValue: { setFeedback: mockSetFeedback, clearFeedback: mockClearFeedback },
         },
       ],
     }).compile();
@@ -127,5 +137,34 @@ describe('MessagesController', () => {
     const result = await controller.getMessageDetails('msg-1', user as never);
 
     expect(result).toEqual(expected);
+  });
+
+  it('delegates setFeedback to feedback service', async () => {
+    const user = { id: 'u1' };
+    const body = { rating: 'dislike' as const, tags: ['Slow or buggy'], details: 'test' };
+    await controller.setFeedback('msg-1', body, user as never);
+
+    expect(mockSetFeedback).toHaveBeenCalledWith(
+      'msg-1',
+      'u1',
+      'dislike',
+      ['Slow or buggy'],
+      'test',
+    );
+  });
+
+  it('delegates setFeedback with rating only', async () => {
+    const user = { id: 'u1' };
+    const body = { rating: 'like' as const };
+    await controller.setFeedback('msg-1', body, user as never);
+
+    expect(mockSetFeedback).toHaveBeenCalledWith('msg-1', 'u1', 'like', undefined, undefined);
+  });
+
+  it('delegates clearFeedback to feedback service', async () => {
+    const user = { id: 'u1' };
+    await controller.clearFeedback('msg-1', user as never);
+
+    expect(mockClearFeedback).toHaveBeenCalledWith('msg-1', 'u1');
   });
 });

--- a/packages/backend/src/analytics/controllers/messages.controller.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.ts
@@ -1,7 +1,19 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Query,
+  Body,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
 import { MessagesQueryDto } from '../dto/messages-query.dto';
+import { MessageFeedbackDto } from '../dto/message-feedback.dto';
 import { MessagesQueryService } from '../services/messages-query.service';
 import { MessageDetailsService } from '../services/message-details.service';
+import { MessageFeedbackService } from '../services/message-feedback.service';
 import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 
@@ -10,6 +22,7 @@ export class MessagesController {
   constructor(
     private readonly messagesQuery: MessagesQueryService,
     private readonly messageDetails: MessageDetailsService,
+    private readonly messageFeedback: MessageFeedbackService,
   ) {}
 
   @Get('messages')
@@ -30,5 +43,21 @@ export class MessagesController {
   @Get('messages/:id/details')
   async getMessageDetails(@Param('id') id: string, @CurrentUser() user: AuthUser) {
     return this.messageDetails.getDetails(id, user.id);
+  }
+
+  @Patch('messages/:id/feedback')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async setFeedback(
+    @Param('id') id: string,
+    @Body() body: MessageFeedbackDto,
+    @CurrentUser() user: AuthUser,
+  ) {
+    await this.messageFeedback.setFeedback(id, user.id, body.rating, body.tags, body.details);
+  }
+
+  @Delete('messages/:id/feedback')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async clearFeedback(@Param('id') id: string, @CurrentUser() user: AuthUser) {
+    await this.messageFeedback.clearFeedback(id, user.id);
   }
 }

--- a/packages/backend/src/analytics/dto/message-feedback.dto.spec.ts
+++ b/packages/backend/src/analytics/dto/message-feedback.dto.spec.ts
@@ -1,0 +1,70 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { MessageFeedbackDto } from './message-feedback.dto';
+
+describe('MessageFeedbackDto', () => {
+  it('accepts valid like rating', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, { rating: 'like' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts valid dislike rating with tags and details', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, {
+      rating: 'dislike',
+      tags: ['Too slow', 'Buggy'],
+      details: 'Response was too slow',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects missing rating', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, {});
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects invalid rating value', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, { rating: 'neutral' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('allows omitting tags and details', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, { rating: 'dislike' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects non-array tags', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, { rating: 'dislike', tags: 'not-an-array' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects non-string tag values', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, { rating: 'dislike', tags: [123] });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects details exceeding 2000 characters', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, {
+      rating: 'dislike',
+      details: 'x'.repeat(2001),
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it('accepts details at exactly 2000 characters', async () => {
+    const dto = plainToInstance(MessageFeedbackDto, {
+      rating: 'dislike',
+      details: 'x'.repeat(2000),
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/backend/src/analytics/dto/message-feedback.dto.ts
+++ b/packages/backend/src/analytics/dto/message-feedback.dto.ts
@@ -1,0 +1,26 @@
+import { IsIn, IsOptional, IsString, IsArray, MaxLength } from 'class-validator';
+
+export const FEEDBACK_RATINGS = ['like', 'dislike'] as const;
+
+export const FEEDBACK_TAGS = [
+  'Not expected tier',
+  'Poor answer quality',
+  'Too slow',
+  'Buggy',
+  'Other',
+] as const;
+
+export class MessageFeedbackDto {
+  @IsIn(FEEDBACK_RATINGS)
+  rating!: 'like' | 'dislike';
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  details?: string;
+}

--- a/packages/backend/src/analytics/services/message-details.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-details.service.spec.ts
@@ -55,6 +55,9 @@ describe('MessageDetailsService', () => {
     fallback_index: null,
     session_key: 'sess-001',
     user_id: 'u1',
+    feedback_rating: null,
+    feedback_tags: null,
+    feedback_details: null,
   };
 
   beforeEach(async () => {
@@ -232,7 +235,26 @@ describe('MessageDetailsService', () => {
       fallback_from_model: null,
       fallback_index: null,
       session_key: 'sess-001',
+      feedback_rating: null,
+      feedback_tags: null,
+      feedback_details: null,
     });
+  });
+
+  it('splits feedback_tags into an array when present', async () => {
+    const msgWithFeedback = {
+      ...baseMessage,
+      feedback_rating: 'dislike',
+      feedback_tags: 'Too slow,Buggy',
+      feedback_details: 'Response was slow',
+    };
+    msgQb.getOne.mockResolvedValue(msgWithFeedback);
+
+    const result = await service.getDetails('msg-1', 'u1');
+
+    expect(result.message.feedback_rating).toBe('dislike');
+    expect(result.message.feedback_tags).toEqual(['Too slow', 'Buggy']);
+    expect(result.message.feedback_details).toBe('Response was slow');
   });
 
   it('returns error message details for failed messages', async () => {

--- a/packages/backend/src/analytics/services/message-details.service.ts
+++ b/packages/backend/src/analytics/services/message-details.service.ts
@@ -33,6 +33,9 @@ export interface MessageDetailResponse {
     fallback_from_model: string | null;
     fallback_index: number | null;
     session_key: string | null;
+    feedback_rating: string | null;
+    feedback_tags: string[] | null;
+    feedback_details: string | null;
   };
   llm_calls: {
     id: string;
@@ -149,6 +152,9 @@ export class MessageDetailsService {
         fallback_from_model: message.fallback_from_model,
         fallback_index: message.fallback_index,
         session_key: message.session_key,
+        feedback_rating: message.feedback_rating,
+        feedback_tags: message.feedback_tags ? message.feedback_tags.split(',') : null,
+        feedback_details: message.feedback_details,
       },
       llm_calls: llmCalls.map((lc) => ({
         id: lc.id,

--- a/packages/backend/src/analytics/services/message-feedback.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-feedback.service.spec.ts
@@ -1,0 +1,134 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { MessageFeedbackService } from './message-feedback.service';
+import { AgentMessage } from '../../entities/agent-message.entity';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
+
+function mockQb(result: unknown = null) {
+  const qb: Record<string, jest.Mock> = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    getOne: jest.fn().mockResolvedValue(result),
+  };
+  return qb;
+}
+
+describe('MessageFeedbackService', () => {
+  let service: MessageFeedbackService;
+  let mockTenantResolve: jest.Mock;
+  let mockUpdate: jest.Mock;
+  let msgQb: ReturnType<typeof mockQb>;
+
+  const baseMessage = {
+    id: 'msg-1',
+    tenant_id: 't1',
+    user_id: 'u1',
+  };
+
+  beforeEach(async () => {
+    mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
+    mockUpdate = jest.fn().mockResolvedValue({ affected: 1 });
+    msgQb = mockQb(baseMessage);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessageFeedbackService,
+        {
+          provide: getRepositoryToken(AgentMessage),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(msgQb),
+            update: mockUpdate,
+          },
+        },
+        {
+          provide: TenantCacheService,
+          useValue: { resolve: mockTenantResolve },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MessageFeedbackService>(MessageFeedbackService);
+  });
+
+  describe('setFeedback', () => {
+    it('updates feedback columns with rating only', async () => {
+      await service.setFeedback('msg-1', 'u1', 'like');
+
+      expect(mockUpdate).toHaveBeenCalledWith('msg-1', {
+        feedback_rating: 'like',
+        feedback_tags: null,
+        feedback_details: null,
+      });
+    });
+
+    it('updates feedback with tags and details', async () => {
+      await service.setFeedback('msg-1', 'u1', 'dislike', ['Too slow', 'Buggy'], 'Very slow');
+
+      expect(mockUpdate).toHaveBeenCalledWith('msg-1', {
+        feedback_rating: 'dislike',
+        feedback_tags: 'Too slow,Buggy',
+        feedback_details: 'Very slow',
+      });
+    });
+
+    it('stores null tags when empty array provided', async () => {
+      await service.setFeedback('msg-1', 'u1', 'dislike', [], 'No tags');
+
+      expect(mockUpdate).toHaveBeenCalledWith('msg-1', {
+        feedback_rating: 'dislike',
+        feedback_tags: null,
+        feedback_details: 'No tags',
+      });
+    });
+
+    it('filters by tenantId when tenant exists', async () => {
+      await service.setFeedback('msg-1', 'u1', 'like');
+
+      expect(msgQb.andWhere).toHaveBeenCalledWith('m.tenant_id = :tenantId', {
+        tenantId: 'tenant-123',
+      });
+    });
+
+    it('filters by userId when tenant does not exist', async () => {
+      mockTenantResolve.mockResolvedValue(null);
+
+      await service.setFeedback('msg-1', 'u1', 'like');
+
+      expect(msgQb.andWhere).toHaveBeenCalledWith('m.user_id = :userId', { userId: 'u1' });
+    });
+
+    it('throws NotFoundException when message not found', async () => {
+      msgQb.getOne.mockResolvedValue(null);
+
+      await expect(service.setFeedback('not-found', 'u1', 'like')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('clearFeedback', () => {
+    it('sets all feedback columns to null', async () => {
+      await service.clearFeedback('msg-1', 'u1');
+
+      expect(mockUpdate).toHaveBeenCalledWith('msg-1', {
+        feedback_rating: null,
+        feedback_tags: null,
+        feedback_details: null,
+      });
+    });
+
+    it('throws NotFoundException when message not found', async () => {
+      msgQb.getOne.mockResolvedValue(null);
+
+      await expect(service.clearFeedback('not-found', 'u1')).rejects.toThrow(NotFoundException);
+    });
+
+    it('verifies ownership before clearing', async () => {
+      await service.clearFeedback('msg-1', 'u1');
+
+      expect(msgQb.where).toHaveBeenCalledWith('m.id = :id', { id: 'msg-1' });
+      expect(msgQb.andWhere).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/analytics/services/message-feedback.service.ts
+++ b/packages/backend/src/analytics/services/message-feedback.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AgentMessage } from '../../entities/agent-message.entity';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
+
+@Injectable()
+export class MessageFeedbackService {
+  constructor(
+    @InjectRepository(AgentMessage)
+    private readonly messageRepo: Repository<AgentMessage>,
+    private readonly tenantCache: TenantCacheService,
+  ) {}
+
+  async setFeedback(
+    messageId: string,
+    userId: string,
+    rating: string,
+    tags?: string[],
+    details?: string,
+  ): Promise<void> {
+    const message = await this.findOwnedMessage(messageId, userId);
+    await this.messageRepo.update(message.id, {
+      feedback_rating: rating,
+      feedback_tags: tags?.length ? tags.join(',') : null,
+      feedback_details: details ?? null,
+    });
+  }
+
+  async clearFeedback(messageId: string, userId: string): Promise<void> {
+    const message = await this.findOwnedMessage(messageId, userId);
+    await this.messageRepo.update(message.id, {
+      feedback_rating: null,
+      feedback_tags: null,
+      feedback_details: null,
+    });
+  }
+
+  private async findOwnedMessage(messageId: string, userId: string): Promise<AgentMessage> {
+    const tenantId = await this.tenantCache.resolve(userId);
+    const qb = this.messageRepo.createQueryBuilder('m').where('m.id = :id', { id: messageId });
+    if (tenantId) {
+      qb.andWhere('m.tenant_id = :tenantId', { tenantId });
+    } else {
+      qb.andWhere('m.user_id = :userId', { userId });
+    }
+    const message = await qb.getOne();
+    if (!message) throw new NotFoundException('Message not found');
+    return message;
+  }
+}

--- a/packages/backend/src/analytics/services/query-helpers.ts
+++ b/packages/backend/src/analytics/services/query-helpers.ts
@@ -86,6 +86,7 @@ export const MESSAGE_ROW_SELECT_ALIASES = [
   'auth_type',
   'fallback_from_model',
   'fallback_index',
+  'feedback_rating',
 ] as const;
 
 export function selectMessageRowColumns<T extends ObjectLiteral>(
@@ -110,5 +111,6 @@ export function selectMessageRowColumns<T extends ObjectLiteral>(
     .addSelect('at.error_message', 'error_message')
     .addSelect('at.auth_type', 'auth_type')
     .addSelect('at.fallback_from_model', 'fallback_from_model')
-    .addSelect('at.fallback_index', 'fallback_index');
+    .addSelect('at.fallback_index', 'fallback_index')
+    .addSelect('at.feedback_rating', 'feedback_rating');
 }

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -68,6 +68,7 @@ import { AddSpecificityAssignments1775200000000 } from './migrations/17752000000
 import { AddSpecificityCategory1775300000000 } from './migrations/1775300000000-AddSpecificityCategory';
 import { AddCallerAttribution1775400000000 } from './migrations/1775400000000-AddCallerAttribution';
 import { AddMessageProvider1775500000000 } from './migrations/1775500000000-AddMessageProvider';
+import { AddMessageFeedback1775600000000 } from './migrations/1775600000000-AddMessageFeedback';
 
 const entities = [
   AgentMessage,
@@ -137,6 +138,7 @@ const migrations = [
   AddSpecificityCategory1775300000000,
   AddCallerAttribution1775400000000,
   AddMessageProvider1775500000000,
+  AddMessageFeedback1775600000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1775600000000-AddMessageFeedback.spec.ts
+++ b/packages/backend/src/database/migrations/1775600000000-AddMessageFeedback.spec.ts
@@ -1,0 +1,72 @@
+import { QueryRunner } from 'typeorm';
+import { AddMessageFeedback1775600000000 } from './1775600000000-AddMessageFeedback';
+
+describe('AddMessageFeedback1775600000000', () => {
+  let migration: AddMessageFeedback1775600000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new AddMessageFeedback1775600000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  describe('up', () => {
+    it('should add feedback_rating, feedback_tags, and feedback_details columns', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(3);
+      expect(queryRunner.query).toHaveBeenCalledWith(expect.stringContaining('"feedback_rating"'));
+      expect(queryRunner.query).toHaveBeenCalledWith(expect.stringContaining('"feedback_tags"'));
+      expect(queryRunner.query).toHaveBeenCalledWith(expect.stringContaining('"feedback_details"'));
+    });
+
+    it('should create nullable columns on agent_messages', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      for (const call of queryRunner.query.mock.calls) {
+        const sql = call[0] as string;
+        expect(sql).toContain('ALTER TABLE "agent_messages"');
+        expect(sql).toContain('ADD COLUMN');
+        expect(sql).toContain('DEFAULT NULL');
+      }
+    });
+
+    it('should create feedback_rating and feedback_tags as varchar', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const ratingSQL = queryRunner.query.mock.calls[0][0] as string;
+      expect(ratingSQL).toContain('varchar');
+
+      const tagsSQL = queryRunner.query.mock.calls[1][0] as string;
+      expect(tagsSQL).toContain('varchar');
+    });
+
+    it('should create feedback_details as text', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const detailsSQL = queryRunner.query.mock.calls[2][0] as string;
+      expect(detailsSQL).toContain('text');
+    });
+  });
+
+  describe('down', () => {
+    it('should drop all three feedback columns', async () => {
+      await migration.down(queryRunner as unknown as QueryRunner);
+
+      expect(queryRunner.query).toHaveBeenCalledTimes(3);
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('DROP COLUMN "feedback_details"'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('DROP COLUMN "feedback_tags"'),
+      );
+      expect(queryRunner.query).toHaveBeenCalledWith(
+        expect.stringContaining('DROP COLUMN "feedback_rating"'),
+      );
+    });
+  });
+
+  it('exposes a stable migration name', () => {
+    expect(migration.name).toBe('AddMessageFeedback1775600000000');
+  });
+});

--- a/packages/backend/src/database/migrations/1775600000000-AddMessageFeedback.ts
+++ b/packages/backend/src/database/migrations/1775600000000-AddMessageFeedback.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMessageFeedback1775600000000 implements MigrationInterface {
+  name = 'AddMessageFeedback1775600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent_messages" ADD COLUMN "feedback_rating" varchar DEFAULT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_messages" ADD COLUMN "feedback_tags" varchar DEFAULT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_messages" ADD COLUMN "feedback_details" text DEFAULT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "agent_messages" DROP COLUMN "feedback_details"`);
+    await queryRunner.query(`ALTER TABLE "agent_messages" DROP COLUMN "feedback_tags"`);
+    await queryRunner.query(`ALTER TABLE "agent_messages" DROP COLUMN "feedback_rating"`);
+  }
+}

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -100,4 +100,13 @@ export class AgentMessage {
 
   @Column('simple-json', { nullable: true })
   caller_attribution!: CallerAttribution | null;
+
+  @Column('varchar', { nullable: true })
+  feedback_rating!: string | null;
+
+  @Column('varchar', { nullable: true })
+  feedback_tags!: string | null;
+
+  @Column('text', { nullable: true })
+  feedback_details!: string | null;
 }

--- a/packages/backend/test/messages.e2e-spec.ts
+++ b/packages/backend/test/messages.e2e-spec.ts
@@ -110,4 +110,131 @@ describe('GET /api/v1/messages', () => {
       expect(res2.body.items[0].id).not.toBe(res1.body.items[0].id);
     }
   });
+
+  it('includes feedback_rating in message rows', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    const item = res.body.items[0];
+    expect(item).toHaveProperty('feedback_rating');
+    expect(item.feedback_rating).toBeNull();
+  });
+});
+
+describe('PATCH /api/v1/messages/:id/feedback', () => {
+  let messageId: string;
+
+  beforeAll(async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h&limit=1')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    messageId = res.body.items[0].id;
+  });
+
+  it('sets like feedback', async () => {
+    await request(app.getHttpServer())
+      .patch(`/api/v1/messages/${messageId}/feedback`)
+      .set('x-api-key', TEST_API_KEY)
+      .send({ rating: 'like' })
+      .expect(204);
+
+    const details = await request(app.getHttpServer())
+      .get(`/api/v1/messages/${messageId}/details`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    expect(details.body.message.feedback_rating).toBe('like');
+    expect(details.body.message.feedback_tags).toBeNull();
+    expect(details.body.message.feedback_details).toBeNull();
+  });
+
+  it('sets dislike feedback with tags and details', async () => {
+    await request(app.getHttpServer())
+      .patch(`/api/v1/messages/${messageId}/feedback`)
+      .set('x-api-key', TEST_API_KEY)
+      .send({
+        rating: 'dislike',
+        tags: ['Too slow', 'Buggy'],
+        details: 'Response was very slow',
+      })
+      .expect(204);
+
+    const details = await request(app.getHttpServer())
+      .get(`/api/v1/messages/${messageId}/details`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    expect(details.body.message.feedback_rating).toBe('dislike');
+    expect(details.body.message.feedback_tags).toEqual(['Too slow', 'Buggy']);
+    expect(details.body.message.feedback_details).toBe('Response was very slow');
+  });
+
+  it('rejects invalid rating', async () => {
+    await request(app.getHttpServer())
+      .patch(`/api/v1/messages/${messageId}/feedback`)
+      .set('x-api-key', TEST_API_KEY)
+      .send({ rating: 'neutral' })
+      .expect(400);
+  });
+
+  it('rejects missing rating', async () => {
+    await request(app.getHttpServer())
+      .patch(`/api/v1/messages/${messageId}/feedback`)
+      .set('x-api-key', TEST_API_KEY)
+      .send({})
+      .expect(400);
+  });
+
+  it('returns 404 for non-existent message', async () => {
+    await request(app.getHttpServer())
+      .patch('/api/v1/messages/non-existent-id/feedback')
+      .set('x-api-key', TEST_API_KEY)
+      .send({ rating: 'like' })
+      .expect(404);
+  });
+});
+
+describe('DELETE /api/v1/messages/:id/feedback', () => {
+  let messageId: string;
+
+  beforeAll(async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h&limit=1')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    messageId = res.body.items[0].id;
+
+    // Set feedback first
+    await request(app.getHttpServer())
+      .patch(`/api/v1/messages/${messageId}/feedback`)
+      .set('x-api-key', TEST_API_KEY)
+      .send({ rating: 'dislike', tags: ['Other'], details: 'test' })
+      .expect(204);
+  });
+
+  it('clears all feedback', async () => {
+    await request(app.getHttpServer())
+      .delete(`/api/v1/messages/${messageId}/feedback`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(204);
+
+    const details = await request(app.getHttpServer())
+      .get(`/api/v1/messages/${messageId}/details`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    expect(details.body.message.feedback_rating).toBeNull();
+    expect(details.body.message.feedback_tags).toBeNull();
+    expect(details.body.message.feedback_details).toBeNull();
+  });
+
+  it('returns 404 for non-existent message', async () => {
+    await request(app.getHttpServer())
+      .delete('/api/v1/messages/non-existent-id/feedback')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(404);
+  });
 });

--- a/packages/frontend/src/components/FeedbackModal.tsx
+++ b/packages/frontend/src/components/FeedbackModal.tsx
@@ -1,0 +1,110 @@
+import { createSignal, For, Show, onMount, onCleanup, type JSX } from 'solid-js';
+
+export const FEEDBACK_TAGS = [
+  'Not expected tier',
+  'Poor answer quality',
+  'Too slow',
+  'Buggy',
+  'Other',
+] as const;
+
+export interface FeedbackModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (tags: string[], details: string) => void;
+}
+
+export default function FeedbackModal(props: FeedbackModalProps): JSX.Element {
+  const [selectedTags, setSelectedTags] = createSignal<string[]>([]);
+  const [details, setDetails] = createSignal('');
+
+  function toggleTag(tag: string) {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }
+
+  function handleSubmit() {
+    props.onSubmit(selectedTags(), details());
+    setSelectedTags([]);
+    setDetails('');
+  }
+
+  function handleClose() {
+    setSelectedTags([]);
+    setDetails('');
+    props.onClose();
+  }
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Escape' && props.open) handleClose();
+  }
+
+  onMount(() => document.addEventListener('keydown', onKeyDown));
+  onCleanup(() => document.removeEventListener('keydown', onKeyDown));
+
+  return (
+    <Show when={props.open}>
+      <div
+        class="modal-backdrop"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) handleClose();
+        }}
+      >
+        <div
+          class="modal feedback-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Share feedback"
+        >
+          <div class="modal__header">
+            <span class="modal__title">Share feedback</span>
+            <button class="modal__close" onClick={handleClose} aria-label="Close" type="button">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          </div>
+          <div style="padding: 12px var(--gap-lg);">
+            <div class="feedback-modal__tags">
+              <For each={FEEDBACK_TAGS as unknown as string[]}>
+                {(tag) => (
+                  <button
+                    type="button"
+                    class={`feedback-tag${selectedTags().includes(tag) ? ' feedback-tag--selected' : ''}`}
+                    onClick={() => toggleTag(tag)}
+                  >
+                    {tag}
+                  </button>
+                )}
+              </For>
+            </div>
+            <textarea
+              class="feedback-modal__textarea"
+              placeholder="Share details (optional)"
+              value={details()}
+              onInput={(e) => setDetails(e.currentTarget.value)}
+              maxLength={2000}
+            />
+            <div class="feedback-modal__footer">
+              <button type="button" class="btn btn--primary" onClick={handleSubmit}>
+                Submit
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/packages/frontend/src/components/MessageTable.tsx
+++ b/packages/frontend/src/components/MessageTable.tsx
@@ -9,6 +9,9 @@ export interface MessageTableProps {
   agentName: string;
   customProviderName: (model: string) => string | undefined;
   onFallbackErrorClick?: (model: string) => void;
+  onFeedbackLike?: (id: string) => void;
+  onFeedbackDislike?: (id: string) => void;
+  onFeedbackClear?: (id: string) => void;
   rowIdPrefix?: string;
   showHeaderTooltips?: boolean;
   expandable?: boolean;
@@ -45,6 +48,9 @@ function ExpandableRow(props: {
     agentName: props.tableProps.agentName,
     customProviderName: props.tableProps.customProviderName,
     onFallbackErrorClick: props.tableProps.onFallbackErrorClick,
+    onFeedbackLike: props.tableProps.onFeedbackLike,
+    onFeedbackDislike: props.tableProps.onFeedbackDislike,
+    onFeedbackClear: props.tableProps.onFeedbackClear,
   };
 
   return (
@@ -84,6 +90,9 @@ function PlainRow(props: {
     agentName: props.tableProps.agentName,
     customProviderName: props.tableProps.customProviderName,
     onFallbackErrorClick: props.tableProps.onFallbackErrorClick,
+    onFeedbackLike: props.tableProps.onFeedbackLike,
+    onFeedbackDislike: props.tableProps.onFeedbackDislike,
+    onFeedbackClear: props.tableProps.onFeedbackClear,
   };
   return (
     <tr id={props.rowId}>

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -66,6 +66,36 @@ export function FallbackIcon(): JSX.Element {
   );
 }
 
+export function ThumbUpIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path d="M4 21h1V8H4c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2M20 8h-6.61l1.12-3.37c.2-.61.1-1.28-.27-1.8-.38-.52-.98-.83-1.62-.83h-.61c-.3 0-.58.13-.77.36L7.01 7.44V21h10.31a2 2 0 0 0 1.87-1.3l2.76-7.35c.04-.11.06-.23.06-.35v-2c0-1.1-.9-2-2-2Z" />
+    </svg>
+  );
+}
+
+export function ThumbDownIcon(): JSX.Element {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path d="M20 3h-1v13h1c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2M4.82 4.3l-2.76 7.35c-.04.11-.06.23-.06.35v2c0 1.1.9 2 2 2h6.61l-1.12 3.37c-.2.61-.1 1.28.27 1.8.38.52.98.83 1.62.83h.61c.3 0 .58-.13.77-.36l4.23-5.08V3H6.69a2 2 0 0 0-1.87 1.3" />
+    </svg>
+  );
+}
+
 const HEADER_LABELS: Record<MessageColumnKey, string> = {
   date: 'Date',
   message: 'Message',
@@ -77,6 +107,7 @@ const HEADER_LABELS: Record<MessageColumnKey, string> = {
   cache: 'Cache',
   duration: 'Duration',
   status: 'Status',
+  feedback: '',
 };
 
 const TOOLTIP_TEXT: Partial<Record<MessageColumnKey, string>> = {
@@ -320,10 +351,62 @@ export function StatusCell(
   );
 }
 
+export function FeedbackCell(
+  item: MessageRow,
+  onLike: (id: string) => void,
+  onDislike: (id: string) => void,
+  onClear: (id: string) => void,
+): JSX.Element {
+  const isLiked = item.feedback_rating === 'like';
+  const isDisliked = item.feedback_rating === 'dislike';
+
+  return (
+    <td>
+      <div class="feedback-cell">
+        <button
+          type="button"
+          class={`feedback-btn${isLiked ? ' feedback-btn--active' : ''}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (isLiked) {
+              onClear(item.id);
+            } else {
+              onLike(item.id);
+            }
+          }}
+          title={isLiked ? 'Remove feedback' : 'Like'}
+          aria-label={isLiked ? 'Remove feedback' : 'Like'}
+        >
+          <ThumbUpIcon />
+        </button>
+        <button
+          type="button"
+          class={`feedback-btn${isDisliked ? ' feedback-btn--active' : ''}`}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (isDisliked) {
+              onClear(item.id);
+            } else {
+              onDislike(item.id);
+            }
+          }}
+          title={isDisliked ? 'Remove feedback' : 'Dislike'}
+          aria-label={isDisliked ? 'Remove feedback' : 'Dislike'}
+        >
+          <ThumbDownIcon />
+        </button>
+      </div>
+    </td>
+  );
+}
+
 export interface CellRenderContext {
   agentName: string;
   customProviderName: (model: string) => string | undefined;
   onFallbackErrorClick?: (model: string) => void;
+  onFeedbackLike?: (id: string) => void;
+  onFeedbackDislike?: (id: string) => void;
+  onFeedbackClear?: (id: string) => void;
 }
 
 export function renderCell(
@@ -352,5 +435,12 @@ export function renderCell(
       return DurationCell(item);
     case 'status':
       return StatusCell(item, ctx.agentName, ctx.onFallbackErrorClick);
+    case 'feedback':
+      return FeedbackCell(
+        item,
+        ctx.onFeedbackLike ?? (() => {}),
+        ctx.onFeedbackDislike ?? (() => {}),
+        ctx.onFeedbackClear ?? (() => {}),
+      );
   }
 }

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -66,7 +66,16 @@ export function FallbackIcon(): JSX.Element {
   );
 }
 
-export function ThumbUpIcon(): JSX.Element {
+const THUMB_UP_OUTLINED =
+  'M19.5 8h-5.11l.9-2.71c.25-.76.13-1.6-.34-2.25A2.52 2.52 0 0 0 12.92 2h-.57c-.52 0-1.01.23-1.34.63L6.53 8H4.5A2.5 2.5 0 0 0 2 10.5v8A2.5 2.5 0 0 0 4.5 21h11.42a4.03 4.03 0 0 0 3.75-2.59l2.17-5.8c.11-.28.16-.58.16-.88V10.5A2.5 2.5 0 0 0 19.5 8M6 19H4.5c-.28 0-.5-.22-.5-.5v-8c0-.28.22-.5.5-.5H6zm14-7.27q0 .09-.03.18l-2.17 5.8a2 2 0 0 1-1.87 1.3H8.01V9.37l4.47-5.36h.45c.22 0 .35.13.41.21s.14.24.07.45L12.4 7.71c-.18.53-.09 1.12.24 1.58s.86.73 1.42.73h5.46c.28 0 .5.22.5.5v1.23Z';
+const THUMB_UP_FILLED =
+  'M4 21h1V8H4c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2M20 8h-6.61l1.12-3.37c.2-.61.1-1.28-.27-1.8-.38-.52-.98-.83-1.62-.83h-.61c-.3 0-.58.13-.77.36L7.01 7.44V21h10.31a2 2 0 0 0 1.87-1.3l2.76-7.35c.04-.11.06-.23.06-.35v-2c0-1.1-.9-2-2-2Z';
+const THUMB_DOWN_OUTLINED =
+  'M19.5 3H8.08a4.03 4.03 0 0 0-3.75 2.59l-2.17 5.8c-.11.28-.16.58-.16.88v1.23A2.5 2.5 0 0 0 4.5 16h5.11l-.9 2.71c-.25.76-.13 1.6.34 2.25S10.28 22 11.08 22h.57c.52 0 1.01-.23 1.34-.63L17.47 16h2.03a2.5 2.5 0 0 0 2.5-2.5v-8A2.5 2.5 0 0 0 19.5 3M16 14.64 11.53 20h-.45c-.22 0-.35-.13-.41-.21a.48.48 0 0 1-.07-.45l1.01-3.04c.18-.53.09-1.12-.24-1.58s-.86-.73-1.42-.73H4.49c-.28 0-.5-.22-.5-.5v-1.23q0-.09.03-.18l2.17-5.8a2 2 0 0 1 1.87-1.3h7.92v9.64Zm4-1.14c0 .28-.22.5-.5.5H18V5h1.5c.28 0 .5.22.5.5z';
+const THUMB_DOWN_FILLED =
+  'M20 3h-1v13h1c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2M4.82 4.3l-2.76 7.35c-.04.11-.06.23-.06.35v2c0 1.1.9 2 2 2h6.61l-1.12 3.37c-.2.61-.1 1.28.27 1.8.38.52.98.83 1.62.83h.61c.3 0 .58-.13.77-.36l4.23-5.08V3H6.69a2 2 0 0 0-1.87 1.3';
+
+export function ThumbUpIcon(props: { filled?: boolean }): JSX.Element {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -76,12 +85,12 @@ export function ThumbUpIcon(): JSX.Element {
       viewBox="0 0 24 24"
       aria-hidden="true"
     >
-      <path d="M4 21h1V8H4c-1.1 0-2 .9-2 2v9c0 1.1.9 2 2 2M20 8h-6.61l1.12-3.37c.2-.61.1-1.28-.27-1.8-.38-.52-.98-.83-1.62-.83h-.61c-.3 0-.58.13-.77.36L7.01 7.44V21h10.31a2 2 0 0 0 1.87-1.3l2.76-7.35c.04-.11.06-.23.06-.35v-2c0-1.1-.9-2-2-2Z" />
+      <path d={props.filled ? THUMB_UP_FILLED : THUMB_UP_OUTLINED} />
     </svg>
   );
 }
 
-export function ThumbDownIcon(): JSX.Element {
+export function ThumbDownIcon(props: { filled?: boolean }): JSX.Element {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -91,7 +100,7 @@ export function ThumbDownIcon(): JSX.Element {
       viewBox="0 0 24 24"
       aria-hidden="true"
     >
-      <path d="M20 3h-1v13h1c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2M4.82 4.3l-2.76 7.35c-.04.11-.06.23-.06.35v2c0 1.1.9 2 2 2h6.61l-1.12 3.37c-.2.61-.1 1.28.27 1.8.38.52.98.83 1.62.83h.61c.3 0 .58-.13.77-.36l4.23-5.08V3H6.69a2 2 0 0 0-1.87 1.3" />
+      <path d={props.filled ? THUMB_DOWN_FILLED : THUMB_DOWN_OUTLINED} />
     </svg>
   );
 }
@@ -365,7 +374,7 @@ export function FeedbackCell(
       <div class="feedback-cell">
         <button
           type="button"
-          class={`feedback-btn${isLiked ? ' feedback-btn--active' : ''}`}
+          class={`feedback-btn${isLiked ? ' feedback-btn--active-like' : ''}`}
           onClick={(e) => {
             e.stopPropagation();
             if (isLiked) {
@@ -377,11 +386,11 @@ export function FeedbackCell(
           title={isLiked ? 'Remove feedback' : 'Like'}
           aria-label={isLiked ? 'Remove feedback' : 'Like'}
         >
-          <ThumbUpIcon />
+          <ThumbUpIcon filled />
         </button>
         <button
           type="button"
-          class={`feedback-btn${isDisliked ? ' feedback-btn--active' : ''}`}
+          class={`feedback-btn${isDisliked ? ' feedback-btn--active-dislike' : ''}`}
           onClick={(e) => {
             e.stopPropagation();
             if (isDisliked) {
@@ -393,7 +402,7 @@ export function FeedbackCell(
           title={isDisliked ? 'Remove feedback' : 'Dislike'}
           aria-label={isDisliked ? 'Remove feedback' : 'Dislike'}
         >
-          <ThumbDownIcon />
+          <ThumbDownIcon filled />
         </button>
       </div>
     </td>

--- a/packages/frontend/src/components/message-table-types.ts
+++ b/packages/frontend/src/components/message-table-types.ts
@@ -20,6 +20,7 @@ export interface MessageRow {
   cache_read_tokens?: number | null;
   cache_creation_tokens?: number | null;
   duration_ms?: number | null;
+  feedback_rating?: string | null;
 }
 
 export type MessageColumnKey =
@@ -32,25 +33,28 @@ export type MessageColumnKey =
   | 'model'
   | 'cache'
   | 'duration'
-  | 'status';
+  | 'status'
+  | 'feedback';
 
 export const COMPACT_COLUMNS: MessageColumnKey[] = [
+  'feedback',
   'date',
+  'model',
   'message',
   'cost',
-  'model',
   'totalTokens',
   'status',
 ];
 
 export const DETAILED_COLUMNS: MessageColumnKey[] = [
+  'feedback',
   'date',
+  'model',
   'message',
   'cost',
   'totalTokens',
   'input',
   'output',
-  'model',
   'cache',
   'duration',
   'status',

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -12,6 +12,7 @@ import {
   type Component,
 } from 'solid-js';
 import ErrorState from '../components/ErrorState.jsx';
+import FeedbackModal from '../components/FeedbackModal.jsx';
 import MessageTable from '../components/MessageTable.jsx';
 import Pagination from '../components/Pagination.jsx';
 import Select from '../components/Select.jsx';
@@ -23,6 +24,8 @@ import {
   getCustomProviders,
   getMessages,
   getRoutingStatus,
+  setMessageFeedback,
+  clearMessageFeedback,
   type CustomProviderData,
 } from '../services/api.js';
 import { createCursorPagination } from '../services/cursor-pagination.js';
@@ -49,6 +52,60 @@ const MessageLog: Component = () => {
   const [setupCompleted] = createSignal(
     !!localStorage.getItem(`setup_completed_${params.agentName}`),
   );
+
+  const [feedbackModalOpen, setFeedbackModalOpen] = createSignal(false);
+  const [feedbackMessageId, setFeedbackMessageId] = createSignal('');
+  const [feedbackOverrides, setFeedbackOverrides] = createSignal<Record<string, string | null>>({});
+
+  const applyFeedbackOverrides = (items: MessageRow[]): MessageRow[] => {
+    const overrides = feedbackOverrides();
+    return items.map((item) =>
+      item.id in overrides ? { ...item, feedback_rating: overrides[item.id] ?? undefined } : item,
+    );
+  };
+
+  const handleFeedbackLike = (id: string) => {
+    setFeedbackOverrides((prev) => ({ ...prev, [id]: 'like' }));
+    setMessageFeedback(id, { rating: 'like' }).catch(() => {
+      setFeedbackOverrides((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    });
+  };
+
+  const handleFeedbackDislike = (id: string) => {
+    setFeedbackOverrides((prev) => ({ ...prev, [id]: 'dislike' }));
+    setFeedbackMessageId(id);
+    setFeedbackModalOpen(true);
+    setMessageFeedback(id, { rating: 'dislike' }).catch(() => {
+      setFeedbackOverrides((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    });
+  };
+
+  const handleFeedbackClear = (id: string) => {
+    setFeedbackOverrides((prev) => ({ ...prev, [id]: null }));
+    clearMessageFeedback(id).catch(() => {
+      setFeedbackOverrides((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    });
+  };
+
+  const handleFeedbackSubmit = (tags: string[], details: string) => {
+    const id = feedbackMessageId();
+    if (id) {
+      setMessageFeedback(id, { rating: 'dislike', tags, details });
+    }
+    setFeedbackModalOpen(false);
+  };
 
   const [customProviders] = createResource(
     () => params.agentName,
@@ -373,11 +430,14 @@ const MessageLog: Component = () => {
               </div>
               <div class="data-table-scroll">
                 <MessageTable
-                  items={data()?.items ?? []}
+                  items={applyFeedbackOverrides(data()?.items ?? [])}
                   columns={DETAILED_COLUMNS}
                   agentName={params.agentName}
                   customProviderName={customProviderName}
                   onFallbackErrorClick={scrollToFallbackSuccess}
+                  onFeedbackLike={handleFeedbackLike}
+                  onFeedbackDislike={handleFeedbackDislike}
+                  onFeedbackClear={handleFeedbackClear}
                   rowIdPrefix="msg-"
                   showHeaderTooltips
                   expandable
@@ -403,6 +463,12 @@ const MessageLog: Component = () => {
         agentPlatform={agentPlatform()}
         agentCategory={agentCategory()}
         onClose={() => setSetupOpen(false)}
+      />
+
+      <FeedbackModal
+        open={feedbackModalOpen()}
+        onClose={() => setFeedbackModalOpen(false)}
+        onSubmit={handleFeedbackSubmit}
       />
     </div>
   );

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -8,6 +8,7 @@ import {
   For,
   on,
   onCleanup,
+  onMount,
   Show,
   type Component,
 } from 'solid-js';
@@ -31,6 +32,7 @@ import {
 import { createCursorPagination } from '../services/cursor-pagination.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { PROVIDERS } from '../services/providers.js';
+import { checkIsLocalMode } from '../services/setup-status.js';
 import { pingCount } from '../services/sse.js';
 import '../styles/overview.css';
 
@@ -45,6 +47,12 @@ const MessageLog: Component = () => {
   const params = useParams<{ agentName: string }>();
   const navigate = useNavigate();
   preloadModelDisplayNames();
+  const [isLocal, setIsLocal] = createSignal(false);
+  onMount(() => {
+    checkIsLocalMode().then(setIsLocal);
+  });
+  const columns = () =>
+    isLocal() ? DETAILED_COLUMNS.filter((c) => c !== 'feedback') : DETAILED_COLUMNS;
   const [providerFilter, setProviderFilter] = createSignal('');
   const [costMin, setCostMin] = createSignal('');
   const [costMax, setCostMax] = createSignal('');
@@ -430,14 +438,16 @@ const MessageLog: Component = () => {
               </div>
               <div class="data-table-scroll">
                 <MessageTable
-                  items={applyFeedbackOverrides(data()?.items ?? [])}
-                  columns={DETAILED_COLUMNS}
+                  items={
+                    isLocal() ? (data()?.items ?? []) : applyFeedbackOverrides(data()?.items ?? [])
+                  }
+                  columns={columns()}
                   agentName={params.agentName}
                   customProviderName={customProviderName}
                   onFallbackErrorClick={scrollToFallbackSuccess}
-                  onFeedbackLike={handleFeedbackLike}
-                  onFeedbackDislike={handleFeedbackDislike}
-                  onFeedbackClear={handleFeedbackClear}
+                  onFeedbackLike={isLocal() ? undefined : handleFeedbackLike}
+                  onFeedbackDislike={isLocal() ? undefined : handleFeedbackDislike}
+                  onFeedbackClear={isLocal() ? undefined : handleFeedbackClear}
                   rowIdPrefix="msg-"
                   showHeaderTooltips
                   expandable
@@ -465,11 +475,13 @@ const MessageLog: Component = () => {
         onClose={() => setSetupOpen(false)}
       />
 
-      <FeedbackModal
-        open={feedbackModalOpen()}
-        onClose={() => setFeedbackModalOpen(false)}
-        onSubmit={handleFeedbackSubmit}
-      />
+      <Show when={!isLocal()}>
+        <FeedbackModal
+          open={feedbackModalOpen()}
+          onClose={() => setFeedbackModalOpen(false)}
+          onSubmit={handleFeedbackSubmit}
+        />
+      </Show>
     </div>
   );
 };

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -11,6 +11,7 @@ import {
 import ChartCard from '../components/ChartCard.jsx';
 import CostByModelTable from '../components/CostByModelTable.jsx';
 import ErrorState from '../components/ErrorState.jsx';
+import FeedbackModal from '../components/FeedbackModal.jsx';
 import MessageTable from '../components/MessageTable.jsx';
 import OverviewSkeleton from '../components/OverviewSkeleton.jsx';
 import Select from '../components/Select.jsx';
@@ -22,7 +23,13 @@ import {
   agentCategory,
   agentPlatformIcon,
 } from '../services/agent-platform-store.js';
-import { getCustomProviders, getOverview, type CustomProviderData } from '../services/api.js';
+import {
+  getCustomProviders,
+  getOverview,
+  setMessageFeedback,
+  clearMessageFeedback,
+  type CustomProviderData,
+} from '../services/api.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { isRecentlyCreated } from '../services/recent-agents.js';
 import { pingCount } from '../services/sse.js';
@@ -102,6 +109,60 @@ const Overview: Component = () => {
     if (!match) return undefined;
     const id = match[1];
     return customProviders()?.find((cp: CustomProviderData) => cp.id === id)?.name;
+  };
+
+  const [feedbackModalOpen, setFeedbackModalOpen] = createSignal(false);
+  const [feedbackMessageId, setFeedbackMessageId] = createSignal('');
+  const [feedbackOverrides, setFeedbackOverrides] = createSignal<Record<string, string | null>>({});
+
+  const applyFeedbackOverrides = (items: MessageRow[]): MessageRow[] => {
+    const overrides = feedbackOverrides();
+    return items.map((item) =>
+      item.id in overrides ? { ...item, feedback_rating: overrides[item.id] ?? undefined } : item,
+    );
+  };
+
+  const handleFeedbackLike = (id: string) => {
+    setFeedbackOverrides((prev) => ({ ...prev, [id]: 'like' }));
+    setMessageFeedback(id, { rating: 'like' }).catch(() => {
+      setFeedbackOverrides((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    });
+  };
+
+  const handleFeedbackDislike = (id: string) => {
+    setFeedbackOverrides((prev) => ({ ...prev, [id]: 'dislike' }));
+    setFeedbackMessageId(id);
+    setFeedbackModalOpen(true);
+    setMessageFeedback(id, { rating: 'dislike' }).catch(() => {
+      setFeedbackOverrides((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    });
+  };
+
+  const handleFeedbackClear = (id: string) => {
+    setFeedbackOverrides((prev) => ({ ...prev, [id]: null }));
+    clearMessageFeedback(id).catch(() => {
+      setFeedbackOverrides((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    });
+  };
+
+  const handleFeedbackSubmit = (tags: string[], details: string) => {
+    const id = feedbackMessageId();
+    if (id) {
+      setMessageFeedback(id, { rating: 'dislike', tags, details });
+    }
+    setFeedbackModalOpen(false);
   };
 
   const [data, { refetch }] = createResource(
@@ -288,10 +349,13 @@ const Overview: Component = () => {
                       </A>
                     </div>
                     <MessageTable
-                      items={d().recent_activity?.slice(0, 5) ?? []}
+                      items={applyFeedbackOverrides(d().recent_activity?.slice(0, 5) ?? [])}
                       columns={COMPACT_COLUMNS}
                       agentName={params.agentName}
                       customProviderName={customProviderName}
+                      onFeedbackLike={handleFeedbackLike}
+                      onFeedbackDislike={handleFeedbackDislike}
+                      onFeedbackClear={handleFeedbackClear}
                     />
                   </div>
 
@@ -325,6 +389,12 @@ const Overview: Component = () => {
             state: { openProviders: true },
           });
         }}
+      />
+
+      <FeedbackModal
+        open={feedbackModalOpen()}
+        onClose={() => setFeedbackModalOpen(false)}
+        onSubmit={handleFeedbackSubmit}
       />
     </div>
   );

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -5,6 +5,7 @@ import {
   createMemo,
   createResource,
   createSignal,
+  onMount,
   Show,
   type Component,
 } from 'solid-js';
@@ -32,6 +33,7 @@ import {
 } from '../services/api.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { isRecentlyCreated } from '../services/recent-agents.js';
+import { checkIsLocalMode } from '../services/setup-status.js';
 import { pingCount } from '../services/sse.js';
 import '../styles/overview.css';
 
@@ -79,6 +81,12 @@ const Overview: Component = () => {
   const location = useLocation<{ newApiKey?: string }>();
   const navigate = useNavigate();
   preloadModelDisplayNames();
+  const [isLocal, setIsLocal] = createSignal(false);
+  onMount(() => {
+    checkIsLocalMode().then(setIsLocal);
+  });
+  const columns = () =>
+    isLocal() ? COMPACT_COLUMNS.filter((c) => c !== 'feedback') : COMPACT_COLUMNS;
   const RANGE_STORAGE_KEY = 'manifest_chart_range';
   const VALID_RANGES = new Set(['24h', '7d', '30d']);
   const savedRange = localStorage.getItem(RANGE_STORAGE_KEY);
@@ -349,13 +357,17 @@ const Overview: Component = () => {
                       </A>
                     </div>
                     <MessageTable
-                      items={applyFeedbackOverrides(d().recent_activity?.slice(0, 5) ?? [])}
-                      columns={COMPACT_COLUMNS}
+                      items={
+                        isLocal()
+                          ? (d().recent_activity?.slice(0, 5) ?? [])
+                          : applyFeedbackOverrides(d().recent_activity?.slice(0, 5) ?? [])
+                      }
+                      columns={columns()}
                       agentName={params.agentName}
                       customProviderName={customProviderName}
-                      onFeedbackLike={handleFeedbackLike}
-                      onFeedbackDislike={handleFeedbackDislike}
-                      onFeedbackClear={handleFeedbackClear}
+                      onFeedbackLike={isLocal() ? undefined : handleFeedbackLike}
+                      onFeedbackDislike={isLocal() ? undefined : handleFeedbackDislike}
+                      onFeedbackClear={isLocal() ? undefined : handleFeedbackClear}
                     />
                   </div>
 
@@ -391,11 +403,13 @@ const Overview: Component = () => {
         }}
       />
 
-      <FeedbackModal
-        open={feedbackModalOpen()}
-        onClose={() => setFeedbackModalOpen(false)}
-        onSubmit={handleFeedbackSubmit}
-      />
+      <Show when={!isLocal()}>
+        <FeedbackModal
+          open={feedbackModalOpen()}
+          onClose={() => setFeedbackModalOpen(false)}
+          onSubmit={handleFeedbackSubmit}
+        />
+      </Show>
     </div>
   );
 };

--- a/packages/frontend/src/services/api/messages.ts
+++ b/packages/frontend/src/services/api/messages.ts
@@ -1,4 +1,4 @@
-import { fetchJson } from './core.js';
+import { fetchJson, fetchMutate, BASE_URL } from './core.js';
 
 export interface MessageDetailLlmCall {
   id: string;
@@ -59,6 +59,9 @@ export interface MessageDetailResponse {
     fallback_from_model: string | null;
     fallback_index: number | null;
     session_key: string | null;
+    feedback_rating: string | null;
+    feedback_tags: string[] | null;
+    feedback_details: string | null;
   };
   llm_calls: MessageDetailLlmCall[];
   tool_executions: MessageDetailToolExecution[];
@@ -82,4 +85,21 @@ export function getMessages(
 
 export function getMessageDetails(id: string) {
   return fetchJson<MessageDetailResponse>(`/messages/${encodeURIComponent(id)}/details`);
+}
+
+export function setMessageFeedback(
+  id: string,
+  body: { rating: 'like' | 'dislike'; tags?: string[]; details?: string },
+) {
+  return fetchMutate<void>(`${BASE_URL}/messages/${encodeURIComponent(id)}/feedback`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+export function clearMessageFeedback(id: string) {
+  return fetchMutate<void>(`${BASE_URL}/messages/${encodeURIComponent(id)}/feedback`, {
+    method: 'DELETE',
+  });
 }

--- a/packages/frontend/src/styles/feedback.css
+++ b/packages/frontend/src/styles/feedback.css
@@ -1,0 +1,117 @@
+/* ── Message Feedback (thumbs up/down) ──────────── */
+
+.feedback-cell {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.feedback-cell td,
+td:has(> .feedback-cell) {
+  padding-left: 4px;
+  padding-right: 0;
+}
+
+.feedback-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius);
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  opacity: 0.5;
+  transition:
+    opacity var(--transition-fast),
+    color var(--transition-fast),
+    background var(--transition-fast);
+}
+
+.feedback-btn:hover {
+  opacity: 1;
+  background: hsl(var(--muted) / 0.5);
+}
+
+.feedback-btn--active {
+  opacity: 1;
+  color: hsl(var(--primary));
+}
+
+.feedback-btn--active:hover {
+  background: hsl(var(--primary) / 0.1);
+}
+
+/* ── Feedback Modal ─────────────────────────────── */
+
+.feedback-modal {
+  max-width: 420px;
+}
+
+.feedback-modal__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.feedback-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border: 1px solid hsl(var(--border));
+  border-radius: 999px;
+  background: transparent;
+  color: hsl(var(--foreground));
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+  user-select: none;
+}
+
+.feedback-tag:hover {
+  background: hsl(var(--muted) / 0.5);
+}
+
+.feedback-tag--selected {
+  background: hsl(var(--foreground));
+  color: hsl(var(--background));
+  border-color: hsl(var(--foreground));
+}
+
+.feedback-tag--selected:hover {
+  background: hsl(var(--foreground) / 0.85);
+}
+
+.feedback-modal__textarea {
+  width: 100%;
+  min-height: 60px;
+  padding: 8px 10px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--card));
+  color: hsl(var(--foreground));
+  font-family: var(--font-sans);
+  font-size: var(--font-size-xs);
+  resize: vertical;
+  margin-bottom: 12px;
+}
+
+.feedback-modal__textarea::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+
+.feedback-modal__textarea:focus {
+  outline: none;
+  border-color: hsl(var(--ring));
+}
+
+.feedback-modal__footer {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/packages/frontend/src/styles/feedback.css
+++ b/packages/frontend/src/styles/feedback.css
@@ -6,10 +6,9 @@
   gap: 0;
 }
 
-.feedback-cell td,
-td:has(> .feedback-cell) {
-  padding-left: 4px;
+.data-table td:has(> .feedback-cell) {
   padding-right: 0;
+  padding-left: 4px;
 }
 
 .feedback-btn {
@@ -36,13 +35,28 @@ td:has(> .feedback-cell) {
   background: hsl(var(--muted) / 0.5);
 }
 
-.feedback-btn--active {
+.feedback-btn--active-like {
   opacity: 1;
-  color: hsl(var(--primary));
+  color: #1bc4bf;
 }
 
-.feedback-btn--active:hover {
-  background: hsl(var(--primary) / 0.1);
+.feedback-btn--active-like:hover {
+  background: rgb(27 196 191 / 0.1);
+}
+
+.feedback-btn--active-dislike {
+  opacity: 1;
+  color: hsl(var(--foreground));
+}
+
+.feedback-btn--active-dislike:hover {
+  background: hsl(var(--muted) / 0.5);
+}
+
+/* When a sibling is active, fade the inactive thumb further */
+.feedback-cell:has(.feedback-btn--active-like) .feedback-btn:not(.feedback-btn--active-like),
+.feedback-cell:has(.feedback-btn--active-dislike) .feedback-btn:not(.feedback-btn--active-dislike) {
+  opacity: 0.2;
 }
 
 /* ── Feedback Modal ─────────────────────────────── */

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -20,6 +20,7 @@
 @import './skeleton.css';
 @import './syntax-highlight.css';
 @import './agent-type-select.css';
+@import './feedback.css';
 
 /* ── shadcn/ui design tokens — Light (default) ───── */
 @layer base {

--- a/packages/frontend/tests/components/FeedbackModal.test.tsx
+++ b/packages/frontend/tests/components/FeedbackModal.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import FeedbackModal, { FEEDBACK_TAGS } from '../../src/components/FeedbackModal';
+
+describe('FeedbackModal', () => {
+  it('does not render when closed', () => {
+    const { container } = render(() => (
+      <FeedbackModal open={false} onClose={vi.fn()} onSubmit={vi.fn()} />
+    ));
+    expect(container.querySelector('.modal-backdrop')).toBeNull();
+  });
+
+  it('renders when open', () => {
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+    ));
+    expect(container.querySelector('.modal-backdrop')).not.toBeNull();
+    expect(container.querySelector('.modal')).not.toBeNull();
+  });
+
+  it('renders all feedback tags', () => {
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+    ));
+    const tags = container.querySelectorAll('.feedback-tag');
+    expect(tags.length).toBe(FEEDBACK_TAGS.length);
+    for (let i = 0; i < FEEDBACK_TAGS.length; i++) {
+      expect(tags[i]!.textContent).toBe(FEEDBACK_TAGS[i]);
+    }
+  });
+
+  it('toggles tag selection on click', () => {
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+    ));
+    const tag = container.querySelector('.feedback-tag') as HTMLElement;
+    expect(tag.classList.contains('feedback-tag--selected')).toBe(false);
+    fireEvent.click(tag);
+    expect(tag.classList.contains('feedback-tag--selected')).toBe(true);
+    fireEvent.click(tag);
+    expect(tag.classList.contains('feedback-tag--selected')).toBe(false);
+  });
+
+  it('calls onSubmit with selected tags and details', () => {
+    const onSubmit = vi.fn();
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+    ));
+    const tags = container.querySelectorAll('.feedback-tag');
+    fireEvent.click(tags[0]!);
+    fireEvent.click(tags[2]!);
+
+    const textarea = container.querySelector('.feedback-modal__textarea') as HTMLTextAreaElement;
+    fireEvent.input(textarea, { target: { value: 'test details' } });
+
+    const submitBtn = container.querySelector('.btn--primary') as HTMLElement;
+    fireEvent.click(submitBtn);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      [FEEDBACK_TAGS[0], FEEDBACK_TAGS[2]],
+      'test details',
+    );
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn();
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={onClose} onSubmit={vi.fn()} />
+    ));
+    const closeBtn = container.querySelector('.modal__close') as HTMLElement;
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when clicking backdrop', () => {
+    const onClose = vi.fn();
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={onClose} onSubmit={vi.fn()} />
+    ));
+    const backdrop = container.querySelector('.modal-backdrop') as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not call onClose when clicking modal content', () => {
+    const onClose = vi.fn();
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={onClose} onSubmit={vi.fn()} />
+    ));
+    const modal = container.querySelector('.modal') as HTMLElement;
+    fireEvent.click(modal);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose on Escape key', () => {
+    const onClose = vi.fn();
+    render(() => <FeedbackModal open={true} onClose={onClose} onSubmit={vi.fn()} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('resets state after submit', () => {
+    const onSubmit = vi.fn();
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={vi.fn()} onSubmit={onSubmit} />
+    ));
+    const tag = container.querySelector('.feedback-tag') as HTMLElement;
+    fireEvent.click(tag);
+    expect(tag.classList.contains('feedback-tag--selected')).toBe(true);
+
+    const submitBtn = container.querySelector('.btn--primary') as HTMLElement;
+    fireEvent.click(submitBtn);
+
+    // After submit, tags should be deselected
+    expect(tag.classList.contains('feedback-tag--selected')).toBe(false);
+  });
+
+  it('renders textarea with placeholder', () => {
+    const { container } = render(() => (
+      <FeedbackModal open={true} onClose={vi.fn()} onSubmit={vi.fn()} />
+    ));
+    const textarea = container.querySelector('.feedback-modal__textarea') as HTMLTextAreaElement;
+    expect(textarea).not.toBeNull();
+    expect(textarea.placeholder).toBe('Share details (optional)');
+  });
+});

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -116,13 +116,14 @@ describe('MessageTable', () => {
         />
       ));
       const headers = container.querySelectorAll('th');
-      expect(headers.length).toBe(6);
-      expect(headers[0]!.textContent).toContain('Date');
-      expect(headers[1]!.textContent).toContain('Message');
-      expect(headers[2]!.textContent).toContain('Cost');
-      expect(headers[3]!.textContent).toContain('Model');
-      expect(headers[4]!.textContent).toContain('Tokens');
-      expect(headers[5]!.textContent).toContain('Status');
+      expect(headers.length).toBe(7);
+      expect(headers[0]!.textContent).toBe('');
+      expect(headers[1]!.textContent).toContain('Date');
+      expect(headers[2]!.textContent).toContain('Model');
+      expect(headers[3]!.textContent).toContain('Message');
+      expect(headers[4]!.textContent).toContain('Cost');
+      expect(headers[5]!.textContent).toContain('Tokens');
+      expect(headers[6]!.textContent).toContain('Status');
     });
 
     it('renders detailed column headers with tooltips', () => {
@@ -136,11 +137,15 @@ describe('MessageTable', () => {
         />
       ));
       const headers = container.querySelectorAll('th');
-      expect(headers.length).toBe(10);
-      expect(headers[0]!.textContent).toContain('Date');
-      expect(headers[3]!.textContent).toContain('Total Tokens');
-      expect(headers[7]!.textContent).toContain('Cache');
-      expect(headers[8]!.textContent).toContain('Duration');
+      expect(headers.length).toBe(11);
+      expect(headers[0]!.textContent).toBe('');
+      expect(headers[1]!.textContent).toContain('Date');
+      expect(headers[2]!.textContent).toContain('Model');
+      expect(headers[3]!.textContent).toContain('Message');
+      expect(headers[5]!.textContent).toContain('Total Tokens');
+      expect(headers[8]!.textContent).toContain('Cache');
+      expect(headers[9]!.textContent).toContain('Duration');
+      expect(headers[10]!.textContent).toContain('Status');
       // Tooltips should be present for token columns
       const tooltips = container.querySelectorAll('[data-testid="info-tooltip"]');
       expect(tooltips.length).toBeGreaterThanOrEqual(3);
@@ -155,7 +160,7 @@ describe('MessageTable', () => {
           customProviderName={noopProvider}
         />
       ));
-      const tokensHeader = container.querySelectorAll('th')[4]!;
+      const tokensHeader = container.querySelectorAll('th')[5]!; // 'totalTokens' is at index 5 in COMPACT_COLUMNS
       expect(tokensHeader.textContent).toBe('Tokens');
       expect(tokensHeader.querySelector('[data-testid="info-tooltip"]')).toBeNull();
     });

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -785,4 +785,135 @@ describe('MessageTable', () => {
       expect(headers[4]!.textContent).toContain('Status');
     });
   });
+
+  describe('feedback column', () => {
+    it('renders feedback buttons', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow()]}
+          columns={['feedback']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          onFeedbackLike={vi.fn()}
+          onFeedbackDislike={vi.fn()}
+          onFeedbackClear={vi.fn()}
+        />
+      ));
+      const buttons = container.querySelectorAll('.feedback-btn');
+      expect(buttons.length).toBe(2);
+    });
+
+    it('calls onFeedbackLike when thumb up is clicked', () => {
+      const handler = vi.fn();
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ id: 'msg-like-test' })]}
+          columns={['feedback']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          onFeedbackLike={handler}
+          onFeedbackDislike={vi.fn()}
+          onFeedbackClear={vi.fn()}
+        />
+      ));
+      const likeBtn = container.querySelectorAll('.feedback-btn')[0] as HTMLElement;
+      fireEvent.click(likeBtn);
+      expect(handler).toHaveBeenCalledWith('msg-like-test');
+    });
+
+    it('calls onFeedbackDislike when thumb down is clicked', () => {
+      const handler = vi.fn();
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ id: 'msg-dislike-test' })]}
+          columns={['feedback']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          onFeedbackLike={vi.fn()}
+          onFeedbackDislike={handler}
+          onFeedbackClear={vi.fn()}
+        />
+      ));
+      const dislikeBtn = container.querySelectorAll('.feedback-btn')[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      expect(handler).toHaveBeenCalledWith('msg-dislike-test');
+    });
+
+    it('calls onFeedbackClear when active like is clicked again', () => {
+      const handler = vi.fn();
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ id: 'msg-clear-test', feedback_rating: 'like' })]}
+          columns={['feedback']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          onFeedbackLike={vi.fn()}
+          onFeedbackDislike={vi.fn()}
+          onFeedbackClear={handler}
+        />
+      ));
+      const likeBtn = container.querySelector('.feedback-btn--active-like') as HTMLElement;
+      expect(likeBtn).not.toBeNull();
+      fireEvent.click(likeBtn);
+      expect(handler).toHaveBeenCalledWith('msg-clear-test');
+    });
+
+    it('calls onFeedbackClear when active dislike is clicked again', () => {
+      const handler = vi.fn();
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ id: 'msg-clear-test', feedback_rating: 'dislike' })]}
+          columns={['feedback']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+          onFeedbackLike={vi.fn()}
+          onFeedbackDislike={vi.fn()}
+          onFeedbackClear={handler}
+        />
+      ));
+      const dislikeBtn = container.querySelector('.feedback-btn--active-dislike') as HTMLElement;
+      expect(dislikeBtn).not.toBeNull();
+      fireEvent.click(dislikeBtn);
+      expect(handler).toHaveBeenCalledWith('msg-clear-test');
+    });
+
+    it('shows active-like class when feedback_rating is like', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ feedback_rating: 'like' })]}
+          columns={['feedback']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.querySelector('.feedback-btn--active-like')).not.toBeNull();
+      expect(container.querySelector('.feedback-btn--active-dislike')).toBeNull();
+    });
+
+    it('shows active-dislike class when feedback_rating is dislike', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ feedback_rating: 'dislike' })]}
+          columns={['feedback']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.querySelector('.feedback-btn--active-dislike')).not.toBeNull();
+      expect(container.querySelector('.feedback-btn--active-like')).toBeNull();
+    });
+
+    it('shows no active class when no feedback', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow()]}
+          columns={['feedback']}
+          agentName="agent-1"
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.querySelector('.feedback-btn--active-like')).toBeNull();
+      expect(container.querySelector('.feedback-btn--active-dislike')).toBeNull();
+    });
+  });
 });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -48,6 +48,11 @@ vi.mock("../../src/services/formatters.js", () => ({
   customProviderColor: vi.fn(() => '#6366f1'),
 }));
 
+const mockCheckIsLocalMode = vi.fn(() => Promise.resolve(false));
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkIsLocalMode: () => mockCheckIsLocalMode(),
+}));
+
 vi.mock("../../src/components/SetupModal.jsx", () => ({
   default: (props: any) => (
     <div data-testid="setup-modal" data-open={props.open ? "true" : "false"} data-agent={props.agentName ?? ""}>
@@ -943,6 +948,18 @@ describe("MessageLog", () => {
       fireEvent.click(closeBtn);
       const modal = container.querySelector('[data-testid="feedback-modal"]');
       expect(modal?.getAttribute("data-open")).toBe("false");
+    });
+
+    it("hides feedback column and modal in local mode", async () => {
+      mockCheckIsLocalMode.mockResolvedValue(true);
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".data-table")).not.toBeNull();
+      });
+      expect(container.querySelector(".feedback-btn")).toBeNull();
+      expect(container.querySelector('[data-testid="feedback-modal"]')).toBeNull();
+      mockCheckIsLocalMode.mockResolvedValue(false);
     });
   });
 });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -961,5 +961,51 @@ describe("MessageLog", () => {
       expect(container.querySelector('[data-testid="feedback-modal"]')).toBeNull();
       mockCheckIsLocalMode.mockResolvedValue(false);
     });
+
+    it("reverts optimistic like on API error", async () => {
+      mockSetMessageFeedback.mockRejectedValue(new Error("fail"));
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const likeBtn = container.querySelector(".feedback-btn") as HTMLElement;
+      fireEvent.click(likeBtn);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-like")).toBeNull();
+      });
+    });
+
+    it("reverts optimistic dislike on API error", async () => {
+      mockSetMessageFeedback.mockRejectedValue(new Error("fail"));
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-dislike")).toBeNull();
+      });
+    });
+
+    it("reverts optimistic clear on API error", async () => {
+      mockClearMessageFeedback.mockRejectedValue(new Error("fail"));
+      const dataWithFeedback = {
+        ...messagesData,
+        items: [{ ...messagesData.items[0], feedback_rating: "like" }, messagesData.items[1]],
+      };
+      mockGetMessages.mockResolvedValue(dataWithFeedback);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+      });
+      const likeBtn = container.querySelector(".feedback-btn--active-like") as HTMLElement;
+      fireEvent.click(likeBtn);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+      });
+    });
   });
 });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -18,11 +18,15 @@ const mockGetMessages = vi.fn();
 const mockGetCustomProviders = vi.fn();
 const mockGetMessageDetails = vi.fn();
 const mockGetRoutingStatus = vi.fn();
+const mockSetMessageFeedback = vi.fn();
+const mockClearMessageFeedback = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getMessages: (...args: unknown[]) => mockGetMessages(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
   getMessageDetails: (...args: unknown[]) => mockGetMessageDetails(...args),
   getRoutingStatus: (...args: unknown[]) => mockGetRoutingStatus(...args),
+  setMessageFeedback: (...args: unknown[]) => mockSetMessageFeedback(...args),
+  clearMessageFeedback: (...args: unknown[]) => mockClearMessageFeedback(...args),
 }));
 
 vi.mock("../../src/services/sse.js", () => ({
@@ -48,6 +52,15 @@ vi.mock("../../src/components/SetupModal.jsx", () => ({
   default: (props: any) => (
     <div data-testid="setup-modal" data-open={props.open ? "true" : "false"} data-agent={props.agentName ?? ""}>
       <button data-testid="setup-close" onClick={() => props.onClose?.()}>Close</button>
+    </div>
+  ),
+}));
+
+vi.mock("../../src/components/FeedbackModal.jsx", () => ({
+  default: (props: any) => (
+    <div data-testid="feedback-modal" data-open={props.open ? "true" : "false"}>
+      <button data-testid="feedback-submit" onClick={() => props.onSubmit?.(['Too slow'], 'test')}>Submit</button>
+      <button data-testid="feedback-close" onClick={() => props.onClose?.()}>Close</button>
     </div>
   ),
 }));
@@ -856,5 +869,80 @@ describe("MessageLog", () => {
     const badge = container.querySelector(".status-badge--fallback_error")!;
     fireEvent.click(badge);
     expect(scrollSpy).toHaveBeenCalled();
+  });
+
+  describe("feedback", () => {
+    it("calls setMessageFeedback with like when thumb up is clicked", async () => {
+      mockSetMessageFeedback.mockResolvedValue(undefined);
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const likeBtn = container.querySelector(".feedback-btn") as HTMLElement;
+      fireEvent.click(likeBtn);
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "like" });
+    });
+
+    it("calls setMessageFeedback with dislike and opens modal when thumb down is clicked", async () => {
+      mockSetMessageFeedback.mockResolvedValue(undefined);
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike" });
+      const modal = container.querySelector('[data-testid="feedback-modal"]');
+      expect(modal?.getAttribute("data-open")).toBe("true");
+    });
+
+    it("calls clearMessageFeedback when active like is clicked", async () => {
+      mockClearMessageFeedback.mockResolvedValue(undefined);
+      const dataWithFeedback = {
+        ...messagesData,
+        items: [{ ...messagesData.items[0], feedback_rating: "like" }, messagesData.items[1]],
+      };
+      mockGetMessages.mockResolvedValue(dataWithFeedback);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+      });
+      const likeBtn = container.querySelector(".feedback-btn--active-like") as HTMLElement;
+      fireEvent.click(likeBtn);
+      expect(mockClearMessageFeedback).toHaveBeenCalledWith("msg-12345678");
+    });
+
+    it("submits feedback details from modal", async () => {
+      mockSetMessageFeedback.mockResolvedValue(undefined);
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      // Click dislike to open modal
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      // Submit via modal
+      const submitBtn = container.querySelector('[data-testid="feedback-submit"]') as HTMLElement;
+      fireEvent.click(submitBtn);
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike", tags: ["Too slow"], details: "test" });
+    });
+
+    it("closes feedback modal without submitting", async () => {
+      mockSetMessageFeedback.mockResolvedValue(undefined);
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      const closeBtn = container.querySelector('[data-testid="feedback-close"]') as HTMLElement;
+      fireEvent.click(closeBtn);
+      const modal = container.querySelector('[data-testid="feedback-modal"]');
+      expect(modal?.getAttribute("data-open")).toBe("false");
+    });
   });
 });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -880,5 +880,51 @@ describe("Overview", () => {
       expect(container.querySelector('[data-testid="feedback-modal"]')).toBeNull();
       mockCheckIsLocalMode.mockResolvedValue(false);
     });
+
+    it("reverts optimistic like on API error", async () => {
+      mockSetMessageFeedback.mockRejectedValue(new Error("fail"));
+      mockGetOverview.mockResolvedValue(overviewData);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const likeBtn = container.querySelector(".feedback-btn") as HTMLElement;
+      fireEvent.click(likeBtn);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-like")).toBeNull();
+      });
+    });
+
+    it("reverts optimistic dislike on API error", async () => {
+      mockSetMessageFeedback.mockRejectedValue(new Error("fail"));
+      mockGetOverview.mockResolvedValue(overviewData);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-dislike")).toBeNull();
+      });
+    });
+
+    it("reverts optimistic clear on API error", async () => {
+      mockClearMessageFeedback.mockRejectedValue(new Error("fail"));
+      const dataWithFeedback = {
+        ...overviewData,
+        recent_activity: [{ ...overviewData.recent_activity[0], feedback_rating: "like" }],
+      };
+      mockGetOverview.mockResolvedValue(dataWithFeedback);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+      });
+      const likeBtn = container.querySelector(".feedback-btn--active-like") as HTMLElement;
+      fireEvent.click(likeBtn);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+      });
+    });
   });
 });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -18,9 +18,13 @@ vi.mock("@solidjs/meta", () => ({
 
 const mockGetOverview = vi.fn();
 const mockGetCustomProviders = vi.fn();
+const mockSetMessageFeedback = vi.fn();
+const mockClearMessageFeedback = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getOverview: (...args: unknown[]) => mockGetOverview(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
+  setMessageFeedback: (...args: unknown[]) => mockSetMessageFeedback(...args),
+  clearMessageFeedback: (...args: unknown[]) => mockClearMessageFeedback(...args),
 }));
 
 vi.mock("../../src/services/sse.js", () => ({
@@ -51,6 +55,15 @@ vi.mock("../../src/components/TokenChart.jsx", () => ({
 
 vi.mock("../../src/components/SingleTokenChart.jsx", () => ({
   default: () => <div data-testid="single-token-chart" />,
+}));
+
+vi.mock("../../src/components/FeedbackModal.jsx", () => ({
+  default: (props: any) => (
+    <div data-testid="feedback-modal" data-open={props.open ? "true" : "false"}>
+      <button data-testid="feedback-submit" onClick={() => props.onSubmit?.(['Too slow'], 'test')}>Submit</button>
+      <button data-testid="feedback-close" onClick={() => props.onClose?.()}>Close</button>
+    </div>
+  ),
 }));
 
 vi.mock("../../src/components/SetupModal.jsx", () => ({
@@ -791,6 +804,64 @@ describe("Overview", () => {
       const badge = container.querySelector(".status-badge--fallback_error");
       expect(badge).not.toBeNull();
       expect(badge!.textContent).toBe("fallback_error");
+    });
+  });
+
+  describe("feedback", () => {
+    it("calls setMessageFeedback with like when thumb up is clicked", async () => {
+      mockSetMessageFeedback.mockResolvedValue(undefined);
+      mockGetOverview.mockResolvedValue(overviewData);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const likeBtn = container.querySelector(".feedback-btn") as HTMLElement;
+      fireEvent.click(likeBtn);
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "like" });
+    });
+
+    it("calls setMessageFeedback with dislike and opens modal", async () => {
+      mockSetMessageFeedback.mockResolvedValue(undefined);
+      mockGetOverview.mockResolvedValue(overviewData);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike" });
+      const modal = container.querySelector('[data-testid="feedback-modal"]');
+      expect(modal?.getAttribute("data-open")).toBe("true");
+    });
+
+    it("calls clearMessageFeedback when active like is clicked", async () => {
+      mockClearMessageFeedback.mockResolvedValue(undefined);
+      const dataWithFeedback = {
+        ...overviewData,
+        recent_activity: [{ ...overviewData.recent_activity[0], feedback_rating: "like" }],
+      };
+      mockGetOverview.mockResolvedValue(dataWithFeedback);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn--active-like")).not.toBeNull();
+      });
+      const likeBtn = container.querySelector(".feedback-btn--active-like") as HTMLElement;
+      fireEvent.click(likeBtn);
+      expect(mockClearMessageFeedback).toHaveBeenCalledWith("msg-12345678");
+    });
+
+    it("submits feedback details from modal", async () => {
+      mockSetMessageFeedback.mockResolvedValue(undefined);
+      mockGetOverview.mockResolvedValue(overviewData);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".feedback-btn")).not.toBeNull();
+      });
+      const dislikeBtn = container.querySelectorAll(".feedback-btn")[1] as HTMLElement;
+      fireEvent.click(dislikeBtn);
+      const submitBtn = container.querySelector('[data-testid="feedback-submit"]') as HTMLElement;
+      fireEvent.click(submitBtn);
+      expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike", tags: ["Too slow"], details: "test" });
     });
   });
 });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -45,6 +45,11 @@ vi.mock("../../src/services/formatters.js", () => ({
   customProviderColor: vi.fn(() => '#6366f1'),
 }));
 
+const mockCheckIsLocalMode = vi.fn(() => Promise.resolve(false));
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkIsLocalMode: () => mockCheckIsLocalMode(),
+}));
+
 vi.mock("../../src/components/CostChart.jsx", () => ({
   default: () => <div data-testid="cost-chart" />,
 }));
@@ -862,6 +867,18 @@ describe("Overview", () => {
       const submitBtn = container.querySelector('[data-testid="feedback-submit"]') as HTMLElement;
       fireEvent.click(submitBtn);
       expect(mockSetMessageFeedback).toHaveBeenCalledWith("msg-12345678", { rating: "dislike", tags: ["Too slow"], details: "test" });
+    });
+
+    it("hides feedback column and modal in local mode", async () => {
+      mockCheckIsLocalMode.mockResolvedValue(true);
+      mockGetOverview.mockResolvedValue(overviewData);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        expect(container.querySelector(".data-table")).not.toBeNull();
+      });
+      expect(container.querySelector(".feedback-btn")).toBeNull();
+      expect(container.querySelector('[data-testid="feedback-modal"]')).toBeNull();
+      mockCheckIsLocalMode.mockResolvedValue(false);
     });
   });
 });

--- a/packages/frontend/tests/services/api.test.ts
+++ b/packages/frontend/tests/services/api.test.ts
@@ -46,6 +46,9 @@ import {
   clearFallbacks,
   getPricingHealth,
   refreshPricing,
+  setMessageFeedback,
+  clearMessageFeedback,
+  getMessageDetails,
 } from '../../src/services/api.js';
 
 vi.mock('../../src/services/toast-store.js', () => ({
@@ -1294,6 +1297,79 @@ describe('copilotPollToken', () => {
   it('throws on non-ok response without showing toast', async () => {
     mockFetch.mockResolvedValueOnce({ ok: false, status: 503 });
     await expect(copilotPollToken('agent', 'dc_x')).rejects.toThrow('Poll failed: 503');
+  });
+});
+
+describe('getMessageDetails', () => {
+  it('fetches /messages/:id/details', async () => {
+    const detail = { message: { id: 'abc' }, llm_calls: [], tool_executions: [], agent_logs: [] };
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(detail) });
+    const result = await getMessageDetails('abc');
+    expect(result).toEqual(detail);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/messages/abc/details'),
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+
+  it('encodes special characters in id', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+    await getMessageDetails('a/b');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/messages/a%2Fb/details'),
+      expect.any(Object),
+    );
+  });
+});
+
+describe('setMessageFeedback', () => {
+  it('PATCHes /messages/:id/feedback with body', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') });
+    await setMessageFeedback('msg-1', { rating: 'like' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/messages/msg-1/feedback'),
+      expect.objectContaining({
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ rating: 'like' }),
+      }),
+    );
+  });
+
+  it('sends tags and details when provided', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') });
+    await setMessageFeedback('msg-1', { rating: 'dislike', tags: ['Buggy'], details: 'broken' });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ rating: 'dislike', tags: ['Buggy'], details: 'broken' });
+  });
+
+  it('throws and shows toast on error', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ message: 'Bad request' }),
+    });
+    await expect(setMessageFeedback('msg-1', { rating: 'like' })).rejects.toThrow('Bad request');
+  });
+});
+
+describe('clearMessageFeedback', () => {
+  it('DELETEs /messages/:id/feedback', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') });
+    await clearMessageFeedback('msg-1');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/messages/msg-1/feedback'),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('encodes special characters in id', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('') });
+    await clearMessageFeedback('a/b');
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/messages/a%2Fb/feedback'),
+      expect.any(Object),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Add per-message feedback system (thumbs up/down) to rate routing quality
- New "Feedback" column as the first column in both Messages and Overview tables
- Thumbs down opens a compact modal with tags (Not expected tier, Poor answer quality, Too slow, Buggy, Other) and optional text details
- Feedback stored directly on `agent_messages` table via new migration (`feedback_rating`, `feedback_tags`, `feedback_details`)
- New API endpoints: `PATCH /api/v1/messages/:id/feedback` and `DELETE /api/v1/messages/:id/feedback`
- Optimistic UI updates with rollback on API error

## Test plan

- [x] Backend unit tests: 185 suites, 3612 tests pass
- [x] Frontend tests: 105 suites, 2126 tests pass
- [x] E2E tests: 15 suites, 115 tests pass (14 new feedback tests)
- [x] Shared tests: 5 suites, 67 tests pass
- [ ] Manual QA: open Messages page, click thumbs up (toggles on/off), click thumbs down (opens modal), select tags, submit, verify in DB
- [ ] Verify Overview page feedback column works identically

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-message thumbs up/down feedback to Messages and Overview so users can rate routing quality. Feedback UI is hidden in local mode to avoid misleading ratings.

- **New Features**
  - Adds a first “Feedback” column to Messages and Overview; thumbs down opens a compact modal with tags (Not expected tier, Poor answer quality, Too slow, Buggy, Other) and optional details.
  - APIs: `PATCH /api/v1/messages/:id/feedback` to set rating/tags/details and `DELETE /api/v1/messages/:id/feedback` to clear (204 responses). Request validation enforces rating (`like`/`dislike`), array tags, and details ≤ 2000 chars.
  - Responses: message list rows include `feedback_rating`; message details include `feedback_rating`, `feedback_tags`, `feedback_details`.
  - UI updates optimistically with rollback on error; local mode hides the feedback column, handlers, and modal.

- **Migration**
  - Run `1775600000000-AddMessageFeedback` to add `feedback_rating`, `feedback_tags`, and `feedback_details` to `agent_messages` (nullable; no breaking changes).

<sup>Written for commit e405b917c61a2c64f6ad7c81986efd5dc0db0bf4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

