### PR TITLE
feat: add param_defaults to header tiers

### DIFF
--- a/.changeset/header-tier-param-defaults.md
+++ b/.changeset/header-tier-param-defaults.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add `param_defaults` storage to header tiers (custom routing) so the same per-assignment request body defaults available on default and task-specific routing also work when a custom header tier matches. Adds the `header_tiers.param_defaults` JSONB column, the `PATCH /api/v1/routing/:agent/header-tiers/:id/params` endpoint, and threads the configured defaults through resolution into the proxy merge — applied to the primary route AND every fallback in the tier, filtered per-attempt against whichever provider the iteration is talking to. No frontend surface yet; the dialog wiring lands in a follow-up.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -92,6 +92,7 @@ import { AddParamDefaultsColumns1785000000000 } from './migrations/1785000000000
 import { AddProviderKeyLabelAndPriority1785000000000 } from './migrations/1785000000000-AddProviderKeyLabelAndPriority';
 import { AddProviderKeyLabelToAgentMessages1785100000000 } from './migrations/1785100000000-AddProviderKeyLabelToAgentMessages';
 import { AddRequestParamsColumn1786000000000 } from './migrations/1786000000000-AddRequestParamsColumn';
+import { AddHeaderTierParamDefaults1787000000000 } from './migrations/1787000000000-AddHeaderTierParamDefaults';
 
 const entities = [
   AgentMessage,
@@ -185,6 +186,7 @@ const migrations = [
   AddProviderKeyLabelAndPriority1785000000000,
   AddProviderKeyLabelToAgentMessages1785100000000,
   AddRequestParamsColumn1786000000000,
+  AddHeaderTierParamDefaults1787000000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1787000000000-AddHeaderTierParamDefaults.spec.ts
+++ b/packages/backend/src/database/migrations/1787000000000-AddHeaderTierParamDefaults.spec.ts
@@ -1,0 +1,27 @@
+import { AddHeaderTierParamDefaults1787000000000 } from './1787000000000-AddHeaderTierParamDefaults';
+
+describe('AddHeaderTierParamDefaults1787000000000', () => {
+  let migration: AddHeaderTierParamDefaults1787000000000;
+  let queryRunner: { query: jest.Mock };
+
+  beforeEach(() => {
+    migration = new AddHeaderTierParamDefaults1787000000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('up adds a nullable jsonb param_defaults column on header_tiers', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await migration.up(queryRunner as any);
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      `ALTER TABLE "header_tiers" ADD COLUMN IF NOT EXISTS "param_defaults" jsonb DEFAULT NULL`,
+    );
+  });
+
+  it('down drops the column', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await migration.down(queryRunner as any);
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      `ALTER TABLE "header_tiers" DROP COLUMN IF EXISTS "param_defaults"`,
+    );
+  });
+});

