### PR TITLE
refactor(routing): route subscription disconnects through OAuth cleanup endpoints

### DIFF
--- a/.changeset/refactor-oauth-local-disconnect.md
+++ b/.changeset/refactor-oauth-local-disconnect.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Route Anthropic and MiniMax subscription disconnects through provider-specific OAuth cleanup endpoints

--- a/packages/backend/src/routing/minimax-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.spec.ts
@@ -124,4 +124,15 @@ describe('MinimaxOauthController', () => {
     );
     expect(result).toEqual({ ok: true, notifications: [] });
   });
+
+  it('rejects repeated revoke label query parameters', async () => {
+    await expect(
+      controller.revoke('my-agent', ['Key 1', 'Key 2'], { id: 'user-1' } as never),
+    ).rejects.toMatchObject({
+      message: 'label query parameter must be a string',
+      status: HttpStatus.BAD_REQUEST,
+    });
+    expect(resolveAgent.resolve).not.toHaveBeenCalled();
+    expect(providerService.removeProvider).not.toHaveBeenCalled();
+  });
 });

--- a/packages/backend/src/routing/minimax-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.controller.spec.ts
@@ -2,11 +2,13 @@ import { HttpException, HttpStatus } from '@nestjs/common';
 import { MinimaxOauthController } from './oauth/minimax-oauth.controller';
 import { MinimaxOauthService } from './oauth/minimax-oauth.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
