### PR TITLE
fix(proxy): normalize image_url for Responses API

### DIFF
--- a/.changeset/clean-images-respond.md
+++ b/.changeset/clean-images-respond.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Normalize Chat Completions `image_url` parts to Responses API `input_image` parts before forwarding to `/v1/responses`.

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-helpers-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-helpers-converters.spec.ts
@@ -177,17 +177,21 @@ describe('chatgpt-helpers converters', () => {
       expect(convertContent(objContent, 'user')).toBe(objContent);
     });
 
-    it('should remap text type parts in array content', () => {
+    it('should remap text and image_url parts in array content', () => {
       const result = convertContent(
         [
           { type: 'text', text: 'Hello' },
-          { type: 'image_url', image_url: { url: 'http://example.com' } },
+          { type: 'image_url', image_url: { url: 'http://example.com', detail: 'high' } },
         ],
         'user',
-      ) as { type: string }[];
+      ) as Record<string, unknown>[];
 
       expect(result[0].type).toBe('input_text');
-      expect(result[1].type).toBe('image_url');
+      expect(result[1]).toEqual({
+        type: 'input_image',
+        image_url: 'http://example.com',
+        detail: 'high',
+      });
     });
 
     it('should remap text type to output_text for assistant array content', () => {

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-request.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-request.spec.ts
@@ -97,7 +97,7 @@ describe('ChatGPT Adapter – toResponsesRequest', () => {
     expect(input[0].content[0].type).toBe('output_text');
   });
 
-  it('preserves non-text content part types', () => {
+  it('converts Chat Completions image_url parts to Responses input_image parts', () => {
     const body = {
       messages: [
         {
@@ -110,10 +110,13 @@ describe('ChatGPT Adapter – toResponsesRequest', () => {
       ],
     };
     const result = toResponsesRequest(body, 'gpt-5');
-    const input = result.input as { content: { type: string }[] }[];
+    const input = result.input as { content: Record<string, unknown>[] }[];
 
     expect(input[0].content[0].type).toBe('input_text');
-    expect(input[0].content[1].type).toBe('image_url');
+    expect(input[0].content[1]).toEqual({
+      type: 'input_image',
+      image_url: 'http://example.com/img.png',
+    });
   });
 
   it('filters system and developer messages from input array', () => {

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -184,6 +184,40 @@ describe('Responses adapter', () => {
     ]);
   });
 
+  it('normalizes legacy image_url content parts in native Responses input lists', () => {
+    expect(
+      toNativeResponsesRequest(
+        {
+          input: [
+            {
+              role: 'user',
+              content: [
+                { type: 'input_text', text: 'look' },
+                {
+                  type: 'image_url',
+                  image_url: { url: 'https://example.test/image.png', detail: 'low' },
+                },
+              ],
+            },
+          ],
+        },
+        'gpt-5.4',
+      ).input,
+    ).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'look' },
+          {
+            type: 'input_image',
+            image_url: 'https://example.test/image.png',
+            detail: 'low',
+          },
+        ],
+      },
+    ]);
+  });
+
   it('can force streaming for native backends that always return SSE', () => {
     expect(
       toNativeResponsesRequest({ input: 'hi', stream: false }, 'gpt-5.4', {

--- a/packages/backend/src/routing/proxy/chatgpt-helpers.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-helpers.spec.ts
@@ -110,14 +110,14 @@ describe('chatgpt-helpers', () => {
       expect(convertContent('hi', 'assistant')).toEqual([{ type: 'output_text', text: 'hi' }]);
     });
 
-    it('renames "text" parts to input_text/output_text but leaves other parts alone', () => {
+    it('renames user text and image_url parts to Responses content parts', () => {
       const parts = [
         { type: 'text', text: 'hello' },
         { type: 'image_url', image_url: { url: 'x' } },
       ];
       expect(convertContent(parts, 'user')).toEqual([
         { type: 'input_text', text: 'hello' },
-        { type: 'image_url', image_url: { url: 'x' } },
+        { type: 'input_image', image_url: 'x' },
       ]);
     });
 

--- a/packages/backend/src/routing/proxy/chatgpt-helpers.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-helpers.ts
@@ -51,10 +51,29 @@ export function convertContent(content: unknown, role: string): unknown {
 
   if (!Array.isArray(content)) return content;
 
-  return (content as { type?: string; text?: string }[]).map((part) => {
+  return content.map((part) => {
+    if (!isObjectRecord(part)) return part;
     if (part.type === 'text') return { ...part, type: partType };
+    if (part.type === 'image_url' && role !== 'assistant') {
+      const imageUrl = extractImageUrl(part.image_url);
+      if (imageUrl) {
+        return { type: 'input_image', image_url: imageUrl, ...extractImageDetail(part) };
+      }
+    }
     return part;
   });
+}
+
+function extractImageUrl(imageUrl: unknown): string | null {
+  if (typeof imageUrl === 'string') return imageUrl;
+  if (!isObjectRecord(imageUrl) || typeof imageUrl.url !== 'string') return null;
+  return imageUrl.url;
+}
+
+function extractImageDetail(part: Record<string, unknown>): { detail?: string } {
+  const nested = isObjectRecord(part.image_url) ? part.image_url.detail : undefined;
+  const detail = typeof part.detail === 'string' ? part.detail : nested;
+  return typeof detail === 'string' ? { detail } : {};
 }
 
 export function extractInstructions(messages: OpenAIMessage[]): string {

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -182,6 +182,8 @@ export function toNativeResponsesRequest(
   }
   if (opts?.inputList) {
     request.input = toNativeResponsesInput(body.input);
+  } else if (body.input !== undefined) {
+    request.input = normalizeNativeResponsesInput(body.input);
   }
   if (
     opts?.defaultInstructions &&
@@ -190,6 +192,18 @@ export function toNativeResponsesRequest(
     request.instructions = DEFAULT_INSTRUCTIONS;
   }
   return request;
+}
+
+function normalizeNativeResponsesInput(input: unknown): unknown {
+  if (!Array.isArray(input)) return input;
+
+  return input.map((item) => {
+    if (!isRecord(item)) return item;
+    if (item.type === 'function_call' || item.type === 'function_call_output') return item;
+
+    const role = typeof item.role === 'string' ? item.role : 'user';
+    return { ...item, content: toNativeResponsesContent(item.content, role) };
+  });
 }
 
 function toNativeResponsesInput(input: unknown): unknown {
@@ -221,8 +235,26 @@ function toNativeResponsesContent(content: unknown, role: string): unknown {
     if (typeof part.text === 'string' && (part.type === 'text' || part.type === undefined)) {
       return { ...part, type: partType };
     }
+    if (part.type === 'image_url' && role !== 'assistant') {
+      const imageUrl = extractImageUrl(part.image_url);
+      if (imageUrl) {
+        return { type: 'input_image', image_url: imageUrl, ...extractImageDetail(part) };
+      }
+    }
     return part;
   });
+}
+
+function extractImageUrl(imageUrl: unknown): string | null {
+  if (typeof imageUrl === 'string') return imageUrl;
+  if (!isRecord(imageUrl) || typeof imageUrl.url !== 'string') return null;
+  return imageUrl.url;
+}
+
+function extractImageDetail(part: JsonRecord): { detail?: string } {
+  const nested = isRecord(part.image_url) ? part.image_url.detail : undefined;
+  const detail = typeof part.detail === 'string' ? part.detail : nested;
+  return typeof detail === 'string' ? { detail } : {};
 }
 
 export function fromChatCompletionResponse(body: JsonRecord, model: string): JsonRecord {


### PR DESCRIPTION
## Summary

- normalize Chat Completions `image_url` content parts to Responses API `input_image` parts before forwarding to `/v1/responses`
- apply the normalization in both the Chat Completions-to-Responses adapter and native Responses forwarding path
- add focused regressions for the previous `image_url` passthrough behavior
- add a `manifest` patch changeset

Closes #1773.

## Validation

- `npm test --workspace=packages/backend -- chatgpt-request.spec.ts chatgpt-helpers-converters.spec.ts responses-adapter.spec.ts`
- `npm run build --workspace=packages/shared`
- `cd packages/backend && npx tsc --noEmit`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize `image_url` content parts to Responses `input_image` across the proxy, including nested object formats. Fixes mismatches when forwarding Chat Completions and native Responses requests.

- **Bug Fixes**
  - Convert Chat Completions `image_url` parts to `input_image`, flatten the URL and preserve `detail`.
  - Normalize legacy `image_url` parts in native Responses inputs (list and non-list, non-assistant roles).
  - Added regression tests and updated expectations for both adapter paths.
  - Added a `manifest` patch changeset.

<sup>Written for commit 3ad268d6d0e42b7536773c482468b972e00f4c09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

