### PR TITLE
fix: strip adaptive thinking for Haiku

### DIFF
--- a/.changeset/strip-haiku-adaptive-thinking.md
+++ b/.changeset/strip-haiku-adaptive-thinking.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Strip adaptive thinking when Anthropic Messages requests are routed to Claude Haiku.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -122,6 +122,41 @@ describe('Anthropic Adapter', () => {
       expect(result.stop_sequences).toEqual(['STOP', 'END']);
     });
 
+    it('strips adaptive thinking when routing to Claude Haiku 4.5', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        thinking: { type: 'adaptive' },
+      };
+
+      expect(toAnthropicRequest(body, 'claude-haiku-4-5-20251001').thinking).toBeUndefined();
+      expect(toAnthropicRequest(body, 'anthropic/claude-haiku-4.5').thinking).toBeUndefined();
+      expect(toAnthropicRequest(body, 'claude-haiku-4').thinking).toBeUndefined();
+    });
+
+    it('preserves extended thinking for Claude Haiku 4.5', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        thinking: { type: 'enabled', budget_tokens: 2048 },
+      };
+
+      const result = toAnthropicRequest(body, 'claude-haiku-4-5-20251001');
+      expect(result.thinking).toEqual({ type: 'enabled', budget_tokens: 2048 });
+    });
+
+    it('preserves adaptive thinking for adaptive-capable Claude models', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        thinking: { type: 'adaptive' },
+      };
+
+      expect(toAnthropicRequest(body, 'claude-sonnet-4-6').thinking).toEqual({
+        type: 'adaptive',
+      });
+      expect(toAnthropicRequest(body, 'claude-opus-4-6').thinking).toEqual({
+        type: 'adaptive',
+      });
+    });
+
     it('wraps a bare string `stop` value into stop_sequences (chat_completions accepts both shapes)', () => {
       // Cubic flagged: if a chat_completions client sends `stop: "END"`,
       // the previous code dropped it because it only handled arrays.

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -32,6 +32,28 @@ interface AnthropicTool {
 }
 
 const CACHE = { type: 'ephemeral' } as const;
+const ANTHROPIC_PREFIX = 'anthropic/';
+
+function bareAnthropicModel(model: string): string {
+  return model.startsWith(ANTHROPIC_PREFIX) ? model.slice(ANTHROPIC_PREFIX.length) : model;
+}
+
+function isClaudeHaikuModel(model: string): boolean {
+  const bare = bareAnthropicModel(model).replace(/\./g, '-');
+  return bare.startsWith('claude-haiku-');
+}
+
+function shouldForwardAnthropicThinking(thinking: unknown, model: string): boolean {
+  if (
+    thinking &&
+    typeof thinking === 'object' &&
+    !Array.isArray(thinking) &&
+    (thinking as Record<string, unknown>).type === 'adaptive'
+  ) {
+    return !isClaudeHaikuModel(model);
+  }
+  return true;
+}
 
 /**
  * System prompt required by Anthropic's subscription OAuth API to unlock
@@ -231,7 +253,9 @@ export function toAnthropicRequest(
   // Anthropic-native fields forwarded when the inbound request originated as
   // Anthropic Messages (POST /v1/messages). Chat-completions clients won't
   // set these, so this is a no-op for the OpenAI-compat path.
-  if (body.thinking !== undefined) result.thinking = body.thinking;
+  if (body.thinking !== undefined && shouldForwardAnthropicThinking(body.thinking, _model)) {
+    result.thinking = body.thinking;
+  }
   // chat_completions `stop` accepts string OR string[]; Anthropic
   // `stop_sequences` is always an array. Wrap a bare string so a single
   // stop sequence isn't silently dropped.


### PR DESCRIPTION
### ✨ What changed
- Drop adaptive thinking when Anthropic routing resolves to Claude Haiku.
- Keep extended thinking for Haiku and adaptive thinking for Sonnet/Opus.
- Add adapter regressions and a patch changeset.

### 💭 Why
Claude Code can send adaptive thinking while Manifest routes lower tiers to Haiku. Anthropic rejects that pair with `adaptive thinking is not supported on this model`.

### 👤 For users
Claude Code routing can use Haiku tiers without hitting the adaptive-thinking 400.

### 📝 Notes
Closes #1908
- Focused Anthropic adapter tests passed.
- Backend typecheck, backend build, changed-file ESLint, and `git diff --check` passed.
- Live Anthropic API-key test confirmed direct 400 and patched 200.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop forwarding adaptive thinking when routing to Claude Haiku to prevent Anthropic 400s; extended thinking on Haiku and adaptive on Sonnet/Opus are preserved. Fixes #1908.

- **Bug Fixes**
  - Detect Haiku models (including `anthropic/` prefix and dotted variants) and drop `thinking: { type: 'adaptive' }`.
  - Added tests for Haiku stripping and for preserving extended/adaptive thinking where supported, plus a patch changeset.

<sup>Written for commit ee47ba7baa187a6c87d860a5208b6cee6b2e7a11. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1928?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

