### PR TITLE
feat(wingman): add Anthropic SDK profile

### DIFF
--- a/.changeset/wingman-anthropic-sdk-profile.md
+++ b/.changeset/wingman-anthropic-sdk-profile.md
@@ -1,0 +1,4 @@
+---
+---
+
+Dev-only change in `packages/wingman/`. Wingman is excluded from production builds and Docker bundles, so this PR doesn't ship to users.

--- a/packages/wingman/public/icons/providers/anthropic.svg
+++ b/packages/wingman/public/icons/providers/anthropic.svg
@@ -1,0 +1,1 @@
+<svg fill="#181818" fill-rule="evenodd" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>Anthropic</title><path d="M13.827 3.52h3.603L24 20h-3.603l-6.57-16.48zm-7.258 0h3.767L16.906 20h-3.674l-1.343-3.461H5.017l-1.344 3.46H0L6.57 3.522zm4.132 9.959L8.453 7.687 6.205 13.48H10.7z"></path></svg>

--- a/packages/wingman/src/App.tsx
+++ b/packages/wingman/src/App.tsx
@@ -4,7 +4,7 @@ import Sidebar from './components/Sidebar.jsx';
 import Conversation from './components/Conversation.jsx';
 import Composer from './components/Composer.jsx';
 import { type HeaderEntry } from './components/HeaderEditor.jsx';
