### PR TITLE
fix(routing): support multiple OAuth subscription keys per provider

### DIFF
--- a/.changeset/fix-oauth-multi-key.md
+++ b/.changeset/fix-oauth-multi-key.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix "Add another key" button for OAuth subscription providers

--- a/packages/backend/src/routing/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.spec.ts
@@ -19,6 +19,7 @@ describe('MinimaxOauthService', () => {
     providerService = {
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
+      nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ProviderService>;
 
     configService = {
@@ -123,6 +124,8 @@ describe('MinimaxOauthService', () => {
         'minimax',
         expect.any(String),
         'subscription',
+        undefined,
+        undefined,
       );
       expect(discoveryService.discoverModels).toHaveBeenCalled();
     });

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -14,17 +14,15 @@ function mockResponse(status: number, body: unknown, text = ''): Response {
   } as unknown as Response;
 }
 
-function createProviderService(): {
-  svc: ProviderService;
-  upsertProvider: jest.Mock;
-  recalculateTiers: jest.Mock;
-} {
+function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
   return {
-    svc: { upsertProvider, recalculateTiers } as unknown as ProviderService,
+    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
+    nextOAuthLabel,
   };
 }
 
@@ -140,6 +138,8 @@ describe('AnthropicOauthService', () => {
         'anthropic',
         expect.stringContaining('"t":"access-1"'),
         'subscription',
+        undefined,
+        undefined,
       );
       expect(discovery.discoverModels).toHaveBeenCalled();
       expect(providerService.recalculateTiers).toHaveBeenCalledWith('agent-1');

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -121,12 +121,15 @@ export class AnthropicOauthService {
       e: Date.now() + data.expires_in * 1000,
     };
 
+    const label = await this.providerService.nextOAuthLabel(pending.agentId, 'anthropic');
     const { provider: savedProvider } = await this.providerService.upsertProvider(
       pending.agentId,
       pending.userId,
       'anthropic',
       serializeOAuthTokenBlob(blob),
       'subscription',
+      undefined,
+      label,
     );
     try {
       await this.discoveryService.discoverModels(savedProvider);

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
@@ -27,17 +27,15 @@ function createConfig(): ConfigService {
   return { get: () => undefined } as unknown as ConfigService;
 }
 
-function createProviderService(): {
-  svc: ProviderService;
-  upsertProvider: jest.Mock;
-  recalculateTiers: jest.Mock;
-} {
+function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
   return {
-    svc: { upsertProvider, recalculateTiers } as unknown as ProviderService,
+    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
+    nextOAuthLabel,
   };
 }
 
@@ -246,6 +244,8 @@ describe('MinimaxOauthService', () => {
         'minimax',
         expect.stringContaining('"t":"at"'),
         'subscription',
+        undefined,
+        undefined,
       );
       expect(discovery.discoverModels).toHaveBeenCalled();
       expect(provider.recalculateTiers).toHaveBeenCalledWith('agent-1');

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.ts
@@ -204,12 +204,15 @@ export class MinimaxOauthService {
       e: toAbsoluteExpiryTimestamp(payload.expired_in),
       u: resourceUrl,
     };
+    const label = await this.providerService.nextOAuthLabel(pending.agentId, 'minimax');
     const { provider: savedProvider } = await this.providerService.upsertProvider(
       pending.agentId,
       pending.userId,
       'minimax',
       JSON.stringify(blob),
       'subscription',
+      undefined,
+      label,
     );
     try {
       await this.discoveryService.discoverModels(savedProvider);

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.ts
@@ -63,23 +63,28 @@ export class OpenaiOauthController {
   }
 
   /**
-   * Revoke the stored OpenAI OAuth token (best-effort) and disconnect the provider.
+   * Revoke stored OpenAI OAuth token(s) (best-effort) and disconnect the provider.
    */
   @Post('revoke')
-  async revoke(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+  async revoke(
+    @Query('agentName') agentName: string,
+    @Query('label') label: string | undefined,
+    @CurrentUser() user: AuthUser,
+  ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
     const agent = await this.resolveAgent.resolve(user.id, agentName);
-    const apiKey = await this.providerKeyService.getProviderApiKey(
-      agent.id,
-      'openai',
-      'subscription',
-    );
+    const keyLabel = label?.trim() || undefined;
+    const keys = await this.providerKeyService.getProviderKeys(agent.id, 'openai', 'subscription');
+    const keysToRevoke = keyLabel
+      ? keys.filter((key) => key.label.toLowerCase() === keyLabel.toLowerCase())
+      : keys;
 
-    if (apiKey) {
+    for (const key of keysToRevoke) {
+      if (!key.apiKey) continue;
       try {
-        const blob = JSON.parse(apiKey) as OAuthTokenBlob;
+        const blob = JSON.parse(key.apiKey) as OAuthTokenBlob;
         if (blob.t) await this.oauthService.revokeToken(blob.t);
         if (blob.r) await this.oauthService.revokeToken(blob.r);
       } catch {
@@ -87,9 +92,14 @@ export class OpenaiOauthController {
       }
     }
 
-    await this.providerService.removeProvider(agent.id, 'openai', 'subscription');
+    const { notifications } = await this.providerService.removeProvider(
+      agent.id,
+      'openai',
+      'subscription',
+      keyLabel,
+    );
 
-    return { ok: true };
+    return { ok: true, notifications };
   }
 
   /**

--- a/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
@@ -25,17 +25,15 @@ function createConfig(nodeEnv = 'production'): ConfigService {
   } as unknown as ConfigService;
 }
 
-function createProviderService(): {
-  svc: ProviderService;
-  upsertProvider: jest.Mock;
-  recalculateTiers: jest.Mock;
-} {
+function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
   return {
-    svc: { upsertProvider, recalculateTiers } as unknown as ProviderService,
+    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
+    nextOAuthLabel,
   };
 }
 
@@ -144,6 +142,8 @@ describe('OpenaiOauthService', () => {
         'openai',
         expect.stringContaining('"t":"access-1"'),
         'subscription',
+        undefined,
+        undefined,
       );
       expect(discovery.discoverModels).toHaveBeenCalled();
       expect(providerService.recalculateTiers).toHaveBeenCalledWith('agent-1');

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -114,12 +114,15 @@ export class OpenaiOauthService {
       r: data.refresh_token,
       e: Date.now() + data.expires_in * 1000,
     };
+    const label = await this.providerService.nextOAuthLabel(pending.agentId, 'openai');
     const { provider: savedProvider } = await this.providerService.upsertProvider(
       pending.agentId,
       pending.userId,
       'openai',
       serializeOAuthTokenBlob(blob),
       'subscription',
+      undefined,
+      label,
     );
     try {
       await this.discoveryService.discoverModels(savedProvider);

--- a/packages/backend/src/routing/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.spec.ts
@@ -26,7 +26,7 @@ describe('OpenaiOauthController', () => {
     } as unknown as jest.Mocked<ResolveAgentService>;
 
     providerKeyService = {
-      getProviderApiKey: jest.fn(),
+      getProviderKeys: jest.fn(),
     } as unknown as jest.Mocked<ProviderKeyService>;
 
     providerService = {
@@ -142,64 +142,121 @@ describe('OpenaiOauthController', () => {
   describe('revoke', () => {
     it('throws 400 when agentName is missing', async () => {
       await expect(
-        controller.revoke(undefined as unknown as string, { id: 'user-1' } as never),
+        controller.revoke(undefined as unknown as string, undefined, { id: 'user-1' } as never),
       ).rejects.toThrow(HttpException);
     });
 
     it('throws 400 when agentName is empty string', async () => {
-      await expect(controller.revoke('', { id: 'user-1' } as never)).rejects.toThrow(HttpException);
+      await expect(controller.revoke('', undefined, { id: 'user-1' } as never)).rejects.toThrow(
+        HttpException,
+      );
     });
 
-    it('revokes both access and refresh tokens from stored blob', async () => {
+    it('revokes every active OpenAI subscription key when no label is provided', async () => {
       resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
-      const blob = JSON.stringify({ t: 'access-tok', r: 'refresh-tok', e: Date.now() + 3600000 });
-      providerKeyService.getProviderApiKey.mockResolvedValue(blob);
+      providerKeyService.getProviderKeys.mockResolvedValue([
+        {
+          id: 'key-1',
+          label: 'Default',
+          priority: 0,
+          apiKey: JSON.stringify({ t: 'access-tok', r: 'refresh-tok', e: Date.now() + 3600000 }),
+          region: null,
+        },
+        {
+          id: 'key-2',
+          label: 'Key 2',
+          priority: 1,
+          apiKey: JSON.stringify({ t: 'access-2', r: 'refresh-2', e: Date.now() + 3600000 }),
+          region: null,
+        },
+      ]);
 
-      const result = await controller.revoke('my-agent', { id: 'user-1' } as never);
+      const result = await controller.revoke('my-agent', undefined, { id: 'user-1' } as never);
 
-      expect(providerKeyService.getProviderApiKey).toHaveBeenCalledWith(
+      expect(providerKeyService.getProviderKeys).toHaveBeenCalledWith(
         'agent-id-1',
         'openai',
         'subscription',
       );
       expect(oauthService.revokeToken).toHaveBeenCalledWith('access-tok');
       expect(oauthService.revokeToken).toHaveBeenCalledWith('refresh-tok');
+      expect(oauthService.revokeToken).toHaveBeenCalledWith('access-2');
+      expect(oauthService.revokeToken).toHaveBeenCalledWith('refresh-2');
       expect(providerService.removeProvider).toHaveBeenCalledWith(
         'agent-id-1',
         'openai',
         'subscription',
+        undefined,
       );
-      expect(result).toEqual({ ok: true });
+      expect(result).toEqual({ ok: true, notifications: [] });
+    });
+
+    it('revokes and removes only the labeled OpenAI subscription key', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+      providerKeyService.getProviderKeys.mockResolvedValue([
+        {
+          id: 'key-1',
+          label: 'Default',
+          priority: 0,
+          apiKey: JSON.stringify({ t: 'access-tok', r: 'refresh-tok', e: Date.now() + 3600000 }),
+          region: null,
+        },
+        {
+          id: 'key-2',
+          label: 'Key 2',
+          priority: 1,
+          apiKey: JSON.stringify({ t: 'access-2', r: 'refresh-2', e: Date.now() + 3600000 }),
+          region: null,
+        },
+      ]);
+
+      const result = await controller.revoke('my-agent', 'Key 2', { id: 'user-1' } as never);
+
+      expect(oauthService.revokeToken).not.toHaveBeenCalledWith('access-tok');
+      expect(oauthService.revokeToken).not.toHaveBeenCalledWith('refresh-tok');
+      expect(oauthService.revokeToken).toHaveBeenCalledWith('access-2');
+      expect(oauthService.revokeToken).toHaveBeenCalledWith('refresh-2');
+      expect(providerService.removeProvider).toHaveBeenCalledWith(
+        'agent-id-1',
+        'openai',
+        'subscription',
+        'Key 2',
+      );
+      expect(result).toEqual({ ok: true, notifications: [] });
     });
 
     it('returns ok even when no stored token exists', async () => {
       resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
-      providerKeyService.getProviderApiKey.mockResolvedValue(null);
+      providerKeyService.getProviderKeys.mockResolvedValue([]);
 
-      const result = await controller.revoke('my-agent', { id: 'user-1' } as never);
+      const result = await controller.revoke('my-agent', undefined, { id: 'user-1' } as never);
 
       expect(oauthService.revokeToken).not.toHaveBeenCalled();
       expect(providerService.removeProvider).toHaveBeenCalledWith(
         'agent-id-1',
         'openai',
         'subscription',
+        undefined,
       );
-      expect(result).toEqual({ ok: true });
+      expect(result).toEqual({ ok: true, notifications: [] });
     });
 
     it('returns ok when token blob is not valid JSON', async () => {
       resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
-      providerKeyService.getProviderApiKey.mockResolvedValue('not-json');
+      providerKeyService.getProviderKeys.mockResolvedValue([
+        { id: 'key-1', label: 'Default', priority: 0, apiKey: 'not-json', region: null },
+      ]);
 
-      const result = await controller.revoke('my-agent', { id: 'user-1' } as never);
+      const result = await controller.revoke('my-agent', undefined, { id: 'user-1' } as never);
 
       expect(oauthService.revokeToken).not.toHaveBeenCalled();
       expect(providerService.removeProvider).toHaveBeenCalledWith(
         'agent-id-1',
         'openai',
         'subscription',
+        undefined,
       );
-      expect(result).toEqual({ ok: true });
+      expect(result).toEqual({ ok: true, notifications: [] });
     });
   });
 

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -34,6 +34,7 @@ describe('OpenaiOauthService', () => {
     providerService = {
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
+      nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<ProviderService>;
 
     configService = {
@@ -117,6 +118,8 @@ describe('OpenaiOauthService', () => {
         'openai',
         expect.any(String),
         'subscription',
+        undefined,
+        undefined,
       );
 
       const storedBlob: OAuthTokenBlob = JSON.parse(

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -454,4 +454,36 @@ describe('ProviderService — route-only cleanup paths', () => {
       ).rejects.toThrow('MiniMax subscription region must be one of: global, cn');
     });
   });
+
+  describe('nextOAuthLabel', () => {
+    it('returns undefined when no subscription rows exist', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      const label = await svc.nextOAuthLabel('agent-1', 'openai');
+      expect(label).toBeUndefined();
+    });
+
+    it('returns "Key 2" when one subscription row exists', async () => {
+      providerRepo.find.mockResolvedValue([{ label: 'Default', is_active: true }]);
+      const label = await svc.nextOAuthLabel('agent-1', 'openai');
+      expect(label).toBe('Key 2');
+    });
+
+    it('skips existing labels', async () => {
+      providerRepo.find.mockResolvedValue([
+        { label: 'Default', is_active: true },
+        { label: 'Key 2', is_active: true },
+      ]);
+      const label = await svc.nextOAuthLabel('agent-1', 'openai');
+      expect(label).toBe('Key 3');
+    });
+
+    it('is case-insensitive when checking existing labels', async () => {
+      providerRepo.find.mockResolvedValue([
+        { label: 'Default', is_active: true },
+        { label: 'key 2', is_active: true },
+      ]);
+      const label = await svc.nextOAuthLabel('agent-1', 'openai');
+      expect(label).toBe('Key 3');
+    });
+  });
 });

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -834,4 +834,28 @@ export class ProviderService {
     if (active.length === 0) return 0;
     return Math.max(...active.map((r) => r.priority)) + 1;
   }
+
+  /**
+   * Returns a unique label for a new OAuth key. If no row exists yet for this
+   * (agent, provider, subscription) tuple, returns undefined so the caller
+   * falls through to the legacy single-key upsert (creating "Default"). When
+   * a "Default" row already exists, returns "Key 2", "Key 3", etc.
+   */
+  async nextOAuthLabel(agentId: string, provider: string): Promise<string | undefined> {
+    const existing = await this.providerRepo.find({
+      where: {
+        agent_id: agentId,
+        provider,
+        auth_type: 'subscription' as AuthType,
+        is_active: true,
+      },
+    });
+    if (existing.length === 0) return undefined;
+    const lower = new Set(existing.map((r) => r.label.toLowerCase()));
+    for (let n = existing.length + 1; n < 100; n++) {
+      const candidate = `Key ${n}`;
+      if (!lower.has(candidate.toLowerCase())) return candidate;
+    }
+    return `Key ${existing.length + 1}`;
+  }
 }

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -56,7 +56,7 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
 
   // When "Add another key" is clicked in the header, launch a new OAuth popup.
   createEffect(() => {
-    if (props.addKeyOpen?.() && props.connected()) {
+    if (props.addKeyOpen?.() && props.connected() && !props.busy()) {
       props.setAddKeyOpen?.(false);
       void handleSignIn();
     }

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -1,4 +1,13 @@
-import { createSignal, onMount, Show, type Component, type Accessor, type Setter } from 'solid-js';
+import {
+  createEffect,
+  createSignal,
+  For,
+  onMount,
+  Show,
+  type Component,
+  type Accessor,
+  type Setter,
+} from 'solid-js';
 import type { ProviderDef } from '../services/providers.js';
 import {
   startAnthropicOAuth,
@@ -6,7 +15,9 @@ import {
   revokeAnthropicOAuth,
   getAnthropicOAuthPending,
   disconnectProvider,
+  renameProviderKey,
   type AuthType,
+  type RoutingProvider,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 
@@ -21,7 +32,12 @@ interface Props {
   onBack: () => void;
   onUpdate: () => void;
   onClose: () => void;
+  addKeyOpen?: Accessor<boolean>;
+  setAddKeyOpen?: Setter<boolean>;
+  activeKeys?: Accessor<RoutingProvider[]>;
 }
+
+const MAX_LABEL_LENGTH = 50;
 
 /**
  * Anthropic subscription connect view. Sign in with Claude opens an OAuth
@@ -33,6 +49,18 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
   const [state, setState] = createSignal<string | null>(null);
   const [input, setInput] = createSignal('');
   const [error, setError] = createSignal<string | null>(null);
+  const [renamingId, setRenamingId] = createSignal<string | null>(null);
+  const [renameValue, setRenameValue] = createSignal('');
+
+  const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
+
+  // When "Add another key" is clicked in the header, launch a new OAuth popup.
+  createEffect(() => {
+    if (props.addKeyOpen?.() && props.connected()) {
+      props.setAddKeyOpen?.(false);
+      void handleSignIn();
+    }
+  });
 
   // Restore any pending OAuth flow so the paste field still works after the
   // modal was closed mid-dance.
@@ -102,7 +130,6 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
       await submitAnthropicOAuth(props.agentName, code, authState);
       toast.success(`${props.provDef.name} subscription connected`);
       props.onUpdate();
-      props.onClose();
     } catch {
       setError('Failed to exchange code. The code may have expired — sign in again to retry.');
     } finally {
@@ -128,6 +155,58 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
       props.onUpdate();
     } catch {
       // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const handleDeleteKey = async (label: string) => {
+    props.setBusy(true);
+    try {
+      const result = await disconnectProvider(
+        props.agentName,
+        props.provId,
+        props.selectedAuthType(),
+        label,
+      );
+      if (result?.notifications?.length) {
+        for (const msg of result.notifications) {
+          toast.error(msg);
+        }
+      }
+      props.onUpdate();
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const startRename = (k: RoutingProvider) => {
+    setRenamingId(k.id);
+    setRenameValue(k.label);
+  };
+
+  const commitRename = async (k: RoutingProvider) => {
+    const newLabel = renameValue().trim();
+    if (!newLabel || newLabel === k.label) {
+      setRenamingId(null);
+      return;
+    }
+    props.setBusy(true);
+    try {
+      await renameProviderKey(
+        props.agentName,
+        props.provId,
+        k.label,
+        newLabel,
+        props.selectedAuthType(),
+      );
+      toast.success(`Renamed to "${newLabel}"`);
+      setRenamingId(null);
+      props.onUpdate();
+    } catch {
+      // toast handled upstream
     } finally {
       props.setBusy(false);
     }
@@ -191,20 +270,123 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
         </div>
       </Show>
       <Show when={props.connected()}>
-        <div class="provider-detail__field">
-          <span class="provider-detail__no-key">
-            Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
-          </span>
-        </div>
-        <button
-          class="btn btn--outline provider-detail__action provider-detail__disconnect"
-          disabled={props.busy()}
-          onClick={handleDisconnect}
-        >
-          <Show when={!props.busy()} fallback={<span class="spinner" />}>
-            Disconnect
-          </Show>
-        </button>
+        {/* Multi-key list */}
+        <Show when={isMultiKey()}>
+          <div class="provider-detail__field">
+            <label class="provider-detail__label">Accounts</label>
+            <ul
+              role="list"
+              aria-label={`OAuth accounts for ${props.provDef.name}`}
+              style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px;"
+            >
+              <For each={props.activeKeys!()}>
+                {(k) => (
+                  <li style="display: flex; align-items: center; gap: 8px; padding: 8px 10px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--muted) / 0.3);">
+                    <Show
+                      when={renamingId() === k.id}
+                      fallback={
+                        <>
+                          <div style="flex: 1; min-width: 0;">
+                            <div style="font-weight: 500; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                              {k.label}
+                            </div>
+                            <div style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                              Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+                            </div>
+                          </div>
+                          <button
+                            class="btn btn--outline btn--sm"
+                            style="flex-shrink: 0;"
+                            disabled={props.busy()}
+                            onClick={() => startRename(k)}
+                          >
+                            Rename
+                          </button>
+                          <button
+                            class="provider-detail__disconnect-icon"
+                            disabled={props.busy()}
+                            onClick={() => handleDeleteKey(k.label)}
+                            aria-label={`Delete account ${k.label}`}
+                            title="Delete account"
+                          >
+                            <svg
+                              width="16"
+                              height="16"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              aria-hidden="true"
+                            >
+                              <path d="M3 6h18" />
+                              <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                              <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                            </svg>
+                          </button>
+                        </>
+                      }
+                    >
+                      <input
+                        class="provider-detail__input"
+                        type="text"
+                        maxlength={MAX_LABEL_LENGTH}
+                        aria-label={`Rename ${k.label}`}
+                        value={renameValue()}
+                        onInput={(e) => setRenameValue(e.currentTarget.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') commitRename(k);
+                          if (e.key === 'Escape') setRenamingId(null);
+                        }}
+                      />
+                      <button
+                        class="btn btn--primary btn--sm"
+                        disabled={props.busy()}
+                        onClick={() => commitRename(k)}
+                      >
+                        Save
+                      </button>
+                      <button
+                        class="btn btn--outline btn--sm"
+                        disabled={props.busy()}
+                        onClick={() => setRenamingId(null)}
+                      >
+                        Cancel
+                      </button>
+                    </Show>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </div>
+          <button
+            class="btn btn--outline provider-detail__action provider-detail__disconnect"
+            disabled={props.busy()}
+            onClick={handleDisconnect}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Disconnect all
+            </Show>
+          </button>
+        </Show>
+        {/* Single key — original view */}
+        <Show when={!isMultiKey()}>
+          <div class="provider-detail__field">
+            <span class="provider-detail__no-key">
+              Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+            </span>
+          </div>
+          <button
+            class="btn btn--outline provider-detail__action provider-detail__disconnect"
+            disabled={props.busy()}
+            onClick={handleDisconnect}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Disconnect
+            </Show>
+          </button>
+        </Show>
       </Show>
     </>
   );

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -1,5 +1,7 @@
 import {
+  createEffect,
   createSignal,
+  For,
   onCleanup,
   Show,
   type Accessor,
@@ -11,9 +13,11 @@ import {
   connectProvider,
   disconnectProvider,
   pollMinimaxOAuth,
+  renameProviderKey,
   startMinimaxOAuth,
   type AuthType,
   type MinimaxOAuthRegion,
+  type RoutingProvider,
 } from '../services/api.js';
 import { validateSubscriptionKey } from '../services/provider-utils.js';
 import { toast } from '../services/toast-store.js';
@@ -29,7 +33,12 @@ interface Props {
   onBack: () => void;
   onUpdate: () => void;
   onClose: () => void;
+  addKeyOpen?: Accessor<boolean>;
+  setAddKeyOpen?: Setter<boolean>;
+  activeKeys?: Accessor<RoutingProvider[]>;
 }
+
+const MAX_LABEL_LENGTH = 50;
 
 interface DeviceCodeFlow {
   flowId: string;
@@ -47,6 +56,18 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [selectedRegion, setSelectedRegion] = createSignal<MinimaxOAuthRegion>('global');
   const [altToken, setAltToken] = createSignal('');
   const [altError, setAltError] = createSignal<string | null>(null);
+  const [renamingId, setRenamingId] = createSignal<string | null>(null);
+  const [renameValue, setRenameValue] = createSignal('');
+
+  const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
+
+  // When "Add another key" is clicked in the header, launch a new device code flow.
+  createEffect(() => {
+    if (props.addKeyOpen?.() && props.connected()) {
+      props.setAddKeyOpen?.(false);
+      void handleStart();
+    }
+  });
 
   const handleAltConnect = async () => {
     const trimmed = altToken().replace(/\s/g, '');
@@ -69,7 +90,6 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
       });
       toast.success(`${props.provDef.name} subscription connected`);
       props.onUpdate();
-      props.onClose();
     } catch {
       // error toast from fetchMutate
     } finally {
@@ -118,6 +138,58 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     }
   };
 
+  const handleDeleteKey = async (label: string) => {
+    props.setBusy(true);
+    try {
+      const result = await disconnectProvider(
+        props.agentName,
+        props.provId,
+        props.selectedAuthType(),
+        label,
+      );
+      if (result?.notifications?.length) {
+        for (const msg of result.notifications) {
+          toast.error(msg);
+        }
+      }
+      props.onUpdate();
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const startRename = (k: RoutingProvider) => {
+    setRenamingId(k.id);
+    setRenameValue(k.label);
+  };
+
+  const commitRename = async (k: RoutingProvider) => {
+    const newLabel = renameValue().trim();
+    if (!newLabel || newLabel === k.label) {
+      setRenamingId(null);
+      return;
+    }
+    props.setBusy(true);
+    try {
+      await renameProviderKey(
+        props.agentName,
+        props.provId,
+        k.label,
+        newLabel,
+        props.selectedAuthType(),
+      );
+      toast.success(`Renamed to "${newLabel}"`);
+      setRenamingId(null);
+      props.onUpdate();
+    } catch {
+      // toast handled upstream
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
   const runPoll = async (flowGeneration = activeFlowGeneration) => {
     if (isDisposed || flowGeneration !== activeFlowGeneration) return;
     const current = flow();
@@ -143,7 +215,6 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
         clearPollTimer();
         toast.success(`${props.provDef.name} subscription connected`);
         props.onUpdate();
-        props.onClose();
         return;
       }
 
@@ -306,20 +377,123 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
         </Show>
       </Show>
       <Show when={props.connected()}>
-        <div class="provider-detail__field">
-          <span class="provider-detail__no-key">
-            Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
-          </span>
-        </div>
-        <button
-          class="btn btn--outline provider-detail__action provider-detail__disconnect"
-          disabled={props.busy()}
-          onClick={handleDisconnect}
-        >
-          <Show when={!props.busy()} fallback={<span class="spinner" />}>
-            Disconnect
-          </Show>
-        </button>
+        {/* Multi-key list */}
+        <Show when={isMultiKey()}>
+          <div class="provider-detail__field">
+            <label class="provider-detail__label">Accounts</label>
+            <ul
+              role="list"
+              aria-label={`Accounts for ${props.provDef.name}`}
+              style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px;"
+            >
+              <For each={props.activeKeys!()}>
+                {(k) => (
+                  <li style="display: flex; align-items: center; gap: 8px; padding: 8px 10px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--muted) / 0.3);">
+                    <Show
+                      when={renamingId() === k.id}
+                      fallback={
+                        <>
+                          <div style="flex: 1; min-width: 0;">
+                            <div style="font-weight: 500; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                              {k.label}
+                            </div>
+                            <div style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                              Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+                            </div>
+                          </div>
+                          <button
+                            class="btn btn--outline btn--sm"
+                            style="flex-shrink: 0;"
+                            disabled={props.busy()}
+                            onClick={() => startRename(k)}
+                          >
+                            Rename
+                          </button>
+                          <button
+                            class="provider-detail__disconnect-icon"
+                            disabled={props.busy()}
+                            onClick={() => handleDeleteKey(k.label)}
+                            aria-label={`Delete account ${k.label}`}
+                            title="Delete account"
+                          >
+                            <svg
+                              width="16"
+                              height="16"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              aria-hidden="true"
+                            >
+                              <path d="M3 6h18" />
+                              <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                              <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                            </svg>
+                          </button>
+                        </>
+                      }
+                    >
+                      <input
+                        class="provider-detail__input"
+                        type="text"
+                        maxlength={MAX_LABEL_LENGTH}
+                        aria-label={`Rename ${k.label}`}
+                        value={renameValue()}
+                        onInput={(e) => setRenameValue(e.currentTarget.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') commitRename(k);
+                          if (e.key === 'Escape') setRenamingId(null);
+                        }}
+                      />
+                      <button
+                        class="btn btn--primary btn--sm"
+                        disabled={props.busy()}
+                        onClick={() => commitRename(k)}
+                      >
+                        Save
+                      </button>
+                      <button
+                        class="btn btn--outline btn--sm"
+                        disabled={props.busy()}
+                        onClick={() => setRenamingId(null)}
+                      >
+                        Cancel
+                      </button>
+                    </Show>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </div>
+          <button
+            class="btn btn--outline provider-detail__action provider-detail__disconnect"
+            disabled={props.busy()}
+            onClick={handleDisconnect}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Disconnect all
+            </Show>
+          </button>
+        </Show>
+        {/* Single key — original view */}
+        <Show when={!isMultiKey()}>
+          <div class="provider-detail__field">
+            <span class="provider-detail__no-key">
+              Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+            </span>
+          </div>
+          <button
+            class="btn btn--outline provider-detail__action provider-detail__disconnect"
+            disabled={props.busy()}
+            onClick={handleDisconnect}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Disconnect
+            </Show>
+          </button>
+        </Show>
       </Show>
     </>
   );

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -63,7 +63,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
 
   // When "Add another key" is clicked in the header, launch a new device code flow.
   createEffect(() => {
-    if (props.addKeyOpen?.() && props.connected()) {
+    if (props.addKeyOpen?.() && props.connected() && !props.busy()) {
       props.setAddKeyOpen?.(false);
       void handleStart();
     }

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -1,14 +1,26 @@
-import { createSignal, Show, type Component, type Accessor, type Setter } from 'solid-js';
+import {
+  createEffect,
+  createSignal,
+  For,
+  Show,
+  type Component,
+  type Accessor,
+  type Setter,
+} from 'solid-js';
 import type { ProviderDef } from '../services/providers.js';
 import {
   getOpenaiOAuthUrl,
   submitOpenaiOAuthCallback,
   revokeOpenaiOAuth,
   disconnectProvider,
+  renameProviderKey,
   type AuthType,
+  type RoutingProvider,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import { monitorOAuthPopup } from '../services/oauth-popup.js';
+
+const MAX_LABEL_LENGTH = 50;
 
 interface Props {
   provDef: ProviderDef;
@@ -21,12 +33,27 @@ interface Props {
   onBack: () => void;
   onUpdate: () => void;
   onClose: () => void;
+  addKeyOpen?: Accessor<boolean>;
+  setAddKeyOpen?: Setter<boolean>;
+  activeKeys?: Accessor<RoutingProvider[]>;
 }
 
 const OAuthDetailView: Component<Props> = (props) => {
   const [popupOpened, setPopupOpened] = createSignal(false);
   const [pasteUrl, setPasteUrl] = createSignal('');
   const [pasteError, setPasteError] = createSignal<string | null>(null);
+  const [renamingId, setRenamingId] = createSignal<string | null>(null);
+  const [renameValue, setRenameValue] = createSignal('');
+
+  const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
+
+  // When "Add another key" is clicked in the header, launch a new OAuth popup.
+  createEffect(() => {
+    if (props.addKeyOpen?.() && props.connected()) {
+      props.setAddKeyOpen?.(false);
+      void handleOAuthLogin();
+    }
+  });
 
   const handleOAuthLogin = async () => {
     props.setBusy(true);
@@ -50,7 +77,6 @@ const OAuthDetailView: Component<Props> = (props) => {
         onSuccess: () => {
           toast.success(`${props.provDef.name} subscription connected`);
           props.onUpdate();
-          props.onClose();
         },
         onFailure: () => {
           // Popup closed without auto-redirect — user needs to paste the URL
@@ -79,7 +105,6 @@ const OAuthDetailView: Component<Props> = (props) => {
       await submitOpenaiOAuthCallback(code, state);
       toast.success(`${props.provDef.name} subscription connected`);
       props.onUpdate();
-      props.onClose();
     } catch {
       setPasteError('Failed to exchange token. The URL may have expired — try logging in again.');
     } finally {
@@ -105,6 +130,58 @@ const OAuthDetailView: Component<Props> = (props) => {
       props.onUpdate();
     } catch {
       // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const handleDeleteKey = async (label: string) => {
+    props.setBusy(true);
+    try {
+      const result = await disconnectProvider(
+        props.agentName,
+        props.provId,
+        props.selectedAuthType(),
+        label,
+      );
+      if (result?.notifications?.length) {
+        for (const msg of result.notifications) {
+          toast.error(msg);
+        }
+      }
+      props.onUpdate();
+    } catch {
+      // error toast from fetchMutate
+    } finally {
+      props.setBusy(false);
+    }
+  };
+
+  const startRename = (k: RoutingProvider) => {
+    setRenamingId(k.id);
+    setRenameValue(k.label);
+  };
+
+  const commitRename = async (k: RoutingProvider) => {
+    const newLabel = renameValue().trim();
+    if (!newLabel || newLabel === k.label) {
+      setRenamingId(null);
+      return;
+    }
+    props.setBusy(true);
+    try {
+      await renameProviderKey(
+        props.agentName,
+        props.provId,
+        k.label,
+        newLabel,
+        props.selectedAuthType(),
+      );
+      toast.success(`Renamed to "${newLabel}"`);
+      setRenamingId(null);
+      props.onUpdate();
+    } catch {
+      // toast handled upstream
     } finally {
       props.setBusy(false);
     }
@@ -184,20 +261,123 @@ const OAuthDetailView: Component<Props> = (props) => {
         </Show>
       </Show>
       <Show when={props.connected()}>
-        <div class="provider-detail__field">
-          <span class="provider-detail__no-key">
-            Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
-          </span>
-        </div>
-        <button
-          class="btn btn--outline provider-detail__action provider-detail__disconnect"
-          disabled={props.busy()}
-          onClick={handleDisconnect}
-        >
-          <Show when={!props.busy()} fallback={<span class="spinner" />}>
-            Disconnect
-          </Show>
-        </button>
+        {/* Multi-key list */}
+        <Show when={isMultiKey()}>
+          <div class="provider-detail__field">
+            <label class="provider-detail__label">Accounts</label>
+            <ul
+              role="list"
+              aria-label={`OAuth accounts for ${props.provDef.name}`}
+              style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px;"
+            >
+              <For each={props.activeKeys!()}>
+                {(k) => (
+                  <li style="display: flex; align-items: center; gap: 8px; padding: 8px 10px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--muted) / 0.3);">
+                    <Show
+                      when={renamingId() === k.id}
+                      fallback={
+                        <>
+                          <div style="flex: 1; min-width: 0;">
+                            <div style="font-weight: 500; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                              {k.label}
+                            </div>
+                            <div style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                              Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+                            </div>
+                          </div>
+                          <button
+                            class="btn btn--outline btn--sm"
+                            style="flex-shrink: 0;"
+                            disabled={props.busy()}
+                            onClick={() => startRename(k)}
+                          >
+                            Rename
+                          </button>
+                          <button
+                            class="provider-detail__disconnect-icon"
+                            disabled={props.busy()}
+                            onClick={() => handleDeleteKey(k.label)}
+                            aria-label={`Delete account ${k.label}`}
+                            title="Delete account"
+                          >
+                            <svg
+                              width="16"
+                              height="16"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                              aria-hidden="true"
+                            >
+                              <path d="M3 6h18" />
+                              <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                              <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                            </svg>
+                          </button>
+                        </>
+                      }
+                    >
+                      <input
+                        class="provider-detail__input"
+                        type="text"
+                        maxlength={MAX_LABEL_LENGTH}
+                        aria-label={`Rename ${k.label}`}
+                        value={renameValue()}
+                        onInput={(e) => setRenameValue(e.currentTarget.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') commitRename(k);
+                          if (e.key === 'Escape') setRenamingId(null);
+                        }}
+                      />
+                      <button
+                        class="btn btn--primary btn--sm"
+                        disabled={props.busy()}
+                        onClick={() => commitRename(k)}
+                      >
+                        Save
+                      </button>
+                      <button
+                        class="btn btn--outline btn--sm"
+                        disabled={props.busy()}
+                        onClick={() => setRenamingId(null)}
+                      >
+                        Cancel
+                      </button>
+                    </Show>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </div>
+          <button
+            class="btn btn--outline provider-detail__action provider-detail__disconnect"
+            disabled={props.busy()}
+            onClick={handleDisconnect}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Disconnect all
+            </Show>
+          </button>
+        </Show>
+        {/* Single key — original view */}
+        <Show when={!isMultiKey()}>
+          <div class="provider-detail__field">
+            <span class="provider-detail__no-key">
+              Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
+            </span>
+          </div>
+          <button
+            class="btn btn--outline provider-detail__action provider-detail__disconnect"
+            disabled={props.busy()}
+            onClick={handleDisconnect}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Disconnect
+            </Show>
+          </button>
+        </Show>
       </Show>
     </>
   );

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -12,7 +12,6 @@ import {
   getOpenaiOAuthUrl,
   submitOpenaiOAuthCallback,
   revokeOpenaiOAuth,
-  disconnectProvider,
   renameProviderKey,
   type AuthType,
   type RoutingProvider,
@@ -115,12 +114,7 @@ const OAuthDetailView: Component<Props> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      await revokeOpenaiOAuth(props.agentName).catch(() => {});
-      const result = await disconnectProvider(
-        props.agentName,
-        props.provId,
-        props.selectedAuthType(),
-      );
+      const result = await revokeOpenaiOAuth(props.agentName);
       if (result?.notifications?.length) {
         for (const msg of result.notifications) {
           toast.error(msg);
@@ -138,12 +132,7 @@ const OAuthDetailView: Component<Props> = (props) => {
   const handleDeleteKey = async (label: string) => {
     props.setBusy(true);
     try {
-      const result = await disconnectProvider(
-        props.agentName,
-        props.provId,
-        props.selectedAuthType(),
-        label,
-      );
+      const result = await revokeOpenaiOAuth(props.agentName, label);
       if (result?.notifications?.length) {
         for (const msg of result.notifications) {
           toast.error(msg);

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -49,7 +49,7 @@ const OAuthDetailView: Component<Props> = (props) => {
 
   // When "Add another key" is clicked in the header, launch a new OAuth popup.
   createEffect(() => {
-    if (props.addKeyOpen?.() && props.connected()) {
+    if (props.addKeyOpen?.() && props.connected() && !props.busy()) {
       props.setAddKeyOpen?.(false);
       void handleOAuthLogin();
     }

--- a/packages/frontend/src/components/ProviderDetailView.tsx
+++ b/packages/frontend/src/components/ProviderDetailView.tsx
@@ -374,6 +374,9 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
           onBack={props.onBack}
           onUpdate={props.onUpdate}
           onClose={props.onClose}
+          addKeyOpen={addKeyOpen}
+          setAddKeyOpen={setAddKeyOpen}
+          activeKeys={activeKeys}
         />
       </Show>
 
@@ -390,6 +393,9 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
           onBack={props.onBack}
           onUpdate={props.onUpdate}
           onClose={props.onClose}
+          addKeyOpen={addKeyOpen}
+          setAddKeyOpen={setAddKeyOpen}
+          activeKeys={activeKeys}
         />
       </Show>
 
@@ -406,6 +412,9 @@ const ProviderDetailView: Component<ProviderDetailViewProps> = (props) => {
           onBack={props.onBack}
           onUpdate={props.onUpdate}
           onClose={props.onClose}
+          addKeyOpen={addKeyOpen}
+          setAddKeyOpen={setAddKeyOpen}
+          activeKeys={activeKeys}
         />
       </Show>
 

--- a/packages/frontend/src/services/api/oauth.ts
+++ b/packages/frontend/src/services/api/oauth.ts
@@ -30,9 +30,11 @@ export function submitOpenaiOAuthCallback(code: string, state: string) {
   });
 }
 
-export function revokeOpenaiOAuth(agentName: string) {
-  return fetchMutate<{ ok: boolean }>(
-    `/oauth/openai/revoke?agentName=${encodeURIComponent(agentName)}`,
+export function revokeOpenaiOAuth(agentName: string, label?: string) {
+  const params = new URLSearchParams({ agentName });
+  if (label) params.set('label', label);
+  return fetchMutate<{ ok: boolean; notifications?: string[] }>(
+    `/oauth/openai/revoke?${params.toString()}`,
     { method: 'POST' },
   );
 }

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -433,4 +433,103 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
     renderMultiKeyView(keys);
     expect(screen.getByText('Disconnect all')).toBeDefined();
   });
+
+  it('handleDeleteKey surfaces notifications from disconnectProvider', async () => {
+    mockDisconnectProvider.mockResolvedValue({
+      notifications: ['Key still in use by another agent'],
+    });
+    const keys = [
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
+    ];
+    renderMultiKeyView(keys);
+
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Key still in use by another agent');
+    });
+  });
+
+  it('handleDeleteKey catch branch when disconnectProvider fails', async () => {
+    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+    const keys = [
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
+    ];
+    const { onUpdate } = renderMultiKeyView(keys);
+
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalled();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('commitRename catch branch when renameProviderKey fails', async () => {
+    mockRenameProviderKey.mockRejectedValue(new Error('network'));
+    const keys = [
+      makeKey({ id: 'k1', label: 'Old' }),
+      makeKey({ id: 'k2', label: 'Other' }),
+    ];
+    const { onUpdate } = renderMultiKeyView(keys);
+
+    const renameButtons = screen.getAllByText('Rename');
+    fireEvent.click(renameButtons[0]);
+
+    const input = screen.getByLabelText('Rename Old');
+    fireEvent.input(input, { target: { value: 'New' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockRenameProviderKey).toHaveBeenCalled();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+function renderViewWithAddKeyOpen() {
+  const [busy, setBusy] = createSignal(false);
+  const [addKeyOpen, setAddKeyOpen] = createSignal(true);
+  const onBack = vi.fn();
+  const onUpdate = vi.fn();
+  const onClose = vi.fn();
+  const keys = [makeKey()];
+  const result = render(() => (
+    <AnthropicOAuthDetailView
+      provDef={provDef}
+      provId="anthropic"
+      agentName="test-agent"
+      connected={() => true}
+      selectedAuthType={() => 'subscription'}
+      busy={busy}
+      setBusy={setBusy}
+      onBack={onBack}
+      onUpdate={onUpdate}
+      onClose={onClose}
+      addKeyOpen={addKeyOpen}
+      setAddKeyOpen={setAddKeyOpen}
+      activeKeys={() => keys}
+    />
+  ));
+  return { ...result, onBack, onUpdate, onClose, setAddKeyOpen };
+}
+
+describe('AnthropicOAuthDetailView — addKeyOpen effect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAnthropicOAuthPending.mockResolvedValue({ state: null });
+  });
+
+  it('auto-launches handleSignIn when addKeyOpen is true and connected', async () => {
+    mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 'abc' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderViewWithAddKeyOpen();
+
+    await waitFor(() => {
+      expect(mockStartAnthropicOAuth).toHaveBeenCalledWith('test-agent');
+    });
+  });
 });

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -134,7 +134,7 @@ describe('AnthropicOAuthDetailView', () => {
     });
     expect(mockToastSuccess).toHaveBeenCalledWith('Anthropic subscription connected');
     expect(onUpdate).toHaveBeenCalled();
-    expect(onClose).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it('rejects input that does not look like an authorization code', () => {

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -7,6 +7,7 @@ const mockSubmitAnthropicOAuth = vi.fn();
 const mockRevokeAnthropicOAuth = vi.fn();
 const mockGetAnthropicOAuthPending = vi.fn();
 const mockDisconnectProvider = vi.fn();
+const mockRenameProviderKey = vi.fn();
 const mockToastError = vi.fn();
 const mockToastSuccess = vi.fn();
 
@@ -16,6 +17,7 @@ vi.mock('../../src/services/api.js', () => ({
   revokeAnthropicOAuth: (...args: unknown[]) => mockRevokeAnthropicOAuth(...args),
   getAnthropicOAuthPending: (...args: unknown[]) => mockGetAnthropicOAuthPending(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
+  renameProviderKey: (...args: unknown[]) => mockRenameProviderKey(...args),
 }));
 
 vi.mock('../../src/services/toast-store.js', () => ({
@@ -27,6 +29,7 @@ vi.mock('../../src/services/toast-store.js', () => ({
 
 import AnthropicOAuthDetailView from '../../src/components/AnthropicOAuthDetailView';
 import type { ProviderDef } from '../../src/services/providers.js';
+import type { RoutingProvider } from '../../src/services/api.js';
 
 const provDef: ProviderDef = {
   id: 'anthropic',
@@ -314,5 +317,120 @@ describe('AnthropicOAuthDetailView', () => {
     fireEvent.click(screen.getByText('Sign in with Claude'));
     await waitFor(() => expect(mockStartAnthropicOAuth).toHaveBeenCalled());
     expect(screen.getByText('Sign in with Claude')).toBeDefined();
+  });
+});
+
+function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
+  return {
+    id: 'key-1',
+    provider: 'anthropic',
+    auth_type: 'subscription',
+    is_active: true,
+    has_api_key: true,
+    key_prefix: null,
+    label: 'Account 1',
+    priority: 1,
+    region: null,
+    connected_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderMultiKeyView(keys: RoutingProvider[]) {
+  const [busy, setBusy] = createSignal(false);
+  const onBack = vi.fn();
+  const onUpdate = vi.fn();
+  const onClose = vi.fn();
+  const result = render(() => (
+    <AnthropicOAuthDetailView
+      provDef={provDef}
+      provId="anthropic"
+      agentName="test-agent"
+      connected={() => true}
+      selectedAuthType={() => 'subscription'}
+      busy={busy}
+      setBusy={setBusy}
+      onBack={onBack}
+      onUpdate={onUpdate}
+      onClose={onClose}
+      activeKeys={() => keys}
+    />
+  ));
+  return { ...result, onBack, onUpdate, onClose };
+}
+
+describe('AnthropicOAuthDetailView — multi-key', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAnthropicOAuthPending.mockResolvedValue({ state: null });
+  });
+
+  it('renders the multi-key list when activeKeys has 2+ items', () => {
+    const keys = [
+      makeKey({ id: 'k1', label: 'Work' }),
+      makeKey({ id: 'k2', label: 'Personal' }),
+    ];
+    renderMultiKeyView(keys);
+    expect(screen.getByText('Accounts')).toBeDefined();
+    expect(screen.getByText('Work')).toBeDefined();
+    expect(screen.getByText('Personal')).toBeDefined();
+  });
+
+  it('rename flow: clicking Rename shows input and saving calls renameProviderKey', async () => {
+    mockRenameProviderKey.mockResolvedValue({ id: 'k1', label: 'New', priority: 1 });
+    const keys = [
+      makeKey({ id: 'k1', label: 'Old' }),
+      makeKey({ id: 'k2', label: 'Other' }),
+    ];
+    const { onUpdate } = renderMultiKeyView(keys);
+
+    const renameButtons = screen.getAllByText('Rename');
+    fireEvent.click(renameButtons[0]);
+
+    const input = screen.getByLabelText('Rename Old');
+    fireEvent.input(input, { target: { value: 'New' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockRenameProviderKey).toHaveBeenCalledWith(
+        'test-agent',
+        'anthropic',
+        'Old',
+        'New',
+        'subscription',
+      );
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith('Renamed to "New"');
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('delete individual key calls disconnectProvider with label', async () => {
+    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    const keys = [
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
+    ];
+    const { onUpdate } = renderMultiKeyView(keys);
+
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalledWith(
+        'test-agent',
+        'anthropic',
+        'subscription',
+        'Primary',
+      );
+    });
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('shows "Disconnect all" button in multi-key mode', () => {
+    const keys = [
+      makeKey({ id: 'k1', label: 'A' }),
+      makeKey({ id: 'k2', label: 'B' }),
+    ];
+    renderMultiKeyView(keys);
+    expect(screen.getByText('Disconnect all')).toBeDefined();
   });
 });

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -86,7 +86,7 @@ describe("DeviceCodeDetailView — MiniMax Coding Plan token alternative", () =>
     });
     expect(mockToast.success).toHaveBeenCalledWith("MiniMax subscription connected");
     expect(props.onUpdate).toHaveBeenCalled();
-    expect(props.onClose).toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
   });
 
   it("forwards the selected CN region with the pasted token", async () => {

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -7,6 +7,7 @@ vi.mock("../../src/services/api.js", () => ({
   disconnectProvider: vi.fn(),
   pollMinimaxOAuth: vi.fn(),
   startMinimaxOAuth: vi.fn(),
+  renameProviderKey: vi.fn(),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({
@@ -14,10 +15,10 @@ vi.mock("../../src/services/toast-store.js", () => ({
 }));
 
 import DeviceCodeDetailView from "../../src/components/DeviceCodeDetailView";
-import { connectProvider } from "../../src/services/api.js";
+import { connectProvider, disconnectProvider, renameProviderKey } from "../../src/services/api.js";
 import { toast } from "../../src/services/toast-store.js";
 import { getProvider } from "../../src/services/provider-utils";
-import type { AuthType } from "../../src/services/api.js";
+import type { AuthType, RoutingProvider } from "../../src/services/api.js";
 
 const mockConnectProvider = connectProvider as ReturnType<typeof vi.fn>;
 const mockToast = toast as {
@@ -155,5 +156,124 @@ describe("DeviceCodeDetailView — MiniMax Coding Plan token alternative", () =>
     expect(
       screen.queryByText('MiniMax subscription tokens start with "sk-cp-"'),
     ).toBeNull();
+  });
+});
+
+const mockDisconnectProvider = disconnectProvider as ReturnType<typeof vi.fn>;
+const mockRenameProviderKey = renameProviderKey as ReturnType<typeof vi.fn>;
+
+function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
+  return {
+    id: "key-1",
+    provider: "minimax",
+    auth_type: "subscription",
+    is_active: true,
+    has_api_key: true,
+    key_prefix: null,
+    label: "Account 1",
+    priority: 1,
+    region: null,
+    connected_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderMultiKeyMinimax(keys: RoutingProvider[]) {
+  const provDef = getProvider("minimax")!;
+  const [busy, setBusy] = createSignal(false);
+  const [authType] = createSignal<AuthType>("subscription");
+  const onBack = vi.fn();
+  const onUpdate = vi.fn();
+  const onClose = vi.fn();
+  const result = render(() => (
+    <DeviceCodeDetailView
+      provDef={provDef}
+      provId="minimax"
+      agentName="test-agent"
+      connected={() => true}
+      selectedAuthType={authType}
+      busy={busy}
+      setBusy={setBusy}
+      onBack={onBack}
+      onUpdate={onUpdate}
+      onClose={onClose}
+      activeKeys={() => keys}
+    />
+  ));
+  return { ...result, onBack, onUpdate, onClose };
+}
+
+describe("DeviceCodeDetailView — multi-key", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders multi-key list when activeKeys has 2+ items", () => {
+    const keys = [
+      makeKey({ id: "k1", label: "Work" }),
+      makeKey({ id: "k2", label: "Personal" }),
+    ];
+    renderMultiKeyMinimax(keys);
+    expect(screen.getByText("Accounts")).toBeDefined();
+    expect(screen.getByText("Work")).toBeDefined();
+    expect(screen.getByText("Personal")).toBeDefined();
+  });
+
+  it("rename flow: clicking Rename shows input and saving calls renameProviderKey", async () => {
+    mockRenameProviderKey.mockResolvedValue({ id: "k1", label: "New", priority: 1 });
+    const keys = [
+      makeKey({ id: "k1", label: "Old" }),
+      makeKey({ id: "k2", label: "Other" }),
+    ];
+    const { onUpdate } = renderMultiKeyMinimax(keys);
+
+    const renameButtons = screen.getAllByText("Rename");
+    fireEvent.click(renameButtons[0]);
+
+    const input = screen.getByLabelText("Rename Old");
+    fireEvent.input(input, { target: { value: "New" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockRenameProviderKey).toHaveBeenCalledWith(
+        "test-agent",
+        "minimax",
+        "Old",
+        "New",
+        "subscription",
+      );
+    });
+    expect(mockToast.success).toHaveBeenCalledWith('Renamed to "New"');
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it("delete individual key calls disconnectProvider with label", async () => {
+    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    const keys = [
+      makeKey({ id: "k1", label: "Primary" }),
+      makeKey({ id: "k2", label: "Secondary" }),
+    ];
+    const { onUpdate } = renderMultiKeyMinimax(keys);
+
+    fireEvent.click(screen.getByLabelText("Delete account Primary"));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalledWith(
+        "test-agent",
+        "minimax",
+        "subscription",
+        "Primary",
+      );
+    });
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it("shows Disconnect all button in multi-key mode", () => {
+    const keys = [
+      makeKey({ id: "k1", label: "A" }),
+      makeKey({ id: "k2", label: "B" }),
+    ];
+    renderMultiKeyMinimax(keys);
+    expect(screen.getByText("Disconnect all")).toBeDefined();
   });
 });

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -276,4 +276,112 @@ describe("DeviceCodeDetailView — multi-key", () => {
     renderMultiKeyMinimax(keys);
     expect(screen.getByText("Disconnect all")).toBeDefined();
   });
+
+  it("handleDeleteKey surfaces notifications from disconnectProvider", async () => {
+    mockDisconnectProvider.mockResolvedValue({
+      notifications: ["Key still shared with another agent"],
+    });
+    const keys = [
+      makeKey({ id: "k1", label: "Primary" }),
+      makeKey({ id: "k2", label: "Secondary" }),
+    ];
+    renderMultiKeyMinimax(keys);
+
+    fireEvent.click(screen.getByLabelText("Delete account Primary"));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Key still shared with another agent");
+    });
+  });
+
+  it("handleDeleteKey catch branch when disconnectProvider fails", async () => {
+    mockDisconnectProvider.mockRejectedValue(new Error("network"));
+    const keys = [
+      makeKey({ id: "k1", label: "Primary" }),
+      makeKey({ id: "k2", label: "Secondary" }),
+    ];
+    const { onUpdate } = renderMultiKeyMinimax(keys);
+
+    fireEvent.click(screen.getByLabelText("Delete account Primary"));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalled();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it("commitRename catch branch when renameProviderKey fails", async () => {
+    mockRenameProviderKey.mockRejectedValue(new Error("network"));
+    const keys = [
+      makeKey({ id: "k1", label: "Old" }),
+      makeKey({ id: "k2", label: "Other" }),
+    ];
+    const { onUpdate } = renderMultiKeyMinimax(keys);
+
+    const renameButtons = screen.getAllByText("Rename");
+    fireEvent.click(renameButtons[0]);
+
+    const input = screen.getByLabelText("Rename Old");
+    fireEvent.input(input, { target: { value: "New" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockRenameProviderKey).toHaveBeenCalled();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});
+
+function renderConnectedWithAddKeyOpen() {
+  const provDef = getProvider("minimax")!;
+  const [busy, setBusy] = createSignal(false);
+  const [authType] = createSignal<AuthType>("subscription");
+  const [addKeyOpen, setAddKeyOpen] = createSignal(true);
+  const onBack = vi.fn();
+  const onUpdate = vi.fn();
+  const onClose = vi.fn();
+  const keys = [makeKey()];
+  const result = render(() => (
+    <DeviceCodeDetailView
+      provDef={provDef}
+      provId="minimax"
+      agentName="test-agent"
+      connected={() => true}
+      selectedAuthType={authType}
+      busy={busy}
+      setBusy={setBusy}
+      onBack={onBack}
+      onUpdate={onUpdate}
+      onClose={onClose}
+      addKeyOpen={addKeyOpen}
+      setAddKeyOpen={setAddKeyOpen}
+      activeKeys={() => keys}
+    />
+  ));
+  return { ...result, onBack, onUpdate, onClose, setAddKeyOpen };
+}
+
+describe("DeviceCodeDetailView — addKeyOpen effect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("auto-launches handleStart when addKeyOpen is true and connected", async () => {
+    const startMinimaxOAuth = (await import("../../src/services/api.js")).startMinimaxOAuth as ReturnType<typeof vi.fn>;
+    startMinimaxOAuth.mockResolvedValue({
+      flowId: "f1",
+      userCode: "ABCD-1234",
+      verificationUri: "https://minimax.io/verify",
+      expiresAt: Date.now() + 60000,
+      pollIntervalMs: 2000,
+    });
+    const openSpy = vi.spyOn(window, "open").mockReturnValue({ closed: false, opener: null, location: { replace: vi.fn() } } as unknown as Window);
+
+    renderConnectedWithAddKeyOpen();
+
+    await waitFor(() => {
+      expect(startMinimaxOAuth).toHaveBeenCalledWith("test-agent", "global");
+    });
+    openSpy.mockRestore();
+  });
 });

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
+
+const mockGetOpenaiOAuthUrl = vi.fn();
+const mockSubmitOpenaiOAuthCallback = vi.fn();
+const mockRevokeOpenaiOAuth = vi.fn();
+const mockDisconnectProvider = vi.fn();
+const mockRenameProviderKey = vi.fn();
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+
+vi.mock('../../src/services/api.js', () => ({
+  getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  submitOpenaiOAuthCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
+  revokeOpenaiOAuth: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
+  disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
+  renameProviderKey: (...args: unknown[]) => mockRenameProviderKey(...args),
+}));
+
+vi.mock('../../src/services/toast-store.js', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
+
+vi.mock('../../src/services/oauth-popup.js', () => ({
+  monitorOAuthPopup: vi.fn(),
+}));
+
+import OAuthDetailView from '../../src/components/OAuthDetailView';
+import type { ProviderDef } from '../../src/services/providers.js';
+import type { RoutingProvider } from '../../src/services/api.js';
+
+const provDef: ProviderDef = {
+  id: 'openai',
+  name: 'OpenAI',
+  color: '#10a37f',
+  initial: 'O',
+  subtitle: '',
+  models: [],
+  keyPrefix: 'sk-',
+  minKeyLength: 20,
+  keyPlaceholder: '',
+  supportsSubscription: true,
+  subscriptionLabel: 'ChatGPT Plus subscription',
+  subscriptionAuthMode: 'oauth',
+};
+
+function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
+  return {
+    id: 'key-1',
+    provider: 'openai',
+    auth_type: 'subscription',
+    is_active: true,
+    has_api_key: true,
+    key_prefix: null,
+    label: 'Account 1',
+    priority: 1,
+    region: null,
+    connected_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderView(opts: {
+  connected?: boolean;
+  activeKeys?: RoutingProvider[];
+  addKeyOpen?: boolean;
+} = {}) {
+  const [busy, setBusy] = createSignal(false);
+  const [addKeyOpen, setAddKeyOpen] = createSignal(opts.addKeyOpen ?? false);
+  const onBack = vi.fn();
+  const onUpdate = vi.fn();
+  const onClose = vi.fn();
+  const keys = opts.activeKeys ?? [];
+  const result = render(() => (
+    <OAuthDetailView
+      provDef={provDef}
+      provId="openai"
+      agentName="test-agent"
+      connected={() => opts.connected ?? false}
+      selectedAuthType={() => 'subscription'}
+      busy={busy}
+      setBusy={setBusy}
+      onBack={onBack}
+      onUpdate={onUpdate}
+      onClose={onClose}
+      addKeyOpen={addKeyOpen}
+      setAddKeyOpen={setAddKeyOpen}
+      activeKeys={() => keys}
+    />
+  ));
+  return { ...result, onBack, onUpdate, onClose, setAddKeyOpen };
+}
+
+describe('OAuthDetailView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows "Log in with" button when not connected', () => {
+    renderView();
+    expect(screen.getByText('Log in with OpenAI')).toBeDefined();
+  });
+
+  it('shows "Connected via" text and Disconnect button for single-key connected state', () => {
+    renderView({ connected: true, activeKeys: [makeKey()] });
+    expect(screen.getByText(/Connected via ChatGPT Plus subscription/)).toBeDefined();
+    expect(screen.getByText('Disconnect')).toBeDefined();
+  });
+
+  it('shows "Accounts" label and lists both keys in multi-key mode', () => {
+    const keys = [
+      makeKey({ id: 'k1', label: 'Work account' }),
+      makeKey({ id: 'k2', label: 'Personal account' }),
+    ];
+    renderView({ connected: true, activeKeys: keys });
+    expect(screen.getByText('Accounts')).toBeDefined();
+    expect(screen.getByText('Work account')).toBeDefined();
+    expect(screen.getByText('Personal account')).toBeDefined();
+  });
+
+  it('shows "Disconnect all" button in multi-key mode', () => {
+    const keys = [
+      makeKey({ id: 'k1', label: 'A' }),
+      makeKey({ id: 'k2', label: 'B' }),
+    ];
+    renderView({ connected: true, activeKeys: keys });
+    expect(screen.getByText('Disconnect all')).toBeDefined();
+  });
+
+  it('clicking Rename shows input and saving calls renameProviderKey', async () => {
+    mockRenameProviderKey.mockResolvedValue({ id: 'k1', label: 'New name', priority: 1 });
+    const keys = [
+      makeKey({ id: 'k1', label: 'Old name' }),
+      makeKey({ id: 'k2', label: 'Other' }),
+    ];
+    const { onUpdate } = renderView({ connected: true, activeKeys: keys });
+
+    const renameButtons = screen.getAllByText('Rename');
+    fireEvent.click(renameButtons[0]);
+
+    const input = screen.getByLabelText('Rename Old name');
+    fireEvent.input(input, { target: { value: 'New name' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockRenameProviderKey).toHaveBeenCalledWith(
+        'test-agent',
+        'openai',
+        'Old name',
+        'New name',
+        'subscription',
+      );
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith('Renamed to "New name"');
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('clicking delete on a key calls disconnectProvider with label', async () => {
+    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    const keys = [
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
+    ];
+    const { onUpdate } = renderView({ connected: true, activeKeys: keys });
+
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalledWith(
+        'test-agent',
+        'openai',
+        'subscription',
+        'Primary',
+      );
+    });
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('addKeyOpen effect triggers getOpenaiOAuthUrl when connected', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView({ connected: true, activeKeys: [makeKey()], addKeyOpen: true });
+
+    await waitFor(() => {
+      expect(mockGetOpenaiOAuthUrl).toHaveBeenCalledWith('test-agent');
+    });
+  });
+
+  it('shows popup-blocked toast when window.open returns null', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue(null);
+
+    renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(expect.stringMatching(/Popup was blocked/));
+    });
+  });
+
+  it('Disconnect all calls disconnectProvider without label', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
+    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+    const keys = [
+      makeKey({ id: 'k1', label: 'A' }),
+      makeKey({ id: 'k2', label: 'B' }),
+    ];
+    const { onBack, onUpdate } = renderView({ connected: true, activeKeys: keys });
+
+    fireEvent.click(screen.getByText('Disconnect all'));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalledWith(
+        'test-agent',
+        'openai',
+        'subscription',
+      );
+    });
+    expect(onBack).toHaveBeenCalled();
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('commitRename cancels if new label is same as old', async () => {
+    const keys = [
+      makeKey({ id: 'k1', label: 'Same' }),
+      makeKey({ id: 'k2', label: 'Other' }),
+    ];
+    renderView({ connected: true, activeKeys: keys });
+
+    const renameButtons = screen.getAllByText('Rename');
+    fireEvent.click(renameButtons[0]);
+
+    // Don't change the value, just submit
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(mockRenameProviderKey).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -159,8 +159,8 @@ describe('OAuthDetailView', () => {
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it('clicking delete on a key calls disconnectProvider with label', async () => {
-    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+  it('clicking delete on a key revokes the matching labeled OAuth token', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({ notifications: [] });
     const keys = [
       makeKey({ id: 'k1', label: 'Primary' }),
       makeKey({ id: 'k2', label: 'Secondary' }),
@@ -170,13 +170,9 @@ describe('OAuthDetailView', () => {
     fireEvent.click(screen.getByLabelText('Delete account Primary'));
 
     await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalledWith(
-        'test-agent',
-        'openai',
-        'subscription',
-        'Primary',
-      );
+      expect(mockRevokeOpenaiOAuth).toHaveBeenCalledWith('test-agent', 'Primary');
     });
+    expect(mockDisconnectProvider).not.toHaveBeenCalled();
     expect(onUpdate).toHaveBeenCalled();
   });
 
@@ -203,9 +199,8 @@ describe('OAuthDetailView', () => {
     });
   });
 
-  it('Disconnect all calls disconnectProvider without label', async () => {
-    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
-    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+  it('Disconnect all revokes all OpenAI OAuth tokens', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true, notifications: [] });
     const keys = [
       makeKey({ id: 'k1', label: 'A' }),
       makeKey({ id: 'k2', label: 'B' }),
@@ -215,12 +210,9 @@ describe('OAuthDetailView', () => {
     fireEvent.click(screen.getByText('Disconnect all'));
 
     await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalledWith(
-        'test-agent',
-        'openai',
-        'subscription',
-      );
+      expect(mockRevokeOpenaiOAuth).toHaveBeenCalledWith('test-agent');
     });
+    expect(mockDisconnectProvider).not.toHaveBeenCalled();
     expect(onBack).toHaveBeenCalled();
     expect(onUpdate).toHaveBeenCalled();
   });
@@ -340,9 +332,8 @@ describe('OAuthDetailView', () => {
     });
   });
 
-  it('handleDisconnect calls revokeOpenaiOAuth and disconnectProvider (single-key)', async () => {
-    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
-    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+  it('handleDisconnect calls revokeOpenaiOAuth (single-key)', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true, notifications: [] });
 
     const { onBack, onUpdate } = renderView({ connected: true, activeKeys: [makeKey()] });
     fireEvent.click(screen.getByText('Disconnect'));
@@ -350,20 +341,14 @@ describe('OAuthDetailView', () => {
     await waitFor(() => {
       expect(mockRevokeOpenaiOAuth).toHaveBeenCalledWith('test-agent');
     });
-    await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalledWith(
-        'test-agent',
-        'openai',
-        'subscription',
-      );
-    });
+    expect(mockDisconnectProvider).not.toHaveBeenCalled();
     expect(onBack).toHaveBeenCalled();
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it('handleDisconnect surfaces notifications from disconnectProvider', async () => {
-    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
-    mockDisconnectProvider.mockResolvedValue({
+  it('handleDisconnect surfaces notifications from revokeOpenaiOAuth', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({
+      ok: true,
       notifications: ['Shared subscription warning'],
     });
 
@@ -376,21 +361,21 @@ describe('OAuthDetailView', () => {
     expect(onBack).toHaveBeenCalled();
   });
 
-  it('handleDisconnect catch branch when disconnectProvider fails', async () => {
-    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
-    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+  it('handleDisconnect catch branch when revokeOpenaiOAuth fails', async () => {
+    mockRevokeOpenaiOAuth.mockRejectedValue(new Error('network'));
 
     const { onBack } = renderView({ connected: true, activeKeys: [makeKey()] });
     fireEvent.click(screen.getByText('Disconnect'));
 
     await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalled();
+      expect(mockRevokeOpenaiOAuth).toHaveBeenCalled();
     });
     expect(onBack).not.toHaveBeenCalled();
   });
 
-  it('handleDeleteKey surfaces notifications from disconnectProvider', async () => {
-    mockDisconnectProvider.mockResolvedValue({
+  it('handleDeleteKey surfaces notifications from revokeOpenaiOAuth', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({
+      ok: true,
       notifications: ['Key removal warning'],
     });
     const keys = [
@@ -406,8 +391,8 @@ describe('OAuthDetailView', () => {
     });
   });
 
-  it('handleDeleteKey catch branch when disconnectProvider fails', async () => {
-    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+  it('handleDeleteKey catch branch when revokeOpenaiOAuth fails', async () => {
+    mockRevokeOpenaiOAuth.mockRejectedValue(new Error('network'));
     const keys = [
       makeKey({ id: 'k1', label: 'Primary' }),
       makeKey({ id: 'k2', label: 'Secondary' }),
@@ -417,7 +402,7 @@ describe('OAuthDetailView', () => {
     fireEvent.click(screen.getByLabelText('Delete account Primary'));
 
     await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalled();
+      expect(mockRevokeOpenaiOAuth).toHaveBeenCalled();
     });
     expect(onUpdate).not.toHaveBeenCalled();
   });

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -240,4 +240,230 @@ describe('OAuthDetailView', () => {
 
     expect(mockRenameProviderKey).not.toHaveBeenCalled();
   });
+
+  it('handlePasteSubmit exchanges a valid callback URL', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    mockSubmitOpenaiOAuthCallback.mockResolvedValue({ ok: true });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    const { onUpdate } = renderView();
+    // Click login to open popup and show the paste input
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+    await waitFor(() => expect(mockGetOpenaiOAuthUrl).toHaveBeenCalled());
+
+    // Now the paste input should be visible
+    const input = await waitFor(() => screen.getByPlaceholderText(/localhost:1455/));
+    fireEvent.input(input, {
+      target: { value: 'http://localhost:1455/auth/callback?code=abc123&state=xyz789' },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(mockSubmitOpenaiOAuthCallback).toHaveBeenCalledWith('abc123', 'xyz789');
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith('OpenAI subscription connected');
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('handlePasteSubmit shows error when URL is missing code or state', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+    await waitFor(() => expect(mockGetOpenaiOAuthUrl).toHaveBeenCalled());
+
+    const input = await waitFor(() => screen.getByPlaceholderText(/localhost:1455/));
+    fireEvent.input(input, {
+      target: { value: 'http://localhost:1455/auth/callback?code=abc123' },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/URL is missing the authorization code/)).toBeDefined();
+    });
+    expect(mockSubmitOpenaiOAuthCallback).not.toHaveBeenCalled();
+  });
+
+  it('handlePasteSubmit shows error when exchange fails', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    mockSubmitOpenaiOAuthCallback.mockRejectedValue(new Error('expired'));
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+    await waitFor(() => expect(mockGetOpenaiOAuthUrl).toHaveBeenCalled());
+
+    const input = await waitFor(() => screen.getByPlaceholderText(/localhost:1455/));
+    fireEvent.input(input, {
+      target: { value: 'http://localhost:1455/auth/callback?code=abc&state=xyz' },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to exchange token/)).toBeDefined();
+    });
+  });
+
+  it('handlePasteSubmit does nothing when input is empty', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+    await waitFor(() => expect(mockGetOpenaiOAuthUrl).toHaveBeenCalled());
+
+    const input = await waitFor(() => screen.getByPlaceholderText(/localhost:1455/));
+    fireEvent.input(input, { target: { value: '   ' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    expect(mockSubmitOpenaiOAuthCallback).not.toHaveBeenCalled();
+  });
+
+  it('handlePasteSubmit submits on Enter key', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    mockSubmitOpenaiOAuthCallback.mockResolvedValue({ ok: true });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+    await waitFor(() => expect(mockGetOpenaiOAuthUrl).toHaveBeenCalled());
+
+    const input = await waitFor(() => screen.getByPlaceholderText(/localhost:1455/));
+    fireEvent.input(input, {
+      target: { value: 'http://localhost:1455/auth/callback?code=abc&state=xyz' },
+    });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockSubmitOpenaiOAuthCallback).toHaveBeenCalledWith('abc', 'xyz');
+    });
+  });
+
+  it('handleDisconnect calls revokeOpenaiOAuth and disconnectProvider (single-key)', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
+    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+
+    const { onBack, onUpdate } = renderView({ connected: true, activeKeys: [makeKey()] });
+    fireEvent.click(screen.getByText('Disconnect'));
+
+    await waitFor(() => {
+      expect(mockRevokeOpenaiOAuth).toHaveBeenCalledWith('test-agent');
+    });
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalledWith(
+        'test-agent',
+        'openai',
+        'subscription',
+      );
+    });
+    expect(onBack).toHaveBeenCalled();
+    expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('handleDisconnect surfaces notifications from disconnectProvider', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
+    mockDisconnectProvider.mockResolvedValue({
+      notifications: ['Shared subscription warning'],
+    });
+
+    const { onBack } = renderView({ connected: true, activeKeys: [makeKey()] });
+    fireEvent.click(screen.getByText('Disconnect'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Shared subscription warning');
+    });
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it('handleDisconnect catch branch when disconnectProvider fails', async () => {
+    mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
+    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+
+    const { onBack } = renderView({ connected: true, activeKeys: [makeKey()] });
+    fireEvent.click(screen.getByText('Disconnect'));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalled();
+    });
+    expect(onBack).not.toHaveBeenCalled();
+  });
+
+  it('handleDeleteKey surfaces notifications from disconnectProvider', async () => {
+    mockDisconnectProvider.mockResolvedValue({
+      notifications: ['Key removal warning'],
+    });
+    const keys = [
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
+    ];
+    renderView({ connected: true, activeKeys: keys });
+
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Key removal warning');
+    });
+  });
+
+  it('handleDeleteKey catch branch when disconnectProvider fails', async () => {
+    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+    const keys = [
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
+    ];
+    const { onUpdate } = renderView({ connected: true, activeKeys: keys });
+
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalled();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('commitRename catch branch when renameProviderKey fails', async () => {
+    mockRenameProviderKey.mockRejectedValue(new Error('network'));
+    const keys = [
+      makeKey({ id: 'k1', label: 'Old name' }),
+      makeKey({ id: 'k2', label: 'Other' }),
+    ];
+    const { onUpdate } = renderView({ connected: true, activeKeys: keys });
+
+    const renameButtons = screen.getAllByText('Rename');
+    fireEvent.click(renameButtons[0]);
+
+    const input = screen.getByLabelText('Rename Old name');
+    fireEvent.input(input, { target: { value: 'New name' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockRenameProviderKey).toHaveBeenCalled();
+    });
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('pasteError is shown and cleared on new input', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+    await waitFor(() => expect(mockGetOpenaiOAuthUrl).toHaveBeenCalled());
+
+    const input = await waitFor(() => screen.getByPlaceholderText(/localhost:1455/));
+    // Submit invalid URL to trigger error
+    fireEvent.input(input, {
+      target: { value: 'http://localhost:1455/auth/callback?code=abc' },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/URL is missing the authorization code/)).toBeDefined();
+    });
+
+    // Typing again should clear the error
+    fireEvent.input(input, { target: { value: 'http://other' } });
+    expect(screen.queryByText(/URL is missing the authorization code/)).toBeNull();
+  });
 });

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1439,7 +1439,7 @@ describe('ProviderSelectModal', () => {
       vi.restoreAllMocks();
     });
 
-    it('closes the modal when MiniMax approval succeeds', async () => {
+    it('stays open when MiniMax approval succeeds', async () => {
       vi.useFakeTimers();
       vi.spyOn(window, 'open').mockReturnValue({
         close: vi.fn(),
@@ -1470,7 +1470,7 @@ describe('ProviderSelectModal', () => {
       await waitFor(() => {
         expect(toast.success).toHaveBeenCalledWith('MiniMax subscription connected');
         expect(onUpdate).toHaveBeenCalled();
-        expect(onClose).toHaveBeenCalled();
+        expect(onClose).not.toHaveBeenCalled();
       });
 
       vi.useRealTimers();
@@ -1984,7 +1984,7 @@ describe('ProviderSelectModal', () => {
       });
       expect(mockPopup.close).toHaveBeenCalled();
       expect(onUpdate).toHaveBeenCalled();
-      expect(onClose).toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
 
       vi.restoreAllMocks();
     });
@@ -2084,7 +2084,7 @@ describe('ProviderSelectModal', () => {
         expect(toast.success).toHaveBeenCalledWith('OpenAI subscription connected');
       });
       expect(onUpdate).toHaveBeenCalled();
-      expect(onClose).toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
 
       vi.restoreAllMocks();
     });
@@ -2124,7 +2124,7 @@ describe('ProviderSelectModal', () => {
         expect(toast.success).toHaveBeenCalledWith('OpenAI subscription connected');
       });
       expect(onUpdate).toHaveBeenCalled();
-      expect(onClose).toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
 
       vi.restoreAllMocks();
     });
@@ -2161,7 +2161,7 @@ describe('ProviderSelectModal', () => {
       });
       expect(mockPopup.close).toHaveBeenCalled();
       expect(onUpdate).toHaveBeenCalled();
-      expect(onClose).toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
 
       vi.restoreAllMocks();
     });

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -1880,7 +1880,7 @@ describe('ProviderSelectModal', () => {
       expect(onSwitches.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('disconnects OpenAI OAuth subscription and revokes token', async () => {
+    it('disconnects OpenAI OAuth subscription through the revoke endpoint', async () => {
       const subProvider: RoutingProvider = {
         id: 'p-openai-sub',
         provider: 'openai',
@@ -1903,12 +1903,12 @@ describe('ProviderSelectModal', () => {
 
       await waitFor(() => {
         expect(mockRevokeOpenaiOAuth).toHaveBeenCalledWith('test-agent');
-        expect(mockDisconnectProvider).toHaveBeenCalledWith('test-agent', 'openai', 'subscription');
       });
+      expect(mockDisconnectProvider).not.toHaveBeenCalled();
       expect(onUpdate).toHaveBeenCalled();
     });
 
-    it('still disconnects when token revocation fails', async () => {
+    it('does not call generic disconnect when OpenAI revoke request fails', async () => {
       mockRevokeOpenaiOAuth.mockRejectedValue(new Error('revoke failed'));
       const subProvider: RoutingProvider = {
         id: 'p-openai-sub',
@@ -1931,9 +1931,10 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Disconnect'));
 
       await waitFor(() => {
-        expect(mockDisconnectProvider).toHaveBeenCalledWith('test-agent', 'openai', 'subscription');
+        expect(mockRevokeOpenaiOAuth).toHaveBeenCalledWith('test-agent');
       });
-      expect(onUpdate).toHaveBeenCalled();
+      expect(mockDisconnectProvider).not.toHaveBeenCalled();
+      expect(onUpdate).not.toHaveBeenCalled();
     });
 
     it('shows popup blocked error when window.open returns null', async () => {

--- a/packages/frontend/tests/services/api/oauth.test.ts
+++ b/packages/frontend/tests/services/api/oauth.test.ts
@@ -38,7 +38,15 @@ describe('oauth API client', () => {
     const fetchMock = setupFetch({ ok: true });
     await oauth.revokeOpenaiOAuth('my agent');
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toContain('/api/v1/oauth/openai/revoke?agentName=my%20agent');
+    expect(url).toContain('/api/v1/oauth/openai/revoke?agentName=my+agent');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('revokeOpenaiOAuth includes the encoded key label when provided', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.revokeOpenaiOAuth('my agent', 'Key 2');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/openai/revoke?agentName=my+agent&label=Key+2');
     expect((init as RequestInit).method).toBe('POST');
   });
 


### PR DESCRIPTION
Closes #1870

## What changed
- OAuth provider modal stays open after connecting, instead of closing immediately
- "Add another key" button now triggers a new OAuth popup for subscription providers
- Connected OAuth accounts are displayed as a list with rename and delete controls
- Backend OAuth callbacks create a new row (Key 2, Key 3...) instead of overwriting the first

## Why
Clicking "Add another key" on an OAuth provider (OpenAI, Anthropic, MiniMax) caused the button to disappear with no action. Three bugs compounded: the modal closed on first connection, the add-key form was excluded for OAuth flows, and the backend always overwrote the same database row.

## For users
Multiple OAuth accounts per provider now work. After connecting the first account, the "Add another key" button opens a new OAuth popup. All connected accounts appear in a list with rename and delete options.

## For operators
No operator impact.

## How to test
1. Open Routing, click OpenAI (subscription tab)
2. Connect via OAuth: the modal should stay open and show "Add another key"
3. Click "Add another key": a new OAuth popup should open
4. After the second connection, both accounts should appear in a labeled list
5. Verify rename and individual delete work on each account

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable multiple OAuth subscription keys per provider in Routing. The modal stays open after connecting, and "Add another key" launches a new flow so each account is saved as a separate labeled key.

- **New Features**
  - OAuth/device-code modals stay open after connect; "Add another key" auto-starts a new flow when connected.
  - With 2+ keys, show an Accounts list with rename and per-key delete; also support Disconnect all.
  - Backend generates unique labels (“Key 2”, “Key 3”…), upserts new subscription rows, and OpenAI’s revoke endpoint now revokes all keys or a single labeled key and returns notifications; the frontend uses this for per-key delete and Disconnect all.

- **Bug Fixes**
  - Guard the "Add another key" effect to avoid starting a new OAuth/device-code flow while busy.

<sup>Written for commit 0c4703627d22dfc22cfa7ffbb35ff104c7b1d9ad. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1925?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

