### PR TITLE
feat(openai): mint real api.openai.com key from ChatGPT subscription …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,17 @@ coverage/
 .gstack/
 scripts/.env.verify
 scripts/verify-free-model-ids.sh
+
+# Craft Agent workspace artifacts (not part of the project)
+sessions/
+config.json
+events.jsonl
+views.json
+labels/
+statuses/
+skills/
+AGENTS.md
+.claude-plugin/
+.fieldflow/
+icon.svg
+packages/openclaw-plugin/

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -103,26 +103,6 @@ describe('filterNonChatModels', () => {
     });
   });
 
-  describe('OpenAI subscription patterns', () => {
-    it('filters moderation models for openai-subscription', () => {
-      const models = [makeModel('text-moderation-latest'), makeModel('gpt-4o')];
-      const result = filterNonChatModels(models, 'openai-subscription');
-      expect(result.map((m) => m.id)).toEqual(['gpt-4o']);
-    });
-
-    it('filters audio models for openai-subscription', () => {
-      const models = [makeModel('gpt-4o-audio-preview'), makeModel('gpt-4o')];
-      const result = filterNonChatModels(models, 'openai-subscription');
-      expect(result.map((m) => m.id)).toEqual(['gpt-4o']);
-    });
-
-    it('filters chatgpt-image models for openai-subscription', () => {
-      const models = [makeModel('chatgpt-image-latest'), makeModel('gpt-4o')];
-      const result = filterNonChatModels(models, 'openai-subscription');
-      expect(result.map((m) => m.id)).toEqual(['gpt-4o']);
-    });
-  });
-
   describe('Gemini-specific patterns', () => {
     it('filters aqs- prefixed models', () => {
       const models = [makeModel('aqs-gemini-model'), makeModel('gemini-2.5-flash')];
@@ -319,9 +299,8 @@ describe('filterNonChatModels', () => {
   });
 
   describe('PROVIDER_NON_CHAT registry', () => {
-    it('has entries for openai, openai-subscription, gemini, mistral, and xai', () => {
+    it('has entries for openai, gemini, mistral, and xai', () => {
       expect(PROVIDER_NON_CHAT).toHaveProperty('openai');
-      expect(PROVIDER_NON_CHAT).toHaveProperty('openai-subscription');
       expect(PROVIDER_NON_CHAT).toHaveProperty('gemini');
       expect(PROVIDER_NON_CHAT).toHaveProperty('mistral');
       expect(PROVIDER_NON_CHAT).toHaveProperty('xai');

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -18,7 +18,6 @@ describe('ProviderModelFetcherService', () => {
   it('should have configs for all providers including subscription variants', () => {
     const expected = [
       'openai',
-      'openai-subscription',
       'deepseek',
       'mistral',
       'moonshot',
@@ -1156,148 +1155,6 @@ describe('ProviderModelFetcherService', () => {
     });
   });
 
-  /* ── OpenAI subscription parser ── */
-
-  describe('parseOpenaiSubscription (via openai provider with subscription authType)', () => {
-    it('should parse valid Codex models response', async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          models: [
-            {
-              slug: 'gpt-5.3-codex',
-              display_name: 'GPT-5.3 Codex',
-              context_window: 192000,
-              visibility: 'list',
-              supported_in_api: true,
-              priority: 10,
-            },
-            {
-              slug: 'gpt-5.2-codex',
-              display_name: 'GPT-5.2 Codex',
-              context_window: 200000,
-              visibility: 'list',
-              supported_in_api: true,
-            },
-          ],
-        }),
-      });
-
-      const result = await service.fetch('openai', 'oauth-token', 'subscription');
-      expect(result).toHaveLength(2);
-      expect(result[0]).toEqual(
-        expect.objectContaining({
-          id: 'gpt-5.3-codex',
-          displayName: 'GPT-5.3 Codex',
-          provider: 'openai',
-          contextWindow: 192000,
-          inputPricePerToken: 0,
-          outputPricePerToken: 0,
-          capabilityCode: true,
-          qualityScore: 3,
-        }),
-      );
-      expect(result[1].id).toBe('gpt-5.2-codex');
-    });
-
-    it('should filter out models with visibility !== list', async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          models: [
-            { slug: 'visible-model', visibility: 'list' },
-            { slug: 'hidden-model', visibility: 'hidden' },
-            { slug: 'no-visibility' },
-          ],
-        }),
-      });
-
-      const result = await service.fetch('openai', 'token', 'subscription');
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('visible-model');
-    });
-
-    it('should use slug as displayName when display_name is missing', async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          models: [{ slug: 'gpt-5.4', visibility: 'list' }],
-        }),
-      });
-
-      const result = await service.fetch('openai', 'token', 'subscription');
-      expect(result[0].displayName).toBe('gpt-5.4');
-    });
-
-    it('should default context_window to 200000', async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          models: [{ slug: 'test-model', visibility: 'list' }],
-        }),
-      });
-
-      const result = await service.fetch('openai', 'token', 'subscription');
-      expect(result[0].contextWindow).toBe(200000);
-    });
-
-    it('should return [] when models is not an array', async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        json: async () => ({ models: 'not-array' }),
-      });
-
-      const result = await service.fetch('openai', 'token', 'subscription');
-      expect(result).toEqual([]);
-    });
-
-    it('should return [] when models is missing', async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        json: async () => ({}),
-      });
-
-      const result = await service.fetch('openai', 'token', 'subscription');
-      expect(result).toEqual([]);
-    });
-
-    it('should filter out entries without string slug', async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          models: [
-            { slug: 123, visibility: 'list' },
-            { visibility: 'list' },
-            { slug: 'valid', visibility: 'list' },
-          ],
-        }),
-      });
-
-      const result = await service.fetch('openai', 'token', 'subscription');
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('valid');
-    });
-
-    it('should send Codex CLI headers', async () => {
-      fetchSpy.mockResolvedValue({
-        ok: true,
-        json: async () => ({ models: [] }),
-      });
-
-      await service.fetch('openai', 'my-oauth-token', 'subscription');
-
-      expect(fetchSpy).toHaveBeenCalledWith(
-        'https://chatgpt.com/backend-api/codex/models?client_version=0.99.0',
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            Authorization: 'Bearer my-oauth-token',
-            originator: 'codex_cli_rs',
-          }),
-        }),
-      );
-    });
-  });
-
   /* ── Copilot parser ── */
 
   describe('parseCopilot (via copilot provider)', () => {
@@ -1440,18 +1297,17 @@ describe('ProviderModelFetcherService', () => {
 
   /* ── OpenAI subscription routing ── */
 
-  it('should route openai+subscription to openai-subscription config', async () => {
+  it('should route openai+subscription through the standard openai config (RFC 8693 minted key)', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
-      json: async () => ({ models: [] }),
+      json: async () => ({ data: [] }),
     });
 
-    await service.fetch('openai', 'token', 'subscription');
+    // Subscription users hold a real api.openai.com key minted via token
+    // exchange — they hit the same /v1/models endpoint as sk- keys.
+    await service.fetch('openai', 'sk-minted', 'subscription');
 
-    expect(fetchSpy).toHaveBeenCalledWith(
-      expect.stringContaining('chatgpt.com/backend-api/codex/models'),
-      expect.anything(),
-    );
+    expect(fetchSpy).toHaveBeenCalledWith('https://api.openai.com/v1/models', expect.anything());
   });
 
   it('should use regular openai config when authType is not subscription', async () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -101,8 +101,6 @@ export const UNIVERSAL_NON_CHAT_RE =
 export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
   openai:
     /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio|^chatgpt-image|^gpt-image-|search-api)/i,
-  'openai-subscription':
-    /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|audio|^chatgpt-image|^gpt-image-)/i,
   gemini:
     /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview|robotics)/i,
   mistral:
@@ -280,27 +278,6 @@ const parseOllama = createModelParser<OllamaModelEntry>({
   qualityScore: 2,
 });
 
-/* ── OpenAI subscription (Codex CLI models API) ── */
-
-interface OpenAISubscriptionModelEntry {
-  slug: string;
-  display_name?: string;
-  context_window?: number;
-  visibility?: string;
-  supported_in_api?: boolean;
-}
-
-const parseOpenaiSubscription = createModelParser<OpenAISubscriptionModelEntry>({
-  arrayKey: 'models',
-  filter: (entry) => typeof entry.slug === 'string' && entry.visibility === 'list',
-  getId: (entry) => entry.slug,
-  getDisplayName: (entry, id) => entry.display_name || id,
-  contextWindow: (entry) => entry.context_window ?? 200000,
-  inputPricePerToken: 0,
-  outputPricePerToken: 0,
-  capabilityCode: true,
-});
-
 /* ── GitHub Copilot (subscription-only, OpenAI-compatible /models) ── */
 
 const parseCopilot = createModelParser<OpenAIModelEntry>({
@@ -319,16 +296,6 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     endpoint: 'https://api.openai.com/v1/models',
     buildHeaders: bearerHeaders,
     parse: parseOpenAIDeduped,
-  },
-  'openai-subscription': {
-    endpoint: 'https://chatgpt.com/backend-api/codex/models?client_version=0.99.0',
-    buildHeaders: (key: string) => ({
-      Authorization: `Bearer ${key}`,
-      'Content-Type': 'application/json',
-      originator: 'codex_cli_rs',
-      'user-agent': 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown',
-    }),
-    parse: parseOpenaiSubscription,
   },
   deepseek: {
     endpoint: 'https://api.deepseek.com/models',
@@ -447,10 +414,9 @@ export class ProviderModelFetcherService {
     endpointOverride?: string,
   ): Promise<DiscoveredModel[]> {
     let configKey = providerId.toLowerCase();
-    // OpenAI subscription tokens use a different models endpoint
-    if (configKey === 'openai' && authType === 'subscription') {
-      configKey = 'openai-subscription';
-    } else if (configKey === 'minimax' && authType === 'subscription') {
+    // OpenAI subscription users hold a real api.openai.com key (minted via
+    // RFC 8693 token exchange) — they get the same model list as sk- keys.
+    if (configKey === 'minimax' && authType === 'subscription') {
       configKey = 'minimax-subscription';
     } else if (configKey === 'zai' && authType === 'subscription') {
       configKey = 'zai-subscription';

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.ts
@@ -80,7 +80,8 @@ export class OpenaiOauthController {
     if (apiKey) {
       try {
         const blob = JSON.parse(apiKey) as OAuthTokenBlob;
-        if (blob.t) await this.oauthService.revokeToken(blob.t);
+        // blob.t holds a minted api.openai.com key (no public revoke endpoint);
+        // revoking the OAuth refresh token invalidates the grant chain.
         if (blob.r) await this.oauthService.revokeToken(blob.r);
       } catch {
         this.logger.warn('Could not parse OAuth token blob for revocation');

--- a/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
@@ -79,6 +79,10 @@ describe('OpenaiOauthService', () => {
       expect(parsed.searchParams.get('scope')).toBe('openid profile email offline_access');
       expect(parsed.searchParams.get('redirect_uri')).toBe('http://localhost:1455/auth/callback');
       expect(parsed.searchParams.get('state')?.length).toBeGreaterThan(0);
+      // Required so the resulting id_token carries organization_id and can be
+      // exchanged for an api.openai.com key (RFC 8693).
+      expect(parsed.searchParams.get('id_token_add_organizations')).toBe('true');
+      expect(parsed.searchParams.get('codex_cli_simplified_flow')).toBe('true');
       expect(svc.getPendingCount()).toBe(1);
     });
 
@@ -117,37 +121,49 @@ describe('OpenaiOauthService', () => {
       expect(svc.getPendingCount()).toBe(0);
     });
 
-    it('exchanges a valid code, stores the blob, and triggers model discovery', async () => {
-      fetchMock.mockResolvedValue(
-        mockResponse(200, {
-          access_token: 'access-1',
-          refresh_token: 'refresh-1',
-          expires_in: 3600,
-        }),
-      );
+    it('exchanges code, mints an api.openai.com key, stores it, and triggers discovery', async () => {
+      fetchMock
+        // 1. authorization_code → tokens (incl. id_token)
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            id_token: 'id-token-1',
+            access_token: 'access-1',
+            refresh_token: 'refresh-1',
+            expires_in: 3600,
+          }),
+        )
+        // 2. RFC 8693 token-exchange → minted API key
+        .mockResolvedValueOnce(
+          mockResponse(200, { access_token: 'sk-minted-1', expires_in: 1800 }),
+        );
       const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
       const state = new URL(url).searchParams.get('state')!;
 
       await svc.exchangeCode(state, 'auth-code');
 
-      expect(fetchMock).toHaveBeenCalledTimes(1);
-      const [tokenUrl, init] = fetchMock.mock.calls[0];
-      expect(tokenUrl).toBe('https://auth.openai.com/oauth/token');
-      const body = new URLSearchParams(init.body.toString());
-      expect(body.get('grant_type')).toBe('authorization_code');
-      expect(body.get('code')).toBe('auth-code');
-      expect(body.get('code_verifier')?.length).toBeGreaterThan(0);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [authCodeCall, exchangeCall] = fetchMock.mock.calls;
+      expect(authCodeCall[0]).toBe('https://auth.openai.com/oauth/token');
+      expect(new URLSearchParams(authCodeCall[1].body.toString()).get('grant_type')).toBe(
+        'authorization_code',
+      );
+      expect(exchangeCall[0]).toBe('https://auth.openai.com/oauth/token');
+      const exchangeBody = new URLSearchParams(exchangeCall[1].body.toString());
+      expect(exchangeBody.get('grant_type')).toBe(
+        'urn:ietf:params:oauth:grant-type:token-exchange',
+      );
+      expect(exchangeBody.get('subject_token')).toBe('id-token-1');
+      expect(exchangeBody.get('requested_token')).toBe('openai-api-key');
 
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
         'agent-1',
         'user-1',
         'openai',
-        expect.stringContaining('"t":"access-1"'),
+        expect.stringContaining('"t":"sk-minted-1"'),
         'subscription',
       );
       expect(discovery.discoverModels).toHaveBeenCalled();
       expect(providerService.recalculateTiers).toHaveBeenCalledWith('agent-1');
-      // State is one-time-use.
       expect(svc.getPendingCount()).toBe(0);
     });
 
@@ -158,10 +174,60 @@ describe('OpenaiOauthService', () => {
       await expect(svc.exchangeCode(state, 'bad')).rejects.toThrow('Token exchange failed');
     });
 
-    it('swallows discovery errors (OAuth success is not rolled back)', async () => {
-      fetchMock.mockResolvedValue(
+    it('throws when the token-exchange step returns no access_token', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            id_token: 'id-1',
+            access_token: 'a',
+            refresh_token: 'r',
+            expires_in: 60,
+          }),
+        )
+        .mockResolvedValueOnce(mockResponse(200, {}));
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'c')).rejects.toThrow(
+        'API key exchange returned no access_token',
+      );
+    });
+
+    it('throws when the token-exchange step returns a non-2xx status', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            id_token: 'id-1',
+            access_token: 'a',
+            refresh_token: 'r',
+            expires_in: 60,
+          }),
+        )
+        .mockResolvedValueOnce(mockResponse(401, {}, 'invalid_subject_token'));
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'c')).rejects.toThrow('API key exchange failed');
+    });
+
+    it('throws when the OAuth response omits id_token', async () => {
+      fetchMock.mockResolvedValueOnce(
         mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
       );
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'c')).rejects.toThrow('OAuth response missing id_token');
+    });
+
+    it('swallows discovery errors (OAuth success is not rolled back)', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            id_token: 'id-1',
+            access_token: 'a',
+            refresh_token: 'r',
+            expires_in: 60,
+          }),
+        )
+        .mockResolvedValueOnce(mockResponse(200, { access_token: 'sk-x', expires_in: 60 }));
       discovery.discoverModels.mockRejectedValue(new Error('boom'));
       const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
       const state = new URL(url).searchParams.get('state')!;
