### PR TITLE
feat: add Google AI Pro/Ultra subscription support via Code Assist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14829,7 +14829,7 @@
       }
     },
     "packages/manifest": {
-      "version": "6.0.0"
+      "version": "6.0.1"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1385,6 +1385,33 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).not.toHaveBeenCalled();
     });
 
+    it('should bypass live discovery for gemini subscription and surface known models', async () => {
+      mockDecrypt.mockReturnValue(
+        JSON.stringify({
+          t: 'access',
+          r: 'refresh',
+          e: Date.now() + 60_000,
+          u: 'project-1',
+        }),
+      );
+
+      const result = await service.discoverModels(
+        makeProvider({
+          provider: 'gemini',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted-blob',
+        }),
+      );
+
+      const ids = result.map((m) => m.id);
+      // The Code Assist gateway has no public /models endpoint, so we must
+      // never call the fetcher for gemini subscriptions; the curated
+      // SUBSCRIPTION_PROVIDER_CONFIGS list is the source of truth.
+      expect(fetcher.fetch).not.toHaveBeenCalled();
+      expect(ids).toEqual(expect.arrayContaining(['gemini-3.1-pro', 'gemini-2.5-pro']));
+      for (const m of result) expect(m.authType).toBe('subscription');
+    });
+
     it('should exchange Copilot GitHub token before fetching models', async () => {
       mockDecrypt.mockReturnValue('ghu_github_oauth_token');
       mockCopilotTokenService.getCopilotToken.mockResolvedValue('tid=copilot-api-token');
@@ -1593,7 +1620,9 @@ describe('ModelDiscoveryService', () => {
 
   describe('buildSubscriptionFallbackModels', () => {
     it('should return empty for unsupported providers', () => {
-      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'gemini');
+      // Use a provider that is genuinely not in SUBSCRIPTION_PROVIDER_CONFIGS;
+      // mistral has no subscription support, unlike gemini/openai/anthropic.
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'mistral');
       expect(result).toEqual([]);
     });
 
@@ -1847,7 +1876,10 @@ describe('ModelDiscoveryService', () => {
     it('should return raw unchanged for non-subscription providers', () => {
       const raw: DiscoveredModel[] = [makeModel({ id: 'model-1' })];
 
-      const result = supplementWithKnownModels(raw, 'gemini');
+      // mistral isn't in SUBSCRIPTION_PROVIDER_CONFIGS, so the helper should
+      // not supplement anything. (gemini was the historical placeholder, but
+      // it's now a real subscription provider.)
+      const result = supplementWithKnownModels(raw, 'mistral');
 
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('model-1');
@@ -2184,6 +2216,52 @@ describe('ModelDiscoveryService', () => {
       expect(mockPricingSync.getAll).toHaveBeenCalled();
       expect(result).toHaveLength(1);
       expect(result[0].id).toBe('gpt-4o');
+    });
+
+    it('should filter out models confirmed by models.dev to lack tool support', async () => {
+      // Personal AI agents almost always include tools in every request, so
+      // models with `toolCall === false` in models.dev are unusable. Branch
+      // coverage for line 182: the if-true arm of `mdEntry && mdEntry.toolCall === false`.
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'tool-less-model',
+        name: 'Tool-less Model',
+        inputPricePerToken: 0.001,
+        outputPricePerToken: 0.002,
+        toolCall: false,
+      });
+
+      const models = [makeModel({ id: 'tool-less-model' })];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(result).toHaveLength(0);
+    });
+
+    it('should fall back to model contextWindow / displayName when models.dev entry omits them', async () => {
+      // Branch coverage for lines 307-308: `?? model.contextWindow` and
+      // `|| model.displayName` right-hand sides. The mdEntry has a price but
+      // no contextWindow and an empty name string, so the model's own
+      // values must show through.
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'partial-md-entry',
+        name: '', // falsy, so `|| model.displayName` should fire
+        inputPricePerToken: 0.001,
+        outputPricePerToken: 0.002,
+        // contextWindow undefined → `?? model.contextWindow` should fire
+      });
+
+      const models = [
+        makeModel({
+          id: 'partial-md-entry',
+          displayName: 'Original Display',
+          contextWindow: 64321,
+        }),
+      ];
+      fetcher.fetch.mockResolvedValue(models);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(result[0].displayName).toBe('Original Display');
+      expect(result[0].contextWindow).toBe(64321);
     });
 
     it('should skip models.dev fallback when modelsDevSync is null', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -81,6 +81,12 @@ export class ModelDiscoveryService {
             endpointOverride = blob.u;
           }
         }
+      } else if (lowerProvider === 'gemini') {
+        // The Code Assist gateway has no public /models endpoint, so live
+        // discovery isn't possible. Drop the token to fall through to the
+        // subscription-fallback path; `supplementWithKnownModels` then
+        // surfaces the curated Google AI Pro / Ultra whitelist.
+        apiKey = '';
       } else if (lowerProvider === 'copilot' && this.copilotTokenService) {
         try {
           apiKey = await this.copilotTokenService.getCopilotToken(apiKey);

--- a/packages/backend/src/routing/gemini-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/gemini-oauth.controller.spec.ts
@@ -1,0 +1,237 @@
+import { HttpException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { GeminiOauthController } from './oauth/gemini-oauth.controller';
+import { GeminiOauthService } from './oauth/gemini-oauth.service';
+import { ResolveAgentService } from './routing-core/resolve-agent.service';
+import { ProviderKeyService } from './routing-core/provider-key.service';
+import { ProviderService } from './routing-core/provider.service';
+import { Request, Response } from 'express';
+
+describe('GeminiOauthController', () => {
+  let controller: GeminiOauthController;
+  let oauthService: jest.Mocked<GeminiOauthService>;
+  let resolveAgent: jest.Mocked<ResolveAgentService>;
+  let providerKeyService: jest.Mocked<ProviderKeyService>;
+  let providerService: jest.Mocked<ProviderService>;
+  let configService: jest.Mocked<ConfigService>;
+
+  beforeEach(() => {
+    oauthService = {
+      generateAuthorizationUrl: jest.fn(),
+      revokeToken: jest.fn().mockResolvedValue(undefined),
+      exchangeCode: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<GeminiOauthService>;
+
+    resolveAgent = { resolve: jest.fn() } as unknown as jest.Mocked<ResolveAgentService>;
+
+    providerKeyService = {
+      getProviderApiKey: jest.fn(),
+    } as unknown as jest.Mocked<ProviderKeyService>;
+
+    providerService = {
+      removeProvider: jest.fn().mockResolvedValue({ notifications: [] }),
+    } as unknown as jest.Mocked<ProviderService>;
+
+    configService = {
+      get: jest.fn().mockReturnValue(undefined),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    controller = new GeminiOauthController(
+      oauthService,
+      resolveAgent,
+      providerKeyService,
+      providerService,
+      configService,
+    );
+  });
+
+  function buildReq(host = 'localhost:3001'): Request {
+    return {
+      protocol: 'http',
+      get: jest.fn().mockReturnValue(host),
+    } as unknown as Request;
+  }
+
+  describe('authorize', () => {
+    it('returns the authorize URL for a valid agent', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-1' } as never);
+      oauthService.generateAuthorizationUrl.mockResolvedValue(
+        'https://accounts.google.com/o/oauth2/v2/auth?...',
+      );
+
+      const result = await controller.authorize('my-agent', { id: 'u-1' } as never, buildReq());
+
+      expect(resolveAgent.resolve).toHaveBeenCalledWith('u-1', 'my-agent');
+      expect(oauthService.generateAuthorizationUrl).toHaveBeenCalledWith(
+        'agent-1',
+        'u-1',
+        'http://localhost:3001',
+      );
+      expect(result).toEqual({ url: 'https://accounts.google.com/o/oauth2/v2/auth?...' });
+    });
+
+    it('throws 400 when agentName is missing', async () => {
+      await expect(
+        controller.authorize(undefined as unknown as string, { id: 'u-1' } as never, buildReq()),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('throws 400 when agentName is empty', async () => {
+      await expect(controller.authorize('', { id: 'u-1' } as never, buildReq())).rejects.toThrow(
+        HttpException,
+      );
+    });
+
+    it('uses BETTER_AUTH_URL when configured, ignoring Host header', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-1' } as never);
+      oauthService.generateAuthorizationUrl.mockResolvedValue('https://google.example/');
+      configService.get.mockReturnValue('https://manifest.example.com');
+
+      await controller.authorize('my-agent', { id: 'u-1' } as never, buildReq('evil.example'));
+
+      expect(oauthService.generateAuthorizationUrl).toHaveBeenCalledWith(
+        'agent-1',
+        'u-1',
+        'https://manifest.example.com',
+      );
+    });
+
+    it('translates port-in-use into 503', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-1' } as never);
+      oauthService.generateAuthorizationUrl.mockRejectedValue(
+        new Error('Port 1456 is already in use.'),
+      );
+      await expect(
+        controller.authorize('my-agent', { id: 'u-1' } as never, buildReq()),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('uses a generic 503 message when a non-Error is thrown', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-1' } as never);
+      oauthService.generateAuthorizationUrl.mockRejectedValue('string-error');
+      await expect(
+        controller.authorize('my-agent', { id: 'u-1' } as never, buildReq()),
+      ).rejects.toThrow('Failed to start OAuth callback server');
+    });
+  });
+
+  describe('revoke', () => {
+    it('throws 400 when agentName is missing', async () => {
+      await expect(
+        controller.revoke(undefined as unknown as string, { id: 'u-1' } as never),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('revokes both access and refresh tokens', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-1' } as never);
+      const blob = JSON.stringify({
+        t: 'access',
+        r: 'refresh',
+        e: Date.now() + 3_600_000,
+        u: 'proj-1',
+      });
+      providerKeyService.getProviderApiKey.mockResolvedValue(blob);
+
+      const result = await controller.revoke('my-agent', { id: 'u-1' } as never);
+
+      expect(providerKeyService.getProviderApiKey).toHaveBeenCalledWith(
+        'agent-1',
+        'gemini',
+        'subscription',
+      );
+      expect(oauthService.revokeToken).toHaveBeenCalledWith('access');
+      expect(oauthService.revokeToken).toHaveBeenCalledWith('refresh');
+      expect(providerService.removeProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'gemini',
+        'subscription',
+      );
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('returns ok when no token is stored', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-1' } as never);
+      providerKeyService.getProviderApiKey.mockResolvedValue(null);
+
+      const result = await controller.revoke('my-agent', { id: 'u-1' } as never);
+
+      expect(oauthService.revokeToken).not.toHaveBeenCalled();
+      expect(providerService.removeProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'gemini',
+        'subscription',
+      );
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('returns ok when stored value is not valid JSON', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-1' } as never);
+      providerKeyService.getProviderApiKey.mockResolvedValue('not-json');
+
+      const result = await controller.revoke('my-agent', { id: 'u-1' } as never);
+
+      expect(oauthService.revokeToken).not.toHaveBeenCalled();
+      expect(providerService.removeProvider).toHaveBeenCalled();
+      expect(result).toEqual({ ok: true });
+    });
+  });
+
+  describe('callback (POST)', () => {
+    it('exchanges code and returns ok', async () => {
+      const result = await controller.callback('code', 'state', { id: 'u-1' } as never);
+      expect(oauthService.exchangeCode).toHaveBeenCalledWith('state', 'code');
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('throws 400 when code is missing', async () => {
+      await expect(controller.callback('', 'state', { id: 'u-1' } as never)).rejects.toThrow(
+        HttpException,
+      );
+    });
+
+    it('throws 400 when state is missing', async () => {
+      await expect(controller.callback('code', '', { id: 'u-1' } as never)).rejects.toThrow(
+        HttpException,
+      );
+    });
+
+    it('translates Error from exchange into 400', async () => {
+      oauthService.exchangeCode = jest.fn().mockRejectedValue(new Error('Invalid state'));
+      await expect(controller.callback('code', 'bad', { id: 'u-1' } as never)).rejects.toThrow(
+        HttpException,
+      );
+    });
+
+    it('uses generic message when exchange throws a non-Error', async () => {
+      oauthService.exchangeCode = jest.fn().mockRejectedValue('string-error');
+      await expect(controller.callback('code', 'bad', { id: 'u-1' } as never)).rejects.toThrow(
+        'Token exchange failed',
+      );
+    });
+  });
+
+  describe('done', () => {
+    let res: jest.Mocked<Response>;
+
+    beforeEach(() => {
+      res = {
+        setHeader: jest.fn(),
+        send: jest.fn(),
+      } as unknown as jest.Mocked<Response>;
+    });
+
+    it('returns success HTML with nonce-based CSP when ok=1', () => {
+      controller.done('1', res);
+      const cspCall = res.setHeader.mock.calls.find((c) => c[0] === 'Content-Security-Policy');
+      expect(cspCall![1]).toMatch(/^default-src 'none'; script-src 'nonce-[A-Za-z0-9+/=]+'$/);
+      expect(res.send).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-success'));
+    });
+
+    it('returns error HTML with nonce-based CSP when ok=0', () => {
+      controller.done('0', res);
+      const cspCall = res.setHeader.mock.calls.find((c) => c[0] === 'Content-Security-Policy');
+      expect(cspCall![1]).toMatch(/^default-src 'none'; script-src 'nonce-[A-Za-z0-9+/=]+'$/);
+      expect(res.send).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/gemini-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/gemini-oauth.controller.ts
@@ -1,0 +1,137 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Query,
+  Req,
+  Res,
+  Logger,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomBytes } from 'crypto';
+import { Request, Response } from 'express';
+import { Public } from '../../common/decorators/public.decorator';
+import { CurrentUser } from '../../auth/current-user.decorator';
+import { AuthUser } from '../../auth/auth.instance';
+import { GeminiOauthService } from './gemini-oauth.service';
+import { OAuthTokenBlob, oauthDoneHtml } from './openai-oauth.types';
+import { ResolveAgentService } from '../routing-core/resolve-agent.service';
+import { ProviderService } from '../routing-core/provider.service';
+import { ProviderKeyService } from '../routing-core/provider-key.service';
+
+/**
+ * Mirrors {@link OpenaiOauthController} for the Google AI Pro / Ultra
+ * subscription flow. The frontend opens the returned authorize URL in a
+ * popup; the loopback callback server inside {@link GeminiOauthService}
+ * exchanges the code, then redirects to `/api/v1/oauth/gemini/done` so
+ * the popup can postMessage the result back to the dashboard.
+ */
+@Controller('api/v1/oauth/gemini')
+export class GeminiOauthController {
+  private readonly logger = new Logger(GeminiOauthController.name);
+
+  constructor(
+    private readonly oauthService: GeminiOauthService,
+    private readonly resolveAgent: ResolveAgentService,
+    private readonly providerKeyService: ProviderKeyService,
+    private readonly providerService: ProviderService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Get('authorize')
+  async authorize(
+    @Query('agentName') agentName: string,
+    @CurrentUser() user: AuthUser,
+    @Req() req: Request,
+  ) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    // Prefer BETTER_AUTH_URL (operator-controlled) over the request Host header
+    // so a forged Host can't redirect the popup to an attacker-controlled URL.
+    const trustedBackendUrl = this.configService.get<string>('BETTER_AUTH_URL');
+    const backendUrl = trustedBackendUrl || `${req.protocol}://${req.get('host')}`;
+    try {
+      const url = await this.oauthService.generateAuthorizationUrl(agent.id, user.id, backendUrl);
+      return { url };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start OAuth callback server';
+      throw new HttpException(message, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  /**
+   * Revoke the stored Gemini OAuth token at Google (best-effort) and remove
+   * the subscription provider record locally.
+   */
+  @Post('revoke')
+  async revoke(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    const apiKey = await this.providerKeyService.getProviderApiKey(
+      agent.id,
+      'gemini',
+      'subscription',
+    );
+
+    if (apiKey) {
+      try {
+        const blob = JSON.parse(apiKey) as OAuthTokenBlob;
+        // Revoke both tokens — Google treats them as separate revocable
+        // credentials so we explicitly hit each.
+        if (blob.t) await this.oauthService.revokeToken(blob.t);
+        if (blob.r) await this.oauthService.revokeToken(blob.r);
+      } catch {
+        this.logger.warn('Could not parse Gemini OAuth blob for revocation');
+      }
+    }
+
+    await this.providerService.removeProvider(agent.id, 'gemini', 'subscription');
+    return { ok: true };
+  }
+
+  /**
+   * Manual callback used by cloud deployments where the loopback callback
+   * server isn't reachable. The frontend extracts code+state from the
+   * popup's failed redirect and POSTs them here.
+   */
+  @Post('callback')
+  async callback(
+    @Body('code') code: string,
+    @Body('state') state: string,
+    @CurrentUser() _user: AuthUser,
+  ) {
+    if (!code || !state) {
+      throw new HttpException('code and state are required', HttpStatus.BAD_REQUEST);
+    }
+    try {
+      await this.oauthService.exchangeCode(state, code);
+      return { ok: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Token exchange failed';
+      this.logger.error(`Gemini OAuth callback exchange failed: ${message}`);
+      throw new HttpException(message, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  /**
+   * Completion page. The loopback callback server redirects to this route on
+   * the main backend's origin so postMessage / BroadcastChannel reach the
+   * opener (same origin).
+   */
+  @Get('done')
+  @Public()
+  done(@Query('ok') ok: string, @Res() res: Response) {
+    const success = ok === '1';
+    const nonce = randomBytes(16).toString('base64');
+    res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Content-Security-Policy', `default-src 'none'; script-src 'nonce-${nonce}'`);
+    res.send(oauthDoneHtml(success, nonce));
+  }
+}

--- a/packages/backend/src/routing/oauth/gemini-oauth.service.callback.spec.ts
+++ b/packages/backend/src/routing/oauth/gemini-oauth.service.callback.spec.ts
@@ -1,0 +1,439 @@
+/**
+ * Loopback callback-server coverage for {@link GeminiOauthService}. The main
+ * spec uses `nodeEnv: 'production'` to bypass the loopback listener entirely;
+ * here we mock `http.createServer` so we can exercise `ensureCallbackServer`
+ * and `handleCallbackRequest` without binding a real port. Mirrors the
+ * OpenaiOauthService loopback test pattern.
+ */
+import { createServer } from 'http';
+import { ConfigService } from '@nestjs/config';
+import { GeminiOauthService } from './gemini-oauth.service';
+import { ProviderService } from '../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const fetchMock = jest.fn() as jest.Mock<Promise<any>>;
+global.fetch = fetchMock;
+
+jest.mock('http', () => {
+  const actual = jest.requireActual('http');
+  return {
+    ...actual,
+    createServer: jest.fn(() => ({
+      listen: jest.fn((_port: number, _host: string, cb?: () => void) => cb?.()),
+      close: jest.fn(),
+      on: jest.fn(),
+      unref: jest.fn(),
+    })),
+  };
+});
+
+const createServerMock = createServer as unknown as jest.Mock<unknown>;
+
+describe('GeminiOauthService loopback callback server', () => {
+  let service: GeminiOauthService;
+  let providerService: jest.Mocked<ProviderService>;
+  let discoveryService: { discoverModels: jest.Mock };
+
+  beforeEach(() => {
+    providerService = {
+      upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
+      recalculateTiers: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<ProviderService>;
+    discoveryService = { discoverModels: jest.fn().mockResolvedValue([]) };
+    const configService = {
+      get: (key: string) => {
+        if (key === 'app.nodeEnv') return 'development';
+        if (key === 'GOOGLE_GEMINI_CLIENT_ID') return 'test-client';
+        if (key === 'GOOGLE_GEMINI_CLIENT_SECRET') return 'test-secret';
+        return undefined;
+      },
+    } as unknown as ConfigService;
+    service = new GeminiOauthService(
+      providerService,
+      configService,
+      discoveryService as unknown as ModelDiscoveryService,
+    );
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).callbackServer = null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).serverReady = null;
+    createServerMock.mockClear();
+  });
+
+  it('rejects with EADDRINUSE message when port 1456 is taken', async () => {
+    let errorHandler: (err: NodeJS.ErrnoException) => void = () => undefined;
+    createServerMock.mockReturnValueOnce({
+      listen: jest.fn(),
+      close: jest.fn(),
+      on: jest.fn((_event: string, handler: (err: NodeJS.ErrnoException) => void) => {
+        errorHandler = handler;
+      }),
+      unref: jest.fn(),
+    });
+    const promise = service.generateAuthorizationUrl('agent-1', 'user-1');
+    const err = new Error('EADDRINUSE') as NodeJS.ErrnoException;
+    err.code = 'EADDRINUSE';
+    errorHandler(err);
+    await expect(promise).rejects.toThrow(
+      "Port 1456 is already in use. Run 'lsof -i :1456' to find the process.",
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((service as any).callbackServer).toBeNull();
+  });
+
+  it('rejects with a generic message on non-EADDRINUSE server errors', async () => {
+    let errorHandler: (err: NodeJS.ErrnoException) => void = () => undefined;
+    createServerMock.mockReturnValueOnce({
+      listen: jest.fn(),
+      close: jest.fn(),
+      on: jest.fn((_event: string, handler: (err: NodeJS.ErrnoException) => void) => {
+        errorHandler = handler;
+      }),
+      unref: jest.fn(),
+    });
+    const promise = service.generateAuthorizationUrl('agent-1', 'user-1');
+    const err = new Error('boom') as NodeJS.ErrnoException;
+    err.code = 'ECONNREFUSED';
+    errorHandler(err);
+    await expect(promise).rejects.toThrow('Callback server failed: boom');
+  });
+
+  function captureRequestHandler(): { handler: (req: unknown, res: unknown) => void } {
+    const captured: { handler: (req: unknown, res: unknown) => void } = {
+      handler: () => undefined,
+    };
+    createServerMock.mockImplementationOnce((handler: (req: unknown, res: unknown) => void) => {
+      captured.handler = handler;
+      return {
+        listen: jest.fn((_p: number, _h: string, cb?: () => void) => cb?.()),
+        close: jest.fn(),
+        on: jest.fn(),
+        unref: jest.fn(),
+      };
+    });
+    return captured;
+  }
+
+  it('returns 404 for non-callback paths', async () => {
+    const captured = captureRequestHandler();
+    await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler({ url: '/some/other/path' }, res);
+    expect(res.writeHead).toHaveBeenCalledWith(404);
+    expect(res.end).toHaveBeenCalledWith('Not found');
+  });
+
+  it('serves success HTML when token exchange + project discovery succeed', async () => {
+    const captured = captureRequestHandler();
+    const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const state = new URL(url).searchParams.get('state')!;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'tok', refresh_token: 'ref', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ cloudaicompanionProject: 'proj-1' }),
+      });
+
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler({ url: `/oauth/callback?code=the-code&state=${state}` }, res);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-success'));
+  });
+
+  it('serves error HTML when the provider returns an OAuth error param', async () => {
+    const captured = captureRequestHandler();
+    const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const state = new URL(url).searchParams.get('state')!;
+
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler(
+      {
+        url: `/oauth/callback?error=access_denied&error_description=User+denied&state=${state}`,
+      },
+      res,
+    );
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
+    expect(service.getPendingCount()).toBe(0);
+  });
+
+  it('serves error HTML when token exchange fails', async () => {
+    const captured = captureRequestHandler();
+    await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler({ url: '/oauth/callback?code=x&state=invalid-state' }, res);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
+  });
+
+  it('redirects to /api/v1/oauth/gemini/done on the trusted backendUrl when set', async () => {
+    const captured = captureRequestHandler();
+    const url = await service.generateAuthorizationUrl(
+      'agent-1',
+      'user-1',
+      'http://localhost:3001',
+    );
+    const state = new URL(url).searchParams.get('state')!;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'tok', refresh_token: 'ref', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ cloudaicompanionProject: 'proj-1' }),
+      });
+
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler({ url: `/oauth/callback?code=the-code&state=${state}` }, res);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(res.writeHead).toHaveBeenCalledWith(302, {
+      Location: 'http://localhost:3001/api/v1/oauth/gemini/done?ok=1',
+    });
+  });
+
+  it('treats a malformed backendUrl as untrusted (returns inline HTML)', async () => {
+    const captured = captureRequestHandler();
+    // `not a real url` fails URL parsing inside isAllowedRedirectOrigin →
+    // service must not crash and must serve the inline /done HTML response.
+    // The backendUrl is gated through `isAllowedRedirectOrigin` again at
+    // generateAuthorizationUrl time so we go through that ungated path here
+    // by reaching directly into pending state to install the bogus value.
+    await service.generateAuthorizationUrl('agent-1', 'user-1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const pending = (service as any).pending as Map<string, { backendUrl: string }>;
+    const [stateKey] = [...pending.keys()];
+    pending.get(stateKey)!.backendUrl = '::: not a url :::';
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'tok', refresh_token: 'ref', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ cloudaicompanionProject: 'proj-1' }),
+      });
+
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler({ url: `/oauth/callback?code=x&state=${stateKey}` }, res);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+  });
+
+  it('falls back to inline HTML when backendUrl is an external (non-loopback) origin', async () => {
+    const captured = captureRequestHandler();
+    const url = await service.generateAuthorizationUrl(
+      'agent-1',
+      'user-1',
+      'https://evil.example.com',
+    );
+    const state = new URL(url).searchParams.get('state')!;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'tok', refresh_token: 'ref', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ cloudaicompanionProject: 'proj-1' }),
+      });
+
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler({ url: `/oauth/callback?code=the-code&state=${state}` }, res);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-success'));
+  });
+
+  it('shuts the loopback server down once the last pending state resolves', async () => {
+    const captured = captureRequestHandler();
+    const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const state = new URL(url).searchParams.get('state')!;
+    // Snapshot the close mock from the most recent createServer call.
+    const close = (createServerMock.mock.results[0].value as { close: jest.Mock }).close;
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'tok', refresh_token: 'ref', expires_in: 3600 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ cloudaicompanionProject: 'proj-1' }),
+      });
+
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler({ url: `/oauth/callback?code=the-code&state=${state}` }, res);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('redirects with ok=0 to the trusted backendUrl when the OAuth callback errors', async () => {
+    const captured = captureRequestHandler();
+    const url = await service.generateAuthorizationUrl(
+      'agent-1',
+      'user-1',
+      'http://localhost:3001',
+    );
+    const state = new URL(url).searchParams.get('state')!;
+
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    // Provider returned ?error=... — sendDoneResponse must redirect with ok=0
+    // (the failure-redirect arm of the success?'1':'0' ternary).
+    captured.handler({ url: `/oauth/callback?error=access_denied&state=${state}` }, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(302, {
+      Location: 'http://localhost:3001/api/v1/oauth/gemini/done?ok=0',
+    });
+  });
+
+  it('falls back to the OAuth error code when no error_description is provided', async () => {
+    const captured = captureRequestHandler();
+    const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const state = new URL(url).searchParams.get('state')!;
+
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    // No `error_description` — the service must fall back to the bare `error`
+    // value when logging and still serve the inline error HTML.
+    captured.handler({ url: `/oauth/callback?error=access_denied&state=${state}` }, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
+  });
+
+  it('returns 404 when req.url is missing entirely', async () => {
+    const captured = captureRequestHandler();
+    await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    // The defensive `req.url ?? '/'` branch — Node never sets req.url to
+    // undefined in practice, but handleCallbackRequest must still return 404
+    // rather than crash if it ever does.
+    captured.handler({}, res);
+    expect(res.writeHead).toHaveBeenCalledWith(404);
+  });
+
+  it('treats a callback with empty code/state as a token-exchange failure', async () => {
+    // Hits the `?? ''` fallbacks for both the `code` and `state` query params:
+    // when `state` is empty the lookup fails and exchangeCode rejects, which
+    // routes through the failure path of sendDoneResponse.
+    const captured = captureRequestHandler();
+    await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const res = { writeHead: jest.fn(), end: jest.fn() };
+    captured.handler({ url: '/oauth/callback' }, res);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    expect(res.end).toHaveBeenCalledWith(expect.stringContaining('manifest-oauth-error'));
+  });
+
+  it('returns immediately from ensureCallbackServer when callbackServer is already running', async () => {
+    // Hits the `if (this.callbackServer) return Promise.resolve();` early-return
+    // branch (line 356). The first generateAuthorizationUrl creates the server;
+    // the second call must short-circuit because callbackServer is already set.
+    await service.generateAuthorizationUrl('agent-1', 'user-1');
+    expect(createServerMock).toHaveBeenCalledTimes(1);
+    await service.generateAuthorizationUrl('agent-2', 'user-2');
+    // No second createServer call — the existing server is reused.
+    expect(createServerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns immediately from ensureCallbackServer when serverReady is already pending', async () => {
+    // Hits the `if (this.serverReady) return this.serverReady;` early-return
+    // branch (line 357). We start one auth flow (which sets serverReady but
+    // never resolves because we don't fire the listen callback), then start a
+    // second flow that should re-use the same in-flight promise.
+    const listenSpy = jest.fn();
+    createServerMock.mockImplementationOnce(() => ({
+      listen: listenSpy, // never invokes the cb → server never reports ready
+      close: jest.fn(),
+      on: jest.fn(),
+      unref: jest.fn(),
+    }));
+    const firstAuth = service.generateAuthorizationUrl('agent-1', 'user-1');
+    // After the first call, serverReady is set but unresolved.
+    // The second call should *not* call createServer again — the early-return
+    // branch hands back the existing promise.
+    void service.generateAuthorizationUrl('agent-2', 'user-2').catch(() => {
+      // Will never resolve because the first listen never finishes; that's
+      // fine for the branch coverage assertion.
+    });
+    expect(createServerMock).toHaveBeenCalledTimes(1);
+    expect(listenSpy).toHaveBeenCalledTimes(1);
+    // Don't await firstAuth — the Promise is intentionally pending; jest will
+    // tear down the suite without resolving it. Mark it as handled to avoid
+    // an unhandled-rejection warning in case of process teardown ordering.
+    firstAuth.catch(() => undefined);
+  });
+
+  it('skips spinning a callback server when nodeEnv is production', async () => {
+    // Branch at line 87: if app.nodeEnv resolves to 'production', the
+    // service should not call createServer at all.
+    createServerMock.mockClear();
+    const prodService = new GeminiOauthService(
+      providerService,
+      {
+        get: (key: string) => {
+          if (key === 'app.nodeEnv') return 'production';
+          if (key === 'GOOGLE_GEMINI_CLIENT_ID') return 'test-client';
+          if (key === 'GOOGLE_GEMINI_CLIENT_SECRET') return 'test-secret';
+          return undefined;
+        },
+      } as unknown as ConfigService,
+      discoveryService as unknown as ModelDiscoveryService,
+    );
+    await prodService.generateAuthorizationUrl('agent-1', 'user-1');
+    expect(createServerMock).not.toHaveBeenCalled();
+  });
+
+  it('defaults nodeEnv to development when ConfigService returns nothing', async () => {
+    // Line 87 nullish-coalescing branch: when configService.get returns
+    // undefined for app.nodeEnv, the service treats the install as a dev
+    // box and spins up the loopback callback listener.
+    createServerMock.mockClear();
+    const undefService = new GeminiOauthService(
+      providerService,
+      {
+        get: (key: string) => {
+          if (key === 'GOOGLE_GEMINI_CLIENT_ID') return 'test-client';
+          if (key === 'GOOGLE_GEMINI_CLIENT_SECRET') return 'test-secret';
+          return undefined;
+        },
+      } as unknown as ConfigService,
+      discoveryService as unknown as ModelDiscoveryService,
+    );
+    await undefService.generateAuthorizationUrl('agent-1', 'user-1');
+    expect(createServerMock).toHaveBeenCalled();
+  });
+
+  it('treats Code Assist onboarding non-OK response as no project (covers warn branch)', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'tok', refresh_token: 'ref', expires_in: 3600 }),
+      })
+      // loadCodeAssist returns no project
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      // onboardUser returns a non-OK status — should warn and return ''
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => '' });
+
+    const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
+    const state = new URL(url).searchParams.get('state')!;
+    await service.exchangeCode(state, 'code');
+    const stored = (providerService.upsertProvider as jest.Mock).mock.calls[0][3] as string;
+    expect(stored).not.toContain('"u":');
+  });
+});

--- a/packages/backend/src/routing/oauth/gemini-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/gemini-oauth.service.spec.ts
@@ -1,0 +1,519 @@
+import { ConfigService } from '@nestjs/config';
+import { GeminiOauthService, pickOnboardTierId } from './gemini-oauth.service';
+import { ProviderService } from '../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+
+const originalFetch = global.fetch;
+
+function mockResponse(status: number, body: unknown, text = ''): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => text || JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function createConfig(overrides: Record<string, string | undefined> = {}): ConfigService {
+  return {
+    get: (key: string) => {
+      if (key in overrides) return overrides[key];
+      if (key === 'app.nodeEnv') return 'production';
+      return undefined;
+    },
+  } as unknown as ConfigService;
+}
+
+function createProviderService() {
+  const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
+  const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  return {
+    svc: { upsertProvider, recalculateTiers } as unknown as ProviderService,
+    upsertProvider,
+    recalculateTiers,
+  };
+}
+
+function createDiscovery() {
+  const discoverModels = jest.fn().mockResolvedValue(undefined);
+  return { svc: { discoverModels } as unknown as ModelDiscoveryService, discoverModels };
+}
+
+describe('GeminiOauthService', () => {
+  let fetchMock: jest.Mock;
+  let providerService: ReturnType<typeof createProviderService>;
+  let discovery: ReturnType<typeof createDiscovery>;
+  let svc: GeminiOauthService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    providerService = createProviderService();
+    discovery = createDiscovery();
+    svc = new GeminiOauthService(
+      providerService.svc,
+      createConfig({
+        GOOGLE_GEMINI_CLIENT_ID: 'test-client',
+        GOOGLE_GEMINI_CLIENT_SECRET: 'test-secret',
+      }),
+      discovery.svc,
+    );
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('generateAuthorizationUrl', () => {
+    it('builds an OAuth URL with PKCE, offline access, and a fresh state', async () => {
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const parsed = new URL(url);
+      expect(parsed.origin + parsed.pathname).toBe('https://accounts.google.com/o/oauth2/v2/auth');
+      expect(parsed.searchParams.get('response_type')).toBe('code');
+      expect(parsed.searchParams.get('access_type')).toBe('offline');
+      expect(parsed.searchParams.get('prompt')).toBe('consent');
+      expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(parsed.searchParams.get('code_challenge')?.length).toBeGreaterThan(0);
+      expect(parsed.searchParams.get('redirect_uri')).toBe('http://localhost:1456/oauth/callback');
+      expect(parsed.searchParams.get('scope')).toContain('cloud-platform');
+      expect(svc.getPendingCount()).toBe(1);
+    });
+
+    it('uses operator-supplied client credentials when env vars are set', async () => {
+      const customSvc = new GeminiOauthService(
+        providerService.svc,
+        createConfig({
+          GOOGLE_GEMINI_CLIENT_ID: 'override-client',
+          GOOGLE_GEMINI_CLIENT_SECRET: 'override-secret',
+        }),
+        discovery.svc,
+      );
+      const url = await customSvc.generateAuthorizationUrl('a', 'u');
+      expect(new URL(url).searchParams.get('client_id')).toBe('override-client');
+    });
+
+    it('throws a helpful error when neither client id nor secret is configured', async () => {
+      const unconfigured = new GeminiOauthService(
+        providerService.svc,
+        createConfig(),
+        discovery.svc,
+      );
+      expect(unconfigured.isConfigured()).toBe(false);
+      await expect(unconfigured.generateAuthorizationUrl('a', 'u')).rejects.toThrow(
+        /GOOGLE_GEMINI_CLIENT_ID/,
+      );
+    });
+
+    it('purges expired pending states on each call', async () => {
+      await svc.generateAuthorizationUrl('a1', 'u1');
+      jest.advanceTimersByTime(10 * 60 * 1000 + 1);
+      await svc.generateAuthorizationUrl('a2', 'u2');
+      expect(svc.getPendingCount()).toBe(1);
+    });
+  });
+
+  describe('exchangeCode', () => {
+    it('rejects unknown states', async () => {
+      await expect(svc.exchangeCode('bogus', 'code')).rejects.toThrow(
+        'Invalid or expired OAuth state',
+      );
+    });
+
+    it('rejects (and purges) expired states', async () => {
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      jest.advanceTimersByTime(10 * 60 * 1000 + 1);
+      await expect(svc.exchangeCode(state, 'code')).rejects.toThrow('OAuth state expired');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('exchanges a code, discovers the project id, and stores the blob', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            access_token: 'access-1',
+            refresh_token: 'refresh-1',
+            expires_in: 3600,
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse(200, { cloudaicompanionProject: 'proj-42', currentTier: { id: 'PRO' } }),
+        );
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+
+      await svc.exchangeCode(state, 'auth-code');
+
+      const [tokenUrl, init] = fetchMock.mock.calls[0];
+      expect(tokenUrl).toBe('https://oauth2.googleapis.com/token');
+      const tokenBody = new URLSearchParams(init.body.toString());
+      expect(tokenBody.get('grant_type')).toBe('authorization_code');
+      expect(tokenBody.get('code')).toBe('auth-code');
+      expect(tokenBody.get('client_secret')?.length).toBeGreaterThan(0);
+
+      const [discoveryUrl] = fetchMock.mock.calls[1];
+      expect(discoveryUrl).toBe('https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist');
+
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'gemini',
+        expect.stringContaining('"u":"proj-42"'),
+        'subscription',
+      );
+      expect(discovery.discoverModels).toHaveBeenCalled();
+      expect(providerService.recalculateTiers).toHaveBeenCalledWith('agent-1');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('onboards the user via LRO when no project exists yet', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            access_token: 'access-1',
+            refresh_token: 'refresh-1',
+            expires_in: 3600,
+          }),
+        )
+        // loadCodeAssist returns no project
+        .mockResolvedValueOnce(mockResponse(200, {}))
+        // onboardUser returns a completed LRO
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            done: true,
+            response: { cloudaicompanionProject: { id: 'proj-new' } },
+          }),
+        );
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+
+      await svc.exchangeCode(state, 'auth-code');
+
+      expect(fetchMock.mock.calls[2][0]).toBe(
+        'https://cloudcode-pa.googleapis.com/v1internal:onboardUser',
+      );
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'gemini',
+        expect.stringContaining('"u":"proj-new"'),
+        'subscription',
+      );
+    });
+
+    it('rejects when Google omits a refresh_token', async () => {
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(200, { access_token: 'access', expires_in: 3600 }),
+      );
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'code')).rejects.toThrow(
+        /did not return a refresh_token/,
+      );
+    });
+
+    it('throws when the token endpoint returns an error', async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse(400, {}, 'invalid_grant'));
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'bad')).rejects.toThrow('Token exchange failed');
+    });
+
+    it('still stores the blob (without project) when discovery returns non-OK', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+        )
+        .mockResolvedValueOnce(mockResponse(403, {}));
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'c')).resolves.toBeUndefined();
+      const stored = providerService.upsertProvider.mock.calls[0][3] as string;
+      expect(stored).not.toContain('"u":');
+    });
+
+    it('swallows model discovery errors so OAuth still completes', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+        )
+        .mockResolvedValueOnce(mockResponse(200, { cloudaicompanionProject: 'proj' }));
+      discovery.discoverModels.mockRejectedValue(new Error('boom'));
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'c')).resolves.toBeUndefined();
+      expect(providerService.upsertProvider).toHaveBeenCalled();
+    });
+
+    it('treats an onboardUser network failure as no-project rather than crashing', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+        )
+        .mockResolvedValueOnce(mockResponse(200, {}))
+        .mockRejectedValueOnce(new Error('net'));
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'c')).resolves.toBeUndefined();
+      const stored = providerService.upsertProvider.mock.calls[0][3] as string;
+      expect(stored).not.toContain('"u":');
+    });
+
+    it('treats a loadCodeAssist network error as empty project', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+        )
+        .mockRejectedValueOnce(new Error('dns failure'));
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+      await expect(svc.exchangeCode(state, 'c')).resolves.toBeUndefined();
+      const stored = providerService.upsertProvider.mock.calls[0][3] as string;
+      expect(stored).not.toContain('"u":');
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('reuses the previous refresh token when Google omits a new one', async () => {
+      fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'a2', expires_in: 60 }));
+      const blob = await svc.refreshAccessToken('old-refresh');
+      expect(blob.r).toBe('old-refresh');
+      expect(blob.e).toBe(Date.now() + 60 * 1000);
+    });
+
+    it('uses the rotated refresh token when Google sends one', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a', refresh_token: 'rotated', expires_in: 60 }),
+      );
+      const blob = await svc.refreshAccessToken('old');
+      expect(blob.r).toBe('rotated');
+    });
+
+    it('throws on non-2xx', async () => {
+      fetchMock.mockResolvedValue(mockResponse(401, {}, 'expired_grant'));
+      await expect(svc.refreshAccessToken('r')).rejects.toThrow('Token refresh failed');
+    });
+  });
+
+  describe('unwrapToken', () => {
+    it('returns null for malformed blobs', async () => {
+      expect(await svc.unwrapToken('not-json', 'a', 'u')).toBeNull();
+      expect(await svc.unwrapToken(JSON.stringify({}), 'a', 'u')).toBeNull();
+    });
+
+    it('returns the cached blob when the access token is still valid', async () => {
+      const blob = {
+        t: 'access',
+        r: 'refresh',
+        e: Date.now() + 10 * 60 * 1000,
+        u: 'proj-1',
+      };
+      const result = await svc.unwrapToken(JSON.stringify(blob), 'a', 'u');
+      expect(result).toEqual(blob);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('refreshes near-expiry tokens, persists, and preserves the project id', async () => {
+      const blob = {
+        t: 'old',
+        r: 'rf',
+        e: Date.now() + 30_000,
+        u: 'proj-1',
+      };
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
+      );
+      const result = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+      expect(result?.t).toBe('new');
+      expect(result?.u).toBe('proj-1');
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'gemini',
+        expect.stringContaining('"u":"proj-1"'),
+        'subscription',
+      );
+    });
+
+    it('returns null when the refresh call fails', async () => {
+      const blob = { t: 'old', r: 'rf', e: Date.now() + 1000 };
+      fetchMock.mockRejectedValue(new Error('network'));
+      expect(await svc.unwrapToken(JSON.stringify(blob), 'a', 'u')).toBeNull();
+    });
+  });
+
+  describe('revokeToken', () => {
+    it('POSTs the token to the revoke endpoint', async () => {
+      fetchMock.mockResolvedValue(mockResponse(200, {}));
+      await svc.revokeToken('tok');
+      const [revokeUrl] = fetchMock.mock.calls[0];
+      expect(revokeUrl).toBe('https://oauth2.googleapis.com/revoke?token=tok');
+    });
+
+    it('silently logs on non-2xx', async () => {
+      fetchMock.mockResolvedValue(mockResponse(400, {}, 'bad'));
+      await expect(svc.revokeToken('x')).resolves.toBeUndefined();
+    });
+
+    it('silently logs on network failure', async () => {
+      fetchMock.mockRejectedValue(new Error('network'));
+      await expect(svc.revokeToken('x')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('clearPendingState', () => {
+    it('removes a known pending state', async () => {
+      const url = await svc.generateAuthorizationUrl('a', 'u');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(svc.getPendingCount()).toBe(1);
+      svc.clearPendingState(state);
+      expect(svc.getPendingCount()).toBe(0);
+    });
+  });
+
+  describe('lazy project recovery in unwrapToken', () => {
+    it('runs project discovery when the cached blob is missing it, then persists', async () => {
+      const blob = {
+        t: 'access',
+        r: 'refresh',
+        e: Date.now() + 10 * 60 * 1000,
+        // no `u` field — the original onboarding 400'd, leaving us project-less
+      };
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(200, { cloudaicompanionProject: 'proj-recovered' }),
+      );
+      const result = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+      expect(result?.u).toBe('proj-recovered');
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'gemini',
+        expect.stringContaining('"u":"proj-recovered"'),
+        'subscription',
+      );
+    });
+
+    it('returns the original blob when lazy discovery still finds no project', async () => {
+      const blob = { t: 'access', r: 'refresh', e: Date.now() + 10 * 60 * 1000 };
+      // loadCodeAssist returns no project → onboardUser returns non-OK → ''
+      fetchMock
+        .mockResolvedValueOnce(mockResponse(200, {}))
+        .mockResolvedValueOnce(mockResponse(500, {}));
+      const result = await svc.unwrapToken(JSON.stringify(blob), 'a', 'u');
+      expect(result?.u).toBeUndefined();
+      // No persistence when nothing changed.
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onboardUser request shape', () => {
+    it('sends the gateway-reported currentTier id', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+        )
+        .mockResolvedValueOnce(mockResponse(200, { currentTier: { id: 'legacy-tier' } }))
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            done: true,
+            response: { cloudaicompanionProject: { id: 'proj' } },
+          }),
+        );
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+      await svc.exchangeCode(state, 'code');
+
+      const [, init] = fetchMock.mock.calls[2];
+      const body = JSON.parse(init.body) as { tierId: string; cloudaicompanionProject?: string };
+      expect(body.tierId).toBe('legacy-tier');
+      expect(body.cloudaicompanionProject).toBeUndefined();
+    });
+
+    it('falls back to the default-flagged allowedTier when no currentTier is reported', async () => {
+      fetchMock
+        .mockResolvedValueOnce(
+          mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            allowedTiers: [{ id: 'legacy-tier' }, { id: 'free-tier', isDefault: true }],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            done: true,
+            response: { cloudaicompanionProject: { id: 'proj' } },
+          }),
+        );
+      const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+      await svc.exchangeCode(state, 'code');
+
+      const body = JSON.parse(fetchMock.mock.calls[2][1].body) as { tierId: string };
+      expect(body.tierId).toBe('free-tier');
+    });
+  });
+
+  describe('pickOnboardTierId', () => {
+    it('prefers currentTier.id over allowedTiers', () => {
+      expect(pickOnboardTierId({ currentTier: { id: 'a' }, allowedTiers: [{ id: 'b' }] })).toBe(
+        'a',
+      );
+    });
+
+    it('falls back to default-flagged allowedTier', () => {
+      expect(pickOnboardTierId({ allowedTiers: [{ id: 'b' }, { id: 'c', isDefault: true }] })).toBe(
+        'c',
+      );
+    });
+
+    it('falls back to first allowedTier when none flagged default', () => {
+      expect(pickOnboardTierId({ allowedTiers: [{ id: 'b' }, { id: 'c' }] })).toBe('b');
+    });
+
+    it('falls back to standard-tier when nothing else is provided', () => {
+      expect(pickOnboardTierId({})).toBe('standard-tier');
+    });
+  });
+
+  describe('resolveCodeAssistProject', () => {
+    it('returns the project when loadCodeAssist already has one', async () => {
+      fetchMock.mockResolvedValue(mockResponse(200, { cloudaicompanionProject: 'proj-direct' }));
+      const id = await svc.resolveCodeAssistProject('access');
+      expect(id).toBe('proj-direct');
+    });
+
+    it('polls a pending LRO until done', async () => {
+      fetchMock
+        .mockResolvedValueOnce(mockResponse(200, {}))
+        .mockResolvedValueOnce(mockResponse(200, { done: false, name: 'operations/abc' }))
+        .mockResolvedValueOnce(
+          mockResponse(200, {
+            done: true,
+            response: { cloudaicompanionProject: { id: 'proj-eventual' } },
+          }),
+        );
+      const promise = svc.resolveCodeAssistProject('access');
+      // Allow the polling timer to elapse.
+      await jest.runAllTimersAsync();
+      const id = await promise;
+      expect(id).toBe('proj-eventual');
+    });
+
+    it('returns empty string when polling fails partway', async () => {
+      fetchMock
+        .mockResolvedValueOnce(mockResponse(200, {}))
+        .mockResolvedValueOnce(mockResponse(200, { done: false, name: 'operations/x' }))
+        .mockResolvedValueOnce(mockResponse(500, {}));
+      const promise = svc.resolveCodeAssistProject('access');
+      await jest.runAllTimersAsync();
+      expect(await promise).toBe('');
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/gemini-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/gemini-oauth.service.ts
@@ -1,0 +1,518 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomBytes, createHash } from 'crypto';
+import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
+import { ProviderService } from '../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
+import {
+  PendingOAuth,
+  OAuthTokenBlob,
+  oauthDoneHtml,
+  parseOAuthTokenBlob,
+} from './openai-oauth.types';
+
+/**
+ * The Gemini CLI ships its own "Desktop / installed application" OAuth
+ * credentials inside `@google/gemini-cli-core`. Operators that want
+ * Manifest to use those same credentials should set them via env vars:
+ *
+ *   GOOGLE_GEMINI_CLIENT_ID
+ *   GOOGLE_GEMINI_CLIENT_SECRET
+ *
+ * (The Gemini CLI's source for finding them is
+ *  `github.com/google-gemini/gemini-cli` →
+ *  `packages/core/src/code_assist/oauth2.ts`.)
+ *
+ * We intentionally don't bundle them in the source tree — Google's
+ * Desktop OAuth secret is "public by design" but GitHub secret scanning
+ * still flags it, and shipping it here would prevent any operator from
+ * running their own audited build.
+ */
+
+const AUTHORIZE_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const REVOKE_URL = 'https://oauth2.googleapis.com/revoke';
+const CODE_ASSIST_BASE = 'https://cloudcode-pa.googleapis.com';
+
+const SCOPES = [
+  'openid',
+  'email',
+  'profile',
+  'https://www.googleapis.com/auth/cloud-platform',
+].join(' ');
+
+// Gemini CLI uses a random localhost port; we use a fixed loopback port so
+// the redirect URI is stable in dev and matches the OpenAI subscription
+// pattern. Port 1456 is one above the OpenAI callback (1455) to avoid
+// collisions when both flows are exercised in the same dev session.
+const CALLBACK_PORT = 1456;
+const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/oauth/callback`;
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+interface CodeAssistTier {
+  id?: string;
+  isDefault?: boolean;
+}
+
+interface CodeAssistDiscoveryResponse {
+  cloudaicompanionProject?: string;
+  currentTier?: CodeAssistTier;
+  allowedTiers?: CodeAssistTier[];
+}
+
+// Tier identifiers used by the Code Assist gateway. Mirrors the gemini-cli
+// `UserTierId` enum (packages/core/src/code_assist/types.ts) — sending the
+// right tier in `onboardUser` is required for the call to succeed; the
+// gateway returns 400 when `tierId` is omitted or set to an unknown value.
+const TIER_FREE = 'free-tier';
+const TIER_STANDARD = 'standard-tier';
+const TIER_LEGACY = 'legacy-tier';
+
+interface CodeAssistOnboardLro {
+  done?: boolean;
+  name?: string;
+  response?: { cloudaicompanionProject?: { id?: string } };
+}
+
+@Injectable()
+export class GeminiOauthService {
+  private readonly logger = new Logger(GeminiOauthService.name);
+  /** In-memory pending OAuth flows (not safe behind a load balancer). */
+  private readonly pending = new Map<string, PendingOAuth>();
+  private callbackServer: Server | null = null;
+  private serverReady: Promise<void> | null = null;
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly useCallbackServer: boolean;
+
+  constructor(
+    private readonly providerService: ProviderService,
+    private readonly configService: ConfigService,
+    private readonly discoveryService: ModelDiscoveryService,
+  ) {
+    this.clientId = this.configService.get<string>('GOOGLE_GEMINI_CLIENT_ID') ?? '';
+    this.clientSecret = this.configService.get<string>('GOOGLE_GEMINI_CLIENT_SECRET') ?? '';
+    // Loopback callback only runs in development. Production deployments
+    // (cloud, Docker self-hosted) must configure their own GOOGLE_GEMINI_*
+    // credentials with their public domain registered as a redirect URI;
+    // in that environment Manifest's frontend posts the code+state to the
+    // /callback endpoint instead of relying on a loopback listener.
+    this.useCallbackServer =
+      (this.configService.get<string>('app.nodeEnv') ?? 'development') !== 'production';
+  }
+
+  /** True when the operator has supplied OAuth credentials via env vars. */
+  isConfigured(): boolean {
+    return Boolean(this.clientId && this.clientSecret);
+  }
+
+  async generateAuthorizationUrl(
+    agentId: string,
+    userId: string,
+    backendUrl?: string,
+  ): Promise<string> {
+    if (!this.isConfigured()) {
+      throw new Error(
+        'Google OAuth is not configured. Set GOOGLE_GEMINI_CLIENT_ID and GOOGLE_GEMINI_CLIENT_SECRET in the environment.',
+      );
+    }
+    this.cleanupExpired();
+    const state = randomBytes(32).toString('hex');
+    const verifier = randomBytes(32).toString('base64url');
+    const challenge = createHash('sha256').update(verifier).digest('base64url');
+    const safeBackendUrl = backendUrl && this.isAllowedRedirectOrigin(backendUrl) ? backendUrl : '';
+    this.pending.set(state, {
+      verifier,
+      agentId,
+      userId,
+      backendUrl: safeBackendUrl,
+      expiresAt: Date.now() + STATE_TTL_MS,
+    });
+    if (this.useCallbackServer) {
+      await this.ensureCallbackServer();
+    }
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      redirect_uri: REDIRECT_URI,
+      response_type: 'code',
+      scope: SCOPES,
+      // `offline` is required to receive a refresh_token from Google; without
+      // it the callback returns only a short-lived access_token and the
+      // proxy starts hitting 401s after an hour.
+      access_type: 'offline',
+      // `consent` forces Google to re-issue a refresh_token even if the user
+      // has previously granted the scopes. Without this Google's token
+      // endpoint silently omits `refresh_token` on subsequent flows.
+      prompt: 'consent',
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    });
+    return `${AUTHORIZE_URL}?${params.toString()}`;
+  }
+
+  async exchangeCode(state: string, code: string): Promise<void> {
+    const pending = this.pending.get(state);
+    if (!pending) throw new Error('Invalid or expired OAuth state');
+    if (pending.expiresAt < Date.now()) {
+      this.pending.delete(state);
+      throw new Error('OAuth state expired');
+    }
+    this.pending.delete(state);
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+        code_verifier: pending.verifier,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`Gemini token exchange failed: ${scrubSecrets(text)}`);
+      throw new Error('Token exchange failed');
+    }
+    const data = (await response.json()) as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in: number;
+    };
+    if (!data.refresh_token) {
+      throw new Error(
+        'Google did not return a refresh_token. Re-authorize with prompt=consent and access_type=offline.',
+      );
+    }
+    const projectId = await this.resolveCodeAssistProject(data.access_token);
+    const blob: OAuthTokenBlob = {
+      t: data.access_token,
+      r: data.refresh_token,
+      e: Date.now() + data.expires_in * 1000,
+    };
+    if (projectId) blob.u = projectId;
+    const { provider: savedProvider } = await this.providerService.upsertProvider(
+      pending.agentId,
+      pending.userId,
+      'gemini',
+      JSON.stringify(blob),
+      'subscription',
+    );
+    try {
+      await this.discoveryService.discoverModels(savedProvider);
+      await this.providerService.recalculateTiers(pending.agentId);
+    } catch (err) {
+      this.logger.warn(`Model discovery after Gemini OAuth failed: ${err}`);
+    }
+    this.logger.log(
+      `Gemini OAuth token stored for agent=${pending.agentId} (project=${projectId || 'none'})`,
+    );
+    this.shutdownCallbackServerIfIdle();
+  }
+
+  async refreshAccessToken(refreshToken: string): Promise<OAuthTokenBlob> {
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: this.clientId,
+        client_secret: this.clientSecret,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`Gemini token refresh failed: ${scrubSecrets(text)}`);
+      throw new Error('Token refresh failed');
+    }
+    const data = (await response.json()) as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in: number;
+    };
+    return {
+      t: data.access_token,
+      // Google rotates refresh_tokens infrequently; reuse the previous one
+      // when the response omits a new one, otherwise we'd lose the ability
+      // to refresh after the next access_token expires.
+      r: data.refresh_token || refreshToken,
+      e: Date.now() + data.expires_in * 1000,
+    };
+  }
+
+  /**
+   * Parse an OAuth blob and return a refreshed-if-needed copy. The Code
+   * Assist proxy needs both the access token (for Bearer auth) and the
+   * project id (for the request envelope), so we return the full blob
+   * shape. `proxy-fallback.service.resolveApiKey` extracts both fields.
+   *
+   * If the persisted blob is missing the project id (e.g. Code Assist
+   * onboarding 400'd at OAuth time, or Google completed onboarding only
+   * after the popup closed), we lazily re-run project discovery here and
+   * persist the result so subsequent proxy calls get a working envelope.
+   */
+  async unwrapToken(
+    rawValue: string,
+    agentId: string,
+    userId: string,
+  ): Promise<OAuthTokenBlob | null> {
+    const blob = parseOAuthTokenBlob(rawValue);
+    if (!blob) return null;
+    let working = blob;
+    if (Date.now() >= blob.e - 60_000) {
+      try {
+        working = await this.refreshAccessToken(blob.r);
+        // Preserve the project id across refreshes — the refresh response
+        // doesn't include it and Code Assist still expects it on every call.
+        if (blob.u && !working.u) working.u = blob.u;
+        this.logger.log(`Gemini OAuth token refreshed for agent=${agentId}`);
+      } catch (err) {
+        this.logger.error(`Failed to refresh Gemini token for agent=${agentId}: ${err}`);
+        return null;
+      }
+    }
+    if (!working.u) {
+      const projectId = await this.resolveCodeAssistProject(working.t);
+      if (projectId) {
+        working = { ...working, u: projectId };
+        this.logger.log(
+          `Gemini Code Assist project resolved lazily for agent=${agentId} (project=${projectId})`,
+        );
+      }
+    }
+    if (working !== blob) {
+      await this.providerService.upsertProvider(
+        agentId,
+        userId,
+        'gemini',
+        JSON.stringify(working),
+        'subscription',
+      );
+    }
+    return working;
+  }
+
+  /** Revoke an OAuth token at Google (best-effort). */
+  async revokeToken(token: string): Promise<void> {
+    try {
+      const response = await fetch(`${REVOKE_URL}?token=${encodeURIComponent(token)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        this.logger.warn(`Gemini token revocation failed: ${scrubSecrets(text)}`);
+      } else {
+        this.logger.log('Gemini OAuth token revoked');
+      }
+    } catch (err) {
+      this.logger.warn(`Gemini token revocation error: ${err}`);
+    }
+  }
+
+  /** Returns the number of pending OAuth states (for testing). */
+  getPendingCount(): number {
+    return this.pending.size;
+  }
+
+  /** Remove a pending OAuth state. */
+  clearPendingState(state: string): void {
+    this.pending.delete(state);
+  }
+
+  /**
+   * Discover the user's Cloud project via the Code Assist API, provisioning
+   * a managed project if none exists. Mirrors the `loadCodeAssist` →
+   * `onboardUser` LRO sequence the Gemini CLI uses on first run.
+   *
+   * Returns the project id, or an empty string when discovery fails. An
+   * empty project id is acceptable for free-tier callers; AI Pro / Ultra
+   * subscribers will receive their managed project on the second invocation
+   * after onboarding completes server-side.
+   */
+  async resolveCodeAssistProject(accessToken: string): Promise<string> {
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    };
+    const metadata = {
+      ideType: 'IDE_UNSPECIFIED',
+      platform: 'PLATFORM_UNSPECIFIED',
+      pluginType: 'GEMINI',
+    };
+    try {
+      const res = await fetch(`${CODE_ASSIST_BASE}/v1internal:loadCodeAssist`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ metadata }),
+      });
+      if (!res.ok) {
+        this.logger.warn(`Code Assist project discovery returned ${res.status}`);
+        return '';
+      }
+      const data = (await res.json()) as CodeAssistDiscoveryResponse;
+      if (data.cloudaicompanionProject) return data.cloudaicompanionProject;
+      const tierId = pickOnboardTierId(data);
+      return await this.onboardCodeAssistUser(headers, metadata, tierId);
+    } catch (err) {
+      this.logger.warn(`Gemini project discovery failed: ${err}`);
+      return '';
+    }
+  }
+
+  private async onboardCodeAssistUser(
+    headers: Record<string, string>,
+    metadata: Record<string, string>,
+    tierId: string,
+  ): Promise<string> {
+    // The CLI shape: { tierId, cloudaicompanionProject?, metadata }. For
+    // free-tier accounts the gateway provisions a managed project — passing
+    // `cloudaicompanionProject: undefined` (omitted from the body) is the
+    // documented way to request that.
+    const body: Record<string, unknown> = { tierId, metadata };
+    try {
+      const res = await fetch(`${CODE_ASSIST_BASE}/v1internal:onboardUser`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        this.logger.warn(`Code Assist onboarding returned ${res.status}`);
+        return '';
+      }
+      let lro = (await res.json()) as CodeAssistOnboardLro;
+      // Poll the long-running operation up to ~30 seconds. Onboarding is
+      // typically instant for AI Pro / Ultra accounts; free-tier accounts
+      // sometimes take a few seconds while Google provisions a project.
+      for (let i = 0; i < 6 && !lro.done && lro.name; i++) {
+        await new Promise((r) => setTimeout(r, 5000));
+        const poll = await fetch(`${CODE_ASSIST_BASE}/v1internal/${lro.name}`, { headers });
+        if (!poll.ok) break;
+        lro = (await poll.json()) as CodeAssistOnboardLro;
+      }
+      return lro.response?.cloudaicompanionProject?.id ?? '';
+    } catch (err) {
+      this.logger.warn(`Gemini onboarding failed: ${err}`);
+      return '';
+    }
+  }
+
+  /** Spins up an HTTP server on the loopback port to receive the OAuth callback. */
+  private ensureCallbackServer(): Promise<void> {
+    if (this.callbackServer) return Promise.resolve();
+    if (this.serverReady) return this.serverReady;
+    this.serverReady = new Promise<void>((resolve, reject) => {
+      const server = createServer((req, res) => this.handleCallbackRequest(req, res));
+      server.on('error', (err: NodeJS.ErrnoException) => {
+        this.callbackServer = null;
+        this.serverReady = null;
+        if (err.code === 'EADDRINUSE') {
+          this.logger.warn(`Port ${CALLBACK_PORT} in use — Gemini callback server not started`);
+          reject(
+            new Error(
+              `Port ${CALLBACK_PORT} is already in use. Run 'lsof -i :${CALLBACK_PORT}' to find the process.`,
+            ),
+          );
+        } else {
+          this.logger.error(`Gemini callback server error: ${err.message}`);
+          reject(new Error(`Callback server failed: ${err.message}`));
+        }
+      });
+      server.listen(CALLBACK_PORT, '127.0.0.1', () => {
+        this.logger.log(`Gemini OAuth callback server listening on port ${CALLBACK_PORT}`);
+        this.callbackServer = server;
+        resolve();
+      });
+      server.unref();
+    });
+    return this.serverReady;
+  }
+
+  private handleCallbackRequest(req: IncomingMessage, res: ServerResponse): void {
+    const url = new URL(req.url ?? '/', `http://localhost:${CALLBACK_PORT}`);
+    if (url.pathname !== '/oauth/callback') {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const code = url.searchParams.get('code') ?? '';
+    const state = url.searchParams.get('state') ?? '';
+    const error = url.searchParams.get('error');
+    const appUrl = this.pending.get(state)?.backendUrl || '';
+    if (error) {
+      const desc = url.searchParams.get('error_description') ?? error;
+      this.logger.error(`Gemini OAuth callback error: ${desc}`);
+      this.pending.delete(state);
+      this.shutdownCallbackServerIfIdle();
+      this.sendDoneResponse(res, false, appUrl);
+      return;
+    }
+    this.exchangeCode(state, code)
+      .then(() => this.sendDoneResponse(res, true, appUrl))
+      .catch((err) => {
+        this.logger.error(`Gemini OAuth callback failed: ${err}`);
+        this.sendDoneResponse(res, false, appUrl);
+      });
+  }
+
+  private isAllowedRedirectOrigin(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      const hostname = parsed.hostname;
+      return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    } catch {
+      return false;
+    }
+  }
+
+  private sendDoneResponse(res: ServerResponse, success: boolean, appUrl: string): void {
+    if (appUrl && this.isAllowedRedirectOrigin(appUrl)) {
+      const ok = success ? '1' : '0';
+      res.writeHead(302, { Location: `${appUrl}/api/v1/oauth/gemini/done?ok=${ok}` });
+      res.end();
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(oauthDoneHtml(success));
+    }
+  }
+
+  private shutdownCallbackServerIfIdle(): void {
+    if (this.pending.size === 0 && this.callbackServer) {
+      this.callbackServer.close();
+      this.callbackServer = null;
+      this.serverReady = null;
+      this.logger.log('Gemini OAuth callback server shut down (no pending flows)');
+    }
+  }
+
+  private cleanupExpired(): void {
+    const now = Date.now();
+    for (const [key, val] of this.pending) {
+      if (val.expiresAt < now) this.pending.delete(key);
+    }
+  }
+}
+
+/**
+ * Pick the tier id to send in `onboardUser`, mirroring the gemini-cli
+ * resolution order: prefer the gateway-reported current tier, then any
+ * `allowedTier` flagged as default, finally fall back to STANDARD.
+ */
+export function pickOnboardTierId(data: CodeAssistDiscoveryResponse): string {
+  if (data.currentTier?.id) return data.currentTier.id;
+  const defaultAllowed = data.allowedTiers?.find((t) => t.isDefault && t.id);
+  if (defaultAllowed?.id) return defaultAllowed.id;
+  const firstAllowed = data.allowedTiers?.find((t) => t.id);
+  if (firstAllowed?.id) return firstAllowed.id;
+  return TIER_STANDARD;
+}
+
+export const __codeAssistTierIds = {
+  FREE: TIER_FREE,
+  STANDARD: TIER_STANDARD,
+  LEGACY: TIER_LEGACY,
+};

