### PR TITLE
fix(proxy): preserve DeepSeek reasoning_content through aggregator routes

### DIFF
--- a/.changeset/fix-deepseek-reasoning-content-aggregators.md
+++ b/.changeset/fix-deepseek-reasoning-content-aggregators.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Preserve DeepSeek `reasoning_content` on every follow-up turn, regardless of which provider proxies it (OpenCode Go, custom providers, future aggregators). Fixes a hard failure on OpenCode Go's `deepseek-v4-pro` ("The reasoning_content in the thinking mode must be passed back to the API") — issue #1862.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -189,6 +189,75 @@ describe('provider-client-converters', () => {
       expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
+    it('should preserve reasoning_content for opencode-go deepseek models (issue #1862)', () => {
+      // OpenCode Go's subscription proxies forward DeepSeek requests to the
+      // upstream DeepSeek API, which enforces "reasoning_content must be
+      // passed back" on every thinking-mode follow-up turn.
+      const body = {
+        messages: [
+          { role: 'user', content: 'hello' },
+          { role: 'assistant', content: 'hi', reasoning_content: 'I considered...' },
+          { role: 'user', content: 'continue' },
+        ],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'opencode-go', 'opencode-go/deepseek-v4-pro');
+      const messages = result.messages as any[];
+
+      expect(messages[1]).toHaveProperty('reasoning_content', 'I considered...');
+    });
+
+    it('should strip reasoning_content for opencode-go non-deepseek models', () => {
+      const body = {
+        messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'opencode-go', 'opencode-go/glm-5.1');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+
+    it('should preserve reasoning_content for custom providers proxying DeepSeek', () => {
+      // proxy-fallback.service strips the "custom:<uuid>/" prefix before
+      // calling ProviderClient.forward, so in production sanitizeOpenAiBody
+      // sees the already-bare model id.
+      const body = {
+        messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'custom', 'deepseek-reasoner');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
+    });
+
+    it('should match deepseek family models case-insensitively', () => {
+      const body = {
+        messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'opencode-go', 'opencode-go/DeepSeek-V4-Pro');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
+    });
+
+    it('should strip reasoning_content for deepseek-derived slugs on strict OpenAI endpoints', () => {
+      // Community distillations carry the DeepSeek name but are hosted by
+      // providers that may not implement DeepSeek's echo contract and may
+      // reject unknown message fields. The endpoint allowlist excludes
+      // them — substring-match alone is not enough.
+      for (const endpointKey of ['mistral', 'anthropic', 'openai']) {
+        const body = {
+          messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
+        };
+        const result = sanitizeOpenAiBody(body, endpointKey, 'deepseek-r1-distill-llama-70b');
+        const messages = result.messages as any[];
+        expect(messages[0]).not.toHaveProperty('reasoning_content');
+      }
+    });
+
     /* ── Message sanitization: reasoning_details ── */
 
     it('should strip reasoning_details for non-openrouter providers', () => {

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -117,10 +117,40 @@ function usesOpenAiMaxCompletionTokens(endpointKey: string, bareModel: string): 
   );
 }
 
+/**
+ * Endpoints that either forward directly to DeepSeek (native, OpenCode Go) or
+ * tolerate `reasoning_content` as a passthrough on `deepseek-*` slugs
+ * (OpenRouter, custom proxies). Restricting the substring match to this set
+ * prevents false positives on strict OpenAI-compatible hosts that happen to
+ * serve a DeepSeek-derived community slug (e.g. `deepseek-r1-distill-*` on
+ * Mistral or native OpenAI) and would reject the unknown message field.
+ */
+const DEEPSEEK_AWARE_ENDPOINTS = new Set(['openrouter', 'opencode-go', 'custom']);
+
+/**
+ * DeepSeek's thinking-mode API rejects follow-up turns that don't echo back the
+ * previous assistant's `reasoning_content` ("The `reasoning_content` in the
+ * thinking mode must be passed back to the API"). Preserve it for:
+ *  - the native `deepseek` endpoint (always)
+ *  - aggregator/proxy endpoints whose `deepseek-*` slugs forward to a DeepSeek
+ *    engine (OpenRouter `deepseek/*`, OpenCode Go `deepseek-*` — issue #1862 —
+ *    and user-supplied custom providers).
+ * Strict OpenAI-compatible endpoints (Mistral, native OpenAI, etc.) keep
+ * stripping the field even if a community fine-tune slug contains "deepseek".
+ */
 function supportsReasoningContent(endpointKey: string, model: string): boolean {
   if (endpointKey === 'deepseek') return true;
-  if (endpointKey === 'openrouter') return model.toLowerCase().startsWith('deepseek/');
-  return false;
+  if (!DEEPSEEK_AWARE_ENDPOINTS.has(endpointKey)) return false;
+  // Bare model id after stripping any vendor/aggregator prefix:
+  //   "deepseek/r1"             → "r1"            — OpenRouter, not deepseek-family
+  //   "openrouter" + "deepseek/deepseek-r1" → "deepseek-r1" ✓
+  //   "opencode-go/deepseek-v4-pro" → "deepseek-v4-pro" ✓
+  //   "custom:<uuid>/deepseek-reasoner" → "deepseek-reasoner" ✓
+  // (proxy-fallback.service strips "custom:<uuid>/" before forward, so in
+  // practice the custom path passes the already-bare model — both shapes
+  // are handled.)
+  const bare = model.toLowerCase().split('/').pop() ?? '';
+  return bare.includes('deepseek');
 }
 
 /**


### PR DESCRIPTION
### ✨ What changed
- `supportsReasoningContent` keeps `reasoning_content` for `deepseek-*` models routed via `openrouter`, `opencode-go`, and `custom` endpoints, not just the native `deepseek` endpoint.
- Endpoint allowlist guards the substring match so strict OpenAI-compatible hosts (Mistral, OpenAI, etc.) still strip the field on community `deepseek-*-distill-*` slugs.

### 💭 Why
DeepSeek's thinking-mode API rejects follow-up turns missing `reasoning_content` (`"The reasoning_content in the thinking mode must be passed back to the API"`). OpenCode Go's subscription proxy forwards to DeepSeek under the hood, so its `deepseek-v4-pro` was hitting that error on every multi-turn request (#1862).

### 👤 For users
DeepSeek routes that go through OpenCode Go, OpenRouter `deepseek/*`, or custom proxies now work on multi-turn conversations instead of failing on turn 2.

### 📝 Notes
- Closes #1862
- Follow-up candidate: move the policy onto `ProviderEndpoint` as a per-endpoint capability predicate (codex P3) so format-specific adapters (Anthropic, Google) could honor it too. Not needed today since every DeepSeek route is OpenAI-format.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves DeepSeek `reasoning_content` on follow-up turns for models routed via `openrouter`, `opencode-go`, and `custom`, not just the native `deepseek` endpoint. Fixes multi‑turn failures on OpenCode Go’s `deepseek-v4-pro` (issue #1862).

- **Bug Fixes**
  - Detect DeepSeek by the bare model id on an endpoint allowlist; keep `reasoning_content` when the bare id contains “deepseek” (case-insensitive).
  - Continue stripping on strict OpenAI-compatible endpoints (`openai`, `mistral`, `anthropic`) and on non‑DeepSeek or community distill slugs.
  - Added tests for `opencode-go`, `custom`, OpenRouter DeepSeek models, case-insensitive matching, and distill slugs.

<sup>Written for commit d25320a46012ab8c9f5f6fd9adc417cf4aaad68b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

