### PR TITLE
fix(routing): show params button when DeepSeek is a fallback

### DIFF
--- a/.changeset/params-fallback-visibility.md
+++ b/.changeset/params-fallback-visibility.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show the Model Parameters button on a routing tier when any route in the tier — primary or fallback — uses a params-compatible provider. Previously the button was gated to the primary route only, so a tier with DeepSeek configured as a fallback hid the toggle even though the proxy already applies tier-level `param_defaults` to whichever provider an attempt actually targets. The dialog's provider-default hint follows the first compatible route in the ordered (primary, …fallbacks) list.

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -392,8 +392,8 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                     <Show
                       when={
                         props.onConfigureParams &&
-                        route()?.provider &&
-                        providerThinkingDefault(route()!.provider) !== undefined
+                        provId() &&
+                        providerThinkingDefault(provId()!) !== undefined
                       }
                     >
                       <button

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -19,6 +19,7 @@ import {
 import { toast } from '../services/toast-store.js';
 import { authBadgeFor } from './AuthBadge.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
+import { providerThinkingDefault } from 'manifest-shared';
 
 interface FallbackListProps {
   agentName: string;
@@ -52,6 +53,12 @@ interface FallbackListProps {
     routes?: ModelRoute[],
   ) => Promise<unknown>;
   persistClearFallbacks?: (agentName: string, tier: string) => Promise<unknown>;
+  // Open the tier's Model Parameters dialog. Rendered per-row when the
+  // row's route provider consumes a known param key (today only DeepSeek's
+  // `thinking`). Param defaults are tier-scoped — the proxy filters per
+  // attempt against the actual provider — so the affordance can attach to
+  // whichever fallback row is compatible without owning its own state.
+  onConfigureParams?: () => void;
 }
 
 const FallbackList: Component<FallbackListProps> = (props) => {
@@ -381,6 +388,42 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                         fallbackIndex={i()}
                         onPick={(label) => setLabelAt(i(), label)}
                       />
+                    </Show>
+                    <Show
+                      when={
+                        props.onConfigureParams &&
+                        route()?.provider &&
+                        providerThinkingDefault(route()!.provider) !== undefined
+                      }
+                    >
+                      <button
+                        class="fallback-list__params"
+                        onClick={() => props.onConfigureParams!()}
+                        title="Model parameters"
+                        aria-label={`Configure model parameters for ${modelLabel(model())}`}
+                      >
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          aria-hidden="true"
+                        >
+                          <line x1="4" y1="21" x2="4" y2="14" />
+                          <line x1="4" y1="10" x2="4" y2="3" />
+                          <line x1="12" y1="21" x2="12" y2="12" />
+                          <line x1="12" y1="8" x2="12" y2="3" />
+                          <line x1="20" y1="21" x2="20" y2="16" />
+                          <line x1="20" y1="12" x2="20" y2="3" />
+                          <line x1="1" y1="14" x2="7" y2="14" />
+                          <line x1="9" y1="8" x2="15" y2="8" />
+                          <line x1="17" y1="16" x2="23" y2="16" />
+                        </svg>
+                      </button>
                     </Show>
                     <button
                       class="fallback-list__remove"

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -149,26 +149,29 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
   const [primaryDropTarget, setPrimaryDropTarget] = createSignal(false);
   const [paramsDialogOpen, setParamsDialogOpen] = createSignal(false);
 
-  // The sliders icon renders when any route in the tier (primary or fallback)
-  // hits a provider whose API consumes a known param key — today only
-  // DeepSeek's `thinking`. Param defaults are stored at the tier level and
-  // filtered per-attempt against the actual provider in the proxy, so a tier
-  // with DeepSeek only as a fallback still benefits from the toggle. The
-  // dialog's provider-default hint follows the first compatible route in the
-  // ordered list, primary first.
-  const orderedRouteProviders = (): string[] => {
+  // The sliders icon renders next to whichever route — primary or fallback —
+  // uses a provider whose API consumes a known param key (today only
+  // DeepSeek's `thinking`). Param defaults are stored at the tier level and
+  // filtered per-attempt against the actual provider in the proxy, so the
+  // affordance attaches to the route that actually consumes the value rather
+  // than always living next to the primary.
+  const primaryProvider = (): string | null => {
     const t = props.tier();
-    if (!t) return [];
-    const out: string[] = [];
-    const primary = effectiveRoute(t)?.provider;
-    if (primary) out.push(primary);
-    for (const r of t.fallback_routes ?? []) {
-      if (r.provider) out.push(r.provider);
-    }
-    return out;
+    return t ? (effectiveRoute(t)?.provider ?? null) : null;
   };
-  const paramSurfaceProvider = () =>
-    orderedRouteProviders().find((p) => providerThinkingDefault(p) !== undefined) ?? null;
+  const primarySupportsParams = () => {
+    const p = primaryProvider();
+    return p !== null && providerThinkingDefault(p) !== undefined;
+  };
+  const paramSurfaceProvider = (): string | null => {
+    const fromPrimary = primaryProvider();
+    if (fromPrimary && providerThinkingDefault(fromPrimary) !== undefined) return fromPrimary;
+    const t = props.tier();
+    for (const r of t?.fallback_routes ?? []) {
+      if (r.provider && providerThinkingDefault(r.provider) !== undefined) return r.provider;
+    }
+    return null;
+  };
   const supportsParams = () => paramSurfaceProvider() !== null;
   const paramsConfigured = () => (props.tier()?.param_defaults ?? null) !== null;
 
@@ -507,7 +510,7 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                             }}
                             disabled={() => props.changingTier() === props.stage.id}
                           />
-                          <Show when={supportsParams() && props.persistParamDefaults}>
+                          <Show when={primarySupportsParams() && props.persistParamDefaults}>
                             <button
                               class="routing-card__chip-action"
                               classList={{
@@ -605,6 +608,9 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
               onFallbackDragEnd={() => setFallbackDragging(null)}
               persistFallbacks={props.persistFallbacks}
               persistClearFallbacks={props.persistClearFallbacks}
+              onConfigureParams={
+                props.persistParamDefaults ? () => setParamsDialogOpen(true) : undefined
+              }
             />
           </div>
         </Show>

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -149,20 +149,27 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
   const [primaryDropTarget, setPrimaryDropTarget] = createSignal(false);
   const [paramsDialogOpen, setParamsDialogOpen] = createSignal(false);
 
-  // The sliders icon only renders for providers whose API consumes a known
-  // param key (today: DeepSeek's `thinking`). Picking the resolved primary's
-  // provider here keeps the icon consistent with the chip the user is
-  // looking at — multi-key compat is implicit because params are stored at
-  // the tier level, independent of which key is currently pinned.
-  const paramSurfaceProvider = () => {
+  // The sliders icon renders when any route in the tier (primary or fallback)
+  // hits a provider whose API consumes a known param key — today only
+  // DeepSeek's `thinking`. Param defaults are stored at the tier level and
+  // filtered per-attempt against the actual provider in the proxy, so a tier
+  // with DeepSeek only as a fallback still benefits from the toggle. The
+  // dialog's provider-default hint follows the first compatible route in the
+  // ordered list, primary first.
+  const orderedRouteProviders = (): string[] => {
     const t = props.tier();
-    const route = t ? effectiveRoute(t) : null;
-    return route?.provider ?? null;
+    if (!t) return [];
+    const out: string[] = [];
+    const primary = effectiveRoute(t)?.provider;
+    if (primary) out.push(primary);
+    for (const r of t.fallback_routes ?? []) {
+      if (r.provider) out.push(r.provider);
+    }
+    return out;
   };
-  const supportsParams = () => {
-    const p = paramSurfaceProvider();
-    return p !== null && providerThinkingDefault(p) !== undefined;
-  };
+  const paramSurfaceProvider = () =>
+    orderedRouteProviders().find((p) => providerThinkingDefault(p) !== undefined) ?? null;
+  const supportsParams = () => paramSurfaceProvider() !== null;
   const paramsConfigured = () => (props.tier()?.param_defaults ?? null) !== null;
 
   const handlePrimaryDragStart = (e: DragEvent) => {

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -980,6 +980,23 @@
   color: hsl(var(--destructive));
 }
 
+.fallback-list__params {
+  background: none;
+  border: none;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  line-height: 1;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  transition: color var(--transition-fast);
+}
+
+.fallback-list__params:hover {
+  color: hsl(var(--foreground));
+}
+
 /* Add fallback — uses btn btn--outline btn--sm, just adds spacing */
 .fallback-list__add {
   margin-top: 6px;

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -1045,4 +1045,58 @@ describe("FallbackList", () => {
       );
     });
   });
+
+  describe("per-row params button", () => {
+    const deepseekRoute = {
+      provider: "deepseek",
+      authType: "api_key" as const,
+      model: "deepseek-v4-flash",
+      keyLabel: null,
+    };
+    const openaiRoute = {
+      provider: "openai",
+      authType: "api_key" as const,
+      model: "gpt-4o",
+      keyLabel: null,
+    };
+
+    it("renders the params button on a fallback row whose provider consumes a known param key", () => {
+      const onConfigureParams = vi.fn();
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={["deepseek-v4-flash"]}
+          fallbackRoutes={[deepseekRoute] as any}
+          onConfigureParams={onConfigureParams}
+        />
+      ));
+      const btn = container.querySelector(".fallback-list__params") as HTMLButtonElement | null;
+      expect(btn).not.toBeNull();
+      fireEvent.click(btn!);
+      expect(onConfigureParams).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT render the params button when the row's provider has no known param key", () => {
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={["gpt-4o"]}
+          fallbackRoutes={[openaiRoute] as any}
+          onConfigureParams={vi.fn()}
+        />
+      ));
+      expect(container.querySelector(".fallback-list__params")).toBeNull();
+    });
+
+    it("does NOT render the params button when onConfigureParams is undefined", () => {
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          fallbacks={["deepseek-v4-flash"]}
+          fallbackRoutes={[deepseekRoute] as any}
+        />
+      ));
+      expect(container.querySelector(".fallback-list__params")).toBeNull();
+    });
+  });
 });

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -1098,5 +1098,28 @@ describe("FallbackList", () => {
       ));
       expect(container.querySelector(".fallback-list__params")).toBeNull();
     });
