### PR TITLE
fix(routing): point MiniMax key link to actual key page

### DIFF
--- a/.changeset/minimax-key-url.md
+++ b/.changeset/minimax-key-url.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Update MiniMax "Where to get an API key" link to point to the actual key page (`/user-center/basic-information/interface-key`) instead of the API docs overview.

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -3,7 +3,7 @@ export const ROUTING_PROVIDER_API_KEY_URLS: Record<string, string> = {
   deepseek: 'https://platform.deepseek.com/api_keys',
   gemini: 'https://aistudio.google.com/apikey',
   groq: 'https://console.groq.com/keys',
-  minimax: 'https://platform.minimax.io/docs/api-reference/api-overview',
+  minimax: 'https://platform.minimax.io/user-center/basic-information/interface-key',
   mistral: 'https://console.mistral.ai/api-keys/',
   moonshot: 'https://platform.moonshot.ai/',
   ollama: 'https://ollama.com/download',


### PR DESCRIPTION
## Summary

- The MiniMax provider's "Where to get an API key" link in the routing UI was pointing at the API docs overview (`/docs/api-reference/api-overview`), which doesn't show users where to create or copy a key.
- Updated `ROUTING_PROVIDER_API_KEY_URLS.minimax` in `packages/frontend/src/services/provider-api-key-urls.ts` to point at `https://platform.minimax.io/user-center/basic-information/interface-key`, the actual interface-key page.

## Test plan

- [x] `npm run lint` — no new errors (pre-existing warnings only)
- [x] `cd packages/frontend && npx tsc --noEmit`
- [x] `cd packages/frontend && npx vitest run tests/services/providers.test.ts tests/components/ProviderKeyForm.test.tsx` — 99 passed
- [ ] Manual: click the MiniMax "Where to get an API key" link in the routing UI and confirm it opens the key page

Changeset: `manifest` patch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the MiniMax “Where to get an API key” link in the routing UI to open the actual interface-key page. Users now land directly on the page where they can create or copy a key.

<sup>Written for commit 9f64594dd4448fa65ff4f36dfc26487ad01aeeaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

