### PR TITLE
fix: normalize Anthropic tool schemas

### DIFF
--- a/.changeset/quiet-advisors-share.md
+++ b/.changeset/quiet-advisors-share.md
@@ -2,4 +2,4 @@
 "manifest": patch
 ---
 
-Coerce unknown Anthropic Messages tool types to custom tools instead of forwarding unsupported server-tool tags.
+Coerce unknown Anthropic Messages tool types to custom tools instead of forwarding unsupported server-tool tags, and normalize missing array `items` in forwarded tool schemas for OpenAI compatibility.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -304,6 +304,46 @@ describe('Anthropic Messages adapter', () => {
       });
     });
 
+    it('adds missing array items in Anthropic tool schemas before OpenAI forwarding', () => {
+      const inputSchema = {
+        type: 'object',
+        properties: {
+          codebase_context: {
+            anyOf: [{ type: 'string' }, { type: 'object' }, { type: 'array' }],
+          },
+          existing_items: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      };
+      const result = messagesToChatCompletionsRequest({
+        messages: [{ role: 'user', content: 'x' }],
+        tools: [
+          {
+            name: 'mcp__revenuecat__create-paywall-ai',
+            description: 'Create a paywall',
+            input_schema: inputSchema,
+          },
+        ],
+      });
+
+      const tools = result.tools as Array<Record<string, Record<string, unknown>>>;
+      expect(tools[0].function.parameters).toEqual({
+        type: 'object',
+        properties: {
+          codebase_context: {
+            anyOf: [{ type: 'string' }, { type: 'object' }, { type: 'array', items: {} }],
+          },
+          existing_items: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+      });
+      expect(inputSchema.properties.codebase_context.anyOf[2]).toEqual({ type: 'array' });
+    });
+
     it('omits the stash when no server tools are present', () => {
       const result = messagesToChatCompletionsRequest({
         messages: [{ role: 'user', content: 'x' }],

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -40,6 +40,30 @@ function isAnthropicServerToolType(type: string): boolean {
   );
 }
 
+function normalizeOpenAiFunctionSchema(schema: unknown): unknown {
+  if (schema === null || schema === undefined || typeof schema !== 'object') {
+    return schema;
+  }
+
+  if (Array.isArray(schema)) {
+    return schema.map((item) => normalizeOpenAiFunctionSchema(item));
+  }
+
+  const result: JsonRecord = {};
+  for (const [key, value] of Object.entries(schema)) {
+    result[key] = normalizeOpenAiFunctionSchema(value);
+  }
+
+  const type = result.type;
+  const isArraySchema =
+    type === 'array' || (Array.isArray(type) && type.some((item) => item === 'array'));
+  if (isArraySchema && result.items === undefined) {
+    result.items = {};
+  }
+
+  return result;
+}
+
 function safeJsonStringify(value: unknown): string {
   try {
     return typeof value === 'string' ? value : JSON.stringify(value ?? '');
@@ -164,7 +188,7 @@ function toChatTools(tools: unknown[]): JsonRecord[] {
       name: typeof tool.name === 'string' ? tool.name : 'unknown',
       ...(typeof tool.description === 'string' && { description: tool.description }),
       ...(tool.input_schema !== undefined
-        ? { parameters: tool.input_schema }
+        ? { parameters: normalizeOpenAiFunctionSchema(tool.input_schema) }
         : typeof tool.type === 'string' &&
             tool.type !== 'custom' &&
             !isAnthropicServerToolType(tool.type)


### PR DESCRIPTION
### ✨ What changed
- Anthropic Messages tool schemas add missing `items` for array branches.
- The regression test covers `codebase_context.anyOf[2]` from the MCP failure.
- The #1901 changeset now mentions OpenAI tool schema normalization.

### 💭 Why
OpenAI rejects function schemas where an array branch omits `items`. Some MCP tools expose schemas that Anthropic accepts but OpenAI rejects.

### 👤 For users
Claude Code MCP tools should no longer fail with `array schema missing items`.

### 📝 Notes
Follow-up to #1901, which was already merged.

Validation: focused adapter test, focused adapter coverage, backend typecheck, backend lint warnings-only, `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Anthropic Messages tool input schemas by auto-filling missing array items before forwarding to OpenAI. This fixes rejections and prevents "array schema missing items" errors in Claude Code MCP tools.

- **Bug Fixes**
  - Insert `{}` as `items` for any `array` type, including nested and `anyOf` branches.
  - Apply normalization in the Anthropic Messages adapter and add a test covering `codebase_context.anyOf[2]`.
  - Aligns with Linear issue 1897 on OpenAI tool schema compatibility.

<sup>Written for commit dede6c45d4f265a53228fb954404978e2126fc57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