+
+    it("renders the params button when fallbackRoutes is null and provider is derived from the models list", () => {
+      // Legacy / pre-backfill data path: structured routes are not available
+      // yet, but the row's provider can still be resolved via the model
+      // catalog. Visibility must follow the resolved provider, not require
+      // an explicit ModelRoute.
+      const onConfigureParams = vi.fn();
+      const modelsWithDeepseek = [
+        ...models,
+        { model_name: "deepseek-v4-flash", provider: "DeepSeek" },
+      ] as any[];
+      const { container } = render(() => (
+        <FallbackList
+          {...defaultProps}
+          models={modelsWithDeepseek}
+          fallbacks={["deepseek-v4-flash"]}
+          fallbackRoutes={null}
+          onConfigureParams={onConfigureParams}
+        />
+      ));
+      const btn = container.querySelector(".fallback-list__params") as HTMLButtonElement | null;
+      expect(btn).not.toBeNull();
+    });
   });
 });

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -1247,7 +1247,7 @@ describe("RoutingTierCard", () => {
         <RoutingTierCard {...makeProps({ persistParamDefaults: vi.fn() })} />
       ));
       const labels = Array.from(
-        container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
+        container.querySelectorAll<HTMLButtonElement>("button"),
       ).map((b) => b.getAttribute("aria-label"));
       expect(labels.some((l) => l?.startsWith("Configure model parameters"))).toBe(false);
     });
