### PR TITLE
feat: per-provider model refresh with truthful feedback

### DIFF
--- a/.changeset/per-provider-refresh-models.md
+++ b/.changeset/per-provider-refresh-models.md
@@ -1,0 +1,5 @@
+---
+"manifest": minor
+---
+
+Per-provider model refresh: a small refresh button next to each provider in the Connect Providers detail view and next to each section header in the model picker. Toasts now report the actual count or upstream error instead of a blanket "Models refreshed" lie. Empty discovery results no longer wipe a non-empty cache, so a transient API hiccup can't silently empty the model list. The model picker subtitle now shows "Default tier" instead of just "tier".

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -477,13 +477,26 @@ describe('ModelDiscoveryService', () => {
           models_fetched_at: '2026-04-01T08:00:00.000Z',
         }),
       );
-      fetcher.fetch.mockRejectedValue(new Error('upstream timeout'));
+      // discoverModels itself swallows fetcher errors, so to land in the
+      // refreshProvider catch we make the cache-write throw instead.
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'gpt-4o' })]);
+      providerRepo.save.mockRejectedValueOnce(new Error('DB write failed'));
 
       const result = await service.refreshProvider('agent-1', 'openai');
       expect(result.ok).toBe(false);
       expect(result.model_count).toBe(2);
-      expect(result.error).toBe('upstream timeout');
+      expect(result.error).toBe('DB write failed');
       expect(result.last_fetched_at).toBe('2026-04-01T08:00:00.000Z');
+    });
+
+    it('reports a non-Error thrown value via String() in the error field', async () => {
+      providerRepo.findOne.mockResolvedValue(makeProvider({ provider: 'openai' }));
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'gpt-4o' })]);
+      providerRepo.save.mockRejectedValueOnce('plain-string-failure');
+
+      const result = await service.refreshProvider('agent-1', 'openai');
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe('plain-string-failure');
     });
   });
 

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -410,6 +410,107 @@ describe('ModelDiscoveryService', () => {
     });
   });
 
