### PR TITLE
ci: filter wingman out of Railway build

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,5 @@
 [build]
-buildCommand = "npm run build"
+buildCommand = "npx turbo build --filter=manifest-backend --filter=manifest-frontend --filter=manifest-shared"
 
 [deploy]
 startCommand = "npm start"


### PR DESCRIPTION
### Why
Railway's build runs \`npm run build\` which builds every workspace, including \`packages/wingman\`. Wingman is a dev-only gateway tester (already excluded from the Docker image via \`.dockerignore\` and the Dockerfile's turbo \`--filter\` list), and its \`vite-plugin-solid\` resolution fails under Railway's Nixpacks install, breaking deploys.

### What changed
- \`railway.toml\` now uses \`npx turbo build --filter=manifest-backend --filter=manifest-frontend --filter=manifest-shared\`, matching the Dockerfile.

### For operators
Next Railway deploy will skip wingman and succeed. No env or runtime changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip building the dev-only `packages/wingman` on Railway to stop deploy failures caused by `vite-plugin-solid` resolution under Nixpacks. Railway now builds only the runtime packages using `turbo` filters that match the Dockerfile.

<sup>Written for commit e169aa52a7a6c42e5f40f570e69d334b8c1664c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

