### PR TITLE
fix(routing): prevent long model names from overflowing tier cards

### DIFF
--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -139,6 +139,7 @@
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   min-height: 0;
+  overflow: hidden;
 }
 
 .dark .routing-card {
@@ -261,6 +262,7 @@
 .routing-card__model-chip {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   background: #f7f5ed;
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
@@ -275,6 +277,7 @@
 .routing-card__chip-main {
   display: flex;
   align-items: center;
+  min-width: 0;
   gap: 6px;
   padding: 6px 8px;
 }
@@ -393,7 +396,7 @@
 
 .routing-card__override {
   display: inline-flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
   flex: 1;
   min-width: 0;


### PR DESCRIPTION
## Summary

- Long model names (e.g. `custom:869cda85-2957-4209-bace-263bbfb61f0b/MiniMax-M2.7`) were pushing tier cards beyond their grid column, breaking the 4-column layout
- Add `min-width: 0` on `.routing-card__model-chip` and `.routing-card__chip-main` so the existing `text-overflow: ellipsis` actually kicks in
- Add `overflow: hidden` on `.routing-card` as a safety net
- Fix provider icon vertical alignment in the model chip (`flex-start` → `center`)

## Test plan

- [x] Frontend tests pass (2178/2178)
- [ ] Verify long model names show ellipsis instead of overflowing
- [ ] Verify all 4 tier cards remain equal width
- [ ] Verify provider icons are vertically centered with model name text

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tier cards overflowing their grid when model names are long by enabling proper ellipsis and clamping overflow. Also centers the provider icon in the model chip.

- **Bug Fixes**
  - Add min-width: 0 to model chip containers so ellipsis applies.
  - Add overflow: hidden to the card to prevent layout spill.
  - Center provider icon by switching align-items to center.

<sup>Written for commit a1ebb2b787bf97d94d041cd597d2aee6e8e22102. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

