### PR TITLE
feat: add Craft agent setup

### DIFF
--- a/packages/frontend/public/icons/craft.svg
+++ b/packages/frontend/public/icons/craft.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="8" fill="#1A1A2E"/>
+  <path d="M22 10.5C20.4 8.9 18.3 8 16 8C11.6 8 8 11.6 8 16C8 20.4 11.6 24 16 24C18.3 24 20.4 23.1 22 21.5" stroke="#6C63FF" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M19 13L22 10L25 13" stroke="#6C63FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M22 10V17" stroke="#6C63FF" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/packages/frontend/src/components/CraftAgentSetup.tsx
+++ b/packages/frontend/src/components/CraftAgentSetup.tsx
@@ -1,0 +1,79 @@
+import { createSignal, Show, type Component } from 'solid-js';
+import CopyButton from './CopyButton.jsx';
+import CodeBlock from './CodeBlock.jsx';
+import { getCraftAgentConfigSnippet } from '../services/framework-snippets.js';
+
+interface Props {
+  apiKey: string | null;
+  keyPrefix: string | null;
+  baseUrl: string;
+}
+
+const EyeIcon: Component<{ open: boolean }> = (props) => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <Show
+      when={props.open}
+      fallback={
+        <>
+          <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+          <circle cx="12" cy="12" r="3" />
+        </>
+      }
+    >
+      <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" />
+      <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
+      <path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" />
+      <path d="m2 2 20 20" />
+    </Show>
+  </svg>
+);
+
+const CraftAgentSetup: Component<Props> = (props) => {
+  const [keyRevealed, setKeyRevealed] = createSignal(false);
+
+  const hasFullKey = () => !!props.apiKey;
+  const masked = () => (props.keyPrefix ? `${props.keyPrefix}...` : 'mnfst_YOUR_KEY');
+  const copyKey = () => props.apiKey ?? masked();
+  const visibleKey = () => (keyRevealed() && props.apiKey ? props.apiKey : masked());
+
+  const settingsCopy = () => getCraftAgentConfigSnippet(props.baseUrl, copyKey());
+  const settingsShown = () => getCraftAgentConfigSnippet(props.baseUrl, visibleKey());
+
+  return (
+    <div class="setup-agents-card">
+      <p class="setup-method__hint">
+        Edit <code class="setup-model-hint__code">~/.craft/config.json</code> and point the
+        <code class="setup-model-hint__code">manifest</code> provider at the Manifest endpoint.
+      </p>
+
+      <div class="setup-cli-block">
+        <div class="setup-cli-block__actions">
+          <Show when={hasFullKey()}>
+            <button
+              class="modal-terminal__copy"
+              onClick={() => setKeyRevealed(!keyRevealed())}
+              aria-label={keyRevealed() ? 'Hide API key' : 'Reveal API key'}
+              title={keyRevealed() ? 'Hide key' : 'Reveal key'}
+            >
+              <EyeIcon open={keyRevealed()} />
+            </button>
+          </Show>
+          <CopyButton text={settingsCopy()} />
+        </div>
+        <CodeBlock code={settingsShown()} language="json" />
+      </div>
+    </div>
+  );
+};
+
+export default CraftAgentSetup;

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -3,11 +3,12 @@ import FrameworkSnippets from './FrameworkSnippets.jsx';
 import OpenClawSetup from './OpenClawSetup.jsx';
 import HermesSetup from './HermesSetup.jsx';
 import NanobotSetup from './NanobotSetup.jsx';
+import CraftAgentSetup from './CraftAgentSetup.jsx';
 import ClaudeCodeSetup from './ClaudeCodeSetup.jsx';
 import type { ToolkitId } from '../services/framework-snippets.js';
 
 type SetupTab = 'toolkits' | 'agents';
