### PR TITLE
fix: preserve reasoning_content in multi-turn tool-use for DeepSeek, Kimi K2, and OpenCode Go

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -1,4 +1,8 @@
-import { sanitizeOpenAiBody } from '../provider-client-converters';
+import {
+  sanitizeOpenAiBody,
+  supportsReasoningContent,
+  createDeepSeekStreamTransformer,
+} from '../provider-client-converters';
 
 describe('provider-client-converters', () => {
   describe('sanitizeOpenAiBody', () => {
@@ -839,6 +843,304 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('max_completion_tokens', 4096);
       expect(result).not.toHaveProperty('store');
       expect(result).not.toHaveProperty('service_tier');
+    });
+
+    /* ── reasoning_content re-injection via lookup ── */
+
+    it('re-injects reasoning_content via lookup when missing from assistant message', () => {
+      const lookup = jest.fn().mockReturnValue('cached reasoning');
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: 'ok',
+            tool_calls: [
+              { id: 'call_xyz', type: 'function', function: { name: 'f', arguments: '{}' } },
+            ],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).toHaveBeenCalledWith('call_xyz');
+      expect(messages[0]).toHaveProperty('reasoning_content', 'cached reasoning');
+    });
+
+    it('does not re-inject when reasoning_content is already present', () => {
+      const lookup = jest.fn().mockReturnValue('cached');
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: 'ok',
+            reasoning_content: 'existing',
+            tool_calls: [{ id: 'call_xyz', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).not.toHaveBeenCalled();
+      expect(messages[0]).toHaveProperty('reasoning_content', 'existing');
+    });
+
+    it('does not re-inject when there are no tool_calls', () => {
+      const lookup = jest.fn().mockReturnValue('cached');
+      const body = {
+        messages: [{ role: 'assistant', content: 'ok' }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).not.toHaveBeenCalled();
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+
+    it('does not re-inject when lookup returns null', () => {
+      const lookup = jest.fn().mockReturnValue(null);
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: 'ok',
+            tool_calls: [{ id: 'call_xyz', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const messages = result.messages as any[];
+
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+
+    it('does not re-inject for non-deepseek providers even with a lookup', () => {
+      const lookup = jest.fn().mockReturnValue('cached');
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: 'ok',
+            tool_calls: [{ id: 'call_xyz', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'anthropic', 'claude-3', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).not.toHaveBeenCalled();
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+
+    it('does not re-inject when first tool_call id is non-string', () => {
+      const lookup = jest.fn().mockReturnValue('cached');
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: 'ok',
+            tool_calls: [{ id: 12345, type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).not.toHaveBeenCalled();
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+  });
+
+  describe('supportsReasoningContent', () => {
+    it('returns true for deepseek endpoint', () => {
+      expect(supportsReasoningContent('deepseek', 'deepseek-chat')).toBe(true);
+    });
+
+    it('returns true for moonshot endpoint (Kimi K2)', () => {
+      expect(supportsReasoningContent('moonshot', 'kimi-k2')).toBe(true);
+    });
+
+    it('returns true for opencode-go with kimi model', () => {
+      expect(supportsReasoningContent('opencode-go', 'opencode-go/kimi-k2.5')).toBe(true);
+    });
+
+    it('returns true for opencode-go with deepseek model', () => {
+      expect(supportsReasoningContent('opencode-go', 'opencode-go/deepseek-r1')).toBe(true);
+    });
+
+    it('returns true for opencode-go with glm model', () => {
+      expect(supportsReasoningContent('opencode-go', 'opencode-go/glm-5.1')).toBe(true);
+    });
+
+    it('returns false for opencode-go with non-reasoning model', () => {
+      expect(supportsReasoningContent('opencode-go', 'opencode-go/llama-4')).toBe(false);
+    });
+
+    it('returns true for openrouter with deepseek model', () => {
+      expect(supportsReasoningContent('openrouter', 'deepseek/deepseek-r1')).toBe(true);
+    });
+
+    it('returns true for openrouter with moonshotai model', () => {
+      expect(supportsReasoningContent('openrouter', 'moonshotai/kimi-k2')).toBe(true);
+    });
+
+    it('returns false for openrouter with non-deepseek non-moonshot model', () => {
+      expect(supportsReasoningContent('openrouter', 'openai/gpt-4o')).toBe(false);
+    });
+
+    it('returns false for anthropic endpoint', () => {
+      expect(supportsReasoningContent('anthropic', 'claude-3')).toBe(false);
+    });
+
+    it('returns false for openai endpoint', () => {
+      expect(supportsReasoningContent('openai', 'o3')).toBe(false);
+    });
+  });
+
+  describe('createDeepSeekStreamTransformer', () => {
+    it('passes through a plain JSON chunk as SSE', () => {
+      const transformer = createDeepSeekStreamTransformer();
+      const chunk = JSON.stringify({
+        choices: [{ delta: { content: 'hi' }, finish_reason: null }],
+      });
+      expect(transformer(chunk)).toBe(`data: ${chunk}\n\n`);
+    });
+
+    it('accumulates reasoning_content and fires callback on finish_reason tool_calls', () => {
+      const callback = jest.fn();
+      const transformer = createDeepSeekStreamTransformer(callback);
+
+      const chunk1 = JSON.stringify({
+        choices: [{ delta: { reasoning_content: 'I think ' }, finish_reason: null }],
+      });
+      const chunk2 = JSON.stringify({
+        choices: [{ delta: { reasoning_content: 'carefully.' }, finish_reason: null }],
+      });
+      const chunk3 = JSON.stringify({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_abc',
+                  type: 'function',
+                  function: { name: 'f', arguments: '' },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      });
+      const chunk4 = JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] });
+
+      transformer(chunk1);
+      transformer(chunk2);
+      transformer(chunk3);
+      transformer(chunk4);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith('call_abc', 'I think carefully.');
+    });
+
+    it('does not fire callback when there is no reasoning_content', () => {
+      const callback = jest.fn();
+      const transformer = createDeepSeekStreamTransformer(callback);
+
+      const chunk = JSON.stringify({
+        choices: [
+          {
+            delta: { tool_calls: [{ id: 'call_abc', function: {} }] },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      });
+      transformer(chunk);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('does not fire callback when there is no tool call id', () => {
+      const callback = jest.fn();
+      const transformer = createDeepSeekStreamTransformer(callback);
+
+      const chunk1 = JSON.stringify({
+        choices: [{ delta: { reasoning_content: 'thinking' }, finish_reason: null }],
+      });
+      const chunk2 = JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] });
+      transformer(chunk1);
+      transformer(chunk2);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('only fires callback once even if finish_reason appears again', () => {
+      const callback = jest.fn();
+      const transformer = createDeepSeekStreamTransformer(callback);
+
+      const setup = JSON.stringify({
+        choices: [
+          {
+            delta: { reasoning_content: 'r', tool_calls: [{ id: 'call_1', function: {} }] },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      });
+      transformer(setup);
+      transformer(setup); // second call should not fire again
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('captures only the first tool call id across multiple chunks', () => {
+      const callback = jest.fn();
+      const transformer = createDeepSeekStreamTransformer(callback);
+
+      const chunk1 = JSON.stringify({
+        choices: [{ delta: { reasoning_content: 'r' }, finish_reason: null }],
+      });
+      const chunk2 = JSON.stringify({
+        choices: [{ delta: { tool_calls: [{ id: 'call_first' }] }, finish_reason: null }],
+      });
+      const chunk3 = JSON.stringify({
+        choices: [{ delta: { tool_calls: [{ id: 'call_second' }] }, finish_reason: null }],
+      });
+      const chunk4 = JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] });
+
+      transformer(chunk1);
+      transformer(chunk2);
+      transformer(chunk3);
+      transformer(chunk4);
+
+      expect(callback).toHaveBeenCalledWith('call_first', 'r');
+    });
+
+    it('works without a callback (no-op accumulation, still returns chunk)', () => {
+      const transformer = createDeepSeekStreamTransformer();
+      const chunk = JSON.stringify({
+        choices: [
+          {
+            delta: { reasoning_content: 'r', tool_calls: [{ id: 'c' }] },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      });
+      const out = transformer(chunk);
+      expect(out).toBe(`data: ${chunk}\n\n`);
+    });
+
+    it('passes through non-JSON chunks unchanged', () => {
+      const transformer = createDeepSeekStreamTransformer();
+      const result = transformer('not valid json');
+      expect(result).toBe('data: not valid json\n\n');
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -486,6 +486,9 @@ describe('proxy-response-handler', () => {
         convertGoogleStreamChunk: jest.fn(),
         createAnthropicStreamTransformer: jest.fn().mockReturnValue(jest.fn()),
         convertChatGptStreamChunk: jest.fn(),
+        createDeepSeekStreamTransformer: jest
+          .fn()
+          .mockReturnValue(jest.fn().mockReturnValue('data: {}\n\n')),
       };
     }
 
@@ -838,6 +841,100 @@ describe('proxy-response-handler', () => {
 
       // Should not throw — just drops the signatures silently.
       expect(() => capturedTransform!('{}')).not.toThrow();
+    });
+
+    it('should use DeepSeek transformer for deepseek provider streams', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'deepseek', model: 'deepseek-reasoner' });
+
+      await handleStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      expect(client.createDeepSeekStreamTransformer).toHaveBeenCalledWith(undefined);
+      expect(pipeStreamSpy).toHaveBeenCalledWith(
+        forward.response.body,
+        res,
+        expect.any(Function),
+        undefined,
+      );
+    });
+
+    it('wires reasoning cache callback for DeepSeek streams', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'deepseek', model: 'deepseek-reasoner' });
+      const reasoningCache = { store: jest.fn() };
+      const sessionKey = 'sess-ds-stream';
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        sessionKey,
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      const callback = client.createDeepSeekStreamTransformer.mock.calls[0][0];
+      expect(typeof callback).toBe('function');
+      callback('call_ds1', 'I was thinking...');
+      expect(reasoningCache.store).toHaveBeenCalledWith(
+        'sess-ds-stream',
+        'call_ds1',
+        'I was thinking...',
+      );
+    });
+
+    it('DeepSeek chunk transform passes non-null output through toClientChunk', async () => {
+      let capturedTransform: ((chunk: string) => string | null) | undefined;
+      pipeStreamSpy.mockImplementation(
+        (_body: unknown, _res: unknown, transform: (chunk: string) => string | null) => {
+          capturedTransform = transform;
+          return Promise.resolve(null);
+        },
+      );
+
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'deepseek', model: 'deepseek-reasoner' });
+
+      await handleStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      expect(capturedTransform).toBeDefined();
+      // transformer returns a non-null SSE string — expect it wrapped by toClientChunk
+      const out = capturedTransform!('{}');
+      expect(out).toBeTruthy();
+    });
+
+    it('should use DeepSeek transformer for openrouter with deepseek model', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'openrouter', model: 'deepseek/deepseek-r1' });
+
+      await handleStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      expect(client.createDeepSeekStreamTransformer).toHaveBeenCalled();
+    });
+
+    it('should NOT use DeepSeek transformer for openrouter with non-deepseek model', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'openrouter', model: 'openai/gpt-4o' });
+
+      await handleStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      expect(client.createDeepSeekStreamTransformer).not.toHaveBeenCalled();
+      // Falls through to raw passthrough
+      expect(pipeStreamSpy).toHaveBeenCalledWith(forward.response.body, res);
     });
   });
 
@@ -1293,6 +1390,172 @@ describe('proxy-response-handler', () => {
       // _extractedSignatures should be deleted from the response body
       const sentBody = res.json.mock.calls[0][0];
       expect(sentBody._extractedSignatures).toBeUndefined();
+    });
+
+    it('caches reasoning_content from raw OpenAI-compat response when tool_calls present', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const reasoningCache = { store: jest.fn() };
+      const sessionKey = 'sess-ds';
+
+      const body = {
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              reasoning_content: 'I should call the tool.',
+              tool_calls: [
+                { id: 'call_ds1', type: 'function', function: { name: 'f', arguments: '{}' } },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta({ provider: 'deepseek', model: 'deepseek-reasoner' });
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        sessionKey,
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      expect(reasoningCache.store).toHaveBeenCalledWith(
+        'sess-ds',
+        'call_ds1',
+        'I should call the tool.',
+      );
+      // reasoning_content stays in the response body — the client needs it
+      const sentBody = res.json.mock.calls[0][0];
+      expect(sentBody.choices[0].message.reasoning_content).toBe('I should call the tool.');
+    });
+
+    it('does not cache when reasoning_content is absent', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const reasoningCache = { store: jest.fn() };
+
+      const body = {
+        choices: [
+          {
+            message: { role: 'assistant', content: 'hi', tool_calls: [{ id: 'call_1' }] },
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta();
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        'sess',
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      expect(reasoningCache.store).not.toHaveBeenCalled();
+    });
+
+    it('does not cache when tool_calls are absent', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const reasoningCache = { store: jest.fn() };
+
+      const body = {
+        choices: [
+          {
+            message: { role: 'assistant', content: 'hi', reasoning_content: 'r' },
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta();
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        'sess',
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      expect(reasoningCache.store).not.toHaveBeenCalled();
+    });
+
+    it('does not cache when sessionKey is absent', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const reasoningCache = { store: jest.fn() };
+
+      const body = {
+        choices: [
+          {
+            message: {
+              reasoning_content: 'r',
+              tool_calls: [{ id: 'call_1' }],
+            },
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta();
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        undefined, // no sessionKey
+        undefined,
+        'chat_completions',
+        reasoningCache as any,
+      );
+
+      expect(reasoningCache.store).not.toHaveBeenCalled();
+    });
+
+    it('does not cache when reasoningCache is absent', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+
+      const body = {
+        choices: [
+          {
+            message: {
+              reasoning_content: 'r',
+              tool_calls: [{ id: 'call_1' }],
+            },
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta();
+
+      // Should not throw
+      await expect(
+        handleNonStreamResponse(res as any, forward as any, meta, {}, client as any),
+      ).resolves.toBeDefined();
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -5,6 +5,7 @@ import { ProxyMessageDedup } from '../proxy-message-dedup';
 import { IngestEventBusService } from '../../../common/services/ingest-event-bus.service';
 import { ThoughtSignatureCache } from '../thought-signature-cache';
 import { ThinkingBlockCache } from '../thinking-block-cache';
+import { ReasoningContentCache } from '../reasoning-content-cache';
 
 /**
  * Flush enough microtasks for the recorder's fire-and-forget chain to
@@ -162,6 +163,7 @@ describe('ProxyController', () => {
       recorder,
       new ThoughtSignatureCache(),
       new ThinkingBlockCache(),
+      new ReasoningContentCache(),
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -12,6 +12,7 @@ import type { LimitCheckService } from '../../../notifications/services/limit-ch
 import type { ProxyFallbackService } from '../proxy-fallback.service';
 import type { ThoughtSignatureCache } from '../thought-signature-cache';
 import type { ThinkingBlockCache } from '../thinking-block-cache';
+import type { ReasoningContentCache } from '../reasoning-content-cache';
 
 /**
  * Stream-warmup helper is mocked because the real implementation depends on
@@ -54,6 +55,7 @@ describe('ProxyService — orchestration', () => {
   let configService: ConfigService;
   let signatureCache: ThoughtSignatureCache;
   let thinkingCache: ThinkingBlockCache;
+  let reasoningCache: ReasoningContentCache;
   let svc: ProxyService;
 
   beforeEach(() => {
@@ -86,6 +88,9 @@ describe('ProxyService — orchestration', () => {
       retrieve: jest.fn().mockReturnValue(null),
     } as unknown as ThoughtSignatureCache;
     thinkingCache = { retrieve: jest.fn().mockReturnValue(null) } as unknown as ThinkingBlockCache;
+    reasoningCache = {
+      retrieve: jest.fn().mockReturnValue(null),
+    } as unknown as ReasoningContentCache;
 
     svc = new ProxyService(
       resolveService as unknown as ResolveService,
@@ -99,6 +104,7 @@ describe('ProxyService — orchestration', () => {
       configService,
       signatureCache,
       thinkingCache,
+      reasoningCache,
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -1,0 +1,132 @@
+import { ReasoningContentCache } from '../reasoning-content-cache';
+
+describe('ReasoningContentCache', () => {
+  let cache: ReasoningContentCache;
+
+  beforeEach(() => {
+    cache = new ReasoningContentCache();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('stores and retrieves a reasoning_content string', () => {
+    cache.store('session-1', 'call_abc', 'I need to think about this...');
+    expect(cache.retrieve('session-1', 'call_abc')).toBe('I need to think about this...');
+  });
+
+  it('returns null for a non-existent key', () => {
+    expect(cache.retrieve('no-session', 'no-call')).toBeNull();
+  });
+
+  it('store with empty string is a no-op', () => {
+    cache.store('session-1', 'call_abc', '');
+    expect(cache.retrieve('session-1', 'call_abc')).toBeNull();
+  });
+
+  it('returns null and deletes the entry when it has expired', () => {
+    const realNow = Date.now;
+    const baseTime = 1000000000000;
+
+    Date.now = () => baseTime;
+    cache.store('session-1', 'call_abc', 'reasoning');
+
+    Date.now = () => baseTime + 31 * 60 * 1000;
+    expect(cache.retrieve('session-1', 'call_abc')).toBeNull();
+
+    // Entry should be deleted — second retrieve is still null
+    expect(cache.retrieve('session-1', 'call_abc')).toBeNull();
+
+    Date.now = realNow;
+  });
+
+  it('returns the content when it has not yet expired', () => {
+    const realNow = Date.now;
+    const baseTime = 1000000000000;
+
+    Date.now = () => baseTime;
+    cache.store('session-1', 'call_abc', 'reasoning');
+
+    Date.now = () => baseTime + 29 * 60 * 1000;
+    expect(cache.retrieve('session-1', 'call_abc')).toBe('reasoning');
+
+    Date.now = realNow;
+  });
+
+  it('clearSession removes all entries for a given session', () => {
+    cache.store('session-A', 'call_1', 'reasoning-a1');
+    cache.store('session-A', 'call_2', 'reasoning-a2');
+    cache.store('session-B', 'call_1', 'reasoning-b1');
+
+    cache.clearSession('session-A');
+
+    expect(cache.retrieve('session-A', 'call_1')).toBeNull();
+    expect(cache.retrieve('session-A', 'call_2')).toBeNull();
+    expect(cache.retrieve('session-B', 'call_1')).toBe('reasoning-b1');
+  });
+
+  it('clearSession does not throw for a non-existent session', () => {
+    expect(() => cache.clearSession('unknown')).not.toThrow();
+  });
+
+  it('stores entries for multiple sessions independently', () => {
+    cache.store('s1', 'call_1', 'r1');
+    cache.store('s2', 'call_1', 'r2');
+    cache.store('s3', 'call_2', 'r3');
+
+    expect(cache.retrieve('s1', 'call_1')).toBe('r1');
+    expect(cache.retrieve('s2', 'call_1')).toBe('r2');
+    expect(cache.retrieve('s3', 'call_2')).toBe('r3');
+  });
+
+  it('overwrites an existing entry for the same session and tool call id', () => {
+    cache.store('session-1', 'call_1', 'old reasoning');
+    cache.store('session-1', 'call_1', 'new reasoning');
+    expect(cache.retrieve('session-1', 'call_1')).toBe('new reasoning');
+  });
+
+  describe('maybeCleanup (lazy eviction)', () => {
+    it('evicts expired entries when cleanup interval has elapsed', () => {
+      const realNow = Date.now;
+      const baseTime = 1000000000000;
+
+      Date.now = () => baseTime;
+      const localCache = new ReasoningContentCache();
+      localCache.store('s1', 'call_1', 'first');
+
+      // Advance past TTL (30 min) AND cleanup interval (5 min)
+      Date.now = () => baseTime + 31 * 60 * 1000;
+
+      // Store a new entry — this triggers maybeCleanup
+      localCache.store('s2', 'call_2', 'second');
+
+      // Expired entry should have been evicted
+      expect(localCache.retrieve('s1', 'call_1')).toBeNull();
+      // New entry is still valid
+      expect(localCache.retrieve('s2', 'call_2')).toBe('second');
+
+      Date.now = realNow;
+    });
+
+    it('does not evict entries when cleanup interval has not elapsed', () => {
+      const realNow = Date.now;
+      const baseTime = 1000000000000;
+
+      Date.now = () => baseTime;
+      const localCache = new ReasoningContentCache();
+      localCache.store('s1', 'call_1', 'first');
+
+      // Advance only 2 minutes (less than 5 min cleanup interval)
+      Date.now = () => baseTime + 2 * 60 * 1000;
+      localCache.store('s2', 'call_2', 'second');
+
+      // s1 has not expired (only 2 min, TTL is 30 min)
+      expect(localCache.retrieve('s1', 'call_1')).toBe('first');
+      expect(localCache.retrieve('s2', 'call_2')).toBe('second');
+
+      Date.now = realNow;
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -69,7 +69,7 @@ export function createAnthropicTransformer(
 export { toGoogleRequest, toAnthropicRequest, toResponsesRequest, collectChatGptSseResponse };
 export type { GoogleStreamChunkResult } from './google-adapter';
 export type { ThinkingBlocksCallback } from './anthropic-adapter';
-export type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
+export type { SignatureLookup, ThinkingBlockLookup, ReasoningContentLookup } from './proxy-types';
 
 // ─── OpenAI body sanitization (used by ProviderClient.forward) ───────────────
 
@@ -131,29 +131,84 @@ const OPENCODE_GO_REASONING_MODEL_FAMILY_RE =
 /**
  * Some reasoning APIs reject follow-up turns that don't echo back the previous
  * assistant's `reasoning_content`. Preserve it for:
- *  - the native `deepseek` endpoint (always)
- *  - OpenCode Go's known reasoning model families
- *  - aggregator/proxy endpoints whose `deepseek-*` slugs forward to a DeepSeek
- *    engine (OpenRouter `deepseek/*` and user-supplied custom providers).
+ *  - the native `deepseek` and `moonshot` endpoints (always)
+ *  - OpenCode Go's known reasoning model families (kimi, deepseek, glm, etc.)
+ *  - OpenRouter `deepseek/*` slugs and `moonshotai/*` slugs (Kimi K2 via OpenRouter)
+ *  - user-supplied custom providers
  * Strict OpenAI-compatible endpoints (Mistral, native OpenAI, etc.) keep
  * stripping the field even if a community fine-tune slug contains "deepseek".
  */
-function supportsReasoningContent(endpointKey: string, model: string): boolean {
+export function supportsReasoningContent(endpointKey: string, model: string): boolean {
   if (endpointKey === 'deepseek') return true;
+  if (endpointKey === 'moonshot') return true;
   if (!REASONING_CONTENT_AWARE_ENDPOINTS.has(endpointKey)) return false;
-  // Bare model id after stripping any vendor/aggregator prefix:
-  //   "deepseek/r1"             → "r1"            — OpenRouter, not deepseek-family
-  //   "openrouter" + "deepseek/deepseek-r1" → "deepseek-r1" ✓
-  //   "opencode-go/kimi-k2.6" → "kimi-k2.6" ✓
-  //   "custom:<uuid>/deepseek-reasoner" → "deepseek-reasoner" ✓
-  // (proxy-fallback.service strips "custom:<uuid>/" before forward, so in
-  // practice the custom path passes the already-bare model — both shapes
-  // are handled.)
   const bare = model.toLowerCase().split('/').pop() ?? '';
   if (endpointKey === 'opencode-go') {
     return OPENCODE_GO_REASONING_MODEL_FAMILY_RE.test(bare);
   }
-  return bare.includes('deepseek');
+  // openrouter, custom: deepseek family or moonshotai/* (Kimi K2 via OpenRouter)
+  return bare.includes('deepseek') || model.toLowerCase().startsWith('moonshotai/');
+}
+
+/**
+ * Callback fired once per assistant turn when the stream transformer has
+ * assembled the complete reasoning_content. The response handler caches it
+ * keyed by the first tool_call id for re-injection on the next turn.
+ */
+export type ReasoningContentCallback = (firstToolCallId: string, content: string) => void;
+
+/**
+ * Creates a stateful DeepSeek stream transformer that accumulates
+ * reasoning_content across SSE delta chunks and fires a callback when the
+ * turn completes (finish_reason: 'tool_calls'). The chunks are passed
+ * through unchanged so the client still sees the full reasoning chain.
+ *
+ * pipeStream strips the `data: ` prefix before calling the transformer and
+ * expects the returned string to already include it.
+ */
+export function createDeepSeekStreamTransformer(
+  onReasoningContent?: ReasoningContentCallback,
+): (chunk: string) => string | null {
+  let accumulatedReasoning = '';
+  let firstToolCallId: string | null = null;
+  let fired = false;
+
+  const tryFire = () => {
+    if (!fired && onReasoningContent && accumulatedReasoning && firstToolCallId) {
+      onReasoningContent(firstToolCallId, accumulatedReasoning);
+      fired = true;
+    }
+  };
+
+  return (chunk: string): string | null => {
+    try {
+      const parsed = JSON.parse(chunk) as Record<string, unknown>;
+      const choice = (parsed.choices as Array<Record<string, unknown>> | undefined)?.[0];
+      const delta = choice?.delta as Record<string, unknown> | undefined;
+
+      if (delta) {
+        if (typeof delta.reasoning_content === 'string') {
+          accumulatedReasoning += delta.reasoning_content;
+        }
+        const toolCalls = delta.tool_calls as Array<Record<string, unknown>> | undefined;
+        if (Array.isArray(toolCalls)) {
+          for (const tc of toolCalls) {
+            if (firstToolCallId === null && typeof tc.id === 'string' && tc.id) {
+              firstToolCallId = tc.id;
+            }
+          }
+        }
+      }
+
+      if (choice?.finish_reason === 'tool_calls') {
+        tryFire();
+      }
+    } catch {
+      // Pass non-JSON chunks through unchanged
+    }
+
+    return `data: ${chunk}\n\n`;
+  };
 }
 
 /**
@@ -168,7 +223,12 @@ function supportsReasoningDetails(endpointKey: string): boolean {
   return endpointKey === 'openrouter';
 }
 
-function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: string): unknown {
+function sanitizeOpenAiMessages(
+  messages: unknown,
+  endpointKey: string,
+  model: string,
+  reasoningContentLookup?: (firstToolCallId: string) => string | null,
+): unknown {
   if (!Array.isArray(messages)) return messages;
 
   const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
@@ -243,6 +303,23 @@ function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: s
       delete cleaned.reasoning_details;
     }
 
+    // Re-inject cached reasoning_content for reasoning models that require it.
+    // OpenAI-compat clients drop the field when replaying conversation history,
+    // so we cache it on the response path and restore it here.
+    if (
+      preserveReasoningContent &&
+      !cleaned.reasoning_content &&
+      Array.isArray(cleaned.tool_calls) &&
+      cleaned.tool_calls.length > 0 &&
+      reasoningContentLookup
+    ) {
+      const firstToolCallId = (cleaned.tool_calls[0] as Record<string, unknown>).id;
+      if (typeof firstToolCallId === 'string') {
+        const cached = reasoningContentLookup(firstToolCallId);
+        if (cached) cleaned.reasoning_content = cached;
+      }
+    }
+
     if (isMistral && Array.isArray(cleaned.tool_calls)) {
       cleaned.tool_calls = cleaned.tool_calls.map((toolCall) => {
         if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) {
@@ -285,6 +362,7 @@ export function sanitizeOpenAiBody(
   body: Record<string, unknown>,
   endpointKey: string,
   model: string,
+  reasoningContentLookup?: (firstToolCallId: string) => string | null,
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
@@ -302,7 +380,7 @@ export function sanitizeOpenAiBody(
     // would reject the unknown parameter.
     if (key.startsWith('_anthropic')) continue;
     if (key === 'messages') {
-      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model);
+      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model, reasoningContentLookup);
       continue;
     }
     // Rewrite max_tokens → max_completion_tokens for OpenAI-backed endpoints that

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -18,6 +18,7 @@ import {
   convertAnthropicResponse as anthropicResponseConverter,
   convertAnthropicStreamChunk as anthropicStreamChunkConverter,
   createAnthropicTransformer,
+  createDeepSeekStreamTransformer as deepSeekStreamTransformer,
 } from './provider-client-converters';
 import { ForwardOptions } from './proxy-types';
 import { toNativeResponsesRequest } from './responses-adapter';
@@ -121,6 +122,7 @@ export class ProviderClient {
       stream,
       signatureLookup: opts.signatureLookup,
       thinkingLookup: opts.thinkingLookup,
+      reasoningContentLookup: opts.reasoningContentLookup,
     });
 
     const finalHeaders = extraHeaders ? { ...headers, ...extraHeaders } : headers;
@@ -201,6 +203,7 @@ export class ProviderClient {
     stream: boolean;
     signatureLookup?: ForwardOptions['signatureLookup'];
     thinkingLookup?: ForwardOptions['thinkingLookup'];
+    reasoningContentLookup?: ForwardOptions['reasoningContentLookup'];
   }): { url: string; headers: Record<string, string>; requestBody: Record<string, unknown> } {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
     // For non-chat_completions inbound modes ('responses', 'messages'), the
@@ -274,7 +277,12 @@ export class ProviderClient {
     }
 
     // OpenAI-compatible path (default)
-    const sanitized = sanitizeOpenAiBody(requestSource, endpointKey, ctx.model);
+    const sanitized = sanitizeOpenAiBody(
+      requestSource,
+      endpointKey,
+      ctx.model,
+      ctx.reasoningContentLookup,
+    );
     if (stream && SUPPORTS_USAGE_STREAM_OPTIONS.has(endpointKey)) {
       const existing =
         typeof sanitized.stream_options === 'object' && sanitized.stream_options !== null
@@ -339,5 +347,6 @@ export class ProviderClient {
   readonly convertAnthropicResponse = anthropicResponseConverter;
   readonly convertAnthropicStreamChunk = anthropicStreamChunkConverter;
   readonly createAnthropicStreamTransformer = createAnthropicTransformer;
+  readonly createDeepSeekStreamTransformer = deepSeekStreamTransformer;
   readonly collectChatGptSseResponse = chatGptSseCollector;
 }

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -61,7 +61,7 @@ import {
   buildTransportErrorResponse,
   describeTransportError,
 } from './proxy-transport';
-import type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
+import type { SignatureLookup, ThinkingBlockLookup, ReasoningContentLookup } from './proxy-types';
 import type { ProxyApiMode } from './proxy-types';
 
 export interface FailedFallback {
@@ -109,6 +109,7 @@ export class ProxyFallbackService {
     chatBody?: Record<string, unknown>,
     fallbackRoutes?: ModelRoute[] | null,
     paramMergeContext?: ParamMergeContext,
+    reasoningContentLookup?: ReasoningContentLookup,
   ): Promise<{
     success: {
       forward: ForwardResult;
@@ -224,6 +225,7 @@ export class ProxyFallbackService {
         signatureLookup,
         thinkingLookup,
         paramMergeContext,
+        reasoningContentLookup,
       });
 
       if (forward.response.ok) {
@@ -269,6 +271,7 @@ export class ProxyFallbackService {
     signatureLookup?: SignatureLookup;
     thinkingLookup?: ThinkingBlockLookup;
     paramMergeContext?: ParamMergeContext;
+    reasoningContentLookup?: ReasoningContentLookup;
   }): Promise<ForwardResult> {
     try {
       return await this.forwardToProvider(opts);
@@ -307,6 +310,7 @@ export class ProxyFallbackService {
     signatureLookup?: SignatureLookup;
     thinkingLookup?: ThinkingBlockLookup;
     paramMergeContext?: ParamMergeContext;
+    reasoningContentLookup?: ReasoningContentLookup;
   }): Promise<ForwardResult> {
     const {
       provider,
@@ -317,6 +321,7 @@ export class ProxyFallbackService {
       providerRegion,
       signatureLookup,
       thinkingLookup,
+      reasoningContentLookup,
     } = opts;
     // Recompute the param-defaults merge against *this* iteration's provider,
     // not whatever the primary route happened to be. Without this, DeepSeek's
@@ -375,6 +380,7 @@ export class ProxyFallbackService {
       apiMode: opts.apiMode,
       signatureLookup,
       thinkingLookup,
+      reasoningContentLookup,
     });
   }
 }

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -20,9 +20,11 @@ import {
 import type { ProxyApiMode } from './proxy-types';
 import type { ThoughtSignatureCache } from './thought-signature-cache';
 import type { ThinkingBlockCache, ThinkingBlock } from './thinking-block-cache';
+import type { ReasoningContentCache } from './reasoning-content-cache';
 import type { ExtractedSignature } from './google-adapter';
 import type { ExtractedThinkingBlocks } from './anthropic-adapter';
 import type { CallerAttribution } from './caller-classifier';
+import { supportsReasoningContent } from './provider-client-converters';
 
 const logger = new Logger('ProxyResponseHandler');
 
@@ -274,6 +276,7 @@ export async function handleStreamResponse(
   sessionKey?: string,
   thinkingCache?: ThinkingBlockCache,
   apiMode: ProxyApiMode = 'chat_completions',
+  reasoningCache?: ReasoningContentCache,
 ): Promise<StreamUsage | null> {
   initSseHeaders(res, metaHeaders);
 
@@ -331,6 +334,19 @@ export async function handleStreamResponse(
       finalize,
     );
   }
+  if (supportsReasoningContent(meta.provider, meta.model)) {
+    const onReasoningContent =
+      reasoningCache && sessionKey
+        ? (firstToolCallId: string, content: string) => {
+            reasoningCache.store(sessionKey, firstToolCallId, content);
+          }
+        : undefined;
+    const transformer = providerClient.createDeepSeekStreamTransformer(onReasoningContent);
+    return pipeStream(forward.response.body!, res, (chunk) => {
+      const out = transformer(chunk);
+      return out ? toClientChunk(out) : null;
+    }, finalize);
+  }
   if (forward.isChatGpt) {
     return pipeStream(
       forward.response.body!,
@@ -349,6 +365,34 @@ export async function handleStreamResponse(
   return pipeStream(forward.response.body!, res);
 }
 
+/**
+ * Extracts and caches reasoning_content from an OpenAI-compatible response body.
+ * Called for any provider response that may contain reasoning_content alongside
+ * tool_calls — we cache it so it can be re-injected on the next turn when the
+ * client replays the conversation without it.
+ */
+function cacheReasoningContent(
+  responseBody: unknown,
+  cache: ReasoningContentCache | undefined,
+  sessionKey: string | undefined,
+): void {
+  if (!cache || !sessionKey) return;
+  const body = responseBody as Record<string, unknown> | undefined;
+  const choices = body?.choices;
+  if (!Array.isArray(choices) || choices.length === 0) return;
+  const message = (choices[0] as Record<string, unknown>)?.message as
+    | Record<string, unknown>
+    | undefined;
+  if (!message) return;
+  const reasoningContent = message.reasoning_content;
+  if (typeof reasoningContent !== 'string' || !reasoningContent) return;
+  const toolCalls = message.tool_calls;
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return;
+  const firstToolCallId = (toolCalls[0] as Record<string, unknown>).id;
+  if (typeof firstToolCallId !== 'string' || !firstToolCallId) return;
+  cache.store(sessionKey, firstToolCallId, reasoningContent);
+}
+
 /** Reads and converts a non-streaming response, extracting usage data. */
 export async function handleNonStreamResponse(
   res: ExpressResponse,
@@ -360,6 +404,7 @@ export async function handleNonStreamResponse(
   sessionKey?: string,
   thinkingCache?: ThinkingBlockCache,
   apiMode: ProxyApiMode = 'chat_completions',
+  reasoningCache?: ReasoningContentCache,
 ): Promise<StreamUsage | null> {
   let responseBody: unknown;
 
@@ -394,6 +439,7 @@ export async function handleNonStreamResponse(
     responseBody = providerClient.collectChatGptSseResponse(sseText, meta.model);
   } else {
     responseBody = await forward.response.json();
+    cacheReasoningContent(responseBody, reasoningCache, sessionKey);
   }
 
   if (apiMode === 'responses' && !forward.isResponses) {

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -16,6 +16,15 @@ export type SignatureLookup = (toolCallId: string) => string | null;
  * assistant turn; returns the ordered block sequence or null.
  */
 export type ThinkingBlockLookup = (firstToolUseId: string) => ThinkingBlock[] | null;
+
+/**
+ * Optional lookup to re-inject cached reasoning_content values that were
+ * stripped by the client (DeepSeek and compatible providers). Called with
+ * the first tool_call id from the assistant turn; returns the cached
+ * reasoning_content string or null.
+ */
+export type ReasoningContentLookup = (firstToolCallId: string) => string | null;
+
 export type ProxyApiMode = 'chat_completions' | 'responses' | 'messages';
 
 export interface OpenAIMessage {
@@ -47,6 +56,8 @@ export interface ForwardOptions {
   signatureLookup?: SignatureLookup;
   /** Lookup for re-injecting cached thinking blocks (Anthropic only). */
   thinkingLookup?: ThinkingBlockLookup;
+  /** Lookup for re-injecting cached reasoning_content (DeepSeek and compatible providers). */
+  reasoningContentLookup?: ReasoningContentLookup;
 }
 
 /** Options for ProxyService.proxyRequest. */

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -19,6 +19,7 @@ import { ProviderClient } from './provider-client';
 import { ProxyMessageRecorder } from './proxy-message-recorder';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
+import { ReasoningContentCache } from './reasoning-content-cache';
 import { classifyCaller } from './caller-classifier';
 import { sanitizeRequestHeaders } from './request-headers';
 import {
@@ -53,6 +54,7 @@ export class ProxyController {
     private readonly recorder: ProxyMessageRecorder,
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
+    private readonly reasoningCache: ReasoningContentCache,
   ) {}
 
   @Post('chat/completions')
@@ -163,6 +165,7 @@ export class ProxyController {
           sessionKey,
           this.thinkingCache,
           apiMode,
+          this.reasoningCache,
         );
       } else {
         streamUsage = await handleNonStreamResponse(
@@ -175,6 +178,7 @@ export class ProxyController {
           sessionKey,
           this.thinkingCache,
           apiMode,
+          this.reasoningCache,
         );
       }
 

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -22,6 +22,7 @@ import { SessionMomentumService } from './session-momentum.service';
 import { CopilotTokenService } from './copilot-token.service';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
+import { ReasoningContentCache } from './reasoning-content-cache';
 import { ProxyExceptionFilter } from './proxy-exception.filter';
 
 @Module({
@@ -49,6 +50,7 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
     CopilotTokenService,
     ThoughtSignatureCache,
     ThinkingBlockCache,
+    ReasoningContentCache,
     ProxyExceptionFilter,
   ],
 })

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -24,9 +24,11 @@ import {
   ProxyRequestOptions,
   SignatureLookup,
   ThinkingBlockLookup,
+  ReasoningContentLookup,
 } from './proxy-types';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
+import { ReasoningContentCache } from './reasoning-content-cache';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
 import { formatManifestError } from '../../common/errors/error-codes';
 import { peekStream } from './stream-warmup';
@@ -113,6 +115,7 @@ export class ProxyService {
     private readonly config: ConfigService,
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
+    private readonly reasoningCache: ReasoningContentCache,
   ) {}
 
   async proxyRequest(opts: ProxyRequestOptions): Promise<ProxyResult> {
@@ -179,6 +182,8 @@ export class ProxyService {
       this.signatureCache.retrieve(sessionKey, toolCallId);
     const thinkingLookup = (firstToolUseId: string) =>
       this.thinkingCache.retrieve(sessionKey, firstToolUseId);
+    const reasoningContentLookup = (firstToolCallId: string) =>
+      this.reasoningCache.retrieve(sessionKey, firstToolCallId);
 
     // Per-attempt param-defaults merge happens inside the fallback service
     // so each forward (primary + every fallback iteration) re-applies the
@@ -222,6 +227,7 @@ export class ProxyService {
       signatureLookup,
       thinkingLookup,
       paramMergeContext,
+      reasoningContentLookup,
     });
 
     if (!forward.response.ok && shouldTriggerFallback(forward.response.status)) {
@@ -238,6 +244,7 @@ export class ProxyService {
         signal,
         signatureLookup,
         thinkingLookup,
+        reasoningContentLookup,
         apiMode,
         paramMergeContext,
       });
@@ -298,6 +305,7 @@ export class ProxyService {
         signal,
         signatureLookup,
         thinkingLookup,
+        reasoningContentLookup,
         apiMode,
         paramMergeContext,
       });
@@ -415,6 +423,7 @@ export class ProxyService {
     signal?: AbortSignal;
     signatureLookup: SignatureLookup;
     thinkingLookup: ThinkingBlockLookup;
+    reasoningContentLookup: ReasoningContentLookup;
     apiMode: ProxyApiMode;
     paramMergeContext: ParamMergeContext;
   }): Promise<ProxyResult | null> {
@@ -464,6 +473,7 @@ export class ProxyService {
       chatBody,
       fallbackRoutes,
       args.paramMergeContext,
+      args.reasoningContentLookup,
     );
 
     this.recordTierIfScoring(sessionKey, resolved.tier);

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -1,0 +1,61 @@
+const TTL_MS = 30 * 60 * 1000;
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * In-memory cache for DeepSeek (and compatible) reasoning_content strings.
+ *
+ * When a reasoning model returns `reasoning_content` alongside `tool_calls`,
+ * OpenAI-compat clients strip the field when building the conversation history
+ * for the next turn. The provider then rejects the request:
+ *
+ *   "The reasoning_content in the thinking mode must be passed back to the API."
+ *
+ * Manifest caches the reasoning_content here and re-injects it into the
+ * matching assistant message when forwarding the next turn.
+ *
+ * Keyed by `${sessionKey}:${firstToolCallId}` — the first tool_call id from
+ * the assistant turn uniquely identifies it within the session, and the client
+ * echoes those ids back unchanged in subsequent requests.
+ */
+export class ReasoningContentCache {
+  private cache = new Map<string, { content: string; expiresAt: number }>();
+  private lastCleanup = Date.now();
+
+  /** Store the reasoning_content string for an assistant turn. */
+  store(sessionKey: string, firstToolCallId: string, content: string): void {
+    if (!content) return;
+    this.maybeCleanup();
+    this.cache.set(`${sessionKey}:${firstToolCallId}`, {
+      content,
+      expiresAt: Date.now() + TTL_MS,
+    });
+  }
+
+  /** Retrieve the cached reasoning_content, or null if not found/expired. */
+  retrieve(sessionKey: string, firstToolCallId: string): string | null {
+    const entry = this.cache.get(`${sessionKey}:${firstToolCallId}`);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(`${sessionKey}:${firstToolCallId}`);
+      return null;
+    }
+    return entry.content;
+  }
+
+  /** Clear all cached entries for a session. */
+  clearSession(sessionKey: string): void {
+    const prefix = `${sessionKey}:`;
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(prefix)) this.cache.delete(key);
+    }
+  }
+
+  private maybeCleanup(): void {
+    const now = Date.now();
+    if (now - this.lastCleanup < CLEANUP_INTERVAL_MS) return;
+    this.lastCleanup = now;
+    for (const [key, entry] of this.cache) {
+      if (now > entry.expiresAt) this.cache.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

When a reasoning model (DeepSeek, Kimi K2, or similar) responds with both `reasoning_content` and `tool_calls` in the same assistant turn, the next request in the conversation fails with:

> The reasoning_content in the thinking mode must be passed back to the API.

This happens because OpenAI-compatible clients and SDKs treat `reasoning_content` as an unknown field and strip it when they replay the conversation history for the next turn. These providers require the field to be present in every assistant message that had reasoning enabled — so the stripped message causes a hard rejection.

Fixes #1729.

## Solution

This PR applies the **cache-and-reinject pattern** that Manifest already uses for two analogous cases:

- `ThinkingBlockCache` — Anthropic extended thinking blocks
- `ThoughtSignatureCache` — Google thought signatures

A new `ReasoningContentCache` (30-minute TTL, lazy cleanup) stores the `reasoning_content` string from the provider response, keyed by `sessionKey + firstToolCallId`. On the next request, `sanitizeOpenAiMessages` looks up the cache and re-injects the field into any assistant message that has `tool_calls` but is missing `reasoning_content`.

The fix is gated behind `supportsReasoningContent(endpointKey, model)` — currently true for:
- `deepseek` (native endpoint)
- `moonshot` (native endpoint — Kimi K2)
- `opencode-go` — Kimi K2 (`opencode-go/kimi-*`) and DeepSeek (`opencode-go/deepseek-*`) models
- `openrouter` + any model whose name starts with `deepseek/` or `moonshotai/`

All other providers are completely unaffected.

## What changed

| File | Change |
|------|--------|
| `reasoning-content-cache.ts` | New TTL cache class (mirrors `ThinkingBlockCache`) |
| `provider-client-converters.ts` | `supportsReasoningContent()`, `createDeepSeekStreamTransformer()`, re-injection logic in `sanitizeOpenAiMessages` |
| `proxy-response-handler.ts` | Streaming branch + `cacheReasoningContent()` for non-streaming responses |
| `proxy-types.ts` | New `ReasoningContentLookup` type added to `ForwardOptions` |
| `provider-client.ts` | Passes `reasoningContentLookup` through `buildRequest`; exposes `createDeepSeekStreamTransformer` as a property |
| `proxy-fallback.service.ts` | Threads `reasoningContentLookup` through the fallback chain |
| `proxy.service.ts` | Creates the lookup closure from the cache; passes it to the forward and fallback paths |
| `proxy.module.ts` | Registers `ReasoningContentCache` as a provider |
| `proxy.controller.ts` | Injects `ReasoningContentCache`; passes it to stream and non-stream response handlers |
| `__tests__/reasoning-content-cache.spec.ts` | Full unit test suite for the new cache |
| `__tests__/provider-client-converters.spec.ts` | Tests for `supportsReasoningContent`, `createDeepSeekStreamTransformer`, and re-injection logic |
| `__tests__/proxy-response-handler.spec.ts` | Tests for the streaming branch and `cacheReasoningContent` |
| `__tests__/proxy.service.spec.ts` / `proxy.controller.spec.ts` | Updated constructors to include the new cache mock |

## Relationship to PR #1810

PR #1810 addresses the Anthropic endpoint path. This PR is independent and covers the OpenAI-compatible path — DeepSeek native, Kimi K2 native, OpenCode Go (Kimi K2 and DeepSeek models), and all of the above via OpenRouter.
