### PR TITLE
fix: custom providers work in the Playground

### DIFF
--- a/.changeset/playground-custom-providers.md
+++ b/.changeset/playground-custom-providers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix custom providers in the Playground. Selecting a model from a custom (OpenAI/Anthropic-compatible) provider now resolves its endpoint instead of failing with "Provider request failed".

--- a/packages/backend/src/playground/playground.module.ts
+++ b/packages/backend/src/playground/playground.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
+import { CustomProvider } from '../entities/custom-provider.entity';
 import { CommonModule } from '../common/common.module';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { RoutingCoreModule } from '../routing/routing-core/routing-core.module';
@@ -13,7 +14,7 @@ import { PlaygroundHistoryService } from './playground-history.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AgentMessage, PlaygroundRun, PlaygroundColumn]),
+    TypeOrmModule.forFeature([AgentMessage, PlaygroundRun, PlaygroundColumn, CustomProvider]),
     CommonModule,
     ModelPricesModule,
     RoutingCoreModule,

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -9,6 +9,7 @@ import type { IngestEventBusService } from '../common/services/ingest-event-bus.
 import type { PlaygroundHistoryService } from './playground-history.service';
 import type { Repository } from 'typeorm';
 import type { AgentMessage } from '../entities/agent-message.entity';
+import type { CustomProvider } from '../entities/custom-provider.entity';
 import type { RunPlaygroundDto } from './dto/run-playground.dto';
 
 const USER_ID = 'user-1';
@@ -144,6 +145,7 @@ interface Mocks {
   eventBus: { emit: jest.Mock };
   history: { saveColumn: jest.Mock };
   messageRepo: { insert: jest.Mock };
+  customProviderRepo: { findOne: jest.Mock };
 }
 
 function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService; mocks: Mocks } {
@@ -171,6 +173,7 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     eventBus: { emit: jest.fn() },
     history: { saveColumn: jest.fn().mockResolvedValue('col-1') },
     messageRepo: { insert: jest.fn().mockResolvedValue(undefined) },
+    customProviderRepo: { findOne: jest.fn().mockResolvedValue(null) },
     ...mocks,
   };
   const service = new PlaygroundService(
@@ -181,6 +184,7 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     full.eventBus as unknown as IngestEventBusService,
     full.history as unknown as PlaygroundHistoryService,
     full.messageRepo as unknown as Repository<AgentMessage>,
+    full.customProviderRepo as unknown as Repository<CustomProvider>,
   );
   return { service, mocks: full };
 }
@@ -234,6 +238,31 @@ describe('PlaygroundService.runStream', () => {
       status: 'success',
       content: 'hello',
     });
+  });
+
+  it('resolves a custom provider endpoint and forwards the raw (unprefixed) model name', async () => {
+    const { service, mocks } = buildService();
+    mocks.customProviderRepo.findOne.mockResolvedValue({
+      id: 'abc',
+      base_url: 'https://nebius.example/v1',
+      api_kind: 'openai',
+    });
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream(['data: {"choices":[{"delta":{"content":"OK"}}]}\n\n', 'data: [DONE]\n\n']),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ provider: 'custom:abc', model: 'custom:abc/meta-llama/Llama-3.1-8B' }),
+      asRes(res),
+    );
+
+    const call = mocks.providerClient.forward.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.provider).toBe('custom:abc');
+    expect(call.customEndpoint).toBeDefined();
+    // Prefix stripped — the custom endpoint expects the bare upstream model id.
+    expect(call.model).toBe('meta-llama/Llama-3.1-8B');
   });
 
   it('defaults all token counts to 0 when the stream reports no usage block', async () => {

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -5,7 +5,10 @@ import { v4 as uuid } from 'uuid';
 import type { Response as ExpressResponse } from 'express';
 import type { AuthType, PlaygroundStreamEvent } from 'manifest-shared';
 import { AgentMessage } from '../entities/agent-message.entity';
+import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderClient } from '../routing/proxy/provider-client';
+import { buildCustomEndpoint } from '../routing/proxy/provider-endpoints';
+import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
 import { ProviderKeyService } from '../routing/routing-core/provider-key.service';
 import { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
@@ -32,6 +35,8 @@ export class PlaygroundService {
     private readonly history: PlaygroundHistoryService,
     @InjectRepository(AgentMessage)
     private readonly messageRepo: Repository<AgentMessage>,
+    @InjectRepository(CustomProvider)
+    private readonly customProviderRepo: Repository<CustomProvider>,
   ) {}
 
   /**
@@ -75,17 +80,34 @@ export class PlaygroundService {
     const abort = new AbortController();
     res.on('close', () => abort.abort());
 
+    // Custom providers carry their endpoint (base URL + API kind) on the
+    // CustomProvider row, not in the static registry — resolve it the same
+    // way the proxy does, otherwise ProviderClient has no endpoint to forward
+    // to and crashes on `endpoint.format`.
+    let customEndpoint: ReturnType<typeof buildCustomEndpoint> | undefined;
+    let forwardModel = dto.model;
+    if (CustomProviderService.isCustom(dto.provider)) {
+      const cp = await this.customProviderRepo.findOne({
+        where: { id: CustomProviderService.extractId(dto.provider) },
+      });
+      if (cp) {
+        customEndpoint = buildCustomEndpoint(cp.base_url, cp.api_kind ?? 'openai');
+        forwardModel = CustomProviderService.rawModelName(dto.model);
+      }
+    }
+
     const startedAt = Date.now();
     let forward;
     try {
       forward = await this.providerClient.forward({
         provider: dto.provider,
         apiKey,
-        model: dto.model,
+        model: forwardModel,
         body: buildForwardBody(dto),
         stream: true,
         authType,
         extraHeaders,
+        customEndpoint,
         signal: abort.signal,
       });
     } catch (err) {


### PR DESCRIPTION
### 💭 Why
Picking a model from a custom (OpenAI/Anthropic-compatible) provider in the Playground always failed with "Provider request failed: Cannot read properties of undefined (reading 'format')". Found while testing real provider keys end to end (Nebius via a custom provider).

### ✨ What changed
- Playground resolves the CustomProvider row and builds its endpoint (base URL + API kind) before forwarding, and strips the `custom:<id>/` prefix from the model. Mirrors the main proxy path.

### 👤 For users
Custom providers now run in the Playground instead of erroring. Verified live with 13 provider keys (OpenAI, Anthropic key + subscription, Gemini, Mistral, DeepSeek, Z.AI, xAI, Moonshot, OpenRouter, Nebius custom) all returning responses.

### 📝 Notes
- Follow-up to the Playground feature (#1937). Not a migration or config change.
- The reported Claude-subscription 401 was a separate, expired `sk-ant-oat01-` token on the deployed instance, not a code bug. The subscription path works with a fresh token.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes custom providers in the Playground by resolving their endpoint and stripping the model prefix, preventing "Provider request failed: Cannot read properties of undefined (reading 'format')". Selecting models from `custom:` providers now works.

- **Bug Fixes**
  - Resolve `CustomProvider` from the DB and build its endpoint before forwarding; pass `customEndpoint` to `ProviderClient`.
  - Strip `custom:<id>/` from the model so the upstream receives the raw model name.
  - Wire the `CustomProvider` repository into the module and add a test for endpoint resolution and model forwarding.

<sup>Written for commit d00e52b6a17f69c90589797df31d8af9b25df6eb. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1940?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

