### PR TITLE
feat: add Anthropic Messages-compatible endpoint at POST /v1/messages

### DIFF
--- a/.changeset/anthropic-messages-endpoint.md
+++ b/.changeset/anthropic-messages-endpoint.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add an Anthropic Messages-compatible endpoint at `POST /v1/messages`. Anthropic SDK clients (Claude Code, `@anthropic-ai/sdk`) can now point `ANTHROPIC_BASE_URL` at a Manifest gateway and route through Manifest's tier/specificity pipeline like any OpenAI client. The implementation translates Anthropic Messages requests into the internal chat-completions form (and back on the response side), reusing the existing routing, scoring, fallback, and recording machinery.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,8 @@ All analytics queries filter by user via `addTenantFilter(qb, userId)` from `que
 | POST | `/api/v1/routing/:agentName/ollama/sync` | Session/API Key | Sync Ollama models |
 | POST | `/api/v1/routing/resolve` | Bearer (mnfst_*) | Model resolution |
 | POST | `/v1/chat/completions` | Bearer (mnfst_*) | LLM proxy (OpenAI-compatible) |
+| POST | `/v1/responses` | Bearer (mnfst_*) | LLM proxy (OpenAI Responses API) |
+| POST | `/v1/messages` | Bearer (mnfst_*) | LLM proxy (Anthropic Messages API) |
 | GET | `/api/v1/events` | Session | SSE real-time events |
 | GET | `/api/v1/github/stars` | Public | GitHub star count |
 

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -1,0 +1,477 @@
+import {
+  chatCompletionsResponseToMessages,
+  createMessagesStreamTransformer,
+  messagesToChatCompletionsRequest,
+} from '../anthropic-messages-adapter';
+
+describe('Anthropic Messages adapter', () => {
+  describe('messagesToChatCompletionsRequest', () => {
+    it('converts a basic request with string content', () => {
+      const result = messagesToChatCompletionsRequest({
+        model: 'claude-sonnet-4',
+        max_tokens: 256,
+        system: 'Be concise.',
+        messages: [{ role: 'user', content: 'Hello' }],
+        temperature: 0.7,
+        top_p: 0.9,
+        stream: true,
+        stop_sequences: ['STOP'],
+        metadata: { user_id: 'u1' },
+      });
+
+      expect(result).toEqual({
+        messages: [
+          { role: 'system', content: 'Be concise.' },
+          { role: 'user', content: 'Hello' },
+        ],
+        model: 'claude-sonnet-4',
+        max_tokens: 256,
+        temperature: 0.7,
+        top_p: 0.9,
+        stream: true,
+        stop: ['STOP'],
+        metadata: { user_id: 'u1' },
+      });
+    });
+
+    it('joins array-form system prompts and ignores non-text parts', () => {
+      const result = messagesToChatCompletionsRequest({
+        system: [
+          { type: 'text', text: 'Line one.' },
+          { type: 'text', text: 'Line two.' },
+          { type: 'unknown' },
+        ],
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      expect(result.messages).toEqual([
+        { role: 'system', content: 'Line one.\n\nLine two.' },
+        { role: 'user', content: 'hi' },
+      ]);
+    });
+
+    it('omits system message when system is empty or absent', () => {
+      const noSystem = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+      });
+      expect(noSystem.messages).toEqual([{ role: 'user', content: 'x' }]);
+
+      const emptyArray = messagesToChatCompletionsRequest({
+        system: [],
+        messages: [{ role: 'user', content: 'x' }],
+      });
+      expect(emptyArray.messages).toEqual([{ role: 'user', content: 'x' }]);
+    });
+
+    it('keeps text-only multimodal user content as a string', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'text', text: 'just text' }],
+          },
+        ],
+      });
+      expect(result.messages).toEqual([{ role: 'user', content: 'just text' }]);
+    });
+
+    it('translates base64 and url image blocks into chat-completions image_url parts', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'look' },
+              {
+                type: 'image',
+                source: { type: 'base64', media_type: 'image/jpeg', data: 'AAA' },
+              },
+              { type: 'image', source: { type: 'url', url: 'https://x.test/y.png' } },
+              { type: 'image', source: { type: 'base64', data: 'no-mime' } },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'look' },
+            { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,AAA' } },
+            { type: 'image_url', image_url: { url: 'https://x.test/y.png' } },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,no-mime' } },
+          ],
+        },
+      ]);
+    });
+
+    it('translates assistant tool_use blocks into tool_calls', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'text', text: "I'll look it up." },
+              { type: 'tool_use', id: 'tu_1', name: 'search', input: { q: 'cats' } },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        {
+          role: 'assistant',
+          content: "I'll look it up.",
+          tool_calls: [
+            {
+              id: 'tu_1',
+              type: 'function',
+              function: { name: 'search', arguments: '{"q":"cats"}' },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('keeps assistant tool_use-only messages with content set to null', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tu_2', name: 'lookup', input: {} }],
+          },
+        ],
+      });
+      expect(result.messages).toEqual([
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            { id: 'tu_2', type: 'function', function: { name: 'lookup', arguments: '{}' } },
+          ],
+        },
+      ]);
+    });
+
+    it('converts user tool_result blocks into role=tool messages', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'tool_result', tool_use_id: 'tu_1', content: 'found 3' },
+              { type: 'tool_result', tool_use_id: 'tu_2', content: { rows: 5 } },
+            ],
+          },
+        ],
+      });
+
+      expect(result.messages).toEqual([
+        { role: 'tool', tool_call_id: 'tu_1', content: 'found 3' },
+        { role: 'tool', tool_call_id: 'tu_2', content: '{"rows":5}' },
+      ]);
+    });
+
+    it('falls back to "unknown" for missing tool ids and synthesizes assistant ids', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          { role: 'user', content: [{ type: 'tool_result', content: 'r' }] },
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', input: {} }],
+          },
+        ],
+      });
+
+      const messages = result.messages as Array<Record<string, unknown>>;
+      expect(messages[0]).toEqual({ role: 'tool', tool_call_id: 'unknown', content: 'r' });
+      const assistantMsg = messages[1];
+      const toolCalls = assistantMsg.tool_calls as Array<Record<string, unknown>>;
+      expect(toolCalls).toHaveLength(1);
+      expect(toolCalls[0].id).toMatch(/^[0-9a-f-]{36}$/);
+      expect((toolCalls[0].function as Record<string, unknown>).name).toBe('unknown');
+    });
+
+    it('translates tools and tool_choice variants', () => {
+      const auto = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [
+          { name: 'search', description: 'Search', input_schema: { type: 'object' } },
+          { name: 'noschema' },
+        ],
+        tool_choice: { type: 'auto' },
+      });
+      expect(auto.tools).toEqual([
+        {
+          type: 'function',
+          function: { name: 'search', description: 'Search', parameters: { type: 'object' } },
+        },
+        { type: 'function', function: { name: 'noschema' } },
+      ]);
+      expect(auto.tool_choice).toBe('auto');
+
+      const any = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tool_choice: { type: 'any' },
+      });
+      expect(any.tool_choice).toBe('required');
+
+      const named = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tool_choice: { type: 'tool', name: 'search' },
+      });
+      expect(named.tool_choice).toEqual({ type: 'function', function: { name: 'search' } });
+
+      const ignoredNamed = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tool_choice: { type: 'tool' },
+      });
+      expect(ignoredNamed.tool_choice).toBeUndefined();
+    });
+
+    it('skips malformed message entries', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: ['nope', null, { role: 'user', content: 'ok' }],
+      } as Record<string, unknown>);
+      expect(result.messages).toEqual([{ role: 'user', content: 'ok' }]);
+    });
+  });
+
+  describe('chatCompletionsResponseToMessages', () => {
+    it('converts a text-only chat completion into an Anthropic message', () => {
+      const result = chatCompletionsResponseToMessages(
+        {
+          id: 'cc_1',
+          model: 'gpt-4o-mini',
+          choices: [{ message: { content: 'hello there' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 4, completion_tokens: 2, cache_read_tokens: 1 },
+        },
+        'gpt-4o-mini',
+      );
+
+      expect(result).toEqual({
+        id: 'cc_1',
+        type: 'message',
+        role: 'assistant',
+        model: 'gpt-4o-mini',
+        content: [{ type: 'text', text: 'hello there' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 4,
+          output_tokens: 2,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 1,
+        },
+      });
+    });
+
+    it('extracts text from array-shaped content and emits tool_use blocks', () => {
+      const result = chatCompletionsResponseToMessages(
+        {
+          choices: [
+            {
+              message: {
+                content: [
+                  { type: 'text', text: 'part1 ' },
+                  { type: 'text', text: 'part2' },
+                  { not: 'a record' },
+                ],
+                tool_calls: [
+                  {
+                    id: 'tc_1',
+                    function: { name: 'search', arguments: '{"q":"a"}' },
+                  },
+                  {
+                    function: { name: 'lookup', arguments: 'not-json' },
+                  },
+                  { not: 'a function' },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        },
+        'fallback',
+      );
+
+      expect(result.content).toEqual([
+        { type: 'text', text: 'part1 part2' },
+        { type: 'tool_use', id: 'tc_1', name: 'search', input: { q: 'a' } },
+        expect.objectContaining({ type: 'tool_use', name: 'lookup', input: {} }),
+      ]);
+      expect(result.stop_reason).toBe('tool_use');
+    });
+
+    it('maps stop reasons and falls back to end_turn for unknown values', () => {
+      const length = chatCompletionsResponseToMessages(
+        { choices: [{ message: { content: 'x' }, finish_reason: 'length' }] },
+        'm',
+      );
+      expect(length.stop_reason).toBe('max_tokens');
+
+      const unknown = chatCompletionsResponseToMessages(
+        { choices: [{ message: { content: 'x' }, finish_reason: 'mystery' }] },
+        'm',
+      );
+      expect(unknown.stop_reason).toBe('end_turn');
+
+      const noChoices = chatCompletionsResponseToMessages({ choices: 'bad' as unknown }, 'm');
+      expect(noChoices.content).toEqual([]);
+      expect(noChoices.stop_reason).toBe('end_turn');
+      expect(noChoices.id).toMatch(/^msg_[0-9a-f]{32}$/);
+      expect(noChoices.model).toBe('m');
+    });
+
+    it('handles missing content and missing usage gracefully', () => {
+      const result = chatCompletionsResponseToMessages(
+        { choices: [{ message: {}, finish_reason: 'stop' }] },
+        'm',
+      );
+      expect(result.content).toEqual([]);
+      expect(result.usage).toEqual({
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      });
+    });
+  });
+
+  describe('createMessagesStreamTransformer', () => {
+    function flushChunks(
+      transformer: { transform: (c: string) => string | null; finalize: () => string | null },
+      chunks: string[],
+    ): string {
+      const out = chunks.map((c) => transformer.transform(c) ?? '').join('');
+      const tail = transformer.finalize() ?? '';
+      return out + tail;
+    }
+
+    it('emits message_start, content_block events, message_delta, and message_stop for plain text', () => {
+      const t = createMessagesStreamTransformer('claude-sonnet-4');
+      const chunks = [
+        'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+        'data: {"choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\n',
+      ];
+      const sse = flushChunks(t, chunks);
+
+      const events = sse
+        .split('\n\n')
+        .filter(Boolean)
+        .map((block) => {
+          const eventLine = block.split('\n')[0]!;
+          const dataLine = block.split('\n')[1]!;
+          return {
+            event: eventLine.replace('event: ', ''),
+            data: JSON.parse(dataLine.replace('data: ', '')),
+          };
+        });
+
+      expect(events.map((e) => e.event)).toEqual([
+        'message_start',
+        'content_block_start',
+        'content_block_delta',
+        'content_block_delta',
+        'content_block_stop',
+        'message_delta',
+        'message_stop',
+      ]);
+
+      expect(events[0].data.message.id).toMatch(/^msg_/);
+      expect(events[0].data.message.model).toBe('claude-sonnet-4');
+      expect(events[1].data.content_block).toEqual({ type: 'text', text: '' });
+      expect(events[2].data.delta).toEqual({ type: 'text_delta', text: 'Hel' });
+      expect(events[3].data.delta).toEqual({ type: 'text_delta', text: 'lo' });
+      expect(events[5].data.delta).toEqual({ stop_reason: 'end_turn', stop_sequence: null });
+      expect(events[5].data.usage).toEqual({
+        input_tokens: 3,
+        output_tokens: 2,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      });
+    });
+
+    it('emits tool_use content_block_start and input_json_delta for tool calls', () => {
+      const t = createMessagesStreamTransformer('claude-sonnet-4');
+      const sse = flushChunks(t, [
+        'data: {"model":"claude","choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc_a","function":{"name":"search","arguments":"{\\"q"}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\":\\"x\\"}"}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+      ]);
+
+      expect(sse).toContain(
+        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tc_a","name":"search","input":{}}}',
+      );
+      expect(sse).toContain(
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"q"}}',
+      );
+      expect(sse).toContain('"stop_reason":"tool_use"');
+    });
+
+    it('finalize is idempotent — second call returns null', () => {
+      const t = createMessagesStreamTransformer('m');
+      t.transform('data: {"choices":[{"delta":{"content":"x"},"finish_reason":"stop"}]}\n\n');
+      const first = t.finalize();
+      expect(first).toContain('event: message_stop');
+      expect(t.finalize()).toBeNull();
+    });
+
+    it('starts the message even when only an empty payload is seen (initial chunk)', () => {
+      const t = createMessagesStreamTransformer('m');
+      const chunk = 'data: {"choices":[{"delta":{}}]}\n\n';
+      const out = t.transform(chunk);
+      expect(out).toContain('event: message_start');
+    });
+
+    it('ignores unparseable payloads without breaking the stream', () => {
+      const t = createMessagesStreamTransformer('m');
+      expect(t.transform('data: not-json\n\n')).toBeNull();
+      expect(t.transform('data: "scalar"\n\n')).toBeNull();
+      expect(t.transform('data: [DONE]\n\n')).toBeNull();
+
+      const real = t.transform('data: {"choices":[{"delta":{"content":"a"}}]}\n\n');
+      expect(real).toContain('event: message_start');
+      expect(real).toContain('"text":"a"');
+    });
+
+    it('captures usage from a finish_reason chunk that also carries usage', () => {
+      const t = createMessagesStreamTransformer('m');
+      const sse = [
+        t.transform('data: {"choices":[{"delta":{"content":"x"}}]}\n\n') ?? '',
+        t.transform(
+          'data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1}}\n\n',
+        ) ?? '',
+        t.finalize() ?? '',
+      ].join('');
+      expect(sse).toContain('"input_tokens":1');
+      expect(sse).toContain('"output_tokens":1');
+    });
+
+    it('falls back to safe stringification when assistant tool input contains circular refs', () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      const result = messagesToChatCompletionsRequest({
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'tu_c', name: 'cycle', input: circular }],
+          },
+        ],
+      });
+      const messages = result.messages as Array<Record<string, unknown>>;
+      const toolCalls = messages[0].tool_calls as Array<Record<string, unknown>>;
+      expect((toolCalls[0].function as Record<string, unknown>).arguments).toBe('');
+    });
+
+    it('handles raw payloads without a `data:` prefix', () => {
+      const t = createMessagesStreamTransformer('m');
+      const out = t.transform('{"choices":[{"delta":{"content":"raw"}}]}');
+      expect(out).toContain('event: message_start');
+      expect(out).toContain('"text":"raw"');
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -497,7 +497,12 @@ describe('proxy-response-handler', () => {
 
       await handleStreamResponse(res as any, forward as any, meta, {}, client as any);
 
-      expect(pipeStreamSpy).toHaveBeenCalledWith(forward.response.body, res, expect.any(Function));
+      expect(pipeStreamSpy).toHaveBeenCalledWith(
+        forward.response.body,
+        res,
+        expect.any(Function),
+        undefined,
+      );
     });
 
     it('should use Anthropic adapter for Anthropic responses', async () => {
@@ -555,7 +560,12 @@ describe('proxy-response-handler', () => {
 
       await handleStreamResponse(res as any, forward as any, meta, {}, client as any);
 
-      expect(pipeStreamSpy).toHaveBeenCalledWith(forward.response.body, res, expect.any(Function));
+      expect(pipeStreamSpy).toHaveBeenCalledWith(
+        forward.response.body,
+        res,
+        expect.any(Function),
+        undefined,
+      );
     });
 
     it('ChatGPT stream transformer delegates each chunk to convertChatGptStreamChunk', async () => {
@@ -594,6 +604,97 @@ describe('proxy-response-handler', () => {
 
       // Called with only 2 args (no transformer)
       expect(pipeStreamSpy).toHaveBeenCalledWith(forward.response.body, res);
+    });
+
+    it('passes a finalize callback to pipeStream when apiMode=messages (default OpenAI provider)', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta();
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'messages',
+      );
+
+      expect(pipeStreamSpy).toHaveBeenCalledWith(
+        forward.response.body,
+        res,
+        expect.any(Function),
+        expect.any(Function),
+      );
+    });
+
+    it('wraps the ChatGPT stream chunk converter through the messages transformer', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward({ isChatGpt: true });
+      const client = mockProviderClient();
+      client.convertChatGptStreamChunk.mockReturnValue(
+        'data: {"choices":[{"delta":{"content":"x"}}]}\n\n',
+      );
+      const meta = makeMeta();
+
+      let captured: ((chunk: string) => string | null) | undefined;
+      pipeStreamSpy.mockImplementation(
+        async (_b: unknown, _r: unknown, transform?: (c: string) => string | null) => {
+          captured = transform;
+          return null;
+        },
+      );
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'messages',
+      );
+
+      expect(captured).toBeDefined();
+      const out = captured!('data: ignored\n\n');
+      expect(out).toContain('event: message_start');
+      expect(out).toContain('event: content_block_delta');
+    });
+
+    it('returns null when the ChatGPT-converted chunk is empty under apiMode=messages', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward({ isChatGpt: true });
+      const client = mockProviderClient();
+      client.convertChatGptStreamChunk.mockReturnValue(null);
+      const meta = makeMeta();
+
+      let captured: ((chunk: string) => string | null) | undefined;
+      pipeStreamSpy.mockImplementation(
+        async (_b: unknown, _r: unknown, transform?: (c: string) => string | null) => {
+          captured = transform;
+          return null;
+        },
+      );
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'messages',
+      );
+
+      expect(captured!('chunk')).toBeNull();
     });
 
     it('should pass through native Responses streams without a transformer', async () => {
@@ -1023,6 +1124,38 @@ describe('proxy-response-handler', () => {
       expect(forward.response.text).toHaveBeenCalled();
       expect(forward.response.json).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith(response);
+    });
+
+    it('converts a chat_completions response into Anthropic Messages when apiMode=messages', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const body = {
+        id: 'cc_42',
+        choices: [{ message: { content: 'hello' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 6, completion_tokens: 4 },
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta();
+
+      const usage = await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined,
+        undefined,
+        'messages',
+      );
+
+      const sent = (res.json as jest.Mock).mock.calls[0][0];
+      expect(sent.type).toBe('message');
+      expect(sent.role).toBe('assistant');
+      expect(sent.content).toEqual([{ type: 'text', text: 'hello' }]);
+      expect(sent.stop_reason).toBe('end_turn');
+      expect(sent.usage).toMatchObject({ input_tokens: 6, output_tokens: 4 });
+      expect(usage).toMatchObject({ prompt_tokens: 6, completion_tokens: 4 });
     });
 
     it('should return null usage when no usage data in response', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -252,6 +252,54 @@ describe('ProxyController', () => {
     expect(json.usage.input_tokens).toBe(4);
   });
 
+  it('should expose /v1/messages and convert chat completions output to Anthropic Messages format', async () => {
+    const responseBody = {
+      id: 'cc_1',
+      model: 'claude-sonnet-4',
+      choices: [{ message: { content: 'hi there' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+    };
+    const mockProviderResp = new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    proxyService.proxyRequest.mockResolvedValue({
+      forward: {
+        response: mockProviderResp,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      },
+      meta: {
+        tier: 'simple',
+        model: 'claude-sonnet-4',
+        provider: 'Anthropic',
+        confidence: 0.9,
+        reason: 'scored',
+      },
+    });
+
+    const req = mockRequest({
+      model: 'claude-sonnet-4',
+      max_tokens: 64,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    const { res } = mockResponse();
+
+    await controller.messages(req as never, res as never);
+
+    expect(proxyService.proxyRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ apiMode: 'messages' }),
+    );
+    const json = (res.json as jest.Mock).mock.calls[0][0];
+    expect(json.type).toBe('message');
+    expect(json.role).toBe('assistant');
+    expect(json.content).toEqual([{ type: 'text', text: 'hi there' }]);
+    expect(json.stop_reason).toBe('end_turn');
+    expect(json.usage).toMatchObject({ input_tokens: 4, output_tokens: 2 });
+  });
+
   it('should pass through native Responses JSON bodies', async () => {
     const responseBody = {
       id: 'resp_1',

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -190,6 +190,37 @@ describe('pipeStream', () => {
     expect(written).toContain('data: [DONE]\n\n');
   });
 
+  it('writes the finalize trailer before [DONE] and captures usage from it', async () => {
+    const { res, written } = mockResponse();
+    const stream = createReadableStream(['data: chunk1\n\n']);
+    const transform = (chunk: string) => `out:${chunk}\n\n`;
+    const finalize = () =>
+      'event: message_delta\ndata: {"usage":{"input_tokens":7,"output_tokens":3}}\n\n' +
+      'event: message_stop\ndata: {"type":"message_stop"}\n\n';
+
+    const usage = await pipeStream(stream, res as never, transform, finalize);
+
+    const concatenated = written.join('');
+    const doneIdx = concatenated.indexOf('data: [DONE]');
+    const stopIdx = concatenated.indexOf('event: message_stop');
+    expect(stopIdx).toBeGreaterThan(-1);
+    expect(doneIdx).toBeGreaterThan(stopIdx);
+    expect(usage).toMatchObject({ prompt_tokens: 7, completion_tokens: 3 });
+  });
+
+  it('skips a null finalize trailer without writing extra bytes', async () => {
+    const { res, written } = mockResponse();
+    const stream = createReadableStream(['data: only\n\n']);
+    const transform = (chunk: string) => `out:${chunk}\n\n`;
+    const finalize = jest.fn().mockReturnValue(null);
+
+    await pipeStream(stream, res as never, transform, finalize);
+
+    expect(finalize).toHaveBeenCalledTimes(1);
+    expect(written).toContain('data: [DONE]\n\n');
+    expect(written.some((w) => w.startsWith('event: '))).toBe(false);
+  });
+
   it('should not write [DONE] for non-transformed streams', async () => {
     const { res, written } = mockResponse();
     const stream = createReadableStream(['data: test\n\n']);

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -1,0 +1,467 @@
+/**
+ * Translates between the public Anthropic Messages API format
+ * (POST /v1/messages) and the internal chat-completions request/response
+ * format used by Manifest's routing pipeline. Mirrors `responses-adapter.ts`
+ * for the OpenAI Responses API.
+ */
+import { randomUUID } from 'crypto';
+
+import { OpenAIMessage } from './proxy-types';
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function safeJsonStringify(value: unknown): string {
+  try {
+    return typeof value === 'string' ? value : JSON.stringify(value ?? '');
+  } catch {
+    return '';
+  }
+}
+
+function systemToString(system: unknown): string {
+  if (typeof system === 'string') return system;
+  if (!Array.isArray(system)) return '';
+  return system
+    .filter(isRecord)
+    .map((part) => (typeof part.text === 'string' ? part.text : ''))
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function anthropicContentToChat(content: unknown): {
+  text: string;
+  parts: JsonRecord[];
+  toolUses: Array<{ id: string; name: string; input: unknown }>;
+  toolResults: Array<{ toolUseId: string; content: string }>;
+} {
+  const out = {
+    text: '',
+    parts: [] as JsonRecord[],
+    toolUses: [] as Array<{ id: string; name: string; input: unknown }>,
+    toolResults: [] as Array<{ toolUseId: string; content: string }>,
+  };
+
+  if (typeof content === 'string') {
+    out.text = content;
+    if (content) out.parts.push({ type: 'text', text: content });
+    return out;
+  }
+  if (!Array.isArray(content)) return out;
+
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (block.type === 'text' && typeof block.text === 'string') {
+      out.text += block.text;
+      out.parts.push({ type: 'text', text: block.text });
+    } else if (block.type === 'image' && isRecord(block.source)) {
+      const source = block.source;
+      if (source.type === 'base64' && typeof source.data === 'string') {
+        const mediaType = typeof source.media_type === 'string' ? source.media_type : 'image/png';
+        out.parts.push({
+          type: 'image_url',
+          image_url: { url: `data:${mediaType};base64,${source.data}` },
+        });
+      } else if (source.type === 'url' && typeof source.url === 'string') {
+        out.parts.push({ type: 'image_url', image_url: { url: source.url } });
+      }
+    } else if (block.type === 'tool_use') {
+      out.toolUses.push({
+        id: typeof block.id === 'string' ? block.id : randomUUID(),
+        name: typeof block.name === 'string' ? block.name : 'unknown',
+        input: block.input ?? {},
+      });
+    } else if (block.type === 'tool_result') {
+      out.toolResults.push({
+        toolUseId: typeof block.tool_use_id === 'string' ? block.tool_use_id : 'unknown',
+        content: safeJsonStringify(block.content),
+      });
+    }
+  }
+
+  return out;
+}
+
+function buildUserOrAssistantMessage(
+  role: 'user' | 'assistant',
+  content: unknown,
+): OpenAIMessage[] {
+  const { text, parts, toolUses, toolResults } = anthropicContentToChat(content);
+  const messages: OpenAIMessage[] = [];
+
+  // tool_result blocks become standalone tool-role messages in chat_completions.
+  for (const result of toolResults) {
+    messages.push({ role: 'tool', tool_call_id: result.toolUseId, content: result.content });
+  }
+
+  if (role === 'assistant') {
+    const tool_calls = toolUses.map((tu) => ({
+      id: tu.id,
+      type: 'function',
+      function: { name: tu.name, arguments: safeJsonStringify(tu.input) },
+    }));
+    if (text || tool_calls.length > 0) {
+      const message: OpenAIMessage = { role: 'assistant', content: text || null };
+      if (tool_calls.length > 0) message.tool_calls = tool_calls;
+      messages.push(message);
+    }
+    return messages;
+  }
+
+  // user role
+  const otherParts = parts.filter((p) => p.type !== 'text');
+  const hasNonText = otherParts.length > 0;
+  const hasText = parts.some((p) => p.type === 'text');
+  if (hasText && !hasNonText) {
+    if (text) messages.push({ role: 'user', content: text });
+  } else if (hasNonText) {
+    messages.push({ role: 'user', content: parts });
+  }
+  return messages;
+}
+
+function toChatTools(tools: unknown[]): JsonRecord[] {
+  return tools.filter(isRecord).map((tool) => ({
+    type: 'function',
+    function: {
+      name: typeof tool.name === 'string' ? tool.name : 'unknown',
+      ...(typeof tool.description === 'string' && { description: tool.description }),
+      ...(tool.input_schema !== undefined && { parameters: tool.input_schema }),
+    },
+  }));
+}
+
+function toChatToolChoice(choice: unknown): unknown {
+  if (!isRecord(choice)) return undefined;
+  if (choice.type === 'auto') return 'auto';
+  if (choice.type === 'any') return 'required';
+  if (choice.type === 'tool' && typeof choice.name === 'string') {
+    return { type: 'function', function: { name: choice.name } };
+  }
+  return undefined;
+}
+
+/** Anthropic Messages request → chat_completions request (used for routing/forwarding). */
+export function messagesToChatCompletionsRequest(body: JsonRecord): JsonRecord {
+  const messages: OpenAIMessage[] = [];
+
+  const systemText = systemToString(body.system);
+  if (systemText) messages.push({ role: 'system', content: systemText });
+
+  const inputMessages = Array.isArray(body.messages) ? body.messages : [];
+  for (const item of inputMessages) {
+    if (!isRecord(item)) continue;
+    const role = item.role === 'assistant' ? 'assistant' : 'user';
+    messages.push(...buildUserOrAssistantMessage(role, item.content));
+  }
+
+  const chatBody: JsonRecord = { messages };
+
+  if (typeof body.model === 'string') chatBody.model = body.model;
+  if (body.max_tokens !== undefined) chatBody.max_tokens = body.max_tokens;
+  if (body.temperature !== undefined) chatBody.temperature = body.temperature;
+  if (body.top_p !== undefined) chatBody.top_p = body.top_p;
+  if (body.stream !== undefined) chatBody.stream = body.stream;
+  if (body.metadata !== undefined) chatBody.metadata = body.metadata;
+  if (body.stop_sequences !== undefined) chatBody.stop = body.stop_sequences;
+
+  if (Array.isArray(body.tools)) chatBody.tools = toChatTools(body.tools);
+  const toolChoice = toChatToolChoice(body.tool_choice);
+  if (toolChoice !== undefined) chatBody.tool_choice = toolChoice;
+
+  return chatBody;
+}
+
+const STOP_REASON_MAP: Record<string, string> = {
+  stop: 'end_turn',
+  length: 'max_tokens',
+  tool_calls: 'tool_use',
+};
+
+function toAnthropicStopReason(finishReason: unknown): string {
+  if (typeof finishReason !== 'string') return 'end_turn';
+  return STOP_REASON_MAP[finishReason] ?? 'end_turn';
+}
+
+function toAnthropicUsage(usage: unknown): JsonRecord {
+  const u = isRecord(usage) ? usage : {};
+  const inputTokens = typeof u.prompt_tokens === 'number' ? u.prompt_tokens : 0;
+  const outputTokens = typeof u.completion_tokens === 'number' ? u.completion_tokens : 0;
+  const cacheRead = typeof u.cache_read_tokens === 'number' ? u.cache_read_tokens : 0;
+  return {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: cacheRead,
+  };
+}
+
+function safeParseJson(value: unknown): unknown {
+  if (typeof value !== 'string') return value ?? {};
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+/** chat_completions response → Anthropic Messages response. */
+export function chatCompletionsResponseToMessages(body: JsonRecord, model: string): JsonRecord {
+  const choices = Array.isArray(body.choices) ? body.choices : [];
+  const firstChoice = isRecord(choices[0]) ? choices[0] : {};
+  const message = isRecord(firstChoice.message) ? firstChoice.message : {};
+
+  const content: JsonRecord[] = [];
+  const text =
+    typeof message.content === 'string'
+      ? message.content
+      : Array.isArray(message.content)
+        ? (message.content as Array<JsonRecord>)
+            .filter(isRecord)
+            .map((p) => (typeof p.text === 'string' ? p.text : ''))
+            .join('')
+        : '';
+  if (text) content.push({ type: 'text', text });
+
+  if (Array.isArray(message.tool_calls)) {
+    for (const call of message.tool_calls) {
+      if (!isRecord(call) || !isRecord(call.function)) continue;
+      content.push({
+        type: 'tool_use',
+        id: typeof call.id === 'string' ? call.id : `toolu_${randomUUID().replace(/-/g, '')}`,
+        name: typeof call.function.name === 'string' ? call.function.name : '',
+        input: safeParseJson(call.function.arguments),
+      });
+    }
+  }
+
+  const stopReason = toAnthropicStopReason(firstChoice.finish_reason);
+
+  return {
+    id: typeof body.id === 'string' ? body.id : `msg_${randomUUID().replace(/-/g, '')}`,
+    type: 'message',
+    role: 'assistant',
+    model: typeof body.model === 'string' ? body.model : model,
+    content,
+    stop_reason: stopReason,
+    stop_sequence: null,
+    usage: toAnthropicUsage(body.usage),
+  };
+}
+
+interface StreamState {
+  messageId: string;
+  model: string;
+  startedMessage: boolean;
+  textIndex: number | null;
+  textOpened: boolean;
+  toolCalls: Map<number, { id: string; index: number; argBuffer: string; opened: boolean }>;
+  finalUsage: JsonRecord | null;
+  stopReason: string | null;
+  endedMessage: boolean;
+}
+
+export interface MessagesStreamTransformer {
+  transform: (chunk: string) => string | null;
+  finalize: () => string | null;
+}
+
+export function createMessagesStreamTransformer(model: string): MessagesStreamTransformer {
+  const state: StreamState = {
+    messageId: `msg_${randomUUID().replace(/-/g, '')}`,
+    model,
+    startedMessage: false,
+    textIndex: null,
+    textOpened: false,
+    toolCalls: new Map(),
+    finalUsage: null,
+    stopReason: null,
+    endedMessage: false,
+  };
+
+  return {
+    transform: (chunk: string) => transformStreamChunk(chunk, state),
+    finalize: () => {
+      const events = closeStream(state);
+      return events.length > 0 ? events.join('') : null;
+    },
+  };
+}
+
+function transformStreamChunk(chunk: string, state: StreamState): string | null {
+  const events: string[] = [];
+  for (const payload of extractDataPayloads(chunk)) {
+    if (payload === '[DONE]') continue;
+    const data = safeParse(payload);
+    if (!data) continue;
+
+    if (!state.startedMessage) {
+      events.push(buildMessageStartEvent(state, data));
+      state.startedMessage = true;
+    }
+
+    const choices = Array.isArray(data.choices) ? data.choices : [];
+    if (choices.length === 0 && isRecord(data.usage)) {
+      state.finalUsage = toAnthropicUsage(data.usage);
+      continue;
+    }
+
+    const choice = isRecord(choices[0]) ? choices[0] : null;
+    if (!choice) continue;
+    const delta = isRecord(choice.delta) ? choice.delta : {};
+
+    if (typeof delta.content === 'string' && delta.content.length > 0) {
+      if (state.textIndex === null) {
+        state.textIndex = nextBlockIndex(state);
+        events.push(
+          formatMessagesEvent('content_block_start', {
+            type: 'content_block_start',
+            index: state.textIndex,
+            content_block: { type: 'text', text: '' },
+          }),
+        );
+        state.textOpened = true;
+      }
+      events.push(
+        formatMessagesEvent('content_block_delta', {
+          type: 'content_block_delta',
+          index: state.textIndex,
+          delta: { type: 'text_delta', text: delta.content },
+        }),
+      );
+    }
+
+    if (Array.isArray(delta.tool_calls)) {
+      for (const call of delta.tool_calls) {
+        if (!isRecord(call)) continue;
+        const callIndex = typeof call.index === 'number' ? call.index : 0;
+        let entry = state.toolCalls.get(callIndex);
+        if (!entry) {
+          entry = {
+            id: typeof call.id === 'string' ? call.id : `toolu_${randomUUID().replace(/-/g, '')}`,
+            index: nextBlockIndex(state),
+            argBuffer: '',
+            opened: false,
+          };
+          state.toolCalls.set(callIndex, entry);
+        }
+        const fn = isRecord(call.function) ? call.function : {};
+        if (!entry.opened) {
+          events.push(
+            formatMessagesEvent('content_block_start', {
+              type: 'content_block_start',
+              index: entry.index,
+              content_block: {
+                type: 'tool_use',
+                id: entry.id,
+                name: typeof fn.name === 'string' ? fn.name : '',
+                input: {},
+              },
+            }),
+          );
+          entry.opened = true;
+        }
+        if (typeof fn.arguments === 'string' && fn.arguments.length > 0) {
+          entry.argBuffer += fn.arguments;
+          events.push(
+            formatMessagesEvent('content_block_delta', {
+              type: 'content_block_delta',
+              index: entry.index,
+              delta: { type: 'input_json_delta', partial_json: fn.arguments },
+            }),
+          );
+        }
+      }
+    }
+
+    if (choice.finish_reason) {
+      state.stopReason = toAnthropicStopReason(choice.finish_reason);
+      if (isRecord(data.usage) && !state.finalUsage) {
+        state.finalUsage = toAnthropicUsage(data.usage);
+      }
+    }
+  }
+
+  return events.length > 0 ? events.join('') : null;
+}
+
+function nextBlockIndex(state: StreamState): number {
+  return (state.textIndex !== null ? 1 : 0) + state.toolCalls.size;
+}
+
+function buildMessageStartEvent(state: StreamState, data: JsonRecord): string {
+  const usage = isRecord(data.usage) ? toAnthropicUsage(data.usage) : toAnthropicUsage({});
+  return formatMessagesEvent('message_start', {
+    type: 'message_start',
+    message: {
+      id: state.messageId,
+      type: 'message',
+      role: 'assistant',
+      model: typeof data.model === 'string' ? data.model : state.model,
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage,
+    },
+  });
+}
+
+function closeStream(state: StreamState): string[] {
+  if (state.endedMessage) return [];
+  const events: string[] = [];
+
+  if (state.textOpened && state.textIndex !== null) {
+    events.push(
+      formatMessagesEvent('content_block_stop', {
+        type: 'content_block_stop',
+        index: state.textIndex,
+      }),
+    );
+  }
+  for (const entry of state.toolCalls.values()) {
+    if (!entry.opened) continue;
+    events.push(
+      formatMessagesEvent('content_block_stop', {
+        type: 'content_block_stop',
+        index: entry.index,
+      }),
+    );
+  }
+
+  events.push(
+    formatMessagesEvent('message_delta', {
+      type: 'message_delta',
+      delta: {
+        stop_reason: state.stopReason ?? 'end_turn',
+        stop_sequence: null,
+      },
+      usage: state.finalUsage ?? toAnthropicUsage({}),
+    }),
+  );
+  events.push(formatMessagesEvent('message_stop', { type: 'message_stop' }));
+  state.endedMessage = true;
+  return events;
+}
+
+function extractDataPayloads(chunk: string): string[] {
+  const lines = chunk.split('\n').map((line) => line.trim());
+  const dataLines = lines.filter((line) => line.startsWith('data:'));
+  if (dataLines.length > 0) return dataLines.map((line) => line.slice(5).trim());
+  return [chunk.trim()].filter(Boolean);
+}
+
+function safeParse(data: string): JsonRecord | null {
+  try {
+    const parsed = JSON.parse(data);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatMessagesEvent(event: string, data: JsonRecord): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -198,7 +198,12 @@ export class ProviderClient {
     thinkingLookup?: ForwardOptions['thinkingLookup'];
   }): { url: string; headers: Record<string, string>; requestBody: Record<string, unknown> } {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
-    const requestSource = ctx.apiMode === 'responses' ? (chatBody ?? body) : body;
+    // For non-chat_completions inbound modes ('responses', 'messages'), the
+    // routing layer pre-translated the request into chat_completions form
+    // (`chatBody`). Provider adapters all consume chat_completions, so prefer
+    // `chatBody` when present.
+    const requestSource =
+      ctx.apiMode && ctx.apiMode !== 'chat_completions' ? (chatBody ?? body) : body;
 
     if (endpoint.format === 'google') {
       // Google accepts the API key via header (set by buildHeaders below) so

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -13,6 +13,10 @@ import {
   collectResponsesSseResponse,
   fromChatCompletionResponse,
 } from './responses-adapter';
+import {
+  chatCompletionsResponseToMessages,
+  createMessagesStreamTransformer,
+} from './anthropic-messages-adapter';
 import type { ProxyApiMode } from './proxy-types';
 import type { ThoughtSignatureCache } from './thought-signature-cache';
 import type { ThinkingBlockCache, ThinkingBlock } from './thinking-block-cache';
@@ -263,23 +267,38 @@ export async function handleStreamResponse(
 ): Promise<StreamUsage | null> {
   initSseHeaders(res, metaHeaders);
 
+  const messagesTransformer =
+    apiMode === 'messages' ? createMessagesStreamTransformer(meta.model) : null;
+  const finalize = messagesTransformer ? () => messagesTransformer.finalize() : undefined;
   const toClientChunk =
-    apiMode === 'responses' ? chatCompletionStreamChunkToResponses : (chunk: string) => chunk;
+    apiMode === 'responses'
+      ? chatCompletionStreamChunkToResponses
+      : messagesTransformer
+        ? messagesTransformer.transform
+        : (chunk: string) => chunk;
 
   if (apiMode === 'responses' && forward.isResponses) {
     return pipeStream(forward.response.body!, res);
   }
 
   if (forward.isGoogle) {
-    return pipeStream(forward.response.body!, res, (chunk) => {
-      const { chunk: out, signatures } = providerClient.convertGoogleStreamChunk(chunk, meta.model);
-      if (signatureCache && sessionKey) {
-        for (const s of signatures) {
-          signatureCache.store(sessionKey, s.toolCallId, s.signature);
+    return pipeStream(
+      forward.response.body!,
+      res,
+      (chunk) => {
+        const { chunk: out, signatures } = providerClient.convertGoogleStreamChunk(
+          chunk,
+          meta.model,
+        );
+        if (signatureCache && sessionKey) {
+          for (const s of signatures) {
+            signatureCache.store(sessionKey, s.toolCallId, s.signature);
+          }
         }
-      }
-      return out ? toClientChunk(out) : null;
-    });
+        return out ? toClientChunk(out) : null;
+      },
+      finalize,
+    );
   }
   if (forward.isAnthropic) {
     const onThinkingBlocks =
@@ -292,18 +311,30 @@ export async function handleStreamResponse(
       meta.model,
       onThinkingBlocks,
     );
-    return pipeStream(forward.response.body!, res, (chunk) => {
-      const out = anthropicTransformer(chunk);
-      return out ? toClientChunk(out) : null;
-    });
-  }
-  if (forward.isChatGpt) {
-    return pipeStream(forward.response.body!, res, (chunk) =>
-      providerClient.convertChatGptStreamChunk(chunk, meta.model),
+    return pipeStream(
+      forward.response.body!,
+      res,
+      (chunk) => {
+        const out = anthropicTransformer(chunk);
+        return out ? toClientChunk(out) : null;
+      },
+      finalize,
     );
   }
-  if (apiMode === 'responses') {
-    return pipeStream(forward.response.body!, res, toClientChunk);
+  if (forward.isChatGpt) {
+    return pipeStream(
+      forward.response.body!,
+      res,
+      (chunk) => {
+        const out = providerClient.convertChatGptStreamChunk(chunk, meta.model);
+        if (!messagesTransformer) return out;
+        return out ? toClientChunk(out) : null;
+      },
+      finalize,
+    );
+  }
+  if (apiMode === 'responses' || apiMode === 'messages') {
+    return pipeStream(forward.response.body!, res, toClientChunk, finalize);
   }
   return pipeStream(forward.response.body!, res);
 }
@@ -357,6 +388,11 @@ export async function handleNonStreamResponse(
 
   if (apiMode === 'responses' && !forward.isResponses) {
     responseBody = fromChatCompletionResponse(responseBody as Record<string, unknown>, meta.model);
+  } else if (apiMode === 'messages') {
+    responseBody = chatCompletionsResponseToMessages(
+      responseBody as Record<string, unknown>,
+      meta.model,
+    );
   }
 
   const body = responseBody as Record<string, unknown> | undefined;

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -16,7 +16,7 @@ export type SignatureLookup = (toolCallId: string) => string | null;
  * assistant turn; returns the ordered block sequence or null.
  */
 export type ThinkingBlockLookup = (firstToolUseId: string) => ThinkingBlock[] | null;
-export type ProxyApiMode = 'chat_completions' | 'responses';
+export type ProxyApiMode = 'chat_completions' | 'responses' | 'messages';
 
 export interface OpenAIMessage {
   role: string;

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -71,6 +71,14 @@ export class ProxyController {
     await this.handleProxyRequest(req, res, 'responses');
   }
 
+  @Post('messages')
+  async messages(
+    @Req() req: Request & { ingestionContext: IngestionContext },
+    @Res() res: ExpressResponse,
+  ): Promise<void> {
+    await this.handleProxyRequest(req, res, 'messages');
+  }
+
   private async handleProxyRequest(
     req: Request & { ingestionContext: IngestionContext },
     res: ExpressResponse,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -31,6 +31,7 @@ import { formatManifestError } from '../../common/errors/error-codes';
 import { peekStream } from './stream-warmup';
 import type { AuthType } from 'manifest-shared';
 import { toChatCompletionsRequest } from './responses-adapter';
+import { messagesToChatCompletionsRequest } from './anthropic-messages-adapter';
 
 const STREAM_WARMUP_MS = 15_000;
 
@@ -108,7 +109,12 @@ export class ProxyService {
       headers,
     } = opts;
     const apiMode = opts.apiMode ?? 'chat_completions';
-    const chatBody = apiMode === 'responses' ? toChatCompletionsRequest(body) : undefined;
+    const chatBody =
+      apiMode === 'responses'
+        ? toChatCompletionsRequest(body)
+        : apiMode === 'messages'
+          ? messagesToChatCompletionsRequest(body)
+          : undefined;
     const routingBody = chatBody ?? body;
     this.validatePayload(routingBody);
 

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -131,6 +131,7 @@ export async function pipeStream(
   source: ReadableStream<Uint8Array>,
   dest: ExpressResponse,
   transform?: (chunk: string) => string | null,
+  finalize?: () => string | null,
 ): Promise<StreamUsage | null> {
   const reader = source.getReader();
   const decoder = new TextDecoder();
@@ -233,10 +234,19 @@ export async function pipeStream(
       }
     }
 
-    // Ensure the stream ends with [DONE] for OpenAI-compatible clients.
-    // Non-transformed streams (OpenAI) already include it from the provider.
-    // Transformed streams (Google) need it added explicitly.
+    // Stream tail. Anthropic Messages clients need a `message_stop` event
+    // (emitted via `finalize`); OpenAI-compatible clients need `data: [DONE]`.
+    // We write both — `data: [DONE]` is harmless for Anthropic SDKs which
+    // ignore non-event lines.
     if (transform) {
+      if (finalize) {
+        const trailing = finalize();
+        if (trailing) {
+          dest.write(trailing);
+          const usage = extractUsageFromSse(trailing);
+          if (usage) capturedUsage = usage;
+        }
+      }
       dest.write('data: [DONE]\n\n');
     }
   } finally {


### PR DESCRIPTION
## Summary

Adds `POST /v1/messages` so any Anthropic-SDK client (Claude Code, `@anthropic-ai/sdk`, etc.) can point `ANTHROPIC_BASE_URL` at a Manifest gateway and route through the existing tier/specificity pipeline.

The new endpoint mirrors the `/v1/responses` pattern: a small adapter translates Anthropic Messages requests into the internal chat-completions form for routing, and translates responses (or SSE streams) back into Anthropic Messages format on the way out. All routing, scoring, fallback, recording, and provider adapters are unchanged.

- New `anthropic-messages-adapter.ts` — request/response translators + a stateful streaming transformer producing `message_start` → `content_block_*` → `message_delta` → `message_stop`
- `ProxyApiMode` extended with `'messages'`; `pipeStream` gains an optional `finalize` callback so the trailer (`message_delta` + `message_stop`) can be emitted after the upstream stream ends
- 100% line coverage on every touched file

## Test plan

- [x] Backend unit tests: 4352 pass (37 proxy suites)
- [x] Backend e2e tests: 138 pass
- [x] Frontend unit tests: 2610 pass
- [x] Shared unit tests: 129 pass
- [x] Lint clean, tsc clean, prod build clean
- [x] Local smoke test: non-stream request returns Anthropic Messages JSON; `stream: true` emits the full SSE event sequence; empty `messages` rejected with 400 `invalid_request_error`
- [ ] End-to-end with Claude Code pointed at a real Anthropic provider (pending review)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Anthropic Messages-compatible endpoint at POST /v1/messages so clients using `@anthropic-ai/sdk` or Claude Code can target Manifest by setting `ANTHROPIC_BASE_URL`. Requests are routed through the existing tier/specificity pipeline, with JSON and SSE translated to/from Anthropic Messages.

- **New Features**
  - New adapter translates Anthropic Messages to internal chat-completions and back; streams emit `message_start` → `content_block_*` → `message_delta` → `message_stop`.
  - Streaming supports a finalize trailer via `pipeStream` to send message tail and usage after upstream ends.
  - Added `'messages'` to `ProxyApiMode`; controller exposes POST /v1/messages; provider client prefers translated `chatBody` for non-chat_completions modes.
  - Non-stream responses and provider streams (OpenAI/ChatGPT, Google, Anthropic) are converted through the adapter within `proxy-response-handler`.

- **Migration**
  - Point `ANTHROPIC_BASE_URL` at the Manifest gateway and call POST /v1/messages with your `mnfst_*` key.
  - No client code changes required for Anthropic SDKs.

<sup>Written for commit ab9f0cb3a0a13a1d7d0589949ae373f176111108. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

