### PR TITLE
fix: surface resend flow on post-signup verification screen

### DIFF
--- a/.changeset/check-email-hint.md
+++ b/.changeset/check-email-hint.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Replace the redundant "Click the link in your email" green box on the post-signup screen with a hint that surfaces the resend flow inline. When a duplicate signup quietly returns no email (Better Auth's anti-enumeration behavior), users now have a visible path to recover via the inline "Resend verification email" link.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14829,7 +14829,7 @@
       }
     },
     "packages/manifest": {
-      "version": "6.0.0"
+      "version": "6.0.1"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -226,16 +226,20 @@ const Register: Component = () => {
               {error()}
             </div>
           )}
-          <div class="auth-form__success">
-            Click the link in your email to verify your account and get started.
-          </div>
-          <button
-            class="auth-form__link-btn"
-            onClick={handleResend}
-            disabled={resendCooldown() > 0}
-          >
-            {resendCooldown() > 0 ? `Resend in ${resendCooldown()}s` : 'Resend verification email'}
-          </button>
+          <p class="auth-form__hint">
+            Already signed up before? The link may have expired.{' '}
+            <button
+              type="button"
+              class="auth-form__link-btn"
+              onClick={handleResend}
+              disabled={resendCooldown() > 0}
+            >
+              {resendCooldown() > 0
+                ? `Resend in ${resendCooldown()}s`
+                : 'Resend verification email'}
+            </button>{' '}
+            to get a new one.
+          </p>
         </div>
 
         <div class="auth-footer">

--- a/packages/frontend/src/styles/auth.css
+++ b/packages/frontend/src/styles/auth.css
@@ -173,6 +173,18 @@
   line-height: 1.5;
 }
 
+.auth-form__hint {
+  margin: 0;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+  text-align: center;
+}
+
+.auth-form__hint .auth-form__link-btn {
+  font-size: inherit;
+}
+
 .auth-form__link-btn {
   background: none;
   border: none;

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -163,7 +163,7 @@ describe("Register", () => {
     fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass12345" } });
     fireEvent.submit(container.querySelector("form")!);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Click the link in your email");
+      expect(container.textContent).toContain("Already signed up before?");
     });
     // Resend button should be present (with cooldown since startCooldown was called)
     const resendBtn = Array.from(container.querySelectorAll("button")).find(


### PR DESCRIPTION
### 💭 Why
After a duplicate signup, Better Auth deliberately returns a fake success response (anti-enumeration) and never sends a verification email. Users land on "Check your email", wait, find nothing, and get stuck. The green box on that screen restated the subtitle and offered no recovery path.

### ✨ What changed
- Replace `auth-form__success` box on the post-signup screen with an inline hint.
- Hint reads "Already signed up before? The link may have expired. [Resend verification email] to get a new one." with the existing resend button as the inline action.
- Added `.auth-form__hint` style (muted, centered, inherits font-size for the inline button).
- Updated the matching test in `Register.test.tsx`.

### 👤 For users
Anyone who hits the "Check your email" screen with no email arriving now sees a clear next step on the same screen instead of a dead-end success message.

### 📝 Notes
Resend goes through `authClient.sendVerificationEmail`, which Better Auth does fire for existing unverified users (unlike sign-up, which silently no-ops to prevent enumeration).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the resend verification flow on the post-signup screen so users aren't stuck when duplicate signups suppress the email. Replaced the redundant success box with an inline hint and action.

- **Bug Fixes**
  - Replaced the green "success" box with an inline hint that includes the existing "Resend verification email" action.
  - Added `.auth-form__hint` styles (muted, centered, inherits font size for the inline button).
  - Updated `Register.test.tsx` to assert the new hint text.

- **Dependencies**
  - Bumped `manifest` to `6.0.1`.

<sup>Written for commit 94c2166748091e1d2d8c1d16dadfd273634c8f8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

