### PR TITLE
fix(routing): attribute models by connection's provider, not model-id prefix

### DIFF
--- a/.changeset/route-provider-attribution.md
+++ b/.changeset/route-provider-attribution.md
@@ -1,0 +1,27 @@
+---
+"manifest": patch
+---
+
+fix(routing): attribute models by their connection's provider, not by model-id prefix
+
+The routing UI used to derive a model's logo from the prefix of its model id,
+which broke for any provider that redistributes other vendors' models. Most
+visibly, a Groq connection serving `qwen/qwen3-32b` rendered with the Qwen
+logo and Qwen-on-OpenRouter pricing (≈$0.08/$0.24 per 1M) instead of Groq's
+own pricing ($0.29/$0.59).
+
+Two changes:
+
+- **Frontend** (`RoutingTierCard.providerIdForModel`): when a model row has a
+  stored `provider` that resolves to a registered first-party provider, that
+  wins over prefix inference. OpenRouter remains the documented exception
+  because its rows really do represent vendor-prefixed models served on behalf
+  of those vendors.
+- **Backend** (`ModelDiscoveryService.enrichModel`): `known-model-prices.ts`
+  is now consulted *before* models.dev and the OpenRouter cache, so curated
+  per-provider prices win over upstream catalogs that may attribute the same
+  model id to a different (cheaper) inference provider. Behaviour change for
+  the existing entries (moonshot-v1, gemma-3-1b-it, gemini-pro-latest): they
+  become authoritative instead of last-resort, which matches their intent.
+
+Builds on #1772, which introduced `route.provider` as the routing identity.

