### PR TITLE
fix(routing): support multiple Copilot accounts

### DIFF
--- a/.changeset/calm-copilot-accounts.md
+++ b/.changeset/calm-copilot-accounts.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Support adding and managing multiple GitHub Copilot subscription accounts.

--- a/packages/backend/src/routing/copilot.controller.spec.ts
+++ b/packages/backend/src/routing/copilot.controller.spec.ts
@@ -20,6 +20,7 @@ describe('CopilotController', () => {
     jest.clearAllMocks();
     mockProviderService = {
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: false }),
+      nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
     };
     mockResolveAgent = {
@@ -79,6 +80,31 @@ describe('CopilotController', () => {
         'copilot',
         'ghu_github_token',
         'subscription',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('stores a second token under the next OAuth label', async () => {
+      mockProviderService.nextOAuthLabel.mockResolvedValue('Key 2');
+      mockCopilotAuth.pollForToken.mockResolvedValue({
+        status: 'complete',
+        token: 'ghu_second_token',
+      });
+
+      await controller.copilotPollToken(mockUser, mockAgentName, {
+        deviceCode: 'dc_abc',
+      } as never);
+
+      expect(mockProviderService.nextOAuthLabel).toHaveBeenCalledWith(TEST_AGENT_ID, 'copilot');
+      expect(mockProviderService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'user-1',
+        'copilot',
+        'ghu_second_token',
+        'subscription',
+        undefined,
+        'Key 2',
       );
     });
 

--- a/packages/backend/src/routing/copilot.controller.ts
+++ b/packages/backend/src/routing/copilot.controller.ts
@@ -31,12 +31,15 @@ export class CopilotController {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
     const result = await this.copilotAuth.pollForToken(body.deviceCode);
     if (result.status === 'complete' && result.token) {
+      const label = await this.providerService.nextOAuthLabel(agent.id, 'copilot');
       const { provider: record } = await this.providerService.upsertProvider(
         agent.id,
         user.id,
         'copilot',
         result.token,
         'subscription',
+        undefined,
+        label,
       );
       try {
         await this.discoveryService.discoverModels(record);

--- a/packages/frontend/src/components/CopilotDeviceLogin.tsx
+++ b/packages/frontend/src/components/CopilotDeviceLogin.tsx
@@ -1,10 +1,11 @@
-import { createSignal, onCleanup, Show, type Component } from 'solid-js';
+import { createSignal, For, onCleanup, Show, type Component } from 'solid-js';
 import { providerIcon } from './ProviderIcon.js';
 import {
   copilotDeviceCode,
   copilotPollToken,
   disconnectProvider,
   type CopilotPollStatus,
+  type RoutingProvider,
 } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 
@@ -25,13 +26,16 @@ type Phase = 'idle' | 'loading' | 'awaiting' | 'success' | 'error';
 interface Props {
   agentName: string;
   connected: boolean;
+  activeKeys?: RoutingProvider[];
   onBack: () => void;
   onConnected: () => void;
+  onUpdated?: () => void;
   onDisconnected: () => void;
 }
 
 const SLOW_DOWN_INCREASE = 5;
 const MAX_POLL_ERRORS = 5;
+const MAX_KEYS_PER_PROVIDER = 5;
 
 const CopilotDeviceLogin: Component<Props> = (props) => {
   const [phase, setPhase] = createSignal<Phase>('idle');
@@ -42,6 +46,11 @@ const CopilotDeviceLogin: Component<Props> = (props) => {
   const [copied, setCopied] = createSignal(false);
   let pollTimeout: ReturnType<typeof setTimeout> | undefined;
   let cancelled = false;
+
+  const activeKeys = () => (props.activeKeys ?? []).slice().sort((a, b) => a.priority - b.priority);
+  const isMultiKey = () => activeKeys().length > 1;
+  const canAddAnother = () => activeKeys().length < MAX_KEYS_PER_PROVIDER;
+  const showConnectedState = () => props.connected && (phase() === 'idle' || phase() === 'error');
 
   onCleanup(() => {
     cancelled = true;
@@ -125,6 +134,21 @@ const CopilotDeviceLogin: Component<Props> = (props) => {
     }
   };
 
+  const handleDeleteKey = async (label: string) => {
+    setBusy(true);
+    try {
+      const result = await disconnectProvider(props.agentName, 'copilot', 'subscription', label);
+      if (result?.notifications?.length) {
+        for (const msg of result.notifications) toast.error(msg);
+      }
+      props.onUpdated?.();
+    } catch {
+      /* error toast from fetchMutate */
+    } finally {
+      setBusy(false);
+    }
+  };
+
   return (
     <div class="provider-detail">
       <button class="modal-back-btn" onClick={props.onBack} aria-label="Back to providers">
@@ -154,10 +178,76 @@ const CopilotDeviceLogin: Component<Props> = (props) => {
       </div>
 
       {/* Connected state */}
-      <Show when={props.connected && phase() !== 'success'}>
-        <p class="provider-detail__hint" style="color: var(--success-color, #22c55e);">
-          Connected via GitHub device login.
-        </p>
+      <Show when={showConnectedState()}>
+        <Show
+          when={isMultiKey()}
+          fallback={
+            <p class="provider-detail__hint" style="color: var(--success-color, #22c55e);">
+              Connected via GitHub device login.
+            </p>
+          }
+        >
+          <div class="provider-detail__field">
+            <label class="provider-detail__label">Accounts</label>
+            <ul
+              role="list"
+              aria-label="Accounts for GitHub Copilot"
+              style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px;"
+            >
+              <For each={activeKeys()}>
+                {(k) => (
+                  <li style="display: flex; align-items: center; gap: 8px; padding: 8px 10px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--muted) / 0.3);">
+                    <div style="flex: 1; min-width: 0;">
+                      <div style="font-weight: 500; font-size: 14px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                        {k.label}
+                      </div>
+                      <div style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
+                        Connected via GitHub Copilot subscription
+                      </div>
+                    </div>
+                    <button
+                      class="provider-detail__disconnect-icon"
+                      disabled={busy()}
+                      onClick={() => handleDeleteKey(k.label)}
+                      aria-label={`Delete account ${k.label}`}
+                      title="Delete account"
+                    >
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M3 6h18" />
+                        <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" />
+                        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2" />
+                      </svg>
+                    </button>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </div>
+        </Show>
+        <Show when={error()}>
+          <div class="provider-detail__error">{error()}</div>
+        </Show>
+        <Show when={canAddAnother()}>
+          <button
+            class="btn btn--primary provider-detail__action"
+            disabled={busy()}
+            onClick={startLogin}
+          >
+            <Show when={!busy()} fallback={<span class="spinner" />}>
+              Add another key
+            </Show>
+          </button>
+        </Show>
         <button
           class="btn btn--outline provider-detail__action provider-detail__disconnect"
           disabled={busy()}

--- a/packages/frontend/src/components/ProviderSelectContent.tsx
+++ b/packages/frontend/src/components/ProviderSelectContent.tsx
@@ -75,6 +75,14 @@ const ProviderSelectContent: Component<ProviderSelectContentProps> = (props) => 
   const getProviderByAuth = (provId: string, authType: AuthType) =>
     props.providers.find((p) => p.provider === provId && p.auth_type === authType);
 
+  const getActiveProviderKeys = (provId: string, authType: AuthType) =>
+    props.providers
+      .filter(
+        (p) => p.provider === provId && p.auth_type === authType && p.is_active && p.has_api_key,
+      )
+      .slice()
+      .sort((a, b) => a.priority - b.priority);
+
   const isConnected = (provId: string): boolean => {
     const p = getProviderByAuth(provId, 'api_key');
     return !!p && p.is_active && p.has_api_key;
@@ -446,11 +454,13 @@ const ProviderSelectContent: Component<ProviderSelectContentProps> = (props) => 
           <CopilotDeviceLogin
             agentName={props.agentName}
             connected={isSubscriptionWithToken(selectedProvider()!)}
+            activeKeys={getActiveProviderKeys(selectedProvider()!, 'subscription')}
             onBack={goBack}
             onConnected={async () => {
               await props.onUpdate();
               goBack();
             }}
+            onUpdated={props.onUpdate}
             onDisconnected={() => {
               goBack();
               props.onUpdate();

--- a/packages/frontend/tests/components/CopilotDeviceLogin.test.tsx
+++ b/packages/frontend/tests/components/CopilotDeviceLogin.test.tsx
@@ -1,27 +1,24 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
 
-vi.mock("../../src/services/api.js", () => ({
+vi.mock('../../src/services/api.js', () => ({
   copilotDeviceCode: vi.fn(),
   copilotPollToken: vi.fn(),
   disconnectProvider: vi.fn(),
 }));
 
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
-vi.mock("../../src/components/ProviderIcon.js", () => ({
-  providerIcon: () => null, customProviderLogo: () => null,
+vi.mock('../../src/components/ProviderIcon.js', () => ({
+  providerIcon: () => null,
+  customProviderLogo: () => null,
 }));
 
-import CopilotDeviceLogin from "../../src/components/CopilotDeviceLogin";
-import {
-  copilotDeviceCode,
-  copilotPollToken,
-  disconnectProvider,
-} from "../../src/services/api.js";
-import { toast } from "../../src/services/toast-store.js";
+import CopilotDeviceLogin from '../../src/components/CopilotDeviceLogin';
+import { copilotDeviceCode, copilotPollToken, disconnectProvider } from '../../src/services/api.js';
+import { toast } from '../../src/services/toast-store.js';
 
 const mockCopilotDeviceCode = copilotDeviceCode as ReturnType<typeof vi.fn>;
 const mockCopilotPollToken = copilotPollToken as ReturnType<typeof vi.fn>;
@@ -30,7 +27,7 @@ const mockToast = toast as { error: ReturnType<typeof vi.fn>; success: ReturnTyp
 
 function renderComponent(overrides: Partial<Parameters<typeof CopilotDeviceLogin>[0]> = {}) {
   const props = {
-    agentName: "test-agent",
+    agentName: 'test-agent',
     connected: false,
     onBack: vi.fn(),
     onConnected: vi.fn(),
@@ -41,38 +38,38 @@ function renderComponent(overrides: Partial<Parameters<typeof CopilotDeviceLogin
   return { ...result, props };
 }
 
-describe("CopilotDeviceLogin", () => {
+describe('CopilotDeviceLogin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
   });
 
-  it("shows Sign in button in idle state", () => {
+  it('shows Sign in button in idle state', () => {
     renderComponent();
-    expect(screen.getByText("Sign in with GitHub")).toBeDefined();
+    expect(screen.getByText('Sign in with GitHub')).toBeDefined();
     expect(screen.getByText(/Requires an active GitHub Copilot subscription/)).toBeDefined();
   });
 
-  it("calls onBack when back button is clicked", async () => {
+  it('calls onBack when back button is clicked', async () => {
     const { props } = renderComponent();
-    await fireEvent.click(screen.getByLabelText("Back to providers"));
+    await fireEvent.click(screen.getByLabelText('Back to providers'));
     expect(props.onBack).toHaveBeenCalled();
   });
 
-  it("shows loading state after clicking Sign in", async () => {
+  it('shows loading state after clicking Sign in', async () => {
     mockCopilotDeviceCode.mockReturnValue(new Promise(() => {})); // never resolves
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
     // Sign in button should be gone, loading spinner appears
-    expect(screen.queryByText("Sign in with GitHub")).toBeNull();
-    expect(document.querySelector(".spinner")).toBeTruthy();
+    expect(screen.queryByText('Sign in with GitHub')).toBeNull();
+    expect(document.querySelector('.spinner')).toBeTruthy();
   });
 
-  it("shows device code and Open GitHub button in awaiting state", async () => {
+  it('shows device code and Open GitHub button in awaiting state', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
@@ -80,125 +77,125 @@ describe("CopilotDeviceLogin", () => {
     mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByText("ABCD-1234")).toBeDefined();
+      expect(screen.getByText('ABCD-1234')).toBeDefined();
     });
     expect(screen.getByText(/Copy the code, then open GitHub/)).toBeDefined();
-    expect(screen.getByText("Open GitHub")).toBeDefined();
-    expect(screen.getByText("Waiting for authorization...")).toBeDefined();
+    expect(screen.getByText('Open GitHub')).toBeDefined();
+    expect(screen.getByText('Waiting for authorization...')).toBeDefined();
 
-    const link = screen.getByText("Open GitHub").closest("a");
+    const link = screen.getByText('Open GitHub').closest('a');
     expect(link).toBeDefined();
-    expect(link!.getAttribute("href")).toBe("https://github.com/login/device");
-    expect(link!.getAttribute("target")).toBe("_blank");
+    expect(link!.getAttribute('href')).toBe('https://github.com/login/device');
+    expect(link!.getAttribute('target')).toBe('_blank');
   });
 
-  it("shows copy button for device code", async () => {
+  it('shows copy button for device code', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
   });
 
-  it("shows error when device code request fails", async () => {
-    mockCopilotDeviceCode.mockRejectedValue(new Error("Network error"));
+  it('shows error when device code request fails', async () => {
+    mockCopilotDeviceCode.mockRejectedValue(new Error('Network error'));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to start GitHub login. Please try again.")).toBeDefined();
+      expect(screen.getByText('Failed to start GitHub login. Please try again.')).toBeDefined();
     });
     // Sign in button should reappear for retry
-    expect(screen.getByText("Sign in with GitHub")).toBeDefined();
+    expect(screen.getByText('Sign in with GitHub')).toBeDefined();
   });
 
-  it("transitions to success when poll returns complete", async () => {
+  it('transitions to success when poll returns complete', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
-    mockCopilotPollToken.mockResolvedValue({ status: "complete" });
+    mockCopilotPollToken.mockResolvedValue({ status: 'complete' });
 
     const { props } = renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     // Advance timer to trigger the first poll
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(screen.getByText("GitHub Copilot connected successfully.")).toBeDefined();
+      expect(screen.getByText('GitHub Copilot connected successfully.')).toBeDefined();
     });
-    expect(mockToast.success).toHaveBeenCalledWith("GitHub Copilot connected");
+    expect(mockToast.success).toHaveBeenCalledWith('GitHub Copilot connected');
     expect(props.onConnected).toHaveBeenCalled();
   });
 
-  it("shows error when poll returns expired", async () => {
+  it('shows error when poll returns expired', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
-    mockCopilotPollToken.mockResolvedValue({ status: "expired" });
+    mockCopilotPollToken.mockResolvedValue({ status: 'expired' });
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(screen.getByText("Device code expired. Please try again.")).toBeDefined();
+      expect(screen.getByText('Device code expired. Please try again.')).toBeDefined();
     });
   });
 
-  it("shows error when poll returns denied", async () => {
+  it('shows error when poll returns denied', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
-    mockCopilotPollToken.mockResolvedValue({ status: "denied" });
+    mockCopilotPollToken.mockResolvedValue({ status: 'denied' });
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(screen.getByText("Authorization was denied.")).toBeDefined();
+      expect(screen.getByText('Authorization was denied.')).toBeDefined();
     });
   });
 
-  it("shows connection lost after MAX_POLL_ERRORS consecutive failures", async () => {
+  it('shows connection lost after MAX_POLL_ERRORS consecutive failures', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
-    mockCopilotPollToken.mockRejectedValue(new Error("Network error"));
+    mockCopilotPollToken.mockRejectedValue(new Error('Network error'));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     // Advance through 5 failed poll attempts (5 seconds each)
     for (let i = 0; i < 5; i++) {
@@ -206,46 +203,200 @@ describe("CopilotDeviceLogin", () => {
     }
 
     await waitFor(() => {
-      expect(screen.getByText("Connection lost. Please try again.")).toBeDefined();
+      expect(screen.getByText('Connection lost. Please try again.')).toBeDefined();
     });
   });
 
-  it("shows connected state with disconnect button", () => {
+  it('shows connected state with disconnect button', () => {
     renderComponent({ connected: true });
-    expect(screen.getByText("Connected via GitHub device login.")).toBeDefined();
-    expect(screen.getByText("Disconnect")).toBeDefined();
+    expect(screen.getByText('Connected via GitHub device login.')).toBeDefined();
+    expect(screen.getByText('Add another key')).toBeDefined();
+    expect(screen.getByText('Disconnect')).toBeDefined();
   });
 
-  it("calls onDisconnected when disconnect is clicked", async () => {
+  it('starts a new device login while already connected', async () => {
+    mockCopilotDeviceCode.mockResolvedValue({
+      device_code: 'dc_second',
+      user_code: 'WXYZ-9876',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    });
+    mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
+
+    renderComponent({ connected: true });
+    await fireEvent.click(screen.getByText('Add another key'));
+
+    await waitFor(() => {
+      expect(mockCopilotDeviceCode).toHaveBeenCalledWith('test-agent');
+      expect(screen.getByText('WXYZ-9876')).toBeDefined();
+    });
+    expect(screen.queryByText('Connected via GitHub device login.')).toBeNull();
+  });
+
+  it('shows connected Copilot accounts when more than one key is active', () => {
+    renderComponent({
+      connected: true,
+      activeKeys: [
+        {
+          id: 'k1',
+          provider: 'copilot',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: true,
+          label: 'Personal',
+          priority: 0,
+          connected_at: '2026-01-01',
+        },
+        {
+          id: 'k2',
+          provider: 'copilot',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: true,
+          label: 'Work',
+          priority: 1,
+          connected_at: '2026-01-01',
+        },
+      ],
+    });
+    expect(screen.getByText('Accounts')).toBeDefined();
+    expect(screen.getByText('Personal')).toBeDefined();
+    expect(screen.getByText('Work')).toBeDefined();
+  });
+
+  it('deletes a labeled Copilot account and reports notifications', async () => {
+    mockDisconnectProvider.mockResolvedValue({
+      notifications: ['Account still used by another route'],
+    });
+    const onUpdated = vi.fn();
+
+    renderComponent({
+      connected: true,
+      onUpdated,
+      activeKeys: [
+        {
+          id: 'k1',
+          provider: 'copilot',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: true,
+          label: 'Personal',
+          priority: 0,
+          connected_at: '2026-01-01',
+        },
+        {
+          id: 'k2',
+          provider: 'copilot',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: true,
+          label: 'Work',
+          priority: 1,
+          connected_at: '2026-01-01',
+        },
+      ],
+    });
+
+    await fireEvent.click(screen.getByLabelText('Delete account Work'));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalledWith(
+        'test-agent',
+        'copilot',
+        'subscription',
+        'Work',
+      );
+    });
+    expect(mockToast.error).toHaveBeenCalledWith('Account still used by another route');
+    expect(onUpdated).toHaveBeenCalled();
+  });
+
+  it('keeps the account list stable when labeled Copilot account deletion fails', async () => {
+    mockDisconnectProvider.mockRejectedValue(new Error('network'));
+    const onUpdated = vi.fn();
+
+    renderComponent({
+      connected: true,
+      onUpdated,
+      activeKeys: [
+        {
+          id: 'k1',
+          provider: 'copilot',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: true,
+          label: 'Personal',
+          priority: 0,
+          connected_at: '2026-01-01',
+        },
+        {
+          id: 'k2',
+          provider: 'copilot',
+          auth_type: 'subscription',
+          is_active: true,
+          has_api_key: true,
+          label: 'Work',
+          priority: 1,
+          connected_at: '2026-01-01',
+        },
+      ],
+    });
+
+    await fireEvent.click(screen.getByLabelText('Delete account Work'));
+
+    await waitFor(() => {
+      expect(mockDisconnectProvider).toHaveBeenCalledWith(
+        'test-agent',
+        'copilot',
+        'subscription',
+        'Work',
+      );
+    });
+    expect(onUpdated).not.toHaveBeenCalled();
+  });
+
+  it('shows an inline connected-state error when adding another Copilot key fails', async () => {
+    mockCopilotDeviceCode.mockRejectedValue(new Error('Network error'));
+
+    renderComponent({ connected: true });
+    await fireEvent.click(screen.getByText('Add another key'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to start GitHub login. Please try again.')).toBeDefined();
+    });
+  });
+
+  it('calls onDisconnected when disconnect is clicked', async () => {
     mockDisconnectProvider.mockResolvedValue({});
 
     const { props } = renderComponent({ connected: true });
-    await fireEvent.click(screen.getByText("Disconnect"));
+    await fireEvent.click(screen.getByText('Disconnect'));
 
     await waitFor(() => {
       expect(props.onDisconnected).toHaveBeenCalled();
     });
-    expect(mockDisconnectProvider).toHaveBeenCalledWith("test-agent", "copilot", "subscription");
+    expect(mockDisconnectProvider).toHaveBeenCalledWith('test-agent', 'copilot', 'subscription');
   });
 
-  it("shows notification toasts on disconnect with notifications", async () => {
+  it('shows notification toasts on disconnect with notifications', async () => {
     mockDisconnectProvider.mockResolvedValue({
-      notifications: ["Tier affected"],
+      notifications: ['Tier affected'],
     });
 
     renderComponent({ connected: true });
-    await fireEvent.click(screen.getByText("Disconnect"));
+    await fireEvent.click(screen.getByText('Disconnect'));
 
     await waitFor(() => {
-      expect(mockToast.error).toHaveBeenCalledWith("Tier affected");
+      expect(mockToast.error).toHaveBeenCalledWith('Tier affected');
     });
   });
 
-  it("handles disconnect failure gracefully", async () => {
-    mockDisconnectProvider.mockRejectedValue(new Error("fail"));
+  it('handles disconnect failure gracefully', async () => {
+    mockDisconnectProvider.mockRejectedValue(new Error('fail'));
 
     const { props } = renderComponent({ connected: true });
-    await fireEvent.click(screen.getByText("Disconnect"));
+    await fireEvent.click(screen.getByText('Disconnect'));
 
     await waitFor(() => {
       // Should not crash — onDisconnected should NOT be called
@@ -253,86 +404,86 @@ describe("CopilotDeviceLogin", () => {
     });
   });
 
-  it("copies device code to clipboard on copy button click", async () => {
+  it('copies device code to clipboard on copy button click', async () => {
     const writeTextMock = vi.fn().mockResolvedValue(undefined);
     Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
 
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "COPY-ME",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'COPY-ME',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
 
-    await fireEvent.click(screen.getByLabelText("Copy device code"));
+    await fireEvent.click(screen.getByLabelText('Copy device code'));
 
     await waitFor(() => {
-      expect(writeTextMock).toHaveBeenCalledWith("COPY-ME");
+      expect(writeTextMock).toHaveBeenCalledWith('COPY-ME');
     });
     // After successful copy, label changes to "Copied"
     await waitFor(() => {
-      expect(screen.getByLabelText("Copied")).toBeDefined();
+      expect(screen.getByLabelText('Copied')).toBeDefined();
     });
 
     // After timeout, label reverts to "Copy device code"
     await vi.advanceTimersByTimeAsync(2000);
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
   });
 
-  it("handles clipboard write failure gracefully", async () => {
-    const writeTextMock = vi.fn().mockRejectedValue(new Error("clipboard denied"));
+  it('handles clipboard write failure gracefully', async () => {
+    const writeTextMock = vi.fn().mockRejectedValue(new Error('clipboard denied'));
     Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
 
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "FAIL-COPY",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'FAIL-COPY',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
 
     renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
 
-    await fireEvent.click(screen.getByLabelText("Copy device code"));
+    await fireEvent.click(screen.getByLabelText('Copy device code'));
 
     // Should not crash — label stays "Copy device code" (not "Copied")
     await waitFor(() => {
-      expect(screen.getByLabelText("Copy device code")).toBeDefined();
+      expect(screen.getByLabelText('Copy device code')).toBeDefined();
     });
   });
 
-  it("increases poll delay on slow_down status", async () => {
+  it('increases poll delay on slow_down status', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     // First poll: slow_down, second poll: complete
     mockCopilotPollToken
-      .mockResolvedValueOnce({ status: "slow_down" })
-      .mockResolvedValueOnce({ status: "complete" });
+      .mockResolvedValueOnce({ status: 'slow_down' })
+      .mockResolvedValueOnce({ status: 'complete' });
 
     const { props } = renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     // First poll at 5 seconds
     await vi.advanceTimersByTimeAsync(5000);
@@ -344,25 +495,25 @@ describe("CopilotDeviceLogin", () => {
     await vi.advanceTimersByTimeAsync(10000);
 
     await waitFor(() => {
-      expect(screen.getByText("GitHub Copilot connected successfully.")).toBeDefined();
+      expect(screen.getByText('GitHub Copilot connected successfully.')).toBeDefined();
     });
     expect(props.onConnected).toHaveBeenCalled();
   });
 
-  it("continues polling on pending status with same delay", async () => {
+  it('continues polling on pending status with same delay', async () => {
     mockCopilotDeviceCode.mockResolvedValue({
-      device_code: "dc_test",
-      user_code: "ABCD-1234",
-      verification_uri: "https://github.com/login/device",
+      device_code: 'dc_test',
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
       expires_in: 900,
       interval: 5,
     });
     mockCopilotPollToken
-      .mockResolvedValueOnce({ status: "pending" })
-      .mockResolvedValueOnce({ status: "complete" });
+      .mockResolvedValueOnce({ status: 'pending' })
+      .mockResolvedValueOnce({ status: 'complete' });
 
     const { props } = renderComponent();
-    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await fireEvent.click(screen.getByText('Sign in with GitHub'));
 
     // First poll at 5 seconds — returns pending
     await vi.advanceTimersByTimeAsync(5000);
@@ -374,7 +525,7 @@ describe("CopilotDeviceLogin", () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     await waitFor(() => {
-      expect(screen.getByText("GitHub Copilot connected successfully.")).toBeDefined();
+      expect(screen.getByText('GitHub Copilot connected successfully.')).toBeDefined();
     });
     expect(props.onConnected).toHaveBeenCalled();
   });

--- a/packages/frontend/tests/components/ProviderSelectContent-copilot-accounts.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectContent-copilot-accounts.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import type { RoutingProvider } from '../../src/services/api';
+
+vi.mock('../../src/services/api.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/api')>();
+
+  return {
+    ...actual,
+    connectProvider: vi.fn(),
+    disconnectProvider: vi.fn().mockResolvedValue({ notifications: [] }),
+  };
+});
+
+vi.mock('../../src/services/setup-status.js', () => ({
+  checkIsSelfHosted: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../../src/services/toast-store.js', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock('../../src/components/ProviderIcon.js', () => ({
+  providerIcon: () => null,
+  customProviderLogo: () => null,
+}));
+
+vi.mock('../../src/components/CopilotDeviceLogin.js', () => ({
+  default: (props: {
+    activeKeys?: Array<{ label: string }>;
+    agentName: string;
+    connected: boolean;
+  }) => (
+    <div
+      data-testid="copilot-device-login"
+      data-agent={props.agentName}
+      data-connected={String(props.connected)}
+      data-active-count={String((props.activeKeys ?? []).length)}
+      data-active-labels={(props.activeKeys ?? []).map((key) => key.label).join(',')}
+    />
+  ),
+}));
+
+import ProviderSelectContent from '../../src/components/ProviderSelectContent';
+
+describe('ProviderSelectContent Copilot accounts', () => {
+  it('passes only active Copilot accounts with usable tokens to the detail view', async () => {
+    const providers: RoutingProvider[] = [
+      {
+        id: 'pending',
+        provider: 'copilot',
+        auth_type: 'subscription',
+        is_active: true,
+        has_api_key: false,
+        label: 'Pending',
+        priority: 0,
+        connected_at: '2026-05-21T00:00:00.000Z',
+      },
+      {
+        id: 'work',
+        provider: 'copilot',
+        auth_type: 'subscription',
+        is_active: true,
+        has_api_key: true,
+        label: 'Work',
+        priority: 1,
+        connected_at: '2026-05-21T00:00:00.000Z',
+      },
+    ];
+
+    const { container } = render(() => (
+      <ProviderSelectContent agentName="test-agent" providers={providers} onUpdate={vi.fn()} />
+    ));
+
+    fireEvent.click(screen.getByText('GitHub Copilot'));
+
+    const detail = await waitFor(() => {
+      const element = container.querySelector('[data-testid="copilot-device-login"]');
+      if (!element) throw new Error('Copilot detail view not found');
+      return element;
+    });
+
+    expect(detail.getAttribute('data-active-count')).toBe('1');
+    expect(detail.getAttribute('data-active-labels')).toBe('Work');
+  });
+});


### PR DESCRIPTION
## Summary
- store additional GitHub Copilot subscription tokens under the next account label instead of overwriting `Default`
- show active Copilot subscription accounts with per-account removal
- keep the connected-state UI focused on the account list while still allowing users to add another Copilot key

## Scope
This is the Copilot-specific part of #1952, split out from the broader draft in #1964. The generic OAuth/device-code connected add-account flow is handled in #1968.

## Validation
- `npm run build --workspace manifest-shared`
- `npm test -- CopilotDeviceLogin.test.tsx` in `packages/frontend`
- `npm test -- copilot.controller.spec.ts --runInBand` in `packages/backend`
- `npx prettier --check .changeset/calm-copilot-accounts.md packages/backend/src/routing/copilot.controller.ts packages/backend/src/routing/copilot.controller.spec.ts packages/frontend/src/components/CopilotDeviceLogin.tsx packages/frontend/src/components/ProviderSelectContent.tsx packages/frontend/tests/components/CopilotDeviceLogin.test.tsx`
- `npx eslint packages/backend/src/routing/copilot.controller.ts packages/frontend/src/components/CopilotDeviceLogin.tsx packages/frontend/src/components/ProviderSelectContent.tsx`
- `git diff --check`
- `npm run build --workspace manifest-backend`
- `npm run build --workspace manifest-frontend`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for multiple GitHub Copilot subscription accounts with an account list, per-account removal, and an “Add another key” flow from the connected view. This implements the Copilot portion of #1952.

- **New Features**
  - Backend: use `nextOAuthLabel` to label additional Copilot tokens and pass the label to `upsertProvider` (no more overwriting `Default`).
  - Frontend: `CopilotDeviceLogin` lists labeled accounts (sorted), lets users delete a specific account, and starts a new device login while connected (max 5), with inline errors when add fails.
  - Frontend: `ProviderSelectContent` passes only active subscription keys with tokens to `CopilotDeviceLogin` and refreshes via `onUpdated`; tests cover multi-key login, add-while-connected, per-account deletion with notifications, and filtering.

<sup>Written for commit ba08e7200ae7c2e13f2cc19db962754017dd8afb. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1967?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

