### PR TITLE
Update audience description for Manifest vs OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ All routing data (tokens, costs, model, duration) is recorded automatically. You
 
 |              | Manifest                                     | OpenRouter                                          |
 | ------------ | -------------------------------------------- | --------------------------------------------------- |
-| Audience | Consumers, Prosumers, devs, AI personal agents, Apps | Enterprise, B2B API volume |
+| Built for | Personal AI agents and consumer apps | Enterprise API traffic |
 | Architecture | Local. Your requests, your providers         | Cloud proxy. All traffic goes through their servers |
 | Cost         | Free                                         | 5% fee on every API call                            |
 | Source code  | MIT, fully open                              | Proprietary                                         |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified positioning in the README comparison table by renaming "Audience" to "Built for" and updating values to "Personal AI agents and consumer apps" vs "Enterprise API traffic" to better reflect target users.

<sup>Written for commit f5788da9388f2f7c800b30211267cd8f8684b92f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

