### PR TITLE
fix(proxy): emit DeepSeek reasoning_content as Anthropic thinking blocks in stream

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -786,13 +786,14 @@ describe('Anthropic Messages adapter', () => {
       expect(events[9].data).toEqual({ type: 'content_block_stop', index: 2 });
     });
 
-    it('defers reasoning_content arriving during a tool_use and flushes it as a thinking block after the tool_use closes', () => {
-      // After a tool_use block has been started, late reasoning_content chunks
-      // are *buffered* rather than splitting the tool_use across two Anthropic
-      // blocks (each Anthropic tool_use block must carry its own complete
-      // input JSON — splitting would break client-side reassembly). The
-      // accumulated reasoning is emitted as a self-contained thinking block
-      // once the tool_use closes (here, on finalize via finish_reason).
+    it('drops reasoning_content arriving during an open tool_use to keep the tool_use block contiguous', () => {
+      // Manifest's Anthropic-compat layer assumes thinking blocks precede
+      // tool_use and replays them in that shape on the next turn. Emitting a
+      // post-tool thinking block would give clients a transcript shape
+      // (`thinking → tool_use → thinking`) we cannot safely replay, so late
+      // reasoning_content arriving while a tool_use is in-progress is dropped
+      // silently. The pre-tool thinking block and the tool_use itself stay
+      // intact.
       const t = createMessagesStreamTransformer('deepseek-v4-flash');
       const sse = flushChunks(t, [
         'data: {"choices":[{"delta":{"reasoning_content":"plan A"}}]}\n\n',
@@ -819,32 +820,32 @@ describe('Anthropic Messages adapter', () => {
         'content_block_delta', // thinking_delta "plan A"
         'content_block_stop', // thinking@0 closed by tool_use
         'content_block_start', // tool_use@1
-        'content_block_delta', // input_json_delta
+        'content_block_delta', // input_json_delta — "plan B" / " continued" dropped while open
         'content_block_stop', // tool_use@1 closed on finalize
-        'content_block_start', // thinking@2 — deferred reasoning flush
-        'content_block_delta', // single combined "plan B continued" delta
-        'content_block_stop', // thinking@2 closed
         'message_delta',
         'message_stop',
       ]);
       expect(events[4].data).toMatchObject({ index: 1, content_block: { type: 'tool_use' } });
       expect(events[6].data).toEqual({ type: 'content_block_stop', index: 1 });
-      expect(events[7].data).toMatchObject({ index: 2, content_block: { type: 'thinking' } });
-      expect(events[8].data).toMatchObject({
-        index: 2,
-        delta: { type: 'thinking_delta', thinking: 'plan B continued' },
-      });
-      expect(events[9].data).toEqual({ type: 'content_block_stop', index: 2 });
+      // No thinking block ever opens after tool_use@1.
+      const postToolThinking = events.find(
+        (e, i) =>
+          e.event === 'content_block_start' &&
+          i > 6 &&
+          (e.data.content_block as { type?: string })?.type === 'thinking',
+      );
+      expect(postToolThinking).toBeUndefined();
     });
 
-    it('keeps a fragmented tool_call on a single tool_use block when reasoning_content interleaves between arg chunks', () => {
-      // Regression for #1907 review: with the previous logic, late
-      // reasoning_content closed the in-progress tool_use, then the next
-      // tool_call delta for the same `index` re-emitted `content_block_start`
-      // against the same (already stopped) tool_use index, breaking
-      // monotonicity. We now buffer the reasoning so the tool_use stays open
-      // and accumulates all its arg chunks into a single Anthropic block —
-      // the only shape where the client can reassemble the input JSON.
+    it('keeps a fragmented tool_call on a single tool_use block while dropping interleaved reasoning_content', () => {
+      // Regression for the #1907 review: late reasoning_content used to close
+      // the in-progress tool_use, then the next arg chunk for the same `index`
+      // re-emitted `content_block_start` against the already-stopped index,
+      // breaking monotonicity. Per the reviewer's follow-up, we now keep the
+      // tool_use contiguous AND drop the interleaved reasoning entirely
+      // rather than flushing a post-tool thinking block — emitting
+      // `thinking → tool_use → thinking` would produce an Anthropic-shaped
+      // transcript we cannot safely replay on the next turn.
       const t = createMessagesStreamTransformer('deepseek-v4-flash');
       const sse = flushChunks(t, [
         'data: {"choices":[{"delta":{"reasoning_content":"plan"}}]}\n\n',
@@ -874,9 +875,6 @@ describe('Anthropic Messages adapter', () => {
         'content_block_delta', // input_json_delta "{\"q\":"
         'content_block_delta', // input_json_delta "1}" — same block, no reopen at @1
         'content_block_stop', // tool_use@1 stopped on finalize
-        'content_block_start', // thinking@2 — deferred "late"
-        'content_block_delta', // thinking_delta "late"
-        'content_block_stop', // thinking@2 stopped
         'message_delta',
         'message_stop',
       ]);
@@ -896,22 +894,21 @@ describe('Anthropic Messages adapter', () => {
       });
       expect(events[7].data).toEqual({ type: 'content_block_stop', index: 1 });
 
-      // Deferred reasoning is flushed at a fresh monotonic index (2).
-      expect(events[8].data).toMatchObject({
-        index: 2,
-        content_block: { type: 'thinking' },
-      });
-      expect(events[9].data).toMatchObject({
-        index: 2,
-        delta: { type: 'thinking_delta', thinking: 'late' },
-      });
-      expect(events[10].data).toEqual({ type: 'content_block_stop', index: 2 });
-
-      // Indices are strictly monotonic — no reuse of a stopped block index.
+      // Indices are strictly monotonic — no reuse of a stopped block index —
+      // and "late" reasoning never produces a third thinking block.
       const blockIndices = events
         .filter((e) => e.event === 'content_block_start')
         .map((e) => e.data.index);
-      expect(blockIndices).toEqual([0, 1, 2]);
+      expect(blockIndices).toEqual([0, 1]);
+
+      // The dropped "late" reasoning is not surfaced as any thinking_delta.
+      const lateLeak = events.find(
+        (e) =>
+          e.event === 'content_block_delta' &&
+          (e.data.delta as { type?: string; thinking?: string })?.type === 'thinking_delta' &&
+          (e.data.delta as { thinking?: string })?.thinking?.includes('late'),
+      );
+      expect(lateLeak).toBeUndefined();
 
       // stop_reason still propagates from the upstream finish_reason.
       const messageDelta = events.find((e) => e.event === 'message_delta');

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -786,11 +786,13 @@ describe('Anthropic Messages adapter', () => {
       expect(events[9].data).toEqual({ type: 'content_block_stop', index: 2 });
     });
 
-    it('closes an in-progress tool_use before opening a new thinking block on late reasoning_content', () => {
-      // After a tool_use block has been started, a late reasoning_content chunk
-      // must (a) stop the tool_use block, then (b) reopen thinking at a fresh
-      // index. A second reasoning chunk in a row must not re-close the already
-      // stopped tool_use — the continue-on-closed branch of closeOpenToolCalls.
+    it('defers reasoning_content arriving during a tool_use and flushes it as a thinking block after the tool_use closes', () => {
+      // After a tool_use block has been started, late reasoning_content chunks
+      // are *buffered* rather than splitting the tool_use across two Anthropic
+      // blocks (each Anthropic tool_use block must carry its own complete
+      // input JSON — splitting would break client-side reassembly). The
+      // accumulated reasoning is emitted as a self-contained thinking block
+      // once the tool_use closes (here, on finalize via finish_reason).
       const t = createMessagesStreamTransformer('deepseek-v4-flash');
       const sse = flushChunks(t, [
         'data: {"choices":[{"delta":{"reasoning_content":"plan A"}}]}\n\n',
@@ -818,11 +820,10 @@ describe('Anthropic Messages adapter', () => {
         'content_block_stop', // thinking@0 closed by tool_use
         'content_block_start', // tool_use@1
         'content_block_delta', // input_json_delta
-        'content_block_stop', // tool_use@1 closed by late reasoning
-        'content_block_start', // thinking@2
-        'content_block_delta', // thinking_delta "plan B"
-        'content_block_delta', // thinking_delta " continued" (no second tool_use stop)
-        'content_block_stop', // thinking@2 closed on finalize
+        'content_block_stop', // tool_use@1 closed on finalize
+        'content_block_start', // thinking@2 — deferred reasoning flush
+        'content_block_delta', // single combined "plan B continued" delta
+        'content_block_stop', // thinking@2 closed
         'message_delta',
         'message_stop',
       ]);
@@ -831,12 +832,90 @@ describe('Anthropic Messages adapter', () => {
       expect(events[7].data).toMatchObject({ index: 2, content_block: { type: 'thinking' } });
       expect(events[8].data).toMatchObject({
         index: 2,
-        delta: { type: 'thinking_delta', thinking: 'plan B' },
+        delta: { type: 'thinking_delta', thinking: 'plan B continued' },
+      });
+      expect(events[9].data).toEqual({ type: 'content_block_stop', index: 2 });
+    });
+
+    it('keeps a fragmented tool_call on a single tool_use block when reasoning_content interleaves between arg chunks', () => {
+      // Regression for #1907 review: with the previous logic, late
+      // reasoning_content closed the in-progress tool_use, then the next
+      // tool_call delta for the same `index` re-emitted `content_block_start`
+      // against the same (already stopped) tool_use index, breaking
+      // monotonicity. We now buffer the reasoning so the tool_use stays open
+      // and accumulates all its arg chunks into a single Anthropic block —
+      // the only shape where the client can reassemble the input JSON.
+      const t = createMessagesStreamTransformer('deepseek-v4-flash');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"reasoning_content":"plan"}}]}\n\n',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc_1","function":{"name":"search","arguments":"{\\"q\\":"}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":"late"}}]}\n\n',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"1}"}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+      ]);
+
+      const events = sse
+        .split('\n\n')
+        .filter(Boolean)
+        .map((block) => {
+          const [eventLine, dataLine] = block.split('\n');
+          return {
+            event: eventLine!.replace('event: ', ''),
+            data: JSON.parse(dataLine!.replace('data: ', '')),
+          };
+        });
+
+      expect(events.map((e) => e.event)).toEqual([
+        'message_start',
+        'content_block_start', // thinking@0
+        'content_block_delta', // thinking_delta "plan"
+        'content_block_stop', // thinking@0 stopped before tool_use opens
+        'content_block_start', // tool_use@1
+        'content_block_delta', // input_json_delta "{\"q\":"
+        'content_block_delta', // input_json_delta "1}" — same block, no reopen at @1
+        'content_block_stop', // tool_use@1 stopped on finalize
+        'content_block_start', // thinking@2 — deferred "late"
+        'content_block_delta', // thinking_delta "late"
+        'content_block_stop', // thinking@2 stopped
+        'message_delta',
+        'message_stop',
+      ]);
+
+      // tool_use stays at index 1 across both arg chunks.
+      expect(events[4].data).toMatchObject({
+        index: 1,
+        content_block: { type: 'tool_use', id: 'tc_1', name: 'search' },
+      });
+      expect(events[5].data).toMatchObject({
+        index: 1,
+        delta: { type: 'input_json_delta', partial_json: '{"q":' },
+      });
+      expect(events[6].data).toMatchObject({
+        index: 1,
+        delta: { type: 'input_json_delta', partial_json: '1}' },
+      });
+      expect(events[7].data).toEqual({ type: 'content_block_stop', index: 1 });
+
+      // Deferred reasoning is flushed at a fresh monotonic index (2).
+      expect(events[8].data).toMatchObject({
+        index: 2,
+        content_block: { type: 'thinking' },
       });
       expect(events[9].data).toMatchObject({
         index: 2,
-        delta: { type: 'thinking_delta', thinking: ' continued' },
+        delta: { type: 'thinking_delta', thinking: 'late' },
       });
+      expect(events[10].data).toEqual({ type: 'content_block_stop', index: 2 });
+
+      // Indices are strictly monotonic — no reuse of a stopped block index.
+      const blockIndices = events
+        .filter((e) => e.event === 'content_block_start')
+        .map((e) => e.data.index);
+      expect(blockIndices).toEqual([0, 1, 2]);
+
+      // stop_reason still propagates from the upstream finish_reason.
+      const messageDelta = events.find((e) => e.event === 'message_delta');
+      expect(messageDelta?.data.delta.stop_reason).toBe('tool_use');
     });
 
     it('finalize is idempotent — second call returns null', () => {

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -594,6 +594,98 @@ describe('Anthropic Messages adapter', () => {
       expect(sse).toContain('"stop_reason":"tool_use"');
     });
 
+    it('translates DeepSeek-style delta.reasoning_content into a leading thinking block', () => {
+      // Without this, Claude clients lose the reasoning trace and the next turn
+      // gets rejected by DeepSeek: "The `reasoning_content` in the thinking
+      // mode must be passed back to the API."
+      const t = createMessagesStreamTransformer('deepseek-v4-flash');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"reasoning_content":"Let me think "}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":"step by step."}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"42"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      ]);
+
+      const events = sse
+        .split('\n\n')
+        .filter(Boolean)
+        .map((block) => {
+          const [eventLine, dataLine] = block.split('\n');
+          return {
+            event: eventLine!.replace('event: ', ''),
+            data: JSON.parse(dataLine!.replace('data: ', '')),
+          };
+        });
+
+      expect(events.map((e) => e.event)).toEqual([
+        'message_start',
+        'content_block_start',
+        'content_block_delta',
+        'content_block_delta',
+        'content_block_stop',
+        'content_block_start',
+        'content_block_delta',
+        'content_block_stop',
+        'message_delta',
+        'message_stop',
+      ]);
+      expect(events[1].data).toEqual({
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'thinking', thinking: '' },
+      });
+      expect(events[2].data.delta).toEqual({ type: 'thinking_delta', thinking: 'Let me think ' });
+      expect(events[3].data.delta).toEqual({ type: 'thinking_delta', thinking: 'step by step.' });
+      expect(events[4].data).toEqual({ type: 'content_block_stop', index: 0 });
+      expect(events[5].data).toEqual({
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'text', text: '' },
+      });
+      expect(events[6].data.delta).toEqual({ type: 'text_delta', text: '42' });
+    });
+
+    it('closes the thinking block on finalize when the stream emits only reasoning_content', () => {
+      const t = createMessagesStreamTransformer('deepseek-v4-flash');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"reasoning_content":"hmm"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      ]);
+      expect(sse).toContain(
+        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}',
+      );
+      expect(sse).toContain('"delta":{"type":"thinking_delta","thinking":"hmm"}');
+      expect(sse).toContain(
+        'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}',
+      );
+    });
+
+    it('closes the thinking block before opening a tool_use block', () => {
+      const t = createMessagesStreamTransformer('deepseek-v4-flash');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"reasoning_content":"plan"}}]}\n\n',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc_1","function":{"name":"search","arguments":"{}"}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n',
+      ]);
+      const order = sse.match(/event: (\w+)/g)!.map((s) => s.replace('event: ', ''));
+      // thinking block must be stopped before the tool_use block starts
+      const thinkingStopAt = order.findIndex(
+        (_, i) =>
+          order[i] === 'content_block_stop' &&
+          // first stop in the stream corresponds to the thinking block
+          order.slice(0, i).filter((e) => e === 'content_block_stop').length === 0,
+      );
+      const toolStartAt = order.findIndex(
+        (e, i) =>
+          e === 'content_block_start' &&
+          order.slice(0, i).filter((x) => x === 'content_block_start').length === 1,
+      );
+      expect(thinkingStopAt).toBeGreaterThan(-1);
+      expect(toolStartAt).toBeGreaterThan(thinkingStopAt);
+      expect(sse).toContain('"content_block":{"type":"tool_use"');
+      expect(sse).toContain('"index":1'); // tool_use gets index 1, after thinking@0
+    });
+
     it('finalize is idempotent — second call returns null', () => {
       const t = createMessagesStreamTransformer('m');
       t.transform('data: {"choices":[{"delta":{"content":"x"},"finish_reason":"stop"}]}\n\n');

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -686,6 +686,159 @@ describe('Anthropic Messages adapter', () => {
       expect(sse).toContain('"index":1'); // tool_use gets index 1, after thinking@0
     });
 
+    it('reopens a fresh thinking block when reasoning_content arrives after text content', () => {
+      // Real providers don't always flush reasoning_content before content —
+      // a late reasoning chunk after text would previously emit a thinking_delta
+      // against an already-stopped block (Anthropic SSE spec violation).
+      const t = createMessagesStreamTransformer('deepseek-v4-flash');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"reasoning_content":"first thought"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"answer"}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":"afterthought"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      ]);
+
+      const events = sse
+        .split('\n\n')
+        .filter(Boolean)
+        .map((block) => {
+          const [eventLine, dataLine] = block.split('\n');
+          return {
+            event: eventLine!.replace('event: ', ''),
+            data: JSON.parse(dataLine!.replace('data: ', '')),
+          };
+        });
+
+      expect(events.map((e) => e.event)).toEqual([
+        'message_start',
+        'content_block_start', // thinking@0
+        'content_block_delta', // thinking_delta "first thought"
+        'content_block_stop', // thinking@0 closed by content
+        'content_block_start', // text@1
+        'content_block_delta', // text_delta "answer"
+        'content_block_stop', // text@1 closed by late reasoning
+        'content_block_start', // thinking@2 (reopen at fresh index)
+        'content_block_delta', // thinking_delta "afterthought"
+        'content_block_stop', // thinking@2 closed on finalize
+        'message_delta',
+        'message_stop',
+      ]);
+      // First thinking block is at index 0
+      expect(events[1].data).toMatchObject({ index: 0, content_block: { type: 'thinking' } });
+      expect(events[2].data).toMatchObject({
+        index: 0,
+        delta: { type: 'thinking_delta', thinking: 'first thought' },
+      });
+      expect(events[3].data).toEqual({ type: 'content_block_stop', index: 0 });
+      // Text takes index 1
+      expect(events[4].data).toMatchObject({ index: 1, content_block: { type: 'text' } });
+      expect(events[6].data).toEqual({ type: 'content_block_stop', index: 1 });
+      // Reopened thinking block must use a fresh index (2), not collide with 0
+      expect(events[7].data).toMatchObject({ index: 2, content_block: { type: 'thinking' } });
+      expect(events[8].data).toMatchObject({
+        index: 2,
+        delta: { type: 'thinking_delta', thinking: 'afterthought' },
+      });
+      expect(events[9].data).toEqual({ type: 'content_block_stop', index: 2 });
+    });
+
+    it('reopens a fresh text block when content arrives after late reasoning_content', () => {
+      // Symmetric case: content first, then a reasoning interlude, then more
+      // content. The second content chunk must open a new text block at a
+      // fresh index rather than emit deltas against the closed text@0.
+      const t = createMessagesStreamTransformer('deepseek-v4-flash');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"content":"hello "}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":"second-guess"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"world"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      ]);
+
+      const events = sse
+        .split('\n\n')
+        .filter(Boolean)
+        .map((block) => {
+          const [eventLine, dataLine] = block.split('\n');
+          return {
+            event: eventLine!.replace('event: ', ''),
+            data: JSON.parse(dataLine!.replace('data: ', '')),
+          };
+        });
+
+      // text@0, thinking@1, text@2
+      expect(events[1].data).toMatchObject({ index: 0, content_block: { type: 'text' } });
+      expect(events[2].data).toMatchObject({
+        index: 0,
+        delta: { type: 'text_delta', text: 'hello ' },
+      });
+      expect(events[3].data).toEqual({ type: 'content_block_stop', index: 0 });
+      expect(events[4].data).toMatchObject({ index: 1, content_block: { type: 'thinking' } });
+      expect(events[5].data).toMatchObject({
+        index: 1,
+        delta: { type: 'thinking_delta', thinking: 'second-guess' },
+      });
+      expect(events[6].data).toEqual({ type: 'content_block_stop', index: 1 });
+      expect(events[7].data).toMatchObject({ index: 2, content_block: { type: 'text' } });
+      expect(events[8].data).toMatchObject({
+        index: 2,
+        delta: { type: 'text_delta', text: 'world' },
+      });
+      expect(events[9].data).toEqual({ type: 'content_block_stop', index: 2 });
+    });
+
+    it('closes an in-progress tool_use before opening a new thinking block on late reasoning_content', () => {
+      // After a tool_use block has been started, a late reasoning_content chunk
+      // must (a) stop the tool_use block, then (b) reopen thinking at a fresh
+      // index. A second reasoning chunk in a row must not re-close the already
+      // stopped tool_use — the continue-on-closed branch of closeOpenToolCalls.
+      const t = createMessagesStreamTransformer('deepseek-v4-flash');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"reasoning_content":"plan A"}}]}\n\n',
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc_1","function":{"name":"search","arguments":"{\\"q\\":1}"}}]}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":"plan B"}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":" continued"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      ]);
+
+      const events = sse
+        .split('\n\n')
+        .filter(Boolean)
+        .map((block) => {
+          const [eventLine, dataLine] = block.split('\n');
+          return {
+            event: eventLine!.replace('event: ', ''),
+            data: JSON.parse(dataLine!.replace('data: ', '')),
+          };
+        });
+
+      expect(events.map((e) => e.event)).toEqual([
+        'message_start',
+        'content_block_start', // thinking@0
+        'content_block_delta', // thinking_delta "plan A"
+        'content_block_stop', // thinking@0 closed by tool_use
+        'content_block_start', // tool_use@1
+        'content_block_delta', // input_json_delta
+        'content_block_stop', // tool_use@1 closed by late reasoning
+        'content_block_start', // thinking@2
+        'content_block_delta', // thinking_delta "plan B"
+        'content_block_delta', // thinking_delta " continued" (no second tool_use stop)
+        'content_block_stop', // thinking@2 closed on finalize
+        'message_delta',
+        'message_stop',
+      ]);
+      expect(events[4].data).toMatchObject({ index: 1, content_block: { type: 'tool_use' } });
+      expect(events[6].data).toEqual({ type: 'content_block_stop', index: 1 });
+      expect(events[7].data).toMatchObject({ index: 2, content_block: { type: 'thinking' } });
+      expect(events[8].data).toMatchObject({
+        index: 2,
+        delta: { type: 'thinking_delta', thinking: 'plan B' },
+      });
+      expect(events[9].data).toMatchObject({
+        index: 2,
+        delta: { type: 'thinking_delta', thinking: ' continued' },
+      });
+    });
+
     it('finalize is idempotent — second call returns null', () => {
       const t = createMessagesStreamTransformer('m');
       t.transform('data: {"choices":[{"delta":{"content":"x"},"finish_reason":"stop"}]}\n\n');

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -319,6 +319,8 @@ interface StreamState {
   messageId: string;
   model: string;
   startedMessage: boolean;
+  thinkingIndex: number | null;
+  thinkingOpened: boolean;
   textIndex: number | null;
   textOpened: boolean;
   toolCalls: Map<number, { id: string; index: number; argBuffer: string; opened: boolean }>;
@@ -337,6 +339,8 @@ export function createMessagesStreamTransformer(model: string): MessagesStreamTr
     messageId: `msg_${randomUUID().replace(/-/g, '')}`,
     model,
     startedMessage: false,
+    thinkingIndex: null,
+    thinkingOpened: false,
     textIndex: null,
     textOpened: false,
     toolCalls: new Map(),
@@ -376,7 +380,33 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
     if (!choice) continue;
     const delta = isRecord(choice.delta) ? choice.delta : {};
 
+    // DeepSeek (and other thinking-mode providers) stream reasoning as
+    // `delta.reasoning_content` separately from `delta.content`. Surface it as
+    // an Anthropic `thinking` content block so clients can echo it back on the
+    // next turn — the upstream rejects follow-ups that don't return the trace.
+    if (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0) {
+      if (state.thinkingIndex === null) {
+        state.thinkingIndex = nextBlockIndex(state);
+        events.push(
+          formatMessagesEvent('content_block_start', {
+            type: 'content_block_start',
+            index: state.thinkingIndex,
+            content_block: { type: 'thinking', thinking: '' },
+          }),
+        );
+        state.thinkingOpened = true;
+      }
+      events.push(
+        formatMessagesEvent('content_block_delta', {
+          type: 'content_block_delta',
+          index: state.thinkingIndex,
+          delta: { type: 'thinking_delta', thinking: delta.reasoning_content },
+        }),
+      );
+    }
+
     if (typeof delta.content === 'string' && delta.content.length > 0) {
+      closeThinkingBlock(state, events);
       if (state.textIndex === null) {
         state.textIndex = nextBlockIndex(state);
         events.push(
@@ -398,6 +428,7 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
     }
 
     if (Array.isArray(delta.tool_calls)) {
+      closeThinkingBlock(state, events);
       for (const call of delta.tool_calls) {
         if (!isRecord(call)) continue;
         const callIndex = typeof call.index === 'number' ? call.index : 0;
@@ -452,7 +483,22 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
 }
 
 function nextBlockIndex(state: StreamState): number {
-  return (state.textIndex !== null ? 1 : 0) + state.toolCalls.size;
+  return (
+    (state.thinkingIndex !== null ? 1 : 0) +
+    (state.textIndex !== null ? 1 : 0) +
+    state.toolCalls.size
+  );
+}
+
+function closeThinkingBlock(state: StreamState, events: string[]): void {
+  if (!state.thinkingOpened || state.thinkingIndex === null) return;
+  events.push(
+    formatMessagesEvent('content_block_stop', {
+      type: 'content_block_stop',
+      index: state.thinkingIndex,
+    }),
+  );
+  state.thinkingOpened = false;
 }
 
 function buildMessageStartEvent(state: StreamState, data: JsonRecord): string {
@@ -475,6 +521,8 @@ function buildMessageStartEvent(state: StreamState, data: JsonRecord): string {
 function closeStream(state: StreamState): string[] {
   if (state.endedMessage) return [];
   const events: string[] = [];
+
+  closeThinkingBlock(state, events);
 
   if (state.textOpened && state.textIndex !== null) {
     events.push(

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -331,12 +331,6 @@ interface StreamState {
   // Monotonic counter — block indices must keep increasing across the whole
   // stream, including across reopens of the same kind.
   nextBlockIndexCounter: number;
-  // Reasoning_content that arrived while a tool_use was in-progress. Splitting
-  // a single OpenAI tool_call across two Anthropic tool_use blocks would break
-  // input-JSON reassembly on the client, so we defer the reasoning until the
-  // tool_use closes naturally (next text content or finalize) and then flush
-  // it as a self-contained thinking block.
-  deferredReasoning: string;
   finalUsage: JsonRecord | null;
   stopReason: string | null;
   endedMessage: boolean;
@@ -358,7 +352,6 @@ export function createMessagesStreamTransformer(model: string): MessagesStreamTr
     textOpened: false,
     toolCalls: new Map(),
     nextBlockIndexCounter: 0,
-    deferredReasoning: '',
     finalUsage: null,
     stopReason: null,
     endedMessage: false,
@@ -403,14 +396,14 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
     // (providers don't guarantee reasoning is fully flushed before content).
     // For text we close it and reopen a fresh thinking block — splitting text
     // across blocks is fine because each Anthropic text block is independent.
-    // For an in-progress tool_use we instead BUFFER the reasoning: splitting a
-    // single OpenAI tool_call across two Anthropic tool_use blocks would break
-    // input-JSON reassembly on the client (each block must carry a complete
-    // input). The buffer is flushed when the tool_use eventually closes.
+    // For an in-progress tool_use we DROP the late reasoning: Manifest's
+    // Anthropic-compat layer assumes thinking blocks precede tool_use and
+    // replays them in that shape on the next turn, so emitting a transcript
+    // like `thinking → tool_use → thinking` would produce a stream we can't
+    // safely replay. Keeping the tool_use block contiguous is the more
+    // defensible tradeoff than surfacing a fragment that breaks replay.
     if (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0) {
-      if (hasOpenToolCall(state)) {
-        state.deferredReasoning += delta.reasoning_content;
-      } else {
+      if (!hasOpenToolCall(state)) {
         closeTextBlock(state, events);
         if (!state.thinkingOpened) {
           state.thinkingIndex = nextBlockIndex(state);
@@ -431,6 +424,7 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
           }),
         );
       }
+      // else: silently drop reasoning_content arriving during an open tool_use.
     }
 
     if (typeof delta.content === 'string' && delta.content.length > 0) {
@@ -550,7 +544,6 @@ function hasOpenToolCall(state: StreamState): boolean {
 }
 
 function closeOpenToolCalls(state: StreamState, events: string[]): void {
-  let closedAny = false;
   for (const entry of state.toolCalls.values()) {
     if (!entry.opened) continue;
     events.push(
@@ -560,37 +553,6 @@ function closeOpenToolCalls(state: StreamState, events: string[]): void {
       }),
     );
     entry.opened = false;
-    closedAny = true;
-  }
-  // If reasoning_content arrived while the tool_use was streaming, we
-  // buffered it instead of splitting the tool_use. Now that the tool_use
-  // is done, flush the buffer as a self-contained thinking block at a fresh
-  // monotonic index. Self-contained (start+delta+stop in one go) so the
-  // surrounding state machine doesn't have to track a fresh in-progress
-  // thinking block here.
-  if (closedAny && state.deferredReasoning.length > 0) {
-    const idx = nextBlockIndex(state);
-    events.push(
-      formatMessagesEvent('content_block_start', {
-        type: 'content_block_start',
-        index: idx,
-        content_block: { type: 'thinking', thinking: '' },
-      }),
-    );
-    events.push(
-      formatMessagesEvent('content_block_delta', {
-        type: 'content_block_delta',
-        index: idx,
-        delta: { type: 'thinking_delta', thinking: state.deferredReasoning },
-      }),
-    );
-    events.push(
-      formatMessagesEvent('content_block_stop', {
-        type: 'content_block_stop',
-        index: idx,
-      }),
-    );
-    state.deferredReasoning = '';
   }
 }
 

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -319,11 +319,18 @@ interface StreamState {
   messageId: string;
   model: string;
   startedMessage: boolean;
+  // Block-state fields track the *currently open* block of each kind. After a
+  // block is stopped, the *Opened flag flips back to false so a subsequent
+  // chunk of the same kind allocates a fresh index — supports providers that
+  // interleave reasoning_content with content or tool_calls.
   thinkingIndex: number | null;
   thinkingOpened: boolean;
   textIndex: number | null;
   textOpened: boolean;
   toolCalls: Map<number, { id: string; index: number; argBuffer: string; opened: boolean }>;
+  // Monotonic counter — block indices must keep increasing across the whole
+  // stream, including across reopens of the same kind.
+  nextBlockIndexCounter: number;
   finalUsage: JsonRecord | null;
   stopReason: string | null;
   endedMessage: boolean;
@@ -344,6 +351,7 @@ export function createMessagesStreamTransformer(model: string): MessagesStreamTr
     textIndex: null,
     textOpened: false,
     toolCalls: new Map(),
+    nextBlockIndexCounter: 0,
     finalUsage: null,
     stopReason: null,
     endedMessage: false,
@@ -384,8 +392,15 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
     // `delta.reasoning_content` separately from `delta.content`. Surface it as
     // an Anthropic `thinking` content block so clients can echo it back on the
     // next turn — the upstream rejects follow-ups that don't return the trace.
+    // Reasoning can also arrive *after* text or a tool_use has already started
+    // (providers don't guarantee reasoning is fully flushed before content),
+    // so close any in-progress block first and reopen thinking at a fresh
+    // index — Anthropic's SSE spec only allows one open content block at a
+    // time, and a stopped block must not receive more deltas.
     if (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0) {
-      if (state.thinkingIndex === null) {
+      closeTextBlock(state, events);
+      closeOpenToolCalls(state, events);
+      if (!state.thinkingOpened) {
         state.thinkingIndex = nextBlockIndex(state);
         events.push(
           formatMessagesEvent('content_block_start', {
@@ -407,7 +422,8 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
 
     if (typeof delta.content === 'string' && delta.content.length > 0) {
       closeThinkingBlock(state, events);
-      if (state.textIndex === null) {
+      closeOpenToolCalls(state, events);
+      if (!state.textOpened) {
         state.textIndex = nextBlockIndex(state);
         events.push(
           formatMessagesEvent('content_block_start', {
@@ -429,6 +445,7 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
 
     if (Array.isArray(delta.tool_calls)) {
       closeThinkingBlock(state, events);
+      closeTextBlock(state, events);
       for (const call of delta.tool_calls) {
         if (!isRecord(call)) continue;
         const callIndex = typeof call.index === 'number' ? call.index : 0;
@@ -482,12 +499,12 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
   return events.length > 0 ? events.join('') : null;
 }
 
+// Monotonic — every kind of block (thinking/text/tool_use) consumes one slot
+// here, even on reopens. Anthropic's content_block_* events index from 0
+// upward; the index of a reopened block must keep climbing, not collide with
+// an earlier one that has already been stopped.
 function nextBlockIndex(state: StreamState): number {
-  return (
-    (state.thinkingIndex !== null ? 1 : 0) +
-    (state.textIndex !== null ? 1 : 0) +
-    state.toolCalls.size
-  );
+  return state.nextBlockIndexCounter++;
 }
 
 function closeThinkingBlock(state: StreamState, events: string[]): void {
@@ -499,6 +516,30 @@ function closeThinkingBlock(state: StreamState, events: string[]): void {
     }),
   );
   state.thinkingOpened = false;
+}
+
+function closeTextBlock(state: StreamState, events: string[]): void {
+  if (!state.textOpened || state.textIndex === null) return;
+  events.push(
+    formatMessagesEvent('content_block_stop', {
+      type: 'content_block_stop',
+      index: state.textIndex,
+    }),
+  );
+  state.textOpened = false;
+}
+
+function closeOpenToolCalls(state: StreamState, events: string[]): void {
+  for (const entry of state.toolCalls.values()) {
+    if (!entry.opened) continue;
+    events.push(
+      formatMessagesEvent('content_block_stop', {
+        type: 'content_block_stop',
+        index: entry.index,
+      }),
+    );
+    entry.opened = false;
+  }
 }
 
 function buildMessageStartEvent(state: StreamState, data: JsonRecord): string {
@@ -523,24 +564,8 @@ function closeStream(state: StreamState): string[] {
   const events: string[] = [];
 
   closeThinkingBlock(state, events);
-
-  if (state.textOpened && state.textIndex !== null) {
-    events.push(
-      formatMessagesEvent('content_block_stop', {
-        type: 'content_block_stop',
-        index: state.textIndex,
-      }),
-    );
-  }
-  for (const entry of state.toolCalls.values()) {
-    if (!entry.opened) continue;
-    events.push(
-      formatMessagesEvent('content_block_stop', {
-        type: 'content_block_stop',
-        index: entry.index,
-      }),
-    );
-  }
+  closeTextBlock(state, events);
+  closeOpenToolCalls(state, events);
 
   events.push(
     formatMessagesEvent('message_delta', {

--- a/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-messages-adapter.ts
@@ -331,6 +331,12 @@ interface StreamState {
   // Monotonic counter — block indices must keep increasing across the whole
   // stream, including across reopens of the same kind.
   nextBlockIndexCounter: number;
+  // Reasoning_content that arrived while a tool_use was in-progress. Splitting
+  // a single OpenAI tool_call across two Anthropic tool_use blocks would break
+  // input-JSON reassembly on the client, so we defer the reasoning until the
+  // tool_use closes naturally (next text content or finalize) and then flush
+  // it as a self-contained thinking block.
+  deferredReasoning: string;
   finalUsage: JsonRecord | null;
   stopReason: string | null;
   endedMessage: boolean;
@@ -352,6 +358,7 @@ export function createMessagesStreamTransformer(model: string): MessagesStreamTr
     textOpened: false,
     toolCalls: new Map(),
     nextBlockIndexCounter: 0,
+    deferredReasoning: '',
     finalUsage: null,
     stopReason: null,
     endedMessage: false,
@@ -393,31 +400,37 @@ function transformStreamChunk(chunk: string, state: StreamState): string | null 
     // an Anthropic `thinking` content block so clients can echo it back on the
     // next turn — the upstream rejects follow-ups that don't return the trace.
     // Reasoning can also arrive *after* text or a tool_use has already started
-    // (providers don't guarantee reasoning is fully flushed before content),
-    // so close any in-progress block first and reopen thinking at a fresh
-    // index — Anthropic's SSE spec only allows one open content block at a
-    // time, and a stopped block must not receive more deltas.
+    // (providers don't guarantee reasoning is fully flushed before content).
+    // For text we close it and reopen a fresh thinking block — splitting text
+    // across blocks is fine because each Anthropic text block is independent.
+    // For an in-progress tool_use we instead BUFFER the reasoning: splitting a
+    // single OpenAI tool_call across two Anthropic tool_use blocks would break
+    // input-JSON reassembly on the client (each block must carry a complete
+    // input). The buffer is flushed when the tool_use eventually closes.
     if (typeof delta.reasoning_content === 'string' && delta.reasoning_content.length > 0) {
-      closeTextBlock(state, events);
-      closeOpenToolCalls(state, events);
-      if (!state.thinkingOpened) {
-        state.thinkingIndex = nextBlockIndex(state);
+      if (hasOpenToolCall(state)) {
+        state.deferredReasoning += delta.reasoning_content;
+      } else {
+        closeTextBlock(state, events);
+        if (!state.thinkingOpened) {
+          state.thinkingIndex = nextBlockIndex(state);
+          events.push(
+            formatMessagesEvent('content_block_start', {
+              type: 'content_block_start',
+              index: state.thinkingIndex,
+              content_block: { type: 'thinking', thinking: '' },
+            }),
+          );
+          state.thinkingOpened = true;
+        }
         events.push(
-          formatMessagesEvent('content_block_start', {
-            type: 'content_block_start',
+          formatMessagesEvent('content_block_delta', {
+            type: 'content_block_delta',
             index: state.thinkingIndex,
-            content_block: { type: 'thinking', thinking: '' },
+            delta: { type: 'thinking_delta', thinking: delta.reasoning_content },
           }),
         );
-        state.thinkingOpened = true;
       }
-      events.push(
-        formatMessagesEvent('content_block_delta', {
-          type: 'content_block_delta',
-          index: state.thinkingIndex,
-          delta: { type: 'thinking_delta', thinking: delta.reasoning_content },
-        }),
-      );
     }
 
     if (typeof delta.content === 'string' && delta.content.length > 0) {
@@ -529,7 +542,15 @@ function closeTextBlock(state: StreamState, events: string[]): void {
   state.textOpened = false;
 }
 
+function hasOpenToolCall(state: StreamState): boolean {
+  for (const entry of state.toolCalls.values()) {
+    if (entry.opened) return true;
+  }
+  return false;
+}
+
 function closeOpenToolCalls(state: StreamState, events: string[]): void {
+  let closedAny = false;
   for (const entry of state.toolCalls.values()) {
     if (!entry.opened) continue;
     events.push(
@@ -539,6 +560,37 @@ function closeOpenToolCalls(state: StreamState, events: string[]): void {
       }),
     );
     entry.opened = false;
+    closedAny = true;
+  }
+  // If reasoning_content arrived while the tool_use was streaming, we
+  // buffered it instead of splitting the tool_use. Now that the tool_use
+  // is done, flush the buffer as a self-contained thinking block at a fresh
+  // monotonic index. Self-contained (start+delta+stop in one go) so the
+  // surrounding state machine doesn't have to track a fresh in-progress
+  // thinking block here.
+  if (closedAny && state.deferredReasoning.length > 0) {
+    const idx = nextBlockIndex(state);
+    events.push(
+      formatMessagesEvent('content_block_start', {
+        type: 'content_block_start',
+        index: idx,
+        content_block: { type: 'thinking', thinking: '' },
+      }),
+    );
+    events.push(
+      formatMessagesEvent('content_block_delta', {
+        type: 'content_block_delta',
+        index: idx,
+        delta: { type: 'thinking_delta', thinking: state.deferredReasoning },
+      }),
+    );
+    events.push(
+      formatMessagesEvent('content_block_stop', {
+        type: 'content_block_stop',
+        index: idx,
+      }),
+    );
+    state.deferredReasoning = '';
   }
 }
 


### PR DESCRIPTION
## Summary

When a client hits the Anthropic Messages endpoint (`POST /v1/messages`) and the request is routed to a DeepSeek (or DeepSeek-family) model in thinking mode, the **streaming** code path silently drops every `delta.reasoning_content` chunk. Clients never see a `thinking` content block, so they can't echo the trace back on the next turn — and the next request comes back as:

```
400 invalid_request_error
The `reasoning_content` in the thinking mode must be passed back to the API.
```

The non-streaming response path already translates `message.reasoning_content` into a leading `{type: "thinking", thinking: "..."}` content block (see `chatCompletionsResponseToMessages` in `anthropic-messages-adapter.ts`). The stream transformer in the same file just didn't have the corresponding logic — `transformStreamChunk` only branched on `delta.content` and `delta.tool_calls`. With Claude CLI defaulting to `stream: true`, every thinking-mode multi-turn conversation that flowed through `/v1/messages` was broken.

Repro in production traffic:

```
ProxyResponseHandler] Upstream error 400: provider=deepseek model=deepseek-v4-flash tier=default
body={"error":{"message":"The `reasoning_content` in the thinking mode must be passed back to the API.",
"type":"invalid_request_error","param":null,"code":"invalid_request_error"}}
HttpErrors] 400 POST /v1/messages?beta=true 514ms ua=claude-cli/2.1.140
```

## What this PR does

In `createMessagesStreamTransformer` (`packages/backend/src/routing/proxy/anthropic-messages-adapter.ts`):

- Track a `thinkingIndex` / `thinkingOpened` on `StreamState`.
- When a chunk carries `delta.reasoning_content`, emit Anthropic-native stream events:
  - `content_block_start` with `{type: "thinking", thinking: ""}`
  - `content_block_delta` with `{type: "thinking_delta", thinking: "..."}`
- Close the thinking block via `content_block_stop` **before** opening either a `text` or `tool_use` block, so the stream never has two open content blocks at once (Anthropic spec).
- Close any still-open thinking block in the final `closeStream` path (e.g. responses that contain only reasoning and never produce a content payload).
- Adjust `nextBlockIndex` so the thinking block reserves index 0 when present.

The shape mirrors what `chatCompletionsResponseToMessages` already produces for non-streaming responses, so streaming and non-streaming paths now agree.

## Why thinking *before* text, not after

DeepSeek streams `delta.reasoning_content` first and `delta.content` second. Surfacing reasoning as a leading block (index 0) preserves that order in the Anthropic event stream, matches the non-streaming projection in this same file, and lines up with how the Anthropic SDK's `thinking` blocks are placed.

## Tests

`packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts` gets three new cases under `createMessagesStreamTransformer`:

1. `translates DeepSeek-style delta.reasoning_content into a leading thinking block` — full `message_start → thinking_start → thinking_delta × 2 → thinking_stop → text_start → text_delta → text_stop → message_delta → message_stop` ordering.
2. `closes the thinking block on finalize when the stream emits only reasoning_content` — reasoning-only response still emits a clean `content_block_stop`.
3. `closes the thinking block before opening a tool_use block` — when the model goes from reasoning straight into a tool call, thinking@0 is stopped before tool_use@1 starts.

All 36 tests in the suite pass. Line coverage on `anthropic-messages-adapter.ts` stays at 100%.

## Related

- #992 — same upstream error message but on the OpenAI chat_completions path (clients omitting `reasoning_content` on history).
- #1862 / #1899 / PR #1872 — preserve `reasoning_content` through aggregator routes (sanitization, not stream translation). The stream-translation gap fixed here is independent of those — `reasoning_content` is allowed through to DeepSeek correctly today; the issue is that the client never received the trace in the first place because the streaming Anthropic adapter dropped it.

## Test plan

- [x] `npx jest packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts` — 36/36 pass.
- [x] Local repro script feeds a synthetic DeepSeek SSE stream through the transformer and prints the translated Anthropic events; ordering and block-stop semantics verified.
- [x] Deployed to a self-hosted instance against real DeepSeek traffic from Claude CLI; the `400 The reasoning_content in the thinking mode must be passed back to the API` errors stopped reproducing after the upgrade.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Anthropic Messages streaming adapter to emit DeepSeek `delta.reasoning_content` as `thinking` blocks, handle interleaved chunks with fresh monotonic indices, and drop late reasoning during an open `tool_use`. This stops 400s in thinking mode and aligns streaming with non‑streaming behavior.

- **Bug Fixes**
  - In `packages/backend/src/routing/proxy/anthropic-messages-adapter.ts`, translate `delta.reasoning_content` into `thinking` blocks (start → `thinking_delta` → stop) and close it before `text`/`tool_use`.
  - Enforce one open block at a time; on interleaving, close and reopen `thinking`/`text` with a stream‑wide monotonic index counter.
  - Drop `reasoning_content` that arrives while any `tool_use` is open to keep the tool call contiguous and replayable; fragmented args for one tool call stay on a single `tool_use` block.
  - Close any open `thinking`/`text`/`tool_use` blocks on finalize; add tests for ordering, reasoning‑only finalize, interleaved reopen (both directions), dropped late reasoning during `tool_use`, and monotonic indices.

<sup>Written for commit d0ef03caa5ad04a8aea0686921418cf8a45c2df8. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1907?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

