### PR TITLE
fix: coerce unknown Anthropic tool types

### DIFF
--- a/.changeset/quiet-advisors-share.md
+++ b/.changeset/quiet-advisors-share.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Coerce unknown Anthropic Messages tool types to custom tools instead of forwarding unsupported server-tool tags.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -422,6 +422,7 @@ describe('Anthropic Messages adapter', () => {
           { type: 'custom', name: 'c1' },
           { type: 'advisor_20260301', name: 'advisor' },
           { type: 'mcp_toolset', name: 'mcp' },
+          { type: 'mcp_toolset_future', name: 'future_mcp' },
           { name: 'c2' },
           { type: 'text_editor_20250728', name: 'str_replace_editor' },
           'not-a-record',

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -238,18 +238,20 @@ describe('Anthropic Messages adapter', () => {
         tools: [
           { type: 'web_search_20250305', name: 'web_search' },
           { type: 'bash_20250124', name: 'bash' },
+          { type: 'mcp_toolset', name: 'mcp' },
           { name: 'my_custom', description: 'c', input_schema: { type: 'object' } },
           { type: 'custom', name: 'explicit_custom', input_schema: { type: 'object' } },
         ],
       });
 
-      // chatBody.tools keeps all four — the scorer reads tool count and
+      // chatBody.tools keeps all five — the scorer reads tool count and
       // function.name and must keep seeing server tools for tier / specificity.
       const tools = result.tools as Array<Record<string, unknown>>;
-      expect(tools).toHaveLength(4);
+      expect(tools).toHaveLength(5);
       expect(tools.map((t) => (t.function as Record<string, unknown>).name)).toEqual([
         'web_search',
         'bash',
+        'mcp',
         'my_custom',
         'explicit_custom',
       ]);
@@ -259,6 +261,7 @@ describe('Anthropic Messages adapter', () => {
       expect(result._anthropicServerTools).toEqual([
         { type: 'web_search_20250305', name: 'web_search' },
         { type: 'bash_20250124', name: 'bash' },
+        { type: 'mcp_toolset', name: 'mcp' },
       ]);
     });
 
@@ -418,12 +421,14 @@ describe('Anthropic Messages adapter', () => {
           { type: 'web_search_20250305', name: 'web_search' },
           { type: 'custom', name: 'c1' },
           { type: 'advisor_20260301', name: 'advisor' },
+          { type: 'mcp_toolset', name: 'mcp' },
           { name: 'c2' },
           { type: 'text_editor_20250728', name: 'str_replace_editor' },
           'not-a-record',
         ]),
       ).toEqual([
         { type: 'web_search_20250305', name: 'web_search' },
+        { type: 'mcp_toolset', name: 'mcp' },
         { type: 'text_editor_20250728', name: 'str_replace_editor' },
       ]);
     });

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -4,6 +4,7 @@ import {
   extractAnthropicServerTools,
   messagesToChatCompletionsRequest,
 } from '../anthropic-messages-adapter';