+  /* ── refreshProvider ── */
+
+  describe('refreshProvider', () => {
+    it('returns Provider not found when no row matches', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+      const result = await service.refreshProvider('agent-1', 'openai');
+      expect(result).toEqual({
+        ok: false,
+        model_count: 0,
+        last_fetched_at: null,
+        error: 'Provider not found',
+      });
+    });
+
+    it('refuses custom providers and reports the cached count', async () => {
+      providerRepo.findOne.mockResolvedValue(
+        makeProvider({
+          provider: 'custom:cp-1',
+          cached_models: [makeModel({ id: 'foo' }), makeModel({ id: 'bar' })],
+          models_fetched_at: '2026-04-12T08:00:00.000Z',
+        }),
+      );
+      const result = await service.refreshProvider('agent-1', 'custom:cp-1');
+      expect(result.ok).toBe(false);
+      expect(result.model_count).toBe(2);
+      expect(result.last_fetched_at).toBe('2026-04-12T08:00:00.000Z');
+      expect(result.error).toContain('Custom providers are managed manually');
+    });
+
+    it('returns ok with the discovered count on success', async () => {
+      const provider = makeProvider({ provider: 'openai' });
+      providerRepo.findOne.mockResolvedValue(provider);
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ id: 'gpt-4o' }),
+        makeModel({ id: 'gpt-4o-mini' }),
+      ]);
+
+      const result = await service.refreshProvider('agent-1', 'openai', 'api_key');
+      expect(providerRepo.findOne).toHaveBeenCalledWith({
+        where: { agent_id: 'agent-1', provider: 'openai', is_active: true, auth_type: 'api_key' },
+      });
+      expect(result.ok).toBe(true);
+      expect(result.model_count).toBe(2);
+      expect(result.error).toBeNull();
+      expect(result.last_fetched_at).toBeDefined();
+    });
+
+    it('returns ok=false with hint when provider returns no models', async () => {
+      const provider = makeProvider({ provider: 'openai', cached_models: null });
+      providerRepo.findOne.mockResolvedValue(provider);
+      fetcher.fetch.mockResolvedValue([]);
+
+      const result = await service.refreshProvider('agent-1', 'openai');
+      expect(result.ok).toBe(false);
+      expect(result.model_count).toBe(0);
+      expect(result.error).toBe('Provider returned no models');
+    });
+
+    it('preserves cached models and reports prior count when discovery throws', async () => {
+      const cachedModels = [makeModel({ id: 'gpt-4o' }), makeModel({ id: 'gpt-4o-mini' })];
+      providerRepo.findOne.mockResolvedValue(
+        makeProvider({
+          provider: 'openai',
+          cached_models: cachedModels,
+          models_fetched_at: '2026-04-01T08:00:00.000Z',
+        }),
+      );
+      fetcher.fetch.mockRejectedValue(new Error('upstream timeout'));
+
+      const result = await service.refreshProvider('agent-1', 'openai');
+      expect(result.ok).toBe(false);
+      expect(result.model_count).toBe(2);
+      expect(result.error).toBe('upstream timeout');
+      expect(result.last_fetched_at).toBe('2026-04-01T08:00:00.000Z');
+    });
+  });
+
+  /* ── empty-result cache preservation ── */
+
+  describe('discoverModels — empty result preserves cache', () => {
+    it('keeps the previous cache when the fetcher returns no models', async () => {
+      const cachedModels = [makeModel({ id: 'gpt-4o' }), makeModel({ id: 'gpt-4o-mini' })];
+      const provider = makeProvider({
+        provider: 'openai',
+        cached_models: cachedModels,
+        models_fetched_at: '2026-04-01T08:00:00.000Z',
+      });
+      fetcher.fetch.mockResolvedValue([]);
+      // Disable fallback sources so the result stays empty.
+      mockPricingSync.getAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockReturnValue([]);
+
+      const result = await service.discoverModels(provider);
+
+      expect(result).toEqual(cachedModels);
+      expect(provider.cached_models).toEqual(cachedModels);
+      expect(provider.models_fetched_at).toBe('2026-04-01T08:00:00.000Z');
+      expect(providerRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
   /* ── getModelsForAgent ── */
 
   describe('getModelsForAgent', () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -233,11 +233,17 @@ export class ModelDiscoveryService {
     if (!provider) {
       return { ok: false, model_count: 0, last_fetched_at: null, error: 'Provider not found' };
     }
+    // Snapshot the pre-refresh state so error/skip paths can report the count
+    // and timestamp the user already had on disk, even after `discoverModels`
+    // mutates the entity in-memory.
+    const previousCount = Array.isArray(provider.cached_models) ? provider.cached_models.length : 0;
+    const previousFetchedAt = provider.models_fetched_at;
+
     if (provider.provider.startsWith('custom:')) {
       return {
         ok: false,
-        model_count: Array.isArray(provider.cached_models) ? provider.cached_models.length : 0,
-        last_fetched_at: provider.models_fetched_at,
+        model_count: previousCount,
+        last_fetched_at: previousFetchedAt,
         error: 'Custom providers are managed manually — edit the provider to update its model list',
       };
     }
@@ -257,8 +263,8 @@ export class ModelDiscoveryService {
       );
       return {
         ok: false,
-        model_count: Array.isArray(provider.cached_models) ? provider.cached_models.length : 0,
-        last_fetched_at: provider.models_fetched_at,
+        model_count: previousCount,
+        last_fetched_at: previousFetchedAt,
         error: message,
       };
     }

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -177,6 +177,17 @@ export class ModelDiscoveryService {
       return true;
     });
 
+    const previousCachedCount = Array.isArray(provider.cached_models)
+      ? provider.cached_models.length
+      : 0;
+
+    if (filtered.length === 0 && previousCachedCount > 0) {
+      this.logger.warn(
+        `Discovery returned 0 models for ${provider.provider} (agent ${provider.agent_id}); kept ${previousCachedCount} cached models`,
+      );
+      return provider.cached_models ?? [];
+    }
+
     provider.cached_models = filtered;
     provider.models_fetched_at = new Date().toISOString();
     await this.providerRepo.save(provider);
@@ -200,6 +211,57 @@ export class ModelDiscoveryService {
           }),
         ),
     );
+  }
+
+  async refreshProvider(
+    agentId: string,
+    providerId: string,
+    authType?: AuthType,
+  ): Promise<{
+    ok: boolean;
+    model_count: number;
+    last_fetched_at: string | null;
+    error: string | null;
+  }> {
+    const where: { agent_id: string; provider: string; is_active: true; auth_type?: AuthType } = {
+      agent_id: agentId,
+      provider: providerId,
+      is_active: true,
+    };
+    if (authType) where.auth_type = authType;
+    const provider = await this.providerRepo.findOne({ where });
+    if (!provider) {
+      return { ok: false, model_count: 0, last_fetched_at: null, error: 'Provider not found' };
+    }
+    if (provider.provider.startsWith('custom:')) {
+      return {
+        ok: false,
+        model_count: Array.isArray(provider.cached_models) ? provider.cached_models.length : 0,
+        last_fetched_at: provider.models_fetched_at,
+        error: 'Custom providers are managed manually — edit the provider to update its model list',
+      };
+    }
+
+    try {
+      const models = await this.discoverModels(provider);
+      return {
+        ok: models.length > 0,
+        model_count: models.length,
+        last_fetched_at: provider.models_fetched_at,
+        error: models.length === 0 ? 'Provider returned no models' : null,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(
+        `Per-provider refresh failed for ${provider.provider} (agent ${agentId}): ${message}`,
+      );
+      return {
+        ok: false,
+        model_count: Array.isArray(provider.cached_models) ? provider.cached_models.length : 0,
+        last_fetched_at: provider.models_fetched_at,
+        error: message,
+      };
+    }
   }
 
   async getModelsForAgent(agentId: string): Promise<DiscoveredModel[]> {

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -44,6 +44,12 @@ describe('ModelController', () => {
     mockDiscoveryService = {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
       discoverAllForAgent: jest.fn().mockResolvedValue(undefined),
+      refreshProvider: jest.fn().mockResolvedValue({
+        ok: true,
+        model_count: 0,
+        last_fetched_at: null,
+        error: null,
+      }),
     };
     mockOllamaSync = {
       sync: jest.fn().mockResolvedValue({ count: 0 }),
@@ -146,6 +152,60 @@ describe('ModelController', () => {
       expect(mockResolveAgent.resolve).toHaveBeenCalledWith('user-1', 'test-agent');
       expect(mockDiscoveryService.discoverAllForAgent).toHaveBeenCalledWith(TEST_AGENT_ID);
       expect(result).toEqual({ ok: true });
+    });
+  });
+
+  /* ── refreshProviderModels ── */
+
+  describe('refreshProviderModels', () => {
+    const mockParams = { agentName: 'test-agent', provider: 'anthropic' } as never;
+
+    it('returns the discovery result and recalculates tiers when ok', async () => {
+      mockDiscoveryService.refreshProvider.mockResolvedValue({
+        ok: true,
+        model_count: 7,
+        last_fetched_at: '2026-04-12T12:00:00.000Z',
+        error: null,
+      });
+
+      const result = await controller.refreshProviderModels(mockUser, mockParams, {});
+
+      expect(mockDiscoveryService.refreshProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'anthropic',
+        undefined,
+      );
+      expect(mockProviderService.recalculateTiers).toHaveBeenCalledWith(TEST_AGENT_ID);
+      expect(result).toEqual({
+        ok: true,
+        model_count: 7,
+        last_fetched_at: '2026-04-12T12:00:00.000Z',
+        error: null,
+      });
+    });
+
+    it('forwards the optional authType query param', async () => {
+      await controller.refreshProviderModels(mockUser, mockParams, { authType: 'subscription' });
+      expect(mockDiscoveryService.refreshProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'anthropic',
+        'subscription',
+      );
+    });
+
+    it('skips tier recalculation when refresh failed', async () => {
+      mockDiscoveryService.refreshProvider.mockResolvedValue({
+        ok: false,
+        model_count: 0,
+        last_fetched_at: null,
+        error: 'Provider returned no models',
+      });
+
+      const result = await controller.refreshProviderModels(mockUser, mockParams, {});
+
+      expect(mockProviderService.recalculateTiers).not.toHaveBeenCalled();
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe('Provider returned no models');
     });
   });
 

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
+import { Controller, Get, Param, Post, Query } from '@nestjs/common';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
 import { ProviderService } from './routing-core/provider.service';
@@ -7,7 +7,11 @@ import { CustomProviderService } from './custom-provider/custom-provider.service
 import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
-import { AgentNameParamDto } from './dto/routing.dto';
+import {
+  AgentNameParamDto,
+  AgentProviderParamDto,
+  RemoveProviderQueryDto,
+} from './dto/routing.dto';
 
 @Controller('api/v1/routing')
 export class ModelController {
@@ -44,6 +48,24 @@ export class ModelController {
     await this.discoveryService.discoverAllForAgent(agent.id);
     await this.providerService.recalculateTiers(agent.id);
     return { ok: true };
+  }
+
+  @Post(':agentName/providers/:provider/refresh-models')
+  async refreshProviderModels(
+    @CurrentUser() user: AuthUser,
+    @Param() params: AgentProviderParamDto,
+    @Query() query: RemoveProviderQueryDto,
+  ) {
+    const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
+    const result = await this.discoveryService.refreshProvider(
+      agent.id,
+      params.provider,
+      query.authType,
+    );
+    if (result.ok) {
+      await this.providerService.recalculateTiers(agent.id);
+    }
+    return result;
   }
 
   @Post('ollama/sync')

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -134,6 +134,8 @@ describe('ProviderController', () => {
           connected_at: '2025-01-01',
           api_key_encrypted: 'enc',
           key_prefix: 'sk-proj-',
+          models_fetched_at: '2026-04-01T10:00:00.000Z',
+          cached_models: [{ id: 'gpt-4o' }, { id: 'gpt-4o-mini' }],
         },
       ]);
 
@@ -150,8 +152,27 @@ describe('ProviderController', () => {
           key_prefix: 'sk-proj-',
           region: null,
           connected_at: '2025-01-01',
+          models_fetched_at: '2026-04-01T10:00:00.000Z',
+          cached_model_count: 2,
         },
       ]);
+    });
+
+    it('returns null models_fetched_at and zero cached_model_count when never discovered', async () => {
+      mockProviderService.getProviders.mockResolvedValue([
+        {
+          id: 'p1',
+          provider: 'anthropic',
+          is_active: true,
+          connected_at: '2025-01-01',
+          api_key_encrypted: 'enc',
+          key_prefix: 'sk-ant-',
+        },
+      ]);
+
+      const result = await controller.getProviders(mockUser, mockAgentName);
+      expect(result[0].models_fetched_at).toBeNull();
+      expect(result[0].cached_model_count).toBe(0);
     });
 
     it('should strip internal fields from response', async () => {

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -81,6 +81,8 @@ export class ProviderController {
       priority: p.priority,
       region: p.region ?? null,
       connected_at: p.connected_at,
+      models_fetched_at: p.models_fetched_at ?? null,
+      cached_model_count: Array.isArray(p.cached_models) ? p.cached_models.length : 0,
     }));
   }
 

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -1,18 +1,21 @@
 import { createSignal, For, Show, type Component } from 'solid-js';
