### PR TITLE
feat: add Anthropic Claude Pro/Max OAuth subscription flow

### DIFF
--- a/.changeset/anthropic-oauth.md
+++ b/.changeset/anthropic-oauth.md
@@ -1,0 +1,13 @@
+---
+"manifest": minor
+---
+
+Add full OAuth flow for the Anthropic Claude Pro / Max subscription. Connecting
+your Claude subscription is now a one-click "Sign in with Claude" → paste the
+authorization code, instead of running `claude setup-token` in a separate
+terminal. Tokens auto-refresh through the same blob/refresh path used by OpenAI.
+
+Internally the OAuth code in `routing/oauth/` was split into shared `core/`
+primitives (PKCE, token-blob storage, pending-state TTL, callback HTML) plus
+per-provider files. The OpenAI service now delegates to the same primitives,
+and a new `oauth/anthropic/` package implements the paste-code flow.

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.config.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.config.ts
@@ -1,0 +1,20 @@
+/**
+ * OAuth constants for the Claude Pro / Max subscription flow.
+ *
+ * These mirror what the `claude setup-token` CLI uses internally — Anthropic
+ * publishes the same client_id and endpoints for any third-party tool that
+ * wants to authenticate end-users with their existing Claude subscription.
+ *
+ * The flow is PKCE with a manual paste-code step: Anthropic's redirect URI
+ * is a console page that displays the authorization code (formatted as
+ * `<code>#<state>`) for the user to copy back into Manifest.
+ */
+export const ANTHROPIC_OAUTH = {
+  CLIENT_ID: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
+  AUTHORIZE_URL: 'https://claude.ai/oauth/authorize',
+  TOKEN_URL: 'https://console.anthropic.com/v1/oauth/token',
+  REDIRECT_URI: 'https://console.anthropic.com/oauth/code/callback',
+  SCOPE: 'org:create_api_key user:profile user:inference',
+  /** Pending authorize state lives this long before the user must restart. */
+  STATE_TTL_MS: 10 * 60 * 1000,
+} as const;

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
@@ -1,0 +1,121 @@
+import { HttpException } from '@nestjs/common';
+import { AnthropicOauthController } from './anthropic-oauth.controller';
+import { AnthropicOauthService } from './anthropic-oauth.service';
+import { ResolveAgentService } from '../../routing-core/resolve-agent.service';
+import { ProviderService } from '../../routing-core/provider.service';
+
+const user = { id: 'user-1', email: 'u@example.com', name: 'U' } as never;
+
+function build() {
+  const oauth = {
+    generateAuthorizationUrl: jest.fn(),
+    exchangeCode: jest.fn(),
+    findPendingForAgent: jest.fn(),
+  } as unknown as AnthropicOauthService;
+  const resolveAgent = {
+    resolve: jest.fn().mockResolvedValue({ id: 'agent-1' }),
+  } as unknown as ResolveAgentService;
+  const providerService = {
+    removeProvider: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ProviderService;
+  return {
+    ctrl: new AnthropicOauthController(oauth, resolveAgent, providerService),
+    oauth,
+    resolveAgent,
+    providerService,
+  };
+}
+
+describe('AnthropicOauthController', () => {
+  describe('authorize', () => {
+    it('rejects when agentName is missing', async () => {
+      const { ctrl } = build();
+      await expect(ctrl.authorize('', user)).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('returns the authorize URL and state for a known agent', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.generateAuthorizationUrl as jest.Mock).mockReturnValue({
+        url: 'https://claude.ai/oauth/authorize?state=s1',
+        state: 's1',
+      });
+      const result = await ctrl.authorize('demo-agent', user);
+      expect(result).toEqual({ url: expect.any(String), state: 's1' });
+      expect(oauth.generateAuthorizationUrl).toHaveBeenCalledWith('agent-1', 'user-1');
+    });
+  });
+
+  describe('exchange', () => {
+    it('rejects missing agentName', async () => {
+      const { ctrl } = build();
+      await expect(ctrl.exchange('', 'code', 'state', user)).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('rejects missing code', async () => {
+      const { ctrl } = build();
+      await expect(ctrl.exchange('agent', '', 'state', user)).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('exchanges the code via the service and returns ok', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.exchangeCode as jest.Mock).mockResolvedValue(undefined);
+      await expect(ctrl.exchange('agent', 'auth-code', 'state-1', user)).resolves.toEqual({
+        ok: true,
+      });
+      expect(oauth.exchangeCode).toHaveBeenCalledWith('auth-code', 'state-1');
+    });
+
+    it('wraps service errors in a 400', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.exchangeCode as jest.Mock).mockRejectedValue(new Error('Token exchange failed'));
+      await expect(ctrl.exchange('agent', 'code', 'state', user)).rejects.toBeInstanceOf(
+        HttpException,
+      );
+    });
+
+    it('wraps non-Error throws with a generic message', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.exchangeCode as jest.Mock).mockRejectedValue('boom');
+      await expect(ctrl.exchange('agent', 'code', 'state', user)).rejects.toThrow(
+        'Token exchange failed',
+      );
+    });
+  });
+
+  describe('pending', () => {
+    it('rejects missing agentName', async () => {
+      const { ctrl } = build();
+      await expect(ctrl.pending('', user)).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('returns the active state when one exists', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.findPendingForAgent as jest.Mock).mockReturnValue({ state: 'abc' });
+      await expect(ctrl.pending('agent', user)).resolves.toEqual({ state: 'abc' });
+      expect(oauth.findPendingForAgent).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('returns {state: null} when no flow is pending', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.findPendingForAgent as jest.Mock).mockReturnValue(null);
+      await expect(ctrl.pending('agent', user)).resolves.toEqual({ state: null });
+    });
+  });
+
+  describe('revoke', () => {
+    it('rejects missing agentName', async () => {
+      const { ctrl } = build();
+      await expect(ctrl.revoke('', user)).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('removes the subscription provider record for the agent', async () => {
+      const { ctrl, providerService } = build();
+      await expect(ctrl.revoke('agent', user)).resolves.toEqual({ ok: true });
+      expect(providerService.removeProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'anthropic',
+        'subscription',
+      );
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
@@ -1,0 +1,94 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Logger,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { CurrentUser } from '../../../auth/current-user.decorator';
+import { AuthUser } from '../../../auth/auth.instance';
+import { ResolveAgentService } from '../../routing-core/resolve-agent.service';
+import { ProviderService } from '../../routing-core/provider.service';
+import { AnthropicOauthService } from './anthropic-oauth.service';
+
+@Controller('api/v1/oauth/anthropic')
+export class AnthropicOauthController {
+  private readonly logger = new Logger(AnthropicOauthController.name);
+
+  constructor(
+    private readonly oauthService: AnthropicOauthService,
+    private readonly resolveAgent: ResolveAgentService,
+    private readonly providerService: ProviderService,
+  ) {}
+
+  /**
+   * Generate the Anthropic OAuth authorize URL with PKCE. The frontend opens
+   * the returned URL in a new tab; Anthropic's redirect page then displays
+   * the authorization code for the user to paste into the SPA.
+   */
+  @Post('authorize')
+  async authorize(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    return this.oauthService.generateAuthorizationUrl(agent.id, user.id);
+  }
+
+  /**
+   * Exchange the pasted authorization payload (`<code>#<state>` or just the
+   * code with state in the body) for an OAuth token blob.
+   */
+  @Post('exchange')
+  async exchange(
+    @Query('agentName') agentName: string,
+    @Body('code') code: string,
+    @Body('state') state: string,
+    @CurrentUser() user: AuthUser,
+  ) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    if (!code) {
+      throw new HttpException('code is required', HttpStatus.BAD_REQUEST);
+    }
+    // Resolve the agent so unknown agents still 404 even if state is valid.
+    await this.resolveAgent.resolve(user.id, agentName);
+    try {
+      await this.oauthService.exchangeCode(code, state);
+      return { ok: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Token exchange failed';
+      this.logger.error(`Anthropic OAuth exchange failed: ${message}`);
+      throw new HttpException(message, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  /**
+   * Hydrates the SPA after a tab/modal close: returns the active pending
+   * state for an agent if a sign-in flow was started but not yet exchanged,
+   * so the paste-code field can be re-rendered without restarting the dance.
+   */
+  @Get('pending')
+  async pending(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    return this.oauthService.findPendingForAgent(agent.id) ?? { state: null };
+  }
+
+  /** Disconnect the Anthropic subscription provider for an agent. */
+  @Post('revoke')
+  async revoke(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    await this.providerService.removeProvider(agent.id, 'anthropic', 'subscription');
+    return { ok: true };
+  }
+}

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -1,0 +1,273 @@
+import { ProviderService } from '../../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
+import { AnthropicOauthService, splitAnthropicAuthPayload } from './anthropic-oauth.service';
+import { ANTHROPIC_OAUTH } from './anthropic-oauth.config';
+
+const originalFetch = global.fetch;
+
+function mockResponse(status: number, body: unknown, text = ''): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => text || JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function createProviderService(): {
+  svc: ProviderService;
+  upsertProvider: jest.Mock;
+  recalculateTiers: jest.Mock;
+} {
+  const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
+  const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  return {
+    svc: { upsertProvider, recalculateTiers } as unknown as ProviderService,
+    upsertProvider,
+    recalculateTiers,
+  };
+}
+
+function createDiscovery(): { svc: ModelDiscoveryService; discoverModels: jest.Mock } {
+  const discoverModels = jest.fn().mockResolvedValue(undefined);
+  return { svc: { discoverModels } as unknown as ModelDiscoveryService, discoverModels };
+}
+
+describe('splitAnthropicAuthPayload', () => {
+  it('returns the bare code when no state suffix is present', () => {
+    expect(splitAnthropicAuthPayload('abc123')).toEqual({ code: 'abc123' });
+  });
+
+  it('splits `<code>#<state>` into separate parts', () => {
+    expect(splitAnthropicAuthPayload('abc#xyz')).toEqual({ code: 'abc', state: 'xyz' });
+  });
+
+  it('treats a trailing # as no state', () => {
+    expect(splitAnthropicAuthPayload('abc#')).toEqual({ code: 'abc', state: undefined });
+  });
+
+  it('trims surrounding whitespace from pasted input', () => {
+    expect(splitAnthropicAuthPayload('  abc#xyz  ')).toEqual({ code: 'abc', state: 'xyz' });
+  });
+});
+
+describe('AnthropicOauthService', () => {
+  let fetchMock: jest.Mock;
+  let providerService: ReturnType<typeof createProviderService>;
+  let discovery: ReturnType<typeof createDiscovery>;
+  let svc: AnthropicOauthService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-01T12:00:00Z'));
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    providerService = createProviderService();
+    discovery = createDiscovery();
+    svc = new AnthropicOauthService(providerService.svc, discovery.svc);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('generateAuthorizationUrl', () => {
+    it('builds a Claude.ai authorize URL with PKCE S256 challenge and tracks pending state', () => {
+      const { url, state } = svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const parsed = new URL(url);
+      expect(parsed.origin + parsed.pathname).toBe(ANTHROPIC_OAUTH.AUTHORIZE_URL);
+      expect(parsed.searchParams.get('client_id')).toBe(ANTHROPIC_OAUTH.CLIENT_ID);
+      expect(parsed.searchParams.get('response_type')).toBe('code');
+      expect(parsed.searchParams.get('redirect_uri')).toBe(ANTHROPIC_OAUTH.REDIRECT_URI);
+      expect(parsed.searchParams.get('scope')).toBe(ANTHROPIC_OAUTH.SCOPE);
+      expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+      expect(parsed.searchParams.get('code_challenge')?.length).toBeGreaterThan(0);
+      expect(parsed.searchParams.get('state')).toBe(state);
+      expect(svc.getPendingCount()).toBe(1);
+    });
+  });
+
+  describe('exchangeCode', () => {
+    it('rejects when no code is supplied', async () => {
+      await expect(svc.exchangeCode('', 'state')).rejects.toThrow('Missing authorization code');
+    });
+
+    it('rejects when no state is supplied', async () => {
+      await expect(svc.exchangeCode('code', undefined)).rejects.toThrow('Missing OAuth state');
+    });
+
+    it('rejects unknown states', async () => {
+      await expect(svc.exchangeCode('code#bogus')).rejects.toThrow(
+        'Invalid or expired OAuth state',
+      );
+    });
+
+    it('rejects (and purges) expired states', async () => {
+      const { state } = svc.generateAuthorizationUrl('a', 'u');
+      jest.advanceTimersByTime(ANTHROPIC_OAUTH.STATE_TTL_MS + 1);
+      await expect(svc.exchangeCode(`code#${state}`)).rejects.toThrow('OAuth state expired');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('exchanges a valid code, stores the blob, and triggers model discovery', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, {
+          access_token: 'access-1',
+          refresh_token: 'refresh-1',
+          expires_in: 3600,
+        }),
+      );
+      const { state } = svc.generateAuthorizationUrl('agent-1', 'user-1');
+
+      await svc.exchangeCode(`auth-code#${state}`);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [tokenUrl, init] = fetchMock.mock.calls[0];
+      expect(tokenUrl).toBe(ANTHROPIC_OAUTH.TOKEN_URL);
+      const body = JSON.parse(init.body);
+      expect(body.grant_type).toBe('authorization_code');
+      expect(body.code).toBe('auth-code');
+      expect(body.state).toBe(state);
+      expect(body.code_verifier?.length).toBeGreaterThan(0);
+
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'anthropic',
+        expect.stringContaining('"t":"access-1"'),
+        'subscription',
+      );
+      expect(discovery.discoverModels).toHaveBeenCalled();
+      expect(providerService.recalculateTiers).toHaveBeenCalledWith('agent-1');
+      expect(svc.getPendingCount()).toBe(0);
+    });
+
+    it('accepts the code and state passed separately', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+      );
+      const { state } = svc.generateAuthorizationUrl('a', 'u');
+      await svc.exchangeCode('plain-code', state);
+      expect(providerService.upsertProvider).toHaveBeenCalled();
+    });
+
+    it('throws when the token endpoint returns an error', async () => {
+      fetchMock.mockResolvedValue(mockResponse(400, {}, 'invalid_grant'));
+      const { state } = svc.generateAuthorizationUrl('a', 'u');
+      await expect(svc.exchangeCode(`bad#${state}`)).rejects.toThrow('Token exchange failed');
+    });
+
+    it('stores an empty refresh token when Anthropic omits one in the response', async () => {
+      // No refresh_token field — defensive fallback exercises the `?? ''`.
+      fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'a', expires_in: 60 }));
+      const { state } = svc.generateAuthorizationUrl('a', 'u');
+      await svc.exchangeCode(`c#${state}`);
+      const stored = providerService.upsertProvider.mock.calls[0][3] as string;
+      expect(JSON.parse(stored).r).toBe('');
+    });
+
+    it('swallows discovery errors so the OAuth save is not rolled back', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+      );
+      discovery.discoverModels.mockRejectedValue(new Error('boom'));
+      const { state } = svc.generateAuthorizationUrl('a', 'u');
+      await expect(svc.exchangeCode(`c#${state}`)).resolves.toBeUndefined();
+      expect(providerService.upsertProvider).toHaveBeenCalled();
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('returns a fresh blob with a new expiry', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a2', refresh_token: 'r2', expires_in: 1800 }),
+      );
+      const blob = await svc.refreshAccessToken('old-refresh');
+      expect(blob).toEqual({ t: 'a2', r: 'r2', e: Date.now() + 1800 * 1000 });
+    });
+
+    it('retains the old refresh token when the server omits a new one', async () => {
+      fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'a2', expires_in: 60 }));
+      const blob = await svc.refreshAccessToken('old');
+      expect(blob.r).toBe('old');
+    });
+
+    it('throws when the refresh endpoint returns a non-2xx status', async () => {
+      fetchMock.mockResolvedValue(mockResponse(400, {}));
+      await expect(svc.refreshAccessToken('r')).rejects.toThrow('Token refresh failed');
+    });
+  });
+
+  describe('unwrapToken', () => {
+    it('returns the raw value when it is not an OAuth blob (legacy setup-token)', async () => {
+      expect(await svc.unwrapToken('sk-ant-oat01-legacy', 'a', 'u')).toBe('sk-ant-oat01-legacy');
+    });
+
+    it('returns null when given an empty string', async () => {
+      expect(await svc.unwrapToken('', 'a', 'u')).toBeNull();
+    });
+
+    it('returns the cached access token when it is still valid', async () => {
+      const blob = JSON.stringify({ t: 'access', r: 'refresh', e: Date.now() + 10 * 60_000 });
+      expect(await svc.unwrapToken(blob, 'a', 'u')).toBe('access');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('refreshes and persists a fresh blob when the token is near expiry', async () => {
+      const blob = JSON.stringify({ t: 'old', r: 'rf', e: Date.now() + 30_000 });
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
+      );
+      const token = await svc.unwrapToken(blob, 'agent-1', 'user-1');
+      expect(token).toBe('new');
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'anthropic',
+        expect.stringContaining('"t":"new"'),
+        'subscription',
+      );
+    });
+
+    it('returns the access token unchanged when the blob has no refresh token', async () => {
+      const blob = JSON.stringify({ t: 'access', r: '', e: Date.now() + 30_000 });
+      expect(await svc.unwrapToken(blob, 'a', 'u')).toBe('access');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the refresh call fails', async () => {
+      const blob = JSON.stringify({ t: 'old', r: 'rf', e: Date.now() + 1_000 });
+      fetchMock.mockRejectedValue(new Error('network'));
+      expect(await svc.unwrapToken(blob, 'a', 'u')).toBeNull();
+    });
+  });
+
+  describe('clearPendingState', () => {
+    it('removes a known pending state', () => {
+      const { state } = svc.generateAuthorizationUrl('a', 'u');
+      expect(svc.getPendingCount()).toBe(1);
+      svc.clearPendingState(state);
+      expect(svc.getPendingCount()).toBe(0);
+    });
+  });
+
+  describe('findPendingForAgent', () => {
+    it('returns the active state when one exists for the agent', () => {
+      const { state } = svc.generateAuthorizationUrl('agent-1', 'user-1');
+      expect(svc.findPendingForAgent('agent-1')).toEqual({ state });
+    });
+
+    it('returns null when no flow is pending for the agent', () => {
+      expect(svc.findPendingForAgent('agent-1')).toBeNull();
+    });
+
+    it('skips entries belonging to other agents', () => {
+      svc.generateAuthorizationUrl('other-agent', 'user-1');
+      expect(svc.findPendingForAgent('agent-1')).toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -1,0 +1,221 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ProviderService } from '../../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
+import { scrubSecrets } from '../../../common/utils/secret-scrub';
+import {
+  generatePkce,
+  generateState,
+  parseOAuthTokenBlob,
+  PendingStore,
+  serializeOAuthTokenBlob,
+  type OAuthTokenBlob,
+  type PendingEntry,
+} from '../core';
+import { ANTHROPIC_OAUTH } from './anthropic-oauth.config';
+
+interface PendingAnthropicOAuth extends PendingEntry {
+  verifier: string;
+  agentId: string;
+  userId: string;
+}
+
+export interface AuthorizeResult {
+  url: string;
+  state: string;
+}
+
+interface AnthropicTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  token_type?: string;
+}
+
+/**
+ * Splits Anthropic's pasted authorization payload. The redirect page renders
+ * `<code>#<state>` for users to copy verbatim, but tolerant clients should
+ * also accept just the code with the state passed alongside.
+ */
+export function splitAnthropicAuthPayload(payload: string): { code: string; state?: string } {
+  const trimmed = payload.trim();
+  const hashIdx = trimmed.indexOf('#');
+  if (hashIdx === -1) return { code: trimmed };
+  return {
+    code: trimmed.slice(0, hashIdx),
+    state: trimmed.slice(hashIdx + 1) || undefined,
+  };
+}
+
+@Injectable()
+export class AnthropicOauthService {
+  private readonly logger = new Logger(AnthropicOauthService.name);
+  private readonly pending = new PendingStore<PendingAnthropicOAuth>(ANTHROPIC_OAUTH.STATE_TTL_MS);
+
+  constructor(
+    private readonly providerService: ProviderService,
+    private readonly discoveryService: ModelDiscoveryService,
+  ) {}
+
+  /**
+   * Build the authorize URL the user opens in a new tab. The state is also
+   * returned so the SPA can pre-fill it on the paste-code step.
+   */
+  generateAuthorizationUrl(agentId: string, userId: string): AuthorizeResult {
+    const state = generateState();
+    const { verifier, challenge } = generatePkce();
+    this.pending.set(state, { verifier, agentId, userId });
+
+    const params = new URLSearchParams({
+      code: 'true',
+      client_id: ANTHROPIC_OAUTH.CLIENT_ID,
+      response_type: 'code',
+      redirect_uri: ANTHROPIC_OAUTH.REDIRECT_URI,
+      scope: ANTHROPIC_OAUTH.SCOPE,
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    });
+    return { url: `${ANTHROPIC_OAUTH.AUTHORIZE_URL}?${params.toString()}`, state };
+  }
+
+  /**
+   * Exchange the pasted authorization code for an OAuth token blob.
+   * `payload` may be either the bare code or the `<code>#<state>` form
+   * Anthropic's redirect page displays.
+   */
+  async exchangeCode(payload: string, fallbackState?: string): Promise<void> {
+    const { code, state: extractedState } = splitAnthropicAuthPayload(payload);
+    const state = extractedState ?? fallbackState;
+    if (!code) throw new Error('Missing authorization code');
+    if (!state) throw new Error('Missing OAuth state');
+
+    const pending = this.pending.peek(state);
+    if (!pending) throw new Error('Invalid or expired OAuth state');
+    if (pending.expiresAt < Date.now()) {
+      this.pending.delete(state);
+      throw new Error('OAuth state expired');
+    }
+    this.pending.delete(state);
+
+    const response = await fetch(ANTHROPIC_OAUTH.TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code,
+        state,
+        client_id: ANTHROPIC_OAUTH.CLIENT_ID,
+        redirect_uri: ANTHROPIC_OAUTH.REDIRECT_URI,
+        code_verifier: pending.verifier,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`Anthropic token exchange failed: ${scrubSecrets(text)}`);
+      throw new Error('Token exchange failed');
+    }
+    const data = (await response.json()) as AnthropicTokenResponse;
+    const blob: OAuthTokenBlob = {
+      t: data.access_token,
+      r: data.refresh_token ?? '',
+      e: Date.now() + data.expires_in * 1000,
+    };
+
+    const { provider: savedProvider } = await this.providerService.upsertProvider(
+      pending.agentId,
+      pending.userId,
+      'anthropic',
+      serializeOAuthTokenBlob(blob),
+      'subscription',
+    );
+    try {
+      await this.discoveryService.discoverModels(savedProvider);
+      await this.providerService.recalculateTiers(pending.agentId);
+    } catch (err) {
+      this.logger.warn(`Model discovery after Anthropic OAuth failed: ${err}`);
+    }
+    this.logger.log(`Anthropic OAuth token stored for agent=${pending.agentId}`);
+  }
+
+  async refreshAccessToken(refreshToken: string): Promise<OAuthTokenBlob> {
+    const response = await fetch(ANTHROPIC_OAUTH.TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: ANTHROPIC_OAUTH.CLIENT_ID,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`Anthropic token refresh failed: ${scrubSecrets(text)}`);
+      throw new Error('Token refresh failed');
+    }
+    const data = (await response.json()) as AnthropicTokenResponse;
+    return {
+      t: data.access_token,
+      r: data.refresh_token || refreshToken,
+      e: Date.now() + data.expires_in * 1000,
+    };
+  }
+
+  /**
+   * Resolve a stored credential to a usable bearer token.
+   *
+   * Two storage shapes are accepted:
+   *   - JSON OAuth blob (from the in-app OAuth flow) — refreshed when stale.
+   *   - Plain string (from the legacy `claude setup-token` paste flow) —
+   *     returned as-is, since those tokens have no refresh counterpart.
+   */
+  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
+    const blob = parseOAuthTokenBlob(rawValue);
+    if (!blob) {
+      // Legacy setup-token paste — keep working until the user reconnects.
+      return rawValue || null;
+    }
+    if (Date.now() < blob.e - 60_000) return blob.t;
+    if (!blob.r) {
+      // OAuth blob without a refresh token — should not happen, but fall back
+      // to the access token rather than nuking the user's session.
+      return blob.t;
+    }
+    try {
+      const refreshed = await this.refreshAccessToken(blob.r);
+      await this.providerService.upsertProvider(
+        agentId,
+        userId,
+        'anthropic',
+        serializeOAuthTokenBlob(refreshed),
+        'subscription',
+      );
+      this.logger.log(`Anthropic OAuth token refreshed for agent=${agentId}`);
+      return refreshed.t;
+    } catch (err) {
+      this.logger.error(`Failed to refresh Anthropic token for agent=${agentId}: ${err}`);
+      return null;
+    }
+  }
+
+  getPendingCount(): number {
+    return this.pending.size();
+  }
+
+  clearPendingState(state: string): void {
+    this.pending.delete(state);
+  }
+
+  /**
+   * Returns the active pending state for an agent if one exists, so the
+   * frontend can re-render the paste-code field after the modal was closed
+   * or the page reloaded mid-flow. Only the `state` is returned — the PKCE
+   * verifier stays server-side.
+   */
+  findPendingForAgent(agentId: string): { state: string } | null {
+    // Linear scan — one entry per active flow per agent at most.
+    for (const [state, value] of this.pending.entries()) {
+      if (value.agentId === agentId) return { state };
+    }
+    return null;
+  }
+}

