### PR TITLE
fix(routing): route GitHub Copilot Codex models to /responses

### DIFF
--- a/.changeset/copilot-codex-routing.md
+++ b/.changeset/copilot-codex-routing.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix GitHub Copilot routing for GPT-5 Codex models. Copilot serves Codex variants (`gpt-5-codex`, `gpt-5.2-codex`, `gpt-5.3-codex`) only via `/responses`, so chat-completions requests now swap to that endpoint instead of returning "Unsupported API for model". Also rewrites `max_tokens` to `max_completion_tokens` for the GPT-5 / o-series family on Copilot, fixing the "Unsupported parameter: 'max_tokens'" error reported alongside.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -670,5 +670,58 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('max_tokens', 2048);
       expect(result).not.toHaveProperty('max_completion_tokens');
     });
+
+    /* ── Copilot: max_tokens → max_completion_tokens (mnfst/manifest#1849) ── */
+
+    it('should convert max_tokens to max_completion_tokens for Copilot GPT-5', () => {
+      const body = { messages: [{ role: 'user', content: 'hi' }], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-5');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should convert max_tokens to max_completion_tokens for Copilot o-series', () => {
+      const body = { messages: [], max_tokens: 2048 };
+
+      const result = sanitizeOpenAiBody(body, 'copilot', 'o3-mini');
+
+      expect(result).toHaveProperty('max_completion_tokens', 2048);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should preserve max_completion_tokens unchanged for Copilot GPT-5 family', () => {
+      const body = { messages: [], max_completion_tokens: 1024 };
+
+      const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-5.2');
+
+      expect(result).toHaveProperty('max_completion_tokens', 1024);
+      expect(result).not.toHaveProperty('max_tokens');
+    });
+
+    it('should NOT convert max_tokens for Copilot GPT-4 family (legacy field still accepted)', () => {
+      const body = { messages: [], max_tokens: 4096 };
+
+      const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-4o');
+
+      expect(result).toHaveProperty('max_tokens', 4096);
+      expect(result).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('should still strip OPENAI_ONLY_FIELDS for Copilot GPT-5', () => {
+      const body = {
+        messages: [],
+        max_tokens: 4096,
+        store: true,
+        service_tier: 'auto',
+      };
+
+      const result = sanitizeOpenAiBody(body, 'copilot', 'gpt-5');
+
+      expect(result).toHaveProperty('max_completion_tokens', 4096);
+      expect(result).not.toHaveProperty('store');
+      expect(result).not.toHaveProperty('service_tier');
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -860,6 +860,152 @@ describe('ProviderClient', () => {
     });
   });
 
+  describe('resolveEndpoint - Copilot Responses-only routing (mnfst/manifest#1849)', () => {
+    // GitHub Copilot serves Codex variants only at /responses; /chat/completions
+    // returns "Unsupported API for model". Mirrors the OpenAI Responses-only swap.
+    const copilotResponsesOnlyModels = [
+      'gpt-5-codex',
+      'gpt-5.2-codex',
+      'gpt-5.3-codex',
+      'gpt-5.1-codex-mini',
+    ];
+
+    it.each(copilotResponsesOnlyModels)(
+      'routes Copilot + Codex model %s to /responses with chatgpt format',
+      async (model) => {
+        mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        const result = await client.forward({
+          provider: 'copilot',
+          apiKey: 'tid=abc',
+          model,
+          body,
+          stream: false,
+        });
+
+        const url = mockFetch.mock.calls[0][0] as string;
+        expect(url).toBe('https://api.githubcopilot.com/responses');
+        expect(result.isChatGpt).toBe(true);
+
+        // Copilot headers preserved (Editor-Version etc.).
+        const headers = mockFetch.mock.calls[0][1].headers;
+        expect(headers['Authorization']).toBe('Bearer tid=abc');
+        expect(headers['Copilot-Integration-Id']).toBe('vscode-chat');
+        expect(headers['Editor-Version']).toBeDefined();
+
+        // Body is Responses-API shape (input/store/instructions), not Chat Completions.
+        const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(Array.isArray(sentBody.input)).toBe(true);
+        expect(sentBody.store).toBe(false);
+        expect(sentBody.instructions).toBeDefined();
+        expect(sentBody.messages).toBeUndefined();
+        expect(sentBody.model).toBe(model);
+      },
+    );
+
+    it('leaves non-Codex Copilot models on /chat/completions', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.githubcopilot.com/chat/completions');
+      expect(result.isChatGpt).toBe(false);
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toBeDefined();
+      expect(sentBody.input).toBeUndefined();
+    });
+
+    it('forces upstream stream:true so the SSE collector can normalise the response', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'gpt-5.3-codex',
+        body,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.stream).toBe(true);
+    });
+
+    it('overrides explicit stream:false from caller for copilot-responses', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'gpt-5.3-codex',
+        body: { ...body, stream: false },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      // Forced upstream so handleNonStreamResponse's SSE collector remains
+      // the single source of truth — see mnfst/manifest#1849.
+      expect(sentBody.stream).toBe(true);
+    });
+
+    it('maps max_tokens to max_output_tokens for Copilot Codex requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'gpt-5-codex',
+        body: { ...body, max_tokens: 2048 },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.max_output_tokens).toBe(2048);
+      expect(sentBody.max_tokens).toBeUndefined();
+    });
+
+    it('maps max_tokens to max_output_tokens for OpenAI Codex (api-key) requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-5.3-codex',
+        body: { ...body, max_tokens: 1024 },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.max_output_tokens).toBe(1024);
+      expect(sentBody.max_tokens).toBeUndefined();
+    });
+
+    it('does NOT map max_tokens to max_output_tokens for ChatGPT subscription', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'oauth-token',
+        model: 'gpt-5.3-codex',
+        body: { ...body, max_tokens: 1024 },
+        stream: false,
+        authType: 'subscription',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      // ChatGPT subscription backend rejects max_output_tokens with
+      // `unsupported_parameter`; never forward it on this path.
+      expect(sentBody.max_output_tokens).toBeUndefined();
+    });
+  });
+
   describe('Z.ai subscription provider', () => {
     it('routes to Coding Plan endpoint with subscription authType', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -206,6 +206,20 @@ describe('PROVIDER_ENDPOINTS', () => {
     });
   });
 
+  it('copilot-responses targets /responses with chatgpt format and Copilot headers', () => {
+    const ep = PROVIDER_ENDPOINTS['copilot-responses'];
+    expect(ep.baseUrl).toBe('https://api.githubcopilot.com');
+    expect(ep.format).toBe('chatgpt');
+    expect(ep.buildPath('gpt-5.3-codex')).toBe('/responses');
+    expect(ep.buildHeaders('ghu_token')).toEqual({
+      Authorization: 'Bearer ghu_token',
+      'Content-Type': 'application/json',
+      'Editor-Version': 'vscode/1.100.0',
+      'Editor-Plugin-Version': 'copilot/1.300.0',
+      'Copilot-Integration-Id': 'vscode-chat',
+    });
+  });
+
   it('anthropic buildPath returns /v1/messages', () => {
     const path = PROVIDER_ENDPOINTS['anthropic'].buildPath('claude-sonnet-4');
     expect(path).toBe('/v1/messages');

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.spec.ts
@@ -158,6 +158,64 @@ describe('chatgpt-adapter', () => {
       // — OpenAI's /v1/responses endpoint rejects or ignores them.
       expect(req).not.toHaveProperty('messages');
       expect(req).not.toHaveProperty('max_tokens');
+      // Default: max_output_tokens is NOT mapped (ChatGPT subscription rejects it).
+      expect(req).not.toHaveProperty('max_output_tokens');
+    });
+
+    it('does not map max_tokens to max_output_tokens by default (subscription safe)', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 4096,
+      };
+
+      const req = toResponsesRequest(body, 'gpt-5-codex');
+
+      expect(req).not.toHaveProperty('max_output_tokens');
+      expect(req).not.toHaveProperty('max_tokens');
+    });
+
+    it('maps max_tokens to max_output_tokens when mapMaxOutputTokens is true', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 4096,
+      };
+
+      const req = toResponsesRequest(body, 'gpt-5-codex', { mapMaxOutputTokens: true });
+
+      expect(req.max_output_tokens).toBe(4096);
+      expect(req).not.toHaveProperty('max_tokens');
+    });
+
+    it('maps max_completion_tokens to max_output_tokens when mapMaxOutputTokens is true', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'hi' }],
+        max_completion_tokens: 2048,
+      };
+
+      const req = toResponsesRequest(body, 'gpt-5-codex', { mapMaxOutputTokens: true });
+
+      expect(req.max_output_tokens).toBe(2048);
+      expect(req).not.toHaveProperty('max_completion_tokens');
+    });
+
+    it('prefers max_completion_tokens over max_tokens when both present', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'hi' }],
+        max_tokens: 4096,
+        max_completion_tokens: 2048,
+      };
+
+      const req = toResponsesRequest(body, 'gpt-5-codex', { mapMaxOutputTokens: true });
+
+      expect(req.max_output_tokens).toBe(2048);
+    });
+
+    it('omits max_output_tokens when caller did not specify a cap', () => {
+      const body = { messages: [{ role: 'user', content: 'hi' }] };
+
+      const req = toResponsesRequest(body, 'gpt-5-codex', { mapMaxOutputTokens: true });
+
+      expect(req).not.toHaveProperty('max_output_tokens');
     });
   });
 

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -21,9 +21,20 @@ import { OpenAIMessage } from './proxy-types';
 
 /* ── Request conversion ── */
 
