### PR TITLE
fix(anthropic): persist and align oauth pending state

### DIFF
--- a/.changeset/fix-anthropic-oauth-state-verifier.md
+++ b/.changeset/fix-anthropic-oauth-state-verifier.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Align Anthropic OAuth state handling with the Claude Code PKCE flow.

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -146,6 +146,11 @@ describe('AnthropicOauthService', () => {
       expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
       expect(parsed.searchParams.get('code_challenge')?.length).toBeGreaterThan(0);
       expect(parsed.searchParams.get('state')).toBe(state);
+      expect(pendingStore.svc.create).toHaveBeenCalledWith(
+        'anthropic',
+        expect.objectContaining({ state, verifier: state }),
+        ANTHROPIC_OAUTH.STATE_TTL_MS,
+      );
       await expect(svc.getPendingCount()).resolves.toBe(1);
     });
   });
@@ -197,7 +202,7 @@ describe('AnthropicOauthService', () => {
       expect(body.grant_type).toBe('authorization_code');
       expect(body.code).toBe('auth-code');
       expect(body.state).toBe(state);
-      expect(body.code_verifier?.length).toBeGreaterThan(0);
+      expect(body.code_verifier).toBe(state);
 
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
         'agent-1',
@@ -219,6 +224,19 @@ describe('AnthropicOauthService', () => {
       );
       const { state } = await svc.generateAuthorizationUrl('a', 'u');
       await svc.exchangeCode('plain-code', state, 'a', 'u');
+      expect(providerService.upsertProvider).toHaveBeenCalled();
+    });
+
+    it('falls back to the latest pending state when the client posts a bare code', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),
+      );
+      const { state } = await svc.generateAuthorizationUrl('a', 'u');
+
+      await svc.exchangeCode('plain-code', undefined, 'a', 'u');
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(JSON.parse(init.body).state).toBe(state);
       expect(providerService.upsertProvider).toHaveBeenCalled();
     });
 

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -4,7 +4,6 @@ import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.
 import { scrubSecrets } from '../../../common/utils/secret-scrub';
 import {
   generatePkce,
-  generateState,
   OAuthPendingFlowStore,
   parseOAuthTokenBlob,
   serializeOAuthTokenBlob,
@@ -56,8 +55,9 @@ export class AnthropicOauthService {
    * returned so the SPA can pre-fill it on the paste-code step.
    */
   async generateAuthorizationUrl(agentId: string, userId: string): Promise<AuthorizeResult> {
-    const state = generateState();
     const { verifier, challenge } = generatePkce();
+    // Claude Code's Anthropic OAuth flow uses the PKCE verifier as state.
+    const state = verifier;
     await this.pendingFlows.create(
       PROVIDER,
       { state, verifier, agentId, userId },
@@ -89,8 +89,12 @@ export class AnthropicOauthService {
     userId: string,
   ): Promise<void> {
     const { code, state: extractedState } = splitAnthropicAuthPayload(payload);
-    const state = extractedState ?? fallbackState;
+    let state = extractedState ?? fallbackState;
     if (!code) throw new Error('Missing authorization code');
+    if (!state) {
+      const latest = await this.pendingFlows.findLatestForAgent(PROVIDER, agentId, userId);
+      state = latest?.state;
+    }
     if (!state) throw new Error('Missing OAuth state');
 
     const pending = await this.pendingFlows.consume(PROVIDER, state, agentId, userId);


### PR DESCRIPTION
## Summary
- align Anthropic OAuth authorize state with the Claude Code PKCE convention by using `state === code_verifier`
- recover the latest server-side pending state when the client posts only a bare code
- add regression coverage and a patch changeset

## Why
- PR #1938 fixed the production-only process-memory problem by persisting pending PKCE state in Postgres, and it has already merged.
- A production retest then reached Anthropic's token endpoint but failed with `Invalid request format`.
- A dummy, non-secret probe against the token endpoint showed Anthropic returns that exact error when required token fields like `state` or `code_verifier` are absent or empty, while a complete fake request returns `invalid_grant` instead.
- Claude Code-compatible Anthropic OAuth examples use the PKCE verifier as the OAuth `state`; this PR makes Manifest do the same for new flows and keeps server-side state recovery as a fallback.

## Validation
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts src/routing/oauth/core/oauth-pending-flow.store.spec.ts`
- `cd packages/backend && npx tsc --noEmit`
- `git diff --check`
- commit-time lint-staged ESLint/Prettier on changed files
