### PR TITLE
fix(routing): propagate fallback auth_type to recorded success row

### DIFF
--- a/.changeset/fix-fallback-auth-type-cost.md
+++ b/.changeset/fix-fallback-auth-type-cost.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix fallback success rows recording the primary route's `auth_type` instead of the fallback's, which caused `cost_usd` to be miscomputed on mixed-auth chains (subscription fallbacks were charged, api_key fallbacks were stored as $0).

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -422,6 +422,25 @@ describe('proxy-response-handler', () => {
       );
     });
 
+    it('passes meta.primaryAuthType (not meta.auth_type) to recordPrimaryFailure (#1173)', () => {
+      // In a fallback-success flow, meta.auth_type holds the FALLBACK's auth
+      // (used to cost the success row). The primary failure row must instead
+      // carry the PRIMARY's auth_type, which lives on meta.primaryAuthType.
+      const recorder = mockRecorder();
+      const meta = makeMeta({
+        fallbackFromModel: 'claude-sonnet-4',
+        primaryProvider: 'anthropic',
+        auth_type: 'subscription',
+        primaryAuthType: 'api_key',
+      });
+
+      recordFallbackFailures(testCtx, meta, undefined, recorder as any);
+
+      const call = recorder.recordPrimaryFailure.mock.calls[0];
+      // 6th positional arg is `authType` on recordPrimaryFailure.
+      expect(call[5]).toBe('api_key');
+    });
+
     it('leaves primary provider undefined when meta.primaryProvider is not set', () => {
       // Guard against regression: without primaryProvider we must NOT fall
       // back to meta.provider (which is the fallback's provider in this flow).

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -346,6 +346,89 @@ describe('ProxyService — orchestration', () => {
       expect(result.meta.primaryProvider).toBe('openai');
     });
 
+    it('returns the successful fallback auth_type, not the primary auth_type (#1173)', async () => {
+      // Mixed-auth chain: primary openai/api_key fails, fallback
+      // anthropic/subscription succeeds. The recorder reads meta.auth_type to
+      // compute cost_usd (subscription => 0, api_key => priced). Returning
+      // the primary's auth_type here charges or zeros the wrong row.
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: [route('anthropic', 'subscription', 'claude')],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: new Response('rate limited', { status: 429 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      fallbackService.tryFallbacks.mockResolvedValue({
+        success: {
+          forward: {
+            response: okResponse(),
+            isGoogle: false,
+            isAnthropic: true,
+            isChatGpt: false,
+          },
+          model: 'claude',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+          authType: 'subscription',
+        },
+        failures: [],
+      } as never);
+
+      const result = await svc.proxyRequest(baseOpts());
+      // Successful fallback row needs the FALLBACK's auth_type for correct cost.
+      expect(result.meta.auth_type).toBe('subscription');
+      // Primary failure row (recorded later by the response handler) needs the
+      // PRIMARY's auth_type — preserved separately so we don't lose it.
+      expect(result.meta.primaryAuthType).toBe('api_key');
+    });
+
+    it('records the api_key fallback auth_type when a subscription primary fails (#1173 inverse)', async () => {
+      // Inverse of the previous case: subscription primary fails to a billed
+      // api_key fallback. Without the fix, the success row would carry
+      // auth_type=subscription and write cost_usd=0 for what was actually
+      // a paid API call.
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-4o'),
+        fallback_routes: [route('anthropic', 'api_key', 'claude')],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: new Response('subscription expired', { status: 503 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      fallbackService.tryFallbacks.mockResolvedValue({
+        success: {
+          forward: {
+            response: okResponse(),
+            isGoogle: false,
+            isAnthropic: true,
+            isChatGpt: false,
+          },
+          model: 'claude',
+          provider: 'anthropic',
+          fallbackIndex: 0,
+          authType: 'api_key',
+        },
+        failures: [],
+      } as never);
+
+      const result = await svc.proxyRequest(baseOpts());
+      expect(result.meta.auth_type).toBe('api_key');
+      expect(result.meta.primaryAuthType).toBe('subscription');
+    });
+
     it('does not trigger fallback when the primary returns 200', async () => {
       fallbackService.tryForwardToProvider.mockResolvedValue({
         response: okResponse(200),

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -206,6 +206,10 @@ export function recordFallbackFailures(
   const fallbackBaseTime = Date.now();
   const failures = failedFallbacks ?? [];
 
+  // The primary's auth_type is preserved separately on a fallback-success flow
+  // (see RoutingMeta.primaryAuthType / #1173). Older meta shapes only carry
+  // `auth_type`, so fall back to it when primaryAuthType is absent.
+  const primaryAuthType = meta.primaryAuthType ?? meta.auth_type;
   recordSafely(
     recorder.recordPrimaryFailure(
       ctx,
@@ -213,7 +217,7 @@ export function recordFallbackFailures(
       meta.fallbackFromModel,
       meta.primaryErrorBody ?? `Provider returned HTTP ${meta.primaryErrorStatus ?? 500}`,
       new Date(fallbackBaseTime).toISOString(),
-      meta.auth_type,
+      primaryAuthType,
       {
         // Use the primary provider explicitly — meta.provider holds the
         // succeeding fallback's provider in this flow, not the primary's.
@@ -234,7 +238,7 @@ export function recordFallbackFailures(
       recorder.recordFailedFallbacks(ctx, meta.tier, meta.fallbackFromModel, failures, {
         baseTimeMs: fallbackBaseTime,
         markHandled: true,
-        authType: meta.auth_type,
+        authType: primaryAuthType,
         reason: meta.reason,
         callerAttribution,
         requestHeaders,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -69,6 +69,13 @@ export interface RoutingMeta {
    * failure row to the correct vendor.
    */
   primaryProvider?: string;
+  /**
+   * Auth type of the primary model when a fallback ultimately succeeded.
+   * In a fallback-success flow, `auth_type` holds the fallback's auth so
+   * the recorder costs the success row correctly; this field preserves the
+   * primary's auth so the primary-failure row stays accurate too. See #1173.
+   */
+  primaryAuthType?: string;
 }
 
 export interface ProxyResult {
@@ -401,11 +408,13 @@ export class ProxyService {
         forward: success.forward,
         meta: this.buildBaseMeta(resolved, success.model, {
           provider: success.provider,
+          auth_type: success.authType,
           fallbackFromModel: primaryModel,
           fallbackIndex: success.fallbackIndex,
           primaryErrorStatus: primaryStatus,
           primaryErrorBody,
           primaryProvider,
+          primaryAuthType: primaryAuth,
         }),
         failedFallbacks: failures,
       };

--- a/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
+++ b/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
@@ -1,0 +1,240 @@
+/**
+ * End-to-end reproduction for #1173 — fallback success records the wrong
+ * `auth_type` (and therefore the wrong `cost_usd`) when the chain mixes
+ * `api_key` and `subscription` auth.
+ *
+ * Drives a real /v1/chat/completions request through the full proxy stack
+ * (resolver, fallback chain, response handler, recorder) and asserts on the
+ * row that lands in `agent_messages`.
+ */
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import {
+  createTestApp,
+  TEST_AGENT_ID,
+  TEST_OTLP_KEY,
+  TEST_TENANT_ID,
+} from './helpers';
+import { encrypt, getEncryptionSecret } from '../src/common/utils/crypto.util';
+import { ModelPricingCacheService } from '../src/model-prices/model-pricing-cache.service';
+import { PricingSyncService } from '../src/database/pricing-sync.service';
+import { RoutingCacheService } from '../src/routing/routing-core/routing-cache.service';
+
+let app: INestApplication;
+let originalFetch: typeof global.fetch;
+const calls: { url: string; status: number }[] = [];
+
+const PRIMARY_MODEL = 'claude-sonnet-4';
+const FALLBACK_MODEL = 'gpt-4o-mini';
+
+beforeAll(async () => {
+  app = await createTestApp();
+
+  // Pricing for the fallback model — cost computation reads this.
+  const sync = app.get(PricingSyncService);
+  (sync.getAll() as Map<string, { input: number; output: number; contextWindow?: number }>).set(
+    'openai/gpt-4o-mini',
+    { input: 0.00000015, output: 0.0000006, contextWindow: 128000 },
+  );
+  await app.get(ModelPricingCacheService).reload();
+
+  const ds = app.get(DataSource);
+  const secret = getEncryptionSecret();
+  const enc = (s: string) => encrypt(s, secret);
+  const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+
+  // Two real (registry) providers so the cleanup that deactivates unsupported
+  // subscription rows leaves them alone:
+  //   - anthropic / api_key   (primary)
+  //   - openai    / subscription (fallback)
+  await ds.query(
+    `INSERT INTO user_providers
+       (id, user_id, agent_id, provider, auth_type, api_key_encrypted, is_active, connected_at, updated_at, key_prefix, cached_models)
+     VALUES ($1,$2,$3,$4,$5,$6,true,$7,$7,$8,$9)`,
+    [
+      'up-anthropic',
+      TEST_TENANT_ID,
+      TEST_AGENT_ID,
+      'anthropic',
+      'api_key',
+      enc('fake-anthropic-key'),
+      now,
+      'sk-ant',
+      JSON.stringify([
+        {
+          id: PRIMARY_MODEL,
+          displayName: PRIMARY_MODEL,
+          provider: 'anthropic',
+          authType: 'api_key',
+          contextWindow: 200000,
+          inputPricePerToken: 0.000003,
+          outputPricePerToken: 0.000015,
+          qualityScore: 5,
+        },
+      ]),
+    ],
+  );
+  await ds.query(
+    `INSERT INTO user_providers
+       (id, user_id, agent_id, provider, auth_type, api_key_encrypted, is_active, connected_at, updated_at, key_prefix, cached_models)
+     VALUES ($1,$2,$3,$4,$5,$6,true,$7,$7,$8,$9)`,
+    [
+      'up-openai-sub',
+      TEST_TENANT_ID,
+      TEST_AGENT_ID,
+      'openai',
+      'subscription',
+      enc('fake-openai-sub-token'),
+      now,
+      'sk-sub',
+      JSON.stringify([
+        {
+          id: FALLBACK_MODEL,
+          displayName: FALLBACK_MODEL,
+          provider: 'openai',
+          authType: 'subscription',
+          contextWindow: 128000,
+          inputPricePerToken: 0.00000015,
+          outputPricePerToken: 0.0000006,
+          qualityScore: 3,
+        },
+      ]),
+    ],
+  );
+
+  // Wire the default tier with the bug scenario: api_key primary -> subscription fallback.
+  // Tiers are created lazily on first `getTiers()` call, so INSERT (not UPDATE)
+  // and use ON CONFLICT in case another code path beat us to it.
+  await ds.query(
+    `INSERT INTO tier_assignments
+       (id, user_id, agent_id, tier, override_route, auto_assigned_route, fallback_routes, updated_at)
+     VALUES ($1,$2,$3,$4,$5::jsonb,NULL,$6::jsonb,$7)
+     ON CONFLICT (agent_id, tier) DO UPDATE SET
+       override_route = EXCLUDED.override_route,
+       fallback_routes = EXCLUDED.fallback_routes`,
+    [
+      'tier-default',
+      TEST_TENANT_ID,
+      TEST_AGENT_ID,
+      'default',
+      JSON.stringify({ provider: 'anthropic', authType: 'api_key', model: PRIMARY_MODEL }),
+      JSON.stringify([{ provider: 'openai', authType: 'subscription', model: FALLBACK_MODEL }]),
+      now,
+    ],
+  );
+
+  // Disable complexity scoring so the resolver always lands on the default tier
+  // (otherwise the scorer might pick `simple`/`standard` and miss our setup).
+  await ds.query(`UPDATE agents SET complexity_routing_enabled = false WHERE id = $1`, [
+    TEST_AGENT_ID,
+  ]);
+
+  // Stub fetch so the primary upstream returns 503 and the fallback upstream
+  // returns 200 with deterministic token usage.
+  originalFetch = global.fetch;
+  global.fetch = (async (input, init) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    if (url.includes('api.anthropic.com')) {
+      calls.push({ url, status: 503 });
+      return new Response(JSON.stringify({ error: { message: 'overloaded' } }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    // OpenAI subscription routes through chatgpt.com; the Codex backend speaks
+    // SSE Responses-API. Return a minimal SSE payload with usage so the
+    // recorder can compute cost (or zero it, with the fix).
+    if (url.includes('chatgpt.com') || url.includes('api.openai.com')) {
+      calls.push({ url, status: 200 });
+      const sse = [
+        `event: response.created`,
+        `data: ${JSON.stringify({ type: 'response.created', response: { id: 'mock-1', model: FALLBACK_MODEL } })}`,
+        ``,
+        `event: response.completed`,
+        `data: ${JSON.stringify({
+          type: 'response.completed',
+          response: {
+            id: 'mock-1',
+            model: FALLBACK_MODEL,
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'pong' }],
+              },
+            ],
+            usage: {
+              input_tokens: 1000,
+              output_tokens: 500,
+              total_tokens: 1500,
+            },
+          },
+        })}`,
+        ``,
+      ].join('\n');
+      return new Response(sse, {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+    }
+    return originalFetch!(input, init);
+  }) as typeof fetch;
+}, 60000);
+
+afterAll(async () => {
+  if (originalFetch) global.fetch = originalFetch;
+  if (app) await app.close();
+});
+
+describe('Proxy fallback success — auth_type/cost_usd attribution (#1173)', () => {
+  it('records fallback auth_type=subscription and cost_usd=0 on subscription fallback success', async () => {
+    const ds = app.get(DataSource);
+    await ds.query(`DELETE FROM agent_messages WHERE agent_id = $1`, [TEST_AGENT_ID]);
+    calls.length = 0;
+
+    // The seeder + auto-assign warm the routing cache before the test's DB
+    // writes, so flush it now or the resolver keeps using the stale tier.
+    app.get(RoutingCacheService).invalidateAgent(TEST_AGENT_ID);
+
+    await request(app.getHttpServer())
+      .post('/v1/chat/completions')
+      .set('Authorization', `Bearer ${TEST_OTLP_KEY}`)
+      .send({ messages: [{ role: 'user', content: 'hello' }] })
+      .expect(200);
+
+    // recordFallbackSuccess fires off the response — wait for it to flush.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const rows = await ds.query(
+      `SELECT model, provider, auth_type, cost_usd, fallback_from_model, status
+         FROM agent_messages
+        WHERE agent_id = $1
+        ORDER BY timestamp DESC`,
+      [TEST_AGENT_ID],
+    );
+    const success = rows.find((r: { status: string }) => r.status === 'ok');
+    expect(success).toBeDefined();
+    // Without the fix, success.auth_type carried 'api_key' (the primary's)
+    // and cost_usd was computed from token pricing — non-zero.
+    expect(success.auth_type).toBe('subscription');
+    expect(Number(success.cost_usd)).toBe(0);
+    expect(success.fallback_from_model).toBe(PRIMARY_MODEL);
+    expect(success.provider).toBe('openai');
+
+    // The primary failure row should keep the primary's auth_type so cost
+    // dashboards still attribute the failure to the right credential.
+    const primaryFailure = rows.find(
+      (r: { status: string; fallback_from_model: string | null }) =>
+        r.status === 'fallback_error' && r.fallback_from_model === null,
+    );
+    expect(primaryFailure).toBeDefined();
+    expect(primaryFailure.auth_type).toBe('api_key');
+    expect(primaryFailure.model).toBe(PRIMARY_MODEL);
+  });
+});

--- a/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
+++ b/packages/backend/test/proxy-fallback-auth.e2e-spec.ts
@@ -131,7 +131,11 @@ beforeAll(async () => {
   ]);
 
   // Stub fetch so the primary upstream returns 503 and the fallback upstream
-  // returns 200 with deterministic token usage.
+  // returns 200 with deterministic token usage. Match by exact hostname (not
+  // substring) so the rule keeps holding even if the proxy adds query strings
+  // or path segments that happen to share characters with these brand names.
+  const PRIMARY_HOSTS = new Set(['api.anthropic.com']);
+  const FALLBACK_HOSTS = new Set(['chatgpt.com', 'api.openai.com']);
   originalFetch = global.fetch;
   global.fetch = (async (input, init) => {
     const url =
@@ -140,7 +144,13 @@ beforeAll(async () => {
         : input instanceof URL
           ? input.toString()
           : input.url;
-    if (url.includes('api.anthropic.com')) {
+    let hostname = '';
+    try {
+      hostname = new URL(url).hostname;
+    } catch {
+      // Non-absolute URL — fall through to the real fetch.
+    }
+    if (PRIMARY_HOSTS.has(hostname)) {
       calls.push({ url, status: 503 });
       return new Response(JSON.stringify({ error: { message: 'overloaded' } }), {
         status: 503,
@@ -150,7 +160,7 @@ beforeAll(async () => {
     // OpenAI subscription routes through chatgpt.com; the Codex backend speaks
     // SSE Responses-API. Return a minimal SSE payload with usage so the
     // recorder can compute cost (or zero it, with the fix).
-    if (url.includes('chatgpt.com') || url.includes('api.openai.com')) {
+    if (FALLBACK_HOSTS.has(hostname)) {
       calls.push({ url, status: 200 });
       const sse = [
         `event: response.created`,


### PR DESCRIPTION
### 💭 Why
On a fallback-success flow, the recorder was reading the primary route's `auth_type` instead of the fallback's. Mixed-auth chains ended up writing the wrong `cost_usd`: subscription fallbacks were charged like billed calls, and api_key fallbacks were stored as \$0. Closes #1173.

### ✨ What changed
- `ProxyService.tryFallbackChain` now sets `meta.auth_type` from the successful fallback.
- New `RoutingMeta.primaryAuthType` preserves the primary's auth for the primary-failure row.
- `recordFallbackFailures` reads `meta.primaryAuthType ?? meta.auth_type` so the primary failure stays attributed correctly.
- Unit tests cover both directions of the bug (api_key→subscription and subscription→api_key) plus the response-handler hand-off.

### 👤 For users
Cost dashboards stop misattributing fallback rows. Subscription fallbacks read \$0, api_key fallbacks read the real token-priced amount.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misattributed costs on fallback-success flows by recording the fallback’s auth on the success row and preserving the primary’s auth for the failure row. Prevents subscription fallbacks being billed and api_key fallbacks being written as $0.

- **Bug Fixes**
  - Set `meta.auth_type` from the successful fallback in `tryFallbackChain`.
  - Added `RoutingMeta.primaryAuthType` to keep the primary’s auth for the failure row.
  - `recordFallbackFailures` now prefers `meta.primaryAuthType` (falls back to `meta.auth_type`).
  - Added unit and end-to-end tests for mixed-auth fallback attribution and `cost_usd`; updated tests to match upstream by hostname to satisfy CodeQL.

<sup>Written for commit f20265431ac80d839b66d207e7402d28377f976e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

