### PR TITLE
fix(anthropic): guard oauth diagnostics

### DIFF
--- a/.changeset/fix-anthropic-oauth-diagnostics.md
+++ b/.changeset/fix-anthropic-oauth-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Make Anthropic OAuth token exchange diagnostics safe when fields are missing.

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -258,6 +258,26 @@ describe('AnthropicOauthService', () => {
       );
     });
 
+    it('logs request shape without crashing when the pending verifier is missing', async () => {
+      fetchMock.mockResolvedValue(mockResponse(400, {}, 'invalid_request'));
+      const logger = { error: jest.fn(), log: jest.fn(), warn: jest.fn() };
+      (svc as unknown as { logger: typeof logger }).logger = logger;
+      jest.spyOn(pendingStore.svc, 'consume').mockResolvedValue({
+        provider: 'anthropic',
+        state: 'state-1',
+        verifier: undefined as unknown as string,
+        agentId: 'agent-1',
+        userId: 'user-1',
+        expiresAt: Date.now() + 60_000,
+      });
+
+      await expect(svc.exchangeCode('bad#state-1', undefined, 'agent-1', 'user-1')).rejects.toThrow(
+        'Token exchange failed',
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('"hasCodeVerifier":false'));
+    });
+
     it('stores an empty refresh token when Anthropic omits one in the response', async () => {
       // No refresh_token field — defensive fallback exercises the `?? ''`.
       fetchMock.mockResolvedValue(mockResponse(200, { access_token: 'a', expires_in: 60 }));

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -237,22 +237,32 @@ export class AnthropicOauthService {
 
 function describeTokenExchangeRequest(request: {
   grant_type: string;
-  code: string;
-  state: string;
-  client_id: string;
-  redirect_uri: string;
-  code_verifier: string;
+  code: unknown;
+  state: unknown;
+  client_id: unknown;
+  redirect_uri: unknown;
+  code_verifier: unknown;
 }) {
+  const codeLength = stringLength(request.code);
+  const stateLength = stringLength(request.state);
+  const codeVerifierLength = stringLength(request.code_verifier);
   return {
     grantType: request.grant_type,
-    hasCode: request.code.length > 0,
-    codeLength: request.code.length,
-    hasState: request.state.length > 0,
-    stateLength: request.state.length,
-    hasCodeVerifier: request.code_verifier.length > 0,
-    codeVerifierLength: request.code_verifier.length,
-    stateMatchesCodeVerifier: request.state === request.code_verifier,
-    hasClientId: request.client_id.length > 0,
-    hasRedirectUri: request.redirect_uri.length > 0,
+    hasCode: codeLength > 0,
+    codeLength,
+    hasState: stateLength > 0,
+    stateLength,
+    hasCodeVerifier: codeVerifierLength > 0,
+    codeVerifierLength,
+    stateMatchesCodeVerifier:
+      typeof request.state === 'string' &&
+      typeof request.code_verifier === 'string' &&
+      request.state === request.code_verifier,
+    hasClientId: stringLength(request.client_id) > 0,
+    hasRedirectUri: stringLength(request.redirect_uri) > 0,
   };
+}
+
+function stringLength(value: unknown): number {
+  return typeof value === 'string' ? value.length : 0;
 }


### PR DESCRIPTION
## Summary
- make Anthropic OAuth token exchange request-shape diagnostics null-safe
- add a regression test where the pending verifier is unexpectedly missing at runtime
- keep the real Anthropic token exchange error visible instead of crashing inside diagnostics

## Why
A production retry after #1942 hit `Cannot read properties of undefined (reading 'length')`, which came from the new diagnostic helper assuming every request field was a string. This follow-up keeps the diagnostic useful even when a field is undefined: e.g. `hasCodeVerifier:false` / `codeVerifierLength:0`.

## Validation
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts src/routing/oauth/core/oauth-pending-flow.store.spec.ts`
- `cd packages/backend && npx tsc --noEmit`
- `git diff --check HEAD~1 HEAD`
- commit-time lint-staged ESLint/Prettier on changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Anthropic OAuth token-exchange diagnostics null-safe to prevent crashes when fields are missing. Keeps the real Anthropic error visible and adds a regression test for a missing code verifier.

- **Bug Fixes**
  - Guard request-shape diagnostics against undefined fields with safe length checks.
  - Preserve Anthropic token-exchange errors instead of crashing; logs now show hasCodeVerifier:false/codeVerifierLength:0.
  - Add regression test for a missing pending verifier.

<sup>Written for commit f2074dd89bc6035e02f9f0304c53c2465c63261e. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1943?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

