### PR TITLE
fix: preserve isResponses across stream warm-up

### DIFF
--- a/.changeset/cyan-knives-own.md
+++ b/.changeset/cyan-knives-own.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Preserve Responses stream classification during stream warm-up.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -650,6 +650,81 @@ describe('ProxyService — orchestration', () => {
       );
       expect(result.forward.response.status).toBe(502);
     });
+    it('preserves isResponses on the peeked stream (warmup success path)', async () => {
+      const streamRes = new Response(new ReadableStream(), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: streamRes,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+        isResponses: true,
+      });
+      mockedPeek.mockResolvedValue({ ok: true, stream: new ReadableStream() } as never);
+
+      const result = await svc.proxyRequest(
+        baseOpts({ body: { messages: [{ role: 'user', content: 'hi' }], stream: true } }),
+      );
+      expect(result.forward.isResponses).toBe(true);
+    });
+
+    it('preserves isResponses on the synthetic 502 forward (warmup failure, no fallbacks)', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'api_key', 'gpt-4o'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      tierService.getTiers.mockResolvedValue([]);
+      const streamRes = new Response(new ReadableStream(), {
+        status: 200,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: streamRes,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+        isResponses: true,
+      });
+      mockedPeek.mockResolvedValue({
+        ok: false,
+        reason: 'closed',
+        message: 'closed before data',
+      } as never);
+
+      const result = await svc.proxyRequest(
+        baseOpts({ body: { messages: [{ role: 'user', content: 'hi' }], stream: true } }),
+      );
+      expect(result.forward.isResponses).toBe(true);
+    });
+
+    it('preserves isResponses on the rebuilt forward when fallbacks are exhausted', async () => {
+      const streamRes = new Response('upstream error', {
+        status: 500,
+        headers: { 'content-type': 'text/event-stream' },
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: streamRes,
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+        isResponses: true,
+      });
+      fallbackService.tryFallbacks.mockResolvedValue({
+        success: null,
+        failures: [{ model: 'claude', provider: 'anthropic', status: 500, error: 'upstream' }],
+      } as never);
+
+      const result = await svc.proxyRequest(
+        baseOpts({ body: { messages: [{ role: 'user', content: 'hi' }] } }),
+      );
+      expect(result.forward.isResponses).toBe(true);
+    });
   });
 
   describe('routing dispatch', () => {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -220,6 +220,7 @@ export class ProxyService {
           isGoogle: forward.isGoogle,
           isAnthropic: forward.isAnthropic,
           isChatGpt: forward.isChatGpt,
+          isResponses: forward.isResponses,
         };
         this.recordTierIfScoring(sessionKey, resolved.tier);
         this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
@@ -238,6 +239,7 @@ export class ProxyService {
         isGoogle: forward.isGoogle,
         isAnthropic: forward.isAnthropic,
         isChatGpt: forward.isChatGpt,
+        isResponses: forward.isResponses,
       };
       const fallbackResult = await this.tryFallbackChain({
         agentId,
@@ -445,6 +447,7 @@ export class ProxyService {
         isGoogle: forward.isGoogle,
         isAnthropic: forward.isAnthropic,
         isChatGpt: forward.isChatGpt,
+        isResponses: forward.isResponses,
       },
       meta: this.buildBaseMeta(resolved, primaryModel),
       failedFallbacks: failures,


### PR DESCRIPTION
## Summary

Preserves `ForwardResult.isResponses` when `ProxyService` reconstructs `ForwardResult` objects during stream warm-up / fallback handling.

Without this flag, `/v1/responses` streaming responses routed through the OpenAI subscription provider can be misclassified as Chat Completions SSE and collapse to only `data: [DONE]`.

Fixes #1843.

## Why

`ProviderClient` sets `isResponses` for native Responses-format upstreams. `ProxyResponseHandler.handleStreamResponse()` relies on that flag to decide whether to raw-pass native Responses SSE:

```ts
apiMode === 'responses' && forward.isResponses
```

Stream warm-up rebuilt the `ForwardResult` but preserved only `isGoogle`, `isAnthropic`, and `isChatGpt`. That dropped `isResponses`.

## Tested

Before patch:

- `/v1/responses` non-streaming text: pass
- `/v1/responses` non-streaming function call: pass
- `/v1/responses` `stream:true`: failed with only `data: [DONE]`
- OpenClaw `api: "openai-responses"` through Manifest: no assistant output

After patch:

- `/v1/responses` `stream:true`: emits normal Responses SSE events including `response.output_text.delta`
- `/v1/responses` non-streaming text: still passes
- `/v1/responses` non-streaming function call: still passes
- OpenClaw `api: "openai-responses"` through Manifest: returns assistant output

## Scope

This change does not alter routing, model selection, model discovery, local model support, or provider availability. It only preserves an existing format flag across response reconstruction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the `isResponses` flag when `ProxyService` rebuilds `ForwardResult` during stream warm‑up and fallback so `/v1/responses` streams are classified correctly and don’t collapse to `data: [DONE]`.

- **Bug Fixes**
  - Preserve `isResponses` in all rebuild paths (warm‑up success/failure and fallback exhaustion) so native Responses SSE is forwarded correctly.
  - Added tests covering these cases; `/v1/responses` with `stream: true` now emits normal Responses SSE; non‑streaming unchanged.

<sup>Written for commit 786dd7646f1f859793cae2e9cb6d1bc302febf92. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

