### PR TITLE
feat: add OpenCode setup

### DIFF
--- a/.changeset/add-opencode-coding-assistant.md
+++ b/.changeset/add-opencode-coding-assistant.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add OpenCode to the Coding Assistant setup flow. The setup screen now renders a paste-ready OpenCode config block for the global or project config, registers Manifest as an OpenAI-compatible provider, and selects `manifest/auto` by default.

--- a/packages/frontend/public/icons/providers/opencode.svg
+++ b/packages/frontend/public/icons/providers/opencode.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 300 300" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="OpenCode">
+  <path d="M210 240H90V120H210V240Z" fill="#CFCECD"/>
+  <path d="M210 60H90V240H210V60ZM270 300H30V0H270V300Z" fill="#211E1E"/>
+</svg>

--- a/packages/frontend/src/components/OpenCodeSetup.tsx
+++ b/packages/frontend/src/components/OpenCodeSetup.tsx
@@ -1,0 +1,104 @@
+import { createSignal, Show, type Component } from 'solid-js';
+import CopyButton from './CopyButton.jsx';
+import CodeBlock from './CodeBlock.jsx';
+
+interface Props {
+  apiKey: string | null;
+  keyPrefix: string | null;
+  baseUrl: string;
+}
+
+function getOpenCodeConfig(baseUrl: string, apiKey: string): string {
+  return `{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "manifest": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Manifest",
+      "options": {
+        "baseURL": "${baseUrl}",
+        "apiKey": "${apiKey}"
+      },
+      "models": {
+        "auto": {
+          "name": "Manifest Auto"
+        }
+      }
+    }
+  },
+  "model": "manifest/auto"
+}`;
+}
+
+const EyeIcon: Component<{ open: boolean }> = (props) => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <Show
+      when={props.open}
+      fallback={
+        <>
+          <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+          <circle cx="12" cy="12" r="3" />
+        </>
+      }
+    >
+      <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" />
+      <path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" />
+      <path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" />
+      <path d="m2 2 20 20" />
+    </Show>
+  </svg>
+);
+
+const OpenCodeSetup: Component<Props> = (props) => {
+  const [keyRevealed, setKeyRevealed] = createSignal(false);
+
+  const placeholderKey = 'mnfst_YOUR_KEY';
+  const hasFullKey = () => !!props.apiKey;
+  const masked = () => (props.keyPrefix ? `${props.keyPrefix}...` : placeholderKey);
+  const copyKey = () => props.apiKey ?? placeholderKey;
+  const visibleKey = () => {
+    if (!props.apiKey) return placeholderKey;
+    return keyRevealed() ? props.apiKey : masked();
+  };
+
+  const settingsCopy = () => getOpenCodeConfig(props.baseUrl, copyKey());
+  const settingsShown = () => getOpenCodeConfig(props.baseUrl, visibleKey());
+
+  return (
+    <div class="setup-agents-card">
+      <p class="setup-method__hint">
+        Add this block to your global{' '}
+        <code class="setup-model-hint__code">~/.config/opencode/opencode.json</code>.
+      </p>
+
+      <div class="setup-cli-block">
+        <div class="setup-cli-block__actions">
+          <Show when={hasFullKey()}>
+            <button
+              class="modal-terminal__copy"
+              onClick={() => setKeyRevealed(!keyRevealed())}
+              aria-label={keyRevealed() ? 'Hide API key' : 'Reveal API key'}
+              title={keyRevealed() ? 'Hide key' : 'Reveal key'}
+            >
+              <EyeIcon open={keyRevealed()} />
+            </button>
+          </Show>
+          <CopyButton text={settingsCopy()} />
+        </div>
+        <CodeBlock code={settingsShown()} language="json" />
+      </div>
+    </div>
+  );
+};
+
+export default OpenCodeSetup;

--- a/packages/frontend/src/components/SetupStepAddProvider.tsx
+++ b/packages/frontend/src/components/SetupStepAddProvider.tsx
@@ -5,10 +5,11 @@ import HermesSetup from './HermesSetup.jsx';
 import NanobotSetup from './NanobotSetup.jsx';
 import CraftAgentSetup from './CraftAgentSetup.jsx';
 import ClaudeCodeSetup from './ClaudeCodeSetup.jsx';