--- a/packages/backend/src/routing/oauth/core/callback-page.spec.ts
+++ b/packages/backend/src/routing/oauth/core/callback-page.spec.ts
@@ -1,0 +1,29 @@
+import { oauthDoneHtml } from './callback-page';
+
+describe('oauthDoneHtml', () => {
+  it('emits a success message and a default Login title', () => {
+    const html = oauthDoneHtml(true);
+    expect(html).toContain('Login successful');
+    expect(html).toContain('manifest-oauth-success');
+    expect(html).toContain('Manifest — Login');
+  });
+
+  it('emits a failure message with retry guidance', () => {
+    const html = oauthDoneHtml(false);
+    expect(html).toContain('Login failed');
+    expect(html).toContain('manifest-oauth-error');
+  });
+
+  it('respects a custom provider label in the page title', () => {
+    expect(oauthDoneHtml(true, undefined, 'OpenAI Login')).toContain('Manifest — OpenAI Login');
+  });
+
+  it('threads a CSP nonce into the inline script tag', () => {
+    expect(oauthDoneHtml(true, 'abc123')).toContain('<script nonce="abc123">');
+  });
+
+  it('omits the nonce attribute when none is provided', () => {
+    expect(oauthDoneHtml(true)).toContain('<script>');
+    expect(oauthDoneHtml(true)).not.toContain('nonce=');
+  });
+});

