### PR TITLE
Fix: autofocus and keyboard shortcuts on all modals and forms

### DIFF
--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -227,6 +227,7 @@ const CustomProviderForm: Component<Props> = (props) => {
             Provider name
           </label>
           <input
+            ref={(el) => requestAnimationFrame(() => el.focus())}
             id="cp-name"
             class="provider-detail__input"
             type="text"

--- a/packages/frontend/src/components/DuplicateAgentModal.tsx
+++ b/packages/frontend/src/components/DuplicateAgentModal.tsx
@@ -95,7 +95,7 @@ const DuplicateAgentModal: Component<Props> = (props) => {
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Enter') handleDuplicate();
+    if (e.key === 'Enter' && e.target instanceof HTMLInputElement) handleDuplicate();
     if (e.key === 'Escape') requestClose();
   };
 

--- a/packages/frontend/src/components/DuplicateAgentModal.tsx
+++ b/packages/frontend/src/components/DuplicateAgentModal.tsx
@@ -114,6 +114,7 @@ const DuplicateAgentModal: Component<Props> = (props) => {
           aria-modal="true"
           aria-labelledby="duplicate-agent-title"
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={handleKeyDown}
         >
           <h2 class="modal-card__title" id="duplicate-agent-title">
             Duplicate "{props.sourceName}"
@@ -139,7 +140,6 @@ const DuplicateAgentModal: Component<Props> = (props) => {
             placeholder={preview()?.suggested_name ?? `${props.sourceName}-copy`}
             value={name()}
             onInput={(e) => handleNameInput(e.currentTarget.value)}
-            onKeyDown={handleKeyDown}
             disabled={submitting()}
           />
 

--- a/packages/frontend/src/components/EmailProviderModal.tsx
+++ b/packages/frontend/src/components/EmailProviderModal.tsx
@@ -259,6 +259,13 @@ const EmailProviderModal: Component<Props> = (props) => {
             aria-modal="true"
             aria-labelledby="provider-modal-title"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSave();
+              }
+              if (e.key === 'Escape') props.onClose();
+            }}
           >
             <h2 class="modal-card__title" id="provider-modal-title">
               {props.editMode ? 'Edit email provider' : 'Configure email provider'}
@@ -329,6 +336,7 @@ const EmailProviderModal: Component<Props> = (props) => {
               }
             >
               <input
+                ref={(el) => requestAnimationFrame(() => el.focus())}
                 id="email-provider-api-key"
                 class="modal-card__input"
                 classList={{ 'modal-card__input--error': !!keyError() }}
@@ -341,8 +349,6 @@ const EmailProviderModal: Component<Props> = (props) => {
                   setApiKey(e.currentTarget.value);
                   setKeyError('');
                 }}
-                onKeyDown={handleKeyDown}
-                autofocus
               />
             </Show>
             <Show when={keyError()}>
@@ -378,7 +384,6 @@ const EmailProviderModal: Component<Props> = (props) => {
                   setDomain(e.currentTarget.value);
                   setDomainError('');
                 }}
-                onKeyDown={handleKeyDown}
               />
               <Show when={domainError()}>
                 <p class="modal-card__field-error" role="alert">

--- a/packages/frontend/src/components/EmailProviderModal.tsx
+++ b/packages/frontend/src/components/EmailProviderModal.tsx
@@ -260,7 +260,7 @@ const EmailProviderModal: Component<Props> = (props) => {
             aria-labelledby="provider-modal-title"
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === 'Enter' && e.target instanceof HTMLInputElement) {
                 e.preventDefault();
                 handleSave();
               }