+import OpenCodeSetup from './OpenCodeSetup.jsx';
 import type { ToolkitId } from '../services/framework-snippets.js';
 
 type SetupTab = 'toolkits' | 'agents';
-type AgentId = 'openclaw' | 'hermes' | 'nanobot' | 'craft' | 'claude-code';
+type AgentId = 'openclaw' | 'hermes' | 'nanobot' | 'craft' | 'claude-code' | 'opencode';
 
 interface Props {
   apiKey: string | null;
@@ -52,7 +53,9 @@ const SetupStepAddProvider: Component<Props> = (props) => {
                 ? 'Connect your Craft agent to Manifest'
                 : props.platform === 'claude-code'
                   ? 'Connect Claude Code to Manifest'
-                  : 'Connect your agent to Manifest'}
+                  : props.platform === 'opencode'
+                    ? 'Connect OpenCode to Manifest'
+                    : 'Connect your agent to Manifest'}
       </h3>
 
       {/* Platform-filtered mode: show only relevant content */}
@@ -72,6 +75,9 @@ const SetupStepAddProvider: Component<Props> = (props) => {
           </Match>
           <Match when={props.platform === 'claude-code'}>
             <ClaudeCodeSetup {...snippetProps()} />
+          </Match>
+          <Match when={props.platform === 'opencode'}>
+            <OpenCodeSetup {...snippetProps()} />
           </Match>
           <Match when={toolkitId()}>
             <FrameworkSnippets
@@ -199,6 +205,22 @@ const SetupStepAddProvider: Component<Props> = (props) => {
                 />
                 Claude Code
               </button>
+              <button
+                class="panel__tab"
+                classList={{ 'panel__tab--active': activeAgent() === 'opencode' }}
+                onClick={() => setActiveAgent('opencode')}
+                role="tab"
+                aria-selected={activeAgent() === 'opencode'}
+              >
+                <img
+                  src="/icons/providers/opencode.svg"
+                  alt=""
+                  class="panel__tab-icon"
+                  width="16"
+                  height="16"
+                />
+                OpenCode
+              </button>
             </div>
           </div>
 
@@ -217,6 +239,9 @@ const SetupStepAddProvider: Component<Props> = (props) => {
             </Match>
             <Match when={activeAgent() === 'claude-code'}>
               <ClaudeCodeSetup {...snippetProps()} />
+            </Match>
+            <Match when={activeAgent() === 'opencode'}>
+              <OpenCodeSetup {...snippetProps()} />
             </Match>
           </Switch>
         </Show>

--- a/packages/frontend/src/styles/agent-type-select.css
+++ b/packages/frontend/src/styles/agent-type-select.css
@@ -140,10 +140,12 @@
 .dark .agent-type-select__trigger-icon[src*='openai'],
 .dark .agent-type-select__trigger-icon[src*='anthropic'],
 .dark .agent-type-select__trigger-icon[src*='vercel'],
+.dark .agent-type-select__trigger-icon[src*='opencode'],
 .dark .agent-type-select__trigger-icon[src*='other'],
 .dark .agent-type-select__option-icon[src*='openai'],
 .dark .agent-type-select__option-icon[src*='anthropic'],
 .dark .agent-type-select__option-icon[src*='vercel'],
+.dark .agent-type-select__option-icon[src*='opencode'],
 .dark .agent-type-select__option-icon[src*='other'] {
   filter: invert(1);
 }

--- a/packages/frontend/src/styles/agents.css
+++ b/packages/frontend/src/styles/agents.css
@@ -188,6 +188,7 @@
 .dark .agent-card__platform-icon[src*='openai'],
 .dark .agent-card__platform-icon[src*='anthropic'],
 .dark .agent-card__platform-icon[src*='vercel'],
+.dark .agent-card__platform-icon[src*='opencode'],
 .dark .agent-card__platform-icon[src*='other'] {
   filter: invert(1);
 }
@@ -467,6 +468,7 @@
 .dark .settings-type__icon[src*='openai'],
 .dark .settings-type__icon[src*='anthropic'],
 .dark .settings-type__icon[src*='vercel'],
+.dark .settings-type__icon[src*='opencode'],
 .dark .settings-type__icon[src*='other'] {
   filter: invert(1);
 }
@@ -475,6 +477,7 @@
 .dark .overview__platform-icon[src*='openai'],
 .dark .overview__platform-icon[src*='anthropic'],
 .dark .overview__platform-icon[src*='vercel'],
+.dark .overview__platform-icon[src*='opencode'],
 .dark .overview__platform-icon[src*='other'] {
   filter: invert(1);
 }

--- a/packages/frontend/src/styles/modals.css
+++ b/packages/frontend/src/styles/modals.css
@@ -79,6 +79,7 @@
 .dark .setup-modal__platform-icon[src*='openai'],
 .dark .setup-modal__platform-icon[src*='anthropic'],
 .dark .setup-modal__platform-icon[src*='vercel'],
+.dark .setup-modal__platform-icon[src*='opencode'],
 .dark .setup-modal__platform-icon[src*='other'] {
   filter: invert(1);
 }

--- a/packages/frontend/tests/components/AgentTypeGrid.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeGrid.test.tsx
@@ -18,12 +18,13 @@ vi.mock("manifest-shared", () => ({
     langchain: "LangChain",
     curl: "cURL",
     "claude-code": "Claude Code",
+    opencode: "OpenCode",
     other: "Other",
   },
   PLATFORMS_BY_CATEGORY: {
     personal: ["openclaw", "hermes", "nanobot", "craft", "other"],
     app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
-    coding: ["claude-code", "other"],
+    coding: ["claude-code", "opencode", "other"],
   },
   PLATFORM_ICONS: {
     openclaw: "/icons/openclaw.png",
@@ -34,6 +35,7 @@ vi.mock("manifest-shared", () => ({
     "vercel-ai-sdk": "/icons/vercel.svg",
     langchain: "/icons/langchain.svg",
     "claude-code": "/icons/providers/claude-code.svg",
+    opencode: "/icons/providers/opencode.svg",
   },
 }));
 
@@ -63,7 +65,7 @@ describe("AgentTypeGrid", () => {
   it("renders all platform options from all three categories", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const options = container.querySelectorAll(".agent-type-select__option");
-    expect(options).toHaveLength(11);
+    expect(options).toHaveLength(12);
   });
 
   it("renders three columns", () => {
@@ -111,6 +113,22 @@ describe("AgentTypeGrid", () => {
     expect(onPlatformChange).toHaveBeenCalledWith("claude-code");
   });
 
+  it("selecting OpenCode routes to coding/opencode", () => {
+    const onCategoryChange = vi.fn();
+    const onPlatformChange = vi.fn();
+    const { container } = render(() => (
+      <AgentTypeGrid
+        {...defaultProps}
+        onCategoryChange={onCategoryChange}
+        onPlatformChange={onPlatformChange}
+      />
+    ));
+    const options = container.querySelectorAll(".agent-type-select__option");
+    fireEvent.click(options[10]); // OpenCode (coding column, second item)
+    expect(onCategoryChange).toHaveBeenCalledWith("coding");
+    expect(onPlatformChange).toHaveBeenCalledWith("opencode");
+  });
+
   it("shows platform icons", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const icons = container.querySelectorAll(".agent-type-select__option-icon");
@@ -138,8 +156,8 @@ describe("AgentTypeGrid", () => {
   it("uses other.svg for coding Other (not the personal-agent variant)", () => {
     const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
     const options = container.querySelectorAll(".agent-type-select__option");
-    // coding/Other is at index 10 (5 personal + 4 app + 1 coding before it)
-    const icon = options[10].querySelector(".agent-type-select__option-icon");
+    // coding/Other is at index 11 (5 personal + 4 app + 2 coding before it)
+    const icon = options[11].querySelector(".agent-type-select__option-icon");
     expect(icon!.getAttribute("src")).toBe("/icons/other.svg");
   });
 
@@ -148,6 +166,13 @@ describe("AgentTypeGrid", () => {
     const options = container.querySelectorAll(".agent-type-select__option");
     const icon = options[9].querySelector(".agent-type-select__option-icon");
     expect(icon!.getAttribute("src")).toBe("/icons/providers/claude-code.svg");
+  });
+
+  it("renders the OpenCode icon in the coding column", () => {
+    const { container } = render(() => <AgentTypeGrid {...defaultProps} />);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    const icon = options[10].querySelector(".agent-type-select__option-icon");
+    expect(icon!.getAttribute("src")).toBe("/icons/providers/opencode.svg");
   });
 
   it("disables buttons when disabled prop is true", () => {

--- a/packages/frontend/tests/components/AgentTypeSelect.test.tsx
+++ b/packages/frontend/tests/components/AgentTypeSelect.test.tsx
@@ -16,12 +16,13 @@ vi.mock("manifest-shared", () => ({
     langchain: "LangChain",
     curl: "cURL",
     "claude-code": "Claude Code",
+    opencode: "OpenCode",
     other: "Other",
   },
   PLATFORMS_BY_CATEGORY: {
     personal: ["openclaw", "hermes", "other"],
     app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
-    coding: ["claude-code", "other"],
+    coding: ["claude-code", "opencode", "other"],
   },
   PLATFORM_ICONS: {
     openclaw: "/icons/openclaw.png",
@@ -30,6 +31,7 @@ vi.mock("manifest-shared", () => ({
     "vercel-ai-sdk": "/icons/vercel.svg",
     langchain: "/icons/langchain.svg",
     "claude-code": "/icons/providers/claude-code.svg",
+    opencode: "/icons/providers/opencode.svg",
   },
 }));
 
@@ -86,8 +88,8 @@ describe("AgentTypeSelect", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const options = container.querySelectorAll(".agent-type-select__option");
-    // personal: 3, app: 4, coding: 2 = 9
-    expect(options).toHaveLength(9);
+    // personal: 3, app: 4, coding: 3 = 10
+    expect(options).toHaveLength(10);
   });
 
   it("shows platform names in options", () => {
@@ -100,16 +102,26 @@ describe("AgentTypeSelect", () => {
     expect(dropdown.textContent).toContain("Vercel AI SDK");
     expect(dropdown.textContent).toContain("LangChain");
     expect(dropdown.textContent).toContain("Claude Code");
+    expect(dropdown.textContent).toContain("OpenCode");
   });
 
   it("places Claude Code in the coding column with the official Claude mark", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const options = container.querySelectorAll(".agent-type-select__option");
-    // Coding column is rightmost: index 7 = claude-code, index 8 = coding/Other
+    // Coding column is rightmost: index 7 = claude-code, index 8 = opencode.
     expect(options[7].textContent).toContain("Claude Code");
     const claudeIcon = options[7].querySelector(".agent-type-select__option-icon");
     expect(claudeIcon!.getAttribute("src")).toBe("/icons/providers/claude-code.svg");
+  });
+
+  it("places OpenCode in the coding column with the OpenCode mark", () => {
+    const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
+    fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
+    const options = container.querySelectorAll(".agent-type-select__option");
+    expect(options[8].textContent).toContain("OpenCode");
+    const opencodeIcon = options[8].querySelector(".agent-type-select__option-icon");
+    expect(opencodeIcon!.getAttribute("src")).toBe("/icons/providers/opencode.svg");
   });
 
   it("shows platform icons in options", () => {
@@ -195,7 +207,7 @@ describe("AgentTypeSelect", () => {
     ));
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const options = container.querySelectorAll(".agent-type-select__option");
-    fireEvent.click(options[8]); // coding Other
+    fireEvent.click(options[9]); // coding Other
     expect(onCategoryChange).toHaveBeenCalledWith("coding");
     expect(onPlatformChange).toHaveBeenCalledWith("other");
   });
@@ -261,10 +273,10 @@ describe("AgentTypeSelect", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const options = container.querySelectorAll(".agent-type-select__option");
-    // personal other at index 2, app other at index 6, coding other at index 8
+    // personal other at index 2, app other at index 6, coding other at index 9
     expect(options[2].textContent).toContain("Other");
     expect(options[6].textContent).toContain("Other");
-    expect(options[8].textContent).toContain("Other");
+    expect(options[9].textContent).toContain("Other");
   });
 
   it("uses the personal-agent icon only for personal/Other (app + coding share other.svg)", () => {
@@ -273,7 +285,7 @@ describe("AgentTypeSelect", () => {
     const options = container.querySelectorAll(".agent-type-select__option");
     const personalOther = options[2].querySelector(".agent-type-select__option-icon");
     const appOther = options[6].querySelector(".agent-type-select__option-icon");
-    const codingOther = options[8].querySelector(".agent-type-select__option-icon");
+    const codingOther = options[9].querySelector(".agent-type-select__option-icon");
     expect(personalOther!.getAttribute("src")).toBe("/icons/other-agent.svg");
     expect(appOther!.getAttribute("src")).toBe("/icons/other.svg");
     expect(codingOther!.getAttribute("src")).toBe("/icons/other.svg");
@@ -304,7 +316,7 @@ describe("AgentTypeSelect", () => {
     const { container } = render(() => <AgentTypeSelect {...defaultProps} />);
     fireEvent.click(container.querySelector(".agent-type-select__trigger")!);
     const options = container.querySelectorAll('[role="option"]');
-    expect(options).toHaveLength(9);
+    expect(options).toHaveLength(10);
   });
 
   it("sets aria-selected on selected option", () => {

--- a/packages/frontend/tests/components/OpenCodeSetup.test.tsx
+++ b/packages/frontend/tests/components/OpenCodeSetup.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+
+import OpenCodeSetup from "../../src/components/OpenCodeSetup";
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+
+vi.stubGlobal("navigator", {
+  clipboard: { writeText },
+});
+
+describe("OpenCodeSetup", () => {
+  beforeEach(() => {
+    writeText.mockClear();
+  });
+
+  it("renders a paste-ready opencode.json block with a placeholder when the full key is unavailable", async () => {
+    const { container } = render(() => (
+      <OpenCodeSetup
+        apiKey={null}
+        keyPrefix="mnfst_live"
+        baseUrl="http://localhost:38240/v1"
+      />
+    ));
+
+    expect(container.textContent).toContain("~/.config/opencode/opencode.json");
+    expect(container.textContent).not.toContain("project root");
+    expect(container.textContent).toContain('"baseURL": "http://localhost:38240/v1"');
+    expect(container.textContent).toContain('"apiKey": "mnfst_YOUR_KEY"');
+    expect(container.textContent).not.toContain('"apiKey": "mnfst_live..."');
+    expect(container.textContent).toContain('"model": "manifest/auto"');
+    expect(screen.queryByLabelText("Reveal API key")).toBeNull();
+
+    const copyConfig = container.querySelector(
+      '.setup-cli-block__actions [aria-label="Copy to clipboard"]',
+    );
+    expect(copyConfig).not.toBeNull();
+    fireEvent.click(copyConfig!);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('"apiKey": "mnfst_YOUR_KEY"'));
+    });
+    expect(writeText).not.toHaveBeenCalledWith(expect.stringContaining("mnfst_live..."));
+  });
+
+  it("reveals and hides the full API key without changing the copy payload", async () => {
+    const { container } = render(() => (
+      <OpenCodeSetup
+        apiKey="mnfst_secret"
+        keyPrefix="mnfst_live"
+        baseUrl="http://localhost:38240/v1"
+      />
+    ));
+
+    expect(container.textContent).toContain('"apiKey": "mnfst_live..."');
+    expect(container.textContent).not.toContain("mnfst_secret");
+
+    fireEvent.click(screen.getByLabelText("Reveal API key"));
+    expect(container.textContent).toContain('"apiKey": "mnfst_secret"');
+
+    fireEvent.click(screen.getByLabelText("Hide API key"));
+    expect(container.textContent).toContain('"apiKey": "mnfst_live..."');
+
+    const copyFullConfig = container.querySelector(
+      '.setup-cli-block__actions [aria-label="Copy to clipboard"]',
+    );
+    expect(copyFullConfig).not.toBeNull();
+    fireEvent.click(copyFullConfig!);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(expect.stringContaining('"apiKey": "mnfst_secret"'));
+    });
+  });
+});

--- a/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
+++ b/packages/frontend/tests/components/SetupStepAddProvider.test.tsx
@@ -46,15 +46,16 @@ describe("SetupStepAddProvider", () => {
     expect(activeBtn!.textContent).toBe("Agents");
   });
 
-  it("shows OpenClaw, Hermes, Nanobot, Craft, and Claude Code tabs inside Agents", () => {
+  it("shows OpenClaw, Hermes, Nanobot, Craft, Claude Code, and OpenCode tabs inside Agents", () => {
     const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
     const agentTabs = container.querySelectorAll(".panel__tab");
-    expect(agentTabs).toHaveLength(5);
+    expect(agentTabs).toHaveLength(6);
     expect(agentTabs[0].textContent).toContain("OpenClaw");
     expect(agentTabs[1].textContent).toContain("Hermes Agent");
     expect(agentTabs[2].textContent).toContain("Nanobot");
     expect(agentTabs[3].textContent).toContain("Craft Agent");
     expect(agentTabs[4].textContent).toContain("Claude Code");
+    expect(agentTabs[5].textContent).toContain("OpenCode");
   });
 
   it("shows Nanobot setup when Nanobot tab clicked", () => {
@@ -79,6 +80,14 @@ describe("SetupStepAddProvider", () => {
     fireEvent.click(agentTabs[3]); // Craft Agent
     expect(container.textContent).toContain("Manifest provider preset");
     expect(container.textContent).toContain("mnfst_YOUR_KEY");
+  });
+
+  it("shows OpenCode setup when OpenCode tab clicked", () => {
+    const { container } = render(() => <SetupStepAddProvider {...defaultProps} />);
+    const agentTabs = container.querySelectorAll(".panel__tab");
+    fireEvent.click(agentTabs[5]); // OpenCode
+    expect(container.textContent).toContain("~/.config/opencode/opencode.json");
+    expect(container.textContent).toContain('"model": "manifest/auto"');
   });
 
   it("defaults to OpenClaw agent tab", () => {
@@ -344,6 +353,22 @@ describe("SetupStepAddProvider", () => {
         <SetupStepAddProvider {...defaultProps} platform="claude-code" />
       ));
       expect(screen.getByText("Connect Claude Code to Manifest")).toBeDefined();
+    });
+
+    it("shows OpenCodeSetup directly when platform is opencode", () => {
+      const { container } = render(() => (
+        <SetupStepAddProvider {...defaultProps} platform="opencode" />
+      ));
+      expect(container.textContent).toContain("~/.config/opencode/opencode.json");
+      expect(container.textContent).toContain('"model": "manifest/auto"');
+      expect(container.querySelector('[aria-label="Setup method"]')).toBeNull();
+    });
+
+    it("shows correct heading for opencode", () => {
+      render(() => (
+        <SetupStepAddProvider {...defaultProps} platform="opencode" />
+      ));
+      expect(screen.getByText("Connect OpenCode to Manifest")).toBeDefined();
     });
 
     it("shows OpenAI SDK snippet when platform is openai-sdk", () => {

--- a/packages/shared/__tests__/agent-type.spec.ts
+++ b/packages/shared/__tests__/agent-type.spec.ts
@@ -17,6 +17,7 @@ describe('agent-type', () => {
       'nanobot',
       'craft',
       'claude-code',
+      'opencode',
       'openai-sdk',
       'anthropic-sdk',
       'vercel-ai-sdk',
@@ -55,10 +56,13 @@ describe('agent-type', () => {
     }
   });
 
-  it('places claude-code under coding only, not personal or app', () => {
+  it('places coding assistants under coding only, not personal or app', () => {
     expect(PLATFORMS_BY_CATEGORY.coding).toContain('claude-code');
+    expect(PLATFORMS_BY_CATEGORY.coding).toContain('opencode');
     expect(PLATFORMS_BY_CATEGORY.personal).not.toContain('claude-code');
+    expect(PLATFORMS_BY_CATEGORY.personal).not.toContain('opencode');
     expect(PLATFORMS_BY_CATEGORY.app).not.toContain('claude-code');
+    expect(PLATFORMS_BY_CATEGORY.app).not.toContain('opencode');
   });
 
   it('keeps "other" available in every category for the unknown-platform fallback', () => {
@@ -114,6 +118,7 @@ describe('agent-type', () => {
       expect(platformIcon('hermes', 'personal')).toBe(PLATFORM_ICONS.hermes);
       expect(platformIcon('nanobot', 'personal')).toBe(PLATFORM_ICONS.nanobot);
       expect(platformIcon('claude-code', 'coding')).toBe(PLATFORM_ICONS['claude-code']);
+      expect(platformIcon('opencode', 'coding')).toBe(PLATFORM_ICONS.opencode);
       expect(platformIcon('openai-sdk', 'app')).toBe(PLATFORM_ICONS['openai-sdk']);
       expect(platformIcon('anthropic-sdk', 'app')).toBe(PLATFORM_ICONS['anthropic-sdk']);
       expect(platformIcon('vercel-ai-sdk', 'app')).toBe(PLATFORM_ICONS['vercel-ai-sdk']);
@@ -126,12 +131,17 @@ describe('agent-type', () => {
       expect(platformIcon('claude-code', 'coding')).toBe('/icons/providers/claude-code.svg');
     });
 
+    it('opencode resolves to the providers/opencode.svg mark', () => {
+      expect(platformIcon('opencode', 'coding')).toBe('/icons/providers/opencode.svg');
+    });
+
     it('returns the platform icon regardless of the category passed (icon is keyed by platform)', () => {
       // Even if the caller passes an inconsistent (platform, category) pair —
       // e.g. a stale row in the DB — we still resolve to the registered icon
       // for the platform. Only "other" branches on category.
       expect(platformIcon('claude-code', 'personal')).toBe(PLATFORM_ICONS['claude-code']);
       expect(platformIcon('claude-code', null)).toBe(PLATFORM_ICONS['claude-code']);
+      expect(platformIcon('opencode', 'personal')).toBe(PLATFORM_ICONS.opencode);
       expect(platformIcon('openclaw', 'coding')).toBe(PLATFORM_ICONS.openclaw);
     });
 

--- a/packages/shared/src/agent-type.ts
+++ b/packages/shared/src/agent-type.ts
@@ -7,6 +7,7 @@ export const AGENT_PLATFORMS = [
   'nanobot',
   'craft',
   'claude-code',
+  'opencode',
   'openai-sdk',
   'anthropic-sdk',
   'vercel-ai-sdk',
@@ -28,6 +29,7 @@ export const PLATFORM_LABELS: Readonly<Record<AgentPlatform, string>> = {
   nanobot: 'Nanobot',
   craft: 'Craft Agent',
   'claude-code': 'Claude Code',
+  opencode: 'OpenCode',
   'openai-sdk': 'OpenAI SDK',
   'anthropic-sdk': 'Anthropic SDK',
   'vercel-ai-sdk': 'Vercel AI SDK',
@@ -39,7 +41,7 @@ export const PLATFORM_LABELS: Readonly<Record<AgentPlatform, string>> = {
 export const PLATFORMS_BY_CATEGORY: Readonly<Record<AgentCategory, readonly AgentPlatform[]>> = {
   personal: ['openclaw', 'hermes', 'nanobot', 'craft', 'other'],
   app: ['openai-sdk', 'anthropic-sdk', 'vercel-ai-sdk', 'langchain', 'other'],
-  coding: ['claude-code', 'other'],
+  coding: ['claude-code', 'opencode', 'other'],
 };
 
 export const PLATFORM_ICONS: Readonly<Partial<Record<AgentPlatform, string>>> = {
@@ -48,6 +50,7 @@ export const PLATFORM_ICONS: Readonly<Partial<Record<AgentPlatform, string>>> = 
   nanobot: '/icons/nanobot.png',
   craft: '/icons/craft.png',
   'claude-code': '/icons/providers/claude-code.svg',
+  opencode: '/icons/providers/opencode.svg',
   'openai-sdk': '/icons/providers/openai.svg',
   'anthropic-sdk': '/icons/providers/anthropic.svg',
   'vercel-ai-sdk': '/icons/vercel.svg',


### PR DESCRIPTION
### ✨ What changed
- Add OpenCode to the Coding Assistant platform list.
- Add a paste-ready OpenCode config setup panel for global `~/.config/opencode/opencode.json` or project `opencode.json` with `manifest/auto`.
- Add focused picker, setup, snippet, and shared metadata tests.

### 💭 Why
OpenCode can use Manifest through its OpenAI-compatible custom provider config.
The setup flow should show that path directly.

### 👤 For users
Users can select OpenCode and copy the Manifest provider config.

### 📝 Notes
- Adds a `manifest` patch changeset.
- Local lint is warnings-only from pre-existing files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenCode to the Coding Assistant with a copy-ready `opencode.json` that registers `manifest` via `@ai-sdk/openai-compatible` and defaults to `manifest/auto`. Users can select OpenCode and paste the global config at `~/.config/opencode/opencode.json` to connect quickly.

- New Features
  - Added OpenCode setup panel with reveal/hide and copy for a JSON block including `$schema`, `baseURL`, `apiKey`, and `"model": "manifest/auto"`.
  - Listed OpenCode in coding pickers and the Agents tab; platform filter shows “Connect OpenCode to Manifest”; added `/icons/providers/opencode.svg` with dark-mode support; updated shared platform maps, tests, and a `manifest` patch changeset.

<sup>Written for commit a254c3237f3fdb988bbcebe8b3c5d0ce4003362a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

