### PR TITLE
fix: open MiniMax authorize page on the right host

### DIFF
--- a/.changeset/minimax-verification-uri-fix.md
+++ b/.changeset/minimax-verification-uri-fix.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix MiniMax Token Plan activation redirecting to the homepage. The MiniMax `/oauth/code` endpoint returns a `verification_uri` pointing at `https://www.minimax.io/oauth-authorize?...`, which 307-redirects to the homepage with no instructions. The real authorize page lives on `platform.minimax.io` (and `platform.minimaxi.com` for the CN region). The MiniMax OAuth start flow now rewrites the host before returning the URI, so users land on the actual page where their 6-digit code can be entered. Closes #1796.

--- a/packages/backend/src/routing/oauth/minimax-oauth-helpers.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth-helpers.spec.ts
@@ -12,6 +12,7 @@ import {
   isMinimaxRegion,
   isOAuthTokenBlob,
   MINIMAX_BASE_URLS,
+  normalizeMinimaxVerificationUri,
   toAbsoluteExpiryTimestamp,
   toPollIntervalMs,
 } from './minimax-oauth-helpers';
@@ -109,6 +110,43 @@ describe('minimax-oauth-helpers', () => {
 
     it('converts small values (assumed to be seconds) to milliseconds', () => {
       expect(toPollIntervalMs(5)).toBe(5000);
+    });
+  });
+
+  describe('normalizeMinimaxVerificationUri', () => {
+    it('rewrites the broken www.minimax.io oauth-authorize host to platform.minimax.io', () => {
+      expect(
+        normalizeMinimaxVerificationUri(
+          'https://www.minimax.io/oauth-authorize?user_code=ABCD-1234&client=OpenClaw',
+        ),
+      ).toBe('https://platform.minimax.io/oauth-authorize?user_code=ABCD-1234&client=OpenClaw');
+    });
+
+    it('rewrites the CN equivalent www.minimaxi.com to platform.minimaxi.com', () => {
+      expect(
+        normalizeMinimaxVerificationUri(
+          'https://www.minimaxi.com/oauth-authorize?user_code=ABCD-1234',
+        ),
+      ).toBe('https://platform.minimaxi.com/oauth-authorize?user_code=ABCD-1234');
+    });
+
+    it('passes through URLs that already point at the correct host', () => {
+      const ok = 'https://platform.minimax.io/oauth-authorize?user_code=Y3CN-NY48';
+      expect(normalizeMinimaxVerificationUri(ok)).toBe(ok);
+    });
+
+    it('passes through unrelated paths even on the broken host', () => {
+      const other = 'https://www.minimax.io/something-else?user_code=Y3CN-NY48';
+      expect(normalizeMinimaxVerificationUri(other)).toBe(other);
+    });
+
+    it('passes through unrelated hosts on the oauth-authorize path', () => {
+      const other = 'https://example.com/oauth-authorize?user_code=Y3CN-NY48';
+      expect(normalizeMinimaxVerificationUri(other)).toBe(other);
+    });
+
+    it('returns the input unchanged when it is not a valid URL', () => {
+      expect(normalizeMinimaxVerificationUri('not a url')).toBe('not a url');
     });
   });
 

--- a/packages/backend/src/routing/oauth/minimax-oauth-helpers.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth-helpers.ts
@@ -34,6 +34,29 @@ export function buildMinimaxResourceUrl(baseUrl: string): string {
   return `${baseUrl}/anthropic`;
 }
 
