### PR TITLE
fix: hide Wingman and Dev badge from non-dev builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,17 +177,17 @@ To use Wingman with `/serve` or any single-service backend on a custom port, set
 
 Wingman is intentionally **not shipped to production or Docker self-hosted bundles**. The exclusion is enforced in four places:
 
-| Layer                              | Mechanism                                                                                                                                         |
-| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `packages/frontend/vite.config.ts` | `__DEV_MODE__` build constant flips to `false` when `VITE_MANIFEST_SELFHOSTED=true` is set; esbuild dead-code-eliminates the FAB + drawer module. |
-| `docker/Dockerfile`                | Build stage runs `turbo build --filter=manifest-backend --filter=manifest-frontend --filter=manifest-shared` — Wingman is never built.            |
-| `.dockerignore`                    | `packages/wingman/` is excluded from the build context.                                                                                           |
-| `.changeset/config.json`           | `manifest-wingman` is in the ignored list — it can never trigger a Docker release.                                                                |
+| Layer                              | Mechanism                                                                                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `packages/frontend/vite.config.ts` | `__DEV_MODE__` is `true` only when Vite runs in dev mode (`vite serve`). Any production build sets it to `false` so esbuild dead-code-eliminates the FAB + drawer module. |
+| `docker/Dockerfile`                | Build stage runs `turbo build --filter=manifest-backend --filter=manifest-frontend --filter=manifest-shared` — Wingman is never built.     |
+| `.dockerignore`                    | `packages/wingman/` is excluded from the build context.                                                                                    |
+| `.changeset/config.json`           | `manifest-wingman` is in the ignored list — it can never trigger a Docker release.                                                         |
 
 After every change to the Wingman code, verify the production bundle stays clean:
 
 ```bash
-VITE_MANIFEST_SELFHOSTED=true npm run build --workspace=manifest-frontend
+npm run build --workspace=manifest-frontend
 grep -lc 'wingman\|Wingman' packages/frontend/dist/assets/*.js | grep -v ':0$'
 # ^ no JS chunk should match
 ```

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -18,13 +18,12 @@ const manifestVersion = (() => {
 export default defineConfig(({ command }) => ({
   define: {
     __MANIFEST_VERSION__: JSON.stringify(manifestVersion),
-    // Wingman is a dev-only tester. The Dockerfile sets
-    // VITE_MANIFEST_SELFHOSTED=true before running vite build, which flips
-    // __DEV_MODE__ to literal `false` so esbuild can dead-code-eliminate
-    // the button + dev badge from the self-hosted bundle. Local builds
-    // (npm run dev / npm run build / /serve) leave it unset, so the
-    // dashboard always shows the dev affordances during development.
-    __DEV_MODE__: JSON.stringify(command === 'serve' || !process.env.VITE_MANIFEST_SELFHOSTED),
+    // Wingman and the orange "Dev" header badge are dev-only affordances.
+    // They ship only when Vite runs in dev mode (`vite serve`). Any
+    // production build — Docker self-hosted, Railway cloud, anything else
+    // — gets `__DEV_MODE__ = false`, so esbuild dead-code-eliminates the
+    // FAB, drawer, and badge.
+    __DEV_MODE__: JSON.stringify(command === 'serve'),
     // Optional build-time override; otherwise the dashboard derives the URL
     // at runtime from the current port (`port + 1`, or `:3002` when the Vite
     // dev frontend is running on `:3000`).


### PR DESCRIPTION
### Why
Wingman's pink FAB and the orange "Dev" header badge were showing up on app.manifest.build. The build-time gate flipped to dev mode whenever `VITE_MANIFEST_SELFHOSTED` was unset, which the Railway cloud build does not set.

### What changed
- `__DEV_MODE__` is now `true` only when Vite runs in dev mode (`vite serve`).
- Any production build (Docker self-hosted, Railway cloud, anything else) strips the FAB, drawer, and badge.
- CONTRIBUTING.md table + verification command updated to match.

### For users
Cloud users on app.manifest.build no longer see the Wingman button or the "Dev" badge.

### Notes
Verified locally: `npm run build --workspace=manifest-frontend` followed by the documented grep over `dist/assets/*.js` returns no Wingman matches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Wingman FAB and “Dev” header badge in all non‑dev builds by gating them behind Vite dev mode only (`__DEV_MODE__` is `true` only during `vite serve`). Production bundles now dead‑code‑eliminate the FAB, drawer, and badge; `CONTRIBUTING.md` updated to reflect the new gate and the simplified verification command.

<sup>Written for commit 3be7f9d8982c2819415ac31686cb30cea033147e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