-type AgentId = 'openclaw' | 'hermes' | 'nanobot' | 'claude-code';
+type AgentId = 'openclaw' | 'hermes' | 'nanobot' | 'craft' | 'claude-code';
 
 interface Props {
   apiKey: string | null;
@@ -47,9 +48,11 @@ const SetupStepAddProvider: Component<Props> = (props) => {
             ? 'Connect your OpenClaw agent to Manifest'
             : props.platform === 'nanobot'
               ? 'Connect your Nanobot agent to Manifest'
-              : props.platform === 'claude-code'
-                ? 'Connect Claude Code to Manifest'
-                : 'Connect your agent to Manifest'}
+              : props.platform === 'craft'
+                ? 'Connect your Craft agent to Manifest'
+                : props.platform === 'claude-code'
+                  ? 'Connect Claude Code to Manifest'
+                  : 'Connect your agent to Manifest'}
       </h3>
 
       {/* Platform-filtered mode: show only relevant content */}
@@ -63,6 +66,9 @@ const SetupStepAddProvider: Component<Props> = (props) => {
           </Match>
           <Match when={props.platform === 'nanobot'}>
             <NanobotSetup {...snippetProps()} />
+          </Match>
+          <Match when={props.platform === 'craft'}>
+            <CraftAgentSetup {...snippetProps()} />
           </Match>
           <Match when={props.platform === 'claude-code'}>
             <ClaudeCodeSetup {...snippetProps()} />
@@ -169,6 +175,16 @@ const SetupStepAddProvider: Component<Props> = (props) => {
               </button>
               <button
                 class="panel__tab"
+                classList={{ 'panel__tab--active': activeAgent() === 'craft' }}
+                onClick={() => setActiveAgent('craft')}
+                role="tab"
+                aria-selected={activeAgent() === 'craft'}
+              >
+                <img src="/icons/craft.svg" alt="" class="panel__tab-icon" width="16" height="16" />
+                Craft Agent
+              </button>
+              <button
+                class="panel__tab"
                 classList={{ 'panel__tab--active': activeAgent() === 'claude-code' }}
                 onClick={() => setActiveAgent('claude-code')}
                 role="tab"
@@ -195,6 +211,9 @@ const SetupStepAddProvider: Component<Props> = (props) => {
             </Match>
             <Match when={activeAgent() === 'nanobot'}>
               <NanobotSetup {...snippetProps()} />
+            </Match>
+            <Match when={activeAgent() === 'craft'}>
+              <CraftAgentSetup {...snippetProps()} />
             </Match>
             <Match when={activeAgent() === 'claude-code'}>
               <ClaudeCodeSetup {...snippetProps()} />

--- a/packages/frontend/src/services/framework-snippets.ts
+++ b/packages/frontend/src/services/framework-snippets.ts
@@ -13,6 +13,7 @@ export const FRAMEWORK_TABS: FrameworkTab[] = [
 ];
 
 export type ToolkitId = 'openai-sdk' | 'anthropic-sdk' | 'vercel-ai-sdk' | 'langchain' | 'curl';
+export type CraftConfigId = 'craft';
 export type OpenAILangId = 'python' | 'typescript';
 export type OpenAIApiId = 'responses' | 'chat-completions';
 
@@ -513,4 +514,25 @@ export function getLangForToolkit(id: ToolkitId, openaiLang?: OpenAILangId): str
 
 export function getOpenClawWizardSnippet(): string {
   return 'openclaw onboard';
+}
+
+export function getCraftAgentConfigSnippet(baseUrl: string, apiKey: string): string {
+  return JSON.stringify(
+    {
+      agents: {
+        defaults: {
+          model: 'auto',
+        },
+      },
+      providers: {
+        manifest: {
+          apiBase: baseUrl,
+          apiKey,
+          model: 'auto',
+        },
+      },
+    },
+    null,
+    2,
+  );
 }

--- a/packages/frontend/tests/components/AgentTypeGrid.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeGrid.test.tsx
@@ -19,7 +19,7 @@ vi.mock("manifest-shared", () => ({
     other: "Other",
   },
   PLATFORMS_BY_CATEGORY: {
-    personal: ["openclaw", "hermes", "other"],
+    personal: ["openclaw", "hermes", "nanobot", "craft", "other"],
     app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
     coding: ["claude-code", "other"],
   },
@@ -59,7 +59,7 @@ describe("AgentTypeGrid", () => {
   it("renders all platform options from all three categories", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const options = container.querySelectorAll(".agent-type-select__option");
-    expect(options).toHaveLength(9);
+    expect(options).toHaveLength(11);
   });
 
   it("renders three columns", () => {
@@ -86,7 +86,7 @@ describe("AgentTypeGrid", () => {
       />
     ));
     const options = container.querySelectorAll(".agent-type-select__option");
-    fireEvent.click(options[3]); // OpenAI SDK (app category)
+    fireEvent.click(options[5]); // OpenAI SDK (app category)
     expect(onCategoryChange).toHaveBeenCalledWith("app");
     expect(onPlatformChange).toHaveBeenCalledWith("openai-sdk");
   });
@@ -102,7 +102,7 @@ describe("AgentTypeGrid", () => {
       />
     ));
     const options = container.querySelectorAll(".agent-type-select__option");
-    fireEvent.click(options[7]); // Claude Code (coding column, first item)
+    fireEvent.click(options[9]); // Claude Code (coding column, first item)
     expect(onCategoryChange).toHaveBeenCalledWith("coding");
     expect(onPlatformChange).toHaveBeenCalledWith("claude-code");
   });
@@ -117,29 +117,32 @@ describe("AgentTypeGrid", () => {
   it("uses other-agent.svg for personal Other", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const options = container.querySelectorAll(".agent-type-select__option");
-    const icon = options[2].querySelector(".agent-type-select__option-icon");
+    const icon = options[4].querySelector(".agent-type-select__option-icon");
     expect(icon!.getAttribute("src")).toBe("/icons/other-agent.svg");
   });
 
   it("uses other.svg for app Other", () => {
-    const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
-    const options = container.querySelectorAll(".agent-type-select__option");
-    const icon = options[6].querySelector(".agent-type-select__option-icon");
+    const { container } = render(() => (
+      <AgentTypeGrid {...defaultProps} category="app" platform="other" />
+    ));
+    const selected = container.querySelector(".agent-type-select__option--selected");
+    const icon = selected?.querySelector(".agent-type-select__option-icon");
+    expect(selected?.textContent).toContain("Other");
     expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
   });
 
   it("uses other.svg for coding Other (not the personal-agent variant)", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const options = container.querySelectorAll(".agent-type-select__option");
-    // coding/Other is at index 8 (3 personal + 4 app + 1 claude-code)
-    const icon = options[8].querySelector(".agent-type-select__option-icon");
+    // coding/Other is at index 10 (3 personal + 4 app + 3 coding before it)
+    const icon = options[10].querySelector(".agent-type-select__option-icon");
     expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
   });
 
   it("renders the official Claude Code icon in the coding column", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const options = container.querySelectorAll(".agent-type-select__option");
-    const icon = options[7].querySelector(".agent-type-select__option-icon");
+    const icon = options[9].querySelector(".agent-type-select__option-icon");
     expect(icon!.getAttribute("src")).toBe("/icons/providers/claude-code.svg");
   });
 
@@ -175,9 +178,7 @@ describe("AgentTypeGrid", () => {
     ));
     const selected = container.querySelectorAll(".agent-type-select__option--selected");
     expect(selected).toHaveLength(1);
-    // app Other is at index 6
-    const options = container.querySelectorAll(".agent-type-select__option");
-    expect(options[6].classList.contains("agent-type-select__option--selected")).toBe(true);
+    expect(selected[0].textContent).toContain("Other");
   });
 
   it("selects coding Claude Code correctly", () => {
@@ -190,7 +191,6 @@ describe("AgentTypeGrid", () => {
     ));
     const selected = container.querySelectorAll(".agent-type-select__option--selected");
     expect(selected).toHaveLength(1);
-    const options = container.querySelectorAll(".agent-type-select__option");
-    expect(options[7].classList.contains("agent-type-select__option--selected")).toBe(true);
+    expect(selected[0].textContent).toContain("Claude Code");
   });
 });