-import type {
-  AuthType,
-  AvailableModel,
-  CustomProviderData,
-  RoutingProvider,
-  TierAssignment,
+import {
+  refreshProviderModels,
+  type AuthType,
+  type AvailableModel,
+  type CustomProviderData,
+  type RoutingProvider,
+  type TierAssignment,
 } from '../services/api.js';
-import { PROVIDERS, STAGES, SPECIFICITY_STAGES } from '../services/providers.js';
+import { PROVIDERS, STAGES, SPECIFICITY_STAGES, DEFAULT_STAGE } from '../services/providers.js';
 import { customProviderColor } from '../services/formatters.js';
 import { inferProviderFromModel, pricePerM, resolveProviderId } from '../services/routing-utils.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
+import { toast } from '../services/toast-store.js';
 
 interface Props {
   tierId: string;
+  agentName?: string;
   models: AvailableModel[];
   tiers: TierAssignment[];
   customProviders?: CustomProviderData[];
@@ -20,6 +23,7 @@ interface Props {
   onSelect: (tierId: string, modelName: string, providerId: string, authType?: AuthType) => void;
   onClose: () => void;
   onConnectProviders?: () => void;
+  onProviderRefreshed?: () => void | Promise<void>;
 }
 
 /** Resolve a display label for a model name, handling vendor-prefixed IDs. */
@@ -67,6 +71,28 @@ const ModelPickerModal: Component<Props> = (props) => {
   const [activeTab, setActiveTab] = createSignal<AuthType>(resolveInitialTab());
   const [search, setSearch] = createSignal('');
   const [showFreeOnly, setShowFreeOnly] = createSignal(false);
+  const [refreshingProvId, setRefreshingProvId] = createSignal<string | null>(null);
+
+  const handleRefreshGroup = async (provId: string, displayName: string) => {
+    if (!props.agentName) return;
+    if (provId.startsWith('custom:')) return;
+    setRefreshingProvId(provId);
+    try {
+      const result = await refreshProviderModels(props.agentName, provId, activeTab());
+      if (result.ok) {
+        toast.success(
+          `${displayName}: refreshed ${result.model_count} model${result.model_count === 1 ? '' : 's'}`,
+        );
+      } else {
+        toast.error(result.error ?? `Couldn't refresh ${displayName}`);
+      }
+      await props.onProviderRefreshed?.();
+    } catch {
+      // network/server error toast already raised by fetchMutate
+    } finally {
+      setRefreshingProvId(null);
+    }
+  };
 
   const providerLabelMap = (): Map<string, string> => {
     const map = new Map<string, string>();
@@ -252,10 +278,8 @@ const ModelPickerModal: Component<Props> = (props) => {
             </div>
             <div class="routing-modal__subtitle">
               {
-                (
-                  STAGES.find((s) => s.id === props.tierId) ??
-                  SPECIFICITY_STAGES.find((s) => s.id === props.tierId)
-                )?.label
+                [DEFAULT_STAGE, ...STAGES, ...SPECIFICITY_STAGES].find((s) => s.id === props.tierId)
+                  ?.label
               }{' '}
               tier
             </div>
@@ -467,6 +491,37 @@ const ModelPickerModal: Component<Props> = (props) => {
                       : providerIcon(group.provId, 16)}
                   </span>
                   <span class="routing-modal__group-name">{group.name}</span>
+                  <Show when={props.agentName && !group.provId.startsWith('custom:')}>
+                    <button
+                      class="routing-modal__group-refresh"
+                      disabled={refreshingProvId() !== null}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void handleRefreshGroup(group.provId, group.name);
+                      }}
+                      aria-label={`Refresh ${group.name} models`}
+                      title={`Refresh ${group.name} models`}
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                        classList={{
+                          'routing-modal__group-refresh-icon--spinning':
+                            refreshingProvId() === group.provId,
+                        }}
+                      >
+                        <path d="M21 12a9 9 0 1 1-3-6.7L21 8" />
+                        <path d="M21 3v5h-5" />
+                      </svg>
+                    </button>
+                  </Show>
                 </div>
                 <For each={group.models}>
                   {(model) => (

--- a/packages/frontend/src/components/ProviderDetailView.tsx
+++ b/packages/frontend/src/components/ProviderDetailView.tsx
@@ -11,10 +11,12 @@ import { providerIcon } from './ProviderIcon.js';
 import {
   connectProvider,
   disconnectProvider,
+  refreshProviderModels,
   type RoutingProvider,
   type AuthType,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
+import { formatTimeAgo } from '../services/formatters.js';
 import CopyButton from './CopyButton.js';
 import ProviderKeyForm, { MAX_KEYS_PER_PROVIDER } from './ProviderKeyForm.js';
 import OAuthDetailView from './OAuthDetailView.js';
@@ -128,6 +130,34 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
     }
   };
 
+  const [refreshing, setRefreshing] = createSignal(false);
+
+  const activeProviderRow = () => getProviderByAuth(props.selectedAuthType());
+  const lastFetchedAgo = () => formatTimeAgo(activeProviderRow()?.models_fetched_at ?? null);
+
+  const handleRefreshModels = async () => {
+    setRefreshing(true);
+    try {
+      const result = await refreshProviderModels(
+        props.agentName,
+        props.provId,
+        props.selectedAuthType(),
+      );
+      if (result.ok) {
+        toast.success(
+          `${provDef.name}: refreshed ${result.model_count} model${result.model_count === 1 ? '' : 's'}`,
+        );
+      } else {
+        toast.error(result.error ?? `Couldn't refresh ${provDef.name}`);
+      }
+      props.onUpdate();
+    } catch {
+      // network/server error toast already raised by fetchMutate
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
@@ -198,18 +228,51 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
                 <span class="provider-detail__beta-badge">beta</span>
               </Show>
             </div>
+            <Show when={connected() && lastFetchedAgo()}>
+              <div class="provider-detail__last-refreshed">
+                Models last refreshed {lastFetchedAgo()}
+              </div>
+            </Show>
           </div>
         </div>
-        <Show when={showAddKeyButton()}>
-          <button
-            type="button"
-            class="btn btn--sm"
-            style="background: hsl(var(--foreground)); color: hsl(var(--background)); border: none; font-size: var(--font-size-xs);"
-            onClick={() => setAddKeyOpen(true)}
-          >
-            Add another key
-          </button>
-        </Show>
+        <div class="provider-detail__header-actions">
+          <Show when={connected()}>
+            <button
+              class="btn btn--outline btn--sm provider-detail__refresh-btn"
+              disabled={refreshing() || props.busy()}
+              onClick={handleRefreshModels}
+              aria-label={`Refresh models from ${provDef.name}`}
+              title={`Refresh models from ${provDef.name}`}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                classList={{ 'provider-detail__refresh-icon--spinning': refreshing() }}
+              >
+                <path d="M21 12a9 9 0 1 1-3-6.7L21 8" />
+                <path d="M21 3v5h-5" />
+              </svg>
+              {refreshing() ? 'Refreshing…' : 'Refresh models'}
+            </button>
+          </Show>
+          <Show when={showAddKeyButton()}>
+            <button
+              type="button"
+              class="btn btn--sm"
+              style="background: hsl(var(--foreground)); color: hsl(var(--background)); border: none; font-size: var(--font-size-xs);"
+              onClick={() => setAddKeyOpen(true)}
+            >
+              Add another key
+            </button>
+          </Show>
+        </div>
       </div>
 
       {/* Subscription sign-in URL instruction (token mode with external sign-in) */}

--- a/packages/frontend/src/components/RoutingModals.tsx
+++ b/packages/frontend/src/components/RoutingModals.tsx
@@ -141,6 +141,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
         {(tierId) => (
           <ModelPickerModal
             tierId={tierId()}
+            agentName={props.agentName()}
             models={props.models()}
             tiers={props.tiers()}
             customProviders={props.customProviders()}
@@ -151,6 +152,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
               props.onDropdownClose();
               props.onOpenProviderModal();
             }}
+            onProviderRefreshed={props.onProviderUpdate}
           />
         )}
       </Show>
@@ -164,6 +166,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
           return (
             <ModelPickerModal
               tierId={category()}
+              agentName={props.agentName()}
               models={props.models()}
               tiers={specificityTiers()}
               customProviders={props.customProviders()}
@@ -176,6 +179,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
                 props.onSpecificityDropdownClose?.();
                 props.onOpenProviderModal();
               }}
+              onProviderRefreshed={props.onProviderUpdate}
             />
           );
         }}
