### PR TITLE
feat: add per-agent breakdown to public stats API

### DIFF
--- a/.changeset/agent-tokens-public-endpoint.md
+++ b/.changeset/agent-tokens-public-endpoint.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add `GET /api/v1/public/agent-tokens` public endpoint. Mirrors the shape of `/provider-tokens` but groups daily-token usage by `(agent_category, agent_platform)` instead of by LLM provider, so the marketing site can show per-agent (OpenClaw, Claude Code, OpenAI SDK, etc.) charts alongside the existing per-provider ones. Excludes the `other` platform bucket and `custom:*` models server-side. Gated by `MANIFEST_PUBLIC_STATS` and cached for 24h, same posture as the rest of the public-stats endpoints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14912,7 +14912,7 @@
       }
     },
     "packages/manifest": {
-      "version": "6.2.0"
+      "version": "6.2.2"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/backend/src/public-stats/public-stats.controller.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.spec.ts
@@ -4,6 +4,7 @@ import type {
   UsageStats,
   FreeModel,
   ProviderDailyTokens,
+  AgentDailyTokens,
 } from './public-stats.service';
 import type { FreeModelsService } from '../free-models/free-models.service';
 
@@ -11,6 +12,7 @@ const mockService: Record<string, jest.Mock> = {
   getUsageStats: jest.fn(),
   getFreeModels: jest.fn(),
   getProviderDailyTokens: jest.fn(),
+  getAgentDailyTokens: jest.fn(),
 };
 
 const mockFreeModelsService: Record<string, jest.Mock> = {
@@ -270,6 +272,120 @@ describe('PublicStatsController', () => {
     });
   });
 