--- a/packages/frontend/tests/components/CraftAgentSetup.test.tsx
+++ b/packages/frontend/tests/components/CraftAgentSetup.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent } from "@solidjs/testing-library";
+
+vi.stubGlobal("navigator", {
+  clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+});
+
+import CraftAgentSetup from "../../src/components/CraftAgentSetup";
+
+describe("CraftAgentSetup", () => {
+  const baseProps = {
+    apiKey: null as string | null,
+    keyPrefix: null as string | null,
+    baseUrl: "http://localhost:3001/v1",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the config.json instruction with the Craft path and provider labels", () => {
+    const { container } = render(() => <CraftAgentSetup {...baseProps} />);
+    expect(container.textContent).toContain("~/.craft/config.json");
+    expect(container.textContent).toContain("manifest");
+    expect(container.textContent).toContain("apiBase");
+    expect(container.textContent).toContain("model");
+  });
+
+  it("renders the JSON config snippet with the base URL and api key", () => {
+    const { container } = render(() => <CraftAgentSetup {...baseProps} />);
+    expect(container.querySelector(".hljs.language-json")).not.toBeNull();
+    expect(container.textContent).toContain("http://localhost:3001/v1");
+    expect(container.textContent).toContain("mnfst_YOUR_KEY");
+  });
+
+  it("masks the API key when only a prefix is available", () => {
+    const { container } = render(() => (
+      <CraftAgentSetup {...baseProps} keyPrefix="mnfst_abc" />
+    ));
+    expect(container.textContent).toContain("mnfst_abc...");
+    expect(container.querySelector('[aria-label="Reveal API key"]')).toBeNull();
+    expect(container.querySelector('[aria-label="Hide API key"]')).toBeNull();
+  });
+
+  it("toggles the API key reveal when the eye button is clicked", () => {
+    const { container } = render(() => (
+      <CraftAgentSetup {...baseProps} apiKey="mnfst_full_secret_value" keyPrefix="mnfst_full" />
+    ));
+    expect(container.textContent).toContain("mnfst_full...");
+    expect(container.textContent).not.toContain("mnfst_full_secret_value");
+
+    const reveal = container.querySelector('[aria-label="Reveal API key"]') as HTMLButtonElement;
+    expect(reveal).not.toBeNull();
+    fireEvent.click(reveal);
+    expect(container.textContent).toContain("mnfst_full_secret_value");
+
+    const hide = container.querySelector('[aria-label="Hide API key"]') as HTMLButtonElement;
+    expect(hide).not.toBeNull();
+    fireEvent.click(hide);
+    expect(container.textContent).not.toContain("mnfst_full_secret_value");
+  });
+
+  it("copy button always uses the real key", () => {
+    const writeText = vi.mocked(navigator.clipboard.writeText);
+    const { container } = render(() => (
+      <CraftAgentSetup {...baseProps} apiKey="mnfst_full_secret_value" keyPrefix="mnfst_full" />
+    ));
+    const copyButton = container.querySelector('button[aria-label*="Copy" i]') as HTMLButtonElement
+      | null;
+    expect(copyButton).not.toBeNull();
+    fireEvent.click(copyButton!);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText.mock.calls[0][0]).toContain("mnfst_full_secret_value");
+  });
+
+  it("renders inside a setup-agents-card", () => {
+    const { container } = render(() => <CraftAgentSetup {...baseProps} />);
+    expect(container.querySelector(".setup-agents-card")).not.toBeNull();
+  });
+});

