### PR TITLE
fix(proxy): preserve full model id for custom provider endpoints

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1614,6 +1614,32 @@ describe('ProviderClient', () => {
       expect(sentBody.stream).toBe(false);
     });
 
+    it('preserves vendor/path model ids for custom endpoints (no prefix stripping)', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const customEndpoint = {
+        baseUrl: 'http://localhost:8000',
+        buildHeaders: (key: string) => ({
+          Authorization: `Bearer ${key}`,
+          'Content-Type': 'application/json',
+        }),
+        buildPath: () => '/v1/chat/completions',
+        format: 'openai' as const,
+      };
+
+      await client.forward({
+        provider: 'custom:uuid',
+        apiKey: 'k',
+        model: 'z-ai/step-3.5-flash',
+        body,
+        stream: false,
+        customEndpoint,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('z-ai/step-3.5-flash');
+    });
+
     it('uses custom endpoint with streaming', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -36,8 +36,10 @@ const PROVIDER_TIMEOUT_MS = 180_000;
  * Models synced from OpenRouter use vendor prefixes, but native APIs expect bare names.
  */
 function stripModelPrefix(model: string, endpointKey: string): string {
-  // OpenRouter accepts and expects vendor prefixes
-  if (endpointKey === 'openrouter') return model;
+  // OpenRouter accepts and expects vendor prefixes.
+  // Custom HTTP gateways store arbitrary upstream model ids (e.g. "z-ai/step-3.5-flash");
+  // stripping the first path segment breaks those backends.
+  if (endpointKey === 'openrouter' || endpointKey === 'custom') return model;
   const slashIdx = model.indexOf('/');
   return slashIdx > 0 ? model.substring(slashIdx + 1) : model;
 }


### PR DESCRIPTION
Custom gateways configure upstream model names like z-ai/step-3.5-flash. stripModelPrefix was stripping the first path segment for all endpoints except openrouter, which broke custom HTTP backends that require the full string. Treat custom the same as openrouter for model passthrough.

Adds a regression test in provider-client.spec.ts.

Made-with: Cursor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves full vendor/path model IDs for custom provider endpoints to avoid breaking custom gateways (e.g., "z-ai/step-3.5-flash"). Aligns custom endpoint behavior with OpenRouter by skipping prefix stripping.

- **Bug Fixes**
  - Treat `custom` endpoints like `openrouter` in model handling to bypass prefix stripping.
  - Add regression test to ensure the full model ID is sent for custom endpoints.

<sup>Written for commit 0f4568c9e566dcf62a0f3577ee78b584c6b7dcc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