--- a/packages/backend/src/database/migrations/1787000000000-AddHeaderTierParamDefaults.ts
+++ b/packages/backend/src/database/migrations/1787000000000-AddHeaderTierParamDefaults.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a nullable `param_defaults` JSONB column to header_tiers, mirroring
+ * the column already present on tier_assignments and specificity_assignments
+ * so the same param-defaults storage and merge work uniformly across all
+ * three routing surfaces.
+ */
+export class AddHeaderTierParamDefaults1787000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "header_tiers" ADD COLUMN IF NOT EXISTS "param_defaults" jsonb DEFAULT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "header_tiers" DROP COLUMN IF EXISTS "param_defaults"`);
+  }
+}

--- a/packages/backend/src/entities/header-tier.entity.ts
+++ b/packages/backend/src/entities/header-tier.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
-import type { ModelRoute, TierColor } from 'manifest-shared';
+import type { ModelRoute, RequestParamDefaults, TierColor } from 'manifest-shared';
 
 @Entity('header_tiers')
 @Index(['agent_id', 'sort_order'])
@@ -44,6 +44,9 @@ export class HeaderTier {
 
   @Column('jsonb', { nullable: true })
   fallback_routes!: ModelRoute[] | null;
+
+  @Column('jsonb', { nullable: true })
+  param_defaults!: RequestParamDefaults | null;
 
   @Column(timestampType(), { default: timestampDefault() })
   created_at!: string;

--- a/packages/backend/src/routing/dto/routing.dto.ts
+++ b/packages/backend/src/routing/dto/routing.dto.ts
@@ -183,12 +183,12 @@ export class SetOverrideDto {
 }
 
 /**
- * Body for `PATCH …/tiers/:tier/params` and `…/specificity/:category/params`.
- * `paramDefaults: null` clears the configured defaults; an object replaces
- * them wholesale. Validation only checks the shape — not the field set —
- * because new provider knobs (`reasoning_effort`, `safety`, custom-provider
- * params, …) shouldn't require a backend release. The frontend curates the
- * surface; the column accepts any JSONB.
+ * Body for the `…/params` PATCH endpoints on tiers, specificity categories,
+ * and header tiers. `paramDefaults: null` clears the configured defaults;
+ * an object replaces them wholesale. Validation only checks the shape — not
+ * the field set — because new provider knobs (`reasoning_effort`, `safety`,
+ * custom-provider params, …) shouldn't require a backend release. The
+ * frontend curates the surface; the column accepts any JSONB.
  */
 export class SetParamDefaultsDto {
   @IsOptional()

--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -513,4 +513,38 @@ describe('HeaderTierService', () => {
       await expect(svc.clearFallbacks('agent-1', 'h1')).rejects.toThrow(NotFoundException);
     });
   });
+
+  describe('setParamDefaults', () => {
+    it('writes the configured defaults and invalidates the cache', async () => {
+      const row = {
+        id: 'h1',
+        agent_id: 'agent-1',
+        param_defaults: null,
+        updated_at: 'old',
+      } as unknown as HeaderTier;
+      repo.findOne.mockResolvedValue(row);
+      const defaults = { thinking: { type: 'disabled' as const } };
+      const result = await svc.setParamDefaults('agent-1', 'h1', defaults);
+      expect(result.param_defaults).toEqual(defaults);
+      expect(result.updated_at).not.toBe('old');
+      expect(repo.save).toHaveBeenCalledWith(row);
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('clears the configured defaults when passed null', async () => {
+      const row = {
+        id: 'h1',
+        agent_id: 'agent-1',
+        param_defaults: { thinking: { type: 'enabled' as const } },
+      } as unknown as HeaderTier;
+      repo.findOne.mockResolvedValue(row);
+      const result = await svc.setParamDefaults('agent-1', 'h1', null);
+      expect(result.param_defaults).toBeNull();
+    });
+
+    it('throws NotFound when row missing', async () => {
+      repo.findOne.mockResolvedValue(null);
+      await expect(svc.setParamDefaults('agent-1', 'h1', null)).rejects.toThrow(NotFoundException);
+    });
+  });
 });

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
@@ -15,6 +15,7 @@ function makeController(overrides?: { tenantId?: string | null }) {
     clearOverride: jest.fn().mockResolvedValue(undefined),
     setFallbacks: jest.fn().mockResolvedValue(['m']),
     clearFallbacks: jest.fn().mockResolvedValue(undefined),
+    setParamDefaults: jest.fn().mockResolvedValue({ id: 'ht-1', param_defaults: null }),
   } as unknown as jest.Mocked<HeaderTierService>;
 
   const resolveAgentService = {
@@ -136,5 +137,18 @@ describe('HeaderTierController', () => {
     const out = await controller.clearFallbacks(user, 'my-agent', 'ht-1');
     expect(service.clearFallbacks).toHaveBeenCalledWith('agent-1', 'ht-1');
     expect(out).toEqual({ ok: true });
+  });
+
+  it('setParamDefaults forwards the body to the service', async () => {
+    const { controller, service } = makeController();
+    const body = { paramDefaults: { thinking: { type: 'disabled' as const } } };
+    await controller.setParamDefaults(user, 'my-agent', 'ht-1', body);
+    expect(service.setParamDefaults).toHaveBeenCalledWith('agent-1', 'ht-1', body.paramDefaults);
+  });
+
+  it('setParamDefaults coerces a missing body to null', async () => {
+    const { controller, service } = makeController();
+    await controller.setParamDefaults(user, 'my-agent', 'ht-1', {});
+    expect(service.setParamDefaults).toHaveBeenCalledWith('agent-1', 'ht-1', null);
   });
 });

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.ts
@@ -23,9 +23,9 @@ import { CurrentUser } from '../../auth/current-user.decorator';
 import type { AuthUser } from '../../auth/auth.instance';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
-import { ModelRouteDto } from '../dto/routing.dto';
+import { ModelRouteDto, SetParamDefaultsDto } from '../dto/routing.dto';
 import { HeaderTierService } from './header-tier.service';
-import { AUTH_TYPES, type TierColor } from 'manifest-shared';
+import { AUTH_TYPES, type RequestParamDefaults, type TierColor } from 'manifest-shared';
 
 interface CreateHeaderTierBody {
   name: string;
@@ -197,5 +197,20 @@ export class HeaderTierController {
     const agent = await this.resolveAgentService.resolve(user.id, agentName);
     await this.headerTierService.clearFallbacks(agent.id, id);
     return { ok: true };
+  }
+
+  @Patch(':agentName/header-tiers/:id/params')
+  async setParamDefaults(
+    @CurrentUser() user: AuthUser,
+    @Param('agentName') agentName: string,
+    @Param('id') id: string,
+    @Body() body: SetParamDefaultsDto,
+  ) {
+    const agent = await this.resolveAgentService.resolve(user.id, agentName);
+    return this.headerTierService.setParamDefaults(
+      agent.id,
+      id,
+      (body.paramDefaults ?? null) as RequestParamDefaults | null,
+    );
   }
 }

--- a/packages/backend/src/routing/header-tiers/header-tier.service.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
-import type { AuthType, ModelRoute } from 'manifest-shared';
+import type { AuthType, ModelRoute, RequestParamDefaults } from 'manifest-shared';
 import { TIER_COLORS, type TierColor } from 'manifest-shared';
 import { HeaderTier } from '../../entities/header-tier.entity';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
@@ -87,6 +87,7 @@ export class HeaderTierService {
       enabled: true,
       override_route: null,
       fallback_routes: null,
+      param_defaults: null,
       created_at: now,
       updated_at: now,
     });
@@ -217,6 +218,24 @@ export class HeaderTierService {
     row.updated_at = new Date().toISOString();
     await this.repo.save(row);
     this.routingCache.invalidateAgent(agentId);
+  }
+
+  /**
+   * Set or clear the configured request body defaults for a header tier.
+   * Pass `null` to clear. Storage is at the tier level, so the same defaults
+   * apply to the primary route AND every fallback in the tier.
+   */
+  async setParamDefaults(
+    agentId: string,
+    id: string,
+    paramDefaults: RequestParamDefaults | null,
+  ): Promise<HeaderTier> {
+    const row = await this.findOrThrow(agentId, id);
+    row.param_defaults = paramDefaults;
+    row.updated_at = new Date().toISOString();
+    await this.repo.save(row);
+    this.routingCache.invalidateAgent(agentId);
+    return row;
   }
 
   /**

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -144,6 +144,36 @@ describe('ResolveService', () => {
       expect(result.header_tier_color).toBe('red');
     });
 
+    it('threads param_defaults from the matched header tier', async () => {
+      const tier = {
+        id: 'h1',
+        name: 'Premium',
+        header_key: 'x-tier',
+        header_value: 'gold',
+        enabled: true,
+        badge_color: 'red',
+        override_route: route('deepseek', 'api_key', 'deepseek-chat'),
+        fallback_routes: null,
+        param_defaults: { thinking: { type: 'disabled' } },
+      } as unknown as HeaderTier;
+      headerTierService.list.mockResolvedValue([tier]);
+
+      const result = await svc.resolve(
+        'agent-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'x-tier': 'gold' },
+      );
+
+      expect(result.reason).toBe('header-match');
+      expect(result.param_defaults).toEqual({ thinking: { type: 'disabled' } });
+    });
+
     it('returns null when no header tiers exist', async () => {
       headerTierService.list.mockResolvedValue([]);
       const result = await svc.resolve(

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -199,6 +199,7 @@ export class ResolveService {
       header_tier_id: match.id,
       header_tier_name: match.name,
       header_tier_color: match.badge_color,
+      param_defaults: match.param_defaults,
     };
   }
 


### PR DESCRIPTION
### ✨ What changed
- New \`header_tiers.param_defaults\` JSONB column (migration 1787).
- New \`PATCH /api/v1/routing/:agent/header-tiers/:id/params\` endpoint reusing \`SetParamDefaultsDto\`.
- \`HeaderTierService.setParamDefaults\` mirrors the tier/specificity shape.
- \`resolveHeaderTier\` threads the matched tier's \`param_defaults\` into \`ResolveResponse\`, so the proxy merge already in place applies them per attempt.

### 💭 Why
Default and task-specific routing already store per-assignment request body defaults (today: DeepSeek's \`thinking\` toggle). Header tiers had no parity, so a custom routing rule could never carry the same configured defaults. This is the backend half of the symmetry; the frontend dialog wiring lands separately.

### 🔧 For operators
- Migration adds one nullable column; auto-runs on boot.
- No env vars or config changes.

### 📝 Notes
- No frontend in this PR.
- Codex review: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `param_defaults` to header tiers and apply them during resolution, enabling header-based rules to set request body defaults across primary and fallback routes. Adds `PATCH /api/v1/routing/:agent/header-tiers/:id/params` to set or clear these defaults.

- **New Features**
  - Store defaults in `header_tiers.param_defaults` (JSONB).
  - Proxy merges defaults per attempt; filtered to the active provider.
  - `SetParamDefaultsDto` accepts an object or `null` to clear.

- **Migration**
  - Adds nullable `param_defaults` column; runs on boot.
  - No env or config changes.

<sup>Written for commit 8d55f2df03528b0670b0397880e63100a6044062. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

