### PR TITLE
fix(routing): persist fallbacks when same provider is offered via two auth types

### DIFF
--- a/.changeset/fix-fallback-same-provider.md
+++ b/.changeset/fix-fallback-same-provider.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix silent failure when adding a fallback that shares a provider with an existing route. Adding an OpenAI API key model as a fallback to an OpenAI subscription model (or any other same-provider, different-auth combination) now persists correctly instead of showing a success toast and dropping the change. The frontend now sends the explicit `(provider, authType, model)` tuple alongside the model name so the backend can disambiguate when the same model id is offered by two connected providers. Affects both complexity tier and specificity ("custom") routing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14829,7 +14829,7 @@
       }
     },
     "packages/manifest": {
-      "version": "6.0.0"
+      "version": "6.0.2"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -136,12 +136,21 @@ const Routing: Component = () => {
     setFallbackPickerTier(null);
     if (isSpecificityTier(tierId)) {
       const sa = specificityAssignments()?.find((a) => a.category === tierId);
-      const current = sa?.fallback_routes?.map((r) => r.model) ?? [];
+      const currentRoutes = sa?.fallback_routes ?? [];
+      const current = currentRoutes.map((r) => r.model);
       if (current.includes(modelName)) return;
       const updated = [...current, modelName];
+      // Pass explicit (provider, authType, model) routes so the backend can
+      // disambiguate when the same model id is offered by multiple connected
+      // providers (e.g. OpenAI subscription + OpenAI API key both expose
+      // gpt-4o). Without this the backend silently stores nothing.
+      const updatedRoutes =
+        authType !== undefined
+          ? [...currentRoutes, { provider: providerId, authType, model: modelName }]
+          : undefined;
       try {
         const { setSpecificityFallbacks } = await import('../services/api.js');
-        await setSpecificityFallbacks(agentName(), tierId, updated);
+        await setSpecificityFallbacks(agentName(), tierId, updated, updatedRoutes);
         await refetchSpecificity();
         toast.success('Fallback added');
       } catch {

--- a/packages/frontend/src/pages/RoutingActions.tsx
+++ b/packages/frontend/src/pages/RoutingActions.tsx
@@ -95,18 +95,27 @@ export function createRoutingActions(input: RoutingActionsInput) {
   const handleAddFallback = async (
     tierId: string,
     modelName: string,
-    _providerId: string,
-    _authType?: AuthType,
+    providerId: string,
+    authType?: AuthType,
   ) => {
     const tier = getTier(tierId);
     const currentRoutes = tier?.fallback_routes ?? [];
     const current = currentRoutes.map((r) => r.model);
     if (current.includes(modelName)) return;
     const updated = [...current, modelName];
+    // Pass the explicit (provider, authType, model) tuple alongside the model
+    // name. Without it, the backend can't disambiguate when the same model id
+    // is offered by two of the user's connected providers (e.g. OpenAI
+    // subscription + OpenAI API key both expose gpt-4o), which causes the
+    // backend's unambiguousRoute() to return null and silently drop the save.
+    const updatedRoutes: ModelRoute[] | undefined =
+      authType !== undefined
+        ? [...currentRoutes, { provider: providerId, authType, model: modelName }]
+        : undefined;
     setFallbackOverrides((prev) => ({ ...prev, [tierId]: updated }));
     setAddingFallback(tierId);
     try {
-      const persistedRoutes = await setFallbacks(input.agentName(), tierId, updated);
+      const persistedRoutes = await setFallbacks(input.agentName(), tierId, updated, updatedRoutes);
       input.mutateTiers((prev) =>
         prev?.map((t) => (t.tier === tierId ? { ...t, fallback_routes: persistedRoutes } : t)),
       );

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -185,6 +185,18 @@ vi.mock("../../src/components/RoutingModals.js", () => ({
           add-spec-fallback
         </button>
         <button
+          data-testid="modal-trigger-add-spec-fallback-no-auth"
+          onClick={() =>
+            (props.onAddFallback as (id: string, m: string, p: string, a?: string) => void)(
+              "coding",
+              "spec-fb",
+              "openai",
+            )
+          }
+        >
+          add-spec-fallback-no-auth
+        </button>
+        <button
           data-testid="modal-trigger-spec-override"
           onClick={() =>
             (
@@ -617,7 +629,36 @@ describe("Routing page", () => {
     });
   });
 
-  it("calls setSpecificityFallbacks when modals add a fallback for a specificity tier", async () => {
+  it("omits the routes payload when the spec fallback caller has no authType", async () => {
+    mockGetSpecificityAssignments.mockResolvedValue([
+      {
+        id: "s1",
+        agent_id: "a",
+        category: "coding",
+        is_active: true,
+        override_route: null,
+        auto_assigned_route: null,
+        fallback_routes: [],
+        updated_at: "2025-01-01",
+      },
+    ]);
+    mockSetSpecificityFallbacks.mockResolvedValue(undefined);
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId("modal-trigger-add-spec-fallback-no-auth")).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId("modal-trigger-add-spec-fallback-no-auth"));
+    await waitFor(() => {
+      expect(mockSetSpecificityFallbacks).toHaveBeenCalledWith(
+        "demo",
+        "coding",
+        ["spec-fb"],
+        undefined,
+      );
+    });
+  });
+
+  it("calls setSpecificityFallbacks with explicit routes when modals add a fallback for a specificity tier", async () => {
     mockGetSpecificityAssignments.mockResolvedValue([
       {
         id: "s1",
@@ -637,7 +678,12 @@ describe("Routing page", () => {
     });
     fireEvent.click(screen.getByTestId("modal-trigger-add-spec-fallback"));
     await waitFor(() => {
-      expect(mockSetSpecificityFallbacks).toHaveBeenCalledWith("demo", "coding", ["spec-fb"]);
+      expect(mockSetSpecificityFallbacks).toHaveBeenCalledWith(
+        "demo",
+        "coding",
+        ["spec-fb"],
+        [{ provider: "openai", authType: "api_key", model: "spec-fb" }],
+      );
     });
   });
 

--- a/packages/frontend/tests/pages/RoutingActions.test.ts
+++ b/packages/frontend/tests/pages/RoutingActions.test.ts
@@ -183,13 +183,59 @@ describe("createRoutingActions", () => {
       ]);
       const { actions } = setupActions();
       await actions.handleAddFallback("simple", "fb-new", "openai", "api_key");
-      expect(mockSetFallbacks).toHaveBeenCalledWith("demo", "simple", ["fb-1", "fb-2", "fb-new"]);
+      expect(mockSetFallbacks).toHaveBeenCalledWith(
+        "demo",
+        "simple",
+        ["fb-1", "fb-2", "fb-new"],
+        [
+          { provider: "openai", authType: "api_key", model: "fb-1" },
+          { provider: "anthropic", authType: "api_key", model: "fb-2" },
+          { provider: "openai", authType: "api_key", model: "fb-new" },
+        ],
+      );
       expect(actions.getTier("simple")?.fallback_routes?.map((r) => r.model)).toEqual([
         "fb-1",
         "fb-2",
         "fb-new",
       ]);
       expect(mockToastSuccess).toHaveBeenCalledWith("Fallback added");
+    });
+
+    it("sends explicit (provider, authType) route so backend can disambiguate same-provider models", async () => {
+      // Repros the user-reported bug: primary is OpenAI subscription gpt-4o;
+      // user adds OpenAI API key gpt-4o as the first fallback. The backend's
+      // unambiguousRoute() can't pick by model name alone because gpt-4o
+      // appears twice in the discovered model list (once per authType), so
+      // without an explicit route payload it returns null and silently drops
+      // the save. The frontend must therefore always send the route tuple.
+      const tier: TierAssignment = {
+        ...baseTier,
+        override_route: { provider: "openai", authType: "subscription", model: "gpt-4o" },
+        fallback_routes: null,
+      };
+      mockSetFallbacks.mockResolvedValue([
+        { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      ]);
+      const { actions } = setupActions([tier]);
+      await actions.handleAddFallback("simple", "gpt-4o", "openai", "api_key");
+      expect(mockSetFallbacks).toHaveBeenCalledWith(
+        "demo",
+        "simple",
+        ["gpt-4o"],
+        [{ provider: "openai", authType: "api_key", model: "gpt-4o" }],
+      );
+    });
+
+    it("omits the routes payload when the caller has no authType", async () => {
+      mockSetFallbacks.mockResolvedValue([]);
+      const { actions } = setupActions();
+      await actions.handleAddFallback("simple", "fb-new", "openai");
+      expect(mockSetFallbacks).toHaveBeenCalledWith(
+        "demo",
+        "simple",
+        ["fb-1", "fb-2", "fb-new"],
+        undefined,
+      );
     });
 
     it("rolls back the optimistic state on failure", async () => {


### PR DESCRIPTION
## Summary

Fix silent fallback failure when the same provider is connected with two auth types. Adding an OpenAI API key model as a fallback to an OpenAI subscription model (or any same-provider, different-auth combination) showed a "Fallback added" toast but the routing UI stayed empty even after refresh. Affected both complexity tiers and specificity ("custom") routings.

Cross-provider fallbacks (e.g. OpenAI sub → DeepSeek API) worked fine — the bug only triggered when the same model id was offered by two of the user's connected providers.

## Root cause

The frontend "add fallback" handlers passed only the model name to `setFallbacks` / `setSpecificityFallbacks`. With two connected providers exposing the same model id, the backend's `unambiguousRoute()` (`packages/backend/src/routing/routing-core/route-helpers.ts`) sees two matches by model id and returns `null`, `buildFallbackRoutes()` returns `null`, the column is stored as `null`, and the controller returns `[]`. The toast fires on success, the UI re-renders with an empty list.

The escape hatch — an explicit `(provider, authType, model)` `routes` payload — was already wired through:
- backend `setFallbacks` / `setSpecificityFallbacks` validate it against discovered models
- frontend remove and reorder paths in `FallbackList.tsx` already send it

Only the two add-fallback handlers were missing it.

## Changes

- `packages/frontend/src/pages/RoutingActions.tsx` — `handleAddFallback` now uses the `providerId` / `authType` it receives (was `_providerId` / `_authType`) to build a `ModelRoute[]` from existing `fallback_routes` plus the new entry, and passes it to `setFallbacks`.
- `packages/frontend/src/pages/Routing.tsx` — same fix in the specificity branch of the page-level `handleAddFallback`, which now passes the routes to `setSpecificityFallbacks`.
- Tests cover the user-reported scenario (OpenAI sub primary + add OpenAI API gpt-4o fallback) and both authType-present / authType-absent branches.

No backend changes — the validation and disambiguation logic was already correct, just being denied the data it needed.

## Test plan

- [x] `npx vitest run` (frontend, 2621 tests pass with coverage; `Routing.tsx` 99.72%, `RoutingActions.tsx` 100%)
- [x] `npm run lint` (0 errors)
- [x] `npm run build` (success)
- [x] `tsc --noEmit` clean for backend and frontend
- [x] Local cloud-mode server boots; health + page = 200
- [ ] Manual: connect OpenAI subscription + OpenAI API key for one agent, override the standard tier with OpenAI sub gpt-4o, then add OpenAI API gpt-4o as a fallback — verify it persists and shows in the UI without refresh
- [ ] Manual: same flow inside a specificity ("custom") category
- [ ] Regression: cross-provider fallback (e.g. OpenAI sub primary + DeepSeek API fallback) still works


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent failure when adding a fallback from the same provider using a different auth type. Fallbacks now persist and show in the UI for both tiers and specificity routing.

- **Bug Fixes**
  - `packages/frontend/src/pages/RoutingActions.tsx`: `handleAddFallback` now sends an explicit `(provider, authType, model)` route array to `setFallbacks` when `authType` is provided.
  - `packages/frontend/src/pages/Routing.tsx`: specificity branch now sends the explicit routes to `setSpecificityFallbacks`.
  - Keeps previous behavior when `authType` is undefined (omits routes payload).
  - Added tests covering same-provider/different-auth, specificity, and no-auth branches.
  - No backend changes; existing validation now receives the needed data.

<sup>Written for commit 9a0e8c36fe02d0ce19880166eaa10d891d235609. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

