### PR TITLE
feat: show "Last used" hint on sign-in pages

### DIFF
--- a/.changeset/last-auth-method-hint.md
+++ b/.changeset/last-auth-method-hint.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Show a small "Last used" badge on the sign-in and sign-up pages so returning visitors can see at a glance which method (email or one of the social providers) they used last time. The hint is stored per-browser in `localStorage` and is best-effort: it falls back silently when storage is unavailable.

--- a/packages/frontend/src/components/SocialButtons.tsx
+++ b/packages/frontend/src/components/SocialButtons.tsx
@@ -1,5 +1,6 @@
 import { For, Show, type Component, type JSX } from 'solid-js';
 import { authClient } from '../services/auth-client.js';
+import { setLastAuthMethod } from '../services/last-auth-method.js';
 
 type Provider = 'google' | 'github' | 'discord';
 
@@ -10,6 +11,7 @@ const allProviders: { id: Provider; label: string }[] = [
 ];
 
 const handleSocialLogin = (provider: Provider) => {
+  setLastAuthMethod(provider);
   authClient.signIn.social({
     provider,
     callbackURL: '/',
@@ -50,7 +52,9 @@ const providerIcons: Record<Provider, () => JSX.Element> = {
   ),
 };
 
-const SocialButtons: Component<{ enabledProviders?: string[] }> = (props) => {
+const SocialButtons: Component<{ enabledProviders?: string[]; lastUsed?: string | null }> = (
+  props,
+) => {
   const visible = () => {
     if (!props.enabledProviders) return allProviders;
     return allProviders.filter((p) => props.enabledProviders!.includes(p.id));
@@ -66,7 +70,12 @@ const SocialButtons: Component<{ enabledProviders?: string[] }> = (props) => {
               onClick={() => handleSocialLogin(provider.id)}
             >
               <span class="auth-social-btn__icon">{providerIcons[provider.id]()}</span>
-              {provider.label}
+              <span class="auth-social-btn__label">{provider.label}</span>
+              <Show when={props.lastUsed === provider.id}>
+                <span class="auth-last-used" aria-label="Last used">
+                  Last used
+                </span>
+              </Show>
             </button>
           )}
         </For>

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { Title, Meta } from '@solidjs/meta';
 import { type Component, createSignal, createUniqueId, onCleanup, onMount, Show } from 'solid-js';
 import SocialButtons from '../components/SocialButtons.jsx';
 import { authClient } from '../services/auth-client.js';
+import { getLastAuthMethod, setLastAuthMethod } from '../services/last-auth-method.js';
 import { checkSocialProviders } from '../services/setup-status.js';
 
 const RESEND_COOLDOWN_SECONDS = 60;
@@ -15,6 +16,7 @@ const Login: Component = () => {
   const [needsVerification, setNeedsVerification] = createSignal(false);
   const [resendCooldown, setResendCooldown] = createSignal(0);
   const [socialProviders, setSocialProviders] = createSignal<string[]>([]);
+  const [lastAuthMethod] = createSignal(getLastAuthMethod());
   const [searchParams] = useSearchParams();
   const emailId = createUniqueId();
   const passwordId = createUniqueId();
@@ -75,6 +77,7 @@ const Login: Component = () => {
       return;
     }
 
+    setLastAuthMethod('email');
     window.location.href = '/';
   };
 
@@ -104,7 +107,7 @@ const Login: Component = () => {
         <p class="auth-header__subtitle">Take control of your AI agent costs</p>
       </div>
 
-      <SocialButtons enabledProviders={socialProviders()} />
+      <SocialButtons enabledProviders={socialProviders()} lastUsed={lastAuthMethod()} />
 
       <Show when={socialProviders().length > 0}>
         <div class="auth-divider">
@@ -163,7 +166,14 @@ const Login: Component = () => {
           </A>
         </div>
         <button class="auth-form__submit" type="submit" disabled={loading()}>
-          {loading() ? <span class="spinner" /> : 'Sign in'}
+          <Show when={loading()} fallback={<span>Sign in</span>}>
+            <span class="spinner" />
+          </Show>
+          <Show when={!loading() && lastAuthMethod() === 'email'}>
+            <span class="auth-last-used" aria-label="Last used">
+              Last used
+            </span>
+          </Show>
         </button>
       </form>
       <div class="auth-footer">

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -166,14 +166,7 @@ const Login: Component = () => {
           </A>
         </div>
         <button class="auth-form__submit" type="submit" disabled={loading()}>
-          <Show when={loading()} fallback={<span>Sign in</span>}>
-            <span class="spinner" />
-          </Show>
-          <Show when={!loading() && lastAuthMethod() === 'email'}>
-            <span class="auth-last-used" aria-label="Last used">
-              Last used
-            </span>
-          </Show>
+          {loading() ? <span class="spinner" /> : 'Sign in'}
         </button>
       </form>
       <div class="auth-footer">

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -3,6 +3,7 @@ import { Title, Meta } from '@solidjs/meta';
 import { type Component, createSignal, createUniqueId, onCleanup, onMount, Show } from 'solid-js';
 import SocialButtons from '../components/SocialButtons.jsx';
 import { authClient } from '../services/auth-client.js';
+import { getLastAuthMethod, setLastAuthMethod } from '../services/last-auth-method.js';
 import { checkSocialProviders } from '../services/setup-status.js';
 
 const RESEND_COOLDOWN_SECONDS = 60;
@@ -17,6 +18,7 @@ const Register: Component = () => {
   const [alreadyExists, setAlreadyExists] = createSignal(false);
   const [resendCooldown, setResendCooldown] = createSignal(0);
   const [socialProviders, setSocialProviders] = createSignal<string[]>([]);
+  const [lastAuthMethod] = createSignal(getLastAuthMethod());
   const nameId = createUniqueId();
   const emailId = createUniqueId();
   const passwordId = createUniqueId();
@@ -68,6 +70,7 @@ const Register: Component = () => {
       return;
     }
     setAlreadyExists(false);
+    setLastAuthMethod('email');
 
     if (data?.token) {
       window.location.href = '/';
@@ -110,7 +113,7 @@ const Register: Component = () => {
               <p class="auth-header__subtitle">Monitor your AI agents' costs and usage</p>
             </div>
 
-            <SocialButtons enabledProviders={socialProviders()} />
+            <SocialButtons enabledProviders={socialProviders()} lastUsed={lastAuthMethod()} />
 
             <Show when={socialProviders().length > 0}>
               <div class="auth-divider">
@@ -182,7 +185,14 @@ const Register: Component = () => {
                 />
               </label>
               <button class="auth-form__submit" type="submit" disabled={loading()}>
-                {loading() ? <span class="spinner" /> : 'Create account'}
+                <Show when={loading()} fallback={<span>Create account</span>}>
+                  <span class="spinner" />
+                </Show>
+                <Show when={!loading() && lastAuthMethod() === 'email'}>
+                  <span class="auth-last-used" aria-label="Last used">
+                    Last used
+                  </span>
+                </Show>
               </button>
             </form>
             <p class="auth-terms">

--- a/packages/frontend/src/pages/Register.tsx
+++ b/packages/frontend/src/pages/Register.tsx
@@ -185,14 +185,7 @@ const Register: Component = () => {
                 />
               </label>
               <button class="auth-form__submit" type="submit" disabled={loading()}>
-                <Show when={loading()} fallback={<span>Create account</span>}>
-                  <span class="spinner" />
-                </Show>
-                <Show when={!loading() && lastAuthMethod() === 'email'}>
-                  <span class="auth-last-used" aria-label="Last used">
-                    Last used
-                  </span>
-                </Show>
+                {loading() ? <span class="spinner" /> : 'Create account'}
               </button>
             </form>
             <p class="auth-terms">

--- a/packages/frontend/src/services/last-auth-method.ts
+++ b/packages/frontend/src/services/last-auth-method.ts
@@ -1,0 +1,21 @@
+export type AuthMethod = 'email' | 'google' | 'github' | 'discord';
+
+const STORAGE_KEY = 'manifest:last-auth-method';
+const VALID: ReadonlySet<AuthMethod> = new Set(['email', 'google', 'github', 'discord']);
+
+export const getLastAuthMethod = (): AuthMethod | null => {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    return value && VALID.has(value as AuthMethod) ? (value as AuthMethod) : null;
+  } catch {
+    return null;
+  }
+};
+
+export const setLastAuthMethod = (method: AuthMethod): void => {
+  try {
+    localStorage.setItem(STORAGE_KEY, method);
+  } catch {
+    // localStorage may be unavailable (private mode, disabled storage); the hint is best-effort.
+  }
+};

--- a/packages/frontend/src/styles/auth.css
+++ b/packages/frontend/src/styles/auth.css
@@ -127,6 +127,10 @@
 }
 
 .auth-form__submit {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   height: 2.75rem;
   background: hsl(var(--primary));
   color: hsl(var(--primary-foreground));
@@ -229,6 +233,7 @@
 }
 
 .auth-social-btn {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -270,6 +275,27 @@
 }
 .auth-social-btn--discord:hover {
   border-color: #5865f2;
+}
+
+/* ── "Last used" badge ───────────────────────────── */
+.auth-last-used {
+  position: absolute;
+  right: var(--gap-md);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 0.125rem 0.5rem;
+  background: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  border-radius: 999px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  pointer-events: none;
+}
+
+.auth-form__submit .auth-last-used {
+  background: hsl(var(--primary-foreground) / 0.18);
+  color: hsl(var(--primary-foreground));
 }
 
 /* ── Auth Footer / Terms ─────────────────────────── */

--- a/packages/frontend/src/styles/auth.css
+++ b/packages/frontend/src/styles/auth.css
@@ -127,10 +127,6 @@
 }
 
 .auth-form__submit {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   height: 2.75rem;
   background: hsl(var(--primary));
   color: hsl(var(--primary-foreground));
@@ -291,11 +287,6 @@
   font-weight: 500;
   letter-spacing: 0.01em;
   pointer-events: none;
-}
-
-.auth-form__submit .auth-last-used {
-  background: hsl(var(--primary-foreground) / 0.18);
-  color: hsl(var(--primary-foreground));
 }
 
 /* ── Auth Footer / Terms ─────────────────────────── */

--- a/packages/frontend/tests/components/SocialButtons.test.tsx
+++ b/packages/frontend/tests/components/SocialButtons.test.tsx
@@ -10,10 +10,12 @@ vi.mock("../../src/services/auth-client.js", () => ({
 }));
 
 import SocialButtons from "../../src/components/SocialButtons";
+import { getLastAuthMethod } from "../../src/services/last-auth-method";
 
 describe("SocialButtons", () => {
   beforeEach(() => {
     mockSignInSocial.mockClear();
+    localStorage.clear();
   });
 
   it("renders all 3 social buttons when no enabledProviders prop", () => {
@@ -51,5 +53,24 @@ describe("SocialButtons", () => {
     render(() => <SocialButtons />);
     await fireEvent.click(screen.getByText("Continue with Discord"));
     expect(mockSignInSocial).toHaveBeenCalledWith(expect.objectContaining({ provider: "discord" }));
+  });
+
+  it("renders the Last used badge only on the matching provider", () => {
+    const { container } = render(() => <SocialButtons lastUsed="github" />);
+    const badges = container.querySelectorAll(".auth-last-used");
+    expect(badges.length).toBe(1);
+    const githubBtn = container.querySelector(".auth-social-btn--github")!;
+    expect(githubBtn.querySelector(".auth-last-used")).not.toBeNull();
+  });
+
+  it("renders no badge when lastUsed does not match a social provider", () => {
+    const { container } = render(() => <SocialButtons lastUsed="email" />);
+    expect(container.querySelector(".auth-last-used")).toBeNull();
+  });
+
+  it("persists the chosen provider before redirecting", async () => {
+    render(() => <SocialButtons />);
+    await fireEvent.click(screen.getByText("Continue with Google"));
+    expect(getLastAuthMethod()).toBe("google");
   });
 });

--- a/packages/frontend/tests/pages/Login.test.tsx
+++ b/packages/frontend/tests/pages/Login.test.tsx
@@ -248,13 +248,6 @@ describe("Login", () => {
     expect(getLastAuthMethod()).toBeNull();
   });
 
-  it("shows Last used badge on submit when previous method was email", () => {
-    setLastAuthMethod("email");
-    const { container } = render(() => <Login />);
-    const submit = container.querySelector('button[type="submit"]')!;
-    expect(submit.querySelector(".auth-last-used")).not.toBeNull();
-  });
-
   it("forwards lastUsed to SocialButtons when previous method was a provider", async () => {
     mockCheckSocialProviders.mockResolvedValue(["github"]);
     setLastAuthMethod("github");

--- a/packages/frontend/tests/pages/Login.test.tsx
+++ b/packages/frontend/tests/pages/Login.test.tsx
@@ -33,6 +33,7 @@ vi.mock("../../src/services/setup-status.js", () => ({
 }));
 
 import Login from "../../src/pages/Login";
+import { getLastAuthMethod, setLastAuthMethod } from "../../src/services/last-auth-method";
 
 describe("Login", () => {
   beforeEach(() => {
@@ -40,6 +41,7 @@ describe("Login", () => {
     mockSearchParams = {};
     mockSignInEmail.mockResolvedValue({});
     mockCheckSocialProviders.mockResolvedValue([]);
+    localStorage.clear();
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
   });
 
@@ -213,6 +215,55 @@ describe("Login", () => {
       expect(container.textContent).toContain("Resend verification email");
     });
     vi.useRealTimers();
+  });
+
+  it("stores email as last auth method on successful sign-in", async () => {
+    mockSignInEmail.mockResolvedValue({ error: null });
+    const { container } = render(() => <Login />);
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: "t@t.com" },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: "password123" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(getLastAuthMethod()).toBe("email");
+    });
+  });
+
+  it("does not store last auth method when sign-in fails", async () => {
+    mockSignInEmail.mockResolvedValue({ error: { message: "nope" } });
+    const { container } = render(() => <Login />);
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: "t@t.com" },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: "wrong" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("nope");
+    });
+    expect(getLastAuthMethod()).toBeNull();
+  });
+
+  it("shows Last used badge on submit when previous method was email", () => {
+    setLastAuthMethod("email");
+    const { container } = render(() => <Login />);
+    const submit = container.querySelector('button[type="submit"]')!;
+    expect(submit.querySelector(".auth-last-used")).not.toBeNull();
+  });
+
+  it("forwards lastUsed to SocialButtons when previous method was a provider", async () => {
+    mockCheckSocialProviders.mockResolvedValue(["github"]);
+    setLastAuthMethod("github");
+    const { container } = render(() => <Login />);
+    await vi.waitFor(() => {
+      const githubBtn = container.querySelector(".auth-social-btn--github");
+      expect(githubBtn).not.toBeNull();
+      expect(githubBtn!.querySelector(".auth-last-used")).not.toBeNull();
+    });
   });
 
   it("shows resend error when sendVerificationEmail fails", async () => {

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -29,11 +29,13 @@ vi.mock("../../src/services/setup-status.js", () => ({
 }));
 
 import Register from "../../src/pages/Register";
+import { getLastAuthMethod, setLastAuthMethod } from "../../src/services/last-auth-method";
 
 describe("Register", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSignUpEmail.mockResolvedValue({});
+    localStorage.clear();
   });
 
   it("renders create account heading", () => {
@@ -221,6 +223,46 @@ describe("Register", () => {
       });
     }
     vi.useRealTimers();
+  });
+
+  it("stores email as last auth method on successful signup", async () => {
+    mockSignUpEmail.mockResolvedValue({ error: null });
+    const { container } = render(() => <Register />);
+    fireEvent.input(container.querySelector('input[type="text"]')!, { target: { value: "Test" } });
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: "test@test.com" },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: "pass12345" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(getLastAuthMethod()).toBe("email");
+    });
+  });
+
+  it("does not store last auth method when signup fails", async () => {
+    mockSignUpEmail.mockResolvedValue({ error: { message: "boom" } });
+    const { container } = render(() => <Register />);
+    fireEvent.input(container.querySelector('input[type="text"]')!, { target: { value: "Test" } });
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: "t@t.com" },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: "pass12345" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("boom");
+    });
+    expect(getLastAuthMethod()).toBeNull();
+  });
+
+  it("shows Last used badge on submit when previous method was email", () => {
+    setLastAuthMethod("email");
+    const { container } = render(() => <Register />);
+    const submit = container.querySelector('button[type="submit"]')!;
+    expect(submit.querySelector(".auth-last-used")).not.toBeNull();
   });
 
   it("shows back to sign in link on verification screen", async () => {

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -29,7 +29,7 @@ vi.mock("../../src/services/setup-status.js", () => ({
 }));
 
 import Register from "../../src/pages/Register";
-import { getLastAuthMethod, setLastAuthMethod } from "../../src/services/last-auth-method";
+import { getLastAuthMethod } from "../../src/services/last-auth-method";
 
 describe("Register", () => {
   beforeEach(() => {
@@ -256,13 +256,6 @@ describe("Register", () => {
       expect(container.textContent).toContain("boom");
     });
     expect(getLastAuthMethod()).toBeNull();
-  });
-
-  it("shows Last used badge on submit when previous method was email", () => {
-    setLastAuthMethod("email");
-    const { container } = render(() => <Register />);
-    const submit = container.querySelector('button[type="submit"]')!;
-    expect(submit.querySelector(".auth-last-used")).not.toBeNull();
   });
 
   it("shows back to sign in link on verification screen", async () => {

--- a/packages/frontend/tests/services/last-auth-method.test.ts
+++ b/packages/frontend/tests/services/last-auth-method.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getLastAuthMethod, setLastAuthMethod } from '../../src/services/last-auth-method';
+
+const STORAGE_KEY = 'manifest:last-auth-method';
+
+describe('last-auth-method', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns null when nothing has been stored', () => {
+    expect(getLastAuthMethod()).toBeNull();
+  });
+
+  it('round-trips a valid method', () => {
+    setLastAuthMethod('google');
+    expect(getLastAuthMethod()).toBe('google');
+  });
+
+  it('persists the latest write', () => {
+    setLastAuthMethod('google');
+    setLastAuthMethod('email');
+    expect(getLastAuthMethod()).toBe('email');
+  });
+
+  it('accepts every supported provider', () => {
+    for (const method of ['email', 'google', 'github', 'discord'] as const) {
+      setLastAuthMethod(method);
+      expect(getLastAuthMethod()).toBe(method);
+    }
+  });
+
+  it('rejects unrecognized values stored under the key', () => {
+    localStorage.setItem(STORAGE_KEY, 'twitter');
+    expect(getLastAuthMethod()).toBeNull();
+  });
+
+  it('returns null when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    expect(getLastAuthMethod()).toBeNull();
+  });
+
+  it('swallows errors when localStorage.setItem throws', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+    expect(() => setLastAuthMethod('github')).not.toThrow();
+  });
+});


### PR DESCRIPTION
### ✨ What changed
- New `last-auth-method` helper persists the most recent auth choice in `localStorage`.
- `SocialButtons` writes the chosen provider before the OAuth redirect and renders a small "Last used" pill on the matching button.
- Login / Register write `'email'` after a successful email sign-in / sign-up so the hint flips correctly when users switch methods.

### 💭 Why
Returning visitors land on `/login` with no signal of which method they used last time, so they default to retyping a password instead of clicking the social button they actually use. This is the same pattern GitHub, Linear, and Vercel ship.

### 👤 For users
On the next visit, the provider button (Google / GitHub / Discord) you used last time shows a small "Last used" pill. Hint is per-browser, best-effort: private mode and disabled storage fall back to no pill silently.

### 📝 Notes
- Frontend-only change. Email submit button intentionally has no pill (the primary CTA is always visible, and the badge looked off on the filled button).
- 100% line coverage on the new helper and all touched components / pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small “Last used” badge on Login and Register that highlights the auth method you used last time, stored per-browser for a quicker next sign-in. The choice is saved before OAuth redirects and after successful email auth, and falls back silently if storage isn’t available.

- **New Features**
  - New `last-auth-method` helper reads/writes under `manifest:last-auth-method` with validation and try/catch.
  - `SocialButtons` saves the chosen provider pre-redirect and shows the badge on the matching button (via `lastUsed` prop).
  - Login/Register set `email` after successful form auth; no badge on the email submit button.

<sup>Written for commit ed2edc96dab60d3cc88b5aad2dd007aaa0759868. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