@@ -171,24 +237,48 @@ describe('OpenaiOauthService', () => {
   });
 
   describe('refreshAccessToken', () => {
-    it('returns a fresh blob with a new expiry', async () => {
-      fetchMock.mockResolvedValue(
-        mockResponse(200, {
-          access_token: 'a2',
-          refresh_token: 'r2',
-          expires_in: 1800,
-        }),
-      );
+    it('refreshes OAuth tokens, mints a new api.openai.com key, returns blob', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            id_token: 'id-2',
+            access_token: 'a2',
+            refresh_token: 'r2',
+            expires_in: 1800,
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse(200, { access_token: 'sk-minted-2', expires_in: 7200 }),
+        );
       const blob = await svc.refreshAccessToken('old-refresh');
-      expect(blob.t).toBe('a2');
+      expect(blob.t).toBe('sk-minted-2');
       expect(blob.r).toBe('r2');
-      expect(blob.e).toBe(Date.now() + 1800 * 1000);
+      expect(blob.e).toBe(Date.now() + 7200 * 1000);
     });
 
     it('retains the old refresh token when the server omits a new one', async () => {
-      fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'a2', expires_in: 60 }));
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, { id_token: 'id-2', access_token: 'a2', expires_in: 60 }),
+        )
+        .mockResolvedValueOnce(mockResponse(200, { access_token: 'sk-x', expires_in: 60 }));
       const blob = await svc.refreshAccessToken('old-refresh');
       expect(blob.r).toBe('old-refresh');