--- a/packages/backend/src/routing/oauth/core/callback-page.ts
+++ b/packages/backend/src/routing/oauth/core/callback-page.ts
@@ -1,0 +1,26 @@
+/**
+ * HTML the popup window shows after the OAuth dance completes. Posts a
+ * BroadcastChannel message and a window.opener postMessage so the SPA can
+ * detect completion without polling, then auto-closes.
+ */
+export function oauthDoneHtml(success: boolean, nonce?: string, providerLabel = 'Login'): string {
+  const message = success ? 'manifest-oauth-success' : 'manifest-oauth-error';
+  const text = success
+    ? 'Login successful!'
+    : 'Login failed. Please close this window and try again.';
+  const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
+
+  return `<!DOCTYPE html>
+<html>
+<head><title>Manifest — ${providerLabel}</title></head>
+<body style="font-family:system-ui;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;margin:0;background:#111;color:#eee;">
+<p>${text}</p>
+<p id="hint" style="font-size:13px;color:#888;display:none;">You can close this window.</p>
+<script${nonceAttr}>
+try{var bc=new BroadcastChannel('manifest-oauth');bc.postMessage({type:'${message}'});bc.close();}catch(e){}
+if(window.opener){window.opener.postMessage({type:'${message}'},window.location.origin);}
+setTimeout(function(){window.close();document.getElementById('hint').style.display='block';},1500);
+</script>
+</body>
+</html>`;
+}

--- a/packages/backend/src/routing/oauth/core/index.ts
+++ b/packages/backend/src/routing/oauth/core/index.ts
@@ -1,0 +1,9 @@
+export { generatePkce, generateState, type PkcePair } from './pkce';
+export {
+  isOAuthTokenBlob,
+  parseOAuthTokenBlob,
+  serializeOAuthTokenBlob,
+  type OAuthTokenBlob,
+} from './oauth-blob';
+export { PendingStore, type PendingEntry } from './pending-store';
+export { oauthDoneHtml } from './callback-page';

--- a/packages/backend/src/routing/oauth/core/oauth-blob.spec.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-blob.spec.ts
@@ -1,0 +1,50 @@
+import { isOAuthTokenBlob, parseOAuthTokenBlob, serializeOAuthTokenBlob } from './oauth-blob';
+
+describe('oauth-blob', () => {
+  describe('isOAuthTokenBlob', () => {
+    it('accepts the minimum shape', () => {
+      expect(isOAuthTokenBlob({ t: 'access', r: 'refresh', e: 123 })).toBe(true);
+    });
+
+    it('accepts the optional resource URL field', () => {
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b', e: 1, u: 'https://x' })).toBe(true);
+    });
+
+    it('rejects missing or wrong-typed fields', () => {
+      expect(isOAuthTokenBlob(null)).toBe(false);
+      expect(isOAuthTokenBlob('string')).toBe(false);
+      expect(isOAuthTokenBlob({})).toBe(false);
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b' })).toBe(false); // missing e
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b', e: '1' })).toBe(false); // e wrong type
+      expect(isOAuthTokenBlob({ t: 'a', r: 'b', e: 1, u: 5 })).toBe(false); // u wrong type
+    });
+  });
+
+  describe('parseOAuthTokenBlob', () => {
+    it('round-trips a serialized blob', () => {
+      const blob = { t: 'access', r: 'refresh', e: 1234 };
+      expect(parseOAuthTokenBlob(serializeOAuthTokenBlob(blob))).toEqual(blob);
+    });
+
+    it('preserves the optional resource URL when present', () => {
+      const blob = { t: 'a', r: 'b', e: 5, u: 'https://api.example.com' };
+      expect(parseOAuthTokenBlob(serializeOAuthTokenBlob(blob))).toEqual(blob);
+    });
+
+    it('omits the resource URL field when not present', () => {
+      const parsed = parseOAuthTokenBlob('{"t":"a","r":"b","e":5}');
+      expect(parsed).toEqual({ t: 'a', r: 'b', e: 5 });
+      expect(parsed!.u).toBeUndefined();
+    });
+
+    it('returns null for malformed JSON', () => {
+      expect(parseOAuthTokenBlob('not-json')).toBeNull();
+      expect(parseOAuthTokenBlob('')).toBeNull();
+    });
+
+    it('returns null when JSON parses but the shape is wrong', () => {
+      expect(parseOAuthTokenBlob('{}')).toBeNull();
+      expect(parseOAuthTokenBlob('{"t":"a"}')).toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/core/oauth-blob.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-blob.ts
@@ -1,0 +1,42 @@
+/**
+ * Compact JSON shape used to persist OAuth credentials in
+ * `user_providers.api_key`. Field names are single letters to keep the
+ * encrypted payload small.
+ */
+export interface OAuthTokenBlob {
+  /** Access token. */
+  t: string;
+  /** Refresh token. */
+  r: string;
+  /** Access-token expiry (epoch ms). */
+  e: number;
+  /** Provider-specific resource URL (e.g. MiniMax region base URL). */
+  u?: string;
+}
+
+export function isOAuthTokenBlob(value: unknown): value is OAuthTokenBlob {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Partial<OAuthTokenBlob>;
+  return (
+    typeof v.t === 'string' &&
+    typeof v.r === 'string' &&
+    typeof v.e === 'number' &&
+    (v.u === undefined || typeof v.u === 'string')
+  );
+}
+
+export function parseOAuthTokenBlob(rawValue: string): OAuthTokenBlob | null {
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (!isOAuthTokenBlob(parsed)) return null;
+    return parsed.u !== undefined
+      ? { t: parsed.t, r: parsed.r, e: parsed.e, u: parsed.u }
+      : { t: parsed.t, r: parsed.r, e: parsed.e };
+  } catch {
+    return null;
+  }
+}
+
+export function serializeOAuthTokenBlob(blob: OAuthTokenBlob): string {
+  return JSON.stringify(blob);
+}

--- a/packages/backend/src/routing/oauth/core/pending-store.spec.ts
+++ b/packages/backend/src/routing/oauth/core/pending-store.spec.ts
@@ -1,0 +1,85 @@
+import { PendingStore } from './pending-store';
+
+interface FakeEntry {
+  expiresAt: number;
+  payload: string;
+}
+
+describe('PendingStore', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stores entries and stamps an expiresAt based on the configured TTL', () => {
+    const store = new PendingStore<FakeEntry>(10_000);
+    const entry = store.set('key', { payload: 'hello' });
+    expect(entry.payload).toBe('hello');
+    expect(entry.expiresAt).toBe(Date.now() + 10_000);
+    expect(store.size()).toBe(1);
+  });
+
+  it('get returns the entry while fresh and undefined once expired', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('k', { payload: 'x' });
+    expect(store.get('k')?.payload).toBe('x');
+    jest.advanceTimersByTime(1_001);
+    expect(store.get('k')).toBeUndefined();
+    expect(store.isEmpty()).toBe(true);
+  });
+
+  it('peek returns expired entries (so callers can produce a specific error)', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('k', { payload: 'x' });
+    jest.advanceTimersByTime(2_000);
+    expect(store.peek('k')?.payload).toBe('x');
+  });
+
+  it('consume returns the entry and removes it (one-time-use)', () => {
+    const store = new PendingStore<FakeEntry>(10_000);
+    store.set('k', { payload: 'x' });
+    expect(store.consume('k')?.payload).toBe('x');
+    expect(store.consume('k')).toBeUndefined();
+  });
+
+  it('delete removes an entry by key', () => {
+    const store = new PendingStore<FakeEntry>(10_000);
+    store.set('k', { payload: 'x' });
+    store.delete('k');
+    expect(store.size()).toBe(0);
+  });
+
+  it('cleans up expired entries opportunistically on size/set calls', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('a', { payload: '1' });
+    store.set('b', { payload: '2' });
+    expect(store.size()).toBe(2);
+    jest.advanceTimersByTime(1_500);
+    // size() triggers cleanup
+    expect(store.size()).toBe(0);
+  });
+
+  it('returns undefined from peek for unknown keys', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    expect(store.peek('nope')).toBeUndefined();
+  });
+
+  it('iterates over fresh entries via entries()', () => {
+    const store = new PendingStore<FakeEntry>(10_000);
+    store.set('a', { payload: '1' });
+    store.set('b', { payload: '2' });
+    const seen = [...store.entries()].map(([k, v]) => `${k}:${v.payload}`).sort();
+    expect(seen).toEqual(['a:1', 'b:2']);
+  });
+
+  it('skips expired entries when iterating', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('a', { payload: '1' });
+    jest.advanceTimersByTime(1_500);
+    expect([...store.entries()]).toEqual([]);
+  });
+});

--- a/packages/backend/src/routing/oauth/core/pending-store.ts
+++ b/packages/backend/src/routing/oauth/core/pending-store.ts
@@ -1,0 +1,79 @@
+/**
+ * In-memory TTL map for pending OAuth flows (state → flow data). Each
+ * provider service holds its own instance — sharing one across providers
+ * would tangle their cleanup cadences for no benefit.
+ *
+ * Not safe behind a load balancer. The OAuth flows that use this store
+ * complete in-process within a few minutes, which is acceptable for
+ * single-replica deployments and dev. Multi-replica deployments would
+ * need a Redis-backed store; out of scope here.
+ */
+export interface PendingEntry {
+  expiresAt: number;
+}
+
+export class PendingStore<T extends PendingEntry> {
+  private readonly entries_ = new Map<string, T>();
+
+  constructor(private readonly ttlMs: number) {}
+
+  set(key: string, value: Omit<T, 'expiresAt'> & Partial<PendingEntry>): T {
+    this.cleanup();
+    const entry = { ...value, expiresAt: Date.now() + this.ttlMs } as T;
+    this.entries_.set(key, entry);
+    return entry;
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.entries_.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt < Date.now()) {
+      this.entries_.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  /** Returns the entry even if expired — caller decides how to differentiate. */
+  peek(key: string): T | undefined {
+    return this.entries_.get(key);
+  }
+
+  /** Get and remove in one step — the typical state-consumed-on-exchange pattern. */
+  consume(key: string): T | undefined {
+    const entry = this.get(key);
+    if (entry) this.entries_.delete(key);
+    return entry;
+  }
+
+  delete(key: string): void {
+    this.entries_.delete(key);
+  }
+
+  size(): number {
+    this.cleanup();
+    return this.entries_.size;
+  }
+
+  isEmpty(): boolean {
+    return this.size() === 0;
+  }
+
+  /**
+   * Iterate over (key, value) for fresh entries only. Useful when a caller
+   * needs to find an entry by something other than its key (e.g. agentId).
+   */
+  *entries(): IterableIterator<[string, T]> {
+    this.cleanup();
+    for (const [key, value] of this.entries_) {
+      yield [key, value];
+    }
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [key, value] of this.entries_) {
+      if (value.expiresAt < now) this.entries_.delete(key);
+    }
+  }
+}

