### PR TITLE
fix: improve mobile dashboard layout

### DIFF
--- a/.changeset/mobile-dashboard-phone.md
+++ b/.changeset/mobile-dashboard-phone.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Improve the dashboard layout on phone-sized screens with a compact navigation drawer, tighter header chrome, and mobile-sized chart stats.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,5 +1,12 @@
 import { useLocation } from '@solidjs/router';
-import { onCleanup, onMount, Show, type ParentComponent } from 'solid-js';
+import {
+  createEffect,
+  createSignal,
+  onCleanup,
+  onMount,
+  Show,
+  type ParentComponent,
+} from 'solid-js';
 import Header from './components/Header.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import AuthGuard from './components/AuthGuard.jsx';
@@ -17,8 +24,16 @@ const SseConnector: ParentComponent = (props) => {
 
 const App: ParentComponent = (props) => {
   const location = useLocation();
+  const [mobileNavOpen, setMobileNavOpen] = createSignal(false);
   const isAgentMode = () => location.pathname.startsWith('/agents/');
   const showSidebar = () => isAgentMode();
+
+  createEffect<string | undefined>((previousPath) => {
+    const currentPath = location.pathname;
+    if (currentPath === previousPath) return currentPath;
+    setMobileNavOpen(false);
+    return currentPath;
+  });
 
   return (
     <AuthGuard>
@@ -27,10 +42,24 @@ const App: ParentComponent = (props) => {
           <a href="#main-content" class="skip-link">
             Skip to main content
           </a>
-          <Header />
-          <div class="app-body">
+          <Header
+            showMobileNavToggle={showSidebar()}
+            mobileNavOpen={mobileNavOpen()}
+            onMobileNavToggle={() => setMobileNavOpen((open) => !open)}
+          />
+          <Show when={showSidebar()}>
+            <Show when={mobileNavOpen()}>
+              <button
+                type="button"
+                class="mobile-nav-backdrop"
+                aria-label="Close navigation menu"
+                onClick={() => setMobileNavOpen(false)}
+              />
+            </Show>
+          </Show>
+          <div class="app-body" classList={{ 'app-body--with-sidebar': showSidebar() }}>
             <Show when={showSidebar()}>
-              <Sidebar />
+              <Sidebar mobileOpen={mobileNavOpen()} onNavigate={() => setMobileNavOpen(false)} />
             </Show>
             <main
               id="main-content"

--- a/packages/frontend/src/components/AgentTypeSelect.tsx
+++ b/packages/frontend/src/components/AgentTypeSelect.tsx
@@ -77,6 +77,9 @@ const AgentTypeSelect: Component<Props> = (props) => {
             class="agent-type-select__trigger-icon"
           />
         </Show>
+        <span class="agent-type-select__trigger-label">
+          {props.platform ? PLATFORM_LABELS[props.platform] : 'Select'}
+        </span>
         <svg
           class="agent-type-select__caret"
           xmlns="http://www.w3.org/2000/svg"

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -13,7 +13,13 @@ const STAR_CACHE_KEY = 'github-star-count';
 const STAR_CACHE_TS_KEY = 'github-star-ts';
 const STAR_CACHE_TTL = 3600000; // 1 hour
 
-const Header: Component = () => {
+interface HeaderProps {
+  showMobileNavToggle?: boolean;
+  mobileNavOpen?: boolean;
+  onMobileNavToggle?: () => void;
+}
+
+const Header: Component<HeaderProps> = (props) => {
   const getAgentName = useAgentName();
   const location = useLocation();
   const [menuOpen, setMenuOpen] = createSignal(false);
@@ -214,6 +220,22 @@ const Header: Component = () => {
         </Show>
       </div>
       <div class="header__right">
+        <Show when={props.showMobileNavToggle}>
+          <button
+            type="button"
+            class="mobile-nav-toggle"
+            aria-label={
+              props.mobileNavOpen === true ? 'Close navigation menu' : 'Open navigation menu'
+            }
+            aria-controls="agent-navigation"
+            aria-expanded={props.mobileNavOpen === true}
+            onClick={props.onMobileNavToggle}
+          >
+            <span aria-hidden="true" />
+            <span aria-hidden="true" />
+            <span aria-hidden="true" />
+          </button>
+        </Show>
         <a href={docsUrl()} target="_blank" rel="noopener noreferrer" class="header__docs-link">
           <svg
             width="13"

--- a/packages/frontend/src/components/SetupModal.tsx
+++ b/packages/frontend/src/components/SetupModal.tsx
@@ -43,7 +43,7 @@ const SetupModal: Component<{
         }}
       >
         <div
-          class="modal-card"
+          class="modal-card setup-modal"
           style="max-width: 600px;"
           role="dialog"
           aria-modal="true"
@@ -60,7 +60,9 @@ const SetupModal: Component<{
                   class="setup-modal__platform-icon"
                 />
               </Show>
-              Set up agent: <em>{props.agentName}</em>
+              <span class="setup-modal__title-text">
+                Set up agent: <em>{props.agentName}</em>
+              </span>
             </div>
             <button class="modal__close" onClick={() => props.onClose()} aria-label="Close">
               <svg

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,12 @@ import { A, useLocation } from '@solidjs/router';
 import { Show, type Component } from 'solid-js';
 import { useAgentName, agentPath } from '../services/routing.js';
 
-const Sidebar: Component = () => {
+interface SidebarProps {
+  mobileOpen?: boolean;
+  onNavigate?: () => void;
+}
+
+const Sidebar: Component<SidebarProps> = (props) => {
   const location = useLocation();
   const getAgentName = useAgentName();
 
@@ -15,7 +20,17 @@ const Sidebar: Component = () => {
   };
 
   return (
-    <nav class="sidebar" aria-label="Agent navigation">
+    <nav
+      id="agent-navigation"
+      class="sidebar"
+      classList={{ 'sidebar--mobile-open': props.mobileOpen === true }}
+      aria-label="Agent navigation"
+      onClick={(event) => {
+        if ((event.target as HTMLElement).closest('a.sidebar__link')) {
+          props.onNavigate?.();
+        }
+      }}
+    >
       <Show when={!getAgentName()}>
         <A
           href="/"

--- a/packages/frontend/src/styles/agent-type-select.css
+++ b/packages/frontend/src/styles/agent-type-select.css
@@ -46,6 +46,10 @@
   height: 24px;
 }
 
+.agent-type-select__trigger-label {
+  display: none;
+}
+
 .agent-type-select__caret {
   color: hsl(var(--muted-foreground));
   flex-shrink: 0;
@@ -148,4 +152,50 @@
 .dark .agent-type-select__option-icon[src*='opencode'],
 .dark .agent-type-select__option-icon[src*='other'] {
   filter: invert(1);
+}
+
+@media (max-width: 768px) {
+  .agent-type-select-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--gap-sm);
+  }
+
+  .agent-type-select-row > div {
+    width: 100%;
+  }
+
+  .agent-type-select {
+    width: 100%;
+  }
+
+  .agent-type-select__trigger {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 8px;
+  }
+
+  .agent-type-select__trigger-label {
+    display: inline;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .agent-type-select__dropdown {
+    flex-direction: column;
+    max-height: min(58vh, 420px);
+    overflow-y: auto;
+  }
+
+  .agent-type-select__group-label {
+    padding: 8px 10px 4px;
+  }
+
+  .agent-type-select__option {
+    min-height: 40px;
+  }
 }

--- a/packages/frontend/src/styles/modals.css
+++ b/packages/frontend/src/styles/modals.css
@@ -72,6 +72,14 @@
   gap: 10px;
 }
 
+.setup-modal__title-text {
+  min-width: 0;
+}
+
+.setup-modal__title-text em {
+  overflow-wrap: anywhere;
+}
+
 .setup-modal__platform-icon {
   flex-shrink: 0;
 }
@@ -344,6 +352,97 @@
 .modal-card__footer .btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .modal-overlay {
+    align-items: flex-start;
+    padding: 12px;
+    overflow-y: auto;
+  }
+
+  .modal-card {
+    max-height: calc(100dvh - 24px);
+    overflow-y: auto;
+    border-radius: 14px;
+    padding: 24px;
+    overscroll-behavior: contain;
+  }
+
+  .setup-modal {
+    max-width: 100% !important;
+  }
+
+  .setup-modal__header {
+    align-items: flex-start;
+    gap: var(--gap-sm);
+  }
+
+  .setup-modal__header .modal-card__title {
+    align-items: flex-start;
+    font-size: var(--font-size-lg);
+    line-height: 1.25;
+    min-width: 0;
+  }
+
+  .setup-modal__platform-icon {
+    width: 24px;
+    height: 24px;
+    margin-top: 1px;
+  }
+
+  .setup-modal__title-text {
+    display: block;
+    line-height: 1.25;
+  }
+
+  .setup-modal__title-text em {
+    font-style: normal;
+    font-weight: 700;
+  }
+
+  .setup-modal__nav {
+    position: sticky;
+    bottom: -24px;
+    margin: var(--gap-lg) -24px -24px;
+    padding: var(--gap-md) 24px calc(var(--gap-md) + env(safe-area-inset-bottom, 0px));
+    border-top: 1px solid hsl(var(--border));
+    background: hsl(var(--card));
+  }
+
+  .setup-modal__next,
+  .modal-card__footer .btn {
+    width: 100%;
+  }
+
+  .modal-card__footer {
+    justify-content: stretch;
+  }
+}
+
+@media (max-width: 480px) {
+  .modal-overlay {
+    padding: 10px;
+  }
+
+  .modal-card {
+    max-height: calc(100dvh - 20px);
+    padding: 20px;
+  }
+
+  .modal-card__title {
+    font-size: var(--font-size-lg);
+  }
+
+  .modal-card__desc {
+    margin-bottom: var(--gap-md);
+  }
+
+  .setup-modal__nav {
+    bottom: -20px;
+    margin: var(--gap-lg) -20px -20px;
+    padding: var(--gap-md) 20px calc(var(--gap-md) + env(safe-area-inset-bottom, 0px));
+  }
 }
 
 /* Stepper */

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -866,6 +866,11 @@ h6 {
   border-top: 1px solid hsl(var(--sidebar-border));
 }
 
+.mobile-nav-toggle,
+.mobile-nav-backdrop {
+  display: none;
+}
+
 /* ── Theme Toggle ─────────────────────────────────── */
 .theme-toggle {
   display: flex;
@@ -1177,12 +1182,147 @@ h6 {
 }
 
 @media (max-width: 768px) {
+  .header {
+    padding: 0 var(--gap-md);
+  }
+  .header__left {
+    flex: 1;
+    overflow: hidden;
+  }
+  .header__logo-img {
+    width: 124px;
+    margin-bottom: 7px;
+  }
+  .header__separator,
+  .header__breadcrumb-link,
+  .header__docs-link,
+  .header__github-star,
+  .header__star-separator {
+    display: none;
+  }
+  .header__breadcrumb-current {
+    max-width: min(38vw, 180px);
+  }
+  .header__breadcrumb-current > span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .header__gear {
+    flex-shrink: 0;
+  }
+  .header__right {
+    flex-shrink: 0;
+  }
   .main-content {
     margin-left: 0;
     padding: var(--gap-md);
   }
+  .mobile-nav-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    flex-direction: column;
+    gap: 4px;
+    padding: 0;
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    background: hsl(var(--card));
+    color: hsl(var(--foreground));
+    cursor: pointer;
+    transition:
+      background var(--transition-fast),
+      border-color var(--transition-fast),
+      color var(--transition-fast);
+  }
+  .mobile-nav-toggle:hover {
+    background: hsl(var(--accent));
+  }
+  .mobile-nav-toggle:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+  }
+  .mobile-nav-toggle span {
+    width: 16px;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+    transition:
+      opacity var(--transition-fast),
+      transform var(--transition-fast);
+  }
+  .mobile-nav-toggle[aria-expanded='true'] span:nth-child(1) {
+    transform: translateY(6px) rotate(45deg);
+  }
+  .mobile-nav-toggle[aria-expanded='true'] span:nth-child(2) {
+    opacity: 0;
+  }
+  .mobile-nav-toggle[aria-expanded='true'] span:nth-child(3) {
+    transform: translateY(-6px) rotate(-45deg);
+  }
+  .mobile-nav-backdrop {
+    display: block;
+    position: fixed;
+    inset: var(--header-height) 0 0;
+    z-index: 44;
+    border: 0;
+    background: hsl(var(--background) / 0.9);
+  }
   .sidebar {
-    display: none;
+    position: fixed;
+    top: var(--header-height);
+    bottom: 0;
+    left: 0;
+    z-index: 45;
+    display: flex;
+    width: min(82vw, 300px);
+    height: calc(100vh - var(--header-height));
+    max-height: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: var(--gap-md) 0 calc(var(--gap-md) + env(safe-area-inset-bottom, 0px));
+    overflow-x: hidden;
+    overflow-y: auto;
+    border-top: 0;
+    border-right: 1px solid hsl(var(--sidebar-border));
+    background: hsl(var(--sidebar-background));
+    box-shadow: none;
+    transform: translateX(-100%);
+    transition: transform var(--transition-base);
+  }
+  .sidebar--mobile-open {
+    transform: translateX(0);
+  }
+  .sidebar__section-label,
+  .sidebar__spacer,
+  .sidebar__feedback {
+    display: block;
+  }
+  .sidebar__link {
+    flex: 0 0 auto;
+    min-width: 0;
+    margin: 1px 0.5rem;
+    padding: 8px var(--gap-lg);
+    border-radius: var(--radius);
+    line-height: 1.3;
+    white-space: nowrap;
+  }
+  .sidebar__link:hover {
+    background: hsl(var(--sidebar-accent));
+    color: hsl(var(--sidebar-accent-foreground));
+  }
+  .sidebar__link.active {
+    background: hsl(var(--sidebar-accent));
+    color: hsl(var(--sidebar-primary));
+  }
+  .sidebar__link.active:hover {
+    background: hsl(var(--sidebar-accent));
+    color: hsl(var(--sidebar-primary));
   }
   .cards-grid {
     grid-template-columns: 1fr 1fr;
@@ -1195,14 +1335,122 @@ h6 {
     align-items: flex-start;
     gap: var(--gap-md);
   }
+  .page-header > div:first-child {
+    width: 100%;
+    min-width: 0;
+  }
+  .page-header h1 {
+    min-width: 0;
+    flex-wrap: wrap;
+    font-size: var(--font-size-xl);
+    letter-spacing: 0;
+    overflow-wrap: anywhere;
+  }
+  .page-header h1 img {
+    flex-shrink: 0;
+  }
+  .header-controls {
+    width: 100%;
+    flex-wrap: wrap;
+    align-items: stretch;
+  }
+  .header-controls .select {
+    width: 100%;
+  }
   .container--sm,
   .container--md {
     max-width: 100%;
   }
+  .chart-card__header {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: stretch;
+  }
+  .chart-card__stat {
+    min-width: 0;
+    padding: 12px;
+    border-right: 0;
+    border-bottom: 1px solid hsl(var(--border));
+  }
+  .chart-card__stat:first-child {
+    padding-left: 12px;
+  }
+  .chart-card__stat:nth-child(odd) {
+    border-right: 1px solid hsl(var(--border));
+  }
+  .chart-card__stat:last-of-type {
+    border-right: 0;
+  }
+  .chart-card__stat:nth-child(odd):last-of-type {
+    grid-column: 1 / -1;
+  }
+  .chart-card__label {
+    font-size: var(--font-size-xs);
+    line-height: 1.3;
+  }
+  .chart-card__value {
+    font-size: var(--font-size-xl);
+    letter-spacing: 0;
+    overflow-wrap: anywhere;
+  }
+  .chart-card__value-row {
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  .chart-card__body {
+    padding: var(--gap-sm);
+  }
+  .u-legend {
+    grid-template-columns: 1fr !important;
+    gap: 2px !important;
+  }
+  .u-legend .u-series:not(:first-child) {
+    padding-left: 0 !important;
+  }
+  .panel {
+    padding: var(--gap-md);
+    overflow-x: auto;
+  }
+  .panel__title {
+    margin-bottom: var(--gap-md);
+  }
+  .data-table {
+    font-size: var(--font-size-xs);
+  }
+  .data-table th,
+  .data-table td {
+    padding: 10px 12px;
+  }
+  .empty-state {
+    padding: var(--gap-xl) var(--gap-md);
+  }
 }
 
 @media (max-width: 480px) {
+  .header__logo-img {
+    width: 112px;
+  }
+  .header__mode-badge {
+    display: none;
+  }
+  .header__breadcrumb-current {
+    max-width: 34vw;
+  }
+  .mobile-nav-toggle {
+    width: 34px;
+    height: 34px;
+  }
   .cards-grid {
     grid-template-columns: 1fr;
+  }
+  .chart-card__value {
+    font-size: var(--font-size-lg);
+  }
+}
+
+@media (max-width: 360px) {
+  .header__gear {
+    display: none;
   }
 }

--- a/packages/frontend/src/styles/wizard.css
+++ b/packages/frontend/src/styles/wizard.css
@@ -815,3 +815,74 @@
   color: hsl(var(--muted-foreground));
   font-style: italic;
 }
+
+@media (max-width: 768px) {
+  .setup-step__heading {
+    font-size: var(--font-size-base);
+    line-height: 1.35;
+  }
+
+  .setup-step__desc {
+    margin-bottom: 12px;
+  }
+
+  .setup-segment {
+    display: flex;
+    width: 100%;
+  }
+
+  .setup-segment__btn {
+    flex: 1;
+    min-width: 0;
+    padding: 7px 8px;
+    line-height: 1.2;
+    white-space: normal;
+  }
+
+  .setup-method-tabs .panel__tabs {
+    display: flex;
+    height: auto;
+    min-height: 2.25rem;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+
+  .setup-method-tabs .panel__tabs::-webkit-scrollbar {
+    display: none;
+  }
+
+  .setup-method-tabs .panel__tab {
+    flex: 0 0 auto;
+    height: 2rem;
+    padding-inline: 12px;
+  }
+
+  .setup-method__code {
+    max-width: 100%;
+    padding: 44px 12px 12px;
+    overflow-x: auto;
+    overflow-wrap: anywhere;
+    word-break: normal;
+  }
+
+  .modal-terminal__body {
+    padding: 44px 12px 12px;
+    overflow-x: auto;
+  }
+
+  .framework-snippets__field,
+  .setup-onboard-fields__row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .framework-snippets__value {
+    width: 100%;
+  }
+
+  .setup-info-grid {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+}

--- a/packages/frontend/tests/components/App.test.tsx
+++ b/packages/frontend/tests/components/App.test.tsx
@@ -1,16 +1,37 @@
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@solidjs/testing-library";
+import { fireEvent, render } from "@solidjs/testing-library";
+
+const routerState = vi.hoisted(() => ({
+  pathname: "/",
+}));
 
 vi.mock("@solidjs/router", () => ({
-  useLocation: () => ({ pathname: "/" }),
+  useLocation: () => routerState,
 }));
 
 vi.mock("../../src/components/Header.jsx", () => ({
-  default: () => <div data-testid="header">Header</div>,
+  default: (props: any) => (
+    <div data-testid="header">
+      Header
+      {props.showMobileNavToggle && (
+        <button
+          data-testid="mobile-nav-toggle"
+          aria-expanded={String(props.mobileNavOpen)}
+          onClick={props.onMobileNavToggle}
+        >
+          Menu
+        </button>
+      )}
+    </div>
+  ),
 }));
 
 vi.mock("../../src/components/Sidebar.jsx", () => ({
-  default: () => <div data-testid="sidebar">Sidebar</div>,
+  default: (props: any) => (
+    <div data-testid="sidebar" data-mobile-open={props.mobileOpen ? "true" : "false"}>
+      Sidebar
+    </div>
+  ),
 }));
 
 vi.mock("../../src/components/AuthGuard.jsx", () => ({
@@ -25,6 +46,7 @@ import App from "../../src/App";
 
 beforeEach(() => {
   sessionStorage.clear();
+  routerState.pathname = "/";
 });
 
 describe("App", () => {
@@ -52,20 +74,45 @@ describe("App", () => {
     const { container } = render(() => <App />);
     expect(container.querySelector('[data-testid="sidebar"]')).toBeNull();
   });
+
+  it("does not show mobile navigation toggle on non-agent paths", () => {
+    const { container } = render(() => <App />);
+    expect(container.querySelector('[data-testid="mobile-nav-toggle"]')).toBeNull();
+  });
 });
 
 describe("App with agent path", () => {
-  it("shows sidebar on /agents/ paths", async () => {
-    // Override the useLocation mock to return an agent path
-    const routerMock = await import("@solidjs/router");
-    const original = routerMock.useLocation;
-    (routerMock as any).useLocation = () => ({ pathname: "/agents/demo" });
-    try {
-      const { container } = render(() => <App />);
-      expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
-    } finally {
-      (routerMock as any).useLocation = original;
-    }
+  it("shows sidebar on /agents/ paths", () => {
+    routerState.pathname = "/agents/demo";
+
+    const { container } = render(() => <App />);
+
+    expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
+    expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();
+  });
+
+  it("opens and closes the mobile sidebar drawer", () => {
+    routerState.pathname = "/agents/demo";
+
+    const { container } = render(() => <App />);
+    const toggle = container.querySelector('[data-testid="mobile-nav-toggle"]');
+    const sidebar = container.querySelector('[data-testid="sidebar"]');
+
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(sidebar?.getAttribute("data-mobile-open")).toBe("false");
+
+    fireEvent.click(toggle!);
+
+    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
+    expect(sidebar?.getAttribute("data-mobile-open")).toBe("true");
+    expect(container.querySelector(".mobile-nav-backdrop")).not.toBeNull();
+
+    fireEvent.click(container.querySelector(".mobile-nav-backdrop")!);
+
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(sidebar?.getAttribute("data-mobile-open")).toBe("false");
+    expect(container.querySelector(".mobile-nav-backdrop")).toBeNull();
   });
 });
 

--- a/packages/frontend/tests/components/Header.test.tsx
+++ b/packages/frontend/tests/components/Header.test.tsx
@@ -118,6 +118,29 @@ describe("Header", () => {
     await fireEvent.click(document.body);
     expect(screen.queryByText("Alice")).toBeNull();
   });
+
+  it("renders the closed mobile navigation toggle", () => {
+    render(() => <Header showMobileNavToggle mobileNavOpen={false} />);
+
+    const toggle = screen.getByLabelText("Open navigation menu");
+    expect(toggle.getAttribute("aria-controls")).toBe("agent-navigation");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("renders the open mobile navigation toggle and handles clicks", async () => {
+    const onMobileNavToggle = vi.fn();
+
+    render(() => (
+      <Header showMobileNavToggle mobileNavOpen onMobileNavToggle={onMobileNavToggle} />
+    ));
+
+    const toggle = screen.getByLabelText("Close navigation menu");
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+
+    await fireEvent.click(toggle);
+
+    expect(onMobileNavToggle).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("Header - GitHub star button", () => {

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import { render, screen } from "@solidjs/testing-library";
+import { fireEvent, render, screen } from "@solidjs/testing-library";
 
 let mockAgentName: string | null = "test-agent";
 let mockPathname = "/agents/test-agent";
@@ -107,6 +107,25 @@ describe("Sidebar with agent", () => {
     const nav = container.querySelector("nav.sidebar");
     expect(nav).not.toBeNull();
     expect(nav?.getAttribute("aria-label")).toBe("Agent navigation");
+  });
+
+  it("applies the mobile open class", () => {
+    const { container } = render(() => <Sidebar mobileOpen />);
+    const nav = container.querySelector("nav.sidebar");
+    expect(nav?.classList.contains("sidebar--mobile-open")).toBe(true);
+  });
+
+  it("calls onNavigate when a sidebar link is clicked", async () => {
+    const onNavigate = vi.fn();
+    const { container } = render(() => <Sidebar onNavigate={onNavigate} />);
+    const link = container.querySelector("a.sidebar__link");
+
+    expect(link).not.toBeNull();
+    link!.addEventListener("click", (event) => event.preventDefault(), { once: true });
+
+    await fireEvent.click(link!);
+
+    expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 
   it("shows feedback hint text", () => {


### PR DESCRIPTION
### ✨ What changed
- Adds a mobile header burger for agent navigation.
- Turns the sidebar into a phone drawer with a flat backdrop.
- Tightens dashboard cards, chart stats, tables, and headers on phones.
- Makes connect and setup dialogs fit narrow screens.

### 💭 Why
The dashboard was hard to use on phones. The old sidebar and setup dialog did not fit small viewports.

### 👤 For users
Phone users can navigate agents and complete setup without clipped content.

### 📝 Notes
Validation: focused frontend tests, typecheck, lint, Vite build, and 320px Playwright smoke.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the dashboard on phones by adding a slide‑in navigation drawer and tightening layout spacing so pages fit small screens without clipping.

- New Features
  - Header burger toggles agent navigation; adds backdrop; ARIA labels; auto-closes on route change and link tap.
  - Sidebar becomes a slide‑in drawer under the header; `aria-controls` wired to `id="agent-navigation"`; `app-body--with-sidebar` applied when agent nav is present.
  - Setup/connect modal is fully responsive: full-width on mobile, sticky footer actions, better title wrapping, safe‑area padding, smaller tabs/fields.
  - Mobile polish across cards, chart stats, tables, headers; `AgentTypeSelect` shows the selected label and stacks options vertically.
  - Tests cover the mobile drawer toggle, backdrop close, `aria-expanded`, and link-tap close behavior.

<sup>Written for commit 47f9d88ab29ca768f9bf3e534eac96dc3bb20b84. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1924?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

