### PR TITLE
fix(routing): filter internal Azure routing models from GitHub Copilot

### DIFF
--- a/.changeset/filter-copilot-routers.md
+++ b/.changeset/filter-copilot-routers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Filter internal Azure routing models from GitHub Copilot provider

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -523,6 +523,25 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].contextWindow).toBe(128000);
     });
 
+    it('should filter out non-chat models from cached results', async () => {
+      const providers = [
+        makeProvider({
+          provider: 'copilot',
+          cached_models: [
+            makeModel({ id: 'copilot/claude-opus-4.7', provider: 'copilot' }),
+            makeModel({ id: 'copilot/accounts/msft/routers/f185i3v4', provider: 'copilot' }),
+            makeModel({ id: 'copilot/accounts/msft/routers/fmfeto88', provider: 'copilot' }),
+          ],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('agent-1');
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('copilot/claude-opus-4.7');
+    });
+
     it('should deduplicate custom provider models by composite key', async () => {
       providerRepo.find.mockResolvedValue([]);
       customProviderRepo.find.mockResolvedValue([

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserProvider } from '../entities/user-provider.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
-import { ProviderModelFetcherService } from './provider-model-fetcher.service';
+import { ProviderModelFetcherService, filterNonChatModels } from './provider-model-fetcher.service';
 import { ProviderModelRegistryService } from './provider-model-registry.service';
 import { DiscoveredModel } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
@@ -208,8 +208,9 @@ export class ModelDiscoveryService {
 
     for (const p of providers) {
       if (p.provider.startsWith('custom:')) continue;
-      const cached = p.cached_models;
-      if (!Array.isArray(cached)) continue;
+      const rawCached = p.cached_models;
+      if (!Array.isArray(rawCached)) continue;
+      const cached = filterNonChatModels(rawCached, p.provider.toLowerCase());
       const providerAuthType = p.auth_type === 'subscription' ? 'subscription' : 'api_key';
       for (const m of cached) {
         const effectiveAuthType = m.authType ?? providerAuthType;

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1347,6 +1347,26 @@ describe('ProviderModelFetcherService', () => {
       const result = await service.fetch('copilot', 'tid=token');
       expect(result).toEqual([]);
     });
+
+    it('should filter out internal Azure routing models', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            { id: 'claude-opus-4.7' },
+            { id: 'gpt-4o' },
+            { id: 'accounts/msft/routers/f185i3v4' },
+            { id: 'accounts/msft/routers/fmfeto88' },
+            { id: 'accounts/msft/routers/gdjv4v2v' },
+          ],
+        }),
+      });
+
+      const result = await service.fetch('copilot', 'tid=token');
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('copilot/claude-opus-4.7');
+      expect(result[1].id).toBe('copilot/gpt-4o');
+    });
   });
 
   /* ── OpenAI subscription routing ── */

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -116,6 +116,7 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
   mistral:
     /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime)|^labs-|^mistral-vibe-cli)/i,
   xai: /(?:imagine|multi-agent)/i,
+  copilot: /accounts\/[^/]+\/routers\//i,
 };
 
 /**


### PR DESCRIPTION
## Summary

- The Copilot API (`api.githubcopilot.com/models`) returns internal Azure routing entries (`accounts/msft/routers/*`) that are infrastructure-level load balancing endpoints, not user-facing chat models
- Added `copilot` entry to `PROVIDER_NON_CHAT` regex filter to exclude these at fetch time
- Applied `filterNonChatModels()` at cache-read time in `getModelsForAgent()` so previously-cached routing entries are also filtered out

## Test plan

- [x] Added unit test for filtering at fetch time (`provider-model-fetcher.service.spec.ts`)
- [x] Added unit test for filtering at cache-read time (`model-discovery.service.spec.ts`)
- [ ] Connect GitHub Copilot as a provider and verify `accounts/msft/routers/*` models no longer appear in the model selection modal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters internal Azure routing models from GitHub Copilot so only real chat models appear. Filtering runs on fetch and on cache reads to remove `accounts/msft/routers/*` entries.

- **Bug Fixes**
  - Added `copilot` to `PROVIDER_NON_CHAT` to exclude router IDs.
  - Applied `filterNonChatModels()` to cached results in `getModelsForAgent()`.
  - Added unit tests for both fetch-time and cache-time filtering.

<sup>Written for commit e63813848ce94271905424a3742edc5fca0a6117. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

