### PR TITLE
fix(openai-subscription): strip Codex-unsupported params before forwarding

### DIFF
--- a/.changeset/wacky-moles-yell.md
+++ b/.changeset/wacky-moles-yell.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Strip Codex-unsupported parameters on the OpenAI subscription proxy path. Requests forwarded to `chatgpt.com/backend-api/codex/responses` now drop `temperature`, `top_p`, `max_output_tokens`, `metadata`, `safety_identifier`, `prompt_cache_retention`, and `truncation` before the upstream call, and force `store: false`. Previously these fields propagated through and Codex returned `400 unsupported_parameter`, breaking OpenAI-SDK clients that set sampling defaults. Closes #1791.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -232,6 +232,58 @@ describe('ProviderClient', () => {
       expect(sentBody.stream).toBe(true);
     });
 
+    it('strips Codex-unsupported params on the subscription Responses path', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'oauth-token',
+        model: 'gpt-5.4-mini',
+        body: {
+          input: 'Hello',
+          stream: false,
+          temperature: 0.3,
+          top_p: 0.5,
+          max_output_tokens: 50,
+          metadata: { x: '1' },
+          safety_identifier: 'probe',
+          prompt_cache_retention: '24h',
+          truncation: 'auto',
+          store: true,
+        },
+        stream: false,
+        authType: 'subscription',
+        apiMode: 'responses',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent).not.toHaveProperty('temperature');
+      expect(sent).not.toHaveProperty('top_p');
+      expect(sent).not.toHaveProperty('max_output_tokens');
+      expect(sent).not.toHaveProperty('metadata');
+      expect(sent).not.toHaveProperty('safety_identifier');
+      expect(sent).not.toHaveProperty('prompt_cache_retention');
+      expect(sent).not.toHaveProperty('truncation');
+      expect(sent.store).toBe(false);
+    });
+
+    it('keeps Codex-unsupported params for the openai-responses (api-key) path', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'codex-mini-latest',
+        body: { input: 'Hello', temperature: 0.3, max_output_tokens: 50 },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent.temperature).toBe(0.3);
+      expect(sent.max_output_tokens).toBe(50);
+    });
+
     it('uses normalized chat body for non-native Responses providers', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -192,6 +192,41 @@ describe('Responses adapter', () => {
     ).toBe(true);
   });
 