--- a/packages/frontend/tests/services/framework-snippets.test.ts
+++ b/packages/frontend/tests/services/framework-snippets.test.ts
@@ -21,6 +21,7 @@ import {
   getSnippetForToolkit,
   getLangForToolkit,
   getOpenClawWizardSnippet,
+  getCraftAgentConfigSnippet,
 } from "../../src/services/framework-snippets";
 
 describe("FRAMEWORK_TABS", () => {
@@ -71,6 +72,15 @@ describe("TOOLKIT_TABS", () => {
     expect(TOOLKIT_TABS[2].icon).toBe("/icons/vercel.svg");
     expect(TOOLKIT_TABS[3].icon).toBe("/icons/langchain.png");
     expect(TOOLKIT_TABS[4].icon).toBeUndefined();
+  });
+
+  it("renders Craft config JSON", () => {
+    const snippet = getCraftAgentConfigSnippet("http://localhost:3001/v1", "mnfst_key");
+    expect(snippet).toContain('"providers"');
+    expect(snippet).toContain('"manifest"');
+    expect(snippet).toContain('"apiBase": "http://localhost:3001/v1"');
+    expect(snippet).toContain('"apiKey": "mnfst_key"');
+    expect(snippet).toContain('"model": "auto"');
   });
 });
 

