### PR TITLE
fix: preserve OpenCode Go reasoning content

### DIFF
--- a/.changeset/thin-cars-think.md
+++ b/.changeset/thin-cars-think.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Preserve OpenCode Go reasoning content for known non-DeepSeek reasoning model families.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -221,12 +221,46 @@ describe('provider-client-converters', () => {
       expect(messages[1]).toHaveProperty('reasoning_content', 'I considered...');
     });
 
-    it('should strip reasoning_content for opencode-go non-deepseek models', () => {
+    it('should preserve reasoning_content for opencode-go reasoning model families', () => {
+      const body = {
+        messages: [
+          { role: 'user', content: 'x' },
+          {
+            role: 'assistant',
+            content: '',
+            reasoning_content: 'thinking',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'foo', arguments: '{}' },
+              },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_1', content: '{}' },
+        ],
+      };
+
+      for (const model of [
+        'opencode-go/kimi-k2.6',
+        'opencode-go/glm-5.1',
+        'opencode-go/qwen3.6-plus',
+        'opencode-go/minimax-m2.7',
+        'opencode-go/mimo-v2.5',
+      ]) {
+        const result = sanitizeOpenAiBody(body, 'opencode-go', model);
+        const messages = result.messages as any[];
+
+        expect(messages[1]).toHaveProperty('reasoning_content', 'thinking');
+      }
+    });
+
+    it('should strip reasoning_content for unknown opencode-go model families', () => {
       const body = {
         messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
       };
 
-      const result = sanitizeOpenAiBody(body, 'opencode-go', 'opencode-go/glm-5.1');
+      const result = sanitizeOpenAiBody(body, 'opencode-go', 'opencode-go/claude-sonnet-4');
       const messages = result.messages as any[];
 
       expect(messages[0]).not.toHaveProperty('reasoning_content');

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -118,38 +118,41 @@ function usesOpenAiMaxCompletionTokens(endpointKey: string, bareModel: string): 
 }
 
 /**
- * Endpoints that either forward directly to DeepSeek (native, OpenCode Go) or
- * tolerate `reasoning_content` as a passthrough on `deepseek-*` slugs
- * (OpenRouter, custom proxies). Restricting the substring match to this set
- * prevents false positives on strict OpenAI-compatible hosts that happen to
- * serve a DeepSeek-derived community slug (e.g. `deepseek-r1-distill-*` on
- * Mistral or native OpenAI) and would reject the unknown message field.
+ * Endpoints that tolerate `reasoning_content` for at least one model family.
+ * Restricting model-family matching to this set prevents false positives on
+ * strict OpenAI-compatible hosts that happen to serve a reasoning-derived
+ * community slug and would reject the unknown message field.
  */
-const DEEPSEEK_AWARE_ENDPOINTS = new Set(['openrouter', 'opencode-go', 'custom']);
+const REASONING_CONTENT_AWARE_ENDPOINTS = new Set(['openrouter', 'opencode-go', 'custom']);
+
+const OPENCODE_GO_REASONING_MODEL_FAMILY_RE =
+  /^(?:deepseek|kimi|glm|qwen|minimax|mimo)(?:[-_.\d]|$)/i;
 
 /**
- * DeepSeek's thinking-mode API rejects follow-up turns that don't echo back the
- * previous assistant's `reasoning_content` ("The `reasoning_content` in the
- * thinking mode must be passed back to the API"). Preserve it for:
+ * Some reasoning APIs reject follow-up turns that don't echo back the previous
+ * assistant's `reasoning_content`. Preserve it for:
  *  - the native `deepseek` endpoint (always)
+ *  - OpenCode Go's known reasoning model families
  *  - aggregator/proxy endpoints whose `deepseek-*` slugs forward to a DeepSeek
- *    engine (OpenRouter `deepseek/*`, OpenCode Go `deepseek-*` — issue #1862 —
- *    and user-supplied custom providers).
+ *    engine (OpenRouter `deepseek/*` and user-supplied custom providers).
  * Strict OpenAI-compatible endpoints (Mistral, native OpenAI, etc.) keep
  * stripping the field even if a community fine-tune slug contains "deepseek".
  */
 function supportsReasoningContent(endpointKey: string, model: string): boolean {
   if (endpointKey === 'deepseek') return true;
-  if (!DEEPSEEK_AWARE_ENDPOINTS.has(endpointKey)) return false;
+  if (!REASONING_CONTENT_AWARE_ENDPOINTS.has(endpointKey)) return false;
   // Bare model id after stripping any vendor/aggregator prefix:
   //   "deepseek/r1"             → "r1"            — OpenRouter, not deepseek-family
   //   "openrouter" + "deepseek/deepseek-r1" → "deepseek-r1" ✓
-  //   "opencode-go/deepseek-v4-pro" → "deepseek-v4-pro" ✓
+  //   "opencode-go/kimi-k2.6" → "kimi-k2.6" ✓
   //   "custom:<uuid>/deepseek-reasoner" → "deepseek-reasoner" ✓
   // (proxy-fallback.service strips "custom:<uuid>/" before forward, so in
   // practice the custom path passes the already-bare model — both shapes
   // are handled.)
   const bare = model.toLowerCase().split('/').pop() ?? '';
+  if (endpointKey === 'opencode-go') {
+    return OPENCODE_GO_REASONING_MODEL_FAMILY_RE.test(bare);
+  }
   return bare.includes('deepseek');
 }
 


### PR DESCRIPTION
### ✨ What changed
- Preserve `reasoning_content` for OpenCode Go Kimi, GLM, Qwen, MiniMax, and MiMo.
- Keep strict endpoints stripping unknown reasoning fields.
- Add sanitizer regression coverage and a patch changeset.

### 💭 Why
Tool-call follow-up requests need to replay assistant reasoning for these OpenCode Go models. Manifest stripped it outside DeepSeek, which could make upstream reject continuations and trigger fallback.

### 👤 For users
OpenCode Go reasoning models keep multi-turn tool-use conversations on the selected route.

### 📝 Notes
Fixes #1899

Validated locally with focused backend tests, backend lint, shared build, backend typecheck, backend build, and `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `reasoning_content` for OpenCode Go reasoning models so tool-call follow-ups can replay assistant reasoning without fallback. Strict OpenAI-compatible endpoints continue stripping unknown fields.

- **Bug Fixes**
  - Preserve `reasoning_content` on `opencode-go` for `deepseek`, `kimi`, `glm`, `qwen`, `minimax`, and `mimo` model families; strip for unknown families.
  - Limit passthrough to `openrouter`, `opencode-go`, and `custom` endpoints to avoid breaking strict hosts.
  - Add sanitizer regression tests and a patch changeset. Fixes #1899.

<sup>Written for commit f4fb1049406debe3fb2abb0b3e1e65e064ee47b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