@@ -1264,7 +1264,7 @@ describe("RoutingTierCard", () => {
         />
       ));
       const labels = Array.from(
-        container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
+        container.querySelectorAll<HTMLButtonElement>("button"),
       ).map((b) => b.getAttribute("aria-label"));
       expect(labels.some((l) => l?.startsWith("Configure model parameters"))).toBe(false);
     });
@@ -1282,7 +1282,7 @@ describe("RoutingTierCard", () => {
         />
       ));
       const btn = Array.from(
-        container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
+        container.querySelectorAll<HTMLButtonElement>("button"),
       ).find((b) => b.getAttribute("aria-label")?.startsWith("Configure model parameters"));
       expect(btn).toBeDefined();
       // Configured-state class only flips when param_defaults is non-null. Plain
@@ -1307,17 +1307,17 @@ describe("RoutingTierCard", () => {
         />
       ));
       const btn = Array.from(
-        container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
+        container.querySelectorAll<HTMLButtonElement>("button"),
       ).find((b) => b.getAttribute("aria-label")?.startsWith("Configure model parameters"));
       expect(btn).toBeDefined();
       expect(btn!.classList.contains("routing-card__chip-action--configured")).toBe(true);
     });
 
-    it("renders the sliders icon when DeepSeek is only a fallback", () => {
-      // Primary is OpenAI (no thinking param), fallback is DeepSeek. The
-      // tier-level `param_defaults` is filtered per-attempt against each
-      // route's provider in the proxy, so the affordance must be reachable
-      // even when the user picked OpenAI as primary.
+    it("hides the chip-level params button when primary is not params-compatible (DeepSeek only as fallback)", () => {
+      // Primary OpenAI (no thinking), DeepSeek as fallback. The chip-level
+      // icon would be misleading here — the params apply to DeepSeek, not
+      // Claude/OpenAI — so the chip stays clean. The fallback row gets its
+      // own button via FallbackList (covered by FallbackList tests).
       const openaiPrimaryDeepseekFallback: TierAssignment = {
         id: "t-mixed",
         agent_id: "a1",
@@ -1367,10 +1367,42 @@ describe("RoutingTierCard", () => {
           })}
         />
       ));
-      const btn = Array.from(
+      const chipBtn = Array.from(
         container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
       ).find((b) => b.getAttribute("aria-label")?.startsWith("Configure model parameters"));
-      expect(btn).toBeDefined();
+      expect(chipBtn).toBeUndefined();
+    });
+
+    it("passes onConfigureParams to FallbackList when persistParamDefaults is wired", () => {
+      const persist = vi.fn();
+      render(() => (
+        <RoutingTierCard
+          {...makeProps({
+            tier: () => deepseekTier,
+            models: () => deepseekModels,
+            activeProviders: () => deepseekProviders,
+            connectedProviders: () => deepseekProviders,
+            persistParamDefaults: persist,
+          })}
+        />
+      ));
+      const fbProps = fallbackListProps[fallbackListProps.length - 1];
+      expect(typeof fbProps.onConfigureParams).toBe("function");
+    });
+
+    it("omits onConfigureParams on FallbackList when persistParamDefaults is not wired", () => {
+      render(() => (
+        <RoutingTierCard
+          {...makeProps({
+            tier: () => deepseekTier,
+            models: () => deepseekModels,
+            activeProviders: () => deepseekProviders,
+            connectedProviders: () => deepseekProviders,
+          })}
+        />
+      ));
+      const fbProps = fallbackListProps[fallbackListProps.length - 1];
+      expect(fbProps.onConfigureParams).toBeUndefined();
     });
 
     it("does not render the sliders icon when neither primary nor any fallback is params-compatible", () => {
@@ -1442,7 +1474,7 @@ describe("RoutingTierCard", () => {
         />
       ));
       const labels = Array.from(
-        container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
+        container.querySelectorAll<HTMLButtonElement>("button"),
       ).map((b) => b.getAttribute("aria-label"));
       expect(labels.some((l) => l?.startsWith("Configure model parameters"))).toBe(false);
     });
@@ -1463,7 +1495,7 @@ describe("RoutingTierCard", () => {
         />
       ));
       const btn = Array.from(
-        container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
+        container.querySelectorAll<HTMLButtonElement>("button"),
       ).find((b) => b.getAttribute("aria-label")?.startsWith("Configure model parameters"))!;
       fireEvent.click(btn);
 

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -1313,6 +1313,140 @@ describe("RoutingTierCard", () => {
       expect(btn!.classList.contains("routing-card__chip-action--configured")).toBe(true);
     });
 
+    it("renders the sliders icon when DeepSeek is only a fallback", () => {
+      // Primary is OpenAI (no thinking param), fallback is DeepSeek. The
+      // tier-level `param_defaults` is filtered per-attempt against each
+      // route's provider in the proxy, so the affordance must be reachable
+      // even when the user picked OpenAI as primary.
+      const openaiPrimaryDeepseekFallback: TierAssignment = {
+        id: "t-mixed",
+        agent_id: "a1",
+        tier: "simple",
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        auto_assigned_route: null,
+        fallback_routes: [
+          { provider: "deepseek", authType: "api_key", model: "deepseek-v4-flash" },
+        ],
+        updated_at: "2025-01-01",
+      };
+      const mixedModels: AvailableModel[] = [
+        ...deepseekModels,
+        {
+          model_name: "gpt-4o",
+          provider: "OpenAI",
+          auth_type: "api_key",
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+          context_window: 128000,
+          capability_reasoning: false,
+          capability_code: false,
+          quality_score: 8,
+          display_name: "GPT-4o",
+        },
+      ];
+      const mixedProviders: RoutingProvider[] = [
+        ...deepseekProviders,
+        {
+          id: "p-oa",
+          provider: "openai",
+          auth_type: "api_key",
+          is_active: true,
+          has_api_key: true,
+          connected_at: "2025-01-01",
+        },
+      ];
+      const { container } = render(() => (
+        <RoutingTierCard
+          {...makeProps({
+            tier: () => openaiPrimaryDeepseekFallback,
+            models: () => mixedModels,
+            activeProviders: () => mixedProviders,
+            connectedProviders: () => mixedProviders,
+            persistParamDefaults: vi.fn(),
+            getFallbacksFor: () => ["deepseek-v4-flash"],
+          })}
+        />
+      ));
+      const btn = Array.from(
+        container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
+      ).find((b) => b.getAttribute("aria-label")?.startsWith("Configure model parameters"));
+      expect(btn).toBeDefined();
+    });
+
+    it("does not render the sliders icon when neither primary nor any fallback is params-compatible", () => {
+      const openaiOnlyTier: TierAssignment = {
+        id: "t-oa",
+        agent_id: "a1",
+        tier: "simple",
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        auto_assigned_route: null,
+        fallback_routes: [
+          { provider: "anthropic", authType: "api_key", model: "claude-sonnet-4-6" },
+        ],
+        updated_at: "2025-01-01",
+      };
+      const openaiAnthropicModels: AvailableModel[] = [
+        {
+          model_name: "gpt-4o",
+          provider: "OpenAI",
+          auth_type: "api_key",
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+          context_window: 128000,
+          capability_reasoning: false,
+          capability_code: false,
+          quality_score: 8,
+          display_name: "GPT-4o",
+        },
+        {
+          model_name: "claude-sonnet-4-6",
+          provider: "Anthropic",
+          auth_type: "api_key",
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+          context_window: 200000,
+          capability_reasoning: false,
+          capability_code: false,
+          quality_score: 9,
+          display_name: "Claude Sonnet 4.6",
+        },
+      ];
+      const openaiAnthropicProviders: RoutingProvider[] = [
+        {
+          id: "p-oa",
+          provider: "openai",
+          auth_type: "api_key",
+          is_active: true,
+          has_api_key: true,
+          connected_at: "2025-01-01",
+        },
+        {
+          id: "p-an",
+          provider: "anthropic",
+          auth_type: "api_key",
+          is_active: true,
+          has_api_key: true,
+          connected_at: "2025-01-01",
+        },
+      ];
+      const { container } = render(() => (
+        <RoutingTierCard
+          {...makeProps({
+            tier: () => openaiOnlyTier,
+            models: () => openaiAnthropicModels,
+            activeProviders: () => openaiAnthropicProviders,
+            connectedProviders: () => openaiAnthropicProviders,
+            persistParamDefaults: vi.fn(),
+            getFallbacksFor: () => ["claude-sonnet-4-6"],
+          })}
+        />
+      ));
+      const labels = Array.from(
+        container.querySelectorAll<HTMLButtonElement>(".routing-card__chip-action"),
+      ).map((b) => b.getAttribute("aria-label"));
+      expect(labels.some((l) => l?.startsWith("Configure model parameters"))).toBe(false);
+    });
+
     it("clicking the icon opens the dialog and saving flows through persistParamDefaults + onParamDefaultsSaved", async () => {
       const persist = vi.fn().mockResolvedValue(undefined);
       const saved = vi.fn();

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -1313,6 +1313,71 @@ describe("RoutingTierCard", () => {
       expect(btn!.classList.contains("routing-card__chip-action--configured")).toBe(true);
     });
 
+    it("opens the dialog with DeepSeek's default when DeepSeek is the fallback (not the primary)", async () => {
+      // Drives the fallback iteration in paramSurfaceProvider: primary is
+      // not params-compatible, so the dialog's provider hint must come from
+      // the first compatible fallback.
+      const openaiPrimaryDeepseekFallback: TierAssignment = {
+        id: "t-mixed",
+        agent_id: "a1",
+        tier: "simple",
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        auto_assigned_route: null,
+        fallback_routes: [
+          { provider: "deepseek", authType: "api_key", model: "deepseek-v4-flash" },
+        ],
+        updated_at: "2025-01-01",
+      };
+      const mixedModels: AvailableModel[] = [
+        ...deepseekModels,
+        {
+          model_name: "gpt-4o",
+          provider: "OpenAI",
+          auth_type: "api_key",
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+          context_window: 128000,
+          capability_reasoning: false,
+          capability_code: false,
+          quality_score: 8,
+          display_name: "GPT-4o",
+        },
+      ];
+      const mixedProviders: RoutingProvider[] = [
+        ...deepseekProviders,
+        {
+          id: "p-oa",
+          provider: "openai",
+          auth_type: "api_key",
+          is_active: true,
+          has_api_key: true,
+          connected_at: "2025-01-01",
+        },
+      ];
+      const { container } = render(() => (
+        <RoutingTierCard
+          {...makeProps({
+            tier: () => openaiPrimaryDeepseekFallback,
+            models: () => mixedModels,
+            activeProviders: () => mixedProviders,
+            connectedProviders: () => mixedProviders,
+            persistParamDefaults: vi.fn(),
+            getFallbacksFor: () => ["deepseek-v4-flash"],
+          })}
+        />
+      ));
+      const fbProps = fallbackListProps[fallbackListProps.length - 1];
+      (fbProps.onConfigureParams as () => void)();
+      // The dialog mounts and the provider-default hint reads from DeepSeek
+      // (the first compatible route), not from OpenAI.
+      const hint = await waitFor(() => {
+        const el = container.querySelector(".model-params__label-hint");
+        expect(el).not.toBeNull();
+        return el!;
+      });
+      expect(hint.textContent).toContain("enabled");
+    });
+
     it("hides the chip-level params button when primary is not params-compatible (DeepSeek only as fallback)", () => {
       // Primary OpenAI (no thinking), DeepSeek as fallback. The chip-level
       // icon would be misleading here — the params apply to DeepSeek, not
@@ -1373,9 +1438,9 @@ describe("RoutingTierCard", () => {
       expect(chipBtn).toBeUndefined();
     });
 
-    it("passes onConfigureParams to FallbackList when persistParamDefaults is wired", () => {
+    it("passes onConfigureParams to FallbackList when persistParamDefaults is wired and the callback opens the dialog", async () => {
       const persist = vi.fn();
-      render(() => (
+      const { container } = render(() => (
         <RoutingTierCard
           {...makeProps({
             tier: () => deepseekTier,
@@ -1388,6 +1453,12 @@ describe("RoutingTierCard", () => {
       ));
       const fbProps = fallbackListProps[fallbackListProps.length - 1];
       expect(typeof fbProps.onConfigureParams).toBe("function");
+      // Invoke the callback the way FallbackList would on a row click; the
+      // dialog must mount with the same state as the chip-level click path.
+      (fbProps.onConfigureParams as () => void)();
+      await waitFor(() => {
+        expect(container.querySelector(".model-params__toggle")).not.toBeNull();
+      });
     });
 
     it("omits onConfigureParams on FallbackList when persistParamDefaults is not wired", () => {


### PR DESCRIPTION
### ✨ What changed
- \`RoutingTierCard\` visibility for the Model Parameters button now scans \`[primary, ...fallback_routes]\` for a params-compatible provider.
- Dialog's provider-default hint follows the first compatible route in that ordered list.
- Two new test cases: DeepSeek-as-fallback shows the icon; OpenAI + Anthropic mix hides it.

### 💭 Why
Today the icon hides if the primary route is OpenAI but DeepSeek is a fallback, even though the proxy already applies tier-level \`param_defaults\` per attempt against whichever provider an iteration actually targets (\`filterParamDefaultsForProvider\`). The button should be reachable whenever any route in the slot can consume a known param key.

### 📝 Notes
- No backend change.
- Header-tier card and unsupported-provider visibility are tracked as separate follow-ups.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the Model Parameters button whenever any route in a tier—primary or fallback—supports params (e.g., DeepSeek). The button appears next to that route; the chip hides when only a fallback is compatible, and the dialog hint uses the first compatible provider.

- **Bug Fixes**
  - Fallback-row visibility now resolves the provider ID from `fallback_routes` or the model catalog, so it works without structured routes; tests cover both the fallback iteration and catalog-resolved paths.

<sup>Written for commit 80d38ad997479a9041c379356c40c317c1681120. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

