### PR TITLE
feat: add Coding Assistant category and move Claude Code into it

### DIFF
--- a/.changeset/coding-assistant-category.md
+++ b/.changeset/coding-assistant-category.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Add a "Coding Assistant" category in the agent picker and move Claude Code into it. The Connect Agent / Change Agent Type modal now shows three columns instead of two: Personal AI Agent | App AI SDK | Coding Assistant. Claude Code is no longer mis-bucketed under personal agents — it sits in the new column with the existing copper-orange Claude mark. Picker order, icons, and the existing Claude Code setup wizard are unchanged.

--- a/packages/backend/src/telemetry/payload-builder.service.spec.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.spec.ts
@@ -12,6 +12,11 @@ interface BucketRow {
   bucket: string | null;
   count: string;
 }
+interface CategoryPlatformRow {
+  category: string | null;
+  platform: string | null;
+  count: string;
+}
 interface TotalsRow {
   total: string;
   input_tokens: string | null;
@@ -23,7 +28,7 @@ interface MockData {
   tiers: BucketRow[];
   authTypes: BucketRow[];
   totals: TotalsRow | undefined;
-  agentPlatforms: BucketRow[];
+  agentPlatforms: CategoryPlatformRow[];
   agentsCount: number;
 }
 
@@ -55,6 +60,7 @@ async function makeService(partial: Partial<MockData>): Promise<PayloadBuilderSe
       addSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
       getRawMany: jest.fn().mockResolvedValue(entry.rows ?? []),
       getRawOne: jest.fn().mockResolvedValue(entry.row),
     };
@@ -215,11 +221,26 @@ describe('PayloadBuilderService', () => {
     expect(payload.messages_by_tier).toEqual({ unknown: 5, simple: 10 });
   });
 