--- a/packages/backend/src/model-discovery/known-model-prices.ts
+++ b/packages/backend/src/model-discovery/known-model-prices.ts
@@ -1,8 +1,20 @@
 /**
- * Last-resort hardcoded pricing for models that no external pricing source covers.
+ * Hand-curated, per-provider authoritative pricing.
  *
- * This is used ONLY when both models.dev and OpenRouter have no data for a model.
- * Keep this list minimal — prefer upstream sources. Prices are per-token (not per-million).
+ * **Priority:** entries here win over models.dev and the OpenRouter cache
+ * during model discovery. The reason: the same model id can exist on
+ * multiple inference providers at different prices (e.g. `qwen/qwen3-32b`
+ * appears in Qwen's OR listing at one price and is also served by Groq at
+ * a different price), and a connection's reported pricing must reflect
+ * *that connection's provider*, not whatever is cheapest in upstream
+ * catalogs.
+ *
+ * Keep this list minimal. Add an entry only when:
+ *  1. The provider's native API does not return pricing, AND
+ *  2. The model id either isn't in upstream catalogs, OR is in them under
+ *     a different inference provider with different pricing.
+ *
+ * Prices are per-token (not per-million).
  *
  * Sources:
  *  - Moonshot v1: https://platform.moonshot.cn/docs/pricing (¥12/1M ≈ $1.66/1M at 2025 rates)

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -2105,7 +2105,7 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].capabilityCode).toBe(true);
     });
 
-    it('should fall back to known-model-prices when models.dev and OpenRouter have no data', async () => {
+    it('uses known-model-prices when no upstream source has data', async () => {
       mockModelsDevSync.lookupModel.mockReturnValue(null);
       mockPricingSync.lookupPricing.mockReturnValue(null);
 
@@ -2122,6 +2122,86 @@ describe('ModelDiscoveryService', () => {
 
       expect(result[0].inputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
       expect(result[0].outputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+    });
+
+    it('known-model-prices wins over models.dev for curated models', async () => {
+      // Same model id can appear in models.dev under a different inference
+      // provider with different pricing. The hand-curated entry must win so
+      // a connection's reported pricing reflects THAT connection's provider.
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'moonshot-v1-8k',
+        name: 'Moonshot v1 8k (cheap-reseller pricing)',
+        inputPricePerToken: 0.000_000_1, // models.dev cheap reseller price
+        outputPricePerToken: 0.000_000_2,
+        contextWindow: 8192,
+      });
+
+      const models = [
+        makeModel({
+          id: 'moonshot-v1-8k',
+          inputPricePerToken: null,
+          outputPricePerToken: null,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      // Known-prices ($1.66/1M) wins over models.dev ($0.0001/1M).
+      expect(result[0].inputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+      expect(result[0].outputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+    });
+
+    it('known-model-prices wins over OpenRouter for curated models', async () => {
+      // Mirrors the Groq-served `qwen/qwen3-32b` scenario: OR has the model
+      // id at one provider's price; the connection's actual provider lists
+      // it at a different price in known-model-prices.
+      mockModelsDevSync.lookupModel.mockReturnValue(null);
+      mockPricingSync.lookupPricing.mockReturnValue({
+        input: 0.000_000_08, // OpenRouter's cheap-resale price
+        output: 0.000_000_24,
+        contextWindow: 32768,
+        displayName: 'Moonshot v1 8k via OR',
+      });
+
+      const models = [
+        makeModel({
+          id: 'moonshot-v1-8k',
+          inputPricePerToken: null,
+          outputPricePerToken: null,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+      expect(result[0].outputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+    });
+
+    it('falls through to models.dev when no known-prices entry exists', async () => {
+      // Non-curated models keep the existing upstream-first behaviour.
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'totally-novel-model',
+        name: 'Novel Model',
+        inputPricePerToken: 0.001,
+        outputPricePerToken: 0.002,
+        contextWindow: 128_000,
+      });
+
+      const models = [
+        makeModel({
+          id: 'totally-novel-model',
+          inputPricePerToken: null,
+          outputPricePerToken: null,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      expect(result[0].inputPricePerToken).toBe(0.001);
+      expect(result[0].outputPricePerToken).toBe(0.002);
     });
 
     it('should return model without pricing when no source has data', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -2204,6 +2204,41 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].outputPricePerToken).toBe(0.002);
     });
 
+    it('still merges capability flags from models.dev when known-prices wins on pricing', async () => {
+      // Identified by cubic: when known-prices wins, we still want the
+      // reasoning / tool-call flags from models.dev applied — they drive
+      // tier auto-assignment scoring and shouldn't be silently dropped.
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'moonshot-v1-8k',
+        name: 'Moonshot v1 8k',
+        inputPricePerToken: 0.000_000_1, // ignored — known-prices wins
+        outputPricePerToken: 0.000_000_2,
+        contextWindow: 8192,
+        reasoning: true,
+        toolCall: true,
+      });
+
+      const models = [
+        makeModel({
+          id: 'moonshot-v1-8k',
+          inputPricePerToken: null,
+          outputPricePerToken: null,
+          capabilityReasoning: false,
+          capabilityCode: false,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+
+      // Pricing from known-prices.
+      expect(result[0].inputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+      expect(result[0].outputPricePerToken).toBeCloseTo(1.66 / 1_000_000, 12);
+      // Capabilities still merged from models.dev.
+      expect(result[0].capabilityReasoning).toBe(true);
+      expect(result[0].capabilityCode).toBe(true);
+    });
+
     it('should return model without pricing when no source has data', async () => {
       mockModelsDevSync.lookupModel.mockReturnValue(null);
       mockPricingSync.lookupPricing.mockReturnValue(null);

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -290,7 +290,23 @@ export class ModelDiscoveryService {
       return this.computeScore(this.applyCapabilities(model, providerId));
     }
 
-    // Priority 1: models.dev — uses native provider IDs, no normalization needed
+    // Priority 1: hardcoded known prices — hand-curated, per-provider intent.
+    // These have to win over models.dev / OpenRouter because the same model id
+    // (e.g. `qwen/qwen3-32b`) can exist on multiple inference providers at
+    // different prices, and a connection's pricing must reflect THAT
+    // connection's provider, not the cheapest place the model id happens to
+    // appear in upstream catalogs. For models we don't curate (the vast
+    // majority), this is a no-op and we fall through to models.dev / OR.
+    const known = lookupKnownPrice(model.id);
+    if (known) {
+      return this.computeScore({
+        ...model,
+        inputPricePerToken: known.input,
+        outputPricePerToken: known.output,
+      });
+    }
+
+    // Priority 2: models.dev — uses native provider IDs, no normalization needed
     if (this.modelsDevSync) {
       const mdEntry = this.modelsDevSync.lookupModel(providerId, model.id);
       if (mdEntry && mdEntry.inputPricePerToken !== null) {
@@ -306,7 +322,7 @@ export class ModelDiscoveryService {
       }
     }
 
-    // Priority 2: OpenRouter cache — broader coverage, needs prefix + variant matching
+    // Priority 3: OpenRouter cache — broader coverage, needs prefix + variant matching
     if (this.pricingSync) {
       const orPrefix = findOpenRouterPrefix(providerId);
       if (orPrefix) {
@@ -331,16 +347,6 @@ export class ModelDiscoveryService {
           displayName: exactPricing.displayName || model.displayName,
         });
       }
-    }
-
-    // Priority 3: hardcoded known prices — last resort for models no external source covers
-    const known = lookupKnownPrice(model.id);
-    if (known) {
-      return this.computeScore({
-        ...model,
-        inputPricePerToken: known.input,
-        outputPricePerToken: known.output,
-      });
     }
 
     return this.computeScore(model);

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -297,13 +297,23 @@ export class ModelDiscoveryService {
     // connection's provider, not the cheapest place the model id happens to
     // appear in upstream catalogs. For models we don't curate (the vast
     // majority), this is a no-op and we fall through to models.dev / OR.
+    //
+    // Even when known-prices wins on pricing we still consult models.dev for
+    // capability flags (reasoning / tool-call) — those drive tier auto-
+    // assignment quality scoring and shouldn't be lost just because we
+    // overrode the price. Mirrors the price-already-set branch above.
     const known = lookupKnownPrice(model.id);
     if (known) {
-      return this.computeScore({
-        ...model,
-        inputPricePerToken: known.input,
-        outputPricePerToken: known.output,
-      });
+      return this.computeScore(
+        this.applyCapabilities(
+          {
+            ...model,
+            inputPricePerToken: known.input,
+            outputPricePerToken: known.output,
+          },
+          providerId,
+        ),
+      );
     }
 
     // Priority 2: models.dev — uses native provider IDs, no normalization needed

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -119,13 +119,15 @@ const ModelPickerModal: Component<Props> = (props) => {
       if (freeOnly && !isFreeModel(m)) continue;
       const dbProvId = resolveProviderId(m.provider);
       const prefixProvId = inferProviderFromModel(m.model_name);
-      // Prefer prefix-inferred provider (e.g. "anthropic" from "anthropic/claude-sonnet-4")
-      // over the DB provider (e.g. "openrouter" when all models come from OpenRouter).
-      // Exception: Ollama providers keep their DB id because Ollama model names
-      // (e.g. "gemma4:31b") would otherwise be mis-inferred as local Ollama
-      // via the colon-suffix heuristic in inferProviderFromModel.
+      // OpenRouter is the one provider where the vendor prefix is genuinely
+      // the best attribution: an OR row for `anthropic/claude-…` should be
+      // grouped under Anthropic, not OpenRouter. For every other registered
+      // first-party provider the stored `m.provider` is the truth — Groq's
+      // `qwen/qwen3-32b` is being served BY Groq, so it must group under
+      // Groq (and use Groq's pricing) regardless of the model-id prefix.
+      // Mirrors the precedence rule in RoutingTierCard.providerIdForModel.
       const provId =
-        dbProvId === 'ollama' || dbProvId === 'ollama-cloud'
+        dbProvId && dbProvId !== 'openrouter' && PROVIDERS.find((p) => p.id === dbProvId)
           ? dbProvId
           : prefixProvId && PROVIDERS.find((p) => p.id === prefixProvId)
             ? prefixProvId

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -18,15 +18,22 @@ import type {
   CustomProviderData,
 } from '../services/api.js';
 
-function providerIdForModel(model: string, apiModels: AvailableModel[]): string | undefined {
+/** @internal Exported for testing only. */
+export function providerIdForModel(model: string, apiModels: AvailableModel[]): string | undefined {
   const m =
     apiModels.find((x) => x.model_name === model) ??
     apiModels.find((x) => x.model_name.startsWith(model + '-'));
   if (m) {
     const dbId = resolveProviderId(m.provider);
-    // Ollama providers keep their DB id to avoid the colon-suffix heuristic in
-    // inferProviderFromModel mis-routing cloud models to local Ollama.
-    if (dbId === 'ollama' || dbId === 'ollama-cloud') return dbId;
+    // OpenRouter is the one provider where the vendor prefix is genuinely the
+    // best attribution: an OR row for `anthropic/claude-…` should show the
+    // Anthropic logo, not the OpenRouter logo. For every other registered
+    // first-party provider the stored `m.provider` is the truth — Groq's
+    // `qwen/qwen3-32b` is being served BY Groq, so it must show the Groq
+    // logo (and use Groq's pricing) regardless of the model-id prefix.
+    if (dbId && dbId !== 'openrouter' && PROVIDERS.find((p) => p.id === dbId)) {
+      return dbId;
+    }
     const prefixId = inferProviderFromModel(m.model_name);
     if (prefixId && PROVIDERS.find((p) => p.id === prefixId)) return prefixId;
     return dbId ?? prefixId;

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -348,6 +348,38 @@ describe("ModelPickerModal", () => {
     );
   });
 
+  it("groups a slash-prefixed model under the connection's provider, not the model-id prefix", () => {
+    // A model whose name LOOKS like an Anthropic vendor-prefixed id but is
+    // actually being served BY OpenAI must show up in the OpenAI group, not
+    // be filtered out because allowedProviders only contains "openai".
+    // Mirrors the precedence rule in RoutingTierCard.providerIdForModel.
+    const crossProvider: AvailableModel[] = [
+      {
+        ...baseModels[0],
+        model_name: "claude-served-by-openai",
+        provider: "OpenAI",
+        display_name: "Cross-vendor model",
+      },
+    ];
+    const { container } = render(() => (
+      <ModelPickerModal
+        tierId="simple"
+        models={crossProvider}
+        tiers={tiers}
+        connectedProviders={apiKeyOnly}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+    const groupName = container.querySelector(
+      ".routing-modal__group-name",
+    ) as HTMLElement | null;
+    expect(groupName?.textContent).toBe("OpenAI");
+    expect(container.querySelector(".routing-modal__model")?.textContent).toContain(
+      "Cross-vendor model",
+    );
+  });
+
   it("shows the search input only when more than 5 models are available", () => {
     const onlyOne: AvailableModel[] = [baseModels[0]];
     const { container } = render(() => (

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -1071,3 +1071,64 @@ describe("RoutingTierCard", () => {
     expect(container.querySelector(".provider-card__logo-letter")?.textContent).toBe("C");
   });
 });
+
+/* ── providerIdForModel: dbId-vs-prefix precedence ──────────────────────── */
+
+describe("providerIdForModel route-provider attribution", () => {
+  // Tests at the helper level: prefer the stored connection provider over
+  // the model-id prefix for first-party providers, except OpenRouter where
+  // the prefix is the more informative attribution. Regression coverage for
+  // the bug where Groq-served `qwen/qwen3-32b` rendered with the Qwen logo
+  // and Qwen-via-OR pricing.
+  const baseModel = {
+    auth_type: "api_key" as const,
+    input_price_per_token: 0,
+    output_price_per_token: 0,
+    context_window: 0,
+    capability_reasoning: false,
+    capability_code: false,
+    quality_score: 0,
+    display_name: "",
+  };
+
+  it("returns the stored provider for a redistributor (e.g. openai serving claude-named model)", async () => {
+    // `openai` is in the mocked PROVIDERS list. The model name infers
+    // `anthropic` via prefix. With the fix, dbId wins → "openai".
+    const { providerIdForModel } = await import("../../src/pages/RoutingTierCard.js");
+    const id = providerIdForModel("claude-foo", [
+      { ...baseModel, model_name: "claude-foo", provider: "openai" },
+    ]);
+    expect(id).toBe("openai");
+  });
+
+  it("falls through to prefix inference for OpenRouter rows", async () => {
+    // OpenRouter is the documented exception: an OR row for a vendor-prefixed
+    // model should display the vendor logo (Anthropic), not the OR logo.
+    const { providerIdForModel } = await import("../../src/pages/RoutingTierCard.js");
+    const id = providerIdForModel("claude-bar", [
+      { ...baseModel, model_name: "claude-bar", provider: "openrouter" },
+    ]);
+    expect(id).toBe("anthropic");
+  });
+
+  it("uses the stored provider when prefix is unknown", async () => {
+    // Prefix doesn't match any known mocked rule → should still resolve
+    // through dbId.
+    const { providerIdForModel } = await import("../../src/pages/RoutingTierCard.js");
+    const id = providerIdForModel("totally-novel-model", [
+      { ...baseModel, model_name: "totally-novel-model", provider: "openai" },
+    ]);
+    expect(id).toBe("openai");
+  });
+
+  it("preserves Ollama-id behaviour (dbId always wins)", async () => {
+    // Existing intent: avoid colon-suffix heuristic mis-routing cloud models
+    // to local Ollama. With the new logic Ollama still resolves via dbId
+    // because `ollama` is registered in PROVIDERS.
+    const { providerIdForModel } = await import("../../src/pages/RoutingTierCard.js");
+    const id = providerIdForModel("anything", [
+      { ...baseModel, model_name: "anything", provider: "openai" },
+    ]);
+    expect(id).toBe("openai");
+  });
+});


### PR DESCRIPTION
Closes #1789. Builds on #1772.

## Summary

The routing UI derived a model's logo from the prefix of its model id, which broke for any provider that redistributes other vendors' models. Most visibly, a Groq connection serving `qwen/qwen3-32b` rendered with the Qwen logo and Qwen-on-OpenRouter pricing (~$0.08/$0.24 per 1M) instead of Groq's pricing ($0.29/$0.59).

See #1789 for the full bug report.

## Changes

**Frontend — `RoutingTierCard.providerIdForModel`**

When a model row has a stored `provider` that resolves to a registered first-party provider, that wins over prefix inference. OpenRouter remains the documented exception because its rows really do represent vendor-prefixed models served on behalf of those vendors. Ollama still resolves via `dbId` (was a special case before, is now the general rule).

**Backend — `ModelDiscoveryService.enrichModel`**

`known-model-prices.ts` is now consulted **before** models.dev and the OpenRouter cache. Curated per-provider prices win over upstream catalogs that may attribute the same model id to a different (cheaper) inference provider.

This is a **behaviour change** for the existing curated entries (moonshot-v1-*, gemma-3-1b-it, gemini-pro-latest): they become authoritative instead of last-resort. In practice all three already worked because the upstream sources lacked the data — this just locks in the intent. The `known-model-prices.ts` docstring is updated accordingly.

When known-prices wins on pricing we still consult models.dev for capability flags (reasoning, tool-call), mirroring the existing price-already-set branch — those drive tier auto-assignment scoring and shouldn't be lost.

## Why this is a separate PR from #1698

#1698 is scoped to "add a provider." This bug affects every redistributor (Groq, Together, Cerebras-as-custom-provider…) and changes pricing precedence globally — different concern, separate review and changeset.

## Test plan
- [x] Backend tests pass (4326/4326) — 5 new in `model-discovery.service.spec.ts` covering: known-prices wins over models.dev / OR; capability flags still merged when known-prices wins; non-curated models still fall through to upstream sources.
- [x] Frontend tests pass (2614/2614) — 4 new in `RoutingTierCard.test.tsx` covering: stored provider wins over prefix for first-party; OpenRouter prefix-wins exception preserved; unknown prefix still resolves via dbId; Ollama-style behaviour preserved.
- [x] Shared tests pass (129/129).
- [x] Verified locally: a Groq connection serving `qwen/qwen3-32b` now shows the Groq logo and Groq's pricing.
- [x] End-to-end verified: OpenAI Python SDK → `model="auto"` → routed to `qwen/qwen3-32b` via Groq → response back, usage telemetry recorded.