### PR TITLE
fix: preserve Anthropic server tools through /v1/messages

### DIFF
--- a/.changeset/fix-1886-anthropic-server-tools.md
+++ b/.changeset/fix-1886-anthropic-server-tools.md
@@ -1,0 +1,12 @@
+---
+'manifest': patch
+---
+
+fix(proxy): preserve Anthropic server tools through /v1/messages double-conversion (#1886)
+
+Claude Code requests routed through `POST /v1/messages` to an Anthropic upstream
+failed with `tools.N.custom.input_schema: Field required` because server tools
+(web_search, bash, text_editor, computer, code_execution) lost their `type` tag
+during the Anthropic → OpenAI → Anthropic translation and were re-emitted as
+custom tools missing the required `input_schema`. Server tools are now stashed
+on the translated body and re-emitted unchanged when the upstream is Anthropic.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -256,6 +256,54 @@ describe('Anthropic Adapter', () => {
       expect(tools).toEqual([{ type: 'web_search_20250305', name: 'web_search' }]);
     });
 
+    it('strips a pre-existing cache_control on stashed server tools when injectCacheControl is false', () => {
+      // A client-supplied breakpoint on the inbound server tool must not
+      // leak through when the subscription path disables caching, or
+      // Anthropic still treats the request as cached.
+      const body = {
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [{ type: 'function', function: { name: 'web_search' } }],
+        _anthropicServerTools: [
+          {
+            type: 'web_search_20250305',
+            name: 'web_search',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514', {
+        injectCacheControl: false,
+      });
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toEqual([{ type: 'web_search_20250305', name: 'web_search' }]);
+    });
+
+    it('skips malformed entries in _anthropicServerTools instead of throwing', () => {
+      // Defensive: any non-object entry (null, primitive, array) should be
+      // dropped before spread so a bad stash doesn't fail the whole request.
+      const body = {
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [
+          { type: 'function', function: { name: 'web_search' } },
+          {
+            type: 'function',
+            function: { name: 'my_custom', parameters: { type: 'object' } },
+          },
+        ],
+        _anthropicServerTools: [
+          null,
+          'not-an-object',
+          ['array'],
+          { type: 'web_search_20250305', name: 'web_search' },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(2);
+      expect(tools[0]).toMatchObject({ type: 'web_search_20250305', name: 'web_search' });
+      expect(tools[1]).toMatchObject({ name: 'my_custom' });
+    });
+
     it('converts tool_calls in assistant messages to tool_use blocks', () => {
       const body = {
         messages: [

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -185,6 +185,77 @@ describe('Anthropic Adapter', () => {
       expect(tools[1].cache_control).toEqual({ type: 'ephemeral' });
     });
 
+    it('re-emits stashed Anthropic server tools with their type tag and drops their function-shaped duplicates (issue #1886)', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Search' }],
+        // Function-shaped duplicates that toChatTools would have emitted for
+        // the server tools, plus a real custom tool.
+        tools: [
+          { type: 'function', function: { name: 'web_search' } },
+          { type: 'function', function: { name: 'bash' } },
+          {
+            type: 'function',
+            function: {
+              name: 'my_custom',
+              description: 'do thing',
+              parameters: { type: 'object' },
+            },
+          },
+        ],
+        _anthropicServerTools: [
+          { type: 'web_search_20250305', name: 'web_search' },
+          { type: 'bash_20250124', name: 'bash' },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(3);
+      // Server tools first, with type tag intact and no input_schema.
+      expect(tools[0]).toMatchObject({ type: 'web_search_20250305', name: 'web_search' });
+      expect(tools[0].input_schema).toBeUndefined();
+      expect(tools[1]).toMatchObject({ type: 'bash_20250124', name: 'bash' });
+      expect(tools[1].input_schema).toBeUndefined();
+      // Custom tool keeps input_schema. cache_control breakpoint lands on
+      // the last (custom) tool.
+      expect(tools[2].name).toBe('my_custom');
+      expect(tools[2].input_schema).toEqual({ type: 'object' });
+      expect(tools[2].cache_control).toEqual({ type: 'ephemeral' });
+      // Server-tool entries don't get a cache_control breakpoint.
+      expect(tools[0].cache_control).toBeUndefined();
+      expect(tools[1].cache_control).toBeUndefined();
+    });
+
+    it('emits stashed server tools even when no custom tools are present', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [{ type: 'function', function: { name: 'web_search' } }],
+        _anthropicServerTools: [{ type: 'web_search_20250305', name: 'web_search' }],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toEqual([
+        {
+          type: 'web_search_20250305',
+          name: 'web_search',
+          cache_control: { type: 'ephemeral' },
+        },
+      ]);
+    });
+
+    it('omits cache_control on stashed server tools when injectCacheControl is false', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [{ type: 'function', function: { name: 'web_search' } }],
+        _anthropicServerTools: [{ type: 'web_search_20250305', name: 'web_search' }],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514', {
+        injectCacheControl: false,
+      });
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toEqual([{ type: 'web_search_20250305', name: 'web_search' }]);
+    });
+
     it('converts tool_calls in assistant messages to tool_use blocks', () => {
       const body = {
         messages: [

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -1,6 +1,7 @@
 import {
   chatCompletionsResponseToMessages,
   createMessagesStreamTransformer,
+  extractAnthropicServerTools,
   messagesToChatCompletionsRequest,
 } from '../anthropic-messages-adapter';
 
@@ -230,6 +231,44 @@ describe('Anthropic Messages adapter', () => {
       expect(ignoredNamed.tool_choice).toBeUndefined();
     });
 
+    it('stashes Anthropic server tools and still exposes them to the scorer (issue #1886)', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [
+          { type: 'web_search_20250305', name: 'web_search' },
+          { type: 'bash_20250124', name: 'bash' },
+          { name: 'my_custom', description: 'c', input_schema: { type: 'object' } },
+          { type: 'custom', name: 'explicit_custom', input_schema: { type: 'object' } },
+        ],
+      });
+
+      // chatBody.tools keeps all four — the scorer reads tool count and
+      // function.name and must keep seeing server tools for tier / specificity.
+      const tools = result.tools as Array<Record<string, unknown>>;
+      expect(tools).toHaveLength(4);
+      expect(tools.map((t) => (t.function as Record<string, unknown>).name)).toEqual([
+        'web_search',
+        'bash',
+        'my_custom',
+        'explicit_custom',
+      ]);
+
+      // Originals are stashed so toAnthropicRequest can re-emit them with the
+      // `type` tag intact.
+      expect(result._anthropicServerTools).toEqual([
+        { type: 'web_search_20250305', name: 'web_search' },
+        { type: 'bash_20250124', name: 'bash' },
+      ]);
+    });
+
+    it('omits the stash when no server tools are present', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [{ name: 'plain', input_schema: { type: 'object' } }],
+      });
+      expect(result._anthropicServerTools).toBeUndefined();
+    });
+
     it('forwards Anthropic-native thinking and top_k onto chatBody', () => {
       const result = messagesToChatCompletionsRequest({
         messages: [{ role: 'user', content: 'x' }],
@@ -329,6 +368,28 @@ describe('Anthropic Messages adapter', () => {
         messages: ['nope', null, { role: 'user', content: 'ok' }],
       } as Record<string, unknown>);
       expect(result.messages).toEqual([{ role: 'user', content: 'ok' }]);
+    });
+  });
+
+  describe('extractAnthropicServerTools', () => {
+    it('returns tools whose type is a non-custom string', () => {
+      expect(
+        extractAnthropicServerTools([
+          { type: 'web_search_20250305', name: 'web_search' },
+          { type: 'custom', name: 'c1' },
+          { name: 'c2' },
+          { type: 'text_editor_20250728', name: 'str_replace_editor' },
+          'not-a-record',
+        ]),
+      ).toEqual([
+        { type: 'web_search_20250305', name: 'web_search' },
+        { type: 'text_editor_20250728', name: 'str_replace_editor' },
+      ]);
+    });
+
+    it('returns an empty array when no server tools are present', () => {
+      expect(extractAnthropicServerTools([{ type: 'custom', name: 'c' }])).toEqual([]);
+      expect(extractAnthropicServerTools([])).toEqual([]);
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -20,6 +20,20 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('stream_options');
     });
 
+    it('strips Manifest-internal _anthropic* stash fields on every provider (issue #1886)', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        model: 'gpt-4o',
+        _anthropicServerTools: [{ type: 'web_search_20250305', name: 'web_search' }],
+      };
+
+      const openai = sanitizeOpenAiBody(body, 'openai', 'gpt-4o');
+      expect(openai).not.toHaveProperty('_anthropicServerTools');
+
+      const groq = sanitizeOpenAiBody(body, 'groq', 'llama-3');
+      expect(groq).not.toHaveProperty('_anthropicServerTools');
+    });
+
     it('should strip OpenAI-only fields for non-passthrough providers', () => {
       const body = {
         messages: [{ role: 'user', content: 'Hi' }],

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -186,10 +186,30 @@ export function toAnthropicRequest(
   };
   if (systemBlocks.length > 0) result.system = systemBlocks;
 
-  const tools = convertTools(body.tools as Array<Record<string, unknown>> | undefined);
-  if (tools) {
-    if (shouldCache) tools[tools.length - 1].cache_control = CACHE;
-    result.tools = tools;
+  // Re-emit Anthropic server tools (web_search_*, bash_*, text_editor_*, etc.)
+  // unchanged when the inbound request was Anthropic Messages and stashed them
+  // on the body. The OpenAI tool shape can't represent a server tool's `type`
+  // tag, so convertTools would produce nameless customs that Anthropic rejects
+  // (issue #1886). Drop function-shaped entries whose name collides with a
+  // stashed server tool, then prepend the originals.
+  const stashedServerTools = Array.isArray(body._anthropicServerTools)
+    ? (body._anthropicServerTools as Array<Record<string, unknown>>)
+    : [];
+  const serverToolNames = new Set<string>();
+  for (const t of stashedServerTools) {
+    if (typeof t.name === 'string') serverToolNames.add(t.name);
+  }
+  const convertedTools = convertTools(body.tools as Array<Record<string, unknown>> | undefined);
+  const customTools: AnthropicTool[] = convertedTools
+    ? convertedTools.filter((t) => !serverToolNames.has(t.name))
+    : [];
+  const combinedTools: AnthropicTool[] = [
+    ...stashedServerTools.map((t) => ({ ...t }) as unknown as AnthropicTool),
+    ...customTools,
+  ];
+  if (combinedTools.length > 0) {
+    if (shouldCache) combinedTools[combinedTools.length - 1].cache_control = CACHE;
+    result.tools = combinedTools;
   }
 
   if (body.temperature !== undefined) result.temperature = body.temperature;

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -192,8 +192,13 @@ export function toAnthropicRequest(
   // tag, so convertTools would produce nameless customs that Anthropic rejects
   // (issue #1886). Drop function-shaped entries whose name collides with a
   // stashed server tool, then prepend the originals.
+  //
+  // Filter to plain objects up front so a malformed stash element (null,
+  // primitive, array) doesn't throw on spread or break the name index.
   const stashedServerTools = Array.isArray(body._anthropicServerTools)
-    ? (body._anthropicServerTools as Array<Record<string, unknown>>)
+    ? body._anthropicServerTools.filter(
+        (t): t is Record<string, unknown> => !!t && typeof t === 'object' && !Array.isArray(t),
+      )
     : [];
   const serverToolNames = new Set<string>();
   for (const t of stashedServerTools) {
@@ -203,8 +208,16 @@ export function toAnthropicRequest(
   const customTools: AnthropicTool[] = convertedTools
     ? convertedTools.filter((t) => !serverToolNames.has(t.name))
     : [];
+  // Strip any pre-existing cache_control on stashed entries when caching is
+  // disabled (e.g. subscription OAuth path) — otherwise a client-supplied
+  // breakpoint would leak through and Anthropic would still treat the
+  // request as cached.
   const combinedTools: AnthropicTool[] = [
-    ...stashedServerTools.map((t) => ({ ...t }) as unknown as AnthropicTool),
+    ...stashedServerTools.map((t) => {
+      const clone = { ...t } as Record<string, unknown>;
+      if (!shouldCache) delete clone.cache_control;
+      return clone as unknown as AnthropicTool;
+    }),
     ...customTools,
   ];
   if (combinedTools.length > 0) {

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -142,6 +142,25 @@ function toChatTools(tools: unknown[]): JsonRecord[] {
   }));
 }
 
+// Anthropic server tools (web_search_*, bash_*, text_editor_*, computer_*,
+// code_execution_*, etc.) declare themselves with a versioned `type` tag and
+// no `input_schema` — Anthropic resolves the schema server-side from `type`.
+// The OpenAI chat_completions tool shape has no analogue, so a naive
+// translation drops the `type` and re-emits them as nameless custom tools,
+// which Anthropic then rejects with `tools.N.custom.input_schema: Field
+// required` (issue #1886). Stash the originals on chatBody and have
+// toAnthropicRequest re-emit them unchanged when the upstream is Anthropic.
+export function extractAnthropicServerTools(tools: unknown[]): JsonRecord[] {
+  const out: JsonRecord[] = [];
+  for (const tool of tools) {
+    if (!isRecord(tool)) continue;
+    if (typeof tool.type === 'string' && tool.type !== 'custom') {
+      out.push(tool);
+    }
+  }
+  return out;
+}
+
 function toChatToolChoice(choice: unknown): unknown {
   if (!isRecord(choice)) return undefined;
   if (choice.type === 'auto') return 'auto';
@@ -185,7 +204,11 @@ export function messagesToChatCompletionsRequest(body: JsonRecord): JsonRecord {
   if (body.thinking !== undefined) chatBody.thinking = body.thinking;
   if (body.top_k !== undefined) chatBody.top_k = body.top_k;
 
-  if (Array.isArray(body.tools)) chatBody.tools = toChatTools(body.tools);
+  if (Array.isArray(body.tools)) {
+    chatBody.tools = toChatTools(body.tools);
+    const serverTools = extractAnthropicServerTools(body.tools);
+    if (serverTools.length > 0) chatBody._anthropicServerTools = serverTools;
+  }
   const toolChoice = toChatToolChoice(body.tool_choice);
   if (toolChoice !== undefined) chatBody.tool_choice = toolChoice;
 

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -251,6 +251,11 @@ export function sanitizeOpenAiBody(
 
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
+    // Strip Manifest-internal fields stashed by inbound adapters (e.g.
+    // `_anthropicServerTools` from anthropic-messages-adapter). These are
+    // only consumed by toAnthropicRequest; OpenAI-compatible upstreams
+    // would reject the unknown parameter.
+    if (key.startsWith('_anthropic')) continue;
     if (key === 'messages') {
       cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model);
       continue;


### PR DESCRIPTION
### What changed
- Stash Anthropic server tools (`web_search_*`, `bash_*`, `text_editor_*`, `computer_*`, `code_execution_*`) on the translated chat body and re-emit them unchanged when the upstream is Anthropic.
- `sanitizeOpenAiBody` strips any `_anthropic*` Manifest-internal field before forwarding to non-Anthropic upstreams.

### Why
Claude Code requests to `/v1/messages` lost their server-tool `type` tag in the Anthropic → OpenAI → Anthropic round-trip and were re-emitted as custom tools without `input_schema`. Anthropic rejected with `tools.N.custom.input_schema: Field required`.

### For users
Claude Code (and any Anthropic-Messages client using server tools) now routes through Manifest to Anthropic without 400s.

### Notes
Fixes #1886. Tests added on the inbound stash, the outbound re-emit, and the OpenAI-side strip. Codex review: clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Anthropic server tools through `/v1/messages` so Claude Code requests route without 400s. Hardens re-emit and sanitize logic for edge cases; fixes #1886.

- **Bug Fixes**
  - Stash server tools (`web_search_*`, `bash_*`, `text_editor_*`, `computer_*`, `code_execution_*`) as `_anthropicServerTools` during Messages→Chat translation, while keeping them visible to the scorer.
  - On Anthropic upstreams, re-emit stashed tools with their versioned `type`, drop function-shaped duplicates, and handle caching: keep the `cache_control` breakpoint on the last tool when enabled; strip any `cache_control` on stashed tools when caching is disabled; skip malformed stash entries instead of throwing.
  - Strip `_anthropic*` fields in `sanitizeOpenAiBody` for OpenAI-compatible providers to avoid unknown-parameter errors.

<sup>Written for commit ff42ab9afc11e72e4d4f502b897ff9cdd21a3ca0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

