### PR TITLE
chore: remove unused duplication spec imports

### DIFF
--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -4,11 +4,6 @@ import { ConflictException, NotFoundException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { AgentDuplicationService } from './agent-duplication.service';
 import { Agent } from '../../entities/agent.entity';
-import { AgentApiKey } from '../../entities/agent-api-key.entity';
-import { UserProvider } from '../../entities/user-provider.entity';
-import { CustomProvider } from '../../entities/custom-provider.entity';
-import { TierAssignment } from '../../entities/tier-assignment.entity';
-import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { RoutingCacheService } from '../../routing/routing-core/routing-cache.service';
 
 process.env['BETTER_AUTH_SECRET'] = 'a'.repeat(64);


### PR DESCRIPTION
## Summary
- remove unused entity imports from `agent-duplication.service.spec.ts`
- clears the lint annotations surfaced after the AgentModelParams merge

## Validation
- `npm ci --prefer-offline --no-audit --no-fund`
- `npm run build --workspace=packages/shared`
- `npm run lint --workspace=packages/backend -- --quiet`
- `npm --workspace packages/backend test -- agent-duplication.service.spec.ts --runInBand`
- `git diff --check`

## Notes
- No changeset: test-only cleanup, no package behavior change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused entity imports from agent-duplication.service.spec.ts to clear lint warnings and tidy the test. No runtime or test behavior changes.

<sup>Written for commit 0fd44e3df95892a826479f12f2f72a9c691cf2a3. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1933?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

