### PR TITLE
fix: surface Anthropic OAuth rate limits

### DIFF
--- a/.changeset/fresh-lamps-smile.md
+++ b/.changeset/fresh-lamps-smile.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Surface Anthropic OAuth token exchange rate-limit errors instead of showing the generic expired-code message.

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts
@@ -1,6 +1,6 @@
-import { HttpException } from '@nestjs/common';
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { AnthropicOauthController } from './anthropic-oauth.controller';
-import { AnthropicOauthService } from './anthropic-oauth.service';
+import { AnthropicOauthExchangeError, AnthropicOauthService } from './anthropic-oauth.service';
 import { ResolveAgentService } from '../../routing-core/resolve-agent.service';
 import { ProviderService } from '../../routing-core/provider.service';
 
@@ -71,6 +71,21 @@ describe('AnthropicOauthController', () => {
       await expect(ctrl.exchange('agent', 'code', 'state', user)).rejects.toBeInstanceOf(
         HttpException,
       );
+    });
+
+    it('preserves rate-limit status from service errors', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.exchangeCode as jest.Mock).mockRejectedValue(
+        new AnthropicOauthExchangeError('Anthropic rate-limited the OAuth token exchange.', 429),
+      );
+
+      try {
+        await ctrl.exchange('agent', 'code', 'state', user);
+        throw new Error('Expected exchange to fail');
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpException);
+        expect((err as HttpException).getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
+      }
     });
 
     it('wraps non-Error throws with a generic message', async () => {

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.controller.ts
@@ -12,7 +12,7 @@ import { CurrentUser } from '../../../auth/current-user.decorator';
 import { AuthUser } from '../../../auth/auth.instance';
 import { ResolveAgentService } from '../../routing-core/resolve-agent.service';
 import { ProviderService } from '../../routing-core/provider.service';
-import { AnthropicOauthService } from './anthropic-oauth.service';
+import { AnthropicOauthExchangeError, AnthropicOauthService } from './anthropic-oauth.service';
 import { optionalTrimmedStringQuery } from '../query-params';
 
 @Controller('api/v1/oauth/anthropic')
@@ -64,7 +64,10 @@ export class AnthropicOauthController {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Token exchange failed';
       this.logger.error(`Anthropic OAuth exchange failed: ${message}`);
-      throw new HttpException(message, HttpStatus.BAD_REQUEST);
+      throw new HttpException(
+        message,
+        err instanceof AnthropicOauthExchangeError ? err.status : HttpStatus.BAD_REQUEST,
+      );
     }
   }
 

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -1,6 +1,10 @@
 import { ProviderService } from '../../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
-import { AnthropicOauthService, splitAnthropicAuthPayload } from './anthropic-oauth.service';
+import {
+  AnthropicOauthExchangeError,
+  AnthropicOauthService,
+  splitAnthropicAuthPayload,
+} from './anthropic-oauth.service';
 import { ANTHROPIC_OAUTH } from './anthropic-oauth.config';
 import {
   OAuthPendingFlowStore,
@@ -256,6 +260,24 @@ describe('AnthropicOauthService', () => {
       expect(logger.error).toHaveBeenCalledWith(
         expect.stringContaining('"stateMatchesCodeVerifier":true'),
       );
+    });
+
+    it('preserves Anthropic token endpoint rate limits as rate-limit errors', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(400, {
+          error: {
+            type: 'rate_limit_error',
+            message: 'Rate limited. Please try again later.',
+          },
+        }),
+      );
+      const { state } = await svc.generateAuthorizationUrl('a', 'u');
+
+      await expect(svc.exchangeCode(`bad#${state}`, undefined, 'a', 'u')).rejects.toMatchObject({
+        message:
+          'Anthropic rate-limited the OAuth token exchange. Please wait a minute, then sign in again.',
+        status: 429,
+      } satisfies Partial<AnthropicOauthExchangeError>);
     });
 
     it('falls back to state when the pending verifier is missing', async () => {

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { HttpStatus, Injectable, Logger } from '@nestjs/common';
 import { ProviderService } from '../../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../../common/utils/secret-scrub';
@@ -21,6 +21,16 @@ interface AnthropicTokenResponse {
   refresh_token?: string;
   expires_in: number;
   token_type?: string;
+}
+
+export class AnthropicOauthExchangeError extends Error {
+  constructor(
+    message: string,
+    readonly status: HttpStatus,
+  ) {
+    super(message);
+    this.name = 'AnthropicOauthExchangeError';
+  }
 }
 
 const PROVIDER = 'anthropic';
@@ -127,7 +137,7 @@ export class AnthropicOauthService {
           describeTokenExchangeRequest(tokenRequest),
         )}`,
       );
-      throw new Error('Token exchange failed');
+      throw anthropicTokenExchangeError(response.status, text);
     }
     const data = (await response.json()) as AnthropicTokenResponse;
     const blob: OAuthTokenBlob = {
@@ -232,6 +242,27 @@ export class AnthropicOauthService {
   async findPendingForAgent(agentId: string, userId: string): Promise<{ state: string } | null> {
     const pending = await this.pendingFlows.findLatestForAgent(PROVIDER, agentId, userId);
     return pending ? { state: pending.state } : null;
+  }
+}
+
+function anthropicTokenExchangeError(status: number, text: string): AnthropicOauthExchangeError {
+  const providerError = parseAnthropicProviderError(text);
+  if (status === HttpStatus.TOO_MANY_REQUESTS || providerError?.type === 'rate_limit_error') {
+    return new AnthropicOauthExchangeError(
+      'Anthropic rate-limited the OAuth token exchange. Please wait a minute, then sign in again.',
+      HttpStatus.TOO_MANY_REQUESTS,
+    );
+  }
+  return new AnthropicOauthExchangeError('Token exchange failed', HttpStatus.BAD_REQUEST);
+}
+
+function parseAnthropicProviderError(text: string): { type?: string } | null {
+  try {
+    const parsed = JSON.parse(text) as { error?: { type?: unknown } };
+    const type = parsed.error?.type;
+    return typeof type === 'string' ? { type } : null;
+  } catch {
+    return null;
   }
 }
 

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -118,8 +118,12 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
       await submitAnthropicOAuth(props.agentName, raw, authState);
       toast.success(`${props.provDef.name} subscription connected`);
       props.onUpdate();
-    } catch {
-      setError('Failed to exchange code. The code may have expired — sign in again to retry.');
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Failed to exchange code. The code may have expired — sign in again to retry.',
+      );
     } finally {
       props.setBusy(false);
     }

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -234,7 +234,7 @@ describe('AnthropicOAuthDetailView', () => {
     fireEvent.click(screen.getByText('Connect'));
 
     await waitFor(() => {
-      expect(screen.getByText(/Failed to exchange code/)).toBeDefined();
+      expect(screen.getByText('boom')).toBeDefined();
     });
   });
 

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -238,6 +238,28 @@ describe('AnthropicOAuthDetailView', () => {
     });
   });
 
+  it('shows the generic exchange error when the failure is not an Error object', async () => {
+    mockStartAnthropicOAuth.mockResolvedValue({ url: 'https://x', state: 's1' });
+    mockSubmitAnthropicOAuth.mockRejectedValue('boom');
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView();
+    fireEvent.click(screen.getByText('Sign in with Claude'));
+    await waitFor(() => expect(mockStartAnthropicOAuth).toHaveBeenCalled());
+
+    const codeInput = screen.getByLabelText('Anthropic authorization code');
+    fireEvent.input(codeInput, { target: { value: 'code#s1' } });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Failed to exchange code. The code may have expired — sign in again to retry.',
+        ),
+      ).toBeDefined();
+    });
+  });
+
   it('falls back gracefully when the pending lookup throws on mount', async () => {
     mockGetAnthropicOAuthPending.mockRejectedValue(new Error('network'));
     renderView();


### PR DESCRIPTION
## Summary

- Preserve Anthropic OAuth token-exchange rate-limit failures as HTTP 429 instead of collapsing them to a generic bad-request error.
- Surface the backend exchange error message in the Anthropic subscription UI so users see the rate-limit retry guidance.
- Add focused backend and frontend regression coverage.

## Validation

- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/backend -- src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts src/routing/oauth/anthropic/anthropic-oauth.controller.spec.ts`
- `npm test --workspace=packages/frontend -- AnthropicOAuthDetailView.test.tsx`
- `git diff --check`

## Notes

Split out of #1950 so the MPS refactor stays focused on model parameter schema and scoped saved values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Anthropic OAuth token-exchange rate limits as HTTP 429 and surfaces the provider’s guidance in the UI. This helps users retry correctly instead of seeing a generic expired-code error.

- **Bug Fixes**
  - Map both HTTP 429 and provider `rate_limit_error` bodies to 429 via `AnthropicOauthExchangeError`.
  - Controller forwards the service error status instead of collapsing to 400.
  - UI shows the backend error message in `AnthropicOAuthDetailView`, and falls back to a generic message for non-Error failures.
  - Added tests for 429 handling, message rendering, and the non-Error fallback path.

<sup>Written for commit a764018eefef7a7e3a049e3371b9f8d605522b9b. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1958?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