-  it('returns agents_by_platform grouped by agent_platform', async () => {
+  it('collapses unknown routing_tier strings to "other" so a future write path cannot leak verbatim values', async () => {
+    // Defense-in-depth: if some caller writes "warp-speed" into routing_tier,
+    // the whitelist clamps it to "other" before it leaves the install.
+    const service = await makeService({
+      tiers: [
+        { bucket: 'simple', count: '4' },
+        { bucket: 'warp-speed', count: '6' },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.messages_by_tier).toEqual({ simple: 4, other: 6 });
+  });
+
+  it('returns agents_by_platform grouped by agent_platform with bare keys for known platforms', async () => {
     const service = await makeService({
       agentPlatforms: [
-        { bucket: 'openclaw', count: '3' },
-        { bucket: 'hermes', count: '1' },
+        { category: 'personal', platform: 'openclaw', count: '3' },
+        { category: 'personal', platform: 'hermes', count: '1' },
       ],
     });
 
@@ -228,9 +249,57 @@ describe('PayloadBuilderService', () => {
     expect(payload.agents_by_platform).toEqual({ openclaw: 3, hermes: 1 });
   });
 
+  it('emits composite "<category>:other" keys so peacock can tell the three Other variants apart', async () => {
+    const service = await makeService({
+      agentPlatforms: [
+        { category: 'personal', platform: 'other', count: '5' },
+        { category: 'app', platform: 'other', count: '2' },
+        { category: 'coding', platform: 'other', count: '1' },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.agents_by_platform).toEqual({
+      'personal:other': 5,
+      'app:other': 2,
+      'coding:other': 1,
+    });
+  });
+
+  it('mixes bare and composite keys in the same payload (known platforms stay bare)', async () => {
+    const service = await makeService({
+      agentPlatforms: [
+        { category: 'personal', platform: 'openclaw', count: '4' },
+        { category: 'coding', platform: 'claude-code', count: '2' },
+        { category: 'personal', platform: 'other', count: '3' },
+        { category: 'coding', platform: 'other', count: '1' },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.agents_by_platform).toEqual({
+      openclaw: 4,
+      'claude-code': 2,
+      'personal:other': 3,
+      'coding:other': 1,
+    });
+  });
+
+  it('falls back to bare "other" when the row has no category (legacy un-migrated rows)', async () => {
+    const service = await makeService({
+      agentPlatforms: [{ category: null, platform: 'other', count: '7' }],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.agents_by_platform).toEqual({ other: 7 });
+  });
+
   it('buckets NULL agent_platform rows under "unknown"', async () => {
     const service = await makeService({
-      agentPlatforms: [{ bucket: null, count: '2' }],
+      agentPlatforms: [{ category: 'personal', platform: null, count: '2' }],
     });
 
     const payload = await service.build('inst', '1.0.0');

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -98,13 +98,32 @@ export class PayloadBuilderService {
       .getRawMany<BucketRow>();
   }
 
+  /**
+   * `other` is a sentinel valid in every category (personal/app/coding), so a
+   * bare `agent_platform` bucket loses the category dimension peacock needs to
+   * tell "Other personal agent" from "Other coding tool". For the `other`
+   * platform we emit a composite `<category>:other` key (peacock's
+   * platform-classification.ts already handles this format); known platforms
+   * stay as bare keys so existing self-hosted reports don't change shape.
+   */
   private async agentsByPlatform(): Promise<BucketRow[]> {
-    return this.agents
+    interface CategoryPlatformRow {
+      category: string | null;
+      platform: string | null;
+      count: string;
+    }
+    const rows = await this.agents
       .createQueryBuilder('a')
-      .select('a.agent_platform', 'bucket')
+      .select('a.agent_category', 'category')
+      .addSelect('a.agent_platform', 'platform')
       .addSelect('COUNT(*)', 'count')
-      .groupBy('a.agent_platform')
-      .getRawMany<BucketRow>();
+      .groupBy('a.agent_category')
+      .addGroupBy('a.agent_platform')
+      .getRawMany<CategoryPlatformRow>();
+    return rows.map((r) => ({
+      bucket: r.platform === 'other' && r.category ? `${r.category}:${r.platform}` : r.platform,
+      count: r.count,
+    }));
   }
 
   private async totals(): Promise<TotalsRow> {

--- a/packages/frontend/tests/components/AgentTypeGrid.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeGrid.test.tsx
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@solidjs/testing-library";
 
 vi.mock("manifest-shared", () => ({
-  AGENT_CATEGORIES: ["personal", "app"],
+  AGENT_CATEGORIES: ["personal", "app", "coding"],
   CATEGORY_LABELS: {
     personal: "Personal AI Agent",
     app: "App AI SDK",
+    coding: "Coding Assistant",
   },
   PLATFORM_LABELS: {
     openclaw: "OpenClaw",
@@ -14,11 +15,13 @@ vi.mock("manifest-shared", () => ({
     "vercel-ai-sdk": "Vercel AI SDK",
     langchain: "LangChain",
     curl: "cURL",
+    "claude-code": "Claude Code",
     other: "Other",
   },
   PLATFORMS_BY_CATEGORY: {
     personal: ["openclaw", "hermes", "other"],
     app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
+    coding: ["claude-code", "other"],
   },
   PLATFORM_ICONS: {
     openclaw: "/icons/openclaw.png",
@@ -26,6 +29,7 @@ vi.mock("manifest-shared", () => ({
     "openai-sdk": "/icons/providers/openai.svg",
     "vercel-ai-sdk": "/icons/vercel.svg",
     langchain: "/icons/langchain.svg",
+    "claude-code": "/icons/providers/claude-code.svg",
   },
 }));
 
@@ -43,24 +47,25 @@ describe("AgentTypeGrid", () => {
     vi.clearAllMocks();
   });
 
-  it("renders inline grid with both category groups", () => {
+  it("renders inline grid with all three category groups in order", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const labels = container.querySelectorAll(".agent-type-select__group-label");
-    expect(labels).toHaveLength(2);
+    expect(labels).toHaveLength(3);
     expect(labels[0].textContent).toContain("Personal AI Agent");
     expect(labels[1].textContent).toContain("App AI SDK");
+    expect(labels[2].textContent).toContain("Coding Assistant");
   });
 
-  it("renders all platform options from both categories", () => {
+  it("renders all platform options from all three categories", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const options = container.querySelectorAll(".agent-type-select__option");
-    expect(options).toHaveLength(7);
+    expect(options).toHaveLength(9);
   });
 
-  it("renders two columns", () => {
+  it("renders three columns", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const columns = container.querySelectorAll(".agent-type-select__column");
-    expect(columns).toHaveLength(2);
+    expect(columns).toHaveLength(3);
   });
 
   it("marks selected option", () => {
@@ -86,6 +91,22 @@ describe("AgentTypeGrid", () => {
     expect(onPlatformChange).toHaveBeenCalledWith("openai-sdk");
   });
 
+  it("selecting Claude Code routes to coding/claude-code", () => {
+    const onCategoryChange = vi.fn();
+    const onPlatformChange = vi.fn();
+    const { container } = render(() => (
+      <AgentTypeGrid
+        {...defaultProps}
+        onCategoryChange={onCategoryChange}
+        onPlatformChange={onPlatformChange}
+      />
+    ));
+    const options = container.querySelectorAll(".agent-type-select__option");
+    fireEvent.click(options[7]); // Claude Code (coding column, first item)
+    expect(onCategoryChange).toHaveBeenCalledWith("coding");
+    expect(onPlatformChange).toHaveBeenCalledWith("claude-code");
+  });
+
   it("shows platform icons", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const icons = container.querySelectorAll(".agent-type-select__option-icon");
@@ -105,6 +126,21 @@ describe("AgentTypeGrid", () => {
     const options = container.querySelectorAll(".agent-type-select__option");
     const icon = options[6].querySelector(".agent-type-select__option-icon");
     expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
+  });
+
+  it("uses other.svg for coding Other (not the personal-agent variant)", () => {
+    const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    // coding/Other is at index 8 (3 personal + 4 app + 1 claude-code)
+    const icon = options[8].querySelector(".agent-type-select__option-icon");
+    expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
+  });
+
+  it("renders the official Claude Code icon in the coding column", () => {
+    const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    const icon = options[7].querySelector(".agent-type-select__option-icon");
+    expect(icon!.getAttribute("src")).toBe("/icons/providers/claude-code.svg");
   });
 
   it("disables buttons when disabled prop is true", () => {
@@ -130,15 +166,11 @@ describe("AgentTypeGrid", () => {
   });
 
   it("selects app Other correctly", () => {
-    const onCategoryChange = vi.fn();
-    const onPlatformChange = vi.fn();
     const { container } = render(() => (
       <AgentTypeGrid
         {...defaultProps}
         category="app"
         platform="other"
-        onCategoryChange={onCategoryChange}
-        onPlatformChange={onPlatformChange}
       />
     ));
     const selected = container.querySelectorAll(".agent-type-select__option--selected");
@@ -146,5 +178,19 @@ describe("AgentTypeGrid", () => {
     // app Other is at index 6
     const options = container.querySelectorAll(".agent-type-select__option");
     expect(options[6].classList.contains("agent-type-select__option--selected")).toBe(true);
+  });
+
+  it("selects coding Claude Code correctly", () => {
+    const { container } = render(() => (
+      <AgentTypeGrid
+        {...defaultProps}
+        category="coding"
+        platform="claude-code"
+      />
+    ));
+    const selected = container.querySelectorAll(".agent-type-select__option--selected");
+    expect(selected).toHaveLength(1);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    expect(options[7].classList.contains("agent-type-select__option--selected")).toBe(true);
   });
 });

--- a/packages/frontend/tests/components/AgentTypeSelect.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeSelect.test.tsx
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@solidjs/testing-library";
 
 vi.mock("manifest-shared", () => ({
-  AGENT_CATEGORIES: ["personal", "app"],
+  AGENT_CATEGORIES: ["personal", "app", "coding"],
   CATEGORY_LABELS: {
     personal: "Personal AI Agent",
     app: "App AI SDK",
+    coding: "Coding Assistant",
   },
   PLATFORM_LABELS: {
     openclaw: "OpenClaw",
@@ -14,11 +15,13 @@ vi.mock("manifest-shared", () => ({
     "vercel-ai-sdk": "Vercel AI SDK",
     langchain: "LangChain",
     curl: "cURL",
+    "claude-code": "Claude Code",
     other: "Other",
   },
   PLATFORMS_BY_CATEGORY: {
     personal: ["openclaw", "hermes", "other"],
     app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
+    coding: ["claude-code", "other"],
   },
   PLATFORM_ICONS: {
     openclaw: "/icons/openclaw.png",
@@ -26,6 +29,7 @@ vi.mock("manifest-shared", () => ({
     "openai-sdk": "/icons/providers/openai.svg",
     "vercel-ai-sdk": "/icons/vercel.svg",
     langchain: "/icons/langchain.svg",
+    "claude-code": "/icons/providers/claude-code.svg",
   },
 }));
 
@@ -68,21 +72,22 @@ describe("AgentTypeSelect", () => {
     expect(container.querySelector(".agent-type-select__dropdown")).not.toBeNull();
   });
 
-  it("shows both category group labels in dropdown", () => {
+  it("shows all three category group labels in dropdown order (personal → app → coding)", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const labels = container.querySelectorAll(".agent-type-select__group-label");
-    expect(labels).toHaveLength(2);
+    expect(labels).toHaveLength(3);
     expect(labels[0].textContent).toContain("Personal AI Agent");
     expect(labels[1].textContent).toContain("App AI SDK");
+    expect(labels[2].textContent).toContain("Coding Assistant");
   });
 
-  it("shows all platforms from both categories in dropdown", () => {
+  it("shows all platforms from all three categories in dropdown", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const options = container.querySelectorAll(".agent-type-select__option");
-    // personal: openclaw, hermes, other; app: openai-sdk, vercel-ai-sdk, langchain, other = 7
-    expect(options).toHaveLength(7);
+    // personal: 3, app: 4, coding: 2 = 9
+    expect(options).toHaveLength(9);
   });
 
   it("shows platform names in options", () => {
@@ -94,6 +99,17 @@ describe("AgentTypeSelect", () => {
     expect(dropdown.textContent).toContain("OpenAI SDK");
     expect(dropdown.textContent).toContain("Vercel AI SDK");
     expect(dropdown.textContent).toContain("LangChain");
+    expect(dropdown.textContent).toContain("Claude Code");
+  });
+
+  it("places Claude Code in the coding column with the official Claude mark", () => {
+    const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
+    fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    // Coding column is rightmost: index 7 = claude-code, index 8 = coding/Other
+    expect(options[7].textContent).toContain("Claude Code");
+    const claudeIcon = options[7].querySelector(".agent-type-select__option-icon");
+    expect(claudeIcon!.getAttribute("src")).toBe("/icons/providers/claude-code.svg");
   });
 
   it("shows platform icons in options", () => {
@@ -149,6 +165,41 @@ describe("AgentTypeSelect", () => {
     expect(onPlatformChange).toHaveBeenCalledWith("openai-sdk");
   });
 
+  it("calls with coding category when Claude Code selected", () => {
+    const onCategoryChange = vi.fn();
+    const onPlatformChange = vi.fn();
+    const { container } = render(() => (
+      <AgentTypeSelect
+        {...defaultProps}
+        onCategoryChange={onCategoryChange}
+        onPlatformChange={onPlatformChange}
+      />
+    ));
+    fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    // Click "Claude Code" (index 7, coding category: after personal[3] + app[4])
+    fireEvent.click(options[7]);
+    expect(onCategoryChange).toHaveBeenCalledWith("coding");
+    expect(onPlatformChange).toHaveBeenCalledWith("claude-code");
+  });
+
+  it("calls with coding category when coding/Other selected", () => {
+    const onCategoryChange = vi.fn();
+    const onPlatformChange = vi.fn();
+    const { container } = render(() => (
+      <AgentTypeSelect
+        {...defaultProps}
+        onCategoryChange={onCategoryChange}
+        onPlatformChange={onPlatformChange}
+      />
+    ));
+    fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    fireEvent.click(options[8]); // coding Other
+    expect(onCategoryChange).toHaveBeenCalledWith("coding");
+    expect(onPlatformChange).toHaveBeenCalledWith("other");
+  });
+
   it("closes dropdown after selection", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
@@ -198,23 +249,34 @@ describe("AgentTypeSelect", () => {
     expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
   });
 
-  it("shows Other in both personal and app groups", () => {
-    const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
-    fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
-    const options = container.querySelectorAll(".agent-type-select__option");
-    // personal other at index 2, app other at index 6
-    expect(options[2].textContent).toContain("Other");
-    expect(options[6].textContent).toContain("Other");
+  it("shows other.svg for coding other (not the personal-agent variant)", () => {
+    const { container } = render(() => (
+      <AgentTypeSelect {...defaultProps} category="coding" platform="other" />
+    ));
+    const icon = container.querySelector(".agent-type-select__trigger-icon");
+    expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
   });
 
-  it("uses different icons for personal other vs app other in dropdown", () => {
+  it("shows Other in all three groups", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const options = container.querySelectorAll(".agent-type-select__option");
-    const personalOtherIcon = options[2].querySelector(".agent-type-select__option-icon");
-    const appOtherIcon = options[6].querySelector(".agent-type-select__option-icon");
-    expect(personalOtherIcon!.getAttribute("src")).toBe("/icons/other-agent.svg");
-    expect(personalOtherIcon!.getAttribute("src")).not.toBe(appOtherIcon!.getAttribute("src"));
+    // personal other at index 2, app other at index 6, coding other at index 8
+    expect(options[2].textContent).toContain("Other");
+    expect(options[6].textContent).toContain("Other");
+    expect(options[8].textContent).toContain("Other");
+  });
+
+  it("uses the personal-agent icon only for personal/Other (app + coding share other.svg)", () => {
+    const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
+    fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    const personalOther = options[2].querySelector(".agent-type-select__option-icon");
+    const appOther = options[6].querySelector(".agent-type-select__option-icon");
+    const codingOther = options[8].querySelector(".agent-type-select__option-icon");
+    expect(personalOther!.getAttribute("src")).toBe("/icons/other-agent.svg");
+    expect(appOther!.getAttribute("src")).toBe("/icons/other.svg");
+    expect(codingOther!.getAttribute("src")).toBe("/icons/other.svg");
   });
 
   it("sets aria-expanded on trigger", () => {
@@ -242,7 +304,7 @@ describe("AgentTypeSelect", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const options = container.querySelectorAll('[role="option"]');
-    expect(options).toHaveLength(7);
+    expect(options).toHaveLength(9);
   });
 
   it("sets aria-selected on selected option", () => {
@@ -277,5 +339,21 @@ describe("AgentTypeSelect", () => {
     const icon = container.querySelector(".agent-type-select__trigger-icon");
     expect(icon).not.toBeNull();
     expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
+  });
+
+  it("aria-label says 'Select' when no platform is selected, otherwise the platform label", () => {
+    const { container: blankContainer } = render(() => (
+      <AgentTypeSelect {...defaultProps} category={null} platform={null} />
+    ));
+    expect(
+      blankContainer.querySelector(".agent-type-select__trigger")!.getAttribute("aria-label"),
+    ).toBe("Agent type: Select");
+
+    const { container: pickedContainer } = render(() => (
+      <AgentTypeSelect {...defaultProps} category="coding" platform="claude-code" />
+    ));
+    expect(
+      pickedContainer.querySelector(".agent-type-select__trigger")!.getAttribute("aria-label"),
+    ).toBe("Agent type: Claude Code");
   });
 });

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -75,7 +75,7 @@ vi.mock("../../src/services/recent-agents.js", () => ({
 }));
 
 vi.mock("manifest-shared", () => ({
-  AGENT_CATEGORIES: ["personal", "app"],
+  AGENT_CATEGORIES: ["personal", "app", "coding"],
   platformIcon: (plat: string | null, cat: string | null) => {
     if (!plat) return undefined;
     if (plat === "other") return cat === "personal" ? "/icons/other-agent.svg" : "/icons/other.svg";
@@ -85,12 +85,14 @@ vi.mock("manifest-shared", () => ({
       "openai-sdk": "/icons/providers/openai.svg",
       "vercel-ai-sdk": "/icons/vercel.svg",
       langchain: "/icons/langchain.svg",
+      "claude-code": "/icons/providers/claude-code.svg",
     };
     return icons[plat];
   },
   CATEGORY_LABELS: {
     personal: "Personal AI Agent",
     app: "App AI SDK",
+    coding: "Coding Assistant",
   },
   PLATFORM_LABELS: {
     openclaw: "OpenClaw",
@@ -99,11 +101,13 @@ vi.mock("manifest-shared", () => ({
     "vercel-ai-sdk": "Vercel AI SDK",
     langchain: "LangChain",
     curl: "cURL",
+    "claude-code": "Claude Code",
     other: "Other",
   },
   PLATFORMS_BY_CATEGORY: {
     personal: ["openclaw", "hermes", "other"],
     app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
+    coding: ["claude-code", "other"],
   },
   PLATFORM_ICONS: {
     openclaw: "/icons/openclaw.png",
@@ -111,6 +115,7 @@ vi.mock("manifest-shared", () => ({
     "openai-sdk": "/icons/providers/openai.svg",
     "vercel-ai-sdk": "/icons/vercel.svg",
     langchain: "/icons/langchain.svg",
+    "claude-code": "/icons/providers/claude-code.svg",
   },
 }));
 

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -90,18 +90,20 @@ vi.mock("../../src/services/recent-agents.js", () => ({
 }));
 
 vi.mock("manifest-shared", () => ({
-  AGENT_CATEGORIES: ["personal", "app"],
+  AGENT_CATEGORIES: ["personal", "app", "coding"],
   PLATFORM_ICONS: {
     openclaw: "/icons/openclaw.png",
     hermes: "/icons/hermes.png",
     "openai-sdk": "/icons/providers/openai.svg",
     "vercel-ai-sdk": "/icons/vercel.svg",
     langchain: "/icons/langchain.svg",
+    "claude-code": "/icons/providers/claude-code.svg",
     other: "/icons/other.svg",
   },
   PLATFORMS_BY_CATEGORY: {
     personal: ["openclaw", "hermes", "other"],
     app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
+    coding: ["claude-code", "other"],
   },
   platformIcon: (plat: string | null, cat: string | null) => {
     if (!plat) return undefined;
@@ -112,6 +114,7 @@ vi.mock("manifest-shared", () => ({
       "openai-sdk": "/icons/providers/openai.svg",
       "vercel-ai-sdk": "/icons/vercel.svg",
       langchain: "/icons/langchain.svg",
+      "claude-code": "/icons/providers/claude-code.svg",
     };
     return icons[plat];
   },

--- a/packages/shared/__tests__/agent-type.spec.ts
+++ b/packages/shared/__tests__/agent-type.spec.ts
@@ -10,7 +10,7 @@ import {
 
 describe('agent-type', () => {
   it('exposes the full set of categories and platforms', () => {
-    expect(AGENT_CATEGORIES).toEqual(['personal', 'app']);
+    expect(AGENT_CATEGORIES).toEqual(['personal', 'app', 'coding']);
     expect(AGENT_PLATFORMS).toEqual([
       'openclaw',
       'hermes',
@@ -24,13 +24,23 @@ describe('agent-type', () => {
     ]);
   });
 
+  it('places coding as the last category so the picker reads personal → app → coding', () => {
+    expect(AGENT_CATEGORIES[AGENT_CATEGORIES.length - 1]).toBe('coding');
+  });
+
   it('provides a human label for every category and platform', () => {
     for (const category of AGENT_CATEGORIES) {
       expect(typeof CATEGORY_LABELS[category]).toBe('string');
+      expect(CATEGORY_LABELS[category].length).toBeGreaterThan(0);
     }
     for (const platform of AGENT_PLATFORMS) {
       expect(typeof PLATFORM_LABELS[platform]).toBe('string');
+      expect(PLATFORM_LABELS[platform].length).toBeGreaterThan(0);
     }
+  });
+
+  it('labels the new coding category as "Coding Assistant"', () => {
+    expect(CATEGORY_LABELS.coding).toBe('Coding Assistant');
   });
 
   it('maps every category to a non-empty list of platforms that are all registered', () => {
@@ -43,6 +53,33 @@ describe('agent-type', () => {
     }
   });
 
+  it('places claude-code under coding only, not personal or app', () => {
+    expect(PLATFORMS_BY_CATEGORY.coding).toContain('claude-code');
+    expect(PLATFORMS_BY_CATEGORY.personal).not.toContain('claude-code');
+    expect(PLATFORMS_BY_CATEGORY.app).not.toContain('claude-code');
+  });
+
+  it('keeps "other" available in every category for the unknown-platform fallback', () => {
+    for (const category of AGENT_CATEGORIES) {
+      expect(PLATFORMS_BY_CATEGORY[category]).toContain('other');
+    }
+  });
+
+  it('does not duplicate any non-other platform across categories (other is the only sentinel)', () => {
+    const seen = new Map<string, string>();
+    for (const category of AGENT_CATEGORIES) {
+      for (const platform of PLATFORMS_BY_CATEGORY[category]) {
+        if (platform === 'other') continue;
+        if (seen.has(platform)) {
+          throw new Error(
+            `Platform "${platform}" appears in both "${seen.get(platform)}" and "${category}"`,
+          );
+        }
+        seen.set(platform, category);
+      }
+    }
+  });
+
   describe('platformIcon', () => {
     it('returns undefined for missing input', () => {
       expect(platformIcon(null, null)).toBeUndefined();
@@ -50,24 +87,49 @@ describe('agent-type', () => {
       expect(platformIcon('', 'personal')).toBeUndefined();
     });
 
+    it('treats every falsy platform value the same regardless of category', () => {
+      for (const cat of [null, undefined, 'personal', 'app', 'coding', 'unknown']) {
+        expect(platformIcon(null, cat)).toBeUndefined();
+        expect(platformIcon(undefined, cat)).toBeUndefined();
+        expect(platformIcon('', cat)).toBeUndefined();
+      }
+    });
+
     it('returns the personal-agent icon for "other" in the personal category', () => {
       expect(platformIcon('other', 'personal')).toBe('/icons/other-agent.svg');
     });
 
-    it('returns the generic "other" icon for "other" in the app category (or unknown)', () => {
+    it('returns the generic "other" icon for "other" in any non-personal category', () => {
       expect(platformIcon('other', 'app')).toBe('/icons/other.svg');
+      expect(platformIcon('other', 'coding')).toBe('/icons/other.svg');
       expect(platformIcon('other', null)).toBe('/icons/other.svg');
       expect(platformIcon('other', undefined)).toBe('/icons/other.svg');
+      expect(platformIcon('other', 'not-a-real-category')).toBe('/icons/other.svg');
     });
 
     it('returns the registered icon for known platforms', () => {
       expect(platformIcon('openclaw', 'personal')).toBe(PLATFORM_ICONS.openclaw);
       expect(platformIcon('hermes', 'personal')).toBe(PLATFORM_ICONS.hermes);
+      expect(platformIcon('claude-code', 'coding')).toBe(PLATFORM_ICONS['claude-code']);
       expect(platformIcon('openai-sdk', 'app')).toBe(PLATFORM_ICONS['openai-sdk']);
-      expect(platformIcon('vercel-ai-sdk', 'app')).toBe(PLATFORM_ICONS['vercel-ai-sdk']);
       expect(platformIcon('anthropic-sdk', 'app')).toBe(PLATFORM_ICONS['anthropic-sdk']);
-      expect(platformIcon('claude-code', 'personal')).toBe(PLATFORM_ICONS['claude-code']);
+      expect(platformIcon('vercel-ai-sdk', 'app')).toBe(PLATFORM_ICONS['vercel-ai-sdk']);
       expect(platformIcon('langchain', 'app')).toBe(PLATFORM_ICONS.langchain);
+    });
+
+    it('claude-code resolves to the official providers/claude-code.svg mark on main', () => {
+      // Pinning the path explicitly so a future drift away from the upstream
+      // Claude mark fails this test loudly rather than silently.
+      expect(platformIcon('claude-code', 'coding')).toBe('/icons/providers/claude-code.svg');
+    });
+
+    it('returns the platform icon regardless of the category passed (icon is keyed by platform)', () => {
+      // Even if the caller passes an inconsistent (platform, category) pair —
+      // e.g. a stale row in the DB — we still resolve to the registered icon
+      // for the platform. Only "other" branches on category.
+      expect(platformIcon('claude-code', 'personal')).toBe(PLATFORM_ICONS['claude-code']);
+      expect(platformIcon('claude-code', null)).toBe(PLATFORM_ICONS['claude-code']);
+      expect(platformIcon('openclaw', 'coding')).toBe(PLATFORM_ICONS.openclaw);
     });
 
     it('returns undefined for platforms with no registered icon', () => {
@@ -76,6 +138,14 @@ describe('agent-type', () => {
 
     it('returns undefined for unknown platform strings (no injection via string)', () => {
       expect(platformIcon('not-a-real-platform', 'personal')).toBeUndefined();
+      expect(platformIcon('__proto__', 'personal')).toBeUndefined();
+      expect(platformIcon('constructor', 'personal')).toBeUndefined();
+    });
+
+    it('every registered icon path is a relative path under /icons/', () => {
+      for (const path of Object.values(PLATFORM_ICONS)) {
+        expect(path).toMatch(/^\/icons\//);
+      }
     });
   });
 });

--- a/packages/shared/src/agent-type.ts
+++ b/packages/shared/src/agent-type.ts
@@ -1,4 +1,4 @@
-export const AGENT_CATEGORIES = ['personal', 'app'] as const;
+export const AGENT_CATEGORIES = ['personal', 'app', 'coding'] as const;
 export type AgentCategory = (typeof AGENT_CATEGORIES)[number];
 
 export const AGENT_PLATFORMS = [
@@ -17,6 +17,7 @@ export type AgentPlatform = (typeof AGENT_PLATFORMS)[number];
 export const CATEGORY_LABELS: Readonly<Record<AgentCategory, string>> = {
   personal: 'Personal AI Agent',
   app: 'App AI SDK',
+  coding: 'Coding Assistant',
 };
 
 export const PLATFORM_LABELS: Readonly<Record<AgentPlatform, string>> = {
@@ -32,8 +33,9 @@ export const PLATFORM_LABELS: Readonly<Record<AgentPlatform, string>> = {
 };
 
 export const PLATFORMS_BY_CATEGORY: Readonly<Record<AgentCategory, readonly AgentPlatform[]>> = {
-  personal: ['openclaw', 'hermes', 'claude-code', 'other'],
+  personal: ['openclaw', 'hermes', 'other'],
   app: ['openai-sdk', 'anthropic-sdk', 'vercel-ai-sdk', 'langchain', 'other'],
+  coding: ['claude-code', 'other'],
 };
 
 export const PLATFORM_ICONS: Readonly<Partial<Record<AgentPlatform, string>>> = {
@@ -55,5 +57,8 @@ export function platformIcon(
   if (platform === 'other') {
     return category === 'personal' ? '/icons/other-agent.svg' : '/icons/other.svg';
   }
+  // Object.hasOwn so a hostile string like "__proto__" or "constructor" can't
+  // resolve to a value on Object.prototype.
+  if (!Object.hasOwn(PLATFORM_ICONS, platform)) return undefined;
   return PLATFORM_ICONS[platform as AgentPlatform];
 }


### PR DESCRIPTION
### 💭 Why
Claude Code was bucketed under Personal AI Agent in the picker. It is a coding assistant, so it deserves its own column for analytics + onboarding clarity (peacock reads agent_platform / agent_category from telemetry).

### ✨ What changed
- Add `coding` to `AGENT_CATEGORIES` (placed last so the picker reads Personal | App | Coding).
- Move `claude-code` from `personal` to the new `coding: ['claude-code', 'other']` group.
- Harden `platformIcon()` with `Object.hasOwn` against `__proto__` / `constructor` strings.
- New shared edge-case tests (155 total) and updated frontend mocks.

### 👤 For users
Connect Agent and Change Agent Type modals now show three columns. Claude Code lives in the rightmost Coding Assistant column. Existing agents (`agent_category`, `agent_platform`) continue to work; the icon is the same Claude mark from main.

### 🔧 For operators
None. The DB columns are `varchar` and already accept any string. Telemetry surfaces `claude-code` as before via `agents_by_platform`. Peacock will need a follow-up to map `claude-code` → `coding` in its `inferCategory` heuristic for the legend.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Coding Assistant category to the agent picker and move `claude-code` into it for clearer onboarding and better analytics. The Connect Agent and Change Agent Type modals now show three columns: Personal AI Agent, App AI SDK, Coding Assistant.

- **New Features**
  - Add `coding` to `AGENT_CATEGORIES` (ordered last) and map `PLATFORMS_BY_CATEGORY.coding = ['claude-code', 'other']`; remove `claude-code` from `personal`.
  - Keep platform icons; `claude-code` uses `/icons/providers/claude-code.svg`.

- **Bug Fixes**
  - Telemetry: group `agents_by_platform` by category + platform and emit `<category>:other` for `other`; known platforms stay bare and legacy null-category rows fall back to `other`.
  - Clamp unknown `routing_tier` values to `other` and harden `platformIcon()` with `Object.hasOwn`; add shared edge-case tests and update frontend tests/mocks for the three-column picker.

<sup>Written for commit e33c6a762eef4d55b60a3556f5867ce28d08f9bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

