### PR TITLE
Add auth-aware provider params

### DIFF
--- a/.changeset/auth-aware-provider-params.md
+++ b/.changeset/auth-aware-provider-params.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Make per-model provider parameters auth-aware and registry-driven across storage, proxy merging, and the routing UI.

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -266,7 +266,7 @@ describe('AgentDuplicationService', () => {
             provider: 'deepseek',
             auth_type: 'api_key',
             model_name: 'deepseek-v4',
-            params: { thinking: { type: 'disabled' } },
+            params: { thinking: 'disabled' },
           },
           // Custom-provider-keyed row exercises the remap path so a route
           // pointing to `custom:<old-uuid>` lands on the new agent's custom
@@ -278,7 +278,7 @@ describe('AgentDuplicationService', () => {
             provider: 'custom:cp1',
             auth_type: 'api_key',
             model_name: 'qwen-72b',
-            params: { thinking: { type: 'enabled' } },
+            params: { thinking: 'enabled' },
           },
         ],
       };
@@ -328,7 +328,7 @@ describe('AgentDuplicationService', () => {
       const deepseekRow = mpRows.find((r) => r['provider'] === 'deepseek')!;
       expect(deepseekRow['agent_id']).toBe(agentRow['id']);
       expect(deepseekRow['model_name']).toBe('deepseek-v4');
-      expect(deepseekRow['params']).toEqual({ thinking: { type: 'disabled' } });
+      expect(deepseekRow['params']).toEqual({ thinking: 'disabled' });
       const customRow = mpRows.find((r) => String(r['provider']).startsWith('custom:'))!;
       expect(customRow['provider']).toBe(`custom:${newCustomId}`);
       expect(customRow['agent_id']).toBe(agentRow['id']);

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -263,6 +263,7 @@ describe('AgentDuplicationService', () => {
             id: 'mp1',
             user_id: 'u1',
             agent_id: 'src-1',
+            scope_key: 'tier:simple',
             provider: 'deepseek',
             auth_type: 'api_key',
             model_name: 'deepseek-v4',
@@ -275,6 +276,7 @@ describe('AgentDuplicationService', () => {
             id: 'mp2',
             user_id: 'u1',
             agent_id: 'src-1',
+            scope_key: 'header:ht-1',
             provider: 'custom:cp1',
             auth_type: 'api_key',
             model_name: 'qwen-72b',
@@ -327,10 +329,12 @@ describe('AgentDuplicationService', () => {
       ] as string;
       const deepseekRow = mpRows.find((r) => r['provider'] === 'deepseek')!;
       expect(deepseekRow['agent_id']).toBe(agentRow['id']);
+      expect(deepseekRow['scope_key']).toBe('tier:simple');
       expect(deepseekRow['model_name']).toBe('deepseek-v4');
       expect(deepseekRow['params']).toEqual({ thinking: 'disabled' });
       const customRow = mpRows.find((r) => String(r['provider']).startsWith('custom:'))!;
       expect(customRow['provider']).toBe(`custom:${newCustomId}`);
+      expect(customRow['scope_key']).toBe('header:ht-1');
       expect(customRow['agent_id']).toBe(agentRow['id']);
 
       expect(mockInvalidateAgent).toHaveBeenCalledWith(agentRow['id']);

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -238,6 +238,7 @@ export class AgentDuplicationService {
             id: uuidv4(),
             user_id: p.user_id,
             agent_id: newAgentId,
+            scope_key: p.scope_key,
             // Same `custom:<uuid>` remap as user_providers / tier_assignments
             // / specificity_assignments above. Without this, a params row
             // configured for `custom:<old-uuid>` would point to the source

--- a/packages/backend/src/analytics/services/message-details.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-details.service.spec.ts
@@ -267,7 +267,7 @@ describe('MessageDetailsService', () => {
     // ships, but the JSONB column accepts any shape so future provider
     // models and user-defined custom params land here without a schema
     // migration; the projection just round-trips whatever is stored.
-    const params = { thinking: { type: 'disabled' } };
+    const params = { thinking: 'disabled' };
     msgQb.getOne.mockResolvedValue({ ...baseMessage, request_params: params });
     const result = await service.getDetails('msg-1', 'u1');
     expect(result.message.request_params).toEqual(params);
@@ -278,7 +278,7 @@ describe('MessageDetailsService', () => {
     // would break the future "users define their own custom-provider
     // params" UI. Anything the proxy stores has to come back through.
     const future = {
-      thinking: { type: 'enabled' },
+      thinking: 'enabled',
       reasoning_effort: 'high',
       custom_safety: { mode: 'permissive', threshold: 0.8 },
     };

--- a/packages/backend/src/analytics/services/message-details.service.ts
+++ b/packages/backend/src/analytics/services/message-details.service.ts
@@ -168,7 +168,7 @@ export class MessageDetailsService {
         feedback_tags: message.feedback_tags ? message.feedback_tags.split(',') : null,
         feedback_details: message.feedback_details,
         request_headers: message.request_headers,
-        request_params: message.request_params,
+        request_params: message.request_params as RequestParamDefaults | null,
         caller_attribution: message.caller_attribution,
         header_tier_id: message.header_tier_id,
         header_tier_name: message.header_tier_name,

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -99,6 +99,8 @@ import { AddAgentModelParams1787000000000 } from './migrations/1787000000000-Add
 import { AddBenchmarkHistory1788000000000 } from './migrations/1788000000000-AddBenchmarkHistory';
 import { RenameBenchmarkToPlayground1789000000000 } from './migrations/1789000000000-RenameBenchmarkToPlayground';
 import { AddOAuthPendingFlows1789100000000 } from './migrations/1789100000000-AddOAuthPendingFlows';
+import { FlattenAgentModelParamsThinking1789200000000 } from './migrations/1789200000000-FlattenAgentModelParamsThinking';
+import { ScopeAgentModelParams1789300000000 } from './migrations/1789300000000-ScopeAgentModelParams';
 
 const entities = [
   AgentMessage,
@@ -199,6 +201,8 @@ const migrations = [
   AddBenchmarkHistory1788000000000,
   RenameBenchmarkToPlayground1789000000000,
   AddOAuthPendingFlows1789100000000,
+  FlattenAgentModelParamsThinking1789200000000,
+  ScopeAgentModelParams1789300000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -103,6 +103,9 @@ import { AddOAuthPendingFlows1789100000000 } from './migrations/1789100000000-Ad
 import { FlattenAgentModelParamsThinking1789200000000 } from './migrations/1789200000000-FlattenAgentModelParamsThinking';
 import { ScopeAgentModelParams1789300000000 } from './migrations/1789300000000-ScopeAgentModelParams';
 import { AddProviderParamSpecs1789400000000 } from './migrations/1789400000000-AddProviderParamSpecs';
+import { AddProviderParamSpecGroups1789500000000 } from './migrations/1789500000000-AddProviderParamSpecGroups';
+import { AddProviderParamDependencies1789600000000 } from './migrations/1789600000000-AddProviderParamDependencies';
+import { AddOpenAiProviderParamSpecs1789700000000 } from './migrations/1789700000000-AddOpenAiProviderParamSpecs';
 
 const entities = [
   AgentMessage,
@@ -207,6 +210,9 @@ const migrations = [
   FlattenAgentModelParamsThinking1789200000000,
   ScopeAgentModelParams1789300000000,
   AddProviderParamSpecs1789400000000,
+  AddProviderParamSpecGroups1789500000000,
+  AddProviderParamDependencies1789600000000,
+  AddOpenAiProviderParamSpecs1789700000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -20,6 +20,7 @@ import { SpecificityAssignment } from '../entities/specificity-assignment.entity
 import { HeaderTier } from '../entities/header-tier.entity';
 import { InstallMetadata } from '../entities/install-metadata.entity';
 import { AgentModelParams } from '../entities/agent-model-params.entity';
+import { ProviderParamSpecEntity } from '../entities/provider-param-spec.entity';
 import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
 import { DatabaseSeederService } from './database-seeder.service';
@@ -101,6 +102,7 @@ import { RenameBenchmarkToPlayground1789000000000 } from './migrations/178900000
 import { AddOAuthPendingFlows1789100000000 } from './migrations/1789100000000-AddOAuthPendingFlows';
 import { FlattenAgentModelParamsThinking1789200000000 } from './migrations/1789200000000-FlattenAgentModelParamsThinking';
 import { ScopeAgentModelParams1789300000000 } from './migrations/1789300000000-ScopeAgentModelParams';
+import { AddProviderParamSpecs1789400000000 } from './migrations/1789400000000-AddProviderParamSpecs';
 
 const entities = [
   AgentMessage,
@@ -121,6 +123,7 @@ const entities = [
   HeaderTier,
   InstallMetadata,
   AgentModelParams,
+  ProviderParamSpecEntity,
   PlaygroundRun,
   PlaygroundColumn,
 ];
@@ -203,6 +206,7 @@ const migrations = [
   AddOAuthPendingFlows1789100000000,
   FlattenAgentModelParamsThinking1789200000000,
   ScopeAgentModelParams1789300000000,
+  AddProviderParamSpecs1789400000000,
 ];
 
 @Module({
@@ -249,6 +253,7 @@ const migrations = [
       SpecificityAssignment,
       HeaderTier,
       AgentModelParams,
+      ProviderParamSpecEntity,
     ]),
     ModelPricesModule,
   ],

--- a/packages/backend/src/database/migrations/1789200000000-FlattenAgentModelParamsThinking.spec.ts
+++ b/packages/backend/src/database/migrations/1789200000000-FlattenAgentModelParamsThinking.spec.ts
@@ -1,0 +1,32 @@
+import { FlattenAgentModelParamsThinking1789200000000 } from './1789200000000-FlattenAgentModelParamsThinking';
+
+describe('FlattenAgentModelParamsThinking1789200000000', () => {
+  let migration: FlattenAgentModelParamsThinking1789200000000;
+  let queryRunner: { query: jest.Mock };
+
+  beforeEach(() => {
+    migration = new FlattenAgentModelParamsThinking1789200000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('up flattens legacy nested thinking storage into the UI value', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await migration.up(queryRunner as any);
+    const sql = queryRunner.query.mock.calls.map((c) => c[0] as string).join('\n');
+
+    expect(sql).toContain('UPDATE agent_model_params');
+    expect(sql).toContain("params = jsonb_set(params - 'thinking', '{thinking}'");
+    expect(sql).toContain("params->'thinking'->'type'");
+    expect(sql).toContain("jsonb_typeof(params->'thinking') = 'object'");
+  });
+
+  it('down restores the previous nested thinking shape', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await migration.down(queryRunner as any);
+    const sql = queryRunner.query.mock.calls.map((c) => c[0] as string).join('\n');
+
+    expect(sql).toContain('UPDATE agent_model_params');
+    expect(sql).toContain("jsonb_build_object('type', params->'thinking')");
+    expect(sql).toContain("jsonb_typeof(params->'thinking') = 'string'");
+  });
+});

--- a/packages/backend/src/database/migrations/1789200000000-FlattenAgentModelParamsThinking.ts
+++ b/packages/backend/src/database/migrations/1789200000000-FlattenAgentModelParamsThinking.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Store model params as UI values instead of provider wire shapes. DeepSeek
+ * thinking rows previously stored `{ thinking: { type: "enabled" } }`; the
+ * registry now stores `{ thinking: "enabled" }` and handles wire transforms
+ * only during outbound request merging.
+ */
+export class FlattenAgentModelParamsThinking1789200000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE agent_model_params
+      SET params = jsonb_set(params - 'thinking', '{thinking}', params->'thinking'->'type')
+      WHERE params ? 'thinking'
+        AND jsonb_typeof(params->'thinking') = 'object'
+        AND params->'thinking' ? 'type'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE agent_model_params
+      SET params = jsonb_set(
+        params - 'thinking',
+        '{thinking}',
+        jsonb_build_object('type', params->'thinking')
+      )
+      WHERE params ? 'thinking'
+        AND jsonb_typeof(params->'thinking') = 'string'
+    `);
+  }
+}

--- a/packages/backend/src/database/migrations/1789300000000-ScopeAgentModelParams.spec.ts
+++ b/packages/backend/src/database/migrations/1789300000000-ScopeAgentModelParams.spec.ts
@@ -1,0 +1,29 @@
+import { ScopeAgentModelParams1789300000000 } from './1789300000000-ScopeAgentModelParams';
+
+describe('ScopeAgentModelParams1789300000000', () => {
+  let migration: ScopeAgentModelParams1789300000000;
+  let queryRunner: { query: jest.Mock };
+
+  beforeEach(() => {
+    migration = new ScopeAgentModelParams1789300000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('up adds scope_key and replaces the unique route index with a scoped identity', async () => {
+    await migration.up(queryRunner as never);
+    const sql = queryRunner.query.mock.calls.map(([q]) => String(q)).join('\n');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "scope_key"');
+    expect(sql).toContain("'tier:' || tier AS scope_key");
+    expect(sql).toContain("'specificity:' || category AS scope_key");
+    expect(sql).toContain("'header:' || id AS scope_key");
+    expect(sql).toContain('("agent_id", "scope_key", "provider", "model_name", "auth_type")');
+  });
+
+  it('down collapses scoped duplicates before restoring the old unique route index', async () => {
+    await migration.down(queryRunner as never);
+    const sql = queryRunner.query.mock.calls.map(([q]) => String(q)).join('\n');
+    expect(sql).toContain('ROW_NUMBER() OVER');
+    expect(sql).toContain('DROP COLUMN IF EXISTS "scope_key"');
+    expect(sql).toContain('("agent_id", "provider", "auth_type", "model_name")');
+  });
+});

--- a/packages/backend/src/database/migrations/1789300000000-ScopeAgentModelParams.ts
+++ b/packages/backend/src/database/migrations/1789300000000-ScopeAgentModelParams.ts
@@ -1,0 +1,225 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a route-scope dimension to model params so the same provider/auth/model
+ * can be configured differently in complexity tiers, task-specific tiers, and
+ * header tiers.
+ */
+export class ScopeAgentModelParams1789300000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "agent_model_params"
+      ADD COLUMN IF NOT EXISTS "scope_key" varchar
+    `);
+
+    await queryRunner.query(`
+      UPDATE "agent_model_params"
+      SET "scope_key" = '__legacy__'
+      WHERE "scope_key" IS NULL
+    `);
+
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_agent_model_params_route"`);
+
+    await queryRunner.query(`
+      WITH route_sources AS (
+        SELECT
+          agent_id,
+          'tier:' || tier AS scope_key,
+          COALESCE(override_route, auto_assigned_route) AS primary_route,
+          fallback_routes
+        FROM tier_assignments
+        UNION ALL
+        SELECT
+          agent_id,
+          'specificity:' || category AS scope_key,
+          COALESCE(override_route, auto_assigned_route) AS primary_route,
+          fallback_routes
+        FROM specificity_assignments
+        UNION ALL
+        SELECT
+          agent_id,
+          'header:' || id AS scope_key,
+          override_route AS primary_route,
+          fallback_routes
+        FROM header_tiers
+      ),
+      primary_routes AS (
+        SELECT
+          agent_id,
+          scope_key,
+          LOWER(primary_route->>'provider') AS provider,
+          primary_route->>'authType' AS auth_type,
+          primary_route->>'model' AS model_name
+        FROM route_sources
+        WHERE primary_route IS NOT NULL
+          AND jsonb_typeof(primary_route) = 'object'
+          AND primary_route ? 'provider'
+          AND primary_route ? 'authType'
+          AND primary_route ? 'model'
+      ),
+      fallback_routes AS (
+        SELECT
+          rs.agent_id,
+          rs.scope_key,
+          LOWER(fr->>'provider') AS provider,
+          fr->>'authType' AS auth_type,
+          fr->>'model' AS model_name
+        FROM route_sources rs
+        CROSS JOIN LATERAL jsonb_array_elements(rs.fallback_routes) AS arr(fr)
+        WHERE rs.fallback_routes IS NOT NULL
+          AND jsonb_typeof(rs.fallback_routes) = 'array'
+          AND jsonb_typeof(fr) = 'object'
+          AND fr ? 'provider'
+          AND fr ? 'authType'
+          AND fr ? 'model'
+      ),
+      route_rows AS (
+        SELECT DISTINCT * FROM primary_routes
+        UNION
+        SELECT DISTINCT * FROM fallback_routes
+      ),
+      legacy_rows AS (
+        SELECT *
+        FROM "agent_model_params"
+        WHERE scope_key = '__legacy__'
+      )
+      INSERT INTO "agent_model_params" (
+        "id",
+        "user_id",
+        "agent_id",
+        "scope_key",
+        "provider",
+        "auth_type",
+        "model_name",
+        "params",
+        "created_at",
+        "updated_at"
+      )
+      SELECT
+        gen_random_uuid()::text,
+        p.user_id,
+        p.agent_id,
+        r.scope_key,
+        p.provider,
+        p.auth_type,
+        p.model_name,
+        p.params,
+        p.created_at,
+        now()
+      FROM legacy_rows p
+      JOIN route_rows r
+        ON r.agent_id = p.agent_id
+       AND r.provider = LOWER(p.provider)
+       AND r.auth_type = p.auth_type
+       AND r.model_name = p.model_name
+    `);
+
+    await queryRunner.query(`
+      WITH route_sources AS (
+        SELECT
+          agent_id,
+          COALESCE(override_route, auto_assigned_route) AS primary_route,
+          fallback_routes
+        FROM tier_assignments
+        UNION ALL
+        SELECT
+          agent_id,
+          COALESCE(override_route, auto_assigned_route) AS primary_route,
+          fallback_routes
+        FROM specificity_assignments
+        UNION ALL
+        SELECT
+          agent_id,
+          override_route AS primary_route,
+          fallback_routes
+        FROM header_tiers
+      ),
+      primary_routes AS (
+        SELECT
+          agent_id,
+          LOWER(primary_route->>'provider') AS provider,
+          primary_route->>'authType' AS auth_type,
+          primary_route->>'model' AS model_name
+        FROM route_sources
+        WHERE primary_route IS NOT NULL
+          AND jsonb_typeof(primary_route) = 'object'
+          AND primary_route ? 'provider'
+          AND primary_route ? 'authType'
+          AND primary_route ? 'model'
+      ),
+      fallback_routes AS (
+        SELECT
+          rs.agent_id,
+          LOWER(fr->>'provider') AS provider,
+          fr->>'authType' AS auth_type,
+          fr->>'model' AS model_name
+        FROM route_sources rs
+        CROSS JOIN LATERAL jsonb_array_elements(rs.fallback_routes) AS arr(fr)
+        WHERE rs.fallback_routes IS NOT NULL
+          AND jsonb_typeof(rs.fallback_routes) = 'array'
+          AND jsonb_typeof(fr) = 'object'
+          AND fr ? 'provider'
+          AND fr ? 'authType'
+          AND fr ? 'model'
+      ),
+      route_rows AS (
+        SELECT DISTINCT * FROM primary_routes
+        UNION
+        SELECT DISTINCT * FROM fallback_routes
+      )
+      DELETE FROM "agent_model_params" p
+      USING route_rows r
+      WHERE p.scope_key = '__legacy__'
+        AND r.agent_id = p.agent_id
+        AND r.provider = LOWER(p.provider)
+        AND r.auth_type = p.auth_type
+        AND r.model_name = p.model_name
+    `);
+
+    await queryRunner.query(`
+      UPDATE "agent_model_params"
+      SET "scope_key" = 'tier:default'
+      WHERE "scope_key" = '__legacy__'
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "agent_model_params"
+      ALTER COLUMN "scope_key" SET NOT NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "idx_agent_model_params_route"
+      ON "agent_model_params" ("agent_id", "scope_key", "provider", "model_name", "auth_type")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_agent_model_params_route"`);
+
+    await queryRunner.query(`
+      WITH ranked AS (
+        SELECT
+          id,
+          ROW_NUMBER() OVER (
+            PARTITION BY agent_id, provider, auth_type, model_name
+            ORDER BY updated_at DESC, id DESC
+          ) AS row_rank
+        FROM "agent_model_params"
+      )
+      DELETE FROM "agent_model_params" p
+      USING ranked r
+      WHERE p.id = r.id
+        AND r.row_rank > 1
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "agent_model_params"
+      DROP COLUMN IF EXISTS "scope_key"
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "idx_agent_model_params_route"
+      ON "agent_model_params" ("agent_id", "provider", "auth_type", "model_name")
+    `);
+  }
+}

--- a/packages/backend/src/database/migrations/1789400000000-AddProviderParamSpecs.spec.ts
+++ b/packages/backend/src/database/migrations/1789400000000-AddProviderParamSpecs.spec.ts
@@ -1,0 +1,28 @@
+import { AddProviderParamSpecs1789400000000 } from './1789400000000-AddProviderParamSpecs';
+
+describe('AddProviderParamSpecs1789400000000', () => {
+  let migration: AddProviderParamSpecs1789400000000;
+  let queryRunner: { query: jest.Mock };
+
+  beforeEach(() => {
+    migration = new AddProviderParamSpecs1789400000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('creates the provider_param_specs table and seeds current built-in specs', async () => {
+    await migration.up(queryRunner as never);
+    const sql = queryRunner.query.mock.calls.map(([q]) => String(q)).join('\n');
+    const params = queryRunner.query.mock.calls.map(([, p]) => p).filter(Boolean);
+
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS "provider_param_specs"');
+    expect(sql).toContain('"control_kind" varchar NOT NULL');
+    expect(sql).toContain('"default_value" jsonb NOT NULL');
+    expect(sql).toContain('"serializer" varchar DEFAULT NULL');
+    expect(params).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(['anthropic-api-key-base-max-tokens', 'anthropic', 'api_key']),
+        expect.arrayContaining(['deepseek-api-key-base-thinking', 'deepseek', 'api_key']),
+      ]),
+    );
+  });
+});

--- a/packages/backend/src/database/migrations/1789400000000-AddProviderParamSpecs.ts
+++ b/packages/backend/src/database/migrations/1789400000000-AddProviderParamSpecs.ts
@@ -1,0 +1,215 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+type SeedRow = readonly [
+  id: string,
+  provider: string,
+  authType: string,
+  modelName: string | null,
+  paramKey: string,
+  controlKind: string,
+  label: string,
+  defaultValue: unknown,
+  values: readonly string[] | null,
+  minValue: number | null,
+  maxValue: number | null,
+  stepValue: number | null,
+  serializer: string | null,
+  sortOrder: number,
+];
+
+export class AddProviderParamSpecs1789400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "provider_param_specs" (
+        "id" varchar PRIMARY KEY,
+        "provider" varchar NOT NULL,
+        "auth_type" varchar NOT NULL,
+        "model_name" varchar DEFAULT NULL,
+        "param_key" varchar NOT NULL,
+        "control_kind" varchar NOT NULL,
+        "label" varchar NOT NULL,
+        "default_value" jsonb NOT NULL,
+        "values" jsonb DEFAULT NULL,
+        "min_value" double precision DEFAULT NULL,
+        "max_value" double precision DEFAULT NULL,
+        "step_value" double precision DEFAULT NULL,
+        "serializer" varchar DEFAULT NULL,
+        "sort_order" integer NOT NULL DEFAULT 0,
+        "created_at" timestamp NOT NULL DEFAULT now(),
+        "updated_at" timestamp NOT NULL DEFAULT now(),
+        CONSTRAINT "chk_provider_param_specs_control_kind"
+          CHECK ("control_kind" IN ('toggle', 'select', 'slider', 'number'))
+      )
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "idx_provider_param_specs_route_key"
+      ON "provider_param_specs" ("provider", "auth_type", COALESCE("model_name", ''), "param_key")
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_provider_param_specs_lookup"
+      ON "provider_param_specs" ("provider", "auth_type", "model_name", "sort_order")
+    `);
+
+    const rows: SeedRow[] = [
+      [
+        'anthropic-api-key-base-max-tokens',
+        'anthropic',
+        'api_key',
+        null,
+        'max_tokens',
+        'number',
+        'Max tokens',
+        4096,
+        null,
+        1,
+        null,
+        null,
+        null,
+        10,
+      ],
+      [
+        'anthropic-api-key-base-temperature',
+        'anthropic',
+        'api_key',
+        null,
+        'temperature',
+        'slider',
+        'Temperature',
+        1,
+        null,
+        0,
+        1,
+        0.1,
+        null,
+        20,
+      ],
+      [
+        'anthropic-api-key-base-top-p',
+        'anthropic',
+        'api_key',
+        null,
+        'top_p',
+        'slider',
+        'Top P',
+        1,
+        null,
+        0,
+        1,
+        0.01,
+        null,
+        30,
+      ],
+      [
+        'anthropic-api-key-base-top-k',
+        'anthropic',
+        'api_key',
+        null,
+        'top_k',
+        'number',
+        'Top K',
+        0,
+        null,
+        0,
+        null,
+        null,
+        null,
+        40,
+      ],
+      [
+        'deepseek-api-key-base-thinking',
+        'deepseek',
+        'api_key',
+        null,
+        'thinking',
+        'toggle',
+        'Thinking mode',
+        'enabled',
+        ['enabled', 'disabled'],
+        null,
+        null,
+        null,
+        null,
+        10,
+      ],
+    ];
+
+    for (const row of rows) {
+      const [
+        id,
+        provider,
+        authType,
+        modelName,
+        paramKey,
+        controlKind,
+        label,
+        defaultValue,
+        values,
+        minValue,
+        maxValue,
+        stepValue,
+        serializer,
+        sortOrder,
+      ] = row;
+      await queryRunner.query(
+        `
+          INSERT INTO "provider_param_specs"
+            (
+              "id",
+              "provider",
+              "auth_type",
+              "model_name",
+              "param_key",
+              "control_kind",
+              "label",
+              "default_value",
+              "values",
+              "min_value",
+              "max_value",
+              "step_value",
+              "serializer",
+              "sort_order"
+            )
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10, $11, $12, $13, $14)
+          ON CONFLICT ON CONSTRAINT "provider_param_specs_pkey" DO UPDATE
+          SET
+            "provider" = EXCLUDED."provider",
+            "auth_type" = EXCLUDED."auth_type",
+            "model_name" = EXCLUDED."model_name",
+            "param_key" = EXCLUDED."param_key",
+            "control_kind" = EXCLUDED."control_kind",
+            "label" = EXCLUDED."label",
+            "default_value" = EXCLUDED."default_value",
+            "values" = EXCLUDED."values",
+            "min_value" = EXCLUDED."min_value",
+            "max_value" = EXCLUDED."max_value",
+            "step_value" = EXCLUDED."step_value",
+            "serializer" = EXCLUDED."serializer",
+            "sort_order" = EXCLUDED."sort_order",
+            "updated_at" = now()
+        `,
+        [
+          id,
+          provider,
+          authType,
+          modelName,
+          paramKey,
+          controlKind,
+          label,
+          JSON.stringify(defaultValue),
+          values === null ? null : JSON.stringify(values),
+          minValue,
+          maxValue,
+          stepValue,
+          serializer,
+          sortOrder,
+        ],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_provider_param_specs_lookup"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_provider_param_specs_route_key"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "provider_param_specs"`);
+  }
+}

--- a/packages/backend/src/database/migrations/1789500000000-AddProviderParamSpecGroups.spec.ts
+++ b/packages/backend/src/database/migrations/1789500000000-AddProviderParamSpecGroups.spec.ts
@@ -1,0 +1,40 @@
+import { AddProviderParamSpecGroups1789500000000 } from './1789500000000-AddProviderParamSpecGroups';
+
+describe('AddProviderParamSpecGroups1789500000000', () => {
+  let migration: AddProviderParamSpecGroups1789500000000;
+  let queryRunner: { query: jest.Mock };
+
+  beforeEach(() => {
+    migration = new AddProviderParamSpecGroups1789500000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('adds grouping metadata and seeds Anthropic thinking controls', async () => {
+    await migration.up(queryRunner as never);
+    const sql = queryRunner.query.mock.calls.map(([q]) => String(q)).join('\n');
+    const params = queryRunner.query.mock.calls.map(([, p]) => p).filter(Boolean);
+
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "group_key"');
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "depends_on_value" jsonb');
+    expect(params).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([
+          'anthropic-api-key-base-thinking-type',
+          'anthropic',
+          'api_key',
+          null,
+          'type',
+          'thinking',
+        ]),
+        expect.arrayContaining([
+          'anthropic-api-key-base-thinking-budget-tokens',
+          'anthropic',
+          'api_key',
+          null,
+          'budget_tokens',
+          'thinking',
+        ]),
+      ]),
+    );
+  });
+});

--- a/packages/backend/src/database/migrations/1789500000000-AddProviderParamSpecGroups.ts
+++ b/packages/backend/src/database/migrations/1789500000000-AddProviderParamSpecGroups.ts
@@ -1,0 +1,191 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+type GroupSeedRow = readonly [
+  id: string,
+  provider: string,
+  authType: string,
+  modelName: string | null,
+  paramKey: string,
+  groupKey: string,
+  groupLabel: string,
+  controlKind: string,
+  label: string,
+  defaultValue: unknown,
+  values: readonly string[] | null,
+  minValue: number | null,
+  maxValue: number | null,
+  stepValue: number | null,
+  serializer: string | null,
+  dependsOnKey: string | null,
+  dependsOnValue: unknown,
+  sortOrder: number,
+];
+
+export class AddProviderParamSpecGroups1789500000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "provider_param_specs"
+        ADD COLUMN IF NOT EXISTS "group_key" varchar DEFAULT NULL,
+        ADD COLUMN IF NOT EXISTS "group_label" varchar DEFAULT NULL,
+        ADD COLUMN IF NOT EXISTS "depends_on_key" varchar DEFAULT NULL,
+        ADD COLUMN IF NOT EXISTS "depends_on_value" jsonb DEFAULT NULL
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_provider_param_specs_group"
+      ON "provider_param_specs" ("provider", "auth_type", "model_name", "group_key", "sort_order")
+    `);
+
+    const rows: GroupSeedRow[] = [
+      [
+        'anthropic-api-key-base-thinking-type',
+        'anthropic',
+        'api_key',
+        null,
+        'type',
+        'thinking',
+        'Thinking',
+        'select',
+        'Thinking mode',
+        'disabled',
+        ['disabled', 'adaptive', 'enabled'],
+        null,
+        null,
+        null,
+        'anthropic_thinking',
+        null,
+        null,
+        50,
+      ],
+      [
+        'anthropic-api-key-base-thinking-budget-tokens',
+        'anthropic',
+        'api_key',
+        null,
+        'budget_tokens',
+        'thinking',
+        'Thinking',
+        'number',
+        'Budget tokens',
+        4096,
+        null,
+        1024,
+        null,
+        null,
+        'anthropic_thinking',
+        'type',
+        'enabled',
+        60,
+      ],
+    ];
+
+    for (const row of rows) {
+      const [
+        id,
+        provider,
+        authType,
+        modelName,
+        paramKey,
+        groupKey,
+        groupLabel,
+        controlKind,
+        label,
+        defaultValue,
+        values,
+        minValue,
+        maxValue,
+        stepValue,
+        serializer,
+        dependsOnKey,
+        dependsOnValue,
+        sortOrder,
+      ] = row;
+      await queryRunner.query(
+        `
+          INSERT INTO "provider_param_specs"
+            (
+              "id",
+              "provider",
+              "auth_type",
+              "model_name",
+              "param_key",
+              "group_key",
+              "group_label",
+              "control_kind",
+              "label",
+              "default_value",
+              "values",
+              "min_value",
+              "max_value",
+              "step_value",
+              "serializer",
+              "depends_on_key",
+              "depends_on_value",
+              "sort_order"
+            )
+          VALUES (
+            $1, $2, $3, $4, $5, $6, $7, $8, $9,
+            $10::jsonb, $11::jsonb, $12, $13, $14, $15, $16, $17::jsonb, $18
+          )
+          ON CONFLICT ON CONSTRAINT "provider_param_specs_pkey" DO UPDATE
+          SET
+            "provider" = EXCLUDED."provider",
+            "auth_type" = EXCLUDED."auth_type",
+            "model_name" = EXCLUDED."model_name",
+            "param_key" = EXCLUDED."param_key",
+            "group_key" = EXCLUDED."group_key",
+            "group_label" = EXCLUDED."group_label",
+            "control_kind" = EXCLUDED."control_kind",
+            "label" = EXCLUDED."label",
+            "default_value" = EXCLUDED."default_value",
+            "values" = EXCLUDED."values",
+            "min_value" = EXCLUDED."min_value",
+            "max_value" = EXCLUDED."max_value",
+            "step_value" = EXCLUDED."step_value",
+            "serializer" = EXCLUDED."serializer",
+            "depends_on_key" = EXCLUDED."depends_on_key",
+            "depends_on_value" = EXCLUDED."depends_on_value",
+            "sort_order" = EXCLUDED."sort_order",
+            "updated_at" = now()
+        `,
+        [
+          id,
+          provider,
+          authType,
+          modelName,
+          paramKey,
+          groupKey,
+          groupLabel,
+          controlKind,
+          label,
+          JSON.stringify(defaultValue),
+          values === null ? null : JSON.stringify(values),
+          minValue,
+          maxValue,
+          stepValue,
+          serializer,
+          dependsOnKey,
+          dependsOnValue === null ? null : JSON.stringify(dependsOnValue),
+          sortOrder,
+        ],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM "provider_param_specs"
+      WHERE "id" IN (
+        'anthropic-api-key-base-thinking-type',
+        'anthropic-api-key-base-thinking-budget-tokens'
+      )
+    `);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_provider_param_specs_group"`);
+    await queryRunner.query(`
+      ALTER TABLE "provider_param_specs"
+        DROP COLUMN IF EXISTS "depends_on_value",
+        DROP COLUMN IF EXISTS "depends_on_key",
+        DROP COLUMN IF EXISTS "group_label",
+        DROP COLUMN IF EXISTS "group_key"
+    `);
+  }
+}

--- a/packages/backend/src/database/migrations/1789600000000-AddProviderParamDependencies.spec.ts
+++ b/packages/backend/src/database/migrations/1789600000000-AddProviderParamDependencies.spec.ts
@@ -1,0 +1,33 @@
+import { AddProviderParamDependencies1789600000000 } from './1789600000000-AddProviderParamDependencies';
+
+describe('AddProviderParamDependencies1789600000000', () => {
+  let migration: AddProviderParamDependencies1789600000000;
+  let queryRunner: { query: jest.Mock };
+
+  beforeEach(() => {
+    migration = new AddProviderParamDependencies1789600000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('adds dependency metadata and marks Anthropic sampling params incompatible with thinking', async () => {
+    await migration.up(queryRunner as never);
+    const sql = queryRunner.query.mock.calls.map(([q]) => String(q)).join('\n');
+    const params = queryRunner.query.mock.calls.map(([, p]) => p).filter(Boolean);
+
+    expect(sql).toContain('ADD COLUMN IF NOT EXISTS "dependencies" jsonb');
+    expect(sql).toContain("'anthropic-api-key-base-top-p'");
+    expect(sql).toContain("'anthropic-api-key-base-top-k'");
+    expect(params[0]).toEqual([
+      JSON.stringify([
+        {
+          effect: 'disable',
+          when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+        },
+        {
+          effect: 'omit',
+          when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+        },
+      ]),
+    ]);
+  });
+});

--- a/packages/backend/src/database/migrations/1789600000000-AddProviderParamDependencies.ts
+++ b/packages/backend/src/database/migrations/1789600000000-AddProviderParamDependencies.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+const THINKING_SAMPLING_DEPENDENCIES = [
+  {
+    effect: 'disable',
+    when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+  },
+  {
+    effect: 'omit',
+    when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+  },
+];
+
+export class AddProviderParamDependencies1789600000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "provider_param_specs"
+        ADD COLUMN IF NOT EXISTS "dependencies" jsonb DEFAULT NULL
+    `);
+    await queryRunner.query(
+      `
+        UPDATE "provider_param_specs"
+        SET "dependencies" = $1::jsonb,
+            "updated_at" = now()
+        WHERE "id" IN (
+          'anthropic-api-key-base-top-p',
+          'anthropic-api-key-base-top-k'
+        )
+      `,
+      [JSON.stringify(THINKING_SAMPLING_DEPENDENCIES)],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      UPDATE "provider_param_specs"
+      SET "dependencies" = NULL,
+          "updated_at" = now()
+      WHERE "id" IN (
+        'anthropic-api-key-base-top-p',
+        'anthropic-api-key-base-top-k'
+      )
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "provider_param_specs"
+        DROP COLUMN IF EXISTS "dependencies"
+    `);
+  }
+}

--- a/packages/backend/src/database/migrations/1789700000000-AddOpenAiProviderParamSpecs.spec.ts
+++ b/packages/backend/src/database/migrations/1789700000000-AddOpenAiProviderParamSpecs.spec.ts
@@ -1,0 +1,60 @@
+import { AddOpenAiProviderParamSpecs1789700000000 } from './1789700000000-AddOpenAiProviderParamSpecs';
+
+describe('AddOpenAiProviderParamSpecs1789700000000', () => {
+  let migration: AddOpenAiProviderParamSpecs1789700000000;
+  let queryRunner: { query: jest.Mock };
+
+  beforeEach(() => {
+    migration = new AddOpenAiProviderParamSpecs1789700000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('seeds OpenAI API-key param specs with model-aware overrides', async () => {
+    await migration.up(queryRunner as never);
+    const sql = queryRunner.query.mock.calls.map(([q]) => String(q)).join('\n');
+    const params = queryRunner.query.mock.calls.map(([, p]) => p).filter(Boolean);
+
+    expect(sql).toContain('INSERT INTO "provider_param_specs"');
+    expect(sql).toContain('"model_name"');
+    expect(sql).toContain('"serializer" = NULL');
+    expect(params).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([
+          'openai-api-key-base-max-tokens',
+          'openai',
+          'api_key',
+          null,
+          'max_tokens',
+          'number',
+        ]),
+        expect.arrayContaining([
+          'openai-api-key-gpt-4o-temperature',
+          'openai',
+          'api_key',
+          'gpt-4o',
+          'temperature',
+          'slider',
+        ]),
+        expect.arrayContaining([
+          'openai-api-key-o3-reasoning-effort',
+          'openai',
+          'api_key',
+          'o3',
+          'reasoning_effort',
+          'select',
+        ]),
+        expect.arrayContaining([
+          'openai-api-key-gpt-5-1-reasoning-effort',
+          'openai',
+          'api_key',
+          'gpt-5.1',
+          'reasoning_effort',
+          'select',
+          'Reasoning effort',
+          JSON.stringify('none'),
+          JSON.stringify(['none', 'low', 'medium', 'high']),
+        ]),
+      ]),
+    );
+  });
+});

--- a/packages/backend/src/database/migrations/1789700000000-AddOpenAiProviderParamSpecs.spec.ts
+++ b/packages/backend/src/database/migrations/1789700000000-AddOpenAiProviderParamSpecs.spec.ts
@@ -57,4 +57,20 @@ describe('AddOpenAiProviderParamSpecs1789700000000', () => {
       ]),
     );
   });
+
+  it('rolls back only the exact rows seeded by the migration', async () => {
+    await migration.down(queryRunner as never);
+    const [sql, params] = queryRunner.query.mock.calls[0]!;
+
+    expect(String(sql)).toContain('DELETE FROM "provider_param_specs"');
+    expect(String(sql)).toContain('WHERE "id" IN');
+    expect(String(sql)).not.toContain('LIKE');
+    expect(params).toEqual(
+      expect.arrayContaining([
+        'openai-api-key-base-max-tokens',
+        'openai-api-key-gpt-4o-temperature',
+        'openai-api-key-o3-reasoning-effort',
+      ]),
+    );
+  });
 });

--- a/packages/backend/src/database/migrations/1789700000000-AddOpenAiProviderParamSpecs.ts
+++ b/packages/backend/src/database/migrations/1789700000000-AddOpenAiProviderParamSpecs.ts
@@ -126,23 +126,27 @@ function row(modelName: string | null, template: SpecTemplate): SeedRow {
   ];
 }
 
+function openAiParamRows(): SeedRow[] {
+  return [
+    row(null, MAX_TOKENS),
+    ...OPENAI_CHAT_SAMPLING_MODELS.flatMap((model) =>
+      [MAX_TOKENS, TEMPERATURE, TOP_P].map((spec) => row(model, spec)),
+    ),
+    ...OPENAI_O_SERIES_REASONING_MODELS.flatMap((model) =>
+      [MAX_TOKENS, REASONING_EFFORT].map((spec) => row(model, spec)),
+    ),
+    ...OPENAI_GPT5_REASONING_MODELS.flatMap((model) =>
+      [MAX_TOKENS, TEMPERATURE, TOP_P, REASONING_EFFORT].map((spec) => row(model, spec)),
+    ),
+    ...OPENAI_GPT51_REASONING_MODELS.flatMap((model) =>
+      [MAX_TOKENS, TEMPERATURE, TOP_P, GPT_5_1_REASONING_EFFORT].map((spec) => row(model, spec)),
+    ),
+  ];
+}
+
 export class AddOpenAiProviderParamSpecs1789700000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const rows: SeedRow[] = [
-      row(null, MAX_TOKENS),
-      ...OPENAI_CHAT_SAMPLING_MODELS.flatMap((model) =>
-        [MAX_TOKENS, TEMPERATURE, TOP_P].map((spec) => row(model, spec)),
-      ),
-      ...OPENAI_O_SERIES_REASONING_MODELS.flatMap((model) =>
-        [MAX_TOKENS, REASONING_EFFORT].map((spec) => row(model, spec)),
-      ),
-      ...OPENAI_GPT5_REASONING_MODELS.flatMap((model) =>
-        [MAX_TOKENS, TEMPERATURE, TOP_P, REASONING_EFFORT].map((spec) => row(model, spec)),
-      ),
-      ...OPENAI_GPT51_REASONING_MODELS.flatMap((model) =>
-        [MAX_TOKENS, TEMPERATURE, TOP_P, GPT_5_1_REASONING_EFFORT].map((spec) => row(model, spec)),
-      ),
-    ];
+    const rows = openAiParamRows();
 
     for (const seed of rows) {
       const [
@@ -217,11 +221,14 @@ export class AddOpenAiProviderParamSpecs1789700000000 implements MigrationInterf
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`
+    const ids = openAiParamRows().map(([id]) => id);
+    const placeholders = ids.map((_, index) => `$${index + 1}`).join(', ');
+    await queryRunner.query(
+      `
       DELETE FROM "provider_param_specs"
-      WHERE "provider" = 'openai'
-        AND "auth_type" = 'api_key'
-        AND "id" LIKE 'openai-api-key-%'
-    `);
+      WHERE "id" IN (${placeholders})
+    `,
+      ids,
+    );
   }
 }

--- a/packages/backend/src/database/migrations/1789700000000-AddOpenAiProviderParamSpecs.ts
+++ b/packages/backend/src/database/migrations/1789700000000-AddOpenAiProviderParamSpecs.ts
@@ -1,0 +1,227 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+type SeedRow = readonly [
+  id: string,
+  provider: string,
+  authType: string,
+  modelName: string | null,
+  paramKey: string,
+  controlKind: string,
+  label: string,
+  defaultValue: unknown,
+  values: readonly string[] | null,
+  minValue: number | null,
+  maxValue: number | null,
+  stepValue: number | null,
+  sortOrder: number,
+];
+
+type SpecTemplate = {
+  key: string;
+  kind: 'select' | 'slider' | 'number';
+  label: string;
+  defaultValue: unknown;
+  values?: readonly string[];
+  min?: number;
+  max?: number;
+  step?: number;
+  sortOrder: number;
+};
+
+const MAX_TOKENS: SpecTemplate = {
+  key: 'max_tokens',
+  kind: 'number',
+  label: 'Max tokens',
+  defaultValue: 4096,
+  min: 1,
+  sortOrder: 10,
+};
+
+const TEMPERATURE: SpecTemplate = {
+  key: 'temperature',
+  kind: 'slider',
+  label: 'Temperature',
+  defaultValue: 1,
+  min: 0,
+  max: 2,
+  step: 0.1,
+  sortOrder: 20,
+};
+
+const TOP_P: SpecTemplate = {
+  key: 'top_p',
+  kind: 'slider',
+  label: 'Top P',
+  defaultValue: 1,
+  min: 0,
+  max: 1,
+  step: 0.01,
+  sortOrder: 30,
+};
+
+const REASONING_EFFORT: SpecTemplate = {
+  key: 'reasoning_effort',
+  kind: 'select',
+  label: 'Reasoning effort',
+  defaultValue: 'medium',
+  values: ['minimal', 'low', 'medium', 'high'],
+  sortOrder: 40,
+};
+
+const GPT_5_1_REASONING_EFFORT: SpecTemplate = {
+  ...REASONING_EFFORT,
+  defaultValue: 'none',
+  values: ['none', 'low', 'medium', 'high'],
+};
+
+const OPENAI_CHAT_SAMPLING_MODELS = [
+  'gpt-4o',
+  'gpt-4o-mini',
+  'gpt-4o-2024-11-20',
+  'gpt-4.1',
+  'gpt-4.1-mini',
+  'gpt-4.1-nano',
+  'gpt-4-turbo',
+  'gpt-4-turbo-2024-04-09',
+  'gpt-3.5-turbo',
+  'chatgpt-4o-latest',
+] as const;
+
+const OPENAI_O_SERIES_REASONING_MODELS = [
+  'o1',
+  'o1-mini',
+  'o1-preview',
+  'o3',
+  'o3-mini',
+  'o4-mini',
+] as const;
+
+const OPENAI_GPT5_REASONING_MODELS = [
+  'gpt-5',
+  'gpt-5-mini',
+  'gpt-5-nano',
+  'gpt-5-chat-latest',
+  'gpt-5.2',
+  'gpt-5.4',
+] as const;
+
+const OPENAI_GPT51_REASONING_MODELS = ['gpt-5.1'] as const;
+
+function row(modelName: string | null, template: SpecTemplate): SeedRow {
+  const modelPart = modelName ? modelName.replace(/[^a-z0-9]+/gi, '-').toLowerCase() : 'base';
+  return [
+    `openai-api-key-${modelPart}-${template.key.replace(/_/g, '-')}`,
+    'openai',
+    'api_key',
+    modelName,
+    template.key,
+    template.kind,
+    template.label,
+    template.defaultValue,
+    template.values ?? null,
+    template.min ?? null,
+    template.max ?? null,
+    template.step ?? null,
+    template.sortOrder,
+  ];
+}
+
+export class AddOpenAiProviderParamSpecs1789700000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const rows: SeedRow[] = [
+      row(null, MAX_TOKENS),
+      ...OPENAI_CHAT_SAMPLING_MODELS.flatMap((model) =>
+        [MAX_TOKENS, TEMPERATURE, TOP_P].map((spec) => row(model, spec)),
+      ),
+      ...OPENAI_O_SERIES_REASONING_MODELS.flatMap((model) =>
+        [MAX_TOKENS, REASONING_EFFORT].map((spec) => row(model, spec)),
+      ),
+      ...OPENAI_GPT5_REASONING_MODELS.flatMap((model) =>
+        [MAX_TOKENS, TEMPERATURE, TOP_P, REASONING_EFFORT].map((spec) => row(model, spec)),
+      ),
+      ...OPENAI_GPT51_REASONING_MODELS.flatMap((model) =>
+        [MAX_TOKENS, TEMPERATURE, TOP_P, GPT_5_1_REASONING_EFFORT].map((spec) => row(model, spec)),
+      ),
+    ];
+
+    for (const seed of rows) {
+      const [
+        id,
+        provider,
+        authType,
+        modelName,
+        paramKey,
+        controlKind,
+        label,
+        defaultValue,
+        values,
+        minValue,
+        maxValue,
+        stepValue,
+        sortOrder,
+      ] = seed;
+      await queryRunner.query(
+        `
+          INSERT INTO "provider_param_specs"
+            (
+              "id",
+              "provider",
+              "auth_type",
+              "model_name",
+              "param_key",
+              "control_kind",
+              "label",
+              "default_value",
+              "values",
+              "min_value",
+              "max_value",
+              "step_value",
+              "sort_order"
+            )
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10, $11, $12, $13)
+          ON CONFLICT ON CONSTRAINT "provider_param_specs_pkey" DO UPDATE
+          SET
+            "provider" = EXCLUDED."provider",
+            "auth_type" = EXCLUDED."auth_type",
+            "model_name" = EXCLUDED."model_name",
+            "param_key" = EXCLUDED."param_key",
+            "control_kind" = EXCLUDED."control_kind",
+            "label" = EXCLUDED."label",
+            "default_value" = EXCLUDED."default_value",
+            "values" = EXCLUDED."values",
+            "min_value" = EXCLUDED."min_value",
+            "max_value" = EXCLUDED."max_value",
+            "step_value" = EXCLUDED."step_value",
+            "serializer" = NULL,
+            "dependencies" = NULL,
+            "sort_order" = EXCLUDED."sort_order",
+            "updated_at" = now()
+        `,
+        [
+          id,
+          provider,
+          authType,
+          modelName,
+          paramKey,
+          controlKind,
+          label,
+          JSON.stringify(defaultValue),
+          values === null ? null : JSON.stringify(values),
+          minValue,
+          maxValue,
+          stepValue,
+          sortOrder,
+        ],
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM "provider_param_specs"
+      WHERE "provider" = 'openai'
+        AND "auth_type" = 'api_key'
+        AND "id" LIKE 'openai-api-key-%'
+    `);
+  }
+}

--- a/packages/backend/src/entities/agent-message.entity.ts
+++ b/packages/backend/src/entities/agent-message.entity.ts
@@ -1,7 +1,6 @@
 import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
 import { timestampType } from '../common/utils/postgres-sql';
 import type { CallerAttribution } from '../routing/proxy/caller-classifier';
-import type { RequestParamDefaults } from 'manifest-shared';
 
 @Entity('agent_messages')
 @Index(['tenant_id', 'agent_id', 'timestamp'])
@@ -115,7 +114,7 @@ export class AgentMessage {
   request_headers!: Record<string, string> | null;
 
   @Column('jsonb', { nullable: true })
-  request_params!: RequestParamDefaults | null;
+  request_params!: object | null;
 
   @Column('varchar', { nullable: true })
   header_tier_id!: string | null;

--- a/packages/backend/src/entities/agent-model-params.entity.ts
+++ b/packages/backend/src/entities/agent-model-params.entity.ts
@@ -5,11 +5,10 @@ import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
 /**
  * Per-(agent, route) outbound request body defaults. Replaces the old
  * `tier_assignments.param_defaults` / `specificity_assignments.param_defaults`
- * blobs: params now travel with the route identity (`provider`, `auth_type`,
- * `model`) regardless of which slot the route happens to occupy. This makes
- * configuring DeepSeek's `thinking` toggle a one-time act that applies in
- * every tier, every specificity category, every header tier, and every
- * fallback position where `deepseek-v3.1` is selected.
+ * blobs: params now travel with the scoped route identity (`scope_key`,
+ * `provider`, `model`, `auth_type`). The same model can be configured
+ * differently in the default/complexity tiers, task-specific tiers, and
+ * custom header tiers.
  *
  * `keyLabel` is intentionally NOT part of the unique key — provider API
  * knobs like `thinking` don't differ by which API key is used. If a future
@@ -17,7 +16,7 @@ import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
  * it to its own column.
  */
 @Entity('agent_model_params')
-@Index(['agent_id', 'provider', 'auth_type', 'model_name'], { unique: true })
+@Index(['agent_id', 'scope_key', 'provider', 'model_name', 'auth_type'], { unique: true })
 export class AgentModelParams {
   @PrimaryColumn('varchar')
   id!: string;
@@ -27,6 +26,9 @@ export class AgentModelParams {
 
   @Column('varchar')
   agent_id!: string;
+
+  @Column('varchar')
+  scope_key!: string;
 
   @Column('varchar')
   provider!: string;

--- a/packages/backend/src/entities/agent-model-params.entity.ts
+++ b/packages/backend/src/entities/agent-model-params.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
-import type { AuthType, RequestParamDefaults } from 'manifest-shared';
+import type { AuthType } from 'manifest-shared';
 import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
 
 /**
@@ -38,7 +38,7 @@ export class AgentModelParams {
   model_name!: string;
 
   @Column('jsonb')
-  params!: RequestParamDefaults;
+  params!: object;
 
   @Column(timestampType(), { default: timestampDefault() })
   created_at!: string;

--- a/packages/backend/src/entities/provider-param-spec.entity.ts
+++ b/packages/backend/src/entities/provider-param-spec.entity.ts
@@ -1,5 +1,5 @@
 import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
-import type { AuthType, JsonValue, ParamControl } from 'manifest-shared';
+import type { AuthType, JsonValue, ParamControl, ProviderParamDependency } from 'manifest-shared';
 import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
 
 @Entity('provider_param_specs')
@@ -19,6 +19,12 @@ export class ProviderParamSpecEntity {
 
   @Column('varchar')
   param_key!: string;
+
+  @Column('varchar', { nullable: true, default: null })
+  group_key!: string | null;
+
+  @Column('varchar', { nullable: true, default: null })
+  group_label!: string | null;
 
   @Column('varchar')
   control_kind!: ParamControl['kind'];
@@ -43,6 +49,15 @@ export class ProviderParamSpecEntity {
 
   @Column('varchar', { nullable: true, default: null })
   serializer!: string | null;
+
+  @Column('varchar', { nullable: true, default: null })
+  depends_on_key!: string | null;
+
+  @Column('jsonb', { nullable: true, default: null })
+  depends_on_value!: JsonValue | null;
+
+  @Column('jsonb', { nullable: true, default: null })
+  dependencies!: ProviderParamDependency[] | null;
 
   @Column('integer', { default: 0 })
   sort_order!: number;

--- a/packages/backend/src/entities/provider-param-spec.entity.ts
+++ b/packages/backend/src/entities/provider-param-spec.entity.ts
@@ -1,0 +1,55 @@
+import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import type { AuthType, JsonValue, ParamControl } from 'manifest-shared';
+import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
+
+@Entity('provider_param_specs')
+@Index(['provider', 'auth_type', 'model_name', 'sort_order'])
+export class ProviderParamSpecEntity {
+  @PrimaryColumn('varchar')
+  id!: string;
+
+  @Column('varchar')
+  provider!: string;
+
+  @Column('varchar')
+  auth_type!: AuthType;
+
+  @Column('varchar', { nullable: true, default: null })
+  model_name!: string | null;
+
+  @Column('varchar')
+  param_key!: string;
+
+  @Column('varchar')
+  control_kind!: ParamControl['kind'];
+
+  @Column('varchar')
+  label!: string;
+
+  @Column('jsonb')
+  default_value!: JsonValue;
+
+  @Column('jsonb', { nullable: true, default: null })
+  values!: string[] | null;
+
+  @Column('double precision', { nullable: true, default: null })
+  min_value!: number | null;
+
+  @Column('double precision', { nullable: true, default: null })
+  max_value!: number | null;
+
+  @Column('double precision', { nullable: true, default: null })
+  step_value!: number | null;
+
+  @Column('varchar', { nullable: true, default: null })
+  serializer!: string | null;
+
+  @Column('integer', { default: 0 })
+  sort_order!: number;
+
+  @Column(timestampType(), { default: timestampDefault() })
+  created_at!: string;
+
+  @Column(timestampType(), { default: timestampDefault() })
+  updated_at!: string;
+}

--- a/packages/backend/src/routing/__tests__/model-params.controller.spec.ts
+++ b/packages/backend/src/routing/__tests__/model-params.controller.spec.ts
@@ -44,6 +44,7 @@ describe('ModelParamsController', () => {
     it('returns the projected list for the agent', async () => {
       service.list.mockResolvedValueOnce([
         {
+          scope_key: 'tier:simple',
           provider: 'deepseek',
           auth_type: 'api_key',
           model_name: 'deepseek-v4',
@@ -55,6 +56,7 @@ describe('ModelParamsController', () => {
 
       expect(result).toEqual([
         {
+          scope: 'tier:simple',
           provider: 'deepseek',
           authType: 'api_key',
           model: 'deepseek-v4',
@@ -67,6 +69,7 @@ describe('ModelParamsController', () => {
   describe('PUT /model-params', () => {
     it('persists compatible params and returns the projected row', async () => {
       service.set.mockResolvedValueOnce({
+        scope_key: 'tier:simple',
         provider: 'deepseek',
         auth_type: 'api_key',
         model_name: 'deepseek-v4',
@@ -77,6 +80,7 @@ describe('ModelParamsController', () => {
         mockUser,
         { agentName: 'demo' },
         {
+          scope: 'tier:simple',
           provider: 'deepseek',
           authType: 'api_key',
           model: 'deepseek-v4',
@@ -87,12 +91,14 @@ describe('ModelParamsController', () => {
       expect(service.set).toHaveBeenCalledWith(
         'agent-1',
         'user-1',
+        'tier:simple',
         'deepseek',
         'api_key',
         'deepseek-v4',
         { thinking: 'disabled' },
       );
       expect(result).toEqual({
+        scope: 'tier:simple',
         provider: 'deepseek',
         authType: 'api_key',
         model: 'deepseek-v4',
@@ -102,7 +108,8 @@ describe('ModelParamsController', () => {
 
     it('persists all Anthropic API-key scalar params', async () => {
       service.set.mockImplementation(
-        async (_agentId, _userId, provider, authType, model, params) => ({
+        async (_agentId, _userId, scope, provider, authType, model, params) => ({
+          scope_key: scope,
           provider,
           auth_type: authType,
           model_name: model,
@@ -121,6 +128,7 @@ describe('ModelParamsController', () => {
         mockUser,
         { agentName: 'demo' },
         {
+          scope: 'tier:expert',
           provider: 'anthropic',
           authType: 'api_key',
           model: 'claude-opus-4-7',
@@ -131,6 +139,7 @@ describe('ModelParamsController', () => {
       expect(service.set).toHaveBeenCalledWith(
         'agent-1',
         'user-1',
+        'tier:expert',
         'anthropic',
         'api_key',
         'claude-opus-4-7',
@@ -140,7 +149,8 @@ describe('ModelParamsController', () => {
     });
 
     it('strips keys the provider does not consume and persists only the compatible subset', async () => {
-      service.set.mockImplementation(async (_a, _u, p, a, m, params) => ({
+      service.set.mockImplementation(async (_a, _u, scope, p, a, m, params) => ({
+        scope_key: scope,
         provider: p,
         auth_type: a,
         model_name: m,
@@ -154,6 +164,7 @@ describe('ModelParamsController', () => {
         mockUser,
         { agentName: 'demo' },
         {
+          scope: 'tier:simple',
           provider: 'deepseek',
           authType: 'api_key',
           model: 'deepseek-v4',
@@ -170,6 +181,7 @@ describe('ModelParamsController', () => {
           mockUser,
           { agentName: 'demo' },
           {
+            scope: 'tier:simple',
             provider: 'deepseek',
             authType: 'api_key',
             model: 'deepseek-v4',
@@ -185,6 +197,7 @@ describe('ModelParamsController', () => {
           mockUser,
           { agentName: 'demo' },
           {
+            scope: 'tier:simple',
             provider: 'openai',
             authType: 'api_key',
             model: 'gpt-4o',
@@ -201,13 +214,20 @@ describe('ModelParamsController', () => {
         mockUser,
         { agentName: 'demo' },
         {
+          scope: 'tier:simple',
           provider: 'deepseek',
           authType: 'api_key',
           model: 'deepseek-v4',
         },
       );
 
-      expect(service.delete).toHaveBeenCalledWith('agent-1', 'deepseek', 'api_key', 'deepseek-v4');
+      expect(service.delete).toHaveBeenCalledWith(
+        'agent-1',
+        'tier:simple',
+        'deepseek',
+        'api_key',
+        'deepseek-v4',
+      );
       expect(result).toEqual({ ok: true });
     });
   });

--- a/packages/backend/src/routing/__tests__/model-params.controller.spec.ts
+++ b/packages/backend/src/routing/__tests__/model-params.controller.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ModelParamsController } from '../model-params.controller';
 import { AgentModelParamsService } from '../routing-core/agent-model-params.service';
+import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
 import { AuthUser } from '../../auth/auth.instance';
 
@@ -16,6 +17,10 @@ describe('ModelParamsController', () => {
     delete: jest.Mock;
     get: jest.Mock;
   }>;
+  let providerParamSpecs: jest.Mocked<{
+    getRegistry: jest.Mock;
+    getSpecs: jest.Mock;
+  }>;
   let resolveAgent: jest.Mocked<{ resolve: jest.Mock }>;
 
   beforeEach(async () => {
@@ -25,6 +30,10 @@ describe('ModelParamsController', () => {
       delete: jest.fn(),
       get: jest.fn(),
     };
+    providerParamSpecs = {
+      getRegistry: jest.fn(),
+      getSpecs: jest.fn(),
+    };
     resolveAgent = {
       resolve: jest.fn().mockResolvedValue(mockAgent),
     };
@@ -33,6 +42,7 @@ describe('ModelParamsController', () => {
       controllers: [ModelParamsController],
       providers: [
         { provide: AgentModelParamsService, useValue: service },
+        { provide: ProviderParamSpecService, useValue: providerParamSpecs },
         { provide: ResolveAgentService, useValue: resolveAgent },
       ],
     }).compile();
@@ -66,8 +76,43 @@ describe('ModelParamsController', () => {
     });
   });
 
+  describe('GET /model-param-specs', () => {
+    it('returns the backend-loaded param spec registry', async () => {
+      const registry = {
+        'deepseek:api_key': {
+          base: [
+            {
+              key: 'thinking',
+              control: {
+                kind: 'toggle',
+                label: 'Thinking mode',
+                values: ['enabled', 'disabled'],
+                default: 'enabled',
+              },
+            },
+          ],
+        },
+      };
+      providerParamSpecs.getRegistry.mockResolvedValueOnce(registry);
+
+      await expect(controller.specs(mockUser, { agentName: 'demo' })).resolves.toBe(registry);
+      expect(resolveAgent.resolve).toHaveBeenCalledWith('user-1', 'demo');
+    });
+  });
+
   describe('PUT /model-params', () => {
     it('persists compatible params and returns the projected row', async () => {
+      providerParamSpecs.getSpecs.mockResolvedValueOnce([
+        {
+          key: 'thinking',
+          control: {
+            kind: 'toggle',
+            label: 'Thinking mode',
+            values: ['enabled', 'disabled'],
+            default: 'enabled',
+          },
+        },
+      ]);
       service.set.mockResolvedValueOnce({
         scope_key: 'tier:simple',
         provider: 'deepseek',
@@ -107,6 +152,24 @@ describe('ModelParamsController', () => {
     });
 
     it('persists all Anthropic API-key scalar params', async () => {
+      providerParamSpecs.getSpecs.mockResolvedValueOnce([
+        {
+          key: 'max_tokens',
+          control: { kind: 'number', label: 'Max tokens', min: 1, default: 4096 },
+        },
+        {
+          key: 'temperature',
+          control: { kind: 'slider', label: 'Temperature', min: 0, max: 1, step: 0.1, default: 1 },
+        },
+        {
+          key: 'top_p',
+          control: { kind: 'slider', label: 'Top P', min: 0, max: 1, step: 0.01, default: 1 },
+        },
+        {
+          key: 'top_k',
+          control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+        },
+      ]);
       service.set.mockImplementation(
         async (_agentId, _userId, scope, provider, authType, model, params) => ({
           scope_key: scope,
@@ -149,6 +212,17 @@ describe('ModelParamsController', () => {
     });
 
     it('strips keys the provider does not consume and persists only the compatible subset', async () => {
+      providerParamSpecs.getSpecs.mockResolvedValueOnce([
+        {
+          key: 'thinking',
+          control: {
+            kind: 'toggle',
+            label: 'Thinking mode',
+            values: ['enabled', 'disabled'],
+            default: 'enabled',
+          },
+        },
+      ]);
       service.set.mockImplementation(async (_a, _u, scope, p, a, m, params) => ({
         scope_key: scope,
         provider: p,
@@ -192,6 +266,7 @@ describe('ModelParamsController', () => {
     });
 
     it('throws when the provider does not consume any of the supplied keys', async () => {
+      providerParamSpecs.getSpecs.mockResolvedValueOnce([]);
       await expect(
         controller.set(
           mockUser,

--- a/packages/backend/src/routing/__tests__/model-params.controller.spec.ts
+++ b/packages/backend/src/routing/__tests__/model-params.controller.spec.ts
@@ -169,6 +169,22 @@ describe('ModelParamsController', () => {
           key: 'top_k',
           control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
         },
+        {
+          key: 'type',
+          group: { key: 'thinking', label: 'Thinking' },
+          control: {
+            kind: 'select',
+            label: 'Thinking mode',
+            values: ['disabled', 'adaptive', 'enabled'],
+            default: 'disabled',
+          },
+        },
+        {
+          key: 'budget_tokens',
+          group: { key: 'thinking', label: 'Thinking' },
+          visibleWhen: { key: 'type', equals: 'enabled' },
+          control: { kind: 'number', label: 'Budget tokens', min: 1024, default: 4096 },
+        },
       ]);
       service.set.mockImplementation(
         async (_agentId, _userId, scope, provider, authType, model, params) => ({
@@ -185,6 +201,7 @@ describe('ModelParamsController', () => {
         temperature: 0.6,
         top_p: 0.77,
         top_k: 10,
+        thinking: { type: 'enabled', budget_tokens: 4096 },
       };
 
       const result = await controller.set(

--- a/packages/backend/src/routing/__tests__/model-params.controller.spec.ts
+++ b/packages/backend/src/routing/__tests__/model-params.controller.spec.ts
@@ -47,7 +47,7 @@ describe('ModelParamsController', () => {
           provider: 'deepseek',
           auth_type: 'api_key',
           model_name: 'deepseek-v4',
-          params: { thinking: { type: 'disabled' } },
+          params: { thinking: 'disabled' },
         },
       ]);
 
@@ -58,7 +58,7 @@ describe('ModelParamsController', () => {
           provider: 'deepseek',
           authType: 'api_key',
           model: 'deepseek-v4',
-          params: { thinking: { type: 'disabled' } },
+          params: { thinking: 'disabled' },
         },
       ]);
     });
@@ -70,7 +70,7 @@ describe('ModelParamsController', () => {
         provider: 'deepseek',
         auth_type: 'api_key',
         model_name: 'deepseek-v4',
-        params: { thinking: { type: 'disabled' } },
+        params: { thinking: 'disabled' },
       });
 
       const result = await controller.set(
@@ -80,7 +80,7 @@ describe('ModelParamsController', () => {
           provider: 'deepseek',
           authType: 'api_key',
           model: 'deepseek-v4',
-          params: { thinking: { type: 'disabled' } },
+          params: { thinking: 'disabled' },
         },
       );
 
@@ -90,14 +90,53 @@ describe('ModelParamsController', () => {
         'deepseek',
         'api_key',
         'deepseek-v4',
-        { thinking: { type: 'disabled' } },
+        { thinking: 'disabled' },
       );
       expect(result).toEqual({
         provider: 'deepseek',
         authType: 'api_key',
         model: 'deepseek-v4',
-        params: { thinking: { type: 'disabled' } },
+        params: { thinking: 'disabled' },
       });
+    });
+
+    it('persists all Anthropic API-key scalar params', async () => {
+      service.set.mockImplementation(
+        async (_agentId, _userId, provider, authType, model, params) => ({
+          provider,
+          auth_type: authType,
+          model_name: model,
+          params,
+        }),
+      );
+
+      const paramDefaults = {
+        max_tokens: 1234,
+        temperature: 0.6,
+        top_p: 0.77,
+        top_k: 10,
+      };
+
+      const result = await controller.set(
+        mockUser,
+        { agentName: 'demo' },
+        {
+          provider: 'anthropic',
+          authType: 'api_key',
+          model: 'claude-opus-4-7',
+          params: paramDefaults,
+        },
+      );
+
+      expect(service.set).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'anthropic',
+        'api_key',
+        'claude-opus-4-7',
+        paramDefaults,
+      );
+      expect(result.params).toEqual(paramDefaults);
     });
 
     it('strips keys the provider does not consume and persists only the compatible subset', async () => {
@@ -118,11 +157,11 @@ describe('ModelParamsController', () => {
           provider: 'deepseek',
           authType: 'api_key',
           model: 'deepseek-v4',
-          params: { thinking: { type: 'enabled' } },
+          params: { thinking: 'enabled' },
         },
       );
 
-      expect(out.params).toEqual({ thinking: { type: 'enabled' } });
+      expect(out.params).toEqual({ thinking: 'enabled' });
     });
 
     it('throws when the params payload contains no configurable keys at all', async () => {
@@ -149,7 +188,7 @@ describe('ModelParamsController', () => {
             provider: 'openai',
             authType: 'api_key',
             model: 'gpt-4o',
-            params: { thinking: { type: 'enabled' } },
+            params: { thinking: 'enabled' },
           },
         ),
       ).rejects.toBeInstanceOf(BadRequestException);

--- a/packages/backend/src/routing/dto/__tests__/model-params.dto.spec.ts
+++ b/packages/backend/src/routing/dto/__tests__/model-params.dto.spec.ts
@@ -11,6 +11,7 @@ describe('model-params DTOs', () => {
   describe('SetModelParamsBodyDto', () => {
     it('accepts a well-formed body and preserves arbitrary params keys for registry validation', () => {
       const dto = plainToInstance(SetModelParamsBodyDto, {
+        scope: 'tier:simple',
         provider: 'deepseek',
         authType: 'api_key',
         model: 'deepseek-v4',
@@ -23,6 +24,7 @@ describe('model-params DTOs', () => {
 
     it('does not recurse into params values; the controller registry gate validates them', () => {
       const dto = plainToInstance(SetModelParamsBodyDto, {
+        scope: 'tier:simple',
         provider: 'deepseek',
         authType: 'api_key',
         model: 'deepseek-v4',
@@ -33,6 +35,7 @@ describe('model-params DTOs', () => {
 
     it('rejects unknown authType values (limited to AUTH_TYPES)', () => {
       const dto = plainToInstance(SetModelParamsBodyDto, {
+        scope: 'tier:simple',
         provider: 'deepseek',
         authType: 'bogus',
         model: 'deepseek-v4',
@@ -43,6 +46,7 @@ describe('model-params DTOs', () => {
 
     it('rejects when params is missing (ValidateIf forces the field)', () => {
       const dto = plainToInstance(SetModelParamsBodyDto, {
+        scope: 'tier:simple',
         provider: 'deepseek',
         authType: 'api_key',
         model: 'deepseek-v4',
@@ -54,6 +58,7 @@ describe('model-params DTOs', () => {
   describe('DeleteModelParamsBodyDto', () => {
     it('accepts a route identity body', () => {
       const dto = plainToInstance(DeleteModelParamsBodyDto, {
+        scope: 'tier:simple',
         provider: 'deepseek',
         authType: 'api_key',
         model: 'deepseek-v4',
@@ -63,6 +68,7 @@ describe('model-params DTOs', () => {
 
     it('rejects empty provider', () => {
       const dto = plainToInstance(DeleteModelParamsBodyDto, {
+        scope: 'tier:simple',
         provider: '',
         authType: 'api_key',
         model: 'deepseek-v4',

--- a/packages/backend/src/routing/dto/__tests__/model-params.dto.spec.ts
+++ b/packages/backend/src/routing/dto/__tests__/model-params.dto.spec.ts
@@ -5,47 +5,30 @@ import {
   DeleteModelParamsBodyDto,
   ModelParamsBodyDto,
   SetModelParamsBodyDto,
-  ThinkingParamsDto,
 } from '../model-params.dto';
 
 describe('model-params DTOs', () => {
-  describe('ThinkingParamsDto', () => {
-    it('accepts the two known values', () => {
-      for (const type of ['enabled', 'disabled']) {
-        const dto = plainToInstance(ThinkingParamsDto, { type });
-        expect(validateSync(dto)).toHaveLength(0);
-      }
-    });
-
-    it('rejects unknown values', () => {
-      const dto = plainToInstance(ThinkingParamsDto, { type: 'maybe' });
-      expect(validateSync(dto).length).toBeGreaterThan(0);
-    });
-  });
-
   describe('SetModelParamsBodyDto', () => {
-    it('accepts a well-formed body and constructs the nested ModelParamsBodyDto via @Type', () => {
+    it('accepts a well-formed body and preserves arbitrary params keys for registry validation', () => {
       const dto = plainToInstance(SetModelParamsBodyDto, {
         provider: 'deepseek',
         authType: 'api_key',
         model: 'deepseek-v4',
-        params: { thinking: { type: 'disabled' } },
+        params: { thinking: 'disabled', temperature: 0.7 },
       });
-      // `params` is constructed by @Type(() => ModelParamsBodyDto) — proves
-      // the factory function ran.
-      expect(dto.params).toBeInstanceOf(ModelParamsBodyDto);
-      expect(dto.params.thinking).toBeInstanceOf(ThinkingParamsDto);
+      expect(dto).toBeInstanceOf(ModelParamsBodyDto);
+      expect(dto.params).toEqual({ thinking: 'disabled', temperature: 0.7 });
       expect(validateSync(dto)).toHaveLength(0);
     });
 
-    it('rejects an invalid nested params payload', () => {
+    it('does not recurse into params values; the controller registry gate validates them', () => {
       const dto = plainToInstance(SetModelParamsBodyDto, {
         provider: 'deepseek',
         authType: 'api_key',
         model: 'deepseek-v4',
         params: { thinking: { type: 'bogus' } },
       });
-      expect(validateSync(dto).length).toBeGreaterThan(0);
+      expect(validateSync(dto)).toHaveLength(0);
     });
 
     it('rejects unknown authType values (limited to AUTH_TYPES)', () => {
@@ -53,7 +36,7 @@ describe('model-params DTOs', () => {
         provider: 'deepseek',
         authType: 'bogus',
         model: 'deepseek-v4',
-        params: { thinking: { type: 'disabled' } },
+        params: { thinking: 'disabled' },
       });
       expect(validateSync(dto).length).toBeGreaterThan(0);
     });

--- a/packages/backend/src/routing/dto/model-params.dto.ts
+++ b/packages/backend/src/routing/dto/model-params.dto.ts
@@ -15,6 +15,10 @@ export class ModelParamsBodyDto {
 export class SetModelParamsBodyDto extends ModelParamsBodyDto {
   @IsString()
   @IsNotEmpty()
+  scope!: string;
+
+  @IsString()
+  @IsNotEmpty()
   provider!: string;
 
   @IsIn(AUTH_TYPES)
@@ -31,6 +35,10 @@ export class SetModelParamsBodyDto extends ModelParamsBodyDto {
 }
 
 export class DeleteModelParamsBodyDto {
+  @IsString()
+  @IsNotEmpty()
+  scope!: string;
+
   @IsString()
   @IsNotEmpty()
   provider!: string;

--- a/packages/backend/src/routing/dto/model-params.dto.ts
+++ b/packages/backend/src/routing/dto/model-params.dto.ts
@@ -1,29 +1,18 @@
-import { IsIn, IsNotEmpty, IsObject, IsOptional, IsString, ValidateNested } from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsIn, IsNotEmpty, IsObject, IsString } from 'class-validator';
 
 import { AUTH_TYPES, type AuthType, type RequestParamDefaults } from 'manifest-shared';
 
 /**
- * Subset of valid `RequestParamDefaults` keys this DTO understands today.
- * The shape is curated: when a new provider knob lands (`reasoning_effort`,
- * safety toggles, etc.), append the corresponding `ThinkingParamsDto`-style
- * nested class and a `@ValidateIf` clause to keep the JSONB schema honest.
- * Unknown keys are stripped by the global `ValidationPipe`'s `whitelist`,
- * so a curious client can't slip a free-form payload past the gate.
+ * Param keys and value shapes are validated by the registry-aware controller
+ * gate. The DTO only keeps the top-level object intact so whitelist mode
+ * does not strip arbitrary future param keys before the registry sees them.
  */
-export class ThinkingParamsDto {
-  @IsIn(['enabled', 'disabled'])
-  type!: 'enabled' | 'disabled';
+export class ModelParamsBodyDto {
+  @IsObject()
+  params!: RequestParamDefaults;
 }
 
-export class ModelParamsBodyDto implements RequestParamDefaults {
-  @IsOptional()
-  @ValidateNested()
-  @Type(() => ThinkingParamsDto)
-  thinking?: ThinkingParamsDto;
-}
-
-export class SetModelParamsBodyDto {
+export class SetModelParamsBodyDto extends ModelParamsBodyDto {
   @IsString()
   @IsNotEmpty()
   provider!: string;
@@ -38,10 +27,7 @@ export class SetModelParamsBodyDto {
   // Always required on PUT — to clear params, call DELETE instead. Routing
   // through one path per intent keeps the storage model simple (no "save
   // empty == delete" magic at the controller layer).
-  @IsObject()
-  @ValidateNested()
-  @Type(() => ModelParamsBodyDto)
-  params!: ModelParamsBodyDto;
+  declare params: RequestParamDefaults;
 }
 
 export class DeleteModelParamsBodyDto {

--- a/packages/backend/src/routing/model-params.controller.ts
+++ b/packages/backend/src/routing/model-params.controller.ts
@@ -28,6 +28,7 @@ export class ModelParamsController {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
     const rows = await this.modelParamsService.list(agent.id);
     return rows.map((r) => ({
+      scope: r.scope_key,
       provider: r.provider,
       authType: r.auth_type,
       model: r.model_name,
@@ -36,10 +37,10 @@ export class ModelParamsController {
   }
 
   /**
-   * Upsert one route's params. Body shape carries the full route identity
-   * because model names can contain slashes (e.g. `anthropic/claude-3.5-…`)
-   * and putting them in the URL path requires encoding gymnastics no client
-   * remembers to do.
+   * Upsert one scoped route's params. Body shape carries the full route
+   * identity because model names can contain slashes (e.g.
+   * `anthropic/claude-3.5-…`) and putting them in the URL path requires
+   * encoding gymnastics no client remembers to do.
    *
    * Provider/key compatibility is enforced here, not in the DTO: the DTO
    * preserves the params object while this method checks the
@@ -62,12 +63,14 @@ export class ModelParamsController {
     const saved = await this.modelParamsService.set(
       agent.id,
       user.id,
+      body.scope,
       body.provider,
       body.authType,
       body.model,
       sanitized,
     );
     return {
+      scope: saved.scope_key,
       provider: saved.provider,
       authType: saved.auth_type,
       model: saved.model_name,
@@ -87,7 +90,13 @@ export class ModelParamsController {
     @Body() body: DeleteModelParamsBodyDto,
   ) {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
-    await this.modelParamsService.delete(agent.id, body.provider, body.authType, body.model);
+    await this.modelParamsService.delete(
+      agent.id,
+      body.scope,
+      body.provider,
+      body.authType,
+      body.model,
+    );
     return { ok: true };
   }
 

--- a/packages/backend/src/routing/model-params.controller.ts
+++ b/packages/backend/src/routing/model-params.controller.ts
@@ -2,11 +2,13 @@ import { BadRequestException, Body, Controller, Delete, Get, Param, Put } from '
 import {
   pickProviderCompatibleParams,
   type AuthType,
+  type ProviderParamSpecRegistry,
   type RequestParamDefaults,
 } from 'manifest-shared';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
 import { AgentModelParamsService } from './routing-core/agent-model-params.service';
+import { ProviderParamSpecService } from './routing-core/provider-param-spec.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { AgentNameParamDto } from './dto/routing.dto';
 import { DeleteModelParamsBodyDto, SetModelParamsBodyDto } from './dto/model-params.dto';
@@ -15,8 +17,18 @@ import { DeleteModelParamsBodyDto, SetModelParamsBodyDto } from './dto/model-par
 export class ModelParamsController {
   constructor(
     private readonly modelParamsService: AgentModelParamsService,
+    private readonly providerParamSpecs: ProviderParamSpecService,
     private readonly resolveAgentService: ResolveAgentService,
   ) {}
+
+  @Get(':agentName/model-param-specs')
+  async specs(
+    @CurrentUser() user: AuthUser,
+    @Param() params: AgentNameParamDto,
+  ): Promise<ProviderParamSpecRegistry> {
+    await this.resolveAgentService.resolve(user.id, params.agentName);
+    return this.providerParamSpecs.getRegistry();
+  }
 
   /**
    * Full list for the agent. The frontend calls this once on Routing page
@@ -43,7 +55,7 @@ export class ModelParamsController {
    * encoding gymnastics no client remembers to do.
    *
    * Provider/key compatibility is enforced here, not in the DTO: the DTO
-   * preserves the params object while this method checks the
+   * preserves the params object while this method checks DB-backed
    * (provider, auth_type, model, key) compatibility so an incompatible route
    * does not save a payload it would silently drop at proxy time.
    */
@@ -54,7 +66,7 @@ export class ModelParamsController {
     @Body() body: SetModelParamsBodyDto,
   ) {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
-    const sanitized = this.assertCompatibleParams(
+    const sanitized = await this.assertCompatibleParams(
       body.provider,
       body.authType,
       body.model,
@@ -101,32 +113,32 @@ export class ModelParamsController {
   }
 
   /**
-   * Provider/key compatibility gate, driven by the single
-   * `PROVIDER_PARAM_SPECS` registry in `manifest-shared`. Returns the
-   * params trimmed to the keys the provider actually consumes — a partially
-   * incompatible payload still saves the compatible part rather than
-   * throwing, matching the proxy's lenient merge behavior.
+   * Provider/key compatibility gate, driven by the DB-backed provider param
+   * specs. Returns the params trimmed to the keys the provider actually
+   * consumes — a partially incompatible payload still saves the compatible
+   * part rather than throwing, matching the proxy's lenient merge behavior.
    *
    * Throws when the payload is empty (no keys at all) or when no key is
    * compatible with the provider — those are user errors the UI should
    * surface, not silently swallow.
    *
-   * Adding a new provider knob is one entry in `PROVIDER_PARAM_SPECS`;
-   * this method does not need to change.
+   * Adding a new provider knob is one row in `provider_param_specs`; this
+   * method does not need to change.
    */
-  private assertCompatibleParams(
+  private async assertCompatibleParams(
     provider: string,
     authType: AuthType,
     model: string,
     params: RequestParamDefaults,
-  ): RequestParamDefaults {
+  ): Promise<RequestParamDefaults> {
     const keys = Object.keys(params).filter(
       (k) => (params as Record<string, unknown>)[k] !== undefined,
     );
     if (keys.length === 0) {
       throw new BadRequestException('params must contain at least one configurable field');
     }
-    const out = pickProviderCompatibleParams(provider, authType, model, params);
+    const specs = await this.providerParamSpecs.getSpecs(provider, authType, model);
+    const out = pickProviderCompatibleParams(params, specs);
     if (Object.keys(out).length === 0) {
       throw new BadRequestException(
         `Provider "${provider}" does not consume any of the supplied params`,

--- a/packages/backend/src/routing/model-params.controller.ts
+++ b/packages/backend/src/routing/model-params.controller.ts
@@ -1,5 +1,9 @@
 import { BadRequestException, Body, Controller, Delete, Get, Param, Put } from '@nestjs/common';
-import { pickProviderCompatibleParams, type RequestParamDefaults } from 'manifest-shared';
+import {
+  pickProviderCompatibleParams,
+  type AuthType,
+  type RequestParamDefaults,
+} from 'manifest-shared';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
 import { AgentModelParamsService } from './routing-core/agent-model-params.service';
@@ -38,9 +42,9 @@ export class ModelParamsController {
    * remembers to do.
    *
    * Provider/key compatibility is enforced here, not in the DTO: the DTO
-   * validates only the shape of each known key, while this method checks
-   * the (provider, key) compatibility so an OpenAI route doesn't get a
-   * `thinking` payload it would silently drop at proxy time.
+   * preserves the params object while this method checks the
+   * (provider, auth_type, model, key) compatibility so an incompatible route
+   * does not save a payload it would silently drop at proxy time.
    */
   @Put(':agentName/model-params')
   async set(
@@ -49,7 +53,12 @@ export class ModelParamsController {
     @Body() body: SetModelParamsBodyDto,
   ) {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
-    const sanitized = this.assertCompatibleParams(body.provider, body.params);
+    const sanitized = this.assertCompatibleParams(
+      body.provider,
+      body.authType,
+      body.model,
+      body.params,
+    );
     const saved = await this.modelParamsService.set(
       agent.id,
       user.id,
@@ -98,6 +107,8 @@ export class ModelParamsController {
    */
   private assertCompatibleParams(
     provider: string,
+    authType: AuthType,
+    model: string,
     params: RequestParamDefaults,
   ): RequestParamDefaults {
     const keys = Object.keys(params).filter(
@@ -106,7 +117,7 @@ export class ModelParamsController {
     if (keys.length === 0) {
       throw new BadRequestException('params must contain at least one configurable field');
     }
-    const out = pickProviderCompatibleParams(provider, params);
+    const out = pickProviderCompatibleParams(provider, authType, model, params);
     if (Object.keys(out).length === 0) {
       throw new BadRequestException(
         `Provider "${provider}" does not consume any of the supplied params`,

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
@@ -10,6 +10,7 @@ import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
+import { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
 
 /**
  * Locks the route-aware behavior of ProxyFallbackService.tryFallbacks:
@@ -80,6 +81,9 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
       set: jest.fn(),
       delete: jest.fn(),
     } as unknown as AgentModelParamsService;
+    const providerParamSpecs = {
+      getSpecs: jest.fn().mockResolvedValue([]),
+    } as unknown as ProviderParamSpecService;
 
     service = new ProxyFallbackService(
       providerKeyService,
@@ -91,6 +95,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
       copilotToken,
       pricingCache,
       modelParamsService,
+      providerParamSpecs,
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -13,6 +13,17 @@ import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
+import { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
+
+const thinkingSpec = {
+  key: 'thinking',
+  control: {
+    kind: 'toggle' as const,
+    label: 'Thinking mode',
+    values: ['enabled', 'disabled'] as const,
+    default: 'enabled',
+  },
+};
 
 describe('ProxyFallbackService', () => {
   let service: ProxyFallbackService;
@@ -25,6 +36,7 @@ describe('ProxyFallbackService', () => {
   let copilotToken: jest.Mocked<CopilotTokenService>;
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
   let modelParamsService: jest.Mocked<AgentModelParamsService>;
+  let providerParamSpecs: jest.Mocked<ProviderParamSpecService>;
 
   beforeEach(() => {
     providerKeyService = {
@@ -69,6 +81,9 @@ describe('ProxyFallbackService', () => {
       set: jest.fn(),
       delete: jest.fn(),
     } as unknown as jest.Mocked<AgentModelParamsService>;
+    providerParamSpecs = {
+      getSpecs: jest.fn().mockResolvedValue([thinkingSpec]),
+    } as unknown as jest.Mocked<ProviderParamSpecService>;
 
     service = new ProxyFallbackService(
       providerKeyService,
@@ -80,6 +95,7 @@ describe('ProxyFallbackService', () => {
       copilotToken,
       pricingCache,
       modelParamsService,
+      providerParamSpecs,
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -154,11 +154,12 @@ describe('ProxyFallbackService', () => {
         stream: false,
         sessionKey: 'sess-1',
         authType: 'api_key',
-        paramMergeContext: { agentId: 'agent-1' },
+        paramMergeContext: { agentId: 'agent-1', scopeKey: 'tier:simple' },
       });
 
       expect(modelParamsService.get).toHaveBeenCalledWith(
         'agent-1',
+        'tier:simple',
         'deepseek',
         'api_key',
         'deepseek-v4-flash',
@@ -190,7 +191,7 @@ describe('ProxyFallbackService', () => {
         stream: false,
         sessionKey: 'sess-1',
         authType: 'api_key',
-        paramMergeContext: { agentId: 'agent-1' },
+        paramMergeContext: { agentId: 'agent-1', scopeKey: 'tier:simple' },
       });
 
       const forwarded = providerClient.forward.mock.calls[0][0];
@@ -217,7 +218,7 @@ describe('ProxyFallbackService', () => {
         stream: false,
         sessionKey: 'sess-1',
         authType: 'api_key',
-        paramMergeContext: { agentId: 'agent-1' },
+        paramMergeContext: { agentId: 'agent-1', scopeKey: 'tier:simple' },
       });
 
       const forwarded = providerClient.forward.mock.calls[0][0];

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -144,7 +144,7 @@ describe('ProxyFallbackService', () => {
         isAnthropic: false,
         isChatGpt: false,
       });
-      modelParamsService.get.mockResolvedValueOnce({ thinking: { type: 'disabled' } });
+      modelParamsService.get.mockResolvedValueOnce({ thinking: 'disabled' });
 
       await service.tryForwardToProvider({
         provider: 'deepseek',
@@ -165,7 +165,7 @@ describe('ProxyFallbackService', () => {
       );
       expect(providerClient.forward).toHaveBeenCalledWith(
         expect.objectContaining({
-          body: expect.objectContaining({ thinking: { type: 'disabled' } }),
+          body: expect.objectContaining({ thinking: 'disabled' }),
         }),
       );
     });
@@ -204,7 +204,7 @@ describe('ProxyFallbackService', () => {
         isAnthropic: false,
         isChatGpt: false,
       });
-      modelParamsService.get.mockResolvedValueOnce({ thinking: { type: 'disabled' } });
+      modelParamsService.get.mockResolvedValueOnce({ thinking: 'disabled' });
 
       await service.tryForwardToProvider({
         provider: 'deepseek',
@@ -212,7 +212,7 @@ describe('ProxyFallbackService', () => {
         model: 'deepseek-v4-flash',
         body: {
           messages: [{ role: 'user', content: 'hi' }],
-          thinking: { type: 'enabled' },
+          thinking: 'enabled',
         },
         stream: false,
         sessionKey: 'sess-1',
@@ -221,7 +221,7 @@ describe('ProxyFallbackService', () => {
       });
 
       const forwarded = providerClient.forward.mock.calls[0][0];
-      expect(forwarded.body.thinking).toEqual({ type: 'enabled' });
+      expect(forwarded.body.thinking).toEqual('enabled');
     });
 
     it('skips the lookup when paramMergeContext is omitted (e.g. legacy callers)', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -1205,7 +1205,7 @@ describe('ProxyMessageRecorder', () => {
   // (the back-compat property: existing call sites that don't know about
   // this feature don't accidentally write garbage).
   describe('request_params persistence', () => {
-    const params = { thinking: { type: 'disabled' as const } };
+    const params = { thinking: 'disabled' };
 
     it('recordProviderError persists requestParams when supplied', async () => {
       await recorder.recordProviderError(ctx, 500, 'oops', { requestParams: params });
@@ -1278,7 +1278,7 @@ describe('ProxyMessageRecorder', () => {
       // point of the JSONB column. Test that with a multi-key fixture the
       // field round-trips byte-identically.
       const future = {
-        thinking: { type: 'enabled' },
+        thinking: 'enabled',
         reasoning_effort: 'high',
         custom_safety: { mode: 'permissive', threshold: 0.8 },
       } as never;

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -14,6 +14,7 @@ import type { ProxyFallbackService } from '../proxy-fallback.service';
 import type { ThoughtSignatureCache } from '../thought-signature-cache';
 import type { ThinkingBlockCache } from '../thinking-block-cache';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
+import type { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
 
 /**
  * Stream-warmup helper is mocked because the real implementation depends on
@@ -34,6 +35,16 @@ const route = (provider: string, authType: ModelRoute['authType'], model: string
 
 const okResponse = (status = 200) =>
   new Response('{"ok":true}', { status, headers: { 'content-type': 'application/json' } });
+
+const thinkingSpec = {
+  key: 'thinking',
+  control: {
+    kind: 'toggle' as const,
+    label: 'Thinking mode',
+    values: ['enabled', 'disabled'] as const,
+    default: 'enabled',
+  },
+};
 
 describe('ProxyService — orchestration', () => {
   let resolveService: jest.Mocked<Pick<ResolveService, 'resolve' | 'resolveForTier'>>;
@@ -58,6 +69,7 @@ describe('ProxyService — orchestration', () => {
   let signatureCache: ThoughtSignatureCache;
   let thinkingCache: ThinkingBlockCache;
   let modelParamsService: { get: jest.Mock; list: jest.Mock; set: jest.Mock; delete: jest.Mock };
+  let providerParamSpecs: { getSpecs: jest.Mock };
   let svc: ProxyService;
 
   beforeEach(() => {
@@ -98,6 +110,13 @@ describe('ProxyService — orchestration', () => {
       set: jest.fn(),
       delete: jest.fn(),
     };
+    providerParamSpecs = {
+      getSpecs: jest
+        .fn()
+        .mockImplementation(async (provider: string, authType: string) =>
+          provider.toLowerCase() === 'deepseek' && authType === 'api_key' ? [thinkingSpec] : [],
+        ),
+    };
 
     svc = new ProxyService(
       resolveService as unknown as ResolveService,
@@ -113,6 +132,7 @@ describe('ProxyService — orchestration', () => {
       signatureCache,
       thinkingCache,
       modelParamsService as unknown as AgentModelParamsService,
+      providerParamSpecs as unknown as ProviderParamSpecService,
     );
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -334,7 +334,7 @@ describe('ProxyService — orchestration', () => {
         score: 5,
         reason: 'scored',
       });
-      modelParamsService.get.mockResolvedValueOnce({ thinking: { type: 'enabled' } });
+      modelParamsService.get.mockResolvedValueOnce({ thinking: 'enabled' });
       fallbackService.tryForwardToProvider.mockResolvedValue({
         response: okResponse(),
         isGoogle: false,
@@ -400,15 +400,15 @@ describe('ProxyService — orchestration', () => {
         baseOpts({
           body: {
             messages: [{ role: 'user', content: 'hi' }],
-            thinking: { type: 'enabled' },
+            thinking: 'enabled',
           } as never,
         }),
       );
       // The body still carries the client-supplied thinking field — the
       // fallback service's merge respects that by presence.
-      expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body.thinking).toEqual({
-        type: 'enabled',
-      });
+      expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body.thinking).toEqual(
+        'enabled',
+      );
     });
 
     it('does not record momentum for non-scoring tiers (e.g. "default")', async () => {
@@ -435,8 +435,7 @@ describe('ProxyService — orchestration', () => {
     // tests pin (a) it gets populated for the primary provider on success,
     // (b) the snapshot is re-derived per provider so a fallback record
     // never carries another vendor's knob, and (c) providers without a
-    // known param key (today: anything that isn't DeepSeek for `thinking`)
-    // produce a null snapshot so existing rows stay clean.
+    // known param key produce a null snapshot so existing rows stay clean.
     it("populates meta.request_params with the provider's effective default for known keys (DeepSeek thinking enabled)", async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
@@ -456,7 +455,7 @@ describe('ProxyService — orchestration', () => {
       // No saved per-model params for this attempt, so the snapshot
       // records the provider's own natural API default. DeepSeek's
       // silent default is `enabled`.
-      expect(result.meta.request_params).toEqual({ thinking: { type: 'enabled' } });
+      expect(result.meta.request_params).toEqual({ thinking: 'enabled' });
     });
 
     it("snapshot reflects the user's stored override when present", async () => {
@@ -468,7 +467,7 @@ describe('ProxyService — orchestration', () => {
         score: 5,
         reason: 'scored',
       });
-      modelParamsService.get.mockResolvedValueOnce({ thinking: { type: 'enabled' } });
+      modelParamsService.get.mockResolvedValueOnce({ thinking: 'enabled' });
       fallbackService.tryForwardToProvider.mockResolvedValue({
         response: okResponse(),
         isGoogle: false,
@@ -476,15 +475,14 @@ describe('ProxyService — orchestration', () => {
         isChatGpt: false,
       });
       const result = await svc.proxyRequest(baseOpts());
-      expect(result.meta.request_params).toEqual({ thinking: { type: 'enabled' } });
+      expect(result.meta.request_params).toEqual({ thinking: 'enabled' });
     });
 
-    it('snapshot is null when the provider has no known param keys (today: any non-DeepSeek provider)', async () => {
+    it('snapshot is null when the provider has no known param keys', async () => {
       // Forward-compat property: providers that never appear in the
-      // `PROVIDER_THINKING_DEFAULTS` registry produce a null snapshot,
-      // so the existing experience for OpenAI/Anthropic/Gemini/etc. rows
-      // stays unchanged. New providers light up by adding an entry to
-      // the registry — no proxy code needed.
+      // provider-param registry produce a null snapshot, so the existing
+      // experience for unsupported rows stays unchanged. New providers
+      // light up by adding an entry to the registry — no proxy code needed.
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         route: route('openai', 'api_key', 'gpt-4o'),

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -300,7 +300,7 @@ describe('ProxyService — orchestration', () => {
       expect(momentum.recordCategory).not.toHaveBeenCalled();
     });
 
-    it('hands the fallback service a paramMergeContext carrying just the agentId', async () => {
+    it('hands the fallback service a paramMergeContext carrying the agentId and route scope', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         route: route('deepseek', 'api_key', 'deepseek-v4-flash'),
@@ -322,7 +322,7 @@ describe('ProxyService — orchestration', () => {
       // service so each fallback iteration looks up its own (provider,
       // auth, model) tuple.
       expect(call.body).toEqual({ messages: [{ role: 'user', content: 'hi' }] });
-      expect(call.paramMergeContext).toEqual({ agentId: 'agent-1' });
+      expect(call.paramMergeContext).toEqual({ agentId: 'agent-1', scopeKey: 'tier:standard' });
     });
 
     it('looks up the primary route model params for the snapshot', async () => {
@@ -345,10 +345,43 @@ describe('ProxyService — orchestration', () => {
       await svc.proxyRequest(baseOpts());
       expect(modelParamsService.get).toHaveBeenCalledWith(
         'agent-1',
+        'tier:standard',
         'deepseek',
         'api_key',
         'deepseek-v4-flash',
       );
+    });
+
+    it('scopes primary model params by the matched routing surface', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('deepseek', 'api_key', 'deepseek-v4-flash'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'specificity',
+        specificity_category: 'coding',
+      });
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(modelParamsService.get).toHaveBeenCalledWith(
+        'agent-1',
+        'specificity:coding',
+        'deepseek',
+        'api_key',
+        'deepseek-v4-flash',
+      );
+      expect(fallbackService.tryForwardToProvider.mock.calls[0][0].paramMergeContext).toEqual({
+        agentId: 'agent-1',
+        scopeKey: 'specificity:coding',
+      });
     });
 
     // Snapshot lookup must use the same normalized model id as the forward.
@@ -374,6 +407,7 @@ describe('ProxyService — orchestration', () => {
       await svc.proxyRequest(baseOpts());
       expect(modelParamsService.get).toHaveBeenCalledWith(
         'agent-1',
+        'tier:standard',
         'anthropic',
         'api_key',
         'claude-sonnet-4-6',

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -2,23 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { AuthType, ModelRoute } from 'manifest-shared';
-import { applyRequestParamDefaults } from 'manifest-shared';
+import { applyRequestParamDefaults, getProviderParamSpecs } from 'manifest-shared';
 import { AgentModelParamsService } from '../routing-core/agent-model-params.service';
-
-/**
- * Context for the per-attempt param-defaults merge. Carries the agentId so
- * `applyParamMerge` can ask the model-params service for the configuration
- * that belongs to this attempt's (provider, auth_type, model) tuple — not
- * the primary route's. Storage is model-scoped on the new
- * `agent_model_params` table, so cross-provider leak is structurally
- * impossible; we no longer need a provider-keyed filter, and Manifest's
- * old tier-aware opinion layer is gone too (only the user's explicit
- * config and the provider's natural default participate).
- */
-export interface ParamMergeContext {
-  agentId: string;
-}
-
 import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
@@ -48,6 +33,21 @@ import {
 } from './proxy-transport';
 import type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
 import type { ProxyApiMode } from './proxy-types';
+
+/**
+ * Context for the per-attempt param-defaults merge. Carries the agentId so
+ * `applyParamMerge` can ask the model-params service for the configuration
+ * that belongs to this attempt's (provider, auth_type, model) tuple — not
+ * the primary route's. Storage is model-scoped on the new
+ * `agent_model_params` table, so cross-provider leak is structurally
+ * impossible; we no longer need a provider-keyed filter, and Manifest's
+ * old tier-aware opinion layer is gone too. The registry for the exact
+ * provider/auth/model route decides which saved UI values can become
+ * outbound wire fields.
+ */
+export interface ParamMergeContext {
+  agentId: string;
+}
 
 export interface FailedFallback {
   model: string;
@@ -97,13 +97,15 @@ export class ProxyFallbackService {
     model: string,
   ): Promise<Record<string, unknown>> {
     if (!ctx || !authType) return body;
+    const typedAuthType = authType as AuthType;
     const modelParams = await this.modelParamsService.get(
       ctx.agentId,
       provider,
-      authType as AuthType,
+      typedAuthType,
       model,
     );
-    return applyRequestParamDefaults(body, modelParams);
+    const specs = getProviderParamSpecs(provider, typedAuthType, model);
+    return applyRequestParamDefaults(body, modelParams, specs);
   }
 
   async tryFallbacks(
@@ -151,7 +153,7 @@ export class ProxyFallbackService {
       const requestedModel = fallbackModels[i];
       const route = useStructuredRoutes ? fallbackRoutes![i] : null;
       let provider: string | undefined;
-      let authType: AuthType;
+      let authType: AuthType | undefined;
       // Pinned key label: prefer the structured route's keyLabel. Each
       // fallback can be pinned to a specific provider key (e.g. "Work" vs
       // "Personal" Anthropic Console). When no route is supplied (legacy
@@ -186,6 +188,10 @@ export class ProxyFallbackService {
           provider,
           excludeAuth,
         )) as AuthType;
+      }
+      if (!provider || !authType) {
+        this.logger.debug(`Fallback ${i}: skipping model=${requestedModel} (no provider data)`);
+        continue;
       }
 
       const model = normalizeProviderModel(provider, requestedModel);

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -2,8 +2,9 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import type { AuthType, ModelRoute } from 'manifest-shared';
-import { applyRequestParamDefaults, getProviderParamSpecs } from 'manifest-shared';
+import { applyRequestParamDefaults } from 'manifest-shared';
 import { AgentModelParamsService } from '../routing-core/agent-model-params.service';
+import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
 import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
@@ -75,6 +76,7 @@ export class ProxyFallbackService {
     private readonly copilotToken: CopilotTokenService,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly modelParamsService: AgentModelParamsService,
+    private readonly providerParamSpecs: ProviderParamSpecService,
   ) {}
 
   /**
@@ -103,7 +105,7 @@ export class ProxyFallbackService {
       typedAuthType,
       model,
     );
-    const specs = getProviderParamSpecs(provider, typedAuthType, model);
+    const specs = await this.providerParamSpecs.getSpecs(provider, typedAuthType, model);
     return applyRequestParamDefaults(body, modelParams, specs);
   }
 

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -35,18 +35,16 @@ import type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
 import type { ProxyApiMode } from './proxy-types';
 
 /**
- * Context for the per-attempt param-defaults merge. Carries the agentId so
- * `applyParamMerge` can ask the model-params service for the configuration
- * that belongs to this attempt's (provider, auth_type, model) tuple — not
- * the primary route's. Storage is model-scoped on the new
- * `agent_model_params` table, so cross-provider leak is structurally
- * impossible; we no longer need a provider-keyed filter, and Manifest's
- * old tier-aware opinion layer is gone too. The registry for the exact
- * provider/auth/model route decides which saved UI values can become
- * outbound wire fields.
+ * Context for the per-attempt param-defaults merge. Carries the agentId and
+ * route scope so `applyParamMerge` can ask the model-params service for the
+ * configuration that belongs to this attempt's scoped (provider, auth_type,
+ * model) tuple — not merely the primary model or a globally shared model row.
+ * The registry for the exact provider/auth/model route decides which saved
+ * UI values can become outbound wire fields.
  */
 export interface ParamMergeContext {
   agentId: string;
+  scopeKey: string;
 }
 
 export interface FailedFallback {
@@ -81,7 +79,7 @@ export class ProxyFallbackService {
 
   /**
    * Per-attempt merge: look up the user's saved params for this
-   * (agent, provider, auth_type, model) tuple and fold them into the
+   * (agent, scope, provider, auth_type, model) tuple and fold them into the
    * outbound body. Returns the original body unchanged when no config
    * exists — the provider's natural default applies in that case.
    *
@@ -100,6 +98,7 @@ export class ProxyFallbackService {
     const typedAuthType = authType as AuthType;
     const modelParams = await this.modelParamsService.get(
       ctx.agentId,
+      ctx.scopeKey,
       provider,
       typedAuthType,
       model,
@@ -340,10 +339,9 @@ export class ProxyFallbackService {
       thinkingLookup,
     } = opts;
     // Per-attempt merge: ask the model-params service for this iteration's
-    // (provider, auth_type, model) config. Storage is model-scoped on the
-    // new agent_model_params table, so a primary OpenAI route with a
-    // DeepSeek fallback no longer needs the old per-provider filter —
-    // OpenAI's lookup returns null, DeepSeek's returns its own row.
+    // scoped (provider, auth_type, model) config. A primary OpenAI route
+    // with a DeepSeek fallback gets the same route scope but different
+    // provider/model tuple, so each attempt reads only its own row.
     const body = await this.applyParamMerge(
       opts.body,
       opts.paramMergeContext,

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -69,9 +69,9 @@ export interface FallbackSuccessOpts extends HeaderTierRef {
   callerAttribution?: CallerAttribution | null;
   requestHeaders?: Record<string, string> | null;
   /**
-   * Snapshot of effective request body parameters (today: DeepSeek
-   * `thinking`) merged into the outbound provider request. `null` when no
-   * known params apply. Persisted to `agent_messages.request_params`.
+   * Snapshot of effective request body parameters merged into the outbound
+   * provider request. `null` when no known params apply. Persisted to
+   * `agent_messages.request_params`.
    */
   requestParams?: RequestParamDefaults | null;
 }
@@ -87,9 +87,9 @@ export interface SuccessMessageOpts extends HeaderTierRef {
   callerAttribution?: CallerAttribution | null;
   requestHeaders?: Record<string, string> | null;
   /**
-   * Snapshot of effective request body parameters (today: DeepSeek
-   * `thinking`) merged into the outbound provider request. `null` when no
-   * known params apply. Persisted to `agent_messages.request_params`.
+   * Snapshot of effective request body parameters merged into the outbound
+   * provider request. `null` when no known params apply. Persisted to
+   * `agent_messages.request_params`.
    */
   requestParams?: RequestParamDefaults | null;
 }

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -83,7 +83,7 @@ export interface RoutingMeta {
   primaryAuthType?: string;
   /**
    * Effective request body parameters for this attempt — the merged result
-   * of (1) client body keys in `REQUEST_PARAM_KEYS`, (2) the user's saved
+   * of (1) route-supported client body keys, (2) the user's saved
    * per-route params from `agent_model_params` for the attempt's
    * (provider, auth_type, model) tuple, and (3) the provider's natural
    * API default for any unset key. Persisted on
@@ -195,7 +195,7 @@ export class ProxyService {
     // Snapshot of which known param keys are *effectively in play* for the
     // primary attempt. Stored on every `agent_messages` row recorded for
     // this request so the dashboard can display the effective parameters
-    // (today: DeepSeek's `thinking` toggle) in the expanded message detail.
+    // in the expanded message detail.
     // Re-derived for fallback successes against the actual fallback
     // provider so the persisted snapshot matches what was sent on that row.
     const primaryModelParams = await this.modelParamsService.get(
@@ -208,6 +208,8 @@ export class ProxyService {
       body: routingBody as Record<string, unknown>,
       modelParams: primaryModelParams,
       provider: route.provider,
+      authType: route.authType,
+      model: primaryModel,
     });
 
     const forward = await this.fallbackService.tryForwardToProvider({
@@ -486,11 +488,15 @@ export class ProxyService {
             success.model,
           )
         : null;
-      const fallbackRequestParams = snapshotRequestParams({
-        body: body as Record<string, unknown>,
-        modelParams: fallbackModelParams,
-        provider: success.provider,
-      });
+      const fallbackRequestParams = success.authType
+        ? snapshotRequestParams({
+            body: body as Record<string, unknown>,
+            modelParams: fallbackModelParams,
+            provider: success.provider,
+            authType: success.authType,
+            model: success.model,
+          })
+        : null;
       return {
         forward: success.forward,
         meta: this.buildBaseMeta(resolved, success.model, {
@@ -530,11 +536,16 @@ export class ProxyService {
             primaryModel,
           )
         : null;
-    const exhaustedRequestParams = snapshotRequestParams({
-      body: body as Record<string, unknown>,
-      modelParams: primaryModelParams,
-      provider: primaryProvider ?? '',
-    });
+    const exhaustedRequestParams =
+      primaryProvider && primaryAuth
+        ? snapshotRequestParams({
+            body: body as Record<string, unknown>,
+            modelParams: primaryModelParams,
+            provider: primaryProvider,
+            authType: primaryAuth as AuthType,
+            model: primaryModel,
+          })
+        : null;
     return {
       forward: {
         response: rebuilt,

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -33,6 +33,7 @@ import {
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
 import { AgentModelParamsService } from '../routing-core/agent-model-params.service';
+import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
 import { formatManifestError } from '../../common/errors/error-codes';
 import { peekStream } from './stream-warmup';
@@ -122,6 +123,7 @@ export class ProxyService {
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
     private readonly modelParamsService: AgentModelParamsService,
+    private readonly providerParamSpecs: ProviderParamSpecService,
   ) {}
 
   async proxyRequest(opts: ProxyRequestOptions): Promise<ProxyResult> {
@@ -214,12 +216,15 @@ export class ProxyService {
       route.authType,
       primaryModel,
     );
+    const primaryParamSpecs = await this.providerParamSpecs.getSpecs(
+      route.provider,
+      route.authType,
+      primaryModel,
+    );
     const primaryRequestParams = snapshotRequestParams({
       body: routingBody as Record<string, unknown>,
       modelParams: primaryModelParams,
-      provider: route.provider,
-      authType: route.authType,
-      model: primaryModel,
+      specs: primaryParamSpecs,
     });
 
     const forward = await this.fallbackService.tryForwardToProvider({
@@ -503,9 +508,11 @@ export class ProxyService {
         ? snapshotRequestParams({
             body: body as Record<string, unknown>,
             modelParams: fallbackModelParams,
-            provider: success.provider,
-            authType: success.authType,
-            model: success.model,
+            specs: await this.providerParamSpecs.getSpecs(
+              success.provider,
+              success.authType,
+              success.model,
+            ),
           })
         : null;
       return {
@@ -553,9 +560,11 @@ export class ProxyService {
         ? snapshotRequestParams({
             body: body as Record<string, unknown>,
             modelParams: primaryModelParams,
-            provider: primaryProvider,
-            authType: primaryAuth as AuthType,
-            model: primaryModel,
+            specs: await this.providerParamSpecs.getSpecs(
+              primaryProvider,
+              primaryAuth as AuthType,
+              primaryModel,
+            ),
           })
         : null;
     return {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -12,7 +12,11 @@ import { LimitCheckService } from '../../notifications/services/limit-check.serv
 import { shouldTriggerFallback } from './fallback-status-codes';
 import { Tier, TIERS, ScorerMessage } from '../../scoring/types';
 import type { RequestParamDefaults, SpecificityCategory, TierSlot } from 'manifest-shared';
-import { SPECIFICITY_CATEGORIES, snapshotRequestParams } from 'manifest-shared';
+import {
+  SPECIFICITY_CATEGORIES,
+  modelParamsScopeForRouting,
+  snapshotRequestParams,
+} from 'manifest-shared';
 import type { ParamMergeContext } from './proxy-fallback.service';
 import {
   ProxyFallbackService,
@@ -85,7 +89,7 @@ export interface RoutingMeta {
    * Effective request body parameters for this attempt — the merged result
    * of (1) route-supported client body keys, (2) the user's saved
    * per-route params from `agent_model_params` for the attempt's
-   * (provider, auth_type, model) tuple, and (3) the provider's natural
+   * (scope, provider, auth_type, model) tuple, and (3) the provider's natural
    * API default for any unset key. Persisted on
    * `agent_messages.request_params` so the dashboard can show "this
    * request had thinking=disabled" alongside Request Headers in the
@@ -187,10 +191,15 @@ export class ProxyService {
 
     // Per-attempt param-defaults merge happens inside the fallback service
     // so each forward (primary + every fallback iteration) looks up its
-    // own (provider, auth_type, model) tuple in the model-params service.
-    // Pass the agentId here as a thin context bag; the storage is already
-    // route-scoped, so no per-provider filter is needed downstream.
-    const paramMergeContext: ParamMergeContext = { agentId };
+    // own scoped (provider, auth_type, model) tuple in the model-params
+    // service. Pass the agentId + route scope here as a thin context bag;
+    // storage is already route-scoped, so no per-provider filter is needed.
+    const modelParamsScope = modelParamsScopeForRouting({
+      tier: resolved.tier,
+      specificityCategory: resolved.specificity_category,
+      headerTierId: resolved.header_tier_id,
+    });
+    const paramMergeContext: ParamMergeContext = { agentId, scopeKey: modelParamsScope };
 
     // Snapshot of which known param keys are *effectively in play* for the
     // primary attempt. Stored on every `agent_messages` row recorded for
@@ -200,6 +209,7 @@ export class ProxyService {
     // provider so the persisted snapshot matches what was sent on that row.
     const primaryModelParams = await this.modelParamsService.get(
       agentId,
+      modelParamsScope,
       route.provider,
       route.authType,
       primaryModel,
@@ -477,12 +487,13 @@ export class ProxyService {
     this.recordCategoryIfValid(sessionKey, resolved.specificity_category);
 
     if (success) {
-      // Re-snapshot for the fallback's actual provider — its model-scoped
-      // params row (if any) is what was actually applied. Different model
-      // → different lookup → different snapshot, matching the wire.
+      // Re-snapshot for the fallback's actual provider — its scoped params
+      // row (if any) is what was actually applied. Different route scope or
+      // model means different lookup, matching the wire.
       const fallbackModelParams = success.authType
         ? await this.modelParamsService.get(
             args.paramMergeContext.agentId,
+            args.paramMergeContext.scopeKey,
             success.provider,
             success.authType,
             success.model,
@@ -531,6 +542,7 @@ export class ProxyService {
       primaryProvider && primaryAuth && resolved.route
         ? await this.modelParamsService.get(
             args.paramMergeContext.agentId,
+            args.paramMergeContext.scopeKey,
             primaryProvider,
             primaryAuth as 'api_key' | 'subscription' | 'local',
             primaryModel,

--- a/packages/backend/src/routing/routing-core/__tests__/agent-model-params.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/agent-model-params.service.spec.ts
@@ -92,6 +92,7 @@ describe('AgentModelParamsService', () => {
     it('returns the matching row params (case-insensitive provider match)', async () => {
       const rows = [
         {
+          scope_key: 'tier:simple',
           provider: 'DeepSeek',
           auth_type: 'api_key',
           model_name: 'deepseek-v4',
@@ -100,20 +101,27 @@ describe('AgentModelParamsService', () => {
       ];
       repo.find.mockResolvedValueOnce(rows);
 
-      const result = await service.get('agent-1', 'deepseek', 'api_key', 'deepseek-v4');
+      const result = await service.get(
+        'agent-1',
+        'tier:simple',
+        'deepseek',
+        'api_key',
+        'deepseek-v4',
+      );
 
       expect(result).toEqual({ thinking: 'disabled' });
     });
 
     it('returns null when no row matches (steady state for most attempts)', async () => {
       repo.find.mockResolvedValueOnce([]);
-      const result = await service.get('agent-1', 'openai', 'api_key', 'gpt-4o');
+      const result = await service.get('agent-1', 'tier:simple', 'openai', 'api_key', 'gpt-4o');
       expect(result).toBeNull();
     });
 
     it('matches on full (provider, auth_type, model_name) tuple — same model under different auth is distinct', async () => {
       const rows = [
         {
+          scope_key: 'tier:simple',
           provider: 'openai',
           auth_type: 'subscription',
           model_name: 'gpt-4o',
@@ -123,7 +131,37 @@ describe('AgentModelParamsService', () => {
       repo.find.mockResolvedValueOnce(rows);
 
       // Same model, different auth_type → no match
-      expect(await service.get('agent-1', 'openai', 'api_key', 'gpt-4o')).toBeNull();
+      expect(await service.get('agent-1', 'tier:simple', 'openai', 'api_key', 'gpt-4o')).toBeNull();
+    });
+
+    it('keeps the same provider/auth/model distinct across tier scopes', async () => {
+      const rows = [
+        {
+          scope_key: 'tier:simple',
+          provider: 'anthropic',
+          auth_type: 'api_key',
+          model_name: 'claude-opus-4-7',
+          params: { temperature: 0.2 },
+        },
+        {
+          scope_key: 'tier:expert',
+          provider: 'anthropic',
+          auth_type: 'api_key',
+          model_name: 'claude-opus-4-7',
+          params: { temperature: 0.8 },
+        },
+      ] as unknown as AgentModelParams[];
+      repo.find.mockResolvedValueOnce(rows);
+
+      const result = await service.get(
+        'agent-1',
+        'tier:expert',
+        'anthropic',
+        'api_key',
+        'claude-opus-4-7',
+      );
+
+      expect(result).toEqual({ temperature: 0.8 });
     });
   });
 
@@ -131,6 +169,7 @@ describe('AgentModelParamsService', () => {
     it('runs the atomic INSERT ... ON CONFLICT upsert, invalidates the cache, then re-fetches the canonical row', async () => {
       const saved = {
         id: 'p1',
+        scope_key: 'tier:simple',
         provider: 'deepseek',
         auth_type: 'api_key',
         model_name: 'deepseek-v4',
@@ -138,9 +177,17 @@ describe('AgentModelParamsService', () => {
       } as unknown as AgentModelParams;
       repo.findOneOrFail.mockResolvedValueOnce(saved);
 
-      const result = await service.set('agent-1', 'user-1', 'DeepSeek', 'api_key', 'deepseek-v4', {
-        thinking: 'disabled',
-      });
+      const result = await service.set(
+        'agent-1',
+        'user-1',
+        'tier:simple',
+        'DeepSeek',
+        'api_key',
+        'deepseek-v4',
+        {
+          thinking: 'disabled',
+        },
+      );
 
       // QueryBuilder upsert ran (concurrent-safe — no findOne+save race).
       expect(repo.createQueryBuilder).toHaveBeenCalled();
@@ -151,6 +198,7 @@ describe('AgentModelParamsService', () => {
       expect(repo.findOneOrFail).toHaveBeenCalledWith({
         where: {
           agent_id: 'agent-1',
+          scope_key: 'tier:simple',
           provider: 'deepseek',
           auth_type: 'api_key',
           model_name: 'deepseek-v4',
@@ -162,9 +210,10 @@ describe('AgentModelParamsService', () => {
 
   describe('delete', () => {
     it('removes the row and invalidates the agent cache', async () => {
-      await service.delete('agent-1', 'DeepSeek', 'api_key', 'deepseek-v4');
+      await service.delete('agent-1', 'tier:simple', 'DeepSeek', 'api_key', 'deepseek-v4');
       expect(repo.delete).toHaveBeenCalledWith({
         agent_id: 'agent-1',
+        scope_key: 'tier:simple',
         provider: 'deepseek',
         auth_type: 'api_key',
         model_name: 'deepseek-v4',

--- a/packages/backend/src/routing/routing-core/__tests__/agent-model-params.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/agent-model-params.service.spec.ts
@@ -95,14 +95,14 @@ describe('AgentModelParamsService', () => {
           provider: 'DeepSeek',
           auth_type: 'api_key',
           model_name: 'deepseek-v4',
-          params: { thinking: { type: 'disabled' } },
+          params: { thinking: 'disabled' },
         } as unknown as AgentModelParams,
       ];
       repo.find.mockResolvedValueOnce(rows);
 
       const result = await service.get('agent-1', 'deepseek', 'api_key', 'deepseek-v4');
 
-      expect(result).toEqual({ thinking: { type: 'disabled' } });
+      expect(result).toEqual({ thinking: 'disabled' });
     });
 
     it('returns null when no row matches (steady state for most attempts)', async () => {
@@ -117,7 +117,7 @@ describe('AgentModelParamsService', () => {
           provider: 'openai',
           auth_type: 'subscription',
           model_name: 'gpt-4o',
-          params: { thinking: { type: 'enabled' } },
+          params: { thinking: 'enabled' },
         } as unknown as AgentModelParams,
       ];
       repo.find.mockResolvedValueOnce(rows);
@@ -134,12 +134,12 @@ describe('AgentModelParamsService', () => {
         provider: 'deepseek',
         auth_type: 'api_key',
         model_name: 'deepseek-v4',
-        params: { thinking: { type: 'disabled' } },
+        params: { thinking: 'disabled' },
       } as unknown as AgentModelParams;
       repo.findOneOrFail.mockResolvedValueOnce(saved);
 
       const result = await service.set('agent-1', 'user-1', 'DeepSeek', 'api_key', 'deepseek-v4', {
-        thinking: { type: 'disabled' },
+        thinking: 'disabled',
       });
 
       // QueryBuilder upsert ran (concurrent-safe — no findOne+save race).

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -1,0 +1,101 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ProviderParamSpecEntity } from '../../../entities/provider-param-spec.entity';
+import { ProviderParamSpecService } from '../provider-param-spec.service';
+
+describe('ProviderParamSpecService', () => {
+  let service: ProviderParamSpecService;
+  let repo: { find: jest.Mock };
+
+  beforeEach(async () => {
+    repo = { find: jest.fn() };
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProviderParamSpecService,
+        { provide: getRepositoryToken(ProviderParamSpecEntity), useValue: repo },
+      ],
+    }).compile();
+    service = module.get(ProviderParamSpecService);
+  });
+
+  it('resolves base specs by provider/auth and caches the registry', async () => {
+    repo.find.mockResolvedValueOnce([
+      {
+        id: 'deepseek-api-key-base-thinking',
+        provider: 'deepseek',
+        auth_type: 'api_key',
+        model_name: null,
+        param_key: 'thinking',
+        control_kind: 'toggle',
+        label: 'Thinking mode',
+        default_value: 'enabled',
+        values: ['enabled', 'disabled'],
+        min_value: null,
+        max_value: null,
+        step_value: null,
+        serializer: null,
+        sort_order: 10,
+      },
+    ]);
+
+    await expect(service.getSpecs('DeepSeek', 'api_key', 'deepseek-v4')).resolves.toEqual([
+      {
+        key: 'thinking',
+        control: {
+          kind: 'toggle',
+          label: 'Thinking mode',
+          values: ['enabled', 'disabled'],
+          default: 'enabled',
+        },
+      },
+    ]);
+    await expect(service.getSpecs('deepseek', 'api_key', 'other-model')).resolves.toHaveLength(1);
+    expect(repo.find).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses model rows as wholesale overrides when present', async () => {
+    repo.find.mockResolvedValueOnce([
+      {
+        id: 'unit-base-temperature',
+        provider: 'unit',
+        auth_type: 'api_key',
+        model_name: null,
+        param_key: 'temperature',
+        control_kind: 'slider',
+        label: 'Temperature',
+        default_value: 1,
+        values: null,
+        min_value: 0,
+        max_value: 2,
+        step_value: null,
+        serializer: null,
+        sort_order: 10,
+      },
+      {
+        id: 'unit-special-reasoning',
+        provider: 'unit',
+        auth_type: 'api_key',
+        model_name: 'unit/special:model',
+        param_key: 'reasoning_effort',
+        control_kind: 'select',
+        label: 'Reasoning effort',
+        default_value: 'medium',
+        values: ['low', 'medium', 'high'],
+        min_value: null,
+        max_value: null,
+        step_value: null,
+        serializer: null,
+        sort_order: 10,
+      },
+    ]);
+
+    await expect(
+      service
+        .getSpecs('unit', 'api_key', 'unit/special:model')
+        .then((specs) => specs.map((s) => s.key)),
+    ).resolves.toEqual(['reasoning_effort']);
+    await expect(
+      service.getSpecs('unit', 'api_key', 'other-model').then((specs) => specs.map((s) => s.key)),
+    ).resolves.toEqual(['temperature']);
+  });
+});

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -98,4 +98,129 @@ describe('ProviderParamSpecService', () => {
       service.getSpecs('unit', 'api_key', 'other-model').then((specs) => specs.map((s) => s.key)),
     ).resolves.toEqual(['temperature']);
   });
+
+  it('maps grouped Anthropic thinking rows with conditional visibility and serializer', async () => {
+    repo.find.mockResolvedValueOnce([
+      {
+        id: 'anthropic-api-key-base-thinking-type',
+        provider: 'anthropic',
+        auth_type: 'api_key',
+        model_name: null,
+        param_key: 'type',
+        group_key: 'thinking',
+        group_label: 'Thinking',
+        control_kind: 'select',
+        label: 'Thinking mode',
+        default_value: 'disabled',
+        values: ['disabled', 'adaptive', 'enabled'],
+        min_value: null,
+        max_value: null,
+        step_value: null,
+        serializer: 'anthropic_thinking',
+        depends_on_key: null,
+        depends_on_value: null,
+        sort_order: 50,
+      },
+      {
+        id: 'anthropic-api-key-base-thinking-budget-tokens',
+        provider: 'anthropic',
+        auth_type: 'api_key',
+        model_name: null,
+        param_key: 'budget_tokens',
+        group_key: 'thinking',
+        group_label: 'Thinking',
+        control_kind: 'number',
+        label: 'Budget tokens',
+        default_value: 4096,
+        values: null,
+        min_value: 1024,
+        max_value: null,
+        step_value: null,
+        serializer: 'anthropic_thinking',
+        depends_on_key: 'type',
+        depends_on_value: 'enabled',
+        sort_order: 60,
+      },
+    ]);
+
+    const specs = await service.getSpecs('anthropic', 'api_key', 'claude-sonnet-4-6');
+
+    expect(specs).toMatchObject([
+      {
+        key: 'type',
+        group: { key: 'thinking', label: 'Thinking' },
+        control: {
+          kind: 'select',
+          label: 'Thinking mode',
+          values: ['disabled', 'adaptive', 'enabled'],
+          default: 'disabled',
+        },
+      },
+      {
+        key: 'budget_tokens',
+        group: { key: 'thinking', label: 'Thinking' },
+        visibleWhen: { key: 'type', equals: 'enabled' },
+        control: { kind: 'number', label: 'Budget tokens', min: 1024, default: 4096 },
+      },
+    ]);
+    expect(specs[0].group?.serialize?.({ type: 'adaptive' })).toEqual({
+      thinking: { type: 'adaptive' },
+    });
+    expect(specs[0].group?.serialize?.({ type: 'enabled', budget_tokens: 4096 })).toEqual({
+      thinking: { type: 'enabled', budget_tokens: 4096 },
+    });
+    expect(specs[0].group?.serialize?.({ type: 'disabled' })).toEqual({});
+  });
+
+  it('maps provider param dependency metadata', async () => {
+    repo.find.mockResolvedValueOnce([
+      {
+        id: 'anthropic-api-key-base-top-k',
+        provider: 'anthropic',
+        auth_type: 'api_key',
+        model_name: null,
+        param_key: 'top_k',
+        group_key: null,
+        group_label: null,
+        control_kind: 'number',
+        label: 'Top K',
+        default_value: 0,
+        values: null,
+        min_value: 0,
+        max_value: null,
+        step_value: null,
+        serializer: null,
+        depends_on_key: null,
+        depends_on_value: null,
+        dependencies: [
+          {
+            effect: 'disable',
+            when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+          },
+          {
+            effect: 'omit',
+            when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+          },
+        ],
+        sort_order: 40,
+      },
+    ]);
+
+    await expect(service.getSpecs('anthropic', 'api_key', 'claude-sonnet-4-6')).resolves.toEqual([
+      {
+        key: 'top_k',
+        control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+        dependencies: [
+          {
+            effect: 'disable',
+            when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+          },
+          {
+            effect: 'omit',
+            when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/packages/backend/src/routing/routing-core/agent-model-params.service.ts
+++ b/packages/backend/src/routing/routing-core/agent-model-params.service.ts
@@ -9,8 +9,8 @@ import { RoutingCacheService } from './routing-cache.service';
 /**
  * Per-(agent, route) outbound request body defaults. Replaces the legacy
  * per-slot `param_defaults` blobs on tier/specificity assignments: now
- * params travel with the route identity (provider, auth_type, model) so
- * one configuration applies anywhere the model is used.
+ * params travel with the scoped route identity (scope_key, provider, model,
+ * auth_type) so the same model can have different settings per tier.
  *
  * The proxy hits `get()` on every attempt, so the implementation reads
  * through a per-agent list cache (set once, served from memory for the
@@ -45,6 +45,7 @@ export class AgentModelParamsService {
    */
   async get(
     agentId: string,
+    scopeKey: string,
     provider: string,
     authType: AuthType,
     modelName: string,
@@ -52,6 +53,7 @@ export class AgentModelParamsService {
     const rows = await this.list(agentId);
     const match = rows.find(
       (r) =>
+        r.scope_key === scopeKey &&
         r.provider.toLowerCase() === provider.toLowerCase() &&
         r.auth_type === authType &&
         r.model_name === modelName,
@@ -61,8 +63,8 @@ export class AgentModelParamsService {
 
   /**
    * Atomic upsert for one route's params. The unique index on (agent_id,
-   * provider, auth_type, model_name) drives the ON CONFLICT clause so two
-   * concurrent writes for the same route resolve deterministically instead
+   * scope_key, provider, model_name, auth_type) drives the ON CONFLICT
+   * clause so two concurrent writes for the same route resolve deterministically instead
    * of racing on `findOne` + `save` and failing one with a duplicate-key
    * error.
    *
@@ -73,6 +75,7 @@ export class AgentModelParamsService {
   async set(
     agentId: string,
     userId: string,
+    scopeKey: string,
     provider: string,
     authType: AuthType,
     modelName: string,
@@ -87,12 +90,16 @@ export class AgentModelParamsService {
         id: randomUUID(),
         user_id: userId,
         agent_id: agentId,
+        scope_key: scopeKey,
         provider: normalizedProvider,
         auth_type: authType,
         model_name: modelName,
         params,
       })
-      .orUpdate(['params', 'updated_at'], ['agent_id', 'provider', 'auth_type', 'model_name'])
+      .orUpdate(
+        ['params', 'updated_at'],
+        ['agent_id', 'scope_key', 'provider', 'model_name', 'auth_type'],
+      )
       .setParameter('updated_at', new Date().toISOString())
       .execute();
     this.cache.invalidateModelParams(agentId);
@@ -105,6 +112,7 @@ export class AgentModelParamsService {
     const row = await this.repo.findOneOrFail({
       where: {
         agent_id: agentId,
+        scope_key: scopeKey,
         provider: normalizedProvider,
         auth_type: authType,
         model_name: modelName,
@@ -120,12 +128,14 @@ export class AgentModelParamsService {
    */
   async delete(
     agentId: string,
+    scopeKey: string,
     provider: string,
     authType: AuthType,
     modelName: string,
   ): Promise<void> {
     await this.repo.delete({
       agent_id: agentId,
+      scope_key: scopeKey,
       provider: provider.toLowerCase(),
       auth_type: authType,
       model_name: modelName,

--- a/packages/backend/src/routing/routing-core/agent-model-params.service.ts
+++ b/packages/backend/src/routing/routing-core/agent-model-params.service.ts
@@ -56,7 +56,7 @@ export class AgentModelParamsService {
         r.auth_type === authType &&
         r.model_name === modelName,
     );
-    return match?.params ?? null;
+    return (match?.params as RequestParamDefaults | undefined) ?? null;
   }
 
   /**

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -6,6 +6,7 @@ import {
   type AuthType,
   type JsonValue,
   type ParamControl,
+  type ProviderParamDependency,
   type ProviderParamSpec,
   type ProviderParamSpecGroup,
   type ProviderParamSpecRegistry,
@@ -16,7 +17,9 @@ const CACHE_TTL_MS = 120_000;
 
 type Serializer = (value: JsonValue) => Record<string, JsonValue>;
 
-const SERIALIZERS: Record<string, Serializer> = {};
+const SERIALIZERS: Record<string, Serializer> = {
+  anthropic_thinking: serializeAnthropicThinking,
+};
 
 @Injectable()
 export class ProviderParamSpecService {
@@ -95,10 +98,62 @@ export class ProviderParamSpecService {
     if (row.serializer) {
       const serialize = SERIALIZERS[row.serializer];
       if (!serialize) throw new Error(`Unknown provider param serializer: ${row.serializer}`);
-      spec.serialize = serialize;
+      if (row.group_key) {
+        spec.group = {
+          key: row.group_key,
+          label: row.group_label ?? row.group_key,
+          serialize,
+        };
+      } else {
+        spec.serialize = serialize;
+      }
+    } else if (row.group_key) {
+      spec.group = {
+        key: row.group_key,
+        label: row.group_label ?? row.group_key,
+      };
     }
 
+    if (row.depends_on_key) {
+      spec.visibleWhen = {
+        key: row.depends_on_key,
+        equals: row.depends_on_value,
+      };
+    }
+    if (row.dependencies) spec.dependencies = this.rowToDependencies(row);
+
     return spec;
+  }
+
+  private rowToDependencies(row: ProviderParamSpecEntity): ProviderParamDependency[] {
+    if (!Array.isArray(row.dependencies)) {
+      throw new Error(`Invalid provider param dependencies: ${row.id}`);
+    }
+
+    return row.dependencies.map((dependency) => {
+      if (!isRecord(dependency) || !isRecord(dependency.when)) {
+        throw new Error(`Invalid provider param dependency: ${row.id}`);
+      }
+      if (dependency.effect !== 'disable' && dependency.effect !== 'omit') {
+        throw new Error(`Invalid provider param dependency effect: ${row.id}`);
+      }
+      if (typeof dependency.when.key !== 'string' || dependency.when.key.length === 0) {
+        throw new Error(`Invalid provider param dependency key: ${row.id}`);
+      }
+      const values = dependency.when.values;
+      if (values !== undefined && !Array.isArray(values)) {
+        throw new Error(`Invalid provider param dependency values: ${row.id}`);
+      }
+
+      return {
+        effect: dependency.effect,
+        when: {
+          key: dependency.when.key,
+          ...('equals' in dependency.when ? { equals: dependency.when.equals as JsonValue } : {}),
+          ...(values !== undefined ? { values: values as JsonValue[] } : {}),
+        },
+      };
+    });
   }
 
   private rowToControl(row: ProviderParamSpecEntity): ParamControl {
@@ -160,4 +215,26 @@ export class ProviderParamSpecService {
   private isStringTuple(value: unknown): value is [string, string] {
     return this.isStringArray(value) && value.length === 2;
   }
+}
+
+function serializeAnthropicThinking(value: JsonValue): Record<string, JsonValue> {
+  if (!isRecord(value)) return {};
+
+  if (value.type === 'adaptive') {
+    return { thinking: { type: 'adaptive' } };
+  }
+
+  if (value.type !== 'enabled') return {};
+  const budgetTokens = value.budget_tokens;
+  if (typeof budgetTokens !== 'number' || !Number.isFinite(budgetTokens)) return {};
+  return {
+    thinking: {
+      type: 'enabled',
+      budget_tokens: Math.trunc(budgetTokens),
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, JsonValue> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -1,0 +1,163 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  getProviderParamSpecs,
+  type AuthType,
+  type JsonValue,
+  type ParamControl,
+  type ProviderParamSpec,
+  type ProviderParamSpecGroup,
+  type ProviderParamSpecRegistry,
+} from 'manifest-shared';
+import { ProviderParamSpecEntity } from '../../entities/provider-param-spec.entity';
+
+const CACHE_TTL_MS = 120_000;
+
+type Serializer = (value: JsonValue) => Record<string, JsonValue>;
+
+const SERIALIZERS: Record<string, Serializer> = {};
+
+@Injectable()
+export class ProviderParamSpecService {
+  private cache: { registry: ProviderParamSpecRegistry; expiresAt: number } | null = null;
+
+  constructor(
+    @InjectRepository(ProviderParamSpecEntity)
+    private readonly repo: Repository<ProviderParamSpecEntity>,
+  ) {}
+
+  async getRegistry(): Promise<ProviderParamSpecRegistry> {
+    if (this.cache && this.cache.expiresAt > Date.now()) return this.cache.registry;
+
+    const rows = await this.repo.find({
+      order: {
+        provider: 'ASC',
+        auth_type: 'ASC',
+        model_name: 'ASC',
+        sort_order: 'ASC',
+        param_key: 'ASC',
+      },
+    });
+    const registry = this.rowsToRegistry(rows);
+    this.cache = { registry, expiresAt: Date.now() + CACHE_TTL_MS };
+    return registry;
+  }
+
+  async getSpecs(
+    providerId: string | undefined,
+    authType: AuthType | undefined,
+    model?: string | undefined,
+  ): Promise<readonly ProviderParamSpec[]> {
+    return getProviderParamSpecs(await this.getRegistry(), providerId, authType, model);
+  }
+
+  private rowsToRegistry(rows: ProviderParamSpecEntity[]): ProviderParamSpecRegistry {
+    const registry: Record<string, ProviderParamSpecGroup> = {};
+
+    for (const row of rows) {
+      const groupKey = `${row.provider.toLowerCase()}:${row.auth_type}` as `${string}:${AuthType}`;
+      const existing = registry[groupKey];
+      const group: {
+        base: ProviderParamSpec[];
+        byModel?: Record<string, ProviderParamSpec[]>;
+      } = existing
+        ? {
+            base: [...existing.base],
+            byModel: existing.byModel
+              ? Object.fromEntries(
+                  Object.entries(existing.byModel).map(([model, specs]) => [model, [...specs]]),
+                )
+              : undefined,
+          }
+        : { base: [] };
+
+      const spec = this.rowToSpec(row);
+      if (row.model_name) {
+        group.byModel ??= {};
+        group.byModel[row.model_name] ??= [];
+        group.byModel[row.model_name].push(spec);
+      } else {
+        group.base.push(spec);
+      }
+      registry[groupKey] = group;
+    }
+
+    return registry as ProviderParamSpecRegistry;
+  }
+
+  private rowToSpec(row: ProviderParamSpecEntity): ProviderParamSpec {
+    const spec: ProviderParamSpec = {
+      key: row.param_key,
+      control: this.rowToControl(row),
+    };
+
+    if (row.serializer) {
+      const serialize = SERIALIZERS[row.serializer];
+      if (!serialize) throw new Error(`Unknown provider param serializer: ${row.serializer}`);
+      spec.serialize = serialize;
+    }
+
+    return spec;
+  }
+
+  private rowToControl(row: ProviderParamSpecEntity): ParamControl {
+    switch (row.control_kind) {
+      case 'toggle':
+        if (!this.isStringTuple(row.values) || typeof row.default_value !== 'string') {
+          throw new Error(`Invalid toggle provider param spec: ${row.id}`);
+        }
+        return {
+          kind: 'toggle',
+          label: row.label,
+          values: row.values,
+          default: row.default_value,
+        };
+      case 'select':
+        if (!this.isStringArray(row.values) || typeof row.default_value !== 'string') {
+          throw new Error(`Invalid select provider param spec: ${row.id}`);
+        }
+        return {
+          kind: 'select',
+          label: row.label,
+          values: row.values,
+          default: row.default_value,
+        };
+      case 'slider':
+        if (
+          typeof row.default_value !== 'number' ||
+          typeof row.min_value !== 'number' ||
+          typeof row.max_value !== 'number'
+        ) {
+          throw new Error(`Invalid slider provider param spec: ${row.id}`);
+        }
+        return {
+          kind: 'slider',
+          label: row.label,
+          min: row.min_value,
+          max: row.max_value,
+          ...(typeof row.step_value === 'number' ? { step: row.step_value } : {}),
+          default: row.default_value,
+        };
+      case 'number':
+        if (typeof row.default_value !== 'number') {
+          throw new Error(`Invalid number provider param spec: ${row.id}`);
+        }
+        return {
+          kind: 'number',
+          label: row.label,
+          ...(typeof row.min_value === 'number' ? { min: row.min_value } : {}),
+          ...(typeof row.max_value === 'number' ? { max: row.max_value } : {}),
+          default: row.default_value,
+        };
+    }
+  }
+
+  private isStringArray(value: unknown): value is string[] {
+    return Array.isArray(value) && value.every((v) => typeof v === 'string');
+  }
+
+  private isStringTuple(value: unknown): value is [string, string] {
+    return this.isStringArray(value) && value.length === 2;
+  }
+}

--- a/packages/backend/src/routing/routing-core/routing-core.module.ts
+++ b/packages/backend/src/routing/routing-core/routing-core.module.ts
@@ -4,6 +4,7 @@ import { UserProvider } from '../../entities/user-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 import { AgentModelParams } from '../../entities/agent-model-params.entity';
+import { ProviderParamSpecEntity } from '../../entities/provider-param-spec.entity';
 import { Agent } from '../../entities/agent.entity';
 import { Tenant } from '../../entities/tenant.entity';
 import { AgentMessage } from '../../entities/agent-message.entity';
@@ -19,6 +20,7 @@ import { ResolveAgentService } from './resolve-agent.service';
 import { SpecificityService } from './specificity.service';
 import { SpecificityPenaltyService } from './specificity-penalty.service';
 import { AgentModelParamsService } from './agent-model-params.service';
+import { ProviderParamSpecService } from './provider-param-spec.service';
 
 @Module({
   imports: [
@@ -27,6 +29,7 @@ import { AgentModelParamsService } from './agent-model-params.service';
       TierAssignment,
       SpecificityAssignment,
       AgentModelParams,
+      ProviderParamSpecEntity,
       Agent,
       Tenant,
       AgentMessage,
@@ -45,6 +48,7 @@ import { AgentModelParamsService } from './agent-model-params.service';
     SpecificityService,
     SpecificityPenaltyService,
     AgentModelParamsService,
+    ProviderParamSpecService,
   ],
   exports: [
     TypeOrmModule,
@@ -58,6 +62,7 @@ import { AgentModelParamsService } from './agent-model-params.service';
     SpecificityService,
     SpecificityPenaltyService,
     AgentModelParamsService,
+    ProviderParamSpecService,
   ],
 })
 export class RoutingCoreModule {}

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -1,5 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CanActivate, ExecutionContext, INestApplication, Injectable, UnauthorizedException, ValidationPipe } from '@nestjs/common';
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication,
+  Injectable,
+  UnauthorizedException,
+  ValidationPipe,
+} from '@nestjs/common';
 import { APP_GUARD, Reflector } from '@nestjs/core';
 import { CacheModule } from '@nestjs/cache-manager';
 import { ConfigModule } from '@nestjs/config';
@@ -27,6 +34,7 @@ import { SpecificityAssignment } from '../src/entities/specificity-assignment.en
 import { HeaderTier } from '../src/entities/header-tier.entity';
 import { InstallMetadata } from '../src/entities/install-metadata.entity';
 import { AgentModelParams } from '../src/entities/agent-model-params.entity';
+import { ProviderParamSpecEntity } from '../src/entities/provider-param-spec.entity';
 import { PlaygroundRun } from '../src/entities/playground-run.entity';
 import { PlaygroundColumn } from '../src/entities/playground-column.entity';
 import { HealthModule } from '../src/health/health.module';
@@ -47,7 +55,29 @@ export const TEST_TENANT_ID = 'test-tenant-001';
 export const TEST_AGENT_ID = 'test-agent-001';
 export const TEST_OTLP_KEY = 'mnfst_test-otlp-key-001';
 
-const entities = [AgentMessage, LlmCall, ToolExecution, AgentLog, ApiKey, Tenant, Agent, AgentApiKey, NotificationRule, NotificationLog, UserProvider, TierAssignment, CustomProvider, EmailProviderConfig, SpecificityAssignment, HeaderTier, InstallMetadata, AgentModelParams, PlaygroundRun, PlaygroundColumn];
+const entities = [
+  AgentMessage,
+  LlmCall,
+  ToolExecution,
+  AgentLog,
+  ApiKey,
+  Tenant,
+  Agent,
+  AgentApiKey,
+  NotificationRule,
+  NotificationLog,
+  UserProvider,
+  TierAssignment,
+  CustomProvider,
+  EmailProviderConfig,
+  SpecificityAssignment,
+  HeaderTier,
+  InstallMetadata,
+  AgentModelParams,
+  ProviderParamSpecEntity,
+  PlaygroundRun,
+  PlaygroundColumn,
+];
 const OPENROUTER_MODELS_URL = 'https://openrouter.ai/api/v1/models';
 const OPENROUTER_MODELS_FIXTURE = {
   data: [
@@ -109,9 +139,7 @@ const OPENROUTER_MODELS_FIXTURE = {
 function buildTypeOrmConfig(): TypeOrmModuleOptions {
   return {
     type: 'postgres' as const,
-    url:
-      process.env['DATABASE_URL'] ??
-      'postgresql://myuser:mypassword@localhost:5432/mydatabase',
+    url: process.env['DATABASE_URL'] ?? 'postgresql://myuser:mypassword@localhost:5432/mydatabase',
     entities,
     synchronize: true,
     dropSchema: true,
@@ -145,7 +173,8 @@ class MockSessionGuard implements CanActivate {
 export async function createTestApp(): Promise<INestApplication> {
   process.env['API_KEY'] = TEST_API_KEY;
   process.env['NODE_ENV'] = 'test';
-  process.env['BETTER_AUTH_SECRET'] = process.env['BETTER_AUTH_SECRET'] ?? 'test-secret-for-e2e-at-least-32chars!!';
+  process.env['BETTER_AUTH_SECRET'] =
+    process.env['BETTER_AUTH_SECRET'] ?? 'test-secret-for-e2e-at-least-32chars!!';
   const restoreFetch = stubOpenRouterPricingFetch();
 
   try {
@@ -167,9 +196,7 @@ export async function createTestApp(): Promise<INestApplication> {
         PublicStatsModule,
         SetupModule,
       ],
-      providers: [
-        { provide: APP_GUARD, useClass: MockSessionGuard },
-      ],
+      providers: [{ provide: APP_GUARD, useClass: MockSessionGuard }],
     }).compile();
 
     const app = moduleFixture.createNestApplication();
@@ -187,7 +214,14 @@ export async function createTestApp(): Promise<INestApplication> {
     // Seed test API key (hashed)
     await ds.query(
       `INSERT INTO api_keys (id, key, key_hash, key_prefix, user_id, name, created_at) VALUES ($1, NULL, $2, $3, $4, $5, $6)`,
-      ['test-key-id', hashKey(TEST_API_KEY), keyPrefix(TEST_API_KEY), TEST_USER_ID, 'Test Key', now],
+      [
+        'test-key-id',
+        hashKey(TEST_API_KEY),
+        keyPrefix(TEST_API_KEY),
+        TEST_USER_ID,
+        'Test Key',
+        now,
+      ],
     );
 
     // Seed test tenant, agent, and OTLP key (hashed)
@@ -201,7 +235,15 @@ export async function createTestApp(): Promise<INestApplication> {
     );
     await ds.query(
       `INSERT INTO agent_api_keys (id, key, key_hash, key_prefix, label, tenant_id, agent_id, is_active, created_at) VALUES ($1, NULL, $2, $3, $4, $5, $6, true, $7)`,
-      ['test-otlp-key-id', hashKey(TEST_OTLP_KEY), keyPrefix(TEST_OTLP_KEY), 'Test OTLP Key', TEST_TENANT_ID, TEST_AGENT_ID, now],
+      [
+        'test-otlp-key-id',
+        hashKey(TEST_OTLP_KEY),
+        keyPrefix(TEST_OTLP_KEY),
+        'Test OTLP Key',
+        TEST_TENANT_ID,
+        TEST_AGENT_ID,
+        now,
+      ],
     );
 
     // Reload pricing cache from deterministic fixture data to keep e2e startup fast.

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createEffect, onCleanup, For, Show, type Component } from 'solid-js';
 import {
   clearFallbacks,
+  modelParamsScopeForTier,
   setFallbacks,
   type AuthType,
   type AvailableModel,
@@ -26,6 +27,7 @@ import ModelParamsAffordance from './ModelParamsAffordance.jsx';
 interface FallbackListProps {
   agentName: string;
   tier: string;
+  modelParamsScope?: string;
   tierData?: () => TierAssignment | undefined;
   fallbacks: string[];
   // Optional structured route per fallback. When present (length matches
@@ -59,15 +61,18 @@ interface FallbackListProps {
    * Per-route params getter, threaded from the routing page boundary. When
    * present, every fallback row whose provider consumes a known param key
    * renders a `<ModelParamsAffordance>` for its own `(provider, authType,
-   * model)` tuple. Saving from a fallback row updates the parent's cache
-   * just like saving from the primary chip does.
+   * model)` tuple within this fallback list's route scope. Saving from a
+   * fallback row updates the parent's cache just like saving from the primary
+   * chip does, without leaking across tiers.
    */
   getModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
   ) => RequestParamDefaults | null;
   setModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -94,6 +99,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
   const [dragIndex, setDragIndex] = createSignal<number | null>(null);
   const [dropSlot, setDropSlot] = createSignal<number | null>(null);
   let listRef: HTMLDivElement | undefined;
+  const modelParamsScope = () => props.modelParamsScope ?? modelParamsScopeForTier(props.tier);
 
   const modelLabel = (model: string): string => {
     const info = props.models.find((m) => m.model_name === model);
@@ -427,6 +433,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                       }
                     >
                       <ModelParamsAffordance
+                        scope={modelParamsScope()}
                         provider={provId()}
                         authType={(auth() as AuthType) ?? undefined}
                         model={model()}

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -7,6 +7,7 @@ import {
   type AvailableModel,
   type CustomProviderData,
   type ModelRoute,
+  type ProviderParamSpecRegistry,
   type RequestParamDefaults,
   type RoutingProvider,
   type TierAssignment,
@@ -28,6 +29,7 @@ interface FallbackListProps {
   agentName: string;
   tier: string;
   modelParamsScope?: string;
+  modelParamSpecs?: () => ProviderParamSpecRegistry;
   tierData?: () => TierAssignment | undefined;
   fallbacks: string[];
   // Optional structured route per fallback. When present (length matches
@@ -434,6 +436,7 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                     >
                       <ModelParamsAffordance
                         scope={modelParamsScope()}
+                        specRegistry={props.modelParamSpecs?.() ?? {}}
                         provider={provId()}
                         authType={(auth() as AuthType) ?? undefined}
                         model={model()}

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -4,6 +4,7 @@ import type {
   AvailableModel,
   CustomProviderData,
   ModelRoute,
+  ProviderParamSpecRegistry,
   RequestParamDefaults,
   RoutingProvider,
 } from '../services/api.js';
@@ -51,6 +52,7 @@ interface Props {
   onFallbacksUpdate: (fallbacks: string[], routes?: ModelRoute[] | null) => void;
   onEdit?: () => void;
   onDisable?: () => void;
+  modelParamSpecs?: () => ProviderParamSpecRegistry;
   /**
    * Per-route params getter, threaded from the routing page boundary. When
    * present, the primary chip and every fallback row render a
@@ -333,6 +335,7 @@ const HeaderTierCard: Component<Props> = (props) => {
                   >
                     <ModelParamsAffordance
                       scope={modelParamsScope()}
+                      specRegistry={props.modelParamSpecs?.() ?? {}}
                       provider={providerId()}
                       authType={(effectiveAuth() as AuthType) ?? undefined}
                       model={modelName()}
@@ -382,6 +385,7 @@ const HeaderTierCard: Component<Props> = (props) => {
             agentName={props.agentName}
             tier={props.tier.id}
             modelParamsScope={modelParamsScope()}
+            modelParamSpecs={props.modelParamSpecs}
             fallbacks={fallbacks()}
             fallbackRoutes={props.tier.fallback_routes ?? null}
             models={props.models}

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -13,6 +13,7 @@ import {
   setHeaderTierFallbacks,
   clearHeaderTierFallbacks,
 } from '../services/api/header-tiers.js';
+import { modelParamsScopeForHeaderTier } from '../services/api.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
 import { authBadgeFor } from './AuthBadge.js';
 import { resolveProviderId, inferProviderFromModel, pricePerM } from '../services/routing-utils.js';
@@ -53,16 +54,18 @@ interface Props {
   /**
    * Per-route params getter, threaded from the routing page boundary. When
    * present, the primary chip and every fallback row render a
-   * `<ModelParamsAffordance>` for their own `(provider, authType, model)`
-   * tuple. Closes the gap where the custom (header-tier) routing surface
-   * had no params support at all.
+   * `<ModelParamsAffordance>` for their own scoped `(provider, authType,
+   * model)` tuple. Closes the gap where the custom (header-tier) routing
+   * surface had no params support at all.
    */
   getModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
   ) => RequestParamDefaults | null;
   setModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -79,6 +82,7 @@ const HeaderTierCard: Component<Props> = (props) => {
 
   const currentModel = (): string | null => props.tier.override_route?.model ?? null;
   const fallbacks = (): string[] => props.tier.fallback_routes?.map((r) => r.model) ?? [];
+  const modelParamsScope = () => modelParamsScopeForHeaderTier(props.tier.id);
 
   const providerId = (): string | undefined => {
     const m = currentModel();
@@ -328,6 +332,7 @@ const HeaderTierCard: Component<Props> = (props) => {
                     }
                   >
                     <ModelParamsAffordance
+                      scope={modelParamsScope()}
                       provider={providerId()}
                       authType={(effectiveAuth() as AuthType) ?? undefined}
                       model={modelName()}
@@ -376,6 +381,7 @@ const HeaderTierCard: Component<Props> = (props) => {
           <FallbackList
             agentName={props.agentName}
             tier={props.tier.id}
+            modelParamsScope={modelParamsScope()}
             fallbacks={fallbacks()}
             fallbackRoutes={props.tier.fallback_routes ?? null}
             models={props.models}

--- a/packages/frontend/src/components/MessageDetailsSections.tsx
+++ b/packages/frontend/src/components/MessageDetailsSections.tsx
@@ -3,7 +3,7 @@ import InfoTooltip from './InfoTooltip.jsx';
 
 const MODEL_PARAMS_TOOLTIP =
   'Provider-specific request parameters that affected this call — e.g. ' +
-  "DeepSeek's `thinking` toggle. The set is curated per provider today; " +
+  "DeepSeek's `thinking` toggle or Anthropic sampling controls. The set is curated per provider; " +
   'support for additional models and custom user-defined parameters lands ' +
   'here as it ships.';
 

--- a/packages/frontend/src/components/ModelParamsAffordance.tsx
+++ b/packages/frontend/src/components/ModelParamsAffordance.tsx
@@ -42,8 +42,8 @@ interface Props {
 /**
  * Per-model "Parameters" affordance: a small gear/sliders button next to a
  * model row that opens the curated parameters dialog. Visibility is driven
- * by the route's provider — only providers Manifest knows how to talk about
- * (today: DeepSeek's `thinking`) render the button at all.
+ * by the route's provider/auth/model tuple — only routes with shared registry
+ * specs render the button at all.
  *
  * The component is intentionally dumb about persistence: it does not own
  * fetch or cache state. The parent (`Routing.tsx`) fetches the agent's full
@@ -55,7 +55,8 @@ const ModelParamsAffordance: Component<Props> = (props) => {
   const [dialogOpen, setDialogOpen] = createSignal(false);
 
   const supports = () =>
-    props.provider !== undefined && getProviderParamSpecs(props.provider).length > 0;
+    props.provider !== undefined &&
+    getProviderParamSpecs(props.provider, props.authType, props.model).length > 0;
 
   const current = () => {
     if (!props.provider || !props.authType) return null;
@@ -69,14 +70,16 @@ const ModelParamsAffordance: Component<Props> = (props) => {
       <button
         type="button"
         class="routing-card__chip-action"
-        classList={{ 'routing-card__chip-action--configured': configured() }}
+        classList={{
+          'routing-card__chip-action--configured': configured(),
+          'routing-card__chip-action--dialog-open': dialogOpen(),
+        }}
         onClick={(e) => {
           e.stopPropagation();
           setDialogOpen(true);
         }}
         disabled={props.disabled}
         aria-label={`Configure model parameters for ${props.slotLabel}`}
-        title="Model parameters"
       >
         <span class="routing-tooltip">Parameters</span>
         <svg
@@ -108,6 +111,8 @@ const ModelParamsAffordance: Component<Props> = (props) => {
           slotLabel={props.slotLabel}
           current={current()}
           provider={props.provider!}
+          authType={props.authType!}
+          model={props.model}
           onSave={(next) => props.setParams(props.provider!, props.authType!, props.model, next)}
           onClose={() => setDialogOpen(false)}
         />

--- a/packages/frontend/src/components/ModelParamsAffordance.tsx
+++ b/packages/frontend/src/components/ModelParamsAffordance.tsx
@@ -1,5 +1,5 @@
 import { createSignal, Show, type Component } from 'solid-js';
-import { getProviderParamSpecs } from 'manifest-shared';
+import { getProviderParamSpecs, type ProviderParamSpecRegistry } from 'manifest-shared';
 import type { AuthType, RequestParamDefaults } from '../services/api.js';
 import ModelParamsDialog from './ModelParamsDialog.jsx';
 
@@ -14,6 +14,8 @@ interface Props {
   slotLabel: string;
   /** Route-scope key (tier/default, task-specific category, or header tier). */
   scope: string;
+  /** Backend-loaded provider param registry. */
+  specRegistry: ProviderParamSpecRegistry;
   /**
    * Read the currently-saved params for this route from the parent's loaded
    * map. Called on every render so reactivity flows through the parent's
@@ -50,7 +52,7 @@ interface Props {
 /**
  * Per-model "Parameters" affordance: a small gear/sliders button next to a
  * model row that opens the curated parameters dialog. Visibility is driven
- * by the route's provider/auth/model tuple — only routes with shared registry
+ * by the route's provider/auth/model tuple — only routes with DB-backed
  * specs render the button at all.
  *
  * The component is intentionally dumb about persistence: it does not own
@@ -62,9 +64,9 @@ interface Props {
 const ModelParamsAffordance: Component<Props> = (props) => {
   const [dialogOpen, setDialogOpen] = createSignal(false);
 
-  const supports = () =>
-    props.provider !== undefined &&
-    getProviderParamSpecs(props.provider, props.authType, props.model).length > 0;
+  const specs = () =>
+    getProviderParamSpecs(props.specRegistry, props.provider, props.authType, props.model);
+  const supports = () => props.provider !== undefined && specs().length > 0;
 
   const current = () => {
     if (!props.provider || !props.authType) return null;
@@ -118,9 +120,7 @@ const ModelParamsAffordance: Component<Props> = (props) => {
           open={dialogOpen()}
           slotLabel={props.slotLabel}
           current={current()}
-          provider={props.provider!}
-          authType={props.authType!}
-          model={props.model}
+          specs={specs()}
           onSave={(next) =>
             props.setParams(props.scope, props.provider!, props.authType!, props.model, next)
           }

--- a/packages/frontend/src/components/ModelParamsAffordance.tsx
+++ b/packages/frontend/src/components/ModelParamsAffordance.tsx
@@ -12,13 +12,20 @@ interface Props {
   model: string;
   /** Display label for the dialog header (e.g. "deepseek-v4-flash"). */
   slotLabel: string;
+  /** Route-scope key (tier/default, task-specific category, or header tier). */
+  scope: string;
   /**
    * Read the currently-saved params for this route from the parent's loaded
    * map. Called on every render so reactivity flows through the parent's
-   * signal — saving in one slot updates the badge on every other slot that
-   * resolves to the same `(provider, authType, model)` tuple.
+   * signal — saving in one slot updates only rows with the same scoped
+   * `(provider, authType, model)` tuple.
    */
-  getParams: (provider: string, authType: AuthType, model: string) => RequestParamDefaults | null;
+  getParams: (
+    scope: string,
+    provider: string,
+    authType: AuthType,
+    model: string,
+  ) => RequestParamDefaults | null;
   /**
    * Persist the new params for this route. The dialog passes `null` when the
    * chosen value matches the provider's natural default — the parent should
@@ -27,6 +34,7 @@ interface Props {
    * reflects the new value.
    */
   setParams: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -48,8 +56,8 @@ interface Props {
  * The component is intentionally dumb about persistence: it does not own
  * fetch or cache state. The parent (`Routing.tsx`) fetches the agent's full
  * model-params map once on page boot and threads `getParams` / `setParams`
- * down, so every model row across every routing surface stays in sync from
- * a single source of truth.
+ * down, so every scoped model row stays in sync from a single source of
+ * truth without leaking values across tiers.
  */
 const ModelParamsAffordance: Component<Props> = (props) => {
   const [dialogOpen, setDialogOpen] = createSignal(false);
@@ -60,7 +68,7 @@ const ModelParamsAffordance: Component<Props> = (props) => {
 
   const current = () => {
     if (!props.provider || !props.authType) return null;
-    return props.getParams(props.provider, props.authType, props.model);
+    return props.getParams(props.scope, props.provider, props.authType, props.model);
   };
 
   const configured = () => current() !== null;
@@ -113,7 +121,9 @@ const ModelParamsAffordance: Component<Props> = (props) => {
           provider={props.provider!}
           authType={props.authType!}
           model={props.model}
-          onSave={(next) => props.setParams(props.provider!, props.authType!, props.model, next)}
+          onSave={(next) =>
+            props.setParams(props.scope, props.provider!, props.authType!, props.model, next)
+          }
           onClose={() => setDialogOpen(false)}
         />
       </Show>

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -50,9 +50,8 @@ const readValue = (spec: ProviderParamSpec, current: RequestParamDefaults | null
   const storageKey = providerParamStorageKey(spec);
   const stored = (current as Record<string, unknown> | null)?.[storageKey];
   if (spec.group) {
-    return isRecord(stored) && stored[spec.key] !== undefined
-      ? stored[spec.key]
-      : spec.control.default;
+    const groupValue = isRecord(stored) ? stored[spec.key] : undefined;
+    return groupValue === undefined ? spec.control.default : groupValue;
   }
   if (stored && typeof stored === 'object' && !Array.isArray(stored) && 'type' in stored) {
     return (stored as { type: JsonValue }).type;
@@ -142,9 +141,8 @@ const ModelParamsDialog: Component<Props> = (props) => {
     const storageKey = providerParamStorageKey(spec);
     const stored = draft()[storageKey];
     if (!spec.group) return stored ?? spec.control.default;
-    return isRecord(stored) && stored[spec.key] !== undefined
-      ? stored[spec.key]
-      : spec.control.default;
+    const groupValue = isRecord(stored) ? stored[spec.key] : undefined;
+    return groupValue === undefined ? spec.control.default : groupValue;
   };
 
   const setSpecValue = (spec: ProviderParamSpec, value: JsonValue) => {

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -312,7 +312,10 @@ const ModelParamsDialog: Component<Props> = (props) => {
             {(spec) => (
               <div class="model-params__row">
                 <div class="model-params__label">
-                  <div class="model-params__label-title">{spec.control.label}</div>
+                  <div class="model-params__label-title">
+                    <span>{spec.control.label}</span>
+                    <code class="model-params__param-key">{spec.key}</code>
+                  </div>
                   <div class="model-params__label-hint">
                     Provider default: {spec.control.default}
                   </div>

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -1,5 +1,10 @@
 import { createSignal, createEffect, For, Show, type Component } from 'solid-js';
-import type { ParamControl, ProviderParamSpec } from 'manifest-shared';
+import {
+  providerParamHasEffect,
+  providerParamStorageKey,
+  type ParamControl,
+  type ProviderParamSpec,
+} from 'manifest-shared';
 import type { JsonValue, RequestParamDefaults } from '../services/api.js';
 import Select from './Select.jsx';
 
@@ -29,8 +34,26 @@ interface Props {
  */
 type DraftState = Record<string, JsonValue>;
 
+type SpecRenderItem =
+  | { kind: 'spec'; spec: ProviderParamSpec }
+  | { kind: 'group'; key: string; label: string; specs: ProviderParamSpec[] };
+
+const isRecord = (value: unknown): value is Record<string, JsonValue> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const valuesEqual = (a: JsonValue, b: JsonValue) =>
+  typeof a === 'object' || typeof b === 'object'
+    ? JSON.stringify(a) === JSON.stringify(b)
+    : a === b;
+
 const readValue = (spec: ProviderParamSpec, current: RequestParamDefaults | null): JsonValue => {
-  const stored = (current as Record<string, unknown> | null)?.[spec.key];
+  const storageKey = providerParamStorageKey(spec);
+  const stored = (current as Record<string, unknown> | null)?.[storageKey];
+  if (spec.group) {
+    return isRecord(stored) && stored[spec.key] !== undefined
+      ? stored[spec.key]
+      : spec.control.default;
+  }
   if (stored && typeof stored === 'object' && !Array.isArray(stored) && 'type' in stored) {
     return (stored as { type: JsonValue }).type;
   }
@@ -42,8 +65,36 @@ const stateFromCurrent = (
   current: RequestParamDefaults | null,
 ): DraftState => {
   const draft: DraftState = {};
-  for (const spec of specs) draft[spec.key] = readValue(spec, current);
+  for (const spec of specs) {
+    const storageKey = providerParamStorageKey(spec);
+    if (spec.group) {
+      const existing = isRecord(draft[storageKey]) ? draft[storageKey] : {};
+      draft[storageKey] = { ...existing, [spec.key]: readValue(spec, current) };
+      continue;
+    }
+    draft[storageKey] = readValue(spec, current);
+  }
   return draft;
+};
+
+const renderItemsFromSpecs = (specs: readonly ProviderParamSpec[]): SpecRenderItem[] => {
+  const items: SpecRenderItem[] = [];
+  const seenGroups = new Set<string>();
+  for (const spec of specs) {
+    if (!spec.group) {
+      items.push({ kind: 'spec', spec });
+      continue;
+    }
+    if (seenGroups.has(spec.group.key)) continue;
+    seenGroups.add(spec.group.key);
+    items.push({
+      kind: 'group',
+      key: spec.group.key,
+      label: spec.group.label,
+      specs: specs.filter((s) => s.group?.key === spec.group?.key),
+    });
+  }
+  return items;
 };
 
 type ToggleControl = Extract<ParamControl, { kind: 'toggle' }>;
@@ -76,6 +127,7 @@ const sliderValue = (value: number, control: SliderControl): number => {
 
 const ModelParamsDialog: Component<Props> = (props) => {
   const specs = () => props.specs;
+  const renderItems = () => renderItemsFromSpecs(specs());
   const [draft, setDraft] = createSignal<DraftState>(stateFromCurrent(specs(), props.current));
   const [saving, setSaving] = createSignal(false);
 
@@ -86,17 +138,45 @@ const ModelParamsDialog: Component<Props> = (props) => {
     if (props.open) setDraft(stateFromCurrent(specs(), props.current));
   });
 
-  const setKey = (key: string, value: JsonValue) => {
-    setDraft({ ...draft(), [key]: value });
+  const specValue = (spec: ProviderParamSpec): JsonValue => {
+    const storageKey = providerParamStorageKey(spec);
+    const stored = draft()[storageKey];
+    if (!spec.group) return stored ?? spec.control.default;
+    return isRecord(stored) && stored[spec.key] !== undefined
+      ? stored[spec.key]
+      : spec.control.default;
   };
 
+  const setSpecValue = (spec: ProviderParamSpec, value: JsonValue) => {
+    const storageKey = providerParamStorageKey(spec);
+    if (!spec.group) {
+      setDraft({ ...draft(), [storageKey]: value });
+      return;
+    }
+    const existing = draft()[storageKey];
+    const nextGroup = isRecord(existing) ? { ...existing } : {};
+    nextGroup[spec.key] = value;
+    setDraft({ ...draft(), [storageKey]: nextGroup });
+  };
+
+  const isSpecVisible = (spec: ProviderParamSpec): boolean => {
+    if (!spec.visibleWhen) return true;
+    const storageKey = providerParamStorageKey(spec);
+    const source = spec.group ? draft()[storageKey] : draft();
+    const actual = isRecord(source) ? source[spec.visibleWhen.key] : undefined;
+    return valuesEqual(actual ?? null, spec.visibleWhen.equals);
+  };
+  const isSpecDisabled = (spec: ProviderParamSpec): boolean =>
+    providerParamHasEffect(spec, draft(), 'disable');
+  const isControlDisabled = (spec: ProviderParamSpec): boolean => saving() || isSpecDisabled(spec);
+
   const stringValue = (spec: ProviderParamSpec, control: ToggleControl | SelectControl) => {
-    const value = draft()[spec.key];
+    const value = specValue(spec);
     return typeof value === 'string' ? value : control.default;
   };
 
   const numericValue = (spec: ProviderParamSpec, control: SliderControl | NumberControl) => {
-    const value = draft()[spec.key];
+    const value = specValue(spec);
     return typeof value === 'number' && Number.isFinite(value) ? value : control.default;
   };
 
@@ -110,8 +190,8 @@ const ModelParamsDialog: Component<Props> = (props) => {
         class="model-params__toggle"
         aria-pressed={isOn()}
         aria-label={`${control.label}: ${currentValue()}`}
-        disabled={saving()}
-        onClick={() => setKey(spec.key, isOn() ? offValue : onValue)}
+        disabled={isControlDisabled(spec)}
+        onClick={() => setSpecValue(spec, isOn() ? offValue : onValue)}
       >
         <span class="provider-toggle__switch" classList={{ 'provider-toggle__switch--on': isOn() }}>
           <span class="provider-toggle__switch-thumb" />
@@ -126,7 +206,8 @@ const ModelParamsDialog: Component<Props> = (props) => {
         label={control.label}
         options={control.values.map((v) => ({ label: v, value: v }))}
         value={stringValue(spec, control)}
-        onChange={(v) => setKey(spec.key, v)}
+        disabled={isControlDisabled(spec)}
+        onChange={(v) => setSpecValue(spec, v)}
       />
     </div>
   );
@@ -140,7 +221,8 @@ const ModelParamsDialog: Component<Props> = (props) => {
       return clampNumber(((value() - control.min) / span) * 100, 0, 0, 100);
     };
     const setSliderValue = (next: number) => {
-      setKey(spec.key, sliderValue(next, control));
+      if (isControlDisabled(spec)) return;
+      setSpecValue(spec, sliderValue(next, control));
     };
     const setFromPointer = (clientX: number) => {
       if (!sliderRef) return;
@@ -152,7 +234,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
       setSliderValue(Number.parseFloat(raw));
     };
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (saving()) return;
+      if (isControlDisabled(spec)) return;
       const step = sliderStep(control);
       switch (e.key) {
         case 'ArrowLeft':
@@ -181,16 +263,16 @@ const ModelParamsDialog: Component<Props> = (props) => {
           ref={sliderRef}
           class="model-params__slider"
           role="slider"
-          tabIndex={saving() ? -1 : 0}
+          tabIndex={isControlDisabled(spec) ? -1 : 0}
           aria-label={control.label}
           aria-valuemin={control.min}
           aria-valuemax={control.max}
           aria-valuenow={value()}
           aria-valuetext={String(value())}
-          aria-disabled={saving()}
+          aria-disabled={isControlDisabled(spec)}
           style={`--model-params-slider-progress: ${progress()}%;`}
           onPointerDown={(e) => {
-            if (saving()) return;
+            if (isControlDisabled(spec)) return;
             e.preventDefault();
             e.currentTarget.setPointerCapture?.(e.pointerId);
             setFromPointer(e.clientX);
@@ -215,7 +297,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
           max={control.max}
           step={sliderStep(control)}
           value={value()}
-          disabled={saving()}
+          disabled={isControlDisabled(spec)}
           aria-label={`${control.label} value`}
           onInput={(e) => setFromTextInput(e.currentTarget.value)}
         />
@@ -226,8 +308,9 @@ const ModelParamsDialog: Component<Props> = (props) => {
   const NumberRow = (spec: ProviderParamSpec, control: NumberControl) => {
     const value = () => numericValue(spec, control);
     const setFromInput = (raw: string) => {
+      if (isControlDisabled(spec)) return;
       const parsed = Number.parseFloat(raw);
-      setKey(spec.key, clampNumber(parsed, control.default, control.min, control.max));
+      setSpecValue(spec, clampNumber(parsed, control.default, control.min, control.max));
     };
     return (
       <input
@@ -236,7 +319,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
         min={control.min}
         max={control.max}
         value={value()}
-        disabled={saving()}
+        disabled={isControlDisabled(spec)}
         aria-label={control.label}
         onInput={(e) => setFromInput(e.currentTarget.value)}
       />
@@ -267,10 +350,29 @@ const ModelParamsDialog: Component<Props> = (props) => {
       // and the dashboard snapshot reflects the provider default, not an
       // explicit override.
       const out: RequestParamDefaults = {};
+      const handledGroups = new Set<string>();
       for (const spec of specs()) {
-        const value = draft()[spec.key] ?? spec.control.default;
-        if (value !== spec.control.default) {
-          out[spec.key] = value;
+        const storageKey = providerParamStorageKey(spec);
+        if (spec.group) {
+          if (handledGroups.has(storageKey)) continue;
+          handledGroups.add(storageKey);
+          const groupSpecs = specs().filter((s) => s.group?.key === spec.group?.key);
+          const visibleSpecs = groupSpecs.filter(
+            (groupSpec) => isSpecVisible(groupSpec) && !isSpecDisabled(groupSpec),
+          );
+          const hasOverride = visibleSpecs.some(
+            (s) => !valuesEqual(specValue(s), s.control.default),
+          );
+          if (!hasOverride) continue;
+          const value: Record<string, JsonValue> = {};
+          for (const groupSpec of visibleSpecs) value[groupSpec.key] = specValue(groupSpec);
+          out[storageKey] = value;
+          continue;
+        }
+        if (isSpecDisabled(spec)) continue;
+        const value = specValue(spec);
+        if (!valuesEqual(value, spec.control.default)) {
+          out[storageKey] = value;
         }
       }
       const next: RequestParamDefaults | null = Object.keys(out).length === 0 ? null : out;
@@ -283,6 +385,29 @@ const ModelParamsDialog: Component<Props> = (props) => {
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === 'Escape' && !saving()) props.onClose();
+  };
+
+  const ParamRow = (rowProps: { spec: ProviderParamSpec }) => {
+    const spec = () => rowProps.spec;
+    return (
+      <div
+        class="model-params__row"
+        classList={{ 'model-params__row--disabled': isSpecDisabled(spec()) }}
+      >
+        <div class="model-params__label">
+          <div class="model-params__label-title">
+            <span>{spec().control.label}</span>
+            <code class="model-params__param-key">{spec().key}</code>
+          </div>
+          <div class="model-params__label-hint">
+            {isSpecDisabled(spec())
+              ? 'Unavailable with selected parameters'
+              : `Provider default: ${spec().control.default}`}
+          </div>
+        </div>
+        {renderControl(spec())}
+      </div>
+    );
   };
 
   return (
@@ -307,21 +432,28 @@ const ModelParamsDialog: Component<Props> = (props) => {
           </h2>
           <p class="modal-card__desc">Defaults for {props.slotLabel}. Client requests override.</p>
 
-          <For each={specs()}>
-            {(spec) => (
-              <div class="model-params__row">
-                <div class="model-params__label">
-                  <div class="model-params__label-title">
-                    <span>{spec.control.label}</span>
-                    <code class="model-params__param-key">{spec.key}</code>
+          <For each={renderItems()}>
+            {(item) =>
+              item.kind === 'group' ? (
+                <div class="model-params__group">
+                  <div class="model-params__group-header">
+                    <span>{item.label}</span>
+                    <code class="model-params__param-key">{item.key}</code>
                   </div>
-                  <div class="model-params__label-hint">
-                    Provider default: {spec.control.default}
-                  </div>
+                  <For each={item.specs}>
+                    {(spec) => (
+                      <Show when={isSpecVisible(spec)}>
+                        <ParamRow spec={spec} />
+                      </Show>
+                    )}
+                  </For>
                 </div>
-                {renderControl(spec)}
-              </div>
-            )}
+              ) : (
+                <Show when={isSpecVisible(item.spec)}>
+                  <ParamRow spec={item.spec} />
+                </Show>
+              )
+            }
           </For>
 
           <div class="modal-card__footer">

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createEffect, For, Show, type Component } from 'solid-js';
-import { getProviderParamSpecs, type ProviderParamSpec } from 'manifest-shared';
-import type { RequestParamDefaults } from '../services/api.js';
+import { getProviderParamSpecs, type ParamControl, type ProviderParamSpec } from 'manifest-shared';
+import type { AuthType, JsonValue, RequestParamDefaults } from '../services/api.js';
+import Select from './Select.jsx';
 
 interface Props {
   open: boolean;
@@ -10,6 +11,10 @@ interface Props {
   current: RequestParamDefaults | null;
   /** The provider this route resolves to — drives which spec entries render. */
   provider: string;
+  /** Auth type this route uses — provider params can differ by auth path. */
+  authType: AuthType;
+  /** Provider-normalized model id — model overrides replace provider base specs. */
+  model: string;
   /**
    * Persist new defaults. Called with `null` when every chosen value
    * matches the provider's natural default (no override needed) and with a
@@ -21,24 +26,16 @@ interface Props {
 }
 
 /**
- * Local-state shape: one string per spec key. The dialog is fully driven
- * by `getProviderParamSpecs(provider)` — adding a new provider knob is
- * one entry in `PROVIDER_PARAM_SPECS`, and (provided its control kind has
- * a renderer below) the dialog picks it up automatically.
+ * Local-state shape: one UI/storage value per spec key. The dialog is fully
+ * driven by `getProviderParamSpecs(provider, authType, model)` — adding a
+ * new provider knob is one registry entry, and the matching control kind
+ * below renders it automatically.
  */
-type DraftState = Record<string, string>;
+type DraftState = Record<string, JsonValue>;
 
-const readValue = (spec: ProviderParamSpec, current: RequestParamDefaults | null): string => {
+const readValue = (spec: ProviderParamSpec, current: RequestParamDefaults | null): JsonValue => {
   const stored = (current as Record<string, unknown> | null)?.[spec.key];
-  // Today every control has its value at `{ <key>: { type: <value> } }`.
-  // When a graded knob (e.g. reasoning_effort) lands with a different wire
-  // shape (`{ reasoning_effort: 'medium' }`), broaden this reader to
-  // accept both shapes — the renderer below stays identical.
-  if (stored && typeof stored === 'object' && 'type' in stored) {
-    const v = (stored as { type: unknown }).type;
-    if (typeof v === 'string') return v;
-  }
-  return spec.control.default;
+  return stored === undefined ? spec.control.default : (stored as JsonValue);
 };
 
 const stateFromCurrent = (
@@ -50,8 +47,36 @@ const stateFromCurrent = (
   return draft;
 };
 
+type ToggleControl = Extract<ParamControl, { kind: 'toggle' }>;
+type SelectControl = Extract<ParamControl, { kind: 'select' }>;
+type SliderControl = Extract<ParamControl, { kind: 'slider' }>;
+type NumberControl = Extract<ParamControl, { kind: 'number' }>;
+
+const clampNumber = (value: number, fallback: number, min?: number, max?: number): number => {
+  if (!Number.isFinite(value)) return fallback;
+  let next = value;
+  if (min !== undefined) next = Math.max(min, next);
+  if (max !== undefined) next = Math.min(max, next);
+  return next;
+};
+
+const decimalPlaces = (value: number): number => {
+  const text = String(value);
+  if (!text.includes('.')) return 0;
+  return text.split('.')[1]?.length ?? 0;
+};
+
+const sliderStep = (control: SliderControl): number => control.step ?? 1;
+
+const sliderValue = (value: number, control: SliderControl): number => {
+  const step = sliderStep(control);
+  const snapped = Math.round((value - control.min) / step) * step + control.min;
+  const clamped = clampNumber(snapped, control.default, control.min, control.max);
+  return Number(clamped.toFixed(decimalPlaces(step)));
+};
+
 const ModelParamsDialog: Component<Props> = (props) => {
-  const specs = () => getProviderParamSpecs(props.provider);
+  const specs = () => getProviderParamSpecs(props.provider, props.authType, props.model);
   const [draft, setDraft] = createSignal<DraftState>(stateFromCurrent(specs(), props.current));
   const [saving, setSaving] = createSignal(false);
 
@@ -62,8 +87,175 @@ const ModelParamsDialog: Component<Props> = (props) => {
     if (props.open) setDraft(stateFromCurrent(specs(), props.current));
   });
 
-  const setKey = (key: string, value: string) => {
+  const setKey = (key: string, value: JsonValue) => {
     setDraft({ ...draft(), [key]: value });
+  };
+
+  const stringValue = (spec: ProviderParamSpec, control: ToggleControl | SelectControl) => {
+    const value = draft()[spec.key];
+    return typeof value === 'string' ? value : control.default;
+  };
+
+  const numericValue = (spec: ProviderParamSpec, control: SliderControl | NumberControl) => {
+    const value = draft()[spec.key];
+    return typeof value === 'number' && Number.isFinite(value) ? value : control.default;
+  };
+
+  const ToggleRow = (spec: ProviderParamSpec, control: ToggleControl) => {
+    const [onValue, offValue] = control.values;
+    const currentValue = () => stringValue(spec, control);
+    const isOn = () => currentValue() === onValue;
+    return (
+      <button
+        type="button"
+        class="model-params__toggle"
+        aria-pressed={isOn()}
+        aria-label={`${control.label}: ${currentValue()}`}
+        disabled={saving()}
+        onClick={() => setKey(spec.key, isOn() ? offValue : onValue)}
+      >
+        <span class="provider-toggle__switch" classList={{ 'provider-toggle__switch--on': isOn() }}>
+          <span class="provider-toggle__switch-thumb" />
+        </span>
+      </button>
+    );
+  };
+
+  const SelectRow = (spec: ProviderParamSpec, control: SelectControl) => (
+    <div class="model-params__field">
+      <Select
+        label={control.label}
+        options={control.values.map((v) => ({ label: v, value: v }))}
+        value={stringValue(spec, control)}
+        onChange={(v) => setKey(spec.key, v)}
+      />
+    </div>
+  );
+
+  const SliderRow = (spec: ProviderParamSpec, control: SliderControl) => {
+    let sliderRef: HTMLDivElement | undefined;
+    const value = () => numericValue(spec, control);
+    const progress = () => {
+      const span = control.max - control.min;
+      if (span <= 0) return 0;
+      return clampNumber(((value() - control.min) / span) * 100, 0, 0, 100);
+    };
+    const setSliderValue = (next: number) => {
+      setKey(spec.key, sliderValue(next, control));
+    };
+    const setFromPointer = (clientX: number) => {
+      if (!sliderRef) return;
+      const rect = sliderRef.getBoundingClientRect();
+      const ratio = clampNumber((clientX - rect.left) / rect.width, 0, 0, 1);
+      setSliderValue(control.min + ratio * (control.max - control.min));
+    };
+    const setFromTextInput = (raw: string) => {
+      setSliderValue(Number.parseFloat(raw));
+    };
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (saving()) return;
+      const step = sliderStep(control);
+      switch (e.key) {
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          e.preventDefault();
+          setSliderValue(value() - step);
+          break;
+        case 'ArrowRight':
+        case 'ArrowUp':
+          e.preventDefault();
+          setSliderValue(value() + step);
+          break;
+        case 'Home':
+          e.preventDefault();
+          setSliderValue(control.min);
+          break;
+        case 'End':
+          e.preventDefault();
+          setSliderValue(control.max);
+          break;
+      }
+    };
+    return (
+      <div class="model-params__range">
+        <div
+          ref={sliderRef}
+          class="model-params__slider"
+          role="slider"
+          tabIndex={saving() ? -1 : 0}
+          aria-label={control.label}
+          aria-valuemin={control.min}
+          aria-valuemax={control.max}
+          aria-valuenow={value()}
+          aria-valuetext={String(value())}
+          aria-disabled={saving()}
+          style={`--model-params-slider-progress: ${progress()}%;`}
+          onPointerDown={(e) => {
+            if (saving()) return;
+            e.preventDefault();
+            e.currentTarget.setPointerCapture?.(e.pointerId);
+            setFromPointer(e.clientX);
+          }}
+          onPointerMove={(e) => {
+            if (!e.currentTarget.hasPointerCapture?.(e.pointerId)) return;
+            setFromPointer(e.clientX);
+          }}
+          onPointerUp={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
+          onPointerCancel={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
+          onKeyDown={handleKeyDown}
+        >
+          <span class="model-params__slider-track" aria-hidden="true">
+            <span class="model-params__slider-fill" />
+          </span>
+          <span class="model-params__slider-thumb" aria-hidden="true" />
+        </div>
+        <input
+          class="model-params__slider-input"
+          type="number"
+          min={control.min}
+          max={control.max}
+          step={sliderStep(control)}
+          value={value()}
+          disabled={saving()}
+          aria-label={`${control.label} value`}
+          onInput={(e) => setFromTextInput(e.currentTarget.value)}
+        />
+      </div>
+    );
+  };
+
+  const NumberRow = (spec: ProviderParamSpec, control: NumberControl) => {
+    const value = () => numericValue(spec, control);
+    const setFromInput = (raw: string) => {
+      const parsed = Number.parseFloat(raw);
+      setKey(spec.key, clampNumber(parsed, control.default, control.min, control.max));
+    };
+    return (
+      <input
+        class="model-params__number"
+        type="number"
+        min={control.min}
+        max={control.max}
+        value={value()}
+        disabled={saving()}
+        aria-label={control.label}
+        onInput={(e) => setFromInput(e.currentTarget.value)}
+      />
+    );
+  };
+
+  const renderControl = (spec: ProviderParamSpec) => {
+    const control = spec.control;
+    switch (control.kind) {
+      case 'toggle':
+        return ToggleRow(spec, control);
+      case 'select':
+        return SelectRow(spec, control);
+      case 'slider':
+        return SliderRow(spec, control);
+      case 'number':
+        return NumberRow(spec, control);
+    }
   };
 
   const handleSave = async () => {
@@ -75,15 +267,14 @@ const ModelParamsDialog: Component<Props> = (props) => {
       // matches the defaults, pass `null` so the parent deletes the row
       // and the dashboard snapshot reflects the provider default, not an
       // explicit override.
-      const out: Record<string, unknown> = {};
+      const out: RequestParamDefaults = {};
       for (const spec of specs()) {
-        const value = draft()[spec.key];
+        const value = draft()[spec.key] ?? spec.control.default;
         if (value !== spec.control.default) {
-          out[spec.key] = { type: value };
+          out[spec.key] = value;
         }
       }
-      const next: RequestParamDefaults | null =
-        Object.keys(out).length === 0 ? null : (out as RequestParamDefaults);
+      const next: RequestParamDefaults | null = Object.keys(out).length === 0 ? null : out;
       await props.onSave(next);
       props.onClose();
     } finally {
@@ -126,30 +317,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
                     Provider default: {spec.control.default}
                   </div>
                 </div>
-                <Show when={spec.control.kind === 'toggle'}>
-                  {(() => {
-                    const [onValue, offValue] = spec.control.values;
-                    const currentValue = () => draft()[spec.key];
-                    const isOn = () => currentValue() === onValue;
-                    return (
-                      <button
-                        type="button"
-                        class="model-params__toggle"
-                        aria-pressed={isOn()}
-                        aria-label={`${spec.control.label}: ${currentValue()}`}
-                        disabled={saving()}
-                        onClick={() => setKey(spec.key, isOn() ? offValue : onValue)}
-                      >
-                        <span
-                          class="provider-toggle__switch"
-                          classList={{ 'provider-toggle__switch--on': isOn() }}
-                        >
-                          <span class="provider-toggle__switch-thumb" />
-                        </span>
-                      </button>
-                    );
-                  })()}
-                </Show>
+                {renderControl(spec)}
               </div>
             )}
           </For>

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -31,6 +31,9 @@ type DraftState = Record<string, JsonValue>;
 
 const readValue = (spec: ProviderParamSpec, current: RequestParamDefaults | null): JsonValue => {
   const stored = (current as Record<string, unknown> | null)?.[spec.key];
+  if (stored && typeof stored === 'object' && !Array.isArray(stored) && 'type' in stored) {
+    return (stored as { type: JsonValue }).type;
+  }
   return stored === undefined ? spec.control.default : (stored as JsonValue);
 };
 

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -1,6 +1,6 @@
 import { createSignal, createEffect, For, Show, type Component } from 'solid-js';
-import { getProviderParamSpecs, type ParamControl, type ProviderParamSpec } from 'manifest-shared';
-import type { AuthType, JsonValue, RequestParamDefaults } from '../services/api.js';
+import type { ParamControl, ProviderParamSpec } from 'manifest-shared';
+import type { JsonValue, RequestParamDefaults } from '../services/api.js';
 import Select from './Select.jsx';
 
 interface Props {
@@ -9,12 +9,8 @@ interface Props {
   slotLabel: string;
   /** Currently configured params for this route; null when none set. */
   current: RequestParamDefaults | null;
-  /** The provider this route resolves to — drives which spec entries render. */
-  provider: string;
-  /** Auth type this route uses — provider params can differ by auth path. */
-  authType: AuthType;
-  /** Provider-normalized model id — model overrides replace provider base specs. */
-  model: string;
+  /** Provider/auth/model-resolved specs loaded from the backend registry. */
+  specs: readonly ProviderParamSpec[];
   /**
    * Persist new defaults. Called with `null` when every chosen value
    * matches the provider's natural default (no override needed) and with a
@@ -27,9 +23,9 @@ interface Props {
 
 /**
  * Local-state shape: one UI/storage value per spec key. The dialog is fully
- * driven by `getProviderParamSpecs(provider, authType, model)` — adding a
- * new provider knob is one registry entry, and the matching control kind
- * below renders it automatically.
+ * driven by backend-loaded provider param specs — adding a new provider
+ * knob is one database row, and the matching control kind below renders it
+ * automatically.
  */
 type DraftState = Record<string, JsonValue>;
 
@@ -76,7 +72,7 @@ const sliderValue = (value: number, control: SliderControl): number => {
 };
 
 const ModelParamsDialog: Component<Props> = (props) => {
-  const specs = () => getProviderParamSpecs(props.provider, props.authType, props.model);
+  const specs = () => props.specs;
   const [draft, setDraft] = createSignal<DraftState>(stateFromCurrent(specs(), props.current));
   const [saving, setSaving] = createSignal(false);
 

--- a/packages/frontend/src/components/Select.tsx
+++ b/packages/frontend/src/components/Select.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show, onCleanup, type Component } from 'solid-js';
+import { createEffect, createSignal, For, Show, onCleanup, type Component } from 'solid-js';
 
 interface SelectOption {
   label: string;
@@ -18,11 +18,16 @@ interface SelectProps {
 const Select: Component<SelectProps> = (props) => {
   const [open, setOpen] = createSignal(false);
   let ref: HTMLDivElement | undefined;
+  const isOpen = () => open() && !props.disabled;
 
   const selectedLabel = () => {
     const opt = props.options.find((o) => o.value === props.value);
     return opt?.label ?? props.placeholder ?? 'Select...';
   };
+
+  createEffect(() => {
+    if (props.disabled) setOpen(false);
+  });
 
   const handleClickOutside = (e: MouseEvent) => {
     if (ref && !ref.contains(e.target as Node)) {
@@ -47,14 +52,14 @@ const Select: Component<SelectProps> = (props) => {
     <div class="custom-select" ref={ref}>
       <button
         class="custom-select__trigger"
-        classList={{ 'custom-select__trigger--open': open() }}
+        classList={{ 'custom-select__trigger--open': isOpen() }}
         onClick={() => {
           if (!props.disabled) setOpen(!open());
         }}
         disabled={props.disabled}
         type="button"
         aria-haspopup="listbox"
-        aria-expanded={open()}
+        aria-expanded={isOpen()}
         aria-label={props.label ?? selectedLabel()}
       >
         <span class="custom-select__value">{props.displayValue ?? selectedLabel()}</span>
@@ -73,7 +78,7 @@ const Select: Component<SelectProps> = (props) => {
           <path d="m6 9 6 6 6-6" />
         </svg>
       </button>
-      <Show when={open()}>
+      <Show when={isOpen()}>
         <div class="custom-select__dropdown" role="listbox">
           <For each={props.options}>
             {(opt) => (
@@ -81,9 +86,14 @@ const Select: Component<SelectProps> = (props) => {
                 class="custom-select__option"
                 classList={{ 'custom-select__option--selected': props.value === opt.value }}
                 onClick={() => {
+                  if (props.disabled) {
+                    setOpen(false);
+                    return;
+                  }
                   props.onChange(opt.value);
                   setOpen(false);
                 }}
+                disabled={props.disabled}
                 type="button"
                 role="option"
                 aria-selected={props.value === opt.value}

--- a/packages/frontend/src/components/Select.tsx
+++ b/packages/frontend/src/components/Select.tsx
@@ -12,6 +12,7 @@ interface SelectProps {
   placeholder?: string;
   label?: string;
   displayValue?: string;
+  disabled?: boolean;
 }
 
 const Select: Component<SelectProps> = (props) => {
@@ -47,7 +48,10 @@ const Select: Component<SelectProps> = (props) => {
       <button
         class="custom-select__trigger"
         classList={{ 'custom-select__trigger--open': open() }}
-        onClick={() => setOpen(!open())}
+        onClick={() => {
+          if (!props.disabled) setOpen(!open());
+        }}
+        disabled={props.disabled}
         type="button"
         aria-haspopup="listbox"
         aria-expanded={open()}

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -26,11 +26,13 @@ import {
   getComplexityStatus,
   toggleComplexity,
   listModelParams,
+  listModelParamSpecs,
   setModelParams as setModelParamsApi,
   deleteModelParams,
   modelParamsKey,
   type AgentModelParamsRow,
   type AuthType,
+  type ProviderParamSpecRegistry,
   type RequestParamDefaults,
   type SpecificityAssignment,
   type TierAssignment,
@@ -80,6 +82,11 @@ const Routing: Component = () => {
     () => agentName(),
     (name) => listModelParams(name).catch(() => [] as AgentModelParamsRow[]),
   );
+  const [modelParamSpecs] = createResource(
+    () => agentName(),
+    (name) => listModelParamSpecs(name).catch(() => ({}) as ProviderParamSpecRegistry),
+  );
+  const modelParamSpecRegistry = () => modelParamSpecs() ?? ({} as ProviderParamSpecRegistry);
   const modelParamsMap = createMemo(() => {
     const map = new Map<string, RequestParamDefaults>();
     for (const row of modelParams() ?? []) {
@@ -476,6 +483,7 @@ const Routing: Component = () => {
                   togglingComplexity={togglingComplexity}
                   onToggleComplexity={handleToggleComplexity}
                   embedded
+                  modelParamSpecs={modelParamSpecRegistry}
                   getModelParams={getModelParamsFor}
                   setModelParams={setModelParamsFor}
                 />
@@ -522,6 +530,7 @@ const Routing: Component = () => {
                   refetchAll={refetchAll}
                   refetchSpecificity={() => refetchSpecificity() as unknown as Promise<void>}
                   embedded
+                  modelParamSpecs={modelParamSpecRegistry}
                   getModelParams={getModelParamsFor}
                   setModelParams={setModelParamsFor}
                 />
@@ -536,6 +545,7 @@ const Routing: Component = () => {
                   externalRefetch={() => void refetchHeaderTiers()}
                   externalMutate={mutateHeaderTiers}
                   embedded
+                  modelParamSpecs={modelParamSpecRegistry}
                   getModelParams={getModelParamsFor}
                   setModelParams={setModelParamsFor}
                 />

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -73,10 +73,9 @@ const Routing: Component = () => {
   const [togglingComplexity, setTogglingComplexity] = createSignal(false);
   const complexityEnabled = () => complexityStatus()?.enabled ?? true;
 
-  // Per-route model params, fetched once and threaded down. Every model-row
-  // affordance reads through `getModelParamsFor` so saving in one slot
-  // reflects on every other slot that resolves to the same route — no
-  // per-component fetches, no stale-cache races.
+  // Per-route model params, fetched once and threaded down. Scope separates
+  // default/complexity tiers, task-specific tiers, and custom header tiers so
+  // the same model can have different values in different routing surfaces.
   const [modelParams, { mutate: mutateModelParams }] = createResource(
     () => agentName(),
     (name) => listModelParams(name).catch(() => [] as AgentModelParamsRow[]),
@@ -84,17 +83,19 @@ const Routing: Component = () => {
   const modelParamsMap = createMemo(() => {
     const map = new Map<string, RequestParamDefaults>();
     for (const row of modelParams() ?? []) {
-      map.set(modelParamsKey(row.provider, row.authType, row.model), row.params);
+      map.set(modelParamsKey(row.scope, row.provider, row.authType, row.model), row.params);
     }
     return map;
   });
   const getModelParamsFor = (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
   ): RequestParamDefaults | null =>
-    modelParamsMap().get(modelParamsKey(provider, authType, model)) ?? null;
+    modelParamsMap().get(modelParamsKey(scope, provider, authType, model)) ?? null;
   const setModelParamsFor = async (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -105,11 +106,12 @@ const Routing: Component = () => {
       // natural default. Delete the row so the table stays clean and the
       // dashboard snapshot reflects the provider default, not an explicit
       // override.
-      await deleteModelParams(agentName(), { provider, authType, model });
+      await deleteModelParams(agentName(), { scope, provider, authType, model });
       mutateModelParams((rows) =>
         (rows ?? []).filter(
           (r) =>
             !(
+              r.scope === scope &&
               r.provider.toLowerCase() === provider.toLowerCase() &&
               r.authType === authType &&
               r.model === model
@@ -118,11 +120,18 @@ const Routing: Component = () => {
       );
       return;
     }
-    const saved = await setModelParamsApi(agentName(), { provider, authType, model, params: next });
+    const saved = await setModelParamsApi(agentName(), {
+      scope,
+      provider,
+      authType,
+      model,
+      params: next,
+    });
     mutateModelParams((rows) => {
       const without = (rows ?? []).filter(
         (r) =>
           !(
+            r.scope === scope &&
             r.provider.toLowerCase() === provider.toLowerCase() &&
             r.authType === authType &&
             r.model === model

--- a/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
+++ b/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
@@ -3,6 +3,7 @@ import type {
   AuthType,
   AvailableModel,
   CustomProviderData,
+  ProviderParamSpecRegistry,
   RequestParamDefaults,
   RoutingProvider,
   TierAssignment,
@@ -18,6 +19,7 @@ export interface RoutingDefaultTierSectionProps {
   customProviders: () => CustomProviderData[];
   activeProviders: () => RoutingProvider[];
   connectedProviders: () => RoutingProvider[];
+  modelParamSpecs?: () => ProviderParamSpecRegistry;
   tiersLoading: boolean;
   changingTier: () => string | null;
   resettingTier: () => string | null;
@@ -77,6 +79,7 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
       <RoutingTierCard
         stage={DEFAULT_STAGE}
         modelParamsScope={modelParamsScopeForTier(DEFAULT_STAGE.id)}
+        modelParamSpecs={props.modelParamSpecs}
         tier={props.tier}
         models={props.models}
         customProviders={props.customProviders}
@@ -108,6 +111,7 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
           <RoutingTierCard
             stage={stage}
             modelParamsScope={modelParamsScopeForTier(stage.id)}
+            modelParamSpecs={props.modelParamSpecs}
             tier={() => props.getTier(stage.id)}
             models={props.models}
             customProviders={props.customProviders}

--- a/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
+++ b/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
@@ -8,6 +8,7 @@ import type {
   TierAssignment,
 } from '../services/api.js';
 import { DEFAULT_STAGE, STAGES } from '../services/providers.js';
+import { modelParamsScopeForTier } from '../services/api.js';
 import RoutingTierCard from './RoutingTierCard.js';
 
 export interface RoutingDefaultTierSectionProps {
@@ -45,6 +46,7 @@ export interface RoutingDefaultTierSectionProps {
    * affordance shows the configured-state badge without per-row fetches.
    */
   getModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -55,6 +57,7 @@ export interface RoutingDefaultTierSectionProps {
    * callback down to the affordance.
    */
   setModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -73,6 +76,7 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
     >
       <RoutingTierCard
         stage={DEFAULT_STAGE}
+        modelParamsScope={modelParamsScopeForTier(DEFAULT_STAGE.id)}
         tier={props.tier}
         models={props.models}
         customProviders={props.customProviders}
@@ -103,6 +107,7 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
         {(stage) => (
           <RoutingTierCard
             stage={stage}
+            modelParamsScope={modelParamsScopeForTier(stage.id)}
             tier={() => props.getTier(stage.id)}
             models={props.models}
             customProviders={props.customProviders}

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -14,6 +14,7 @@ import type {
   AuthType,
   CustomProviderData,
   ModelRoute,
+  ProviderParamSpecRegistry,
   RequestParamDefaults,
   RoutingProvider,
 } from '../services/api.js';
@@ -29,6 +30,7 @@ export interface RoutingHeaderTiersSectionProps {
   externalRefetch?: () => void;
   externalMutate?: (mutator: (prev: HeaderTier[] | undefined) => HeaderTier[] | undefined) => void;
   embedded?: boolean;
+  modelParamSpecs?: () => ProviderParamSpecRegistry;
   getModelParams?: (
     scope: string,
     provider: string,
@@ -184,6 +186,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                 }
                 onEdit={() => setModalTier(tier)}
                 onDisable={() => handleToggle(tier.id, false)}
+                modelParamSpecs={props.modelParamSpecs}
                 getModelParams={props.getModelParams}
                 setModelParams={props.setModelParams}
               />

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -30,11 +30,13 @@ export interface RoutingHeaderTiersSectionProps {
   externalMutate?: (mutator: (prev: HeaderTier[] | undefined) => HeaderTier[] | undefined) => void;
   embedded?: boolean;
   getModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
   ) => RequestParamDefaults | null;
   setModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,

--- a/packages/frontend/src/pages/RoutingSpecificitySection.tsx
+++ b/packages/frontend/src/pages/RoutingSpecificitySection.tsx
@@ -1,6 +1,7 @@
 import { createSignal, For, Show, type Component, type Accessor, type JSX } from 'solid-js';
 import { toast } from '../services/toast-store.js';
 import {
+  modelParamsScopeForSpecificity,
   toggleSpecificity,
   setSpecificityFallbacks,
   clearSpecificityFallbacks,
@@ -165,12 +166,14 @@ export interface RoutingSpecificitySectionProps {
    * state without per-row fetches.
    */
   getModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
   ) => RequestParamDefaults | null;
   /** Persist new params for a single route. */
   setModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -242,6 +245,7 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
             {(stage) => (
               <RoutingTierCard
                 stage={stage}
+                modelParamsScope={modelParamsScopeForSpecificity(stage.id)}
                 tier={() => toTierAssignment(getAssignment(stage.id))}
                 models={props.models}
                 customProviders={props.customProviders}

--- a/packages/frontend/src/pages/RoutingSpecificitySection.tsx
+++ b/packages/frontend/src/pages/RoutingSpecificitySection.tsx
@@ -14,6 +14,7 @@ import type {
   AvailableModel,
   AuthType,
   ModelRoute,
+  ProviderParamSpecRegistry,
   RequestParamDefaults,
   RoutingProvider,
   CustomProviderData,
@@ -142,6 +143,7 @@ export interface RoutingSpecificitySectionProps {
   customProviders: () => CustomProviderData[];
   activeProviders: () => RoutingProvider[];
   connectedProviders: () => RoutingProvider[];
+  modelParamSpecs?: () => ProviderParamSpecRegistry;
   changingTier: () => string | null;
   resettingTier: () => string | null;
   resettingAll: () => boolean;
@@ -246,6 +248,7 @@ const RoutingSpecificitySection: Component<RoutingSpecificitySectionProps> = (pr
               <RoutingTierCard
                 stage={stage}
                 modelParamsScope={modelParamsScopeForSpecificity(stage.id)}
+                modelParamSpecs={props.modelParamSpecs}
                 tier={() => toTierAssignment(getAssignment(stage.id))}
                 models={props.models}
                 customProviders={props.customProviders}

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -21,6 +21,7 @@ import type {
   AvailableModel,
   AuthType,
   ModelRoute,
+  ProviderParamSpecRegistry,
   RequestParamDefaults,
   RoutingProvider,
   CustomProviderData,
@@ -99,6 +100,7 @@ export interface RoutingTierCardProps {
   onAddFallback: (tierId: string) => void;
   getFallbacksFor: (tierId: string) => string[];
   connectedProviders: () => RoutingProvider[];
+  modelParamSpecs?: () => ProviderParamSpecRegistry;
   persistFallbacks?: (
     agentName: string,
     tier: string,
@@ -495,6 +497,7 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                           >
                             <ModelParamsAffordance
                               scope={modelParamsScope()}
+                              specRegistry={props.modelParamSpecs?.() ?? {}}
                               provider={provId()}
                               authType={effectiveAuth() ?? undefined}
                               model={modelName()}
@@ -547,6 +550,7 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
               agentName={props.agentName()}
               tier={props.stage.id}
               modelParamsScope={modelParamsScope()}
+              modelParamSpecs={props.modelParamSpecs}
               tierData={props.tier}
               fallbacks={props.getFallbacksFor(props.stage.id)}
               fallbackRoutes={props.tier()?.fallback_routes ?? null}

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -14,6 +14,7 @@ import { customProviderColor } from '../services/formatters.js';
 import FallbackList from '../components/FallbackList.js';
 import ModelParamsAffordance from '../components/ModelParamsAffordance.jsx';
 import { setFallbacks as setFallbacksApi } from '../services/api.js';
+import { modelParamsScopeForTier } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import type {
   TierAssignment,
@@ -64,6 +65,7 @@ export function providerIdForModel(model: string, apiModels: AvailableModel[]): 
 
 export interface RoutingTierCardProps {
   stage: StageDef;
+  modelParamsScope?: string;
   tier: () => TierAssignment | undefined;
   models: () => AvailableModel[];
   customProviders: () => CustomProviderData[];
@@ -107,9 +109,10 @@ export interface RoutingTierCardProps {
   /**
    * Read saved per-route params from the parent's loaded map. The
    * affordance reads through this so saving in one slot reflects on every
-   * other slot that resolves to the same `(provider, authType, model)`.
+   * other row with the same scoped `(provider, authType, model)`.
    */
   getModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -119,6 +122,7 @@ export interface RoutingTierCardProps {
    * and the local cache update; the card just threads the callback down.
    */
   setModelParams?: (
+    scope: string,
     provider: string,
     authType: AuthType,
     model: string,
@@ -134,6 +138,7 @@ const effectiveRoute = (
 const effectiveModel = (t: TierAssignment): string | null => effectiveRoute(t)?.model ?? null;
 
 const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
+  const modelParamsScope = () => props.modelParamsScope ?? modelParamsScopeForTier(props.stage.id);
   const eff = () => {
     const t = props.tier();
     return t ? effectiveModel(t) : null;
@@ -489,6 +494,7 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                             when={props.setModelParams && props.getModelParams && effectiveAuth()}
                           >
                             <ModelParamsAffordance
+                              scope={modelParamsScope()}
                               provider={provId()}
                               authType={effectiveAuth() ?? undefined}
                               model={modelName()}
@@ -540,6 +546,7 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
             <FallbackList
               agentName={props.agentName()}
               tier={props.stage.id}
+              modelParamsScope={modelParamsScope()}
               tierData={props.tier}
               fallbacks={props.getFallbacksFor(props.stage.id)}
               fallbackRoutes={props.tier()?.fallback_routes ?? null}

--- a/packages/frontend/src/services/api/messages.ts
+++ b/packages/frontend/src/services/api/messages.ts
@@ -70,10 +70,10 @@ export interface MessageDetailResponse {
     request_headers: Record<string, string> | null;
     /**
      * Per-message snapshot of effective model parameters merged into the
-     * outbound provider request (today: `{ thinking: { type: 'enabled' |
-     * 'disabled' } }` for DeepSeek; future provider knobs append here as
-     * keys are added to `RequestParamDefaults` in `manifest-shared`). The
-     * `unknown` value type lets the dashboard render arbitrary shapes
+     * outbound provider request (for example DeepSeek `thinking` or Anthropic
+     * generation controls). Future provider knobs append here through the
+     * shared provider-param registry. The `unknown` value type lets the dashboard
+     * render arbitrary shapes
      * (incl. forthcoming user-defined custom-provider params) without a
      * frontend release per knob.
      */

--- a/packages/frontend/src/services/api/model-params.ts
+++ b/packages/frontend/src/services/api/model-params.ts
@@ -1,13 +1,19 @@
 import { fetchJson, fetchMutate, routingPath } from './core.js';
 import type { AuthType } from './routing.js';
 import type { RequestParamDefaults } from 'manifest-shared';
+export {
+  modelParamsScopeForTier,
+  modelParamsScopeForSpecificity,
+  modelParamsScopeForHeaderTier,
+} from 'manifest-shared';
 
 /**
  * Per-route saved request body defaults. The frontend fetches the full set
- * once on Routing page boot and indexes by route identity; every model-row
- * affordance reads from that map without per-row fetches.
+ * once on Routing page boot and indexes by scoped route identity; every
+ * model-row affordance reads from that map without per-row fetches.
  */
 export interface AgentModelParamsRow {
+  scope: string;
   provider: string;
   authType: AuthType;
   model: string;
@@ -20,7 +26,13 @@ export function listModelParams(agentName: string) {
 
 export function setModelParams(
   agentName: string,
-  input: { provider: string; authType: AuthType; model: string; params: RequestParamDefaults },
+  input: {
+    scope: string;
+    provider: string;
+    authType: AuthType;
+    model: string;
+    params: RequestParamDefaults;
+  },
 ) {
   return fetchMutate<AgentModelParamsRow>(routingPath(agentName, 'model-params'), {
     method: 'PUT',
@@ -31,7 +43,7 @@ export function setModelParams(
 
 export function deleteModelParams(
   agentName: string,
-  input: { provider: string; authType: AuthType; model: string },
+  input: { scope: string; provider: string; authType: AuthType; model: string },
 ) {
   return fetchMutate<{ ok: true }>(routingPath(agentName, 'model-params'), {
     method: 'DELETE',
@@ -41,10 +53,15 @@ export function deleteModelParams(
 }
 
 /**
- * Stable key for indexing `AgentModelParamsRow[]` in a Map. Provider is
- * lowercased so case differences between save and lookup don't break the
- * index — the backend stores provider lowercase too.
+ * Stable key for indexing `AgentModelParamsRow[]` in a Map. Scope separates
+ * complexity, task-specific, and custom tiers; provider is lowercased so case
+ * differences between save and lookup don't break the index.
  */
-export function modelParamsKey(provider: string, authType: AuthType, model: string): string {
-  return `${provider.toLowerCase()}::${authType}::${model}`;
+export function modelParamsKey(
+  scope: string,
+  provider: string,
+  authType: AuthType,
+  model: string,
+): string {
+  return `${scope}::${provider.toLowerCase()}::${model}::${authType}`;
 }

--- a/packages/frontend/src/services/api/model-params.ts
+++ b/packages/frontend/src/services/api/model-params.ts
@@ -1,6 +1,7 @@
 import { fetchJson, fetchMutate, routingPath } from './core.js';
 import type { AuthType } from './routing.js';
-import type { RequestParamDefaults } from 'manifest-shared';
+import type { ProviderParamSpecRegistry, RequestParamDefaults } from 'manifest-shared';
+export type { ProviderParamSpecRegistry } from 'manifest-shared';
 export {
   modelParamsScopeForTier,
   modelParamsScopeForSpecificity,
@@ -22,6 +23,10 @@ export interface AgentModelParamsRow {
 
 export function listModelParams(agentName: string) {
   return fetchJson<AgentModelParamsRow[]>(routingPath(agentName, 'model-params'));
+}
+
+export function listModelParamSpecs(agentName: string) {
+  return fetchJson<ProviderParamSpecRegistry>(routingPath(agentName, 'model-param-specs'));
 }
 
 export function setModelParams(

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -173,9 +173,9 @@ export function toggleComplexity(agentName: string) {
  * Per-route outbound request body parameters merged into the provider
  * request before forwarding. Current built-in keys include DeepSeek
  * `thinking` and Anthropic generation controls; new keys land here as
- * their UI ships. Storage is per-(agent, route) on the
- * `agent_model_params` table — see `services/api/model-params.ts` for the
- * CRUD client.
+ * their UI ships. Storage is per-(agent, scoped route) on the
+ * `agent_model_params` table, so the same model can differ by tier — see
+ * `services/api/model-params.ts` for the CRUD client.
  */
 export type { JsonValue, RequestParamDefaults } from 'manifest-shared';
 

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -171,13 +171,13 @@ export function toggleComplexity(agentName: string) {
 
 /**
  * Per-route outbound request body parameters merged into the provider
- * request before forwarding. Today's only knob is DeepSeek's `thinking`
- * toggle; new keys (`reasoning_effort`, `safety`, custom-provider params)
- * land here as their UI ships. Storage is per-(agent, route) on the
+ * request before forwarding. Current built-in keys include DeepSeek
+ * `thinking` and Anthropic generation controls; new keys land here as
+ * their UI ships. Storage is per-(agent, route) on the
  * `agent_model_params` table — see `services/api/model-params.ts` for the
  * CRUD client.
  */
-export type { RequestParamDefaults } from 'manifest-shared';
+export type { JsonValue, RequestParamDefaults } from 'manifest-shared';
 
 export interface TierAssignment {
   id: string;

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -570,6 +570,34 @@
   padding: 12px 0;
 }
 
+.model-params__row--disabled .model-params__label-title,
+.model-params__row--disabled .model-params__label-hint {
+  color: hsl(var(--muted-foreground));
+}
+
+.model-params__group {
+  padding: 8px 0;
+  border-top: 1px solid hsl(var(--border) / 0.65);
+}
+
+.model-params__group:first-of-type {
+  border-top: none;
+}
+
+.model-params__group-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 0 2px;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: hsl(var(--muted-foreground));
+}
+
+.model-params__group .model-params__row {
+  padding: 10px 0;
+}
+
 .model-params__label-title {
   display: flex;
   align-items: baseline;
@@ -626,15 +654,15 @@
 
 .model-params__range {
   display: grid;
-  grid-template-columns: minmax(150px, 1fr) 66px;
+  grid-template-columns: 112px 54px;
   align-items: center;
-  gap: 12px;
-  min-width: 240px;
+  gap: 8px;
+  min-width: 174px;
 }
 
 .model-params__slider {
   position: relative;
-  height: 28px;
+  height: 24px;
   cursor: pointer;
   touch-action: none;
 }
@@ -644,7 +672,7 @@
   left: 0;
   right: 0;
   top: 50%;
-  height: 6px;
+  height: 4px;
   overflow: hidden;
   border-radius: 9999px;
   background: hsl(var(--muted));
@@ -663,9 +691,9 @@
   position: absolute;
   top: 50%;
   left: var(--model-params-slider-progress, 100%);
-  width: 16px;
-  height: 16px;
-  border: 2px solid hsl(var(--card));
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid hsl(var(--card));
   border-radius: 50%;
   background: hsl(var(--success));
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.22);
@@ -678,12 +706,12 @@
 .model-params__slider:hover .model-params__slider-thumb {
   box-shadow:
     0 1px 3px rgb(0 0 0 / 0.22),
-    0 0 0 5px hsl(var(--success) / 0.14);
+    0 0 0 3px hsl(var(--success) / 0.14);
 }
 
 .model-params__slider:focus-visible {
   outline: 2px solid hsl(var(--success) / 0.45);
-  outline-offset: 2px;
+  outline-offset: 1px;
 }
 
 .model-params__slider:focus-visible .model-params__slider-thumb {
@@ -691,16 +719,16 @@
 }
 
 .model-params__slider-input {
-  width: 66px;
-  height: 32px;
-  padding: 0 8px;
+  width: 54px;
+  height: 28px;
+  padding: 0 6px;
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius-sm);
   background: hsl(var(--background));
   color: hsl(var(--foreground));
   color-scheme: light;
   font-family: var(--font-family);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -605,6 +605,124 @@
   cursor: not-allowed;
 }
 
+.model-params__field {
+  min-width: 150px;
+}
+
+.model-params__range {
+  display: grid;
+  grid-template-columns: minmax(150px, 1fr) 66px;
+  align-items: center;
+  gap: 12px;
+  min-width: 240px;
+}
+
+.model-params__slider {
+  position: relative;
+  height: 28px;
+  cursor: pointer;
+  touch-action: none;
+}
+
+.model-params__slider-track {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 6px;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: hsl(var(--muted));
+  transform: translateY(-50%);
+}
+
+.model-params__slider-fill {
+  display: block;
+  width: var(--model-params-slider-progress, 100%);
+  height: 100%;
+  border-radius: inherit;
+  background: hsl(var(--success));
+}
+
+.model-params__slider-thumb {
+  position: absolute;
+  top: 50%;
+  left: var(--model-params-slider-progress, 100%);
+  width: 16px;
+  height: 16px;
+  border: 2px solid hsl(var(--card));
+  border-radius: 50%;
+  background: hsl(var(--success));
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.22);
+  transform: translate(-50%, -50%);
+  transition:
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.model-params__slider:hover .model-params__slider-thumb {
+  box-shadow:
+    0 1px 3px rgb(0 0 0 / 0.22),
+    0 0 0 5px hsl(var(--success) / 0.14);
+}
+
+.model-params__slider:focus-visible {
+  outline: 2px solid hsl(var(--success) / 0.45);
+  outline-offset: 2px;
+}
+
+.model-params__slider:focus-visible .model-params__slider-thumb {
+  transform: translate(-50%, -50%) scale(1.04);
+}
+
+.model-params__slider-input {
+  width: 66px;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-sm);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.model-params__slider-input:focus-visible {
+  outline: 2px solid hsl(var(--success) / 0.45);
+  outline-offset: 2px;
+}
+
+.model-params__slider-input::-webkit-outer-spin-button,
+.model-params__slider-input::-webkit-inner-spin-button {
+  margin: 0;
+}
+
+.model-params__number {
+  width: 112px;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-family: var(--font-family);
+  font-size: var(--font-size-sm);
+}
+
+.model-params__number:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+}
+
+.model-params__number:disabled,
+.model-params__slider[aria-disabled='true'],
+.model-params__slider-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .routing-card__chip-action {
   position: relative;
 }
@@ -653,9 +771,13 @@
   border-top-color: #2a2a2a;
 }
 
-.routing-card__chip-action:hover .routing-tooltip {
+.routing-card__chip-action:hover:not(.routing-card__chip-action--dialog-open) .routing-tooltip {
   opacity: 1;
   transform: translateX(-50%) scale(1);
+}
+
+.routing-card__chip-action--dialog-open .routing-tooltip {
+  display: none;
 }
 
 .routing-card__override {

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -571,8 +571,23 @@
 }
 
 .model-params__label-title {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
   font-size: var(--font-size-sm);
   font-weight: 500;
+}
+
+.model-params__param-key {
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  font-family: var(--font-family-mono);
+  background: hsl(var(--muted) / 0.45);
+  border: 1px solid hsl(var(--border) / 0.7);
+  border-radius: var(--radius-sm);
+  padding: 1px 5px;
 }
 
 .model-params__label-hint {

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -698,6 +698,7 @@
   border-radius: var(--radius-sm);
   background: hsl(var(--background));
   color: hsl(var(--foreground));
+  color-scheme: light;
   font-family: var(--font-family);
   font-size: var(--font-size-sm);
   font-variant-numeric: tabular-nums;
@@ -722,8 +723,14 @@
   border-radius: var(--radius);
   background: hsl(var(--background));
   color: hsl(var(--foreground));
+  color-scheme: light;
   font-family: var(--font-family);
   font-size: var(--font-size-sm);
+}
+
+.dark .model-params__slider-input,
+.dark .model-params__number {
+  color-scheme: dark;
 }
 
 .model-params__number:focus-visible {

--- a/packages/frontend/tests/components/FallbackList.routes.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.routes.test.tsx
@@ -6,6 +6,7 @@ const mockClearFallbacks = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   setFallbacks: (...args: unknown[]) => mockSetFallbacks(...args),
   clearFallbacks: (...args: unknown[]) => mockClearFallbacks(...args),
+  modelParamsScopeForTier: (tier: string) => `tier:${tier}`,
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
+import type { ProviderParamSpecRegistry } from "manifest-shared";
 
 const mockSetFallbacks = vi.fn();
 const mockClearFallbacks = vi.fn();
@@ -42,6 +43,22 @@ vi.mock("../../src/services/provider-utils.js", () => ({
 }));
 
 import FallbackList from "../../src/components/FallbackList";
+
+const modelParamSpecs = (): ProviderParamSpecRegistry => ({
+  "deepseek:api_key": {
+    base: [
+      {
+        key: "thinking",
+        control: {
+          kind: "toggle",
+          label: "Thinking mode",
+          values: ["enabled", "disabled"],
+          default: "enabled",
+        },
+      },
+    ],
+  },
+});
 
 const models = [
   { model_name: "model-a", provider: "OpenAI" },
@@ -1069,6 +1086,7 @@ describe("FallbackList", () => {
           {...defaultProps}
           fallbacks={["deepseek-v4-flash"]}
           fallbackRoutes={[deepseekRoute] as any}
+          modelParamSpecs={modelParamSpecs}
           getModelParams={getModelParams}
           setModelParams={setModelParams}
         />
@@ -1097,6 +1115,7 @@ describe("FallbackList", () => {
           {...defaultProps}
           fallbacks={["gpt-4o"]}
           fallbackRoutes={[openaiRoute] as any}
+          modelParamSpecs={modelParamSpecs}
           getModelParams={vi.fn().mockReturnValue(null)}
           setModelParams={vi.fn()}
         />
@@ -1147,6 +1166,7 @@ describe("FallbackList", () => {
           connectedProviders={connectedProvidersWithDeepseek}
           fallbacks={["deepseek-v4-flash"]}
           fallbackRoutes={null}
+          modelParamSpecs={modelParamSpecs}
           getModelParams={vi.fn().mockReturnValue(null)}
           setModelParams={vi.fn()}
         />

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -6,6 +6,7 @@ const mockClearFallbacks = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   setFallbacks: (...args: unknown[]) => mockSetFallbacks(...args),
   clearFallbacks: (...args: unknown[]) => mockClearFallbacks(...args),
+  modelParamsScopeForTier: (tier: string) => `tier:${tier}`,
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -1189,7 +1189,7 @@ describe("HeaderTierCard", () => {
         "deepseek",
         "api_key",
         "deepseek-v4",
-        { thinking: { type: "disabled" } },
+        { thinking: "disabled" },
       );
     });
   });

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -1186,6 +1186,7 @@ describe("HeaderTierCard", () => {
     fireEvent.click(getByRole("button", { name: "Save" }));
     await waitFor(() => {
       expect(setModelParams).toHaveBeenCalledWith(
+        "header:ht-1",
         "deepseek",
         "api_key",
         "deepseek-v4",

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor } from "@solidjs/testing-library";
+import type { ProviderParamSpecRegistry } from "manifest-shared";
 
 const mockResetHeaderTier = vi.fn();
 const mockSetHeaderTierFallbacks = vi.fn();
@@ -33,6 +34,22 @@ vi.mock("../../src/services/routing-utils.js", () => ({
   pricePerM: (n: number) => `$${(n * 1_000_000).toFixed(2)}`,
   stripCustomPrefix: (m: string) => m,
 }));
+
+const modelParamSpecs = (): ProviderParamSpecRegistry => ({
+  "deepseek:api_key": {
+    base: [
+      {
+        key: "thinking",
+        control: {
+          kind: "toggle",
+          label: "Thinking mode",
+          values: ["enabled", "disabled"],
+          default: "enabled",
+        },
+      },
+    ],
+  },
+});
 
 vi.mock("../../src/services/providers.js", () => ({
   PROVIDERS: [
@@ -1116,6 +1133,7 @@ describe("HeaderTierCard", () => {
         connectedProviders={deepseekProviders}
         onOverride={vi.fn()}
         onFallbacksUpdate={vi.fn()}
+        modelParamSpecs={modelParamSpecs}
         getModelParams={() => null}
         setModelParams={vi.fn().mockResolvedValue(undefined)}
       />
@@ -1171,6 +1189,7 @@ describe("HeaderTierCard", () => {
         connectedProviders={deepseekProviders}
         onOverride={vi.fn()}
         onFallbacksUpdate={vi.fn()}
+        modelParamSpecs={modelParamSpecs}
         getModelParams={() => null}
         setModelParams={setModelParams}
       />

--- a/packages/frontend/tests/components/MessageDetails.test.tsx
+++ b/packages/frontend/tests/components/MessageDetails.test.tsx
@@ -869,7 +869,7 @@ describe('MessageDetails', () => {
         ...detailsResponse,
         message: {
           ...detailsResponse.message,
-          request_params: { thinking: { type: 'disabled' } },
+          request_params: { thinking: 'disabled' },
         },
       };
       mockGetMessageDetails.mockResolvedValue(withParams);
@@ -885,12 +885,12 @@ describe('MessageDetails', () => {
       expect(titleButton!.textContent).toContain('1');
     });
 
-    it('expands on toggle and pretty-prints the thinking object value across multiple lines', async () => {
+    it('expands on toggle and pretty-prints object values across multiple lines', async () => {
       const withParams = {
         ...detailsResponse,
         message: {
           ...detailsResponse.message,
-          request_params: { thinking: { type: 'disabled' } },
+          request_params: { custom_policy: { type: 'disabled' } },
         },
       };
       mockGetMessageDetails.mockResolvedValue(withParams);
@@ -918,7 +918,7 @@ describe('MessageDetails', () => {
         ...detailsResponse,
         message: {
           ...detailsResponse.message,
-          request_params: { thinking: { type: 'enabled' } },
+          request_params: { thinking: 'enabled' },
         },
       };
       mockGetMessageDetails.mockResolvedValue(withParams);
@@ -941,7 +941,7 @@ describe('MessageDetails', () => {
         ...detailsResponse,
         message: {
           ...detailsResponse.message,
-          request_params: { thinking: { type: 'disabled' } },
+          request_params: { thinking: 'disabled' },
         },
       };
       mockGetMessageDetails.mockResolvedValue(withParams);
@@ -972,7 +972,7 @@ describe('MessageDetails', () => {
         message: {
           ...detailsResponse.message,
           request_headers: { 'a-first': '1' },
-          request_params: { thinking: { type: 'disabled' } },
+          request_params: { thinking: 'disabled' },
         },
       };
       mockGetMessageDetails.mockResolvedValue(withBoth);
@@ -994,7 +994,7 @@ describe('MessageDetails', () => {
         message: {
           ...detailsResponse.message,
           request_params: {
-            thinking: { type: 'enabled' },
+            thinking: 'enabled',
             reasoning_effort: 'high',
             // A user-defined custom-provider param — the JSONB column accepts
             // arbitrary keys so future custom-model UIs can land here without

--- a/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
@@ -16,6 +16,7 @@ describe('ModelParamsAffordance', () => {
     ));
     const btn = container.querySelector('button[aria-label^="Configure model parameters"]');
     expect(btn).not.toBeNull();
+    expect(btn?.getAttribute('title')).toBeNull();
   });
 
   it('does NOT render the button when the provider has no known param key', () => {
@@ -67,7 +68,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="deepseek-v4"
         slotLabel="deepseek-v4"
-        getParams={() => ({ thinking: { type: 'disabled' } })}
+        getParams={() => ({ thinking: 'disabled' })}
         setParams={vi.fn()}
       />
     ));
@@ -93,6 +94,7 @@ describe('ModelParamsAffordance', () => {
       'button[aria-label^="Configure model parameters"]',
     ) as HTMLButtonElement;
     fireEvent.click(btn);
+    expect(btn.classList.contains('routing-card__chip-action--dialog-open')).toBe(true);
 
     // Dialog mounts. Flip the thinking toggle to `disabled` (provider default
     // is `enabled` so the dialog seeded that), then save.
@@ -103,7 +105,7 @@ describe('ModelParamsAffordance', () => {
 
     await waitFor(() => {
       expect(setParams).toHaveBeenCalledWith('deepseek', 'api_key', 'deepseek-v4', {
-        thinking: { type: 'disabled' },
+        thinking: 'disabled',
       });
     });
   });
@@ -116,7 +118,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="deepseek-v4"
         slotLabel="deepseek-v4"
-        getParams={() => ({ thinking: { type: 'disabled' } })}
+        getParams={() => ({ thinking: 'disabled' })}
         setParams={setParams}
       />
     ));

--- a/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
@@ -1,11 +1,29 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent, waitFor } from '@solidjs/testing-library';
+import type { ProviderParamSpecRegistry } from 'manifest-shared';
 import ModelParamsAffordance from '../../src/components/ModelParamsAffordance';
 
 describe('ModelParamsAffordance', () => {
+  const specRegistry: ProviderParamSpecRegistry = {
+    'deepseek:api_key': {
+      base: [
+        {
+          key: 'thinking',
+          control: {
+            kind: 'toggle',
+            label: 'Thinking mode',
+            values: ['enabled', 'disabled'],
+            default: 'enabled',
+          },
+        },
+      ],
+    },
+  };
+
   it('renders the button when the route provider consumes a known param key', () => {
     const { container } = render(() => (
       <ModelParamsAffordance
+        specRegistry={specRegistry}
         provider="deepseek"
         authType="api_key"
         model="deepseek-v4"
@@ -23,6 +41,7 @@ describe('ModelParamsAffordance', () => {
   it('does NOT render the button when the provider has no known param key', () => {
     const { container } = render(() => (
       <ModelParamsAffordance
+        specRegistry={specRegistry}
         provider="openai"
         authType="api_key"
         model="gpt-4o"
@@ -38,6 +57,7 @@ describe('ModelParamsAffordance', () => {
   it('does NOT render the button when authType is missing (can not call the endpoint)', () => {
     const { container } = render(() => (
       <ModelParamsAffordance
+        specRegistry={specRegistry}
         provider="deepseek"
         authType={undefined}
         model="deepseek-v4"
@@ -53,6 +73,7 @@ describe('ModelParamsAffordance', () => {
   it('does NOT render the button when provider is undefined', () => {
     const { container } = render(() => (
       <ModelParamsAffordance
+        specRegistry={specRegistry}
         provider={undefined}
         authType="api_key"
         model="deepseek-v4"
@@ -68,6 +89,7 @@ describe('ModelParamsAffordance', () => {
   it('flips the configured class when getParams returns a non-null value', () => {
     const { container } = render(() => (
       <ModelParamsAffordance
+        specRegistry={specRegistry}
         provider="deepseek"
         authType="api_key"
         model="deepseek-v4"
@@ -87,6 +109,7 @@ describe('ModelParamsAffordance', () => {
     const setParams = vi.fn().mockResolvedValue(undefined);
     const { container, getByRole } = render(() => (
       <ModelParamsAffordance
+        specRegistry={specRegistry}
         provider="deepseek"
         authType="api_key"
         model="deepseek-v4"
@@ -120,6 +143,7 @@ describe('ModelParamsAffordance', () => {
     const setParams = vi.fn().mockResolvedValue(undefined);
     const { container, getByRole } = render(() => (
       <ModelParamsAffordance
+        specRegistry={specRegistry}
         provider="deepseek"
         authType="api_key"
         model="deepseek-v4"
@@ -155,6 +179,7 @@ describe('ModelParamsAffordance', () => {
   it('button is disabled when the parent says so', () => {
     const { container } = render(() => (
       <ModelParamsAffordance
+        specRegistry={specRegistry}
         provider="deepseek"
         authType="api_key"
         model="deepseek-v4"

--- a/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
@@ -10,6 +10,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="deepseek-v4"
         slotLabel="deepseek-v4-flash"
+        scope="tier:simple"
         getParams={() => null}
         setParams={vi.fn()}
       />
@@ -26,6 +27,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="gpt-4o"
         slotLabel="gpt-4o"
+        scope="tier:simple"
         getParams={() => null}
         setParams={vi.fn()}
       />
@@ -40,6 +42,7 @@ describe('ModelParamsAffordance', () => {
         authType={undefined}
         model="deepseek-v4"
         slotLabel="deepseek-v4"
+        scope="tier:simple"
         getParams={() => null}
         setParams={vi.fn()}
       />
@@ -54,6 +57,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="deepseek-v4"
         slotLabel="deepseek-v4"
+        scope="tier:simple"
         getParams={() => null}
         setParams={vi.fn()}
       />
@@ -68,6 +72,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="deepseek-v4"
         slotLabel="deepseek-v4"
+        scope="tier:simple"
         getParams={() => ({ thinking: 'disabled' })}
         setParams={vi.fn()}
       />
@@ -86,6 +91,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="deepseek-v4"
         slotLabel="deepseek-v4"
+        scope="tier:simple"
         getParams={() => null}
         setParams={setParams}
       />
@@ -104,7 +110,7 @@ describe('ModelParamsAffordance', () => {
     fireEvent.click(save);
 
     await waitFor(() => {
-      expect(setParams).toHaveBeenCalledWith('deepseek', 'api_key', 'deepseek-v4', {
+      expect(setParams).toHaveBeenCalledWith('tier:simple', 'deepseek', 'api_key', 'deepseek-v4', {
         thinking: 'disabled',
       });
     });
@@ -118,6 +124,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="deepseek-v4"
         slotLabel="deepseek-v4"
+        scope="tier:simple"
         getParams={() => ({ thinking: 'disabled' })}
         setParams={setParams}
       />
@@ -135,7 +142,13 @@ describe('ModelParamsAffordance', () => {
     fireEvent.click(save);
 
     await waitFor(() => {
-      expect(setParams).toHaveBeenCalledWith('deepseek', 'api_key', 'deepseek-v4', null);
+      expect(setParams).toHaveBeenCalledWith(
+        'tier:simple',
+        'deepseek',
+        'api_key',
+        'deepseek-v4',
+        null,
+      );
     });
   });
 
@@ -146,6 +159,7 @@ describe('ModelParamsAffordance', () => {
         authType="api_key"
         model="deepseek-v4"
         slotLabel="deepseek-v4"
+        scope="tier:simple"
         getParams={() => null}
         setParams={vi.fn()}
         disabled

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -80,7 +80,7 @@ describe('ModelParamsDialog', () => {
     expect(q('.model-params__label-title')!.textContent).toContain('Thinking mode');
   });
 
-  it("renders the raw spec key as developer metadata", () => {
+  it('renders the raw spec key as developer metadata', () => {
     render(() => <ModelParamsDialog {...baseProps} />);
     expect(q('.model-params__param-key')!.textContent).toBe('thinking');
   });
@@ -88,11 +88,7 @@ describe('ModelParamsDialog', () => {
   it('saves null when every chosen value matches the provider default', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     render(() => (
-      <ModelParamsDialog
-        {...baseProps}
-        onSave={onSave}
-        current={{ thinking: 'disabled' }}
-      />
+      <ModelParamsDialog {...baseProps} onSave={onSave} current={{ thinking: 'disabled' }} />
     ));
 
     fireEvent.click(q('.model-params__toggle') as HTMLButtonElement); // disabled → enabled
@@ -104,16 +100,12 @@ describe('ModelParamsDialog', () => {
   it('saves an explicit override when at least one value differs from the provider default', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     const onClose = vi.fn();
-    render(() => (
-      <ModelParamsDialog {...baseProps} onSave={onSave} onClose={onClose} />
-    ));
+    render(() => <ModelParamsDialog {...baseProps} onSave={onSave} onClose={onClose} />);
 
     fireEvent.click(q('.model-params__toggle') as HTMLButtonElement); // enabled → disabled
     fireEvent.click(screen.getByText('Save'));
 
-    await waitFor(() =>
-      expect(onSave).toHaveBeenCalledWith({ thinking: 'disabled' }),
-    );
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ thinking: 'disabled' }));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
@@ -128,9 +120,7 @@ describe('ModelParamsDialog', () => {
   it('cancel button closes without persisting', () => {
     const onSave = vi.fn();
     const onClose = vi.fn();
-    render(() => (
-      <ModelParamsDialog {...baseProps} onSave={onSave} onClose={onClose} />
-    ));
+    render(() => <ModelParamsDialog {...baseProps} onSave={onSave} onClose={onClose} />);
 
     fireEvent.click(screen.getByText('Cancel'));
     expect(onSave).not.toHaveBeenCalled();
@@ -217,15 +207,58 @@ describe('ModelParamsDialog', () => {
     await waitFor(() => expect(onSave).toHaveBeenCalledWith({ temperature: 2 }));
   });
 
+  it('supports slider keyboard increments and Home reset', async () => {
+    const specs: ProviderParamSpec[] = [
+      {
+        key: 'temperature',
+        control: {
+          kind: 'slider',
+          label: 'Temperature',
+          min: 0,
+          max: 2,
+          step: 0.1,
+          default: 1,
+        },
+      },
+    ];
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => <ModelParamsDialog {...baseProps} specs={specs} onSave={onSave} />);
+
+    const slider = screen.getByRole('slider', { name: 'Temperature' });
+    Object.defineProperty(slider, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({
+        left: 0,
+        width: 200,
+        top: 0,
+        height: 20,
+        right: 200,
+        bottom: 20,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    });
+
+    const pointerDown = new Event('pointerdown', { bubbles: true, cancelable: true });
+    Object.defineProperty(pointerDown, 'clientX', { value: 50 });
+    Object.defineProperty(pointerDown, 'pointerId', { value: 1 });
+    fireEvent(slider, pointerDown);
+    expect(slider.getAttribute('aria-valuenow')).toBe('0.5');
+    fireEvent.keyDown(slider, { key: 'ArrowLeft' });
+    expect(slider.getAttribute('aria-valuenow')).toBe('0.4');
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    expect(slider.getAttribute('aria-valuenow')).toBe('0.5');
+    fireEvent.keyDown(slider, { key: 'Home' });
+    expect(slider.getAttribute('aria-valuenow')).toBe('0');
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ temperature: 0 }));
+  });
+
   it('renders Anthropic API-key scalar params from resolved specs', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
-    render(() => (
-      <ModelParamsDialog
-        {...baseProps}
-        specs={anthropicSpecs}
-        onSave={onSave}
-      />
-    ));
+    render(() => <ModelParamsDialog {...baseProps} specs={anthropicSpecs} onSave={onSave} />);
 
     const temperatureSlider = screen.getByRole('slider', { name: 'Temperature' });
     const topPSlider = screen.getByRole('slider', { name: 'Top P' });
@@ -235,7 +268,9 @@ describe('ModelParamsDialog', () => {
     fireEvent.input(screen.getByLabelText('Top K'), { target: { value: '40' } });
     fireEvent.click(screen.getByText('Save'));
 
-    expect(temperatureSlider.getAttribute('style')).toContain('--model-params-slider-progress: 40%');
+    expect(temperatureSlider.getAttribute('style')).toContain(
+      '--model-params-slider-progress: 40%',
+    );
     expect(topPSlider.getAttribute('style')).toContain('--model-params-slider-progress: 80%');
     await waitFor(() =>
       expect(onSave).toHaveBeenCalledWith({

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -62,6 +62,11 @@ describe('ModelParamsDialog', () => {
     expect(q('.model-params__label-title')!.textContent).toContain('Thinking mode');
   });
 
+  it("renders the raw spec key as developer metadata", () => {
+    render(() => <ModelParamsDialog {...baseProps} />);
+    expect(q('.model-params__param-key')!.textContent).toBe('thinking');
+  });
+
   it('saves null when every chosen value matches the provider default', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     render(() => (

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -69,6 +69,23 @@ describe('ModelParamsDialog', () => {
     expect(q('.provider-toggle__switch--on')).toBeNull();
   });
 
+  it('normalizes legacy nested thinking overrides when saved', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        onSave={onSave}
+        current={{ thinking: { type: 'disabled' } }}
+      />
+    ));
+
+    const toggle = q('.model-params__toggle') as HTMLButtonElement;
+    expect(toggle.getAttribute('aria-pressed')).toBe('false');
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ thinking: 'disabled' }));
+  });
+
   it("renders the spec's natural default in the hint text", () => {
     render(() => <ModelParamsDialog {...baseProps} />);
     // DeepSeek's spec default is `enabled`.

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, screen, waitFor } from '@solidjs/testing-library';
+import { PROVIDER_PARAM_SPECS } from 'manifest-shared';
 
 import ModelParamsDialog from '../../src/components/ModelParamsDialog';
 
@@ -7,20 +8,28 @@ const q = (sel: string) => document.querySelector(sel);
 
 describe('ModelParamsDialog', () => {
   // Dialog now reads which controls to render from
-  // `PROVIDER_PARAM_SPECS[provider]` in manifest-shared. DeepSeek's spec
-  // declares a single `thinking` toggle with default `enabled`, so these
-  // tests use `provider: 'deepseek'` instead of passing `providerDefault`
-  // directly — the dialog is fully driven by the spec.
+  // `PROVIDER_PARAM_SPECS[provider:authType]` in manifest-shared. DeepSeek's
+  // spec declares a single `thinking` toggle with default `enabled`, so
+  // these tests use the real route identity.
   const baseProps = {
     open: true,
     slotLabel: 'deepseek-v4-flash',
-    current: null as null | { thinking?: { type: 'enabled' | 'disabled' } },
+    current: null as null | Record<string, unknown>,
     provider: 'deepseek',
+    authType: 'api_key' as const,
+    model: 'deepseek-v4-flash',
     onClose: vi.fn(),
     onSave: vi.fn().mockResolvedValue(undefined),
   };
 
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    delete PROVIDER_PARAM_SPECS['test:api_key'];
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete PROVIDER_PARAM_SPECS['test:api_key'];
+  });
 
   it('renders nothing when closed', () => {
     render(() => <ModelParamsDialog {...baseProps} open={false} />);
@@ -36,9 +45,7 @@ describe('ModelParamsDialog', () => {
   });
 
   it('reflects the configured override when present', () => {
-    render(() => (
-      <ModelParamsDialog {...baseProps} current={{ thinking: { type: 'disabled' } }} />
-    ));
+    render(() => <ModelParamsDialog {...baseProps} current={{ thinking: 'disabled' }} />);
     const toggle = q('.model-params__toggle') as HTMLButtonElement;
     expect(toggle.getAttribute('aria-pressed')).toBe('false');
     expect(q('.provider-toggle__switch--on')).toBeNull();
@@ -61,7 +68,7 @@ describe('ModelParamsDialog', () => {
       <ModelParamsDialog
         {...baseProps}
         onSave={onSave}
-        current={{ thinking: { type: 'disabled' } }}
+        current={{ thinking: 'disabled' }}
       />
     ));
 
@@ -82,7 +89,7 @@ describe('ModelParamsDialog', () => {
     fireEvent.click(screen.getByText('Save'));
 
     await waitFor(() =>
-      expect(onSave).toHaveBeenCalledWith({ thinking: { type: 'disabled' } }),
+      expect(onSave).toHaveBeenCalledWith({ thinking: 'disabled' }),
     );
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
@@ -137,5 +144,106 @@ describe('ModelParamsDialog', () => {
     expect(onClose).not.toHaveBeenCalled();
     resolveSave!();
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('renders a select control from the registry and saves its UI value', async () => {
+    PROVIDER_PARAM_SPECS['test:api_key'] = {
+      base: [
+        {
+          key: 'reasoning_effort',
+          control: {
+            kind: 'select',
+            label: 'Reasoning effort',
+            values: ['low', 'medium', 'high'],
+            default: 'medium',
+          },
+        },
+      ],
+    };
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => <ModelParamsDialog {...baseProps} provider="test" onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reasoning effort' }));
+    fireEvent.click(screen.getByRole('option', { name: 'high' }));
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ reasoning_effort: 'high' }));
+  });
+
+  it('renders a slider control and clamps numeric input to the configured range', async () => {
+    PROVIDER_PARAM_SPECS['test:api_key'] = {
+      base: [
+        {
+          key: 'temperature',
+          control: {
+            kind: 'slider',
+            label: 'Temperature',
+            min: 0,
+            max: 2,
+            step: 0.1,
+            default: 1,
+          },
+        },
+      ],
+    };
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => <ModelParamsDialog {...baseProps} provider="test" onSave={onSave} />);
+
+    const slider = screen.getByRole('slider', { name: 'Temperature' });
+    expect(document.querySelector('input[type="range"]')).toBeNull();
+    fireEvent.keyDown(slider, { key: 'End' });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(slider.getAttribute('style')).toContain('--model-params-slider-progress: 100%');
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ temperature: 2 }));
+  });
+
+  it('renders Anthropic API-key scalar params from the real registry entry', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        provider="anthropic"
+        model="claude-sonnet-4-6"
+        onSave={onSave}
+      />
+    ));
+
+    const temperatureSlider = screen.getByRole('slider', { name: 'Temperature' });
+    const topPSlider = screen.getByRole('slider', { name: 'Top P' });
+    fireEvent.input(screen.getByLabelText('Max tokens'), { target: { value: '2048' } });
+    fireEvent.input(screen.getByLabelText('Temperature value'), { target: { value: '0.4' } });
+    fireEvent.input(screen.getByLabelText('Top P value'), { target: { value: '0.8' } });
+    fireEvent.input(screen.getByLabelText('Top K'), { target: { value: '40' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(temperatureSlider.getAttribute('style')).toContain('--model-params-slider-progress: 40%');
+    expect(topPSlider.getAttribute('style')).toContain('--model-params-slider-progress: 80%');
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        max_tokens: 2048,
+        temperature: 0.4,
+        top_p: 0.8,
+        top_k: 40,
+      }),
+    );
+  });
+
+  it('renders a number control and stores numbers instead of input strings', async () => {
+    PROVIDER_PARAM_SPECS['test:api_key'] = {
+      base: [
+        {
+          key: 'budget_tokens',
+          control: { kind: 'number', label: 'Budget tokens', min: 1024, max: 4096, default: 2048 },
+        },
+      ],
+    };
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => <ModelParamsDialog {...baseProps} provider="test" onSave={onSave} />);
+
+    fireEvent.input(screen.getByLabelText('Budget tokens'), { target: { value: '3072' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ budget_tokens: 3072 }));
   });
 });

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -1,34 +1,52 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, screen, waitFor } from '@solidjs/testing-library';
-import { PROVIDER_PARAM_SPECS } from 'manifest-shared';
+import type { ProviderParamSpec } from 'manifest-shared';
 
 import ModelParamsDialog from '../../src/components/ModelParamsDialog';
 
 const q = (sel: string) => document.querySelector(sel);
 
 describe('ModelParamsDialog', () => {
-  // Dialog now reads which controls to render from
-  // `PROVIDER_PARAM_SPECS[provider:authType]` in manifest-shared. DeepSeek's
-  // spec declares a single `thinking` toggle with default `enabled`, so
-  // these tests use the real route identity.
+  const deepseekSpecs: ProviderParamSpec[] = [
+    {
+      key: 'thinking',
+      control: {
+        kind: 'toggle',
+        label: 'Thinking mode',
+        values: ['enabled', 'disabled'],
+        default: 'enabled',
+      },
+    },
+  ];
+  const anthropicSpecs: ProviderParamSpec[] = [
+    {
+      key: 'max_tokens',
+      control: { kind: 'number', label: 'Max tokens', min: 1, default: 4096 },
+    },
+    {
+      key: 'temperature',
+      control: { kind: 'slider', label: 'Temperature', min: 0, max: 1, step: 0.1, default: 1 },
+    },
+    {
+      key: 'top_p',
+      control: { kind: 'slider', label: 'Top P', min: 0, max: 1, step: 0.01, default: 1 },
+    },
+    {
+      key: 'top_k',
+      control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+    },
+  ];
   const baseProps = {
     open: true,
     slotLabel: 'deepseek-v4-flash',
     current: null as null | Record<string, unknown>,
-    provider: 'deepseek',
-    authType: 'api_key' as const,
-    model: 'deepseek-v4-flash',
+    specs: deepseekSpecs,
     onClose: vi.fn(),
     onSave: vi.fn().mockResolvedValue(undefined),
   };
 
   beforeEach(() => {
-    delete PROVIDER_PARAM_SPECS['test:api_key'];
     vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    delete PROVIDER_PARAM_SPECS['test:api_key'];
   });
 
   it('renders nothing when closed', () => {
@@ -100,7 +118,7 @@ describe('ModelParamsDialog', () => {
   });
 
   it('renders nothing for providers with no spec entries', () => {
-    render(() => <ModelParamsDialog {...baseProps} provider="openai" />);
+    render(() => <ModelParamsDialog {...baseProps} specs={[]} />);
     // The dialog still mounts (open=true), but no rows render — the For
     // over zero spec entries collapses to nothing. Saving with no rows
     // produces the empty payload → null.
@@ -152,21 +170,19 @@ describe('ModelParamsDialog', () => {
   });
 
   it('renders a select control from the registry and saves its UI value', async () => {
-    PROVIDER_PARAM_SPECS['test:api_key'] = {
-      base: [
-        {
-          key: 'reasoning_effort',
-          control: {
-            kind: 'select',
-            label: 'Reasoning effort',
-            values: ['low', 'medium', 'high'],
-            default: 'medium',
-          },
+    const specs: ProviderParamSpec[] = [
+      {
+        key: 'reasoning_effort',
+        control: {
+          kind: 'select',
+          label: 'Reasoning effort',
+          values: ['low', 'medium', 'high'],
+          default: 'medium',
         },
-      ],
-    };
+      },
+    ];
     const onSave = vi.fn().mockResolvedValue(undefined);
-    render(() => <ModelParamsDialog {...baseProps} provider="test" onSave={onSave} />);
+    render(() => <ModelParamsDialog {...baseProps} specs={specs} onSave={onSave} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Reasoning effort' }));
     fireEvent.click(screen.getByRole('option', { name: 'high' }));
@@ -176,23 +192,21 @@ describe('ModelParamsDialog', () => {
   });
 
   it('renders a slider control and clamps numeric input to the configured range', async () => {
-    PROVIDER_PARAM_SPECS['test:api_key'] = {
-      base: [
-        {
-          key: 'temperature',
-          control: {
-            kind: 'slider',
-            label: 'Temperature',
-            min: 0,
-            max: 2,
-            step: 0.1,
-            default: 1,
-          },
+    const specs: ProviderParamSpec[] = [
+      {
+        key: 'temperature',
+        control: {
+          kind: 'slider',
+          label: 'Temperature',
+          min: 0,
+          max: 2,
+          step: 0.1,
+          default: 1,
         },
-      ],
-    };
+      },
+    ];
     const onSave = vi.fn().mockResolvedValue(undefined);
-    render(() => <ModelParamsDialog {...baseProps} provider="test" onSave={onSave} />);
+    render(() => <ModelParamsDialog {...baseProps} specs={specs} onSave={onSave} />);
 
     const slider = screen.getByRole('slider', { name: 'Temperature' });
     expect(document.querySelector('input[type="range"]')).toBeNull();
@@ -203,13 +217,12 @@ describe('ModelParamsDialog', () => {
     await waitFor(() => expect(onSave).toHaveBeenCalledWith({ temperature: 2 }));
   });
 
-  it('renders Anthropic API-key scalar params from the real registry entry', async () => {
+  it('renders Anthropic API-key scalar params from resolved specs', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     render(() => (
       <ModelParamsDialog
         {...baseProps}
-        provider="anthropic"
-        model="claude-sonnet-4-6"
+        specs={anthropicSpecs}
         onSave={onSave}
       />
     ));
@@ -235,16 +248,14 @@ describe('ModelParamsDialog', () => {
   });
 
   it('renders a number control and stores numbers instead of input strings', async () => {
-    PROVIDER_PARAM_SPECS['test:api_key'] = {
-      base: [
-        {
-          key: 'budget_tokens',
-          control: { kind: 'number', label: 'Budget tokens', min: 1024, max: 4096, default: 2048 },
-        },
-      ],
-    };
+    const specs: ProviderParamSpec[] = [
+      {
+        key: 'budget_tokens',
+        control: { kind: 'number', label: 'Budget tokens', min: 1024, max: 4096, default: 2048 },
+      },
+    ];
     const onSave = vi.fn().mockResolvedValue(undefined);
-    render(() => <ModelParamsDialog {...baseProps} provider="test" onSave={onSave} />);
+    render(() => <ModelParamsDialog {...baseProps} specs={specs} onSave={onSave} />);
 
     fireEvent.input(screen.getByLabelText('Budget tokens'), { target: { value: '3072' } });
     fireEvent.click(screen.getByText('Save'));

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -30,10 +30,46 @@ describe('ModelParamsDialog', () => {
     {
       key: 'top_p',
       control: { kind: 'slider', label: 'Top P', min: 0, max: 1, step: 0.01, default: 1 },
+      dependencies: [
+        {
+          effect: 'disable',
+          when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+        },
+        {
+          effect: 'omit',
+          when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+        },
+      ],
     },
     {
       key: 'top_k',
       control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+      dependencies: [
+        {
+          effect: 'disable',
+          when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+        },
+        {
+          effect: 'omit',
+          when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+        },
+      ],
+    },
+    {
+      key: 'type',
+      group: { key: 'thinking', label: 'Thinking' },
+      control: {
+        kind: 'select',
+        label: 'Thinking mode',
+        values: ['disabled', 'adaptive', 'enabled'],
+        default: 'disabled',
+      },
+    },
+    {
+      key: 'budget_tokens',
+      group: { key: 'thinking', label: 'Thinking' },
+      visibleWhen: { key: 'type', equals: 'enabled' },
+      control: { kind: 'number', label: 'Budget tokens', min: 1024, default: 4096 },
     },
   ];
   const baseProps = {
@@ -295,6 +331,64 @@ describe('ModelParamsDialog', () => {
         temperature: 0.4,
         top_p: 0.8,
         top_k: 40,
+      }),
+    );
+  });
+
+  it('renders grouped Anthropic thinking params only when their dependency is active', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => <ModelParamsDialog {...baseProps} specs={anthropicSpecs} onSave={onSave} />);
+
+    expect(screen.getByText('Thinking')).not.toBeNull();
+    expect(screen.queryByLabelText('Budget tokens')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Thinking mode' }));
+    fireEvent.click(screen.getByRole('option', { name: 'enabled' }));
+    expect(screen.getByLabelText('Budget tokens')).not.toBeNull();
+    fireEvent.input(screen.getByLabelText('Budget tokens'), { target: { value: '8192' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        thinking: { type: 'enabled', budget_tokens: 8192 },
+      }),
+    );
+  });
+
+  it('persists Anthropic adaptive thinking without the hidden budget field', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => <ModelParamsDialog {...baseProps} specs={anthropicSpecs} onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Thinking mode' }));
+    fireEvent.click(screen.getByRole('option', { name: 'adaptive' }));
+    expect(screen.queryByLabelText('Budget tokens')).toBeNull();
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        thinking: { type: 'adaptive' },
+      }),
+    );
+  });
+
+  it('disables Anthropic top_k when thinking makes it provider-incompatible', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => <ModelParamsDialog {...baseProps} specs={anthropicSpecs} onSave={onSave} />);
+
+    fireEvent.input(screen.getByLabelText('Top K'), { target: { value: '3' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Thinking mode' }));
+    fireEvent.click(screen.getByRole('option', { name: 'adaptive' }));
+
+    expect(screen.getByRole('slider', { name: 'Top P' }).getAttribute('aria-disabled')).toBe(
+      'true',
+    );
+    expect((screen.getByLabelText('Top K') as HTMLInputElement).disabled).toBe(true);
+    expect(screen.getAllByText('Unavailable with selected parameters')).toHaveLength(2);
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() =>
+      expect(onSave).toHaveBeenCalledWith({
+        thinking: { type: 'adaptive' },
       }),
     );
   });

--- a/packages/frontend/tests/components/Select.test.tsx
+++ b/packages/frontend/tests/components/Select.test.tsx
@@ -1,5 +1,6 @@
+import { createSignal } from "solid-js";
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 import Select from "../../src/components/Select";
 
 describe("Select", () => {
@@ -50,5 +51,43 @@ describe("Select", () => {
     const trigger = screen.getByRole("button");
     expect(trigger.getAttribute("aria-haspopup")).toBe("listbox");
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("closes an open dropdown when the control becomes disabled", async () => {
+    const onChange = vi.fn();
+
+    const Harness = () => {
+      const [disabled, setDisabled] = createSignal(false);
+      return (
+        <>
+          <button type="button" onClick={() => setDisabled(true)}>
+            Disable
+          </button>
+          <Select
+            label="Unit select"
+            options={[
+              { label: "Alpha", value: "alpha" },
+              { label: "Beta", value: "beta" },
+            ]}
+            value="alpha"
+            onChange={onChange}
+            disabled={disabled()}
+          />
+        </>
+      );
+    };
+
+    render(() => <Harness />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Unit select" }));
+    expect(screen.queryByRole("listbox")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("Disable"));
+
+    await waitFor(() => expect(screen.queryByRole("listbox")).toBeNull());
+    expect((screen.getByRole("button", { name: "Unit select" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -297,9 +297,9 @@ vi.mock("../../src/pages/RoutingDefaultTierSection.js", () => ({
                 provider: string,
                 authType: string,
                 model: string,
-                p: { thinking: { type: "enabled" | "disabled" } } | null,
+                p: { thinking: "enabled" | "disabled" } | null,
               ) => Promise<unknown>
-            )("deepseek", "api_key", "deepseek-v4", { thinking: { type: "disabled" } })
+            )("deepseek", "api_key", "deepseek-v4", { thinking: "disabled" })
           }
         >
           default-persist-params
@@ -312,7 +312,7 @@ vi.mock("../../src/pages/RoutingDefaultTierSection.js", () => ({
                 provider: string,
                 authType: string,
                 model: string,
-                p: { thinking: { type: "enabled" | "disabled" } } | null,
+                p: { thinking: "enabled" | "disabled" } | null,
               ) => Promise<unknown>
             )("deepseek", "api_key", "deepseek-v4", null)
           }
@@ -344,13 +344,13 @@ vi.mock("../../src/pages/RoutingSpecificitySection.js", () => ({
       provider: string,
       authType: string,
       model: string,
-      paramDefaults: { thinking: { type: "enabled" | "disabled" } } | null,
+      paramDefaults: { thinking: "enabled" | "disabled" } | null,
     ) => Promise<unknown>;
     getModelParams?: (
       provider: string,
       authType: string,
       model: string,
-    ) => { thinking?: { type: "enabled" | "disabled" } } | null;
+    ) => { thinking?: "enabled" | "disabled" } | null;
   }) => (
     <div data-testid="spec-section">
       <button data-testid="spec-open" onClick={() => props.onDropdownOpen("coding")}>
@@ -415,7 +415,7 @@ vi.mock("../../src/pages/RoutingSpecificitySection.js", () => ({
         data-testid="spec-persist-params"
         onClick={() =>
           props.setModelParams?.("deepseek", "api_key", "deepseek-v4", {
-            thinking: { type: "disabled" },
+            thinking: "disabled",
           })
         }
       >
@@ -1202,20 +1202,20 @@ describe("Routing page", () => {
         provider: "DeepSeek",
         authType: "api_key",
         model: "deepseek-v4",
-        params: { thinking: { type: "enabled" } },
+        params: { thinking: "enabled" },
       },
       {
         provider: "openai",
         authType: "api_key",
         model: "gpt-4o",
-        params: { thinking: { type: "enabled" } },
+        params: { thinking: "enabled" },
       },
     ]);
     mockSetModelParams.mockResolvedValue({
       provider: "deepseek",
       authType: "api_key",
       model: "deepseek-v4",
-      params: { thinking: { type: "disabled" } },
+      params: { thinking: "disabled" },
     });
     render(() => <Routing />);
     await waitFor(() => {
@@ -1227,7 +1227,7 @@ describe("Routing page", () => {
         provider: "deepseek",
         authType: "api_key",
         model: "deepseek-v4",
-        params: { thinking: { type: "disabled" } },
+        params: { thinking: "disabled" },
       });
     });
   });
@@ -1240,13 +1240,13 @@ describe("Routing page", () => {
         provider: "DeepSeek",
         authType: "api_key",
         model: "deepseek-v4",
-        params: { thinking: { type: "disabled" } },
+        params: { thinking: "disabled" },
       },
       {
         provider: "anthropic",
         authType: "api_key",
         model: "claude-3-5-sonnet",
-        params: { thinking: { type: "disabled" } },
+        params: { thinking: "disabled" },
       },
     ]);
     mockDeleteModelParams.mockResolvedValue({ ok: true });
@@ -1269,7 +1269,7 @@ describe("Routing page", () => {
       provider: "deepseek",
       authType: "api_key",
       model: "deepseek-v4",
-      params: { thinking: { type: "disabled" } },
+      params: { thinking: "disabled" },
     });
     render(() => <Routing />);
     await waitFor(() => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -38,8 +38,11 @@ vi.mock("../../src/services/api.js", () => ({
   listModelParams: (...args: unknown[]) => mockListModelParams(...args),
   setModelParams: (...args: unknown[]) => mockSetModelParams(...args),
   deleteModelParams: (...args: unknown[]) => mockDeleteModelParams(...args),
-  modelParamsKey: (provider: string, authType: string, model: string) =>
-    `${provider.toLowerCase()}::${authType}::${model}`,
+  modelParamsKey: (scope: string, provider: string, authType: string, model: string) =>
+    `${scope}::${provider.toLowerCase()}::${model}::${authType}`,
+  modelParamsScopeForTier: (tier: string) => `tier:${tier}`,
+  modelParamsScopeForSpecificity: (category: string) => `specificity:${category}`,
+  modelParamsScopeForHeaderTier: (id: string) => `header:${id}`,
   // Re-export types only — no runtime impact
 }));
 
@@ -294,12 +297,13 @@ vi.mock("../../src/pages/RoutingDefaultTierSection.js", () => ({
           onClick={() =>
             (
               props.setModelParams as (
+                scope: string,
                 provider: string,
                 authType: string,
                 model: string,
                 p: { thinking: "enabled" | "disabled" } | null,
               ) => Promise<unknown>
-            )("deepseek", "api_key", "deepseek-v4", { thinking: "disabled" })
+            )("tier:default", "deepseek", "api_key", "deepseek-v4", { thinking: "disabled" })
           }
         >
           default-persist-params
@@ -309,12 +313,13 @@ vi.mock("../../src/pages/RoutingDefaultTierSection.js", () => ({
           onClick={() =>
             (
               props.setModelParams as (
+                scope: string,
                 provider: string,
                 authType: string,
                 model: string,
                 p: { thinking: "enabled" | "disabled" } | null,
               ) => Promise<unknown>
-            )("deepseek", "api_key", "deepseek-v4", null)
+            )("tier:default", "deepseek", "api_key", "deepseek-v4", null)
           }
         >
           default-saved-params
@@ -341,12 +346,14 @@ vi.mock("../../src/pages/RoutingSpecificitySection.js", () => ({
       authType?: string,
     ) => void;
     setModelParams?: (
+      scope: string,
       provider: string,
       authType: string,
       model: string,
       paramDefaults: { thinking: "enabled" | "disabled" } | null,
     ) => Promise<unknown>;
     getModelParams?: (
+      scope: string,
       provider: string,
       authType: string,
       model: string,
@@ -414,7 +421,7 @@ vi.mock("../../src/pages/RoutingSpecificitySection.js", () => ({
       <button
         data-testid="spec-persist-params"
         onClick={() =>
-          props.setModelParams?.("deepseek", "api_key", "deepseek-v4", {
+          props.setModelParams?.("specificity:coding", "deepseek", "api_key", "deepseek-v4", {
             thinking: "disabled",
           })
         }
@@ -423,7 +430,9 @@ vi.mock("../../src/pages/RoutingSpecificitySection.js", () => ({
       </button>
       <button
         data-testid="spec-saved-params"
-        onClick={() => props.getModelParams?.("deepseek", "api_key", "deepseek-v4")}
+        onClick={() =>
+          props.getModelParams?.("specificity:coding", "deepseek", "api_key", "deepseek-v4")
+        }
       >
         spec-saved-params
       </button>
@@ -1199,12 +1208,14 @@ describe("Routing page", () => {
     // covering provider/authType/model comparison) and keeps the non-match.
     mockListModelParams.mockResolvedValue([
       {
+        scope: "tier:default",
         provider: "DeepSeek",
         authType: "api_key",
         model: "deepseek-v4",
         params: { thinking: "enabled" },
       },
       {
+        scope: "specificity:coding",
         provider: "openai",
         authType: "api_key",
         model: "gpt-4o",
@@ -1212,6 +1223,7 @@ describe("Routing page", () => {
       },
     ]);
     mockSetModelParams.mockResolvedValue({
+      scope: "tier:default",
       provider: "deepseek",
       authType: "api_key",
       model: "deepseek-v4",
@@ -1224,6 +1236,7 @@ describe("Routing page", () => {
     fireEvent.click(screen.getByTestId("default-persist-params"));
     await waitFor(() => {
       expect(mockSetModelParams).toHaveBeenCalledWith("demo", {
+        scope: "tier:default",
         provider: "deepseek",
         authType: "api_key",
         model: "deepseek-v4",
@@ -1237,12 +1250,14 @@ describe("Routing page", () => {
     // match (case-insensitive provider compare) and retains the sibling.
     mockListModelParams.mockResolvedValue([
       {
+        scope: "tier:default",
         provider: "DeepSeek",
         authType: "api_key",
         model: "deepseek-v4",
         params: { thinking: "disabled" },
       },
       {
+        scope: "specificity:coding",
         provider: "anthropic",
         authType: "api_key",
         model: "claude-3-5-sonnet",
@@ -1257,6 +1272,7 @@ describe("Routing page", () => {
     fireEvent.click(screen.getByTestId("default-saved-params"));
     await waitFor(() => {
       expect(mockDeleteModelParams).toHaveBeenCalledWith("demo", {
+        scope: "tier:default",
         provider: "deepseek",
         authType: "api_key",
         model: "deepseek-v4",
@@ -1266,6 +1282,7 @@ describe("Routing page", () => {
 
   it("setModelParams on the Specificity Section calls the new endpoint", async () => {
     mockSetModelParams.mockResolvedValue({
+      scope: "specificity:coding",
       provider: "deepseek",
       authType: "api_key",
       model: "deepseek-v4",

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -17,6 +17,7 @@ const mockRefreshPricing = vi.fn();
 const mockGetComplexityStatus = vi.fn();
 const mockToggleComplexity = vi.fn();
 const mockListModelParams = vi.fn();
+const mockListModelParamSpecs = vi.fn();
 const mockSetModelParams = vi.fn();
 const mockDeleteModelParams = vi.fn();
 
@@ -36,6 +37,7 @@ vi.mock("../../src/services/api.js", () => ({
   setSpecificityFallbacks: (...args: unknown[]) => mockSetSpecificityFallbacks(...args),
   clearSpecificityFallbacks: (...args: unknown[]) => mockClearSpecificityFallbacks(...args),
   listModelParams: (...args: unknown[]) => mockListModelParams(...args),
+  listModelParamSpecs: (...args: unknown[]) => mockListModelParamSpecs(...args),
   setModelParams: (...args: unknown[]) => mockSetModelParams(...args),
   deleteModelParams: (...args: unknown[]) => mockDeleteModelParams(...args),
   modelParamsKey: (scope: string, provider: string, authType: string, model: string) =>
@@ -274,6 +276,7 @@ vi.mock("../../src/pages/RoutingDefaultTierSection.js", () => ({
       props.getTier,
       props.complexityEnabled,
       props.togglingComplexity,
+      props.modelParamSpecs,
       props.getModelParams,
       props.setModelParams,
     ];
@@ -517,6 +520,21 @@ beforeEach(() => {
   mockGetPricingHealth.mockResolvedValue({ model_count: 100, last_fetched_at: "2025-01-01" });
   mockToggleComplexity.mockResolvedValue({ enabled: false });
   mockListModelParams.mockResolvedValue([]);
+  mockListModelParamSpecs.mockResolvedValue({
+    "deepseek:api_key": {
+      base: [
+        {
+          key: "thinking",
+          control: {
+            kind: "toggle",
+            label: "Thinking mode",
+            values: ["enabled", "disabled"],
+            default: "enabled",
+          },
+        },
+      ],
+    },
+  });
 });
 
 describe("Routing page", () => {

--- a/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
@@ -36,6 +36,7 @@ vi.mock("../../src/pages/RoutingTierCard.js", () => ({
       props.persistParamDefaults,
       props.onParamDefaultsSaved,
       props.onPinKey,
+      props.modelParamsScope,
       props.getModelParams,
       props.setModelParams,
     ];

--- a/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingSpecificitySection.test.tsx
@@ -8,6 +8,7 @@ vi.mock("../../src/services/api.js", () => ({
   toggleSpecificity: (...args: unknown[]) => mockToggleSpecificity(...args),
   setSpecificityFallbacks: (...args: unknown[]) => mockSetSpecificityFallbacks(...args),
   clearSpecificityFallbacks: (...args: unknown[]) => mockClearSpecificityFallbacks(...args),
+  modelParamsScopeForSpecificity: (category: string) => `specificity:${category}`,
 }));
 
 const mockToastError = vi.fn();
@@ -56,6 +57,7 @@ vi.mock("../../src/pages/RoutingTierCard.js", () => ({
       props.persistClearFallbacks,
       props.persistParamDefaults,
       props.onParamDefaultsSaved,
+      props.modelParamsScope,
       props.getModelParams,
       props.setModelParams,
     ];

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -4,6 +4,7 @@ import { render, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockSetFallbacks = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   setFallbacks: (...args: unknown[]) => mockSetFallbacks(...args),
+  modelParamsScopeForTier: (tier: string) => `tier:${tier}`,
 }));
 
 const mockToastError = vi.fn();
@@ -1317,6 +1318,7 @@ describe("providerIdForModel route-provider attribution", () => {
     fireEvent.click(getByRole("button", { name: "Save" }));
     await waitFor(() => {
       expect(setModelParams).toHaveBeenCalledWith(
+        "tier:simple",
         "deepseek",
         "api_key",
         "deepseek-v4",

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent, waitFor } from "@solidjs/testing-library";
+import type { ProviderParamSpecRegistry } from "manifest-shared";
 
 const mockSetFallbacks = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
@@ -76,6 +77,7 @@ vi.mock("../../src/components/FallbackList.js", () => ({
       props.primaryDragging,
       props.persistFallbacks,
       props.persistClearFallbacks,
+      props.modelParamSpecs,
       props.getModelParams,
       props.setModelParams,
     ];
@@ -202,6 +204,22 @@ const activeProviders: RoutingProvider[] = [
   },
 ];
 
+const modelParamSpecs = (): ProviderParamSpecRegistry => ({
+  "deepseek:api_key": {
+    base: [
+      {
+        key: "thinking",
+        control: {
+          kind: "toggle",
+          label: "Thinking mode",
+          values: ["enabled", "disabled"],
+          default: "enabled",
+        },
+      },
+    ],
+  },
+});
+
 function makeProps(overrides: Partial<Parameters<typeof RoutingTierCard>[0]> = {}) {
   return {
     stage,
@@ -222,6 +240,7 @@ function makeProps(overrides: Partial<Parameters<typeof RoutingTierCard>[0]> = {
     onAddFallback: vi.fn(),
     getFallbacksFor: () => baseTier.fallback_routes!.map((r) => r.model),
     connectedProviders: () => activeProviders,
+    modelParamSpecs,
     getModelParams: () => null,
     setModelParams: vi.fn().mockResolvedValue(undefined),
     ...overrides,

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -1320,7 +1320,7 @@ describe("providerIdForModel route-provider attribution", () => {
         "deepseek",
         "api_key",
         "deepseek-v4",
-        { thinking: { type: "disabled" } },
+        { thinking: "disabled" },
       );
     });
   });

--- a/packages/frontend/tests/services/api/model-params.test.ts
+++ b/packages/frontend/tests/services/api/model-params.test.ts
@@ -37,7 +37,7 @@ describe('model-params API client', () => {
       provider: 'deepseek',
       authType: 'api_key',
       model: 'deepseek-v4',
-      params: { thinking: { type: 'disabled' } },
+      params: { thinking: 'disabled' },
     });
     const [url, init] = vi.mocked(fetch).mock.calls[0];
     expect(url).toContain('/api/v1/routing/demo/model-params');
@@ -46,7 +46,7 @@ describe('model-params API client', () => {
       provider: 'deepseek',
       authType: 'api_key',
       model: 'deepseek-v4',
-      params: { thinking: { type: 'disabled' } },
+      params: { thinking: 'disabled' },
     });
   });
 

--- a/packages/frontend/tests/services/api/model-params.test.ts
+++ b/packages/frontend/tests/services/api/model-params.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   listModelParams,
+  listModelParamSpecs,
   setModelParams,
   deleteModelParams,
   modelParamsKey,
@@ -23,6 +24,19 @@ describe('model-params API client', () => {
     await listModelParams('demo');
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('/routing/demo/model-params'),
+      expect.anything(),
+    );
+  });
+
+  it('listModelParamSpecs GETs the DB-backed param spec registry', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+    await listModelParamSpecs('demo');
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/routing/demo/model-param-specs'),
       expect.anything(),
     );
   });

--- a/packages/frontend/tests/services/api/model-params.test.ts
+++ b/packages/frontend/tests/services/api/model-params.test.ts
@@ -34,6 +34,7 @@ describe('model-params API client', () => {
       text: () => Promise.resolve('{}'),
     } as Response);
     await setModelParams('demo', {
+      scope: 'tier:simple',
       provider: 'deepseek',
       authType: 'api_key',
       model: 'deepseek-v4',
@@ -43,6 +44,7 @@ describe('model-params API client', () => {
     expect(url).toContain('/api/v1/routing/demo/model-params');
     expect((init as RequestInit).method).toBe('PUT');
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      scope: 'tier:simple',
       provider: 'deepseek',
       authType: 'api_key',
       model: 'deepseek-v4',
@@ -57,6 +59,7 @@ describe('model-params API client', () => {
       text: () => Promise.resolve('{"ok":true}'),
     } as Response);
     await deleteModelParams('demo', {
+      scope: 'tier:simple',
       provider: 'deepseek',
       authType: 'api_key',
       model: 'deepseek-v4',
@@ -64,6 +67,7 @@ describe('model-params API client', () => {
     const [, init] = vi.mocked(fetch).mock.calls[0];
     expect((init as RequestInit).method).toBe('DELETE');
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      scope: 'tier:simple',
       provider: 'deepseek',
       authType: 'api_key',
       model: 'deepseek-v4',
@@ -72,14 +76,14 @@ describe('model-params API client', () => {
 
   describe('modelParamsKey', () => {
     it('lowercases the provider so case differences between save and lookup do not break the index', () => {
-      expect(modelParamsKey('DeepSeek', 'api_key', 'deepseek-v4')).toBe(
-        'deepseek::api_key::deepseek-v4',
+      expect(modelParamsKey('tier:simple', 'DeepSeek', 'api_key', 'deepseek-v4')).toBe(
+        'tier:simple::deepseek::deepseek-v4::api_key',
       );
     });
 
     it('keeps auth_type and model verbatim (case-sensitive on those segments)', () => {
-      expect(modelParamsKey('openai', 'subscription', 'gpt-4o')).toBe(
-        'openai::subscription::gpt-4o',
+      expect(modelParamsKey('header:abc', 'openai', 'subscription', 'gpt-4o')).toBe(
+        'header:abc::openai::gpt-4o::subscription',
       );
     });
   });

--- a/packages/shared/__tests__/model-params-scope.spec.ts
+++ b/packages/shared/__tests__/model-params-scope.spec.ts
@@ -1,0 +1,28 @@
+import {
+  modelParamsScopeForHeaderTier,
+  modelParamsScopeForRouting,
+  modelParamsScopeForSpecificity,
+  modelParamsScopeForTier,
+} from '../src/model-params-scope';
+
+describe('model params scope helpers', () => {
+  it('builds explicit scope keys for each routing surface', () => {
+    expect(modelParamsScopeForTier('simple')).toBe('tier:simple');
+    expect(modelParamsScopeForSpecificity('coding')).toBe('specificity:coding');
+    expect(modelParamsScopeForHeaderTier('header-1')).toBe('header:header-1');
+  });
+
+  it('chooses the most specific route scope from resolved routing metadata', () => {
+    expect(
+      modelParamsScopeForRouting({
+        tier: 'standard',
+        specificityCategory: 'coding',
+        headerTierId: 'header-1',
+      }),
+    ).toBe('header:header-1');
+    expect(modelParamsScopeForRouting({ tier: 'standard', specificityCategory: 'coding' })).toBe(
+      'specificity:coding',
+    );
+    expect(modelParamsScopeForRouting({ tier: 'standard' })).toBe('tier:standard');
+  });
+});

--- a/packages/shared/__tests__/provider-params-spec.spec.ts
+++ b/packages/shared/__tests__/provider-params-spec.spec.ts
@@ -1,6 +1,8 @@
 import {
   getProviderParamSpecs,
+  omitProviderIncompatibleParams,
   pickProviderCompatibleParams,
+  providerParamHasEffect,
   type ProviderParamSpecRegistry,
 } from '../src/provider-params-spec';
 
@@ -18,10 +20,46 @@ const registry: ProviderParamSpecRegistry = {
       {
         key: 'top_p',
         control: { kind: 'slider', label: 'Top P', min: 0, max: 1, step: 0.01, default: 1 },
+        dependencies: [
+          {
+            effect: 'disable',
+            when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+          },
+          {
+            effect: 'omit',
+            when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+          },
+        ],
       },
       {
         key: 'top_k',
         control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+        dependencies: [
+          {
+            effect: 'disable',
+            when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+          },
+          {
+            effect: 'omit',
+            when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+          },
+        ],
+      },
+      {
+        key: 'type',
+        group: { key: 'thinking', label: 'Thinking' },
+        control: {
+          kind: 'select',
+          label: 'Thinking mode',
+          values: ['disabled', 'adaptive', 'enabled'],
+          default: 'disabled',
+        },
+      },
+      {
+        key: 'budget_tokens',
+        group: { key: 'thinking', label: 'Thinking' },
+        visibleWhen: { key: 'type', equals: 'enabled' },
+        control: { kind: 'number', label: 'Budget tokens', min: 1024, default: 4096 },
       },
     ],
   },
@@ -45,7 +83,7 @@ describe('provider-params-spec', () => {
     it('returns the provider entries case-insensitively', () => {
       expect(getProviderParamSpecs(registry, 'deepseek', 'api_key')).toHaveLength(1);
       expect(getProviderParamSpecs(registry, 'DeepSeek', 'api_key')).toHaveLength(1);
-      expect(getProviderParamSpecs(registry, 'Anthropic', 'api_key')).toHaveLength(4);
+      expect(getProviderParamSpecs(registry, 'Anthropic', 'api_key')).toHaveLength(6);
     });
 
     it('returns empty for unknown providers, missing input, and auth types with no entry', () => {
@@ -113,11 +151,18 @@ describe('provider-params-spec', () => {
             temperature: 0.4,
             top_p: 0.8,
             top_k: 40,
-            thinking: { type: 'enabled', budget_tokens: 1024 },
+            thinking: { type: 'enabled', budget_tokens: 4096 },
+            budget_tokens: 1024,
           },
           getProviderParamSpecs(registry, 'anthropic', 'api_key', 'claude-sonnet-4-6'),
         ),
-      ).toEqual({ max_tokens: 2048, temperature: 0.4, top_p: 0.8, top_k: 40 });
+      ).toEqual({
+        max_tokens: 2048,
+        temperature: 0.4,
+        top_p: 0.8,
+        top_k: 40,
+        thinking: { type: 'enabled', budget_tokens: 4096 },
+      });
     });
 
     it('drops keys the specs do not consume', () => {
@@ -152,6 +197,48 @@ describe('provider-params-spec', () => {
       );
       expect(out).not.toBe(input);
       expect(input.thinking).toEqual('enabled');
+    });
+  });
+
+  describe('provider param dependencies', () => {
+    const anthropicSpecs = getProviderParamSpecs(
+      registry,
+      'anthropic',
+      'api_key',
+      'claude-sonnet-4-6',
+    );
+    const topKSpec = anthropicSpecs.find((spec) => spec.key === 'top_k')!;
+
+    it('detects effects from dot-path dependency values', () => {
+      expect(providerParamHasEffect(topKSpec, { thinking: { type: 'adaptive' } }, 'disable')).toBe(
+        true,
+      );
+      expect(providerParamHasEffect(topKSpec, { thinking: { type: 'enabled' } }, 'omit')).toBe(
+        true,
+      );
+      expect(providerParamHasEffect(topKSpec, { thinking: { type: 'disabled' } }, 'disable')).toBe(
+        false,
+      );
+    });
+
+    it('omits params whose provider compatibility rule is active', () => {
+      const input = {
+        top_p: 0.4,
+        top_k: 3,
+        thinking: { type: 'adaptive' },
+        temperature: 0.4,
+      };
+
+      expect(omitProviderIncompatibleParams(input, anthropicSpecs)).toEqual({
+        thinking: { type: 'adaptive' },
+        temperature: 0.4,
+      });
+      expect(input).toEqual({
+        top_p: 0.4,
+        top_k: 3,
+        thinking: { type: 'adaptive' },
+        temperature: 0.4,
+      });
     });
   });
 });

--- a/packages/shared/__tests__/provider-params-spec.spec.ts
+++ b/packages/shared/__tests__/provider-params-spec.spec.ts
@@ -240,5 +240,25 @@ describe('provider-params-spec', () => {
         temperature: 0.4,
       });
     });
+
+    it('evaluates omit dependencies against the original param payload', () => {
+      const specs = [
+        {
+          key: 'first',
+          control: { kind: 'select', label: 'First', values: ['keep', 'drop'], default: 'keep' },
+          dependencies: [{ effect: 'omit', when: { key: 'mode', equals: 'drop' } }],
+        },
+        {
+          key: 'second',
+          control: { kind: 'select', label: 'Second', values: ['keep', 'drop'], default: 'keep' },
+          dependencies: [{ effect: 'omit', when: { key: 'first', equals: 'drop' } }],
+        },
+      ] satisfies ProviderParamSpecRegistry['unit:api_key']['base'];
+
+      expect(omitProviderIncompatibleParams({ mode: 'drop', first: 'drop', second: 'drop' }, specs))
+        .toEqual({
+          mode: 'drop',
+        });
+    });
   });
 });

--- a/packages/shared/__tests__/provider-params-spec.spec.ts
+++ b/packages/shared/__tests__/provider-params-spec.spec.ts
@@ -2,18 +2,67 @@ import {
   PROVIDER_PARAM_SPECS,
   getProviderParamSpecs,
   pickProviderCompatibleParams,
-  providerParamDefault,
-  providerSupportsParam,
 } from '../src/provider-params-spec';
 
 describe('provider-params-spec', () => {
+  afterEach(() => {
+    delete PROVIDER_PARAM_SPECS['unit:api_key'];
+  });
+
   describe('PROVIDER_PARAM_SPECS registry', () => {
+    it('declares Anthropic API-key scalar generation params with control shapes + defaults', () => {
+      const group = PROVIDER_PARAM_SPECS['anthropic:api_key'];
+      expect(group).toBeDefined();
+      expect(group.base.map((s) => [s.key, s.control])).toEqual([
+        [
+          'max_tokens',
+          {
+            kind: 'number',
+            label: 'Max tokens',
+            min: 1,
+            default: 4096,
+          },
+        ],
+        [
+          'temperature',
+          {
+            kind: 'slider',
+            label: 'Temperature',
+            min: 0,
+            max: 1,
+            step: 0.1,
+            default: 1,
+          },
+        ],
+        [
+          'top_p',
+          {
+            kind: 'slider',
+            label: 'Top P',
+            min: 0,
+            max: 1,
+            step: 0.01,
+            default: 1,
+          },
+        ],
+        [
+          'top_k',
+          {
+            kind: 'number',
+            label: 'Top K',
+            min: 0,
+            default: 0,
+          },
+        ],
+      ]);
+    });
+
     it('declares DeepSeek thinking with the right control shape + default', () => {
-      const specs = PROVIDER_PARAM_SPECS.deepseek;
-      expect(specs).toBeDefined();
-      expect(specs).toHaveLength(1);
-      expect(specs![0].key).toBe('thinking');
-      expect(specs![0].control).toEqual({
+      const group = PROVIDER_PARAM_SPECS['deepseek:api_key'];
+      expect(group).toBeDefined();
+      expect(group.base).toHaveLength(1);
+      expect(group.base[0].key).toBe('thinking');
+      expect(group.base[0].control).toEqual({
         kind: 'toggle',
         label: 'Thinking mode',
         values: ['enabled', 'disabled'],
@@ -24,75 +73,110 @@ describe('provider-params-spec', () => {
 
   describe('getProviderParamSpecs', () => {
     it('returns the provider entries case-insensitively', () => {
-      expect(getProviderParamSpecs('deepseek')).toHaveLength(1);
-      expect(getProviderParamSpecs('DeepSeek')).toHaveLength(1);
+      expect(getProviderParamSpecs('deepseek', 'api_key')).toHaveLength(1);
+      expect(getProviderParamSpecs('DeepSeek', 'api_key')).toHaveLength(1);
+      expect(getProviderParamSpecs('Anthropic', 'api_key')).toHaveLength(4);
     });
 
-    it('returns empty for unknown providers + missing input', () => {
-      expect(getProviderParamSpecs('openai')).toEqual([]);
-      expect(getProviderParamSpecs(undefined)).toEqual([]);
-      expect(getProviderParamSpecs('')).toEqual([]);
+    it('returns empty for unknown providers, missing input, and auth types with no entry', () => {
+      expect(getProviderParamSpecs('openai', 'api_key')).toEqual([]);
+      expect(getProviderParamSpecs('deepseek', 'subscription')).toEqual([]);
+      expect(getProviderParamSpecs('anthropic', 'subscription')).toEqual([]);
+      expect(getProviderParamSpecs(undefined, 'api_key')).toEqual([]);
+      expect(getProviderParamSpecs('deepseek', undefined)).toEqual([]);
+      expect(getProviderParamSpecs('', 'api_key')).toEqual([]);
     });
 
     it('returns empty for object prototype keys', () => {
-      expect(getProviderParamSpecs('__proto__')).toEqual([]);
-      expect(getProviderParamSpecs('constructor')).toEqual([]);
-    });
-  });
-
-  describe('providerSupportsParam', () => {
-    it('is true for declared (provider, key) pairs', () => {
-      expect(providerSupportsParam('deepseek', 'thinking')).toBe(true);
+      expect(getProviderParamSpecs('__proto__', 'api_key')).toEqual([]);
+      expect(getProviderParamSpecs('constructor', 'api_key')).toEqual([]);
     });
 
-    it('is false for providers whose spec does not declare the key', () => {
-      expect(providerSupportsParam('openai', 'thinking')).toBe(false);
-      expect(providerSupportsParam(undefined, 'thinking')).toBe(false);
-    });
-  });
+    it('uses a model override wholesale when one is declared', () => {
+      PROVIDER_PARAM_SPECS['unit:api_key'] = {
+        base: [
+          {
+            key: 'temperature',
+            control: { kind: 'slider', label: 'Temperature', min: 0, max: 2, default: 1 },
+          },
+        ],
+        byModel: {
+          'unit/special:model': [
+            {
+              key: 'reasoning_effort',
+              control: {
+                kind: 'select',
+                label: 'Reasoning effort',
+                values: ['low', 'medium', 'high'],
+                default: 'medium',
+              },
+            },
+          ],
+        },
+      };
 
-  describe('providerParamDefault', () => {
-    it('returns the control.default of the matching entry', () => {
-      expect(providerParamDefault('deepseek', 'thinking')).toBe('enabled');
-    });
-
-    it('returns undefined when the provider/key pair is not in the spec', () => {
-      expect(providerParamDefault('openai', 'thinking')).toBeUndefined();
-      expect(providerParamDefault(undefined, 'thinking')).toBeUndefined();
+      expect(
+        getProviderParamSpecs('unit', 'api_key', 'unit/special:model').map((s) => s.key),
+      ).toEqual(['reasoning_effort']);
+      expect(getProviderParamSpecs('unit', 'api_key', 'other-model').map((s) => s.key)).toEqual([
+        'temperature',
+      ]);
     });
   });
 
   describe('pickProviderCompatibleParams', () => {
     it('keeps keys the provider consumes', () => {
       expect(
-        pickProviderCompatibleParams('deepseek', { thinking: { type: 'disabled' } }),
-      ).toEqual({ thinking: { type: 'disabled' } });
+        pickProviderCompatibleParams('deepseek', 'api_key', 'deepseek-v4', {
+          thinking: 'disabled',
+        }),
+      ).toEqual({ thinking: 'disabled' });
+      expect(
+        pickProviderCompatibleParams('anthropic', 'api_key', 'claude-sonnet-4-6', {
+          max_tokens: 2048,
+          temperature: 0.4,
+          top_p: 0.8,
+          top_k: 40,
+          thinking: { type: 'enabled', budget_tokens: 1024 },
+        }),
+      ).toEqual({ max_tokens: 2048, temperature: 0.4, top_p: 0.8, top_k: 40 });
     });
 
-    it('drops keys the provider does not consume (e.g. thinking on OpenAI)', () => {
-      // Cast through unknown: the input shape is wider than the curated
-      // RequestParamDefaults at runtime — callers may hand us a stale blob
-      // and the function must trim it, not trust the static type.
+    it('drops keys the provider/auth/model route does not consume', () => {
       expect(
-        pickProviderCompatibleParams('openai', { thinking: { type: 'disabled' } }),
+        pickProviderCompatibleParams('openai', 'api_key', 'gpt-4o', {
+          thinking: 'disabled',
+        }),
+      ).toEqual({});
+      expect(
+        pickProviderCompatibleParams('deepseek', 'subscription', 'deepseek-v4', {
+          thinking: 'disabled',
+        }),
+      ).toEqual({});
+      expect(
+        pickProviderCompatibleParams('anthropic', 'subscription', 'claude-sonnet-4-6', {
+          temperature: 0.4,
+        }),
       ).toEqual({});
     });
 
     it('returns an empty object when the input has no keys at all', () => {
-      expect(pickProviderCompatibleParams('deepseek', {})).toEqual({});
+      expect(pickProviderCompatibleParams('deepseek', 'api_key', 'deepseek-v4', {})).toEqual({});
     });
 
     it('handles undefined provider + missing keys without crashing', () => {
-      expect(pickProviderCompatibleParams(undefined, { thinking: { type: 'enabled' } })).toEqual(
-        {},
-      );
+      expect(
+        pickProviderCompatibleParams(undefined, 'api_key', 'deepseek-v4', {
+          thinking: 'enabled',
+        }),
+      ).toEqual({});
     });
 
     it('does not mutate the input', () => {
-      const input = { thinking: { type: 'enabled' as const } };
-      const out = pickProviderCompatibleParams('deepseek', input);
+      const input = { thinking: 'enabled' };
+      const out = pickProviderCompatibleParams('deepseek', 'api_key', 'deepseek-v4', input);
       expect(out).not.toBe(input);
-      expect(input.thinking).toEqual({ type: 'enabled' });
+      expect(input.thinking).toEqual('enabled');
     });
   });
 });

--- a/packages/shared/__tests__/provider-params-spec.spec.ts
+++ b/packages/shared/__tests__/provider-params-spec.spec.ts
@@ -1,180 +1,155 @@
 import {
-  PROVIDER_PARAM_SPECS,
   getProviderParamSpecs,
   pickProviderCompatibleParams,
+  type ProviderParamSpecRegistry,
 } from '../src/provider-params-spec';
 
+const registry: ProviderParamSpecRegistry = {
+  'anthropic:api_key': {
+    base: [
+      {
+        key: 'max_tokens',
+        control: { kind: 'number', label: 'Max tokens', min: 1, default: 4096 },
+      },
+      {
+        key: 'temperature',
+        control: { kind: 'slider', label: 'Temperature', min: 0, max: 1, step: 0.1, default: 1 },
+      },
+      {
+        key: 'top_p',
+        control: { kind: 'slider', label: 'Top P', min: 0, max: 1, step: 0.01, default: 1 },
+      },
+      {
+        key: 'top_k',
+        control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+      },
+    ],
+  },
+  'deepseek:api_key': {
+    base: [
+      {
+        key: 'thinking',
+        control: {
+          kind: 'toggle',
+          label: 'Thinking mode',
+          values: ['enabled', 'disabled'],
+          default: 'enabled',
+        },
+      },
+    ],
+  },
+};
+
 describe('provider-params-spec', () => {
-  afterEach(() => {
-    delete PROVIDER_PARAM_SPECS['unit:api_key'];
-  });
-
-  describe('PROVIDER_PARAM_SPECS registry', () => {
-    it('declares Anthropic API-key scalar generation params with control shapes + defaults', () => {
-      const group = PROVIDER_PARAM_SPECS['anthropic:api_key'];
-      expect(group).toBeDefined();
-      expect(group.base.map((s) => [s.key, s.control])).toEqual([
-        [
-          'max_tokens',
-          {
-            kind: 'number',
-            label: 'Max tokens',
-            min: 1,
-            default: 4096,
-          },
-        ],
-        [
-          'temperature',
-          {
-            kind: 'slider',
-            label: 'Temperature',
-            min: 0,
-            max: 1,
-            step: 0.1,
-            default: 1,
-          },
-        ],
-        [
-          'top_p',
-          {
-            kind: 'slider',
-            label: 'Top P',
-            min: 0,
-            max: 1,
-            step: 0.01,
-            default: 1,
-          },
-        ],
-        [
-          'top_k',
-          {
-            kind: 'number',
-            label: 'Top K',
-            min: 0,
-            default: 0,
-          },
-        ],
-      ]);
-    });
-
-    it('declares DeepSeek thinking with the right control shape + default', () => {
-      const group = PROVIDER_PARAM_SPECS['deepseek:api_key'];
-      expect(group).toBeDefined();
-      expect(group.base).toHaveLength(1);
-      expect(group.base[0].key).toBe('thinking');
-      expect(group.base[0].control).toEqual({
-        kind: 'toggle',
-        label: 'Thinking mode',
-        values: ['enabled', 'disabled'],
-        default: 'enabled',
-      });
-    });
-  });
-
   describe('getProviderParamSpecs', () => {
     it('returns the provider entries case-insensitively', () => {
-      expect(getProviderParamSpecs('deepseek', 'api_key')).toHaveLength(1);
-      expect(getProviderParamSpecs('DeepSeek', 'api_key')).toHaveLength(1);
-      expect(getProviderParamSpecs('Anthropic', 'api_key')).toHaveLength(4);
+      expect(getProviderParamSpecs(registry, 'deepseek', 'api_key')).toHaveLength(1);
+      expect(getProviderParamSpecs(registry, 'DeepSeek', 'api_key')).toHaveLength(1);
+      expect(getProviderParamSpecs(registry, 'Anthropic', 'api_key')).toHaveLength(4);
     });
 
     it('returns empty for unknown providers, missing input, and auth types with no entry', () => {
-      expect(getProviderParamSpecs('openai', 'api_key')).toEqual([]);
-      expect(getProviderParamSpecs('deepseek', 'subscription')).toEqual([]);
-      expect(getProviderParamSpecs('anthropic', 'subscription')).toEqual([]);
-      expect(getProviderParamSpecs(undefined, 'api_key')).toEqual([]);
-      expect(getProviderParamSpecs('deepseek', undefined)).toEqual([]);
-      expect(getProviderParamSpecs('', 'api_key')).toEqual([]);
+      expect(getProviderParamSpecs(registry, 'openai', 'api_key')).toEqual([]);
+      expect(getProviderParamSpecs(registry, 'deepseek', 'subscription')).toEqual([]);
+      expect(getProviderParamSpecs(registry, 'anthropic', 'subscription')).toEqual([]);
+      expect(getProviderParamSpecs(registry, undefined, 'api_key')).toEqual([]);
+      expect(getProviderParamSpecs(registry, 'deepseek', undefined)).toEqual([]);
+      expect(getProviderParamSpecs(registry, '', 'api_key')).toEqual([]);
     });
 
     it('returns empty for object prototype keys', () => {
-      expect(getProviderParamSpecs('__proto__', 'api_key')).toEqual([]);
-      expect(getProviderParamSpecs('constructor', 'api_key')).toEqual([]);
+      expect(getProviderParamSpecs(registry, '__proto__', 'api_key')).toEqual([]);
+      expect(getProviderParamSpecs(registry, 'constructor', 'api_key')).toEqual([]);
     });
 
     it('uses a model override wholesale when one is declared', () => {
-      PROVIDER_PARAM_SPECS['unit:api_key'] = {
-        base: [
-          {
-            key: 'temperature',
-            control: { kind: 'slider', label: 'Temperature', min: 0, max: 2, default: 1 },
-          },
-        ],
-        byModel: {
-          'unit/special:model': [
+      const localRegistry: ProviderParamSpecRegistry = {
+        'unit:api_key': {
+          base: [
             {
-              key: 'reasoning_effort',
-              control: {
-                kind: 'select',
-                label: 'Reasoning effort',
-                values: ['low', 'medium', 'high'],
-                default: 'medium',
-              },
+              key: 'temperature',
+              control: { kind: 'slider', label: 'Temperature', min: 0, max: 2, default: 1 },
             },
           ],
+          byModel: {
+            'unit/special:model': [
+              {
+                key: 'reasoning_effort',
+                control: {
+                  kind: 'select',
+                  label: 'Reasoning effort',
+                  values: ['low', 'medium', 'high'],
+                  default: 'medium',
+                },
+              },
+            ],
+          },
         },
       };
 
       expect(
-        getProviderParamSpecs('unit', 'api_key', 'unit/special:model').map((s) => s.key),
+        getProviderParamSpecs(localRegistry, 'unit', 'api_key', 'unit/special:model').map(
+          (s) => s.key,
+        ),
       ).toEqual(['reasoning_effort']);
-      expect(getProviderParamSpecs('unit', 'api_key', 'other-model').map((s) => s.key)).toEqual([
-        'temperature',
-      ]);
+      expect(
+        getProviderParamSpecs(localRegistry, 'unit', 'api_key', 'other-model').map((s) => s.key),
+      ).toEqual(['temperature']);
     });
   });
 
   describe('pickProviderCompatibleParams', () => {
-    it('keeps keys the provider consumes', () => {
+    it('keeps keys the specs consume', () => {
       expect(
-        pickProviderCompatibleParams('deepseek', 'api_key', 'deepseek-v4', {
-          thinking: 'disabled',
-        }),
+        pickProviderCompatibleParams(
+          { thinking: 'disabled' },
+          getProviderParamSpecs(registry, 'deepseek', 'api_key', 'deepseek-v4'),
+        ),
       ).toEqual({ thinking: 'disabled' });
       expect(
-        pickProviderCompatibleParams('anthropic', 'api_key', 'claude-sonnet-4-6', {
-          max_tokens: 2048,
-          temperature: 0.4,
-          top_p: 0.8,
-          top_k: 40,
-          thinking: { type: 'enabled', budget_tokens: 1024 },
-        }),
+        pickProviderCompatibleParams(
+          {
+            max_tokens: 2048,
+            temperature: 0.4,
+            top_p: 0.8,
+            top_k: 40,
+            thinking: { type: 'enabled', budget_tokens: 1024 },
+          },
+          getProviderParamSpecs(registry, 'anthropic', 'api_key', 'claude-sonnet-4-6'),
+        ),
       ).toEqual({ max_tokens: 2048, temperature: 0.4, top_p: 0.8, top_k: 40 });
     });
 
-    it('drops keys the provider/auth/model route does not consume', () => {
+    it('drops keys the specs do not consume', () => {
       expect(
-        pickProviderCompatibleParams('openai', 'api_key', 'gpt-4o', {
-          thinking: 'disabled',
-        }),
+        pickProviderCompatibleParams(
+          { thinking: 'disabled' },
+          getProviderParamSpecs(registry, 'openai', 'api_key', 'gpt-4o'),
+        ),
       ).toEqual({});
       expect(
-        pickProviderCompatibleParams('deepseek', 'subscription', 'deepseek-v4', {
-          thinking: 'disabled',
-        }),
-      ).toEqual({});
-      expect(
-        pickProviderCompatibleParams('anthropic', 'subscription', 'claude-sonnet-4-6', {
-          temperature: 0.4,
-        }),
+        pickProviderCompatibleParams(
+          { temperature: 0.4 },
+          getProviderParamSpecs(registry, 'anthropic', 'subscription', 'claude-sonnet-4-6'),
+        ),
       ).toEqual({});
     });
 
     it('returns an empty object when the input has no keys at all', () => {
-      expect(pickProviderCompatibleParams('deepseek', 'api_key', 'deepseek-v4', {})).toEqual({});
-    });
-
-    it('handles undefined provider + missing keys without crashing', () => {
       expect(
-        pickProviderCompatibleParams(undefined, 'api_key', 'deepseek-v4', {
-          thinking: 'enabled',
-        }),
+        pickProviderCompatibleParams(
+          {},
+          getProviderParamSpecs(registry, 'deepseek', 'api_key', 'deepseek-v4'),
+        ),
       ).toEqual({});
     });
 
     it('does not mutate the input', () => {
       const input = { thinking: 'enabled' };
-      const out = pickProviderCompatibleParams('deepseek', 'api_key', 'deepseek-v4', input);
+      const out = pickProviderCompatibleParams(
+        input,
+        getProviderParamSpecs(registry, 'deepseek', 'api_key', 'deepseek-v4'),
+      );
       expect(out).not.toBe(input);
       expect(input.thinking).toEqual('enabled');
     });

--- a/packages/shared/__tests__/request-params-snapshot.spec.ts
+++ b/packages/shared/__tests__/request-params-snapshot.spec.ts
@@ -1,41 +1,33 @@
 import { snapshotRequestParams } from '../src/request-params-snapshot';
+import type { ProviderParamSpec } from '../src/provider-params-spec';
+
+const thinkingSpec: ProviderParamSpec = {
+  key: 'thinking',
+  control: {
+    kind: 'toggle',
+    label: 'Thinking mode',
+    values: ['enabled', 'disabled'],
+    default: 'enabled',
+  },
+};
 
 describe('snapshotRequestParams', () => {
-  it('returns null when the provider has no known param keys (e.g. OpenAI)', () => {
+  it('returns null when the route has no known param specs', () => {
     expect(
       snapshotRequestParams({
         body: { messages: [] },
         modelParams: null,
-        provider: 'openai',
-        authType: 'api_key',
-        model: 'gpt-4o',
-      }),
-    ).toBeNull();
-  });
-
-  it('returns null when the provider supports params under a different auth type', () => {
-    expect(
-      snapshotRequestParams({
-        body: { messages: [] },
-        modelParams: null,
-        provider: 'deepseek',
-        authType: 'subscription',
-        model: 'deepseek-v4',
+        specs: [],
       }),
     ).toBeNull();
   });
 
   it("falls back to the provider's own default for known keys when nothing was overridden", () => {
-    // DeepSeek defaults thinking to enabled. Neither the client nor any
-    // saved per-route config contributed a value, so the snapshot emits the
-    // provider's natural default — that's what the request actually had.
     expect(
       snapshotRequestParams({
         body: { messages: [] },
         modelParams: null,
-        provider: 'deepseek',
-        authType: 'api_key',
-        model: 'deepseek-v4',
+        specs: [thinkingSpec],
       }),
     ).toEqual({ thinking: 'enabled' });
   });
@@ -45,9 +37,7 @@ describe('snapshotRequestParams', () => {
       snapshotRequestParams({
         body: { messages: [] },
         modelParams: { thinking: 'disabled' },
-        provider: 'deepseek',
-        authType: 'api_key',
-        model: 'deepseek-v4',
+        specs: [thinkingSpec],
       }),
     ).toEqual({ thinking: 'disabled' });
   });
@@ -57,9 +47,7 @@ describe('snapshotRequestParams', () => {
       snapshotRequestParams({
         body: { thinking: 'enabled', messages: [] },
         modelParams: { thinking: 'disabled' },
-        provider: 'deepseek',
-        authType: 'api_key',
-        model: 'deepseek-v4',
+        specs: [thinkingSpec],
       }),
     ).toEqual({ thinking: 'enabled' });
   });
@@ -68,9 +56,7 @@ describe('snapshotRequestParams', () => {
     const result = snapshotRequestParams({
       body: { messages: [], temperature: 0.7, thinking: 'enabled' },
       modelParams: null,
-      provider: 'deepseek',
-      authType: 'api_key',
-      model: 'deepseek-v4',
+      specs: [thinkingSpec],
     });
     expect(result).toEqual({ thinking: 'enabled' });
     expect(Object.keys(result!)).not.toContain('temperature');

--- a/packages/shared/__tests__/request-params-snapshot.spec.ts
+++ b/packages/shared/__tests__/request-params-snapshot.spec.ts
@@ -7,6 +7,20 @@ describe('snapshotRequestParams', () => {
         body: { messages: [] },
         modelParams: null,
         provider: 'openai',
+        authType: 'api_key',
+        model: 'gpt-4o',
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null when the provider supports params under a different auth type', () => {
+    expect(
+      snapshotRequestParams({
+        body: { messages: [] },
+        modelParams: null,
+        provider: 'deepseek',
+        authType: 'subscription',
+        model: 'deepseek-v4',
       }),
     ).toBeNull();
   });
@@ -20,37 +34,45 @@ describe('snapshotRequestParams', () => {
         body: { messages: [] },
         modelParams: null,
         provider: 'deepseek',
+        authType: 'api_key',
+        model: 'deepseek-v4',
       }),
-    ).toEqual({ thinking: { type: 'enabled' } });
+    ).toEqual({ thinking: 'enabled' });
   });
 
   it("records the user's saved per-route override when present", () => {
     expect(
       snapshotRequestParams({
         body: { messages: [] },
-        modelParams: { thinking: { type: 'disabled' } },
+        modelParams: { thinking: 'disabled' },
         provider: 'deepseek',
+        authType: 'api_key',
+        model: 'deepseek-v4',
       }),
-    ).toEqual({ thinking: { type: 'disabled' } });
+    ).toEqual({ thinking: 'disabled' });
   });
 
   it("client body wins by presence over saved per-route params", () => {
     expect(
       snapshotRequestParams({
-        body: { thinking: { type: 'enabled' }, messages: [] },
-        modelParams: { thinking: { type: 'disabled' } },
+        body: { thinking: 'enabled', messages: [] },
+        modelParams: { thinking: 'disabled' },
         provider: 'deepseek',
+        authType: 'api_key',
+        model: 'deepseek-v4',
       }),
-    ).toEqual({ thinking: { type: 'enabled' } });
+    ).toEqual({ thinking: 'enabled' });
   });
 
-  it('only emits keys from REQUEST_PARAM_KEYS — extraneous body fields stay out of the snapshot', () => {
+  it('only emits keys from the route specs — extraneous body fields stay out of the snapshot', () => {
     const result = snapshotRequestParams({
-      body: { messages: [], temperature: 0.7, thinking: { type: 'enabled' } },
+      body: { messages: [], temperature: 0.7, thinking: 'enabled' },
       modelParams: null,
       provider: 'deepseek',
+      authType: 'api_key',
+      model: 'deepseek-v4',
     });
-    expect(result).toEqual({ thinking: { type: 'enabled' } });
+    expect(result).toEqual({ thinking: 'enabled' });
     expect(Object.keys(result!)).not.toContain('temperature');
     expect(Object.keys(result!)).not.toContain('messages');
   });

--- a/packages/shared/__tests__/request-params-snapshot.spec.ts
+++ b/packages/shared/__tests__/request-params-snapshot.spec.ts
@@ -11,6 +11,45 @@ const thinkingSpec: ProviderParamSpec = {
   },
 };
 
+const anthropicThinkingSpecs: ProviderParamSpec[] = [
+  {
+    key: 'top_p',
+    control: { kind: 'slider', label: 'Top P', min: 0, max: 1, step: 0.01, default: 1 },
+    dependencies: [
+      {
+        effect: 'omit',
+        when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+      },
+    ],
+  },
+  {
+    key: 'top_k',
+    control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+    dependencies: [
+      {
+        effect: 'omit',
+        when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+      },
+    ],
+  },
+  {
+    key: 'type',
+    group: { key: 'thinking', label: 'Thinking' },
+    control: {
+      kind: 'select',
+      label: 'Thinking mode',
+      values: ['disabled', 'adaptive', 'enabled'],
+      default: 'disabled',
+    },
+  },
+  {
+    key: 'budget_tokens',
+    group: { key: 'thinking', label: 'Thinking' },
+    visibleWhen: { key: 'type', equals: 'enabled' },
+    control: { kind: 'number', label: 'Budget tokens', min: 1024, default: 4096 },
+  },
+];
+
 describe('snapshotRequestParams', () => {
   it('returns null when the route has no known param specs', () => {
     expect(
@@ -42,7 +81,7 @@ describe('snapshotRequestParams', () => {
     ).toEqual({ thinking: 'disabled' });
   });
 
-  it("client body wins by presence over saved per-route params", () => {
+  it('client body wins by presence over saved per-route params', () => {
     expect(
       snapshotRequestParams({
         body: { thinking: 'enabled', messages: [] },
@@ -61,5 +100,35 @@ describe('snapshotRequestParams', () => {
     expect(result).toEqual({ thinking: 'enabled' });
     expect(Object.keys(result!)).not.toContain('temperature');
     expect(Object.keys(result!)).not.toContain('messages');
+  });
+
+  it('records grouped params under the group storage key', () => {
+    expect(
+      snapshotRequestParams({
+        body: { messages: [] },
+        modelParams: { thinking: { type: 'enabled', budget_tokens: 8192 } },
+        specs: anthropicThinkingSpecs,
+      }),
+    ).toEqual({ thinking: { type: 'enabled', budget_tokens: 8192 } });
+  });
+
+  it('uses visible grouped defaults when no grouped override exists', () => {
+    expect(
+      snapshotRequestParams({
+        body: { messages: [] },
+        modelParams: null,
+        specs: anthropicThinkingSpecs,
+      }),
+    ).toEqual({ top_p: 1, top_k: 0, thinking: { type: 'disabled' } });
+  });
+
+  it('omits snapshot params whose provider dependency is active', () => {
+    expect(
+      snapshotRequestParams({
+        body: { messages: [] },
+        modelParams: { top_p: 0.4, top_k: 3, thinking: { type: 'adaptive' } },
+        specs: anthropicThinkingSpecs,
+      }),
+    ).toEqual({ thinking: { type: 'adaptive' } });
   });
 });

--- a/packages/shared/__tests__/request-params.spec.ts
+++ b/packages/shared/__tests__/request-params.spec.ts
@@ -1,37 +1,97 @@
 import { applyRequestParamDefaults } from '../src/request-params';
+import { getProviderParamSpecs, type ProviderParamSpec } from '../src/provider-params-spec';
+
+const thinkingSpec: ProviderParamSpec = {
+  key: 'thinking',
+  control: {
+    kind: 'toggle',
+    label: 'Thinking mode',
+    values: ['enabled', 'disabled'],
+    default: 'enabled',
+  },
+};
+
+const budgetSpec: ProviderParamSpec = {
+  key: 'budget_tokens',
+  control: {
+    kind: 'number',
+    label: 'Budget tokens',
+    min: 1024,
+    default: 2048,
+  },
+  serialize: (v) => ({ thinking: { type: 'enabled', budget_tokens: v } }),
+};
 
 describe('applyRequestParamDefaults', () => {
   it('returns the body unchanged when defaults are null or undefined', () => {
     const body: Record<string, unknown> = { messages: [], stream: true };
-    expect(applyRequestParamDefaults(body, null)).toBe(body);
-    expect(applyRequestParamDefaults(body, undefined)).toBe(body);
+    expect(applyRequestParamDefaults(body, null, [thinkingSpec])).toBe(body);
+    expect(applyRequestParamDefaults(body, undefined, [thinkingSpec])).toBe(body);
   });
 
   it('injects configured defaults when the body has no value for that key', () => {
     const body: Record<string, unknown> = { messages: [] };
-    const merged = applyRequestParamDefaults(body, { thinking: { type: 'disabled' } });
-    expect(merged.thinking).toEqual({ type: 'disabled' });
+    const merged = applyRequestParamDefaults(body, { thinking: 'disabled' }, [thinkingSpec]);
+    expect(merged.thinking).toEqual('disabled');
     expect(merged.messages).toEqual([]);
+  });
+
+  it('uses the spec serializer when a default needs a non-flat wire shape', () => {
+    const body: Record<string, unknown> = { messages: [] };
+    const merged = applyRequestParamDefaults(body, { budget_tokens: 4096 }, [budgetSpec]);
+    expect(merged.thinking).toEqual({ type: 'enabled', budget_tokens: 4096 });
   });
 
   it('lets the request body win by presence — even when the value is null', () => {
     const body: Record<string, unknown> = { messages: [], thinking: null };
-    const merged = applyRequestParamDefaults(body, { thinking: { type: 'disabled' } });
+    const merged = applyRequestParamDefaults(body, { thinking: 'disabled' }, [thinkingSpec]);
     expect(merged.thinking).toBeNull();
   });
 
   it('lets the request body win when it sets a different value', () => {
-    const body: Record<string, unknown> = { messages: [], thinking: { type: 'enabled' } };
-    const merged = applyRequestParamDefaults(body, { thinking: { type: 'disabled' } });
-    expect(merged.thinking).toEqual({ type: 'enabled' });
+    const body: Record<string, unknown> = { messages: [], thinking: 'enabled' };
+    const merged = applyRequestParamDefaults(body, { thinking: 'disabled' }, [thinkingSpec]);
+    expect(merged.thinking).toEqual('enabled');
+  });
+
+  it('lets a request body field override a serialized default fragment', () => {
+    const body: Record<string, unknown> = {
+      messages: [],
+      thinking: { type: 'adaptive' },
+    };
+    const merged = applyRequestParamDefaults(body, { budget_tokens: 4096 }, [budgetSpec]);
+    expect(merged.thinking).toEqual({ type: 'adaptive' });
+  });
+
+  it('ignores defaults with no matching spec entry', () => {
+    const body: Record<string, unknown> = { messages: [] };
+    const merged = applyRequestParamDefaults(body, { temperature: 0.7 }, [thinkingSpec]);
+    expect(merged).toEqual({ messages: [] });
+  });
+
+  it('merges Anthropic API-key scalar defaults through the real registry specs', () => {
+    const body: Record<string, unknown> = { messages: [] };
+    const specs = getProviderParamSpecs('anthropic', 'api_key', 'claude-sonnet-4-6');
+    const merged = applyRequestParamDefaults(
+      body,
+      { max_tokens: 2048, temperature: 0.4, top_p: 0.8, top_k: 40 },
+      specs,
+    );
+    expect(merged).toEqual({
+      max_tokens: 2048,
+      temperature: 0.4,
+      top_p: 0.8,
+      top_k: 40,
+      messages: [],
+    });
   });
 
   it('does not mutate the inputs', () => {
     const body: Record<string, unknown> = { messages: [] };
-    const defaults = { thinking: { type: 'disabled' as const } };
-    const merged = applyRequestParamDefaults(body, defaults);
+    const defaults = { thinking: 'disabled' };
+    const merged = applyRequestParamDefaults(body, defaults, [thinkingSpec]);
     expect(body).toEqual({ messages: [] });
-    expect(defaults).toEqual({ thinking: { type: 'disabled' } });
+    expect(defaults).toEqual({ thinking: 'disabled' });
     expect(merged).not.toBe(body);
   });
 });

--- a/packages/shared/__tests__/request-params.spec.ts
+++ b/packages/shared/__tests__/request-params.spec.ts
@@ -1,4 +1,4 @@
-import { applyRequestParamDefaults } from '../src/request-params';
+import { applyRequestParamDefaults, type JsonValue } from '../src/request-params';
 import type { ProviderParamSpec } from '../src/provider-params-spec';
 
 const thinkingSpec: ProviderParamSpec = {
@@ -13,13 +13,22 @@ const thinkingSpec: ProviderParamSpec = {
 
 const budgetSpec: ProviderParamSpec = {
   key: 'budget_tokens',
+  group: {
+    key: 'thinking',
+    label: 'Thinking',
+    serialize: (v): Record<string, JsonValue> => {
+      if (!v || typeof v !== 'object' || Array.isArray(v)) return {};
+      const record = v as Record<string, unknown>;
+      if (record.type !== 'enabled' || typeof record.budget_tokens !== 'number') return {};
+      return { thinking: { type: 'enabled', budget_tokens: record.budget_tokens } };
+    },
+  },
   control: {
     kind: 'number',
     label: 'Budget tokens',
     min: 1024,
     default: 2048,
   },
-  serialize: (v) => ({ thinking: { type: 'enabled', budget_tokens: v } }),
 };
 
 describe('applyRequestParamDefaults', () => {
@@ -38,7 +47,11 @@ describe('applyRequestParamDefaults', () => {
 
   it('uses the spec serializer when a default needs a non-flat wire shape', () => {
     const body: Record<string, unknown> = { messages: [] };
-    const merged = applyRequestParamDefaults(body, { budget_tokens: 4096 }, [budgetSpec]);
+    const merged = applyRequestParamDefaults(
+      body,
+      { thinking: { type: 'enabled', budget_tokens: 4096 } },
+      [budgetSpec],
+    );
     expect(merged.thinking).toEqual({ type: 'enabled', budget_tokens: 4096 });
   });
 
@@ -59,8 +72,90 @@ describe('applyRequestParamDefaults', () => {
       messages: [],
       thinking: { type: 'adaptive' },
     };
-    const merged = applyRequestParamDefaults(body, { budget_tokens: 4096 }, [budgetSpec]);
+    const merged = applyRequestParamDefaults(
+      body,
+      { thinking: { type: 'enabled', budget_tokens: 4096 } },
+      [budgetSpec],
+    );
     expect(merged.thinking).toEqual({ type: 'adaptive' });
+  });
+
+  it('serializes a grouped default only once when multiple specs share storage', () => {
+    const body: Record<string, unknown> = { messages: [] };
+    const typeSpec: ProviderParamSpec = {
+      key: 'type',
+      group: budgetSpec.group,
+      control: {
+        kind: 'select',
+        label: 'Thinking mode',
+        values: ['disabled', 'enabled'],
+        default: 'disabled',
+      },
+    };
+
+    const merged = applyRequestParamDefaults(
+      body,
+      { thinking: { type: 'enabled', budget_tokens: 4096 } },
+      [typeSpec, budgetSpec],
+    );
+
+    expect(merged).toEqual({
+      thinking: { type: 'enabled', budget_tokens: 4096 },
+      messages: [],
+    });
+  });
+
+  it('omits defaults that conflict with active provider dependencies', () => {
+    const body: Record<string, unknown> = { messages: [] };
+    const typeSpec: ProviderParamSpec = {
+      key: 'type',
+      group: {
+        key: 'thinking',
+        label: 'Thinking',
+        serialize: (v): Record<string, JsonValue> => {
+          if (!v || typeof v !== 'object' || Array.isArray(v)) return {};
+          const record = v as Record<string, unknown>;
+          return record.type === 'adaptive' ? { thinking: { type: 'adaptive' } } : {};
+        },
+      },
+      control: {
+        kind: 'select',
+        label: 'Thinking mode',
+        values: ['disabled', 'adaptive', 'enabled'],
+        default: 'disabled',
+      },
+    };
+    const topKSpec: ProviderParamSpec = {
+      key: 'top_k',
+      control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+      dependencies: [
+        {
+          effect: 'omit',
+          when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+        },
+      ],
+    };
+    const topPSpec: ProviderParamSpec = {
+      key: 'top_p',
+      control: { kind: 'slider', label: 'Top P', min: 0, max: 1, step: 0.01, default: 1 },
+      dependencies: [
+        {
+          effect: 'omit',
+          when: { key: 'thinking.type', values: ['adaptive', 'enabled'] },
+        },
+      ],
+    };
+
+    const merged = applyRequestParamDefaults(
+      body,
+      { top_k: 3, top_p: 0.4, thinking: { type: 'adaptive' } },
+      [topKSpec, topPSpec, typeSpec],
+    );
+
+    expect(merged).toEqual({
+      thinking: { type: 'adaptive' },
+      messages: [],
+    });
   });
 
   it('ignores defaults with no matching spec entry', () => {

--- a/packages/shared/__tests__/request-params.spec.ts
+++ b/packages/shared/__tests__/request-params.spec.ts
@@ -1,5 +1,5 @@
 import { applyRequestParamDefaults } from '../src/request-params';
-import { getProviderParamSpecs, type ProviderParamSpec } from '../src/provider-params-spec';
+import type { ProviderParamSpec } from '../src/provider-params-spec';
 
 const thinkingSpec: ProviderParamSpec = {
   key: 'thinking',
@@ -69,9 +69,26 @@ describe('applyRequestParamDefaults', () => {
     expect(merged).toEqual({ messages: [] });
   });
 
-  it('merges Anthropic API-key scalar defaults through the real registry specs', () => {
+  it('merges Anthropic API-key scalar defaults through resolved specs', () => {
     const body: Record<string, unknown> = { messages: [] };
-    const specs = getProviderParamSpecs('anthropic', 'api_key', 'claude-sonnet-4-6');
+    const specs: ProviderParamSpec[] = [
+      {
+        key: 'max_tokens',
+        control: { kind: 'number', label: 'Max tokens', min: 1, default: 4096 },
+      },
+      {
+        key: 'temperature',
+        control: { kind: 'slider', label: 'Temperature', min: 0, max: 1, step: 0.1, default: 1 },
+      },
+      {
+        key: 'top_p',
+        control: { kind: 'slider', label: 'Top P', min: 0, max: 1, step: 0.01, default: 1 },
+      },
+      {
+        key: 'top_k',
+        control: { kind: 'number', label: 'Top K', min: 0, default: 0 },
+      },
+    ];
     const merged = applyRequestParamDefaults(
       body,
       { max_tokens: 2048, temperature: 0.4, top_p: 0.8, top_k: 40 },

--- a/packages/shared/__tests__/thinking-defaults.spec.ts
+++ b/packages/shared/__tests__/thinking-defaults.spec.ts
@@ -1,18 +1,30 @@
 import { providerThinkingDefault } from '../src/thinking-defaults';
+import type { ProviderParamSpec } from '../src/provider-params-spec';
+
+const thinkingSpec: ProviderParamSpec = {
+  key: 'thinking',
+  control: {
+    kind: 'toggle',
+    label: 'Thinking mode',
+    values: ['enabled', 'disabled'],
+    default: 'enabled',
+  },
+};
 
 describe('providerThinkingDefault', () => {
-  it('returns the registered default for providers whose spec declares the thinking key', () => {
-    expect(providerThinkingDefault('deepseek', 'api_key')).toBe('enabled');
+  it('returns the default from specs that declare the thinking key', () => {
+    expect(providerThinkingDefault([thinkingSpec])).toBe('enabled');
   });
 
-  it('is case-insensitive on the provider id', () => {
-    expect(providerThinkingDefault('DeepSeek', 'api_key')).toBe('enabled');
-  });
-
-  it('returns undefined for routes whose spec has no thinking key', () => {
-    expect(providerThinkingDefault('openai', 'api_key')).toBeUndefined();
-    expect(providerThinkingDefault('deepseek', 'subscription')).toBeUndefined();
-    expect(providerThinkingDefault(undefined, 'api_key')).toBeUndefined();
-    expect(providerThinkingDefault('', 'api_key')).toBeUndefined();
+  it('returns undefined when no spec has a thinking key', () => {
+    expect(
+      providerThinkingDefault([
+        {
+          key: 'temperature',
+          control: { kind: 'slider', label: 'Temperature', min: 0, max: 1, default: 1 },
+        },
+      ]),
+    ).toBeUndefined();
+    expect(providerThinkingDefault([])).toBeUndefined();
   });
 });

--- a/packages/shared/__tests__/thinking-defaults.spec.ts
+++ b/packages/shared/__tests__/thinking-defaults.spec.ts
@@ -2,16 +2,17 @@ import { providerThinkingDefault } from '../src/thinking-defaults';
 
 describe('providerThinkingDefault', () => {
   it('returns the registered default for providers whose spec declares the thinking key', () => {
-    expect(providerThinkingDefault('deepseek')).toBe('enabled');
+    expect(providerThinkingDefault('deepseek', 'api_key')).toBe('enabled');
   });
 
   it('is case-insensitive on the provider id', () => {
-    expect(providerThinkingDefault('DeepSeek')).toBe('enabled');
+    expect(providerThinkingDefault('DeepSeek', 'api_key')).toBe('enabled');
   });
 
-  it('returns undefined for providers whose spec has no thinking key', () => {
-    expect(providerThinkingDefault('openai')).toBeUndefined();
-    expect(providerThinkingDefault(undefined)).toBeUndefined();
-    expect(providerThinkingDefault('')).toBeUndefined();
+  it('returns undefined for routes whose spec has no thinking key', () => {
+    expect(providerThinkingDefault('openai', 'api_key')).toBeUndefined();
+    expect(providerThinkingDefault('deepseek', 'subscription')).toBeUndefined();
+    expect(providerThinkingDefault(undefined, 'api_key')).toBeUndefined();
+    expect(providerThinkingDefault('', 'api_key')).toBeUndefined();
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -32,8 +32,8 @@ export {
   routeToLegacy,
 } from './model-route';
 export type { ModelRoute, LegacyOverrideTriple } from './model-route';
-export { applyRequestParamDefaults, REQUEST_PARAM_KEYS } from './request-params';
-export type { RequestParamDefaults, RequestParamKey } from './request-params';
+export { applyRequestParamDefaults } from './request-params';
+export type { JsonPrimitive, JsonValue, RequestParamDefaults } from './request-params';
 export { snapshotRequestParams } from './request-params-snapshot';
 export type { RequestParamsSnapshotInput } from './request-params-snapshot';
 export { providerThinkingDefault } from './thinking-defaults';
@@ -41,11 +41,13 @@ export type { ThinkingState } from './thinking-defaults';
 export {
   PROVIDER_PARAM_SPECS,
   getProviderParamSpecs,
-  providerParamDefault,
-  providerSupportsParam,
   pickProviderCompatibleParams,
 } from './provider-params-spec';
-export type { ParamControl, ProviderParamSpec } from './provider-params-spec';
+export type {
+  ParamControl,
+  ProviderParamSpec,
+  ProviderParamSpecGroup,
+} from './provider-params-spec';
 export { API_KEY_PREFIX } from './api-key';
 export {
   FALLBACK_KEY_DELIMITER,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -45,15 +45,12 @@ export {
 export type { ModelParamsRoutingScopeInput } from './model-params-scope';
 export { providerThinkingDefault } from './thinking-defaults';
 export type { ThinkingState } from './thinking-defaults';
-export {
-  PROVIDER_PARAM_SPECS,
-  getProviderParamSpecs,
-  pickProviderCompatibleParams,
-} from './provider-params-spec';
+export { getProviderParamSpecs, pickProviderCompatibleParams } from './provider-params-spec';
 export type {
   ParamControl,
   ProviderParamSpec,
   ProviderParamSpecGroup,
+  ProviderParamSpecRegistry,
 } from './provider-params-spec';
 export { API_KEY_PREFIX } from './api-key';
 export {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,13 @@ export { applyRequestParamDefaults } from './request-params';
 export type { JsonPrimitive, JsonValue, RequestParamDefaults } from './request-params';
 export { snapshotRequestParams } from './request-params-snapshot';
 export type { RequestParamsSnapshotInput } from './request-params-snapshot';
+export {
+  modelParamsScopeForTier,
+  modelParamsScopeForSpecificity,
+  modelParamsScopeForHeaderTier,
+  modelParamsScopeForRouting,
+} from './model-params-scope';
+export type { ModelParamsRoutingScopeInput } from './model-params-scope';
 export { providerThinkingDefault } from './thinking-defaults';
 export type { ThinkingState } from './thinking-defaults';
 export {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -45,9 +45,17 @@ export {
 export type { ModelParamsRoutingScopeInput } from './model-params-scope';
 export { providerThinkingDefault } from './thinking-defaults';
 export type { ThinkingState } from './thinking-defaults';
-export { getProviderParamSpecs, pickProviderCompatibleParams } from './provider-params-spec';
+export {
+  getProviderParamSpecs,
+  omitProviderIncompatibleParams,
+  pickProviderCompatibleParams,
+  providerParamHasEffect,
+  providerParamStorageKey,
+} from './provider-params-spec';
 export type {
   ParamControl,
+  ProviderParamDependency,
+  ProviderParamDependencyEffect,
   ProviderParamSpec,
   ProviderParamSpecGroup,
   ProviderParamSpecRegistry,

--- a/packages/shared/src/model-params-scope.ts
+++ b/packages/shared/src/model-params-scope.ts
@@ -1,0 +1,23 @@
+export function modelParamsScopeForTier(tier: string): string {
+  return `tier:${tier}`;
+}
+
+export function modelParamsScopeForSpecificity(category: string): string {
+  return `specificity:${category}`;
+}
+
+export function modelParamsScopeForHeaderTier(headerTierId: string): string {
+  return `header:${headerTierId}`;
+}
+
+export interface ModelParamsRoutingScopeInput {
+  tier: string;
+  specificityCategory?: string;
+  headerTierId?: string;
+}
+
+export function modelParamsScopeForRouting(input: ModelParamsRoutingScopeInput): string {
+  if (input.headerTierId) return modelParamsScopeForHeaderTier(input.headerTierId);
+  if (input.specificityCategory) return modelParamsScopeForSpecificity(input.specificityCategory);
+  return modelParamsScopeForTier(input.tier);
+}

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -1,113 +1,135 @@
-import type { RequestParamDefaults, RequestParamKey } from './request-params';
+import type { AuthType } from './auth-types';
+import type { JsonValue } from './request-params';
 
 /**
  * UI control shape for one configurable param. Drives the dialog render,
  * the server compatibility check, and the snapshot's natural-default
  * lookup from a single declaration.
  *
- * Today the only shape is `toggle` (two-state, e.g. DeepSeek's `thinking`).
- * When a graded knob lands (e.g. OpenAI's `reasoning_effort` with `low` /
- * `medium` / `high`), add a `select` variant here with a `values` array
- * and a `default`.
+ * Each variant maps directly to one dialog renderer. The registry is the
+ * only place a new provider param should need to declare its UI shape.
  */
-export type ParamControl = {
-  kind: 'toggle';
-  /** Human-readable row title rendered in the dialog (e.g. "Thinking mode"). */
-  label: string;
-  values: readonly [string, string];
-  default: string;
-};
+export type ParamControl =
+  | { kind: 'toggle'; label: string; values: readonly [string, string]; default: string }
+  | { kind: 'select'; label: string; values: readonly string[]; default: string }
+  | { kind: 'slider'; label: string; min: number; max: number; step?: number; default: number }
+  | { kind: 'number'; label: string; min?: number; max?: number; default: number };
 
 export interface ProviderParamSpec {
-  /** Key in the outbound request body (must be in `RequestParamDefaults`). */
-  key: RequestParamKey;
+  /** Storage key. Wire shape is `serialize(value)` when present, otherwise `{ [key]: value }`. */
+  key: string;
   /** How the dialog renders it + what the provider does without an override. */
   control: ParamControl;
+  /** Optional transform for provider wire shapes that are not flat request-body fields. */
+  serialize?: (v: JsonValue) => Record<string, JsonValue>;
+}
+
+export interface ProviderParamSpecGroup {
+  base: readonly ProviderParamSpec[];
+  byModel?: Readonly<Record<string, readonly ProviderParamSpec[]>>;
 }
 
 /**
- * Single source of truth: which provider consumes which request-body
- * params, with the UI shape + natural default. Adding a new provider/key
- * here is the only registry edit needed — the snapshot, the server
- * compatibility gate, and (over time) the dialog all read through here.
- *
- * Adding `reasoning_effort` for OpenAI when that ships would look like:
- *
- *   openai: [
- *     {
- *       key: 'reasoning_effort',
- *       control: { kind: 'select', values: ['low', 'medium', 'high'], default: 'medium' },
- *     },
- *   ],
- *
- * That single entry replaces what used to be three separate edits
- * (compatibility map, snapshot defaults map, controller gate branch).
+ * Single source of truth: which provider/auth route consumes which params,
+ * with UI shape, storage key, natural default, and optional wire serializer.
+ * Key format is `provider:authType`; model overrides replace `base`
+ * wholesale when present.
  */
-export const PROVIDER_PARAM_SPECS: Record<string, readonly ProviderParamSpec[]> = {
-  deepseek: [
-    {
-      key: 'thinking',
-      control: {
-        kind: 'toggle',
-        label: 'Thinking mode',
-        values: ['enabled', 'disabled'],
-        default: 'enabled',
+export const PROVIDER_PARAM_SPECS: Record<`${string}:${AuthType}`, ProviderParamSpecGroup> = {
+  'anthropic:api_key': {
+    base: [
+      {
+        key: 'max_tokens',
+        control: {
+          kind: 'number',
+          label: 'Max tokens',
+          min: 1,
+          default: 4096,
+        },
       },
-    },
-  ],
+      {
+        key: 'temperature',
+        control: {
+          kind: 'slider',
+          label: 'Temperature',
+          min: 0,
+          max: 1,
+          step: 0.1,
+          default: 1,
+        },
+      },
+      {
+        key: 'top_p',
+        control: {
+          kind: 'slider',
+          label: 'Top P',
+          min: 0,
+          max: 1,
+          step: 0.01,
+          default: 1,
+        },
+      },
+      {
+        key: 'top_k',
+        control: {
+          kind: 'number',
+          label: 'Top K',
+          min: 0,
+          default: 0,
+        },
+      },
+    ],
+  },
+  'deepseek:api_key': {
+    base: [
+      {
+        key: 'thinking',
+        control: {
+          kind: 'toggle',
+          label: 'Thinking mode',
+          values: ['enabled', 'disabled'],
+          default: 'enabled',
+        },
+      },
+    ],
+  },
 };
 
-/** All param specs for a provider, or empty when the provider has none. */
+/** All param specs for a provider/auth/model route, or empty when the route has none. */
 export function getProviderParamSpecs(
   providerId: string | undefined,
+  authType: AuthType | undefined,
+  model?: string | undefined,
 ): readonly ProviderParamSpec[] {
-  if (!providerId) return [];
-  const key = providerId.toLowerCase();
-  return Object.prototype.hasOwnProperty.call(PROVIDER_PARAM_SPECS, key)
-    ? PROVIDER_PARAM_SPECS[key]
-    : [];
-}
-
-/** True when the provider's spec declares this param key. */
-export function providerSupportsParam(
-  providerId: string | undefined,
-  key: RequestParamKey,
-): boolean {
-  return getProviderParamSpecs(providerId).some((s) => s.key === key);
+  if (!providerId || !authType) return [];
+  const groupKey = `${providerId.toLowerCase()}:${authType}` as `${string}:${AuthType}`;
+  const group = Object.prototype.hasOwnProperty.call(PROVIDER_PARAM_SPECS, groupKey)
+    ? PROVIDER_PARAM_SPECS[groupKey]
+    : undefined;
+  if (!group) return [];
+  if (model && group.byModel && Object.prototype.hasOwnProperty.call(group.byModel, model)) {
+    return group.byModel[model] ?? [];
+  }
+  return group.base;
 }
 
 /**
- * The provider's natural API default for this param (i.e. what happens if
- * the outbound body omits the field). Used by the snapshot to record what
- * a request "had" when neither the client nor the user configured anything.
- */
-export function providerParamDefault(
-  providerId: string | undefined,
-  key: RequestParamKey,
-): string | undefined {
-  const spec = getProviderParamSpecs(providerId).find((s) => s.key === key);
-  return spec?.control.default;
-}
-
-/**
- * Trim a `RequestParamDefaults` payload to only the keys the provider's
- * spec consumes. Centralized here so the server controller and any future
- * client-side preview share the same compatibility logic instead of each
- * restating which (provider, key) pairs are valid.
+ * Trim a params payload to only the storage keys the route's spec consumes.
+ * Centralized here so the server controller and any future client-side
+ * preview share the same compatibility logic.
  *
  * Returns the trimmed payload (may be empty) without mutating the input.
  */
 export function pickProviderCompatibleParams(
   providerId: string | undefined,
-  params: RequestParamDefaults,
-): RequestParamDefaults {
-  const supported = new Set(getProviderParamSpecs(providerId).map((s) => s.key));
-  const out: RequestParamDefaults = {};
+  authType: AuthType | undefined,
+  model: string | undefined,
+  params: Record<string, JsonValue>,
+): Record<string, JsonValue> {
+  const supported = new Set(getProviderParamSpecs(providerId, authType, model).map((s) => s.key));
+  const out: Record<string, JsonValue> = {};
   for (const key of supported) {
-    const value = (params as Record<string, unknown>)[key];
-    if (value !== undefined) {
-      (out as Record<string, unknown>)[key] = value;
-    }
+    if (key in params) out[key] = params[key];
   }
   return out;
 }

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -15,13 +15,38 @@ export type ParamControl =
   | { kind: 'slider'; label: string; min: number; max: number; step?: number; default: number }
   | { kind: 'number'; label: string; min?: number; max?: number; default: number };
 
+export type ProviderParamDependencyEffect = 'disable' | 'omit';
+
+export interface ProviderParamDependency {
+  effect: ProviderParamDependencyEffect;
+  when: {
+    /** Dot path through the draft/storage shape, e.g. `thinking.type`. */
+    key: string;
+    equals?: JsonValue;
+    values?: readonly JsonValue[];
+  };
+}
+
 export interface ProviderParamSpec {
-  /** Storage key. Wire shape is `serialize(value)` when present, otherwise `{ [key]: value }`. */
+  /** Param key within its storage object. Ungrouped specs also use this as their storage key. */
   key: string;
   /** How the dialog renders it + what the provider does without an override. */
   control: ParamControl;
   /** Optional transform for provider wire shapes that are not flat request-body fields. */
   serialize?: (v: JsonValue) => Record<string, JsonValue>;
+  /** Optional grouped storage. Grouped specs persist under `group.key`, not `key`. */
+  group?: {
+    key: string;
+    label: string;
+    serialize?: (v: JsonValue) => Record<string, JsonValue>;
+  };
+  /** Optional dependency used by the dialog to hide conditional controls. */
+  visibleWhen?: {
+    key: string;
+    equals: JsonValue;
+  };
+  /** Provider compatibility rules derived from other param values. */
+  dependencies?: readonly ProviderParamDependency[];
 }
 
 export interface ProviderParamSpecGroup {
@@ -52,6 +77,88 @@ export function getProviderParamSpecs(
   return group.base;
 }
 
+/** Top-level storage key consumed by a spec. */
+export function providerParamStorageKey(spec: ProviderParamSpec): string {
+  return spec.group?.key ?? spec.key;
+}
+
+export function providerParamHasEffect(
+  spec: ProviderParamSpec,
+  values: Record<string, unknown>,
+  effect: ProviderParamDependencyEffect,
+): boolean {
+  return (
+    spec.dependencies?.some(
+      (dependency) =>
+        dependency.effect === effect && providerParamDependencyMatches(dependency, values),
+    ) ?? false
+  );
+}
+
+export function omitProviderIncompatibleParams<T extends Record<string, unknown>>(
+  params: T,
+  specs: readonly ProviderParamSpec[],
+): T {
+  let out: Record<string, unknown> | null = null;
+
+  for (const spec of specs) {
+    const source = out ?? params;
+    if (!providerParamHasEffect(spec, source, 'omit')) continue;
+    out ??= { ...params };
+    omitProviderParam(out, spec);
+  }
+
+  return (out ?? params) as T;
+}
+
+function providerParamDependencyMatches(
+  dependency: ProviderParamDependency,
+  values: Record<string, unknown>,
+): boolean {
+  const actual = providerParamPathValue(values, dependency.when.key);
+  if (dependency.when.values) {
+    return dependency.when.values.some((expected) => jsonValuesEqual(actual, expected));
+  }
+  if ('equals' in dependency.when) return jsonValuesEqual(actual, dependency.when.equals);
+  return false;
+}
+
+function providerParamPathValue(values: Record<string, unknown>, path: string): unknown {
+  let current: unknown = values;
+  for (const segment of path.split('.')) {
+    if (!isRecord(current)) return undefined;
+    current = current[segment];
+  }
+  return current;
+}
+
+function omitProviderParam(params: Record<string, unknown>, spec: ProviderParamSpec): void {
+  if (!spec.group) {
+    delete params[spec.key];
+    return;
+  }
+
+  const existing = params[spec.group.key];
+  if (!isRecord(existing)) return;
+  const next = { ...existing };
+  delete next[spec.key];
+  if (Object.keys(next).length === 0) {
+    delete params[spec.group.key];
+  } else {
+    params[spec.group.key] = next;
+  }
+}
+
+function jsonValuesEqual(a: unknown, b: unknown): boolean {
+  if (typeof a === 'object' || typeof b === 'object')
+    return JSON.stringify(a) === JSON.stringify(b);
+  return a === b;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
  * Trim a params payload to only the storage keys the route's spec consumes.
  * Centralized here so the server controller and any future client-side
@@ -63,7 +170,7 @@ export function pickProviderCompatibleParams(
   params: Record<string, JsonValue>,
   specs: readonly ProviderParamSpec[],
 ): Record<string, JsonValue> {
-  const supported = new Set(specs.map((s) => s.key));
+  const supported = new Set(specs.map(providerParamStorageKey));
   const out: Record<string, JsonValue> = {};
   for (const key of supported) {
     if (key in params) out[key] = params[key];

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -29,82 +29,21 @@ export interface ProviderParamSpecGroup {
   byModel?: Readonly<Record<string, readonly ProviderParamSpec[]>>;
 }
 
-/**
- * Single source of truth: which provider/auth route consumes which params,
- * with UI shape, storage key, natural default, and optional wire serializer.
- * Key format is `provider:authType`; model overrides replace `base`
- * wholesale when present.
- */
-export const PROVIDER_PARAM_SPECS: Record<`${string}:${AuthType}`, ProviderParamSpecGroup> = {
-  'anthropic:api_key': {
-    base: [
-      {
-        key: 'max_tokens',
-        control: {
-          kind: 'number',
-          label: 'Max tokens',
-          min: 1,
-          default: 4096,
-        },
-      },
-      {
-        key: 'temperature',
-        control: {
-          kind: 'slider',
-          label: 'Temperature',
-          min: 0,
-          max: 1,
-          step: 0.1,
-          default: 1,
-        },
-      },
-      {
-        key: 'top_p',
-        control: {
-          kind: 'slider',
-          label: 'Top P',
-          min: 0,
-          max: 1,
-          step: 0.01,
-          default: 1,
-        },
-      },
-      {
-        key: 'top_k',
-        control: {
-          kind: 'number',
-          label: 'Top K',
-          min: 0,
-          default: 0,
-        },
-      },
-    ],
-  },
-  'deepseek:api_key': {
-    base: [
-      {
-        key: 'thinking',
-        control: {
-          kind: 'toggle',
-          label: 'Thinking mode',
-          values: ['enabled', 'disabled'],
-          default: 'enabled',
-        },
-      },
-    ],
-  },
-};
+export type ProviderParamSpecRegistry = Readonly<
+  Record<`${string}:${AuthType}`, ProviderParamSpecGroup>
+>;
 
 /** All param specs for a provider/auth/model route, or empty when the route has none. */
 export function getProviderParamSpecs(
+  registry: ProviderParamSpecRegistry,
   providerId: string | undefined,
   authType: AuthType | undefined,
   model?: string | undefined,
 ): readonly ProviderParamSpec[] {
   if (!providerId || !authType) return [];
   const groupKey = `${providerId.toLowerCase()}:${authType}` as `${string}:${AuthType}`;
-  const group = Object.prototype.hasOwnProperty.call(PROVIDER_PARAM_SPECS, groupKey)
-    ? PROVIDER_PARAM_SPECS[groupKey]
+  const group = Object.prototype.hasOwnProperty.call(registry, groupKey)
+    ? registry[groupKey]
     : undefined;
   if (!group) return [];
   if (model && group.byModel && Object.prototype.hasOwnProperty.call(group.byModel, model)) {
@@ -121,12 +60,10 @@ export function getProviderParamSpecs(
  * Returns the trimmed payload (may be empty) without mutating the input.
  */
 export function pickProviderCompatibleParams(
-  providerId: string | undefined,
-  authType: AuthType | undefined,
-  model: string | undefined,
   params: Record<string, JsonValue>,
+  specs: readonly ProviderParamSpec[],
 ): Record<string, JsonValue> {
-  const supported = new Set(getProviderParamSpecs(providerId, authType, model).map((s) => s.key));
+  const supported = new Set(specs.map((s) => s.key));
   const out: Record<string, JsonValue> = {};
   for (const key of supported) {
     if (key in params) out[key] = params[key];

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -102,8 +102,7 @@ export function omitProviderIncompatibleParams<T extends Record<string, unknown>
   let out: Record<string, unknown> | null = null;
 
   for (const spec of specs) {
-    const source = out ?? params;
-    if (!providerParamHasEffect(spec, source, 'omit')) continue;
+    if (!providerParamHasEffect(spec, params, 'omit')) continue;
     out ??= { ...params };
     omitProviderParam(out, spec);
   }

--- a/packages/shared/src/request-params-snapshot.ts
+++ b/packages/shared/src/request-params-snapshot.ts
@@ -1,4 +1,8 @@
-import type { ProviderParamSpec } from './provider-params-spec';
+import {
+  omitProviderIncompatibleParams,
+  providerParamStorageKey,
+  type ProviderParamSpec,
+} from './provider-params-spec';
 import type { JsonValue, RequestParamDefaults } from './request-params';
 
 /**
@@ -40,16 +44,43 @@ export function snapshotRequestParams(
 ): RequestParamDefaults | null {
   const { body, modelParams, specs } = input;
   const out: RequestParamDefaults = {};
+  const handledGroups = new Set<string>();
   for (const spec of specs) {
-    if (spec.key in body) {
-      out[spec.key] = body[spec.key] as JsonValue;
+    const storageKey = providerParamStorageKey(spec);
+    if (spec.group) {
+      if (handledGroups.has(storageKey)) continue;
+      handledGroups.add(storageKey);
+      if (storageKey in body) {
+        out[storageKey] = body[storageKey] as JsonValue;
+        continue;
+      }
+      if (modelParams && storageKey in modelParams) {
+        out[storageKey] = modelParams[storageKey];
+        continue;
+      }
+      out[storageKey] = groupDefault(specs, spec.group.key);
       continue;
     }
-    if (modelParams && spec.key in modelParams) {
-      out[spec.key] = modelParams[spec.key];
+    if (storageKey in body) {
+      out[storageKey] = body[storageKey] as JsonValue;
       continue;
     }
-    out[spec.key] = spec.control.default;
+    if (modelParams && storageKey in modelParams) {
+      out[storageKey] = modelParams[storageKey];
+      continue;
+    }
+    out[storageKey] = spec.control.default;
   }
-  return Object.keys(out).length > 0 ? out : null;
+  const effective = omitProviderIncompatibleParams(out, specs);
+  return Object.keys(effective).length > 0 ? effective : null;
+}
+
+function groupDefault(specs: readonly ProviderParamSpec[], groupKey: string): JsonValue {
+  const value: Record<string, JsonValue> = {};
+  for (const spec of specs) {
+    if (spec.group?.key !== groupKey) continue;
+    if (spec.visibleWhen && value[spec.visibleWhen.key] !== spec.visibleWhen.equals) continue;
+    value[spec.key] = spec.control.default;
+  }
+  return value;
 }

--- a/packages/shared/src/request-params-snapshot.ts
+++ b/packages/shared/src/request-params-snapshot.ts
@@ -1,31 +1,26 @@
-import {
-  REQUEST_PARAM_KEYS,
-  applyRequestParamDefaults,
-  type RequestParamDefaults,
-} from './request-params';
-import { providerThinkingDefault } from './thinking-defaults';
+import type { AuthType } from './auth-types';
+import { getProviderParamSpecs } from './provider-params-spec';
+import type { JsonValue, RequestParamDefaults } from './request-params';
 
 /**
  * The snapshot of which request body parameters were *effectively in play*
  * for a given proxy attempt — the union of:
  *
- * 1. Whatever known param keys the client sent in their body (top precedence
- *    by presence — including explicit `null`).
+ * 1. Whatever route-supported param keys the client sent in their body (top
+ *    precedence by presence — including explicit `null`).
  * 2. The user's stored params for this attempt's (provider, auth_type,
  *    model) tuple, looked up from the per-route `agent_model_params` table.
- * 3. The provider's natural API default (today: DeepSeek's `thinking`
- *    defaults to `enabled`) so a request where neither the client nor the
- *    user configured anything still records the truth of what the provider
- *    will actually do.
+ * 3. The provider/auth/model spec's natural UI default so a request where
+ *    neither the client nor the user configured anything still records the
+ *    effective value.
  *
  * Recorded per-message on `agent_messages.request_params` so the dashboard
  * can show "this request had thinking=disabled" alongside Request Headers
  * in the expanded row. Returns `null` when no known params are present —
  * the UI hides the accordion in that case to avoid noise.
  *
- * Forward-compatibility: append new param keys to `REQUEST_PARAM_KEYS` in
- * `request-params.ts` and add a per-key fallthrough in this function so
- * the snapshot records the provider's natural default for that key.
+ * Serializers are intentionally not involved: snapshots record UI/storage
+ * values, not provider wire shapes.
  */
 export interface RequestParamsSnapshotInput {
   /** The inbound (pre-merge) client request body. */
@@ -39,37 +34,28 @@ export interface RequestParamsSnapshotInput {
   modelParams: RequestParamDefaults | null | undefined;
   /** The provider that actually received (or will receive) the request. */
   provider: string;
+  /** Auth path used by this provider attempt. */
+  authType: AuthType;
+  /** Provider-normalized model id for this attempt. */
+  model: string;
 }
 
 export function snapshotRequestParams(
   input: RequestParamsSnapshotInput,
 ): RequestParamDefaults | null {
-  const { body, modelParams, provider } = input;
-
-  const merged = applyRequestParamDefaults(body, modelParams);
-
-  // Casting through `unknown` keeps TS honest about the runtime fact:
-  // we're filtering to keys we know are part of `RequestParamDefaults`.
-  // The result satisfies the interface even though the source `merged`
-  // body is wider.
-  const out: Record<string, unknown> = {};
-  for (const key of REQUEST_PARAM_KEYS) {
-    if (key in merged) {
-      out[key] = merged[key];
+  const { body, modelParams, provider, authType, model } = input;
+  const specs = getProviderParamSpecs(provider, authType, model);
+  const out: RequestParamDefaults = {};
+  for (const spec of specs) {
+    if (spec.key in body) {
+      out[spec.key] = body[spec.key] as JsonValue;
       continue;
     }
-    // No client value and no user config touched this key for this request,
-    // but the provider may still consume it with its own default value
-    // (DeepSeek's `thinking` defaults to enabled, for example). Record
-    // that effective state so the dashboard can answer "what did this
-    // specific request actually have?" without the user having to know
-    // the provider's silent defaults.
-    if (key === 'thinking') {
-      const providerDefault = providerThinkingDefault(provider);
-      if (providerDefault !== undefined) {
-        out.thinking = { type: providerDefault };
-      }
+    if (modelParams && spec.key in modelParams) {
+      out[spec.key] = modelParams[spec.key];
+      continue;
     }
+    out[spec.key] = spec.control.default;
   }
-  return Object.keys(out).length > 0 ? (out as unknown as RequestParamDefaults) : null;
+  return Object.keys(out).length > 0 ? out : null;
 }

--- a/packages/shared/src/request-params-snapshot.ts
+++ b/packages/shared/src/request-params-snapshot.ts
@@ -1,5 +1,4 @@
-import type { AuthType } from './auth-types';
-import { getProviderParamSpecs } from './provider-params-spec';
+import type { ProviderParamSpec } from './provider-params-spec';
 import type { JsonValue, RequestParamDefaults } from './request-params';
 
 /**
@@ -32,19 +31,14 @@ export interface RequestParamsSnapshotInput {
    * to be consumed by the attempt's provider.
    */
   modelParams: RequestParamDefaults | null | undefined;
-  /** The provider that actually received (or will receive) the request. */
-  provider: string;
-  /** Auth path used by this provider attempt. */
-  authType: AuthType;
-  /** Provider-normalized model id for this attempt. */
-  model: string;
+  /** The route-supported params for the provider/auth/model attempt. */
+  specs: readonly ProviderParamSpec[];
 }
 
 export function snapshotRequestParams(
   input: RequestParamsSnapshotInput,
 ): RequestParamDefaults | null {
-  const { body, modelParams, provider, authType, model } = input;
-  const specs = getProviderParamSpecs(provider, authType, model);
+  const { body, modelParams, specs } = input;
   const out: RequestParamDefaults = {};
   for (const spec of specs) {
     if (spec.key in body) {

--- a/packages/shared/src/request-params-snapshot.ts
+++ b/packages/shared/src/request-params-snapshot.ts
@@ -9,7 +9,7 @@ import type { JsonValue, RequestParamDefaults } from './request-params';
  * 1. Whatever route-supported param keys the client sent in their body (top
  *    precedence by presence — including explicit `null`).
  * 2. The user's stored params for this attempt's (provider, auth_type,
- *    model) tuple, looked up from the per-route `agent_model_params` table.
+ *    model) tuple, looked up from the scoped `agent_model_params` table.
  * 3. The provider/auth/model spec's natural UI default so a request where
  *    neither the client nor the user configured anything still records the
  *    effective value.
@@ -26,8 +26,8 @@ export interface RequestParamsSnapshotInput {
   /** The inbound (pre-merge) client request body. */
   body: Record<string, unknown>;
   /**
-   * Saved per-route params for the attempt's (provider, auth_type, model)
-   * tuple, or `null` when nothing is configured. Pre-filtered by the
+   * Saved per-route params for the attempt's scoped (provider, auth_type,
+   * model) tuple, or `null` when nothing is configured. Pre-filtered by the
    * controller's compatibility gate, so any keys present are already known
    * to be consumed by the attempt's provider.
    */

--- a/packages/shared/src/request-params.ts
+++ b/packages/shared/src/request-params.ts
@@ -1,9 +1,13 @@
-import type { ProviderParamSpec } from './provider-params-spec';
+import {
+  omitProviderIncompatibleParams,
+  providerParamStorageKey,
+  type ProviderParamSpec,
+} from './provider-params-spec';
 
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | unknown[] | Record<string, unknown>;
 
-/** Per-route UI/storage values keyed by `ProviderParamSpec.key`. */
+/** Per-route UI/storage values keyed by `ProviderParamSpec.key` or `ProviderParamSpec.group.key`. */
 export type RequestParamDefaults = Record<string, JsonValue>;
 
 /**
@@ -17,14 +21,25 @@ export function applyRequestParamDefaults<T extends Record<string, unknown>>(
   defaults: RequestParamDefaults | null | undefined,
   specs: readonly ProviderParamSpec[],
 ): T {
-  if (!defaults) return body;
+  if (!defaults) return omitProviderIncompatibleParams(body, specs);
   const merged: Record<string, JsonValue> = {};
+  const handledGroups = new Set<string>();
   for (const spec of specs) {
-    if (!(spec.key in defaults)) continue;
+    const storageKey = providerParamStorageKey(spec);
+    if (!(storageKey in defaults)) continue;
+    if (spec.group) {
+      if (handledGroups.has(storageKey)) continue;
+      handledGroups.add(storageKey);
+      const fragment = spec.group.serialize
+        ? spec.group.serialize(defaults[storageKey])
+        : { [storageKey]: defaults[storageKey] };
+      Object.assign(merged, fragment);
+      continue;
+    }
     const fragment = spec.serialize
-      ? spec.serialize(defaults[spec.key])
-      : { [spec.key]: defaults[spec.key] };
+      ? spec.serialize(defaults[storageKey])
+      : { [storageKey]: defaults[storageKey] };
     Object.assign(merged, fragment);
   }
-  return { ...merged, ...body } as T;
+  return omitProviderIncompatibleParams({ ...merged, ...body }, specs) as T;
 }

--- a/packages/shared/src/request-params.ts
+++ b/packages/shared/src/request-params.ts
@@ -1,39 +1,30 @@
-/**
- * Per-assignment defaults that get merged into the outbound request body
- * before it is sent to the LLM provider. Currently only `thinking` is
- * supported — DeepSeek's thinking-mode toggle. New provider knobs
- * (reasoning_effort, safety settings, etc.) get added here explicitly as
- * their UI lands, rather than as a free-form bag, so the surface stays
- * curated.
- *
- * Precedence is presence-based, not truthy: if the inbound request body
- * contains the key — even with `null` — the client wins. Otherwise the
- * configured default is injected. If neither is set, the provider's own
- * default applies.
- */
-export interface RequestParamDefaults {
-  thinking?: { type: 'enabled' | 'disabled' };
-}
+import type { ProviderParamSpec } from './provider-params-spec';
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | unknown[] | Record<string, unknown>;
+
+/** Per-route UI/storage values keyed by `ProviderParamSpec.key`. */
+export type RequestParamDefaults = Record<string, JsonValue>;
 
 /**
- * Merge configured defaults into a request body. Body keys win over
- * defaults by presence (not truthiness), so a client that explicitly sends
- * `{ thinking: null }` keeps that null.
+ * Merge configured defaults into a request body using the route's param
+ * specs. Storage stays as UI values; optional serializers run only here,
+ * at outbound merge time. Body keys win over defaults by presence because
+ * the final spread keeps the inbound body last.
  */
 export function applyRequestParamDefaults<T extends Record<string, unknown>>(
   body: T,
   defaults: RequestParamDefaults | null | undefined,
+  specs: readonly ProviderParamSpec[],
 ): T {
   if (!defaults) return body;
-  return { ...defaults, ...body } as T;
+  const merged: Record<string, JsonValue> = {};
+  for (const spec of specs) {
+    if (!(spec.key in defaults)) continue;
+    const fragment = spec.serialize
+      ? spec.serialize(defaults[spec.key])
+      : { [spec.key]: defaults[spec.key] };
+    Object.assign(merged, fragment);
+  }
+  return { ...merged, ...body } as T;
 }
-
-/**
- * Known top-level keys in `RequestParamDefaults`. Append here when adding a
- * new provider knob (`reasoning_effort`, `safety`, …) so the per-message
- * telemetry snapshot picks it up. Stays in sync with the interface above by
- * convention — adding a key without listing it here means the snapshot
- * silently drops it on the way to the dashboard.
- */
-export const REQUEST_PARAM_KEYS = ['thinking'] as const;
-export type RequestParamKey = (typeof REQUEST_PARAM_KEYS)[number];

--- a/packages/shared/src/thinking-defaults.ts
+++ b/packages/shared/src/thinking-defaults.ts
@@ -1,20 +1,24 @@
-import { providerParamDefault } from './provider-params-spec';
+import type { AuthType } from './auth-types';
+import { getProviderParamSpecs } from './provider-params-spec';
 
 /**
- * Two-state value for DeepSeek's `thinking.type` field. The wire shape is
- * curated in `RequestParamDefaults` (a discriminated `thinking: { type }`)
- * because OpenAI/Anthropic chat-completions don't share this knob — adding
- * a provider that consumes `thinking.type` is one entry in
- * `PROVIDER_PARAM_SPECS`, not a new wire schema.
+ * Two-state UI/storage value for DeepSeek's `thinking` field. Provider wire
+ * shapes are handled by `ProviderParamSpec.serialize` when needed.
  */
 export type ThinkingState = 'enabled' | 'disabled';
 
 /**
  * Thin alias preserved for callers that specifically want the thinking-key
- * default (dialog hint, snapshot fallback). Derives from
- * `PROVIDER_PARAM_SPECS` so adding a new provider that consumes `thinking`
- * is one entry in `provider-params-spec.ts`, not a parallel registry edit.
+ * default. Derives from `PROVIDER_PARAM_SPECS` so auth/model-specific
+ * behavior stays in the registry.
  */
-export function providerThinkingDefault(providerId: string | undefined): ThinkingState | undefined {
-  return providerParamDefault(providerId, 'thinking') as ThinkingState | undefined;
+export function providerThinkingDefault(
+  providerId: string | undefined,
+  authType: AuthType | undefined,
+  model?: string | undefined,
+): ThinkingState | undefined {
+  const value = getProviderParamSpecs(providerId, authType, model).find(
+    (spec) => spec.key === 'thinking',
+  )?.control.default;
+  return value === 'enabled' || value === 'disabled' ? value : undefined;
 }

--- a/packages/shared/src/thinking-defaults.ts
+++ b/packages/shared/src/thinking-defaults.ts
@@ -1,5 +1,4 @@
-import type { AuthType } from './auth-types';
-import { getProviderParamSpecs } from './provider-params-spec';
+import type { ProviderParamSpec } from './provider-params-spec';
 
 /**
  * Two-state UI/storage value for DeepSeek's `thinking` field. Provider wire
@@ -8,17 +7,12 @@ import { getProviderParamSpecs } from './provider-params-spec';
 export type ThinkingState = 'enabled' | 'disabled';
 
 /**
- * Thin alias preserved for callers that specifically want the thinking-key
- * default. Derives from `PROVIDER_PARAM_SPECS` so auth/model-specific
- * behavior stays in the registry.
+ * Thin alias for callers that specifically want the thinking-key default
+ * from already-resolved route specs.
  */
 export function providerThinkingDefault(
-  providerId: string | undefined,
-  authType: AuthType | undefined,
-  model?: string | undefined,
+  specs: readonly ProviderParamSpec[],
 ): ThinkingState | undefined {
-  const value = getProviderParamSpecs(providerId, authType, model).find(
-    (spec) => spec.key === 'thinking',
-  )?.control.default;
+  const value = specs.find((spec) => spec.key === 'thinking')?.control.default;
   return value === 'enabled' || value === 'disabled' ? value : undefined;
 }


### PR DESCRIPTION
## Summary
- Move provider/model param specs from the hardcoded shared registry into the `provider_param_specs` Postgres table, seeded by migration with Anthropic API-key params and the DeepSeek thinking toggle.
- Add a backend `ProviderParamSpecService` that loads rows, validates control shapes, resolves provider/auth/model overrides, and keeps a small TTL cache; serializers stay as backend-owned named keys, not dynamic DB code.
- Keep `manifest-shared` as pure types/helpers, wire controller/proxy/snapshot code through resolved specs, and expose `GET /api/v1/routing/:agentName/model-param-specs` so the Routing UI renders controls from DB-backed schema.
- Preserve scoped saved param values per routing surface (`tier:*`, `specificity:*`, `header:*`) and keep the dialog showing friendly labels plus raw param keys.

## Validation
- `npm run build --workspace=packages/shared`
- `cd packages/backend && npx tsc --noEmit`
- `cd packages/frontend && npx tsc --noEmit`
- `cd packages/shared && npx jest __tests__/provider-params-spec.spec.ts __tests__/request-params.spec.ts __tests__/request-params-snapshot.spec.ts __tests__/thinking-defaults.spec.ts`
- `cd packages/backend && npx jest src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts src/routing/routing-core/__tests__/agent-model-params.service.spec.ts src/routing/__tests__/model-params.controller.spec.ts src/routing/proxy/__tests__/proxy-fallback.service.spec.ts src/routing/proxy/__tests__/proxy.service.spec.ts src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts src/database/migrations/1789400000000-AddProviderParamSpecs.spec.ts`
- `cd packages/frontend && npx vitest run tests/services/api/model-params.test.ts tests/components/ModelParamsDialog.test.tsx tests/components/ModelParamsAffordance.test.tsx tests/components/FallbackList.test.tsx tests/components/HeaderTierCard.test.tsx tests/pages/RoutingTierCard.test.tsx tests/pages/Routing.test.tsx tests/pages/RoutingDefaultTierSection.test.tsx tests/pages/RoutingSpecificitySection.test.tsx tests/pages/RoutingHeaderTiersSection.test.tsx`
- `git diff --check` and `git diff --cached --check`
- Local app health check: `curl -fsS http://localhost:3001/api/v1/health`
- Local Postgres check: `provider_param_specs` contains the 5 seeded Anthropic/DeepSeek rows after migration

## Notes
Full backend Jest was not rerun for this final push; earlier local full backend Jest hit the unchanged `playground.service.spec.ts` `tokensPerSec` timing failure under Node v23.7.0. Changed backend/shared/frontend suites and typechecks pass.