### PR TITLE
fix: collect function_call items in Responses SSE adapter

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -451,6 +451,35 @@ describe('Responses adapter', () => {
       );
     });
 
+    it('uses response.function_call_arguments.done as the authoritative final arguments', () => {
+      // Some streams skip per-character deltas (e.g. no-argument calls) and
+      // only ship the final argument string via `.arguments.done`.
+      const completed = {
+        id: 'resp_done',
+        object: 'response',
+        output: [],
+        usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+      };
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","id":"fc_d","call_id":"call_d","name":"get_weather"}}',
+        'event: response.function_call_arguments.done\ndata: {"output_index":0,"item_id":"fc_d","arguments":"{\\"city\\":\\"Paris\\"}"}',
+        `event: response.completed\ndata: ${JSON.stringify({ response: completed })}`,
+        '',
+      ].join('\n\n');
+
+      const result = collectResponsesSseResponse(sse);
+      const output = result.output as Array<Record<string, unknown>>;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toEqual(
+        expect.objectContaining({
+          type: 'function_call',
+          id: 'fc_d',
+          arguments: '{"city":"Paris"}',
+        }),
+      );
+    });
+
     it('does not duplicate function_call items already present in completed.output', () => {
       const completed = {
         id: 'resp_4',
@@ -481,6 +510,41 @@ describe('Responses adapter', () => {
       expect(output[0]).toEqual(
         expect.objectContaining({ id: 'fc_4', arguments: '{"city":"Paris"}' }),
       );
+    });
+
+    it('dedupes by call_id when streamed item omits the output id', () => {
+      // Upstream may emit `output_item.added` without `item.id` while still
+      // including the call already in `completed.output`. Without call_id
+      // dedupe we would append a duplicate and the SDK caller would execute
+      // the same tool twice.
+      const completed = {
+        id: 'resp_5',
+        object: 'response',
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_5',
+            call_id: 'call_5',
+            name: 'get_weather',
+            arguments: '{"city":"Paris"}',
+            status: 'completed',
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+      };
+      const sse = [
+        // No `id` on the streamed item — only call_id is reliably present.
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"call_5","name":"get_weather"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"city\\":\\"Paris\\"}"}',
+        `event: response.completed\ndata: ${JSON.stringify({ response: completed })}`,
+        '',
+      ].join('\n\n');
+
+      const result = collectResponsesSseResponse(sse);
+      const output = result.output as Array<Record<string, unknown>>;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toEqual(expect.objectContaining({ id: 'fc_5', call_id: 'call_5' }));
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -348,6 +348,140 @@ describe('Responses adapter', () => {
         }),
       ]);
     });
