### PR TITLE
Fix dark mode readability for provider text, links, and icons

### DIFF
--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -138,8 +138,10 @@ const OAuthDetailView: Component<Props> = (props) => {
           </p>
           <p class="provider-detail__hint" style="margin-top: 8px;">
             Copy the full URL from the{' '}
-            <span style="color: #000000; font-weight: 500;">popup's address bar</span> and paste it
-            below:
+            <span style="color: hsl(var(--foreground)); font-weight: 500;">
+              popup's address bar
+            </span>{' '}
+            and paste it below:
           </p>
           <video
             src="/images/oauth-callback-example.mp4"

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -254,7 +254,7 @@ export function ModelCell(
             role="img"
             aria-label={`${provName ?? provId} (${authLabel(item.auth_type)})`}
             title={`${provName ?? provId} (${authLabel(item.auth_type)})`}
-            style="display: inline-flex; flex-shrink: 0; position: relative;"
+            style="display: inline-flex; flex-shrink: 0; position: relative; color: hsl(var(--foreground));"
           >
             {providerIcon(provId, 14)}
             {authBadgeFor(item.auth_type, 8)}

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -408,7 +408,7 @@
 
 .provider-detail__hint {
   font-size: var(--font-size-sm);
-  color: hsl(215, 16%, 39%);
+  color: hsl(var(--muted-foreground));
   margin-bottom: 12px;
   line-height: 1.5;
 }


### PR DESCRIPTION
## ✨ What changed
- Provider description text in the setup wizard now uses the theme's muted-foreground color instead of a hardcoded blue-gray
- The "popup's address bar" link in the OAuth flow uses the foreground color instead of hardcoded black
- Provider icons (OpenAI, Anthropic, xAI, Ollama, etc.) in the message list are now white in dark mode instead of gray

## 💭 Why
Several UI elements had hardcoded colors that worked for light mode but were too dark and hard to read in dark mode. The description text was nearly invisible, links disappeared against the dark background, and monochrome provider icons blended into the table rows.

## 👤 For users
- Text in the provider setup wizard is much more readable in dark mode
- Bold links in the OAuth connection flow are visible in dark mode
- Provider icons in the message list are crisp white instead of washed-out gray in dark mode
- No change in light mode appearance

## 🔧 For operators
No operator impact.

## 🧪 How to test
1. Switch to dark mode
2. Go to Routing, click "Add provider", pick any OAuth provider (e.g. OpenAI): the description text and "popup's address bar" link should be clearly readable
3. Go to Messages: provider icons (OpenAI, Anthropic, xAI) should appear white, not gray
4. Switch to light mode and verify the same elements still look correct

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dark mode readability by replacing hardcoded colors with theme variables for provider hints, OAuth link text, and provider icons. Light mode is unchanged.

- **Bug Fixes**
  - Setup wizard hint text uses `--muted-foreground` instead of a fixed blue-gray.
  - OAuth “popup's address bar” link uses `--foreground` instead of black.
  - Provider icons in Messages inherit `--foreground` (white in dark mode) instead of gray.

<sup>Written for commit 38643aa3985f9200f14cc91044f985b4b5985785. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

