### PR TITLE
fix(anthropic): persist OAuth pending state

### DIFF
--- a/.changeset/fix-anthropic-oauth-pending-state.md
+++ b/.changeset/fix-anthropic-oauth-pending-state.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Persist Anthropic OAuth pending state in Postgres so production exchanges survive reloads, restarts, and multi-instance routing.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -98,6 +98,7 @@ import { AddRequestParamsColumn1786000000000 } from './migrations/1786000000000-
 import { AddAgentModelParams1787000000000 } from './migrations/1787000000000-AddAgentModelParams';
 import { AddBenchmarkHistory1788000000000 } from './migrations/1788000000000-AddBenchmarkHistory';
 import { RenameBenchmarkToPlayground1789000000000 } from './migrations/1789000000000-RenameBenchmarkToPlayground';
+import { AddOAuthPendingFlows1789100000000 } from './migrations/1789100000000-AddOAuthPendingFlows';
 
 const entities = [
   AgentMessage,
@@ -197,6 +198,7 @@ const migrations = [
   AddAgentModelParams1787000000000,
   AddBenchmarkHistory1788000000000,
   RenameBenchmarkToPlayground1789000000000,
+  AddOAuthPendingFlows1789100000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1789100000000-AddOAuthPendingFlows.ts
+++ b/packages/backend/src/database/migrations/1789100000000-AddOAuthPendingFlows.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOAuthPendingFlows1789100000000 implements MigrationInterface {
+  name = 'AddOAuthPendingFlows1789100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "oauth_pending_flows" (
+        "provider" varchar NOT NULL,
+        "state" varchar NOT NULL,
+        "code_verifier" text NOT NULL,
+        "agent_id" varchar NOT NULL,
+        "user_id" varchar NOT NULL,
+        "expires_at" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_oauth_pending_flows" PRIMARY KEY ("provider", "state"),
+        CONSTRAINT "FK_oauth_pending_flows_agent"
+          FOREIGN KEY ("agent_id")
+          REFERENCES "agents"("id")
+          ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_oauth_pending_flows_agent_user" ` +
+        `ON "oauth_pending_flows" ("provider", "agent_id", "user_id", "created_at" DESC)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_oauth_pending_flows_expires" ON "oauth_pending_flows" ("expires_at")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_oauth_pending_flows_expires"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_oauth_pending_flows_agent_user"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "oauth_pending_flows"`);
+  }
+}

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
@@ -62,7 +62,7 @@ describe('AnthropicOauthController', () => {
       await expect(ctrl.exchange('agent', 'auth-code', 'state-1', user)).resolves.toEqual({
         ok: true,
       });
-      expect(oauth.exchangeCode).toHaveBeenCalledWith('auth-code', 'state-1');
+      expect(oauth.exchangeCode).toHaveBeenCalledWith('auth-code', 'state-1', 'agent-1', 'user-1');
     });
 
     it('wraps service errors in a 400', async () => {
@@ -90,14 +90,14 @@ describe('AnthropicOauthController', () => {
 
     it('returns the active state when one exists', async () => {
       const { ctrl, oauth } = build();
-      (oauth.findPendingForAgent as jest.Mock).mockReturnValue({ state: 'abc' });
+      (oauth.findPendingForAgent as jest.Mock).mockResolvedValue({ state: 'abc' });
       await expect(ctrl.pending('agent', user)).resolves.toEqual({ state: 'abc' });
-      expect(oauth.findPendingForAgent).toHaveBeenCalledWith('agent-1');
+      expect(oauth.findPendingForAgent).toHaveBeenCalledWith('agent-1', 'user-1');
     });
 
     it('returns {state: null} when no flow is pending', async () => {
       const { ctrl, oauth } = build();
-      (oauth.findPendingForAgent as jest.Mock).mockReturnValue(null);
+      (oauth.findPendingForAgent as jest.Mock).mockResolvedValue(null);
       await expect(ctrl.pending('agent', user)).resolves.toEqual({ state: null });
     });
   });

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
@@ -57,9 +57,9 @@ export class AnthropicOauthController {
       throw new HttpException('code is required', HttpStatus.BAD_REQUEST);
     }
     // Resolve the agent so unknown agents still 404 even if state is valid.
-    await this.resolveAgent.resolve(user.id, agentName);
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
     try {
-      await this.oauthService.exchangeCode(code, state);
+      await this.oauthService.exchangeCode(code, state, agent.id, user.id);
       return { ok: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Token exchange failed';
@@ -79,7 +79,7 @@ export class AnthropicOauthController {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
     const agent = await this.resolveAgent.resolve(user.id, agentName);
-    return this.oauthService.findPendingForAgent(agent.id) ?? { state: null };
+    return (await this.oauthService.findPendingForAgent(agent.id, user.id)) ?? { state: null };
   }
 
   /** Disconnect the Anthropic subscription provider for an agent. */

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -2,6 +2,11 @@ import { ProviderService } from '../../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { AnthropicOauthService, splitAnthropicAuthPayload } from './anthropic-oauth.service';
 import { ANTHROPIC_OAUTH } from './anthropic-oauth.config';
+import {
+  OAuthPendingFlowStore,
+  type OAuthPendingFlowInput,
+  type OAuthPendingFlowRecord,
+} from '../core';
 
 const originalFetch = global.fetch;
 
@@ -31,6 +36,60 @@ function createDiscovery(): { svc: ModelDiscoveryService; discoverModels: jest.M
   return { svc: { discoverModels } as unknown as ModelDiscoveryService, discoverModels };
 }
 
+function createPendingStore() {
+  const flows = new Map<string, OAuthPendingFlowRecord>();
+  const key = (provider: string, state: string) => `${provider}:${state}`;
+  const cleanup = () => {
+    for (const [flowKey, flow] of flows) {
+      if (flow.expiresAt < Date.now()) flows.delete(flowKey);
+    }
+  };
+  const svc = {
+    create: jest.fn(async (provider: string, input: OAuthPendingFlowInput, ttlMs: number) => {
+      cleanup();
+      for (const [flowKey, flow] of flows) {
+        if (
+          flow.provider === provider &&
+          flow.agentId === input.agentId &&
+          flow.userId === input.userId
+        ) {
+          flows.delete(flowKey);
+        }
+      }
+      const record = { provider, ...input, expiresAt: Date.now() + ttlMs };
+      flows.set(key(provider, input.state), record);
+      return record;
+    }),
+    consume: jest.fn(async (provider: string, state: string, agentId: string, userId: string) => {
+      const flow = flows.get(key(provider, state));
+      if (!flow || flow.agentId !== agentId || flow.userId !== userId) return null;
+      flows.delete(key(provider, state));
+      return flow;
+    }),
+    findLatestForAgent: jest.fn(async (provider: string, agentId: string, userId: string) => {
+      cleanup();
+      for (const flow of flows.values()) {
+        if (flow.provider === provider && flow.agentId === agentId && flow.userId === userId) {
+          return flow;
+        }
+      }
+      return null;
+    }),
+    clear: jest.fn(async (provider: string, state: string) => {
+      flows.delete(key(provider, state));
+    }),
+    count: jest.fn(async (provider: string) => {
+      cleanup();
+      let total = 0;
+      for (const flow of flows.values()) {
+        if (flow.provider === provider) total += 1;
+      }
+      return total;
+    }),
+  } as unknown as OAuthPendingFlowStore;
+  return { svc, flows };
+}
+
 describe('splitAnthropicAuthPayload', () => {
   it('returns the bare code when no state suffix is present', () => {
     expect(splitAnthropicAuthPayload('abc123')).toEqual({ code: 'abc123' });
@@ -53,6 +112,7 @@ describe('AnthropicOauthService', () => {
   let fetchMock: jest.Mock;
   let providerService: ReturnType<typeof createProviderService>;
   let discovery: ReturnType<typeof createDiscovery>;
+  let pendingStore: ReturnType<typeof createPendingStore>;
   let svc: AnthropicOauthService;
 
   beforeEach(() => {
@@ -62,7 +122,8 @@ describe('AnthropicOauthService', () => {
     global.fetch = fetchMock as unknown as typeof fetch;
     providerService = createProviderService();
     discovery = createDiscovery();
-    svc = new AnthropicOauthService(providerService.svc, discovery.svc);
+    pendingStore = createPendingStore();
+    svc = new AnthropicOauthService(providerService.svc, discovery.svc, pendingStore.svc);
   });
 
   afterEach(() => {
@@ -74,8 +135,8 @@ describe('AnthropicOauthService', () => {
   });
 
   describe('generateAuthorizationUrl', () => {
-    it('builds a Claude.ai authorize URL with PKCE S256 challenge and tracks pending state', () => {
-      const { url, state } = svc.generateAuthorizationUrl('agent-1', 'user-1');
+    it('builds a Claude.ai authorize URL with PKCE S256 challenge and tracks pending state', async () => {
+      const { url, state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
       const parsed = new URL(url);
       expect(parsed.origin + parsed.pathname).toBe(ANTHROPIC_OAUTH.AUTHORIZE_URL);
       expect(parsed.searchParams.get('client_id')).toBe(ANTHROPIC_OAUTH.CLIENT_ID);
@@ -85,30 +146,36 @@ describe('AnthropicOauthService', () => {
       expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
       expect(parsed.searchParams.get('code_challenge')?.length).toBeGreaterThan(0);
       expect(parsed.searchParams.get('state')).toBe(state);
-      expect(svc.getPendingCount()).toBe(1);
+      await expect(svc.getPendingCount()).resolves.toBe(1);
     });
   });
 
   describe('exchangeCode', () => {
     it('rejects when no code is supplied', async () => {
-      await expect(svc.exchangeCode('', 'state')).rejects.toThrow('Missing authorization code');
+      await expect(svc.exchangeCode('', 'state', 'agent-1', 'user-1')).rejects.toThrow(
+        'Missing authorization code',
+      );
     });
 
     it('rejects when no state is supplied', async () => {
-      await expect(svc.exchangeCode('code', undefined)).rejects.toThrow('Missing OAuth state');
+      await expect(svc.exchangeCode('code', undefined, 'agent-1', 'user-1')).rejects.toThrow(
+        'Missing OAuth state',
+      );
     });
 
     it('rejects unknown states', async () => {
-      await expect(svc.exchangeCode('code#bogus')).rejects.toThrow(
+      await expect(svc.exchangeCode('code#bogus', undefined, 'agent-1', 'user-1')).rejects.toThrow(
         'Invalid or expired OAuth state',
       );
     });
 
     it('rejects (and purges) expired states', async () => {
-      const { state } = svc.generateAuthorizationUrl('a', 'u');
+      const { state } = await svc.generateAuthorizationUrl('a', 'u');
       jest.advanceTimersByTime(ANTHROPIC_OAUTH.STATE_TTL_MS + 1);
-      await expect(svc.exchangeCode(`code#${state}`)).rejects.toThrow('OAuth state expired');
-      expect(svc.getPendingCount()).toBe(0);
+      await expect(svc.exchangeCode(`code#${state}`, undefined, 'a', 'u')).rejects.toThrow(
+        'OAuth state expired',
+      );
+      await expect(svc.getPendingCount()).resolves.toBe(0);
     });
 
     it('exchanges a valid code, stores the blob, and triggers model discovery', async () => {
@@ -119,9 +186,9 @@ describe('AnthropicOauthService', () => {
           expires_in: 3600,
         }),
       );
-      const { state } = svc.generateAuthorizationUrl('agent-1', 'user-1');
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
 
-      await svc.exchangeCode(`auth-code#${state}`);
+      await svc.exchangeCode(`auth-code#${state}`, undefined, 'agent-1', 'user-1');
 
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [tokenUrl, init] = fetchMock.mock.calls[0];
@@ -143,29 +210,31 @@ describe('AnthropicOauthService', () => {
       );
       expect(discovery.discoverModels).toHaveBeenCalled();
       expect(providerService.recalculateTiers).toHaveBeenCalledWith('agent-1');
-      expect(svc.getPendingCount()).toBe(0);
+      await expect(svc.getPendingCount()).resolves.toBe(0);
     });
 
     it('accepts the code and state passed separately', async () => {
       fetchMock.mockResolvedValue(
         mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
       );
-      const { state } = svc.generateAuthorizationUrl('a', 'u');
-      await svc.exchangeCode('plain-code', state);
+      const { state } = await svc.generateAuthorizationUrl('a', 'u');
+      await svc.exchangeCode('plain-code', state, 'a', 'u');
       expect(providerService.upsertProvider).toHaveBeenCalled();
     });
 
     it('throws when the token endpoint returns an error', async () => {
       fetchMock.mockResolvedValue(mockResponse(400, {}, 'invalid_grant'));
-      const { state } = svc.generateAuthorizationUrl('a', 'u');
-      await expect(svc.exchangeCode(`bad#${state}`)).rejects.toThrow('Token exchange failed');
+      const { state } = await svc.generateAuthorizationUrl('a', 'u');
+      await expect(svc.exchangeCode(`bad#${state}`, undefined, 'a', 'u')).rejects.toThrow(
+        'Token exchange failed',
+      );
     });
 
     it('stores an empty refresh token when Anthropic omits one in the response', async () => {
       // No refresh_token field — defensive fallback exercises the `?? ''`.
       fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'a', expires_in: 60 }));
-      const { state } = svc.generateAuthorizationUrl('a', 'u');
-      await svc.exchangeCode(`c#${state}`);
+      const { state } = await svc.generateAuthorizationUrl('a', 'u');
+      await svc.exchangeCode(`c#${state}`, undefined, 'a', 'u');
       const stored = providerService.upsertProvider.mock.calls[0][3] as string;
       expect(JSON.parse(stored).r).toBe('');
     });
@@ -175,8 +244,8 @@ describe('AnthropicOauthService', () => {
         mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
       );
       discovery.discoverModels.mockRejectedValue(new Error('boom'));
-      const { state } = svc.generateAuthorizationUrl('a', 'u');
-      await expect(svc.exchangeCode(`c#${state}`)).resolves.toBeUndefined();
+      const { state } = await svc.generateAuthorizationUrl('a', 'u');
+      await expect(svc.exchangeCode(`c#${state}`, undefined, 'a', 'u')).resolves.toBeUndefined();
       expect(providerService.upsertProvider).toHaveBeenCalled();
     });
   });
@@ -247,27 +316,32 @@ describe('AnthropicOauthService', () => {
   });
 
   describe('clearPendingState', () => {
-    it('removes a known pending state', () => {
-      const { state } = svc.generateAuthorizationUrl('a', 'u');
-      expect(svc.getPendingCount()).toBe(1);
-      svc.clearPendingState(state);
-      expect(svc.getPendingCount()).toBe(0);
+    it('removes a known pending state', async () => {
+      const { state } = await svc.generateAuthorizationUrl('a', 'u');
+      await expect(svc.getPendingCount()).resolves.toBe(1);
+      await svc.clearPendingState(state);
+      await expect(svc.getPendingCount()).resolves.toBe(0);
     });
   });
 
   describe('findPendingForAgent', () => {
-    it('returns the active state when one exists for the agent', () => {
-      const { state } = svc.generateAuthorizationUrl('agent-1', 'user-1');
-      expect(svc.findPendingForAgent('agent-1')).toEqual({ state });
+    it('returns the active state when one exists for the agent and user', async () => {
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+      await expect(svc.findPendingForAgent('agent-1', 'user-1')).resolves.toEqual({ state });
     });
 
-    it('returns null when no flow is pending for the agent', () => {
-      expect(svc.findPendingForAgent('agent-1')).toBeNull();
+    it('returns null when no flow is pending for the agent', async () => {
+      await expect(svc.findPendingForAgent('agent-1', 'user-1')).resolves.toBeNull();
     });
 
-    it('skips entries belonging to other agents', () => {
-      svc.generateAuthorizationUrl('other-agent', 'user-1');
-      expect(svc.findPendingForAgent('agent-1')).toBeNull();
+    it('skips entries belonging to other agents', async () => {
+      await svc.generateAuthorizationUrl('other-agent', 'user-1');
+      await expect(svc.findPendingForAgent('agent-1', 'user-1')).resolves.toBeNull();
+    });
+
+    it('skips entries belonging to other users', async () => {
+      await svc.generateAuthorizationUrl('agent-1', 'other-user');
+      await expect(svc.findPendingForAgent('agent-1', 'user-1')).resolves.toBeNull();
     });
   });
 });

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -5,19 +5,12 @@ import { scrubSecrets } from '../../../common/utils/secret-scrub';
 import {
   generatePkce,
   generateState,
+  OAuthPendingFlowStore,
   parseOAuthTokenBlob,
-  PendingStore,
   serializeOAuthTokenBlob,
   type OAuthTokenBlob,
-  type PendingEntry,
 } from '../core';
 import { ANTHROPIC_OAUTH } from './anthropic-oauth.config';
-
-interface PendingAnthropicOAuth extends PendingEntry {
-  verifier: string;
-  agentId: string;
-  userId: string;
-}
 
 export interface AuthorizeResult {
   url: string;
@@ -30,6 +23,8 @@ interface AnthropicTokenResponse {
   expires_in: number;
   token_type?: string;
 }
+
+const PROVIDER = 'anthropic';
 
 /**
  * Splits Anthropic's pasted authorization payload. The redirect page renders
@@ -49,21 +44,25 @@ export function splitAnthropicAuthPayload(payload: string): { code: string; stat
 @Injectable()
 export class AnthropicOauthService {
   private readonly logger = new Logger(AnthropicOauthService.name);
-  private readonly pending = new PendingStore<PendingAnthropicOAuth>(ANTHROPIC_OAUTH.STATE_TTL_MS);
 
   constructor(
     private readonly providerService: ProviderService,
     private readonly discoveryService: ModelDiscoveryService,
+    private readonly pendingFlows: OAuthPendingFlowStore,
   ) {}
 
   /**
    * Build the authorize URL the user opens in a new tab. The state is also
    * returned so the SPA can pre-fill it on the paste-code step.
    */
-  generateAuthorizationUrl(agentId: string, userId: string): AuthorizeResult {
+  async generateAuthorizationUrl(agentId: string, userId: string): Promise<AuthorizeResult> {
     const state = generateState();
     const { verifier, challenge } = generatePkce();
-    this.pending.set(state, { verifier, agentId, userId });
+    await this.pendingFlows.create(
+      PROVIDER,
+      { state, verifier, agentId, userId },
+      ANTHROPIC_OAUTH.STATE_TTL_MS,
+    );
 
     const params = new URLSearchParams({
       code: 'true',
@@ -83,19 +82,22 @@ export class AnthropicOauthService {
    * `payload` may be either the bare code or the `<code>#<state>` form
    * Anthropic's redirect page displays.
    */
-  async exchangeCode(payload: string, fallbackState?: string): Promise<void> {
+  async exchangeCode(
+    payload: string,
+    fallbackState: string | undefined,
+    agentId: string,
+    userId: string,
+  ): Promise<void> {
     const { code, state: extractedState } = splitAnthropicAuthPayload(payload);
     const state = extractedState ?? fallbackState;
     if (!code) throw new Error('Missing authorization code');
     if (!state) throw new Error('Missing OAuth state');
 
-    const pending = this.pending.peek(state);
+    const pending = await this.pendingFlows.consume(PROVIDER, state, agentId, userId);
     if (!pending) throw new Error('Invalid or expired OAuth state');
     if (pending.expiresAt < Date.now()) {
-      this.pending.delete(state);
       throw new Error('OAuth state expired');
     }
-    this.pending.delete(state);
 
     const response = await fetch(ANTHROPIC_OAUTH.TOKEN_URL, {
       method: 'POST',
@@ -121,11 +123,11 @@ export class AnthropicOauthService {
       e: Date.now() + data.expires_in * 1000,
     };
 
-    const label = await this.providerService.nextOAuthLabel(pending.agentId, 'anthropic');
+    const label = await this.providerService.nextOAuthLabel(pending.agentId, PROVIDER);
     const { provider: savedProvider } = await this.providerService.upsertProvider(
       pending.agentId,
       pending.userId,
-      'anthropic',
+      PROVIDER,
       serializeOAuthTokenBlob(blob),
       'subscription',
       undefined,
@@ -200,12 +202,12 @@ export class AnthropicOauthService {
     }
   }
 
-  getPendingCount(): number {
-    return this.pending.size();
+  getPendingCount(): Promise<number> {
+    return this.pendingFlows.count(PROVIDER);
   }
 
-  clearPendingState(state: string): void {
-    this.pending.delete(state);
+  async clearPendingState(state: string): Promise<void> {
+    await this.pendingFlows.clear(PROVIDER, state);
   }
 
   /**
@@ -214,11 +216,8 @@ export class AnthropicOauthService {
    * or the page reloaded mid-flow. Only the `state` is returned — the PKCE
    * verifier stays server-side.
    */
-  findPendingForAgent(agentId: string): { state: string } | null {
-    // Linear scan — one entry per active flow per agent at most.
-    for (const [state, value] of this.pending.entries()) {
-      if (value.agentId === agentId) return { state };
-    }
-    return null;
+  async findPendingForAgent(agentId: string, userId: string): Promise<{ state: string } | null> {
+    const pending = await this.pendingFlows.findLatestForAgent(PROVIDER, agentId, userId);
+    return pending ? { state: pending.state } : null;
   }
 }

--- a/packages/backend/src/routing/oauth/core/index.ts
+++ b/packages/backend/src/routing/oauth/core/index.ts
@@ -5,5 +5,10 @@ export {
   serializeOAuthTokenBlob,
   type OAuthTokenBlob,
 } from './oauth-blob';
+export {
+  OAuthPendingFlowStore,
+  type OAuthPendingFlowInput,
+  type OAuthPendingFlowRecord,
+} from './oauth-pending-flow.store';
 export { PendingStore, type PendingEntry } from './pending-store';
 export { oauthDoneHtml } from './callback-page';

--- a/packages/backend/src/routing/oauth/core/oauth-pending-flow.store.spec.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-pending-flow.store.spec.ts
@@ -1,0 +1,165 @@
+import { DataSource } from 'typeorm';
+import { OAuthPendingFlowStore } from './oauth-pending-flow.store';
+
+function buildStore() {
+  const query = jest.fn();
+  const dataSource = { query } as unknown as DataSource;
+  return { store: new OAuthPendingFlowStore(dataSource), query };
+}
+
+describe('OAuthPendingFlowStore', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('stores one active pending flow per provider, agent, and user', async () => {
+    const { store, query } = buildStore();
+    query.mockResolvedValue([]);
+
+    await store.create(
+      'anthropic',
+      { state: 's1', verifier: 'v1', agentId: 'agent-1', userId: 'user-1' },
+      600_000,
+    );
+
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(query.mock.calls[0][0]).toContain('DELETE FROM "oauth_pending_flows"');
+    expect(query.mock.calls[0][1]).toEqual(['anthropic']);
+    expect(query.mock.calls[1][0]).toContain('AND "agent_id" = $2');
+    expect(query.mock.calls[1][1]).toEqual(['anthropic', 'agent-1', 'user-1']);
+    expect(query.mock.calls[2][0]).toContain('INSERT INTO "oauth_pending_flows"');
+    expect(query.mock.calls[2][1]).toEqual([
+      'anthropic',
+      's1',
+      'v1',
+      'agent-1',
+      'user-1',
+      new Date('2026-05-01T12:10:00Z'),
+    ]);
+  });
+
+  it('consumes a pending flow scoped to the provider, state, agent, and user', async () => {
+    const { store, query } = buildStore();
+    query.mockResolvedValue([
+      {
+        provider: 'anthropic',
+        state: 's1',
+        code_verifier: 'v1',
+        agent_id: 'agent-1',
+        user_id: 'user-1',
+        expires_at: new Date('2026-05-01T12:10:00Z'),
+      },
+    ]);
+
+    await expect(store.consume('anthropic', 's1', 'agent-1', 'user-1')).resolves.toEqual({
+      provider: 'anthropic',
+      state: 's1',
+      verifier: 'v1',
+      agentId: 'agent-1',
+      userId: 'user-1',
+      expiresAt: new Date('2026-05-01T12:10:00Z').getTime(),
+    });
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('RETURNING'), [
+      'anthropic',
+      's1',
+      'agent-1',
+      'user-1',
+    ]);
+    expect(query.mock.calls[0][0]).toContain('AND "expires_at" > NOW()');
+  });
+
+  it('returns null when no pending flow matches', async () => {
+    const { store, query } = buildStore();
+    query.mockResolvedValue([]);
+
+    await expect(store.consume('anthropic', 'missing', 'agent-1', 'user-1')).resolves.toBeNull();
+  });
+
+  it('finds the latest unexpired flow for an agent and user', async () => {
+    const { store, query } = buildStore();
+    query.mockResolvedValueOnce([]);
+    query.mockResolvedValueOnce([
+      {
+        provider: 'anthropic',
+        state: 's1',
+        code_verifier: 'v1',
+        agent_id: 'agent-1',
+        user_id: 'user-1',
+        expires_at: '2026-05-01T12:10:00.000Z',
+      },
+    ]);
+
+    await expect(store.findLatestForAgent('anthropic', 'agent-1', 'user-1')).resolves.toMatchObject(
+      {
+        provider: 'anthropic',
+        state: 's1',
+        verifier: 'v1',
+        agentId: 'agent-1',
+        userId: 'user-1',
+      },
+    );
+    expect(query.mock.calls[1][0]).toContain('AND "user_id" = $3');
+    expect(query.mock.calls[1][1]).toEqual(['anthropic', 'agent-1', 'user-1']);
+  });
+
+  it('clears a flow by provider and state', async () => {
+    const { store, query } = buildStore();
+    query.mockResolvedValue([]);
+
+    await store.clear('anthropic', 's1');
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('AND "state" = $2'), [
+      'anthropic',
+      's1',
+    ]);
+  });
+
+  it('counts active flows after provider-scoped cleanup', async () => {
+    const { store, query } = buildStore();
+    query.mockResolvedValueOnce([]);
+    query.mockResolvedValueOnce([{ count: '2' }]);
+
+    await expect(store.count('anthropic')).resolves.toBe(2);
+
+    expect(query.mock.calls[0][0]).toContain('"expires_at" <= NOW()');
+    expect(query.mock.calls[0][1]).toEqual(['anthropic']);
+    expect(query.mock.calls[1][0]).toContain('SELECT COUNT(*)::int AS "count"');
+    expect(query.mock.calls[1][1]).toEqual(['anthropic']);
+  });
+
+  it('cleans expired flows across providers when no provider is supplied', async () => {
+    const { store, query } = buildStore();
+    query.mockResolvedValue([]);
+
+    await store.cleanupExpired();
+
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('WHERE "expires_at" <= NOW()'));
+  });
+
+  it('runs hourly cleanup', async () => {
+    const { store } = buildStore();
+    const cleanupExpired = jest.spyOn(store, 'cleanupExpired').mockResolvedValue(undefined);
+
+    await store.cleanupExpiredCron();
+
+    expect(cleanupExpired).toHaveBeenCalledWith();
+  });
+
+  it('logs and swallows hourly cleanup failures', async () => {
+    const { store } = buildStore();
+    jest.spyOn(store, 'cleanupExpired').mockRejectedValue(new Error('db down'));
+    const warn = jest.fn();
+    (store as unknown as { logger: { warn: jest.Mock } }).logger = { warn };
+
+    await expect(store.cleanupExpiredCron()).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledWith(
+      'Failed to clean expired OAuth pending flows: Error: db down',
+    );
+  });
+});

--- a/packages/backend/src/routing/oauth/core/oauth-pending-flow.store.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-pending-flow.store.ts
@@ -1,0 +1,172 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { DataSource } from 'typeorm';
+
+export interface OAuthPendingFlowInput {
+  state: string;
+  verifier: string;
+  agentId: string;
+  userId: string;
+}
+
+export interface OAuthPendingFlowRecord extends OAuthPendingFlowInput {
+  provider: string;
+  expiresAt: number;
+}
+
+interface RawOAuthPendingFlow {
+  provider: string;
+  state: string;
+  code_verifier: string;
+  agent_id: string;
+  user_id: string;
+  expires_at: Date | string;
+}
+
+@Injectable()
+export class OAuthPendingFlowStore {
+  private readonly logger = new Logger(OAuthPendingFlowStore.name);
+
+  constructor(private readonly dataSource: DataSource) {}
+
+  async create(
+    provider: string,
+    input: OAuthPendingFlowInput,
+    ttlMs: number,
+  ): Promise<OAuthPendingFlowRecord> {
+    const expiresAt = new Date(Date.now() + ttlMs);
+
+    await this.cleanupExpired(provider);
+    await this.dataSource.query(
+      `
+        DELETE FROM "oauth_pending_flows"
+        WHERE "provider" = $1
+          AND "agent_id" = $2
+          AND "user_id" = $3
+      `,
+      [provider, input.agentId, input.userId],
+    );
+    await this.dataSource.query(
+      `
+        INSERT INTO "oauth_pending_flows"
+          ("provider", "state", "code_verifier", "agent_id", "user_id", "expires_at")
+        VALUES ($1, $2, $3, $4, $5, $6)
+      `,
+      [provider, input.state, input.verifier, input.agentId, input.userId, expiresAt],
+    );
+
+    return { provider, ...input, expiresAt: expiresAt.getTime() };
+  }
+
+  async consume(
+    provider: string,
+    state: string,
+    agentId: string,
+    userId: string,
+  ): Promise<OAuthPendingFlowRecord | null> {
+    const rows = (await this.dataSource.query(
+      `
+        DELETE FROM "oauth_pending_flows"
+        WHERE "provider" = $1
+          AND "state" = $2
+          AND "agent_id" = $3
+          AND "user_id" = $4
+          AND "expires_at" > NOW()
+        RETURNING "provider", "state", "code_verifier", "agent_id", "user_id", "expires_at"
+      `,
+      [provider, state, agentId, userId],
+    )) as RawOAuthPendingFlow[];
+
+    return rows[0] ? mapRow(rows[0]) : null;
+  }
+
+  async findLatestForAgent(
+    provider: string,
+    agentId: string,
+    userId: string,
+  ): Promise<OAuthPendingFlowRecord | null> {
+    await this.cleanupExpired(provider);
+    const rows = (await this.dataSource.query(
+      `
+        SELECT "provider", "state", "code_verifier", "agent_id", "user_id", "expires_at"
+        FROM "oauth_pending_flows"
+        WHERE "provider" = $1
+          AND "agent_id" = $2
+          AND "user_id" = $3
+          AND "expires_at" > NOW()
+        ORDER BY "created_at" DESC
+        LIMIT 1
+      `,
+      [provider, agentId, userId],
+    )) as RawOAuthPendingFlow[];
+
+    return rows[0] ? mapRow(rows[0]) : null;
+  }
+
+  async clear(provider: string, state: string): Promise<void> {
+    await this.dataSource.query(
+      `
+        DELETE FROM "oauth_pending_flows"
+        WHERE "provider" = $1
+          AND "state" = $2
+      `,
+      [provider, state],
+    );
+  }
+
+  async count(provider: string): Promise<number> {
+    await this.cleanupExpired(provider);
+    const rows = (await this.dataSource.query(
+      `
+        SELECT COUNT(*)::int AS "count"
+        FROM "oauth_pending_flows"
+        WHERE "provider" = $1
+      `,
+      [provider],
+    )) as Array<{ count: number | string }>;
+    return Number(rows[0]?.count ?? 0);
+  }
+
+  async cleanupExpired(provider?: string): Promise<void> {
+    if (provider) {
+      await this.dataSource.query(
+        `
+          DELETE FROM "oauth_pending_flows"
+          WHERE "provider" = $1
+            AND "expires_at" <= NOW()
+        `,
+        [provider],
+      );
+      return;
+    }
+
+    await this.dataSource.query(
+      `
+        DELETE FROM "oauth_pending_flows"
+        WHERE "expires_at" <= NOW()
+      `,
+    );
+  }
+
+  @Cron(CronExpression.EVERY_HOUR)
+  async cleanupExpiredCron(): Promise<void> {
+    try {
+      await this.cleanupExpired();
+    } catch (err) {
+      this.logger.warn(`Failed to clean expired OAuth pending flows: ${err}`);
+    }
+  }
+}
+
+function mapRow(row: RawOAuthPendingFlow): OAuthPendingFlowRecord {
+  const expiresAt =
+    row.expires_at instanceof Date ? row.expires_at.getTime() : new Date(row.expires_at).getTime();
+  return {
+    provider: row.provider,
+    state: row.state,
+    verifier: row.code_verifier,
+    agentId: row.agent_id,
+    userId: row.user_id,
+    expiresAt,
+  };
+}

--- a/packages/backend/src/routing/oauth/oauth.module.ts
+++ b/packages/backend/src/routing/oauth/oauth.module.ts
@@ -8,6 +8,7 @@ import { MinimaxOauthController } from './minimax-oauth.controller';
 import { CopilotDeviceAuthService } from './copilot-device-auth.service';
 import { AnthropicOauthService } from './anthropic/anthropic-oauth.service';
 import { AnthropicOauthController } from './anthropic/anthropic-oauth.controller';
+import { OAuthPendingFlowStore } from './core';
 
 @Module({
   imports: [RoutingCoreModule, ModelDiscoveryModule],
@@ -17,6 +18,7 @@ import { AnthropicOauthController } from './anthropic/anthropic-oauth.controller
     MinimaxOauthService,
     CopilotDeviceAuthService,
     AnthropicOauthService,
+    OAuthPendingFlowStore,
   ],
   exports: [
     OpenaiOauthService,

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -13,7 +13,7 @@ import {
   isManifestUsableProvider,
   isSupportedSubscriptionProvider,
 } from '../../common/utils/subscription-support';
-import type { AuthType } from 'manifest-shared';
+import type { AuthType, ModelRoute } from 'manifest-shared';
 import { TIER_LABELS } from 'manifest-shared';
 import { detectQwenRegion, isQwenRegion, isQwenResolvedRegion } from '../qwen-region';
 import { isMinimaxRegion } from '../oauth/minimax-oauth-helpers';
@@ -707,9 +707,7 @@ export class ProviderService {
     // provider's "Default" key doesn't accidentally rewrite another provider's
     // pinned label that happens to share the same string. Cubic flagged this
     // as P1 — keep it tight.
-    const routeMatchesKey = (
-      route: { provider: string; authType: string; keyLabel?: string | null } | null,
-    ): boolean => {
+    const routeMatchesKey = (route: ModelRoute | null): boolean => {
       if (!route) return false;
       if (!route.keyLabel) return false;
       if (route.keyLabel.toLowerCase() !== previousLower) return false;
@@ -717,7 +715,7 @@ export class ProviderService {
       if (route.authType !== authType) return false;
       return true;
     };
-    const replaceKeyLabel = <T extends { keyLabel?: string | null }>(route: T): T => ({
+    const replaceKeyLabel = (route: ModelRoute): ModelRoute => ({
       ...route,
       keyLabel: nextLabel ?? null,
     });

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -103,30 +103,19 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
       );
       return;
     }
+    const pastedState = raw.slice(raw.indexOf('#') + 1);
+    if (!pastedState) {
+      setError(
+        "That doesn't look like an authorization code. Make sure you copied the full string from the redirect page.",
+      );
+      return;
+    }
 
     props.setBusy(true);
     setError(null);
     try {
-      // The local `state` signal may have been lost (modal close). Hydrate
-      // from the backend so the user can finish without restarting the flow.
-      let authState = state();
-      if (!authState) {
-        try {
-          const pending = await getAnthropicOAuthPending(props.agentName);
-          if (pending.state) {
-            setState(pending.state);
-            authState = pending.state;
-          }
-        } catch {
-          // fall through to the error below
-        }
-      }
-      if (!authState) {
-        setError('Click "Sign in with Claude" first, then paste the authorization code.');
-        return;
-      }
-      const code = raw.slice(0, raw.indexOf('#'));
-      await submitAnthropicOAuth(props.agentName, code, authState);
+      const authState = state() ?? pastedState;
+      await submitAnthropicOAuth(props.agentName, raw, authState);
       toast.success(`${props.provDef.name} subscription connected`);
       props.onUpdate();
     } catch {

--- a/packages/frontend/src/services/api/oauth.ts
+++ b/packages/frontend/src/services/api/oauth.ts
@@ -73,12 +73,12 @@ export function startAnthropicOAuth(agentName: string) {
   );
 }
 
-export function submitAnthropicOAuth(agentName: string, code: string, state: string) {
+export function submitAnthropicOAuth(agentName: string, payload: string, state: string) {
   return fetchMutate<{ ok: boolean }>(
     `/oauth/anthropic/exchange?agentName=${encodeURIComponent(agentName)}`,
     {
       method: 'POST',
-      body: JSON.stringify({ code, state }),
+      body: JSON.stringify({ code: payload, state }),
       headers: { 'Content-Type': 'application/json' },
     },
   );

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -131,7 +131,7 @@ describe('AnthropicOAuthDetailView', () => {
     await waitFor(() => {
       expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith(
         'test-agent',
-        'auth-code-123',
+        OAUTH_PAYLOAD,
         'state-xyz',
       );
     });
@@ -164,16 +164,14 @@ describe('AnthropicOAuthDetailView', () => {
     await waitFor(() => {
       expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith(
         'test-agent',
-        'fresh-code',
+        'fresh-code#persisted-state',
         'persisted-state',
       );
     });
   });
 
-  it('hydrates pending state at submit time when the local signal was lost', async () => {
-    mockGetAnthropicOAuthPending
-      .mockResolvedValueOnce({ state: null }) // onMount call
-      .mockResolvedValueOnce({ state: 'late-state' }); // submit call
+  it('uses the pasted state when the local signal was lost', async () => {
+    mockGetAnthropicOAuthPending.mockResolvedValue({ state: null });
     mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
 
     renderView();
@@ -184,12 +182,17 @@ describe('AnthropicOAuthDetailView', () => {
     fireEvent.click(screen.getByText('Connect'));
 
     await waitFor(() => {
-      expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith('test-agent', 'code', 'late-state');
+      expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith(
+        'test-agent',
+        'code#whatever',
+        'whatever',
+      );
     });
   });
 
-  it('asks the user to sign in first when no pending state is available', async () => {
+  it('submits the full pasted payload even when no pending state hydrates locally', async () => {
     mockGetAnthropicOAuthPending.mockResolvedValue({ state: null });
+    mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
 
     renderView();
     await waitFor(() => expect(mockGetAnthropicOAuthPending).toHaveBeenCalled());
@@ -199,8 +202,21 @@ describe('AnthropicOAuthDetailView', () => {
     fireEvent.click(screen.getByText('Connect'));
 
     await waitFor(() => {
-      expect(screen.getByText(/Click "Sign in with Claude" first/)).toBeDefined();
+      expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith(
+        'test-agent',
+        'orphan-code#orphan-state',
+        'orphan-state',
+      );
     });
+  });
+
+  it('rejects payloads missing the state suffix', () => {
+    renderView();
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'auth-code#' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    expect(screen.getByText(/doesn't look like an authorization code/)).toBeDefined();
     expect(mockSubmitAnthropicOAuth).not.toHaveBeenCalled();
   });
 
@@ -235,10 +251,9 @@ describe('AnthropicOAuthDetailView', () => {
     expect(mockGetAnthropicOAuthPending).not.toHaveBeenCalled();
   });
 
-  it('falls back gracefully when the late-arriving pending lookup throws', async () => {
-    mockGetAnthropicOAuthPending
-      .mockResolvedValueOnce({ state: null }) // onMount
-      .mockRejectedValueOnce(new Error('network')); // submit-time
+  it('does not need a submit-time pending lookup when the pasted payload contains state', async () => {
+    mockGetAnthropicOAuthPending.mockResolvedValue({ state: null });
+    mockSubmitAnthropicOAuth.mockResolvedValue({ ok: true });
 
     renderView();
     await waitFor(() => expect(mockGetAnthropicOAuthPending).toHaveBeenCalledTimes(1));
@@ -248,8 +263,13 @@ describe('AnthropicOAuthDetailView', () => {
     fireEvent.click(screen.getByText('Connect'));
 
     await waitFor(() => {
-      expect(screen.getByText(/Click "Sign in with Claude" first/)).toBeDefined();
+      expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith(
+        'test-agent',
+        'code#whatever',
+        'whatever',
+      );
     });
+    expect(mockGetAnthropicOAuthPending).toHaveBeenCalledTimes(1);
   });
 
   it('submits on Enter inside the paste input', async () => {
@@ -365,10 +385,7 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
   });
 
   it('renders the multi-key list when activeKeys has 2+ items', () => {
-    const keys = [
-      makeKey({ id: 'k1', label: 'Work' }),
-      makeKey({ id: 'k2', label: 'Personal' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Work' }), makeKey({ id: 'k2', label: 'Personal' })];
     renderMultiKeyView(keys);
     expect(screen.getByText('Accounts')).toBeDefined();
     expect(screen.getByText('Work')).toBeDefined();
@@ -377,10 +394,7 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
 
   it('rename flow: clicking Rename shows input and saving calls renameProviderKey', async () => {
     mockRenameProviderKey.mockResolvedValue({ id: 'k1', label: 'New', priority: 1 });
-    const keys = [
-      makeKey({ id: 'k1', label: 'Old' }),
-      makeKey({ id: 'k2', label: 'Other' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Old' }), makeKey({ id: 'k2', label: 'Other' })];
     const { onUpdate } = renderMultiKeyView(keys);
 
     const renameButtons = screen.getAllByText('Rename');
@@ -421,10 +435,7 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
   });
 
   it('shows "Disconnect all" button in multi-key mode', () => {
-    const keys = [
-      makeKey({ id: 'k1', label: 'A' }),
-      makeKey({ id: 'k2', label: 'B' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'A' }), makeKey({ id: 'k2', label: 'B' })];
     renderMultiKeyView(keys);
     expect(screen.getByText('Disconnect all')).toBeDefined();
   });
@@ -465,10 +476,7 @@ describe('AnthropicOAuthDetailView — multi-key', () => {
 
   it('commitRename catch branch when renameProviderKey fails', async () => {
     mockRenameProviderKey.mockRejectedValue(new Error('network'));
-    const keys = [
-      makeKey({ id: 'k1', label: 'Old' }),
-      makeKey({ id: 'k2', label: 'Other' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Old' }), makeKey({ id: 'k2', label: 'Other' })];
     const { onUpdate } = renderMultiKeyView(keys);
 
     const renameButtons = screen.getAllByText('Rename');

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -66,7 +66,8 @@ vi.mock('../../src/services/toast-store.js', () => ({
 }));
 
 vi.mock('../../src/components/ProviderIcon.js', () => ({
-  providerIcon: () => null, customProviderLogo: () => null,
+  providerIcon: () => null,
+  customProviderLogo: () => null,
 }));
 
 import ProviderSelectModal from '../../src/components/ProviderSelectModal';
@@ -171,12 +172,17 @@ describe('ProviderSelectModal', () => {
     expect(screen.getByText('OpenRouter')).toBeDefined();
   });
 
-  it("does not show subscription-only providers in the API Keys tab", () => {
+  it('does not show subscription-only providers in the API Keys tab', () => {
     render(() => (
-      <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+      <ProviderSelectModal
+        providers={[]}
+        onClose={onClose}
+        onUpdate={onUpdate}
+        agentName="test-agent"
+      />
     ));
-    fireEvent.click(screen.getByText("API Keys"));
-    expect(screen.queryByText("GitHub Copilot")).toBeNull();
+    fireEvent.click(screen.getByText('API Keys'));
+    expect(screen.queryByText('GitHub Copilot')).toBeNull();
   });
 
   it("shows toggle switch in 'on' state for connected providers", () => {
@@ -552,7 +558,12 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByLabelText('Disconnect provider'));
 
       await waitFor(() => {
-        expect(mockDisconnectProvider).toHaveBeenCalledWith('test-agent', 'openai', 'api_key', undefined);
+        expect(mockDisconnectProvider).toHaveBeenCalledWith(
+          'test-agent',
+          'openai',
+          'api_key',
+          undefined,
+        );
       });
       expect(onUpdate).toHaveBeenCalled();
     });
@@ -1022,9 +1033,11 @@ describe('ProviderSelectModal', () => {
       fireEvent.click(screen.getByText('Connect'));
 
       await waitFor(() => {
-        // The view strips the `#state` suffix before submitting; the state is
-        // provided alongside as the second arg.
-        expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith('test-agent', 'auth-code-123', 'xyz');
+        expect(mockSubmitAnthropicOAuth).toHaveBeenCalledWith(
+          'test-agent',
+          'auth-code-123#xyz',
+          'xyz',
+        );
       });
       expect(toast.success).toHaveBeenCalledWith('Anthropic subscription connected');
       windowOpenSpy.mockRestore();
@@ -1069,9 +1082,7 @@ describe('ProviderSelectModal', () => {
           agentName="test-agent"
         />
       ));
-      expect(
-        screen.getByText(/Use your existing subscription or paid plan/),
-      ).toBeDefined();
+      expect(screen.getByText(/Use your existing subscription or paid plan/)).toBeDefined();
     });
 
     it('shows tab hint text for API Keys tab', () => {
@@ -1310,9 +1321,7 @@ describe('ProviderSelectModal', () => {
 
     it('opens the popup synchronously then redirects it to the verification URL', async () => {
       const popup = { close: vi.fn(), opener: {}, location: { replace: vi.fn() } };
-      const openSpy = vi
-        .spyOn(window, 'open')
-        .mockReturnValue(popup as unknown as Window);
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(popup as unknown as Window);
 
       render(() => (
         <ProviderSelectModal
@@ -1827,7 +1836,7 @@ describe('ProviderSelectModal', () => {
       ));
       fireEvent.click(screen.getByText('OpenAI'));
       // Should not have a setup token input field
-      const inputs = document.querySelectorAll(".provider-detail__input--masked");
+      const inputs = document.querySelectorAll('.provider-detail__input--masked');
       expect(inputs.length).toBe(0);
     });
 
@@ -2198,12 +2207,17 @@ describe('ProviderSelectModal', () => {
       vi.restoreAllMocks();
     });
 
-    it("opens device login view for copilot instead of toggling directly", async () => {
+    it('opens device login view for copilot instead of toggling directly', async () => {
       render(() => (
-        <ProviderSelectModal providers={[]} onClose={onClose} onUpdate={onUpdate} agentName="test-agent" />
+        <ProviderSelectModal
+          providers={[]}
+          onClose={onClose}
+          onUpdate={onUpdate}
+          agentName="test-agent"
+        />
       ));
       // Find the copilot row and click its toggle area
-      const copilotText = screen.getByText("GitHub Copilot");
+      const copilotText = screen.getByText('GitHub Copilot');
       expect(copilotText).toBeDefined();
 
       // Click the Copilot row (toggle)
@@ -2211,21 +2225,21 @@ describe('ProviderSelectModal', () => {
 
       // Should open device login detail view instead of calling connectProvider
       await waitFor(() => {
-        expect(screen.getByText("Connect providers")).toBeDefined();
+        expect(screen.getByText('Connect providers')).toBeDefined();
       });
       // connectProvider should NOT have been called (device login guard)
       expect(mockConnectProvider).not.toHaveBeenCalled();
     });
 
-    it("opens device login detail view for connected copilot (disconnect via detail)", async () => {
+    it('opens device login detail view for connected copilot (disconnect via detail)', async () => {
       const copilotSubProvider: RoutingProvider = {
-        id: "p-copilot",
-        provider: "copilot",
+        id: 'p-copilot',
+        provider: 'copilot',
         is_active: true,
         has_api_key: true,
-        key_prefix: "ghu_",
-        connected_at: "2025-01-01",
-        auth_type: "subscription",
+        key_prefix: 'ghu_',
+        connected_at: '2025-01-01',
+        auth_type: 'subscription',
       };
       render(() => (
         <ProviderSelectModal
@@ -2236,12 +2250,12 @@ describe('ProviderSelectModal', () => {
         />
       ));
       // Click the copilot row — always navigates to detail view
-      const copilotText = screen.getByText("GitHub Copilot");
+      const copilotText = screen.getByText('GitHub Copilot');
       fireEvent.click(copilotText);
 
       // Should open device login detail view (with disconnect button)
       await waitFor(() => {
-        expect(screen.getByText("Connected via GitHub device login.")).toBeDefined();
+        expect(screen.getByText('Connected via GitHub device login.')).toBeDefined();
       });
     });
   });


### PR DESCRIPTION
## Summary
- persist Anthropic OAuth pending PKCE state in Postgres instead of backend process memory
- scope pending flow consumption by provider, agent, and user
- submit the full pasted `code#state` payload from the frontend so modal/local state loss does not break exchange
- add cleanup for expired pending rows and a patch changeset

## Migration
- Adds `oauth_pending_flows` for short-lived OAuth state/verifier rows.
- Existing startup migrations will create the table automatically.

## Validation
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts src/routing/oauth/core/oauth-pending-flow.store.spec.ts`
- `cd packages/backend && npx jest --coverage --collectCoverageFrom="routing/oauth/core/oauth-pending-flow.store.ts" routing/oauth/core/oauth-pending-flow.store.spec.ts` (100% line coverage for the new store)
- `npm test --workspace=packages/frontend -- AnthropicOAuthDetailView.test.tsx ProviderSelectModal.test.tsx oauth.test.ts`
- `cd packages/backend && npx tsc --noEmit`
- `cd packages/frontend && npx tsc --noEmit`
- `npm run build --workspace=packages/backend`
- `npm run build --workspace=packages/frontend`
- `npm run lint --workspace=packages/backend` (exits 0; existing warnings)
- `npm run lint --workspace=packages/frontend` (exits 0; existing warnings)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist Anthropic OAuth pending PKCE state in Postgres so exchanges survive reloads, restarts, and multi-instance routing. The flow is scoped by provider, agent, and user, and the frontend now submits the full pasted `code#state` to prevent local state loss.

- **New Features**
  - Added `oauth_pending_flows` table and server-side `OAuthPendingFlowStore` with TTL, provider-scoped cleanup, and an hourly cron.
  - Backend exchange consumes pending state with `provider+state+agentId+userId`; pending lookup returns the latest for that agent and user.
  - Frontend validates the pasted payload includes `#state` and sends the full `code#state`; falls back to the pasted state when local state is missing.
  - Tests updated; endpoints unchanged.

- **Migration**
  - Adds `oauth_pending_flows` for short-lived OAuth state/verifier rows.
  - Startup migrations create the table automatically; no manual steps.

<sup>Written for commit 3ff30875d8b94d7a5678ddaa1db7389b3a9d7076. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1938?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