+import { ProviderService } from './routing-core/provider.service';
 
 describe('MinimaxOauthController', () => {
   let controller: MinimaxOauthController;
   let oauthService: jest.Mocked<MinimaxOauthService>;
   let resolveAgent: jest.Mocked<ResolveAgentService>;
+  let providerService: jest.Mocked<ProviderService>;
 
   beforeEach(() => {
     oauthService = {
@@ -18,7 +20,11 @@ describe('MinimaxOauthController', () => {
       resolve: jest.fn(),
     } as unknown as jest.Mocked<ResolveAgentService>;
 
-    controller = new MinimaxOauthController(oauthService, resolveAgent);
+    providerService = {
+      removeProvider: jest.fn().mockResolvedValue({ notifications: [] }),
+    } as unknown as jest.Mocked<ProviderService>;
+
+    controller = new MinimaxOauthController(oauthService, resolveAgent, providerService);
   });
 
   it('starts MiniMax OAuth for the resolved agent', async () => {
@@ -82,5 +88,40 @@ describe('MinimaxOauthController', () => {
       message: 'MiniMax poll unavailable',
       status: HttpStatus.SERVICE_UNAVAILABLE,
     });
+  });
+
+  it('throws 400 when revoke agentName is missing', async () => {
+    await expect(controller.revoke('', undefined, { id: 'user-1' } as never)).rejects.toThrow(
+      HttpException,
+    );
+  });
+
+  it('removes all MiniMax subscription records for the resolved agent', async () => {
+    resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+
+    const result = await controller.revoke('my-agent', undefined, { id: 'user-1' } as never);
+
+    expect(resolveAgent.resolve).toHaveBeenCalledWith('user-1', 'my-agent');
+    expect(providerService.removeProvider).toHaveBeenCalledWith(
+      'agent-id-1',
+      'minimax',
+      'subscription',
+      undefined,
+    );
+    expect(result).toEqual({ ok: true, notifications: [] });
+  });
+
+  it('removes only the labeled MiniMax subscription record', async () => {
+    resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+
+    const result = await controller.revoke('my-agent', 'Key 2', { id: 'user-1' } as never);
+
+    expect(providerService.removeProvider).toHaveBeenCalledWith(
+      'agent-id-1',
+      'minimax',
+      'subscription',
+      'Key 2',
+    );
+    expect(result).toEqual({ ok: true, notifications: [] });
   });
 });

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
@@ -135,5 +135,15 @@ describe('AnthropicOauthController', () => {
         'Key 2',
       );
     });
+
+    it('rejects repeated label query parameters', async () => {
+      const { ctrl, resolveAgent, providerService } = build();
+      await expect(ctrl.revoke('agent', ['Key 1', 'Key 2'], user)).rejects.toMatchObject({
+        message: 'label query parameter must be a string',
+        status: 400,
+      });
+      expect(resolveAgent.resolve).not.toHaveBeenCalled();
+      expect(providerService.removeProvider).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
@@ -16,7 +16,7 @@ function build() {
     resolve: jest.fn().mockResolvedValue({ id: 'agent-1' }),
   } as unknown as ResolveAgentService;
   const providerService = {
-    removeProvider: jest.fn().mockResolvedValue(undefined),
+    removeProvider: jest.fn().mockResolvedValue({ notifications: [] }),
   } as unknown as ProviderService;
   return {
     ctrl: new AnthropicOauthController(oauth, resolveAgent, providerService),
@@ -105,16 +105,34 @@ describe('AnthropicOauthController', () => {
   describe('revoke', () => {
     it('rejects missing agentName', async () => {
       const { ctrl } = build();
-      await expect(ctrl.revoke('', user)).rejects.toBeInstanceOf(HttpException);
+      await expect(ctrl.revoke('', undefined, user)).rejects.toBeInstanceOf(HttpException);
     });
 
-    it('removes the subscription provider record for the agent', async () => {
+    it('removes all Anthropic subscription records for the agent', async () => {
       const { ctrl, providerService } = build();
-      await expect(ctrl.revoke('agent', user)).resolves.toEqual({ ok: true });
+      await expect(ctrl.revoke('agent', undefined, user)).resolves.toEqual({
+        ok: true,
+        notifications: [],
+      });
       expect(providerService.removeProvider).toHaveBeenCalledWith(
         'agent-1',
         'anthropic',
         'subscription',
+        undefined,
+      );
+    });
+
+    it('removes only the labeled Anthropic subscription record', async () => {
+      const { ctrl, providerService } = build();
+      await expect(ctrl.revoke('agent', 'Key 2', user)).resolves.toEqual({
+        ok: true,
+        notifications: [],
+      });
+      expect(providerService.removeProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'anthropic',
+        'subscription',
+        'Key 2',
       );
     });
   });

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
@@ -13,6 +13,7 @@ import { AuthUser } from '../../../auth/auth.instance';
 import { ResolveAgentService } from '../../routing-core/resolve-agent.service';
 import { ProviderService } from '../../routing-core/provider.service';
 import { AnthropicOauthService } from './anthropic-oauth.service';
+import { optionalTrimmedStringQuery } from '../query-params';
 
 @Controller('api/v1/oauth/anthropic')
 export class AnthropicOauthController {
@@ -85,14 +86,14 @@ export class AnthropicOauthController {
   @Post('revoke')
   async revoke(
     @Query('agentName') agentName: string,
-    @Query('label') label: string | undefined,
+    @Query('label') label: string | string[] | undefined,
     @CurrentUser() user: AuthUser,
   ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
+    const keyLabel = optionalTrimmedStringQuery(label, 'label');
     const agent = await this.resolveAgent.resolve(user.id, agentName);
-    const keyLabel = label?.trim() || undefined;
     const { notifications } = await this.providerService.removeProvider(
       agent.id,
       'anthropic',

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
@@ -83,12 +83,22 @@ export class AnthropicOauthController {
 
   /** Disconnect the Anthropic subscription provider for an agent. */
   @Post('revoke')
-  async revoke(@Query('agentName') agentName: string, @CurrentUser() user: AuthUser) {
+  async revoke(
+    @Query('agentName') agentName: string,
+    @Query('label') label: string | undefined,
+    @CurrentUser() user: AuthUser,
+  ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
     const agent = await this.resolveAgent.resolve(user.id, agentName);
-    await this.providerService.removeProvider(agent.id, 'anthropic', 'subscription');
-    return { ok: true };
+    const keyLabel = label?.trim() || undefined;
+    const { notifications } = await this.providerService.removeProvider(
+      agent.id,
+      'anthropic',
+      'subscription',
+      keyLabel,
+    );
+    return { ok: true, notifications };
   }
 }

--- a/packages/backend/src/routing/oauth/minimax-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.controller.ts
@@ -4,6 +4,7 @@ import { AuthUser } from '../../auth/auth.instance';
 import { isMinimaxRegion, MinimaxOauthService } from './minimax-oauth.service';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
 import { ProviderService } from '../routing-core/provider.service';
+import { optionalTrimmedStringQuery } from './query-params';
 
 @Controller('api/v1/oauth/minimax')
 export class MinimaxOauthController {
@@ -55,14 +56,14 @@ export class MinimaxOauthController {
   @Post('revoke')
   async revoke(
     @Query('agentName') agentName: string,
-    @Query('label') label: string | undefined,
+    @Query('label') label: string | string[] | undefined,
     @CurrentUser() user: AuthUser,
   ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
+    const keyLabel = optionalTrimmedStringQuery(label, 'label');
     const agent = await this.resolveAgent.resolve(user.id, agentName);
-    const keyLabel = label?.trim() || undefined;
     const { notifications } = await this.providerService.removeProvider(
       agent.id,
       'minimax',

--- a/packages/backend/src/routing/oauth/minimax-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.controller.ts
@@ -3,12 +3,14 @@ import { CurrentUser } from '../../auth/current-user.decorator';
 import { AuthUser } from '../../auth/auth.instance';
 import { isMinimaxRegion, MinimaxOauthService } from './minimax-oauth.service';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
+import { ProviderService } from '../routing-core/provider.service';
 
 @Controller('api/v1/oauth/minimax')
 export class MinimaxOauthController {
   constructor(
     private readonly oauthService: MinimaxOauthService,
     private readonly resolveAgent: ResolveAgentService,
+    private readonly providerService: ProviderService,
   ) {}
 
   @Post('start')
@@ -48,5 +50,25 @@ export class MinimaxOauthController {
       const message = err instanceof Error ? err.message : 'Failed to poll MiniMax OAuth';
       throw new HttpException(message, HttpStatus.SERVICE_UNAVAILABLE);
     }
+  }
+
+  @Post('revoke')
+  async revoke(
+    @Query('agentName') agentName: string,
+    @Query('label') label: string | undefined,
+    @CurrentUser() user: AuthUser,
+  ) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    const keyLabel = label?.trim() || undefined;
+    const { notifications } = await this.providerService.removeProvider(
+      agent.id,
+      'minimax',
+      'subscription',
+      keyLabel,
+    );
+    return { ok: true, notifications };
   }
 }

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.ts
@@ -20,6 +20,7 @@ import { OpenaiOauthService, OAuthTokenBlob, oauthDoneHtml } from './openai-oaut
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
 import { ProviderService } from '../routing-core/provider.service';
 import { ProviderKeyService } from '../routing-core/provider-key.service';
+import { optionalTrimmedStringQuery } from './query-params';
 
 @Controller('api/v1/oauth/openai')
 export class OpenaiOauthController {
@@ -68,14 +69,14 @@ export class OpenaiOauthController {
   @Post('revoke')
   async revoke(
     @Query('agentName') agentName: string,
-    @Query('label') label: string | undefined,
+    @Query('label') label: string | string[] | undefined,
     @CurrentUser() user: AuthUser,
   ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
+    const keyLabel = optionalTrimmedStringQuery(label, 'label');
     const agent = await this.resolveAgent.resolve(user.id, agentName);
-    const keyLabel = label?.trim() || undefined;
     const keys = await this.providerKeyService.getProviderKeys(agent.id, 'openai', 'subscription');
     const keysToRevoke = keyLabel
       ? keys.filter((key) => key.label.toLowerCase() === keyLabel.toLowerCase())

--- a/packages/backend/src/routing/oauth/query-params.ts
+++ b/packages/backend/src/routing/oauth/query-params.ts
@@ -1,0 +1,12 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export function optionalTrimmedStringQuery(
+  value: string | string[] | undefined,
+  name: string,
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') {
+    throw new HttpException(`${name} query parameter must be a string`, HttpStatus.BAD_REQUEST);
+  }
+  return value.trim() || undefined;
+}

--- a/packages/backend/src/routing/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.spec.ts
@@ -1,4 +1,4 @@
-import { HttpException } from '@nestjs/common';
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { OpenaiOauthController } from './oauth/openai-oauth.controller';
 import { OpenaiOauthService } from './oauth/openai-oauth.service';
@@ -223,6 +223,18 @@ describe('OpenaiOauthController', () => {
         'Key 2',
       );
       expect(result).toEqual({ ok: true, notifications: [] });
+    });
+
+    it('rejects repeated label query parameters', async () => {
+      await expect(
+        controller.revoke('my-agent', ['Key 1', 'Key 2'], { id: 'user-1' } as never),
+      ).rejects.toMatchObject({
+        message: 'label query parameter must be a string',
+        status: HttpStatus.BAD_REQUEST,
+      });
+      expect(resolveAgent.resolve).not.toHaveBeenCalled();
+      expect(providerKeyService.getProviderKeys).not.toHaveBeenCalled();
+      expect(providerService.removeProvider).not.toHaveBeenCalled();
     });
 
     it('returns ok even when no stored token exists', async () => {

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -14,7 +14,6 @@ import {
   submitAnthropicOAuth,
   revokeAnthropicOAuth,
   getAnthropicOAuthPending,
-  disconnectProvider,
   renameProviderKey,
   type AuthType,
   type RoutingProvider,
@@ -140,12 +139,7 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      await revokeAnthropicOAuth(props.agentName).catch(() => {});
-      const result = await disconnectProvider(
-        props.agentName,
-        props.provId,
-        props.selectedAuthType(),
-      );
+      const result = await revokeAnthropicOAuth(props.agentName);
       if (result?.notifications?.length) {
         for (const msg of result.notifications) {
           toast.error(msg);
@@ -163,12 +157,7 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
   const handleDeleteKey = async (label: string) => {
     props.setBusy(true);
     try {
-      const result = await disconnectProvider(
-        props.agentName,
-        props.provId,
-        props.selectedAuthType(),
-        label,
-      );
+      const result = await revokeAnthropicOAuth(props.agentName, label);
       if (result?.notifications?.length) {
         for (const msg of result.notifications) {
           toast.error(msg);

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -11,9 +11,9 @@ import {
 import type { ProviderDef } from '../services/providers.js';
 import {
   connectProvider,
-  disconnectProvider,
   pollMinimaxOAuth,
   renameProviderKey,
+  revokeMinimaxOAuth,
   startMinimaxOAuth,
   type AuthType,
   type MinimaxOAuthRegion,
@@ -119,11 +119,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const handleDisconnect = async () => {
     props.setBusy(true);
     try {
-      const result = await disconnectProvider(
-        props.agentName,
-        props.provId,
-        props.selectedAuthType(),
-      );
+      const result = await revokeMinimaxOAuth(props.agentName);
       if (result?.notifications?.length) {
         for (const msg of result.notifications) {
           toast.error(msg);
@@ -141,12 +137,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const handleDeleteKey = async (label: string) => {
     props.setBusy(true);
     try {
-      const result = await disconnectProvider(
-        props.agentName,
-        props.provId,
-        props.selectedAuthType(),
-        label,
-      );
+      const result = await revokeMinimaxOAuth(props.agentName, label);
       if (result?.notifications?.length) {
         for (const msg of result.notifications) {
           toast.error(msg);

--- a/packages/frontend/src/services/api/oauth.ts
+++ b/packages/frontend/src/services/api/oauth.ts
@@ -52,6 +52,15 @@ export function pollMinimaxOAuth(flowId: string) {
   });
 }
 
+export function revokeMinimaxOAuth(agentName: string, label?: string) {
+  const params = new URLSearchParams({ agentName });
+  if (label) params.set('label', label);
+  return fetchMutate<{ ok: boolean; notifications?: string[] }>(
+    `/oauth/minimax/revoke?${params.toString()}`,
+    { method: 'POST' },
+  );
+}
+
 export interface AnthropicOAuthAuthorizeResponse {
   url: string;
   state: string;
@@ -79,9 +88,11 @@ export function getAnthropicOAuthPending(agentName: string) {
   return fetchJson<{ state: string | null }>(`/oauth/anthropic/pending`, { agentName });
 }
 
-export function revokeAnthropicOAuth(agentName: string) {
-  return fetchMutate<{ ok: boolean }>(
-    `/oauth/anthropic/revoke?agentName=${encodeURIComponent(agentName)}`,
+export function revokeAnthropicOAuth(agentName: string, label?: string) {
+  const params = new URLSearchParams({ agentName });
+  if (label) params.set('label', label);
+  return fetchMutate<{ ok: boolean; notifications?: string[] }>(
+    `/oauth/anthropic/revoke?${params.toString()}`,
     { method: 'POST' },
   );
 }

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -274,8 +274,8 @@ describe('AnthropicOAuthDetailView', () => {
   });
 
   it('surfaces server-side notifications when disconnect returns them', async () => {
-    mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true });
-    mockDisconnectProvider.mockResolvedValue({
+    mockRevokeAnthropicOAuth.mockResolvedValue({
+      ok: true,
       notifications: ['Subscription is shared with another agent'],
     });
 
@@ -288,26 +288,25 @@ describe('AnthropicOAuthDetailView', () => {
     expect(onBack).toHaveBeenCalled();
   });
 
-  it('continues with disconnect when revoke fails (best-effort cleanup)', async () => {
+  it('does not call generic disconnect when revoke request fails', async () => {
     mockRevokeAnthropicOAuth.mockRejectedValue(new Error('revoke failed'));
-    mockDisconnectProvider.mockResolvedValue({ ok: true });
 
     const { onBack, onUpdate } = renderView(true);
     fireEvent.click(screen.getByText('Disconnect'));
 
-    await waitFor(() => expect(mockDisconnectProvider).toHaveBeenCalled());
-    expect(onBack).toHaveBeenCalled();
-    expect(onUpdate).toHaveBeenCalled();
+    await waitFor(() => expect(mockRevokeAnthropicOAuth).toHaveBeenCalledWith('test-agent'));
+    expect(mockDisconnectProvider).not.toHaveBeenCalled();
+    expect(onBack).not.toHaveBeenCalled();
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 
-  it('does not throw when disconnect itself fails', async () => {
-    mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true });
-    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+  it('does not navigate back when revoke request fails', async () => {
+    mockRevokeAnthropicOAuth.mockRejectedValue(new Error('network'));
 
     const { onBack } = renderView(true);
     fireEvent.click(screen.getByText('Disconnect'));
 
-    await waitFor(() => expect(mockDisconnectProvider).toHaveBeenCalled());
+    await waitFor(() => expect(mockRevokeAnthropicOAuth).toHaveBeenCalledWith('test-agent'));
     expect(onBack).not.toHaveBeenCalled();
   });
 
@@ -404,8 +403,8 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it('delete individual key calls disconnectProvider with label', async () => {
-    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+  it('delete individual key calls revokeAnthropicOAuth with label', async () => {
+    mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true, notifications: [] });
     const keys = [
       makeKey({ id: 'k1', label: 'Primary' }),
       makeKey({ id: 'k2', label: 'Secondary' }),
@@ -415,13 +414,9 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
     fireEvent.click(screen.getByLabelText('Delete account Primary'));
 
     await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalledWith(
-        'test-agent',
-        'anthropic',
-        'subscription',
-        'Primary',
-      );
+      expect(mockRevokeAnthropicOAuth).toHaveBeenCalledWith('test-agent', 'Primary');
     });
+    expect(mockDisconnectProvider).not.toHaveBeenCalled();
     expect(onUpdate).toHaveBeenCalled();
   });
 
@@ -434,8 +429,9 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
     expect(screen.getByText('Disconnect all')).toBeDefined();
   });
 
-  it('handleDeleteKey surfaces notifications from disconnectProvider', async () => {
-    mockDisconnectProvider.mockResolvedValue({
+  it('handleDeleteKey surfaces notifications from revokeAnthropicOAuth', async () => {
+    mockRevokeAnthropicOAuth.mockResolvedValue({
+      ok: true,
       notifications: ['Key still in use by another agent'],
     });
     const keys = [
@@ -451,8 +447,8 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
     });
   });
 
-  it('handleDeleteKey catch branch when disconnectProvider fails', async () => {
-    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+  it('handleDeleteKey catch branch when revokeAnthropicOAuth fails', async () => {
+    mockRevokeAnthropicOAuth.mockRejectedValue(new Error('network'));
     const keys = [
       makeKey({ id: 'k1', label: 'Primary' }),
       makeKey({ id: 'k2', label: 'Secondary' }),
@@ -462,7 +458,7 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
     fireEvent.click(screen.getByLabelText('Delete account Primary'));
 
     await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalled();
+      expect(mockRevokeAnthropicOAuth).toHaveBeenCalledWith('test-agent', 'Primary');
     });
     expect(onUpdate).not.toHaveBeenCalled();
   });

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -6,6 +6,7 @@ vi.mock("../../src/services/api.js", () => ({
   connectProvider: vi.fn(),
   disconnectProvider: vi.fn(),
   pollMinimaxOAuth: vi.fn(),
+  revokeMinimaxOAuth: vi.fn(),
   startMinimaxOAuth: vi.fn(),
   renameProviderKey: vi.fn(),
 }));
@@ -15,7 +16,12 @@ vi.mock("../../src/services/toast-store.js", () => ({
 }));
 
 import DeviceCodeDetailView from "../../src/components/DeviceCodeDetailView";
-import { connectProvider, disconnectProvider, renameProviderKey } from "../../src/services/api.js";
+import {
+  connectProvider,
+  disconnectProvider,
+  renameProviderKey,
+  revokeMinimaxOAuth,
+} from "../../src/services/api.js";
 import { toast } from "../../src/services/toast-store.js";
 import { getProvider } from "../../src/services/provider-utils";
 import type { AuthType, RoutingProvider } from "../../src/services/api.js";
@@ -160,6 +166,7 @@ describe("DeviceCodeDetailView — MiniMax Coding Plan token alternative", () =>
 });
 
 const mockDisconnectProvider = disconnectProvider as ReturnType<typeof vi.fn>;
+const mockRevokeMinimaxOAuth = revokeMinimaxOAuth as ReturnType<typeof vi.fn>;
 const mockRenameProviderKey = renameProviderKey as ReturnType<typeof vi.fn>;
 
 function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
@@ -247,8 +254,8 @@ describe("DeviceCodeDetailView — multi-key", () => {
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it("delete individual key calls disconnectProvider with label", async () => {
-    mockDisconnectProvider.mockResolvedValue({ notifications: [] });
+  it("delete individual key calls revokeMinimaxOAuth with label", async () => {
+    mockRevokeMinimaxOAuth.mockResolvedValue({ ok: true, notifications: [] });
     const keys = [
       makeKey({ id: "k1", label: "Primary" }),
       makeKey({ id: "k2", label: "Secondary" }),
@@ -258,13 +265,9 @@ describe("DeviceCodeDetailView — multi-key", () => {
     fireEvent.click(screen.getByLabelText("Delete account Primary"));
 
     await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalledWith(
-        "test-agent",
-        "minimax",
-        "subscription",
-        "Primary",
-      );
+      expect(mockRevokeMinimaxOAuth).toHaveBeenCalledWith("test-agent", "Primary");
     });
+    expect(mockDisconnectProvider).not.toHaveBeenCalled();
     expect(onUpdate).toHaveBeenCalled();
   });
 
@@ -277,8 +280,9 @@ describe("DeviceCodeDetailView — multi-key", () => {
     expect(screen.getByText("Disconnect all")).toBeDefined();
   });
 
-  it("handleDeleteKey surfaces notifications from disconnectProvider", async () => {
-    mockDisconnectProvider.mockResolvedValue({
+  it("handleDeleteKey surfaces notifications from revokeMinimaxOAuth", async () => {
+    mockRevokeMinimaxOAuth.mockResolvedValue({
+      ok: true,
       notifications: ["Key still shared with another agent"],
     });
     const keys = [
@@ -294,8 +298,8 @@ describe("DeviceCodeDetailView — multi-key", () => {
     });
   });
 
-  it("handleDeleteKey catch branch when disconnectProvider fails", async () => {
-    mockDisconnectProvider.mockRejectedValue(new Error("network"));
+  it("handleDeleteKey catch branch when revokeMinimaxOAuth fails", async () => {
+    mockRevokeMinimaxOAuth.mockRejectedValue(new Error("network"));
     const keys = [
       makeKey({ id: "k1", label: "Primary" }),
       makeKey({ id: "k2", label: "Secondary" }),
@@ -305,7 +309,7 @@ describe("DeviceCodeDetailView — multi-key", () => {
     fireEvent.click(screen.getByLabelText("Delete account Primary"));
 
     await waitFor(() => {
-      expect(mockDisconnectProvider).toHaveBeenCalled();
+      expect(mockRevokeMinimaxOAuth).toHaveBeenCalledWith("test-agent", "Primary");
     });
     expect(onUpdate).not.toHaveBeenCalled();
   });

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -34,6 +34,7 @@ const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
 const mockPollMinimaxOAuth = vi.fn();
 const mockRevokeOpenaiOAuth = vi.fn();
+const mockRevokeMinimaxOAuth = vi.fn();
 const mockStartMinimaxOAuth = vi.fn();
 const mockStartAnthropicOAuth = vi.fn();
 const mockSubmitAnthropicOAuth = vi.fn();
@@ -49,6 +50,7 @@ vi.mock('../../src/services/api.js', () => ({
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
   pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
+  revokeMinimaxOAuth: (...args: unknown[]) => mockRevokeMinimaxOAuth(...args),
   startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
   startAnthropicOAuth: (...args: unknown[]) => mockStartAnthropicOAuth(...args),
   submitAnthropicOAuth: (...args: unknown[]) => mockSubmitAnthropicOAuth(...args),
@@ -117,6 +119,8 @@ describe('ProviderSelectModal', () => {
       pollIntervalMs: 2000,
     });
     mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true });
+    mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true, notifications: [] });
+    mockRevokeMinimaxOAuth.mockResolvedValue({ ok: true, notifications: [] });
     mockStartMinimaxOAuth.mockResolvedValue({
       flowId: 'flow-1',
       userCode: 'ABCD-1234',
@@ -1036,8 +1040,7 @@ describe('ProviderSelectModal', () => {
         connected_at: '2025-01-01',
         auth_type: 'subscription',
       };
-      mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true });
-      mockDisconnectProvider.mockResolvedValue({ ok: true });
+      mockRevokeAnthropicOAuth.mockResolvedValue({ ok: true, notifications: [] });
 
       render(() => (
         <ProviderSelectModal
@@ -1053,16 +1056,7 @@ describe('ProviderSelectModal', () => {
       await waitFor(() => {
         expect(mockRevokeAnthropicOAuth).toHaveBeenCalledWith('test-agent');
       });
-      await waitFor(() => {
-        expect(mockDisconnectProvider).toHaveBeenCalled();
-      });
-      // Match the first three positional args; ignore any trailing trackers
-      // some test runners append (CI consistently sees a 4th `undefined`,
-      // local does not).
-      const [agent, provider, authType] = mockDisconnectProvider.mock.calls[0];
-      expect(agent).toBe('test-agent');
-      expect(provider).toBe('anthropic');
-      expect(authType).toBe('subscription');
+      expect(mockDisconnectProvider).not.toHaveBeenCalled();
       expect(onUpdate).toHaveBeenCalled();
     });
 
@@ -1654,7 +1648,7 @@ describe('ProviderSelectModal', () => {
       expect(screen.getByText(/Connected via MiniMax Coding Plan/)).toBeDefined();
     });
 
-    it('disconnects MiniMax without revoking OpenAI OAuth', async () => {
+    it('disconnects MiniMax through its provider-specific cleanup endpoint', async () => {
       const subProvider: RoutingProvider = {
         id: 'p-minimax-sub',
         provider: 'minimax',
@@ -1677,17 +1671,15 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Disconnect'));
 
       await waitFor(() => {
-        expect(mockDisconnectProvider).toHaveBeenCalledWith(
-          'test-agent',
-          'minimax',
-          'subscription',
-        );
+        expect(mockRevokeMinimaxOAuth).toHaveBeenCalledWith('test-agent');
       });
+      expect(mockDisconnectProvider).not.toHaveBeenCalled();
       expect(mockRevokeOpenaiOAuth).not.toHaveBeenCalled();
     });
 
     it('shows MiniMax disconnect notifications as error toasts', async () => {
-      mockDisconnectProvider.mockResolvedValueOnce({
+      mockRevokeMinimaxOAuth.mockResolvedValueOnce({
+        ok: true,
         notifications: ['MiniMax tiers were recalculated.'],
       });
       const subProvider: RoutingProvider = {

--- a/packages/frontend/tests/services/api/oauth.test.ts
+++ b/packages/frontend/tests/services/api/oauth.test.ts
@@ -88,6 +88,22 @@ describe('oauth API client', () => {
     expect(url).toContain('flowId=flow-1');
   });
 
+  it('revokeMinimaxOAuth POSTs with the encoded agent name in the URL', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.revokeMinimaxOAuth('my agent');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/minimax/revoke?agentName=my+agent');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('revokeMinimaxOAuth includes the encoded key label when provided', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.revokeMinimaxOAuth('my agent', 'Key 2');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/minimax/revoke?agentName=my+agent&label=Key+2');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
   it('startAnthropicOAuth POSTs the encoded agent name and returns the auth URL + state', async () => {
     const fetchMock = setupFetch({ url: 'https://claude.ai/oauth/authorize?state=s', state: 's' });
     const out = await oauth.startAnthropicOAuth('my agent');
@@ -124,7 +140,15 @@ describe('oauth API client', () => {
     const fetchMock = setupFetch({ ok: true });
     await oauth.revokeAnthropicOAuth('my agent');
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toContain('/api/v1/oauth/anthropic/revoke?agentName=my%20agent');
+    expect(url).toContain('/api/v1/oauth/anthropic/revoke?agentName=my+agent');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('revokeAnthropicOAuth includes the encoded key label when provided', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.revokeAnthropicOAuth('my agent', 'Key 2');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/anthropic/revoke?agentName=my+agent&label=Key+2');
     expect((init as RequestInit).method).toBe('POST');
   });
 });


### PR DESCRIPTION
## Summary
- route Anthropic subscription disconnect and per-key delete through the Anthropic OAuth cleanup endpoint
- add a MiniMax OAuth cleanup endpoint and use it from the device-code subscription UI
- keep behavior local-only for providers without documented upstream token revocation, while preserving provider cleanup notifications

## Validation
- npm run build --workspace=manifest-shared
- npm test -- --runInBand src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts src/routing/minimax-oauth.controller.spec.ts src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts src/routing/oauth/minimax-oauth.service.spec.ts (from packages/backend)
- npm test -- --run tests/components/AnthropicOAuthDetailView.test.tsx tests/components/DeviceCodeDetailView.test.tsx tests/components/ProviderSelectModal.test.tsx tests/services/api/oauth.test.ts (from packages/frontend)
- npm run build --workspace=manifest-backend
- npm run build --workspace=manifest-frontend
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Anthropic and MiniMax subscription disconnects through provider-specific OAuth cleanup endpoints, with optional per-key removal via a validated label. The frontend now calls these endpoints and shows any provider cleanup notifications.

- **New Features**
  - Added a MiniMax OAuth cleanup endpoint to revoke all or a labeled subscription key and return cleanup notifications.

- **Refactors**
  - Anthropic revoke now accepts an optional key label, returns notifications, and uses shared label parsing/validation; MiniMax and OpenAI revoke use the same validation.
  - Anthropic and MiniMax use a unified backend path that calls `removeProvider`.
  - Frontend and API client switch to provider-specific revoke calls (`revokeMinimaxOAuth(agentName, label?)`, updated `revokeAnthropicOAuth(agentName, label?)`); tests updated.

<sup>Written for commit cf8eb2e1c95c3766c7af375ea497802c31ae1981. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1927?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

