### PR TITLE
fix: clear disconnected auth routes

### DIFF
--- a/.changeset/auth-scoped-disconnect.md
+++ b/.changeset/auth-scoped-disconnect.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix provider disconnect cleanup so removing an OAuth subscription clears routes pinned to that auth type even when an API-key credential for the same provider remains connected.

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -8,9 +8,13 @@ import type { TierAutoAssignService } from '../tier-auto-assign.service';
 import type { RoutingCacheService } from '../routing-cache.service';
 import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 
-const route = (provider: string, model: string): ModelRoute => ({
+const route = (
+  provider: string,
+  model: string,
+  authType: ModelRoute['authType'] = 'api_key',
+): ModelRoute => ({
   provider,
-  authType: 'api_key',
+  authType,
   model,
 });
 
@@ -253,6 +257,72 @@ describe('ProviderService — route-only cleanup paths', () => {
       expect(tierRepo.find).not.toHaveBeenCalled();
       expect(result.notifications).toEqual([]);
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('clears only disconnected auth-type routes when another auth type stays active', async () => {
+      const subscriptionRow = {
+        id: 'p-sub',
+        agent_id: 'agent-1',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        is_active: true,
+      };
+      providerRepo.find
+        // Active rows matching the disconnect target.
+        .mockResolvedValueOnce([subscriptionRow])
+        // Sibling API-key row remains active for the same provider.
+        .mockResolvedValueOnce([
+          {
+            id: 'p-api',
+            agent_id: 'agent-1',
+            provider: 'anthropic',
+            auth_type: 'api_key',
+            is_active: true,
+          },
+        ]);
+      tierRepo.find.mockResolvedValueOnce([
+        {
+          tier: 'standard',
+          override_route: route('anthropic', 'claude-sonnet-4-6', 'subscription'),
+          fallback_routes: [
+            route('anthropic', 'claude-opus-4-6', 'subscription'),
+            route('anthropic', 'claude-haiku-4-6', 'api_key'),
+          ],
+        } as unknown as TierAssignment,
+      ]);
+      tierRepo.find.mockResolvedValueOnce([
+        {
+          tier: 'standard',
+          override_route: null,
+          auto_assigned_route: route('anthropic', 'claude-haiku-4-6'),
+        } as unknown as TierAssignment,
+      ]);
+      specRepo.find.mockResolvedValue([
+        {
+          category: 'coding',
+          override_route: route('anthropic', 'claude-sonnet-4-6', 'subscription'),
+          fallback_routes: [
+            route('anthropic', 'claude-opus-4-6', 'subscription'),
+            route('anthropic', 'claude-haiku-4-6', 'api_key'),
+          ],
+        } as unknown as SpecificityAssignment,
+      ]);
+
+      const result = await svc.removeProvider('agent-1', 'anthropic', 'subscription');
+
+      expect(subscriptionRow.is_active).toBe(false);
+      const savedTiers = tierRepo.save.mock.calls[0][0];
+      expect(savedTiers[0].override_route).toBeNull();
+      expect(savedTiers[0].fallback_routes).toEqual([
+        route('anthropic', 'claude-haiku-4-6', 'api_key'),
+      ]);
+      const savedSpec = specRepo.save.mock.calls[0][0];
+      expect(savedSpec[0].override_route).toBeNull();
+      expect(savedSpec[0].fallback_routes).toEqual([
+        route('anthropic', 'claude-haiku-4-6', 'api_key'),
+      ]);
+      expect(autoAssign.recalculate).toHaveBeenCalledWith('agent-1');
+      expect(result.notifications[0]).toMatch(/claude-sonnet-4-6 is no longer available/);
     });
 
     it('throws NotFoundException when no provider record exists', async () => {

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -475,13 +475,17 @@ export class ProviderService {
       where: { agent_id: agentId, provider, is_active: true },
     });
 
-    if (otherActive.some((record) => isManifestUsableProvider(record))) {
-      // Provider is still available via the other auth type — skip override clearing
+    const hasOtherUsableAuthType = otherActive.some((record) => isManifestUsableProvider(record));
+    if (hasOtherUsableAuthType && !authType) {
+      // Provider is still available and the caller did not target a specific
+      // auth type, so preserve existing route assignments.
       this.routingCache.invalidateAgent(agentId);
       return { notifications: [] };
     }
 
-    const { invalidated } = await this.cleanupProviderReferences(agentId, [provider]);
+    const { invalidated } = await this.cleanupProviderReferences(agentId, [provider], {
+      authType: hasOtherUsableAuthType ? authType : undefined,
+    });
     await this.autoAssign.recalculate(agentId);
     this.routingCache.invalidateAgent(agentId);
 
@@ -619,6 +623,7 @@ export class ProviderService {
   private async cleanupProviderReferences(
     agentId: string,
     providers: string[],
+    options?: { authType?: AuthType },
   ): Promise<{ invalidated: { tier: string; modelName: string }[]; hadTierAssignments: boolean }> {
     if (providers.length === 0) return { invalidated: [], hadTierAssignments: false };
 
@@ -632,8 +637,11 @@ export class ProviderService {
     };
 
     const invalidated: { tier: string; modelName: string }[] = [];
-    const routeBelongs = (route: { provider: string; model: string } | null): boolean => {
+    const routeBelongs = (
+      route: { provider: string; model: string; authType?: AuthType | null } | null,
+    ): boolean => {
       if (!route) return false;
+      if (options?.authType && route.authType !== options.authType) return false;
       if (providerNames.has(route.provider.toLowerCase())) return true;
       return modelBelongs(route.model);
     };


### PR DESCRIPTION
## Summary

- scope provider disconnect cleanup by auth type when a same-provider credential remains
- remove stale subscription routes after Anthropic OAuth disconnect while preserving API-key routes
- add a mixed-auth regression test and patch changeset

## Root cause

Provider cleanup skipped routing cleanup whenever another usable credential existed for the same provider. In mixed Anthropic auth setups, disconnecting OAuth left subscription-pinned routes visible because the remaining API-key credential short-circuited cleanup for the whole provider.

## Validation

- npm run test --workspace=packages/backend -- routing/routing-core/__tests__/provider.service.spec.ts --runInBand
- npx tsc --noEmit (packages/backend)
- npm run build --workspace=packages/backend
- npx eslint packages/backend/src/routing/routing-core/provider.service.ts packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
- npm run lint (warnings only)
- npx prettier --check packages/backend/src/routing/routing-core/provider.service.ts packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts .changeset/auth-scoped-disconnect.md
- git diff --check
- npm run test --workspace=packages/backend -- routing/routing-core/__tests__/provider.service.spec.ts --runInBand --coverage --coverageReporters=text --collectCoverageFrom=routing/routing-core/provider.service.ts

Fixes #1256


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes provider disconnect cleanup so routes tied to a disconnected auth type are removed, while routes for other auth types on the same provider stay intact. In mixed Anthropic auth setups, disconnecting OAuth now clears subscription-pinned routes and keeps API-key routes.

- **Bug Fixes**
  - Scope route cleanup by `authType` when another usable credential exists for the same provider.
  - Pass targeted `authType` into `cleanupProviderReferences` and refine `routeBelongs` filtering.
  - Update `removeProvider` to preserve assignments only when no `authType` is specified; otherwise clean only that auth type.
  - Add regression test in `packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts` and patch changeset.

<sup>Written for commit 3b345e723262988aa06297e6df2151772df5fe8a. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1965?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

