### PR TITLE
fix(routing): support multiple subscription accounts

### DIFF
--- a/.changeset/tidy-subscription-accounts.md
+++ b/.changeset/tidy-subscription-accounts.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix adding multiple subscription accounts for Copilot and OAuth-backed providers.

--- a/packages/backend/src/routing/copilot.controller.spec.ts
+++ b/packages/backend/src/routing/copilot.controller.spec.ts
@@ -20,6 +20,7 @@ describe('CopilotController', () => {
     jest.clearAllMocks();
     mockProviderService = {
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: false }),
+      nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
     };
     mockResolveAgent = {
@@ -79,6 +80,31 @@ describe('CopilotController', () => {
         'copilot',
         'ghu_github_token',
         'subscription',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('stores a second token under the next OAuth label', async () => {
+      mockProviderService.nextOAuthLabel.mockResolvedValue('Key 2');
+      mockCopilotAuth.pollForToken.mockResolvedValue({
+        status: 'complete',
+        token: 'ghu_second_token',
+      });
+
+      await controller.copilotPollToken(mockUser, mockAgentName, {
+        deviceCode: 'dc_abc',
+      } as never);
+
+      expect(mockProviderService.nextOAuthLabel).toHaveBeenCalledWith(TEST_AGENT_ID, 'copilot');
+      expect(mockProviderService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'user-1',
+        'copilot',
+        'ghu_second_token',
+        'subscription',
+        undefined,
+        'Key 2',
       );
     });
 

--- a/packages/backend/src/routing/copilot.controller.ts
+++ b/packages/backend/src/routing/copilot.controller.ts
@@ -31,12 +31,15 @@ export class CopilotController {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
     const result = await this.copilotAuth.pollForToken(body.deviceCode);
     if (result.status === 'complete' && result.token) {
+      const label = await this.providerService.nextOAuthLabel(agent.id, 'copilot');
       const { provider: record } = await this.providerService.upsertProvider(
         agent.id,
         user.id,
         'copilot',
         result.token,
         'subscription',
+        undefined,
+        label,
       );
       try {
         await this.discoveryService.discoverModels(record);

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -231,6 +231,27 @@ describe('AnthropicOauthService', () => {
       expect(providerService.upsertProvider).toHaveBeenCalled();
     });
 
+    it('uses the next OAuth label when adding another Anthropic account', async () => {
+      providerService.nextOAuthLabel.mockResolvedValue('Key 2');
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a2', refresh_token: 'r2', expires_in: 60 }),
+      );
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+
+      await svc.exchangeCode(`second-code#${state}`, undefined, 'agent-1', 'user-1');
+
+      expect(providerService.nextOAuthLabel).toHaveBeenCalledWith('agent-1', 'anthropic');
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'anthropic',
+        expect.stringContaining('"t":"a2"'),
+        'subscription',
+        undefined,
+        'Key 2',
+      );
+    });
+
     it('falls back to the latest pending state when the client posts a bare code', async () => {
       fetchMock.mockResolvedValue(
         mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 60 }),

--- a/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
+++ b/packages/frontend/src/components/AnthropicOAuthDetailView.tsx
@@ -50,12 +50,16 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
   const [error, setError] = createSignal<string | null>(null);
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameValue, setRenameValue] = createSignal('');
+  const [addingAccount, setAddingAccount] = createSignal(false);
 
   const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
+  const showConnectFlow = () => !props.connected() || addingAccount();
+  const showConnectedFlow = () => props.connected() && !addingAccount();
 
   // When "Add another key" is clicked in the header, launch a new OAuth popup.
   createEffect(() => {
     if (props.addKeyOpen?.() && props.connected() && !props.busy()) {
+      setAddingAccount(true);
       props.setAddKeyOpen?.(false);
       void handleSignIn();
     }
@@ -85,8 +89,10 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
           'Popup was blocked by your browser. Allow popups for this site, then try again.',
         );
         setState(null);
+        if (props.connected()) setAddingAccount(false);
       }
     } catch {
+      if (props.connected()) setAddingAccount(false);
       // error toast from fetchMutate
     } finally {
       props.setBusy(false);
@@ -117,12 +123,22 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
       const authState = state() ?? pastedState;
       await submitAnthropicOAuth(props.agentName, raw, authState);
       toast.success(`${props.provDef.name} subscription connected`);
+      setAddingAccount(false);
+      setInput('');
+      setState(null);
       props.onUpdate();
     } catch {
       setError('Failed to exchange code. The code may have expired — sign in again to retry.');
     } finally {
       props.setBusy(false);
     }
+  };
+
+  const cancelAddAccount = () => {
+    setAddingAccount(false);
+    setInput('');
+    setError(null);
+    setState(null);
   };
 
   const handleDisconnect = async () => {
@@ -192,7 +208,7 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
 
   return (
     <>
-      <Show when={!props.connected()}>
+      <Show when={showConnectFlow()}>
         <div class="anthropic-detail__primary">
           <p class="provider-detail__hint">
             Sign in with your Claude Pro or Max account — Manifest will route through your
@@ -246,8 +262,17 @@ const AnthropicOAuthDetailView: Component<Props> = (props) => {
             </Show>
           </button>
         </div>
+        <Show when={addingAccount()}>
+          <button
+            class="btn btn--outline provider-detail__action"
+            disabled={props.busy()}
+            onClick={cancelAddAccount}
+          >
+            Cancel
+          </button>
+        </Show>
       </Show>
-      <Show when={props.connected()}>
+      <Show when={showConnectedFlow()}>
         {/* Multi-key list */}
         <Show when={isMultiKey()}>
           <div class="provider-detail__field">

--- a/packages/frontend/src/components/CopilotDeviceLogin.tsx
+++ b/packages/frontend/src/components/CopilotDeviceLogin.tsx
@@ -1,10 +1,11 @@
-import { createSignal, onCleanup, Show, type Component } from 'solid-js';
+import { createSignal, For, onCleanup, Show, type Component } from 'solid-js';
 import { providerIcon } from './ProviderIcon.js';
 import {
   copilotDeviceCode,
   copilotPollToken,
   disconnectProvider,
   type CopilotPollStatus,
+  type RoutingProvider,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 
@@ -25,13 +26,16 @@ type Phase = 'idle' | 'loading' | 'awaiting' | 'success' | 'error';
 interface Props {
   agentName: string;
   connected: boolean;
+  activeKeys?: RoutingProvider[];
   onBack: () => void;
   onConnected: () => void;
+  onUpdated?: () => void;
   onDisconnected: () => void;
 }
 
 const SLOW_DOWN_INCREASE = 5;
 const MAX_POLL_ERRORS = 5;
+const MAX_KEYS_PER_PROVIDER = 5;
 
 const CopilotDeviceLogin: Component<Props> = (props) => {
   const [phase, setPhase] = createSignal<Phase>('idle');
@@ -42,6 +46,11 @@ const CopilotDeviceLogin: Component<Props> = (props) => {
   const [copied, setCopied] = createSignal(false);
   let pollTimeout: ReturnType<typeof setTimeout> | undefined;
   let cancelled = false;
+
+  const activeKeys = () => (props.activeKeys ?? []).slice().sort((a, b) => a.priority - b.priority);
+  const isMultiKey = () => activeKeys().length > 1;
+  const canAddAnother = () => activeKeys().length < MAX_KEYS_PER_PROVIDER;
+  const showConnectedState = () => props.connected && (phase() === 'idle' || phase() === 'error');
 
   onCleanup(() => {
     cancelled = true;
@@ -125,6 +134,21 @@ const CopilotDeviceLogin: Component<Props> = (props) => {
     }
   };
 
+  const handleDeleteKey = async (label: string) => {
+    setBusy(true);
+    try {
+      const result = await disconnectProvider(props.agentName, 'copilot', 'subscription', label);
+      if (result?.notifications?.length) {
+        for (const msg of result.notifications) toast.error(msg);
+      }
+      props.onUpdated?.();
+    } catch {
+      /* error toast from fetchMutate */
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <div class="provider-detail">
       <button class="modal-back-btn" onClick={props.onBack} aria-label="Back to providers">
@@ -154,10 +178,76 @@ const CopilotDeviceLogin: Component<Props> = (props) => {
       </div>
 
       {/* Connected state */}
-      <Show when={props.connected && phase() !== 'success'}>
-        <p class="provider-detail__hint" style="color: var(--success-color, #22c55e);">
-          Connected via GitHub device login.
-        </p>
+      <Show when={showConnectedState()}>
+        <Show
+          when={isMultiKey()}
+          fallback={
+            <p class="provider-detail__hint" style="color: var(--success-color, #22c55e);">
+              Connected via GitHub device login.
+            </p>
+          }
+        >
+          <div class="provider-detail__field">
+            <label class="provider-detail__label">Accounts</label>
+            <ul
+              role="list"
+              aria-label="Accounts for GitHub Copilot"
+              style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px;"
+            >
+              <For each={activeKeys()}>
+                {(k) => (
+                  <li style="display: flex; align-items: center; gap: 8px; padding: 8px 10px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--muted) / 0.3);">
+                    <div style="flex: 1; min-width: 0;">
+                      <div style="font-weight: 500; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                        {k.label}
+                      </div>
+                      <div style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                        Connected via GitHub Copilot subscription
+                      </div>
+                    </div>
+                    <button
+                      class="provider-detail__disconnect-icon"
+                      disabled={busy()}
+                      onClick={() => handleDeleteKey(k.label)}
+                      aria-label={`Delete account ${k.label}`}
+                      title="Delete account"
+                    >
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M3 6h18" />
+                        <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                      </svg>
+                    </button>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </div>
+        </Show>
+        <Show when={error()}>
+          <div class="provider-detail__error">{error()}</div>
+        </Show>
+        <Show when={canAddAnother()}>
+          <button
+            class="btn btn--primary provider-detail__action"
+            disabled={busy()}
+            onClick={startLogin}
+          >
+            <Show when={!busy()} fallback={<span class="spinner" />}>
+              Add another key
+            </Show>
+          </button>
+        </Show>
         <button
           class="btn btn--outline provider-detail__action provider-detail__disconnect"
           disabled={busy()}

--- a/packages/frontend/src/components/DeviceCodeDetailView.tsx
+++ b/packages/frontend/src/components/DeviceCodeDetailView.tsx
@@ -19,6 +19,7 @@ import {
   type MinimaxOAuthRegion,
   type RoutingProvider,
 } from '../services/api.js';
+import { suggestNextProviderKeyLabel } from '../services/provider-key-labels.js';
 import { validateSubscriptionKey } from '../services/provider-utils.js';
 import { toast } from '../services/toast-store.js';
 
@@ -58,12 +59,17 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
   const [altError, setAltError] = createSignal<string | null>(null);
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameValue, setRenameValue] = createSignal('');
+  const [addingAccount, setAddingAccount] = createSignal(false);
 
   const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
+  const activeKeyLabels = () => (props.activeKeys?.() ?? []).map((k) => k.label);
+  const showConnectFlow = () => !props.connected() || addingAccount();
+  const showConnectedFlow = () => props.connected() && !addingAccount();
 
   // When "Add another key" is clicked in the header, launch a new device code flow.
   createEffect(() => {
     if (props.addKeyOpen?.() && props.connected() && !props.busy()) {
+      setAddingAccount(true);
       props.setAddKeyOpen?.(false);
       void handleStart();
     }
@@ -78,6 +84,7 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     }
     props.setBusy(true);
     try {
+      const label = addingAccount() ? suggestNextProviderKeyLabel(activeKeyLabels()) : undefined;
       await connectProvider(props.agentName, {
         provider: props.provId,
         apiKey: trimmed,
@@ -87,8 +94,11 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
         // api.minimaxi.com). Stick the picker's current value on the row so
         // the proxy fallback honors CN tokens.
         region: selectedRegion(),
+        ...(label && { label }),
       });
       toast.success(`${props.provDef.name} subscription connected`);
+      setAddingAccount(false);
+      setAltToken('');
       props.onUpdate();
     } catch {
       // error toast from fetchMutate
@@ -205,6 +215,8 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
       if (result.status === 'success') {
         clearPollTimer();
         toast.success(`${props.provDef.name} subscription connected`);
+        setAddingAccount(false);
+        setFlow(null);
         props.onUpdate();
         return;
       }
@@ -275,9 +287,18 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
     clearPollTimer();
   });
 
+  const cancelAddAccount = () => {
+    setAddingAccount(false);
+    setFlow(null);
+    setStatusMessage(null);
+    setAltToken('');
+    setAltError(null);
+    clearPollTimer();
+  };
+
   return (
     <>
-      <Show when={!props.connected()}>
+      <Show when={showConnectFlow()}>
         <Show
           when={flow()}
           fallback={
@@ -366,8 +387,17 @@ const DeviceCodeDetailView: Component<Props> = (props) => {
             </Show>
           </>
         </Show>
+        <Show when={addingAccount()}>
+          <button
+            class="btn btn--outline provider-detail__action"
+            disabled={props.busy()}
+            onClick={cancelAddAccount}
+          >
+            Cancel
+          </button>
+        </Show>
       </Show>
-      <Show when={props.connected()}>
+      <Show when={showConnectedFlow()}>
         {/* Multi-key list */}
         <Show when={isMultiKey()}>
           <div class="provider-detail__field">

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -43,12 +43,16 @@ const OAuthDetailView: Component<Props> = (props) => {
   const [pasteError, setPasteError] = createSignal<string | null>(null);
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameValue, setRenameValue] = createSignal('');
+  const [addingAccount, setAddingAccount] = createSignal(false);
 
   const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
+  const showConnectFlow = () => !props.connected() || addingAccount();
+  const showConnectedFlow = () => props.connected() && !addingAccount();
 
   // When "Add another key" is clicked in the header, launch a new OAuth popup.
   createEffect(() => {
     if (props.addKeyOpen?.() && props.connected() && !props.busy()) {
+      setAddingAccount(true);
       props.setAddKeyOpen?.(false);
       void handleOAuthLogin();
     }
@@ -65,6 +69,7 @@ const OAuthDetailView: Component<Props> = (props) => {
         toast.error(
           'Popup was blocked by your browser. Allow popups for this site, then try again.',
         );
+        if (props.connected()) setAddingAccount(false);
         props.setBusy(false);
         return;
       }
@@ -75,6 +80,8 @@ const OAuthDetailView: Component<Props> = (props) => {
       monitorOAuthPopup(popup, {
         onSuccess: () => {
           toast.success(`${props.provDef.name} subscription connected`);
+          setAddingAccount(false);
+          setPopupOpened(false);
           props.onUpdate();
         },
         onFailure: () => {
@@ -82,6 +89,7 @@ const OAuthDetailView: Component<Props> = (props) => {
         },
       });
     } catch {
+      if (props.connected()) setAddingAccount(false);
       props.setBusy(false);
     }
   };
@@ -103,12 +111,22 @@ const OAuthDetailView: Component<Props> = (props) => {
       setPasteError(null);
       await submitOpenaiOAuthCallback(code, state);
       toast.success(`${props.provDef.name} subscription connected`);
+      setAddingAccount(false);
+      setPasteUrl('');
+      setPopupOpened(false);
       props.onUpdate();
     } catch {
       setPasteError('Failed to exchange token. The URL may have expired — try logging in again.');
     } finally {
       props.setBusy(false);
     }
+  };
+
+  const cancelAddAccount = () => {
+    setAddingAccount(false);
+    setPopupOpened(false);
+    setPasteUrl('');
+    setPasteError(null);
   };
 
   const handleDisconnect = async () => {
@@ -178,7 +196,7 @@ const OAuthDetailView: Component<Props> = (props) => {
 
   return (
     <>
-      <Show when={!props.connected()}>
+      <Show when={showConnectFlow()}>
         <Show
           when={popupOpened()}
           fallback={
@@ -248,8 +266,17 @@ const OAuthDetailView: Component<Props> = (props) => {
             </button>
           </div>
         </Show>
+        <Show when={addingAccount()}>
+          <button
+            class="btn btn--outline provider-detail__action"
+            disabled={props.busy()}
+            onClick={cancelAddAccount}
+          >
+            Cancel
+          </button>
+        </Show>
       </Show>
-      <Show when={props.connected()}>
+      <Show when={showConnectedFlow()}>
         {/* Multi-key list */}
         <Show when={isMultiKey()}>
           <div class="provider-detail__field">

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -23,6 +23,7 @@ import {
   getRoutingProviderApiKeyUrl,
   getSubscriptionProviderKeyUrl,
 } from '../services/provider-api-key-urls.js';
+import { suggestNextProviderKeyLabel } from '../services/provider-key-labels.js';
 import { toast } from '../services/toast-store.js';
 
 export const MAX_KEYS_PER_PROVIDER = 5;
@@ -433,7 +434,7 @@ const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) => {
   const [label, setLabel] = createSignal('');
   const [apiKey, setApiKey] = createSignal('');
 
-  const defaultLabel = () => suggestNextLabel(props.existingLabels());
+  const defaultLabel = () => suggestNextProviderKeyLabel(props.existingLabels());
 
   // Sync label suggestion when opened externally
   createEffect(() => {
@@ -717,17 +718,5 @@ const KeyChainView: Component<KeyChainViewProps> = (props) => {
     </div>
   );
 };
-
-function suggestNextLabel(existing: string[]): string {
-  const lower = new Set(existing.map((l) => l.toLowerCase()));
-  // Skip "Default" — it's the legacy single-key label and doesn't suggest
-  // a numbered sibling. The next user-named key reads more naturally as
-  // "Key 2", "Key 3", … starting from the count of named keys.
-  for (let n = existing.length + 1; n < 100; n++) {
-    const candidate = `Key ${n}`;
-    if (!lower.has(candidate.toLowerCase())) return candidate;
-  }
-  return `Key ${existing.length + 1}`;
-}
 
 export default ProviderKeyForm;

--- a/packages/frontend/src/components/ProviderSelectContent.tsx
+++ b/packages/frontend/src/components/ProviderSelectContent.tsx
@@ -75,6 +75,12 @@ const ProviderSelectContent: Component<ProviderSelectContentProps> = (props) => 
   const getProviderByAuth = (provId: string, authType: AuthType) =>
     props.providers.find((p) => p.provider === provId && p.auth_type === authType);
 
+  const getActiveProviderKeys = (provId: string, authType: AuthType) =>
+    props.providers
+      .filter((p) => p.provider === provId && p.auth_type === authType && p.is_active)
+      .slice()
+      .sort((a, b) => a.priority - b.priority);
+
   const isConnected = (provId: string): boolean => {
     const p = getProviderByAuth(provId, 'api_key');
     return !!p && p.is_active && p.has_api_key;
@@ -446,11 +452,13 @@ const ProviderSelectContent: Component<ProviderSelectContentProps> = (props) => 
           <CopilotDeviceLogin
             agentName={props.agentName}
             connected={isSubscriptionWithToken(selectedProvider()!)}
+            activeKeys={getActiveProviderKeys(selectedProvider()!, 'subscription')}
             onBack={goBack}
             onConnected={async () => {
               await props.onUpdate();
               goBack();
             }}
+            onUpdated={props.onUpdate}
             onDisconnected={() => {
               goBack();
               props.onUpdate();

--- a/packages/frontend/src/services/provider-key-labels.ts
+++ b/packages/frontend/src/services/provider-key-labels.ts
@@ -1,0 +1,8 @@
+export function suggestNextProviderKeyLabel(existing: string[]): string {
+  const lower = new Set(existing.map((label) => label.toLowerCase()));
+  for (let n = existing.length + 1; n < 100; n++) {
+    const candidate = `Key ${n}`;
+    if (!lower.has(candidate.toLowerCase())) return candidate;
+  }
+  return `Key ${existing.length + 1}`;
+}

--- a/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/AnthropicOAuthDetailView.test.tsx
@@ -535,5 +535,6 @@ describe('AnthropicOAuthDetailView — addKeyOpen effect', () => {
     await waitFor(() => {
       expect(mockStartAnthropicOAuth).toHaveBeenCalledWith('test-agent');
     });
+    expect(screen.getByLabelText('Anthropic authorization code')).toBeDefined();
   });
 });

--- a/packages/frontend/tests/components/CopilotDeviceLogin.test.tsx
+++ b/packages/frontend/tests/components/CopilotDeviceLogin.test.tsx
@@ -1,27 +1,24 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
 
-vi.mock("../../src/services/api.js", () => ({
+vi.mock('../../src/services/api.js', () => ({
   copilotDeviceCode: vi.fn(),
   copilotPollToken: vi.fn(),
   disconnectProvider: vi.fn(),
 }));
 
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
-vi.mock("../../src/components/ProviderIcon.js", () => ({
-  providerIcon: () => null, customProviderLogo: () => null,
+vi.mock('../../src/components/ProviderIcon.js', () => ({
+  providerIcon: () => null,
+  customProviderLogo: () => null,
 }));
 
-import CopilotDeviceLogin from "../../src/components/CopilotDeviceLogin";
-import {
-  copilotDeviceCode,
-  copilotPollToken,
-  disconnectProvider,
-} from "../../src/services/api.js";
-import { toast } from "../../src/services/toast-store.js";
+import CopilotDeviceLogin from '../../src/components/CopilotDeviceLogin';
+import { copilotDeviceCode, copilotPollToken, disconnectProvider } from '../../src/services/api.js';
+import { toast } from '../../src/services/toast-store.js';
 
 const mockCopilotDeviceCode = copilotDeviceCode as ReturnType<typeof vi.fn>;
 const mockCopilotPollToken = copilotPollToken as ReturnType<typeof vi.fn>;
@@ -30,7 +27,7 @@ const mockToast = toast as { error: ReturnType<typeof vi.fn>; success: ReturnTyp
 
 function renderComponent(overrides: Partial<Parameters<typeof CopilotDeviceLogin>[0]> = {}) {
   const props = {
-    agentName: "test-agent",
+    agentName: 'test-agent',
     connected: false,
     onBack: vi.fn(),
     onConnected: vi.fn(),
@@ -41,38 +38,38 @@ function renderComponent(overrides: Partial<Parameters<typeof CopilotDeviceLogin
   return { ...result, props };
 }
 
-describe("CopilotDeviceLogin", () => {
+describe('CopilotDeviceLogin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
-  it("shows Sign in button in idle state", () => {
+  it('shows Sign in button in idle state', () => {
     renderComponent();
-    expect(screen.getByText("Sign in with GitHub")).toBeDefined();
+    expect(screen.getByText('Sign in with GitHub')).toBeDefined();
     expect(screen.getByText(/Requires an active GitHub Copilot subscription/)).toBeDefined();
   });
 
-  it("calls onBack when back button is clicked", async () => {
+  it('calls onBack when back button is clicked', async () => {
     const { props } = renderComponent();
-    await fireEvent.click(screen.getByLabelText("Back to providers"));
+    await fireEvent.click(screen.getByLabelText('Back to providers'));
     expect(props.onBack).toHaveBeenCalled();
   });
 
-  it("shows loading state after clicking Sign in", async () => {
+  it('shows loading state after clicking Sign in', async () => {
     mockCopilotDeviceCode.mockReturnValue(new Promise(() => {})); // never resolves
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
     // Sign in button should be gone, loading spinner appears
-    expect(screen.queryByText("Sign in with GitHub")).toBeNull();
-    expect(document.querySelector(".spinner")).toBeTruthy();
+    expect(screen.queryByText('Sign in with GitHub')).toBeNull();
+    expect(document.querySelector('.spinner')).toBeTruthy();
   });
 
-  it("shows device code and Open GitHub button in awaiting state", async () => {
+  it('shows device code and Open GitHub button in awaiting state', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
@@ -80,125 +77,125 @@ describe("CopilotDeviceLogin", () => {
     mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByText("ABCD-1234")).toBeDefined();
+      expect(screen.getByText('ABCD-1234')).toBeDefined();
     });
     expect(screen.getByText(/Copy the code, then open GitHub/)).toBeDefined();
-    expect(screen.getByText("Open GitHub")).toBeDefined();
-    expect(screen.getByText("Waiting for authorization...")).toBeDefined();
+    expect(screen.getByText('Open GitHub')).toBeDefined();
+    expect(screen.getByText('Waiting for authorization...')).toBeDefined();
 
-    const link = screen.getByText("Open GitHub").closest("a");
+    const link = screen.getByText('Open GitHub').closest('a');
     expect(link).toBeDefined();
-    expect(link!.getAttribute("href")).toBe("https://github.com/login/device");
-    expect(link!.getAttribute("target")).toBe("_blank");
+    expect(link!.getAttribute('href')).toBe('https://github.com/login/device');
+    expect(link!.getAttribute('target')).toBe('_blank');
   });
 
-  it("shows copy button for device code", async () => {
+  it('shows copy button for device code', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
   });
 
-  it("shows error when device code request fails", async () => {
-    mockCopilotDeviceCode.mockRejectedValue(new Error("Network error"));
+  it('shows error when device code request fails', async () => {
+    mockCopilotDeviceCode.mockRejectedValue(new Error('Network error'));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to start GitHub login. Please try again.")).toBeDefined();
+      expect(screen.getByText('Failed to start GitHub login. Please try again.')).toBeDefined();
     });
     // Sign in button should reappear for retry
-    expect(screen.getByText("Sign in with GitHub")).toBeDefined();
+    expect(screen.getByText('Sign in with GitHub')).toBeDefined();
   });
 
-  it("transitions to success when poll returns complete", async () => {
+  it('transitions to success when poll returns complete', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
-    mockCopilotPollToken.mockResolvedValue({ status: "complete" });
+    mockCopilotPollToken.mockResolvedValue({ status: 'complete' });
 
     const { props } = renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     // Advance timer to trigger the first poll
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(screen.getByText("GitHub Copilot connected successfully.")).toBeDefined();
+      expect(screen.getByText('GitHub Copilot connected successfully.')).toBeDefined();
     });
-    expect(mockToast.success).toHaveBeenCalledWith("GitHub Copilot connected");
+    expect(mockToast.success).toHaveBeenCalledWith('GitHub Copilot connected');
     expect(props.onConnected).toHaveBeenCalled();
   });
 
-  it("shows error when poll returns expired", async () => {
+  it('shows error when poll returns expired', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
-    mockCopilotPollToken.mockResolvedValue({ status: "expired" });
+    mockCopilotPollToken.mockResolvedValue({ status: 'expired' });
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(screen.getByText("Device code expired. Please try again.")).toBeDefined();
+      expect(screen.getByText('Device code expired. Please try again.')).toBeDefined();
     });
   });
 
-  it("shows error when poll returns denied", async () => {
+  it('shows error when poll returns denied', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
-    mockCopilotPollToken.mockResolvedValue({ status: "denied" });
+    mockCopilotPollToken.mockResolvedValue({ status: 'denied' });
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(screen.getByText("Authorization was denied.")).toBeDefined();
+      expect(screen.getByText('Authorization was denied.')).toBeDefined();
     });
   });
 
-  it("shows connection lost after MAX_POLL_ERRORS consecutive failures", async () => {
+  it('shows connection lost after MAX_POLL_ERRORS consecutive failures', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
-    mockCopilotPollToken.mockRejectedValue(new Error("Network error"));
+    mockCopilotPollToken.mockRejectedValue(new Error('Network error'));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     // Advance through 5 failed poll attempts (5 seconds each)
     for (let i = 0; i < 5; i++) {
@@ -206,46 +203,98 @@ describe("CopilotDeviceLogin", () => {
     }
 
     await waitFor(() => {
-      expect(screen.getByText("Connection lost. Please try again.")).toBeDefined();
+      expect(screen.getByText('Connection lost. Please try again.')).toBeDefined();
     });
   });
 
-  it("shows connected state with disconnect button", () => {
+  it('shows connected state with disconnect button', () => {
     renderComponent({ connected: true });
-    expect(screen.getByText("Connected via GitHub device login.")).toBeDefined();
-    expect(screen.getByText("Disconnect")).toBeDefined();
+    expect(screen.getByText('Connected via GitHub device login.')).toBeDefined();
+    expect(screen.getByText('Add another key')).toBeDefined();
+    expect(screen.getByText('Disconnect')).toBeDefined();
   });
 
-  it("calls onDisconnected when disconnect is clicked", async () => {
+  it('starts a new device login while already connected', async () => {
+    mockCopilotDeviceCode.mockResolvedValue({
+      device_code: 'dc_second',
+      user_code: 'WXYZ-9876',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    });
+    mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
+
+    renderComponent({ connected: true });
+    await fireEvent.click(screen.getByText('Add another key'));
+
+    await waitFor(() => {
+      expect(mockCopilotDeviceCode).toHaveBeenCalledWith('test-agent');
+      expect(screen.getByText('WXYZ-9876')).toBeDefined();
+    });
+    expect(screen.queryByText('Connected via GitHub device login.')).toBeNull();
+  });
+
+  it('shows connected Copilot accounts when more than one key is active', () => {
+    renderComponent({
+      connected: true,
+      activeKeys: [
+        {
+          id: 'k1',
+          provider: 'copilot',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: true,
+          label: 'Personal',
+          priority: 0,
+          connected_at: '2026-01-01',
+        },
+        {
+          id: 'k2',
+          provider: 'copilot',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: true,
+          label: 'Work',
+          priority: 1,
+          connected_at: '2026-01-01',
+        },
+      ],
+    });
+    expect(screen.getByText('Accounts')).toBeDefined();
+    expect(screen.getByText('Personal')).toBeDefined();
+    expect(screen.getByText('Work')).toBeDefined();
+  });
+
+  it('calls onDisconnected when disconnect is clicked', async () => {
     mockDisconnectProvider.mockResolvedValue({});
 
     const { props } = renderComponent({ connected: true });
-    await fireEvent.click(screen.getByText("Disconnect"));
+    await fireEvent.click(screen.getByText('Disconnect'));
 
     await waitFor(() => {
       expect(props.onDisconnected).toHaveBeenCalled();
     });
-    expect(mockDisconnectProvider).toHaveBeenCalledWith("test-agent", "copilot", "subscription");
+    expect(mockDisconnectProvider).toHaveBeenCalledWith('test-agent', 'copilot', 'subscription');
   });
 
-  it("shows notification toasts on disconnect with notifications", async () => {
+  it('shows notification toasts on disconnect with notifications', async () => {
     mockDisconnectProvider.mockResolvedValue({
-      notifications: ["Tier affected"],
+      notifications: ['Tier affected'],
     });
 
     renderComponent({ connected: true });
-    await fireEvent.click(screen.getByText("Disconnect"));
+    await fireEvent.click(screen.getByText('Disconnect'));
 
     await waitFor(() => {
-      expect(mockToast.error).toHaveBeenCalledWith("Tier affected");
+      expect(mockToast.error).toHaveBeenCalledWith('Tier affected');
     });
   });
 
-  it("handles disconnect failure gracefully", async () => {
-    mockDisconnectProvider.mockRejectedValue(new Error("fail"));
+  it('handles disconnect failure gracefully', async () => {
+    mockDisconnectProvider.mockRejectedValue(new Error('fail'));
 
     const { props } = renderComponent({ connected: true });
-    await fireEvent.click(screen.getByText("Disconnect"));
+    await fireEvent.click(screen.getByText('Disconnect'));
 
     await waitFor(() => {
       // Should not crash — onDisconnected should NOT be called
@@ -253,86 +302,86 @@ describe("CopilotDeviceLogin", () => {
     });
   });
 
-  it("copies device code to clipboard on copy button click", async () => {
+  it('copies device code to clipboard on copy button click', async () => {
     const writeTextMock = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
 
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "COPY-ME",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'COPY-ME',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
 
-    await fireEvent.click(screen.getByLabelText("Copy device code"));
+    await fireEvent.click(screen.getByLabelText('Copy device code'));
 
     await waitFor(() => {
-      expect(writeTextMock).toHaveBeenCalledWith("COPY-ME");
+      expect(writeTextMock).toHaveBeenCalledWith('COPY-ME');
     });
     // After successful copy, label changes to "Copied"
     await waitFor(() => {
-      expect(screen.getByLabelText("Copied")).toBeDefined();
+      expect(screen.getByLabelText('Copied')).toBeDefined();
     });
 
     // After timeout, label reverts to "Copy device code"
     await vi.advanceTimersByTimeAsync(2000);
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
   });
 
-  it("handles clipboard write failure gracefully", async () => {
-    const writeTextMock = vi.fn().mockRejectedValue(new Error("clipboard denied"));
+  it('handles clipboard write failure gracefully', async () => {
+    const writeTextMock = vi.fn().mockRejectedValue(new Error('clipboard denied'));
     Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
 
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "FAIL-COPY",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'FAIL-COPY',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
 
-    await fireEvent.click(screen.getByLabelText("Copy device code"));
+    await fireEvent.click(screen.getByLabelText('Copy device code'));
 
     // Should not crash — label stays "Copy device code" (not "Copied")
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
   });
 
-  it("increases poll delay on slow_down status", async () => {
+  it('increases poll delay on slow_down status', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     // First poll: slow_down, second poll: complete
     mockCopilotPollToken
-      .mockResolvedValueOnce({ status: "slow_down" })
-      .mockResolvedValueOnce({ status: "complete" });
+      .mockResolvedValueOnce({ status: 'slow_down' })
+      .mockResolvedValueOnce({ status: 'complete' });
 
     const { props } = renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     // First poll at 5 seconds
     await vi.advanceTimersByTimeAsync(5000);
@@ -344,25 +393,25 @@ describe("CopilotDeviceLogin", () => {
     await vi.advanceTimersByTimeAsync(10000);
 
     await waitFor(() => {
-      expect(screen.getByText("GitHub Copilot connected successfully.")).toBeDefined();
+      expect(screen.getByText('GitHub Copilot connected successfully.')).toBeDefined();
     });
     expect(props.onConnected).toHaveBeenCalled();
   });
 
-  it("continues polling on pending status with same delay", async () => {
+  it('continues polling on pending status with same delay', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     mockCopilotPollToken
-      .mockResolvedValueOnce({ status: "pending" })
-      .mockResolvedValueOnce({ status: "complete" });
+      .mockResolvedValueOnce({ status: 'pending' })
+      .mockResolvedValueOnce({ status: 'complete' });
 
     const { props } = renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     // First poll at 5 seconds — returns pending
     await vi.advanceTimersByTimeAsync(5000);
@@ -374,7 +423,7 @@ describe("CopilotDeviceLogin", () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(screen.getByText("GitHub Copilot connected successfully.")).toBeDefined();
+      expect(screen.getByText('GitHub Copilot connected successfully.')).toBeDefined();
     });
     expect(props.onConnected).toHaveBeenCalled();
   });

--- a/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
+++ b/packages/frontend/tests/components/DeviceCodeDetailView.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createSignal } from "solid-js";
-import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createSignal } from 'solid-js';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
 
-vi.mock("../../src/services/api.js", () => ({
+vi.mock('../../src/services/api.js', () => ({
   connectProvider: vi.fn(),
   disconnectProvider: vi.fn(),
   pollMinimaxOAuth: vi.fn(),
@@ -11,20 +11,20 @@ vi.mock("../../src/services/api.js", () => ({
   renameProviderKey: vi.fn(),
 }));
 
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
-import DeviceCodeDetailView from "../../src/components/DeviceCodeDetailView";
+import DeviceCodeDetailView from '../../src/components/DeviceCodeDetailView';
 import {
   connectProvider,
   disconnectProvider,
   renameProviderKey,
   revokeMinimaxOAuth,
-} from "../../src/services/api.js";
-import { toast } from "../../src/services/toast-store.js";
-import { getProvider } from "../../src/services/provider-utils";
-import type { AuthType, RoutingProvider } from "../../src/services/api.js";
+} from '../../src/services/api.js';
+import { toast } from '../../src/services/toast-store.js';
+import { getProvider } from '../../src/services/provider-utils';
+import type { AuthType, RoutingProvider } from '../../src/services/api.js';
 
 const mockConnectProvider = connectProvider as ReturnType<typeof vi.fn>;
 const mockToast = toast as {
@@ -33,13 +33,13 @@ const mockToast = toast as {
 };
 
 function renderMinimax() {
-  const provDef = getProvider("minimax")!;
+  const provDef = getProvider('minimax')!;
   const [busy, setBusy] = createSignal(false);
-  const [authType] = createSignal<AuthType>("subscription");
+  const [authType] = createSignal<AuthType>('subscription');
   const props = {
     provDef,
-    provId: "minimax",
-    agentName: "test-agent",
+    provId: 'minimax',
+    agentName: 'test-agent',
     connected: () => false,
     selectedAuthType: authType,
     busy,
@@ -52,94 +52,92 @@ function renderMinimax() {
   return { ...result, props };
 }
 
-describe("DeviceCodeDetailView — MiniMax Coding Plan token alternative", () => {
+describe('DeviceCodeDetailView — MiniMax Coding Plan token alternative', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders the alternative token paste box for MiniMax", () => {
+  it('renders the alternative token paste box for MiniMax', () => {
     renderMinimax();
-    expect(screen.getByLabelText("MiniMax Coding Plan token")).toBeDefined();
-    expect(screen.getByText("Connect with token")).toBeDefined();
+    expect(screen.getByLabelText('MiniMax Coding Plan token')).toBeDefined();
+    expect(screen.getByText('Connect with token')).toBeDefined();
   });
 
   it("rejects a token that doesn't start with sk-cp-", async () => {
     renderMinimax();
-    const input = screen.getByLabelText("MiniMax Coding Plan token") as HTMLInputElement;
-    await fireEvent.input(input, { target: { value: "sk-wrong-token-long-enough" } });
-    await fireEvent.click(screen.getByText("Connect with token"));
+    const input = screen.getByLabelText('MiniMax Coding Plan token') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'sk-wrong-token-long-enough' } });
+    await fireEvent.click(screen.getByText('Connect with token'));
     await waitFor(() => {
-      expect(
-        screen.getByText('MiniMax subscription tokens start with "sk-cp-"'),
-      ).toBeDefined();
+      expect(screen.getByText('MiniMax subscription tokens start with "sk-cp-"')).toBeDefined();
     });
     expect(mockConnectProvider).not.toHaveBeenCalled();
   });
 
-  it("connects with a valid sk-cp- token, defaulting to global region", async () => {
+  it('connects with a valid sk-cp- token, defaulting to global region', async () => {
     mockConnectProvider.mockResolvedValueOnce(undefined);
     const { props } = renderMinimax();
-    const input = screen.getByLabelText("MiniMax Coding Plan token") as HTMLInputElement;
-    const validToken = "sk-cp-" + "a".repeat(40);
+    const input = screen.getByLabelText('MiniMax Coding Plan token') as HTMLInputElement;
+    const validToken = 'sk-cp-' + 'a'.repeat(40);
     await fireEvent.input(input, { target: { value: validToken } });
-    await fireEvent.click(screen.getByText("Connect with token"));
+    await fireEvent.click(screen.getByText('Connect with token'));
     await waitFor(() => {
-      expect(mockConnectProvider).toHaveBeenCalledWith("test-agent", {
-        provider: "minimax",
+      expect(mockConnectProvider).toHaveBeenCalledWith('test-agent', {
+        provider: 'minimax',
         apiKey: validToken,
-        authType: "subscription",
-        region: "global",
+        authType: 'subscription',
+        region: 'global',
       });
     });
-    expect(mockToast.success).toHaveBeenCalledWith("MiniMax subscription connected");
+    expect(mockToast.success).toHaveBeenCalledWith('MiniMax subscription connected');
     expect(props.onUpdate).toHaveBeenCalled();
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
-  it("forwards the selected CN region with the pasted token", async () => {
+  it('forwards the selected CN region with the pasted token', async () => {
     mockConnectProvider.mockResolvedValueOnce(undefined);
     renderMinimax();
-    const regionSelect = screen.getByLabelText("Region") as HTMLSelectElement;
-    await fireEvent.change(regionSelect, { target: { value: "cn" } });
-    const input = screen.getByLabelText("MiniMax Coding Plan token") as HTMLInputElement;
-    const validToken = "sk-cp-" + "d".repeat(40);
+    const regionSelect = screen.getByLabelText('Region') as HTMLSelectElement;
+    await fireEvent.change(regionSelect, { target: { value: 'cn' } });
+    const input = screen.getByLabelText('MiniMax Coding Plan token') as HTMLInputElement;
+    const validToken = 'sk-cp-' + 'd'.repeat(40);
     await fireEvent.input(input, { target: { value: validToken } });
-    await fireEvent.click(screen.getByText("Connect with token"));
+    await fireEvent.click(screen.getByText('Connect with token'));
     await waitFor(() => {
-      expect(mockConnectProvider).toHaveBeenCalledWith("test-agent", {
-        provider: "minimax",
+      expect(mockConnectProvider).toHaveBeenCalledWith('test-agent', {
+        provider: 'minimax',
         apiKey: validToken,
-        authType: "subscription",
-        region: "cn",
+        authType: 'subscription',
+        region: 'cn',
       });
     });
   });
 
-  it("submits the token on Enter key", async () => {
+  it('submits the token on Enter key', async () => {
     mockConnectProvider.mockResolvedValueOnce(undefined);
     renderMinimax();
-    const input = screen.getByLabelText("MiniMax Coding Plan token") as HTMLInputElement;
-    const validToken = "sk-cp-" + "b".repeat(40);
+    const input = screen.getByLabelText('MiniMax Coding Plan token') as HTMLInputElement;
+    const validToken = 'sk-cp-' + 'b'.repeat(40);
     await fireEvent.input(input, { target: { value: validToken } });
-    await fireEvent.keyDown(input, { key: "Enter" });
+    await fireEvent.keyDown(input, { key: 'Enter' });
     await waitFor(() => {
       expect(mockConnectProvider).toHaveBeenCalled();
     });
   });
 
-  it("disables Connect when input is empty", () => {
+  it('disables Connect when input is empty', () => {
     renderMinimax();
-    const button = screen.getByText("Connect with token").closest("button") as HTMLButtonElement;
+    const button = screen.getByText('Connect with token').closest('button') as HTMLButtonElement;
     expect(button.disabled).toBe(true);
   });
 
-  it("does not close on connect failure and resets busy", async () => {
-    mockConnectProvider.mockRejectedValueOnce(new Error("boom"));
+  it('does not close on connect failure and resets busy', async () => {
+    mockConnectProvider.mockRejectedValueOnce(new Error('boom'));
     const { props } = renderMinimax();
-    const input = screen.getByLabelText("MiniMax Coding Plan token") as HTMLInputElement;
-    const validToken = "sk-cp-" + "c".repeat(40);
+    const input = screen.getByLabelText('MiniMax Coding Plan token') as HTMLInputElement;
+    const validToken = 'sk-cp-' + 'c'.repeat(40);
     await fireEvent.input(input, { target: { value: validToken } });
-    await fireEvent.click(screen.getByText("Connect with token"));
+    await fireEvent.click(screen.getByText('Connect with token'));
     await waitFor(() => {
       expect(mockConnectProvider).toHaveBeenCalled();
     });
@@ -148,20 +146,16 @@ describe("DeviceCodeDetailView — MiniMax Coding Plan token alternative", () =>
     expect(mockToast.success).not.toHaveBeenCalled();
   });
 
-  it("clears validation error when user edits the input", async () => {
+  it('clears validation error when user edits the input', async () => {
     renderMinimax();
-    const input = screen.getByLabelText("MiniMax Coding Plan token") as HTMLInputElement;
-    await fireEvent.input(input, { target: { value: "bad-prefix-long-enough" } });
-    await fireEvent.click(screen.getByText("Connect with token"));
+    const input = screen.getByLabelText('MiniMax Coding Plan token') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'bad-prefix-long-enough' } });
+    await fireEvent.click(screen.getByText('Connect with token'));
     await waitFor(() => {
-      expect(
-        screen.getByText('MiniMax subscription tokens start with "sk-cp-"'),
-      ).toBeDefined();
+      expect(screen.getByText('MiniMax subscription tokens start with "sk-cp-"')).toBeDefined();
     });
-    await fireEvent.input(input, { target: { value: "sk-cp-fresh" } });
-    expect(
-      screen.queryByText('MiniMax subscription tokens start with "sk-cp-"'),
-    ).toBeNull();
+    await fireEvent.input(input, { target: { value: 'sk-cp-fresh' } });
+    expect(screen.queryByText('MiniMax subscription tokens start with "sk-cp-"')).toBeNull();
   });
 });
 
@@ -171,24 +165,24 @@ const mockRenameProviderKey = renameProviderKey as ReturnType<typeof vi.fn>;
 
 function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
   return {
-    id: "key-1",
-    provider: "minimax",
-    auth_type: "subscription",
+    id: 'key-1',
+    provider: 'minimax',
+    auth_type: 'subscription',
     is_active: true,
     has_api_key: true,
     key_prefix: null,
-    label: "Account 1",
+    label: 'Account 1',
     priority: 1,
     region: null,
-    connected_at: "2025-01-01T00:00:00Z",
+    connected_at: '2025-01-01T00:00:00Z',
     ...overrides,
   };
 }
 
 function renderMultiKeyMinimax(keys: RoutingProvider[]) {
-  const provDef = getProvider("minimax")!;
+  const provDef = getProvider('minimax')!;
   const [busy, setBusy] = createSignal(false);
-  const [authType] = createSignal<AuthType>("subscription");
+  const [authType] = createSignal<AuthType>('subscription');
   const onBack = vi.fn();
   const onUpdate = vi.fn();
   const onClose = vi.fn();
@@ -210,124 +204,112 @@ function renderMultiKeyMinimax(keys: RoutingProvider[]) {
   return { ...result, onBack, onUpdate, onClose };
 }
 
-describe("DeviceCodeDetailView — multi-key", () => {
+describe('DeviceCodeDetailView — multi-key', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders multi-key list when activeKeys has 2+ items", () => {
-    const keys = [
-      makeKey({ id: "k1", label: "Work" }),
-      makeKey({ id: "k2", label: "Personal" }),
-    ];
+  it('renders multi-key list when activeKeys has 2+ items', () => {
+    const keys = [makeKey({ id: 'k1', label: 'Work' }), makeKey({ id: 'k2', label: 'Personal' })];
     renderMultiKeyMinimax(keys);
-    expect(screen.getByText("Accounts")).toBeDefined();
-    expect(screen.getByText("Work")).toBeDefined();
-    expect(screen.getByText("Personal")).toBeDefined();
+    expect(screen.getByText('Accounts')).toBeDefined();
+    expect(screen.getByText('Work')).toBeDefined();
+    expect(screen.getByText('Personal')).toBeDefined();
   });
 
-  it("rename flow: clicking Rename shows input and saving calls renameProviderKey", async () => {
-    mockRenameProviderKey.mockResolvedValue({ id: "k1", label: "New", priority: 1 });
-    const keys = [
-      makeKey({ id: "k1", label: "Old" }),
-      makeKey({ id: "k2", label: "Other" }),
-    ];
+  it('rename flow: clicking Rename shows input and saving calls renameProviderKey', async () => {
+    mockRenameProviderKey.mockResolvedValue({ id: 'k1', label: 'New', priority: 1 });
+    const keys = [makeKey({ id: 'k1', label: 'Old' }), makeKey({ id: 'k2', label: 'Other' })];
     const { onUpdate } = renderMultiKeyMinimax(keys);
 
-    const renameButtons = screen.getAllByText("Rename");
+    const renameButtons = screen.getAllByText('Rename');
     fireEvent.click(renameButtons[0]);
 
-    const input = screen.getByLabelText("Rename Old");
-    fireEvent.input(input, { target: { value: "New" } });
-    fireEvent.click(screen.getByText("Save"));
+    const input = screen.getByLabelText('Rename Old');
+    fireEvent.input(input, { target: { value: 'New' } });
+    fireEvent.click(screen.getByText('Save'));
 
     await waitFor(() => {
       expect(mockRenameProviderKey).toHaveBeenCalledWith(
-        "test-agent",
-        "minimax",
-        "Old",
-        "New",
-        "subscription",
+        'test-agent',
+        'minimax',
+        'Old',
+        'New',
+        'subscription',
       );
     });
     expect(mockToast.success).toHaveBeenCalledWith('Renamed to "New"');
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it("delete individual key calls revokeMinimaxOAuth with label", async () => {
+  it('delete individual key calls revokeMinimaxOAuth with label', async () => {
     mockRevokeMinimaxOAuth.mockResolvedValue({ ok: true, notifications: [] });
     const keys = [
-      makeKey({ id: "k1", label: "Primary" }),
-      makeKey({ id: "k2", label: "Secondary" }),
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
     ];
     const { onUpdate } = renderMultiKeyMinimax(keys);
 
-    fireEvent.click(screen.getByLabelText("Delete account Primary"));
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
 
     await waitFor(() => {
-      expect(mockRevokeMinimaxOAuth).toHaveBeenCalledWith("test-agent", "Primary");
+      expect(mockRevokeMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'Primary');
     });
     expect(mockDisconnectProvider).not.toHaveBeenCalled();
     expect(onUpdate).toHaveBeenCalled();
   });
 
-  it("shows Disconnect all button in multi-key mode", () => {
-    const keys = [
-      makeKey({ id: "k1", label: "A" }),
-      makeKey({ id: "k2", label: "B" }),
-    ];
+  it('shows Disconnect all button in multi-key mode', () => {
+    const keys = [makeKey({ id: 'k1', label: 'A' }), makeKey({ id: 'k2', label: 'B' })];
     renderMultiKeyMinimax(keys);
-    expect(screen.getByText("Disconnect all")).toBeDefined();
+    expect(screen.getByText('Disconnect all')).toBeDefined();
   });
 
-  it("handleDeleteKey surfaces notifications from revokeMinimaxOAuth", async () => {
+  it('handleDeleteKey surfaces notifications from revokeMinimaxOAuth', async () => {
     mockRevokeMinimaxOAuth.mockResolvedValue({
       ok: true,
-      notifications: ["Key still shared with another agent"],
+      notifications: ['Key still shared with another agent'],
     });
     const keys = [
-      makeKey({ id: "k1", label: "Primary" }),
-      makeKey({ id: "k2", label: "Secondary" }),
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
     ];
     renderMultiKeyMinimax(keys);
 
-    fireEvent.click(screen.getByLabelText("Delete account Primary"));
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
 
     await waitFor(() => {
-      expect(mockToast.error).toHaveBeenCalledWith("Key still shared with another agent");
+      expect(mockToast.error).toHaveBeenCalledWith('Key still shared with another agent');
     });
   });
 
-  it("handleDeleteKey catch branch when revokeMinimaxOAuth fails", async () => {
-    mockRevokeMinimaxOAuth.mockRejectedValue(new Error("network"));
+  it('handleDeleteKey catch branch when revokeMinimaxOAuth fails', async () => {
+    mockRevokeMinimaxOAuth.mockRejectedValue(new Error('network'));
     const keys = [
-      makeKey({ id: "k1", label: "Primary" }),
-      makeKey({ id: "k2", label: "Secondary" }),
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
     ];
     const { onUpdate } = renderMultiKeyMinimax(keys);
 
-    fireEvent.click(screen.getByLabelText("Delete account Primary"));
+    fireEvent.click(screen.getByLabelText('Delete account Primary'));
 
     await waitFor(() => {
-      expect(mockRevokeMinimaxOAuth).toHaveBeenCalledWith("test-agent", "Primary");
+      expect(mockRevokeMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'Primary');
     });
     expect(onUpdate).not.toHaveBeenCalled();
   });
 
-  it("commitRename catch branch when renameProviderKey fails", async () => {
-    mockRenameProviderKey.mockRejectedValue(new Error("network"));
-    const keys = [
-      makeKey({ id: "k1", label: "Old" }),
-      makeKey({ id: "k2", label: "Other" }),
-    ];
+  it('commitRename catch branch when renameProviderKey fails', async () => {
+    mockRenameProviderKey.mockRejectedValue(new Error('network'));
+    const keys = [makeKey({ id: 'k1', label: 'Old' }), makeKey({ id: 'k2', label: 'Other' })];
     const { onUpdate } = renderMultiKeyMinimax(keys);
 
-    const renameButtons = screen.getAllByText("Rename");
+    const renameButtons = screen.getAllByText('Rename');
     fireEvent.click(renameButtons[0]);
 
-    const input = screen.getByLabelText("Rename Old");
-    fireEvent.input(input, { target: { value: "New" } });
-    fireEvent.click(screen.getByText("Save"));
+    const input = screen.getByLabelText('Rename Old');
+    fireEvent.input(input, { target: { value: 'New' } });
+    fireEvent.click(screen.getByText('Save'));
 
     await waitFor(() => {
       expect(mockRenameProviderKey).toHaveBeenCalled();
@@ -337,9 +319,9 @@ describe("DeviceCodeDetailView — multi-key", () => {
 });
 
 function renderConnectedWithAddKeyOpen() {
-  const provDef = getProvider("minimax")!;
+  const provDef = getProvider('minimax')!;
   const [busy, setBusy] = createSignal(false);
-  const [authType] = createSignal<AuthType>("subscription");
+  const [authType] = createSignal<AuthType>('subscription');
   const [addKeyOpen, setAddKeyOpen] = createSignal(true);
   const onBack = vi.fn();
   const onUpdate = vi.fn();
@@ -365,27 +347,33 @@ function renderConnectedWithAddKeyOpen() {
   return { ...result, onBack, onUpdate, onClose, setAddKeyOpen };
 }
 
-describe("DeviceCodeDetailView — addKeyOpen effect", () => {
+describe('DeviceCodeDetailView — addKeyOpen effect', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("auto-launches handleStart when addKeyOpen is true and connected", async () => {
-    const startMinimaxOAuth = (await import("../../src/services/api.js")).startMinimaxOAuth as ReturnType<typeof vi.fn>;
+  it('auto-launches handleStart when addKeyOpen is true and connected', async () => {
+    const startMinimaxOAuth = (await import('../../src/services/api.js'))
+      .startMinimaxOAuth as ReturnType<typeof vi.fn>;
     startMinimaxOAuth.mockResolvedValue({
-      flowId: "f1",
-      userCode: "ABCD-1234",
-      verificationUri: "https://minimax.io/verify",
+      flowId: 'f1',
+      userCode: 'ABCD-1234',
+      verificationUri: 'https://minimax.io/verify',
       expiresAt: Date.now() + 60000,
       pollIntervalMs: 2000,
     });
-    const openSpy = vi.spyOn(window, "open").mockReturnValue({ closed: false, opener: null, location: { replace: vi.fn() } } as unknown as Window);
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({
+      closed: false,
+      opener: null,
+      location: { replace: vi.fn() },
+    } as unknown as Window);
 
     renderConnectedWithAddKeyOpen();
 
     await waitFor(() => {
-      expect(startMinimaxOAuth).toHaveBeenCalledWith("test-agent", "global");
+      expect(startMinimaxOAuth).toHaveBeenCalledWith('test-agent', 'global');
     });
+    expect(screen.getByText(/A new tab opened with the MiniMax authorization page/)).toBeDefined();
     openSpy.mockRestore();
   });
 });

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -64,11 +64,13 @@ function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
   };
 }
 
-function renderView(opts: {
-  connected?: boolean;
-  activeKeys?: RoutingProvider[];
-  addKeyOpen?: boolean;
-} = {}) {
+function renderView(
+  opts: {
+    connected?: boolean;
+    activeKeys?: RoutingProvider[];
+    addKeyOpen?: boolean;
+  } = {},
+) {
   const [busy, setBusy] = createSignal(false);
   const [addKeyOpen, setAddKeyOpen] = createSignal(opts.addKeyOpen ?? false);
   const onBack = vi.fn();
@@ -123,20 +125,14 @@ describe('OAuthDetailView', () => {
   });
 
   it('shows "Disconnect all" button in multi-key mode', () => {
-    const keys = [
-      makeKey({ id: 'k1', label: 'A' }),
-      makeKey({ id: 'k2', label: 'B' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'A' }), makeKey({ id: 'k2', label: 'B' })];
     renderView({ connected: true, activeKeys: keys });
     expect(screen.getByText('Disconnect all')).toBeDefined();
   });
 
   it('clicking Rename shows input and saving calls renameProviderKey', async () => {
     mockRenameProviderKey.mockResolvedValue({ id: 'k1', label: 'New name', priority: 1 });
-    const keys = [
-      makeKey({ id: 'k1', label: 'Old name' }),
-      makeKey({ id: 'k2', label: 'Other' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Old name' }), makeKey({ id: 'k2', label: 'Other' })];
     const { onUpdate } = renderView({ connected: true, activeKeys: keys });
 
     const renameButtons = screen.getAllByText('Rename');
@@ -185,6 +181,7 @@ describe('OAuthDetailView', () => {
     await waitFor(() => {
       expect(mockGetOpenaiOAuthUrl).toHaveBeenCalledWith('test-agent');
     });
+    expect(screen.getByPlaceholderText(/localhost:1455/)).toBeDefined();
   });
 
   it('shows popup-blocked toast when window.open returns null', async () => {
@@ -201,10 +198,7 @@ describe('OAuthDetailView', () => {
 
   it('Disconnect all revokes all OpenAI OAuth tokens', async () => {
     mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true, notifications: [] });
-    const keys = [
-      makeKey({ id: 'k1', label: 'A' }),
-      makeKey({ id: 'k2', label: 'B' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'A' }), makeKey({ id: 'k2', label: 'B' })];
     const { onBack, onUpdate } = renderView({ connected: true, activeKeys: keys });
 
     fireEvent.click(screen.getByText('Disconnect all'));
@@ -218,10 +212,7 @@ describe('OAuthDetailView', () => {
   });
 
   it('commitRename cancels if new label is same as old', async () => {
-    const keys = [
-      makeKey({ id: 'k1', label: 'Same' }),
-      makeKey({ id: 'k2', label: 'Other' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Same' }), makeKey({ id: 'k2', label: 'Other' })];
     renderView({ connected: true, activeKeys: keys });
 
     const renameButtons = screen.getAllByText('Rename');
@@ -409,10 +400,7 @@ describe('OAuthDetailView', () => {
 
   it('commitRename catch branch when renameProviderKey fails', async () => {
     mockRenameProviderKey.mockRejectedValue(new Error('network'));
-    const keys = [
-      makeKey({ id: 'k1', label: 'Old name' }),
-      makeKey({ id: 'k2', label: 'Other' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Old name' }), makeKey({ id: 'k2', label: 'Other' })];
     const { onUpdate } = renderView({ connected: true, activeKeys: keys });
 
     const renameButtons = screen.getAllByText('Rename');


### PR DESCRIPTION
## Summary

Fixes Manifest-side multi-account bugs for subscription providers:

- let connected OAuth/device-code provider views enter an add-account flow instead of staying stuck in the connected-only state
- add Copilot multi-account UI, including `Add another key`, account listing, and per-label deletion
- save successful second Copilot device-code logins under the next subscription key label instead of overwriting `Default`
- label MiniMax pasted-token add-account saves so they create a new key instead of replacing `Default`
- share next-key label suggestion between API-key and subscription add flows

Closes #1952.

## Root cause

The backend already had labeled provider-key support for most OAuth paths, but several connected subscription UIs never switched from their connected state into the active add-account flow. Copilot also had a separate device-login component that never exposed the multi-key affordance, and its backend token-poll success path saved without a label, so a second connection replaced the default row.

## Notes

This fixes Manifest's add/store/delete behavior for distinct subscription accounts. It does not bypass upstream provider restrictions: if GitHub, Anthropic, OpenAI, or another provider keeps the browser on the same upstream account or returns the same token/account, Manifest cannot force a different paid account.

Includes a `manifest` patch changeset.

## Validation

- `npm test -- CopilotDeviceLogin.test.tsx AnthropicOAuthDetailView.test.tsx DeviceCodeDetailView.test.tsx OAuthDetailView.test.tsx ProviderKeyForm.test.tsx` in `packages/frontend`
- `npm test -- copilot.controller.spec.ts oauth/anthropic/anthropic-oauth.service.spec.ts --runInBand` in `packages/backend`
- `npm test -- DeviceCodeDetailView.test.tsx` in `packages/frontend`
- `npx prettier --check ...` on touched files
- `git diff --check`
- `npx eslint ...` on touched source files
- `npm run build --workspace manifest-frontend`
- `npm run build --workspace manifest-backend`
- local browser smoke on `http://localhost:38252`: fake Copilot `Default` + `Key 2` rows render as two accounts, `Add another key` starts a GitHub device-code flow, deleting `Key 2` leaves `Default` intact, then `Key 2` was restored for manual inspection


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable multiple subscription accounts for Copilot and OAuth-backed providers. Adds add-account flows and correct labeling so new connections create separate keys instead of overwriting the default. Closes #1952.

- New Features
  - Copilot: multi-account UI with account list, Add another key, and per-label delete.
  - OAuth/device-code views (Anthropic, OpenAI, MiniMax): can start an add-account flow while already connected.
  - Shared next-key label suggestion across API-key and subscription flows; up to 5 keys per provider.

- Bug Fixes
  - Copilot device login saves additional tokens under the next OAuth label (e.g., "Key 2") instead of replacing "Default".
  - MiniMax pasted-token connections create a new labeled key rather than overwriting "Default".
  - Backend uses `nextOAuthLabel` for Copilot and Anthropic so added accounts are labeled correctly.
  - Cancel actions properly reset add-account state in connected views.

<sup>Written for commit e91c1d6a6157106d8f7f6e1bec956d45d6acdcea. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1964?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