+export interface ToResponsesRequestOptions {
+  /**
+   * Map `max_tokens` / `max_completion_tokens` → `max_output_tokens`.
+   * The ChatGPT subscription backend (`chatgpt.com/backend-api/codex/responses`)
+   * rejects `max_output_tokens`, so callers that target that endpoint must
+   * leave this disabled. API-key /responses and Copilot /responses accept it.
+   */
+  mapMaxOutputTokens?: boolean;
+}
+
 export function toResponsesRequest(
   body: Record<string, unknown>,
   model: string,
+  options: ToResponsesRequestOptions = {},
 ): Record<string, unknown> {
   const messages = (body.messages ?? []) as OpenAIMessage[];
   const input: Record<string, unknown>[] = [];
@@ -63,6 +74,16 @@ export function toResponsesRequest(
     store: false,
     instructions: extractInstructions(messages),
   };
+
+  // Map Chat Completions token caps to the Responses API field so callers
+  // don't silently lose their output limit when routed to /responses.
+  // Gated because the ChatGPT subscription backend rejects max_output_tokens.
+  if (options.mapMaxOutputTokens) {
+    const maxOutputTokens = body.max_completion_tokens ?? body.max_tokens;
+    if (typeof maxOutputTokens === 'number') {
+      request.max_output_tokens = maxOutputTokens;
+    }
+  }
 
   if (Array.isArray(body.tools)) {
     request.tools = convertTools(body.tools as Record<string, unknown>[]);
@@ -254,10 +275,7 @@ function handleCompletedEvent(dataStr: string, model: string): string {
  * This function consumes the SSE text and builds a non-streaming
  * OpenAI Chat Completion response from the collected events.
  */
-export function collectChatGptSseResponse(
-  sseText: string,
-  model: string,
-): Record<string, unknown> {
+export function collectChatGptSseResponse(sseText: string, model: string): Record<string, unknown> {
   let text = '';
   // Map output_index → tool call to handle mixed output items correctly.
   // The output_index from the API refers to position in the full output array

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -102,6 +102,21 @@ const DEEPSEEK_MAX_TOKENS_LIMIT = 8192;
  */
 const OPENAI_MAX_COMPLETION_TOKENS_RE = /^(o\d|gpt-5)/i;
 
+/**
+ * Endpoints that ultimately hit OpenAI infrastructure and therefore need
+ * `max_tokens` rewritten to `max_completion_tokens` for o-series / GPT-5+.
+ * Copilot belongs here because GitHub Copilot proxies these models to OpenAI
+ * (issue mnfst/manifest#1849).
+ */
+const OPENAI_MAX_COMPLETION_TOKENS_ENDPOINTS = new Set(['openai', 'copilot']);
+
+function usesOpenAiMaxCompletionTokens(endpointKey: string, bareModel: string): boolean {
+  return (
+    OPENAI_MAX_COMPLETION_TOKENS_ENDPOINTS.has(endpointKey) &&
+    OPENAI_MAX_COMPLETION_TOKENS_RE.test(bareModel)
+  );
+}
+
 function supportsReasoningContent(endpointKey: string, model: string): boolean {
   if (endpointKey === 'deepseek') return true;
   if (endpointKey === 'openrouter') return model.toLowerCase().startsWith('deepseek/');
@@ -240,14 +255,11 @@ export function sanitizeOpenAiBody(
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
-  // For OpenAI models that require max_completion_tokens, convert before passthrough.
   // Strip vendor prefix (e.g., "openai/gpt-5" → "gpt-5") before matching.
   const bareForRegex = model.includes('/') ? model.substring(model.indexOf('/') + 1) : model;
+  const needsMaxCompletionTokens = usesOpenAiMaxCompletionTokens(endpointKey, bareForRegex);
   const convertMaxTokens =
-    endpointKey === 'openai' &&
-    OPENAI_MAX_COMPLETION_TOKENS_RE.test(bareForRegex) &&
-    'max_tokens' in body &&
-    !('max_completion_tokens' in body);
+    needsMaxCompletionTokens && 'max_tokens' in body && !('max_completion_tokens' in body);
 
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
@@ -255,19 +267,27 @@ export function sanitizeOpenAiBody(
       cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model);
       continue;
     }
+    // Rewrite max_tokens → max_completion_tokens for OpenAI-backed endpoints that
+    // require it (native OpenAI + Copilot for o-series / GPT-5+). Applies in both
+    // passthrough and non-passthrough branches.
+    if (convertMaxTokens && key === 'max_tokens') {
+      cleaned['max_completion_tokens'] = value;
+      continue;
+    }
     if (passthroughTopLevel) {
-      // Convert max_tokens → max_completion_tokens for newer OpenAI models
-      if (convertMaxTokens && key === 'max_tokens') {
-        cleaned['max_completion_tokens'] = value;
-        continue;
-      }
       cleaned[key] = value;
       continue;
     }
     if (OPENAI_ONLY_FIELDS.has(key)) continue;
     if (key === 'max_completion_tokens') {
-      // Convert to max_tokens unless already set
-      if (!('max_tokens' in body)) cleaned['max_tokens'] = value;
+      // Preserve max_completion_tokens for endpoints that require it; otherwise
+      // downconvert to max_tokens for OpenAI-compatible providers that only know
+      // the legacy field name.
+      if (needsMaxCompletionTokens) {
+        cleaned[key] = value;
+      } else if (!('max_tokens' in body)) {
+        cleaned['max_tokens'] = value;
+      }
       continue;
     }
     cleaned[key] = value;

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -173,6 +173,11 @@ export class ProviderClient {
     if (resolved === 'openai' && OPENAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
       resolved = 'openai-responses';
     }
+    // Copilot serves Codex variants only at /responses; /chat/completions returns
+    // "Unsupported API for model" (gh issue mnfst/manifest#1849).
+    if (resolved === 'copilot' && OPENAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
+      resolved = 'copilot-responses';
+    }
     if (resolved === 'opencode-go') {
       // OpenCode Go uses two different API formats depending on the model:
       // MiniMax models use Anthropic /v1/messages, all others use OpenAI /v1/chat/completions.
@@ -235,23 +240,36 @@ export class ProviderClient {
     }
 
     if (endpoint.format === 'chatgpt') {
+      const requestBody =
+        ctx.apiMode === 'responses'
+          ? // ChatGPT subscription tokens hit the Codex Responses backend, which
+            // requires instruction text, list-shaped input, and upstream SSE even
+            // when Manifest returns a non-streaming JSON response to the caller.
+            // It also rejects sampling/metadata/cache fields the OpenAI SDK
+            // routinely sends, so we drop those before forwarding.
+            toNativeResponsesRequest(body, bareModel, {
+              defaultInstructions: endpointKey === 'openai-subscription',
+              inputList: endpointKey === 'openai-subscription',
+              forceStream: endpointKey === 'openai-subscription',
+              stripCodexUnsupported: endpointKey === 'openai-subscription',
+            })
+          : toResponsesRequest(requestSource, bareModel, {
+              // The ChatGPT subscription backend rejects max_output_tokens with
+              // unsupported_parameter; only opt in for the API-key paths.
+              mapMaxOutputTokens:
+                endpointKey === 'openai-responses' || endpointKey === 'copilot-responses',
+            });
+      // Force upstream streaming for copilot-responses so the SSE collector in
+      // handleNonStreamResponse stays the single source of truth. Without this,
+      // an explicit `stream: false` from the caller could hand us a plain JSON
+      // body that our SSE parser would silently drop (mnfst/manifest#1849).
+      if (endpointKey === 'copilot-responses') {
+        requestBody.stream = true;
+      }
       return {
         url: `${endpoint.baseUrl}${endpoint.buildPath(bareModel)}`,
         headers: endpoint.buildHeaders(apiKey, authType),
-        requestBody:
-          ctx.apiMode === 'responses'
-            ? // ChatGPT subscription tokens hit the Codex Responses backend, which
-              // requires instruction text, list-shaped input, and upstream SSE even
-              // when Manifest returns a non-streaming JSON response to the caller.
-              // It also rejects sampling/metadata/cache fields the OpenAI SDK
-              // routinely sends, so we drop those before forwarding.
-              toNativeResponsesRequest(body, bareModel, {
-                defaultInstructions: endpointKey === 'openai-subscription',
-                inputList: endpointKey === 'openai-subscription',
-                forceStream: endpointKey === 'openai-subscription',
-                stripCodexUnsupported: endpointKey === 'openai-subscription',
-              })
-            : toResponsesRequest(requestSource, bareModel),
+        requestBody,
       };
     }
 

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -189,6 +189,20 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: () => '/chat/completions',
     format: 'openai',
   },
+  // Codex variants (e.g. gpt-5-codex, gpt-5.2-codex, gpt-5.3-codex) only accept
+  // /responses on Copilot — /chat/completions returns "Unsupported API for model".
+  'copilot-responses': {
+    baseUrl: 'https://api.githubcopilot.com',
+    buildHeaders: (apiKey: string) => ({
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'Editor-Version': COPILOT_EDITOR_VERSION,
+      'Editor-Plugin-Version': COPILOT_PLUGIN_VERSION,
+      'Copilot-Integration-Id': 'vscode-chat',
+    }),
+    buildPath: () => '/responses',
+    format: 'chatgpt',
+  },
   openrouter: {
     baseUrl: 'https://openrouter.ai',
     buildHeaders: (apiKey: string) => ({


### PR DESCRIPTION
### ✨ What changed
- New `copilot-responses` endpoint; Codex models on Copilot now post to `/responses` instead of `/chat/completions`.
- `max_tokens` → `max_completion_tokens` rewrite hoisted out of the passthrough branch and extended to Copilot GPT-5 / o-series.
- Chat Completions token caps map to `max_output_tokens` for `openai-responses` and `copilot-responses` (gated; ChatGPT subscription rejects the field).
- Force upstream `stream: true` on `copilot-responses` so the existing SSE collector stays the single source of truth.

### 💭 Why
Copilot returns "Unsupported API for model" for `gpt-5-codex`, `gpt-5.2-codex`, `gpt-5.3-codex` on `/chat/completions`; those variants are served only at `/responses`. The non-Codex GPT-5 family on the same provider rejects `max_tokens` and needs `max_completion_tokens`.

### 👤 For users
GitHub Copilot Pro subscribers can now use GPT-5 Codex models through Manifest, and `max_tokens` works on the non-Codex GPT-5 family.

### 📝 Notes
Closes #1849

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix routing for GitHub Copilot GPT-5 Codex models by sending them to the Responses API and align token limit fields to prevent “Unsupported API/parameter” errors. Closes #1849.

- **Bug Fixes**
  - Added `copilot-responses` endpoint; Codex models (`gpt-5-codex`, `gpt-5.2-codex`, `gpt-5.3-codex`, `gpt-5.1-codex-mini`) now hit `/responses` instead of `/chat/completions`.
  - Rewrote `max_tokens` → `max_completion_tokens` for Copilot GPT-5/o-series; GPT-4 family unchanged.
  - Forwarded token caps as `max_output_tokens` for `openai-responses` and `copilot-responses` (off for `openai-subscription`).
  - Forced upstream `stream: true` on `copilot-responses` to keep the SSE collector as the single source of truth.

<sup>Written for commit c1fe19a95f99ab706bd235b006cfbd3fd8f66329. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