@@ -277,6 +281,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
           return (
             <ModelPickerModal
               tierId={tierId()}
+              agentName={props.agentName()}
               models={filteredModels()}
               tiers={props.tiers()}
               customProviders={props.customProviders()}
@@ -287,6 +292,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
                 props.onFallbackPickerClose();
                 props.onOpenProviderModal();
               }}
+              onProviderRefreshed={props.onProviderUpdate}
             />
           );
         }}

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -19,6 +19,8 @@ export interface RoutingProvider {
   priority: number;
   region?: string | null;
   connected_at: string;
+  models_fetched_at?: string | null;
+  cached_model_count?: number;
 }
 
 /* -- Routing: Status -- */
@@ -270,6 +272,19 @@ export function refreshModels(agentName: string) {
   return fetchMutate<{ ok: boolean }>(routingPath(agentName, 'refresh-models'), {
     method: 'POST',
   });
+}
+
+export interface ProviderRefreshResult {
+  ok: boolean;
+  model_count: number;
+  last_fetched_at: string | null;
+  error: string | null;
+}
+
+export function refreshProviderModels(agentName: string, provider: string, authType?: AuthType) {
+  const base = routingPath(agentName, `providers/${encodeURIComponent(provider)}/refresh-models`);
+  const path = authType ? `${base}?authType=${authType}` : base;
+  return fetchMutate<ProviderRefreshResult>(path, { method: 'POST' });
 }
 
 /* -- Routing: Pricing cache health -- */

