### PR TITLE
fix: preserve provider labels when duplicating agents

### DIFF
--- a/.changeset/fix-duplicate-agent-provider-labels.md
+++ b/.changeset/fix-duplicate-agent-provider-labels.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Preserve provider key labels and priorities when duplicating agents.

--- a/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.spec.ts
@@ -230,6 +230,8 @@ describe('AgentDuplicationService', () => {
             api_key_encrypted: 'enc',
             key_prefix: 'sk-',
             auth_type: 'api_key',
+            label: 'Research key',
+            priority: 2,
             region: null,
             is_active: true,
             cached_models: [{ id: 'm' }],
@@ -332,6 +334,8 @@ describe('AgentDuplicationService', () => {
       const userProviderRow = (insertedRows['UserProvider'] as Array<Record<string, unknown>>)[0];
       expect(userProviderRow['agent_id']).toBe(agentRow['id']);
       expect(userProviderRow['api_key_encrypted']).toBe('enc');
+      expect(userProviderRow['label']).toBe('Research key');
+      expect(userProviderRow['priority']).toBe(2);
       expect(userProviderRow['id']).not.toBe('up1');
 
       // Per-route model params travel with the agent. The deepseek row

--- a/packages/backend/src/analytics/services/agent-duplication.service.ts
+++ b/packages/backend/src/analytics/services/agent-duplication.service.ts
@@ -178,6 +178,8 @@ export class AgentDuplicationService {
             api_key_encrypted: p.api_key_encrypted,
             key_prefix: p.key_prefix,
             auth_type: p.auth_type,
+            label: p.label,
+            priority: p.priority,
             region: p.region,
             is_active: p.is_active,
             connected_at: now,

--- a/packages/backend/test/agent-duplication.e2e-spec.ts
+++ b/packages/backend/test/agent-duplication.e2e-spec.ts
@@ -28,6 +28,8 @@ describe('Agent Duplication (e2e)', () => {
       api_key_encrypted: 'enc-value',
       key_prefix: 'sk-ant',
       auth_type: 'api_key',
+      label: 'Research key',
+      priority: 2,
       region: null,
       is_active: true,
       connected_at: now,
@@ -139,6 +141,8 @@ describe('Agent Duplication (e2e)', () => {
       .find({ where: { agent_id: res.body.agent.id } });
     expect(newProviders).toHaveLength(1);
     expect(newProviders[0].api_key_encrypted).toBe('enc-value');
+    expect(newProviders[0].label).toBe('Research key');
+    expect(newProviders[0].priority).toBe(2);
     expect(newProviders[0].id).not.toBe('up-e2e-1');
 
     const newCustom = await ds


### PR DESCRIPTION
## Summary
- preserve `user_providers.label` and `priority` when duplicating an agent
- add focused unit and e2e assertions for labeled provider keys
- add a `manifest` patch changeset

## Root cause
Duplicate-agent copied provider credentials without the multi-key metadata added by the provider-label migration. On PostgreSQL, the omitted `label` column was emitted as `DEFAULT`, but the database column has no non-null default, so duplication failed with `null value in column "label"`.

Closes #1949.

## Validation
- `npm --workspace packages/shared run build`
- `npm --workspace packages/backend test -- agent-duplication.service.spec.ts --runInBand`
- `DATABASE_URL=postgresql://myuser:mypassword@localhost:5432/manifest_1949_test_1ef6f351 npm --workspace packages/backend run test:e2e -- agent-duplication.e2e-spec.ts`
- `npm --workspace packages/backend run build`
- `git diff --check`
- lint-staged ESLint/Prettier during commit
- manual local verification from `codex/issue-1949-duplicate-agent` succeeded on `http://localhost:3000` / `http://127.0.0.1:3001`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix agent duplication to preserve provider key labels and priorities, preventing null label errors on Postgres. Adds unit and e2e tests for labeled provider keys and publishes a `manifest` patch. Closes #1949.

<sup>Written for commit 492cf463f6d5e37b4dd7a42425bb877db377f05a. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1963?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

