### PR TITLE
fix: strip Codex-rejected params on subscription proxy

### DIFF
--- a/.changeset/wacky-moles-yell.md
+++ b/.changeset/wacky-moles-yell.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Strip Codex-unsupported parameters on the OpenAI subscription proxy path. Requests forwarded to `chatgpt.com/backend-api/codex/responses` now drop `temperature`, `top_p`, `max_output_tokens`, `metadata`, `safety_identifier`, `prompt_cache_retention`, and `truncation` before the upstream call, and force `store: false`. Previously these fields propagated through and Codex returned `400 unsupported_parameter`, breaking OpenAI-SDK clients that set sampling defaults. Closes #1791.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -232,6 +232,58 @@ describe('ProviderClient', () => {
       expect(sentBody.stream).toBe(true);
     });
 
+    it('strips Codex-unsupported params on the subscription Responses path', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'oauth-token',
+        model: 'gpt-5.4-mini',
+        body: {
+          input: 'Hello',
+          stream: false,
+          temperature: 0.3,
+          top_p: 0.5,
+          max_output_tokens: 50,
+          metadata: { x: '1' },
+          safety_identifier: 'probe',
+          prompt_cache_retention: '24h',
+          truncation: 'auto',
+          store: true,
+        },
+        stream: false,
+        authType: 'subscription',
+        apiMode: 'responses',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent).not.toHaveProperty('temperature');
+      expect(sent).not.toHaveProperty('top_p');
+      expect(sent).not.toHaveProperty('max_output_tokens');
+      expect(sent).not.toHaveProperty('metadata');
+      expect(sent).not.toHaveProperty('safety_identifier');
+      expect(sent).not.toHaveProperty('prompt_cache_retention');
+      expect(sent).not.toHaveProperty('truncation');
+      expect(sent.store).toBe(false);
+    });
+
+    it('keeps Codex-unsupported params for the openai-responses (api-key) path', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'codex-mini-latest',
+        body: { input: 'Hello', temperature: 0.3, max_output_tokens: 50 },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent.temperature).toBe(0.3);
+      expect(sent.max_output_tokens).toBe(50);
+    });
+
     it('uses normalized chat body for non-native Responses providers', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -192,6 +192,41 @@ describe('Responses adapter', () => {
     ).toBe(true);
   });
 
