### PR TITLE
fix(anthropic): send oauth token user agent

### DIFF
--- a/.changeset/fix-anthropic-oauth-token-request.md
+++ b/.changeset/fix-anthropic-oauth-token-request.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add Claude Code-compatible Anthropic OAuth token headers and safe request-shape diagnostics.

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -198,6 +198,10 @@ describe('AnthropicOauthService', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const [tokenUrl, init] = fetchMock.mock.calls[0];
       expect(tokenUrl).toBe(ANTHROPIC_OAUTH.TOKEN_URL);
+      expect(init.headers).toEqual({
+        'Content-Type': 'application/json',
+        'User-Agent': 'anthropic',
+      });
       const body = JSON.parse(init.body);
       expect(body.grant_type).toBe('authorization_code');
       expect(body.code).toBe('auth-code');
@@ -243,8 +247,14 @@ describe('AnthropicOauthService', () => {
     it('throws when the token endpoint returns an error', async () => {
       fetchMock.mockResolvedValue(mockResponse(400, {}, 'invalid_grant'));
       const { state } = await svc.generateAuthorizationUrl('a', 'u');
+      const logger = { error: jest.fn(), log: jest.fn(), warn: jest.fn() };
+      (svc as unknown as { logger: typeof logger }).logger = logger;
+
       await expect(svc.exchangeCode(`bad#${state}`, undefined, 'a', 'u')).rejects.toThrow(
         'Token exchange failed',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('"stateMatchesCodeVerifier":true'),
       );
     });
 
@@ -275,6 +285,10 @@ describe('AnthropicOauthService', () => {
       );
       const blob = await svc.refreshAccessToken('old-refresh');
       expect(blob).toEqual({ t: 'a2', r: 'r2', e: Date.now() + 1800 * 1000 });
+      expect(fetchMock.mock.calls[0][1].headers).toEqual({
+        'Content-Type': 'application/json',
+        'User-Agent': 'anthropic',
+      });
     });
 
     it('retains the old refresh token when the server omits a new one', async () => {

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -24,6 +24,10 @@ interface AnthropicTokenResponse {
 }
 
 const PROVIDER = 'anthropic';
+const ANTHROPIC_OAUTH_TOKEN_HEADERS = {
+  'Content-Type': 'application/json',
+  'User-Agent': 'anthropic',
+} as const;
 
 /**
  * Splits Anthropic's pasted authorization payload. The redirect page renders
@@ -89,7 +93,7 @@ export class AnthropicOauthService {
     userId: string,
   ): Promise<void> {
     const { code, state: extractedState } = splitAnthropicAuthPayload(payload);
-    let state = extractedState ?? fallbackState;
+    let state = extractedState ?? fallbackState?.trim();
     if (!code) throw new Error('Missing authorization code');
     if (!state) {
       const latest = await this.pendingFlows.findLatestForAgent(PROVIDER, agentId, userId);
@@ -103,21 +107,26 @@ export class AnthropicOauthService {
       throw new Error('OAuth state expired');
     }
 
+    const tokenRequest = {
+      grant_type: 'authorization_code',
+      code,
+      state,
+      client_id: ANTHROPIC_OAUTH.CLIENT_ID,
+      redirect_uri: ANTHROPIC_OAUTH.REDIRECT_URI,
+      code_verifier: pending.verifier,
+    };
     const response = await fetch(ANTHROPIC_OAUTH.TOKEN_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        grant_type: 'authorization_code',
-        code,
-        state,
-        client_id: ANTHROPIC_OAUTH.CLIENT_ID,
-        redirect_uri: ANTHROPIC_OAUTH.REDIRECT_URI,
-        code_verifier: pending.verifier,
-      }),
+      headers: ANTHROPIC_OAUTH_TOKEN_HEADERS,
+      body: JSON.stringify(tokenRequest),
     });
     if (!response.ok) {
       const text = await response.text();
-      this.logger.error(`Anthropic token exchange failed: ${scrubSecrets(text)}`);
+      this.logger.error(
+        `Anthropic token exchange failed: ${scrubSecrets(text)}; request_shape=${JSON.stringify(
+          describeTokenExchangeRequest(tokenRequest),
+        )}`,
+      );
       throw new Error('Token exchange failed');
     }
     const data = (await response.json()) as AnthropicTokenResponse;
@@ -149,7 +158,7 @@ export class AnthropicOauthService {
   async refreshAccessToken(refreshToken: string): Promise<OAuthTokenBlob> {
     const response = await fetch(ANTHROPIC_OAUTH.TOKEN_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: ANTHROPIC_OAUTH_TOKEN_HEADERS,
       body: JSON.stringify({
         grant_type: 'refresh_token',
         refresh_token: refreshToken,
@@ -224,4 +233,26 @@ export class AnthropicOauthService {
     const pending = await this.pendingFlows.findLatestForAgent(PROVIDER, agentId, userId);
     return pending ? { state: pending.state } : null;
   }
+}
+
+function describeTokenExchangeRequest(request: {
+  grant_type: string;
+  code: string;
+  state: string;
+  client_id: string;
+  redirect_uri: string;
+  code_verifier: string;
+}) {
+  return {
+    grantType: request.grant_type,
+    hasCode: request.code.length > 0,
+    codeLength: request.code.length,
+    hasState: request.state.length > 0,
+    stateLength: request.state.length,
+    hasCodeVerifier: request.code_verifier.length > 0,
+    codeVerifierLength: request.code_verifier.length,
+    stateMatchesCodeVerifier: request.state === request.code_verifier,
+    hasClientId: request.client_id.length > 0,
+    hasRedirectUri: request.redirect_uri.length > 0,
+  };
 }


### PR DESCRIPTION
## Summary
- send the Claude Code-compatible `User-Agent: anthropic` header to Anthropic's OAuth token endpoint for exchange and refresh
- log safe token request shape diagnostics on token exchange failure: booleans and lengths only, no code/verifier/token values
- trim fallback state before exchange and add regression coverage

## Why
- After #1938 fixed production pending-state persistence and #1941 aligned `state === code_verifier`, production still receives Anthropic `Invalid request format` during token exchange.
- The Claude Code OAuth notes call out `Content-Type: application/json` and `User-Agent: anthropic` for the token endpoint.
- If this still fails, the new log will show whether prod is actually sending non-empty `code`, `state`, `code_verifier`, `client_id`, and `redirect_uri`, and whether `state === code_verifier`, without leaking secrets.

## Validation
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts src/routing/oauth/core/oauth-pending-flow.store.spec.ts`
- `cd packages/backend && npx tsc --noEmit`
- `git diff --check HEAD~1 HEAD`
- commit-time lint-staged ESLint/Prettier on changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send Claude Code-compatible headers to Anthropic’s OAuth token endpoint and add safe diagnostics to reduce “Invalid request format” errors during code exchange and refresh.

- **Bug Fixes**
  - Include `Content-Type: application/json` and `User-Agent: anthropic` in token requests (exchange + refresh).
  - Trim fallback `state` before exchange; preserve pending flow and `state === code_verifier` checks.
  - Log safe request-shape details on exchange failure (booleans/lengths only); tests updated to assert headers and logging.

<sup>Written for commit ed0589849601e7924550ce388ae9f94a4e901387. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1942?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

