### PR TITLE
fix: bump Codex client_version so subscription discovers gpt-5.5

### DIFF
--- a/.changeset/codex-client-version-gpt-5-5.md
+++ b/.changeset/codex-client-version-gpt-5-5.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix OpenAI subscription model discovery so newer Codex CLI models (e.g. `gpt-5.5`) appear. The hardcoded `client_version=0.99.0` query param made `https://chatgpt.com/backend-api/codex/models` silently return only the older subset; bump it to `0.128.0` and lift Codex/Copilot client identifiers into a shared constants file so future bumps are a one-line change.

--- a/packages/backend/src/common/constants/subscription-clients.ts
+++ b/packages/backend/src/common/constants/subscription-clients.ts
@@ -1,0 +1,21 @@
+/**
+ * Client identification strings sent to subscription backends that gate model
+ * lists or requests by client version. Lifted into one place so bumping a
+ * version when an upstream releases a new model is a single edit.
+ *
+ * Codex (`https://chatgpt.com/backend-api/codex/...`): the `client_version`
+ * URL param is enforced — older versions silently receive an older model
+ * subset. Bump `CODEX_CLI_VERSION` to track the current `openai/codex` CLI
+ * release. The user-agent string is not enforced, so it stays synthetic.
+ *
+ * Copilot (`https://api.githubcopilot.com/...`): GitHub validates the
+ * `Editor-Version` and `Editor-Plugin-Version` headers; both are bumped
+ * together when GitHub deprecates an older pair.
+ */
+
+export const CODEX_CLI_VERSION = '0.128.0';
+export const CODEX_CLI_ORIGINATOR = 'codex_cli_rs';
+export const CODEX_CLI_USER_AGENT = 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown';
+
+export const COPILOT_EDITOR_VERSION = 'vscode/1.100.0';
+export const COPILOT_PLUGIN_VERSION = 'copilot/1.300.0';

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1287,7 +1287,7 @@ describe('ProviderModelFetcherService', () => {
       await service.fetch('openai', 'my-oauth-token', 'subscription');
 
       expect(fetchSpy).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/codex/models?client_version=0.99.0',
+        'https://chatgpt.com/backend-api/codex/models?client_version=0.128.0',
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: 'Bearer my-oauth-token',

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -1,6 +1,13 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { DiscoveredModel, FetcherConfig } from './model-fetcher';
 import { OLLAMA_CLOUD_HOST, OLLAMA_HOST } from '../common/constants/ollama';
+import {
+  CODEX_CLI_ORIGINATOR,
+  CODEX_CLI_USER_AGENT,
+  CODEX_CLI_VERSION,
+  COPILOT_EDITOR_VERSION,
+  COPILOT_PLUGIN_VERSION,
+} from '../common/constants/subscription-clients';
 import { normalizeMinimaxSubscriptionBaseUrl } from '../routing/provider-base-url';
 import { getQwenCompatibleBaseUrl, normalizeQwenCompatibleBaseUrl } from '../routing/qwen-region';
 import { OpencodeGoCatalogService } from './opencode-go-catalog.service';
@@ -321,12 +328,12 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     parse: parseOpenAIDeduped,
   },
   'openai-subscription': {
-    endpoint: 'https://chatgpt.com/backend-api/codex/models?client_version=0.99.0',
+    endpoint: `https://chatgpt.com/backend-api/codex/models?client_version=${CODEX_CLI_VERSION}`,
     buildHeaders: (key: string) => ({
       Authorization: `Bearer ${key}`,
       'Content-Type': 'application/json',
-      originator: 'codex_cli_rs',
-      'user-agent': 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown',
+      originator: CODEX_CLI_ORIGINATOR,
+      'user-agent': CODEX_CLI_USER_AGENT,
     }),
     parse: parseOpenaiSubscription,
   },
@@ -420,8 +427,8 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     buildHeaders: (key: string) => ({
       Authorization: `Bearer ${key}`,
       Accept: 'application/json',
-      'Editor-Version': 'vscode/1.100.0',
-      'Editor-Plugin-Version': 'copilot/1.300.0',
+      'Editor-Version': COPILOT_EDITOR_VERSION,
+      'Editor-Plugin-Version': COPILOT_PLUGIN_VERSION,
       'Copilot-Integration-Id': 'vscode-chat',
     }),
     parse: parseCopilot,

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -1,5 +1,11 @@
 import { OLLAMA_CLOUD_HOST, OLLAMA_HOST } from '../../common/constants/ollama';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../../common/constants/providers';
+import {
+  CODEX_CLI_ORIGINATOR,
+  CODEX_CLI_USER_AGENT,
+  COPILOT_EDITOR_VERSION,
+  COPILOT_PLUGIN_VERSION,
+} from '../../common/constants/subscription-clients';
 import { normalizeProviderBaseUrl } from '../provider-base-url';
 import { getQwenCompatibleBaseUrl } from '../qwen-region';
 
@@ -68,8 +74,8 @@ const OPENCODE_GO_BASE = 'https://opencode.ai/zen/go';
 const chatgptSubscriptionHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
-  originator: 'codex_cli_rs',
-  'user-agent': 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown',
+  originator: CODEX_CLI_ORIGINATOR,
+  'user-agent': CODEX_CLI_USER_AGENT,
 });
 
 export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
