### PR TITLE
fix(routing): strip non-standard `ref` keyword from Gemini tool params

### DIFF
--- a/.changeset/fix-issue-1858-strip-ref-keyword.md
+++ b/.changeset/fix-issue-1858-strip-ref-keyword.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Strip the non-standard `ref` JSON Schema keyword (no `$` prefix) from Google Gemini tool parameters. Some tool emitters drop the `$` prefix because Protobuf and similar parsers reject dollar-prefixed field names; without this fix Manifest forwarded `ref` verbatim and Google rejected the request with `Invalid JSON payload received. Unknown name "ref"`.

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -149,6 +149,69 @@ describe('Google Adapter', () => {
       expect(props.config.properties).toEqual({ key: { type: 'string' } });
     });
 
+    it('strips both $ref and the non-standard dollar-less ref variant', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'List cities' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'list_cities',
+              parameters: {
+                type: 'object',
+                properties: {
+                  cities: { type: 'array', items: { ref: '#/definitions/City' } },
+                  neighbors: { type: 'array', items: { $ref: '#/definitions/City' } },
+                },
+              },
+            },
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.5-flash');
+
+      const tools = result.tools as Array<{
+        functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+      }>;
+      const props = tools[0].functionDeclarations[0].parameters.properties as Record<
+        string,
+        Record<string, { ref?: string; $ref?: string }>
+      >;
+
+      expect(props.cities.items).not.toHaveProperty('ref');
+      expect(props.neighbors.items).not.toHaveProperty('$ref');
+    });
+
+    it('preserves a user property literally named "ref"', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'lookup' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'lookup',
+              parameters: {
+                type: 'object',
+                properties: { ref: { type: 'string', description: 'reference id' } },
+              },
+            },
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.5-flash');
+
+      const tools = result.tools as Array<{
+        functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+      }>;
+      const props = tools[0].functionDeclarations[0].parameters.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+
+      expect(props).toHaveProperty('ref');
+      expect(props.ref.type).toBe('string');
+    });
+
     it('preserves property names that collide with unsupported schema keywords', () => {
       const body = {
         messages: [{ role: 'user', content: 'Do something' }],

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -50,6 +50,10 @@ const UNSUPPORTED_SCHEMA_FIELDS = new Set([
   '$schema',
   '$id',
   '$ref',
+  // Some tool emitters strip the `$` prefix to satisfy parsers that reject
+  // dollar-prefixed field names (Protobuf is one of them). Treat the
+  // dollar-less variant as equivalent so it doesn't leak through to Google.
+  'ref',
   '$defs',
   'definitions',
   'allOf',


### PR DESCRIPTION
## Summary

Adds the non-standard `ref` JSON Schema keyword (no `$` prefix) to the Gemini sanitizer's unsupported set. `$ref` was already stripped; `ref` was leaking through and Google rejected the request.

Fixes #1858.

## Why

Some tool emitters drop the `$` prefix to satisfy parsers that reject dollar-prefixed field names (Protobuf is one of them). When that happens, Manifest forwarded `ref` verbatim to `https://generativelanguage.googleapis.com/.../generateContent` and Google replied:

```
Invalid JSON payload received. Unknown name "ref" at
'tools[0].function_declarations[0].parameters.properties[0].value.items'
```

## Repro

Confirmed live against the Generative Language API on `gemini-2.5-flash`:

| Tool items schema | Before fix | After fix |
| --- | --- | --- |
| `{ "$ref": "#/x" }` | accepted (stripped) | accepted (stripped) |
| `{ "ref": "#/x" }` | **400 `Unknown name "ref"`** | accepted (stripped) |

Also verified empirically that Google preserves the `$` in error messages, so `ref` in the user's report is literal — not a side effect of Google's parser.

## Tests

- New `strips both $ref and the non-standard dollar-less ref variant` covers the bug.
- New `preserves a user property literally named "ref"` pins that we don't accidentally strip user property names colliding with the keyword (the `isPropertiesMap` branch).
- `google-adapter.spec.ts`: 79/79 pass; full proxy suite (1240 tests) green.
- Coverage on `google-adapter.ts` stays at 100% lines.

## Scope

One file plus the matching test. No routing, model selection, or other adapters touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip the non-standard JSON Schema `ref` (no `$`) from Gemini tool parameters to prevent Google API errors. Fixes #1858.

- **Bug Fixes**
  - Treat `ref` as unsupported in `google-adapter.ts` and strip it alongside `$ref` before calling `generateContent`.
  - Add tests to verify both `$ref` and `ref` are removed, and that a user-defined property named `ref` is preserved.

<sup>Written for commit e7cdfa1bca5ce58a343363e43154d3cc4f98fc99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