--- a/packages/backend/src/routing/oauth/oauth.module.ts
+++ b/packages/backend/src/routing/oauth/oauth.module.ts
@@ -5,12 +5,19 @@ import { OpenaiOauthService } from './openai-oauth.service';
 import { OpenaiOauthController } from './openai-oauth.controller';
 import { MinimaxOauthService } from './minimax-oauth.service';
 import { MinimaxOauthController } from './minimax-oauth.controller';
+import { GeminiOauthService } from './gemini-oauth.service';
+import { GeminiOauthController } from './gemini-oauth.controller';
 import { CopilotDeviceAuthService } from './copilot-device-auth.service';
 
 @Module({
   imports: [RoutingCoreModule, ModelDiscoveryModule],
-  controllers: [OpenaiOauthController, MinimaxOauthController],
-  providers: [OpenaiOauthService, MinimaxOauthService, CopilotDeviceAuthService],
-  exports: [OpenaiOauthService, MinimaxOauthService, CopilotDeviceAuthService],
+  controllers: [OpenaiOauthController, MinimaxOauthController, GeminiOauthController],
+  providers: [
+    OpenaiOauthService,
+    MinimaxOauthService,
+    GeminiOauthService,
+    CopilotDeviceAuthService,
+  ],
+  exports: [OpenaiOauthService, MinimaxOauthService, GeminiOauthService, CopilotDeviceAuthService],
 })
 export class OAuthModule {}