+  it('strips Codex-subscription unsupported params and forces store=false', () => {
+    const result = toNativeResponsesRequest(
+      {
+        input: 'hi',
+        temperature: 0.3,
+        top_p: 0.5,
+        max_output_tokens: 50,
+        metadata: { x: '1' },
+        safety_identifier: 'probe',
+        prompt_cache_retention: '24h',
+        truncation: 'auto',
+        store: true,
+      },
+      'gpt-5.4-mini',
+      { stripCodexUnsupported: true },
+    );
+    expect(result).not.toHaveProperty('temperature');
+    expect(result).not.toHaveProperty('top_p');
+    expect(result).not.toHaveProperty('max_output_tokens');
+    expect(result).not.toHaveProperty('metadata');
+    expect(result).not.toHaveProperty('safety_identifier');
+    expect(result).not.toHaveProperty('prompt_cache_retention');
+    expect(result).not.toHaveProperty('truncation');
+    expect(result.store).toBe(false);
+  });
+
+  it('preserves Codex-subscription unsupported params when the strip flag is off', () => {
+    const result = toNativeResponsesRequest(
+      { input: 'hi', temperature: 0.3, top_p: 0.5 },
+      'gpt-5.4-mini',
+    );
+    expect(result.temperature).toBe(0.3);
+    expect(result.top_p).toBe(0.5);
+  });
+
   describe('fromChatCompletionResponse', () => {
     it('converts text, tool calls, and usage to a Response object', () => {
       const result = fromChatCompletionResponse(

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -238,10 +238,13 @@ export class ProviderClient {
             ? // ChatGPT subscription tokens hit the Codex Responses backend, which
               // requires instruction text, list-shaped input, and upstream SSE even
               // when Manifest returns a non-streaming JSON response to the caller.
+              // It also rejects sampling/metadata/cache fields the OpenAI SDK
+              // routinely sends, so we drop those before forwarding.
               toNativeResponsesRequest(body, bareModel, {
                 defaultInstructions: endpointKey === 'openai-subscription',
                 inputList: endpointKey === 'openai-subscription',
                 forceStream: endpointKey === 'openai-subscription',
+                stripCodexUnsupported: endpointKey === 'openai-subscription',
               })
             : toResponsesRequest(body, bareModel),
       };

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -136,18 +136,50 @@ function toChatToolChoice(toolChoice: unknown): unknown {
   return { type: 'function', function: { name: toolChoice.name } };
 }
 
+/**
+ * Responses API parameters the ChatGPT subscription backend
+ * (chatgpt.com/backend-api/codex/responses) rejects with HTTP 400. Sampling
+ * controls (`temperature`, `top_p`) are locked upstream; `max_output_tokens`,
+ * `metadata`, `safety_identifier`, `prompt_cache_retention`, `truncation` are
+ * not part of its allowlist. Forwarding any of them returns
+ * `unsupported_parameter` and breaks OpenAI-SDK clients.
+ */
+const CODEX_SUBSCRIPTION_UNSUPPORTED_PARAMS = [
+  'temperature',
+  'top_p',
+  'max_output_tokens',
+  'metadata',
+  'safety_identifier',
+  'prompt_cache_retention',
+  'truncation',
+] as const;
+
 export function toNativeResponsesRequest(
   body: JsonRecord,
   model: string,
-  opts?: { defaultInstructions?: boolean; inputList?: boolean; forceStream?: boolean },
+  opts?: {
+    defaultInstructions?: boolean;
+    inputList?: boolean;
+    forceStream?: boolean;
+    stripCodexUnsupported?: boolean;
+  },
 ): JsonRecord {
   const request: JsonRecord = { ...body, model };
+  if (opts?.stripCodexUnsupported) {
+    for (const key of CODEX_SUBSCRIPTION_UNSUPPORTED_PARAMS) {
+      delete request[key];
+    }
+    // The backend also rejects `store: true`. Force it off rather than
+    // letting the request fail on something the caller cannot influence.
+    request.store = false;
+  } else if (body.store === undefined) {
+    request.store = false;
+  }
   if (opts?.forceStream) {
     request.stream = true;
   } else if (body.stream === undefined) {
     request.stream = false;
   }
-  if (body.store === undefined) request.store = false;
   if (opts?.inputList) {
     request.input = toNativeResponsesInput(body.input);
   }


### PR DESCRIPTION
### ✨ What changed
- Drop `temperature`, `top_p`, `max_output_tokens`, `metadata`, `safety_identifier`, `prompt_cache_retention`, `truncation` before forwarding to `chatgpt.com/codex/responses`.
- Force `store: false` on the same path (Codex rejects `store: true`).
- Strip is gated on `endpointKey === 'openai-subscription'`. The api-key Responses path is untouched.

### 💭 Why
Codex's responses backend enforces a strict allowlist. Manifest was forwarding the SDK body unchanged, so `c.responses.create(temperature=0.3)` returned `400 unsupported_parameter` to the caller. Now the param is silently dropped and the request succeeds with the upstream-locked default.

### 👤 For users
SDK clients connected via ChatGPT subscription stop crashing on standard sampling/metadata fields. Sampling control still isn't honoured on this route (Codex locks it server-side); the response echoes `temperature: 1.0` regardless of what the client sent.

### 📝 Notes
- Closes #1791.
- Same approach taken by LiteLLM (#21193) and Hermes (#15916) for the same upstream constraint.
- Verified live with an OAuth-authed dev server: 9/9 probe cases flip from `REJECTED 400` to `STRIPPED`.
- Backend `4326/4326`, frontend `2610/2610`, lint clean, `cubic review` and `codex review` both report no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip Codex-rejected params on the ChatGPT subscription Responses proxy to stop 400s and let OpenAI SDK clients succeed. Also force `store: false`; the API-key `/v1/responses` path is unchanged.

- **Bug Fixes**
  - On the `openai-subscription` path to `chatgpt.com/backend-api/codex/responses`, drop `temperature`, `top_p`, `max_output_tokens`, `metadata`, `safety_identifier`, `prompt_cache_retention`, and `truncation` before forwarding.
  - Force `store: false` on this path (Codex rejects `store: true`).
  - Keep the api-key `/v1/responses` behavior unchanged; add tests to cover strip-on-subscription and preserve-on-api-key cases.

<sup>Written for commit be679c4b6dcd5608a56fc64baa09fc2e30a00717. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