+
+    it('collects function_call items emitted via output_item.added + arguments.delta', () => {
+      // Codex Responses streams the tool call via item.added + delta events
+      // and ships `response.completed` with `output: []`. Without the SSE
+      // collector picking up these events, the SDK sees an empty output
+      // array even though tokens were billed.
+      const completed = {
+        id: 'resp_1',
+        object: 'response',
+        output: [],
+        usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+      };
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"get_weather","arguments":""}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"city\\":"}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"\\"Paris\\"}"}',
+        `event: response.completed\ndata: ${JSON.stringify({ response: completed })}`,
+        '',
+      ].join('\n\n');
+
+      const result = collectResponsesSseResponse(sse);
+      const output = result.output as Array<Record<string, unknown>>;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toEqual(
+        expect.objectContaining({
+          type: 'function_call',
+          id: 'fc_1',
+          call_id: 'call_1',
+          name: 'get_weather',
+          arguments: '{"city":"Paris"}',
+        }),
+      );
+    });
+
+    it('preserves text output alongside a function call at a non-zero output_index', () => {
+      const completed = {
+        id: 'resp_2',
+        object: 'response',
+        output: [],
+        usage: { input_tokens: 8, output_tokens: 4, total_tokens: 12 },
+      };
+      const sse = [
+        'event: response.output_text.delta\ndata: {"delta":"Let me check."}',
+        'event: response.output_item.added\ndata: {"output_index":1,"item":{"type":"function_call","id":"fc_2","call_id":"call_2","name":"search"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":1,"delta":"{\\"q\\":\\"test\\"}"}',
+        `event: response.completed\ndata: ${JSON.stringify({ response: completed })}`,
+        '',
+      ].join('\n\n');
+
+      const result = collectResponsesSseResponse(sse);
+      const output = result.output as Array<Record<string, unknown>>;
+
+      // Text-then-function order is preserved: text first (added by
+      // withCollectedTextOutput), function_call second.
+      expect(output).toHaveLength(2);
+      expect(output[0]).toEqual(
+        expect.objectContaining({
+          type: 'message',
+          content: [{ type: 'output_text', text: 'Let me check.', annotations: [] }],
+        }),
+      );
+      expect(output[1]).toEqual(
+        expect.objectContaining({
+          type: 'function_call',
+          id: 'fc_2',
+          call_id: 'call_2',
+          name: 'search',
+          arguments: '{"q":"test"}',
+        }),
+      );
+    });
+
+    it('prefers the authoritative item from response.output_item.done', () => {
+      const completed = {
+        id: 'resp_3',
+        object: 'response',
+        output: [],
+        usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+      };
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","id":"fc_3","call_id":"call_3","name":"get_weather"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"city\\":"}',
+        // Truncate the partial deltas — `done` carries the authoritative state.
+        'event: response.output_item.done\ndata: {"output_index":0,"item":{"type":"function_call","id":"fc_3","call_id":"call_3","name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}","status":"completed"}}',
+        `event: response.completed\ndata: ${JSON.stringify({ response: completed })}`,
+        '',
+      ].join('\n\n');
+
+      const result = collectResponsesSseResponse(sse);
+      const output = result.output as Array<Record<string, unknown>>;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toEqual(
+        expect.objectContaining({
+          type: 'function_call',
+          id: 'fc_3',
+          arguments: '{"city":"Paris"}',
+          status: 'completed',
+        }),
+      );
+    });
+
+    it('does not duplicate function_call items already present in completed.output', () => {
+      const completed = {
+        id: 'resp_4',
+        object: 'response',
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_4',
+            call_id: 'call_4',
+            name: 'get_weather',
+            arguments: '{"city":"Paris"}',
+            status: 'completed',
+          },
+        ],
+        usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+      };
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","id":"fc_4","call_id":"call_4","name":"get_weather"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"city\\":\\"Paris\\"}"}',
+        `event: response.completed\ndata: ${JSON.stringify({ response: completed })}`,
+        '',
+      ].join('\n\n');
+
+      const result = collectResponsesSseResponse(sse);
+      const output = result.output as Array<Record<string, unknown>>;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toEqual(
+        expect.objectContaining({ id: 'fc_4', arguments: '{"city":"Paris"}' }),
+      );
+    });
   });
 
   describe('chatCompletionStreamChunkToResponses', () => {

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -451,6 +451,30 @@ describe('Responses adapter', () => {
       );
     });
 
+    it('reads final args from response.function_call_arguments.done with nested item shape', () => {
+      // Documented Responses-API variant: { output_index, item: { arguments } }.
+      const completed = {
+        id: 'resp_done_nested',
+        object: 'response',
+        output: [],
+        usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+      };
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","id":"fc_n","call_id":"call_n","name":"get_weather"}}',
+        'event: response.function_call_arguments.done\ndata: {"output_index":0,"item":{"type":"function_call","id":"fc_n","call_id":"call_n","name":"get_weather","arguments":"{\\"city\\":\\"Paris\\"}"}}',
+        `event: response.completed\ndata: ${JSON.stringify({ response: completed })}`,
+        '',
+      ].join('\n\n');
+
+      const result = collectResponsesSseResponse(sse);
+      const output = result.output as Array<Record<string, unknown>>;
+
+      expect(output).toHaveLength(1);
+      expect(output[0]).toEqual(
+        expect.objectContaining({ id: 'fc_n', arguments: '{"city":"Paris"}' }),
+      );
+    });
+
     it('uses response.function_call_arguments.done as the authoritative final arguments', () => {
       // Some streams skip per-character deltas (e.g. no-argument calls) and
       // only ship the final argument string via `.arguments.done`.

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -347,13 +347,22 @@ export function collectResponsesSseResponse(sseText: string): JsonRecord {
       }
     } else if (parsed.event === 'response.function_call_arguments.done') {
       // Some streams (e.g. no-argument calls) skip deltas and only ship the
-      // final argument string here. Treat it as authoritative.
+      // final argument string here. Two shapes are documented: top-level
+      // `arguments` and a nested `item.arguments`. Treat either as
+      // authoritative.
       const data = safeParse(parsed.data);
       if (!data) continue;
       const idx = typeof data.output_index === 'number' ? data.output_index : 0;
       const fc = functionCalls.get(idx);
-      if (fc && typeof data.arguments === 'string') {
-        fc.arguments = data.arguments;
+      const nestedItem = isRecord(data.item) ? (data.item as JsonRecord) : null;
+      const finalArgs =
+        typeof data.arguments === 'string'
+          ? data.arguments
+          : nestedItem && typeof nestedItem.arguments === 'string'
+            ? (nestedItem.arguments as string)
+            : null;
+      if (fc && finalArgs !== null) {
+        fc.arguments = finalArgs;
       }
     } else if (parsed.event === 'response.output_item.done') {
       const data = safeParse(parsed.data);

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -345,6 +345,16 @@ export function collectResponsesSseResponse(sseText: string): JsonRecord {
         const prev = typeof fc.arguments === 'string' ? fc.arguments : '';
         fc.arguments = prev + data.delta;
       }
+    } else if (parsed.event === 'response.function_call_arguments.done') {
+      // Some streams (e.g. no-argument calls) skip deltas and only ship the
+      // final argument string here. Treat it as authoritative.
+      const data = safeParse(parsed.data);
+      if (!data) continue;
+      const idx = typeof data.output_index === 'number' ? data.output_index : 0;
+      const fc = functionCalls.get(idx);
+      if (fc && typeof data.arguments === 'string') {
+        fc.arguments = data.arguments;
+      }
     } else if (parsed.event === 'response.output_item.done') {
       const data = safeParse(parsed.data);
       const item = isRecord(data?.item) ? (data.item as JsonRecord) : null;
@@ -382,17 +392,23 @@ function withCollectedFunctionCalls(
 ): JsonRecord {
   if (collected.size === 0) return response;
   const existing = Array.isArray(response.output) ? (response.output as JsonRecord[]) : [];
-  const existingIds = new Set(
-    existing
-      .filter(
-        (item) => isRecord(item) && item.type === 'function_call' && typeof item.id === 'string',
-      )
-      .map((item) => item.id as string),
-  );
+  const existingIds = new Set<string>();
+  const existingCallIds = new Set<string>();
+  for (const item of existing) {
+    if (!isRecord(item) || item.type !== 'function_call') continue;
+    if (typeof item.id === 'string' && item.id) existingIds.add(item.id);
+    if (typeof item.call_id === 'string' && item.call_id) existingCallIds.add(item.call_id);
+  }
   const ordered = [...collected.entries()].sort(([a], [b]) => a - b).map(([, v]) => v);
-  const toAdd = ordered.filter(
-    (fc) => !(typeof fc.id === 'string' && fc.id && existingIds.has(fc.id)),
-  );
+  const toAdd = ordered.filter((fc) => {
+    const id = typeof fc.id === 'string' ? fc.id : '';
+    const callId = typeof fc.call_id === 'string' ? fc.call_id : '';
+    if (id && existingIds.has(id)) return false;
+    // Fall back to call_id when item id is missing on either side — upstream
+    // can omit `id` on `output_item.added`, but `call_id` is always present.
+    if (callId && existingCallIds.has(callId)) return false;
+    return true;
+  });
   if (toAdd.length === 0) return response;
   return { ...response, output: [...existing, ...toAdd] };
 }

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -308,6 +308,13 @@ function toResponsesUsage(usage: unknown): JsonRecord | null {
 export function collectResponsesSseResponse(sseText: string): JsonRecord {
   let text = '';
   let completed: JsonRecord | null = null;
+  // Track function_call output items emitted incrementally. Keyed by
+  // `output_index` so a tool call can sit at any position in a mixed-output
+  // stream (e.g. assistant message + function_call). Some Codex Responses
+  // streams emit `response.completed` with `output: []` and surface the call
+  // only via `response.output_item.added` + `.function_call_arguments.delta`,
+  // so dropping these events causes the SDK to see no tool call at all.
+  const functionCalls = new Map<number, JsonRecord>();
 
   for (const event of sseText.split('\n\n')) {
     const parsed = parseSseEvent(event);
@@ -315,14 +322,51 @@ export function collectResponsesSseResponse(sseText: string): JsonRecord {
     if (parsed.event === 'response.output_text.delta') {
       const data = safeParse(parsed.data);
       if (typeof data?.delta === 'string') text += data.delta;
-    }
-    if (parsed.event === 'response.completed') {
+    } else if (parsed.event === 'response.output_item.added') {
+      const data = safeParse(parsed.data);
+      const item = isRecord(data?.item) ? (data.item as JsonRecord) : null;
+      if (item && item.type === 'function_call') {
+        const idx = typeof data?.output_index === 'number' ? data.output_index : functionCalls.size;
+        functionCalls.set(idx, {
+          type: 'function_call',
+          id: typeof item.id === 'string' ? item.id : '',
+          call_id: typeof item.call_id === 'string' ? item.call_id : '',
+          name: typeof item.name === 'string' ? item.name : '',
+          arguments: typeof item.arguments === 'string' ? item.arguments : '',
+          ...(typeof item.status === 'string' ? { status: item.status } : {}),
+        });
+      }
+    } else if (parsed.event === 'response.function_call_arguments.delta') {
+      const data = safeParse(parsed.data);
+      if (!data) continue;
+      const idx = typeof data.output_index === 'number' ? data.output_index : 0;
+      const fc = functionCalls.get(idx);
+      if (fc && typeof data.delta === 'string') {
+        const prev = typeof fc.arguments === 'string' ? fc.arguments : '';
+        fc.arguments = prev + data.delta;
+      }
+    } else if (parsed.event === 'response.output_item.done') {
+      const data = safeParse(parsed.data);
+      const item = isRecord(data?.item) ? (data.item as JsonRecord) : null;
+      if (item && item.type === 'function_call') {
+        const idx = typeof data?.output_index === 'number' ? data.output_index : functionCalls.size;
+        // The `done` event carries the authoritative final item — replace any
+        // partial state we accumulated from `added` + delta events.
+        functionCalls.set(idx, item);
+      }
+    } else if (parsed.event === 'response.completed') {
       const data = safeParse(parsed.data);
       completed = isRecord(data?.response) ? data.response : null;
     }
   }
 
-  if (completed) return withCollectedTextOutput(completed, text);
+  if (completed) {
+    let result = withCollectedTextOutput(completed, text);
+    if (functionCalls.size > 0) {
+      result = withCollectedFunctionCalls(result, functionCalls);
+    }
+    return result;
+  }
   return fromChatCompletionResponse(
     {
       choices: [{ message: { content: text } }],
@@ -330,6 +374,27 @@ export function collectResponsesSseResponse(sseText: string): JsonRecord {
     },
     'unknown',
   );
+}
+
+function withCollectedFunctionCalls(
+  response: JsonRecord,
+  collected: Map<number, JsonRecord>,
+): JsonRecord {
+  if (collected.size === 0) return response;
+  const existing = Array.isArray(response.output) ? (response.output as JsonRecord[]) : [];
+  const existingIds = new Set(
+    existing
+      .filter(
+        (item) => isRecord(item) && item.type === 'function_call' && typeof item.id === 'string',
+      )
+      .map((item) => item.id as string),
+  );
+  const ordered = [...collected.entries()].sort(([a], [b]) => a - b).map(([, v]) => v);
+  const toAdd = ordered.filter(
+    (fc) => !(typeof fc.id === 'string' && fc.id && existingIds.has(fc.id)),
+  );
+  if (toAdd.length === 0) return response;
+  return { ...response, output: [...existing, ...toAdd] };
 }
 
 function withCollectedTextOutput(response: JsonRecord, text: string): JsonRecord {


### PR DESCRIPTION
### ✨ What changed
- `collectResponsesSseResponse` now reads `response.output_item.added`, `response.function_call_arguments.delta`, and `response.output_item.done`.
- Function-call items are merged into the completed response output, sorted by `output_index`, deduped against any items already in `completed.output`.
- 4 new unit tests in `responses-adapter.spec.ts` (basic call, mixed text+call, `output_item.done` authoritative, dedupe).

### 💭 Why
On the `openai-subscription` Responses path, Codex emits function calls only as incremental SSE events and ships `response.completed` with `output: []`. The collector ignored those events, so SDK callers saw `output: []` despite billed tokens. The Chat Completions collector handles them correctly; only the native Responses one was missing.

### 👤 For users
OpenAI SDK clients calling `/v1/responses` with `tools` through a ChatGPT subscription now receive `function_call` items in `response.output`. No more silent drops on the Responses path.

### 📝 Notes
- Closes #1816.
- Verified locally: `c.responses.create(model="auto", tools=[get_weather])` returns `output: [function_call(...)]` instead of `[]`. 50-item production-trace replay with full tool registry returns populated output across all items.
- `npx jest --testPathPattern="routing/proxy"`: 37/37 suites, 1171/1171 tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Responses SSE adapter so function_call items streamed as incremental events are collected and included in response.output. SDK clients using /v1/responses with tools on OpenAI subscriptions now receive populated tool calls instead of an empty output.

- **Bug Fixes**
  - Track function_call items by output_index from `response.output_item.added`.
  - Append argument chunks from `response.function_call_arguments.delta`; treat `response.function_call_arguments.done` as final (supports top-level `arguments` and nested `item.arguments`).
  - Prefer the authoritative item from `response.output_item.done`.
  - Merge collected calls into the completed response in order; dedupe by item `id`, or by `call_id` when ids are missing.
  - Add tests for basic call, mixed text+call, authoritative `output_item.done`, arguments-only `arguments.done`, nested `item.arguments.done`, and `call_id`-based dedupe.

<sup>Written for commit 08ef6c84f8ad9975f33e7cde7a6e07126467e20c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