+  describe('getAgentTokens', () => {
+    const AGENT_FIXTURE: AgentDailyTokens[] = [
+      {
+        agent_category: 'personal',
+        agent_platform: 'openclaw',
+        category_label: 'Personal AI Agent',
+        platform_label: 'OpenClaw',
+        total_tokens: 1100000,
+        models: [
+          {
+            model: 'gpt-4o',
+            auth_type: 'api_key',
+            total_tokens: 1100000,
+            total_cost: 1.1,
+            daily: [
+              { date: '2026-04-06', tokens: 500000 },
+              { date: '2026-04-07', tokens: 600000 },
+            ],
+          },
+        ],
+      },
+    ];
+
+    it('fetches agent tokens on first call', async () => {
+      mockService.getAgentDailyTokens.mockResolvedValue(AGENT_FIXTURE);
+
+      const result = await controller.getAgentTokens();
+
+      expect(result.agents).toHaveLength(1);
+      expect(result.agents[0].agent_category).toBe('personal');
+      expect(result.agents[0].agent_platform).toBe('openclaw');
+      expect(result.cached_at).toBeDefined();
+      expect(mockService.getAgentDailyTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns cached within TTL', async () => {
+      mockService.getAgentDailyTokens.mockResolvedValue(AGENT_FIXTURE);
+      await controller.getAgentTokens();
+
+      const result = await controller.getAgentTokens();
+
+      expect(result.agents).toHaveLength(1);
+      expect(mockService.getAgentDailyTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-fetches after TTL expires', async () => {
+      mockService.getAgentDailyTokens.mockResolvedValue(AGENT_FIXTURE);
+      await controller.getAgentTokens();
+
+      const realDateNow = Date.now;
+      Date.now = () => realDateNow() + 86_400_001;
+
+      const updated: AgentDailyTokens[] = [];
+      mockService.getAgentDailyTokens.mockResolvedValue(updated);
+
+      const result = await controller.getAgentTokens();
+
+      expect(result.agents).toEqual([]);
+      Date.now = realDateNow;
+    });
+
+    it('returns fallback when service fails on first call', async () => {
+      mockService.getAgentDailyTokens.mockRejectedValue(new Error('fail'));
+
+      const result = await controller.getAgentTokens();
+
+      expect(result.agents).toEqual([]);
+    });
+
+    it('returns stale cache on error after previous success', async () => {
+      mockService.getAgentDailyTokens.mockResolvedValue(AGENT_FIXTURE);
+      await controller.getAgentTokens();
+
+      const realDateNow = Date.now;
+      Date.now = () => realDateNow() + 86_400_001;
+      mockService.getAgentDailyTokens.mockRejectedValue(new Error('fail'));
+
+      const result = await controller.getAgentTokens();
+
+      expect(result.agents).toHaveLength(1);
+      Date.now = realDateNow;
+    });
+
+    it('deduplicates concurrent requests', async () => {
+      let resolve!: (v: AgentDailyTokens[]) => void;
+      mockService.getAgentDailyTokens.mockReturnValue(
+        new Promise<AgentDailyTokens[]>((r) => {
+          resolve = r;
+        }),
+      );
+
+      const p1 = controller.getAgentTokens();
+      const p2 = controller.getAgentTokens();
+
+      resolve(AGENT_FIXTURE);
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      expect(r1.agents).toHaveLength(1);
+      expect(r2.agents).toHaveLength(1);
+      expect(mockService.getAgentDailyTokens).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears inflight lock after error', async () => {
+      mockService.getAgentDailyTokens.mockRejectedValueOnce(new Error('fail'));
+      await controller.getAgentTokens();
+
+      mockService.getAgentDailyTokens.mockResolvedValue(AGENT_FIXTURE);
+      const result = await controller.getAgentTokens();
+
+      expect(result.agents).toHaveLength(1);
+      expect(mockService.getAgentDailyTokens).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('getFreeProviders', () => {
     beforeEach(() => {
       mockFreeModelsService.getAll.mockReset();
@@ -376,6 +492,16 @@ describe('PublicStatsController', () => {
       expect(mockService.getProviderDailyTokens).not.toHaveBeenCalled();
     });
 
+    it('returns 404 from getAgentTokens without calling the service', async () => {
+      await controller.getAgentTokens().then(
+        () => {
+          throw new Error('expected NotFoundException');
+        },
+        (err) => expectNotFound(err),
+      );
+      expect(mockService.getAgentDailyTokens).not.toHaveBeenCalled();
+    });
+
     it('returns 404 from getFreeProviders without calling the service', () => {
       try {
         controller.getFreeProviders();
@@ -442,6 +568,14 @@ describe('PublicStatsController', () => {
       const result = await controller.getProviderTokens();
 
       expect(result.providers).toEqual([]);
+    });
+
+    it('handles string rejection in agent tokens', async () => {
+      mockService.getAgentDailyTokens.mockRejectedValue('string error');
+
+      const result = await controller.getAgentTokens();
+
+      expect(result.agents).toEqual([]);
     });
   });
 

--- a/packages/backend/src/public-stats/public-stats.controller.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.ts
@@ -7,6 +7,7 @@ import {
   TopModel,
   FreeModel,
   ProviderDailyTokens,
+  AgentDailyTokens,
 } from './public-stats.service';
 import { FreeModelsService, FreeProviderDto } from '../free-models/free-models.service';
 
@@ -27,6 +28,11 @@ interface ProviderTokensResponse {
   cached_at: string;
 }
 
+interface AgentTokensResponse {
+  agents: AgentDailyTokens[];
+  cached_at: string;
+}
+
 interface FreeProvidersResponse {
   providers: FreeProviderDto[];
   last_synced_at: string | null;
@@ -44,6 +50,10 @@ let freeInflight: Promise<FreeModelsResponse> | null = null;
 let cachedProviderTokens: ProviderTokensResponse | null = null;
 let providerTokensTimestamp = 0;
 let providerTokensInflight: Promise<ProviderTokensResponse> | null = null;
+
+let cachedAgentTokens: AgentTokensResponse | null = null;
+let agentTokensTimestamp = 0;
+let agentTokensInflight: Promise<AgentTokensResponse> | null = null;
 
 let cachedFreeProviders: FreeProvidersResponse | null = null;
 let freeProvidersTimestamp = 0;
@@ -118,6 +128,23 @@ export class PublicStatsController {
   }
 
   @Public()
+  @Get('agent-tokens')
+  async getAgentTokens(): Promise<AgentTokensResponse> {
+    this.assertEnabled();
+    if (cachedAgentTokens && Date.now() - agentTokensTimestamp < PUBLIC_STATS_CACHE_TTL_MS) {
+      return cachedAgentTokens;
+    }
+
+    if (!agentTokensInflight) {
+      agentTokensInflight = this.refreshAgentTokens().finally(() => {
+        agentTokensInflight = null;
+      });
+    }
+
+    return agentTokensInflight;
+  }
+
+  @Public()
   @Get('free-providers')
   getFreeProviders(): FreeProvidersResponse {
     this.assertEnabled();
@@ -186,5 +213,21 @@ export class PublicStatsController {
     }
 
     return cachedProviderTokens ?? { providers: [], cached_at: new Date().toISOString() };
+  }
+
+  private async refreshAgentTokens(): Promise<AgentTokensResponse> {
+    try {
+      const agents = await this.service.getAgentDailyTokens();
+      cachedAgentTokens = {
+        agents,
+        cached_at: new Date().toISOString(),
+      };
+      agentTokensTimestamp = Date.now();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Failed to fetch agent tokens: ${msg}`);
+    }
+
+    return cachedAgentTokens ?? { agents: [], cached_at: new Date().toISOString() };
   }
 }

--- a/packages/backend/src/public-stats/public-stats.module.ts
+++ b/packages/backend/src/public-stats/public-stats.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { Agent } from '../entities/agent.entity';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { FreeModelsModule } from '../free-models/free-models.module';
@@ -7,7 +8,7 @@ import { PublicStatsController } from './public-stats.controller';
 import { PublicStatsService } from './public-stats.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AgentMessage]), ModelPricesModule, FreeModelsModule],
+  imports: [TypeOrmModule.forFeature([AgentMessage, Agent]), ModelPricesModule, FreeModelsModule],
   controllers: [PublicStatsController],
   providers: [PublicStatsService],
 })

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -614,4 +614,476 @@ describe('PublicStatsService', () => {
       expect(result[0].models[0].auth_type).toBeNull();
     });
   });
+
+  describe('getAgentDailyTokens', () => {
+    function setupAgentQuery(rows: unknown) {
+      const qb = mockQueryBuilder(rows);
+      qb.innerJoin = jest.fn().mockReturnValue(qb);
+      qb.addGroupBy = jest.fn().mockReturnValue(qb);
+      mockRepo.createQueryBuilder.mockReturnValueOnce(qb);
+      return qb;
+    }
+
+    it('groups tokens by (category, platform) and model with daily breakdown', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-06',
+          tokens: '500000',
+          auth_type: 'api_key',
+          cost: '0.50',
+        },
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '600000',
+          auth_type: 'api_key',
+          cost: '0.60',
+        },
+        {
+          agent_category: 'coding',
+          agent_platform: 'claude-code',
+          model: 'claude-opus',
+          date: '2026-04-07',
+          tokens: '1000000',
+          auth_type: 'api_key',
+          cost: '1.00',
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].agent_category).toBe('personal');
+      expect(result[0].agent_platform).toBe('openclaw');
+      expect(result[0].category_label).toBe('Personal AI Agent');
+      expect(result[0].platform_label).toBe('OpenClaw');
+      expect(result[0].total_tokens).toBe(1100000);
+      expect(result[0].models).toHaveLength(1);
+      expect(result[0].models[0].model).toBe('gpt-4o');
+      expect(result[0].models[0].auth_type).toBe('api_key');
+      expect(result[0].models[0].total_cost).toBeCloseTo(1.1);
+      expect(result[0].models[0].daily).toEqual([
+        { date: '2026-04-06', tokens: 500000 },
+        { date: '2026-04-07', tokens: 600000 },
+      ]);
+      expect(result[1].agent_category).toBe('coding');
+      expect(result[1].agent_platform).toBe('claude-code');
+      expect(result[1].category_label).toBe('Coding Assistant');
+      expect(result[1].platform_label).toBe('Claude Code');
+      expect(result[1].total_tokens).toBe(1000000);
+    });
+
+    it('sorts agent groups by total tokens descending', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '100',
+          auth_type: null,
+          cost: null,
+        },
+        {
+          agent_category: 'coding',
+          agent_platform: 'claude-code',
+          model: 'claude-opus',
+          date: '2026-04-07',
+          tokens: '9999',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result[0].agent_platform).toBe('claude-code');
+      expect(result[1].agent_platform).toBe('openclaw');
+    });
+
+    it('sorts models within an agent group by total tokens descending', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '100',
+          auth_type: null,
+          cost: null,
+        },
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o-mini',
+          date: '2026-04-07',
+          tokens: '9000',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result[0].models[0].model).toBe('gpt-4o-mini');
+      expect(result[0].models[1].model).toBe('gpt-4o');
+    });
+
+    it('returns empty array when no data', async () => {
+      setupAgentQuery([]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('excludes custom models', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'custom:abc/gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it("excludes 'other' platform", async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'other',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('excludes rows with NULL category', async () => {
+      setupAgentQuery([
+        {
+          agent_category: null,
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('excludes rows with NULL platform', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: null,
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('excludes unknown category values', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'mystery',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('excludes unknown platform values', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'mystery-platform',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('handles null tokens', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: null,
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result[0].total_tokens).toBe(0);
+      expect(result[0].models[0].daily[0].tokens).toBe(0);
+    });
+
+    it('sorts daily entries chronologically', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '200',
+          auth_type: null,
+          cost: null,
+        },
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-05',
+          tokens: '100',
+          auth_type: null,
+          cost: null,
+        },
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-06',
+          tokens: '150',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      const dates = result[0].models[0].daily.map((d) => d.date);
+      expect(dates).toEqual(['2026-04-05', '2026-04-06', '2026-04-07']);
+    });
+
+    it('applies 30-day cutoff', async () => {
+      const qb = setupAgentQuery([]);
+
+      await service.getAgentDailyTokens();
+
+      expect(qb.andWhere).toHaveBeenCalledWith(
+        'at.timestamp >= :cutoff30d',
+        expect.objectContaining({ cutoff30d: expect.any(String) }),
+      );
+    });
+
+    it('aggregates multiple models under the same agent group', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '500',
+          auth_type: null,
+          cost: null,
+        },
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o-mini',
+          date: '2026-04-07',
+          tokens: '300',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].agent_platform).toBe('openclaw');
+      expect(result[0].total_tokens).toBe(800);
+      expect(result[0].models).toHaveLength(2);
+    });
+
+    it('separates same model with different auth_types', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'coding',
+          agent_platform: 'claude-code',
+          model: 'claude-sonnet',
+          date: '2026-04-07',
+          tokens: '3000',
+          auth_type: 'api_key',
+          cost: '0.45',
+        },
+        {
+          agent_category: 'coding',
+          agent_platform: 'claude-code',
+          model: 'claude-sonnet',
+          date: '2026-04-07',
+          tokens: '2000',
+          auth_type: 'subscription',
+          cost: '0',
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].models).toHaveLength(2);
+      const apiKeyModel = result[0].models.find((m) => m.auth_type === 'api_key');
+      const subModel = result[0].models.find((m) => m.auth_type === 'subscription');
+      expect(apiKeyModel).toBeDefined();
+      expect(apiKeyModel!.total_tokens).toBe(3000);
+      expect(apiKeyModel!.total_cost).toBeCloseTo(0.45);
+      expect(subModel).toBeDefined();
+      expect(subModel!.total_tokens).toBe(2000);
+      expect(subModel!.total_cost).toBe(0);
+    });
+
+    it('returns null total_cost when all costs are null', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: 'api_key',
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result[0].models[0].total_cost).toBeNull();
+    });
+
+    it('sums cost correctly across multiple days', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-06',
+          tokens: '500',
+          auth_type: 'api_key',
+          cost: '0.10',
+        },
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '500',
+          auth_type: 'api_key',
+          cost: '0.20',
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result[0].models[0].total_cost).toBeCloseTo(0.3);
+    });
+
+    it('includes auth_type as null when not set', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result[0].models[0].auth_type).toBeNull();
+    });
+
+    it('attaches human-readable labels for every supported platform', async () => {
+      setupAgentQuery([
+        {
+          agent_category: 'app',
+          agent_platform: 'openai-sdk',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '100',
+          auth_type: null,
+          cost: null,
+        },
+        {
+          agent_category: 'app',
+          agent_platform: 'anthropic-sdk',
+          model: 'claude-opus',
+          date: '2026-04-07',
+          tokens: '50',
+          auth_type: null,
+          cost: null,
+        },
+        {
+          agent_category: 'app',
+          agent_platform: 'vercel-ai-sdk',
+          model: 'gpt-4o-mini',
+          date: '2026-04-07',
+          tokens: '25',
+          auth_type: null,
+          cost: null,
+        },
+      ]);
+
+      const result = await service.getAgentDailyTokens();
+
+      const byPlatform = Object.fromEntries(result.map((g) => [g.agent_platform, g.platform_label]));
+      expect(byPlatform['openai-sdk']).toBe('OpenAI SDK');
+      expect(byPlatform['anthropic-sdk']).toBe('Anthropic SDK');
+      expect(byPlatform['vercel-ai-sdk']).toBe('Vercel AI SDK');
+      result.forEach((g) => expect(g.category_label).toBe('App AI SDK'));
+    });
+  });
 });

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -1,12 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import {
+  AGENT_CATEGORIES,
+  AGENT_PLATFORMS,
+  CATEGORY_LABELS,
+  PLATFORM_LABELS,
+  type AgentCategory,
+  type AgentPlatform,
+} from 'manifest-shared';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { Agent } from '../entities/agent.entity';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { computeCutoff, sqlDateBucket } from '../common/utils/postgres-sql';
 
 const MAX_RESULTS = 10;
 const EXCLUDED_PROVIDERS = new Set(['Unknown']);
+const EXCLUDED_AGENT_PLATFORMS = new Set<string>(['other']);
+const VALID_AGENT_CATEGORIES = new Set<string>(AGENT_CATEGORIES);
+const VALID_AGENT_PLATFORMS = new Set<string>(AGENT_PLATFORMS);
 
 export interface TopModel {
   model: string;
@@ -46,6 +58,15 @@ export interface ModelBreakdown {
 
 export interface ProviderDailyTokens {
   provider: string;
+  total_tokens: number;
+  models: ModelBreakdown[];
+}
+
+export interface AgentDailyTokens {
+  agent_category: AgentCategory;
+  agent_platform: AgentPlatform;
+  category_label: string;
+  platform_label: string;
   total_tokens: number;
   models: ModelBreakdown[];
 }
@@ -248,6 +269,132 @@ export class PublicStatsService {
         provider,
         total_tokens: data.total,
         models: data.models.sort((a, b) => b.total_tokens - a.total_tokens),
+      }));
+  }
+
+  async getAgentDailyTokens(): Promise<AgentDailyTokens[]> {
+    const cutoff30d = computeCutoff('30 days');
+    const dateBucket = sqlDateBucket('at.timestamp');
+
+    const rows: {
+      agent_category: string | null;
+      agent_platform: string | null;
+      model: string;
+      date: string;
+      tokens: string;
+      auth_type: string | null;
+      cost: string | null;
+    }[] = await this.messageRepo
+      .createQueryBuilder('at')
+      .innerJoin(Agent, 'a', 'a.id = at.agent_id')
+      .select('a.agent_category', 'agent_category')
+      .addSelect('a.agent_platform', 'agent_platform')
+      .addSelect('at.model', 'model')
+      .addSelect(dateBucket, 'date')
+      .addSelect('at.auth_type', 'auth_type')
+      .addSelect('SUM(at.input_tokens + at.output_tokens)', 'tokens')
+      .addSelect('SUM(at.cost_usd)', 'cost')
+      .where('at.model IS NOT NULL')
+      .andWhere('at.timestamp >= :cutoff30d', { cutoff30d })
+      .andWhere('a.agent_category IS NOT NULL')
+      .andWhere('a.agent_platform IS NOT NULL')
+      .groupBy('a.agent_category')
+      .addGroupBy('a.agent_platform')
+      .addGroupBy('at.model')
+      .addGroupBy('date')
+      .addGroupBy('at.auth_type')
+      .orderBy('date', 'ASC')
+      .getRawMany();
+
+    const modelMap = new Map<
+      string,
+      {
+        category: AgentCategory;
+        platform: AgentPlatform;
+        modelName: string;
+        authType: string | null;
+        total: number;
+        cost: number | null;
+        daily: Map<string, number>;
+      }
+    >();
+
+    for (const r of rows) {
+      const modelName = r.model;
+      if (isCustomModel(modelName)) continue;
+      const category = r.agent_category;
+      const platform = r.agent_platform;
+      if (!category || !platform) continue;
+      if (!VALID_AGENT_CATEGORIES.has(category)) continue;
+      if (!VALID_AGENT_PLATFORMS.has(platform)) continue;
+      if (EXCLUDED_AGENT_PLATFORMS.has(platform)) continue;
+
+      const key = `${category}:${platform}:${modelName}:${r.auth_type ?? ''}`;
+      let entry = modelMap.get(key);
+      if (!entry) {
+        entry = {
+          category: category as AgentCategory,
+          platform: platform as AgentPlatform,
+          modelName,
+          authType: r.auth_type ?? null,
+          total: 0,
+          cost: null,
+          daily: new Map(),
+        };
+        modelMap.set(key, entry);
+      }
+      const tokens = Number(r.tokens ?? 0);
+      entry.total += tokens;
+      const rowCost = r.cost != null ? Number(r.cost) : null;
+      if (rowCost != null) {
+        entry.cost = (entry.cost ?? 0) + rowCost;
+      }
+      entry.daily.set(r.date, (entry.daily.get(r.date) ?? 0) + tokens);
+    }
+
+    const agentMap = new Map<
+      string,
+      {
+        category: AgentCategory;
+        platform: AgentPlatform;
+        total: number;
+        models: ModelBreakdown[];
+      }
+    >();
+
+    for (const [, entry] of modelMap) {
+      const groupKey = `${entry.category}:${entry.platform}`;
+      let group = agentMap.get(groupKey);
+      if (!group) {
+        group = {
+          category: entry.category,
+          platform: entry.platform,
+          total: 0,
+          models: [],
+        };
+        agentMap.set(groupKey, group);
+      }
+      group.total += entry.total;
+      group.models.push({
+        model: entry.modelName,
+        auth_type: entry.authType,
+        total_tokens: entry.total,
+        total_cost: entry.cost,
+        daily: Array.from(entry.daily.entries())
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([date, tokens]) => ({ date, tokens })),
+      });
+    }
+
+    return Array.from(agentMap.values())
+      .sort((a, b) => b.total - a.total)
+      .map((group) => ({
+        agent_category: group.category,
+        agent_platform: group.platform,
+        category_label: CATEGORY_LABELS[group.category],
+        platform_label: PLATFORM_LABELS[group.platform],
+        total_tokens: group.total,
+        models: group.models.sort((a, b) => b.total_tokens - a.total_tokens),
       }));
   }
 

--- a/packages/backend/test/public-stats.e2e-spec.ts
+++ b/packages/backend/test/public-stats.e2e-spec.ts
@@ -29,6 +29,13 @@ beforeAll(async () => {
        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
     ['ps-msg-3', 'test-tenant-001', 'test-agent-001', 'test-agent', 'test-user-001', now, 150, 75, 'claude-opus-4-6', 'ok'],
   );
+
+  // Tag the seeded agent so the agent-tokens endpoint has a recognised
+  // (category, platform) pair to aggregate the seeded messages under.
+  await ds.query(
+    `UPDATE agents SET agent_category = $1, agent_platform = $2 WHERE id = $3`,
+    ['personal', 'openclaw', 'test-agent-001'],
+  );
 });
 
 afterAll(async () => {
@@ -72,5 +79,39 @@ describe('GET /api/v1/public/free-models', () => {
     expect(Array.isArray(res.body.models)).toBe(true);
     expect(res.body).toHaveProperty('total_models');
     expect(res.body).toHaveProperty('cached_at');
+  });
+});
+
+describe('GET /api/v1/public/agent-tokens', () => {
+  it('aggregates tokens by (category, platform) without auth', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/public/agent-tokens')
+      .expect(200);
+
+    expect(res.body).toHaveProperty('agents');
+    expect(Array.isArray(res.body.agents)).toBe(true);
+    expect(res.body).toHaveProperty('cached_at');
+
+    const group = res.body.agents.find(
+      (g: { agent_category: string; agent_platform: string }) =>
+        g.agent_category === 'personal' && g.agent_platform === 'openclaw',
+    );
+    expect(group).toBeDefined();
+    expect(group.category_label).toBe('Personal AI Agent');
+    expect(group.platform_label).toBe('OpenClaw');
+    // seeded messages: 150 + 300 + 225 = 675 tokens across two models
+    expect(group.total_tokens).toBeGreaterThanOrEqual(675);
+    expect(Array.isArray(group.models)).toBe(true);
+    expect(group.models.length).toBeGreaterThanOrEqual(2);
+
+    const modelNames = group.models.map((m: { model: string }) => m.model);
+    expect(modelNames).toContain('gpt-4o');
+    expect(modelNames).toContain('claude-opus-4-6');
+
+    for (const m of group.models) {
+      expect(m).toHaveProperty('total_tokens');
+      expect(m).toHaveProperty('daily');
+      expect(Array.isArray(m.daily)).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
### 💭 Why
The marketing site already charts daily tokens by LLM provider. This adds the same view grouped by agent (OpenClaw, Claude Code, OpenAI SDK, etc.) so visitors can see which agent flavors actually drive usage. Endpoint only; the chart ships separately on the marketing site.

### ✨ What changed
- New `GET /api/v1/public/agent-tokens` (no auth, 24h cached, `MANIFEST_PUBLIC_STATS` gated).
- Service joins `agents` and groups by `(agent_category, agent_platform, model, auth_type, day)`.
- Excludes the `'other'` platform, NULL category/platform, and `custom:*` models server-side.
- Returns the same `ModelBreakdown` + `daily[]` shape as `/provider-tokens`, plus `category_label` and `platform_label` resolved from `manifest-shared`.

### 🔧 For operators
No migration, no env var change. Endpoint stays dormant until `MANIFEST_PUBLIC_STATS=true`, same as the other public-stats routes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public `GET /api/v1/public/agent-tokens` endpoint to report daily token usage by agent category and platform. This lets the marketing site chart usage by agent (OpenClaw, Claude Code, OpenAI SDK) alongside existing per-provider charts.

- **New Features**
  - New `GET /api/v1/public/agent-tokens` (no auth, 24h cached, gated by `MANIFEST_PUBLIC_STATS`).
  - Groups by `(agent_category, agent_platform, model, auth_type, day)`; excludes `other` platform, NULL category/platform, and `custom:*` models.
  - Response matches `/provider-tokens` (`ModelBreakdown` with `daily[]`) plus `category_label` and `platform_label` from `manifest-shared`. Includes in-flight request deduping and stale-cache fallback.

- **Migration**
  - No migration or env changes. Endpoint stays inactive until `MANIFEST_PUBLIC_STATS=true`.

<sup>Written for commit 74f6fb3ee266ca32c8a89bf3b9c3a04143a5ce7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

