### PR TITLE
fix: hide misleading empty tier label in Playground

### DIFF
--- a/.changeset/playground-hide-empty-tier.md
+++ b/.changeset/playground-hide-empty-tier.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Hide the misleading empty "tier" label in the Playground model picker. The subtitle now only shows when a real routing tier applies.

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -256,6 +256,12 @@ const ModelPickerModal: Component<Props> = (props) => {
   const isLocal = () => activeTab() === 'local';
   const isPaid = () => !isSub() && !isLocal();
 
+  // Resolve the routing-tier label for the subtitle. Callers outside the
+  // routing context (e.g. the Playground) pass a non-tier id, so there is no
+  // matching stage — render no subtitle instead of a bare "tier".
+  const tierLabel = () =>
+    [DEFAULT_STAGE, ...STAGES, ...SPECIFICITY_STAGES].find((s) => s.id === props.tierId)?.label;
+
   return (
     <div
       class="modal-overlay"
@@ -278,13 +284,9 @@ const ModelPickerModal: Component<Props> = (props) => {
             <div class="routing-modal__title" id="model-picker-title">
               Select a model
             </div>
-            <div class="routing-modal__subtitle">
-              {
-                [DEFAULT_STAGE, ...STAGES, ...SPECIFICITY_STAGES].find((s) => s.id === props.tierId)
-                  ?.label
-              }{' '}
-              tier
-            </div>
+            <Show when={tierLabel()}>
+              {(label) => <div class="routing-modal__subtitle">{label()} tier</div>}
+            </Show>
           </div>
           <button class="modal__close" onClick={() => props.onClose()} aria-label="Close">
             <svg

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -201,6 +201,21 @@ describe("ModelPickerModal", () => {
     );
   });
 
+  it("omits the subtitle entirely when the tier id matches no stage (Playground)", () => {
+    const { container } = render(() => (
+      <ModelPickerModal
+        tierId="playground:col-1"
+        models={baseModels}
+        tiers={[]}
+        connectedProviders={apiKeyOnly}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+    // No matching stage → render nothing rather than a misleading bare "tier".
+    expect(container.querySelector(".routing-modal__subtitle")).toBeNull();
+  });
+
   describe("per-group refresh button", () => {
     it("does not render group refresh buttons when agentName is missing", () => {
       const { container } = render(() => (


### PR DESCRIPTION
### 💭 Why
On the Playground, the "Select a model" modal showed a bare "tier" line under the title. The Playground passes a non-routing tier id, so the label resolved to nothing and only the word "tier" was left. It read as broken.

### ✨ What changed
- Subtitle is wrapped in a `Show` and only renders when the tier id maps to a real routing stage.
- Added a test covering the no-match (Playground) case.

### 👤 For users
The Playground model picker no longer shows a stray "tier" label. Routing pages still show "<label> tier" as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the misleading empty "tier" label in the Playground model picker. The subtitle now renders only when `tierId` maps to a real routing stage; routing pages remain unchanged.

- **Bug Fixes**
  - Conditionally render the subtitle only when a matching stage label exists.
  - Added a test covering the no-match Playground case.

<sup>Written for commit 2b1c9b5cb72117af08012abec8542059daf0b97c. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1939?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

