### PR TITLE
feat(proxy): add Responses API endpoint

### DIFF
--- a/.changeset/gentle-responses-arrive.md
+++ b/.changeset/gentle-responses-arrive.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Expose the OpenAI-compatible Responses API proxy at `/v1/responses` and show Responses API setup snippets by default for OpenAI SDK users.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -177,6 +177,83 @@ describe('ProviderClient', () => {
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(sentBody.stream).toBe(true);
     });
+
+    it('routes public Responses API requests for OpenAI to /v1/responses', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: { input: 'Hello', stream: false },
+        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.openai.com/v1/responses',
+        expect.any(Object),
+      );
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).toMatchObject({
+        input: 'Hello',
+        model: 'gpt-4o',
+        stream: false,
+        store: false,
+      });
+      expect(sentBody.messages).toBeUndefined();
+      expect(sentBody.instructions).toBeUndefined();
+      expect(result.isResponses).toBe(true);
+      expect(result.isChatGpt).toBe(false);
+    });
+
+    it('adds default instructions for subscription Responses requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'oauth-token',
+        model: 'gpt-5.4',
+        body: { input: 'Hello', stream: false },
+        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        stream: false,
+        authType: 'subscription',
+        apiMode: 'responses',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.instructions).toBe('You are a helpful assistant.');
+      expect(sentBody.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ]);
+      expect(sentBody.stream).toBe(true);
+    });
+
+    it('uses normalized chat body for non-native Responses providers', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'deepseek',
+        apiKey: 'sk-test',
+        model: 'deepseek-chat',
+        body: { input: 'Hello', stream: false },
+        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.deepseek.com/v1/chat/completions',
+        expect.any(Object),
+      );
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+      expect(sentBody.input).toBeUndefined();
+      expect(result.isResponses).toBe(false);
+    });
   });
 
   describe('Anthropic provider', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -446,13 +446,19 @@ describe('proxy-response-handler', () => {
 
   describe('handleStreamResponse', () => {
     function mockForward(
-      flags: { isGoogle?: boolean; isAnthropic?: boolean; isChatGpt?: boolean } = {},
+      flags: {
+        isGoogle?: boolean;
+        isAnthropic?: boolean;
+        isChatGpt?: boolean;
+        isResponses?: boolean;
+      } = {},
     ) {
       return {
         response: { body: { getReader: jest.fn() } },
         isGoogle: flags.isGoogle ?? false,
         isAnthropic: flags.isAnthropic ?? false,
         isChatGpt: flags.isChatGpt ?? false,
+        isResponses: flags.isResponses ?? false,
       };
     }
 
@@ -590,6 +596,59 @@ describe('proxy-response-handler', () => {
       expect(pipeStreamSpy).toHaveBeenCalledWith(forward.response.body, res);
     });
 
+    it('should pass through native Responses streams without a transformer', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward({ isResponses: true });
+      const client = mockProviderClient();
+      const meta = makeMeta();
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'responses',
+      );
+
+      expect(pipeStreamSpy).toHaveBeenCalledWith(forward.response.body, res);
+    });
+
+    it('should convert chat completion streams when serving Responses clients', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta();
+      let capturedTransform: ((chunk: string) => string | null) | undefined;
+      pipeStreamSpy.mockImplementation(
+        async (_body: unknown, _res: unknown, transform?: (chunk: string) => string | null) => {
+          capturedTransform = transform;
+          return null;
+        },
+      );
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'responses',
+      );
+
+      expect(capturedTransform).toBeDefined();
+      const converted = capturedTransform!(
+        'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}\n\n',
+      );
+      expect(converted).toContain('event: response.output_text.delta');
+    });
+
     it('should cache thought_signatures from Google stream chunks', async () => {
       const { res } = mockResponse();
       const forward = mockForward({ isGoogle: true });
@@ -676,16 +735,26 @@ describe('proxy-response-handler', () => {
 
     function mockForward(
       body: unknown,
-      flags: { isGoogle?: boolean; isAnthropic?: boolean; isChatGpt?: boolean } = {},
+      flags: {
+        isGoogle?: boolean;
+        isAnthropic?: boolean;
+        isChatGpt?: boolean;
+        isResponses?: boolean;
+        contentType?: string;
+      } = {},
     ) {
       return {
         response: {
           json: jest.fn().mockResolvedValue(body),
           text: jest.fn().mockResolvedValue(typeof body === 'string' ? body : JSON.stringify(body)),
+          headers: {
+            get: jest.fn().mockReturnValue(flags.contentType ?? 'application/json'),
+          },
         },
         isGoogle: flags.isGoogle ?? false,
         isAnthropic: flags.isAnthropic ?? false,
         isChatGpt: flags.isChatGpt ?? false,
+        isResponses: flags.isResponses ?? false,
       };
     }
 
@@ -832,6 +901,98 @@ describe('proxy-response-handler', () => {
         cache_creation_tokens: undefined,
       });
       expect(res.json).toHaveBeenCalledWith(body);
+    });
+
+    it('should pass through native Responses JSON and extract Responses usage', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const body = {
+        id: 'resp_123',
+        object: 'response',
+        usage: {
+          input_tokens: 50,
+          input_tokens_details: { cached_tokens: 20 },
+          output_tokens: 25,
+          total_tokens: 75,
+        },
+      };
+      const forward = mockForward(body, { isResponses: true });
+      const meta = makeMeta();
+
+      const usage = await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'responses',
+      );
+
+      expect(usage).toEqual({
+        prompt_tokens: 50,
+        completion_tokens: 25,
+        cache_read_tokens: 20,
+        cache_creation_tokens: 0,
+      });
+      expect(res.json).toHaveBeenCalledWith(body);
+    });
+
+    it('should collect native Responses SSE for non-streaming Responses clients', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const response = { id: 'resp_done', object: 'response', output: [] };
+      const sse = `event: response.completed\ndata: ${JSON.stringify({ response })}\n\n`;
+      const forward = mockForward(sse, {
+        isResponses: true,
+        contentType: 'text/event-stream',
+      });
+      const meta = makeMeta();
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'responses',
+      );
+
+      expect(forward.response.text).toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(response);
+    });
+
+    it('should collect native Responses SSE even when content type is not SSE', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const response = { id: 'resp_done', object: 'response', output: [] };
+      const sse = `event: response.completed\ndata: ${JSON.stringify({ response })}\n\n`;
+      const forward = mockForward(sse, {
+        isResponses: true,
+        contentType: 'application/json',
+      });
+      const meta = makeMeta();
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'responses',
+      );
+
+      expect(forward.response.text).toHaveBeenCalled();
+      expect(forward.response.json).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(response);
     });
 
     it('should return null usage when no usage data in response', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -181,6 +181,89 @@ describe('ProxyController', () => {
     expect(headers['X-Manifest-Reason']).toBe('scored');
   });
 
+  it('should expose /v1/responses and convert chat completions output to Responses format', async () => {
+    const responseBody = {
+      created: 1234,
+      model: 'gpt-4o',
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: {
+        response: mockProviderResp,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ input: 'hi' });
+    const { res } = mockResponse();
+
+    await controller.responses(req as never, res as never);
+
+    expect(proxyService.proxyRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ apiMode: 'responses', body: { input: 'hi' } }),
+    );
+    const json = (res.json as jest.Mock).mock.calls[0][0];
+    expect(json.object).toBe('response');
+    expect(json.output[0].content[0]).toEqual({
+      type: 'output_text',
+      text: 'hello',
+      annotations: [],
+    });
+    expect(json.usage.input_tokens).toBe(4);
+  });
+
+  it('should pass through native Responses JSON bodies', async () => {
+    const responseBody = {
+      id: 'resp_1',
+      object: 'response',
+      output: [{ type: 'message' }],
+      usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: {
+        response: mockProviderResp,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+        isResponses: true,
+      },
+      meta: {
+        tier: 'simple',
+        model: 'gpt-4o',
+        provider: 'OpenAI',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({ input: 'hi' });
+    const { res } = mockResponse();
+
+    await controller.responses(req as never, res as never);
+
+    expect(res.json).toHaveBeenCalledWith(responseBody);
+  });
+
   it('should convert Google response for non-streaming', async () => {
     const googleBody = { candidates: [{ content: { parts: [{ text: 'hi' }] } }] };
     const convertedBody = { choices: [{ message: { content: 'hi' } }] };

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -280,6 +280,58 @@ describe('ProxyService', () => {
     expect(body.messages[2].content).toBe('test');
   });
 
+  it('normalizes Responses API input for routing while preserving the original body', async () => {
+    resolveService.resolve.mockResolvedValue({
+      tier: 'simple',
+      model: 'gpt-4o',
+      provider: 'OpenAI',
+      confidence: 0.9,
+      score: 0.5,
+      reason: 'scored',
+    });
+    providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
+    providerClient.forward.mockResolvedValue({
+      response: new Response('{}', { status: 200 }),
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+      isResponses: true,
+    });
+
+    const responsesBody = {
+      instructions: 'Be concise.',
+      input: 'Hello from responses',
+      max_output_tokens: 64,
+      stream: false,
+    };
+
+    await service.proxyRequest({
+      agentId: 'agent-1',
+      userId: 'user-1',
+      body: responsesBody,
+      apiMode: 'responses',
+      sessionKey: 'default',
+    });
+
+    expect(resolveService.resolve.mock.calls[0][1]).toEqual([
+      { role: 'user', content: 'Hello from responses' },
+    ]);
+    expect(resolveService.resolve.mock.calls[0][4]).toBe(64);
+    expect(providerClient.forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: responsesBody,
+        chatBody: expect.objectContaining({
+          messages: [
+            { role: 'system', content: 'Be concise.' },
+            { role: 'user', content: 'Hello from responses' },
+          ],
+          max_tokens: 64,
+        }),
+        apiMode: 'responses',
+      }),
+    );
+  });
+
   it('returns synthetic response when no model is resolved', async () => {
     resolveService.resolve.mockResolvedValue({
       tier: 'simple',

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -1,0 +1,362 @@
+import {
+  chatCompletionStreamChunkToResponses,
+  collectResponsesSseResponse,
+  fromChatCompletionResponse,
+  toChatCompletionsRequest,
+  toNativeResponsesRequest,
+} from '../responses-adapter';
+
+describe('Responses adapter', () => {
+  describe('toChatCompletionsRequest', () => {
+    it('converts string input, instructions, tools, and max_output_tokens', () => {
+      const result = toChatCompletionsRequest({
+        model: 'gpt-5',
+        instructions: 'Be concise.',
+        input: 'Hello',
+        max_output_tokens: 123,
+        temperature: 0.2,
+        top_p: 0.9,
+        stream: true,
+        metadata: { trace: 'abc' },
+        store: true,
+        user: 'user-1',
+        parallel_tool_calls: false,
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup',
+            description: 'Lookup data',
+            parameters: { type: 'object' },
+            strict: true,
+          },
+        ],
+        tool_choice: { type: 'function', name: 'lookup' },
+      });
+
+      expect(result.messages).toEqual([
+        { role: 'system', content: 'Be concise.' },
+        { role: 'user', content: 'Hello' },
+      ]);
+      expect(result.max_tokens).toBe(123);
+      expect(result.temperature).toBe(0.2);
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'lookup',
+            description: 'Lookup data',
+            parameters: { type: 'object' },
+            strict: true,
+          },
+        },
+      ]);
+      expect(result.tool_choice).toEqual({ type: 'function', function: { name: 'lookup' } });
+    });
+
+    it('converts item lists, images, function calls, and tool outputs', () => {
+      const result = toChatCompletionsRequest({
+        input: [
+          'first',
+          {
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'look' },
+              { type: 'input_image', image_url: 'https://example.test/image.png' },
+            ],
+          },
+          { role: 'user', content: [{ type: 'input_text', text: 'single text' }] },
+          { role: 'user', content: [{ type: 'input_audio', audio: 'abc' }] },
+          { role: 'assistant', content: [{ type: 'output_text', text: 'done' }] },
+          { type: 'function_call', call_id: 'call_1', name: 'search', arguments: '{"q":"x"}' },
+          { type: 'function_call_output', call_id: 'call_1', output: { ok: true } },
+        ],
+        tools: [{ type: 'web_search_preview' }],
+        tool_choice: 'auto',
+      });
+
+      expect(result.messages).toEqual([
+        { role: 'user', content: 'first' },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'look' },
+            { type: 'image_url', image_url: { url: 'https://example.test/image.png' } },
+          ],
+        },
+        { role: 'user', content: 'single text' },
+        { role: 'user', content: [{ type: 'input_audio', audio: 'abc' }] },
+        { role: 'assistant', content: [{ type: 'text', text: 'done' }] },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'search', arguments: '{"q":"x"}' },
+            },
+          ],
+        },
+        { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+      ]);
+      expect(result.tools).toEqual([{ type: 'web_search_preview' }]);
+      expect(result.tool_choice).toBe('auto');
+    });
+
+    it('uses safe defaults for malformed input items', () => {
+      const result = toChatCompletionsRequest({
+        input: [
+          42,
+          { role: 1, content: 7 },
+          { type: 'function_call' },
+          { type: 'function_call_output', output: undefined },
+        ],
+      });
+      const messages = result.messages as Record<string, unknown>[];
+
+      expect(messages[0]).toEqual({ role: 'user', content: 7 });
+      expect(messages[1]).toMatchObject({
+        role: 'assistant',
+        content: null,
+        tool_calls: [{ type: 'function', function: { name: 'unknown', arguments: '{}' } }],
+      });
+      expect(messages[2]).toMatchObject({ role: 'tool', content: '' });
+    });
+  });
+
+  it('builds native Responses requests with resolved model and default flags', () => {
+    expect(toNativeResponsesRequest({ input: 'hi' }, 'gpt-4o')).toEqual({
+      input: 'hi',
+      model: 'gpt-4o',
+      stream: false,
+      store: false,
+    });
+    expect(toNativeResponsesRequest({ input: 'hi', stream: true, store: true }, 'gpt-4o')).toEqual({
+      input: 'hi',
+      model: 'gpt-4o',
+      stream: true,
+      store: true,
+    });
+  });
+
+  it('can add default instructions for native Responses backends that require them', () => {
+    expect(
+      toNativeResponsesRequest({ input: 'hi' }, 'gpt-5.4', { defaultInstructions: true }),
+    ).toMatchObject({
+      input: 'hi',
+      model: 'gpt-5.4',
+      instructions: 'You are a helpful assistant.',
+    });
+
+    expect(
+      toNativeResponsesRequest(
+        { input: 'hi', instructions: 'Follow the house style.' },
+        'gpt-5.4',
+        { defaultInstructions: true },
+      ).instructions,
+    ).toBe('Follow the house style.');
+  });
+
+  it('can normalize SDK Responses input for native backends that require input lists', () => {
+    expect(toNativeResponsesRequest({ input: 'hi' }, 'gpt-5.4', { inputList: true }).input).toEqual(
+      [{ role: 'user', content: [{ type: 'input_text', text: 'hi' }] }],
+    );
+
+    expect(
+      toNativeResponsesRequest(
+        {
+          input: [
+            'first',
+            { role: 'user', content: 'second' },
+            { role: 'assistant', content: [{ type: 'text', text: 'third' }] },
+            { type: 'function_call_output', call_id: 'call_1', output: 'ok' },
+            42,
+          ],
+        },
+        'gpt-5.4',
+        { inputList: true },
+      ).input,
+    ).toEqual([
+      { role: 'user', content: [{ type: 'input_text', text: 'first' }] },
+      { role: 'user', content: [{ type: 'input_text', text: 'second' }] },
+      { role: 'assistant', content: [{ type: 'output_text', text: 'third' }] },
+      { type: 'function_call_output', call_id: 'call_1', output: 'ok' },
+    ]);
+  });
+
+  it('can force streaming for native backends that always return SSE', () => {
+    expect(
+      toNativeResponsesRequest({ input: 'hi', stream: false }, 'gpt-5.4', {
+        forceStream: true,
+      }).stream,
+    ).toBe(true);
+  });
+
+  describe('fromChatCompletionResponse', () => {
+    it('converts text, tool calls, and usage to a Response object', () => {
+      const result = fromChatCompletionResponse(
+        {
+          id: 'chatcmpl_1',
+          object: 'chat.completion',
+          created: 1234,
+          model: 'gpt-4o',
+          choices: [
+            {
+              message: {
+                content: [{ type: 'text', text: 'Hello' }],
+                tool_calls: [
+                  {
+                    id: 'call_1',
+                    type: 'function',
+                    function: { name: 'lookup', arguments: '{"id":1}' },
+                  },
+                ],
+              },
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 3,
+            total_tokens: 13,
+            cache_read_tokens: 4,
+          },
+        },
+        'fallback-model',
+      );
+
+      expect(result.object).toBe('response');
+      expect(result.created_at).toBe(1234);
+      expect(result.model).toBe('gpt-4o');
+      expect(result.output).toEqual([
+        expect.objectContaining({
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello', annotations: [] }],
+        }),
+        expect.objectContaining({
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'lookup',
+          arguments: '{"id":1}',
+        }),
+      ]);
+      expect(result.usage).toEqual({
+        input_tokens: 10,
+        input_tokens_details: { cached_tokens: 4 },
+        output_tokens: 3,
+        output_tokens_details: { reasoning_tokens: 0 },
+        total_tokens: 13,
+      });
+    });
+
+    it('handles missing choices, non-string content, and missing usage', () => {
+      const result = fromChatCompletionResponse({ choices: [{ message: { content: 7 } }] }, 'm');
+      expect(result.model).toBe('m');
+      expect(result.output).toEqual([]);
+      expect(result.usage).toBeNull();
+    });
+  });
+
+  describe('collectResponsesSseResponse', () => {
+    it('returns the completed response object when present', () => {
+      const response = {
+        id: 'resp_1',
+        object: 'response',
+        output: [{ type: 'message' }],
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      };
+      const result = collectResponsesSseResponse(
+        `event: response.completed\ndata: ${JSON.stringify({ response })}\n\n`,
+      );
+
+      expect(result).toEqual(response);
+    });
+
+    it('keeps collected text when the completed response omits output', () => {
+      const response = {
+        id: 'resp_1',
+        object: 'response',
+        output: [],
+        usage: { input_tokens: 1, output_tokens: 2, total_tokens: 3 },
+      };
+      const result = collectResponsesSseResponse(
+        [
+          'event: response.output_text.delta\ndata: {"delta":"Hi"}',
+          `event: response.completed\ndata: ${JSON.stringify({ response })}`,
+          '',
+        ].join('\n\n'),
+      );
+
+      expect(result.output).toEqual([
+        expect.objectContaining({
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hi', annotations: [] }],
+        }),
+      ]);
+    });
+
+    it('falls back to collected output text and ignores malformed events', () => {
+      const result = collectResponsesSseResponse(
+        [
+          'event: response.output_text.delta\ndata: {"delta":"Hi"}',
+          'event: response.output_text.delta\ndata: not-json',
+          '',
+        ].join('\n\n'),
+      );
+
+      expect(result.object).toBe('response');
+      expect(result.output).toEqual([
+        expect.objectContaining({
+          type: 'message',
+          content: [{ type: 'output_text', text: 'Hi', annotations: [] }],
+        }),
+      ]);
+    });
+  });
+
+  describe('chatCompletionStreamChunkToResponses', () => {
+    it('converts chat completion content deltas to Responses SSE events', () => {
+      const result = chatCompletionStreamChunkToResponses(
+        'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}\n\n',
+      );
+
+      expect(result).toContain('event: response.output_text.delta');
+      expect(result).toContain('"delta":"Hi"');
+    });
+
+    it('converts finish chunks to response.completed events', () => {
+      const result = chatCompletionStreamChunkToResponses(
+        JSON.stringify({
+          model: 'gpt-4o',
+          choices: [{ delta: {}, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+        }),
+      );
+
+      expect(result).toContain('event: response.completed');
+      expect(result).toContain('"input_tokens":1');
+    });
+
+    it('converts usage-only stream chunks to response.completed events', () => {
+      const result = chatCompletionStreamChunkToResponses(
+        JSON.stringify({
+          model: 'gpt-4o',
+          choices: [],
+          usage: { prompt_tokens: 5, completion_tokens: 7, total_tokens: 12 },
+        }),
+      );
+
+      expect(result).toContain('event: response.completed');
+      expect(result).toContain('"input_tokens":5');
+      expect(result).toContain('"output_tokens":7');
+    });
+
+    it('ignores done, empty, malformed, and irrelevant chunks', () => {
+      expect(chatCompletionStreamChunkToResponses('data: [DONE]\n\n')).toBeNull();
+      expect(chatCompletionStreamChunkToResponses('')).toBeNull();
+      expect(chatCompletionStreamChunkToResponses('data: not-json\n\n')).toBeNull();
+      expect(chatCompletionStreamChunkToResponses('{"choices":[]}')).toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -604,4 +604,40 @@ describe('extractUsageFromSse', () => {
       cache_creation_tokens: undefined,
     });
   });
+
+  it('should extract usage from Responses API usage objects', () => {
+    const sseText = `data: ${JSON.stringify({
+      usage: {
+        input_tokens: 150,
+        output_tokens: 60,
+        input_tokens_details: { cached_tokens: 25 },
+      },
+    })}\n\n`;
+
+    expect(extractUsageFromSse(sseText)).toEqual({
+      prompt_tokens: 150,
+      completion_tokens: 60,
+      cache_read_tokens: 25,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  it('should extract usage from response.completed events', () => {
+    const sseText = `data: ${JSON.stringify({
+      response: {
+        usage: {
+          input_tokens: 12,
+          output_tokens: 8,
+          input_tokens_details: { cached_tokens: 3 },
+        },
+      },
+    })}\n\n`;
+
+    expect(extractUsageFromSse(sseText)).toEqual({
+      prompt_tokens: 12,
+      completion_tokens: 8,
+      cache_read_tokens: 3,
+      cache_creation_tokens: 0,
+    });
+  });
 });

--- a/packages/backend/src/routing/proxy/chatgpt-helpers.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-helpers.ts
@@ -6,7 +6,7 @@ import { randomUUID } from 'crypto';
 
 import { OpenAIMessage } from './proxy-types';
 
-const DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
+export const DEFAULT_INSTRUCTIONS = 'You are a helpful assistant.';
 
 export function convertAssistantToolCalls(toolCalls: unknown[]): Record<string, unknown>[] {
   return toolCalls.flatMap((toolCall) => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -16,10 +16,9 @@ import {
   convertAnthropicResponse as anthropicResponseConverter,
   convertAnthropicStreamChunk as anthropicStreamChunkConverter,
   createAnthropicTransformer,
-  type GoogleStreamChunkResult,
-  type ThinkingBlocksCallback,
 } from './provider-client-converters';
 import { ForwardOptions } from './proxy-types';
+import { toNativeResponsesRequest } from './responses-adapter';
 
 export interface ForwardResult {
   response: Response;
@@ -29,6 +28,8 @@ export interface ForwardResult {
   isAnthropic: boolean;
   /** True when we converted from ChatGPT Responses API format (needs SSE transform). */
   isChatGpt: boolean;
+  /** True when the upstream already speaks the public Responses API format. */
+  isResponses?: boolean;
 }
 
 const PROVIDER_TIMEOUT_MS = 180_000;
@@ -77,10 +78,12 @@ export class ProviderClient {
       provider,
       authType,
       model,
+      opts.apiMode,
     );
     const isGoogle = endpoint.format === 'google';
     const isAnthropic = endpoint.format === 'anthropic';
-    const isChatGpt = endpoint.format === 'chatgpt';
+    const isResponses = opts.apiMode === 'responses' && endpoint.format === 'chatgpt';
+    const isChatGpt = endpoint.format === 'chatgpt' && !isResponses;
 
     const bareModel = stripModelPrefix(model, endpointKey);
     const { url, headers, requestBody } = this.buildRequest({
@@ -91,6 +94,8 @@ export class ProviderClient {
       apiKey,
       authType,
       body,
+      chatBody: opts.chatBody,
+      apiMode: opts.apiMode,
       stream,
       signatureLookup: opts.signatureLookup,
       thinkingLookup: opts.thinkingLookup,
@@ -104,6 +109,7 @@ export class ProviderClient {
       isGoogle,
       isAnthropic,
       isChatGpt,
+      isResponses,
     });
   }
 
@@ -112,6 +118,7 @@ export class ProviderClient {
     provider: string,
     authType: string | undefined,
     model: string,
+    apiMode: ForwardOptions['apiMode'],
   ): { endpoint: ProviderEndpoint; endpointKey: string } {
     if (customEndpoint) {
       return { endpoint: customEndpoint, endpointKey: 'custom' };
@@ -123,6 +130,9 @@ export class ProviderClient {
     if (authType === 'subscription') {
       const override = resolveSubscriptionEndpointKey(resolved);
       if (override) resolved = override;
+    }
+    if (apiMode === 'responses' && resolved === 'openai') {
+      resolved = 'openai-responses';
     }
     // OpenAI rejects these models on /v1/chat/completions; forward to /v1/responses.
     if (resolved === 'openai' && OPENAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
@@ -146,11 +156,14 @@ export class ProviderClient {
     apiKey: string;
     authType: string | undefined;
     body: Record<string, unknown>;
+    chatBody?: Record<string, unknown>;
+    apiMode?: ForwardOptions['apiMode'];
     stream: boolean;
     signatureLookup?: ForwardOptions['signatureLookup'];
     thinkingLookup?: ForwardOptions['thinkingLookup'];
   }): { url: string; headers: Record<string, string>; requestBody: Record<string, unknown> } {
-    const { endpoint, endpointKey, bareModel, apiKey, authType, body, stream } = ctx;
+    const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
+    const requestSource = ctx.apiMode === 'responses' ? (chatBody ?? body) : body;
 
     if (endpoint.format === 'google') {
       // Google Gemini API requires the key as a URL parameter (not a header).
@@ -160,13 +173,13 @@ export class ProviderClient {
       return {
         url,
         headers: endpoint.buildHeaders(apiKey, authType),
-        requestBody: toGoogleRequest(body, bareModel, ctx.signatureLookup),
+        requestBody: toGoogleRequest(requestSource, bareModel, ctx.signatureLookup),
       };
     }
 
     if (endpoint.format === 'anthropic') {
       const isSubscription = authType === 'subscription';
-      const requestBody = toAnthropicRequest(body, bareModel, {
+      const requestBody = toAnthropicRequest(requestSource, bareModel, {
         injectCacheControl: !isSubscription,
         injectSubscriptionIdentity: isSubscription,
         thinkingLookup: ctx.thinkingLookup,
@@ -184,12 +197,22 @@ export class ProviderClient {
       return {
         url: `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`,
         headers: endpoint.buildHeaders(apiKey, authType),
-        requestBody: toResponsesRequest(body, bareModel),
+        requestBody:
+          ctx.apiMode === 'responses'
+            ? // ChatGPT subscription tokens hit the Codex Responses backend, which
+              // requires instruction text, list-shaped input, and upstream SSE even
+              // when Manifest returns a non-streaming JSON response to the caller.
+              toNativeResponsesRequest(body, bareModel, {
+                defaultInstructions: endpointKey === 'openai-subscription',
+                inputList: endpointKey === 'openai-subscription',
+                forceStream: endpointKey === 'openai-subscription',
+              })
+            : toResponsesRequest(body, bareModel),
       };
     }
 
     // OpenAI-compatible path (default)
-    const sanitized = sanitizeOpenAiBody(body, endpointKey, ctx.model);
+    const sanitized = sanitizeOpenAiBody(requestSource, endpointKey, ctx.model);
     if (stream && SUPPORTS_USAGE_STREAM_OPTIONS.has(endpointKey)) {
       const existing =
         typeof sanitized.stream_options === 'object' && sanitized.stream_options !== null
@@ -213,7 +236,12 @@ export class ProviderClient {
     headers: Record<string, string>,
     requestBody: Record<string, unknown>,
     signal: AbortSignal | undefined,
-    formatFlags: { isGoogle: boolean; isAnthropic: boolean; isChatGpt: boolean },
+    formatFlags: {
+      isGoogle: boolean;
+      isAnthropic: boolean;
+      isChatGpt: boolean;
+      isResponses?: boolean;
+    },
   ): Promise<ForwardResult> {
     const timeoutSignal = AbortSignal.timeout(PROVIDER_TIMEOUT_MS);
     const fetchSignal = signal ? AbortSignal.any([timeoutSignal, signal]) : timeoutSignal;

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -27,6 +27,7 @@ import {
   describeTransportError,
 } from './proxy-transport';
 import type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
+import type { ProxyApiMode } from './proxy-types';
 
 export interface FailedFallback {
   model: string;
@@ -64,6 +65,8 @@ export class ProxyFallbackService {
     primaryAuthType?: string,
     signatureLookup?: SignatureLookup,
     thinkingLookup?: ThinkingBlockLookup,
+    apiMode?: ProxyApiMode,
+    chatBody?: Record<string, unknown>,
   ): Promise<{
     success: {
       forward: ForwardResult;
@@ -140,10 +143,12 @@ export class ProxyFallbackService {
         apiKey: resolvedCredentials.apiKey,
         model,
         body,
+        chatBody,
         stream,
         sessionKey,
         signal,
         authType,
+        apiMode,
         resourceUrl: resolvedCredentials.resourceUrl,
         providerRegion,
         signatureLookup,
@@ -181,12 +186,14 @@ export class ProxyFallbackService {
     apiKey: string;
     model: string;
     body: Record<string, unknown>;
+    chatBody?: Record<string, unknown>;
     stream: boolean;
     sessionKey: string;
     signal?: AbortSignal;
     authType?: string;
     resourceUrl?: string;
     providerRegion?: string | null;
+    apiMode?: ProxyApiMode;
     signatureLookup?: SignatureLookup;
     thinkingLookup?: ThinkingBlockLookup;
   }): Promise<ForwardResult> {
@@ -216,18 +223,21 @@ export class ProxyFallbackService {
     apiKey: string;
     model: string;
     body: Record<string, unknown>;
+    chatBody?: Record<string, unknown>;
     stream: boolean;
     sessionKey: string;
     signal?: AbortSignal;
     authType?: string;
     resourceUrl?: string;
     providerRegion?: string | null;
+    apiMode?: ProxyApiMode;
     signatureLookup?: SignatureLookup;
     thinkingLookup?: ThinkingBlockLookup;
   }): Promise<ForwardResult> {
     const {
       provider,
       body,
+      chatBody,
       stream,
       signal,
       authType,
@@ -276,11 +286,13 @@ export class ProxyFallbackService {
       apiKey: effectiveKey,
       model: forwardModel,
       body,
+      chatBody,
       stream,
       signal,
       extraHeaders,
       customEndpoint,
       authType,
+      apiMode: opts.apiMode,
       signatureLookup,
       thinkingLookup,
     });

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -8,6 +8,12 @@ import { ProxyMessageRecorder } from './proxy-message-recorder';
 import { ProviderClient } from './provider-client';
 import { initSseHeaders, pipeStream, StreamUsage } from './stream-writer';
 import { sanitizeProviderError } from './proxy-error-sanitizer';
+import {
+  chatCompletionStreamChunkToResponses,
+  collectResponsesSseResponse,
+  fromChatCompletionResponse,
+} from './responses-adapter';
+import type { ProxyApiMode } from './proxy-types';
 import type { ThoughtSignatureCache } from './thought-signature-cache';
 import type { ThinkingBlockCache, ThinkingBlock } from './thinking-block-cache';
 import type { ExtractedSignature } from './google-adapter';
@@ -253,8 +259,16 @@ export async function handleStreamResponse(
   signatureCache?: ThoughtSignatureCache,
   sessionKey?: string,
   thinkingCache?: ThinkingBlockCache,
+  apiMode: ProxyApiMode = 'chat_completions',
 ): Promise<StreamUsage | null> {
   initSseHeaders(res, metaHeaders);
+
+  const toClientChunk =
+    apiMode === 'responses' ? chatCompletionStreamChunkToResponses : (chunk: string) => chunk;
+
+  if (apiMode === 'responses' && forward.isResponses) {
+    return pipeStream(forward.response.body!, res);
+  }
 
   if (forward.isGoogle) {
     return pipeStream(forward.response.body!, res, (chunk) => {
@@ -264,7 +278,7 @@ export async function handleStreamResponse(
           signatureCache.store(sessionKey, s.toolCallId, s.signature);
         }
       }
-      return out;
+      return out ? toClientChunk(out) : null;
     });
   }
   if (forward.isAnthropic) {
@@ -274,16 +288,22 @@ export async function handleStreamResponse(
             thinkingCache.store(sessionKey, firstToolUseId, blocks);
           }
         : undefined;
-    return pipeStream(
-      forward.response.body!,
-      res,
-      providerClient.createAnthropicStreamTransformer(meta.model, onThinkingBlocks),
+    const anthropicTransformer = providerClient.createAnthropicStreamTransformer(
+      meta.model,
+      onThinkingBlocks,
     );
+    return pipeStream(forward.response.body!, res, (chunk) => {
+      const out = anthropicTransformer(chunk);
+      return out ? toClientChunk(out) : null;
+    });
   }
   if (forward.isChatGpt) {
     return pipeStream(forward.response.body!, res, (chunk) =>
       providerClient.convertChatGptStreamChunk(chunk, meta.model),
     );
+  }
+  if (apiMode === 'responses') {
+    return pipeStream(forward.response.body!, res, toClientChunk);
   }
   return pipeStream(forward.response.body!, res);
 }
@@ -298,10 +318,13 @@ export async function handleNonStreamResponse(
   signatureCache?: ThoughtSignatureCache,
   sessionKey?: string,
   thinkingCache?: ThinkingBlockCache,
+  apiMode: ProxyApiMode = 'chat_completions',
 ): Promise<StreamUsage | null> {
   let responseBody: unknown;
 
-  if (forward.isGoogle) {
+  if (apiMode === 'responses' && forward.isResponses) {
+    responseBody = await readNativeResponsesBody(forward.response);
+  } else if (forward.isGoogle) {
     const googleData = (await forward.response.json()) as Record<string, unknown>;
     responseBody = providerClient.convertGoogleResponse(googleData, meta.model);
     const sigs = (responseBody as Record<string, unknown>)?._extractedSignatures as
@@ -332,15 +355,32 @@ export async function handleNonStreamResponse(
     responseBody = await forward.response.json();
   }
 
+  if (apiMode === 'responses' && !forward.isResponses) {
+    responseBody = fromChatCompletionResponse(responseBody as Record<string, unknown>, meta.model);
+  }
+
   const body = responseBody as Record<string, unknown> | undefined;
-  const usage = body?.usage as Record<string, number> | undefined;
+  const usage = body?.usage as Record<string, number | Record<string, number>> | undefined;
   let streamUsage: StreamUsage | null = null;
   if (usage && typeof usage.prompt_tokens === 'number') {
     streamUsage = {
       prompt_tokens: usage.prompt_tokens,
-      completion_tokens: usage.completion_tokens ?? 0,
-      cache_read_tokens: usage.cache_read_tokens,
-      cache_creation_tokens: usage.cache_creation_tokens,
+      completion_tokens: typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0,
+      cache_read_tokens:
+        typeof usage.cache_read_tokens === 'number' ? usage.cache_read_tokens : undefined,
+      cache_creation_tokens:
+        typeof usage.cache_creation_tokens === 'number' ? usage.cache_creation_tokens : undefined,
+    };
+  } else if (usage && typeof usage.input_tokens === 'number') {
+    const inputDetails =
+      typeof usage.input_tokens_details === 'object' && usage.input_tokens_details !== null
+        ? (usage.input_tokens_details as Record<string, number>)
+        : undefined;
+    streamUsage = {
+      prompt_tokens: usage.input_tokens,
+      completion_tokens: typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
+      cache_read_tokens: inputDetails?.cached_tokens,
+      cache_creation_tokens: 0,
     };
   }
 
@@ -348,6 +388,25 @@ export async function handleNonStreamResponse(
   setHeaders(res, metaHeaders);
   res.json(responseBody);
   return streamUsage;
+}
+
+async function readNativeResponsesBody(response: Response): Promise<unknown> {
+  const contentType = response.headers.get('content-type') ?? '';
+  const text = await response.text();
+  const trimmed = text.trimStart();
+
+  // ChatGPT subscription Responses can return SSE text without an SSE content
+  // type. Inspecting the body keeps non-streaming SDK calls from trying to parse
+  // `event: ...` as JSON.
+  if (
+    contentType.includes('text/event-stream') ||
+    trimmed.startsWith('event:') ||
+    trimmed.startsWith('data:')
+  ) {
+    return collectResponsesSseResponse(text);
+  }
+
+  return JSON.parse(text);
 }
 
 /** Records the success message or fallback success after response is sent. */

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -16,6 +16,7 @@ export type SignatureLookup = (toolCallId: string) => string | null;
  * assistant turn; returns the ordered block sequence or null.
  */
 export type ThinkingBlockLookup = (firstToolUseId: string) => ThinkingBlock[] | null;
+export type ProxyApiMode = 'chat_completions' | 'responses';
 
 export interface OpenAIMessage {
   role: string;
@@ -35,6 +36,8 @@ export interface ForwardOptions {
   apiKey: string;
   model: string;
   body: Record<string, unknown>;
+  chatBody?: Record<string, unknown>;
+  apiMode?: ProxyApiMode;
   stream: boolean;
   signal?: AbortSignal;
   extraHeaders?: Record<string, string>;
@@ -51,6 +54,7 @@ export interface ProxyRequestOptions {
   agentId: string;
   userId: string;
   body: Record<string, unknown>;
+  apiMode?: ProxyApiMode;
   sessionKey: string;
   tenantId?: string;
   agentName?: string;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -31,6 +31,7 @@ import {
 } from './proxy-response-handler';
 import { ProxyExceptionFilter, isChatRenderingClient } from './proxy-exception.filter';
 import { sendFriendlyResponse } from './proxy-friendly-response';
+import type { ProxyApiMode } from './proxy-types';
 
 const MAX_SEEN_USERS = 10_000;
 const SEEN_USER_TTL_MS = 24 * 60 * 60 * 1000;
@@ -57,6 +58,22 @@ export class ProxyController {
   async chatCompletions(
     @Req() req: Request & { ingestionContext: IngestionContext },
     @Res() res: ExpressResponse,
+  ): Promise<void> {
+    await this.handleProxyRequest(req, res, 'chat_completions');
+  }
+
+  @Post('responses')
+  async responses(
+    @Req() req: Request & { ingestionContext: IngestionContext },
+    @Res() res: ExpressResponse,
+  ): Promise<void> {
+    await this.handleProxyRequest(req, res, 'responses');
+  }
+
+  private async handleProxyRequest(
+    req: Request & { ingestionContext: IngestionContext },
+    res: ExpressResponse,
+    apiMode: ProxyApiMode,
   ): Promise<void> {
     const { userId } = req.ingestionContext;
     const body = req.body as Record<string, unknown>;
@@ -88,6 +105,7 @@ export class ProxyController {
         signal: clientAbort.signal,
         specificityOverride,
         headers: req.headers,
+        apiMode,
       });
 
       this.trackFirstProxyRequest(userId);
@@ -135,6 +153,7 @@ export class ProxyController {
           this.signatureCache,
           sessionKey,
           this.thinkingCache,
+          apiMode,
         );
       } else {
         streamUsage = await handleNonStreamResponse(
@@ -146,6 +165,7 @@ export class ProxyController {
           this.signatureCache,
           sessionKey,
           this.thinkingCache,
+          apiMode,
         );
       }
 

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -18,11 +18,17 @@ import {
   normalizeProviderModel,
   resolveApiKey,
 } from './proxy-fallback.service';
-import { ProxyRequestOptions, SignatureLookup, ThinkingBlockLookup } from './proxy-types';
+import {
+  ProxyApiMode,
+  ProxyRequestOptions,
+  SignatureLookup,
+  ThinkingBlockLookup,
+} from './proxy-types';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
 import type { AuthType } from 'manifest-shared';
+import { toChatCompletionsRequest } from './responses-adapter';
 
 type ResolvedRouting = Awaited<ReturnType<ResolveService['resolve']>>;
 
@@ -97,16 +103,19 @@ export class ProxyService {
       specificityOverride,
       headers,
     } = opts;
-    this.validatePayload(body);
+    const apiMode = opts.apiMode ?? 'chat_completions';
+    const chatBody = apiMode === 'responses' ? toChatCompletionsRequest(body) : undefined;
+    const routingBody = chatBody ?? body;
+    this.validatePayload(routingBody);
 
     const limitMessage = await this.enforceLimits(tenantId, agentName);
     if (limitMessage) {
-      return buildFriendlyResponse(limitMessage, body.stream === true, 'limit_exceeded');
+      return buildFriendlyResponse(limitMessage, routingBody.stream === true, 'limit_exceeded');
     }
 
     const resolved = await this.resolveRouting(
       agentId,
-      body,
+      routingBody,
       sessionKey,
       specificityOverride,
       headers,
@@ -146,10 +155,12 @@ export class ProxyService {
       apiKey: credentials.apiKey,
       model: primaryModel,
       body,
+      chatBody,
       stream,
       sessionKey,
       signal,
       authType: resolved.auth_type,
+      apiMode,
       resourceUrl: credentials.resourceUrl,
       providerRegion: credentials.providerRegion,
       signatureLookup,
@@ -164,11 +175,13 @@ export class ProxyService {
         primaryModel,
         forward,
         body,
+        chatBody,
         stream,
         sessionKey,
         signal,
         signatureLookup,
         thinkingLookup,
+        apiMode,
       });
       if (fallbackResult) return fallbackResult;
     }
@@ -265,14 +278,27 @@ export class ProxyService {
     primaryModel: string;
     forward: ForwardResult;
     body: ProxyRequestOptions['body'];
+    chatBody?: ProxyRequestOptions['body'];
     stream: boolean;
     sessionKey: string;
     signal?: AbortSignal;
     signatureLookup: SignatureLookup;
     thinkingLookup: ThinkingBlockLookup;
+    apiMode: ProxyApiMode;
   }): Promise<ProxyResult | null> {
-    const { agentId, userId, resolved, primaryModel, forward, body, stream, sessionKey, signal } =
-      args;
+    const {
+      agentId,
+      userId,
+      resolved,
+      primaryModel,
+      forward,
+      body,
+      chatBody,
+      stream,
+      sessionKey,
+      signal,
+      apiMode,
+    } = args;
     const tiers = await this.tierService.getTiers(agentId);
     const assignment = tiers.find((t) => t.tier === resolved.tier);
     const fallbackModels = resolved.fallback_models ?? assignment?.fallback_models;
@@ -293,6 +319,8 @@ export class ProxyService {
       resolved.auth_type,
       args.signatureLookup,
       args.thinkingLookup,
+      apiMode,
+      chatBody,
     );
 
     this.recordTierIfScoring(sessionKey, resolved.tier);

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -1,0 +1,418 @@
+import { randomUUID } from 'crypto';
+
+import { DEFAULT_INSTRUCTIONS } from './chatgpt-helpers';
+import { OpenAIMessage } from './proxy-types';
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter(isRecord)
+    .map((part) => (typeof part.text === 'string' ? part.text : ''))
+    .join('');
+}
+
+function toChatContent(content: unknown, role: string): unknown {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return content;
+
+  const converted = content.filter(isRecord).map((part) => {
+    if (typeof part.text === 'string') return { type: 'text', text: part.text };
+    if (part.type === 'input_image' && typeof part.image_url === 'string') {
+      return { type: 'image_url', image_url: { url: part.image_url } };
+    }
+    return part;
+  });
+
+  if (converted.length === 1 && converted[0]?.type === 'text' && role !== 'assistant') {
+    return converted[0].text;
+  }
+  return converted;
+}
+
+function responseInputItemToMessage(item: JsonRecord): OpenAIMessage[] {
+  if (item.type === 'function_call') {
+    return [
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: typeof item.call_id === 'string' ? item.call_id : randomUUID(),
+            type: 'function',
+            function: {
+              name: typeof item.name === 'string' ? item.name : 'unknown',
+              arguments: typeof item.arguments === 'string' ? item.arguments : '{}',
+            },
+          },
+        ],
+      },
+    ];
+  }
+
+  if (item.type === 'function_call_output') {
+    return [
+      {
+        role: 'tool',
+        tool_call_id: typeof item.call_id === 'string' ? item.call_id : randomUUID(),
+        content:
+          item.output === undefined || item.output === null
+            ? ''
+            : typeof item.output === 'string'
+              ? item.output
+              : JSON.stringify(item.output),
+      },
+    ];
+  }
+
+  const role = typeof item.role === 'string' ? item.role : 'user';
+  return [{ role, content: toChatContent(item.content, role) }];
+}
+
+export function toChatCompletionsRequest(body: JsonRecord): JsonRecord {
+  const messages: OpenAIMessage[] = [];
+  const instructions = body.instructions;
+  if (typeof instructions === 'string' && instructions.trim()) {
+    messages.push({ role: 'system', content: instructions });
+  }
+
+  const input = body.input;
+  if (typeof input === 'string') {
+    messages.push({ role: 'user', content: input });
+  } else if (Array.isArray(input)) {
+    for (const item of input) {
+      if (typeof item === 'string') {
+        messages.push({ role: 'user', content: item });
+      } else if (isRecord(item)) {
+        messages.push(...responseInputItemToMessage(item));
+      }
+    }
+  }
+
+  const chatBody: JsonRecord = { messages };
+  for (const key of [
+    'model',
+    'temperature',
+    'top_p',
+    'stream',
+    'metadata',
+    'store',
+    'user',
+    'parallel_tool_calls',
+  ]) {
+    if (body[key] !== undefined) chatBody[key] = body[key];
+  }
+
+  if (body.max_output_tokens !== undefined) chatBody.max_tokens = body.max_output_tokens;
+  if (Array.isArray(body.tools)) chatBody.tools = toChatTools(body.tools);
+  if (body.tool_choice !== undefined) chatBody.tool_choice = toChatToolChoice(body.tool_choice);
+
+  return chatBody;
+}
+
+function toChatTools(tools: unknown[]): JsonRecord[] {
+  return tools.filter(isRecord).map((tool) => {
+    if (tool.type !== 'function') return tool;
+    return {
+      type: 'function',
+      function: {
+        name: tool.name,
+        ...(tool.description !== undefined && { description: tool.description }),
+        ...(tool.parameters !== undefined && { parameters: tool.parameters }),
+        ...(tool.strict !== undefined && { strict: tool.strict }),
+      },
+    };
+  });
+}
+
+function toChatToolChoice(toolChoice: unknown): unknown {
+  if (!isRecord(toolChoice) || toolChoice.type !== 'function') return toolChoice;
+  return { type: 'function', function: { name: toolChoice.name } };
+}
+
+export function toNativeResponsesRequest(
+  body: JsonRecord,
+  model: string,
+  opts?: { defaultInstructions?: boolean; inputList?: boolean; forceStream?: boolean },
+): JsonRecord {
+  const request: JsonRecord = { ...body, model };
+  if (opts?.forceStream) {
+    request.stream = true;
+  } else if (body.stream === undefined) {
+    request.stream = false;
+  }
+  if (body.store === undefined) request.store = false;
+  if (opts?.inputList) {
+    request.input = toNativeResponsesInput(body.input);
+  }
+  if (
+    opts?.defaultInstructions &&
+    (typeof request.instructions !== 'string' || !request.instructions.trim())
+  ) {
+    request.instructions = DEFAULT_INSTRUCTIONS;
+  }
+  return request;
+}
+
+function toNativeResponsesInput(input: unknown): unknown {
+  if (typeof input === 'string') {
+    return [{ role: 'user', content: [{ type: 'input_text', text: input }] }];
+  }
+  if (!Array.isArray(input)) return input;
+
+  return input.flatMap((item) => {
+    if (typeof item === 'string') {
+      return [{ role: 'user', content: [{ type: 'input_text', text: item }] }];
+    }
+    if (!isRecord(item) || item.type === 'function_call' || item.type === 'function_call_output') {
+      return isRecord(item) ? [item] : [];
+    }
+
+    const role = typeof item.role === 'string' ? item.role : 'user';
+    return [{ ...item, role, content: toNativeResponsesContent(item.content, role) }];
+  });
+}
+
+function toNativeResponsesContent(content: unknown, role: string): unknown {
+  const partType = role === 'assistant' ? 'output_text' : 'input_text';
+
+  if (typeof content === 'string') return [{ type: partType, text: content }];
+  if (!Array.isArray(content)) return content;
+
+  return content.filter(isRecord).map((part) => {
+    if (typeof part.text === 'string' && (part.type === 'text' || part.type === undefined)) {
+      return { ...part, type: partType };
+    }
+    return part;
+  });
+}
+
+export function fromChatCompletionResponse(body: JsonRecord, model: string): JsonRecord {
+  const choices = Array.isArray(body.choices) ? body.choices : [];
+  const firstChoice = isRecord(choices[0]) ? choices[0] : {};
+  const message = isRecord(firstChoice.message) ? firstChoice.message : {};
+  const output: JsonRecord[] = [];
+  const contentText = textFromContent(message.content);
+
+  if (contentText) {
+    output.push({
+      type: 'message',
+      id: `msg_${randomUUID().replace(/-/g, '')}`,
+      status: 'completed',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: contentText, annotations: [] }],
+    });
+  }
+
+  if (Array.isArray(message.tool_calls)) {
+    for (const toolCall of message.tool_calls) {
+      if (!isRecord(toolCall) || !isRecord(toolCall.function)) continue;
+      output.push({
+        type: 'function_call',
+        id: `fc_${randomUUID().replace(/-/g, '')}`,
+        call_id: typeof toolCall.id === 'string' ? toolCall.id : randomUUID(),
+        name: typeof toolCall.function.name === 'string' ? toolCall.function.name : '',
+        arguments:
+          typeof toolCall.function.arguments === 'string' ? toolCall.function.arguments : '{}',
+        status: 'completed',
+      });
+    }
+  }
+
+  const created = typeof body.created === 'number' ? body.created : Math.floor(Date.now() / 1000);
+  return {
+    id: `resp_${randomUUID().replace(/-/g, '')}`,
+    object: 'response',
+    created_at: created,
+    status: 'completed',
+    completed_at: created,
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    max_output_tokens: null,
+    model: typeof body.model === 'string' ? body.model : model,
+    output,
+    parallel_tool_calls: true,
+    previous_response_id: null,
+    reasoning: { effort: null, summary: null },
+    store: false,
+    temperature: null,
+    text: { format: { type: 'text' } },
+    tool_choice: 'auto',
+    tools: [],
+    top_p: null,
+    truncation: 'disabled',
+    usage: toResponsesUsage(body.usage),
+    user: null,
+    metadata: {},
+  };
+}
+
+function toResponsesUsage(usage: unknown): JsonRecord | null {
+  if (!isRecord(usage)) return null;
+  const promptTokens = typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : 0;
+  const completionTokens =
+    typeof usage.completion_tokens === 'number' ? usage.completion_tokens : 0;
+  const totalTokens =
+    typeof usage.total_tokens === 'number' ? usage.total_tokens : promptTokens + completionTokens;
+  const cachedTokens =
+    typeof usage.cache_read_tokens === 'number' ? usage.cache_read_tokens : undefined;
+
+  return {
+    input_tokens: promptTokens,
+    input_tokens_details: { cached_tokens: cachedTokens ?? 0 },
+    output_tokens: completionTokens,
+    output_tokens_details: { reasoning_tokens: 0 },
+    total_tokens: totalTokens,
+  };
+}
+
+export function collectResponsesSseResponse(sseText: string): JsonRecord {
+  let text = '';
+  let completed: JsonRecord | null = null;
+
+  for (const event of sseText.split('\n\n')) {
+    const parsed = parseSseEvent(event);
+    if (!parsed) continue;
+    if (parsed.event === 'response.output_text.delta') {
+      const data = safeParse(parsed.data);
+      if (typeof data?.delta === 'string') text += data.delta;
+    }
+    if (parsed.event === 'response.completed') {
+      const data = safeParse(parsed.data);
+      completed = isRecord(data?.response) ? data.response : null;
+    }
+  }
+
+  if (completed) return withCollectedTextOutput(completed, text);
+  return fromChatCompletionResponse(
+    {
+      choices: [{ message: { content: text } }],
+      usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+    },
+    'unknown',
+  );
+}
+
+function withCollectedTextOutput(response: JsonRecord, text: string): JsonRecord {
+  if (!text) return response;
+  const output = Array.isArray(response.output) ? response.output : [];
+  const hasTextOutput = output.some((item) => {
+    if (!isRecord(item) || !Array.isArray(item.content)) return false;
+    return item.content.some(
+      (part) => isRecord(part) && part.type === 'output_text' && typeof part.text === 'string',
+    );
+  });
+  if (hasTextOutput) return response;
+
+  return {
+    ...response,
+    output: [
+      ...output,
+      {
+        type: 'message',
+        id: `msg_${randomUUID().replace(/-/g, '')}`,
+        status: 'completed',
+        role: 'assistant',
+        content: [{ type: 'output_text', text, annotations: [] }],
+      },
+    ],
+  };
+}
+
+function parseSseEvent(raw: string): { event: string; data: string } | null {
+  let event = '';
+  let data = '';
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('event: ')) event = line.slice(7).trim();
+    if (line.startsWith('data: ')) data += line.slice(6);
+  }
+  return event || data ? { event, data } : null;
+}
+
+function safeParse(data: string): JsonRecord | null {
+  try {
+    const parsed = JSON.parse(data);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function chatCompletionStreamChunkToResponses(chunk: string): string | null {
+  const payloads = extractDataPayloads(chunk);
+  const events: string[] = [];
+
+  for (const payload of payloads) {
+    if (payload === '[DONE]') continue;
+    const data = safeParse(payload);
+    if (!data) continue;
+    const choices = Array.isArray(data.choices) ? data.choices : [];
+    if (choices.length === 0 && isRecord(data.usage)) {
+      events.push(
+        formatResponsesEvent('response.completed', {
+          type: 'response.completed',
+          response: fromChatCompletionResponse(
+            {
+              model: typeof data.model === 'string' ? data.model : undefined,
+              usage: data.usage,
+              choices: [{ message: { content: '' } }],
+            },
+            typeof data.model === 'string' ? data.model : 'unknown',
+          ),
+        }),
+      );
+      continue;
+    }
+
+    const choice = isRecord(choices[0]) ? choices[0] : null;
+    const delta = isRecord(choice?.delta) ? choice.delta : {};
+
+    if (typeof delta.content === 'string' && delta.content.length > 0) {
+      events.push(
+        formatResponsesEvent('response.output_text.delta', {
+          type: 'response.output_text.delta',
+          item_id: 'msg_0',
+          output_index: 0,
+          content_index: 0,
+          delta: delta.content,
+        }),
+      );
+    }
+
+    if (choice?.finish_reason) {
+      events.push(
+        formatResponsesEvent('response.completed', {
+          type: 'response.completed',
+          response: fromChatCompletionResponse(
+            {
+              model: typeof data.model === 'string' ? data.model : undefined,
+              usage: data.usage,
+              choices: [{ message: { content: '' } }],
+            },
+            typeof data.model === 'string' ? data.model : 'unknown',
+          ),
+        }),
+      );
+    }
+  }
+
+  return events.length > 0 ? events.join('') : null;
+}
+
+function extractDataPayloads(chunk: string): string[] {
+  const lines = chunk.split('\n').map((line) => line.trim());
+  const dataLines = lines.filter((line) => line.startsWith('data:'));
+  if (dataLines.length > 0) return dataLines.map((line) => line.slice(5).trim());
+  return [chunk.trim()].filter(Boolean);
+}
+
+function formatResponsesEvent(event: string, data: JsonRecord): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -24,6 +24,22 @@ export function extractUsageFromSse(sseText: string): StreamUsage | null {
           cache_creation_tokens: obj.usage.cache_creation_tokens,
         };
       }
+      if (obj.usage && typeof obj.usage.input_tokens === 'number') {
+        return {
+          prompt_tokens: obj.usage.input_tokens,
+          completion_tokens: obj.usage.output_tokens ?? 0,
+          cache_read_tokens: obj.usage.input_tokens_details?.cached_tokens,
+          cache_creation_tokens: 0,
+        };
+      }
+      if (obj.response?.usage && typeof obj.response.usage.input_tokens === 'number') {
+        return {
+          prompt_tokens: obj.response.usage.input_tokens,
+          completion_tokens: obj.response.usage.output_tokens ?? 0,
+          cache_read_tokens: obj.response.usage.input_tokens_details?.cached_tokens,
+          cache_creation_tokens: 0,
+        };
+      }
     } catch {
       /* ignore parse errors */
     }
@@ -135,6 +151,23 @@ export async function pipeStream(
                   cache_read_tokens: obj.usage.cache_read_tokens,
                   cache_creation_tokens: obj.usage.cache_creation_tokens,
                 };
+              } else if (obj.usage && typeof obj.usage.input_tokens === 'number') {
+                capturedUsage = {
+                  prompt_tokens: obj.usage.input_tokens,
+                  completion_tokens: obj.usage.output_tokens ?? 0,
+                  cache_read_tokens: obj.usage.input_tokens_details?.cached_tokens,
+                  cache_creation_tokens: 0,
+                };
+              } else if (
+                obj.response?.usage &&
+                typeof obj.response.usage.input_tokens === 'number'
+              ) {
+                capturedUsage = {
+                  prompt_tokens: obj.response.usage.input_tokens,
+                  completion_tokens: obj.response.usage.output_tokens ?? 0,
+                  cache_read_tokens: obj.response.usage.input_tokens_details?.cached_tokens,
+                  cache_creation_tokens: 0,
+                };
               }
             } catch {
               /* ignore non-JSON events */
@@ -162,6 +195,20 @@ export async function pipeStream(
               completion_tokens: obj.usage.completion_tokens ?? 0,
               cache_read_tokens: obj.usage.cache_read_tokens,
               cache_creation_tokens: obj.usage.cache_creation_tokens,
+            };
+          } else if (obj.usage && typeof obj.usage.input_tokens === 'number') {
+            capturedUsage = {
+              prompt_tokens: obj.usage.input_tokens,
+              completion_tokens: obj.usage.output_tokens ?? 0,
+              cache_read_tokens: obj.usage.input_tokens_details?.cached_tokens,
+              cache_creation_tokens: 0,
+            };
+          } else if (obj.response?.usage && typeof obj.response.usage.input_tokens === 'number') {
+            capturedUsage = {
+              prompt_tokens: obj.response.usage.input_tokens,
+              completion_tokens: obj.response.usage.output_tokens ?? 0,
+              cache_read_tokens: obj.response.usage.input_tokens_details?.cached_tokens,
+              cache_creation_tokens: 0,
             };
           }
         } catch {

--- a/packages/backend/test/proxy.e2e-spec.ts
+++ b/packages/backend/test/proxy.e2e-spec.ts
@@ -81,6 +81,16 @@ describe('Proxy E2E — /v1/chat/completions', () => {
     expect(res.body.error.message).toContain('Missing the Authorization header');
   });
 
+  it('rejects unauthenticated Responses API requests with HTTP 401', async () => {
+    const res = await api()
+      .post('/v1/responses')
+      .send({ input: 'hello' })
+      .expect(401);
+
+    expect(res.body.error.type).toBe('auth_error');
+    expect(res.body.error.message).toContain('Missing the Authorization header');
+  });
+
   it('returns the friendly envelope when the caller opts into SSE chat semantics', async () => {
     const res = await api()
       .post('/v1/chat/completions')
@@ -93,6 +103,15 @@ describe('Proxy E2E — /v1/chat/completions', () => {
 
   it('returns HTTP 400 when messages are missing', async () => {
     const res = await bearer(api().post('/v1/chat/completions'))
+      .send({})
+      .expect(400);
+
+    expect(res.body.error.type).toBe('invalid_request_error');
+    expect(res.body.error.message).toContain('messages');
+  });
+
+  it('returns HTTP 400 when Responses API input is missing', async () => {
+    const res = await bearer(api().post('/v1/responses'))
       .send({})
       .expect(400);
 

--- a/packages/frontend/src/components/FrameworkSnippets.tsx
+++ b/packages/frontend/src/components/FrameworkSnippets.tsx
@@ -1,12 +1,13 @@
 import { createEffect, createSignal, For, Show, type Component } from 'solid-js';
 import CopyButton from './CopyButton.jsx';
-import CodeBlock from './CodeBlock.jsx';
 import { highlight } from '../services/syntax-highlight.js';
 import {
   type ToolkitId,
   type OpenAILangId,
+  type OpenAIApiId,
   TOOLKIT_TABS,
   SDK_LANG_TOGGLE,
+  OPENAI_API_TOGGLE,
   getStoredToolkit,
   storeToolkit,
   getStoredOpenAILang,
@@ -70,6 +71,7 @@ const FrameworkSnippets: Component<Props> = (props) => {
     props.defaultToolkit ?? getStoredToolkit(),
   );
   const [openaiLang, setOpenaiLang] = createSignal<OpenAILangId>(getStoredOpenAILang());
+  const [openaiApi, setOpenaiApi] = createSignal<OpenAIApiId>('responses');
   const [keyRevealed, setKeyRevealed] = createSignal(!props.hideFullKey);
 
   createEffect(() => {
@@ -101,9 +103,17 @@ const FrameworkSnippets: Component<Props> = (props) => {
       displayKey(),
       openaiLang(),
       props.customHeaders,
+      openaiApi(),
     );
   const snippetForCopy = () =>
-    getSnippetForToolkit(activeTab(), props.baseUrl, copyKey(), openaiLang(), props.customHeaders);
+    getSnippetForToolkit(
+      activeTab(),
+      props.baseUrl,
+      copyKey(),
+      openaiLang(),
+      props.customHeaders,
+      openaiApi(),
+    );
   const language = () => getLangForToolkit(activeTab(), openaiLang());
 
   const headerEntries = (): [string, string][] =>
@@ -134,21 +144,41 @@ const FrameworkSnippets: Component<Props> = (props) => {
         </Show>
 
         <Show when={activeTab() === 'openai-sdk' || activeTab() === 'vercel-ai-sdk'}>
-          <div class="toolkit-lang-toggle" role="tablist" aria-label="Language">
-            <For each={SDK_LANG_TOGGLE}>
-              {(lang) => (
-                <button
-                  class="toolkit-lang-toggle__btn"
-                  classList={{ 'toolkit-lang-toggle__btn--active': openaiLang() === lang.id }}
-                  onClick={() => handleLangChange(lang.id)}
-                  role="tab"
-                  aria-selected={openaiLang() === lang.id}
-                >
-                  <img src={lang.icon} alt="" width="14" height="14" />
-                  {lang.label}
-                </button>
-              )}
-            </For>
+          <div class="framework-snippets__toggle-row">
+            <div class="toolkit-lang-toggle" role="tablist" aria-label="Language">
+              <For each={SDK_LANG_TOGGLE}>
+                {(lang) => (
+                  <button
+                    class="toolkit-lang-toggle__btn"
+                    classList={{ 'toolkit-lang-toggle__btn--active': openaiLang() === lang.id }}
+                    onClick={() => handleLangChange(lang.id)}
+                    role="tab"
+                    aria-selected={openaiLang() === lang.id}
+                  >
+                    <img src={lang.icon} alt="" width="14" height="14" />
+                    {lang.label}
+                  </button>
+                )}
+              </For>
+            </div>
+
+            <Show when={activeTab() === 'openai-sdk'}>
+              <div class="toolkit-api-toggle" role="tablist" aria-label="OpenAI API">
+                <For each={OPENAI_API_TOGGLE}>
+                  {(api) => (
+                    <button
+                      class="toolkit-api-toggle__btn"
+                      classList={{ 'toolkit-api-toggle__btn--active': openaiApi() === api.id }}
+                      onClick={() => setOpenaiApi(api.id)}
+                      role="tab"
+                      aria-selected={openaiApi() === api.id}
+                    >
+                      {api.label}
+                    </button>
+                  )}
+                </For>
+              </div>
+            </Show>
           </div>
         </Show>
 

--- a/packages/frontend/src/components/OpenClawSetup.tsx
+++ b/packages/frontend/src/components/OpenClawSetup.tsx
@@ -146,7 +146,7 @@ const OpenClawSetup: Component<Props> = (props) => {
               <CopyButton text={copyKey()} />
             </span>
           </div>
-          <OnboardField label="Endpoint compatibility" value="OpenAI-compatible" />
+          <OnboardField label="Endpoint compatibility" value="OpenAI Responses-compatible" />
           <OnboardField label="Model ID" value="auto" copyable />
           <OnboardField label="Endpoint ID" value="manifest" copyable />
         </div>

--- a/packages/frontend/src/components/RoutingInstructionModal.tsx
+++ b/packages/frontend/src/components/RoutingInstructionModal.tsx
@@ -2,7 +2,6 @@ import { type Component, Show, createResource, createSignal } from 'solid-js';
 import CopyButton from './CopyButton.jsx';
 import ModelSelectDropdown from './ModelSelectDropdown.jsx';
 import SetupStepAddProvider from './SetupStepAddProvider.jsx';
-import { PROVIDERS } from '../services/providers.js';
 import { getAgentKey } from '../services/api.js';
 import { agentPlatform } from '../services/agent-platform-store.js';
 
@@ -16,12 +15,7 @@ interface Props {
 
 const RoutingInstructionModal: Component<Props> = (props) => {
   const [selectedModel, setSelectedModel] = createSignal<string | null>(null);
-  const [selectedLabel, setSelectedLabel] = createSignal<string | null>(null);
   const isEnable = () => props.mode === 'enable';
-  const providerName = () => {
-    if (!props.connectedProvider) return null;
-    return PROVIDERS.find((p) => p.id === props.connectedProvider)?.name ?? props.connectedProvider;
-  };
   const title = () => (isEnable() ? 'Activate routing' : 'Deactivate routing');
   const modelOrPlaceholder = () => selectedModel() ?? '<provider/model>';
 
@@ -36,28 +30,11 @@ const RoutingInstructionModal: Component<Props> = (props) => {
     return `${window.location.origin}/v1`;
   };
 
-  const displayKey = () =>
-    apiKeyData()?.apiKey ??
-    (apiKeyData()?.keyPrefix ? `${apiKeyData()!.keyPrefix}...` : 'mnfst_YOUR_KEY');
-  const isKeyTruncated = () => !apiKeyData()?.apiKey;
-
-  const enableCmd = () => {
-    const providerJson = JSON.stringify({
-      baseUrl: baseUrl(),
-      api: 'openai-completions',
-      apiKey: displayKey(),
-      models: [{ id: 'auto', name: 'Manifest Auto' }],
-    });
-    return `openclaw config set models.providers.manifest '${providerJson}'\nopenclaw config set agents.defaults.model.primary manifest/auto\nopenclaw gateway restart`;
-  };
-
   const disableCmd = () =>
     `openclaw config unset models.providers.manifest\nopenclaw config unset agents.defaults.models.manifest/auto\nopenclaw config set agents.defaults.model.primary ${modelOrPlaceholder()}\nopenclaw gateway restart`;
-  const command = () => (isEnable() ? enableCmd() : disableCmd());
 
-  const handleModelSelect = (cliValue: string, displayLabel: string) => {
+  const handleModelSelect = (cliValue: string) => {
     setSelectedModel(cliValue);
-    setSelectedLabel(displayLabel);
   };
 
   return (

--- a/packages/frontend/src/services/framework-snippets.ts
+++ b/packages/frontend/src/services/framework-snippets.ts
@@ -14,6 +14,7 @@ export const FRAMEWORK_TABS: FrameworkTab[] = [
 
 export type ToolkitId = 'openai-sdk' | 'vercel-ai-sdk' | 'langchain' | 'curl';
 export type OpenAILangId = 'python' | 'typescript';
+export type OpenAIApiId = 'responses' | 'chat-completions';
 
 export interface ToolkitTab {
   id: ToolkitId;
@@ -34,9 +35,19 @@ export interface OpenAILangTab {
   icon: string;
 }
 
+export interface OpenAIApiTab {
+  id: OpenAIApiId;
+  label: string;
+}
+
 export const SDK_LANG_TOGGLE: OpenAILangTab[] = [
   { id: 'python', label: 'Python', icon: '/icons/python.svg' },
   { id: 'typescript', label: 'TypeScript', icon: '/icons/typescript.svg' },
+];
+
+export const OPENAI_API_TOGGLE: OpenAIApiTab[] = [
+  { id: 'responses', label: 'Responses API' },
+  { id: 'chat-completions', label: 'Chat Completions' },
 ];
 
 /** @deprecated Use SDK_LANG_TOGGLE instead */
@@ -103,6 +114,50 @@ function headerLine(
   return `${indent}${keyword}${sep}${dict},`;
 }
 
+function getOpenAIChatPythonSnippet(
+  baseUrl: string,
+  apiKey: string,
+  customHeaders?: CustomHeaders,
+): Snippet {
+  const openaiHeaders = headerLine(customHeaders, 'py-kwarg', 'default_headers');
+  return {
+    title: 'Chat Completions',
+    code: `from openai import OpenAI
+
+client = OpenAI(
+    base_url="${baseUrl}",
+    api_key="${apiKey}",${openaiHeaders}
+)
+
+response = client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Hello"}],
+)`,
+  };
+}
+
+function getOpenAIChatTypeScriptSnippet(
+  baseUrl: string,
+  apiKey: string,
+  customHeaders?: CustomHeaders,
+): Snippet {
+  const openaiHeaders = headerLine(customHeaders, 'ts-prop', 'defaultHeaders');
+  return {
+    title: 'Chat Completions',
+    code: `import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "${baseUrl}",
+  apiKey: "${apiKey}",${openaiHeaders}
+});
+
+const response = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello" }],
+});`,
+  };
+}
+
 export function getPythonSnippets(
   baseUrl: string,
   apiKey: string,
@@ -130,9 +185,10 @@ client = OpenAI(
     api_key="${apiKey}",${openaiHeaders}
 )
 
-response = client.chat.completions.create(
+response = client.responses.create(
     model="auto",
-    messages=[{"role": "user", "content": "Hello"}],
+    input="Hello",
+    store=False,
 )`,
     },
   ];
@@ -193,9 +249,10 @@ const client = new OpenAI({
   apiKey: "${apiKey}",${openaiHeaders}
 });
 
-const response = await client.chat.completions.create({
+const response = await client.responses.create({
   model: "auto",
-  messages: [{ role: "user", content: "Hello" }],
+  input: "Hello",
+  store: false,
 });`,
     },
   ];
@@ -204,7 +261,7 @@ const response = await client.chat.completions.create({
 export function getOpenClawSnippet(baseUrl: string, apiKey: string): string {
   const providerJson = JSON.stringify({
     baseUrl,
-    api: 'openai-completions',
+    api: 'openai-responses',
     apiKey,
     models: [{ id: 'auto', name: 'Manifest Auto' }],
   });
@@ -236,12 +293,13 @@ export function getCurlSnippet(
   return [
     {
       title: 'cURL',
-      code: `curl -X POST ${baseUrl}/chat/completions \\
+      code: `curl -X POST ${baseUrl}/responses \\
   -H "Authorization: Bearer ${apiKey}" \\
   -H "Content-Type: application/json" \\
 ${extraHeaders}  -d '{
     "model": "auto",
-    "messages": [{"role": "user", "content": "Hello"}]
+    "input": "Hello",
+    "store": false
   }'`,
     },
   ];
@@ -307,9 +365,15 @@ export function getSnippetForToolkit(
   apiKey: string,
   openaiLang: OpenAILangId = 'python',
   customHeaders?: CustomHeaders,
+  openaiApi: OpenAIApiId = 'responses',
 ): Snippet {
   switch (id) {
     case 'openai-sdk':
+      if (openaiApi === 'chat-completions') {
+        return openaiLang === 'python'
+          ? getOpenAIChatPythonSnippet(baseUrl, apiKey, customHeaders)
+          : getOpenAIChatTypeScriptSnippet(baseUrl, apiKey, customHeaders);
+      }
       return openaiLang === 'python'
         ? getPythonSnippets(baseUrl, apiKey, customHeaders)[1]!
         : getTypeScriptSnippets(baseUrl, apiKey, customHeaders)[1]!;

--- a/packages/frontend/src/styles/wizard.css
+++ b/packages/frontend/src/styles/wizard.css
@@ -663,19 +663,40 @@
 }
 
 /* ── Toolkit language toggle ─────────────────────── */
-.toolkit-lang-toggle {
-  display: inline-flex;
-  gap: 2px;
-  padding: 2px;
-  background: hsl(var(--muted));
-  border-radius: var(--radius);
+.framework-snippets__toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
   margin-bottom: 12px;
 }
 
-.toolkit-lang-toggle__btn {
+.toolkit-lang-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  min-height: 28px;
+  padding: 2px;
+  background: hsl(var(--muted));
+  border-radius: var(--radius);
+}
+
+.toolkit-api-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  min-height: 28px;
+  padding: 2px;
+  background: hsl(var(--muted));
+  border-radius: var(--radius);
+}
+
+.toolkit-lang-toggle__btn,
+.toolkit-api-toggle__btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  height: 24px;
   padding: 4px 12px;
   border: none;
   border-radius: calc(var(--radius) - 2px);
@@ -684,21 +705,25 @@
   font-family: var(--font-family);
   font-size: var(--font-size-xs);
   font-weight: 500;
+  line-height: 1;
   cursor: pointer;
   transition: all var(--transition-fast);
 }
 
-.toolkit-lang-toggle__btn:hover {
+.toolkit-lang-toggle__btn:hover,
+.toolkit-api-toggle__btn:hover {
   color: hsl(var(--foreground));
 }
 
-.toolkit-lang-toggle__btn--active {
+.toolkit-lang-toggle__btn--active,
+.toolkit-api-toggle__btn--active {
   background: hsl(var(--background));
   color: hsl(var(--foreground));
   font-weight: 600;
 }
 
-.toolkit-lang-toggle__btn:focus-visible {
+.toolkit-lang-toggle__btn:focus-visible,
+.toolkit-api-toggle__btn:focus-visible {
   outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
 }

--- a/packages/frontend/tests/components/FrameworkSnippets.test.tsx
+++ b/packages/frontend/tests/components/FrameworkSnippets.test.tsx
@@ -133,6 +133,26 @@ describe("FrameworkSnippets", () => {
   it("shows OpenAI Python SDK snippet by default", () => {
     const { container } = render(() => <FrameworkSnippets {...defaultProps} />);
     expect(container.textContent).toContain("from openai import OpenAI");
+    expect(container.textContent).toContain("Responses API");
+    expect(container.textContent).toContain("Chat Completions");
+    expect(container.textContent).toContain("client.responses.create");
+    expect(container.textContent).not.toContain("chat.completions.create");
+  });
+
+  it("switches to Chat Completions with the OpenAI API toggle", () => {
+    const { container } = render(() => <FrameworkSnippets {...defaultProps} />);
+    const apiBtns = container.querySelectorAll(".toolkit-api-toggle__btn");
+    expect(apiBtns).toHaveLength(2);
+    expect(apiBtns[0].textContent).toContain("Responses API");
+    expect(apiBtns[1].textContent).toContain("Chat Completions");
+    expect(apiBtns[0].classList.contains("toolkit-api-toggle__btn--active")).toBe(true);
+
+    fireEvent.click(apiBtns[1]);
+
+    expect(apiBtns[1].classList.contains("toolkit-api-toggle__btn--active")).toBe(true);
+    expect(container.textContent).not.toContain("client.responses.create");
+    expect(container.textContent).toContain("client.chat.completions.create");
+    expect(container.textContent).toContain('messages=[{"role": "user", "content": "Hello"}]');
   });
 
   it("shows language toggle on OpenAI SDK tab", () => {
@@ -149,6 +169,17 @@ describe("FrameworkSnippets", () => {
     const langBtns = container.querySelectorAll(".toolkit-lang-toggle__btn");
     fireEvent.click(langBtns[1]); // TypeScript
     expect(container.textContent).toContain('import OpenAI from "openai"');
+    expect(container.textContent).toContain("client.responses.create");
+  });
+
+  it("shows TypeScript Chat Completions when both toggles are selected", () => {
+    const { container } = render(() => <FrameworkSnippets {...defaultProps} />);
+    const langBtns = container.querySelectorAll(".toolkit-lang-toggle__btn");
+    fireEvent.click(langBtns[1]); // TypeScript
+    const apiBtns = container.querySelectorAll(".toolkit-api-toggle__btn");
+    fireEvent.click(apiBtns[1]); // Chat Completions
+    expect(container.textContent).toContain("client.chat.completions.create");
+    expect(container.textContent).toContain('messages: [{ role: "user", content: "Hello" }]');
   });
 
   it("switches to Vercel AI SDK tab on click", () => {
@@ -181,6 +212,13 @@ describe("FrameworkSnippets", () => {
     expect(container.querySelector(".toolkit-lang-toggle")).toBeNull();
     fireEvent.click(tabs[3]); // cURL
     expect(container.querySelector(".toolkit-lang-toggle")).toBeNull();
+  });
+
+  it("hides OpenAI API toggle outside the OpenAI SDK tab", () => {
+    const { container } = render(() => <FrameworkSnippets {...defaultProps} />);
+    const tabs = container.querySelectorAll(".panel__tab");
+    fireEvent.click(tabs[1]); // Vercel AI SDK
+    expect(container.querySelector(".toolkit-api-toggle")).toBeNull();
   });
 
   it("switches to LangChain tab on click", () => {

--- a/packages/frontend/tests/components/OpenClawSetup.test.tsx
+++ b/packages/frontend/tests/components/OpenClawSetup.test.tsx
@@ -126,7 +126,7 @@ describe("OpenClawSetup", () => {
     expect(fields[0].textContent).toContain("http://localhost:3001/v1");
     expect(fields[1].textContent).toContain("API Key");
     expect(fields[2].textContent).toContain("Endpoint compatibility");
-    expect(fields[2].textContent).toContain("OpenAI-compatible");
+    expect(fields[2].textContent).toContain("OpenAI Responses-compatible");
     expect(fields[3].textContent).toContain("Model ID");
     expect(fields[3].textContent).toContain("auto");
     expect(fields[4].textContent).toContain("Endpoint ID");
@@ -189,6 +189,15 @@ describe("OpenClawSetup", () => {
       <OpenClawSetup {...defaultProps} baseUrl="https://example.com/v1" />
     ));
     expect(container.textContent).toContain("https://example.com/v1");
+    expect(container.textContent).toContain("openai-responses");
+    expect(container.textContent).not.toContain("openai-completions");
+  });
+
+  it("labels the onboarding compatibility as Responses-compatible", () => {
+    const { container } = render(() => <OpenClawSetup {...defaultProps} />);
+    const segment = container.querySelector(".setup-segment--full");
+    fireEvent.click(segment!.querySelectorAll(".setup-segment__btn")[1]);
+    expect(container.textContent).toContain("OpenAI Responses-compatible");
   });
 
   it("renders CLI copy button with snippet text containing masked key", () => {

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -136,7 +136,7 @@ describe("SetupStepAddProvider", () => {
     expect(fields[0].textContent).toContain("http://localhost:3001/v1");
     expect(fields[1].textContent).toContain("API Key");
     expect(fields[2].textContent).toContain("Endpoint compatibility");
-    expect(fields[2].textContent).toContain("OpenAI-compatible");
+    expect(fields[2].textContent).toContain("OpenAI Responses-compatible");
     expect(fields[3].textContent).toContain("Model ID");
     expect(fields[3].textContent).toContain("auto");
     expect(fields[4].textContent).toContain("Endpoint ID");
@@ -275,6 +275,8 @@ describe("SetupStepAddProvider", () => {
       expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
       // Should show OpenAI-specific code
       expect(container.textContent).toContain("OpenAI");
+      expect(container.textContent).toContain("client.responses.create");
+      expect(container.textContent).not.toContain("chat.completions.create");
     });
 
     it("shows Vercel AI SDK snippet when platform is vercel-ai-sdk", () => {

--- a/packages/frontend/tests/services/framework-snippets.test.ts
+++ b/packages/frontend/tests/services/framework-snippets.test.ts
@@ -12,6 +12,7 @@ import {
   TOOLKIT_TABS,
   OPENAI_SDK_LANGS,
   SDK_LANG_TOGGLE,
+  OPENAI_API_TOGGLE,
   getVercelPythonSnippet,
   getStoredToolkit,
   storeToolkit,
@@ -87,6 +88,15 @@ describe("SDK_LANG_TOGGLE", () => {
 
   it("has two language options", () => {
     expect(SDK_LANG_TOGGLE).toHaveLength(2);
+  });
+});
+
+describe("OPENAI_API_TOGGLE", () => {
+  it("defaults to Responses API before Chat Completions", () => {
+    expect(OPENAI_API_TOGGLE).toEqual([
+      { id: "responses", label: "Responses API" },
+      { id: "chat-completions", label: "Chat Completions" },
+    ]);
   });
 });
 
@@ -226,6 +236,9 @@ describe("getPythonSnippets", () => {
     expect(snippets[1].title).toBe("OpenAI Python SDK");
     expect(snippets[1].code).toContain("from openai import OpenAI");
     expect(snippets[1].code).toContain("http://example.com/v1");
+    expect(snippets[1].code).toContain("client.responses.create");
+    expect(snippets[1].code).toContain('input="Hello"');
+    expect(snippets[1].code).not.toContain("chat.completions.create");
   });
 });
 
@@ -247,6 +260,9 @@ describe("getTypeScriptSnippets", () => {
     const snippets = getTypeScriptSnippets("http://example.com/v1", "mnfst_xyz");
     expect(snippets[1].title).toBe("OpenAI TypeScript SDK");
     expect(snippets[1].code).toContain('import OpenAI from "openai"');
+    expect(snippets[1].code).toContain("client.responses.create");
+    expect(snippets[1].code).toContain('input: "Hello"');
+    expect(snippets[1].code).not.toContain("chat.completions.create");
   });
 });
 
@@ -262,7 +278,8 @@ describe("getOpenClawSnippet", () => {
     const snippet = getOpenClawSnippet("https://app.manifest.build/v1", "mnfst_test");
     expect(snippet).toContain("app.manifest.build/v1");
     expect(snippet).toContain("mnfst_test");
-    expect(snippet).toContain("openai-completions");
+    expect(snippet).toContain("openai-responses");
+    expect(snippet).not.toContain("openai-completions");
   });
 });
 
@@ -291,7 +308,9 @@ describe("getCurlSnippet", () => {
     expect(snippets[0].title).toBe("cURL");
     expect(snippets[0].code).toContain("curl -X POST");
     expect(snippets[0].code).toContain("Bearer mnfst_abc");
-    expect(snippets[0].code).toContain("http://example.com/v1/chat/completions");
+    expect(snippets[0].code).toContain("http://example.com/v1/responses");
+    expect(snippets[0].code).toContain('"input": "Hello"');
+    expect(snippets[0].code).not.toContain("chat/completions");
   });
 });
 
@@ -327,12 +346,44 @@ describe("getSnippetForToolkit", () => {
     const result = getSnippetForToolkit("openai-sdk", "http://x/v1", "key", "python");
     expect(result.title).toBe("OpenAI Python SDK");
     expect(result.code).toContain("from openai import OpenAI");
+    expect(result.code).toContain("client.responses.create");
   });
 
   it("returns OpenAI TypeScript SDK for openai-sdk with typescript lang", () => {
     const result = getSnippetForToolkit("openai-sdk", "http://x/v1", "key", "typescript");
     expect(result.title).toBe("OpenAI TypeScript SDK");
     expect(result.code).toContain('import OpenAI from "openai"');
+    expect(result.code).toContain("client.responses.create");
+  });
+
+  it("returns OpenAI Python Chat Completions when selected", () => {
+    const result = getSnippetForToolkit(
+      "openai-sdk",
+      "http://x/v1",
+      "key",
+      "python",
+      undefined,
+      "chat-completions",
+    );
+    expect(result.title).toBe("Chat Completions");
+    expect(result.code).toContain("client.chat.completions.create");
+    expect(result.code).toContain('messages=[{"role": "user", "content": "Hello"}]');
+    expect(result.code).not.toContain("client.responses.create");
+  });
+
+  it("returns OpenAI TypeScript Chat Completions when selected", () => {
+    const result = getSnippetForToolkit(
+      "openai-sdk",
+      "http://x/v1",
+      "key",
+      "typescript",
+      undefined,
+      "chat-completions",
+    );
+    expect(result.title).toBe("Chat Completions");
+    expect(result.code).toContain("client.chat.completions.create");
+    expect(result.code).toContain('messages: [{ role: "user", content: "Hello" }]');
+    expect(result.code).not.toContain("client.responses.create");
   });
 
   it("defaults to python for openai-sdk", () => {


### PR DESCRIPTION
Closes #1711.

## Summary
- add OpenAI-compatible `/v1/responses` proxy support for Manifest
- normalize Responses API requests for ChatGPT subscription routing: default instructions, list-shaped input, and upstream SSE
- preserve Responses SSE text in non-streaming SDK responses
- update OpenAI SDK, cURL, and OpenClaw setup snippets to default to Responses API

## Validation
- `npm test --workspace=packages/backend -- responses-adapter.spec.ts provider-client.spec.ts proxy-response-handler.spec.ts proxy.service.spec.ts proxy.controller.spec.ts stream-writer.spec.ts`
- `npm run test:e2e --workspace=packages/backend -- --runTestsByPath test/proxy.e2e-spec.ts`
- `npm test --workspace=packages/frontend -- framework-snippets.test.ts FrameworkSnippets.test.tsx SetupStepAddProvider.test.tsx OpenClawSetup.test.tsx RoutingInstructionModal.test.tsx`
- `npm run build`
- `npm run lint` (0 errors; warnings only)
- real OpenAI Python SDK `client.responses.create(...)` through `http://localhost:38240/v1` returned `model=gpt-5.4`, `status=completed`, and `output_text="manifest responses api works"`; telemetry latest row recorded `gpt-5.4/openai/subscription ok` with no fallback
- browser checked demo-agent Routing setup modal on `http://localhost:38240`: OpenClaw setup now uses `"api":"openai-responses"`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an OpenAI-compatible Responses API at `/v1/responses` and makes it the default in snippets and setup. Addresses issue #1711 by enabling `client.responses.create`, vendor-agnostic routing, and consistent streaming/JSON conversion across providers.

- **New Features**
  - Endpoint: new `/v1/responses` route with OpenAI-compatible schema; non-native providers are converted to Responses for clients (streams → SSE, JSON → Response objects).
  - Routing and normalization:
    - OpenAI → `/v1/responses`; ChatGPT subscriptions add default instructions, normalize `input` to lists, and force upstream SSE.
    - For non-native Responses providers, we derive `messages`/`max_tokens` from the Responses body for routing while preserving the original body for forwarding.
  - Streaming and JSON:
    - Pass through native Responses SSE/JSON; collect `response.completed` bodies even when content type isn’t SSE.
    - Convert Chat Completions streams to Responses SSE and non-stream JSON to Responses objects; extract usage from Responses `usage` and `response.completed` events.
  - Adapter: new `responses-adapter` (`toChatCompletionsRequest`, `toNativeResponsesRequest`, `fromChatCompletionResponse`, and stream transformers) to translate between Responses and Chat Completions.
  - Frontend updates:
    - Default `openai` SDK and cURL snippets use `/v1/responses` with `client.responses.create`.
    - OpenAI SDK snippets add an API toggle (Responses API vs Chat Completions).
    - OpenClaw setup labeled “OpenAI Responses-compatible”.
  - Tests: unit tests for adapter/proxy and E2E coverage for `/v1/responses` auth and validation.

- **Migration**
  - Prefer `client.responses.create` and POST to `/v1/responses` (include `store: false` for parity); OpenClaw config uses `api: "openai-responses"`.
  - Existing `/v1/chat/completions` clients continue to work; no breaking changes.

<sup>Written for commit cc09e4f30949b9ca44908ad0acfb231c5a2f8252. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