--- a/packages/shared/src/agent-type.ts
+++ b/packages/shared/src/agent-type.ts
@@ -5,6 +5,7 @@ export const AGENT_PLATFORMS = [
   'openclaw',
   'hermes',
   'nanobot',
+  'craft',
   'claude-code',
   'openai-sdk',
   'anthropic-sdk',
@@ -25,6 +26,7 @@ export const PLATFORM_LABELS: Readonly<Record<AgentPlatform, string>> = {
   openclaw: 'OpenClaw',
   hermes: 'Hermes Agent',
   nanobot: 'Nanobot',
+  craft: 'Craft Agent',
   'claude-code': 'Claude Code',
   'openai-sdk': 'OpenAI SDK',
   'anthropic-sdk': 'Anthropic SDK',
@@ -35,7 +37,7 @@ export const PLATFORM_LABELS: Readonly<Record<AgentPlatform, string>> = {
 };
 
 export const PLATFORMS_BY_CATEGORY: Readonly<Record<AgentCategory, readonly AgentPlatform[]>> = {
-  personal: ['openclaw', 'hermes', 'nanobot', 'other'],
+  personal: ['openclaw', 'hermes', 'nanobot', 'craft', 'other'],
   app: ['openai-sdk', 'anthropic-sdk', 'vercel-ai-sdk', 'langchain', 'other'],
   coding: ['claude-code', 'other'],
 };
@@ -44,6 +46,7 @@ export const PLATFORM_ICONS: Readonly<Partial<Record<AgentPlatform, string>>> = 
   openclaw: '/icons/openclaw.png',
   hermes: '/icons/hermes.png',
   nanobot: '/icons/nanobot.png',
+  craft: '/icons/craft.svg',
   'claude-code': '/icons/providers/claude-code.svg',
   'openai-sdk': '/icons/providers/openai.svg',
   'anthropic-sdk': '/icons/providers/anthropic.svg',


### PR DESCRIPTION
### ✨ What changed
- Adds Craft Agent to the supported agent list and setup picker.
- Adds a JSON setup card for `~/.craft/config.json`.
- Adds Craft icon and focused frontend test coverage.

### 💭 Why
Craft should sit alongside the other supported agents in the setup flow. This gives users a paste-ready config path instead of treating Craft as a generic endpoint.

### 👤 For users
Users can now pick Craft Agent in the setup UI and copy a ready-to-paste Manifest config.

### 📝 Notes
- Focused checks passed:
  - `npm --workspace=packages/shared run build`
  - `npm --workspace=packages/frontend exec -- vitest run tests/components/CraftAgentSetup.test.tsx tests/components/AgentTypeGrid.test.tsx tests/services/framework-snippets.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Craft Agent as a first-class setup option. Users can choose Craft in the setup flow and copy a ready-to-paste `~/.craft/config.json` pointing at the Manifest endpoint.

- **New Features**
  - Added Craft tab and `CraftAgentSetup` with JSON snippet from `getCraftAgentConfigSnippet`, plus reveal/copy API key.
  - Included `craft` in platform lists, labels, and icons; wired into `SetupStepAddProvider`.
  - Added focused tests for the setup card, agent grid updates, and snippet generator.

<sup>Written for commit a73d00de86f4f2a8fb9b34e5e9fb001988c12c2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