--- a/packages/frontend/src/services/formatters.ts
+++ b/packages/frontend/src/services/formatters.ts
@@ -144,3 +144,26 @@ export function formatRelativeTime(ts: string): string {
   if (diffDays === 1) return 'Yesterday';
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
+
+/**
+ * Format a timestamp as a coarse "time ago" (e.g. "Just now", "5m ago",
+ * "3h ago", "Yesterday", "Mar 5"). Returns null when input is null/empty so
+ * callers can render a placeholder instead.
+ */
+export function formatTimeAgo(ts: string | null | undefined): string | null {
+  if (!ts) return null;
+  const normalized = ts.replace(' ', 'T');
+  const d = new Date(normalized.endsWith('Z') ? normalized : normalized + 'Z');
+  const diffMs = Date.now() - d.getTime();
+  if (!Number.isFinite(diffMs) || diffMs < 0) return null;
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 45) return 'Just now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDays = Math.floor(diffHr / 24);
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -291,7 +291,7 @@ export interface StageDef {
 export const DEFAULT_STAGE: StageDef = {
   id: 'default',
   step: 0,
-  label: 'Regular',
+  label: 'Default',
   desc: 'Handles every request.',
 };
 

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -143,6 +143,47 @@
   color: hsl(var(--muted-foreground));
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  flex: 1;
+}
+
+.routing-modal__group-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.routing-modal__group-refresh:hover:not(:disabled) {
+  color: hsl(var(--foreground));
+  border-color: hsl(var(--border));
+  background: hsl(var(--muted) / 0.6);
+}
+
+.routing-modal__group-refresh:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.routing-modal__group-refresh-icon--spinning {
+  animation: routing-modal-group-refresh-spin 0.9s linear infinite;
+}
+
+@keyframes routing-modal-group-refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .routing-modal__model {

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -285,6 +285,36 @@
   color: hsl(var(--foreground));
 }
 
+.provider-detail__last-refreshed {
+  margin-top: 2px;
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+}
+
+.provider-detail__header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.provider-detail__refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.provider-detail__refresh-icon--spinning {
+  animation: provider-detail-refresh-spin 0.9s linear infinite;
+}
+
+@keyframes provider-detail-refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .provider-detail__beta-badge {
   font-size: 10px;
   font-weight: 600;

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, fireEvent } from "@solidjs/testing-library";
+import { render, fireEvent, screen, waitFor } from "@solidjs/testing-library";
 
 vi.mock("../../src/components/ProviderIcon.js", () => ({
   providerIcon: () => null,
@@ -27,6 +27,7 @@ vi.mock("../../src/services/providers.js", () => ({
     { id: "complex", label: "Complex" },
   ],
   SPECIFICITY_STAGES: [{ id: "coding", label: "Coding" }],
+  DEFAULT_STAGE: { id: "default", label: "Default" },
 }));
 
 vi.mock("../../src/services/routing-utils.js", () => ({
@@ -41,6 +42,24 @@ vi.mock("../../src/services/routing-utils.js", () => ({
 
 vi.mock("../../src/services/formatters.js", () => ({
   customProviderColor: () => "#000",
+}));
+
+const { mockRefreshProviderModels, mockToastSuccess, mockToastError } = vi.hoisted(() => ({
+  mockRefreshProviderModels: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("../../src/services/api.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    refreshProviderModels: (...args: unknown[]) => mockRefreshProviderModels(...args),
+  };
+});
+
+vi.mock("../../src/services/toast-store.js", () => ({
+  toast: { success: mockToastSuccess, error: mockToastError, warning: vi.fn() },
 }));
 
 import ModelPickerModal from "../../src/components/ModelPickerModal";
@@ -130,6 +149,12 @@ const tiers: TierAssignment[] = [
 describe("ModelPickerModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRefreshProviderModels.mockResolvedValue({
+      ok: true,
+      model_count: 4,
+      last_fetched_at: "2026-04-12T10:00:00Z",
+      error: null,
+    });
   });
 
   it("renders the tier label as subtitle when the tier matches a STAGES entry", () => {
@@ -158,6 +183,131 @@ describe("ModelPickerModal", () => {
       />
     ));
     expect(container.querySelector(".routing-modal__subtitle")?.textContent).toContain("Coding");
+  });
+
+  it("renders the DEFAULT_STAGE label as subtitle for the default tier", () => {
+    const { container } = render(() => (
+      <ModelPickerModal
+        tierId="default"
+        models={baseModels}
+        tiers={[]}
+        connectedProviders={apiKeyOnly}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(container.querySelector(".routing-modal__subtitle")?.textContent).toContain(
+      "Default tier",
+    );
+  });
+
+  describe("per-group refresh button", () => {
+    it("does not render group refresh buttons when agentName is missing", () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="default"
+          models={baseModels}
+          tiers={[]}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      expect(container.querySelector(".routing-modal__group-refresh")).toBeNull();
+    });
+
+    it("renders a refresh button next to each non-custom group when agentName is set", () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="default"
+          agentName="demo-agent"
+          models={baseModels}
+          tiers={[]}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      const buttons = container.querySelectorAll(".routing-modal__group-refresh");
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it("calls refreshProviderModels with provider id and active tab on click", async () => {
+      const onProviderRefreshed = vi.fn();
+      render(() => (
+        <ModelPickerModal
+          tierId="default"
+          agentName="demo-agent"
+          models={baseModels}
+          tiers={[]}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+          onProviderRefreshed={onProviderRefreshed}
+        />
+      ));
+
+      const btn = screen.getByLabelText("Refresh OpenAI models");
+      fireEvent.click(btn);
+
+      await waitFor(() => {
+        expect(mockRefreshProviderModels).toHaveBeenCalledWith(
+          "demo-agent",
+          "openai",
+          "api_key",
+        );
+        expect(mockToastSuccess).toHaveBeenCalledWith("OpenAI: refreshed 4 models");
+        expect(onProviderRefreshed).toHaveBeenCalled();
+      });
+    });
+
+    it("shows the backend error message when refresh fails", async () => {
+      mockRefreshProviderModels.mockResolvedValueOnce({
+        ok: false,
+        model_count: 0,
+        last_fetched_at: null,
+        error: "Provider returned no models",
+      });
+      render(() => (
+        <ModelPickerModal
+          tierId="default"
+          agentName="demo-agent"
+          models={baseModels}
+          tiers={[]}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+
+      fireEvent.click(screen.getByLabelText("Refresh OpenAI models"));
+
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith("Provider returned no models");
+      });
+    });
+
+    it("does not bubble click to the parent overlay", async () => {
+      const onClose = vi.fn();
+      render(() => (
+        <ModelPickerModal
+          tierId="default"
+          agentName="demo-agent"
+          models={baseModels}
+          tiers={[]}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={onClose}
+        />
+      ));
+
+      fireEvent.click(screen.getByLabelText("Refresh OpenAI models"));
+
+      await waitFor(() => {
+        expect(mockRefreshProviderModels).toHaveBeenCalled();
+      });
+      expect(onClose).not.toHaveBeenCalled();
+    });
   });
 
   it("hides tabs when only one auth category is connected", () => {

--- a/packages/frontend/tests/components/ProviderDetailView.test.tsx
+++ b/packages/frontend/tests/components/ProviderDetailView.test.tsx
@@ -4,10 +4,16 @@ import { createSignal, type Accessor, type Setter } from 'solid-js';
 
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
+const mockRefreshProviderModels = vi.fn();
 
 vi.mock('../../src/services/api.js', () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
+  refreshProviderModels: (...args: unknown[]) => mockRefreshProviderModels(...args),
+}));
+
+vi.mock('../../src/services/formatters.js', () => ({
+  formatTimeAgo: (ts: string | null | undefined) => (ts ? '5m ago' : null),
 }));
 
 vi.mock('../../src/services/toast-store.js', () => ({
@@ -77,6 +83,12 @@ describe('ProviderDetailView', () => {
     vi.clearAllMocks();
     mockConnectProvider.mockResolvedValue({});
     mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    mockRefreshProviderModels.mockResolvedValue({
+      ok: true,
+      model_count: 3,
+      last_fetched_at: '2026-04-12T10:00:00Z',
+      error: null,
+    });
   });
 
   describe('Ollama connect flow', () => {
@@ -228,5 +240,138 @@ describe('ProviderDetailView', () => {
     const props = createTestProps({ provId: 'anthropic' });
     render(() => <ProviderDetailView {...props} />);
     expect(screen.getByTestId('provider-key-form')).toBeDefined();
+  });
+
+  describe('per-provider refresh button', () => {
+    const connectedAnthropicSub: RoutingProvider[] = [
+      {
+        id: 'p1',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        is_active: true,
+        has_api_key: true,
+        connected_at: '2025-01-01',
+        models_fetched_at: '2026-04-12T09:55:00Z',
+      },
+    ];
+
+    it('hides the refresh button when the provider is not connected', () => {
+      const props = createTestProps({ provId: 'anthropic', providers: [] });
+      render(() => <ProviderDetailView {...props} />);
+      expect(screen.queryByLabelText('Refresh models from Anthropic')).toBeNull();
+    });
+
+    it('shows the refresh button and last-refreshed indicator when connected', () => {
+      const props = createTestProps({
+        provId: 'anthropic',
+        providers: connectedAnthropicSub,
+        selectedAuthType: 'subscription',
+      });
+      render(() => <ProviderDetailView {...props} />);
+      expect(screen.getByLabelText('Refresh models from Anthropic')).toBeDefined();
+      expect(screen.getByText('Models last refreshed 5m ago')).toBeDefined();
+    });
+
+    it('calls refreshProviderModels with the provider and auth type and shows a success toast', async () => {
+      const props = createTestProps({
+        provId: 'anthropic',
+        providers: connectedAnthropicSub,
+        selectedAuthType: 'subscription',
+      });
+      render(() => <ProviderDetailView {...props} />);
+
+      fireEvent.click(screen.getByLabelText('Refresh models from Anthropic'));
+
+      await waitFor(() => {
+        expect(mockRefreshProviderModels).toHaveBeenCalledWith(
+          'test-agent',
+          'anthropic',
+          'subscription',
+        );
+        expect(toast.success).toHaveBeenCalledWith('Anthropic: refreshed 3 models');
+        expect(props.onUpdate).toHaveBeenCalled();
+      });
+    });
+
+    it('shows a singular model count in the success toast', async () => {
+      mockRefreshProviderModels.mockResolvedValueOnce({
+        ok: true,
+        model_count: 1,
+        last_fetched_at: '2026-04-12T10:00:00Z',
+        error: null,
+      });
+      const props = createTestProps({
+        provId: 'anthropic',
+        providers: connectedAnthropicSub,
+        selectedAuthType: 'subscription',
+      });
+      render(() => <ProviderDetailView {...props} />);
+
+      fireEvent.click(screen.getByLabelText('Refresh models from Anthropic'));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Anthropic: refreshed 1 model');
+      });
+    });
+
+    it('shows the backend error message in the toast when refresh fails', async () => {
+      mockRefreshProviderModels.mockResolvedValueOnce({
+        ok: false,
+        model_count: 0,
+        last_fetched_at: null,
+        error: 'Provider returned no models',
+      });
+      const props = createTestProps({
+        provId: 'anthropic',
+        providers: connectedAnthropicSub,
+        selectedAuthType: 'subscription',
+      });
+      render(() => <ProviderDetailView {...props} />);
+
+      fireEvent.click(screen.getByLabelText('Refresh models from Anthropic'));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('Provider returned no models');
+        expect(props.onUpdate).toHaveBeenCalled();
+      });
+    });
+
+    it("falls back to a generic message when the backend doesn't supply one", async () => {
+      mockRefreshProviderModels.mockResolvedValueOnce({
+        ok: false,
+        model_count: 0,
+        last_fetched_at: null,
+        error: null,
+      });
+      const props = createTestProps({
+        provId: 'anthropic',
+        providers: connectedAnthropicSub,
+        selectedAuthType: 'subscription',
+      });
+      render(() => <ProviderDetailView {...props} />);
+
+      fireEvent.click(screen.getByLabelText('Refresh models from Anthropic'));
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith("Couldn't refresh Anthropic");
+      });
+    });
+
+    it('swallows network errors without throwing', async () => {
+      mockRefreshProviderModels.mockRejectedValueOnce(new Error('boom'));
+      const props = createTestProps({
+        provId: 'anthropic',
+        providers: connectedAnthropicSub,
+        selectedAuthType: 'subscription',
+      });
+      render(() => <ProviderDetailView {...props} />);
+
+      fireEvent.click(screen.getByLabelText('Refresh models from Anthropic'));
+
+      await waitFor(() => {
+        expect(mockRefreshProviderModels).toHaveBeenCalled();
+      });
+      expect(props.onUpdate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/frontend/tests/services/api-extra.test.ts
+++ b/packages/frontend/tests/services/api-extra.test.ts
@@ -4,6 +4,7 @@ import { submitOpenaiOAuthCallback } from '../../src/services/api/oauth.js';
 import {
   probeCustomProvider,
   refreshModels,
+  refreshProviderModels,
   deleteCustomProvider,
   updateCustomProvider,
   createCustomProvider,
@@ -70,6 +71,29 @@ describe('api/routing', () => {
     const [url, init] = mockFetch.mock.calls[0];
     expect(url).toBe('/api/v1/routing/demo-agent/refresh-models');
     expect(init.method).toBe('POST');
+  });
+
+  it('refreshProviderModels POSTs to the per-provider refresh endpoint and forwards the result', async () => {
+    mockOk({ ok: true, model_count: 5, last_fetched_at: '2026-04-12T10:00:00Z', error: null });
+    const out = await refreshProviderModels('demo-agent', 'anthropic', 'subscription');
+    expect(out).toEqual({
+      ok: true,
+      model_count: 5,
+      last_fetched_at: '2026-04-12T10:00:00Z',
+      error: null,
+    });
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      '/api/v1/routing/demo-agent/providers/anthropic/refresh-models?authType=subscription',
+    );
+    expect(init.method).toBe('POST');
+  });
+
+  it('refreshProviderModels omits the authType query when not provided', async () => {
+    mockOk({ ok: true, model_count: 0, last_fetched_at: null, error: null });
+    await refreshProviderModels('demo-agent', 'openai');
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/v1/routing/demo-agent/providers/openai/refresh-models');
   });
 
   it('probeCustomProvider POSTs the base URL + optional key and returns the model list', async () => {

--- a/packages/frontend/tests/services/formatters.test.ts
+++ b/packages/frontend/tests/services/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatNumber, formatCost, formatTrend, formatStatus, formatMetricType, formatErrorMessage, formatRelativeTime, formatTime, formatDuration } from "../../src/services/formatters";
+import { formatNumber, formatCost, formatTrend, formatStatus, formatMetricType, formatErrorMessage, formatRelativeTime, formatTime, formatDuration, formatTimeAgo } from "../../src/services/formatters";
 
 describe("formatNumber", () => {
   it("formats millions", () => {
@@ -146,5 +146,52 @@ describe("formatRelativeTime", () => {
     const ts = oldDate.toISOString();
     const result = formatRelativeTime(ts);
     expect(result).toMatch(/\w+ \d+/);
+  });
+});
+
+describe("formatTimeAgo", () => {
+  it("returns null for null/undefined/empty input", () => {
+    expect(formatTimeAgo(null)).toBeNull();
+    expect(formatTimeAgo(undefined)).toBeNull();
+    expect(formatTimeAgo("")).toBeNull();
+  });
+  it("returns null for future timestamps (clock skew)", () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    expect(formatTimeAgo(future)).toBeNull();
+  });
+  it("returns null for unparseable timestamps", () => {
+    expect(formatTimeAgo("not-a-date")).toBeNull();
+  });
+  it('returns "Just now" for timestamps under 45 seconds', () => {
+    const ts = new Date(Date.now() - 5_000).toISOString();
+    expect(formatTimeAgo(ts)).toBe("Just now");
+  });
+  it("returns minutes for under-an-hour timestamps", () => {
+    const ts = new Date(Date.now() - 5 * 60_000).toISOString();
+    expect(formatTimeAgo(ts)).toBe("5m ago");
+  });
+  it("returns hours for under-a-day timestamps", () => {
+    const ts = new Date(Date.now() - 3 * 3_600_000).toISOString();
+    expect(formatTimeAgo(ts)).toBe("3h ago");
+  });
+  it('returns "Yesterday" for timestamps a day old', () => {
+    const ts = new Date(Date.now() - 25 * 3_600_000).toISOString();
+    expect(formatTimeAgo(ts)).toBe("Yesterday");
+  });
+  it("returns days ago for timestamps within the last week", () => {
+    const ts = new Date(Date.now() - 4 * 86_400_000).toISOString();
+    expect(formatTimeAgo(ts)).toBe("4d ago");
+  });
+  it("falls back to a localized date for older timestamps", () => {
+    const ts = new Date(Date.now() - 30 * 86_400_000).toISOString();
+    const result = formatTimeAgo(ts);
+    expect(result).toMatch(/\w+ \d+/);
+  });
+  it("accepts the legacy `2026-01-01 12:00:00` (no T, no Z) shape", () => {
+    const ts = new Date(Date.now() - 2 * 60_000)
+      .toISOString()
+      .replace("T", " ")
+      .replace(/\.\d+Z$/, "");
+    expect(formatTimeAgo(ts)).toBe("2m ago");
   });
 });


### PR DESCRIPTION
### 💭 Why
The global "Refresh models" button looked like it worked even when discovery failed, and a transient API hiccup could silently empty `cached_models`. Discussion #1826 reported the symptom: cached lists going stale (or empty) with no signal to the user.

### ✨ What changed
- New `POST /api/v1/routing/:agent/providers/:provider/refresh-models` returning `{ ok, model_count, last_fetched_at, error }`.
- Per-provider refresh button next to the provider name in `ProviderDetailView` and next to each section header in the model picker.
- "Models last refreshed Xm ago" indicator in the provider detail view.
- `discoverModels` no longer overwrites a non-empty `cached_models` when the upstream `/models` returns empty.
- `GET /providers` exposes `models_fetched_at` and `cached_model_count`.
- Picker subtitle reads "Default tier" instead of just "tier" (`DEFAULT_STAGE` is now in the lookup, label flipped from "Regular" to "Default").

### 👤 For users
Refresh now reports the real outcome. "Anthropic: refreshed 9 models" on success, the actual upstream error string on failure ("Provider returned no models", 401, network timeout, etc). Users can refresh providers one at a time instead of all-or-nothing. A flaky API call no longer wipes a previously-good model list.

### 📝 Notes
Refs https://github.com/mnfst/manifest/discussions/1826. The discussion's second ask (built-in translation) is intentionally out of scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-provider model refresh with accurate feedback across backend and UI. Users can refresh one provider at a time, see the real result, and avoid cache wipes from flaky or empty discoveries.

- New Features
  - POST `/api/v1/routing/:agent/providers/:provider/refresh-models` returns `{ ok, model_count, last_fetched_at, error }`, accepts optional `authType`, and recalculates tiers on success.
  - Refresh buttons in Provider Detail and next to each provider group in the model picker, with spinners and toasts showing counts or upstream errors. Provider Detail shows “Models last refreshed Xm ago.”
  - GET `/providers` now includes `models_fetched_at` and `cached_model_count`.
  - Model picker subtitle now says “Default tier.”

- Bug Fixes
  - Empty upstream discoveries no longer overwrite a non-empty `cached_models`.
  - Per-provider refresh preserves caches on failure and reports the previous cached count and `last_fetched_at`; true upstream error strings are returned.
  - Custom providers are blocked from auto-refresh and report the cached count.

<sup>Written for commit 2ba0dbb4399d98d0cb60cf2233268ab7358d39fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