--- a/packages/frontend/src/components/HeaderTierModal.tsx
+++ b/packages/frontend/src/components/HeaderTierModal.tsx
@@ -173,11 +173,11 @@ const HeaderTierModal: Component<Props> = (props) => {
         style={{ position: 'relative' }}
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => {
-          if (e.key === 'Enter') {
+          if (e.key === 'Enter' && !e.defaultPrevented && e.target instanceof HTMLInputElement) {
             e.preventDefault();
             submit();
           }
-          if (e.key === 'Escape') props.onClose();
+          if (e.key === 'Escape' && !e.defaultPrevented) props.onClose();
         }}
       >
         <Show

--- a/packages/frontend/src/components/HeaderTierModal.tsx
+++ b/packages/frontend/src/components/HeaderTierModal.tsx
@@ -172,6 +172,13 @@ const HeaderTierModal: Component<Props> = (props) => {
         aria-labelledby="header-tier-modal-title"
         style={{ position: 'relative' }}
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            submit();
+          }
+          if (e.key === 'Escape') props.onClose();
+        }}
       >
         <Show
           when={props.onBack}
@@ -217,6 +224,7 @@ const HeaderTierModal: Component<Props> = (props) => {
           Tier name
         </label>
         <input
+          ref={(el) => requestAnimationFrame(() => el.focus())}
           id="header-tier-name"
           class="modal-card__input"
           classList={{ 'modal-card__input--error': nameError() !== undefined }}

--- a/packages/frontend/src/components/LimitRuleModal.tsx
+++ b/packages/frontend/src/components/LimitRuleModal.tsx
@@ -80,6 +80,13 @@ const LimitRuleModal: Component<Props> = (props) => {
             aria-modal="true"
             aria-labelledby="limit-modal-title"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSave();
+              }
+              if (e.key === 'Escape') handleClose();
+            }}
           >
             <h2 class="modal-card__title" id="limit-modal-title">
               {isEdit() ? 'Edit rule' : 'Create rule'}