@@ -170,8 +176,8 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: (apiKey: string) => ({
       Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
-      'Editor-Version': 'vscode/1.100.0',
-      'Editor-Plugin-Version': 'copilot/1.300.0',
+      'Editor-Version': COPILOT_EDITOR_VERSION,
+      'Editor-Plugin-Version': COPILOT_PLUGIN_VERSION,
       'Copilot-Integration-Id': 'vscode-chat',
     }),
     buildPath: () => '/chat/completions',


### PR DESCRIPTION
## Summary

Closes #1797.

OpenAI subscription model discovery missed `gpt-5.5` (and `gpt-5.3-codex-spark`) because Manifest hits the Codex `/models` endpoint with a stale `client_version` query parameter. The endpoint silently filters its response by that value — older versions get the older model subset even when the user's actual Codex CLI sees the new ones locally.

- Bump `client_version` from `0.99.0` → `0.128.0` in `packages/backend/src/model-discovery/provider-model-fetcher.service.ts`.
- Lift Codex + Copilot client identifiers into a new `packages/backend/src/common/constants/subscription-clients.ts`. The same identifiers were duplicated between the model fetcher and the proxy (`provider-endpoints.ts`); consolidating them makes the next bump a one-line change.
- Update the matching test assertion in `provider-model-fetcher.service.spec.ts`.

## Verification

Reproduced the gating against the real upstream with a Codex subscription token:

| Request | Returned slugs |
| --- | --- |
| `client_version=0.99.0` (current Manifest) | `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2`, `codex-auto-review` |
| `client_version=0.128.0` (this PR) | `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`, `codex-auto-review` |

Bumping the user-agent independently has no effect — only the URL parameter gates the response — so the user-agent constant keeps its existing synthetic value (`codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown`) to avoid impersonating a specific real client.

## Test plan

- [x] `npx jest provider-model-fetcher.service.spec provider-endpoints.spec provider-client.spec` — 280 tests pass
- [ ] Manual: connect an OpenAI subscription in the dashboard, confirm `gpt-5.5` appears in the discovered model list

## Followup

`CODEX_CLI_VERSION` will need bumping again whenever OpenAI gates a future model behind a newer Codex CLI release. The constants file is now the single place to do that. A dynamic version fetch (e.g. polling `openai/codex` GitHub releases at boot) was considered but deferred — it adds an external dependency at startup for a problem that surfaces every few months, and Copilot's headers don't have a clean equivalent source for the same treatment, so consistency would degrade.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI subscription model discovery so newer Codex models (like `gpt-5.5`) appear by updating the gated `client_version`. Also consolidates Codex and Copilot client identifiers to make future bumps a single edit.

- **Bug Fixes**
  - Bumped Codex `client_version` from `0.99.0` to `0.128.0` so `/codex/models` returns the latest models.
  - Updated the corresponding test in `provider-model-fetcher.service.spec.ts`.

- **Refactors**
  - Moved Codex and Copilot client identifiers into `packages/backend/src/common/constants/subscription-clients.ts`.
  - Switched `provider-model-fetcher.service.ts` and `routing/proxy/provider-endpoints.ts` to use these constants to remove duplication.

<sup>Written for commit cf98f7000bd74d176c34376b700d68d59f16e7d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

