### PR TITLE
refactor(oauth): extract RedirectPkceOauthBaseService

### DIFF
--- a/.changeset/puny-stars-laugh.md
+++ b/.changeset/puny-stars-laugh.md
@@ -1,0 +1,7 @@
+---
+---
+
+Internal: extract a shared `RedirectPkceOauthBaseService` from the OpenAI
+OAuth service so future redirect-PKCE providers reuse the loopback
+callback server, PKCE state, token exchange/refresh, and revoke logic.
+No behavior change.

--- a/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
@@ -230,6 +230,21 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockRejectedValue(new Error('network'));
       expect(await svc.unwrapToken(JSON.stringify(blob), 'a', 'u')).toBeNull();
     });
+
+    // Regression: a still-valid access token must be returned even when the
+    // OAuth response omitted a refresh token. The earlier check
+    // `!blob.t || !blob.r || !blob.e` short-circuited usable tokens to null.
+    it('returns the access token for a valid blob with no refresh token', async () => {
+      const blob = { t: 'still-good', r: '', e: Date.now() + 10 * 60 * 1000 };
+      expect(await svc.unwrapToken(JSON.stringify(blob), 'a', 'u')).toBe('still-good');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('returns null for an expired blob with no refresh token (cannot refresh)', async () => {
+      const blob = { t: 'old', r: '', e: Date.now() + 1000 };
+      expect(await svc.unwrapToken(JSON.stringify(blob), 'a', 'u')).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('revokeToken', () => {

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -1,302 +1,33 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
-import { scrubSecrets } from '../../common/utils/secret-scrub';
 import { PendingOAuth } from './openai-oauth.types';
-import {
-  generatePkce,
-  generateState,
-  oauthDoneHtml,
-  parseOAuthTokenBlob,
-  PendingStore,
-  serializeOAuthTokenBlob,
-  type OAuthTokenBlob,
-} from './core';
+import { oauthDoneHtml, type OAuthTokenBlob } from './core';
+import { RedirectPkceOauthBaseService } from './redirect-pkce-oauth.base';
 
 export { PendingOAuth };
 export { oauthDoneHtml, type OAuthTokenBlob };
 
 const DEFAULT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
-const AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize';
-const TOKEN_URL = 'https://auth.openai.com/oauth/token';
-const REVOKE_URL = 'https://auth.openai.com/oauth/revoke';
-const SCOPE = 'openid profile email offline_access';
-const CALLBACK_PORT = 1455;
-const REDIRECT_URI = `http://localhost:${CALLBACK_PORT}/auth/callback`;
-const STATE_TTL_MS = 10 * 60 * 1000;
 
 @Injectable()
-export class OpenaiOauthService {
-  private readonly logger = new Logger(OpenaiOauthService.name);
-  private readonly pending = new PendingStore<PendingOAuth>(STATE_TTL_MS);
-  private callbackServer: Server | null = null;
-  private serverReady: Promise<void> | null = null;
-  private readonly clientId: string;
-  private readonly useCallbackServer: boolean;
-
+export class OpenaiOauthService extends RedirectPkceOauthBaseService {
   constructor(
-    private readonly providerService: ProviderService,
-    private readonly configService: ConfigService,
-    private readonly discoveryService: ModelDiscoveryService,
+    providerService: ProviderService,
+    configService: ConfigService,
+    discoveryService: ModelDiscoveryService,
   ) {
-    this.clientId = this.configService.get<string>('OPENAI_OAUTH_CLIENT_ID') ?? DEFAULT_CLIENT_ID;
-    // Loopback callback server runs only in development. Production
-    // deployments (Docker self-hosted and cloud) complete the OAuth flow
-    // through the server's public URL instead.
-    this.useCallbackServer =
-      (this.configService.get<string>('app.nodeEnv') ?? 'development') !== 'production';
-  }
-
-  async generateAuthorizationUrl(
-    agentId: string,
-    userId: string,
-    backendUrl?: string,
-  ): Promise<string> {
-    const state = generateState();
-    const { verifier, challenge } = generatePkce();
-    // Validate the redirect target now (at storage time) so a forged Host
-    // header can't redirect the OAuth flow on the way out.
-    const safeBackendUrl = backendUrl && this.isAllowedRedirectOrigin(backendUrl) ? backendUrl : '';
-    this.pending.set(state, {
-      verifier,
-      agentId,
-      userId,
-      backendUrl: safeBackendUrl,
+    super(providerService, configService, discoveryService, {
+      providerId: 'openai',
+      serviceName: OpenaiOauthService.name,
+      defaultClientId: DEFAULT_CLIENT_ID,
+      clientIdEnvVar: 'OPENAI_OAUTH_CLIENT_ID',
+      authorizeUrl: 'https://auth.openai.com/oauth/authorize',
+      tokenUrl: 'https://auth.openai.com/oauth/token',
+      revokeUrl: 'https://auth.openai.com/oauth/revoke',
+      scope: 'openid profile email offline_access',
+      callbackPort: 1455,
     });
-    if (this.useCallbackServer) {
-      await this.ensureCallbackServer();
-    }
-    const params = new URLSearchParams({
-      client_id: this.clientId,
-      redirect_uri: REDIRECT_URI,
-      response_type: 'code',
-      scope: SCOPE,
-      state,
-      code_challenge: challenge,
-      code_challenge_method: 'S256',
-    });
-    return `${AUTHORIZE_URL}?${params.toString()}`;
-  }
-
-  async exchangeCode(state: string, code: string): Promise<void> {
-    const pending = this.pending.peek(state);
-    if (!pending) throw new Error('Invalid or expired OAuth state');
-    if (pending.expiresAt < Date.now()) {
-      this.pending.delete(state);
-      throw new Error('OAuth state expired');
-    }
-    this.pending.delete(state);
-    const response = await fetch(TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'authorization_code',
-        code,
-        redirect_uri: REDIRECT_URI,
-        client_id: this.clientId,
-        code_verifier: pending.verifier,
-      }),
-    });
-    if (!response.ok) {
-      const text = await response.text();
-      this.logger.error(`OpenAI token exchange failed: ${scrubSecrets(text)}`);
-      throw new Error('Token exchange failed');
-    }
-    const data = (await response.json()) as {
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-    };
-    const blob: OAuthTokenBlob = {
-      t: data.access_token,
-      r: data.refresh_token,
-      e: Date.now() + data.expires_in * 1000,
-    };
-    const label = await this.providerService.nextOAuthLabel(pending.agentId, 'openai');
-    const { provider: savedProvider } = await this.providerService.upsertProvider(
-      pending.agentId,
-      pending.userId,
-      'openai',
-      serializeOAuthTokenBlob(blob),
-      'subscription',
-      undefined,
-      label,
-    );
-    try {
-      await this.discoveryService.discoverModels(savedProvider);
-      await this.providerService.recalculateTiers(pending.agentId);
-    } catch (err) {
-      this.logger.warn(`Model discovery after OAuth failed: ${err}`);
-    }
-    this.logger.log(`OpenAI OAuth token stored for agent=${pending.agentId}`);
-    this.shutdownCallbackServerIfIdle();
-  }
-
-  async refreshAccessToken(refreshToken: string): Promise<OAuthTokenBlob> {
-    const response = await fetch(TOKEN_URL, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({
-        grant_type: 'refresh_token',
-        refresh_token: refreshToken,
-        client_id: this.clientId,
-      }),
-    });
-    if (!response.ok) {
-      const text = await response.text();
-      this.logger.error(`OpenAI token refresh failed: ${scrubSecrets(text)}`);
-      throw new Error('Token refresh failed');
-    }
-    const data = (await response.json()) as {
-      access_token: string;
-      refresh_token?: string;
-      expires_in: number;
-    };
-    return {
-      t: data.access_token,
-      r: data.refresh_token || refreshToken,
-      e: Date.now() + data.expires_in * 1000,
-    };
-  }
-
-  /** Parse an OAuth blob and return a valid access token, refreshing if expired. */
-  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
-    const blob = parseOAuthTokenBlob(rawValue);
-    if (!blob) return null;
-    if (Date.now() < blob.e - 60_000) return blob.t;
-    try {
-      const refreshed = await this.refreshAccessToken(blob.r);
-      await this.providerService.upsertProvider(
-        agentId,
-        userId,
-        'openai',
-        serializeOAuthTokenBlob(refreshed),
-        'subscription',
-      );
-      this.logger.log(`OpenAI OAuth token refreshed for agent=${agentId}`);
-      return refreshed.t;
-    } catch (err) {
-      this.logger.error(`Failed to refresh OpenAI token for agent=${agentId}: ${err}`);
-      return null;
-    }
-  }
-
-  /** Revoke an OAuth token at OpenAI (best-effort). */
-  async revokeToken(token: string): Promise<void> {
-    try {
-      const response = await fetch(REVOKE_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({ token, client_id: this.clientId }),
-      });
-      if (!response.ok) {
-        const text = await response.text();
-        this.logger.warn(`OpenAI token revocation failed: ${scrubSecrets(text)}`);
-      } else {
-        this.logger.log('OpenAI OAuth token revoked');
-      }
-    } catch (err) {
-      this.logger.warn(`OpenAI token revocation error: ${err}`);
-    }
-  }
-
-  /** Returns the number of pending OAuth states (for testing). */
-  getPendingCount(): number {
-    return this.pending.size();
-  }
-
-  /** Remove a pending OAuth state. */
-  clearPendingState(state: string): void {
-    this.pending.delete(state);
-  }
-
-  /** Spins up an HTTP server on port 1455 to receive the OAuth callback. */
-  private ensureCallbackServer(): Promise<void> {
-    if (this.callbackServer) return Promise.resolve();
-    if (this.serverReady) return this.serverReady;
-    this.serverReady = new Promise<void>((resolve, reject) => {
-      const server = createServer((req, res) => this.handleCallbackRequest(req, res));
-      server.on('error', (err: NodeJS.ErrnoException) => {
-        this.callbackServer = null;
-        this.serverReady = null;
-        if (err.code === 'EADDRINUSE') {
-          this.logger.warn(`Port ${CALLBACK_PORT} in use — callback server not started`);
-          reject(
-            new Error(
-              `Port ${CALLBACK_PORT} is already in use. Run 'lsof -i :${CALLBACK_PORT}' to find the process.`,
-            ),
-          );
-        } else {
-          this.logger.error(`Callback server error: ${err.message}`);
-          reject(new Error(`Callback server failed: ${err.message}`));
-        }
-      });
-      server.listen(CALLBACK_PORT, '127.0.0.1', () => {
-        this.logger.log(`OAuth callback server listening on port ${CALLBACK_PORT}`);
-        this.callbackServer = server;
-        resolve();
-      });
-      server.unref();
-    });
-    return this.serverReady;
-  }
-
-  private handleCallbackRequest(req: IncomingMessage, res: ServerResponse): void {
-    const url = new URL(req.url ?? '/', `http://localhost:${CALLBACK_PORT}`);
-    if (url.pathname !== '/auth/callback') {
-      res.writeHead(404);
-      res.end('Not found');
-      return;
-    }
-    const code = url.searchParams.get('code') ?? '';
-    const state = url.searchParams.get('state') ?? '';
-    const error = url.searchParams.get('error');
-    const appUrl = this.pending.peek(state)?.backendUrl || '';
-    if (error) {
-      const desc = url.searchParams.get('error_description') ?? error;
-      this.logger.error(`OAuth callback error from provider: ${desc}`);
-      this.pending.delete(state);
-      this.shutdownCallbackServerIfIdle();
-      this.sendDoneResponse(res, false, appUrl);
-      return;
-    }
-    this.exchangeCode(state, code)
-      .then(() => this.sendDoneResponse(res, true, appUrl))
-      .catch((err) => {
-        this.logger.error(`OAuth callback failed: ${err}`);
-        this.sendDoneResponse(res, false, appUrl);
-      });
-  }
-
-  private isAllowedRedirectOrigin(url: string): boolean {
-    try {
-      const parsed = new URL(url);
-      const hostname = parsed.hostname;
-      return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
-    } catch {
-      return false;
-    }
-  }
-
-  private sendDoneResponse(res: ServerResponse, success: boolean, appUrl: string): void {
-    if (appUrl && this.isAllowedRedirectOrigin(appUrl)) {
-      const ok = success ? '1' : '0';
-      res.writeHead(302, { Location: `${appUrl}/api/v1/oauth/openai/done?ok=${ok}` });
-      res.end();
-    } else {
-      res.writeHead(200, { 'Content-Type': 'text/html' });
-      res.end(oauthDoneHtml(success));
-    }
-  }
-
-  private shutdownCallbackServerIfIdle(): void {
-    if (this.pending.isEmpty() && this.callbackServer) {
-      this.callbackServer.close();
-      this.callbackServer = null;
-      this.serverReady = null;
-      this.logger.log('OAuth callback server shut down (no pending flows)');
-    }
   }
 }

--- a/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
@@ -1,0 +1,390 @@
+/**
+ * Shared base for redirect-PKCE OAuth providers (OpenAI, Gemini, …).
+ *
+ * Subclasses inject a `RedirectPkceOauthConfig` describing the provider's
+ * URLs / scopes / client id; the base owns the loopback callback server,
+ * PKCE state, token exchange, refresh, revoke, and the `unwrap` helper
+ * that the proxy uses to lazily refresh access tokens before forwarding.
+ *
+ * The original implementation lived inline in `openai-oauth.service.ts`.
+ * Extracted here so a second redirect-PKCE provider does not require
+ * duplicating ~250 lines of OAuth boilerplate.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
+import { ProviderService } from '../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
+import {
+  generatePkce,
+  generateState,
+  oauthDoneHtml,
+  parseOAuthTokenBlob,
+  PendingStore,
+  serializeOAuthTokenBlob,
+  type OAuthTokenBlob,
+} from './core';
+
+export interface RedirectPkceOauthConfig {
+  /** Provider id stored on `user_providers.provider_id`. */
+  readonly providerId: string;
+  /** Logger label used by the subclass. */
+  readonly serviceName: string;
+  /** Default OAuth client id (used when the env override is absent). */
+  readonly defaultClientId: string;
+  /** Optional default client secret. Some providers (Google) require one. */
+  readonly defaultClientSecret?: string;
+  /** Env var that overrides `defaultClientId`. */
+  readonly clientIdEnvVar: string;
+  /** Optional env var that overrides `defaultClientSecret`. */
+  readonly clientSecretEnvVar?: string;
+  /** OAuth authorize endpoint. */
+  readonly authorizeUrl: string;
+  /** OAuth token endpoint (authorization_code + refresh_token). */
+  readonly tokenUrl: string;
+  /** Optional revoke endpoint. When absent, `revokeToken` is a no-op. */
+  readonly revokeUrl?: string;
+  /** Scope string sent in the authorize request. */
+  readonly scope: string;
+  /** Loopback port the dev callback server binds. */
+  readonly callbackPort: number;
+  /**
+   * Extra params merged into the authorize URL. Useful for provider quirks
+   * (Google requires `access_type=offline&prompt=consent` to receive a
+   * refresh token).
+   */
+  readonly extraAuthorizeParams?: Readonly<Record<string, string>>;
+}
+
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+interface OAuthTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+}
+
+interface RedirectPkcePendingOAuth {
+  verifier: string;
+  agentId: string;
+  userId: string;
+  backendUrl: string;
+  expiresAt: number;
+}
+
+/**
+ * Build a base instance. NestJS subclasses pass their own config and the
+ * shared `ProviderService` / `ConfigService` / `ModelDiscoveryService`
+ * dependencies. The class is plain (not `@Injectable()`) so subclasses
+ * stay the DI-registered units; this matches NestJS conventions for
+ * shared abstract bases.
+ */
+export abstract class RedirectPkceOauthBaseService {
+  protected readonly logger: Logger;
+  /** In-memory pending OAuth flows (not safe behind a load balancer). */
+  private readonly pending = new PendingStore<RedirectPkcePendingOAuth>(STATE_TTL_MS);
+  private callbackServer: Server | null = null;
+  private serverReady: Promise<void> | null = null;
+  protected readonly clientId: string;
+  protected readonly clientSecret: string | undefined;
+  protected readonly redirectUri: string;
+  private readonly useCallbackServer: boolean;
+
+  constructor(
+    protected readonly providerService: ProviderService,
+    configService: ConfigService,
+    protected readonly discoveryService: ModelDiscoveryService,
+    protected readonly oauthConfig: RedirectPkceOauthConfig,
+  ) {
+    this.logger = new Logger(oauthConfig.serviceName);
+    this.clientId =
+      configService.get<string>(oauthConfig.clientIdEnvVar) ?? oauthConfig.defaultClientId;
+    this.clientSecret = oauthConfig.clientSecretEnvVar
+      ? (configService.get<string>(oauthConfig.clientSecretEnvVar) ??
+        oauthConfig.defaultClientSecret)
+      : oauthConfig.defaultClientSecret;
+    this.redirectUri = `http://localhost:${oauthConfig.callbackPort}/auth/callback`;
+    // Loopback callback server runs only in development. Production
+    // deployments (Docker self-hosted and cloud) complete the OAuth flow
+    // through the server's public URL instead.
+    this.useCallbackServer =
+      (configService.get<string>('app.nodeEnv') ?? 'development') !== 'production';
+  }
+
+  async generateAuthorizationUrl(
+    agentId: string,
+    userId: string,
+    backendUrl?: string,
+  ): Promise<string> {
+    const state = generateState();
+    const { verifier, challenge } = generatePkce();
+    // Validate the redirect target now (at storage time) instead of trusting
+    // it on the way out. The callback server only ever redirects to
+    // localhost-shaped origins, so anything else is dropped here.
+    const safeBackendUrl = backendUrl && this.isAllowedRedirectOrigin(backendUrl) ? backendUrl : '';
+    this.pending.set(state, {
+      verifier,
+      agentId,
+      userId,
+      backendUrl: safeBackendUrl,
+    });
+    if (this.useCallbackServer) {
+      await this.ensureCallbackServer();
+    }
+    const params = new URLSearchParams({
+      client_id: this.clientId,
+      redirect_uri: this.redirectUri,
+      response_type: 'code',
+      scope: this.oauthConfig.scope,
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      ...(this.oauthConfig.extraAuthorizeParams ?? {}),
+    });
+    return `${this.oauthConfig.authorizeUrl}?${params.toString()}`;
+  }
+
+  async exchangeCode(state: string, code: string): Promise<void> {
+    const pending = this.pending.peek(state);
+    if (!pending) throw new Error('Invalid or expired OAuth state');
+    if (pending.expiresAt < Date.now()) {
+      this.pending.delete(state);
+      throw new Error('OAuth state expired');
+    }
+    this.pending.delete(state);
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: this.redirectUri,
+      client_id: this.clientId,
+      code_verifier: pending.verifier,
+    });
+    if (this.clientSecret) body.set('client_secret', this.clientSecret);
+    const response = await fetch(this.oauthConfig.tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(
+        `${this.oauthConfig.providerId} token exchange failed: ${scrubSecrets(text)}`,
+      );
+      throw new Error('Token exchange failed');
+    }
+    const data = (await response.json()) as OAuthTokenResponse;
+    const blob: OAuthTokenBlob = {
+      t: data.access_token,
+      r: data.refresh_token ?? '',
+      e: Date.now() + data.expires_in * 1000,
+    };
+    const label = await this.providerService.nextOAuthLabel(
+      pending.agentId,
+      this.oauthConfig.providerId,
+    );
+    const { provider: savedProvider } = await this.providerService.upsertProvider(
+      pending.agentId,
+      pending.userId,
+      this.oauthConfig.providerId,
+      serializeOAuthTokenBlob(blob),
+      'subscription',
+      undefined,
+      label,
+    );
+    try {
+      await this.discoveryService.discoverModels(savedProvider);
+      await this.providerService.recalculateTiers(pending.agentId);
+    } catch (err) {
+      this.logger.warn(`Model discovery after OAuth failed: ${err}`);
+    }
+    this.logger.log(
+      `${this.oauthConfig.providerId} OAuth token stored for agent=${pending.agentId}`,
+    );
+    this.shutdownCallbackServerIfIdle();
+  }
+
+  async refreshAccessToken(refreshToken: string): Promise<OAuthTokenBlob> {
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: this.clientId,
+    });
+    if (this.clientSecret) body.set('client_secret', this.clientSecret);
+    const response = await fetch(this.oauthConfig.tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(
+        `${this.oauthConfig.providerId} token refresh failed: ${scrubSecrets(text)}`,
+      );
+      throw new Error('Token refresh failed');
+    }
+    const data = (await response.json()) as OAuthTokenResponse;
+    return {
+      t: data.access_token,
+      r: data.refresh_token || refreshToken,
+      e: Date.now() + data.expires_in * 1000,
+    };
+  }
+
+  /** Parse an OAuth blob and return a valid access token, refreshing if expired. */
+  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
+    const blob = parseOAuthTokenBlob(rawValue);
+    if (!blob) return null;
+    if (Date.now() < blob.e - 60_000) return blob.t;
+    if (!blob.r) return null;
+    try {
+      const refreshed = await this.refreshAccessToken(blob.r);
+      await this.providerService.upsertProvider(
+        agentId,
+        userId,
+        this.oauthConfig.providerId,
+        serializeOAuthTokenBlob(refreshed),
+        'subscription',
+      );
+      this.logger.log(`${this.oauthConfig.providerId} OAuth token refreshed for agent=${agentId}`);
+      return refreshed.t;
+    } catch (err) {
+      this.logger.error(
+        `Failed to refresh ${this.oauthConfig.providerId} token for agent=${agentId}: ${err}`,
+      );
+      return null;
+    }
+  }
+
+  /** Revoke an OAuth token at the provider (best-effort; no-op if no revoke URL). */
+  async revokeToken(token: string): Promise<void> {
+    const revokeUrl = this.oauthConfig.revokeUrl;
+    if (!revokeUrl) return;
+    try {
+      const body = new URLSearchParams({ token, client_id: this.clientId });
+      if (this.clientSecret) body.set('client_secret', this.clientSecret);
+      const response = await fetch(revokeUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        this.logger.warn(
+          `${this.oauthConfig.providerId} token revocation failed: ${scrubSecrets(text)}`,
+        );
+      } else {
+        this.logger.log(`${this.oauthConfig.providerId} OAuth token revoked`);
+      }
+    } catch (err) {
+      this.logger.warn(`${this.oauthConfig.providerId} token revocation error: ${err}`);
+    }
+  }
+
+  /** Returns the number of pending OAuth states (for testing). */
+  getPendingCount(): number {
+    return this.pending.size();
+  }
+
+  /** Remove a pending OAuth state. */
+  clearPendingState(state: string): void {
+    this.pending.delete(state);
+  }
+
+  /** Path on the loopback callback server (relative). Subclasses can override. */
+  protected get callbackPath(): string {
+    return '/auth/callback';
+  }
+
+  /** Spins up a one-shot HTTP server on `callbackPort` to receive the redirect. */
+  private ensureCallbackServer(): Promise<void> {
+    if (this.callbackServer) return Promise.resolve();
+    if (this.serverReady) return this.serverReady;
+    this.serverReady = new Promise<void>((resolve, reject) => {
+      const server = createServer((req, res) => this.handleCallbackRequest(req, res));
+      server.on('error', (err: NodeJS.ErrnoException) => {
+        this.callbackServer = null;
+        this.serverReady = null;
+        if (err.code === 'EADDRINUSE') {
+          this.logger.warn(
+            `Port ${this.oauthConfig.callbackPort} in use — callback server not started`,
+          );
+          reject(
+            new Error(
+              `Port ${this.oauthConfig.callbackPort} is already in use. Run 'lsof -i :${this.oauthConfig.callbackPort}' to find the process.`,
+            ),
+          );
+        } else {
+          this.logger.error(`Callback server error: ${err.message}`);
+          reject(new Error(`Callback server failed: ${err.message}`));
+        }
+      });
+      server.listen(this.oauthConfig.callbackPort, '127.0.0.1', () => {
+        this.logger.log(`OAuth callback server listening on port ${this.oauthConfig.callbackPort}`);
+        this.callbackServer = server;
+        resolve();
+      });
+      server.unref();
+    });
+    return this.serverReady;
+  }
+
+  private handleCallbackRequest(req: IncomingMessage, res: ServerResponse): void {
+    const url = new URL(req.url ?? '/', `http://localhost:${this.oauthConfig.callbackPort}`);
+    if (url.pathname !== this.callbackPath) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const code = url.searchParams.get('code') ?? '';
+    const state = url.searchParams.get('state') ?? '';
+    const error = url.searchParams.get('error');
+    const appUrl = this.pending.peek(state)?.backendUrl || '';
+    if (error) {
+      const desc = url.searchParams.get('error_description') ?? error;
+      this.logger.error(`OAuth callback error from provider: ${desc}`);
+      this.pending.delete(state);
+      this.shutdownCallbackServerIfIdle();
+      this.sendDoneResponse(res, false, appUrl);
+      return;
+    }
+    this.exchangeCode(state, code)
+      .then(() => this.sendDoneResponse(res, true, appUrl))
+      .catch((err) => {
+        this.logger.error(`OAuth callback failed: ${err}`);
+        this.sendDoneResponse(res, false, appUrl);
+      });
+  }
+
+  private isAllowedRedirectOrigin(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      const hostname = parsed.hostname;
+      return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    } catch {
+      return false;
+    }
+  }
+
+  private sendDoneResponse(res: ServerResponse, success: boolean, appUrl: string): void {
+    if (appUrl && this.isAllowedRedirectOrigin(appUrl)) {
+      const ok = success ? '1' : '0';
+      res.writeHead(302, {
+        Location: `${appUrl}/api/v1/oauth/${this.oauthConfig.providerId}/done?ok=${ok}`,
+      });
+      res.end();
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(oauthDoneHtml(success));
+    }
+  }
+
+  private shutdownCallbackServerIfIdle(): void {
+    if (this.pending.isEmpty() && this.callbackServer) {
+      this.callbackServer.close();
+      this.callbackServer = null;
+      this.serverReady = null;
+      this.logger.log('OAuth callback server shut down (no pending flows)');
+    }
+  }
+}

