### PR TITLE
feat(telemetry): include cost_usd_total and cost_usd_by_provider

### DIFF
--- a/packages/backend/src/telemetry/dto/telemetry-payload.ts
+++ b/packages/backend/src/telemetry/dto/telemetry-payload.ts
@@ -3,6 +3,10 @@
  * ingest endpoint. All fields are derived aggregates — no per-request events,
  * no identifiers beyond the random `install_id` and the Manifest version.
  * Additive changes keep `schema_version: 1`; breaking changes bump it.
+ *
+ * Optional fields are flagged as such because installs running older Manifest
+ * versions emit a strict subset. Receivers should feature-detect on presence,
+ * not on `schema_version`.
  */
 export interface TelemetryPayloadV1 {
   schema_version: 1;
@@ -18,6 +22,24 @@ export interface TelemetryPayloadV1 {
   // Volume
   tokens_input_total: number;
   tokens_output_total: number;
+
+  /**
+   * Total dollar value flowing through the install over the 24h window,
+   * summed from the same `cost_usd` Manifest computes at routing time.
+   * Rounded to cents to avoid leaking precision. Always present on installs
+   * that ship this field — `0` when nothing chargeable was routed (e.g.
+   * Ollama-only fleets). Optional in the DTO because older installs predate
+   * the field; absence means "fall back to estimating from token counts".
+   */
+  cost_usd_total?: number;
+
+  /**
+   * Per-provider breakdown of `cost_usd_total`, keyed by the same canonical
+   * provider buckets as `messages_by_provider` (registry ID for known
+   * providers, `"custom"` for user-defined ones, `"unknown"` for legacy
+   * NULLs). Values rounded to cents. Empty `{}` when no chargeable rows.
+   */
+  cost_usd_by_provider?: Record<string, number>;
 
   // Configuration
   agents_total: number;

--- a/packages/backend/src/telemetry/payload-builder.service.spec.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.spec.ts
@@ -7,6 +7,7 @@ import { PayloadBuilderService } from './payload-builder.service';
 interface ProviderRow {
   provider: string | null;
   count: string;
+  cost?: string | null;
 }
 interface BucketRow {
   bucket: string | null;
@@ -21,6 +22,7 @@ interface TotalsRow {
   total: string;
   input_tokens: string | null;
   output_tokens: string | null;
+  cost?: string | null;
 }
 
 interface MockData {
@@ -173,6 +175,83 @@ describe('PayloadBuilderService', () => {
     expect(payload.messages_total).toBe(0);
     expect(payload.tokens_input_total).toBe(0);
     expect(payload.tokens_output_total).toBe(0);
+  });
+
+  it('emits cost_usd_total = 0 and cost_usd_by_provider = {} when no cost data', async () => {
+    const service = await makeService({
+      providers: [{ provider: 'anthropic', count: '3' }],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.cost_usd_total).toBe(0);
+    expect(payload.cost_usd_by_provider).toEqual({});
+  });
+
+  it('sums cost_usd_total from totals.cost and rounds to cents', async () => {
+    const service = await makeService({
+      totals: {
+        total: '10',
+        input_tokens: '0',
+        output_tokens: '0',
+        cost: '12.345678',
+      },
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.cost_usd_total).toBe(12.35);
+  });
+
+  it('buckets cost_usd_by_provider with the same canonicalization as messages', async () => {
+    const service = await makeService({
+      providers: [
+        { provider: 'anthropic', count: '10', cost: '5.4321' },
+        { provider: 'openai', count: '5', cost: '2.1' },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.cost_usd_by_provider).toEqual({ anthropic: 5.43, openai: 2.1 });
+  });
+
+  it('collapses custom provider costs into a single "custom" bucket', async () => {
+    const service = await makeService({
+      providers: [
+        { provider: 'anthropic', count: '2', cost: '1.00' },
+        { provider: 'my-self-hosted-vllm', count: '4', cost: '0.50' },
+        { provider: 'another-custom', count: '1', cost: '0.25' },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.cost_usd_by_provider).toEqual({ anthropic: 1, custom: 0.75 });
+  });
+
+  it('skips zero and null costs from cost_usd_by_provider', async () => {
+    const service = await makeService({
+      providers: [
+        { provider: 'ollama', count: '100', cost: '0' },
+        { provider: 'anthropic', count: '3', cost: '1.50' },
+        { provider: 'openai', count: '1', cost: null },
+      ],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.cost_usd_by_provider).toEqual({ anthropic: 1.5 });
+  });
+
+  it('drops cost_usd_by_provider buckets that round to 0 after rounding', async () => {
+    const service = await makeService({
+      providers: [{ provider: 'anthropic', count: '1', cost: '0.001' }],
+    });
+
+    const payload = await service.build('inst', '1.0.0');
+
+    expect(payload.cost_usd_by_provider).toEqual({});
   });
 
   it('returns messages_by_tier grouped across the 4 canonical tiers', async () => {

--- a/packages/backend/src/telemetry/payload-builder.service.ts
+++ b/packages/backend/src/telemetry/payload-builder.service.ts
@@ -14,6 +14,7 @@ const AUTH_TYPE_WHITELIST: ReadonlySet<string> = new Set<string>(AUTH_TYPES);
 interface ProviderAggregateRow {
   provider: string | null;
   count: string;
+  cost: string | null;
 }
 
 interface BucketRow {
@@ -25,6 +26,7 @@ interface TotalsRow {
   total: string;
   input_tokens: string | null;
   output_tokens: string | null;
+  cost: string | null;
 }
 
 /**
@@ -66,6 +68,8 @@ export class PayloadBuilderService {
       messages_by_auth_type: this.bucketsToRecord(authRows, 'unknown', AUTH_TYPE_WHITELIST),
       tokens_input_total: Number(totals.input_tokens ?? 0),
       tokens_output_total: Number(totals.output_tokens ?? 0),
+      cost_usd_total: roundCents(Number(totals.cost ?? 0)),
+      cost_usd_by_provider: this.collapseProviderCosts(providerRows),
       agents_total: agentsTotal,
       agents_by_platform: this.bucketsToRecord(agentPlatformRows, 'unknown'),
       platform: process.platform,
@@ -78,6 +82,7 @@ export class PayloadBuilderService {
       .createQueryBuilder('m')
       .select('m.provider', 'provider')
       .addSelect('COUNT(*)', 'count')
+      .addSelect('COALESCE(SUM(m.cost_usd), 0)', 'cost')
       .where(`m.timestamp >= NOW() - INTERVAL '24 hours'`)
       .groupBy('m.provider')
       .getRawMany<ProviderAggregateRow>();
@@ -132,9 +137,10 @@ export class PayloadBuilderService {
       .select('COUNT(*)', 'total')
       .addSelect('SUM(m.input_tokens)', 'input_tokens')
       .addSelect('SUM(m.output_tokens)', 'output_tokens')
+      .addSelect('COALESCE(SUM(m.cost_usd), 0)', 'cost')
       .where(`m.timestamp >= NOW() - INTERVAL '24 hours'`)
       .getRawOne<TotalsRow>();
-    return row ?? { total: '0', input_tokens: '0', output_tokens: '0' };
+    return row ?? { total: '0', input_tokens: '0', output_tokens: '0', cost: '0' };
   }
 
   /**
@@ -148,6 +154,29 @@ export class PayloadBuilderService {
     for (const row of rows) {
       const bucket = this.bucketFor(row.provider);
       out[bucket] = (out[bucket] ?? 0) + Number(row.count);
+    }
+    return out;
+  }
+
+  /**
+   * Same bucketing as `collapseProviders`, but sums `cost_usd` instead of
+   * row counts. Custom provider names collapse into a single `"custom"`
+   * bucket, so admin-configured BYOK pricing never appears keyed by the
+   * raw provider string. Values are rounded to cents to avoid emitting
+   * micro-precision floats over the wire.
+   */
+  private collapseProviderCosts(rows: ProviderAggregateRow[]): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const row of rows) {
+      const cost = row.cost == null ? 0 : Number(row.cost);
+      if (!Number.isFinite(cost) || cost <= 0) continue;
+      const bucket = this.bucketFor(row.provider);
+      out[bucket] = (out[bucket] ?? 0) + cost;
+    }
+    for (const key of Object.keys(out)) {
+      const rounded = roundCents(out[key]);
+      if (rounded === 0) delete out[key];
+      else out[key] = rounded;
     }
     return out;
   }
@@ -173,4 +202,9 @@ export class PayloadBuilderService {
     }
     return out;
   }
+}
+
+function roundCents(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.round(value * 100) / 100;
 }


### PR DESCRIPTION
## Summary

Self-hosted installs already compute `cost_usd` per message at routing time but never shipped that value back. Downstream dashboards (peacock) had to fall back to estimating fleet GMV from token counts × per-provider blended rates — accurate to roughly ±2× on a per-install basis. This PR closes the gap with two optional fields in the daily telemetry payload.

- **`cost_usd_total`** — sum of `agent_messages.cost_usd` over the 24h window, rounded to cents. `0` for Ollama-only / free-API installs.
- **`cost_usd_by_provider`** — same total split per provider using the same bucketing as `messages_by_provider`. Custom providers collapse into a single `"custom"` key so admin-configured BYOK pricing is never keyed by the raw provider name.

Both are **optional** on `TelemetryPayloadV1` (`cost_usd_total?`, `cost_usd_by_provider?`). Installs running older Manifest versions emit a strict subset of the payload, so receivers should feature-detect on presence, not on `schema_version` — which stays at `1` per the additive-changes-keep-the-version rule already documented in the DTO.

## Privacy

Nothing new leaves the box. Cost is a derived rollup of `input_tokens` / `output_tokens` we already ship, multiplied by the in-process pricing table. Cents-rounded to avoid leaking precision. Custom provider names still collapse to `"custom"` — admin-set BYOK rates never appear per-provider-name. Negative / NaN costs are skipped defensively; zero-after-rounding buckets are dropped.

## Backwards compatibility

- `schema_version` stays at `1` (additive change).
- Old installs continue to send the existing 13-field shape; receivers detect cost fields by `payload.cost_usd_total !== undefined`.
- The existing opt-out (`MANIFEST_TELEMETRY_DISABLED=1`) covers the new fields — there's no separate cost opt-out.

## Docs

Docs PR for the format change: mnfst/docs#30

## Test plan

- [x] `npx jest src/telemetry` — 46/46 passing (22 in payload-builder spec, including 7 new cost-related cases)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/telemetry/` — clean
- [ ] Verify with a real self-hosted install: post-deploy, confirm `cost_usd_total` appears in incoming reports and rolls up correctly on peacock once consumer change lands

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds precise cost telemetry to the daily payload so dashboards can use real spend instead of token-based estimates. Both fields are optional, rounded to cents, and preserve privacy.

- **New Features**
  - `cost_usd_total`: sum of `agent_messages.cost_usd` over the last 24h; rounded to cents; `0` for free/Ollama-only installs.
  - `cost_usd_by_provider`: provider breakdown matching `messages_by_provider`; custom providers collapse to `"custom"`; negative/NaN skipped; buckets that round to `0` omitted.
  - Backwards compatible: `schema_version` stays `1`. Consumers should feature-detect these fields when present.

<sup>Written for commit 689c9ad9b156030774d033140216c8faaa967eea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