--- a/packages/backend/src/routing/oauth/core/pkce.spec.ts
+++ b/packages/backend/src/routing/oauth/core/pkce.spec.ts
@@ -1,0 +1,33 @@
+import { createHash } from 'crypto';
+import { generatePkce, generateState } from './pkce';
+
+describe('pkce', () => {
+  describe('generatePkce', () => {
+    it('returns a base64url verifier and a S256 challenge derived from it', () => {
+      const { verifier, challenge } = generatePkce();
+      // base64url alphabet: A-Z a-z 0-9 - _
+      expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+      const expected = createHash('sha256').update(verifier).digest('base64url');
+      expect(challenge).toBe(expected);
+    });
+
+    it('produces a fresh pair on every call', () => {
+      const a = generatePkce();
+      const b = generatePkce();
+      expect(a.verifier).not.toBe(b.verifier);
+      expect(a.challenge).not.toBe(b.challenge);
+    });
+  });
+
+  describe('generateState', () => {
+    it('returns a hex string of the requested byte length', () => {
+      expect(generateState(8)).toMatch(/^[0-9a-f]{16}$/);
+      expect(generateState()).toMatch(/^[0-9a-f]{64}$/); // default 32 bytes
+    });
+
+    it('produces a fresh value on every call', () => {
+      expect(generateState()).not.toBe(generateState());
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/core/pkce.ts
+++ b/packages/backend/src/routing/oauth/core/pkce.ts
@@ -1,0 +1,18 @@
+import { createHash, randomBytes } from 'crypto';
+
+export interface PkcePair {
+  /** Random verifier the client keeps secret until token exchange. */
+  verifier: string;
+  /** SHA-256(verifier), base64url-encoded — sent on /authorize as code_challenge. */
+  challenge: string;
+}
+
+export function generatePkce(): PkcePair {
+  const verifier = randomBytes(32).toString('base64url');
+  const challenge = createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge };
+}
+
+export function generateState(byteLength = 32): string {
+  return randomBytes(byteLength).toString('hex');
+}

--- a/packages/backend/src/routing/oauth/oauth.module.ts
+++ b/packages/backend/src/routing/oauth/oauth.module.ts
@@ -6,11 +6,23 @@ import { OpenaiOauthController } from './openai-oauth.controller';
 import { MinimaxOauthService } from './minimax-oauth.service';
 import { MinimaxOauthController } from './minimax-oauth.controller';
 import { CopilotDeviceAuthService } from './copilot-device-auth.service';
+import { AnthropicOauthService } from './anthropic/anthropic-oauth.service';
+import { AnthropicOauthController } from './anthropic/anthropic-oauth.controller';
 
 @Module({
   imports: [RoutingCoreModule, ModelDiscoveryModule],
-  controllers: [OpenaiOauthController, MinimaxOauthController],
-  providers: [OpenaiOauthService, MinimaxOauthService, CopilotDeviceAuthService],
-  exports: [OpenaiOauthService, MinimaxOauthService, CopilotDeviceAuthService],
+  controllers: [OpenaiOauthController, MinimaxOauthController, AnthropicOauthController],
+  providers: [
+    OpenaiOauthService,
+    MinimaxOauthService,
+    CopilotDeviceAuthService,
+    AnthropicOauthService,
+  ],
+  exports: [
+    OpenaiOauthService,
+    MinimaxOauthService,
+    CopilotDeviceAuthService,
+    AnthropicOauthService,
+  ],
 })
 export class OAuthModule {}

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -1,13 +1,22 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { randomBytes, createHash } from 'crypto';
 import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../common/utils/secret-scrub';
-import { PendingOAuth, OAuthTokenBlob, oauthDoneHtml } from './openai-oauth.types';
+import { PendingOAuth } from './openai-oauth.types';
+import {
+  generatePkce,
+  generateState,
+  oauthDoneHtml,
+  parseOAuthTokenBlob,
+  PendingStore,
+  serializeOAuthTokenBlob,
+  type OAuthTokenBlob,
+} from './core';
 
-export { PendingOAuth, OAuthTokenBlob, oauthDoneHtml };
+export { PendingOAuth };
+export { oauthDoneHtml, type OAuthTokenBlob };
 
 const DEFAULT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize';
@@ -21,8 +30,7 @@ const STATE_TTL_MS = 10 * 60 * 1000;
 @Injectable()
 export class OpenaiOauthService {
   private readonly logger = new Logger(OpenaiOauthService.name);
-  /** In-memory pending OAuth flows (not safe behind a load balancer). */
-  private readonly pending = new Map<string, PendingOAuth>();
+  private readonly pending = new PendingStore<PendingOAuth>(STATE_TTL_MS);
   private callbackServer: Server | null = null;
   private serverReady: Promise<void> | null = null;
   private readonly clientId: string;
@@ -46,20 +54,16 @@ export class OpenaiOauthService {
     userId: string,
     backendUrl?: string,
   ): Promise<string> {
-    this.cleanupExpired();
-    const state = randomBytes(32).toString('hex');
-    const verifier = randomBytes(32).toString('base64url');
-    const challenge = createHash('sha256').update(verifier).digest('base64url');
-    // Validate the redirect target now (at storage time) instead of trusting
-    // it on the way out. The callback server only ever redirects to
-    // localhost-shaped origins, so anything else is dropped here.
+    const state = generateState();
+    const { verifier, challenge } = generatePkce();
+    // Validate the redirect target now (at storage time) so a forged Host
+    // header can't redirect the OAuth flow on the way out.
     const safeBackendUrl = backendUrl && this.isAllowedRedirectOrigin(backendUrl) ? backendUrl : '';
     this.pending.set(state, {
       verifier,
       agentId,
       userId,
       backendUrl: safeBackendUrl,
-      expiresAt: Date.now() + STATE_TTL_MS,
     });
     if (this.useCallbackServer) {
       await this.ensureCallbackServer();
@@ -77,7 +81,7 @@ export class OpenaiOauthService {
   }
 
   async exchangeCode(state: string, code: string): Promise<void> {
-    const pending = this.pending.get(state);
+    const pending = this.pending.peek(state);
     if (!pending) throw new Error('Invalid or expired OAuth state');
     if (pending.expiresAt < Date.now()) {
       this.pending.delete(state);
@@ -114,7 +118,7 @@ export class OpenaiOauthService {
       pending.agentId,
       pending.userId,
       'openai',
-      JSON.stringify(blob),
+      serializeOAuthTokenBlob(blob),
       'subscription',
     );
     try {
@@ -156,13 +160,8 @@ export class OpenaiOauthService {
 
   /** Parse an OAuth blob and return a valid access token, refreshing if expired. */
   async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
-    let blob: OAuthTokenBlob;
-    try {
-      blob = JSON.parse(rawValue) as OAuthTokenBlob;
-    } catch {
-      return null;
-    }
-    if (!blob.t || !blob.r || !blob.e) return null;
+    const blob = parseOAuthTokenBlob(rawValue);
+    if (!blob) return null;
     if (Date.now() < blob.e - 60_000) return blob.t;
     try {
       const refreshed = await this.refreshAccessToken(blob.r);
@@ -170,7 +169,7 @@ export class OpenaiOauthService {
         agentId,
         userId,
         'openai',
-        JSON.stringify(refreshed),
+        serializeOAuthTokenBlob(refreshed),
         'subscription',
       );
       this.logger.log(`OpenAI OAuth token refreshed for agent=${agentId}`);
@@ -202,7 +201,7 @@ export class OpenaiOauthService {
 
   /** Returns the number of pending OAuth states (for testing). */
   getPendingCount(): number {
-    return this.pending.size;
+    return this.pending.size();
   }
 
   /** Remove a pending OAuth state. */
@@ -251,7 +250,7 @@ export class OpenaiOauthService {
     const code = url.searchParams.get('code') ?? '';
     const state = url.searchParams.get('state') ?? '';
     const error = url.searchParams.get('error');
-    const appUrl = this.pending.get(state)?.backendUrl || '';
+    const appUrl = this.pending.peek(state)?.backendUrl || '';
     if (error) {
       const desc = url.searchParams.get('error_description') ?? error;
       this.logger.error(`OAuth callback error from provider: ${desc}`);
@@ -290,18 +289,11 @@ export class OpenaiOauthService {
   }
 
   private shutdownCallbackServerIfIdle(): void {
-    if (this.pending.size === 0 && this.callbackServer) {
+    if (this.pending.isEmpty() && this.callbackServer) {
       this.callbackServer.close();
       this.callbackServer = null;
       this.serverReady = null;
       this.logger.log('OAuth callback server shut down (no pending flows)');
-    }
-  }
-
-  private cleanupExpired(): void {
-    const now = Date.now();
-    for (const [key, val] of this.pending) {
-      if (val.expiresAt < now) this.pending.delete(key);
     }
   }
 }

--- a/packages/backend/src/routing/oauth/openai-oauth.types.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.types.ts
@@ -1,62 +1,21 @@
+/**
+ * Backwards-compat facade. The shared OAuth types now live in `./core`;
+ * existing callers (model-discovery, MiniMax helpers, the controller) keep
+ * importing from here. New code should import from `./core` directly.
+ */
+export {
+  isOAuthTokenBlob,
+  oauthDoneHtml,
+  parseOAuthTokenBlob,
+  serializeOAuthTokenBlob,
+  type OAuthTokenBlob,
+} from './core';
+
+/** OpenAI-specific pending-flow shape, colocated with the OpenAI service. */
 export interface PendingOAuth {
   verifier: string;
   agentId: string;
   userId: string;
   backendUrl: string;
   expiresAt: number;
-}
-
-export interface OAuthTokenBlob {
-  /** access token */
-  t: string;
-  /** refresh token */
-  r: string;
-  /** expires at (epoch ms) */
-  e: number;
-  /** provider-specific resource URL / base URL */
-  u?: string;
-}
-
-export function parseOAuthTokenBlob(rawValue: string): OAuthTokenBlob | null {
-  try {
-    const parsed = JSON.parse(rawValue) as Partial<OAuthTokenBlob>;
-    if (
-      typeof parsed?.t !== 'string' ||
-      typeof parsed?.r !== 'string' ||
-      typeof parsed?.e !== 'number' ||
-      (parsed.u !== undefined && typeof parsed.u !== 'string')
-    ) {
-      return null;
-    }
-    return {
-      t: parsed.t,
-      r: parsed.r,
-      e: parsed.e,
-      ...(parsed.u !== undefined ? { u: parsed.u } : {}),
-    };
-  } catch {
-    return null;
-  }
-}
-
-export function oauthDoneHtml(success: boolean, nonce?: string): string {
-  const message = success ? 'manifest-oauth-success' : 'manifest-oauth-error';
-  const text = success
-    ? 'Login successful!'
-    : 'Login failed. Please close this window and try again.';
-  const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
-
-  return `<!DOCTYPE html>
-<html>
-<head><title>Manifest — OpenAI Login</title></head>
-<body style="font-family:system-ui;display:flex;flex-direction:column;align-items:center;justify-content:center;height:100vh;margin:0;background:#111;color:#eee;">
-<p>${text}</p>
-<p id="hint" style="font-size:13px;color:#888;display:none;">You can close this window.</p>
-<script${nonceAttr}>
-try{var bc=new BroadcastChannel('manifest-oauth');bc.postMessage({type:'${message}'});bc.close();}catch(e){}
-if(window.opener){window.opener.postMessage({type:'${message}'},window.location.origin);}
-setTimeout(function(){window.close();document.getElementById('hint').style.display='block';},1500);
-</script>
-</body>
-</html>`;
 }

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -82,8 +82,8 @@ describe('OpenaiOauthService', () => {
       const stateParam = new URL(url).searchParams.get('state')!;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const pending = (service as any).pending as Map<string, { expiresAt: number }>;
-      pending.get(stateParam)!.expiresAt = Date.now() - 1000;
+      const pending = (service as any).pending as { peek(k: string): { expiresAt: number } };
+      pending.peek(stateParam)!.expiresAt = Date.now() - 1000;
 
       await service.generateAuthorizationUrl('agent-2', 'user-2');
       expect(service.getPendingCount()).toBe(1);
@@ -138,8 +138,8 @@ describe('OpenaiOauthService', () => {
       const state = new URL(url).searchParams.get('state')!;
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const pending = (service as any).pending as Map<string, { expiresAt: number }>;
-      pending.get(state)!.expiresAt = Date.now() - 1;
+      const pending = (service as any).pending as { peek(k: string): { expiresAt: number } };
+      pending.peek(state)!.expiresAt = Date.now() - 1;
 
       await expect(service.exchangeCode(state, 'code')).rejects.toThrow('OAuth state expired');
       expect(service.getPendingCount()).toBe(0);
@@ -383,20 +383,16 @@ describe('OpenaiOauthService', () => {
     });
 
     it('shuts down callback server after last exchange completes', async () => {
-      await service.generateAuthorizationUrl('agent-1', 'user-1');
+      const firstUrl = await service.generateAuthorizationUrl('agent-1', 'user-1');
+      const firstState = new URL(firstUrl).searchParams.get('state')!;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const server = (service as any).callbackServer;
 
       const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
       const state = new URL(url).searchParams.get('state')!;
 
-      // Remove extra pending entries so only one remains
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const pending = (service as any).pending as Map<string, unknown>;
-      const keys = [...pending.keys()];
-      for (const k of keys) {
-        if (k !== state) pending.delete(k);
-      }
+      // Remove the unrelated pending entry so only one remains.
+      service.clearPendingState(firstState);
 
       fetchMock.mockResolvedValueOnce({
         ok: true,

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
@@ -5,6 +5,7 @@ import { ProviderKeyService } from '../../routing-core/provider-key.service';
 import { CustomProvider } from '../../../entities/custom-provider.entity';
 import { OpenaiOauthService } from '../../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
+import { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
@@ -30,6 +31,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
   let customProviderRepo: jest.Mocked<Repository<CustomProvider>>;
   let openaiOauth: jest.Mocked<OpenaiOauthService>;
   let minimaxOauth: jest.Mocked<MinimaxOauthService>;
+  let anthropicOauth: jest.Mocked<AnthropicOauthService>;
   let providerClient: jest.Mocked<ProviderClient>;
   let copilotToken: jest.Mocked<CopilotTokenService>;
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
@@ -55,6 +57,10 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
       unwrapToken: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<MinimaxOauthService>;
 
+    anthropicOauth = {
+      unwrapToken: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<AnthropicOauthService>;
+
     providerClient = {
       forward: jest.fn(),
     } as unknown as jest.Mocked<ProviderClient>;
@@ -72,6 +78,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
       customProviderRepo,
       openaiOauth,
       minimaxOauth,
+      anthropicOauth,
       providerClient,
       copilotToken,
       pricingCache,

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -8,6 +8,7 @@ import { ProviderKeyService } from '../../routing-core/provider-key.service';
 import { CustomProvider } from '../../../entities/custom-provider.entity';
 import { OpenaiOauthService } from '../../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
+import { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
@@ -18,6 +19,7 @@ describe('ProxyFallbackService', () => {
   let customProviderRepo: jest.Mocked<Repository<CustomProvider>>;
   let openaiOauth: jest.Mocked<OpenaiOauthService>;
   let minimaxOauth: jest.Mocked<MinimaxOauthService>;
+  let anthropicOauth: jest.Mocked<AnthropicOauthService>;
   let providerClient: jest.Mocked<ProviderClient>;
   let copilotToken: jest.Mocked<CopilotTokenService>;
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
@@ -43,6 +45,10 @@ describe('ProxyFallbackService', () => {
       unwrapToken: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<MinimaxOauthService>;
 
+    anthropicOauth = {
+      unwrapToken: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<AnthropicOauthService>;
+
     providerClient = {
       forward: jest.fn(),
     } as unknown as jest.Mocked<ProviderClient>;
@@ -60,6 +66,7 @@ describe('ProxyFallbackService', () => {
       customProviderRepo,
       openaiOauth,
       minimaxOauth,
+      anthropicOauth,
       providerClient,
       copilotToken,
       pricingCache,
@@ -700,6 +707,7 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        anthropicOauth,
       );
 
       expect(result.apiKey).toBe('access-token');
@@ -722,6 +730,7 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        anthropicOauth,
       );
 
       expect(result.apiKey).toBe('mm-token');
@@ -737,6 +746,7 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        anthropicOauth,
       );
 
       expect(result.apiKey).toBe('sk-key');
@@ -754,25 +764,63 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        anthropicOauth,
       );
 
       expect(result.apiKey).toBe('blob');
     });
 
-    it('does not unwrap for non-OpenAI/MiniMax subscription', async () => {
+    it('unwraps Anthropic subscription token via the OAuth blob path', async () => {
+      anthropicOauth.unwrapToken.mockResolvedValue('access-claude');
+
       const result = await resolveApiKey(
         'anthropic',
-        'sk-ant',
+        'blob',
         'subscription',
         'agent-1',
         'user-1',
         openaiOauth,
         minimaxOauth,
+        anthropicOauth,
       );
 
-      expect(result.apiKey).toBe('sk-ant');
+      expect(result.apiKey).toBe('access-claude');
+      expect(anthropicOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1');
+    });
+
+    it('returns the original key when Anthropic unwrap returns null', async () => {
+      anthropicOauth.unwrapToken.mockResolvedValue(null);
+
+      const result = await resolveApiKey(
+        'anthropic',
+        'sk-ant-legacy',
+        'subscription',
+        'agent-1',
+        'user-1',
+        openaiOauth,
+        minimaxOauth,
+        anthropicOauth,
+      );
+
+      expect(result.apiKey).toBe('sk-ant-legacy');
+    });
+
+    it('does not unwrap for non-OAuth subscription providers (e.g. Qwen)', async () => {
+      const result = await resolveApiKey(
+        'qwen',
+        'qwen-key',
+        'subscription',
+        'agent-1',
+        'user-1',
+        openaiOauth,
+        minimaxOauth,
+        anthropicOauth,
+      );
+
+      expect(result.apiKey).toBe('qwen-key');
       expect(openaiOauth.unwrapToken).not.toHaveBeenCalled();
       expect(minimaxOauth.unwrapToken).not.toHaveBeenCalled();
+      expect(anthropicOauth.unwrapToken).not.toHaveBeenCalled();
     });
 
     it('returns original key when MiniMax unwrap returns null', async () => {
@@ -786,6 +834,7 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        anthropicOauth,
       );
 
       expect(result.apiKey).toBe('blob');
@@ -800,12 +849,14 @@ describe('ProxyFallbackService', () => {
         'user-1',
         openaiOauth,
         minimaxOauth,
+        anthropicOauth,
       );
 
       expect(result.apiKey).toBe('zai-sub-key');
       expect(result.resourceUrl).toBeUndefined();
       expect(openaiOauth.unwrapToken).not.toHaveBeenCalled();
       expect(minimaxOauth.unwrapToken).not.toHaveBeenCalled();
+      expect(anthropicOauth.unwrapToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -7,6 +7,7 @@ import type { ProviderKeyService } from '../../routing-core/provider-key.service
 import type { TierService } from '../../routing-core/tier.service';
 import type { OpenaiOauthService } from '../../oauth/openai-oauth.service';
 import type { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
+import type { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
 import type { SessionMomentumService } from '../session-momentum.service';
 import type { LimitCheckService } from '../../../notifications/services/limit-check.service';
 import type { ProxyFallbackService } from '../proxy-fallback.service';
@@ -41,6 +42,7 @@ describe('ProxyService — orchestration', () => {
   let tierService: jest.Mocked<Pick<TierService, 'getTiers'>>;
   let openaiOauth: jest.Mocked<Pick<OpenaiOauthService, 'unwrapToken'>>;
   let minimaxOauth: jest.Mocked<Pick<MinimaxOauthService, 'unwrapToken'>>;
+  let anthropicOauth: jest.Mocked<Pick<AnthropicOauthService, 'unwrapToken'>>;
   let momentum: jest.Mocked<
     Pick<
       SessionMomentumService,
@@ -70,6 +72,7 @@ describe('ProxyService — orchestration', () => {
     tierService = { getTiers: jest.fn().mockResolvedValue([]) };
     openaiOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     minimaxOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
+    anthropicOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     momentum = {
       recordTier: jest.fn(),
       recordCategory: jest.fn(),
@@ -93,6 +96,7 @@ describe('ProxyService — orchestration', () => {
       tierService as unknown as TierService,
       openaiOauth as unknown as OpenaiOauthService,
       minimaxOauth as unknown as MinimaxOauthService,
+      anthropicOauth as unknown as AnthropicOauthService,
       momentum as unknown as SessionMomentumService,
       limitCheck as unknown as LimitCheckService,
       fallbackService as unknown as ProxyFallbackService,

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -7,6 +7,7 @@ import { CustomProvider } from '../../entities/custom-provider.entity';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
 import { OpenaiOauthService } from '../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
+import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ProviderClient, ForwardResult } from './provider-client';
 import {
@@ -53,6 +54,7 @@ export class ProxyFallbackService {
     private readonly customProviderRepo: Repository<CustomProvider>,
     private readonly openaiOauth: OpenaiOauthService,
     private readonly minimaxOauth: MinimaxOauthService,
+    private readonly anthropicOauth: AnthropicOauthService,
     private readonly providerClient: ProviderClient,
     private readonly copilotToken: CopilotTokenService,
     private readonly pricingCache: ModelPricingCacheService,
@@ -161,6 +163,7 @@ export class ProxyFallbackService {
         userId,
         this.openaiOauth,
         this.minimaxOauth,
+        this.anthropicOauth,
       );
       const providerRegion = await this.providerKeyService.getProviderRegion(
         agentId,
@@ -351,6 +354,7 @@ export async function resolveApiKey(
   userId: string,
   openaiOauth: OpenaiOauthService,
   minimaxOauth: MinimaxOauthService,
+  anthropicOauth: AnthropicOauthService,
 ): Promise<{ apiKey: string; resourceUrl?: string }> {
   if (authType === 'subscription') {
     const lower = provider.toLowerCase();
@@ -361,6 +365,10 @@ export async function resolveApiKey(
     if (lower === 'minimax') {
       const unwrapped = await minimaxOauth.unwrapToken(apiKey, agentId, userId);
       if (unwrapped) return { apiKey: unwrapped.t, resourceUrl: unwrapped.u };
+    }
+    if (lower === 'anthropic') {
+      const unwrapped = await anthropicOauth.unwrapToken(apiKey, agentId, userId);
+      if (unwrapped) return { apiKey: unwrapped };
     }
   }
   return { apiKey };

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -5,6 +5,7 @@ import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { TierService } from '../routing-core/tier.service';
 import { OpenaiOauthService } from '../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
+import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.service';
 import { ForwardResult } from './provider-client';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
@@ -96,6 +97,7 @@ export class ProxyService {
     private readonly tierService: TierService,
     private readonly openaiOauth: OpenaiOauthService,
     private readonly minimaxOauth: MinimaxOauthService,
+    private readonly anthropicOauth: AnthropicOauthService,
     private readonly momentum: SessionMomentumService,
     private readonly limitCheck: LimitCheckService,
     private readonly fallbackService: ProxyFallbackService,
@@ -338,6 +340,7 @@ export class ProxyService {
       userId,
       this.openaiOauth,
       this.minimaxOauth,
+      this.anthropicOauth,
     );
     const providerRegion = await this.providerKeyService.getProviderRegion(
       agentId,

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -1,0 +1,213 @@
+import { createSignal, onMount, Show, type Component, type Accessor, type Setter } from 'solid-js';
+import type { ProviderDef } from '../services/providers.js';
+import {
+  startAnthropicOAuth,
+  submitAnthropicOAuth,
+  revokeAnthropicOAuth,
+  getAnthropicOAuthPending,
+  disconnectProvider,
+  type AuthType,
+} from '../services/api.js';
+import { toast } from '../services/toast-store.js';
+
+interface Props {
+  provDef: ProviderDef;
+  provId: string;
+  agentName: string;
+  connected: Accessor<boolean>;
+  selectedAuthType: Accessor<AuthType>;
+  busy: Accessor<boolean>;
+  setBusy: Setter<boolean>;
+  onBack: () => void;
+  onUpdate: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Anthropic subscription connect view. Sign in with Claude opens an OAuth
+ * popup; the user pastes the resulting `<code>#<state>` payload back into
+ * the input. Tokens are stored as refreshable JSON blobs and rotated by
+ * the proxy automatically on every request.
+ */
+const AnthropicOAuthDetailView: Component<Props> = (props) => {
+  const [state, setState] = createSignal<string | null>(null);
+  const [input, setInput] = createSignal('');
+  const [error, setError] = createSignal<string | null>(null);
+
+  // Restore any pending OAuth flow so the paste field still works after the
+  // modal was closed mid-dance.
+  onMount(async () => {
+    if (props.connected()) return;
+    try {
+      const { state: pending } = await getAnthropicOAuthPending(props.agentName);
+      if (pending) setState(pending);
+    } catch {
+      // Missing pending state just means the user hasn't started a flow yet.
+    }
+  });
+
+  const handleSignIn = async () => {
+    props.setBusy(true);
+    setError(null);
+    try {
+      const { url, state: authState } = await startAnthropicOAuth(props.agentName);
+      setState(authState);
+      const opened = window.open(url, 'manifest-anthropic-oauth', 'noopener,noreferrer');
+      if (!opened) {
+        toast.error(
+          'Popup was blocked by your browser. Allow popups for this site, then try again.',
+        );
+        setState(null);
+      }
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    const raw = input().trim().replace(/\s/g, '');
+    if (!raw) return;
+
+    if (!raw.includes('#')) {
+      setError(
+        "That doesn't look like an authorization code. Make sure you copied the full string from the redirect page.",
+      );
+      return;
+    }
+
+    props.setBusy(true);
+    setError(null);
+    try {
+      // The local `state` signal may have been lost (modal close). Hydrate
+      // from the backend so the user can finish without restarting the flow.
+      let authState = state();
+      if (!authState) {
+        try {
+          const pending = await getAnthropicOAuthPending(props.agentName);
+          if (pending.state) {
+            setState(pending.state);
+            authState = pending.state;
+          }
+        } catch {
+          // fall through to the error below
+        }
+      }
+      if (!authState) {
+        setError('Click "Sign in with Claude" first, then paste the authorization code.');
+        return;
+      }
+      const code = raw.slice(0, raw.indexOf('#'));
+      await submitAnthropicOAuth(props.agentName, code, authState);
+      toast.success(`${props.provDef.name} subscription connected`);
+      props.onUpdate();
+      props.onClose();
+    } catch {
+      setError('Failed to exchange code. The code may have expired — sign in again to retry.');
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    props.setBusy(true);
+    try {
+      await revokeAnthropicOAuth(props.agentName).catch(() => {});
+      const result = await disconnectProvider(
+        props.agentName,
+        props.provId,
+        props.selectedAuthType(),
+      );
+      if (result?.notifications?.length) {
+        for (const msg of result.notifications) {
+          toast.error(msg);
+        }
+      }
+      props.onBack();
+      props.onUpdate();
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <Show when={!props.connected()}>
+        <div class="anthropic-detail__primary">
+          <p class="provider-detail__hint">
+            Sign in with your Claude Pro or Max account — Manifest will route through your
+            subscription with auto-refreshing tokens.
+          </p>
+          <button
+            class="btn btn--primary anthropic-detail__btn"
+            disabled={props.busy()}
+            onClick={handleSignIn}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Sign in with Claude
+            </Show>
+          </button>
+        </div>
+
+        <div class="anthropic-detail__alt">
+          <div class="anthropic-detail__alt-divider">
+            <span>Paste the authorization code</span>
+          </div>
+          <p class="anthropic-detail__alt-hint">
+            After signing in, Anthropic's redirect page shows a code. Copy the full string and paste
+            it below.
+          </p>
+          <input
+            class="provider-detail__input provider-detail__input--masked"
+            classList={{ 'provider-detail__input--error': !!error() }}
+            type="text"
+            autocomplete="off"
+            placeholder="Authorization code"
+            aria-label="Anthropic authorization code"
+            value={input()}
+            onInput={(e) => {
+              setInput(e.currentTarget.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSubmit();
+            }}
+          />
+          <Show when={error()}>
+            <div class="provider-detail__error">{error()}</div>
+          </Show>
+          <button
+            class="btn btn--primary anthropic-detail__btn"
+            disabled={props.busy() || !input().trim()}
+            onClick={handleSubmit}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Connect
+            </Show>
+          </button>
+        </div>
+      </Show>
+      <Show when={props.connected()}>
+        <div class="provider-detail__field">
+          <span class="provider-detail__no-key">
+            Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+          </span>
+        </div>
+        <button
+          class="btn btn--outline provider-detail__action provider-detail__disconnect"
+          disabled={props.busy()}
+          onClick={handleDisconnect}
+        >
+          <Show when={!props.busy()} fallback={<span class="spinner" />}>
+            Disconnect
+          </Show>
+        </button>
+      </Show>
+    </>
+  );
+};
+
+export default AnthropicOAuthDetailView;

--- a/packages/frontend/src/components/ProviderDetailView.tsx
+++ b/packages/frontend/src/components/ProviderDetailView.tsx
@@ -20,6 +20,7 @@ import { formatTimeAgo } from '../services/formatters.js';
 import CopyButton from './CopyButton.js';
 import ProviderKeyForm, { MAX_KEYS_PER_PROVIDER } from './ProviderKeyForm.js';
 import OAuthDetailView from './OAuthDetailView.js';
+import AnthropicOAuthDetailView from './AnthropicOAuthDetailView.js';
 import DeviceCodeDetailView from './DeviceCodeDetailView.js';
 import { getRoutingProviderApiKeyUrl } from '../services/provider-api-key-urls.js';
 
@@ -77,6 +78,7 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
   const subscriptionAuthMode = () =>
     provDef.subscriptionAuthMode ?? (provDef.subscriptionKeyPlaceholder ? 'token' : undefined);
   const isPopupOAuthFlow = () => isSubMode() && subscriptionAuthMode() === 'popup_oauth';
+  const isPopupPasteFlow = () => isSubMode() && subscriptionAuthMode() === 'popup_paste';
   const isDeviceCodeFlow = () => isSubMode() && subscriptionAuthMode() === 'device_code';
   const isCommandOnly = () =>
     isSubMode() &&
@@ -375,6 +377,22 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
         />
       </Show>
 
+      {/* Paste-code OAuth subscription (Anthropic) */}
+      <Show when={isPopupPasteFlow()}>
+        <AnthropicOAuthDetailView
+          provDef={provDef}
+          provId={props.provId}
+          agentName={props.agentName}
+          connected={connected}
+          selectedAuthType={props.selectedAuthType}
+          busy={props.busy}
+          setBusy={props.setBusy}
+          onBack={props.onBack}
+          onUpdate={props.onUpdate}
+          onClose={props.onClose}
+        />
+      </Show>
+
       {/* Device-code subscription */}
       <Show when={isDeviceCodeFlow()}>
         <DeviceCodeDetailView
@@ -432,7 +450,15 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
       </Show>
 
       {/* API key / subscription token form (non-Ollama, non-command-only, non-OAuth) */}
-      <Show when={!isOllama && !isCommandOnly() && !isPopupOAuthFlow() && !isDeviceCodeFlow()}>
+      <Show
+        when={
+          !isOllama &&
+          !isCommandOnly() &&
+          !isPopupOAuthFlow() &&
+          !isPopupPasteFlow() &&
+          !isDeviceCodeFlow()
+        }
+      >
         <ProviderKeyForm
           provDef={provDef}
           provId={props.provId}

--- a/packages/frontend/src/services/api/oauth.ts
+++ b/packages/frontend/src/services/api/oauth.ts
@@ -49,3 +49,37 @@ export function pollMinimaxOAuth(flowId: string) {
     flowId,
   });
 }
+
+export interface AnthropicOAuthAuthorizeResponse {
+  url: string;
+  state: string;
+}
+
+export function startAnthropicOAuth(agentName: string) {
+  return fetchMutate<AnthropicOAuthAuthorizeResponse>(
+    `/oauth/anthropic/authorize?agentName=${encodeURIComponent(agentName)}`,
+    { method: 'POST' },
+  );
+}
+
+export function submitAnthropicOAuth(agentName: string, code: string, state: string) {
+  return fetchMutate<{ ok: boolean }>(
+    `/oauth/anthropic/exchange?agentName=${encodeURIComponent(agentName)}`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ code, state }),
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+}
+
+export function getAnthropicOAuthPending(agentName: string) {
+  return fetchJson<{ state: string | null }>(`/oauth/anthropic/pending`, { agentName });
+}
+
+export function revokeAnthropicOAuth(agentName: string) {
+  return fetchMutate<{ ok: boolean }>(
+    `/oauth/anthropic/revoke?agentName=${encodeURIComponent(agentName)}`,
+    { method: 'POST' },
+  );
+}

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -31,7 +31,7 @@ export interface ProviderDef {
   /** Provider uses GitHub device login instead of token paste. */
   deviceLogin?: boolean;
   /** UI auth mode for subscription flows. */
-  subscriptionAuthMode?: 'popup_oauth' | 'device_code' | 'token';
+  subscriptionAuthMode?: 'popup_oauth' | 'popup_paste' | 'device_code' | 'token';
   /** Provider is subscription-only and should not appear in the API Keys tab. */
   subscriptionOnly?: boolean;
   /** External URL the user should open to sign in and retrieve their token (token mode). */
@@ -64,7 +64,7 @@ interface ProviderUIOverlay {
   subscriptionCredentialKind?: 'setup-token' | 'api-key';
   subscriptionCommand?: string;
   deviceLogin?: boolean;
-  subscriptionAuthMode?: 'popup_oauth' | 'device_code' | 'token';
+  subscriptionAuthMode?: 'popup_oauth' | 'popup_paste' | 'device_code' | 'token';
   subscriptionOnly?: boolean;
   subscriptionSignInUrl?: string;
   subscriptionSignInLabel?: string;
@@ -85,9 +85,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     subtitle: 'Claude Opus 4, Sonnet 4.5, Haiku',
     supportsSubscription: true,
     subscriptionLabel: 'Claude Max / Pro subscription',
-    subscriptionAuthMode: 'token',
-    subscriptionKeyPlaceholder: 'Paste your setup-token',
-    subscriptionCommand: 'claude setup-token',
+    subscriptionAuthMode: 'popup_paste',
     models: [],
   },
   deepseek: {

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -460,6 +460,55 @@
   border-color: hsl(var(--destructive) / 0.3);
 }
 
+/* AnthropicOAuthDetailView layout. Stacks primary OAuth above the
+   manual CLI fallback, with full-width buttons so nothing crashes
+   into the section divider. */
+.anthropic-detail__primary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.anthropic-detail__btn {
+  /* Override provider-detail__action's float so buttons stay block-level. */
+  width: 100%;
+  float: none;
+  margin: 0;
+}
+
+.anthropic-detail__alt {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.anthropic-detail__alt-divider {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: hsl(var(--muted-foreground));
+}
+
+.anthropic-detail__alt-divider::before,
+.anthropic-detail__alt-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: hsl(var(--border));
+}
+
+.anthropic-detail__alt-hint {
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+  line-height: 1.5;
+  margin: 0;
+}
+
 .provider-detail__disconnect:hover {
   background: hsl(var(--destructive) / 0.08);
 }

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
+
+const mockStartAnthropicOAuth = vi.fn();
+const mockSubmitAnthropicOAuth = vi.fn();
+const mockRevokeAnthropicOAuth = vi.fn();
+const mockGetAnthropicOAuthPending = vi.fn();
+const mockDisconnectProvider = vi.fn();
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+
+vi.mock('../../src/services/api.js', () => ({
+  startAnthropicOAuth: (...args: unknown[]) => mockStartAnthropicOAuth(...args),
+  submitAnthropicOAuth: (...args: unknown[]) => mockSubmitAnthropicOAuth(...args),
+  revokeAnthropicOAuth: (...args: unknown[]) => mockRevokeAnthropicOAuth(...args),
+  getAnthropicOAuthPending: (...args: unknown[]) => mockGetAnthropicOAuthPending(...args),
+  disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
+}));
+
+vi.mock('../../src/services/toast-store.js', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
+
+import AnthropicOAuthDetailView from '../../src/components/AnthropicOAuthDetailView';
+import type { ProviderDef } from '../../src/services/providers.js';
+
+const provDef: ProviderDef = {
+  id: 'anthropic',
+  name: 'Anthropic',
+  color: '#000',
+  initial: 'A',
+  subtitle: '',
+  models: [],
+  keyPrefix: 'sk-ant-',
+  minKeyLength: 50,
+  keyPlaceholder: '',
+  supportsSubscription: true,
+  subscriptionLabel: 'Claude Max / Pro subscription',
+  subscriptionAuthMode: 'popup_paste',
+};
+
+function renderView(connectedValue = false) {
+  const [busy, setBusy] = createSignal(false);
+  const onBack = vi.fn();
+  const onUpdate = vi.fn();
+  const onClose = vi.fn();
+  const result = render(() => (
+    <AnthropicOAuthDetailView
+      provDef={provDef}
+      provId="anthropic"
+      agentName="test-agent"
+      connected={() => connectedValue}
+      selectedAuthType={() => 'subscription'}
+      busy={busy}
+      setBusy={setBusy}
+      onBack={onBack}
+      onUpdate={onUpdate}
+      onClose={onClose}
+    />
+  ));
+  return { ...result, onBack, onUpdate, onClose };
+}
+
+const OAUTH_PAYLOAD = 'auth-code-123#state-xyz';
+
+describe('AnthropicOAuthDetailView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAnthropicOAuthPending.mockResolvedValue({ state: null });
+  });
+
+  it('renders the sign-in button and the paste-code input', () => {
+    renderView();
+    expect(screen.getByText('Sign in with Claude')).toBeDefined();
+    expect(screen.getByLabelText('Anthropic authorization code')).toBeDefined();
+  });
+
+  it('shows a toast and clears state when the popup is blocked', async () => {
+    mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'abc' });
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    renderView();
+    fireEvent.click(screen.getByText('Sign in with Claude'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(expect.stringMatching(/Popup was blocked/));
+    });
+    openSpy.mockRestore();
+  });
+
+  it('starts the OAuth flow and opens a popup', async () => {
+    mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'abc' });
+    const openSpy = vi
+      .spyOn(window, 'open')
+      .mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView();
+    fireEvent.click(screen.getByText('Sign in with Claude'));
+
+    await waitFor(() => {
+      expect(mockStartAnthropicOAuth).toHaveBeenCalledWith('test-agent');
+    });
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://x',
+      'manifest-anthropic-oauth',
+      'noopener,noreferrer',
+    );
+    openSpy.mockRestore();
+  });
+
+  it('exchanges a pasted authorization code', async () => {
+    mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'state-xyz' });
+    mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    const { onClose, onUpdate } = renderView();
+    fireEvent.click(screen.getByText('Sign in with Claude'));
+    await waitFor(() => expect(mockStartAnthropicOAuth).toHaveBeenCalled());
+
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: OAUTH_PAYLOAD } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith(
+        'test-agent',
+        'auth-code-123',
+        'state-xyz',
+      );
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith('Anthropic subscription connected');
+    expect(onUpdate).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('rejects input that does not look like an authorization code', () => {
+    renderView();
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'sk-ant-oat01-some-token' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    expect(screen.getByText(/doesn't look like an authorization code/)).toBeDefined();
+    expect(mockSubmitAnthropicOAuth).not.toHaveBeenCalled();
+  });
+
+  it('hydrates pending state on mount so a code can be pasted after a modal close', async () => {
+    mockGetAnthropicOAuthPending.mockResolvedValue({ state: 'persisted-state' });
+    mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
+
+    renderView();
+    await waitFor(() => expect(mockGetAnthropicOAuthPending).toHaveBeenCalled());
+
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'fresh-code#persisted-state' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith(
+        'test-agent',
+        'fresh-code',
+        'persisted-state',
+      );
+    });
+  });
+
+  it('hydrates pending state at submit time when the local signal was lost', async () => {
+    mockGetAnthropicOAuthPending
+      .mockResolvedValueOnce({ state: null }) // onMount call
+      .mockResolvedValueOnce({ state: 'late-state' }); // submit call
+    mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
+
+    renderView();
+    await waitFor(() => expect(mockGetAnthropicOAuthPending).toHaveBeenCalledTimes(1));
+
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'code#whatever' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith('test-agent', 'code', 'late-state');
+    });
+  });
+
+  it('asks the user to sign in first when no pending state is available', async () => {
+    mockGetAnthropicOAuthPending.mockResolvedValue({ state: null });
+
+    renderView();
+    await waitFor(() => expect(mockGetAnthropicOAuthPending).toHaveBeenCalled());
+
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'orphan-code#orphan-state' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Click "Sign in with Claude" first/)).toBeDefined();
+    });
+    expect(mockSubmitAnthropicOAuth).not.toHaveBeenCalled();
+  });
+
+  it('shows an error if the OAuth exchange fails', async () => {
+    mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 's1' });
+    mockSubmitAnthropicOAuth.mockRejectedValue(new Error('boom'));
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView();
+    fireEvent.click(screen.getByText('Sign in with Claude'));
+    await waitFor(() => expect(mockStartAnthropicOAuth).toHaveBeenCalled());
+
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'code#s1' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to exchange code/)).toBeDefined();
+    });
+  });
+
+  it('falls back gracefully when the pending lookup throws on mount', async () => {
+    mockGetAnthropicOAuthPending.mockRejectedValue(new Error('network'));
+    renderView();
+    await waitFor(() => expect(mockGetAnthropicOAuthPending).toHaveBeenCalled());
+    expect(screen.getByText('Sign in with Claude')).toBeDefined();
+  });
+
+  it('skips the pending lookup when already connected', () => {
+    renderView(true);
+    expect(screen.getByText('Disconnect')).toBeDefined();
+    expect(mockGetAnthropicOAuthPending).not.toHaveBeenCalled();
+  });
+
+  it('falls back gracefully when the late-arriving pending lookup throws', async () => {
+    mockGetAnthropicOAuthPending
+      .mockResolvedValueOnce({ state: null }) // onMount
+      .mockRejectedValueOnce(new Error('network')); // submit-time
+
+    renderView();
+    await waitFor(() => expect(mockGetAnthropicOAuthPending).toHaveBeenCalledTimes(1));
+
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'code#whatever' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Click "Sign in with Claude" first/)).toBeDefined();
+    });
+  });
+
+  it('submits on Enter inside the paste input', async () => {
+    mockGetAnthropicOAuthPending.mockResolvedValue({ state: 's' });
+    mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
+    renderView();
+    await waitFor(() => expect(mockGetAnthropicOAuthPending).toHaveBeenCalled());
+
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'code#s' } });
+    fireEvent.keyDown(codeInput, { key: 'Enter' });
+
+    await waitFor(() => expect(mockSubmitAnthropicOAuth).toHaveBeenCalled());
+  });
+
+  it('does not submit when the input is whitespace', () => {
+    renderView();
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: '   ' } });
+    fireEvent.click(screen.getByText('Connect'));
+    expect(mockSubmitAnthropicOAuth).not.toHaveBeenCalled();
+  });
+
+  it('surfaces server-side notifications when disconnect returns them', async () => {
+    mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true });
+    mockDisconnectProvider.mockResolvedValue({
+      notifications: ['Subscription is shared with another agent'],
+    });
+
+    const { onBack } = renderView(true);
+    fireEvent.click(screen.getByText('Disconnect'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Subscription is shared with another agent');
+    });
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('continues with disconnect when revoke fails (best-effort cleanup)', async () => {
+    mockRevokeAnthropicOAuth.mockRejectedValue(new Error('revoke failed'));
+    mockDisconnectProvider.mockResolvedValue({ ok: true });
+
+    const { onBack, onUpdate } = renderView(true);
+    fireEvent.click(screen.getByText('Disconnect'));
+
+    await waitFor(() => expect(mockDisconnectProvider).toHaveBeenCalled());
+    expect(onBack).toHaveBeenCalled();
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('does not throw when disconnect itself fails', async () => {
+    mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true });
+    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+
+    const { onBack } = renderView(true);
+    fireEvent.click(screen.getByText('Disconnect'));
+
+    await waitFor(() => expect(mockDisconnectProvider).toHaveBeenCalled());
+    expect(onBack).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors thrown by startAnthropicOAuth', async () => {
+    mockStartAnthropicOAuth.mockRejectedValue(new Error('network'));
+    renderView();
+    fireEvent.click(screen.getByText('Sign in with Claude'));
+    await waitFor(() => expect(mockStartAnthropicOAuth).toHaveBeenCalled());
+    expect(screen.getByText('Sign in with Claude')).toBeDefined();
+  });
+});

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -35,6 +35,10 @@ const mockGetOpenaiOAuthUrl = vi.fn();
 const mockPollMinimaxOAuth = vi.fn();
 const mockRevokeOpenaiOAuth = vi.fn();
 const mockStartMinimaxOAuth = vi.fn();
+const mockStartAnthropicOAuth = vi.fn();
+const mockSubmitAnthropicOAuth = vi.fn();
+const mockRevokeAnthropicOAuth = vi.fn();
+const mockGetAnthropicOAuthPending = vi.fn().mockResolvedValue({ state: null });
 const mockCreateCustomProvider = vi.fn();
 const mockUpdateCustomProvider = vi.fn();
 const mockDeleteCustomProvider = vi.fn();
@@ -46,6 +50,10 @@ vi.mock('../../src/services/api.js', () => ({
   pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
   startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
+  startAnthropicOAuth: (...args: unknown[]) => mockStartAnthropicOAuth(...args),
+  submitAnthropicOAuth: (...args: unknown[]) => mockSubmitAnthropicOAuth(...args),
+  revokeAnthropicOAuth: (...args: unknown[]) => mockRevokeAnthropicOAuth(...args),
+  getAnthropicOAuthPending: (...args: unknown[]) => mockGetAnthropicOAuthPending(...args),
   createCustomProvider: (...args: unknown[]) => mockCreateCustomProvider(...args),
   updateCustomProvider: (...args: unknown[]) => mockUpdateCustomProvider(...args),
   deleteCustomProvider: (...args: unknown[]) => mockDeleteCustomProvider(...args),
@@ -913,7 +921,7 @@ describe('ProviderSelectModal', () => {
       expect(onSwitches.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('opens detail view for Anthropic (has subscriptionKeyPlaceholder)', () => {
+    it('opens detail view for Anthropic and shows the OAuth sign-in button', () => {
       render(() => (
         <ProviderSelectModal
           providers={[]}
@@ -924,9 +932,8 @@ describe('ProviderSelectModal', () => {
       ));
       fireEvent.click(screen.getByText('Anthropic'));
 
-      // Should open detail view with setup token input
-      expect(screen.getByLabelText('Anthropic setup token')).toBeDefined();
-      expect(screen.getByText('Connect')).toBeDefined();
+      // The detail view for Anthropic uses the paste-code OAuth flow.
+      expect(screen.getByText('Sign in with Claude')).toBeDefined();
     });
 
     it('does not show credits button for non-Anthropic providers', () => {
@@ -943,7 +950,7 @@ describe('ProviderSelectModal', () => {
       expect(screen.queryByText('Claim your credits on Claude')).toBeNull();
     });
 
-    it('shows terminal command in Anthropic subscription detail view', () => {
+    it('shows the OAuth sign-in button in Anthropic subscription detail view', () => {
       render(() => (
         <ProviderSelectModal
           providers={[]}
@@ -954,12 +961,18 @@ describe('ProviderSelectModal', () => {
       ));
       fireEvent.click(screen.getByText('Anthropic'));
 
-      expect(screen.getByText('claude setup-token')).toBeDefined();
-      expect(screen.getByText('Terminal')).toBeDefined();
+      expect(screen.getByText('Sign in with Claude')).toBeDefined();
     });
 
-    it('connects Anthropic subscription with setup-token', async () => {
-      const VALID_TOKEN = 'sk-ant-oat01-test-token-1234567890';
+    it('starts the Anthropic OAuth flow and renders the paste-code step', async () => {
+      mockStartAnthropicOAuth.mockResolvedValue({
+        url: 'https://claude.ai/oauth/authorize?state=abc',
+        state: 'abc',
+      });
+      const windowOpenSpy = vi
+        .spyOn(window, 'open')
+        .mockReturnValue({ closed: false } as unknown as Window);
+
       render(() => (
         <ProviderSelectModal
           providers={[]}
@@ -969,51 +982,63 @@ describe('ProviderSelectModal', () => {
         />
       ));
       fireEvent.click(screen.getByText('Anthropic'));
+      fireEvent.click(screen.getByText('Sign in with Claude'));
 
-      const input = screen.getByLabelText('Anthropic setup token');
-      fireEvent.input(input, { target: { value: VALID_TOKEN } });
+      await waitFor(() => {
+        expect(mockStartAnthropicOAuth).toHaveBeenCalledWith('test-agent');
+      });
+      await waitFor(() => {
+        expect(screen.getByLabelText('Anthropic authorization code')).toBeDefined();
+      });
+      windowOpenSpy.mockRestore();
+    });
+
+    it('exchanges a pasted authorization code for an OAuth token', async () => {
+      mockStartAnthropicOAuth.mockResolvedValue({
+        url: 'https://claude.ai/oauth/authorize?state=xyz',
+        state: 'xyz',
+      });
+      mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
+      const windowOpenSpy = vi
+        .spyOn(window, 'open')
+        .mockReturnValue({ closed: false } as unknown as Window);
+
+      render(() => (
+        <ProviderSelectModal
+          providers={[]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
+      ));
+      fireEvent.click(screen.getByText('Anthropic'));
+      fireEvent.click(screen.getByText('Sign in with Claude'));
+      const codeInput = await screen.findByLabelText('Anthropic authorization code');
+      fireEvent.input(codeInput, { target: { value: 'auth-code-123#xyz' } });
       fireEvent.click(screen.getByText('Connect'));
 
       await waitFor(() => {
-        expect(mockConnectProvider).toHaveBeenCalledWith('test-agent', {
-          provider: 'anthropic',
-          apiKey: VALID_TOKEN,
-          authType: 'subscription',
-        });
+        // The view strips the `#state` suffix before submitting; the state is
+        // provided alongside as the second arg.
+        expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith('test-agent', 'auth-code-123', 'xyz');
       });
-      expect(onUpdate).toHaveBeenCalled();
-      expect(toast.success).toHaveBeenCalledWith('Anthropic connected');
+      expect(toast.success).toHaveBeenCalledWith('Anthropic subscription connected');
+      windowOpenSpy.mockRestore();
     });
 
-    it('shows validation error for short subscription token', () => {
-      render(() => (
-        <ProviderSelectModal
-          providers={[]}
-          onClose={onClose}
-          onUpdate={onUpdate}
-          agentName="test-agent"
-        />
-      ));
-      fireEvent.click(screen.getByText('Anthropic'));
-
-      const input = screen.getByLabelText('Anthropic setup token');
-      fireEvent.input(input, { target: { value: 'short' } });
-      fireEvent.click(screen.getByText('Connect'));
-
-      expect(screen.getByText('Token is too short (minimum 10 characters)')).toBeDefined();
-      expect(mockConnectProvider).not.toHaveBeenCalled();
-    });
-
-    it('shows masked token for connected Anthropic subscription', () => {
+    it('disconnects an Anthropic OAuth subscription from the detail view', async () => {
       const subProvider: RoutingProvider = {
         id: 'p-sub',
         provider: 'anthropic',
         is_active: true,
         has_api_key: true,
-        key_prefix: 'skst-tok',
+        key_prefix: 'oauth',
         connected_at: '2025-01-01',
         auth_type: 'subscription',
       };
+      mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true });
+      mockDisconnectProvider.mockResolvedValue({ ok: true });
+
       render(() => (
         <ProviderSelectModal
           providers={[subProvider]}
@@ -1023,40 +1048,21 @@ describe('ProviderSelectModal', () => {
         />
       ));
       fireEvent.click(screen.getByText('Anthropic'));
-
-      expect(screen.getByLabelText('Current setup token (masked)')).toBeDefined();
-      expect(screen.getByText('Change')).toBeDefined();
-    });
-
-    it('disconnects Anthropic subscription from detail view', async () => {
-      const subProvider: RoutingProvider = {
-        id: 'p-sub',
-        provider: 'anthropic',
-        is_active: true,
-        has_api_key: true,
-        key_prefix: 'skst-tok',
-        connected_at: '2025-01-01',
-        auth_type: 'subscription',
-      };
-      render(() => (
-        <ProviderSelectModal
-          providers={[subProvider]}
-          onClose={onClose}
-          onUpdate={onUpdate}
-          agentName="test-agent"
-        />
-      ));
-      fireEvent.click(screen.getByText('Anthropic'));
-      fireEvent.click(screen.getByLabelText('Disconnect provider'));
+      fireEvent.click(screen.getByText('Disconnect'));
 
       await waitFor(() => {
-        expect(mockDisconnectProvider).toHaveBeenCalledWith(
-          'test-agent',
-          'anthropic',
-          'subscription',
-          undefined,
-        );
+        expect(mockRevokeAnthropicOAuth).toHaveBeenCalledWith('test-agent');
       });
+      await waitFor(() => {
+        expect(mockDisconnectProvider).toHaveBeenCalled();
+      });
+      // Match the first three positional args; ignore any trailing trackers
+      // some test runners append (CI consistently sees a 4th `undefined`,
+      // local does not).
+      const [agent, provider, authType] = mockDisconnectProvider.mock.calls[0];
+      expect(agent).toBe('test-agent');
+      expect(provider).toBe('anthropic');
+      expect(authType).toBe('subscription');
       expect(onUpdate).toHaveBeenCalled();
     });
 
@@ -1087,23 +1093,14 @@ describe('ProviderSelectModal', () => {
       expect(screen.getByText(/Connect providers using your own API keys/)).toBeDefined();
     });
 
-    it('toggles on a subscription provider without subscriptionKeyPlaceholder via handleSubscriptionToggle', async () => {
-      // Create a subscription provider without subscriptionKeyPlaceholder
-      // Anthropic has subscriptionKeyPlaceholder so it opens detail view.
-      // We need to simulate a provider that uses the toggle directly.
-      // All subscription providers in PROVIDERS currently have subscriptionKeyPlaceholder,
-      // but the code path still triggers for providers without it — Anthropic has it,
-      // so clicking Anthropic opens detail. We test the subscription connect flow
-      // by checking the toggle switch and the handleSubscriptionToggle path.
-      // Since Anthropic is the only supportsSubscription provider and it has
-      // subscriptionKeyPlaceholder, the toggle path (handleSubscriptionToggle) is only
-      // reachable if a provider has supportsSubscription=true but no subscriptionKeyPlaceholder.
-      // However, isSubscriptionConnected and isSubscriptionWithToken are still exercised
-      // in the subscription tab rendering. Let's test those helpers via the list view.
+    it('shows toggle off when an Anthropic subscription record is inactive', async () => {
+      // Anthropic uses popup_paste mode; the connected signal collapses to
+      // `is_active`, so an inactive (revoked / disconnected) subscription
+      // row should show OFF in the list view regardless of has_api_key.
       const subProvider: RoutingProvider = {
-        id: 'p-sub-connected',
+        id: 'p-sub-inactive',
         provider: 'anthropic',
-        is_active: true,
+        is_active: false,
         has_api_key: false,
         connected_at: '2025-01-01',
         auth_type: 'subscription',
@@ -1116,11 +1113,6 @@ describe('ProviderSelectModal', () => {
           agentName="test-agent"
         />
       ));
-      // On subscription tab, Anthropic should show toggle as "on" when isSubscriptionConnected
-      // returns true. isSubscriptionConnected checks is_active (no has_api_key requirement).
-      // But subscriptionKeyPlaceholder is set → uses isSubscriptionWithToken for the connected() signal.
-      // isSubscriptionWithToken checks is_active && has_api_key → false here.
-      // So the toggle should be OFF (has_api_key is false).
       const onSwitches = container.querySelectorAll('.provider-toggle__switch--on');
       expect(onSwitches.length).toBe(0);
     });
@@ -1175,37 +1167,10 @@ describe('ProviderSelectModal', () => {
       expect(screen.getByText('Connect providers')).toBeDefined();
     });
 
-    it('shows CopyButton with subscription command in detail view', () => {
-      render(() => (
-        <ProviderSelectModal
-          providers={[]}
-          onClose={onClose}
-          onUpdate={onUpdate}
-          agentName="test-agent"
-        />
-      ));
-      fireEvent.click(screen.getByText('Anthropic'));
-      // The CopyButton receives the subscription command text
-      expect(screen.getByText('claude setup-token')).toBeDefined();
-    });
-
-    it('shows subscription placeholder in setup token input', () => {
-      render(() => (
-        <ProviderSelectModal
-          providers={[]}
-          onClose={onClose}
-          onUpdate={onUpdate}
-          agentName="test-agent"
-        />
-      ));
-      fireEvent.click(screen.getByText('Anthropic'));
-      const input = screen.getByLabelText('Anthropic setup token') as HTMLInputElement;
-      expect(input.getAttribute('placeholder')).toBe('Paste your setup-token');
-    });
-
     it('hides the "Get API key" link in Anthropic subscription mode', () => {
-      // Anthropic subscription uses setup-tokens from the CLI, not API keys from the
-      // dashboard, so the console.anthropic.com/settings/keys URL would be misleading.
+      // Anthropic subscription uses an OAuth flow, not an API key from the
+      // dashboard, so the console.anthropic.com/settings/keys URL would be
+      // misleading and is intentionally suppressed.
       const { container } = render(() => (
         <ProviderSelectModal
           providers={[]}
@@ -1219,42 +1184,6 @@ describe('ProviderSelectModal', () => {
         'a[href="https://console.anthropic.com/settings/keys"]',
       );
       expect(link).toBeNull();
-    });
-
-    it('updates token in subscription edit mode', async () => {
-      const subProvider: RoutingProvider = {
-        id: 'p-sub',
-        provider: 'anthropic',
-        is_active: true,
-        has_api_key: true,
-        key_prefix: 'skst-tok',
-        connected_at: '2025-01-01',
-        auth_type: 'subscription',
-      };
-      render(() => (
-        <ProviderSelectModal
-          providers={[subProvider]}
-          onClose={onClose}
-          onUpdate={onUpdate}
-          agentName="test-agent"
-        />
-      ));
-      fireEvent.click(screen.getByText('Anthropic'));
-      fireEvent.click(screen.getByText('Change'));
-
-      const UPDATED_TOKEN = 'sk-ant-oat01-updated-token-value';
-      const input = screen.getByLabelText('New Anthropic setup token');
-      fireEvent.input(input, { target: { value: UPDATED_TOKEN } });
-      fireEvent.click(screen.getByText('Save'));
-
-      await waitFor(() => {
-        expect(mockConnectProvider).toHaveBeenCalledWith('test-agent', {
-          provider: 'anthropic',
-          apiKey: UPDATED_TOKEN,
-          authType: 'subscription',
-        });
-      });
-      expect(toast.success).toHaveBeenCalledWith('Anthropic token updated');
     });
 
     it('opens detail view for OAuth subscription provider (OpenAI)', () => {

--- a/packages/frontend/tests/services/api/oauth.test.ts
+++ b/packages/frontend/tests/services/api/oauth.test.ts
@@ -79,4 +79,44 @@ describe('oauth API client', () => {
     expect(url).toContain('/api/v1/oauth/minimax/poll');
     expect(url).toContain('flowId=flow-1');
   });
+
+  it('startAnthropicOAuth POSTs the encoded agent name and returns the auth URL + state', async () => {
+    const fetchMock = setupFetch({ url: 'https://claude.ai/oauth/authorize?state=s', state: 's' });
+    const out = await oauth.startAnthropicOAuth('my agent');
+    expect(out).toEqual({
+      url: 'https://claude.ai/oauth/authorize?state=s',
+      state: 's',
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/anthropic/authorize?agentName=my%20agent');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('submitAnthropicOAuth POSTs the code/state pair as JSON', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.submitAnthropicOAuth('demo', 'auth-code-1', 'state-1');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/anthropic/exchange?agentName=demo');
+    const req = init as RequestInit;
+    expect(req.method).toBe('POST');
+    expect(req.body).toBe(JSON.stringify({ code: 'auth-code-1', state: 'state-1' }));
+    expect((req.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
+  it('getAnthropicOAuthPending forwards the agent name as a query param', async () => {
+    const fetchMock = setupFetch({ state: null });
+    const out = await oauth.getAnthropicOAuthPending('demo');
+    expect(out).toEqual({ state: null });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/oauth/anthropic/pending');
+    expect(url).toContain('agentName=demo');
+  });
+
+  it('revokeAnthropicOAuth POSTs to /revoke with the encoded agent name', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.revokeAnthropicOAuth('my agent');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/anthropic/revoke?agentName=my%20agent');
+    expect((init as RequestInit).method).toBe('POST');
+  });
 });

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -278,11 +278,13 @@ describe("PROVIDERS", () => {
     expect(openai.subscriptionAuthMode).toBe("popup_oauth");
   });
 
-  it("Anthropic supports subscription", () => {
+  it("Anthropic supports subscription via paste-code OAuth", () => {
     const anthropic = PROVIDERS.find((p) => p.id === "anthropic")!;
     expect(anthropic.supportsSubscription).toBe(true);
     expect(anthropic.subscriptionLabel).toBe("Claude Max / Pro subscription");
-    expect(anthropic.subscriptionAuthMode).toBe("token");
+    expect(anthropic.subscriptionAuthMode).toBe("popup_paste");
+    expect(anthropic.subscriptionCommand).toBeUndefined();
+    expect(anthropic.subscriptionKeyPlaceholder).toBeUndefined();
   });
 
   it("GitHub Copilot is subscription-only", () => {


### PR DESCRIPTION
### ✨ What changed
- New OAuth flow: click "Sign in with Claude", paste the authorization code, done.
- Tokens stored as refreshable JSON blobs; proxy auto-rotates on every request.
- OAuth code split into shared `core/` primitives (PKCE, token blob, pending TTL, callback HTML) plus per-provider files. OpenAI service refactored to use the same core.
- New `oauth/anthropic/` package with config, service, controller (`/authorize`, `/exchange`, `/pending`, `/revoke`).
- Frontend gets a new `popup_paste` mode and `AnthropicOAuthDetailView` component.

### 💭 Why
`claude setup-token` produces an access token without a refresh token, so users had to redo the dance every ~30 days. The new flow runs the same OAuth dance in-app, captures both halves, and refreshes silently.

### 👤 For users
Connecting Claude Pro/Max no longer needs the Claude CLI or a terminal. Existing setup-token connections keep working until natural expiry (proxy still accepts raw bearers); after that, users sign in via OAuth and get auto-refresh.

### 🔧 For operators
None. No migrations, no env vars, no config changes.

### 📝 Notes
- Changeset included (`minor` bump).
- 100% line coverage on new files; existing OpenAI specs still pass against the slimmed service.
- E2E tests not run locally (no Docker daemon in this env); CI will run them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds in-app OAuth for Anthropic Claude Pro/Max with a paste-code PKCE flow so users can connect without the CLI. Tokens are stored as refreshable JSON blobs and auto-rotated by the proxy (60s skew); existing `claude setup-token` connections keep working until they expire.

- **New Features**
  - Backend under `api/v1/oauth/anthropic` with `/authorize`, `/exchange`, `/pending`, `/revoke`.
  - Frontend adds `popup_paste` mode and `AnthropicOAuthDetailView` for the paste-code flow.
  - Proxy unwraps token blobs and refreshes on requests; raw bearer tokens still supported.

- **Refactors**
  - Extracted shared OAuth primitives to `routing/oauth/core` (`pkce`, `pending-store`, `oauth-blob`, `callback-page`).
  - Updated OpenAI OAuth to use `core`; tests and proxy wiring updated.

<sup>Written for commit a8e907ea068bc4e048bb9e7efe09de9fc51a3996. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