+import { toAnthropicRequest } from '../anthropic-adapter';
 
 describe('Anthropic Messages adapter', () => {
   describe('messagesToChatCompletionsRequest', () => {
@@ -261,6 +262,45 @@ describe('Anthropic Messages adapter', () => {
       ]);
     });
 
+    it('treats unknown non-custom tool types as custom tools with a safe empty schema (issue #1897)', () => {
+      const result = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [{ type: 'advisor_20260301', name: 'advisor', description: 'Plan the task' }],
+      });
+
+      expect(result._anthropicServerTools).toBeUndefined();
+      expect(result.tools).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'advisor',
+            description: 'Plan the task',
+            parameters: { type: 'object', properties: {}, additionalProperties: false },
+          },
+        },
+      ]);
+    });
+
+    it('round-trips unknown typed tools back to Anthropic as custom tools (issue #1897)', () => {
+      const chatBody = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [
+          { type: 'web_search_20250305', name: 'web_search' },
+          { type: 'advisor_20260301', name: 'advisor' },
+        ],
+      });
+
+      const anthropicBody = toAnthropicRequest(chatBody, 'claude-sonnet-4-20250514');
+      const tools = anthropicBody.tools as Array<Record<string, unknown>>;
+
+      expect(tools[0]).toMatchObject({ type: 'web_search_20250305', name: 'web_search' });
+      expect(tools[1]).toEqual({
+        name: 'advisor',
+        input_schema: { type: 'object', properties: {}, additionalProperties: false },
+        cache_control: { type: 'ephemeral' },
+      });
+    });
+
     it('omits the stash when no server tools are present', () => {
       const result = messagesToChatCompletionsRequest({
         messages: [{ role: 'user', content: 'x' }],
@@ -372,11 +412,12 @@ describe('Anthropic Messages adapter', () => {
   });
 
   describe('extractAnthropicServerTools', () => {
-    it('returns tools whose type is a non-custom string', () => {
+    it('returns tools whose type matches a known Anthropic server-tool prefix', () => {
       expect(
         extractAnthropicServerTools([
           { type: 'web_search_20250305', name: 'web_search' },
           { type: 'custom', name: 'c1' },
+          { type: 'advisor_20260301', name: 'advisor' },
           { name: 'c2' },
           { type: 'text_editor_20250728', name: 'str_replace_editor' },
           'not-a-record',

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -10,8 +10,29 @@ import { OpenAIMessage } from './proxy-types';
 
 type JsonRecord = Record<string, unknown>;
 
+const DEFAULT_CUSTOM_TOOL_INPUT_SCHEMA = {
+  type: 'object',
+  properties: {},
+  additionalProperties: false,
+} as const;
+
+const ANTHROPIC_SERVER_TOOL_PREFIXES = [
+  'bash_',
+  'code_execution_',
+  'computer_',
+  'memory_',
+  'text_editor_',
+  'tool_search_tool_',
+  'web_fetch_',
+  'web_search_',
+] as const;
+
 function isRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isAnthropicServerToolType(type: string): boolean {
+  return ANTHROPIC_SERVER_TOOL_PREFIXES.some((prefix) => type.startsWith(prefix));
 }
 
 function safeJsonStringify(value: unknown): string {
@@ -137,7 +158,13 @@ function toChatTools(tools: unknown[]): JsonRecord[] {
     function: {
       name: typeof tool.name === 'string' ? tool.name : 'unknown',
       ...(typeof tool.description === 'string' && { description: tool.description }),
-      ...(tool.input_schema !== undefined && { parameters: tool.input_schema }),
+      ...(tool.input_schema !== undefined
+        ? { parameters: tool.input_schema }
+        : typeof tool.type === 'string' &&
+            tool.type !== 'custom' &&
+            !isAnthropicServerToolType(tool.type)
+          ? { parameters: DEFAULT_CUSTOM_TOOL_INPUT_SCHEMA }
+          : {}),
     },
   }));
 }
@@ -154,7 +181,7 @@ export function extractAnthropicServerTools(tools: unknown[]): JsonRecord[] {
   const out: JsonRecord[] = [];
   for (const tool of tools) {
     if (!isRecord(tool)) continue;
-    if (typeof tool.type === 'string' && tool.type !== 'custom') {
+    if (typeof tool.type === 'string' && isAnthropicServerToolType(tool.type)) {
       out.push(tool);
     }
   }

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -20,7 +20,6 @@ const ANTHROPIC_SERVER_TOOL_PREFIXES = [
   'bash_',
   'code_execution_',
   'computer_',
-  'mcp_toolset',
   'memory_',
   'text_editor_',
   'tool_search_tool_',
@@ -28,12 +27,17 @@ const ANTHROPIC_SERVER_TOOL_PREFIXES = [
   'web_search_',
 ] as const;
 
+const ANTHROPIC_SERVER_TOOL_TYPES = ['mcp_toolset'] as const;
+
 function isRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 function isAnthropicServerToolType(type: string): boolean {
-  return ANTHROPIC_SERVER_TOOL_PREFIXES.some((prefix) => type.startsWith(prefix));
+  return (
+    ANTHROPIC_SERVER_TOOL_TYPES.includes(type as (typeof ANTHROPIC_SERVER_TOOL_TYPES)[number]) ||
+    ANTHROPIC_SERVER_TOOL_PREFIXES.some((prefix) => type.startsWith(prefix))
+  );
 }
 
 function safeJsonStringify(value: unknown): string {

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -20,6 +20,7 @@ const ANTHROPIC_SERVER_TOOL_PREFIXES = [
   'bash_',
   'code_execution_',
   'computer_',
+  'mcp_toolset',
   'memory_',
   'text_editor_',
   'tool_search_tool_',


### PR DESCRIPTION
### ✨ What changed
- Allowlist Anthropic server-tool prefixes before stashing typed tools.
- Coerce unknown typed tools like `advisor_20260301` to custom tools.
- Add regression and Anthropic wire-body round-trip coverage.

### 💭 Why
Claude Code's `advisor` tool is not an Anthropic server-tool tag. The #1886 fix forwarded every non-custom type verbatim, so Anthropic rejected the first Claude Code request.

### 👤 For users
Claude Code can start `/v1/messages` sessions through Manifest when `advisor` is present.

### 🔧 For operators
No migrations or config changes.

### 📝 Notes
Fixes #1897
Validation: focused adapter test, focused 100% line coverage, backend typecheck, lint, build, and full backend unit suite (4,537 tests).
No live Claude Code subscription check; the wire-body test covers the failed request shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat unknown Anthropic tool types as custom tools and only stash known server tools; match `mcp_toolset` exactly and ignore lookalikes. Claude Code `advisor` now works in `/v1/messages`. Fixes #1897.

- **Bug Fixes**
  - Coerce unknown non-custom types (e.g. `advisor_20260301`) to custom tools with an empty input schema.
  - Allowlist only known server-tool prefixes (e.g. `web_search_`, `code_execution_`) and exact `mcp_toolset` (not `mcp_toolset_*`).
  - Added regression and wire-body round-trip tests, including MCP exact-match coverage.

<sup>Written for commit 14e0ab6a85621cf3b2ce288f949ef6c1bee780d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