+  it('strips Codex-subscription unsupported params and forces store=false', () => {
+    const result = toNativeResponsesRequest(
+      {
+        input: 'hi',
+        temperature: 0.3,
+        top_p: 0.5,
+        max_output_tokens: 50,
+        metadata: { x: '1' },
+        safety_identifier: 'probe',
+        prompt_cache_retention: '24h',
+        truncation: 'auto',
+        store: true,
+      },
+      'gpt-5.4-mini',
+      { stripCodexUnsupported: true },
+    );
+    expect(result).not.toHaveProperty('temperature');
+    expect(result).not.toHaveProperty('top_p');
+    expect(result).not.toHaveProperty('max_output_tokens');
+    expect(result).not.toHaveProperty('metadata');
+    expect(result).not.toHaveProperty('safety_identifier');
+    expect(result).not.toHaveProperty('prompt_cache_retention');
+    expect(result).not.toHaveProperty('truncation');
+    expect(result.store).toBe(false);
+  });
+
+  it('preserves Codex-subscription unsupported params when the strip flag is off', () => {
+    const result = toNativeResponsesRequest(
+      { input: 'hi', temperature: 0.3, top_p: 0.5 },
+      'gpt-5.4-mini',
+    );
+    expect(result.temperature).toBe(0.3);
+    expect(result.top_p).toBe(0.5);
+  });
+
   describe('fromChatCompletionResponse', () => {
     it('converts text, tool calls, and usage to a Response object', () => {
       const result = fromChatCompletionResponse(

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -238,10 +238,13 @@ export class ProviderClient {
             ? // ChatGPT subscription tokens hit the Codex Responses backend, which
               // requires instruction text, list-shaped input, and upstream SSE even
               // when Manifest returns a non-streaming JSON response to the caller.
+              // It also rejects sampling/metadata/cache fields the OpenAI SDK
+              // routinely sends, so we drop those before forwarding.
               toNativeResponsesRequest(body, bareModel, {
                 defaultInstructions: endpointKey === 'openai-subscription',
                 inputList: endpointKey === 'openai-subscription',
                 forceStream: endpointKey === 'openai-subscription',
+                stripCodexUnsupported: endpointKey === 'openai-subscription',
               })
             : toResponsesRequest(body, bareModel),
       };

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -136,18 +136,50 @@ function toChatToolChoice(toolChoice: unknown): unknown {
   return { type: 'function', function: { name: toolChoice.name } };
 }
 
+/**
+ * Responses API parameters the ChatGPT subscription backend
+ * (chatgpt.com/backend-api/codex/responses) rejects with HTTP 400. Sampling
+ * controls (`temperature`, `top_p`) are locked upstream; `max_output_tokens`,
+ * `metadata`, `safety_identifier`, `prompt_cache_retention`, `truncation` are
+ * not part of its allowlist. Forwarding any of them returns
+ * `unsupported_parameter` and breaks OpenAI-SDK clients.
+ */
+const CODEX_SUBSCRIPTION_UNSUPPORTED_PARAMS = [
+  'temperature',
+  'top_p',
+  'max_output_tokens',
+  'metadata',
+  'safety_identifier',
+  'prompt_cache_retention',
+  'truncation',
+] as const;
+
 export function toNativeResponsesRequest(
   body: JsonRecord,
   model: string,
-  opts?: { defaultInstructions?: boolean; inputList?: boolean; forceStream?: boolean },
+  opts?: {
+    defaultInstructions?: boolean;
+    inputList?: boolean;
+    forceStream?: boolean;
+    stripCodexUnsupported?: boolean;
+  },
 ): JsonRecord {
   const request: JsonRecord = { ...body, model };
+  if (opts?.stripCodexUnsupported) {
+    for (const key of CODEX_SUBSCRIPTION_UNSUPPORTED_PARAMS) {
+      delete request[key];
+    }
+    // The backend also rejects `store: true`. Force it off rather than
+    // letting the request fail on something the caller cannot influence.
+    request.store = false;
+  } else if (body.store === undefined) {
+    request.store = false;
+  }
   if (opts?.forceStream) {
     request.stream = true;
   } else if (body.stream === undefined) {
     request.stream = false;
   }
-  if (body.store === undefined) request.store = false;
   if (opts?.inputList) {
     request.input = toNativeResponsesInput(body.input);
   }


### PR DESCRIPTION
## Summary

Closes #1791. The OpenAI SDK is broken against any agent connected via ChatGPT subscription if the caller sets `temperature`, `top_p`, `max_output_tokens`, `metadata`, `safety_identifier`, `prompt_cache_retention`, or `truncation`. Codex's responses backend (`chatgpt.com/backend-api/codex`) enforces a strict allowlist and returns `400 unsupported_parameter`; Manifest was forwarding the body unchanged so that error propagated straight to the SDK client.

This PR strips those 7 fields from the request body when `endpointKey === 'openai-subscription'`, and forces `store: false` (Codex also rejects `store: true`). The behaviour now matches what [LiteLLM](https://github.com/BerriAI/litellm/issues/21193) and Hermes do for the same upstream constraint — silent strip, request succeeds, the upstream-locked sampling values appear in the response. Sampling control on the OAuth route isn't recoverable; this PR makes the SDK contract honour the parts that *are* honourable instead of failing the whole call.

## Repro (before)

```python
from openai import OpenAI
c = OpenAI(base_url="http://localhost:38241/v1", api_key="<agent-key>")
c.responses.create(model="gpt-5.4-mini", input="Hi", temperature=0.3, store=False)
# → 400 Bad request to upstream provider
```

After: 200 OK, response echoes `temperature: 1.0` (Codex default) — no crash.

## Scope

- `packages/backend/src/routing/proxy/responses-adapter.ts` — new `stripCodexUnsupported` opt on `toNativeResponsesRequest`; lists the 7 rejected fields once with a comment explaining each restriction.
- `packages/backend/src/routing/proxy/provider-client.ts` — wires the opt to `endpointKey === 'openai-subscription'`, sitting next to the existing `defaultInstructions` / `inputList` / `forceStream` flags so the behaviour is data-driven and uniform.
- Unit test on the adapter (strip + preserve cases).
- Two integration tests on the proxy: confirms strip on the subscription path, confirms the `openai-responses` (sk-key) path still forwards the full surface.

The api-key path through `api.openai.com/v1/responses` is unaffected — verified by the new `keeps Codex-unsupported params for the openai-responses (api-key) path` test.

## Validation

- `npx tsc --noEmit` clean
- `npm run lint` 0 errors
- `npm run build` clean (turbo)
- Backend Jest: `4326 / 4326` passing
- Frontend Vitest: `2610 / 2610` passing

## Manual repro / regression script

For anyone reviewing, the script that documented the original bug is in [/tmp/manifest-strip-probe.py](.) — bumps each rejected field one at a time and reports verdict (`REJECTED` vs `STRIPPED`). With this change, every case 02–09 flips from `REJECTED (HTTP 400)` to `STRIPPED (sent X, got Y)`.

## Out of scope

- The locked echoed sampling values (`temperature: 1.0` etc.) are upstream behaviour and can't be made to honour the client's request without leaving the OAuth route entirely. Surface that in docs / a UI hint as a follow-up.
- Subscription→API-key fallback for quota exhaustion remains a separate, larger piece of work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400 errors for OpenAI SDK calls routed through the ChatGPT subscription path by stripping Codex-unsupported fields before forwarding. Also forces `store: false` and leaves the api-key path unchanged.

- **Bug Fixes**
  - When `endpointKey === 'openai-subscription'`, drop `temperature`, `top_p`, `max_output_tokens`, `metadata`, `safety_identifier`, `prompt_cache_retention`, and `truncation`.
  - Force `store: false` to avoid Codex rejection of `store: true`.
  - Preserve all parameters on the `openai-responses` (api-key) path.
  - Added unit and integration tests to cover strip and preserve cases.

<sup>Written for commit be679c4b6dcd5608a56fc64baa09fc2e30a00717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

