### PR TITLE
ci: restore GitHub releases on version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,40 @@ jobs:
             echo "No version change (PREV=${PREV:-<none>} CURR=${CURR:-<none>})"
           fi
 
+  github-release:
+    needs: release
+    if: needs.release.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(jq -r .version packages/manifest/package.json)
+          TAG="manifest@${VERSION}"
+
+          # Extract changelog section for this version
+          BODY=$(awk -v ver="## ${VERSION}" \
+            '$0 == ver { found=1; next } found && /^## / { exit } found { print }' \
+            packages/manifest/CHANGELOG.md)
+
+          # Add emoji headers
+          BODY=$(echo "$BODY" | sed \
+            -e 's/^### Major Changes$/### 💥 Major Changes/' \
+            -e 's/^### Minor Changes$/### ✨ Minor Changes/' \
+            -e 's/^### Patch Changes$/### 🐛 Patch Changes/')
+
+          git tag "$TAG" 2>/dev/null || true
+          git push origin "$TAG" 2>/dev/null || true
+
+          gh release create "$TAG" \
+            --title "manifest v${VERSION}" \
+            --notes "${BODY:-No changelog}" \
+            --verify-tag
+
   publish-docker:
     needs: release
     if: needs.release.outputs.should_publish == 'true'


### PR DESCRIPTION
## Summary

- Restore the `github-release` job in `release.yml` that was accidentally removed in 0636c3e1 when the OpenClaw plugin packages were deleted
- On version bump (when a "Version Packages" PR merges), creates a git tag `manifest@{version}` and a GitHub release with the changelog extracted from `packages/manifest/CHANGELOG.md`
- Runs in parallel with `publish-docker` — no impact on Docker build times

No releases were created for versions 5.46.0 through 5.46.7. These can be backfilled manually after merge.

## Test plan

- [ ] Merge a "Version Packages" PR after this lands
- [ ] Verify a new GitHub release appears at https://github.com/mnfst/manifest/releases
- [ ] Verify the release body contains the changelog with emoji headers
- [ ] Verify Docker build still triggers in parallel

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the `github-release` job in `release.yml` so version bumps create a `manifest@{version}` tag and a GitHub release from `packages/manifest/CHANGELOG.md`. Runs in parallel with Docker publishing with no build time impact.

- **Migration**
  - Backfill missing releases for v5.46.0–v5.46.7 after merge.

<sup>Written for commit b2077d5855bececf7dd72ab7713af26ee8557460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