+    });
+
+    it('falls back to a 1h key lifetime when expires_in is missing', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            id_token: 'id-3',
+            access_token: 'a3',
+            refresh_token: 'r3',
+            expires_in: 60,
+          }),
+        )
+        .mockResolvedValueOnce(mockResponse(200, { access_token: 'sk-3' }));
+      const blob = await svc.refreshAccessToken('old-refresh');
+      expect(blob.e).toBe(Date.now() + 3600 * 1000);
     });
 
     it('throws when the refresh endpoint returns a non-2xx status', async () => {
@@ -210,17 +300,24 @@ describe('OpenaiOauthService', () => {
     });
 
     it('refreshes and persists a fresh blob when the token is near expiry', async () => {
-      const blob = { t: 'old', r: 'rf', e: Date.now() + 30_000 }; // within the 60s skew window
-      fetchMock.mockResolvedValue(
-        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
-      );
+      const blob = { t: 'old-key', r: 'rf', e: Date.now() + 30_000 }; // within the 60s skew window
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            id_token: 'id-new',
+            access_token: 'a-new',
+            refresh_token: 'rf2',
+            expires_in: 3600,
+          }),
+        )
+        .mockResolvedValueOnce(mockResponse(200, { access_token: 'sk-fresh', expires_in: 3600 }));
       const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
-      expect(token).toBe('new');
+      expect(token).toBe('sk-fresh');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
         'agent-1',
         'user-1',
         'openai',
-        expect.stringContaining('"t":"new"'),
+        expect.stringContaining('"t":"sk-fresh"'),
         'subscription',
       );
     });

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -17,6 +17,14 @@ const SCOPE = 'openid profile email offline_access';
 const CALLBACK_PORT = 1455;
 const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/auth/callback`;
 const STATE_TTL_MS = 10 * 60 * 1000;
+// RFC 8693 token exchange constants. The grant takes an id_token that
+// carries the user's OpenAI organization_id and returns a real API key
+// that bills against their ChatGPT subscription. Without
+// id_token_add_organizations=true at /authorize, the id_token has no
+// organization_id and the exchange would fail.
+const TOKEN_EXCHANGE_GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
+const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
+const REQUESTED_TOKEN = 'openai-api-key';
 
 @Injectable()
 export class OpenaiOauthService {
@@ -72,6 +80,11 @@ export class OpenaiOauthService {
       state,
       code_challenge: challenge,
       code_challenge_method: 'S256',
+      // Required for the RFC 8693 token exchange in exchangeIdTokenForApiKey:
+      // without id_token_add_organizations the id_token has no organization_id
+      // claim and the exchange returns invalid_subject_token.
+      id_token_add_organizations: 'true',
+      codex_cli_simplified_flow: 'true',
     });
     return `${AUTHORIZE_URL}?${params.toString()}`;
   }
@@ -101,15 +114,12 @@ export class OpenaiOauthService {
       throw new Error('Token exchange failed');
     }
     const data = (await response.json()) as {
+      id_token: string;
       access_token: string;
       refresh_token: string;
       expires_in: number;
     };
-    const blob: OAuthTokenBlob = {
-      t: data.access_token,
-      r: data.refresh_token,
-      e: Date.now() + data.expires_in * 1000,
-    };
+    const blob = await this.mintApiKeyBlob(data.id_token, data.refresh_token);
     const { provider: savedProvider } = await this.providerService.upsertProvider(
       pending.agentId,
       pending.userId,
@@ -143,15 +153,62 @@ export class OpenaiOauthService {
       throw new Error('Token refresh failed');
     }
     const data = (await response.json()) as {
+      id_token: string;
       access_token: string;
       refresh_token?: string;
       expires_in: number;
     };
-    return {
-      t: data.access_token,
-      r: data.refresh_token || refreshToken,
-      e: Date.now() + data.expires_in * 1000,
+    return this.mintApiKeyBlob(data.id_token, data.refresh_token || refreshToken);
+  }
+
+  /**
+   * RFC 8693 token exchange — converts the OAuth id_token (which carries
+   * the user's organization_id) into a real OpenAI API key bound to that
+   * organization. The minted key bills against the user's ChatGPT plan and
+   * works against api.openai.com with the full Responses API surface.
+   */
+  private async exchangeIdTokenForApiKey(idToken: string): Promise<{
+    apiKey: string;
+    expiresAt: number;
+  }> {
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: TOKEN_EXCHANGE_GRANT,
+        client_id: this.clientId,
+        subject_token: idToken,
+        subject_token_type: ID_TOKEN_TYPE,
+        requested_token: REQUESTED_TOKEN,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`OpenAI API key exchange failed: ${scrubSecrets(text)}`);
+      throw new Error('API key exchange failed');
+    }
+    const data = (await response.json()) as {
+      access_token?: string;
+      expires_in?: number;
     };
+    if (!data.access_token) {
+      throw new Error('API key exchange returned no access_token');
+    }
+    // expires_in is optional in the response; fall back to a 1h conservative
+    // lifetime so unwrapToken refreshes on a sane cadence.
+    const lifetimeMs = (data.expires_in ?? 3600) * 1000;
+    return { apiKey: data.access_token, expiresAt: Date.now() + lifetimeMs };
+  }
+
+  /**
+   * Run the token exchange and pack the result into the storage blob shape.
+   * The minted API key lands in `t` so existing consumers (proxy bearer,
+   * model discovery) read it transparently.
+   */
+  private async mintApiKeyBlob(idToken: string, refreshToken: string): Promise<OAuthTokenBlob> {
+    if (!idToken) throw new Error('OAuth response missing id_token');
+    const { apiKey, expiresAt } = await this.exchangeIdTokenForApiKey(idToken);
+    return { t: apiKey, r: refreshToken, e: expiresAt };
   }
 
   /** Parse an OAuth blob and return a valid access token, refreshing if expired. */

--- a/packages/backend/src/routing/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.spec.ts
@@ -150,9 +150,13 @@ describe('OpenaiOauthController', () => {
       await expect(controller.revoke('', { id: 'user-1' } as never)).rejects.toThrow(HttpException);
     });
 
-    it('revokes both access and refresh tokens from stored blob', async () => {
+    it('revokes the OAuth refresh token from the stored blob (api.openai.com key has no public revoke endpoint)', async () => {
       resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
-      const blob = JSON.stringify({ t: 'access-tok', r: 'refresh-tok', e: Date.now() + 3600000 });
+      const blob = JSON.stringify({
+        t: 'sk-minted-key',
+        r: 'refresh-tok',
+        e: Date.now() + 3600000,
+      });
       providerKeyService.getProviderApiKey.mockResolvedValue(blob);
 
       const result = await controller.revoke('my-agent', { id: 'user-1' } as never);
@@ -162,8 +166,10 @@ describe('OpenaiOauthController', () => {
         'openai',
         'subscription',
       );
-      expect(oauthService.revokeToken).toHaveBeenCalledWith('access-tok');
+      // Only the refresh token goes to /oauth/revoke; the minted API key
+      // (blob.t) is not an OAuth token.
       expect(oauthService.revokeToken).toHaveBeenCalledWith('refresh-tok');
+      expect(oauthService.revokeToken).not.toHaveBeenCalledWith('sk-minted-key');
       expect(providerService.removeProvider).toHaveBeenCalledWith(
         'agent-id-1',
         'openai',

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -7,6 +7,16 @@ import { ProviderService } from './routing-core/provider.service';
 const fetchMock = jest.fn() as jest.Mock<Promise<any>>;
 global.fetch = fetchMock;
 
+// Helper: queue the RFC 8693 token-exchange response that follows every
+// successful authorization_code / refresh_token call. Each successful OAuth
+// step now requires TWO fetch mocks — the OAuth /token call, then this one.
+function mockKeyExchangeOk(apiKey = 'sk-minted', expiresIn = 3600): void {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ access_token: apiKey, expires_in: expiresIn }),
+  });
+}
+
 // Stub createServerMock so the callback server never actually binds a port
 jest.mock('http', () => {
   const actual = jest.requireActual('http');
@@ -98,11 +108,13 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id-token-1',
           access_token: 'access-123',
           refresh_token: 'refresh-456',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk('sk-minted-1', 1800);
 
       await service.exchangeCode(state, 'auth-code-xyz');
 
@@ -122,7 +134,8 @@ describe('OpenaiOauthService', () => {
       const storedBlob: OAuthTokenBlob = JSON.parse(
         providerService.upsertProvider.mock.calls[0][3] as string,
       );
-      expect(storedBlob.t).toBe('access-123');
+      // blob.t now holds the api.openai.com key minted via RFC 8693.
+      expect(storedBlob.t).toBe('sk-minted-1');
       expect(storedBlob.r).toBe('refresh-456');
       expect(storedBlob.e).toBeGreaterThan(Date.now());
     });
@@ -166,11 +179,13 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'tok',
           refresh_token: 'ref',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk();
 
       // Should not throw despite discovery failure
       await service.exchangeCode(state, 'code');
@@ -186,11 +201,13 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'tok',
           refresh_token: 'ref',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk();
 
       await service.exchangeCode(state, 'code');
       expect(service.getPendingCount()).toBe(0);
@@ -202,15 +219,17 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'new-access',
           refresh_token: 'new-refresh',
           expires_in: 7200,
         }),
       });
+      mockKeyExchangeOk('sk-minted-refresh', 7200);
 
       const result = await service.refreshAccessToken('old-refresh');
 
-      expect(result.t).toBe('new-access');
+      expect(result.t).toBe('sk-minted-refresh');
       expect(result.r).toBe('new-refresh');
       expect(result.e).toBeGreaterThan(Date.now());
     });
@@ -219,10 +238,12 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'new-access',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk();
 
       const result = await service.refreshAccessToken('original-refresh');
       expect(result.r).toBe('original-refresh');
@@ -271,15 +292,17 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'new-access',
           refresh_token: 'new-refresh',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk('sk-fresh');
 
       const result = await service.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
 
-      expect(result).toBe('new-access');
+      expect(result).toBe('sk-fresh');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
         'agent-1',
         'user-1',
@@ -299,14 +322,16 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'fresh-access',
           refresh_token: 'fresh-refresh',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk('sk-buffered');
 
       const result = await service.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
-      expect(result).toBe('fresh-access');
+      expect(result).toBe('sk-buffered');
     });
 
     it('returns null when refresh fails', async () => {
@@ -401,11 +426,13 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'tok',
           refresh_token: 'ref',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk();
 
       await service.exchangeCode(state, 'code');
       expect(server.close).toHaveBeenCalled();
@@ -491,11 +518,13 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'tok',
           refresh_token: 'ref',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk();
 
       const res = { writeHead: jest.fn(), end: jest.fn() };
       requestHandler!({ url: `/auth/callback?code=the-code&state=${state}` }, res);
@@ -664,11 +693,13 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'tok',
           refresh_token: 'ref',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk();
 
       const res = { writeHead: jest.fn(), end: jest.fn() };
       requestHandler!({ url: `/auth/callback?code=the-code&state=${state}` }, res);
@@ -705,11 +736,13 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'tok',
           refresh_token: 'ref',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk();
 
       const res = { writeHead: jest.fn(), end: jest.fn() };
       requestHandler!({ url: `/auth/callback?code=the-code&state=${state}` }, res);
@@ -742,11 +775,13 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id_token: 'id',
           access_token: 'tok',
           refresh_token: 'ref',
           expires_in: 3600,
         }),
       });
+      mockKeyExchangeOk();
 
       const res = { writeHead: jest.fn(), end: jest.fn() };
       requestHandler!({ url: `/auth/callback?code=the-code&state=${state}` }, res);

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -208,12 +208,12 @@ describe('ProviderClient', () => {
       expect(result.isChatGpt).toBe(false);
     });
 
-    it('adds default instructions for subscription Responses requests', async () => {
+    it('routes openai+subscription to api.openai.com without injecting Codex-specific defaults', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       await client.forward({
         provider: 'openai',
-        apiKey: 'oauth-token',
+        apiKey: 'sk-minted-key',
         model: 'gpt-5.4',
         body: { input: 'Hello', stream: false },
         chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
@@ -222,14 +222,13 @@ describe('ProviderClient', () => {
         apiMode: 'responses',
       });
 
+      // Subscription users hold a real api.openai.com key (RFC 8693 minted),
+      // so they hit the standard Responses endpoint with no defaultInstructions
+      // / inputList / forceStream injection.
       const url = mockFetch.mock.calls[0][0] as string;
-      expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
+      expect(url).toBe('https://api.openai.com/v1/responses');
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.instructions).toBe('You are a helpful assistant.');
-      expect(sentBody.input).toEqual([
-        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
-      ]);
-      expect(sentBody.stream).toBe(true);
+      expect(sentBody.instructions).toBeUndefined();
     });
 
     it('uses normalized chat body for non-native Responses providers', async () => {
@@ -480,13 +479,13 @@ describe('ProviderClient', () => {
     });
   });
 
-  describe('ChatGPT subscription provider', () => {
-    it('routes to chatgpt.com Codex backend with subscription authType', async () => {
+  describe('OpenAI subscription provider (RFC 8693 minted key)', () => {
+    it('routes openai+subscription to api.openai.com (the minted key works there)', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       const result = await client.forward({
         provider: 'openai',
-        apiKey: 'oauth-token',
+        apiKey: 'sk-minted-key',
         model: 'gpt-5',
         body,
         stream: false,
@@ -494,58 +493,15 @@ describe('ProviderClient', () => {
       });
 
       const url = mockFetch.mock.calls[0][0] as string;
-      expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
-      expect(result.isChatGpt).toBe(true);
+      expect(url).toBe('https://api.openai.com/v1/chat/completions');
+      // No more chatgpt-format wrapping; this is a normal OpenAI call.
+      expect(result.isChatGpt).toBe(false);
       expect(result.isGoogle).toBe(false);
       expect(result.isAnthropic).toBe(false);
 
       const headers = mockFetch.mock.calls[0][1].headers;
-      expect(headers['originator']).toBe('codex_cli_rs');
-      expect(headers['Authorization']).toBe('Bearer oauth-token');
-    });
-
-    it('converts request body using toResponsesRequest', async () => {
-      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
-
-      const bodyWithSystem = {
-        messages: [
-          { role: 'system', content: 'Be helpful.' },
-          { role: 'user', content: 'Hello' },
-        ],
-      };
-      await client.forward({
-        provider: 'openai',
-        apiKey: 'token',
-        model: 'gpt-5.3-codex',
-        body: bodyWithSystem,
-        stream: false,
-        authType: 'subscription',
-      });
-
-      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.instructions).toBe('Be helpful.');
-      expect(sentBody.input).toEqual([
-        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
-      ]);
-      expect(sentBody.model).toBe('gpt-5.3-codex');
-      expect(sentBody.stream).toBe(true);
-      expect(sentBody.store).toBe(false);
-    });
-
-    it('sends default instructions when no system or developer prompt is present', async () => {
-      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
-
-      await client.forward({
-        provider: 'openai',
-        apiKey: 'token',
-        model: 'gpt-5.1-codex-mini',
-        body: { messages: [{ role: 'user', content: 'Hello' }] },
-        stream: false,
-        authType: 'subscription',
-      });
-
-      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-      expect(sentBody.instructions).toBe('You are a helpful assistant.');
+      expect(headers['originator']).toBeUndefined();
+      expect(headers['Authorization']).toBe('Bearer sk-minted-key');
     });
 
     it('sets isChatGpt=false for regular OpenAI api_key auth', async () => {
@@ -712,12 +668,12 @@ describe('ProviderClient', () => {
       expect(sentBody.store).toBeUndefined();
     });
 
-    it('keeps subscription + Codex on the Codex backend (subscription override wins)', async () => {
+    it('subscription + Codex model still hits api.openai.com (minted key works for any OpenAI model)', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
       const result = await client.forward({
         provider: 'openai',
-        apiKey: 'oauth-token',
+        apiKey: 'sk-minted-key',
         model: 'gpt-5.3-codex',
         body,
         stream: false,
@@ -725,15 +681,16 @@ describe('ProviderClient', () => {
       });
 
       const url = mockFetch.mock.calls[0][0] as string;
-      // Must stay on chatgpt.com/backend-api (subscription), NOT swap to api.openai.com.
-      expect(url).toBe('https://chatgpt.com/backend-api/codex/responses');
-      expect(url).not.toContain('api.openai.com');
-      expect(result.isChatGpt).toBe(true);
+      // Codex models still route through api.openai.com — the Codex backdoor
+      // is gone, so subscription users hit the same Responses endpoint as
+      // sk-key users.
+      expect(url).toContain('api.openai.com');
+      expect(url).not.toContain('chatgpt.com');
+      expect(result.isChatGpt).toBe(true); // codex models use chatgpt format on api.openai.com/v1/responses
 
-      // Subscription spoofs the Codex CLI user agent; the api_key responses
-      // path does not. This confirms we hit the subscription endpoint.
       const headers = mockFetch.mock.calls[0][1].headers;
-      expect(headers['originator']).toBe('codex_cli_rs');
+      expect(headers['originator']).toBeUndefined();
+      expect(headers['Authorization']).toBe('Bearer sk-minted-key');
     });
 
     it('does not override custom endpoints when a Codex model is used through a custom provider', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -214,26 +214,8 @@ describe('PROVIDER_ENDPOINTS', () => {
     expect(path).toBe('/api/v1/chat/completions');
   });
 
-  it('openai-subscription uses chatgpt.com backend base URL', () => {
-    const ep = PROVIDER_ENDPOINTS['openai-subscription'];
-    expect(ep.baseUrl).toBe('https://chatgpt.com/backend-api');
-  });
-
-  it('openai-subscription builds /codex/responses path', () => {
-    const path = PROVIDER_ENDPOINTS['openai-subscription'].buildPath('gpt-5');
-    expect(path).toBe('/codex/responses');
-  });
-
-  it('openai-subscription uses chatgpt format', () => {
-    expect(PROVIDER_ENDPOINTS['openai-subscription'].format).toBe('chatgpt');
-  });
-
-  it('openai-subscription headers include originator and user-agent', () => {
-    const headers = PROVIDER_ENDPOINTS['openai-subscription'].buildHeaders('oauth-token');
-    expect(headers['Authorization']).toBe('Bearer oauth-token');
-    expect(headers['Content-Type']).toBe('application/json');
-    expect(headers['originator']).toBe('codex_cli_rs');
-    expect(headers['user-agent']).toBe('codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown');
+  it('openai-subscription endpoint is gone — subscription users hit the standard openai endpoint with a minted api.openai.com key', () => {
+    expect(PROVIDER_ENDPOINTS['openai-subscription']).toBeUndefined();
   });
 
   it('minimax-subscription buildPath returns /v1/messages', () => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -235,14 +235,7 @@ export class ProviderClient {
         headers: endpoint.buildHeaders(apiKey, authType),
         requestBody:
           ctx.apiMode === 'responses'
-            ? // ChatGPT subscription tokens hit the Codex Responses backend, which
-              // requires instruction text, list-shaped input, and upstream SSE even
-              // when Manifest returns a non-streaming JSON response to the caller.
-              toNativeResponsesRequest(body, bareModel, {
-                defaultInstructions: endpointKey === 'openai-subscription',
-                inputList: endpointKey === 'openai-subscription',
-                forceStream: endpointKey === 'openai-subscription',
-              })
+            ? toNativeResponsesRequest(body, bareModel)
             : toResponsesRequest(body, bareModel),
       };
     }

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -55,22 +55,9 @@ const opencodeGoAnthropicHeaders = (apiKey: string): Record<string, string> => (
   'anthropic-version': '2023-06-01',
 });
 
-/**
- * ChatGPT subscription OAuth tokens use the Codex backend,
- * which requires specific headers to avoid 403 responses.
- * Note: These headers mimic the Codex CLI client. This is required for the
- * endpoint to accept requests, but may break if OpenAI changes validation.
- */
-const CHATGPT_SUBSCRIPTION_BASE = 'https://chatgpt.com/backend-api';
 const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
 const ZAI_SUBSCRIPTION_BASE = 'https://open.bigmodel.cn/api/coding/paas/v4';
 const OPENCODE_GO_BASE = 'https://opencode.ai/zen/go';
-const chatgptSubscriptionHeaders = (apiKey: string) => ({
-  Authorization: `Bearer ${apiKey}`,
-  'Content-Type': 'application/json',
-  originator: 'codex_cli_rs',
-  'user-agent': 'codex_cli_rs/0.0.0 (Unknown 0; unknown) unknown',
-});
 
 export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   openai: {
@@ -78,12 +65,6 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
-  },
-  'openai-subscription': {
-    baseUrl: CHATGPT_SUBSCRIPTION_BASE,
-    buildHeaders: chatgptSubscriptionHeaders,
-    buildPath: () => '/codex/responses',
-    format: 'chatgpt',
   },
   // Standard OpenAI API key against api.openai.com/v1/responses — used for
   // Codex, -pro, o1-pro, and deep-research models that reject /v1/chat/completions.

--- a/packages/backend/src/routing/proxy/provider-hooks.ts
+++ b/packages/backend/src/routing/proxy/provider-hooks.ts
@@ -11,9 +11,13 @@
  * Maps `(provider-endpoint-key, auth-type)` → endpoint key for subscription
  * flows. Allows a provider to use a different backend endpoint when the
  * authenticated user is on a subscription plan rather than a per-request key.
+ *
+ * OpenAI is intentionally absent: the OAuth flow now mints a real API key via
+ * RFC 8693 token exchange (see openai-oauth.service.ts), so subscription users
+ * route through the standard `openai` endpoint — same wire format as a regular
+ * sk- key, full Responses API surface available.
  */
 const SUBSCRIPTION_ENDPOINT_OVERRIDES: Record<string, string> = {
-  openai: 'openai-subscription',
   minimax: 'minimax-subscription',
   zai: 'zai-subscription',
 };


### PR DESCRIPTION
…via RFC 8693 token exchange

Subscription users were proxied through chatgpt.com/backend-api/codex/responses, which rejects temperature/top_p/max_output_tokens/metadata/safety_identifier/ prompt_cache_retention/truncation and forces store=false. That breaks the OpenAI SDK contract Manifest advertises.

Switch to the RFC 8693 token-exchange grant: trade the OAuth id_token for a real api.openai.com key bound to the user's ChatGPT-Plan organization. The minted key works against the standard /v1/responses (and /v1/chat/completions) endpoint with the full Responses API surface. Bills against the user's subscription, not their personal API balance.

- openai-oauth.service.ts: add id_token_add_organizations + codex_cli_simplified_flow to /authorize so the resulting id_token carries organization_id; capture id_token from /token responses; add exchangeIdTokenForApiKey() helper; blob.t now stores the minted sk- key (transparent to existing consumers).
- provider-hooks.ts: drop the openai → openai-subscription routing override. authType=subscription now falls through to the standard openai endpoint.
- Remove dead code: PROVIDER_ENDPOINTS['openai-subscription'], the PROVIDER_CONFIGS entry, parseOpenaiSubscription parser, PROVIDER_NON_CHAT entry, and the defaultInstructions/inputList/forceStream branches in toNativeResponsesRequest (no longer reachable).
- revoke(): only revoke blob.r (refresh token) — the api.openai.com key has no public revoke endpoint.
- Update affected tests to mock the two-call flow (OAuth /token then RFC 8693 /token) and assert minted key in blob.t.

Closes #1791.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch ChatGPT subscription auth to mint a real `api.openai.com` key via RFC 8693 token exchange, removing the `chatgpt.com` Codex proxy and restoring full Responses API compatibility. Subscription calls now use standard OpenAI endpoints and parameters, billed to the user’s ChatGPT plan.

- **New Features**
  - Exchange OAuth `id_token` for a real `api.openai.com` `sk-` key bound to the user’s ChatGPT organization (RFC 8693).
  - Use the minted key for `/v1/responses` and `/v1/chat/completions` with full parameter support; charges the subscription.
  - OAuth adds `id_token_add_organizations` and `codex_cli_simplified_flow`; token blob now stores the minted key in `t`.

- **Refactors**
  - Removed `openai-subscription` endpoint/configs/parsers and the routing override; `authType=subscription` now routes through `openai`.
  - Dropped Codex-specific request shaping and headers (no default instructions/input list/forced stream).
  - Model discovery for subscription users now hits `https://api.openai.com/v1/models`; removed the subscription non-chat patterns.
  - Revoke only the OAuth refresh token; the minted API key has no public revoke API.
  - Updated tests for the two-call flow and new blob shape; added local workspace entries to `.gitignore`.

<sup>Written for commit eb282f605292eb78ebacb6e36ff93358f297f33d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