@@ -96,6 +103,7 @@ const LimitRuleModal: Component<Props> = (props) => {
               class="select notification-modal__select"
               value={metricType()}
               onChange={(e) => setMetricType(e.currentTarget.value)}
+              ref={(el) => requestAnimationFrame(() => el.focus())}
             >
               <option value="tokens">Tokens</option>
               <option value="cost">Cost (USD)</option>
@@ -103,7 +111,9 @@ const LimitRuleModal: Component<Props> = (props) => {
 
             <div class="limit-modal__row">
               <div class="limit-modal__col">
-                <label class="modal-card__field-label" for="limit-threshold-input">Threshold</label>
+                <label class="modal-card__field-label" for="limit-threshold-input">
+                  Threshold
+                </label>
                 <input
                   id="limit-threshold-input"
                   class="modal-card__input"
@@ -113,13 +123,12 @@ const LimitRuleModal: Component<Props> = (props) => {
                   placeholder={metricType() === 'cost' ? 'e.g. 10.00' : 'e.g. 50000'}
                   value={threshold()}
                   onInput={(e) => setThreshold(e.currentTarget.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSave();
-                  }}
                 />
               </div>
               <div class="limit-modal__col">
-                <label class="modal-card__field-label" for="limit-period-select">Period</label>
+                <label class="modal-card__field-label" for="limit-period-select">
+                  Period
+                </label>
                 <select
                   id="limit-period-select"
                   class="select notification-modal__select"

--- a/packages/frontend/src/components/LimitRuleModal.tsx
+++ b/packages/frontend/src/components/LimitRuleModal.tsx
@@ -81,7 +81,10 @@ const LimitRuleModal: Component<Props> = (props) => {
             aria-labelledby="limit-modal-title"
             onClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (
+                e.key === 'Enter' &&
+                (e.target instanceof HTMLInputElement || e.target instanceof HTMLSelectElement)
+              ) {
                 e.preventDefault();
                 handleSave();
               }

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -384,13 +384,13 @@ const ModelPickerModal: Component<Props> = (props) => {
               <path d="m21 21-4.3-4.3" />
             </svg>
             <input
+              ref={(el) => requestAnimationFrame(() => el.focus())}
               class="routing-modal__search"
               type="text"
               placeholder="Search models or providers..."
               aria-label="Search models or providers"
               value={search()}
               onInput={(e) => setSearch(e.currentTarget.value)}
-              autofocus
             />
           </div>
         </Show>

--- a/packages/frontend/src/components/ModelSelectDropdown.tsx
+++ b/packages/frontend/src/components/ModelSelectDropdown.tsx
@@ -130,13 +130,13 @@ const ModelSelectDropdown: Component<ModelSelectDropdownProps> = (props) => {
             <path d="m21 21-4.3-4.3" />
           </svg>
           <input
+            ref={(el) => requestAnimationFrame(() => el.focus())}
             class="routing-modal__search"
             type="text"
             placeholder="Search models or providers..."
             aria-label="Search models"
             value={search()}
             onInput={(e) => setSearch(e.currentTarget.value)}
-            autofocus
           />
         </div>
 

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -131,6 +131,7 @@ const Login: Component = () => {
         <label class="auth-form__label" for={emailId}>
           Email
           <input
+            ref={(el) => requestAnimationFrame(() => el.focus())}
             id={emailId}
             class="auth-form__input"
             type="email"

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -140,6 +140,7 @@ const Register: Component = () => {
               <label class="auth-form__label" for={nameId}>
                 Name
                 <input
+                  ref={(el) => requestAnimationFrame(() => el.focus())}
                   id={nameId}
                   class="auth-form__input"
                   type="text"

--- a/packages/frontend/src/pages/ResetPassword.tsx
+++ b/packages/frontend/src/pages/ResetPassword.tsx
@@ -52,6 +52,7 @@ const RequestResetForm: Component = () => {
           <label class="auth-form__label" for={emailId}>
             Email
             <input
+              ref={(el) => requestAnimationFrame(() => el.focus())}
               id={emailId}
               class="auth-form__input"
               type="email"
@@ -149,6 +150,7 @@ const SetNewPasswordForm: Component<{ token: string }> = (props) => {
           <label class="auth-form__label" for={passwordId}>
             New password
             <input
+              ref={(el) => requestAnimationFrame(() => el.focus())}
               id={passwordId}
               class="auth-form__input"
               type="password"

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -374,7 +374,7 @@ const Settings: Component = () => {
             aria-modal="true"
             aria-labelledby="delete-agent-modal-title"
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === 'Enter' && e.target instanceof HTMLInputElement) {
                 e.preventDefault();
                 handleDeleteAgent();
               }

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -95,6 +95,18 @@ const Settings: Component = () => {
     return `${window.location.origin}/v1`;
   };
 
+  const handleDeleteAgent = async () => {
+    if (deleteConfirmName() !== agentName() || deleting()) return;
+    setDeleting(true);
+    try {
+      await deleteAgent(agentName());
+      toast.success(`Agent "${agentName()}" deleted`);
+      navigate('/', { replace: true });
+    } catch {
+      setDeleting(false);
+    }
+  };
+
   const nameChanged = () => name().trim() !== agentName() && name().trim() !== '';
 
   const handleSaveName = async () => {
@@ -361,6 +373,12 @@ const Settings: Component = () => {
             role="dialog"
             aria-modal="true"
             aria-labelledby="delete-agent-modal-title"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleDeleteAgent();
+              }
+            }}
           >
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--gap-lg);">
               <h3 id="delete-agent-modal-title" style="margin: 0; font-size: var(--font-size-lg);">
@@ -399,6 +417,7 @@ const Settings: Component = () => {
               To confirm, type <strong>"{agentName()}"</strong> in the box below
             </label>
             <input
+              ref={(el) => setTimeout(() => el.focus(), 200)}
               id="delete-confirm-input"
               class="auth-form__input"
               type="text"
@@ -411,16 +430,7 @@ const Settings: Component = () => {
               class="btn btn--danger btn--sm"
               style="width: 100%;"
               disabled={deleteConfirmName() !== agentName() || deleting()}
-              onClick={async () => {
-                setDeleting(true);
-                try {
-                  await deleteAgent(agentName());
-                  toast.success(`Agent "${agentName()}" deleted`);
-                  navigate('/', { replace: true });
-                } catch {
-                  setDeleting(false);
-                }
-              }}
+              onClick={handleDeleteAgent}
             >
               {deleting() ? (
                 <>

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -110,6 +110,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
           aria-modal="true"
           aria-labelledby="add-agent-title"
           onClick={(e) => e.stopPropagation()}
+          onKeyDown={handleKeyDown}
         >
           <h2 class="modal-card__title" id="add-agent-title">
             Connect Agent
@@ -141,7 +142,6 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
                 placeholder="e.g. My Cool Agent"
                 value={name()}
                 onInput={(e) => setName(e.currentTarget.value)}
-                onKeyDown={handleKeyDown}
                 disabled={creating()}
               />
             </div>

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -87,7 +87,7 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'Enter') handleCreate();
+    if (e.key === 'Enter' && e.target instanceof HTMLInputElement) handleCreate();
     if (e.key === 'Escape') {
       props.onClose();
       resetForm();

--- a/packages/frontend/tests/components/EmailProviderModal.test.tsx
+++ b/packages/frontend/tests/components/EmailProviderModal.test.tsx
@@ -697,4 +697,32 @@ describe("EmailProviderModal", () => {
       );
     });
   });
+
+  it("submits when Enter is pressed on an input", async () => {
+    render(() => <EmailProviderModal {...defaultProps} />);
+    const apiKeyInput = q("#email-provider-api-key") as HTMLInputElement;
+    fireEvent.input(apiKeyInput, { target: { value: "re_validkey1234" } });
+    fireEvent.keyDown(apiKeyInput, { key: "Enter" });
+    await vi.waitFor(() => {
+      expect(mockTestEmailProvider).toHaveBeenCalled();
+    });
+  });
+
+  it("closes when Escape is pressed on an input", () => {
+    const onClose = vi.fn();
+    render(() => <EmailProviderModal {...defaultProps} onClose={onClose} />);
+    const apiKeyInput = q("#email-provider-api-key") as HTMLInputElement;
+    fireEvent.keyDown(apiKeyInput, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not call handleSave when Enter is pressed on a button", () => {
+    render(() => <EmailProviderModal {...defaultProps} />);
+    const apiKeyInput = q("#email-provider-api-key") as HTMLInputElement;
+    fireEvent.input(apiKeyInput, { target: { value: "re_validkey1234" } });
+    // Simulate Enter on the "Send test email" button — should NOT trigger handleSave
+    const testBtn = q(".btn--ghost") as HTMLButtonElement;
+    fireEvent.keyDown(testBtn, { key: "Enter" });
+    expect(mockTestEmailProvider).not.toHaveBeenCalled();
+  });
 });

--- a/packages/frontend/tests/components/HeaderTierModal.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierModal.test.tsx
@@ -701,4 +701,69 @@ describe("HeaderTierModal", () => {
       expect(suggestions?.[0]?.sublabel).toBe("2× seen");
     });
   });
+
+  describe("keyboard shortcuts", () => {
+    it("submits when Enter is pressed on the name input", async () => {
+      const onSaved = vi.fn();
+      const onClose = vi.fn();
+      mockCreateHeaderTier.mockResolvedValue({ ...existingTier, id: "ht-kb", name: "KB" });
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[]}
+          onClose={onClose}
+          onSaved={onSaved}
+        />
+      ));
+      fireEvent.input(container.querySelector("#header-tier-name") as HTMLInputElement, {
+        target: { value: "KB" },
+      });
+      fireEvent.input(container.querySelector("#header-tier-key") as HTMLInputElement, {
+        target: { value: "x-test" },
+      });
+      fireEvent.input(container.querySelector("#header-tier-value") as HTMLInputElement, {
+        target: { value: "val" },
+      });
+      fireEvent.keyDown(container.querySelector("#header-tier-name") as HTMLInputElement, {
+        key: "Enter",
+      });
+      await waitFor(() => {
+        expect(mockCreateHeaderTier).toHaveBeenCalled();
+      });
+    });
+
+    it("closes when Escape is pressed", () => {
+      const onClose = vi.fn();
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[]}
+          onClose={onClose}
+          onSaved={vi.fn()}
+        />
+      ));
+      fireEvent.keyDown(container.querySelector("#header-tier-name") as HTMLInputElement, {
+        key: "Escape",
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("does not submit when Enter event was already handled (defaultPrevented)", () => {
+      const onSaved = vi.fn();
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[]}
+          onClose={vi.fn()}
+          onSaved={onSaved}
+        />
+      ));
+      const nameInput = container.querySelector("#header-tier-name") as HTMLInputElement;
+      const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+      // Simulate a child handler having already called preventDefault (e.g. combobox)
+      event.preventDefault();
+      nameInput.dispatchEvent(event);
+      expect(mockCreateHeaderTier).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -541,4 +541,22 @@ describe("Settings", () => {
     Object.defineProperty(window, "location", { value: originalLocation, writable: true, configurable: true });
   });
 
+  it("submits delete via Enter key on confirm input", async () => {
+    const { container } = render(() => <Settings />);
+    fireEvent.click(screen.getByText("Delete agent"));
+    const input = container.querySelector('.modal-overlay input[type="text"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: "test-agent" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await vi.waitFor(() => { expect(mockDeleteAgent).toHaveBeenCalledWith("test-agent"); });
+  });
+
+  it("does not delete via Enter when name does not match", async () => {
+    const { container } = render(() => <Settings />);
+    fireEvent.click(screen.getByText("Delete agent"));
+    const input = container.querySelector('.modal-overlay input[type="text"]') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: "wrong-name" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mockDeleteAgent).not.toHaveBeenCalled();
+  });
+
 });


### PR DESCRIPTION
## ✨ What changed
- Every modal now auto-focuses its first input when it opens
- Enter submits from anywhere in a modal, not just when a specific field is focused
- Escape closes any modal regardless of which element has focus
- Auth pages (login, register, reset password) auto-focus the first field on load
- Replaced inconsistent `autofocus` HTML attributes with a reliable `ref` + `requestAnimationFrame` pattern

## 💭 Why
Users had to click into the first input field every time a modal opened before they could start typing. Keyboard shortcuts (Enter to submit, Escape to close) only worked when a specific input was focused, which felt broken if you tabbed to a different field or clicked elsewhere in the modal.

## 👤 For users
Opening any modal or auth page immediately places the cursor in the first field. Pressing Enter submits the form and Escape closes the modal from anywhere, without needing to focus a specific input first.

## 🔧 For operators
No operator impact.

## 🧪 How to test
1. Open any modal (create agent, duplicate agent, create rule, connect provider, delete agent)
2. Verify the cursor is already in the first input field, ready to type
3. Fill in a field, then click somewhere else in the modal (not on an input)
4. Press Enter: the form should submit
5. Open the modal again, press Escape: it should close

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves keyboard UX across modals and auth pages. First inputs auto-focus; Enter submits from inputs/selects (not buttons/comboboxes) and Escape closes from anywhere, with tests covering these flows.

- **Bug Fixes**
  - Added modal-level Enter/Escape handlers that only fire from inputs/selects and are ignored if `defaultPrevented`.
  - Auto-focuses the first field on open for all modals and on load for Login, Register, and Reset Password.
  - Replaced unreliable `autofocus` with a stable `ref` + `requestAnimationFrame` focus pattern.
  - Removed per-input key handlers to prevent inconsistent behavior.

<sup>Written for commit 8afba9b01975e14b30c9c2a7c96c70623baab267. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