-import { PROFILES, PROFILE_BY_ID, type Profile, type ProfileLang } from './profiles';
+import { PROFILES, PROFILE_BY_ID, profilePath, type Profile, type ProfileLang } from './profiles';
 import { partitionHeaders, sendRequest, type SendResult } from './send';
 import {
   appendHistory,
@@ -15,6 +15,7 @@ import {
 } from './services/history';
 import { isExecutable, runUserCode } from './runners';
 import { buildMarkdownReport } from './services/gist';
+import { extractAssistantText } from './services/response-shape';
 import GistModal from './components/GistModal.jsx';
 
 const STORAGE = {
@@ -80,18 +81,6 @@ function defaultBaseUrl(): string {
     return `${protocol}//${hostname}:${port || '3001'}`;
   }
   return `${protocol}//${hostname}`;
-}
-
-function extractAssistantText(json: unknown): string | null {
-  if (!json || typeof json !== 'object') return null;
-  const root = json as Record<string, unknown>;
-  const choices = root.choices;
-  if (Array.isArray(choices) && choices.length > 0) {
-    const first = choices[0] as { message?: { content?: unknown }; text?: unknown } | undefined;
-    if (first?.message && typeof first.message.content === 'string') return first.message.content;
-    if (typeof first?.text === 'string') return first.text;
-  }
-  return null;
 }
 
 const App: Component = () => {
@@ -244,7 +233,7 @@ const App: Component = () => {
         next = out.result;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        const url = `${baseUrl().replace(/\/+$/, '')}/v1/chat/completions`;
+        const url = `${baseUrl().replace(/\/+$/, '')}${profilePath(profile())}`;
         next = {
           url,
           status: 0,
@@ -263,7 +252,7 @@ const App: Component = () => {
     } else {
       sentHeaders = recordFromEntries(headerEntries());
       const body = profile().body(params());
-      const url = `${baseUrl().replace(/\/+$/, '')}/v1/chat/completions`;
+      const url = `${baseUrl().replace(/\/+$/, '')}${profilePath(profile())}`;
       next = await sendRequest({ url, apiKey: apiKey(), headers: sentHeaders, body });
     }
 
@@ -318,7 +307,7 @@ const App: Component = () => {
     }
     setActiveHistoryId(entry.id);
     setResult({
-      url: `${entry.baseUrl.replace(/\/+$/, '')}/v1/chat/completions`,
+      url: `${entry.baseUrl.replace(/\/+$/, '')}${next ? profilePath(next) : '/v1/chat/completions'}`,
       status: entry.status,
       statusText: entry.statusText,
       ok: entry.ok,

--- a/packages/wingman/src/components/AssistantMessage.tsx
+++ b/packages/wingman/src/components/AssistantMessage.tsx
@@ -1,5 +1,6 @@
 import { createSignal, For, Show, type Component } from 'solid-js';
 import type { SendResult } from '../send';
+import { extractAssistantText, extractModel, extractUsage } from '../services/response-shape';
 import CodeView from './CodeView.jsx';
 
 interface Props {
@@ -26,37 +27,6 @@ function formatHeaders(headers: Record<string, string>): string {
 function prettyBody(body: string, json: unknown | null): string {
   if (json !== null) return JSON.stringify(json, null, 2);
   return body || '(empty body)';
-}
-
-function extractAssistantText(json: unknown): string | null {
-  if (!json || typeof json !== 'object') return null;
-  const root = json as Record<string, unknown>;
-  const choices = root.choices;
-  if (Array.isArray(choices) && choices.length > 0) {
-    const first = choices[0] as { message?: { content?: unknown }; text?: unknown } | undefined;
-    if (first?.message && typeof first.message.content === 'string') return first.message.content;
-    if (typeof first?.text === 'string') return first.text;
-  }
-  return null;
-}
-
-function extractUsage(json: unknown): { in?: number; out?: number; total?: number } | null {
-  if (!json || typeof json !== 'object') return null;
-  const usage = (json as Record<string, unknown>).usage;
-  if (!usage || typeof usage !== 'object') return null;
-  const u = usage as Record<string, unknown>;
-  const num = (v: unknown) => (typeof v === 'number' ? v : undefined);
-  return {
-    in: num(u.prompt_tokens) ?? num(u.input_tokens),
-    out: num(u.completion_tokens) ?? num(u.output_tokens),
-    total: num(u.total_tokens),
-  };
-}
-
-function extractModel(json: unknown): string | null {
-  if (!json || typeof json !== 'object') return null;
-  const m = (json as Record<string, unknown>).model;
-  return typeof m === 'string' ? m : null;
 }
 
 const StatusPill: Component<{ status: number; ok: boolean; statusText: string }> = (props) => {

--- a/packages/wingman/src/profiles.ts
+++ b/packages/wingman/src/profiles.ts
@@ -204,11 +204,15 @@ hermes chat -q '${p.userMessage.replace(/'/g, "'\\''")}'`,
     body: anthropicBody,
     code: (p, lang) => {
       if (lang === 'python') {
+        // Anthropic's SDK has two auth options: api_key (sends X-Api-Key) and
+        // auth_token (sends Authorization: Bearer). Manifest's proxy reads
+        // Authorization, so use auth_token — api_key wouldn't reach the
+        // AgentKeyAuthGuard at all.
         return `from anthropic import Anthropic
 
 client = Anthropic(
     base_url="${p.baseUrl}",
-    api_key="${p.apiKey || 'mnfst_YOUR_KEY'}",
+    auth_token="${p.apiKey || 'mnfst_YOUR_KEY'}",
 )
 
 response = client.messages.create(
@@ -220,9 +224,11 @@ print(response.content[0].text)`;
       }
       return `import Anthropic from "@anthropic-ai/sdk";
 
+// Manifest accepts the API key via Authorization: Bearer. The Anthropic SDK's
+// apiKey option maps to X-Api-Key — use authToken instead to hit Bearer.
 const client = new Anthropic({
   baseURL: "${p.baseUrl}",
-  apiKey: "${p.apiKey || 'mnfst_YOUR_KEY'}",
+  authToken: "${p.apiKey || 'mnfst_YOUR_KEY'}",
 });
 
 const response = await client.messages.create({

--- a/packages/wingman/src/profiles.ts
+++ b/packages/wingman/src/profiles.ts
@@ -9,6 +9,12 @@ import { HERMES_SYSTEM } from './templates/hermes-system';
 
 export type ProfileMode = 'agent' | 'sdk' | 'raw';
 export type ProfileLang = 'typescript' | 'python' | 'bash';
+/**
+ * Which Manifest entry point the profile targets. Defaults to chat completions
+ * for back-compat. `messages` targets `/v1/messages` (Anthropic Messages API)
+ * so Anthropic-SDK clients can be tested against the proxy.
+ */
+export type ProfileApiMode = 'chat_completions' | 'messages';
 
 export interface ProfileParams {
   baseUrl: string;
@@ -43,9 +49,20 @@ export interface Profile {
    * the TypeScript SDK profiles can do this — Python needs Pyodide.
    */
   executable?: boolean;
+  /**
+   * Manifest entry point this profile hits. Omitting defaults to
+   * `chat_completions` (the `/v1/chat/completions` path). Set to `messages`
+   * for Anthropic-shape clients that hit `/v1/messages`.
+   */
+  apiMode?: ProfileApiMode;
   headers: (params: ProfileParams) => Record<string, string>;
   body: (params: ProfileParams) => Record<string, unknown>;
   code: (params: ProfileParams, lang: ProfileLang) => string;
+}
+
+/** Returns the proxy path for a profile, defaulting to chat completions. */
+export function profilePath(profile: Pick<Profile, 'apiMode'>): string {
+  return profile.apiMode === 'messages' ? '/v1/messages' : '/v1/chat/completions';
 }
 
 function messages(params: ProfileParams) {
@@ -60,6 +77,38 @@ function messages(params: ProfileParams) {
 function jsonBody(body: unknown, indent = 2): string {
   return JSON.stringify(body, null, indent);
 }
+
+function anthropicBody(params: ProfileParams): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: params.model,
+    max_tokens: params.maxTokens ?? 1024,
+    messages: [{ role: 'user', content: params.userMessage }],
+  };
+  if (params.systemPrompt.trim()) {
+    body.system = params.systemPrompt;
+  }
+  if (params.temperature !== undefined) {
+    body.temperature = params.temperature;
+  }
+  return body;
+}
+
+const anthropicSdkHeaders = {
+  // Mirror the stainless fingerprint @anthropic-ai/sdk sends. Anthropic doesn't
+  // require these for forwarding; they make Manifest's request log look like
+  // what a real SDK client would produce.
+  'User-Agent': 'Anthropic/JS 0.40.1',
+  'X-Stainless-Lang': 'js',
+  'X-Stainless-Package-Version': '0.40.1',
+  'X-Stainless-OS': 'Linux',
+  'X-Stainless-Arch': 'x64',
+  'X-Stainless-Runtime': 'node',
+  'X-Stainless-Runtime-Version': 'v22.17.1',
+  'X-Stainless-Retry-Count': '0',
+  'anthropic-version': '2023-06-01',
+  'accept-language': '*',
+  'sec-fetch-mode': 'cors',
+};
 
 const stainlessJs = {
   'User-Agent': 'OpenAI/JS 6.26.0',
@@ -139,6 +188,50 @@ model:
   default: ${p.model}
 EOF
 hermes chat -q '${p.userMessage.replace(/'/g, "'\\''")}'`,
+  },
+  {
+    id: 'anthropic-sdk',
+    label: 'Anthropic SDK',
+    mode: 'sdk',
+    category: 'app',
+    blurb: 'Official Anthropic client (TypeScript or Python). Targets /v1/messages.',
+    icon: '/icons/providers/anthropic.svg',
+    langs: ['typescript', 'python'],
+    defaultLang: 'typescript',
+    headersLocked: true,
+    apiMode: 'messages',
+    headers: () => ({ ...anthropicSdkHeaders }),
+    body: anthropicBody,
+    code: (p, lang) => {
+      if (lang === 'python') {
+        return `from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="${p.baseUrl}",
+    api_key="${p.apiKey || 'mnfst_YOUR_KEY'}",
+)
+
+response = client.messages.create(
+    model="${p.model}",
+    max_tokens=${p.maxTokens ?? 1024},
+    ${p.systemPrompt.trim() ? `system=${JSON.stringify(p.systemPrompt)},\n    ` : ''}messages=[{"role": "user", "content": ${JSON.stringify(p.userMessage)}}],
+)
+print(response.content[0].text)`;
+      }
+      return `import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({
+  baseURL: "${p.baseUrl}",
+  apiKey: "${p.apiKey || 'mnfst_YOUR_KEY'}",
+});
+
+const response = await client.messages.create({
+  model: "${p.model}",
+  max_tokens: ${p.maxTokens ?? 1024},
+  ${p.systemPrompt.trim() ? `system: ${JSON.stringify(p.systemPrompt)},\n  ` : ''}messages: [{ role: "user", content: ${JSON.stringify(p.userMessage)} }],
+});
+console.log(response.content[0].type === "text" ? response.content[0].text : "");`;
+    },
   },
   {
     id: 'openai-sdk',

--- a/packages/wingman/src/services/gist.ts
+++ b/packages/wingman/src/services/gist.ts
@@ -1,4 +1,5 @@
 import type { SendResult } from '../send';
+import { extractAssistantText, extractModel, extractUsage } from './response-shape';
 
 export interface GistContext {
   profileLabel: string;
@@ -38,36 +39,6 @@ function prettyJson(raw: string, parsed: unknown): string {
     return JSON.stringify(parsed, null, 2);
   }
   return raw || '(empty)';
-}
-
-function extractAssistantText(json: unknown): string | null {
-  if (!json || typeof json !== 'object') return null;
-  const choices = (json as Record<string, unknown>).choices;
-  if (Array.isArray(choices) && choices.length > 0) {
-    const first = choices[0] as { message?: { content?: unknown }; text?: unknown } | undefined;
-    if (first?.message && typeof first.message.content === 'string') return first.message.content;
-    if (typeof first?.text === 'string') return first.text;
-  }
-  return null;
-}
-
-function extractUsage(json: unknown): { in?: number; out?: number; total?: number } | null {
-  if (!json || typeof json !== 'object') return null;
-  const usage = (json as Record<string, unknown>).usage;
-  if (!usage || typeof usage !== 'object') return null;
-  const u = usage as Record<string, unknown>;
-  const num = (v: unknown) => (typeof v === 'number' ? v : undefined);
-  return {
-    in: num(u.prompt_tokens) ?? num(u.input_tokens),
-    out: num(u.completion_tokens) ?? num(u.output_tokens),
-    total: num(u.total_tokens),
-  };
-}
-
-function extractModel(json: unknown): string | null {
-  if (!json || typeof json !== 'object') return null;
-  const m = (json as Record<string, unknown>).model;
-  return typeof m === 'string' ? m : null;
 }
 
 function statusEmoji(result: SendResult): string {

--- a/packages/wingman/src/services/response-shape.ts
+++ b/packages/wingman/src/services/response-shape.ts
@@ -38,17 +38,15 @@ export function extractUsage(json: unknown): { in?: number; out?: number; total?
   if (!usage || typeof usage !== 'object') return null;
   const u = usage as Record<string, unknown>;
   const num = (v: unknown) => (typeof v === 'number' ? v : undefined);
-  // Anthropic input_tokens is uncached only; sum cache reads + creation so the
-  // displayed prompt count matches what the user actually paid for.
-  const cacheRead = num(u.cache_read_input_tokens) ?? 0;
-  const cacheCreation = num(u.cache_creation_input_tokens) ?? 0;
-  const anthropicInput = num(u.input_tokens);
-  const anthropicTotal =
-    anthropicInput !== undefined ? anthropicInput + cacheRead + cacheCreation : undefined;
-  const inTokens = num(u.prompt_tokens) ?? anthropicTotal;
+  // Display whatever the upstream usage block actually reports — do not derive
+  // a "total" by summing cache fields. The exact semantics of `input_tokens`
+  // depend on the backend version: pre-#1879 it's the full total (including
+  // cache reads + creation), post-#1879 it's the uncached portion only.
+  // Summing would double-count against pre-#1879 backends.
+  const inTokens = num(u.prompt_tokens) ?? num(u.input_tokens);
   const outTokens = num(u.completion_tokens) ?? num(u.output_tokens);
-  // The Messages API doesn't report total_tokens; derive it so the UI's token
-  // chip (gated on `total`) still shows for Anthropic responses.
+  // Anthropic Messages doesn't include total_tokens; derive in+out so the UI's
+  // token chip (gated on `total`) still renders for Anthropic responses.
   const total =
     num(u.total_tokens) ??
     (inTokens !== undefined && outTokens !== undefined ? inTokens + outTokens : undefined);

--- a/packages/wingman/src/services/response-shape.ts
+++ b/packages/wingman/src/services/response-shape.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared extractors for the response shapes Wingman sees. The same logic was
+ * inlined in three places (App.tsx, AssistantMessage.tsx, gist.ts); centralising
+ * keeps Anthropic Messages support a one-shot change instead of three.
+ */
+
+export function extractAssistantText(json: unknown): string | null {
+  if (!json || typeof json !== 'object') return null;
+  const root = json as Record<string, unknown>;
+
+  // OpenAI chat-completions: choices[0].message.content (string) or .text
+  const choices = root.choices;
+  if (Array.isArray(choices) && choices.length > 0) {
+    const first = choices[0] as { message?: { content?: unknown }; text?: unknown } | undefined;
+    if (first?.message && typeof first.message.content === 'string') return first.message.content;
+    if (typeof first?.text === 'string') return first.text;
+  }
+
+  // Anthropic Messages: content[] with { type: 'text', text: '...' } blocks.
+  // Concat all text blocks in order; ignore tool_use, thinking, etc.
+  const content = root.content;
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== 'object') continue;
+      const b = block as Record<string, unknown>;
+      if (b.type === 'text' && typeof b.text === 'string') parts.push(b.text);
+    }
+    if (parts.length > 0) return parts.join('');
+  }
+
+  return null;
+}
+
+export function extractUsage(json: unknown): { in?: number; out?: number; total?: number } | null {
+  if (!json || typeof json !== 'object') return null;
+  const usage = (json as Record<string, unknown>).usage;
+  if (!usage || typeof usage !== 'object') return null;
+  const u = usage as Record<string, unknown>;
+  const num = (v: unknown) => (typeof v === 'number' ? v : undefined);
+  // Anthropic input_tokens is uncached only; sum cache reads + creation so the
+  // displayed prompt count matches what the user actually paid for.
+  const cacheRead = num(u.cache_read_input_tokens) ?? 0;
+  const cacheCreation = num(u.cache_creation_input_tokens) ?? 0;
+  const anthropicInput = num(u.input_tokens);
+  const anthropicTotal =
+    anthropicInput !== undefined ? anthropicInput + cacheRead + cacheCreation : undefined;
+  return {
+    in: num(u.prompt_tokens) ?? anthropicTotal,
+    out: num(u.completion_tokens) ?? num(u.output_tokens),
+    total: num(u.total_tokens),
+  };
+}
+
+export function extractModel(json: unknown): string | null {
+  if (!json || typeof json !== 'object') return null;
+  const m = (json as Record<string, unknown>).model;
+  return typeof m === 'string' ? m : null;
+}

--- a/packages/wingman/src/services/response-shape.ts
+++ b/packages/wingman/src/services/response-shape.ts
@@ -45,11 +45,14 @@ export function extractUsage(json: unknown): { in?: number; out?: number; total?
   const anthropicInput = num(u.input_tokens);
   const anthropicTotal =
     anthropicInput !== undefined ? anthropicInput + cacheRead + cacheCreation : undefined;
-  return {
-    in: num(u.prompt_tokens) ?? anthropicTotal,
-    out: num(u.completion_tokens) ?? num(u.output_tokens),
-    total: num(u.total_tokens),
-  };
+  const inTokens = num(u.prompt_tokens) ?? anthropicTotal;
+  const outTokens = num(u.completion_tokens) ?? num(u.output_tokens);
+  // The Messages API doesn't report total_tokens; derive it so the UI's token
+  // chip (gated on `total`) still shows for Anthropic responses.
+  const total =
+    num(u.total_tokens) ??
+    (inTokens !== undefined && outTokens !== undefined ? inTokens + outTokens : undefined);
+  return { in: inTokens, out: outTokens, total };
 }
 
 export function extractModel(json: unknown): string | null {


### PR DESCRIPTION
### ✨ What changed
- New **Anthropic SDK** profile in Wingman. Builds an Anthropic-shape body (`system` string, `max_tokens`, `messages` with role/content), sends `anthropic-version` plus a stainless fingerprint, and posts to `/v1/messages`.
- Profiles now carry an optional `apiMode` field (`chat_completions` default, `messages` for the Anthropic path). A single `profilePath()` helper resolves the proxy path so URL construction can't drift across the three call sites in `App.tsx`.
- Consolidated three inlined copies of `extractAssistantText` / `extractUsage` / `extractModel` into `services/response-shape.ts`. Text extractor now reads Anthropic `content[]` blocks; usage extractor reports whatever the upstream block actually contains (no derived sums).

### 💭 Why
Wingman could only test `/v1/chat/completions`. Anthropic-SDK clients (Claude Code, `@anthropic-ai/sdk`) hit `/v1/messages`, which exercises a different translation path inside the proxy. With #1810 shipping that endpoint and #1879 fixing its cache-token round-trip, contributors had no way to dogfood the Anthropic path from the dashboard. Now they can.

### 👤 For users
Pick "Anthropic SDK" from Wingman's profile dropdown. The code editor shows real `@anthropic-ai/sdk` and `anthropic` Python usage. The response panel renders assistant text from `content[].text` and surfaces `usage.input_tokens` / `usage.output_tokens` from the Messages API.

The generated snippets use `authToken` (TS) / `auth_token` (Python) rather than `apiKey`. The Anthropic SDK maps `apiKey` to the `X-Api-Key` header; Manifest's `AgentKeyAuthGuard` reads `Authorization: Bearer`. Using the wrong field would 401.

### 🔧 For operators
Dev-only change. Wingman is excluded from the Docker image and the published `manifest` package; nothing reaches users in production.

### 📝 Notes
- No tests: Wingman has no test runner today. Verified via local build + lint + typecheck + a live boot against the running backend.
- Anthropic icon copied from the dashboard frontend assets.
- Known limitation: the profile builds a simple body shape and isn't `executable`, so editing the SDK code preview doesn't drive Send. Testing `cache_control` request bodies still requires curl. Adding a body editor or an executable Anthropic runner is a follow-up.
- Three codex passes: 1 high (auth field) + 1 low (display total) fixed in commit 2; 1 low (cache sum double-count vs upstream's pre-#1879 adapter) fixed in commit 3 by dropping the sum.