--- a/packages/backend/src/routing/oauth/openai-oauth.types.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.types.ts
@@ -13,7 +13,14 @@ export interface OAuthTokenBlob {
   r: string;
   /** expires at (epoch ms) */
   e: number;
-  /** provider-specific resource URL / base URL */
+  /**
+   * Opaque per-provider resource identifier preserved across token refreshes.
+   * MiniMax stores the partner-specific base URL of the subscription proxy;
+   * Google AI Pro / Ultra stores the GCP project id consumed by the Code
+   * Assist envelope. Interpretation lives in `proxy-fallback.resolveApiKey`
+   * and the per-provider OAuth services — never compare or print this field
+   * generically since its semantics depend on `provider`.
+   */
   u?: string;
 }
 

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -2,6 +2,7 @@ import {
   toGoogleRequest,
   fromGoogleResponse,
   transformGoogleStreamChunk as transformGoogleStreamChunkRaw,
+  wrapCodeAssistRequest,
 } from '../google-adapter';
 
 /**
@@ -409,6 +410,15 @@ describe('Google Adapter', () => {
       const result = toGoogleRequest(body, 'gemini-2.0-flash');
 
       expect(result.generationConfig).toBeUndefined();
+    });
+
+    it('falls back to an empty contents array when body.messages is missing entirely', () => {
+      // Defensive `body.messages || []` branch — the proxy validates payloads
+      // upstream, but the adapter must not crash if a future caller forgets
+      // the messages field (e.g. raw tool-only invocations).
+      const result = toGoogleRequest({}, 'gemini-2.0-flash');
+      expect(result.contents).toEqual([]);
+      expect(result.systemInstruction).toBeUndefined();
     });
 
     it('handles tool_calls with empty arguments string in assistant messages', () => {
@@ -1532,6 +1542,74 @@ describe('Google Adapter', () => {
         name: 'write_file',
         response: { result: 'ok' },
       });
+    });
+  });
+
+  describe('Code Assist envelope (wrapCodeAssistRequest + unwrap on response)', () => {
+    it('wraps the Gemini body with model + project + nested request', () => {
+      const geminiBody = { contents: [{ role: 'user', parts: [{ text: 'hi' }] }] };
+      const env = wrapCodeAssistRequest(geminiBody, 'gemini-2.5-pro', 'project-42');
+      expect(env).toEqual({
+        model: 'gemini-2.5-pro',
+        project: 'project-42',
+        request: {
+          contents: [{ role: 'user', parts: [{ text: 'hi' }] }],
+          model: 'gemini-2.5-pro',
+        },
+      });
+    });
+
+    it('omits the project field when no project id is available', () => {
+      const env = wrapCodeAssistRequest({ contents: [] }, 'gemini-2.5-flash', undefined);
+      expect(env).not.toHaveProperty('project');
+      expect(env.model).toBe('gemini-2.5-flash');
+    });
+
+    it('omits the project field when the project id is empty string', () => {
+      const env = wrapCodeAssistRequest({ contents: [] }, 'gemini-2.5-flash', '');
+      expect(env).not.toHaveProperty('project');
+    });
+
+    it('unwraps Code Assist envelopes in non-streaming responses', () => {
+      const wrapped = {
+        response: {
+          candidates: [
+            {
+              content: { parts: [{ text: 'Hello from Code Assist' }] },
+              finishReason: 'STOP',
+            },
+          ],
+          usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 2, totalTokenCount: 3 },
+        },
+      };
+      const result = fromGoogleResponse(wrapped, 'gemini-2.5-pro');
+      const choices = result.choices as Array<Record<string, unknown>>;
+      expect((choices[0].message as Record<string, unknown>).content).toBe(
+        'Hello from Code Assist',
+      );
+      const usage = result.usage as Record<string, unknown>;
+      expect(usage.prompt_tokens).toBe(1);
+      expect(usage.completion_tokens).toBe(2);
+    });
+
+    it('unwraps Code Assist envelopes in streaming chunks', () => {
+      const chunk = JSON.stringify({
+        response: {
+          candidates: [{ content: { parts: [{ text: 'streamed' }] } }],
+        },
+      });
+      const out = transformGoogleStreamChunkRaw(chunk, 'gemini-2.5-flash').chunk;
+      expect(out).not.toBeNull();
+      expect(out!).toContain('"content":"streamed"');
+    });
+
+    it('still handles non-enveloped responses (Generative Language endpoint)', () => {
+      const direct = {
+        candidates: [{ content: { parts: [{ text: 'direct' }] }, finishReason: 'STOP' }],
+      };
+      const result = fromGoogleResponse(direct, 'gemini-2.5-pro');
+      const choices = result.choices as Array<Record<string, unknown>>;
+      expect((choices[0].message as Record<string, unknown>).content).toBe('direct');
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -143,6 +143,17 @@ describe('provider-client-converters', () => {
       expect(result).not.toHaveProperty('max_tokens');
     });
 
+    it('should delete non-number, non-string max_tokens for deepseek', () => {
+      // The third arm of the typeof ternary (`Number.NaN`) only fires when the
+      // value is something like a boolean, null, or object — none of which can
+      // be parsed as a positive integer token count.
+      const body = { messages: [], max_tokens: true as unknown };
+
+      const result = sanitizeOpenAiBody(body as never, 'deepseek', 'deepseek-chat');
+
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
     /* ── Message sanitization: reasoning_content ── */
 
     it('should strip reasoning_content for non-deepseek providers', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1,7 +1,16 @@
+// SSRF revalidation calls into validatePublicUrl, which is a no-op in test mode
+// unless we mock it. We default to a pass-through resolve so the existing tests
+// keep working, then opt specific tests into rejection by overriding the mock.
+jest.mock('../../../common/utils/url-validation', () => ({
+  validatePublicUrl: jest.fn().mockResolvedValue(undefined),
+}));
+
 import { ProviderClient } from '../provider-client';
+import { validatePublicUrl } from '../../../common/utils/url-validation';
 
 const mockFetch = jest.fn();
 (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
+const mockValidatePublicUrl = validatePublicUrl as jest.Mock;
 
 describe('ProviderClient', () => {
   let client: ProviderClient;
@@ -9,6 +18,8 @@ describe('ProviderClient', () => {
   beforeEach(() => {
     client = new ProviderClient();
     mockFetch.mockReset();
+    mockValidatePublicUrl.mockReset();
+    mockValidatePublicUrl.mockResolvedValue(undefined);
   });
 
   const body = {
@@ -230,6 +241,26 @@ describe('ProviderClient', () => {
         { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
       ]);
       expect(sentBody.stream).toBe(true);
+    });
+
+    it('falls back to the original body when apiMode is "responses" but chatBody is omitted', async () => {
+      // Branch coverage for `chatBody ?? body` in buildRequest. When a
+      // caller forwards a Responses-shaped body without pre-converting to
+      // chat, the converter must operate on the raw `body` itself.
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'deepseek',
+        apiKey: 'sk-test',
+        model: 'deepseek-chat',
+        body: { messages: [{ role: 'user', content: 'inline' }], stream: false },
+        // No chatBody supplied → buildRequest uses body directly.
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toEqual([{ role: 'user', content: 'inline' }]);
     });
 
     it('uses normalized chat body for non-native Responses providers', async () => {
@@ -1030,6 +1061,90 @@ describe('ProviderClient', () => {
       const url = mockFetch.mock.calls[0][0] as string;
       expect(url).toContain('generativelanguage.googleapis.com');
       expect(result.isGoogle).toBe(true);
+    });
+  });
+
+  describe('Google AI Pro / Ultra subscription (Code Assist)', () => {
+    it('routes gemini subscription requests to the Code Assist gateway', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'gemini',
+        apiKey: 'access-token-1',
+        authType: 'subscription',
+        model: 'gemini-2.5-pro',
+        body,
+        stream: false,
+        subscriptionResource: 'project-42',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://cloudcode-pa.googleapis.com/v1internal:generateContent');
+      const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer access-token-1');
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent.model).toBe('gemini-2.5-pro');
+      expect(sent.project).toBe('project-42');
+      // Inner request still carries the standard Gemini contents shape.
+      expect(sent.request.contents[0].parts[0].text).toBe('Hello');
+      expect(sent.request.model).toBe('gemini-2.5-pro');
+    });
+
+    it('switches to :streamGenerateContent when streaming is requested', async () => {
+      mockFetch.mockResolvedValue(new Response('', { status: 200 }));
+
+      await client.forward({
+        provider: 'gemini',
+        apiKey: 'tok',
+        authType: 'subscription',
+        model: 'gemini-2.5-flash',
+        body,
+        stream: true,
+        subscriptionResource: 'project-99',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe(
+        'https://cloudcode-pa.googleapis.com/v1internal:streamGenerateContent?alt=sse',
+      );
+    });
+
+    it('omits the project field from the envelope when no project id is known', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'gemini',
+        apiKey: 'tok',
+        authType: 'subscription',
+        model: 'gemini-2.5-pro',
+        body,
+        stream: false,
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent).not.toHaveProperty('project');
+      expect(sent.model).toBe('gemini-2.5-pro');
+    });
+
+    it('falls back to the public Generative Language endpoint without subscription auth', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'gemini',
+        apiKey: 'AIza-key',
+        model: 'gemini-2.5-pro',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-pro:generateContent',
+      );
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      // No envelope wrapping when not on Code Assist.
+      expect(sent).not.toHaveProperty('request');
+      expect(sent.contents).toBeDefined();
     });
   });
 
@@ -2244,6 +2359,83 @@ describe('ProviderClient', () => {
 
     it('falls back to 180000 ms when env var is zero', async () => {
       expect(await captureTimeoutMs('0')).toBe(180_000);
+    });
+  });
+
+  describe('SSRF re-validation for user-supplied endpoints', () => {
+    // SSRF defense in depth: when an endpoint is flagged with
+    // requiresSsrfRevalidation (custom providers, subscription resource URLs)
+    // the proxy must re-resolve the hostname immediately before forwarding.
+    // A hostile DNS rebind that happened between provider registration and
+    // forward time should surface as "Refusing to forward to disallowed URL".
+    const customEndpoint = {
+      baseUrl: 'https://userprovided.example.com/v1',
+      buildHeaders: (key: string) => ({
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+      }),
+      buildPath: () => '/chat/completions',
+      format: 'openai' as const,
+      requiresSsrfRevalidation: true,
+    };
+
+    it('throws "Refusing to forward to disallowed URL" when validatePublicUrl rejects', async () => {
+      mockValidatePublicUrl.mockRejectedValueOnce(
+        new Error('URLs pointing to private or internal networks are not allowed'),
+      );
+
+      await expect(
+        client.forward({
+          provider: 'custom:rebound',
+          apiKey: 'sk-x',
+          model: 'foo',
+          body,
+          stream: false,
+          customEndpoint,
+        }),
+      ).rejects.toThrow(
+        'Refusing to forward to disallowed URL: URLs pointing to private or internal networks are not allowed',
+      );
+
+      expect(mockValidatePublicUrl).toHaveBeenCalledWith(
+        'https://userprovided.example.com/v1/chat/completions',
+        expect.objectContaining({ allowPrivate: expect.any(Boolean) }),
+      );
+      // Critically: fetch must never have been called once SSRF re-validation
+      // refuses the URL — that's the entire point of the defense.
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('stringifies non-Error rejections from validatePublicUrl', async () => {
+      mockValidatePublicUrl.mockRejectedValueOnce('string-error-from-validator');
+
+      await expect(
+        client.forward({
+          provider: 'custom:rebound',
+          apiKey: 'sk-x',
+          model: 'foo',
+          body,
+          stream: false,
+          customEndpoint,
+        }),
+      ).rejects.toThrow('Refusing to forward to disallowed URL: string-error-from-validator');
+    });
+
+    it('skips revalidation for built-in endpoints without requiresSsrfRevalidation', async () => {
+      mockFetch.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+      });
+
+      // Built-in endpoints (api.openai.com, etc.) are not flagged for
+      // re-validation because their hostnames are static and trusted.
+      expect(mockValidatePublicUrl).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -209,6 +209,17 @@ describe('PROVIDER_ENDPOINTS', () => {
     expect(path).toBe('/v1beta/models/gemini-2.0-flash:generateContent');
   });
 
+  it('google-subscription targets the Code Assist gateway with Bearer auth', () => {
+    const ep = PROVIDER_ENDPOINTS['google-subscription'];
+    expect(ep.baseUrl).toBe('https://cloudcode-pa.googleapis.com');
+    expect(ep.format).toBe('google');
+    expect(ep.buildPath('gemini-2.5-pro')).toBe('/v1internal:generateContent');
+    expect(ep.buildHeaders('access-token')).toEqual({
+      Authorization: 'Bearer access-token',
+      'Content-Type': 'application/json',
+    });
+  });
+
   it('openrouter buildPath returns /api/v1/chat/completions', () => {
     const path = PROVIDER_ENDPOINTS['openrouter'].buildPath('openai/gpt-4o');
     expect(path).toBe('/api/v1/chat/completions');

--- a/packages/backend/src/routing/proxy/__tests__/provider-hooks.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-hooks.spec.ts
@@ -1,0 +1,33 @@
+import { resolveSubscriptionEndpointKey, buildProviderExtraHeaders } from '../provider-hooks';
+
+describe('resolveSubscriptionEndpointKey', () => {
+  it.each([
+    ['openai', 'openai-subscription'],
+    ['minimax', 'minimax-subscription'],
+    ['zai', 'zai-subscription'],
+    ['google', 'google-subscription'],
+  ])('routes %s subscription to %s', (input, expected) => {
+    expect(resolveSubscriptionEndpointKey(input)).toBe(expected);
+  });
+
+  it('returns undefined for providers without a subscription endpoint', () => {
+    expect(resolveSubscriptionEndpointKey('anthropic')).toBeUndefined();
+    expect(resolveSubscriptionEndpointKey('mistral')).toBeUndefined();
+  });
+});
+
+describe('buildProviderExtraHeaders', () => {
+  it('attaches the x-grok-conv-id header for xai (case-insensitive)', () => {
+    expect(buildProviderExtraHeaders('xai', 'sess-123')).toEqual({
+      'x-grok-conv-id': 'sess-123',
+    });
+    expect(buildProviderExtraHeaders('XAI', 'sess-123')).toEqual({
+      'x-grok-conv-id': 'sess-123',
+    });
+  });
+
+  it('returns undefined for providers without forward-time header builders', () => {
+    expect(buildProviderExtraHeaders('openai', 'sess')).toBeUndefined();
+    expect(buildProviderExtraHeaders('gemini', 'sess')).toBeUndefined();
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
@@ -5,6 +5,7 @@ import { ProviderKeyService } from '../../routing-core/provider-key.service';
 import { CustomProvider } from '../../../entities/custom-provider.entity';
 import { OpenaiOauthService } from '../../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
+import { GeminiOauthService } from '../../oauth/gemini-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
@@ -30,6 +31,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
   let customProviderRepo: jest.Mocked<Repository<CustomProvider>>;
   let openaiOauth: jest.Mocked<OpenaiOauthService>;
   let minimaxOauth: jest.Mocked<MinimaxOauthService>;
+  let geminiOauth: jest.Mocked<GeminiOauthService>;
   let providerClient: jest.Mocked<ProviderClient>;
   let copilotToken: jest.Mocked<CopilotTokenService>;
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
@@ -55,6 +57,10 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
       unwrapToken: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<MinimaxOauthService>;
 
+    geminiOauth = {
+      unwrapToken: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<GeminiOauthService>;
+
     providerClient = {
       forward: jest.fn(),
     } as unknown as jest.Mocked<ProviderClient>;
@@ -72,6 +78,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
       customProviderRepo,
       openaiOauth,
       minimaxOauth,
+      geminiOauth,
       providerClient,
       copilotToken,
       pricingCache,

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -8,6 +8,7 @@ import { ProviderKeyService } from '../../routing-core/provider-key.service';
 import { CustomProvider } from '../../../entities/custom-provider.entity';
 import { OpenaiOauthService } from '../../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
+import { GeminiOauthService } from '../../oauth/gemini-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
@@ -18,6 +19,7 @@ describe('ProxyFallbackService', () => {
   let customProviderRepo: jest.Mocked<Repository<CustomProvider>>;
   let openaiOauth: jest.Mocked<OpenaiOauthService>;
   let minimaxOauth: jest.Mocked<MinimaxOauthService>;
+  let geminiOauth: jest.Mocked<GeminiOauthService>;
   let providerClient: jest.Mocked<ProviderClient>;
   let copilotToken: jest.Mocked<CopilotTokenService>;
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
@@ -43,6 +45,10 @@ describe('ProxyFallbackService', () => {
       unwrapToken: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<MinimaxOauthService>;
 
+    geminiOauth = {
+      unwrapToken: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<GeminiOauthService>;
+
     providerClient = {
       forward: jest.fn(),
     } as unknown as jest.Mocked<ProviderClient>;
@@ -60,6 +66,7 @@ describe('ProxyFallbackService', () => {
       customProviderRepo,
       openaiOauth,
       minimaxOauth,
+      geminiOauth,
       providerClient,
       copilotToken,
       pricingCache,
@@ -287,21 +294,76 @@ describe('ProxyFallbackService', () => {
         stream: false,
         sessionKey: 'sess-1',
         authType: 'subscription',
-        resourceUrl: 'https://api.minimax.io/anthropic',
+        subscriptionResource: 'https://api.minimax.io/anthropic',
       });
 
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'minimax',
-        apiKey: 'token',
-        model: 'MiniMax-M2.5',
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'minimax',
+          apiKey: 'token',
+          model: 'MiniMax-M2.5',
+          body,
+          stream: false,
+          customEndpoint: expect.objectContaining({
+            baseUrl: 'https://api.minimax.io/anthropic',
+            format: 'anthropic',
+          }),
+          authType: 'subscription',
+          subscriptionResource: 'https://api.minimax.io/anthropic',
+        }),
+      );
+    });
+
+    it('overrides Qwen base URL when a non-default region is configured', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      // 'singapore' is one of the resolved regions recognized by isQwenResolvedRegion.
+      providerKeyService.getProviderRegion.mockResolvedValueOnce('singapore');
+
+      await service.tryForwardToProvider({
+        provider: 'qwen',
+        apiKey: 'qwen-key',
+        model: 'qwen-max',
         body,
         stream: false,
-        customEndpoint: expect.objectContaining({
-          baseUrl: 'https://api.minimax.io/anthropic',
-          format: 'anthropic',
-        }),
-        authType: 'subscription',
+        sessionKey: 'sess-1',
+        providerRegion: 'singapore',
       });
+
+      // The custom endpoint must be applied with the region-specific
+      // OpenAI-compatible base URL coming from getQwenCompatibleBaseUrl.
+      const forwardArgs = providerClient.forward.mock.calls[0][0];
+      expect(forwardArgs.customEndpoint).toBeDefined();
+      expect(forwardArgs.customEndpoint?.format).toBe('openai');
+      expect(forwardArgs.customEndpoint?.baseUrl).toMatch(/^https:\/\//);
+      expect(forwardArgs.customEndpoint?.requiresSsrfRevalidation).toBe(true);
+    });
+
+    it('does not override Qwen base URL when region is not in the resolved set', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await service.tryForwardToProvider({
+        provider: 'qwen',
+        apiKey: 'qwen-key',
+        model: 'qwen-max',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        providerRegion: null,
+      });
+
+      // No region → no endpoint override → no customEndpoint at all.
+      const forwardArgs = providerClient.forward.mock.calls[0][0];
+      expect(forwardArgs.customEndpoint).toBeUndefined();
     });
 
     it('ignores invalid minimax resource URL', async () => {
@@ -320,18 +382,25 @@ describe('ProxyFallbackService', () => {
         stream: false,
         sessionKey: 'sess-1',
         authType: 'subscription',
-        resourceUrl: 'not-a-valid-url',
+        subscriptionResource: 'not-a-valid-url',
       });
 
-      // Should forward without custom endpoint
-      expect(providerClient.forward).toHaveBeenCalledWith({
-        provider: 'minimax',
-        apiKey: 'token',
-        model: 'MiniMax-M2.5',
-        body,
-        stream: false,
-        authType: 'subscription',
-      });
+      // Should forward without custom endpoint, but the resource URL still
+      // propagates to subscriptionResource so downstream consumers can opt
+      // to use it (e.g. Code Assist envelope) — the MiniMax adapter falls
+      // back to the default endpoint when the URL fails normalization.
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'minimax',
+          apiKey: 'token',
+          model: 'MiniMax-M2.5',
+          body,
+          stream: false,
+          authType: 'subscription',
+          customEndpoint: undefined,
+          subscriptionResource: 'not-a-valid-url',
+        }),
+      );
     });
   });
 
@@ -603,6 +672,62 @@ describe('ProxyFallbackService', () => {
       expect(providerClient.forward).toHaveBeenCalledTimes(2);
     });
 
+    it('uses inferred prefix when the prefix provider is active', async () => {
+      // Branch coverage for the truthy arm of `prefix && hasActiveProvider`.
+      // Model has the `anthropic/` prefix, Anthropic is active for the agent
+      // → provider should be inferred from the prefix without going through
+      // pricingCache or findProviderForModel.
+      providerKeyService.hasActiveProvider.mockResolvedValue(true);
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-ant');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      });
+
+      const result = await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['anthropic/claude-sonnet-4'],
+        body,
+        false,
+        'sess-1',
+        'gpt-4o',
+      );
+
+      expect(result.success).not.toBeNull();
+      expect(result.success!.provider).toBe('anthropic');
+      // findProviderForModel must not be called when the prefix already wins.
+      expect(providerKeyService.findProviderForModel).not.toHaveBeenCalled();
+    });
+
+    it('treats a custom provider id without slash as the entire provider string', async () => {
+      // Branch coverage for `slashIdx > 0 ? substring : requestedModel`. When
+      // a fallback model is just `custom:cp-1` (no slash → no model name),
+      // the whole string is treated as the provider id.
+      providerKeyService.getProviderApiKey.mockResolvedValue('sk-key');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      const result = await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['custom:cp-1'],
+        body,
+        false,
+        'sess-1',
+        'gpt-4o',
+      );
+
+      expect(result.success).not.toBeNull();
+      expect(result.success!.provider).toBe('custom:cp-1');
+    });
+
     it('falls through to findProviderForModel when inferred prefix provider is inactive (#1383)', async () => {
       // Model has 'anthropic/' prefix but Anthropic is disabled
       providerKeyService.hasActiveProvider.mockResolvedValue(false);
@@ -656,6 +781,7 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        geminiOauth,
       );
 
       expect(result.apiKey).toBe('access-token');
@@ -678,10 +804,11 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        geminiOauth,
       );
 
       expect(result.apiKey).toBe('mm-token');
-      expect(result.resourceUrl).toBe('https://api.minimax.io');
+      expect(result.subscriptionResource).toBe('https://api.minimax.io');
     });
 
     it('returns original key for non-subscription auth', async () => {
@@ -693,6 +820,7 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        geminiOauth,
       );
 
       expect(result.apiKey).toBe('sk-key');
@@ -710,6 +838,7 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        geminiOauth,
       );
 
       expect(result.apiKey).toBe('blob');
@@ -724,6 +853,7 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        geminiOauth,
       );
 
       expect(result.apiKey).toBe('sk-ant');
@@ -742,9 +872,52 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        geminiOauth,
       );
 
       expect(result.apiKey).toBe('blob');
+    });
+
+    it('unwraps Gemini subscription token and surfaces the project id as subscriptionResource', async () => {
+      geminiOauth.unwrapToken.mockResolvedValue({
+        t: 'gem-token',
+        r: 'gem-refresh',
+        e: Date.now() + 60000,
+        u: 'project-42',
+      });
+
+      const result = await resolveApiKey(
+        'gemini',
+        'blob',
+        'subscription',
+        'agent-1',
+        'user-1',
+        openaiOauth,
+        minimaxOauth,
+        geminiOauth,
+      );
+
+      expect(result.apiKey).toBe('gem-token');
+      expect(result.subscriptionResource).toBe('project-42');
+      expect(geminiOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1');
+    });
+
+    it('falls back to the raw blob when Gemini unwrap returns null', async () => {
+      geminiOauth.unwrapToken.mockResolvedValue(null);
+
+      const result = await resolveApiKey(
+        'gemini',
+        'blob',
+        'subscription',
+        'agent-1',
+        'user-1',
+        openaiOauth,
+        minimaxOauth,
+        geminiOauth,
+      );
+
+      expect(result.apiKey).toBe('blob');
+      expect(result.subscriptionResource).toBeUndefined();
     });
 
     it('returns Z.ai subscription API key unchanged (no OAuth unwrap)', async () => {
@@ -756,10 +929,11 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        geminiOauth,
       );
 
       expect(result.apiKey).toBe('zai-sub-key');
-      expect(result.resourceUrl).toBeUndefined();
+      expect(result.subscriptionResource).toBeUndefined();
       expect(openaiOauth.unwrapToken).not.toHaveBeenCalled();
       expect(minimaxOauth.unwrapToken).not.toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -7,6 +7,7 @@ import type { ProviderKeyService } from '../../routing-core/provider-key.service
 import type { TierService } from '../../routing-core/tier.service';
 import type { OpenaiOauthService } from '../../oauth/openai-oauth.service';
 import type { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
+import type { GeminiOauthService } from '../../oauth/gemini-oauth.service';
 import type { SessionMomentumService } from '../session-momentum.service';
 import type { LimitCheckService } from '../../../notifications/services/limit-check.service';
 import type { ProxyFallbackService } from '../proxy-fallback.service';
@@ -41,6 +42,7 @@ describe('ProxyService — orchestration', () => {
   let tierService: jest.Mocked<Pick<TierService, 'getTiers'>>;
   let openaiOauth: jest.Mocked<Pick<OpenaiOauthService, 'unwrapToken'>>;
   let minimaxOauth: jest.Mocked<Pick<MinimaxOauthService, 'unwrapToken'>>;
+  let geminiOauth: jest.Mocked<Pick<GeminiOauthService, 'unwrapToken'>>;
   let momentum: jest.Mocked<
     Pick<
       SessionMomentumService,
@@ -70,6 +72,7 @@ describe('ProxyService — orchestration', () => {
     tierService = { getTiers: jest.fn().mockResolvedValue([]) };
     openaiOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     minimaxOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
+    geminiOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     momentum = {
       recordTier: jest.fn(),
       recordCategory: jest.fn(),
@@ -93,6 +96,7 @@ describe('ProxyService — orchestration', () => {
       tierService as unknown as TierService,
       openaiOauth as unknown as OpenaiOauthService,
       minimaxOauth as unknown as MinimaxOauthService,
+      geminiOauth as unknown as GeminiOauthService,
       momentum as unknown as SessionMomentumService,
       limitCheck as unknown as LimitCheckService,
       fallbackService as unknown as ProxyFallbackService,
@@ -705,6 +709,85 @@ describe('ProxyService — orchestration', () => {
       await svc.proxyRequest(baseOpts());
       expect(signatureCache.retrieve).toHaveBeenCalledWith('sess-1', 'tool-call-1');
       expect(thinkingCache.retrieve).toHaveBeenCalledWith('sess-1', 'first-use-1');
+    });
+
+    it('forwards body.tools to the resolver when present', async () => {
+      // Branch coverage: `Array.isArray(body.tools) ? body.tools : undefined`
+      // — pass an array of tools and verify the resolver receives it as the
+      // third positional arg.
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      const tools = [
+        {
+          type: 'function',
+          function: { name: 'web_search', description: 'Search the web' },
+        },
+      ];
+      await svc.proxyRequest(
+        baseOpts({
+          body: {
+            messages: [{ role: 'user', content: 'find cats' }],
+            tools,
+          },
+        }),
+      );
+      // Third positional argument of resolveService.resolve is scoringTools.
+      const callArgs = resolveService.resolve.mock.calls[0];
+      expect(callArgs[2]).toEqual(tools);
+    });
+
+    it('converts a Responses-API body to chat-completions for routing when apiMode is "responses"', async () => {
+      // Branch coverage for line 113: when apiMode === 'responses', the
+      // service must derive a chat-completions body via toChatCompletionsRequest
+      // before scoring/routing — even though the original body keeps the
+      // Responses-API `input` field for downstream forwarding.
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await svc.proxyRequest(
+        baseOpts({
+          apiMode: 'responses',
+          body: {
+            input: 'do the thing',
+            instructions: 'be helpful',
+          } as never,
+        }),
+      );
+
+      // The resolver received synthesized chat-completions messages, not the
+      // raw `input` string — proves toChatCompletionsRequest was applied.
+      const [, scoringMessages] = resolveService.resolve.mock.calls[0];
+      expect(scoringMessages.some((m) => m.role === 'user' && m.content === 'do the thing')).toBe(
+        true,
+      );
+      // chatBody is forwarded alongside the original body for downstream use.
+      const forwardArgs = fallbackService.tryForwardToProvider.mock.calls[0][0];
+      expect(forwardArgs.apiMode).toBe('responses');
+      expect(forwardArgs.chatBody).toBeDefined();
     });
 
     it('strips system / developer roles when scoring', async () => {

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -212,6 +212,45 @@ export interface ExtractedSignature {
   signature: string;
 }
 
+/**
+ * Wrap a Gemini request body in the Code Assist envelope expected by
+ * `cloudcode-pa.googleapis.com/v1internal:generateContent`. Code Assist
+ * needs the GCP project ID at the envelope level (so that AI Pro / Ultra
+ * quotas are billed against the caller's managed project) and re-nests
+ * the standard Gemini body under `request.contents`.
+ *
+ * `projectId` is empty when the OAuth onboarding step couldn't resolve a
+ * project — Code Assist accepts that for free-tier callers, so we still
+ * emit the envelope but skip the field rather than send `project: ""`.
+ */
+export function wrapCodeAssistRequest(
+  geminiBody: Record<string, unknown>,
+  model: string,
+  projectId: string | undefined,
+): Record<string, unknown> {
+  const envelope: Record<string, unknown> = {
+    model,
+    request: { ...geminiBody, model },
+  };
+  if (projectId) envelope.project = projectId;
+  return envelope;
+}
+
+/**
+ * Code Assist responses (non-streaming and streaming alike) wrap the
+ * standard Gemini payload one level deeper, e.g. `{ response: { candidates: [...] } }`.
+ * Peel that wrapper off so the existing Gemini → OpenAI conversion can
+ * operate on the same shape it does for the normal Generative Language
+ * endpoint.
+ */
+function unwrapCodeAssistEnvelope(payload: Record<string, unknown>): Record<string, unknown> {
+  const inner = payload.response;
+  if (inner && typeof inner === 'object' && !Array.isArray(inner)) {
+    return inner as Record<string, unknown>;
+  }
+  return payload;
+}
+
 export function toGoogleRequest(
   body: Record<string, unknown>,
   _model: string,
@@ -261,7 +300,8 @@ export function fromGoogleResponse(
   googleResp: Record<string, unknown>,
   model: string,
 ): Record<string, unknown> & { _extractedSignatures?: ExtractedSignature[] } {
-  const candidates = (googleResp.candidates as Array<Record<string, unknown>>) || [];
+  const inner = unwrapCodeAssistEnvelope(googleResp);
+  const candidates = (inner.candidates as Array<Record<string, unknown>>) || [];
   const candidate = candidates[0];
 
   if (!candidate) {
@@ -276,6 +316,7 @@ export function fromGoogleResponse(
 
   const content = candidate.content as { parts?: Array<Record<string, unknown>> } | undefined;
   const parts = content?.parts || [];
+  const usage = inner.usageMetadata as Record<string, number> | undefined;
 
   let textContent = '';
   const toolCalls: Record<string, unknown>[] = [];
@@ -308,8 +349,6 @@ export function fromGoogleResponse(
 
   const message: Record<string, unknown> = { role: 'assistant', content: textContent || null };
   if (toolCalls.length > 0) message.tool_calls = toolCalls;
-
-  const usage = googleResp.usageMetadata as Record<string, number> | undefined;
 
   return {
     id: `chatcmpl-${randomUUID()}`,
@@ -371,7 +410,8 @@ export function transformGoogleStreamChunk(chunk: string, model: string): Google
     return empty;
   }
 
-  const candidates = (data.candidates as Array<Record<string, unknown>>) || [];
+  const inner = unwrapCodeAssistEnvelope(data);
+  const candidates = (inner.candidates as Array<Record<string, unknown>>) || [];
   const candidate = candidates[0];
   const content = candidate?.content as { parts?: Array<Record<string, unknown>> } | undefined;
   const parts = content?.parts || [];
@@ -416,7 +456,7 @@ export function transformGoogleStreamChunk(chunk: string, model: string): Google
     })}\n\n`;
   }
 
-  const usage = data.usageMetadata as Record<string, number> | undefined;
+  const usage = inner.usageMetadata as Record<string, number> | undefined;
   if (usage) {
     const finishReason = mapFinishReason(candidate ?? {}, toolCalls.length > 0);
     result += `data: ${JSON.stringify({

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -19,6 +19,7 @@ import {
   convertAnthropicStreamChunk as anthropicStreamChunkConverter,
   createAnthropicTransformer,
 } from './provider-client-converters';
+import { wrapCodeAssistRequest } from './google-adapter';
 import { ForwardOptions } from './proxy-types';
 import { toNativeResponsesRequest } from './responses-adapter';
 
@@ -93,6 +94,7 @@ export class ProviderClient {
       extraHeaders,
       customEndpoint,
       authType,
+      subscriptionResource,
     } = opts;
 
     const { endpoint, endpointKey } = this.resolveEndpoint(
@@ -121,6 +123,7 @@ export class ProviderClient {
       stream,
       signatureLookup: opts.signatureLookup,
       thinkingLookup: opts.thinkingLookup,
+      subscriptionResource,
     });
 
     const finalHeaders = extraHeaders ? { ...headers, ...extraHeaders } : headers;
@@ -196,20 +199,36 @@ export class ProviderClient {
     stream: boolean;
     signatureLookup?: ForwardOptions['signatureLookup'];
     thinkingLookup?: ForwardOptions['thinkingLookup'];
+    subscriptionResource?: string;
   }): { url: string; headers: Record<string, string>; requestBody: Record<string, unknown> } {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
     const requestSource = ctx.apiMode === 'responses' ? (chatBody ?? body) : body;
 
     if (endpoint.format === 'google') {
+      const isCodeAssist = endpointKey === 'google-subscription';
       // Google accepts the API key via header (set by buildHeaders below) so
       // we no longer need to embed it in the URL. Keeping the key out of the
       // URL avoids leaking it into upstream proxy / LB access logs.
-      let url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`;
-      if (stream) url += '?alt=sse';
+      let url: string;
+      if (isCodeAssist) {
+        // Code Assist uses verb-style methods (`:streamGenerateContent` vs
+        // `:generateContent`) instead of a path parameter, and still wants
+        // `?alt=sse` to switch streaming responses to Server-Sent Events.
+        const method = stream ? ':streamGenerateContent' : ':generateContent';
+        url = `${endpoint.baseUrl}/v1internal${method}`;
+        if (stream) url += '?alt=sse';
+      } else {
+        url = `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`;
+        if (stream) url += '?alt=sse';
+      }
+      const geminiBody = toGoogleRequest(requestSource, bareModel, ctx.signatureLookup);
+      const requestBody = isCodeAssist
+        ? wrapCodeAssistRequest(geminiBody, bareModel, ctx.subscriptionResource)
+        : geminiBody;
       return {
         url,
         headers: endpoint.buildHeaders(apiKey, authType),
-        requestBody: toGoogleRequest(requestSource, bareModel, ctx.signatureLookup),
+        requestBody,
       };
     }
 

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -65,6 +65,12 @@ const CHATGPT_SUBSCRIPTION_BASE = 'https://chatgpt.com/backend-api';
 const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
 const ZAI_SUBSCRIPTION_BASE = 'https://open.bigmodel.cn/api/coding/paas/v4';
 const OPENCODE_GO_BASE = 'https://opencode.ai/zen/go';
+// Google AI Pro / Ultra subscriptions are reached through the Code Assist
+// gateway (the same backend Gemini CLI talks to). Authenticated requests
+// inherit the caller's AI Pro/Ultra quotas; unauthenticated callers fall
+// back to the free tier limits, so we only ever forward here for the
+// `subscription` auth type.
+const GOOGLE_CODE_ASSIST_BASE = 'https://cloudcode-pa.googleapis.com';
 const chatgptSubscriptionHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   'Content-Type': 'application/json',
@@ -163,6 +169,21 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
       'x-goog-api-key': apiKey,
     }),
     buildPath: (model: string) => `/v1beta/models/${model}:generateContent`,
+    format: 'google',
+  },
+  // Google AI Pro / Ultra subscriptions route through the Code Assist
+  // gateway. The path returned here is the non-streaming method; the
+  // provider client swaps it for `:streamGenerateContent` on streaming
+  // requests. The request and response envelopes are handled in
+  // `google-adapter.ts` (see `wrapCodeAssistRequest` and the Code Assist
+  // unwrap branches in `fromGoogleResponse` / `transformGoogleStreamChunk`).
+  'google-subscription': {
+    baseUrl: GOOGLE_CODE_ASSIST_BASE,
+    buildHeaders: (apiKey: string) => ({
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    }),
+    buildPath: () => '/v1internal:generateContent',
     format: 'google',
   },
   copilot: {

--- a/packages/backend/src/routing/proxy/provider-hooks.ts
+++ b/packages/backend/src/routing/proxy/provider-hooks.ts
@@ -16,6 +16,7 @@ const SUBSCRIPTION_ENDPOINT_OVERRIDES: Record<string, string> = {
   openai: 'openai-subscription',
   minimax: 'minimax-subscription',
   zai: 'zai-subscription',
+  google: 'google-subscription',
 };
 
 export function resolveSubscriptionEndpointKey(endpointKey: string): string | undefined {

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -7,6 +7,7 @@ import { CustomProvider } from '../../entities/custom-provider.entity';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
 import { OpenaiOauthService } from '../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
+import { GeminiOauthService } from '../oauth/gemini-oauth.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ProviderClient, ForwardResult } from './provider-client';
 import {
@@ -53,6 +54,7 @@ export class ProxyFallbackService {
     private readonly customProviderRepo: Repository<CustomProvider>,
     private readonly openaiOauth: OpenaiOauthService,
     private readonly minimaxOauth: MinimaxOauthService,
+    private readonly geminiOauth: GeminiOauthService,
     private readonly providerClient: ProviderClient,
     private readonly copilotToken: CopilotTokenService,
     private readonly pricingCache: ModelPricingCacheService,
@@ -150,6 +152,7 @@ export class ProxyFallbackService {
         userId,
         this.openaiOauth,
         this.minimaxOauth,
+        this.geminiOauth,
       );
       const providerRegion = await this.providerKeyService.getProviderRegion(
         agentId,
@@ -172,7 +175,7 @@ export class ProxyFallbackService {
         signal,
         authType,
         apiMode,
-        resourceUrl: resolvedCredentials.resourceUrl,
+        subscriptionResource: resolvedCredentials.subscriptionResource,
         providerRegion,
         signatureLookup,
         thinkingLookup,
@@ -215,7 +218,7 @@ export class ProxyFallbackService {
     sessionKey: string;
     signal?: AbortSignal;
     authType?: string;
-    resourceUrl?: string;
+    subscriptionResource?: string;
     providerRegion?: string | null;
     apiMode?: ProxyApiMode;
     signatureLookup?: SignatureLookup;
@@ -252,7 +255,7 @@ export class ProxyFallbackService {
     sessionKey: string;
     signal?: AbortSignal;
     authType?: string;
-    resourceUrl?: string;
+    subscriptionResource?: string;
     providerRegion?: string | null;
     apiMode?: ProxyApiMode;
     signatureLookup?: SignatureLookup;
@@ -265,7 +268,7 @@ export class ProxyFallbackService {
       stream,
       signal,
       authType,
-      resourceUrl,
+      subscriptionResource,
       providerRegion,
       signatureLookup,
       thinkingLookup,
@@ -296,8 +299,12 @@ export class ProxyFallbackService {
       }
     } else if (resolveEndpointKey(provider) === 'qwen' && isQwenResolvedRegion(providerRegion)) {
       customEndpoint = buildEndpointOverride(getQwenCompatibleBaseUrl(providerRegion), 'qwen');
-    } else if (authType === 'subscription' && provider.toLowerCase() === 'minimax' && resourceUrl) {
-      const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(resourceUrl);
+    } else if (
+      authType === 'subscription' &&
+      provider.toLowerCase() === 'minimax' &&
+      subscriptionResource
+    ) {
+      const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(subscriptionResource);
       if (minimaxBaseUrl) {
         customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
       } else {
@@ -316,6 +323,7 @@ export class ProxyFallbackService {
       extraHeaders,
       customEndpoint,
       authType,
+      subscriptionResource,
       apiMode: opts.apiMode,
       signatureLookup,
       thinkingLookup,
@@ -331,6 +339,20 @@ export function normalizeProviderModel(provider: string, model: string): string 
   return provider.toLowerCase() === 'anthropic' ? normalizeAnthropicShortModelId(model) : model;
 }
 
+/**
+ * Per-credential context surfaced when an OAuth blob is unwrapped. The
+ * concrete meaning of `subscriptionResource` is provider-specific:
+ *   - MiniMax stores the partner-specific base URL of the subscription
+ *     proxy (later normalized into a custom endpoint override).
+ *   - Google AI Pro / Ultra stores the GCP project id consumed by the
+ *     Code Assist request envelope.
+ * Other providers leave it undefined.
+ */
+export interface ResolvedApiKey {
+  apiKey: string;
+  subscriptionResource?: string;
+}
+
 export async function resolveApiKey(
   provider: string,
   apiKey: string,
@@ -339,7 +361,8 @@ export async function resolveApiKey(
   userId: string,
   openaiOauth: OpenaiOauthService,
   minimaxOauth: MinimaxOauthService,
-): Promise<{ apiKey: string; resourceUrl?: string }> {
+  geminiOauth: GeminiOauthService,
+): Promise<ResolvedApiKey> {
   if (authType === 'subscription') {
     const lower = provider.toLowerCase();
     if (lower === 'openai') {
@@ -348,7 +371,11 @@ export async function resolveApiKey(
     }
     if (lower === 'minimax') {
       const unwrapped = await minimaxOauth.unwrapToken(apiKey, agentId, userId);
-      if (unwrapped) return { apiKey: unwrapped.t, resourceUrl: unwrapped.u };
+      if (unwrapped) return { apiKey: unwrapped.t, subscriptionResource: unwrapped.u };
+    }
+    if (lower === 'gemini') {
+      const unwrapped = await geminiOauth.unwrapToken(apiKey, agentId, userId);
+      if (unwrapped) return { apiKey: unwrapped.t, subscriptionResource: unwrapped.u };
     }
   }
   return { apiKey };

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -43,6 +43,14 @@ export interface ForwardOptions {
   extraHeaders?: Record<string, string>;
   customEndpoint?: ProviderEndpoint;
   authType?: string;
+  /**
+   * Per-credential context attached to an unwrapped OAuth blob. The shape
+   * is provider-specific (a base URL for MiniMax, a GCP project id for
+   * Google AI Pro / Ultra) and `provider-client` interprets it according
+   * to the resolved endpoint. Undefined for providers that don't need any
+   * extra context beyond the access token.
+   */
+  subscriptionResource?: string;
   /** Lookup for re-injecting cached thought_signature values (Google only). */
   signatureLookup?: SignatureLookup;
   /** Lookup for re-injecting cached thinking blocks (Anthropic only). */

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -5,6 +5,7 @@ import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { TierService } from '../routing-core/tier.service';
 import { OpenaiOauthService } from '../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
+import { GeminiOauthService } from '../oauth/gemini-oauth.service';
 import { ForwardResult } from './provider-client';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
@@ -87,6 +88,7 @@ export class ProxyService {
     private readonly tierService: TierService,
     private readonly openaiOauth: OpenaiOauthService,
     private readonly minimaxOauth: MinimaxOauthService,
+    private readonly geminiOauth: GeminiOauthService,
     private readonly momentum: SessionMomentumService,
     private readonly limitCheck: LimitCheckService,
     private readonly fallbackService: ProxyFallbackService,
@@ -165,7 +167,7 @@ export class ProxyService {
       signal,
       authType: route.authType,
       apiMode,
-      resourceUrl: credentials.resourceUrl,
+      subscriptionResource: credentials.subscriptionResource,
       providerRegion: credentials.providerRegion,
       signatureLookup,
       thinkingLookup,
@@ -306,7 +308,11 @@ export class ProxyService {
     agentId: string,
     userId: string,
     resolved: { provider: string; auth_type?: AuthType },
-  ): Promise<{ apiKey: string; resourceUrl?: string; providerRegion?: string | null } | null> {
+  ): Promise<{
+    apiKey: string;
+    subscriptionResource?: string;
+    providerRegion?: string | null;
+  } | null> {
     const apiKey = await this.providerKeyService.getProviderApiKey(
       agentId,
       resolved.provider,
@@ -322,6 +328,7 @@ export class ProxyService {
       userId,
       this.openaiOauth,
       this.minimaxOauth,
+      this.geminiOauth,
     );
     const providerRegion = await this.providerKeyService.getProviderRegion(
       agentId,

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -2,13 +2,58 @@ import { createSignal, Show, type Component, type Accessor, type Setter } from '
 import type { ProviderDef } from '../services/providers.js';
 import {
   getOpenaiOAuthUrl,
-  submitOpenaiOAuthCallback,
   revokeOpenaiOAuth,
+  getGeminiOAuthUrl,
+  revokeGeminiOAuth,
   disconnectProvider,
   type AuthType,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import { monitorOAuthPopup } from '../services/oauth-popup.js';
+
+interface OAuthDispatch {
+  authorize: (agentName: string) => Promise<{ url: string }>;
+  revoke: (agentName: string) => Promise<{ ok: boolean }>;
+  /**
+   * Provider-specific hint shown above the "Log in" button. Lets us be
+   * precise about which account the user should pick — for OpenAI a generic
+   * "your OpenAI account" is fine, but for Google we need to call out that
+   * it must be the account that owns the AI Pro / Ultra subscription so
+   * users don't sign in with a personal Google account that can't route.
+   */
+  loginHint: string;
+  /**
+   * Optional link to the provider's plans/pricing page so users without an
+   * active subscription can sign up before retrying the OAuth flow.
+   */
+  plansUrl?: string;
+  plansLabel?: string;
+}
+
+// Each `popup_oauth` provider supplies its own authorize/revoke endpoints.
+// Wrapping the imports in thunks keeps the dispatch lazy so any test harness
+// that mocks `services/api.js` without re-exporting every OAuth helper
+// doesn't blow up during module evaluation.
+const OPENAI_DISPATCH: OAuthDispatch = {
+  authorize: (agentName) => getOpenaiOAuthUrl(agentName),
+  revoke: (agentName) => revokeOpenaiOAuth(agentName),
+  loginHint: 'Log in with your ChatGPT account to connect your subscription.',
+  plansUrl: 'https://openai.com/chatgpt/pricing/',
+  plansLabel: 'View ChatGPT plans',
+};
+
+const GEMINI_DISPATCH: OAuthDispatch = {
+  authorize: (agentName) => getGeminiOAuthUrl(agentName),
+  revoke: (agentName) => revokeGeminiOAuth(agentName),
+  loginHint: 'Log in with the Google account that owns your AI Pro or Ultra subscription.',
+  plansUrl: 'https://one.google.com/about/google-ai-plans/',
+  plansLabel: 'View Google AI plans',
+};
+
+function getOAuthDispatch(providerId: string): OAuthDispatch {
+  if (providerId === 'gemini') return GEMINI_DISPATCH;
+  return OPENAI_DISPATCH;
+}
 
 interface Props {
   provDef: ProviderDef;
@@ -25,15 +70,12 @@ interface Props {
 
 const OAuthDetailView: Component<Props> = (props) => {
   const [popupOpened, setPopupOpened] = createSignal(false);
-  const [pasteUrl, setPasteUrl] = createSignal('');
-  const [pasteError, setPasteError] = createSignal<string | null>(null);
+  const dispatch = () => getOAuthDispatch(props.provId);
 
   const handleOAuthLogin = async () => {
     props.setBusy(true);
-    setPasteUrl('');
-    setPasteError(null);
     try {
-      const { url } = await getOpenaiOAuthUrl(props.agentName);
+      const { url } = await dispatch().authorize(props.agentName);
       const popup = window.open(url, 'manifest-oauth', 'width=500,height=700');
       if (!popup) {
         toast.error(
@@ -53,7 +95,9 @@ const OAuthDetailView: Component<Props> = (props) => {
           props.onClose();
         },
         onFailure: () => {
-          // Popup closed without auto-redirect — user needs to paste the URL
+          // Popup closed without completing — reset so the user can retry.
+          setPopupOpened(false);
+          toast.error('Sign-in was cancelled. Try again.');
         },
       });
     } catch {
@@ -61,36 +105,12 @@ const OAuthDetailView: Component<Props> = (props) => {
     }
   };
 
-  const handlePasteSubmit = async () => {
-    const raw = pasteUrl().trim();
-    if (!raw) return;
-
-    try {
-      const url = new URL(raw);
-      const code = url.searchParams.get('code');
-      const state = url.searchParams.get('state');
-      if (!code || !state) {
-        setPasteError('URL is missing the authorization code. Make sure you copied the full URL.');
-        return;
-      }
-
-      props.setBusy(true);
-      setPasteError(null);
-      await submitOpenaiOAuthCallback(code, state);
-      toast.success(`${props.provDef.name} subscription connected`);
-      props.onUpdate();
-      props.onClose();
-    } catch {
-      setPasteError('Failed to exchange token. The URL may have expired — try logging in again.');
-    } finally {
-      props.setBusy(false);
-    }
-  };
-
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      await revokeOpenaiOAuth(props.agentName).catch(() => {});
+      await dispatch()
+        .revoke(props.agentName)
+        .catch(() => {});
       const result = await disconnectProvider(
         props.agentName,
         props.provId,
@@ -117,9 +137,7 @@ const OAuthDetailView: Component<Props> = (props) => {
           when={popupOpened()}
           fallback={
             <>
-              <p class="provider-detail__hint">
-                Log in with your {props.provDef.name} account to connect your subscription.
-              </p>
+              <p class="provider-detail__hint">{dispatch().loginHint}</p>
               <button
                 class="btn btn--primary provider-detail__action"
                 disabled={props.busy()}
@@ -129,55 +147,24 @@ const OAuthDetailView: Component<Props> = (props) => {
                   Log in with {props.provDef.name}
                 </Show>
               </button>
+              <Show when={dispatch().plansUrl}>
+                <p class="provider-detail__plans-hint">
+                  No subscription yet?{' '}
+                  <a href={dispatch().plansUrl} target="_blank" rel="noopener noreferrer">
+                    {dispatch().plansLabel}
+                  </a>
+                </p>
+              </Show>
             </>
           }
         >
           <p class="provider-detail__hint">
-            A login window has opened. After you sign in, the popup will show a "can't be reached"
-            page. This is expected.
+            A sign-in window has opened. Complete the flow there — this panel will update
+            automatically once your subscription is connected.
           </p>
-          <p class="provider-detail__hint" style="margin-top: 8px;">
-            Copy the full URL from the{' '}
-            <span style="color: #000000; font-weight: 500;">popup's address bar</span> and paste it
-            below:
-          </p>
-          <video
-            src="/images/oauth-callback-example.mp4"
-            autoplay
-            loop
-            muted
-            playsinline
-            style="width: 100%; border-radius: var(--radius); border: 1px solid hsl(var(--border)); margin-top: 12px;"
-          />
-          <div class="provider-detail__field" style="margin-top: 12px;">
-            <input
-              class="provider-detail__input"
-              classList={{ 'provider-detail__input--error': !!pasteError() }}
-              type="text"
-              autocomplete="off"
-              placeholder="http://localhost:1455/auth/callback?code=..."
-              value={pasteUrl()}
-              onInput={(e) => {
-                setPasteUrl(e.currentTarget.value);
-                setPasteError(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handlePasteSubmit();
-              }}
-            />
-            <Show when={pasteError()}>
-              <div class="provider-detail__error">{pasteError()}</div>
-            </Show>
-            <button
-              class="btn btn--primary btn--sm provider-detail__action"
-              style="margin-top: 8px;"
-              disabled={props.busy() || !pasteUrl().trim()}
-              onClick={handlePasteSubmit}
-            >
-              <Show when={!props.busy()} fallback={<span class="spinner" />}>
-                Connect
-              </Show>
-            </button>
+          <div class="provider-detail__waiting">
+            <span class="spinner" aria-hidden="true" />
+            <span>Waiting for sign-in to complete…</span>
           </div>
         </Show>
       </Show>
@@ -189,6 +176,7 @@ const OAuthDetailView: Component<Props> = (props) => {
         </div>
         <button
           class="btn btn--outline provider-detail__action provider-detail__disconnect"
+          aria-label={`Disconnect ${props.provDef.subscriptionLabel ?? 'subscription'}`}
           disabled={props.busy()}
           onClick={handleDisconnect}
         >

--- a/packages/frontend/src/services/api/oauth.ts
+++ b/packages/frontend/src/services/api/oauth.ts
@@ -49,3 +49,24 @@ export function pollMinimaxOAuth(flowId: string) {
     flowId,
   });
 }
+
+export function getGeminiOAuthUrl(agentName: string) {
+  return fetchJson<{ url: string }>(`/oauth/gemini/authorize`, {
+    agentName,
+  });
+}
+
+export function submitGeminiOAuthCallback(code: string, state: string) {
+  return fetchMutate<{ ok: boolean }>('/oauth/gemini/callback', {
+    method: 'POST',
+    body: JSON.stringify({ code, state }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export function revokeGeminiOAuth(agentName: string) {
+  return fetchMutate<{ ok: boolean }>(
+    `/oauth/gemini/revoke?agentName=${encodeURIComponent(agentName)}`,
+    { method: 'POST' },
+  );
+}

--- a/packages/frontend/src/services/oauth-popup.ts
+++ b/packages/frontend/src/services/oauth-popup.ts
@@ -62,12 +62,14 @@ export function monitorOAuthPopup(
   pollRef = setInterval(() => {
     try {
       const doneUrl = popup.location?.href;
-      if (doneUrl?.includes('/oauth/openai/done')) {
+      // Match any provider's /done page so the same monitor handles OpenAI,
+      // Gemini, and any future popup_oauth provider.
+      if (doneUrl && /\/oauth\/[^/]+\/done(?:[?#]|$)/.test(doneUrl)) {
         const ok = new URL(doneUrl).searchParams.get('ok') === '1';
         handleResult(ok);
       }
     } catch {
-      // Cross-origin -- popup is still on auth.openai.com, keep polling
+      // Cross-origin -- popup is still on the provider's auth domain, keep polling
     }
     // COOP makes popup.closed true immediately -- only stop polling,
     // keep BroadcastChannel alive so the done page message is received.

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -119,7 +119,10 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   gemini: {
     initial: 'G',
-    subtitle: 'Gemini 2.5, Gemini 2.0 Flash',
+    subtitle: 'Gemini 3.1 Pro, 2.5 Pro, 2.5 Flash',
+    supportsSubscription: true,
+    subscriptionLabel: 'Google AI Pro/Ultra subscription',
+    subscriptionAuthMode: 'popup_oauth',
     models: [],
   },
   llamacpp: {

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -413,6 +413,39 @@
   line-height: 1.5;
 }
 
+.provider-detail__plans-hint {
+  clear: both;
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.5;
+  margin: 0;
+  padding-top: 16px;
+}
+
+.provider-detail__plans-hint a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.provider-detail__plans-hint a:hover {
+  color: hsl(var(--foreground));
+}
+
+.provider-detail__paste {
+  clear: both;
+  margin-top: 4px;
+}
+
+.provider-detail__waiting {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-sm);
+  color: hsl(var(--muted-foreground));
+  padding: 12px 0 4px;
+}
+
 .provider-detail__signin-btn {
   display: inline-flex;
   align-items: center;

--- a/packages/frontend/tests/components/ProviderDetailView.test.tsx
+++ b/packages/frontend/tests/components/ProviderDetailView.test.tsx
@@ -214,6 +214,28 @@ describe('ProviderDetailView', () => {
     });
   });
 
+  describe('Google AI Pro / Ultra subscription renders OAuthDetailView', () => {
+    it('renders OAuthDetailView when gemini provider is in popup_oauth subscription mode', () => {
+      const connectedGeminiSub: RoutingProvider[] = [
+        {
+          id: 'p2',
+          provider: 'gemini',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: false,
+          connected_at: '2025-01-01',
+        },
+      ];
+      const props = createTestProps({
+        provId: 'gemini',
+        providers: connectedGeminiSub,
+        selectedAuthType: 'subscription',
+      });
+      render(() => <ProviderDetailView {...props} />);
+      expect(screen.getByTestId('oauth-detail-view')).toBeDefined();
+    });
+  });
+
   it('renders back button', () => {
     const props = createTestProps();
     render(() => <ProviderDetailView {...props} />);

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1292,7 +1292,10 @@ describe('ProviderSelectModal', () => {
         />
       ));
       fireEvent.click(screen.getByText('OpenAI'));
-      expect(screen.getByText(/Log in with your OpenAI account/)).toBeDefined();
+      // The OpenAI dispatch ships its own provider-specific login hint;
+      // the previous "Log in with your {name} account" template was removed
+      // when the OAuthDispatch.loginHint field replaced it.
+      expect(screen.getByText(/Log in with your ChatGPT account/)).toBeDefined();
     });
 
     it('calls getOpenaiOAuthUrl and opens popup on login click', async () => {
@@ -2029,7 +2032,7 @@ describe('ProviderSelectModal', () => {
       vi.restoreAllMocks();
     });
 
-    it('shows paste URL input immediately after clicking login', async () => {
+    it('shows the waiting-for-sign-in indicator immediately after clicking login', async () => {
       const mockPopup = {
         closed: false,
         close: vi.fn(),
@@ -2050,11 +2053,10 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('OpenAI'));
       fireEvent.click(screen.getByText('Log in with OpenAI'));
 
-      // Paste URL field appears immediately (not after popup closes)
+      // The loopback callback handles the redirect automatically — the panel
+      // just shows a "waiting" state until BroadcastChannel/postMessage fires.
       await waitFor(() => {
-        expect(
-          screen.getByPlaceholderText('http://localhost:1455/auth/callback?code=...'),
-        ).toBeDefined();
+        expect(screen.getByText(/Waiting for sign-in to complete/i)).toBeDefined();
       });
       expect(onUpdate).not.toHaveBeenCalled();
 
@@ -2206,7 +2208,7 @@ describe('ProviderSelectModal', () => {
       vi.restoreAllMocks();
     });
 
-    it('keeps paste URL visible after failed OAuth via postMessage', async () => {
+    it('returns to the login button after failed OAuth via postMessage', async () => {
       const mockPopup = {
         closed: false,
         close: vi.fn(),
@@ -2227,19 +2229,16 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('OpenAI'));
       fireEvent.click(screen.getByText('Log in with OpenAI'));
 
-      // Paste URL field is already visible before any message
+      // Waiting indicator appears while the popup is in flight.
       await waitFor(() => {
-        expect(
-          screen.getByPlaceholderText('http://localhost:1455/auth/callback?code=...'),
-        ).toBeDefined();
+        expect(screen.getByText(/Waiting for sign-in to complete/i)).toBeDefined();
       });
 
-      // Error message arrives — paste field still visible, no crash
+      // Error message arrives — panel resets to the login CTA so the user can retry.
       window.dispatchEvent(new MessageEvent('message', { data: { type: 'manifest-oauth-error' } }));
-      await new Promise((r) => setTimeout(r, 50));
-      expect(
-        screen.getByPlaceholderText('http://localhost:1455/auth/callback?code=...'),
-      ).toBeDefined();
+      await waitFor(() => {
+        expect(screen.getByText('Log in with OpenAI')).toBeDefined();
+      });
       expect(onUpdate).not.toHaveBeenCalled();
 
       vi.restoreAllMocks();

--- a/packages/frontend/tests/services/api/oauth.test.ts
+++ b/packages/frontend/tests/services/api/oauth.test.ts
@@ -79,4 +79,33 @@ describe('oauth API client', () => {
     expect(url).toContain('/api/v1/oauth/minimax/poll');
     expect(url).toContain('flowId=flow-1');
   });
+
+  it('getGeminiOAuthUrl forwards agentName as a query param', async () => {
+    const fetchMock = setupFetch({ url: 'https://accounts.google.com/o/oauth2/v2/auth?...' });
+    const out = await oauth.getGeminiOAuthUrl('demo');
+    expect(out.url).toContain('accounts.google.com');
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/oauth/gemini/authorize');
+    expect(url).toContain('agentName=demo');
+  });
+
+  it('submitGeminiOAuthCallback POSTs code+state as JSON', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.submitGeminiOAuthCallback('auth-code', 'state-1');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/gemini/callback');
+    expect((init as RequestInit).method).toBe('POST');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      code: 'auth-code',
+      state: 'state-1',
+    });
+  });
+
+  it('revokeGeminiOAuth POSTs with the encoded agent name in the URL', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.revokeGeminiOAuth('agent name');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/gemini/revoke?agentName=agent%20name');
+    expect((init as RequestInit).method).toBe('POST');
+  });
 });

--- a/packages/frontend/tests/services/oauth-popup.test.ts
+++ b/packages/frontend/tests/services/oauth-popup.test.ts
@@ -80,6 +80,48 @@ describe("monitorOAuthPopup", () => {
     removeListenerSpy.mockRestore();
   });
 
+  it("URL polling matches any /oauth/<provider>/done page (openai + gemini)", () => {
+    for (const path of [
+      "http://localhost:3001/api/v1/oauth/openai/done?ok=1",
+      "http://localhost:3001/api/v1/oauth/gemini/done?ok=1",
+    ]) {
+      const popup = {
+        closed: false,
+        close: vi.fn(),
+        location: { href: path } as unknown as Location,
+      } as unknown as Window;
+
+      const onSuccess = vi.fn();
+      const onFailure = vi.fn();
+
+      monitorOAuthPopup(popup, { onSuccess, onFailure });
+
+      vi.advanceTimersByTime(300);
+
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+      expect(onFailure).not.toHaveBeenCalled();
+    }
+  });
+
+  it("URL polling reports failure when /done page reports ok=0", () => {
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      location: {
+        href: "http://localhost:3001/api/v1/oauth/gemini/done?ok=0",
+      } as unknown as Location,
+    } as unknown as Window;
+
+    const onSuccess = vi.fn();
+    const onFailure = vi.fn();
+
+    monitorOAuthPopup(popup, { onSuccess, onFailure });
+    vi.advanceTimersByTime(300);
+
+    expect(onFailure).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
   it("ignores non-oauth messages", () => {
     const popup = {
       closed: false,

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -18,6 +18,7 @@ describe('SUBSCRIPTION_PROVIDER_CONFIGS', () => {
         'ollama-cloud',
         'zai',
         'opencode-go',
+        'gemini',
       ]),
     );
   });
@@ -97,6 +98,20 @@ describe('getSubscriptionProviderConfig', () => {
     });
   });
 
+  it('returns config for gemini', () => {
+    const config = getSubscriptionProviderConfig('gemini');
+    expect(config).toMatchObject({
+      supportsSubscription: true,
+      subscriptionLabel: 'Google AI Pro/Ultra subscription',
+      subscriptionAuthMode: 'popup_oauth',
+    });
+    expect(config?.subscriptionCapabilities).toMatchObject({
+      maxContextWindow: 1000000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    });
+  });
+
   it('returns config for opencode-go', () => {
     const config = getSubscriptionProviderConfig('opencode-go');
     expect(config).toMatchObject({
@@ -140,6 +155,7 @@ describe('supportsSubscriptionProvider', () => {
     expect(supportsSubscriptionProvider('ollama-cloud')).toBe(true);
     expect(supportsSubscriptionProvider('zai')).toBe(true);
     expect(supportsSubscriptionProvider('opencode-go')).toBe(true);
+    expect(supportsSubscriptionProvider('gemini')).toBe(true);
   });
 
   it('returns false for unsupported providers', () => {
@@ -182,6 +198,13 @@ describe('getSubscriptionKnownModels', () => {
 
   it('returns null for opencode-go (dynamic catalog, no hardcoded list)', () => {
     expect(getSubscriptionKnownModels('opencode-go')).toBeNull();
+  });
+
+  it('returns known models for gemini covering Google AI Pro/Ultra tiers', () => {
+    const models = getSubscriptionKnownModels('gemini');
+    expect(models).toContain('gemini-3.1-pro');
+    expect(models).toContain('gemini-2.5-pro');
+    expect(models).toContain('gemini-2.5-flash');
   });
 
   it('returns null for unsupported providers', () => {

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -100,6 +100,30 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       supportsBatching: false,
     }),
   }),
+  gemini: Object.freeze({
+    supportsSubscription: true as const,
+    subscriptionLabel: 'Google AI Pro/Ultra subscription',
+    subscriptionAuthMode: 'popup_oauth' as const,
+    // Order matters — the auto-assign service falls back to the first entry
+    // when nothing else differentiates the candidates. Lead with the models
+    // every Code Assist account (free, AI Plus, AI Pro, AI Ultra) can hit
+    // reliably, then list the AI Pro/Ultra-only flagship last. Preview
+    // models are intentionally excluded: they 429 on free/AI Pro quota
+    // and aren't a safe default.
+    knownModels: Object.freeze([
+      'gemini-2.5-pro',
+      'gemini-2.5-flash',
+      'gemini-2.5-flash-lite',
+      'gemini-3.1-pro',
+    ]),
+    subscriptionCapabilities: Object.freeze({
+      // Gemini 2.5/3.x Pro all expose the 1M-token context window through
+      // Code Assist when authenticated with a Google AI Pro / Ultra account.
+      maxContextWindow: 1000000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
   copilot: Object.freeze({
     supportsSubscription: true as const,
     subscriptionLabel: 'GitHub Copilot subscription',


### PR DESCRIPTION
## Summary

- Adds Google AI Pro/Ultra subscription support to Manifest, modeled on the existing OpenAI/ChatGPT `popup_oauth` flow.
- Routes subscription requests through `cloudcode-pa.googleapis.com` (the Code Assist gateway the Gemini CLI also uses) so the caller's AI Pro/Ultra quota is honored.
- Frontend exposes "Log in with Google" on the Gemini provider tile, plus a "View Google AI plans" link for users without a subscription.
- Replaces PR #1071 (rebuilt from scratch on top of current `main` — the original branch was 5+ months stale and conflicted heavily).

## How it works

- New `GeminiOauthService` (mirrors `OpenaiOauthService`) handles PKCE OAuth with `access_type=offline`, port-1456 loopback callback in dev, and refresh-token persistence.
- After exchanging the code, calls `loadCodeAssist`/`onboardUser` with the right `tierId` (resolved from the gateway response — `currentTier` → default `allowedTier` → `standard-tier`) to provision a Code Assist project. Project id is stored alongside the token blob.
- `unwrapToken` lazily re-runs project discovery whenever the cached blob has no project id (covers cases where onboarding 400'd at OAuth time, or Google provisioned the project asynchronously).
- New `google-subscription` endpoint in `PROVIDER_ENDPOINTS` and override in `SUBSCRIPTION_ENDPOINT_OVERRIDES`. Request body is wrapped in the Code Assist envelope (`{ model, project, request: <gemini-body> }`); responses (streaming + non-streaming) unwrap the `{ response: ... }` envelope before going through the existing Gemini → OpenAI converter.
- Streaming switches the URL verb to `:streamGenerateContent?alt=sse`.
- `OAuthTokenBlob.u` is documented as an opaque per-provider resource id (MiniMax: base URL, Google: GCP project id).
- Renamed `resourceUrl` → `subscriptionResource` end-to-end so MiniMax (URL) and Google (project id) share the same generic carrier name.

## Curated model whitelist

The Code Assist gateway has no public `/models` endpoint, so we ship a curated list ordered by access tier:

1. `gemini-2.5-pro` — universally accessible (free, AI Plus, AI Pro, AI Ultra)
2. `gemini-2.5-flash`
3. `gemini-2.5-flash-lite`
4. `gemini-3.1-pro` — AI Pro/Ultra flagship

Preview models (`gemini-3-pro-preview`) are intentionally excluded — they 429 for free/AI Pro accounts and aren't a safe default.

## Configuration

Operators must supply Google OAuth credentials via env:

- `GOOGLE_GEMINI_CLIENT_ID`
- `GOOGLE_GEMINI_CLIENT_SECRET`

The Gemini CLI ships its own "Desktop" OAuth credentials in `@google/gemini-cli-core` that work out of the box for self-hosted dev — operators that want to use those can copy them from the CLI source. We don't bundle them here because GitHub secret scanning flags Google's "public-by-design" Desktop secrets.

## UI

- Gemini tile subtitle now reads `Gemini 3.1 Pro, 2.5 Pro, 2.5 Flash`.
- Subscription label: `Google AI Pro/Ultra subscription`.
- Provider-specific login hint per dispatch entry; for Gemini: "Log in with the Google account that owns your AI Pro or Ultra subscription."
- "No subscription yet? View Google AI plans" link to https://one.google.com/about/google-ai-plans/
- Removed the URL-paste fallback UI (the loopback callback handles it transparently); replaced with a simple "Waiting for sign-in to complete…" indicator.
- Aria-label on the Disconnect button.

## Test plan

- [x] Backend unit tests: 4429/4429 passing (245 suites)
- [x] Frontend tests: 2616/2616 passing (139 suites)
- [x] Shared tests: 131/131 passing
- [x] E2E tests: 138/138 passing against fresh DB
- [x] TypeScript compiles clean across all three packages
- [x] 100% line coverage on every changed/new file (gemini-oauth.controller, gemini-oauth.service, google-adapter, provider-client, provider-hooks, provider-endpoints, proxy-fallback, proxy.service, model-discovery)
- [x] Manual: OAuth popup completes via loopback callback, project id resolved, tokens persisted
- [ ] Manual: end-to-end chat completion via subscription (blocked on account-level Code Assist quota during testing — gateway returned 429 RESOURCE_EXHAUSTED across all models; integration is wired correctly, just couldn't validate working models on the test account)

## Files

- New: `gemini-oauth.{service,controller}.ts` + 3 spec files
- New: `provider-hooks.spec.ts`
- Modified: 11 backend source files (proxy layer, model discovery, OAuth module)
- Modified: 4 frontend files (`OAuthDetailView`, `api/oauth.ts`, `oauth-popup.ts`, `providers.ts`, `routing-providers.css`)
- Modified: 1 shared file (`subscription/configs.ts`)
- 36 files changed, +2958 / -145 lines

## Sources

- [Google AI Plans (one.google.com)](https://one.google.com/about/google-ai-plans/)
- [Gemini CLI source — code_assist/setup.ts](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/code_assist/setup.ts)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google AI Pro/Ultra subscription support for the Gemini provider using a popup OAuth flow and routes requests through `cloudcode-pa.googleapis.com` (Code Assist) so user quotas are applied.

- **New Features**
  - Popup OAuth (PKCE, offline access) via `GeminiOauthService`, with loopback callback and refresh-token persistence.
  - Code Assist onboarding: resolves tier, provisions project, stores project id; lazy re-discovery if missing.
  - New `google-subscription` endpoint; wraps requests in the Code Assist envelope and unwraps responses; streaming via `:streamGenerateContent?alt=sse`.
  - Curated model whitelist: `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-3.1-pro`.
  - UI: “Log in with Google” on the Gemini tile, provider-specific login hint, “View Google AI plans” link, and a simple “Waiting for sign-in…” state.

- **Migration**
  - Set `GOOGLE_GEMINI_CLIENT_ID` and `GOOGLE_GEMINI_CLIENT_SECRET`. You may reuse Desktop creds from `@google/gemini-cli-core` if desired.
  - Renamed `resourceUrl` to `subscriptionResource` across the stack (MiniMax uses a base URL; Google uses a GCP project id).

<sup>Written for commit 0c98a09f26d51f375854cece60de42c2fedf7f5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

