### PR TITLE
fix(anthropic): fall back to state as verifier

### DIFF
--- a/.changeset/fix-anthropic-oauth-verifier-fallback.md
+++ b/.changeset/fix-anthropic-oauth-verifier-fallback.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fall back to the OAuth state when Anthropic pending verifier data is missing.

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -258,7 +258,7 @@ describe('AnthropicOauthService', () => {
       );
     });
 
-    it('logs request shape without crashing when the pending verifier is missing', async () => {
+    it('falls back to state when the pending verifier is missing', async () => {
       fetchMock.mockResolvedValue(mockResponse(400, {}, 'invalid_request'));
       const logger = { error: jest.fn(), log: jest.fn(), warn: jest.fn() };
       (svc as unknown as { logger: typeof logger }).logger = logger;
@@ -275,7 +275,11 @@ describe('AnthropicOauthService', () => {
         'Token exchange failed',
       );
 
-      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('"hasCodeVerifier":false'));
+      const [, init] = fetchMock.mock.calls[0];
+      expect(JSON.parse(init.body).code_verifier).toBe('state-1');
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('"stateMatchesCodeVerifier":true'),
+      );
     });
 
     it('stores an empty refresh token when Anthropic omits one in the response', async () => {

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -113,7 +113,7 @@ export class AnthropicOauthService {
       state,
       client_id: ANTHROPIC_OAUTH.CLIENT_ID,
       redirect_uri: ANTHROPIC_OAUTH.REDIRECT_URI,
-      code_verifier: pending.verifier,
+      code_verifier: pending.verifier || state,
     };
     const response = await fetch(ANTHROPIC_OAUTH.TOKEN_URL, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- fall back to the OAuth `state` as `code_verifier` when the pending verifier is missing
- update the missing-verifier regression to assert the fallback request shape
- add a patch changeset

## Why
Production diagnostics from #1943 showed the real token request shape:

```json
{"hasCode":true,"codeLength":48,"hasState":true,"stateLength":43,"hasCodeVerifier":false,"codeVerifierLength":0,"stateMatchesCodeVerifier":false,"hasClientId":true,"hasRedirectUri":true}
```

After #1941, Anthropic OAuth intentionally uses `state === code_verifier`. So if the persisted pending row returns no verifier, using `state` is the correct recovery behavior for new flows and avoids sending an invalid token request.

## Validation
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts src/routing/oauth/core/oauth-pending-flow.store.spec.ts`
- `cd packages/backend && npx tsc --noEmit`
- `git diff --check HEAD~1 HEAD`
- commit-time lint-staged ESLint/Prettier on changed files


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `state` as the `code_verifier` fallback in the Anthropic OAuth token exchange when the pending verifier is missing. This prevents invalid token requests and keeps new flows working.

- **Bug Fixes**
  - Updated tests to assert the fallback where `state` equals `code_verifier`.
  - Added a patch changeset.

<sup>Written for commit 0421e0ae1d7cbd64f12eda2e61ddf49fa78cba05. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1944?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

