### PR TITLE
fix(agents): clean up data on delete so recreated agents start fresh

### DIFF
--- a/.changeset/agent-recreate-clean-slate.md
+++ b/.changeset/agent-recreate-clean-slate.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Recreating an agent with a deleted agent's name no longer surfaces the deleted agent's messages, costs, or routing config. Deletion now hard-clears denormalised rows and invalidates the resolve/routing caches.

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.spec.ts
@@ -4,13 +4,16 @@ import { ConflictException, NotFoundException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { AgentLifecycleService } from './agent-lifecycle.service';
 import { Agent } from '../../entities/agent.entity';
+import { ResolveAgentService } from '../../routing/routing-core/resolve-agent.service';
+import { RoutingCacheService } from '../../routing/routing-core/routing-cache.service';
 
 describe('AgentLifecycleService', () => {
   let service: AgentLifecycleService;
   let mockAgentGetOne: jest.Mock;
-  let mockAgentDelete: jest.Mock;
   let mockTransaction: jest.Mock;
   let mockAgentCreateQueryBuilder: jest.Mock;
+  let mockResolveAgentInvalidate: jest.Mock;
+  let mockRoutingCacheInvalidate: jest.Mock;
 
   beforeEach(async () => {
     mockTransaction = jest
@@ -18,7 +21,8 @@ describe('AgentLifecycleService', () => {
       .mockImplementation(async (cb: (...args: unknown[]) => unknown) => cb());
 
     mockAgentGetOne = jest.fn().mockResolvedValue(null);
-    mockAgentDelete = jest.fn().mockResolvedValue({});
+    mockResolveAgentInvalidate = jest.fn();
+    mockRoutingCacheInvalidate = jest.fn();
 
     const mockAgentQb = {
       select: jest.fn().mockReturnThis(),
@@ -39,12 +43,19 @@ describe('AgentLifecycleService', () => {
           provide: getRepositoryToken(Agent),
           useValue: {
             createQueryBuilder: mockAgentCreateQueryBuilder,
-            delete: mockAgentDelete,
           },
         },
         {
           provide: DataSource,
           useValue: { transaction: mockTransaction },
+        },
+        {
+          provide: ResolveAgentService,
+          useValue: { invalidate: mockResolveAgentInvalidate },
+        },
+        {
+          provide: RoutingCacheService,
+          useValue: { invalidateAgent: mockRoutingCacheInvalidate },
         },
       ],
     }).compile();
@@ -94,19 +105,122 @@ describe('AgentLifecycleService', () => {
   });
 
   describe('deleteAgent', () => {
-    it('should delete agent when found', async () => {
-      mockAgentGetOne.mockResolvedValueOnce({ id: 'agent-id-1', name: 'my-agent' });
+    function setupTransactionMocks(options: { snapshotTablesPresent?: boolean } = {}) {
+      const snapshotTablesPresent = options.snapshotTablesPresent ?? true;
+      const mockExecute = jest.fn().mockResolvedValue({});
+      const mockManagerQb = {
+        delete: jest.fn().mockReturnThis(),
+        from: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        execute: mockExecute,
+      };
+      const mockManagerQuery = jest
+        .fn()
+        .mockImplementation(async (sql: string, params?: unknown[]) => {
+          if (sql.includes('to_regclass')) {
+            const table = params?.[0] as string;
+            return [{ reg: snapshotTablesPresent ? table : null }];
+          }
+          return [];
+        });
+      const mockManagerAgentDelete = jest.fn().mockResolvedValue({});
+
+      mockTransaction.mockImplementation(async (cb: (...args: unknown[]) => unknown) => {
+        const manager = {
+          createQueryBuilder: jest.fn().mockReturnValue(mockManagerQb),
+          query: mockManagerQuery,
+          getRepository: jest.fn().mockReturnValue({ delete: mockManagerAgentDelete }),
+        };
+        return cb(manager);
+      });
+
+      return { mockManagerQb, mockManagerQuery, mockManagerAgentDelete };
+    }
+
+    it('cleans denormalised tables, agent_id-keyed tables, and invalidates caches', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({
+        id: 'agent-id-1',
+        name: 'my-agent',
+        tenant_id: 'tenant-1',
+      });
+      const { mockManagerQb, mockManagerQuery, mockManagerAgentDelete } = setupTransactionMocks();
 
       await service.deleteAgent('test-user', 'my-agent');
-      expect(mockAgentDelete).toHaveBeenCalledWith('agent-id-1');
+
+      expect(mockTransaction).toHaveBeenCalledTimes(1);
+
+      const fromCalls = mockManagerQb.from.mock.calls.map((c: unknown[]) => c[0]);
+      expect(fromCalls).toEqual(
+        expect.arrayContaining([
+          'agent_messages',
+          'agent_logs',
+          'cost_snapshots',
+          'token_usage_snapshots',
+          'notification_rules',
+          'tier_assignments',
+          'specificity_assignments',
+          'header_tiers',
+          'user_providers',
+          'llm_calls',
+          'tool_executions',
+        ]),
+      );
+
+      const tenantNameWhereCalls = mockManagerQb.where.mock.calls.filter(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('agent_name'),
+      );
+      for (const call of tenantNameWhereCalls) {
+        expect(call[1]).toEqual({ tenantId: 'tenant-1', agentName: 'my-agent' });
+      }
+
+      const agentIdWhereCalls = mockManagerQb.where.mock.calls.filter(
+        (c: unknown[]) => typeof c[0] === 'string' && (c[0] as string).includes('agent_id'),
+      );
+      for (const call of agentIdWhereCalls) {
+        expect(call[1]).toEqual({ agentId: 'agent-id-1' });
+      }
+
+      const logsCall = mockManagerQuery.mock.calls.find(
+        (c) =>
+          typeof c[0] === 'string' && (c[0] as string).includes('DELETE FROM notification_logs'),
+      );
+      expect(logsCall).toBeDefined();
+      expect(logsCall?.[0]).toContain('notification_rules');
+      expect(logsCall?.[1]).toEqual(['tenant-1', 'my-agent']);
+
+      expect(mockManagerAgentDelete).toHaveBeenCalledWith('agent-id-1');
+      expect(mockResolveAgentInvalidate).toHaveBeenCalledWith('tenant-1', 'my-agent');
+      expect(mockRoutingCacheInvalidate).toHaveBeenCalledWith('agent-id-1');
     });
 
-    it('should throw NotFoundException when agent not found', async () => {
+    it('skips snapshot tables when they do not exist in the schema', async () => {
+      mockAgentGetOne.mockResolvedValueOnce({
+        id: 'agent-id-1',
+        name: 'my-agent',
+        tenant_id: 'tenant-1',
+      });
+      const { mockManagerQb } = setupTransactionMocks({ snapshotTablesPresent: false });
+
+      await service.deleteAgent('test-user', 'my-agent');
+
+      const fromCalls = mockManagerQb.from.mock.calls.map((c: unknown[]) => c[0]);
+      expect(fromCalls).not.toContain('cost_snapshots');
+      expect(fromCalls).not.toContain('token_usage_snapshots');
+      // Mandatory tables still run.
+      expect(fromCalls).toEqual(
+        expect.arrayContaining(['agent_messages', 'agent_logs', 'tier_assignments']),
+      );
+    });
+
+    it('throws NotFoundException when agent not found and skips cache invalidation', async () => {
       mockAgentGetOne.mockResolvedValueOnce(null);
 
       await expect(service.deleteAgent('test-user', 'nonexistent')).rejects.toThrow(
         NotFoundException,
       );
+      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(mockResolveAgentInvalidate).not.toHaveBeenCalled();
+      expect(mockRoutingCacheInvalidate).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/analytics/services/agent-lifecycle.service.ts
+++ b/packages/backend/src/analytics/services/agent-lifecycle.service.ts
@@ -2,6 +2,23 @@ import { Injectable, ConflictException, NotFoundException } from '@nestjs/common
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { Agent } from '../../entities/agent.entity';
+import { ResolveAgentService } from '../../routing/routing-core/resolve-agent.service';
+import { RoutingCacheService } from '../../routing/routing-core/routing-cache.service';
+
+const TENANT_NAME_SCOPED_TABLES = ['agent_messages', 'agent_logs'] as const;
+
+// Snapshot tables exist in production migrations but have no TypeORM entity,
+// so the e2e synchronize path doesn't create them. Skip silently when absent.
+const OPTIONAL_TENANT_NAME_SCOPED_TABLES = ['cost_snapshots', 'token_usage_snapshots'] as const;
+
+const AGENT_ID_SCOPED_TABLES = [
+  'tier_assignments',
+  'specificity_assignments',
+  'header_tiers',
+  'user_providers',
+  'llm_calls',
+  'tool_executions',
+] as const;
 
 @Injectable()
 export class AgentLifecycleService {
@@ -9,6 +26,8 @@ export class AgentLifecycleService {
     @InjectRepository(Agent)
     private readonly agentRepo: Repository<Agent>,
     private readonly dataSource: DataSource,
+    private readonly resolveAgent: ResolveAgentService,
+    private readonly routingCache: RoutingCacheService,
   ) {}
 
   async findAgentInfo(
@@ -41,7 +60,63 @@ export class AgentLifecycleService {
     if (!agent) {
       throw new NotFoundException(`Agent "${agentName}" not found`);
     }
-    await this.agentRepo.delete(agent.id);
+
+    const { id: agentId, tenant_id: tenantId } = agent;
+
+    await this.dataSource.transaction(async (manager) => {
+      // notification_logs has no tenant_id; scope via rule_id of rules that
+      // belong to this tenant + agent_name BEFORE deleting the rules.
+      await manager.query(
+        `DELETE FROM notification_logs
+         WHERE rule_id IN (
+           SELECT id FROM notification_rules
+           WHERE tenant_id = $1 AND agent_name = $2
+         )`,
+        [tenantId, agentName],
+      );
+
+      for (const table of TENANT_NAME_SCOPED_TABLES) {
+        await manager
+          .createQueryBuilder()
+          .delete()
+          .from(table)
+          .where('tenant_id = :tenantId AND agent_name = :agentName', { tenantId, agentName })
+          .execute();
+      }
+
+      for (const table of OPTIONAL_TENANT_NAME_SCOPED_TABLES) {
+        const present = await manager.query(`SELECT to_regclass($1) AS reg`, [table]);
+        if (!present[0]?.reg) continue;
+        await manager
+          .createQueryBuilder()
+          .delete()
+          .from(table)
+          .where('tenant_id = :tenantId AND agent_name = :agentName', { tenantId, agentName })
+          .execute();
+      }
+
+      await manager
+        .createQueryBuilder()
+        .delete()
+        .from('notification_rules')
+        .where('tenant_id = :tenantId AND agent_name = :agentName', { tenantId, agentName })
+        .execute();
+
+      for (const table of AGENT_ID_SCOPED_TABLES) {
+        await manager
+          .createQueryBuilder()
+          .delete()
+          .from(table)
+          .where('agent_id = :agentId', { agentId })
+          .execute();
+      }
+
+      // agent_api_keys and custom_providers cascade via FK.
+      await manager.getRepository(Agent).delete(agentId);
+    });
+
+    this.resolveAgent.invalidate(tenantId, agentName);
+    this.routingCache.invalidateAgent(agentId);
   }
 
   private async findAgentByUser(userId: string, agentName: string) {

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -85,6 +85,7 @@ import { ReAddComplexityRoutingFlag1781000000000 } from './migrations/1781000000
 import { AddSavingsBaselineModel1782000000000 } from './migrations/1782000000000-AddSavingsBaselineModel';
 import { AddBaselineCostColumns1782100000000 } from './migrations/1782100000000-AddBaselineCostColumns';
 import { RetuneSpecificityMiscategorizedIndex1782000000000 } from './migrations/1782000000000-RetuneSpecificityMiscategorizedIndex';
+import { CleanupOrphanedAgentRows1782200000000 } from './migrations/1782200000000-CleanupOrphanedAgentRows';
 
 const entities = [
   AgentMessage,
@@ -171,6 +172,7 @@ const migrations = [
   AddSavingsBaselineModel1782000000000,
   AddBaselineCostColumns1782100000000,
   RetuneSpecificityMiscategorizedIndex1782000000000,
+  CleanupOrphanedAgentRows1782200000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1782200000000-CleanupOrphanedAgentRows.spec.ts
+++ b/packages/backend/src/database/migrations/1782200000000-CleanupOrphanedAgentRows.spec.ts
@@ -1,0 +1,78 @@
+import { QueryRunner } from 'typeorm';
+import { CleanupOrphanedAgentRows1782200000000 } from './1782200000000-CleanupOrphanedAgentRows';
+
+describe('CleanupOrphanedAgentRows1782200000000', () => {
+  let migration: CleanupOrphanedAgentRows1782200000000;
+  let queryRunner: jest.Mocked<Pick<QueryRunner, 'query'>>;
+
+  beforeEach(() => {
+    migration = new CleanupOrphanedAgentRows1782200000000();
+    queryRunner = {
+      query: jest.fn().mockImplementation(async (sql: string, params?: unknown[]) => {
+        if (typeof sql === 'string' && sql.includes('to_regclass')) {
+          return [{ reg: params?.[0] }];
+        }
+        return undefined;
+      }),
+    };
+  });
+
+  describe('up', () => {
+    it('deletes orphan rows from each agent_id-keyed table and notification_logs', async () => {
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sqls = queryRunner.query.mock.calls.map((c) => c[0] as string);
+
+      const expectedTables = [
+        'agent_messages',
+        'agent_logs',
+        'cost_snapshots',
+        'token_usage_snapshots',
+        'tier_assignments',
+        'specificity_assignments',
+        'header_tiers',
+        'user_providers',
+        'llm_calls',
+        'tool_executions',
+        'notification_rules',
+      ];
+
+      for (const table of expectedTables) {
+        const sql = sqls.find((s) => s.includes(`FROM "${table}"`) && s.includes('NOT EXISTS'));
+        expect(sql).toBeDefined();
+        expect(sql).toContain('agent_id IS NOT NULL');
+        expect(sql).toContain('NOT EXISTS (SELECT 1 FROM "agents"');
+      }
+
+      const logsSql = sqls.find((s) => s.includes('FROM "notification_logs"'));
+      expect(logsSql).toBeDefined();
+      expect(logsSql).toContain('rule_id IS NOT NULL');
+      expect(logsSql).toContain('"notification_rules"');
+    });
+
+    it('skips optional snapshot tables when they are absent from the schema', async () => {
+      queryRunner.query = jest.fn().mockImplementation(async (sql: string) => {
+        if (typeof sql === 'string' && sql.includes('to_regclass')) {
+          return [{ reg: null }];
+        }
+        return undefined;
+      });
+
+      await migration.up(queryRunner as unknown as QueryRunner);
+
+      const sqls = queryRunner.query.mock.calls.map((c) => c[0] as string);
+      expect(sqls.find((s) => s.includes('FROM "cost_snapshots"'))).toBeUndefined();
+      expect(sqls.find((s) => s.includes('FROM "token_usage_snapshots"'))).toBeUndefined();
+      // Mandatory tables and notification_logs still run.
+      expect(sqls.find((s) => s.includes('FROM "agent_messages"'))).toBeDefined();
+      expect(sqls.find((s) => s.includes('FROM "notification_logs"'))).toBeDefined();
+    });
+  });
+
+  describe('down', () => {
+    it('is a no-op', async () => {
+      await migration.down();
+      expect(queryRunner.query).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/database/migrations/1782200000000-CleanupOrphanedAgentRows.ts
+++ b/packages/backend/src/database/migrations/1782200000000-CleanupOrphanedAgentRows.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const AGENT_ID_TABLES = [
+  'agent_messages',
+  'agent_logs',
+  'tier_assignments',
+  'specificity_assignments',
+  'header_tiers',
+  'user_providers',
+  'llm_calls',
+  'tool_executions',
+  'notification_rules',
+] as const;
+
+// cost_snapshots / token_usage_snapshots exist in prod but have no TypeORM
+// entity. Guard with to_regclass so this migration is safe in any schema state.
+const OPTIONAL_AGENT_ID_TABLES = ['cost_snapshots', 'token_usage_snapshots'] as const;
+
+export class CleanupOrphanedAgentRows1782200000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    for (const table of AGENT_ID_TABLES) {
+      await queryRunner.query(
+        `DELETE FROM "${table}"
+         WHERE agent_id IS NOT NULL
+           AND NOT EXISTS (SELECT 1 FROM "agents" a WHERE a.id = "${table}".agent_id)`,
+      );
+    }
+
+    for (const table of OPTIONAL_AGENT_ID_TABLES) {
+      const present = await queryRunner.query(`SELECT to_regclass($1) AS reg`, [table]);
+      if (!present[0]?.reg) continue;
+      await queryRunner.query(
+        `DELETE FROM "${table}"
+         WHERE agent_id IS NOT NULL
+           AND NOT EXISTS (SELECT 1 FROM "agents" a WHERE a.id = "${table}".agent_id)`,
+      );
+    }
+
+    await queryRunner.query(
+      `DELETE FROM "notification_logs"
+       WHERE rule_id IS NOT NULL
+         AND NOT EXISTS (SELECT 1 FROM "notification_rules" r WHERE r.id = "notification_logs".rule_id)`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Cleanup-only migration; orphan rows cannot be restored.
+  }
+}

--- a/packages/backend/test/agent-recreate.e2e-spec.ts
+++ b/packages/backend/test/agent-recreate.e2e-spec.ts
@@ -1,0 +1,103 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { v4 as uuid } from 'uuid';
+import request from 'supertest';
+import { createTestApp, TEST_API_KEY, TEST_TENANT_ID } from './helpers';
+
+let app: INestApplication;
+let ds: DataSource;
+
+beforeAll(async () => {
+  app = await createTestApp();
+  ds = app.get(DataSource);
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('agent delete + recreate (issue #1765)', () => {
+  it('does not surface deleted-agent data on a freshly recreated agent with the same name', async () => {
+    const agentName = 'reusable-agent';
+
+    // Create agent v1
+    const createV1 = await request(app.getHttpServer())
+      .post('/api/v1/agents')
+      .set('x-api-key', TEST_API_KEY)
+      .send({ name: agentName })
+      .expect(201);
+    const v1Id = createV1.body.agent.id as string;
+
+    // Seed denormalised + agent_id-keyed rows for v1
+    const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+    await ds.query(
+      `INSERT INTO agent_messages (id, tenant_id, agent_id, timestamp, status, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, agent_name, user_id, cost_usd)
+       VALUES ($1, $2, $3, $4, 'ok', 'gpt-4o', 100, 50, 0, 0, $5, 'test-user-001', 0.001)`,
+      [uuid(), TEST_TENANT_ID, v1Id, now, agentName],
+    );
+    await ds.query(
+      `INSERT INTO tier_assignments (id, user_id, agent_id, tier, override_model, override_provider)
+       VALUES ($1, 'test-user-001', $2, 'simple', 'gpt-4o-mini', 'openai')`,
+      [uuid(), v1Id],
+    );
+
+    // Sanity: messages visible
+    const before = await request(app.getHttpServer())
+      .get(`/api/v1/messages?agent_name=${agentName}&range=24h`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(before.body.items.length).toBe(1);
+
+    // Delete v1
+    await request(app.getHttpServer())
+      .delete(`/api/v1/agents/${agentName}`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    // Orphan rows are gone
+    const orphanMessages = await ds.query(
+      `SELECT COUNT(*)::int AS count FROM agent_messages WHERE tenant_id = $1 AND agent_name = $2`,
+      [TEST_TENANT_ID, agentName],
+    );
+    expect(orphanMessages[0].count).toBe(0);
+
+    const orphanTiers = await ds.query(
+      `SELECT COUNT(*)::int AS count FROM tier_assignments WHERE agent_id = $1`,
+      [v1Id],
+    );
+    expect(orphanTiers[0].count).toBe(0);
+
+    // Recreate v2 with the same slug
+    const createV2 = await request(app.getHttpServer())
+      .post('/api/v1/agents')
+      .set('x-api-key', TEST_API_KEY)
+      .send({ name: agentName })
+      .expect(201);
+    expect(createV2.body.agent.id).not.toBe(v1Id);
+
+    // Messages list is empty
+    const messages = await request(app.getHttpServer())
+      .get(`/api/v1/messages?agent_name=${agentName}&range=24h`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(messages.body.items).toEqual([]);
+
+    // Costs aggregate is empty
+    const costs = await request(app.getHttpServer())
+      .get(`/api/v1/costs?range=24h&agent_name=${agentName}`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    expect(costs.body.summary.weekly_cost.value).toBe(0);
+    expect(costs.body.by_model).toEqual([]);
+
+    // Tier list does not surface the v1 override
+    const tiers = await request(app.getHttpServer())
+      .get(`/api/v1/routing/${agentName}/tiers`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+    const overridden = (tiers.body as Array<{ override_model: string | null }>).filter(
+      (t) => t.override_model !== null,
+    );
+    expect(overridden).toEqual([]);
+  });
+});


### PR DESCRIPTION
### 💭 Why
Recreating an agent with a previously used slug pulled back the deleted agent's messages, costs, and routing config. The agents row was the only thing being deleted, so anything keyed by `tenant_id+agent_name` (or by the in-memory resolve cache) re-attached itself.

### ✨ What changed
- `deleteAgent` now hard-clears denormalised rows (`agent_messages`, `agent_logs`, `notification_rules`/`notification_logs`) and agent-id-scoped tables (tier/specificity/header/user-provider, `llm_calls`, `tool_executions`) in one transaction.
- Invalidates `ResolveAgentService` and `RoutingCacheService` after delete so a recreated slug gets fresh routing state.
- Cleanup migration purges existing orphan rows on upgrade.
- E2E spec reproduces the bug end-to-end and asserts the recreated agent is empty across `/messages`, `/costs`, and `/routing/:name/tiers`.

### 👤 For users
Deleting an agent and creating a new one with the same name now produces a clean slate. Fixes #1765.

### 🔧 For operators
The new migration `1782200000000-CleanupOrphanedAgentRows` runs on boot and removes orphan rows left behind by previous deletes. Snapshot tables with no TypeORM entity are guarded with `to_regclass`, so the migration is safe across schema variants.