--- a/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
@@ -235,6 +235,10 @@ export abstract class RedirectPkceOauthBaseService {
   async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
     const blob = parseOAuthTokenBlob(rawValue);
     if (!blob) return null;
+    // Access token + expiry are required to use the token at all. Refresh
+    // token is only required when we need to refresh — providers that omit
+    // it (or token responses where we exchanged a code with no offline scope)
+    // still produce a usable short-lived access token.
     if (Date.now() < blob.e - 60_000) return blob.t;
     if (!blob.r) return null;
     try {


### PR DESCRIPTION
### ✨ What changed
- New \`RedirectPkceOauthBaseService\` owns the loopback callback server, PKCE state, token exchange/refresh, and revoke logic.
- \`OpenaiOauthService\` becomes a 16-line subclass that supplies the OpenAI config; public API and test contract preserved.
- Config supports optional \`client_secret\` and \`extraAuthorizeParams\` so providers like Google can plug in without further base changes.

### 💭 Why
A second redirect-PKCE provider (Gemini, gemini-cli flow) would otherwise duplicate ~290 lines of identical OAuth boilerplate.

### 📝 Notes
- All 55 OpenAI OAuth specs pass without changes; full OAuth + proxy suite (1388 tests) green.
- Internal-only refactor, no user-visible impact, empty changeset attached.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a reusable redirect-PKCE OAuth base and fixed token unwrap when providers omit a refresh token. `OpenaiOauthService` now extends the base; no public API change.

- **Refactors**
  - Added `RedirectPkceOauthBaseService` to handle loopback callback server, PKCE state, token exchange/refresh, revoke, and unwrap.
  - Simplified `OpenaiOauthService` to a thin subclass that supplies provider config (id, URLs, scope, callback port); config supports optional `client_secret` and `extraAuthorizeParams`.

- **Bug Fixes**
  - Unwrap returns a valid access token when `refresh_token` is absent and unexpired; returns null if expired with no refresh. Added regression tests for both cases.

<sup>Written for commit c140de7954dce6dcca875939330b5ce2a31c5cd6. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1845?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

