### PR TITLE
fix(routing): support API key fallback for subscription models

### DIFF
--- a/.changeset/gpt-54-mini-api-key-fallback.md
+++ b/.changeset/gpt-54-mini-api-key-fallback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Allow the API-key copy of a subscription primary model to be selected, displayed, and recorded as a fallback in routing.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1555,6 +1555,82 @@ describe('ModelDiscoveryService', () => {
       expect(result).toHaveLength(2);
       expect(result.map((m) => m.authType).sort()).toEqual(['api_key', 'subscription']);
     });
+
+    it('should mirror subscription-only models into api_key when both auth types are connected for the same vendor (issue #1708)', async () => {
+      // Regression: OpenAI's Codex (subscription) endpoint lists gpt-5.4-mini
+      // but /v1/models (api_key) sometimes omits it. With both auth types
+      // connected, the API Keys tab must still offer the model so users can
+      // pick it as a fallback against their primary subscription choice.
+      const providers = [
+        makeProvider({
+          id: 'sub',
+          provider: 'openai',
+          auth_type: 'subscription',
+          cached_models: [
+            makeModel({
+              id: 'gpt-5.4-mini',
+              provider: 'openai',
+              authType: 'subscription',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+            }),
+          ],
+        }),
+        makeProvider({
+          id: 'key',
+          provider: 'openai',
+          auth_type: 'api_key',
+          cached_models: [makeModel({ id: 'gpt-5.4', provider: 'openai', authType: 'api_key' })],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+      mockPricingSync.lookupPricing.mockImplementation((key: string) => {
+        if (key === 'openai/gpt-5.4-mini') {
+          return { input: 0.0000001, output: 0.0000004 };
+        }
+        return null;
+      });
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      const miniApiKey = result.find((m) => m.id === 'gpt-5.4-mini' && m.authType === 'api_key');
+      expect(miniApiKey).toBeDefined();
+      expect(miniApiKey!.inputPricePerToken).toBe(0.0000001);
+      expect(miniApiKey!.outputPricePerToken).toBe(0.0000004);
+      // Subscription variant preserved untouched
+      const miniSub = result.find((m) => m.id === 'gpt-5.4-mini' && m.authType === 'subscription');
+      expect(miniSub).toBeDefined();
+      expect(miniSub!.inputPricePerToken).toBe(0);
+    });
+
+    it('should not mirror subscription models when no api_key provider exists for that vendor', async () => {
+      const providers = [
+        makeProvider({
+          id: 'sub',
+          provider: 'openai',
+          auth_type: 'subscription',
+          cached_models: [
+            makeModel({ id: 'gpt-5.4-mini', provider: 'openai', authType: 'subscription' }),
+          ],
+        }),
+        makeProvider({
+          id: 'key',
+          provider: 'anthropic',
+          auth_type: 'api_key',
+          cached_models: [
+            makeModel({ id: 'claude-opus-4', provider: 'anthropic', authType: 'api_key' }),
+          ],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result.filter((m) => m.id === 'gpt-5.4-mini')).toHaveLength(1);
+      expect(result.find((m) => m.id === 'gpt-5.4-mini')!.authType).toBe('subscription');
+    });
   });
 
   /* ── buildSubscriptionFallbackModels ── */

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1502,6 +1502,7 @@ describe('ModelDiscoveryService', () => {
         makeProvider({
           id: 'p1',
           provider: 'anthropic',
+          auth_type: 'subscription',
           cached_models: [
             makeModel({
               id: 'claude-sonnet-4',
@@ -1513,6 +1514,7 @@ describe('ModelDiscoveryService', () => {
         makeProvider({
           id: 'p2',
           provider: 'anthropic',
+          auth_type: 'subscription',
           cached_models: [
             makeModel({ id: 'claude-sonnet-4', provider: 'anthropic', authType: 'subscription' }),
           ],
@@ -1602,6 +1604,34 @@ describe('ModelDiscoveryService', () => {
       const miniSub = result.find((m) => m.id === 'gpt-5.4-mini' && m.authType === 'subscription');
       expect(miniSub).toBeDefined();
       expect(miniSub!.inputPricePerToken).toBe(0);
+    });
+
+    it('should mirror subscription models when the api_key provider has an empty model cache', async () => {
+      const providers = [
+        makeProvider({
+          id: 'sub',
+          provider: 'openai',
+          auth_type: 'subscription',
+          cached_models: [
+            makeModel({ id: 'gpt-5.4-mini', provider: 'openai', authType: 'subscription' }),
+          ],
+        }),
+        makeProvider({
+          id: 'key',
+          provider: 'openai',
+          auth_type: 'api_key',
+          cached_models: [],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result.find((m) => m.id === 'gpt-5.4-mini' && m.authType === 'api_key')).toBeDefined();
+      expect(
+        result.find((m) => m.id === 'gpt-5.4-mini' && m.authType === 'subscription'),
+      ).toBeDefined();
     });
 
     it('should not mirror subscription models when no api_key provider exists for that vendor', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -211,15 +211,15 @@ export class ModelDiscoveryService {
       if (p.provider.startsWith('custom:')) continue;
       const vendor = p.provider.toLowerCase();
       const providerAuthType = p.auth_type === 'subscription' ? 'subscription' : 'api_key';
+      const providerAuthSet = vendorAuthTypes.get(vendor) ?? new Set();
+      providerAuthSet.add(providerAuthType);
+      vendorAuthTypes.set(vendor, providerAuthSet);
 
       const rawCached = p.cached_models;
       if (!Array.isArray(rawCached)) continue;
       const cached = filterNonChatModels(rawCached, vendor);
       for (const m of cached) {
         const effectiveAuthType = m.authType ?? providerAuthType;
-        const authSet = vendorAuthTypes.get(vendor) ?? new Set();
-        authSet.add(effectiveAuthType);
-        vendorAuthTypes.set(vendor, authSet);
         // Deduplicate by model ID + auth type so subscription and API key
         // versions of the same model are kept as independent entries.
         const dedupeKey = `${m.id}::${effectiveAuthType}`;

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -205,15 +205,21 @@ export class ModelDiscoveryService {
 
     const models: DiscoveredModel[] = [];
     const seen = new Map<string, number>();
+    const vendorAuthTypes = new Map<string, Set<'api_key' | 'subscription'>>();
 
     for (const p of providers) {
       if (p.provider.startsWith('custom:')) continue;
+      const vendor = p.provider.toLowerCase();
+      const providerAuthType = p.auth_type === 'subscription' ? 'subscription' : 'api_key';
+
       const rawCached = p.cached_models;
       if (!Array.isArray(rawCached)) continue;
-      const cached = filterNonChatModels(rawCached, p.provider.toLowerCase());
-      const providerAuthType = p.auth_type === 'subscription' ? 'subscription' : 'api_key';
+      const cached = filterNonChatModels(rawCached, vendor);
       for (const m of cached) {
         const effectiveAuthType = m.authType ?? providerAuthType;
+        const authSet = vendorAuthTypes.get(vendor) ?? new Set();
+        authSet.add(effectiveAuthType);
+        vendorAuthTypes.set(vendor, authSet);
         // Deduplicate by model ID + auth type so subscription and API key
         // versions of the same model are kept as independent entries.
         const dedupeKey = `${m.id}::${effectiveAuthType}`;
@@ -223,6 +229,31 @@ export class ModelDiscoveryService {
         }
       }
     }
+
+    // Mirror subscription-discovered models into the API key list when the
+    // user has both auth types connected for the same vendor. Some provider
+    // APIs return different model sets per auth type (e.g. OpenAI's Codex
+    // endpoint lists gpt-5.x-mini but /v1/models sometimes does not), so
+    // without mirroring, models that are selectable via subscription would
+    // silently be missing from the API Keys tab. Re-run enrichModel to swap
+    // the subscription $0 price for the real per-token pricing.
+    const mirrored: DiscoveredModel[] = [];
+    for (let i = 0; i < models.length; i++) {
+      const m = models[i];
+      if (m.authType !== 'subscription') continue;
+      const vendor = m.provider.toLowerCase();
+      if (vendor.startsWith('custom:')) continue;
+      if (!vendorAuthTypes.get(vendor)?.has('api_key')) continue;
+      const dedupeKey = `${m.id}::api_key`;
+      if (seen.has(dedupeKey)) continue;
+      const reEnriched = this.enrichModel(
+        { ...m, inputPricePerToken: null, outputPricePerToken: null },
+        vendor,
+      );
+      seen.set(dedupeKey, models.length + mirrored.length);
+      mirrored.push({ ...reEnriched, authType: 'api_key' });
+    }
+    models.push(...mirrored);
 
     // Merge custom provider models
     const customProviders = await this.customProviderRepo.find({

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -446,6 +446,7 @@ describe('ProxyFallbackService', () => {
       );
 
       expect(result.success).not.toBeNull();
+      expect(result.success!.authType).toBe('api_key');
       // getAuthType should have been called with the exclusion set
       expect(providerKeyService.getAuthType).toHaveBeenCalledWith(
         'agent-1',

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -387,6 +387,8 @@ describe('proxy-response-handler', () => {
         fallbackFromModel: 'claude-sonnet-4',
         primaryErrorStatus: 503,
         primaryProvider: 'anthropic',
+        auth_type: 'api_key',
+        primaryAuthType: 'subscription',
       });
 
       recordFallbackFailures(testCtx, meta, undefined, recorder as any);
@@ -397,7 +399,7 @@ describe('proxy-response-handler', () => {
         'claude-sonnet-4',
         'Provider returned HTTP 503',
         expect.any(String),
-        undefined,
+        'subscription',
         { provider: 'anthropic', reason: 'auto', callerAttribution: undefined },
       );
     });
@@ -958,7 +960,11 @@ describe('proxy-response-handler', () => {
   describe('recordSuccess', () => {
     it('should record fallback success when fallbackFromModel is set with timestamp', () => {
       const recorder = mockRecorder();
-      const meta = makeMeta({ fallbackFromModel: 'gpt-4o', fallbackIndex: 1 });
+      const meta = makeMeta({
+        fallbackFromModel: 'gpt-4o',
+        fallbackIndex: 1,
+        auth_type: 'api_key',
+      });
       const usage: StreamUsage = { prompt_tokens: 100, completion_tokens: 50 };
 
       recordSuccess(
@@ -977,7 +983,7 @@ describe('proxy-response-handler', () => {
         fallbackFromModel: 'gpt-4o',
         fallbackIndex: 1,
         timestamp: '2025-01-01T00:00:00Z',
-        authType: undefined,
+        authType: 'api_key',
         reason: 'auto',
         usage,
       });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -2177,6 +2177,7 @@ describe('ProxyService', () => {
         model: 'model-a',
         provider: 'ProvA',
         fallbackIndex: 0,
+        authType: 'api_key',
         status: 429,
         errorBody: 'rate limited',
       });
@@ -2541,6 +2542,8 @@ describe('ProxyService', () => {
       expect(result.meta.fallbackFromModel).toBe('claude-sonnet-4');
       expect(result.meta.model).toBe('gpt-4o');
       expect(result.meta.provider).toBe('OpenAI');
+      expect(result.meta.auth_type).toBe('api_key');
+      expect(result.meta.primaryAuthType).toBe('subscription');
       // Primary forwarded with subscription auth_type
       expect(providerClient.forward).toHaveBeenNthCalledWith(
         1,
@@ -2825,6 +2828,7 @@ describe('ProxyService', () => {
         model: 'deepseek-chat',
         provider: 'DeepSeek',
         fallbackIndex: 0,
+        authType: 'api_key',
         status: 504,
         errorBody: 'gateway timeout',
       });

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -32,6 +32,7 @@ export interface FailedFallback {
   model: string;
   provider: string;
   fallbackIndex: number;
+  authType?: 'api_key' | 'subscription';
   status: number;
   errorBody: string;
 }
@@ -69,6 +70,7 @@ export class ProxyFallbackService {
       forward: ForwardResult;
       model: string;
       provider: string;
+      authType: 'api_key' | 'subscription';
       fallbackIndex: number;
     } | null;
     failures: FailedFallback[];
@@ -151,7 +153,7 @@ export class ProxyFallbackService {
       });
 
       if (forward.response.ok) {
-        return { success: { forward, model, provider, fallbackIndex: i }, failures };
+        return { success: { forward, model, provider, authType, fallbackIndex: i }, failures };
       }
 
       const errorBody = await forward.response.text();
@@ -159,6 +161,7 @@ export class ProxyFallbackService {
         model,
         provider,
         fallbackIndex: i,
+        authType,
         status: forward.response.status,
         errorBody,
       });

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -231,7 +231,7 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
           routing_reason: reason ?? null,
           fallback_from_model: primaryModel,
           fallback_index: f.fallbackIndex,
-          auth_type: authType ?? null,
+          auth_type: f.authType ?? authType ?? null,
           caller_attribution: callerAttribution ?? null,
           request_headers: requestHeaders ?? null,
           header_tier_id: headerTierId ?? null,

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -207,7 +207,7 @@ export function recordFallbackFailures(
       meta.fallbackFromModel,
       meta.primaryErrorBody ?? `Provider returned HTTP ${meta.primaryErrorStatus ?? 500}`,
       new Date(fallbackBaseTime).toISOString(),
-      meta.auth_type,
+      meta.primaryAuthType ?? meta.auth_type,
       {
         // Use the primary provider explicitly — meta.provider holds the
         // succeeding fallback's provider in this flow, not the primary's.

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -59,6 +59,7 @@ export interface RoutingMeta {
    * failure row to the correct vendor.
    */
   primaryProvider?: string;
+  primaryAuthType?: string;
 }
 
 export interface ProxyResult {
@@ -303,11 +304,13 @@ export class ProxyService {
         forward: success.forward,
         meta: this.buildBaseMeta(resolved, success.model, {
           provider: success.provider,
+          auth_type: success.authType,
           fallbackFromModel: primaryModel,
           fallbackIndex: success.fallbackIndex,
           primaryErrorStatus: primaryStatus,
           primaryErrorBody,
           primaryProvider: resolved.provider ?? undefined,
+          primaryAuthType: resolved.auth_type,
         }),
         failedFallbacks: failures,
       };

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -3,6 +3,7 @@ import {
   clearFallbacks,
   setFallbacks,
   type AvailableModel,
+  type AuthType,
   type CustomProviderData,
   type RoutingProvider,
 } from '../services/api.js';
@@ -21,6 +22,8 @@ interface FallbackListProps {
   models: AvailableModel[];
   customProviders: CustomProviderData[];
   connectedProviders: RoutingProvider[];
+  primaryModel?: string | null;
+  primaryAuthType?: AuthType | null;
   onUpdate: (updatedFallbacks: string[]) => void;
   onAddFallback: () => void;
   adding?: boolean;
@@ -38,8 +41,19 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   const [dropSlot, setDropSlot] = createSignal<number | null>(null);
   let listRef: HTMLDivElement | undefined;
 
+  const modelInfoFor = (model: string): AvailableModel | undefined => {
+    const matches = props.models.filter((m) => m.model_name === model);
+    if (props.primaryModel === model && props.primaryAuthType) {
+      const alternateAuth = matches.find(
+        (m) => m.auth_type && m.auth_type !== props.primaryAuthType,
+      );
+      if (alternateAuth) return alternateAuth;
+    }
+    return matches[0];
+  };
+
   const modelLabel = (model: string): string => {
-    const info = props.models.find((m) => m.model_name === model);
+    const info = modelInfoFor(model);
     if (info?.display_name) return info.display_name;
     if (info) {
       const provId = resolveProviderId(info.provider);
@@ -49,12 +63,14 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   };
 
   const providerIdFor = (model: string): string | undefined => {
-    const info = props.models.find((m) => m.model_name === model);
+    const info = modelInfoFor(model);
     if (info) return resolveProviderId(info.provider);
     return undefined;
   };
 
-  const authTypeFor = (providerId: string | undefined): string | null => {
+  const authTypeFor = (model: string, providerId: string | undefined): AuthType | null => {
+    const info = modelInfoFor(model);
+    if (info?.auth_type) return info.auth_type;
     if (!providerId) return null;
     const provs = props.connectedProviders.filter(
       (p) => p.provider.toLowerCase() === providerId.toLowerCase(),
@@ -202,7 +218,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
             {(model, i) => {
               const provId = () => providerIdFor(model);
               const isCustom = () => provId()?.startsWith('custom:');
-              const auth = () => authTypeFor(provId());
+              const auth = () => authTypeFor(model, provId());
               const title = () => providerTitle(provId(), auth());
               return (
                 <>

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -266,6 +266,8 @@ const HeaderTierCard: Component<Props> = (props) => {
             models={props.models}
             customProviders={props.customProviders}
             connectedProviders={props.connectedProviders}
+            primaryModel={currentModel()}
+            primaryAuthType={props.tier.override_auth_type}
             onUpdate={(updated) => props.onFallbacksUpdate(updated)}
             onAddFallback={() => setPickerMode('fallback')}
             persistFallbacks={(_agent, tierId, models) =>

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -267,7 +267,7 @@ const HeaderTierCard: Component<Props> = (props) => {
             customProviders={props.customProviders}
             connectedProviders={props.connectedProviders}
             primaryModel={currentModel()}
-            primaryAuthType={props.tier.override_auth_type}
+            primaryAuthType={effectiveAuth()}
             onUpdate={(updated) => props.onFallbacksUpdate(updated)}
             onAddFallback={() => setPickerMode('fallback')}
             persistFallbacks={(_agent, tierId, models) =>

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -163,7 +163,7 @@ const ModelPickerModal: Component<Props> = (props) => {
     const t = props.tiers.find((r) => r.tier === props.tierId);
     if (!t) return null;
     const primary = t.override_model ?? t.auto_assigned_model;
-    const primaryAuthType = t.override_auth_type;
+    const primaryAuthType = t.override_model ? t.override_auth_type : undefined;
     if (primary === modelName && (!primaryAuthType || !authType || authType === primaryAuthType)) {
       return 'Primary';
     }

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -159,11 +159,14 @@ const ModelPickerModal: Component<Props> = (props) => {
   };
 
   /** Returns the role of a model in the current tier: "Primary", "Fallback 1", etc. or null */
-  const modelRole = (modelName: string): string | null => {
+  const modelRole = (modelName: string, authType?: AuthType): string | null => {
     const t = props.tiers.find((r) => r.tier === props.tierId);
     if (!t) return null;
     const primary = t.override_model ?? t.auto_assigned_model;
-    if (primary === modelName) return 'Primary';
+    const primaryAuthType = t.override_auth_type;
+    if (primary === modelName && (!primaryAuthType || !authType || authType === primaryAuthType)) {
+      return 'Primary';
+    }
     const fb = t.fallback_models ?? [];
     const fbIndex = fb.indexOf(modelName);
     if (fbIndex !== -1) return `Fallback ${fbIndex + 1}`;
@@ -406,7 +409,7 @@ const ModelPickerModal: Component<Props> = (props) => {
                         <Show when={isRecommended(model.value)}>
                           <span class="routing-modal__recommended"> (recommended)</span>
                         </Show>
-                        <Show when={modelRole(model.value)}>
+                        <Show when={modelRole(model.value, model.pricing.auth_type)}>
                           {(role) => <span class="routing-modal__role-tag">{role()}</span>}
                         </Show>
                       </span>

--- a/packages/frontend/src/components/RoutingModals.tsx
+++ b/packages/frontend/src/components/RoutingModals.tsx
@@ -99,13 +99,14 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => (
           const t = props.getTier(tierId());
           return t ? (t.override_model ?? t.auto_assigned_model) : null;
         };
+        const effectiveAuthType = () => props.getTier(tierId())?.override_auth_type ?? null;
+        const isCurrentPrimary = (model: AvailableModel) =>
+          model.model_name === effectiveModel() &&
+          (!effectiveAuthType() || !model.auth_type || model.auth_type === effectiveAuthType());
         const filteredModels = () =>
           props
             .models()
-            .filter(
-              (m) =>
-                m.model_name !== effectiveModel() && !currentFallbacks().includes(m.model_name),
-            );
+            .filter((m) => !isCurrentPrimary(m) && !currentFallbacks().includes(m.model_name));
         return (
           <ModelPickerModal
             tierId={tierId()}

--- a/packages/frontend/src/components/RoutingModals.tsx
+++ b/packages/frontend/src/components/RoutingModals.tsx
@@ -99,7 +99,10 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => (
           const t = props.getTier(tierId());
           return t ? (t.override_model ?? t.auto_assigned_model) : null;
         };
-        const effectiveAuthType = () => props.getTier(tierId())?.override_auth_type ?? null;
+        const effectiveAuthType = () => {
+          const t = props.getTier(tierId());
+          return t?.override_model ? (t.override_auth_type ?? null) : null;
+        };
         const isCurrentPrimary = (model: AvailableModel) =>
           model.model_name === effectiveModel() &&
           (!effectiveAuthType() || !model.auth_type || model.auth_type === effectiveAuthType());

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -400,6 +400,8 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
               models={props.models()}
               customProviders={props.customProviders()}
               connectedProviders={props.activeProviders()}
+              primaryModel={eff()}
+              primaryAuthType={props.tier()?.override_auth_type ?? null}
               onUpdate={(updatedFallbacks) =>
                 props.onFallbackUpdate(props.stage.id, updatedFallbacks)
               }

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -84,6 +84,31 @@ describe("FallbackList", () => {
     expect(modelLabels.length).toBe(2);
   });
 
+  it("uses the alternate auth model metadata when fallback matches the subscription primary", () => {
+    const duplicateAuthModels = [
+      { model_name: "gpt-5.4-mini", provider: "OpenAI", auth_type: "subscription" },
+      { model_name: "gpt-5.4-mini", provider: "OpenAI", auth_type: "api_key" },
+    ] as any[];
+
+    const { container } = render(() => (
+      <FallbackList
+        {...defaultProps}
+        fallbacks={["gpt-5.4-mini"]}
+        models={duplicateAuthModels}
+        connectedProviders={[
+          { provider: "openai", auth_type: "subscription", is_active: true },
+          { provider: "openai", auth_type: "api_key", is_active: true },
+        ] as any[]}
+        primaryModel="gpt-5.4-mini"
+        primaryAuthType="subscription"
+      />
+    ));
+
+    expect(container.querySelector(".fallback-list__icon")?.getAttribute("title")).toBe(
+      "OpenAI (API Key)",
+    );
+  });
+
   it("calls onAddFallback when add button in empty state clicked", () => {
     const onAddFallback = vi.fn();
     const { container } = render(() => (

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -53,6 +53,7 @@ vi.mock('../../src/components/FallbackList.js', () => ({
     models: unknown[];
     customProviders: unknown[];
     connectedProviders: unknown[];
+    primaryAuthType?: string | null;
     onAddFallback: () => void;
     onUpdate: (next: string[]) => void;
     persistFallbacks: (agent: string, tierId: string, models: string[]) => Promise<unknown>;
@@ -65,6 +66,7 @@ vi.mock('../../src/components/FallbackList.js', () => ({
       data-models-len={props.models.length}
       data-custom-len={props.customProviders.length}
       data-connected-len={props.connectedProviders.length}
+      data-primary-auth={props.primaryAuthType ?? ''}
     >
       <span data-testid="fallback-count">{props.fallbacks.length}</span>
       <button data-testid="add-fallback" onClick={props.onAddFallback}>
@@ -267,20 +269,22 @@ describe('HeaderTierCard', () => {
 
   it('falls back to subscription auth when no override_auth_type and provider is subscription', () => {
     const subTier: HeaderTier = { ...baseTier, override_auth_type: null };
-    const { container } = mount({
+    const { container, getByTestId } = mount({
       tier: subTier,
       connectedProviders: [{ provider: 'OpenAI', auth_type: 'subscription' }] as never,
     });
     expect(container.textContent).toContain('Included in subscription');
+    expect(getByTestId('mock-fallback-list').dataset.primaryAuth).toBe('subscription');
   });
 
   it('falls back to api_key auth when no override_auth_type and provider is api_key only', () => {
     const apiTier: HeaderTier = { ...baseTier, override_auth_type: null };
-    const { container } = mount({
+    const { container, getByTestId } = mount({
       tier: apiTier,
       connectedProviders: [{ provider: 'openai', auth_type: 'api_key' }] as never,
     });
     expect(container.querySelector('[data-testid="auth-api_key"]')).not.toBeNull();
+    expect(getByTestId('mock-fallback-list').dataset.primaryAuth).toBe('api_key');
   });
 
   it('renders no auth badge when override_auth_type is null and no providers match', () => {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -366,7 +366,8 @@ describe("ModelPickerModal", () => {
     ));
 
     fireEvent.click(screen.getByText("API Keys"));
-    expect(screen.getByText("GPT-5.4 Mini API Key").parentElement?.textContent).toContain("Primary");
+    const apiKeyModel = screen.getByRole("button", { name: /GPT-5\.4 Mini API Key/ });
+    expect(apiKeyModel.textContent).toContain("Primary");
   });
 
   it("filters subscription tab to only subscription providers' models", () => {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -302,6 +302,73 @@ describe("ModelPickerModal", () => {
     expect(onSelect).toHaveBeenCalledWith("simple", "claude-opus-4-6", "anthropic", "subscription");
   });
 
+  it("ignores stale override_auth_type when the primary is auto-assigned", () => {
+    const tiers = [
+      {
+        ...baseTiers[0],
+        auto_assigned_model: "gpt-5.4-mini",
+        override_model: null,
+        override_auth_type: "subscription" as const,
+      },
+    ];
+    const models = [
+      {
+        model_name: "gpt-5.4-mini",
+        provider: "OpenAI",
+        display_name: "GPT-5.4 Mini Subscription",
+        input_price_per_token: 0,
+        output_price_per_token: 0,
+        context_window: 128000,
+        capability_reasoning: true,
+        capability_code: true,
+        auth_type: "subscription" as const,
+      },
+      {
+        model_name: "gpt-5.4-mini",
+        provider: "OpenAI",
+        display_name: "GPT-5.4 Mini API Key",
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        context_window: 128000,
+        capability_reasoning: true,
+        capability_code: true,
+        auth_type: "api_key" as const,
+      },
+    ];
+    const providers = [
+      {
+        id: "p1",
+        provider: "openai",
+        is_active: true,
+        has_api_key: false,
+        auth_type: "subscription" as const,
+        connected_at: "2025-01-01",
+      },
+      {
+        id: "p2",
+        provider: "openai",
+        is_active: true,
+        has_api_key: true,
+        auth_type: "api_key" as const,
+        connected_at: "2025-01-01",
+      },
+    ];
+
+    render(() => (
+      <ModelPickerModal
+        tierId="simple"
+        models={models}
+        tiers={tiers}
+        connectedProviders={providers}
+        onSelect={onSelect}
+        onClose={onClose}
+      />
+    ));
+
+    fireEvent.click(screen.getByText("API Keys"));
+    expect(screen.getByText("GPT-5.4 Mini API Key").parentElement?.textContent).toContain("Primary");
+  });
+
   it("filters subscription tab to only subscription providers' models", () => {
     const providers = [
       { id: "p1", provider: "anthropic", is_active: true, has_api_key: false, auth_type: "subscription" as const, connected_at: "2025-01-01" },

--- a/packages/frontend/tests/components/RoutingModals.test.tsx
+++ b/packages/frontend/tests/components/RoutingModals.test.tsx
@@ -188,4 +188,74 @@ describe("RoutingModals", () => {
     const modalButtons = document.querySelectorAll<HTMLButtonElement>(".routing-modal__model");
     expect(modalButtons.length).toBe(0);
   });
+
+  it("allows an API-key model as a fallback when the same model is the subscription primary", () => {
+    const tier = {
+      ...baseTiers[0],
+      override_model: "gpt-5.4-mini",
+      override_provider: "openai",
+      override_auth_type: "subscription" as const,
+      auto_assigned_model: null,
+    };
+    const models: AvailableModel[] = [
+      {
+        model_name: "gpt-5.4-mini",
+        provider: "OpenAI",
+        display_name: "GPT-5.4 Mini Subscription",
+        input_price_per_token: 0,
+        output_price_per_token: 0,
+        context_window: 128000,
+        capability_reasoning: true,
+        capability_code: true,
+        quality_score: 92,
+        auth_type: "subscription",
+      },
+      {
+        model_name: "gpt-5.4-mini",
+        provider: "OpenAI",
+        display_name: "GPT-5.4 Mini API Key",
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        context_window: 128000,
+        capability_reasoning: true,
+        capability_code: true,
+        quality_score: 92,
+        auth_type: "api_key",
+      },
+    ];
+    const providers: RoutingProvider[] = [
+      {
+        id: "p1",
+        provider: "openai",
+        auth_type: "subscription",
+        is_active: true,
+        has_api_key: false,
+        connected_at: "2025-01-01",
+      },
+      {
+        id: "p2",
+        provider: "openai",
+        auth_type: "api_key",
+        is_active: true,
+        has_api_key: true,
+        connected_at: "2025-01-01",
+      },
+    ];
+    const [fallbackPickerTier] = createSignal<string | null>("simple");
+
+    render(() => (
+      <RoutingModals
+        {...defaultProps()}
+        fallbackPickerTier={fallbackPickerTier}
+        models={() => models}
+        tiers={() => [tier]}
+        connectedProviders={() => providers}
+        getTier={(tierId: string) => (tierId === "simple" ? tier : undefined)}
+      />
+    ));
+
+    expect(screen.queryByText("GPT-5.4 Mini Subscription")).toBeNull();
+    fireEvent.click(screen.getByText("API Keys"));
+    expect(screen.getByText("GPT-5.4 Mini API Key")).toBeDefined();
+  });
 });

--- a/packages/frontend/tests/components/RoutingModals.test.tsx
+++ b/packages/frontend/tests/components/RoutingModals.test.tsx
@@ -258,4 +258,74 @@ describe("RoutingModals", () => {
     fireEvent.click(screen.getByText("API Keys"));
     expect(screen.getByText("GPT-5.4 Mini API Key")).toBeDefined();
   });
+
+  it("ignores stale override_auth_type when filtering auto-assigned fallback primaries", () => {
+    const tier = {
+      ...baseTiers[0],
+      auto_assigned_model: "gpt-5.4-mini",
+      override_model: null,
+      override_provider: null,
+      override_auth_type: "subscription" as const,
+    };
+    const models: AvailableModel[] = [
+      {
+        model_name: "gpt-5.4-mini",
+        provider: "OpenAI",
+        display_name: "GPT-5.4 Mini Subscription",
+        input_price_per_token: 0,
+        output_price_per_token: 0,
+        context_window: 128000,
+        capability_reasoning: true,
+        capability_code: true,
+        quality_score: 92,
+        auth_type: "subscription",
+      },
+      {
+        model_name: "gpt-5.4-mini",
+        provider: "OpenAI",
+        display_name: "GPT-5.4 Mini API Key",
+        input_price_per_token: 0.0000001,
+        output_price_per_token: 0.0000004,
+        context_window: 128000,
+        capability_reasoning: true,
+        capability_code: true,
+        quality_score: 92,
+        auth_type: "api_key",
+      },
+    ];
+    const providers: RoutingProvider[] = [
+      {
+        id: "p1",
+        provider: "openai",
+        auth_type: "subscription",
+        is_active: true,
+        has_api_key: false,
+        connected_at: "2025-01-01",
+      },
+      {
+        id: "p2",
+        provider: "openai",
+        auth_type: "api_key",
+        is_active: true,
+        has_api_key: true,
+        connected_at: "2025-01-01",
+      },
+    ];
+    const [fallbackPickerTier] = createSignal<string | null>("simple");
+
+    render(() => (
+      <RoutingModals
+        {...defaultProps()}
+        fallbackPickerTier={fallbackPickerTier}
+        models={() => models}
+        tiers={() => [tier]}
+        connectedProviders={() => providers}
+        getTier={(tierId: string) => (tierId === "simple" ? tier : undefined)}
+      />
+    ));
+
+    expect(screen.queryByText("GPT-5.4 Mini Subscription")).toBeNull();
+    fireEvent.click(screen.getByText("API Keys"));
+    expect(screen.queryByText("GPT-5.4 Mini API Key")).toBeNull();
+  });
 });

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -301,6 +301,19 @@ describe('RoutingTierCard', () => {
     expect(capturedFallbackListProps.persistClearFallbacks).toBe(clearFn);
   });
 
+  it('passes primary model auth context through to FallbackList', () => {
+    const tier = {
+      ...baseTier,
+      override_model: 'gpt-5.4-mini',
+      override_auth_type: 'subscription',
+    };
+
+    render(() => <RoutingTierCard {...baseProps} tier={() => tier as any} />);
+
+    expect(capturedFallbackListProps.primaryModel).toBe('gpt-5.4-mini');
+    expect(capturedFallbackListProps.primaryAuthType).toBe('subscription');
+  });
+
   it('handlePrimaryDropAtSlot swaps primary with first fallback', async () => {
     const onOverride = vi.fn();
     const onFallbackUpdate = vi.fn();


### PR DESCRIPTION
## Summary

- Allow subscription-provided models to be selected as API-key fallbacks when the same vendor supports both auth paths.
- Resolve fallback routes with the failed primary auth context, so a same-provider/same-model fallback can move from subscription to API key.
- Record fallback telemetry with the actual fallback auth type, while preserving the primary auth type on primary fallback errors.
- Keep the fallback picker auth-aware so same model names can be selected only when they represent a distinct auth route.

Fixes #1708.

## Validation

- Fork staging PR: https://github.com/guillaumegay13/manifest/pull/6
- `npm test --workspace=packages/frontend -- HeaderTierCard.test.tsx FallbackList.test.tsx RoutingModals.test.tsx RoutingTierCard.test.tsx` — 108 passed
- Backend proxy tests — 227 passed during fork PR validation
- Backend typecheck/build passed during fork PR validation
- Targeted backend proxy coverage stayed at 100% line coverage during fork PR validation
- Live `demo-agent` validation: primary failure recorded as `gpt-4o | OpenAI | subscription | fallback_error`, then fallback success recorded as `gpt-5.4-mini | OpenAI | api_key | ok`

## Notes

The fallback state still persists model names, matching the existing data model. The same-model fallback behavior here is intentional: the backend resolver now uses the failed primary auth type to choose the alternate route. A later scalable cleanup can move fallback identity to a structured route like `{ provider, authType, model }`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables API‑key fallback for subscription‑selected models when the same vendor supports both auth paths, with correct routing, discovery, and telemetry. Fixes #1708.

- **Bug Fixes**
  - Discovery mirrors subscription‑only models into `api_key` when both auths are connected for the same vendor and re‑enriches pricing; no mirror if there’s no matching `api_key` connection.
  - Fallback routing resolves with the failed primary’s auth context so the same provider/model can switch from subscription to `api_key`; success metadata now includes the fallback `auth_type`.
  - Telemetry and logs record the actual fallback auth type and preserve the primary auth type on failure rows; the proxy forwards the resolved fallback auth to the recorder.
  - UI is auth‑aware: identical model names are distinct per auth route; filtering and “Primary” tags consider auth type and ignore stale `override_auth_type` for auto‑assigned primaries.

<sup>Written for commit 527aeaebcc2278fc2b23f9c6a9e939a01f47901e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