+const VERIFICATION_HOST_REWRITES: Record<string, string> = {
+  'www.minimax.io': 'platform.minimax.io',
+  'www.minimaxi.com': 'platform.minimaxi.com',
+};
+
+// Upstream MiniMax /oauth/code returns verification_uri pointing at
+// www.minimax.io/oauth-authorize, which 307-redirects to the homepage. The
+// real authorize page lives on platform.{minimax.io,minimaxi.com}. Rewrite
+// only that exact host+path pair so any future upstream fix keeps working.
+export function normalizeMinimaxVerificationUri(verificationUri: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(verificationUri);
+  } catch {
+    return verificationUri;
+  }
+  if (parsed.pathname !== '/oauth-authorize') return verificationUri;
+  const replacement = VERIFICATION_HOST_REWRITES[parsed.hostname];
+  if (!replacement) return verificationUri;
+  parsed.hostname = replacement;
+  return parsed.toString();
+}
+
 export function getMinimaxResourceUrl(resourceUrl?: string): string | null {
   if (!resourceUrl) return null;
   return normalizeMinimaxSubscriptionBaseUrl(resourceUrl);

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
@@ -123,6 +123,28 @@ describe('MinimaxOauthService', () => {
       await expect(svc.startAuthorization('a', 'u')).rejects.toThrow();
     });
 
+    it('rewrites the broken upstream verification_uri host to platform.minimax.io', async () => {
+      // Reproduces issue #1796: the MiniMax /oauth/code endpoint returns a
+      // verification_uri pointing at www.minimax.io/oauth-authorize, which
+      // 307-redirects to the homepage. The real authorize page lives on
+      // platform.minimax.io.
+      fetchMock.mockImplementationOnce(async (_url: string, init: RequestInit) => {
+        const body = new URLSearchParams(String(init.body));
+        return mockResponse(200, {
+          user_code: 'Y3CN-NY48',
+          verification_uri:
+            'https://www.minimax.io/oauth-authorize?user_code=Y3CN-NY48&client=OpenClaw',
+          expired_in: 600,
+          interval: 2,
+          state: body.get('state'),
+        });
+      });
+      const out = await svc.startAuthorization('agent-1', 'user-1', 'global');
+      expect(out.verificationUri).toBe(
+        'https://platform.minimax.io/oauth-authorize?user_code=Y3CN-NY48&client=OpenClaw',
+      );
+    });
+
     it('throws when the echoed state does not match the generated flow id', async () => {
       fetchMock.mockResolvedValueOnce(
         mockResponse(200, {

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.ts
@@ -13,6 +13,7 @@ import {
   buildMinimaxResourceUrl,
   getMinimaxResourceUrl,
   getMinimaxOauthBaseUrl,
+  normalizeMinimaxVerificationUri,
   toAbsoluteExpiryTimestamp,
   toPollIntervalMs,
   isOAuthTokenBlob,
@@ -123,6 +124,7 @@ export class MinimaxOauthService {
     if (payload.state !== flowId) throw new Error('MiniMax OAuth state mismatch');
     const pollIntervalMs = toPollIntervalMs(payload.interval);
     const expiresAt = toAbsoluteExpiryTimestamp(payload.expired_in);
+    const verificationUri = normalizeMinimaxVerificationUri(payload.verification_uri);
     this.pending.set(flowId, {
       verifier,
       userCode: payload.user_code,
@@ -136,7 +138,7 @@ export class MinimaxOauthService {
     return {
       flowId,
       userCode: payload.user_code,
-      verificationUri: payload.verification_uri,
+      verificationUri,
       expiresAt,
       pollIntervalMs,
     };

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -140,16 +140,37 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   };
 
   const handleStart = async () => {
+    // Open the popup synchronously inside the click handler to keep the
+    // user-gesture flag alive; without this, browsers block the post-await
+    // window.open as a "programmatic popup". noopener can't be used here
+    // because Chrome returns null with it set, and we need the popup ref
+    // to redirect it later — we null `popup.opener` ourselves instead.
+    const popup = window.open('about:blank', '_blank');
+    if (!popup) {
+      toast.error('Popup was blocked by your browser. Allow popups for this site, then try again.');
+      return;
+    }
+    try {
+      popup.opener = null;
+    } catch {
+      // Some sandboxed contexts disallow this; the popup is about:blank, harmless.
+    }
+
     props.setBusy(true);
     const flowGeneration = ++activeFlowGeneration;
     clearPollTimer();
     setStatusMessage(null);
     try {
       const nextFlow = await startMinimaxOAuth(props.agentName, selectedRegion());
-      if (isDisposed || flowGeneration !== activeFlowGeneration) return;
+      if (isDisposed || flowGeneration !== activeFlowGeneration) {
+        popup.close();
+        return;
+      }
+      popup.location.replace(nextFlow.verificationUri);
       setFlow(nextFlow);
       schedulePoll(nextFlow.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS, flowGeneration);
     } catch {
+      popup.close();
       if (isDisposed || flowGeneration !== activeFlowGeneration) return;
       setFlow(null);
     } finally {
@@ -203,28 +224,17 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
             </>
           }
         >
-          {(activeFlow) => (
-            <>
-              <p class="provider-detail__hint">
-                Open the {props.provDef.name} authorization page and approve the request to finish
-                connecting.
+          <>
+            <p class="provider-detail__hint">
+              A new tab opened with the {props.provDef.name} authorization page. Approve the request
+              there to finish connecting.
+            </p>
+            <Show when={statusMessage()}>
+              <p class="provider-detail__hint" style="margin-top: 12px;">
+                {statusMessage()}
               </p>
-              <a
-                class="btn btn--primary provider-detail__action"
-                style="margin-top: 12px;"
-                href={activeFlow().verificationUri}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Open {props.provDef.name}
-              </a>
-              <Show when={statusMessage()}>
-                <p class="provider-detail__hint" style="margin-top: 12px;">
-                  {statusMessage()}
-                </p>
-              </Show>
-            </>
-          )}
+            </Show>
+          </>
         </Show>
       </Show>
       <Show when={props.connected()}>

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -129,9 +129,6 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
       );
     } catch {
       if (isDisposed || flowGeneration !== activeFlowGeneration) return;
-      if (flow()?.flowId !== current.flowId) {
-        return;
-      }
       clearPollTimer();
       setStatusMessage(null);
       setFlow(null);
@@ -150,11 +147,9 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
       toast.error('Popup was blocked by your browser. Allow popups for this site, then try again.');
       return;
     }
-    try {
-      popup.opener = null;
-    } catch {
-      // Some sandboxed contexts disallow this; the popup is about:blank, harmless.
-    }
+    // Defang the opener-attack vector that noopener would normally prevent;
+    // the popup is about:blank (same-origin) so this assignment can't throw.
+    popup.opener = null;
 
     props.setBusy(true);
     const flowGeneration = ++activeFlowGeneration;

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -42,7 +42,6 @@ const DEFAULT_POLL_INTERVAL_MS = 2000;
 const DeviceCodeDetailView: Component<Props> = (props) => {
   const [flow, setFlow] = createSignal<DeviceCodeFlow | null>(null);
   const [statusMessage, setStatusMessage] = createSignal<string | null>(null);
-  const [flowError, setFlowError] = createSignal<string | null>(null);
   const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
   let pollTimer: number | undefined;
   let isDisposed = false;
@@ -92,9 +91,10 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     if (!current) return;
 
     if (Date.now() >= current.expiresAt) {
-      setFlowError('This verification code expired. Start again to generate a new one.');
-      setStatusMessage(null);
       clearPollTimer();
+      setStatusMessage(null);
+      setFlow(null);
+      toast.error('This verification code expired. Start again to generate a new one.');
       return;
     }
 
@@ -116,12 +116,12 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
       if (result.status === 'error') {
         clearPollTimer();
-        setFlowError(result.message ?? 'MiniMax login failed. Start again to retry.');
         setStatusMessage(null);
+        setFlow(null);
+        toast.error(result.message ?? `${props.provDef.name} login failed. Start again to retry.`);
         return;
       }
 
-      setFlowError(null);
       setStatusMessage(result.message ?? 'Waiting for approval…');
       schedulePoll(
         result.pollIntervalMs ?? latest.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
@@ -133,8 +133,9 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
         return;
       }
       clearPollTimer();
-      setFlowError('Failed to check approval status. Start again to retry.');
       setStatusMessage(null);
+      setFlow(null);
+      toast.error('Failed to check approval status. Start again to retry.');
     }
   };
 
@@ -142,13 +143,19 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     props.setBusy(true);
     const flowGeneration = ++activeFlowGeneration;
     clearPollTimer();
-    setFlowError(null);
     setStatusMessage(null);
     try {
       const nextFlow = await startMinimaxOAuth(props.agentName, selectedRegion());
       if (isDisposed || flowGeneration !== activeFlowGeneration) return;
+      const popup = window.open(nextFlow.verificationUri, '_blank', 'noopener,noreferrer');
+      if (!popup) {
+        setFlow(null);
+        toast.error(
+          'Popup was blocked by your browser. Allow popups for this site, then try again.',
+        );
+        return;
+      }
       setFlow(nextFlow);
-      window.open(nextFlow.verificationUri, '_blank', 'noopener,noreferrer');
       schedulePoll(nextFlow.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS, flowGeneration);
     } catch {
       if (isDisposed || flowGeneration !== activeFlowGeneration) return;
@@ -213,11 +220,6 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
               <p class="provider-detail__hint" style="margin-top: 12px;">
                 {statusMessage()}
               </p>
-            </Show>
-            <Show when={flowError()}>
-              <div class="provider-detail__error" style="margin-top: 12px;">
-                {flowError()}
-              </div>
             </Show>
           </>
         </Show>

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -147,14 +147,6 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     try {
       const nextFlow = await startMinimaxOAuth(props.agentName, selectedRegion());
       if (isDisposed || flowGeneration !== activeFlowGeneration) return;
-      const popup = window.open(nextFlow.verificationUri, '_blank', 'noopener,noreferrer');
-      if (!popup) {
-        setFlow(null);
-        toast.error(
-          'Popup was blocked by your browser. Allow popups for this site, then try again.',
-        );
-        return;
-      }
       setFlow(nextFlow);
       schedulePoll(nextFlow.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS, flowGeneration);
     } catch {
@@ -211,17 +203,28 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
             </>
           }
         >
-          <>
-            <p class="provider-detail__hint">
-              A new tab opened with the {props.provDef.name} authorization page. Approve the request
-              there to finish connecting.
-            </p>
-            <Show when={statusMessage()}>
-              <p class="provider-detail__hint" style="margin-top: 12px;">
-                {statusMessage()}
+          {(activeFlow) => (
+            <>
+              <p class="provider-detail__hint">
+                Open the {props.provDef.name} authorization page and approve the request to finish
+                connecting.
               </p>
-            </Show>
-          </>
+              <a
+                class="btn btn--primary provider-detail__action"
+                style="margin-top: 12px;"
+                href={activeFlow().verificationUri}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open {props.provDef.name}
+              </a>
+              <Show when={statusMessage()}>
+                <p class="provider-detail__hint" style="margin-top: 12px;">
+                  {statusMessage()}
+                </p>
+              </Show>
+            </>
+          )}
         </Show>
       </Show>
       <Show when={props.connected()}>

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -15,7 +15,6 @@ import {
   type MinimaxOAuthRegion,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
-import CopyButton from './CopyButton.js';
 
 interface Props {
   provDef: ProviderDef;
@@ -63,12 +62,6 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
       if (isDisposed || flowGeneration !== activeFlowGeneration) return;
       void runPoll(flowGeneration);
     }, delayMs);
-  };
-
-  const openVerificationPage = () => {
-    const current = flow();
-    if (!current) return;
-    window.open(current.verificationUri, '_blank', 'noopener,noreferrer');
   };
 
   const handleDisconnect = async () => {
@@ -211,63 +204,22 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
             </>
           }
         >
-          {(activeFlow) => (
-            <>
-              <p class="provider-detail__hint">
-                Your browser should open to the MiniMax authorization page. If MiniMax asks for a
-                one-time code, enter the code shown below.
+          <>
+            <p class="provider-detail__hint">
+              A new tab opened with the {props.provDef.name} authorization page. Approve the request
+              there to finish connecting.
+            </p>
+            <Show when={statusMessage()}>
+              <p class="provider-detail__hint" style="margin-top: 12px;">
+                {statusMessage()}
               </p>
-              <div class="provider-detail__field" style="margin-top: 12px;">
-                <label class="provider-detail__label">Verification Code</label>
-                <div class="provider-detail__key-row">
-                  <input
-                    class="provider-detail__input provider-detail__input--disabled"
-                    type="text"
-                    value={activeFlow().userCode}
-                    readonly
-                    aria-label={`${props.provDef.name} verification code`}
-                  />
-                  <CopyButton text={activeFlow().userCode} />
-                </div>
+            </Show>
+            <Show when={flowError()}>
+              <div class="provider-detail__error" style="margin-top: 12px;">
+                {flowError()}
               </div>
-              <div class="provider-detail__field" style="margin-top: 12px;">
-                <label class="provider-detail__label">Verification Link</label>
-                <div class="provider-detail__key-row">
-                  <input
-                    class="provider-detail__input provider-detail__input--disabled"
-                    type="text"
-                    value={activeFlow().verificationUri}
-                    readonly
-                    aria-label={`${props.provDef.name} verification link`}
-                  />
-                  <CopyButton text={activeFlow().verificationUri} />
-                </div>
-              </div>
-              <div class="provider-detail__field" style="margin-top: 12px;">
-                <button class="btn btn--outline btn--sm" onClick={openVerificationPage}>
-                  Open verification page
-                </button>
-                <button
-                  class="btn btn--ghost btn--sm"
-                  style="margin-left: 8px;"
-                  disabled={props.busy()}
-                  onClick={handleStart}
-                >
-                  Start over
-                </button>
-              </div>
-              <Show when={statusMessage()}>
-                <p class="provider-detail__hint" style="margin-top: 12px;">
-                  {statusMessage()}
-                </p>
-              </Show>
-              <Show when={flowError()}>
-                <div class="provider-detail__error" style="margin-top: 12px;">
-                  {flowError()}
-                </div>
-              </Show>
-            </>
-          )}
+            </Show>
+          </>
         </Show>
       </Show>
       <Show when={props.connected()}>

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1384,7 +1384,7 @@ describe('ProviderSelectModal', () => {
       expect(screen.getByLabelText('Region')).toBeDefined();
     });
 
-    it('starts MiniMax device-code flow and shows code details', async () => {
+    it('starts MiniMax device-code flow and opens the authorization tab', async () => {
       vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
 
       render(() => (
@@ -1401,8 +1401,7 @@ describe('ProviderSelectModal', () => {
       await waitFor(() => {
         expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
       });
-      expect(screen.getByDisplayValue('ABCD-1234')).toBeDefined();
-      expect(screen.getByDisplayValue('https://www.minimax.io/verify')).toBeDefined();
+      expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       expect(window.open).toHaveBeenCalledWith(
         'https://www.minimax.io/verify',
         '_blank',
@@ -1434,7 +1433,7 @@ describe('ProviderSelectModal', () => {
       vi.restoreAllMocks();
     });
 
-    it('shows MiniMax pending status and can reopen the verification page', async () => {
+    it('shows MiniMax pending status while waiting for approval', async () => {
       vi.useFakeTimers();
       vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
       mockPollMinimaxOAuth.mockResolvedValueOnce({
@@ -1456,7 +1455,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByDisplayValue('ABCD-1234')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1465,14 +1464,6 @@ describe('ProviderSelectModal', () => {
         expect(mockPollMinimaxOAuth).toHaveBeenCalledWith('flow-1');
         expect(screen.getByText('Waiting for MiniMax approval…')).toBeDefined();
       });
-
-      fireEvent.click(screen.getByText('Open verification page'));
-
-      expect(window.open).toHaveBeenLastCalledWith(
-        'https://www.minimax.io/verify',
-        '_blank',
-        'noopener,noreferrer',
-      );
 
       vi.useRealTimers();
       vi.restoreAllMocks();
@@ -1496,7 +1487,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByDisplayValue('ABCD-1234')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1532,7 +1523,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByDisplayValue('ABCD-1234')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1564,7 +1555,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByDisplayValue('ABCD-1234')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1603,7 +1594,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByDisplayValue('EXPIRED-1234')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(1);
@@ -1637,7 +1628,7 @@ describe('ProviderSelectModal', () => {
       await waitFor(() => {
         expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
       });
-      expect(screen.queryByDisplayValue('ABCD-1234')).toBeNull();
+      expect(screen.queryByText(/A new tab opened with the MiniMax/)).toBeNull();
       expect(screen.getByText('Connect with MiniMax')).toBeDefined();
     });
 
@@ -1727,96 +1718,6 @@ describe('ProviderSelectModal', () => {
       expect(mockRevokeOpenaiOAuth).not.toHaveBeenCalled();
     });
 
-    it('ignores stale MiniMax poll results while a replacement flow is still starting', async () => {
-      vi.useFakeTimers();
-      const openSpy = vi
-        .spyOn(window, 'open')
-        .mockReturnValue({ closed: false } as unknown as Window);
-
-      let resolveFirstPoll:
-        | ((value: { status: string; message?: string; pollIntervalMs?: number }) => void)
-        | undefined;
-      let resolveSecondStart:
-        | ((value: {
-            flowId: string;
-            userCode: string;
-            verificationUri: string;
-            expiresAt: number;
-            pollIntervalMs: number;
-          }) => void)
-        | undefined;
-      mockStartMinimaxOAuth
-        .mockResolvedValueOnce({
-          flowId: 'flow-1',
-          userCode: 'ABCD-1234',
-          verificationUri: 'https://www.minimax.io/verify',
-          expiresAt: Date.now() + 60_000,
-          pollIntervalMs: 2000,
-        })
-        .mockImplementationOnce(
-          () =>
-            new Promise((resolve) => {
-              resolveSecondStart = resolve;
-            }),
-        );
-      mockPollMinimaxOAuth.mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
-            resolveFirstPoll = resolve;
-          }),
-      );
-
-      render(() => (
-        <ProviderSelectModal
-          providers={[]}
-          onClose={onClose}
-          onUpdate={onUpdate}
-          agentName="test-agent"
-        />
-      ));
-
-      fireEvent.click(screen.getByText('MiniMax'));
-      fireEvent.click(screen.getByText('Connect with MiniMax'));
-
-      await waitFor(() => {
-        expect(screen.getByDisplayValue('ABCD-1234')).toBeDefined();
-      });
-
-      await vi.advanceTimersByTimeAsync(2000);
-      await waitFor(() => {
-        expect(mockPollMinimaxOAuth).toHaveBeenCalledWith('flow-1');
-      });
-
-      fireEvent.click(screen.getByText('Start over'));
-
-      await waitFor(() => {
-        expect(mockStartMinimaxOAuth).toHaveBeenCalledTimes(2);
-      });
-
-      resolveFirstPoll?.({ status: 'success' });
-      await Promise.resolve();
-      await Promise.resolve();
-
-      expect(onClose).not.toHaveBeenCalled();
-      expect(onUpdate).not.toHaveBeenCalled();
-      expect(screen.getByDisplayValue('ABCD-1234')).toBeDefined();
-
-      resolveSecondStart?.({
-        flowId: 'flow-2',
-        userCode: 'WXYZ-9876',
-        verificationUri: 'https://www.minimax.io/verify-2',
-        expiresAt: Date.now() + 60_000,
-        pollIntervalMs: 2000,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByDisplayValue('WXYZ-9876')).toBeDefined();
-      });
-
-      vi.useRealTimers();
-      openSpy.mockRestore();
-    });
-
     it('stops MiniMax polling after the modal unmounts', async () => {
       vi.useFakeTimers();
       vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
@@ -1844,7 +1745,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByDisplayValue('ABCD-1234')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1384,7 +1384,41 @@ describe('ProviderSelectModal', () => {
       expect(screen.getByLabelText('Region')).toBeDefined();
     });
 
-    it('starts MiniMax device-code flow and renders an Open MiniMax anchor link', async () => {
+    it('opens the popup synchronously then redirects it to the verification URL', async () => {
+      const popup = { close: vi.fn(), opener: {}, location: { replace: vi.fn() } };
+      const openSpy = vi
+        .spyOn(window, 'open')
+        .mockReturnValue(popup as unknown as Window);
+
+      render(() => (
+        <ProviderSelectModal
+          providers={[]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
+      ));
+      fireEvent.click(screen.getByText('MiniMax'));
+      fireEvent.click(screen.getByText('Connect with MiniMax'));
+
+      // Synchronous open with about:blank — preserves user-gesture flag.
+      expect(openSpy).toHaveBeenCalledWith('about:blank', '_blank');
+      expect(popup.opener).toBeNull();
+
+      await waitFor(() => {
+        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
+      });
+      await waitFor(() => {
+        expect(popup.location.replace).toHaveBeenCalledWith('https://www.minimax.io/verify');
+      });
+      expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
+
+      vi.restoreAllMocks();
+    });
+
+    it('toasts when the popup is blocked and skips the start call', async () => {
+      vi.spyOn(window, 'open').mockReturnValue(null);
+
       render(() => (
         <ProviderSelectModal
           providers={[]}
@@ -1397,17 +1431,23 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
+        expect(toast.error).toHaveBeenCalledWith(
+          'Popup was blocked by your browser. Allow popups for this site, then try again.',
+        );
       });
-      const openLink = await screen.findByText('Open MiniMax');
-      expect(openLink.tagName).toBe('A');
-      expect(openLink.getAttribute('href')).toBe('https://www.minimax.io/verify');
-      expect(openLink.getAttribute('target')).toBe('_blank');
-      expect(openLink.getAttribute('rel')).toBe('noopener noreferrer');
+      expect(mockStartMinimaxOAuth).not.toHaveBeenCalled();
+      expect(screen.getByText('Connect with MiniMax')).toBeDefined();
+
+      vi.restoreAllMocks();
     });
 
     it('starts MiniMax device-code flow with the selected region', async () => {
-      vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+      vi.spyOn(window, 'open').mockReturnValue({
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      } as unknown as Window);
 
       render(() => (
         <ProviderSelectModal
@@ -1430,7 +1470,12 @@ describe('ProviderSelectModal', () => {
 
     it('shows MiniMax pending status while waiting for approval', async () => {
       vi.useFakeTimers();
-      vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+      vi.spyOn(window, 'open').mockReturnValue({
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      } as unknown as Window);
       mockPollMinimaxOAuth.mockResolvedValueOnce({
         status: 'pending',
         message: 'Waiting for MiniMax approval…',
@@ -1450,7 +1495,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText('Open MiniMax')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1466,7 +1511,12 @@ describe('ProviderSelectModal', () => {
 
     it('closes the modal when MiniMax approval succeeds', async () => {
       vi.useFakeTimers();
-      vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+      vi.spyOn(window, 'open').mockReturnValue({
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      } as unknown as Window);
       mockPollMinimaxOAuth.mockResolvedValueOnce({ status: 'success' });
 
       render(() => (
@@ -1482,7 +1532,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText('Open MiniMax')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1499,7 +1549,12 @@ describe('ProviderSelectModal', () => {
 
     it('toasts MiniMax poll errors and resets to the connect view', async () => {
       vi.useFakeTimers();
-      vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+      vi.spyOn(window, 'open').mockReturnValue({
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      } as unknown as Window);
       mockPollMinimaxOAuth.mockResolvedValueOnce({
         status: 'error',
         message: 'MiniMax rejected the login',
@@ -1518,7 +1573,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText('Open MiniMax')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1535,7 +1590,12 @@ describe('ProviderSelectModal', () => {
 
     it('toasts a retry message when MiniMax polling throws and resets to the connect view', async () => {
       vi.useFakeTimers();
-      vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+      vi.spyOn(window, 'open').mockReturnValue({
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      } as unknown as Window);
       mockPollMinimaxOAuth.mockRejectedValueOnce(new Error('network error'));
 
       render(() => (
@@ -1551,7 +1611,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText('Open MiniMax')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1569,7 +1629,12 @@ describe('ProviderSelectModal', () => {
 
     it('toasts on expired MiniMax codes and resets to the connect view', async () => {
       vi.useFakeTimers();
-      vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+      vi.spyOn(window, 'open').mockReturnValue({
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      } as unknown as Window);
       mockStartMinimaxOAuth.mockResolvedValueOnce({
         flowId: 'expired-flow',
         userCode: 'EXPIRED-1234',
@@ -1591,7 +1656,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText('Open MiniMax')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(1);
@@ -1609,6 +1674,12 @@ describe('ProviderSelectModal', () => {
     });
 
     it('keeps MiniMax in setup mode when starting the device-code flow fails', async () => {
+      vi.spyOn(window, 'open').mockReturnValue({
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      } as unknown as Window);
       mockStartMinimaxOAuth.mockRejectedValueOnce(new Error('MiniMax unavailable'));
 
       render(() => (
@@ -1626,7 +1697,7 @@ describe('ProviderSelectModal', () => {
       await waitFor(() => {
         expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
       });
-      expect(screen.queryByText('Open MiniMax')).toBeNull();
+      expect(screen.queryByText(/A new tab opened with the MiniMax/)).toBeNull();
       expect(screen.getByText('Connect with MiniMax')).toBeDefined();
     });
 
@@ -1718,7 +1789,12 @@ describe('ProviderSelectModal', () => {
 
     it('stops MiniMax polling after the modal unmounts', async () => {
       vi.useFakeTimers();
-      vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+      vi.spyOn(window, 'open').mockReturnValue({
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      } as unknown as Window);
 
       let resolveFirstPoll:
         | ((value: { status: string; message?: string; pollIntervalMs?: number }) => void)
@@ -1743,7 +1819,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText('Open MiniMax')).toBeDefined();
+        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1787,6 +1787,61 @@ describe('ProviderSelectModal', () => {
       expect(mockRevokeOpenaiOAuth).not.toHaveBeenCalled();
     });
 
+    it('closes the popup if the modal unmounts before startMinimaxOAuth resolves', async () => {
+      const popup = {
+        close: vi.fn(),
+        opener: {},
+        location: { replace: vi.fn() },
+        closed: false,
+      };
+      vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
+
+      let resolveStart:
+        | ((value: {
+            flowId: string;
+            userCode: string;
+            verificationUri: string;
+            expiresAt: number;
+            pollIntervalMs: number;
+          }) => void)
+        | undefined;
+      mockStartMinimaxOAuth.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+
+      const view = render(() => (
+        <ProviderSelectModal
+          providers={[]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
+      ));
+
+      fireEvent.click(screen.getByText('MiniMax'));
+      fireEvent.click(screen.getByText('Connect with MiniMax'));
+
+      view.unmount();
+
+      resolveStart?.({
+        flowId: 'late-flow',
+        userCode: 'L8-T8',
+        verificationUri: 'https://www.minimax.io/verify',
+        expiresAt: Date.now() + 60_000,
+        pollIntervalMs: 2000,
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(popup.close).toHaveBeenCalled();
+      expect(popup.location.replace).not.toHaveBeenCalled();
+
+      vi.restoreAllMocks();
+    });
+
     it('stops MiniMax polling after the modal unmounts', async () => {
       vi.useFakeTimers();
       vi.spyOn(window, 'open').mockReturnValue({

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1502,7 +1502,7 @@ describe('ProviderSelectModal', () => {
       vi.restoreAllMocks();
     });
 
-    it('shows MiniMax poll errors inline', async () => {
+    it('toasts MiniMax poll errors and resets to the connect view', async () => {
       vi.useFakeTimers();
       vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
       mockPollMinimaxOAuth.mockResolvedValueOnce({
@@ -1529,15 +1529,16 @@ describe('ProviderSelectModal', () => {
       await vi.advanceTimersByTimeAsync(2000);
 
       await waitFor(() => {
-        expect(screen.getByText('MiniMax rejected the login')).toBeDefined();
+        expect(toast.error).toHaveBeenCalledWith('MiniMax rejected the login');
       });
+      expect(screen.getByText('Connect with MiniMax')).toBeDefined();
       expect(onClose).not.toHaveBeenCalled();
 
       vi.useRealTimers();
       vi.restoreAllMocks();
     });
 
-    it('shows a retry message when MiniMax polling throws', async () => {
+    it('toasts a retry message when MiniMax polling throws and resets to the connect view', async () => {
       vi.useFakeTimers();
       vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
       mockPollMinimaxOAuth.mockRejectedValueOnce(new Error('network error'));
@@ -1561,16 +1562,17 @@ describe('ProviderSelectModal', () => {
       await vi.advanceTimersByTimeAsync(2000);
 
       await waitFor(() => {
-        expect(
-          screen.getByText('Failed to check approval status. Start again to retry.'),
-        ).toBeDefined();
+        expect(toast.error).toHaveBeenCalledWith(
+          'Failed to check approval status. Start again to retry.',
+        );
       });
+      expect(screen.getByText('Connect with MiniMax')).toBeDefined();
 
       vi.useRealTimers();
       vi.restoreAllMocks();
     });
 
-    it('shows an expiry message instead of polling expired MiniMax codes', async () => {
+    it('toasts on expired MiniMax codes and resets to the connect view', async () => {
       vi.useFakeTimers();
       vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
       mockStartMinimaxOAuth.mockResolvedValueOnce({
@@ -1600,13 +1602,40 @@ describe('ProviderSelectModal', () => {
       await vi.advanceTimersByTimeAsync(1);
 
       await waitFor(() => {
-        expect(
-          screen.getByText('This verification code expired. Start again to generate a new one.'),
-        ).toBeDefined();
+        expect(toast.error).toHaveBeenCalledWith(
+          'This verification code expired. Start again to generate a new one.',
+        );
       });
+      expect(screen.getByText('Connect with MiniMax')).toBeDefined();
       expect(mockPollMinimaxOAuth).not.toHaveBeenCalled();
 
       vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    it('toasts when the popup is blocked and stays on the connect view', async () => {
+      vi.spyOn(window, 'open').mockReturnValue(null);
+
+      render(() => (
+        <ProviderSelectModal
+          providers={[]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
+      ));
+
+      fireEvent.click(screen.getByText('MiniMax'));
+      fireEvent.click(screen.getByText('Connect with MiniMax'));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          'Popup was blocked by your browser. Allow popups for this site, then try again.',
+        );
+      });
+      expect(screen.queryByText(/A new tab opened with the MiniMax/)).toBeNull();
+      expect(screen.getByText('Connect with MiniMax')).toBeDefined();
+
       vi.restoreAllMocks();
     });
 

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1384,9 +1384,7 @@ describe('ProviderSelectModal', () => {
       expect(screen.getByLabelText('Region')).toBeDefined();
     });
 
-    it('starts MiniMax device-code flow and opens the authorization tab', async () => {
-      vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
-
+    it('starts MiniMax device-code flow and renders an Open MiniMax anchor link', async () => {
       render(() => (
         <ProviderSelectModal
           providers={[]}
@@ -1401,14 +1399,11 @@ describe('ProviderSelectModal', () => {
       await waitFor(() => {
         expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
       });
-      expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
-      expect(window.open).toHaveBeenCalledWith(
-        'https://www.minimax.io/verify',
-        '_blank',
-        'noopener,noreferrer',
-      );
-
-      vi.restoreAllMocks();
+      const openLink = await screen.findByText('Open MiniMax');
+      expect(openLink.tagName).toBe('A');
+      expect(openLink.getAttribute('href')).toBe('https://www.minimax.io/verify');
+      expect(openLink.getAttribute('target')).toBe('_blank');
+      expect(openLink.getAttribute('rel')).toBe('noopener noreferrer');
     });
 
     it('starts MiniMax device-code flow with the selected region', async () => {
@@ -1455,7 +1450,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
+        expect(screen.getByText('Open MiniMax')).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1487,7 +1482,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
+        expect(screen.getByText('Open MiniMax')).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1523,7 +1518,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
+        expect(screen.getByText('Open MiniMax')).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1556,7 +1551,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
+        expect(screen.getByText('Open MiniMax')).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);
@@ -1596,7 +1591,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
+        expect(screen.getByText('Open MiniMax')).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(1);
@@ -1610,32 +1605,6 @@ describe('ProviderSelectModal', () => {
       expect(mockPollMinimaxOAuth).not.toHaveBeenCalled();
 
       vi.useRealTimers();
-      vi.restoreAllMocks();
-    });
-
-    it('toasts when the popup is blocked and stays on the connect view', async () => {
-      vi.spyOn(window, 'open').mockReturnValue(null);
-
-      render(() => (
-        <ProviderSelectModal
-          providers={[]}
-          onClose={onClose}
-          onUpdate={onUpdate}
-          agentName="test-agent"
-        />
-      ));
-
-      fireEvent.click(screen.getByText('MiniMax'));
-      fireEvent.click(screen.getByText('Connect with MiniMax'));
-
-      await waitFor(() => {
-        expect(toast.error).toHaveBeenCalledWith(
-          'Popup was blocked by your browser. Allow popups for this site, then try again.',
-        );
-      });
-      expect(screen.queryByText(/A new tab opened with the MiniMax/)).toBeNull();
-      expect(screen.getByText('Connect with MiniMax')).toBeDefined();
-
       vi.restoreAllMocks();
     });
 
@@ -1657,7 +1626,7 @@ describe('ProviderSelectModal', () => {
       await waitFor(() => {
         expect(mockStartMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
       });
-      expect(screen.queryByText(/A new tab opened with the MiniMax/)).toBeNull();
+      expect(screen.queryByText('Open MiniMax')).toBeNull();
       expect(screen.getByText('Connect with MiniMax')).toBeDefined();
     });
 
@@ -1774,7 +1743,7 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect with MiniMax'));
 
       await waitFor(() => {
-        expect(screen.getByText(/A new tab opened with the MiniMax/)).toBeDefined();
+        expect(screen.getByText('Open MiniMax')).toBeDefined();
       });
 
       await vi.advanceTimersByTimeAsync(2000);


### PR DESCRIPTION
### ✨ What changed
- Rewrite MiniMax `/oauth/code` `verification_uri` host from `www.{minimax.io,minimaxi.com}` to `platform.{minimax.io,minimaxi.com}` before returning to the frontend.
- Strip the verification code field, link field, "Open verification page" button, and "Start over" button from the device-code modal.

### 💭 Why
MiniMax `/oauth/code` returns `verification_uri = https://www.minimax.io/oauth-authorize?...`, which 307-redirects to the homepage. Users land on minimax.io with a 6-digit code and nowhere to enter it. The real authorize page lives on `platform.minimax.io` and pre-fills the code from the URL, so the modal's manual code/link UI was redundant once the host was correct.

### 👤 For users
Connecting MiniMax (Token Plan, both regions) now opens the actual authorize page with the code pre-filled. The modal collapses to a single wait line and auto-closes on approval, matching the popup-OAuth providers.

### 📝 Notes
- Closes #1796.
- CN region rewrite (`api.minimaxi.com` → `platform.minimaxi.com`) verified by curl probes (`platform.minimaxi.com/oauth-authorize` → 200, `www.minimaxi.com/oauth-authorize` → 404) and unit test, not via live OAuth.
- Backend tests 46/46 pass on the touched files; frontend 2617/2617 pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix MiniMax device-code OAuth by opening the real authorize page on `platform.*` so the code is pre-filled. The modal now opens a popup synchronously, redirects it, auto-closes on approval, and resets cleanly on errors and unmounts. Fixes #1796.

- **Bug Fixes**
  - Rewrite `verification_uri` from `www.minimax.io`/`www.minimaxi.com` to `platform.minimax.io`/`platform.minimaxi.com` for `/oauth-authorize` only (global and CN), with tests.
  - Open a popup early (`about:blank`) on click, then redirect to the verification URL; on popup blocked, poll error/throw, or code expiry, show a toast and reset to the connect view.
  - Close the popup if the modal unmounts before `startMinimaxOAuth` resolves; add a test and remove redundant guard/try-catch paths.

- **Refactors**
  - Remove verification code/link UI and related buttons; the modal now shows a short wait message and closes automatically on approval.

<sup>Written for commit 0c979653a802a008ba01b35f7656bc7207ca7ccb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

