### PR TITLE
fix: route-aware fallback persistence in custom routing UI

### DIFF
--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -118,8 +118,11 @@ const HeaderTierCard: Component<Props> = (props) => {
       await props.onOverride(model, provider, authType);
     } else if (mode === 'fallback') {
       const next = [...fallbacks(), model];
+      const currentRoutes = props.tier.fallback_routes ?? [];
+      const nextRoutes =
+        authType !== undefined ? [...currentRoutes, { provider, authType, model }] : undefined;
       try {
-        await setHeaderTierFallbacks(props.agentName, props.tier.id, next);
+        await setHeaderTierFallbacks(props.agentName, props.tier.id, next, nextRoutes);
         props.onFallbacksUpdate(next);
       } catch {
         // toast handled by FallbackList parent flow normally; keep silent here.

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -19,6 +19,7 @@ import { PROVIDERS } from '../services/providers.js';
 import FallbackList from './FallbackList.js';
 import ModelPickerModal from './ModelPickerModal.js';
 import HeaderTierSnippetModal from './HeaderTierSnippetModal.js';
+import { toast } from '../services/toast-store.js';
 
 function providerIdForModel(model: string, apiModels: AvailableModel[]): string | undefined {
   const m =
@@ -124,8 +125,9 @@ const HeaderTierCard: Component<Props> = (props) => {
       try {
         await setHeaderTierFallbacks(props.agentName, props.tier.id, next, nextRoutes);
         props.onFallbacksUpdate(next);
+        toast.success('Fallback added');
       } catch {
-        // toast handled by FallbackList parent flow normally; keep silent here.
+        toast.error('Failed to add fallback');
       }
     }
   };

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -3,6 +3,7 @@ import type {
   AuthType,
   AvailableModel,
   CustomProviderData,
+  ModelRoute,
   RoutingProvider,
 } from '../services/api.js';
 import {
@@ -44,7 +45,7 @@ interface Props {
   customProviders: CustomProviderData[];
   connectedProviders: RoutingProvider[];
   onOverride: (model: string, provider: string, authType?: AuthType) => void | Promise<void>;
-  onFallbacksUpdate: (fallbacks: string[]) => void;
+  onFallbacksUpdate: (fallbacks: string[], routes?: ModelRoute[] | null) => void;
   onEdit?: () => void;
   onDisable?: () => void;
 }
@@ -124,7 +125,7 @@ const HeaderTierCard: Component<Props> = (props) => {
         authType !== undefined ? [...currentRoutes, { provider, authType, model }] : undefined;
       try {
         await setHeaderTierFallbacks(props.agentName, props.tier.id, next, nextRoutes);
-        props.onFallbacksUpdate(next);
+        props.onFallbacksUpdate(next, nextRoutes ?? null);
         toast.success('Fallback added');
       } catch {
         toast.error('Failed to add fallback');
@@ -340,7 +341,7 @@ const HeaderTierCard: Component<Props> = (props) => {
             models={props.models}
             customProviders={props.customProviders}
             connectedProviders={props.connectedProviders}
-            onUpdate={(updated) => props.onFallbacksUpdate(updated)}
+            onUpdate={(updated, updatedRoutes) => props.onFallbacksUpdate(updated, updatedRoutes)}
             onAddFallback={() => setPickerMode('fallback')}
             persistFallbacks={(_agent, tierId, models, routes) =>
               setHeaderTierFallbacks(props.agentName, tierId, models, routes)

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -53,10 +53,8 @@ const Routing: Component = () => {
     () => agentName(),
     getCustomProviders,
   );
-  const [specificityAssignments, { refetch: refetchSpecificity }] = createResource(
-    () => agentName(),
-    getSpecificityAssignments,
-  );
+  const [specificityAssignments, { refetch: refetchSpecificity, mutate: mutateSpecificity }] =
+    createResource(() => agentName(), getSpecificityAssignments);
   const [headerTiers, { refetch: refetchHeaderTiers, mutate: mutateHeaderTiers }] = createResource(
     () => agentName(),
     (name) => listHeaderTiers(name).catch(() => [] as HeaderTier[]),
@@ -429,19 +427,17 @@ const Routing: Component = () => {
                       setResettingSpecificity(null);
                     }
                   }}
-                  onFallbackUpdate={async (category, updatedFallbacks) => {
-                    try {
-                      if (updatedFallbacks.length === 0) {
-                        const { clearSpecificityFallbacks } = await import('../services/api.js');
-                        await clearSpecificityFallbacks(agentName(), category);
-                      } else {
-                        const { setSpecificityFallbacks } = await import('../services/api.js');
-                        await setSpecificityFallbacks(agentName(), category, updatedFallbacks);
-                      }
-                      await refetchSpecificity();
-                    } catch {
-                      toast.error('Failed to update fallbacks');
-                    }
+                  onFallbackUpdate={(category, _updatedFallbacks, updatedRoutes) => {
+                    // Optimistic local state mutation only. Persistence is
+                    // handled by RoutingTierCard via persistFallbacks (with
+                    // routes), so a second network call here would race the
+                    // first and drop route metadata for ambiguous models.
+                    if (updatedRoutes === undefined) return;
+                    mutateSpecificity((prev) =>
+                      prev?.map((a) =>
+                        a.category === category ? { ...a, fallback_routes: updatedRoutes } : a,
+                      ),
+                    );
                   }}
                   onAddFallback={(category) => setFallbackPickerTier(category)}
                   refetchAll={refetchAll}

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -57,7 +57,7 @@ const Routing: Component = () => {
     () => agentName(),
     getSpecificityAssignments,
   );
-  const [headerTiers, { refetch: refetchHeaderTiers }] = createResource(
+  const [headerTiers, { refetch: refetchHeaderTiers, mutate: mutateHeaderTiers }] = createResource(
     () => agentName(),
     (name) => listHeaderTiers(name).catch(() => [] as HeaderTier[]),
   );
@@ -457,6 +457,7 @@ const Routing: Component = () => {
                   connectedProviders={() => connectedProviders() ?? []}
                   externalTiers={() => headerTiers()}
                   externalRefetch={() => void refetchHeaderTiers()}
+                  externalMutate={mutateHeaderTiers}
                   embedded
                 />
               ),

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -13,6 +13,7 @@ import type {
   AvailableModel,
   AuthType,
   CustomProviderData,
+  ModelRoute,
   RoutingProvider,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
@@ -25,13 +26,14 @@ export interface RoutingHeaderTiersSectionProps {
   connectedProviders: Accessor<RoutingProvider[]>;
   externalTiers?: Accessor<HeaderTier[] | undefined>;
   externalRefetch?: () => void;
+  externalMutate?: (mutator: (prev: HeaderTier[] | undefined) => HeaderTier[] | undefined) => void;
   embedded?: boolean;
 }
 
 type Props = RoutingHeaderTiersSectionProps;
 
 const RoutingHeaderTiersSection: Component<Props> = (props) => {
-  const [internalTiersRes, { refetch: internalRefetch }] = createResource(
+  const [internalTiersRes, { refetch: internalRefetch, mutate: internalMutate }] = createResource(
     () => (props.externalTiers ? false : props.agentName()),
     (name) =>
       listHeaderTiers(name as string).catch((err) => {
@@ -43,6 +45,25 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
   const refetch = () => {
     if (props.externalRefetch) props.externalRefetch();
     else void internalRefetch();
+  };
+
+  // Apply an optimistic update to the resource so the UI reflects fallback
+  // changes immediately, mirroring the tier path. Without this the refetch
+  // races the persist call and shows stale data on first click.
+  // When the caller doesn't know the new routes (e.g. tier reset, which also
+  // clears override_route), fall back to a refetch.
+  const applyFallbackUpdate = (
+    tierId: string,
+    updatedRoutes: ModelRoute[] | null | undefined,
+  ): void => {
+    if (updatedRoutes === undefined) {
+      refetch();
+      return;
+    }
+    const update = (prev: HeaderTier[] | undefined): HeaderTier[] | undefined =>
+      prev?.map((t) => (t.id === tierId ? { ...t, fallback_routes: updatedRoutes } : t));
+    if (props.externalMutate) props.externalMutate(update);
+    else internalMutate(update);
   };
 
   // Manage modal: lists all tiers. `null` = closed.
@@ -144,7 +165,9 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                 customProviders={props.customProviders()}
                 connectedProviders={props.connectedProviders()}
                 onOverride={(m, p, a) => handleOverride(tier.id, m, p, a)}
-                onFallbacksUpdate={() => refetch()}
+                onFallbacksUpdate={(_fallbacks, updatedRoutes) =>
+                  applyFallbackUpdate(tier.id, updatedRoutes)
+                }
                 onEdit={() => setModalTier(tier)}
                 onDisable={() => handleToggle(tier.id, false)}
               />

--- a/packages/frontend/src/pages/RoutingSpecificitySection.tsx
+++ b/packages/frontend/src/pages/RoutingSpecificitySection.tsx
@@ -12,6 +12,7 @@ import type {
   TierAssignment,
   AvailableModel,
   AuthType,
+  ModelRoute,
   RoutingProvider,
   CustomProviderData,
 } from '../services/api.js';
@@ -152,7 +153,7 @@ export interface RoutingSpecificitySectionProps {
     authType?: AuthType,
   ) => void;
   onReset: (category: string) => void;
-  onFallbackUpdate: (category: string, fallbacks: string[]) => void;
+  onFallbackUpdate: (category: string, fallbacks: string[], routes?: ModelRoute[] | null) => void;
   onAddFallback: (category: string) => void;
   refetchAll: () => Promise<void>;
   refetchSpecificity?: () => Promise<void>;

--- a/packages/frontend/src/pages/RoutingSpecificitySection.tsx
+++ b/packages/frontend/src/pages/RoutingSpecificitySection.tsx
@@ -243,8 +243,8 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
                   getAssignment(cat)?.fallback_routes?.map((r) => r.model) ?? []
                 }
                 connectedProviders={props.connectedProviders}
-                persistFallbacks={(_agentName, category, models) =>
-                  setSpecificityFallbacks(_agentName, category, models)
+                persistFallbacks={(_agentName, category, models, routes) =>
+                  setSpecificityFallbacks(_agentName, category, models, routes)
                 }
                 persistClearFallbacks={(_agentName, category) =>
                   clearSpecificityFallbacks(_agentName, category)

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -545,7 +545,15 @@ describe("HeaderTierCard", () => {
     fireEvent.click(getByTestId("fb-add") as HTMLButtonElement);
     fireEvent.click(getByTestId("picker-pick") as HTMLButtonElement);
     await waitFor(() => {
-      expect(mockSetHeaderTierFallbacks).toHaveBeenCalledWith("demo", "ht-1", ["old", "gpt-4o"]);
+      expect(mockSetHeaderTierFallbacks).toHaveBeenCalledWith(
+        "demo",
+        "ht-1",
+        ["old", "gpt-4o"],
+        [
+          { provider: "openai", authType: "api_key", model: "old" },
+          { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        ],
+      );
       expect(onFallbacksUpdate).toHaveBeenCalledWith(["old", "gpt-4o"]);
     });
   });

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -554,7 +554,13 @@ describe("HeaderTierCard", () => {
           { provider: "openai", authType: "api_key", model: "gpt-4o" },
         ],
       );
-      expect(onFallbacksUpdate).toHaveBeenCalledWith(["old", "gpt-4o"]);
+      expect(onFallbacksUpdate).toHaveBeenCalledWith(
+        ["old", "gpt-4o"],
+        [
+          { provider: "openai", authType: "api_key", model: "old" },
+          { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        ],
+      );
     });
   });
 

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -288,7 +288,11 @@ vi.mock("../../src/pages/RoutingSpecificitySection.js", () => ({
   default: (props: {
     onDropdownOpen: (cat: string) => void;
     onReset: (cat: string) => void;
-    onFallbackUpdate: (cat: string, fbs: string[]) => void;
+    onFallbackUpdate: (
+      cat: string,
+      fbs: string[],
+      routes?: { provider: string; authType: string; model: string }[] | null,
+    ) => void;
     onAddFallback: (cat: string) => void;
     onPinKey?: (
       cat: string,
@@ -306,13 +310,23 @@ vi.mock("../../src/pages/RoutingSpecificitySection.js", () => ({
       </button>
       <button
         data-testid="spec-fb-update-add"
-        onClick={() => props.onFallbackUpdate("coding", ["fb1"])}
+        onClick={() =>
+          props.onFallbackUpdate("coding", ["fb1"], [
+            { provider: "openai", authType: "api_key", model: "fb1" },
+          ])
+        }
       >
         spec-fb-add
       </button>
       <button
+        data-testid="spec-fb-update-add-no-routes"
+        onClick={() => props.onFallbackUpdate("coding", ["fb1"])}
+      >
+        spec-fb-add-no-routes
+      </button>
+      <button
         data-testid="spec-fb-update-clear"
-        onClick={() => props.onFallbackUpdate("coding", [])}
+        onClick={() => props.onFallbackUpdate("coding", [], null)}
       >
         spec-fb-clear
       </button>
@@ -624,40 +638,31 @@ describe("Routing page", () => {
     });
   });
 
-  it("calls setSpecificityFallbacks for non-empty fallback updates from the spec section", async () => {
-    mockSetSpecificityFallbacks.mockResolvedValue(undefined);
+  it("does not fire a parallel persist call from spec onFallbackUpdate when routes are provided", async () => {
+    // The optimistic state mutation only updates local resource state.
+    // Persistence is handled by persistFallbacks; a second call here would
+    // race the first and could drop route metadata.
     render(() => <Routing />);
     await waitFor(() => {
       expect(screen.getByTestId("spec-fb-update-add")).toBeDefined();
     });
     fireEvent.click(screen.getByTestId("spec-fb-update-add"));
-    await waitFor(() => {
-      expect(mockSetSpecificityFallbacks).toHaveBeenCalledWith("demo", "coding", ["fb1"]);
-    });
-  });
-
-  it("calls clearSpecificityFallbacks for empty fallback updates from the spec section", async () => {
-    mockClearSpecificityFallbacks.mockResolvedValue(undefined);
-    render(() => <Routing />);
-    await waitFor(() => {
-      expect(screen.getByTestId("spec-fb-update-clear")).toBeDefined();
-    });
     fireEvent.click(screen.getByTestId("spec-fb-update-clear"));
-    await waitFor(() => {
-      expect(mockClearSpecificityFallbacks).toHaveBeenCalledWith("demo", "coding");
-    });
+    // Give the async handler a chance to fire if it were going to.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSetSpecificityFallbacks).not.toHaveBeenCalled();
+    expect(mockClearSpecificityFallbacks).not.toHaveBeenCalled();
   });
 
-  it("toasts when spec fallback update fails", async () => {
-    mockSetSpecificityFallbacks.mockRejectedValue(new Error("boom"));
+  it("returns early when spec onFallbackUpdate is called without routes", async () => {
     render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByTestId("spec-fb-update-add")).toBeDefined();
+      expect(screen.getByTestId("spec-fb-update-add-no-routes")).toBeDefined();
     });
-    fireEvent.click(screen.getByTestId("spec-fb-update-add"));
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith("Failed to update fallbacks");
-    });
+    fireEvent.click(screen.getByTestId("spec-fb-update-add-no-routes"));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSetSpecificityFallbacks).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
   });
 
   describe("handleSpecificityPinKey", () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -642,6 +642,30 @@ describe("Routing page", () => {
     // The optimistic state mutation only updates local resource state.
     // Persistence is handled by persistFallbacks; a second call here would
     // race the first and could drop route metadata.
+    // Seed an assignment so mutateSpecificity actually maps over a non-empty array
+    // (covers the `a.category === category ? ... : a` ternary branches).
+    mockGetSpecificityAssignments.mockResolvedValue([
+      {
+        id: "s1",
+        agent_id: "a",
+        category: "coding",
+        is_active: true,
+        override_route: null,
+        auto_assigned_route: null,
+        fallback_routes: null,
+        updated_at: "2025-01-01",
+      },
+      {
+        id: "s2",
+        agent_id: "a",
+        category: "trading",
+        is_active: true,
+        override_route: null,
+        auto_assigned_route: null,
+        fallback_routes: null,
+        updated_at: "2025-01-01",
+      },
+    ]);
     render(() => <Routing />);
     await waitFor(() => {
       expect(screen.getByTestId("spec-fb-update-add")).toBeDefined();

--- a/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
@@ -49,6 +49,19 @@ vi.mock("../../src/components/HeaderTierCard.js", () => ({
           fb-update
         </button>
         <button
+          data-testid={`fb-update-routes-${tier.id}`}
+          onClick={() =>
+            (
+              props.onFallbacksUpdate as (
+                fallbacks: string[],
+                routes: { provider: string; authType: string; model: string }[],
+              ) => void
+            )(["fb1"], [{ provider: "openai", authType: "api_key", model: "fb1" }])
+          }
+        >
+          fb-update-routes
+        </button>
+        <button
           data-testid={`edit-${tier.id}`}
           onClick={() => (props.onEdit as () => void)?.()}
         >
@@ -224,6 +237,70 @@ describe("RoutingHeaderTiersSection", () => {
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("boom");
     });
+  });
+
+  it("refetches when a card fires onFallbacksUpdate without routes (e.g. tier reset)", async () => {
+    mockListHeaderTiers.mockResolvedValue([tier1]);
+    const { getByTestId } = render(() => (
+      <RoutingHeaderTiersSection
+        {...makeProps({ externalTiers: undefined, externalRefetch: undefined })}
+      />
+    ));
+    await waitFor(() => {
+      expect(getByTestId("fb-update-ht-1")).toBeDefined();
+    });
+    mockListHeaderTiers.mockClear();
+    fireEvent.click(getByTestId("fb-update-ht-1"));
+    await waitFor(() => {
+      expect(mockListHeaderTiers).toHaveBeenCalled();
+    });
+  });
+
+  it("calls externalRefetch when fb update without routes and external prop wired", async () => {
+    const externalRefetch = vi.fn();
+    const { getByTestId } = render(() => (
+      <RoutingHeaderTiersSection
+        {...makeProps({ externalTiers: () => [tier1], externalRefetch })}
+      />
+    ));
+    fireEvent.click(getByTestId("fb-update-ht-1"));
+    expect(externalRefetch).toHaveBeenCalled();
+  });
+
+  it("calls externalMutate optimistically when fb update with routes and external prop wired", async () => {
+    const externalMutate = vi.fn();
+    const { getByTestId } = render(() => (
+      <RoutingHeaderTiersSection
+        {...makeProps({ externalTiers: () => [tier1], externalMutate })}
+      />
+    ));
+    fireEvent.click(getByTestId("fb-update-routes-ht-1"));
+    expect(externalMutate).toHaveBeenCalledTimes(1);
+    const mutator = externalMutate.mock.calls[0]![0] as (
+      prev: { id: string; fallback_routes: unknown }[] | undefined,
+    ) => unknown;
+    const result = mutator([tier1, tier2] as never) as { id: string; fallback_routes: unknown }[];
+    expect(result.find((t) => t.id === "ht-1")?.fallback_routes).toEqual([
+      { provider: "openai", authType: "api_key", model: "fb1" },
+    ]);
+    expect(result.find((t) => t.id === "ht-2")?.fallback_routes).toEqual(tier2.fallback_routes);
+  });
+
+  it("uses internalMutate optimistically when fb update with routes and no external prop", async () => {
+    mockListHeaderTiers.mockResolvedValue([tier1]);
+    const { getByTestId } = render(() => (
+      <RoutingHeaderTiersSection
+        {...makeProps({ externalTiers: undefined, externalRefetch: undefined })}
+      />
+    ));
+    await waitFor(() => {
+      expect(getByTestId("fb-update-routes-ht-1")).toBeDefined();
+    });
+    mockListHeaderTiers.mockClear();
+    fireEvent.click(getByTestId("fb-update-routes-ht-1"));
+    // internalMutate is synchronous and does not refetch
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockListHeaderTiers).not.toHaveBeenCalled();
   });
 
   it("calls toggleHeaderTier with false when disabling from a card", async () => {

--- a/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
@@ -267,9 +267,11 @@ describe("RoutingSpecificitySection", () => {
       a: string,
       c: string,
       m: string[],
+      r?: { provider: string; authType: string; model: string }[],
     ) => Promise<unknown>;
-    await persist("demo", "coding", ["m1"]);
-    expect(mockSetSpecificityFallbacks).toHaveBeenCalledWith("demo", "coding", ["m1"]);
+    const routes = [{ provider: "openai", authType: "api_key", model: "m1" }];
+    await persist("demo", "coding", ["m1"], routes);
+    expect(mockSetSpecificityFallbacks).toHaveBeenCalledWith("demo", "coding", ["m1"], routes);
   });
 
   it("forwards persistClearFallbacks to clearSpecificityFallbacks via the tier card", async () => {


### PR DESCRIPTION
### ✨ What changed
- Header-tier picker now sends `(provider, authType, model)` to the backend, not just the model name.
- Specificity wrapper forwards the `routes` arg to `setSpecificityFallbacks`.
- Header-tier add fallback toasts success/error (was silent on both).
- Remove/reorder fallbacks on header tiers updates UI instantly via `mutate` instead of racing a refetch.
- Specificity `onFallbackUpdate` is optimistic-only. Persistence is owned by `persistFallbacks`, no parallel PUT.

### 💭 Why
After PR #1772 added optional `routes` to the fallback APIs and PR #1779 made `buildFallbackRoutes` throw on ambiguous resolution, several call sites in the routing UI still passed model names only. When the same model id was offered by two auth types on the same provider (e.g. OpenAI subscription + OpenAI API key both expose `gpt-5.4-mini`), the backend couldn't disambiguate and returned 400 `Cannot resolve fallback model "X" to a single connected provider`. The header-tier (Custom Routing) flow was the most visible symptom; the specificity flow had the same bug class plus a duplicate persist call racing the route-aware one.

### 👤 For users
- Custom Routing fallbacks save on first try when subscription + API key offer the same model.
- "Fallback added" / "Failed to add fallback" toasts now show in Custom Routing.
- Removing a fallback in Custom Routing actually disappears on the first click. Was: needed two clicks because the optimistic refetch ran before the persist completed.
- Same-model dual-auth fallbacks work in task-specific (specificity) routing too.

### 📝 Notes
- Found the second bug class via /codex review on the original fix.
- All 2779 frontend tests pass.