### PR TITLE
fix(model-discovery): keep canonical gemini-*-flash-lite-preview aliases

### DIFF
--- a/.changeset/fix-issue-1814-flash-lite-preview.md
+++ b/.changeset/fix-issue-1814-flash-lite-preview.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Stop filtering the canonical `gemini-3.1-flash-lite-preview` (and similar non-dated `flash-lite-preview` aliases) from Gemini model discovery. The previous regex was meant to drop deprecated dated snapshots like `gemini-2.5-flash-lite-preview-09-2025` but over-matched and removed live preview models too. Tightened to require a `-MM-YYYY` date suffix so dated snapshots still get filtered while canonical previews surface.

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -182,6 +182,20 @@ describe('filterNonChatModels', () => {
       expect(result).toHaveLength(2);
     });
 
+    it('keeps canonical flash-lite-preview aliases without a date suffix', () => {
+      // Issue #1814: gemini-3.1-flash-lite-preview is the live, non-deprecated
+      // preview alias. Only the dated snapshot variants are deprecated.
+      const models = [
+        makeModel('gemini-3.1-flash-lite-preview'),
+        makeModel('gemini-3-flash-lite-preview'),
+      ];
+      const result = filterNonChatModels(models, 'gemini');
+      expect(result.map((m) => m.id)).toEqual([
+        'gemini-3.1-flash-lite-preview',
+        'gemini-3-flash-lite-preview',
+      ]);
+    });
+
     it('keeps gemini-image models but filters robotics models', () => {
       const models = [
         makeModel('gemini-2.5-flash-image'),

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -110,8 +110,12 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
     /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|^gpt-3\.5-turbo-instruct|audio|^chatgpt-image|^gpt-image-|search-api)/i,
   'openai-subscription':
     /(?:moderation|davinci|babbage|^text-|realtime|-transcribe|^sora|audio|^chatgpt-image|^gpt-image-)/i,
+  // `flash-lite-preview-MM-YYYY` matches deprecated dated snapshots
+  // (e.g. gemini-2.5-flash-lite-preview-09-2025). The unsuffixed
+  // `gemini-3.1-flash-lite-preview` is the canonical preview alias and
+  // must NOT be filtered.
   gemini:
-    /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview|robotics)/i,
+    /(?:^aqs-|nano-banana|^deep-research|computer-use|^lyria|^gemini-2\.0-flash-lite$|flash-lite-preview-\d{2}-\d{4}$|robotics)/i,
   mistral:
     /(?:^mistral-ocr|moderation|voxtral-.*-(?:transcribe|realtime)|^labs-|^mistral-vibe-cli)/i,
   xai: /(?:imagine|multi-agent)/i,


### PR DESCRIPTION
## Summary

Tightens the Gemini `PROVIDER_NON_CHAT` regex so it only filters dated `flash-lite-preview-MM-YYYY` snapshots, not canonical preview aliases like `gemini-3.1-flash-lite-preview`.

## Why

The regex was added in fbad41807 to drop deprecated dated snapshots (e.g. `gemini-2.5-flash-lite-preview-09-2025`). The bare `flash-lite-preview` pattern over-matches and also drops the live `gemini-3.1-flash-lite-preview` alias, hiding it from model discovery.

## Verified

Live against Google's Generative Language API on the same Google Cloud project:

- Before: 15 Gemini models discovered, `gemini-3.1-flash-lite-preview` filtered out.
- After: 16 Gemini models discovered, `gemini-3.1-flash-lite-preview` surfaces.

End-to-end through the chat-completions proxy:

```
POST /v1/chat/completions  → 200, content="Hello, how are?", tokens 8/5/13
POST /v1/chat/completions w/ tools → 200, finish_reason=tool_calls, args={"city":"Paris"}, tokens 48/16/64
```

The dated snapshot test (`gemini-2.5-flash-lite-preview-09-2025`, `gemini-3.0-flash-lite-preview-01-2026`) still passes — those are still filtered.

## Tests

- `filter-non-chat-models.spec.ts`: existing dated-snapshot test still passes; new test pins that non-dated previews are kept.
- 392 model-discovery tests green.
- `provider-model-fetcher.service.ts`: 100% lines covered (99.43% stmts, 99.08% branch).