### PR TITLE
fix(routing): return 409 instead of 500 on concurrent custom-provider create

### DIFF
--- a/.changeset/custom-provider-409-on-concurrent-create.md
+++ b/.changeset/custom-provider-409-on-concurrent-create.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Translate concurrent-insert unique-violation on `POST /api/v1/routing/:agentName/custom-providers` into HTTP 409 instead of 500. The find-then-insert pre-check in `CustomProviderService.create()` was racy against the `(agent_id, name)` unique index — two parallel requests with the same provider name could both pass the pre-check, then the second insert raised `QueryFailedError` and bubbled past the controller as a 500. Now the insert is wrapped and unique-violation `QueryFailedError`s are translated into the same `ConflictException` the pre-check produces, matching the convention already used for the symmetric race on `Agent` creation in `agents.controller.ts`. Non-unique errors (connection drops, etc.) continue to propagate unchanged.

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -6,7 +6,7 @@ jest.mock('../../common/utils/detect-self-hosted', () => ({
 }));
 
 import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { CustomProviderService } from './custom-provider.service';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { ProviderService } from '../routing-core/provider.service';
@@ -390,6 +390,32 @@ describe('CustomProviderService', () => {
         api_kind: 'anthropic',
       });
       expect(cp.api_kind).toBe('anthropic');
+    });
+
+    it('translates a unique-violation QueryFailedError on insert into ConflictException (race condition)', async () => {
+      // Two parallel POSTs can both pass the find-then-insert pre-check and
+      // race to insert the same (agent_id, name). The unique index raises
+      // QueryFailedError on the second insert; the service must surface
+      // that as 409, matching the pre-check branch above.
+      const { svc, insert } = makeDeps({ findOneResults: [null] });
+      (insert as jest.Mock).mockRejectedValueOnce(
+        new QueryFailedError(
+          'INSERT',
+          [],
+          new Error('duplicate key value violates unique constraint'),
+        ),
+      );
+      await expect(svc.create('agent-1', 'user-1', dto)).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('re-throws non-unique QueryFailedError unchanged from insert', async () => {
+      // Connection drops, FK violations, etc. are not user-correctable —
+      // they must continue to surface as 500 + observability events rather
+      // than getting swallowed as conflicts.
+      const { svc, insert } = makeDeps({ findOneResults: [null] });
+      const err = new QueryFailedError('INSERT', [], new Error('connection refused'));
+      (insert as jest.Mock).mockRejectedValueOnce(err);
+      await expect(svc.create('agent-1', 'user-1', dto)).rejects.toBe(err);
     });
   });
 

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -5,7 +5,7 @@ import {
   BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 import {
   CANONICAL_LOCAL_IDS,
@@ -211,7 +211,21 @@ export class CustomProviderService {
       })),
       created_at: new Date().toISOString(),
     });
-    await this.repo.insert(cp);
+    try {
+      await this.repo.insert(cp);
+    } catch (error) {
+      // The pre-check above is racy: between findOne() and insert(), a
+      // parallel POST with the same (agent_id, name) can land. The
+      // CustomProvider entity declares a unique index on (agent_id, name),
+      // so the second insert raises QueryFailedError(unique-violation).
+      // Translate it into the same ConflictException the pre-check already
+      // produces, so concurrent and sequential creates both surface as 409
+      // instead of leaking 500. Mirrors agents.controller.ts:75-78,117-119.
+      if (error instanceof QueryFailedError && /unique|duplicate/i.test(error.message)) {
+        throw new ConflictException(`Custom provider "${dto.name}" already exists for this agent`);
+      }
+      throw error;
+    }
 
     // Create UserProvider + trigger tier recalculation. When the display
     // name resolves to Ollama / LM Studio we tag the row `'local'` so


### PR DESCRIPTION
## Summary

When two clients call `POST /api/v1/routing/:agentName/custom-providers` simultaneously with the same provider name, the second request currently returns **HTTP 500** because the unique-violation `QueryFailedError` from `repo.insert(cp)` bubbles past the existing pre-check guard. This PR wraps the insert and translates unique-violation errors into the same `ConflictException` (HTTP 409) that the pre-check already produces, so concurrent creates are indistinguishable from sequential ones from the client's perspective.

## Why

`CustomProvider` declares `@Index(['agent_id', 'name'], { unique: true })` (`packages/backend/src/entities/custom-provider.entity.ts:15`). `CustomProviderService.create()` does a find-then-insert pre-check: it calls `findOne({ where: { agent_id, name } })` and throws `ConflictException` if a row exists, then later runs `insert(cp)`. The pre-check is racy — between `findOne` returning null and `insert` running, a parallel request can land the same `(agent_id, name)`. The second insert hits the unique index, postgres raises SQLSTATE `23505`, typeorm wraps it as `QueryFailedError`, and Nest's default exception filter renders it as **500 Internal Server Error**.

The codebase already handles this exact race for `Agent` creation in `packages/backend/src/analytics/controllers/agents.controller.ts:75-78` and `:117-119` (`onboardAgent` and `duplicate` both wrap their service call in `try { ... } catch (e) { if (e instanceof QueryFailedError && /unique|duplicate/i.test(e.message)) throw new ConflictException(...); throw e; }`). The pattern is tested in `packages/backend/src/analytics/controllers/agents.controller.spec.ts:506-558`. This PR adopts the same convention for the symmetric race in `CustomProviderService.create()`.

## Solution

- Extend the existing `import { Repository } from 'typeorm'` to also import `QueryFailedError`.
- Wrap the `repo.insert(cp)` call in `try { ... } catch (error) { if (error instanceof QueryFailedError && /unique|duplicate/i.test(error.message)) { throw new ConflictException(...) } throw error; }`.
- Re-use the same message string the pre-check throws so client-side error handlers can dedupe.
- Two new unit tests in `custom-provider.service.spec.ts` — one positive (unique-violation → 409), one negative (non-unique `QueryFailedError` re-thrown unchanged so `connection refused` etc. still surface as 500 + observability events).

No other call-sites in `custom-provider.service.ts` are touched. No changes to `update()`, `remove()`, or any read paths.

## Testing

- `npm test --workspace=packages/backend` — all **4454+** tests still pass; two new tests added to the existing `describe('create', ...)` block (60/60 in the target spec).
- `npm run lint --workspace=packages/backend` — clean (no new warnings in the modified files).
- `npm run build --workspace=packages/backend` — `nest build` green; the import extension is type-safe.
- Changeset added under `.changeset/` targeting `manifest` (patch).

I did not run the e2e suite (`npm run test:e2e --workspace=packages/backend`) locally because it requires a running Postgres. The unit tests cover both branches of the new try/catch directly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 409 Conflict instead of 500 when two clients concurrently create the same custom provider via POST /api/v1/routing/:agentName/custom-providers. Unique-violation from insert is now translated to a ConflictException so concurrent and sequential creates behave the same.

- **Bug Fixes**
  - Wrap `repo.insert` and map duplicate/unique `QueryFailedError` to `ConflictException` with the same message as the pre-check; non-unique errors still bubble up.
  - Added tests for the conflict path and non-unique pass-through, matching the pattern used in agent creation.

<sup>Written for commit 10a5858f1feee2ee002bfc55cb6ef6937a1c62fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

