### PR TITLE
fix(routing): preserve saved fallbacks on resolution error

### DIFF
--- a/.changeset/issue-1790-fallback-third-item.md
+++ b/.changeset/issue-1790-fallback-third-item.md
@@ -1,0 +1,11 @@
+---
+"manifest": patch
+---
+
+Stop silently wiping the saved fallback list when an unresolvable model is added (issue #1790).
+
+`buildFallbackRoutes()` in `tier`, `specificity`, and `header-tier` services used to return `null` whenever any single model couldn't be resolved to a unique `(provider, authType, model)` tuple. `setFallbacks` then persisted that `null`, so the user's existing `fallback_routes` row was overwritten with `null` and the controller returned `[]`. The toast still said "Fallback added" — the only visible result was the previously-saved fallbacks disappearing.
+
+PR #1825 already plugged the most common trigger by sending an explicit `routes` payload from the add handlers. This change removes the underlying footgun: `buildFallbackRoutes` now throws `400 Bad Request` instead of returning `null`, so the row is left untouched on resolution failure and the frontend shows the error.
+
+Scoped strictly to the backend wipe path. Does not change input validation, the `authType !== undefined` guard in the add handlers, or the discovery-fallback shape of `buildFallbackRoutes`.

--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -429,14 +429,43 @@ describe('HeaderTierService', () => {
       expect(result).toEqual([]);
     });
 
-    it('returns [] when discovery cannot disambiguate', async () => {
+    it('throws when discovery cannot disambiguate', async () => {
       repo.findOne.mockResolvedValue({ id: 'h1', agent_id: 'agent-1' } as HeaderTier);
       discoveryService.getModelsForAgent.mockResolvedValue([
         discovered('gpt-4o', 'openai', 'api_key'),
         discovered('gpt-4o', 'openai', 'subscription'),
       ]);
-      const result = await svc.setFallbacks('agent-1', 'h1', ['gpt-4o']);
-      expect(result).toEqual([]);
+      await expect(svc.setFallbacks('agent-1', 'h1', ['gpt-4o'])).rejects.toThrow(
+        /Cannot resolve fallback model "gpt-4o"/,
+      );
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    // Regression: issue #1790. See tier.service.spec for the full rationale.
+    it('preserves existing fallbacks when an unresolvable model is added (issue #1790)', async () => {
+      const existing = [
+        route('openai', 'api_key', 'gpt-4o'),
+        route('anthropic', 'api_key', 'claude-3-5-sonnet'),
+      ];
+      repo.findOne.mockResolvedValue({
+        id: 'h1',
+        agent_id: 'agent-1',
+        fallback_routes: existing,
+      } as HeaderTier);
+      discoveryService.getModelsForAgent.mockResolvedValue([
+        discovered('gpt-4o', 'openai', 'api_key'),
+        discovered('gpt-4o', 'openai', 'subscription'),
+        discovered('claude-3-5-sonnet', 'anthropic', 'api_key'),
+      ]);
+      await expect(
+        svc.setFallbacks(
+          'agent-1',
+          'h1',
+          ['gpt-4o', 'claude-3-5-sonnet', 'minmax-27'],
+          [...existing, route('minimax', 'api_key', 'minmax-27')],
+        ),
+      ).rejects.toThrow(/Cannot resolve fallback model/);
+      expect(repo.save).not.toHaveBeenCalled();
     });
 
     it('falls back to discovery when provided routes do not align', async () => {

--- a/packages/backend/src/routing/header-tiers/header-tier.service.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.service.ts
@@ -219,6 +219,10 @@ export class HeaderTierService {
     this.routingCache.invalidateAgent(agentId);
   }
 
+  /**
+   * Mirror of {@link TierService.buildFallbackRoutes} — see that docblock for
+   * the issue #1790 rationale on why this throws instead of returning null.
+   */
   private async buildFallbackRoutes(
     agentId: string,
     models: string[],
@@ -243,7 +247,12 @@ export class HeaderTierService {
     const resolved: ModelRoute[] = [];
     for (const m of models) {
       const route = unambiguousRoute(m, available);
-      if (!route) return null;
+      if (!route) {
+        throw new BadRequestException(
+          `Cannot resolve fallback model "${m}" to a single connected provider. ` +
+            `Pass an explicit (provider, authType, model) route, or connect exactly one provider that offers this model.`,
+        );
+      }
       resolved.push(route);
     }
     return resolved;

--- a/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/specificity.service.spec.ts
@@ -297,7 +297,7 @@ describe('SpecificityService', () => {
       expect(await svc.setFallbacks('agent-1', 'coding', [])).toEqual([]);
     });
 
-    it('returns [] when any model cannot be unambiguously resolved', async () => {
+    it('throws when any model cannot be unambiguously resolved', async () => {
       discoveryService.getModelsForAgent.mockResolvedValue([
         discovered('gpt-4o', 'openai', 'api_key'),
         discovered('gpt-4o', 'openai', 'subscription'),
@@ -305,8 +305,35 @@ describe('SpecificityService', () => {
       repo.findOne.mockResolvedValue({
         fallback_routes: null,
       } as SpecificityAssignment);
-      const result = await svc.setFallbacks('agent-1', 'coding', ['gpt-4o']);
-      expect(result).toEqual([]);
+      await expect(svc.setFallbacks('agent-1', 'coding', ['gpt-4o'])).rejects.toThrow(
+        /Cannot resolve fallback model "gpt-4o"/,
+      );
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    // Regression: issue #1790. See tier.service.spec for the full rationale.
+    it('preserves existing fallbacks when an unresolvable model is added (issue #1790)', async () => {
+      const existing = [
+        route('openai', 'api_key', 'gpt-4o'),
+        route('anthropic', 'api_key', 'claude-3-5-sonnet'),
+      ];
+      discoveryService.getModelsForAgent.mockResolvedValue([
+        discovered('gpt-4o', 'openai', 'api_key'),
+        discovered('gpt-4o', 'openai', 'subscription'),
+        discovered('claude-3-5-sonnet', 'anthropic', 'api_key'),
+      ]);
+      repo.findOne.mockResolvedValue({
+        fallback_routes: existing,
+      } as SpecificityAssignment);
+      await expect(
+        svc.setFallbacks(
+          'agent-1',
+          'coding',
+          ['gpt-4o', 'claude-3-5-sonnet', 'minmax-27'],
+          [...existing, route('minimax', 'api_key', 'minmax-27')],
+        ),
+      ).rejects.toThrow(/Cannot resolve fallback model/);
+      expect(repo.save).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
@@ -487,7 +487,7 @@ describe('TierService', () => {
       expect(result).toEqual([]);
     });
 
-    it('returns [] when a model cannot be unambiguously resolved', async () => {
+    it('throws when a model cannot be unambiguously resolved', async () => {
       discoveryService.getModelsForAgent.mockResolvedValue([
         discovered('gpt-4o', 'openai', 'api_key'),
         discovered('gpt-4o', 'openai', 'subscription'),
@@ -498,8 +498,45 @@ describe('TierService', () => {
         fallback_routes: null,
       } as TierAssignment);
 
-      const result = await svc.setFallbacks('agent-1', 'standard', ['gpt-4o']);
-      expect(result).toEqual([]);
+      await expect(svc.setFallbacks('agent-1', 'standard', ['gpt-4o'])).rejects.toThrow(
+        /Cannot resolve fallback model "gpt-4o"/,
+      );
+      expect(tierRepo.save).not.toHaveBeenCalled();
+    });
+
+    // Regression: issue #1790. Adding a new fallback whose (provider, authType,
+    // model) tuple isn't in the discovered list used to fall through to
+    // unambiguousRoute() for every model and return null on the first
+    // ambiguous one — wiping the previously-saved fallbacks. The fix throws
+    // before save, so the existing row is left untouched.
+    it('preserves existing fallbacks when an unresolvable model is added (issue #1790)', async () => {
+      const existing = [
+        route('openai', 'api_key', 'gpt-4o'),
+        route('anthropic', 'api_key', 'claude-3-5-sonnet'),
+      ];
+      discoveryService.getModelsForAgent.mockResolvedValue([
+        discovered('gpt-4o', 'openai', 'api_key'),
+        discovered('gpt-4o', 'openai', 'subscription'),
+        discovered('claude-3-5-sonnet', 'anthropic', 'api_key'),
+      ]);
+      tierRepo.findOne.mockResolvedValue({
+        agent_id: 'agent-1',
+        tier: 'standard',
+        fallback_routes: existing,
+      } as TierAssignment);
+
+      // Caller sends the existing two routes plus a new one whose tuple
+      // doesn't match any discovered model — validation fails, then
+      // unambiguousRoute hits gpt-4o which has two entries.
+      await expect(
+        svc.setFallbacks(
+          'agent-1',
+          'standard',
+          ['gpt-4o', 'claude-3-5-sonnet', 'minmax-27'],
+          [...existing, route('minimax', 'api_key', 'minmax-27')],
+        ),
+      ).rejects.toThrow(/Cannot resolve fallback model/);
+      expect(tierRepo.save).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/routing-core/specificity.service.ts
+++ b/packages/backend/src/routing/routing-core/specificity.service.ts
@@ -180,6 +180,10 @@ export class SpecificityService {
     this.routingCache.invalidateAgent(agentId);
   }
 
+  /**
+   * Mirror of {@link TierService.buildFallbackRoutes} — see that docblock for
+   * the issue #1790 rationale on why this throws instead of returning null.
+   */
   private async buildFallbackRoutes(
     agentId: string,
     models: string[],
@@ -204,7 +208,12 @@ export class SpecificityService {
     const resolved: ModelRoute[] = [];
     for (const m of models) {
       const route = unambiguousRoute(m, available);
-      if (!route) return null;
+      if (!route) {
+        throw new BadRequestException(
+          `Cannot resolve fallback model "${m}" to a single connected provider. ` +
+            `Pass an explicit (provider, authType, model) route, or connect exactly one provider that offers this model.`,
+        );
+      }
       resolved.push(route);
     }
     return resolved;

--- a/packages/backend/src/routing/routing-core/tier.service.ts
+++ b/packages/backend/src/routing/routing-core/tier.service.ts
@@ -236,7 +236,18 @@ export class TierService {
   /**
    * Build the fallback_routes column from caller-provided routes when present,
    * otherwise resolve each model name via discovery. Order is preserved.
-   * Returns null when any model can't be resolved unambiguously.
+   *
+   * Throws BadRequestException when any model can't be resolved to a single
+   * (provider, authType, model) tuple — the caller's existing
+   * `fallback_routes` row is left untouched.
+   *
+   * Issue #1790: this used to `return null` on resolution failure, which
+   * `setFallbacks` then persisted, silently wiping the user's existing
+   * fallback list while the UI toasted "Fallback added". PR #1825 plugged
+   * the most common trigger (same model offered by two authTypes) by making
+   * the frontend send routes; throwing here removes the underlying wipe path
+   * for every other trigger (e.g. disconnected providers, discovery drift,
+   * malformed payloads). It does not narrow which inputs reach this path.
    *
    * `keyLabel` on each route is preserved as-is — the caller decides which
    * provider key each fallback pins to.
@@ -273,7 +284,12 @@ export class TierService {
     const resolved: ModelRoute[] = [];
     for (const m of models) {
       const route = unambiguousRoute(m, available);
-      if (!route) return null;
+      if (!route) {
+        throw new BadRequestException(
+          `Cannot resolve fallback model "${m}" to a single connected provider. ` +
+            `Pass an explicit (provider, authType, model) route, or connect exactly one provider that offers this model.`,
+        );
+      }
       resolved.push(route);
     }
     return resolved;

--- a/packages/frontend/src/pages/RoutingActions.tsx
+++ b/packages/frontend/src/pages/RoutingActions.tsx
@@ -216,12 +216,12 @@ export function createRoutingActions(input: RoutingActionsInput) {
       );
       toast.success('Fallback added');
     } catch {
+      // error toast from fetchMutate
       setFallbackOverrides((prev) => {
         const next = { ...prev };
         delete next[tierId];
         return next;
       });
-      toast.error('Could not add fallback');
     } finally {
       setAddingFallback(null);
       setFallbackOverrides((prev) => {

--- a/packages/frontend/src/pages/RoutingActions.tsx
+++ b/packages/frontend/src/pages/RoutingActions.tsx
@@ -221,6 +221,7 @@ export function createRoutingActions(input: RoutingActionsInput) {
         delete next[tierId];
         return next;
       });
+      toast.error('Could not add fallback');
     } finally {
       setAddingFallback(null);
       setFallbackOverrides((prev) => {


### PR DESCRIPTION
### ✨ What changed
- `buildFallbackRoutes` in `tier`, `specificity`, and `header-tier` services throws `BadRequestException` when a model can't be resolved to a single `(provider, authType, model)` tuple. It used to return `null`.
- `setFallbacks` no longer persists that `null` over the user's `fallback_routes` row. The saved list is left untouched on failure.
- `RoutingActions.tsx` complexity-tier add handler shows `toast.error('Could not add fallback')` in its existing catch (the specificity path already toasted on error).
- 3 existing tests that asserted `result.toEqual([])` on resolution failure now assert `rejects.toThrow` plus `repo.save not called`.
- 3 new regression tests (one per service) pin the issue scenario: existing fallbacks survive when a third add comes in with an unresolvable tuple.

### 💭 Why
The old `null` return was destructive. Any add that fell into the discovery-disambiguation path wiped the user's saved fallbacks, while the UI toasted "Fallback added" and re-rendered an empty list. The user could not tell what happened.

PR #1825 plugged the most common trigger by sending an explicit `routes` payload from the add handlers. That avoids the wipe path on the happy path but does not remove it. This change removes the landmine itself, so any remaining trigger (disconnected provider mid-edit, discovery cache drift, picker firing with `authType = undefined`, malformed payload) surfaces a 400 instead of silently losing data.

### 👤 For users
Adding an unresolvable fallback now shows an error toast and leaves the saved list intact. No change on the happy path.

### 🔧 For operators
None. No migration, no env var, no API contract change beyond `200 + []` becoming `400` on the failure path. The successful path still returns the persisted routes.

### 📝 Notes
- Fixes #1790
- Related: #1825 (frontend-side fix for the same-provider/two-authTypes trigger)
- Out of scope: the `authType !== undefined` guard in the add handlers and the `effectiveAuth = authType ?? 'api_key'` default in `RoutingActions.tsx`. Those are separate footguns worth a follow-up.
- Tests: `npx jest src/routing` (1914 pass), `npx vitest run tests/pages/{Routing,RoutingActions}*` (78 pass).