### PR TITLE
fix: stop slow upstream fetches from failing deploys

### DIFF
--- a/.changeset/railway-nonblocking-startup-syncs.md
+++ b/.changeset/railway-nonblocking-startup-syncs.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Stop slow startup model-catalog syncs from stalling boot past the deploy healthcheck. The OpenRouter, models.dev, GitHub, and modelparameters.dev fetches now run in the background instead of blocking `app.listen()`, and the two that lacked a timeout (OpenRouter, GitHub) now abort after 10s. The pricing cache still warms up with real data once those fetches land.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -493,21 +493,33 @@ describe('ModelsDevSyncService', () => {
   });
 
   describe('onModuleInit', () => {
-    it('should call refreshCache on module init', async () => {
+    it('kicks off refreshCache without blocking', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({}),
       });
 
-      await service.onModuleInit();
+      // Fire-and-forget (must not block boot — see #1894); whenInitialized()
+      // resolves once the startup fetch has settled.
+      service.onModuleInit();
+      await service.whenInitialized();
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should not throw when fetch fails during init', async () => {
-      fetchSpy.mockRejectedValue(new Error('Network error'));
+    it('does not reject when refreshCache rejects', async () => {
+      // Reject refreshCache itself (not just fetch, which it swallows internally)
+      // to exercise onModuleInit's .catch handler.
+      jest.spyOn(service, 'refreshCache').mockRejectedValue(new Error('Network error'));
 
-      await expect(service.onModuleInit()).resolves.toBeUndefined();
+      service.onModuleInit();
+      await expect(service.whenInitialized()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('whenInitialized', () => {
+    it('resolves immediately when onModuleInit has not run', async () => {
+      await expect(service.whenInitialized()).resolves.toBeUndefined();
     });
   });
 

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -96,13 +96,22 @@ export class ModelsDevSyncService implements OnModuleInit {
   /** Map: our provider ID → Map<model ID (native), entry> */
   private cache = new Map<string, Map<string, ModelsDevModelEntry>>();
   private lastFetchedAt: Date | null = null;
+  private initialLoad: Promise<void> | null = null;
 
-  async onModuleInit(): Promise<void> {
-    try {
-      await this.refreshCache();
-    } catch (err) {
-      this.logger.error(`Startup models.dev cache refresh failed: ${err}`);
-    }
+  onModuleInit(): void {
+    // Fire-and-forget so a slow models.dev fetch can't delay app.listen() and
+    // trip Railway's healthcheck (see #1894). ModelPricingCacheService awaits
+    // whenInitialized() before its first reload so warmup still sees data.
+    this.initialLoad = this.refreshCache()
+      .then(() => undefined)
+      .catch((err) => {
+        this.logger.error(`Startup models.dev cache refresh failed: ${err}`);
+      });
+  }
+
+  /** Resolves once the startup refresh has settled (success or handled error). */
+  whenInitialized(): Promise<void> {
+    return this.initialLoad ?? Promise.resolve();
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_4AM)

--- a/packages/backend/src/database/pricing-sync.service.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.spec.ts
@@ -15,7 +15,7 @@ describe('PricingSyncService', () => {
   });
 
   describe('onModuleInit', () => {
-    it('calls refreshCache on init', async () => {
+    it('kicks off refreshCache without blocking and populates the cache', async () => {
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -28,21 +28,30 @@ describe('PricingSyncService', () => {
         }),
       });
 
-      await service.onModuleInit();
-      // onModuleInit fires refreshCache without awaiting — wait for it
-      await new Promise((r) => setTimeout(r, 10));
-      expect(fetchSpy).toHaveBeenCalledWith('https://openrouter.ai/api/v1/models');
+      // onModuleInit is fire-and-forget (must not block boot — see #1894);
+      // whenInitialized() resolves once the startup fetch has landed.
+      service.onModuleInit();
+      await service.whenInitialized();
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://openrouter.ai/api/v1/models',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
       expect(service.getAll().size).toBeGreaterThan(0);
     });
 
-    it('does not throw when refreshCache rejects', async () => {
+    it('does not reject when refreshCache rejects', async () => {
       // Make refreshCache itself reject (not just fetch) to trigger the .catch() handler
       jest.spyOn(service, 'refreshCache').mockRejectedValue(new Error('Unexpected failure'));
 
-      await service.onModuleInit();
-      // Give the async .catch time to execute
-      await new Promise((r) => setTimeout(r, 10));
-      // The error is caught by the .catch; no unhandled rejection
+      service.onModuleInit();
+      // The startup failure is swallowed by the .catch; whenInitialized resolves
+      await expect(service.whenInitialized()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('whenInitialized', () => {
+    it('resolves immediately when onModuleInit has not run', async () => {
+      await expect(service.whenInitialized()).resolves.toBeUndefined();
     });
   });
 

--- a/packages/backend/src/database/pricing-sync.service.ts
+++ b/packages/backend/src/database/pricing-sync.service.ts
@@ -27,20 +27,32 @@ export interface OpenRouterPricingEntry {
 }
 
 const OPENROUTER_API = 'https://openrouter.ai/api/v1/models';
+const FETCH_TIMEOUT_MS = 10000;
 
 @Injectable()
 export class PricingSyncService implements OnModuleInit {
   private readonly logger = new Logger(PricingSyncService.name);
   private cache = new Map<string, OpenRouterPricingEntry>();
   private lastFetchedAt: Date | null = null;
+  private initialLoad: Promise<void> | null = null;
 
-  async onModuleInit(): Promise<void> {
-    // Await startup fetch so ModelPricingCacheService.reload() has data
-    try {
-      await this.refreshCache();
-    } catch (err) {
-      this.logger.error(`Startup OpenRouter cache refresh failed: ${err}`);
-    }
+  onModuleInit(): void {
+    // Kick off the startup fetch WITHOUT blocking boot. A slow or unreachable
+    // OpenRouter previously stalled app.listen() — and with it Railway's
+    // healthcheck — for up to undici's default header timeout (see #1894).
+    // The pricing cache still warms up with real data shortly after the server
+    // starts listening; ModelPricingCacheService awaits whenInitialized()
+    // before its first reload so that warmup sees populated data.
+    this.initialLoad = this.refreshCache()
+      .then(() => undefined)
+      .catch((err) => {
+        this.logger.error(`Startup OpenRouter cache refresh failed: ${err}`);
+      });
+  }
+
+  /** Resolves once the startup refresh has settled (success or handled error). */
+  whenInitialized(): Promise<void> {
+    return this.initialLoad ?? Promise.resolve();
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_3AM)
@@ -95,8 +107,10 @@ export class PricingSyncService implements OnModuleInit {
   }
 
   private async fetchOpenRouterModels(): Promise<OpenRouterModel[] | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
-      const res = await fetch(OPENROUTER_API);
+      const res = await fetch(OPENROUTER_API, { signal: controller.signal });
       if (!res.ok) {
         this.logger.error(`OpenRouter API returned ${res.status}`);
         return null;
@@ -106,6 +120,8 @@ export class PricingSyncService implements OnModuleInit {
     } catch (err) {
       this.logger.error(`Failed to fetch OpenRouter models: ${err}`);
       return null;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/packages/backend/src/free-models/free-models-sync.service.spec.ts
+++ b/packages/backend/src/free-models/free-models-sync.service.spec.ts
@@ -64,20 +64,31 @@ describe('FreeModelsSyncService', () => {
   });
 
   describe('onModuleInit', () => {
-    it('calls refreshCache on init', async () => {
+    it('kicks off refreshCache without blocking and populates the cache', async () => {
+      const refresh = jest.spyOn(service, 'refreshCache');
       fetchSpy.mockResolvedValue({
         ok: true,
         json: async () => sampleData,
       });
 
-      await service.onModuleInit();
-      expect(fetchSpy).toHaveBeenCalledWith(GITHUB_RAW_URL);
+      // Fire-and-forget (must not block boot — see #1894); await the kicked-off
+      // refresh deterministically via the spy's returned promise.
+      service.onModuleInit();
+      await refresh.mock.results[0].value;
+      expect(fetchSpy).toHaveBeenCalledWith(
+        GITHUB_RAW_URL,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
       expect(service.getAll()).toHaveLength(2);
     });
 
-    it('does not throw when refreshCache rejects', async () => {
-      jest.spyOn(service, 'refreshCache').mockRejectedValue(new Error('Unexpected'));
-      await service.onModuleInit();
+    it('does not leave an unhandled rejection when refreshCache rejects', async () => {
+      const refresh = jest
+        .spyOn(service, 'refreshCache')
+        .mockRejectedValue(new Error('Unexpected'));
+      service.onModuleInit();
+      // onModuleInit attaches a .catch that swallows the failure.
+      await expect(refresh.mock.results[0].value).rejects.toThrow('Unexpected');
     });
   });
 

--- a/packages/backend/src/free-models/free-models-sync.service.ts
+++ b/packages/backend/src/free-models/free-models-sync.service.ts
@@ -32,6 +32,7 @@ interface GitHubDataJson {
 // frontend would render. Bump this SHA when refreshing the upstream data.
 const GITHUB_RAW_REF = '8b0feb0e3adda96455bcc380b815454944ff3832';
 const GITHUB_RAW_URL = `https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/${GITHUB_RAW_REF}/data.json`;
+const FETCH_TIMEOUT_MS = 10000;
 
 function isHttpsUrl(value: unknown): value is string {
   if (typeof value !== 'string') return false;
@@ -68,12 +69,13 @@ export class FreeModelsSyncService implements OnModuleInit {
   private cache: GitHubProvider[] = [];
   private lastFetchedAt: Date | null = null;
 
-  async onModuleInit(): Promise<void> {
-    try {
-      await this.refreshCache();
-    } catch (err) {
+  onModuleInit(): void {
+    // Fire-and-forget so a slow GitHub fetch can't delay app.listen() and trip
+    // Railway's healthcheck (see #1894). Nothing reads this cache during boot;
+    // the free-models endpoints tolerate an empty cache until the fetch lands.
+    void this.refreshCache().catch((err) => {
       this.logger.error(`Startup free models sync failed: ${err}`);
-    }
+    });
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
@@ -109,8 +111,10 @@ export class FreeModelsSyncService implements OnModuleInit {
   }
 
   private async fetchData(): Promise<GitHubDataJson | null> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
-      const res = await fetch(GITHUB_RAW_URL);
+      const res = await fetch(GITHUB_RAW_URL, { signal: controller.signal });
       if (!res.ok) {
         this.logger.error(`GitHub raw returned ${res.status}`);
         return null;
@@ -124,6 +128,8 @@ export class FreeModelsSyncService implements OnModuleInit {
     } catch (err) {
       this.logger.error(`Failed to fetch free models data: ${err}`);
       return null;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 }

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -32,7 +32,13 @@ function makeMockModelsDevSync() {
     lookupModel: jest.fn().mockReturnValue(null),
     getModelsForProvider: jest.fn().mockReturnValue([]),
     isProviderSupported: jest.fn().mockReturnValue(false),
+    whenInitialized: jest.fn().mockResolvedValue(undefined),
   };
+}
+
+/** Flush the fire-and-forget warmup chain (whenInitialized + reload microtasks). */
+function flushWarmup(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 describe('ModelPricingCacheService', () => {
@@ -40,23 +46,50 @@ describe('ModelPricingCacheService', () => {
   let mockGetAll: jest.Mock;
   let mockRegistry: ReturnType<typeof makeMockRegistry>;
   let mockModelsDevSync: ReturnType<typeof makeMockModelsDevSync>;
+  let mockPricingSync: { getAll: jest.Mock; whenInitialized: jest.Mock };
 
   beforeEach(() => {
     mockGetAll = jest.fn().mockReturnValue(new Map<string, OpenRouterPricingEntry>());
-    const mockSync = { getAll: mockGetAll } as unknown as PricingSyncService;
+    mockPricingSync = {
+      getAll: mockGetAll,
+      whenInitialized: jest.fn().mockResolvedValue(undefined),
+    };
     mockModelsDevSync = makeMockModelsDevSync();
     mockRegistry = makeMockRegistry();
     service = new ModelPricingCacheService(
-      mockSync,
+      mockPricingSync as unknown as PricingSyncService,
       mockModelsDevSync as unknown as ModelsDevSyncService,
       mockRegistry as unknown as ProviderModelRegistryService,
     );
   });
 
   describe('onApplicationBootstrap', () => {
-    it('should call reload()', async () => {
+    it('warms up the cache after the upstream syncs settle', async () => {
       const spy = jest.spyOn(service, 'reload').mockResolvedValue();
-      await service.onApplicationBootstrap();
+      // onApplicationBootstrap is fire-and-forget so it can't delay boot (#1894).
+      service.onApplicationBootstrap();
+      await flushWarmup();
+      expect(mockPricingSync.whenInitialized).toHaveBeenCalledTimes(1);
+      expect(mockModelsDevSync.whenInitialized).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows errors when reload fails during warmup', async () => {
+      jest.spyOn(service, 'reload').mockRejectedValue(new Error('boom'));
+      service.onApplicationBootstrap();
+      // warmup's try/catch handles it — no unhandled rejection
+      await expect(flushWarmup()).resolves.toBeUndefined();
+    });
+
+    it('tolerates a missing models.dev sync', async () => {
+      const soloService = new ModelPricingCacheService(
+        mockPricingSync as unknown as PricingSyncService,
+        null,
+        mockRegistry as unknown as ProviderModelRegistryService,
+      );
+      const spy = jest.spyOn(soloService, 'reload').mockResolvedValue();
+      soloService.onApplicationBootstrap();
+      await flushWarmup();
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -51,8 +51,25 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
     private readonly customProviderRepo: Repository<CustomProvider> | null = null,
   ) {}
 
-  async onApplicationBootstrap(): Promise<void> {
-    await this.reload();
+  onApplicationBootstrap(): void {
+    // Warm up the pricing cache in the background. The OpenRouter / models.dev
+    // syncs it reads from are now fire-and-forget (see #1894), so awaiting
+    // reload() here would just re-introduce the slow-boot problem. Wait for
+    // those syncs' initial fetch to settle, then build the cache — all off the
+    // app.listen() critical path.
+    void this.warmup();
+  }
+
+  private async warmup(): Promise<void> {
+    try {
+      await Promise.allSettled([
+        this.pricingSync.whenInitialized(),
+        this.modelsDevSync?.whenInitialized() ?? Promise.resolve(),
+      ]);
+      await this.reload();
+    } catch (err) {
+      this.logger.error(`Pricing cache warmup failed: ${err}`);
+    }
   }
 
   /** Rebuild the pricing cache after sync services refresh their data. */

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -142,4 +142,28 @@ describe('ProviderParamSpecService', () => {
     await expect(service.refreshCache()).resolves.toBe(0);
     await expect(service.list()).resolves.toHaveLength(2);
   });
+
+  describe('onModuleInit', () => {
+    it('kicks off refreshCache without blocking and loads the catalog', async () => {
+      mockRemoteCatalog();
+      const service = new ProviderParamSpecService();
+      const refresh = jest.spyOn(service, 'refreshCache');
+
+      // Fire-and-forget (must not block boot — see #1894); await the kicked-off
+      // refresh deterministically via the spy's returned promise.
+      service.onModuleInit();
+      await refresh.mock.results[0].value;
+
+      await expect(service.list()).resolves.toHaveLength(2);
+    });
+
+    it('does not leave an unhandled rejection when the startup refresh rejects', async () => {
+      const service = new ProviderParamSpecService();
+      const refresh = jest.spyOn(service, 'refreshCache').mockRejectedValue(new Error('boom'));
+
+      service.onModuleInit();
+      // onModuleInit attaches a .catch that swallows the failure.
+      await expect(refresh.mock.results[0].value).rejects.toThrow('boom');
+    });
+  });
 });

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -48,12 +48,13 @@ export class ProviderParamSpecService implements OnModuleInit {
   private specs: ProviderParamSpecCatalog = freezeCatalog([]);
   private lastFetchedAt: Date | null = null;
 
-  async onModuleInit(): Promise<void> {
-    try {
-      await this.refreshCache();
-    } catch (err) {
+  onModuleInit(): void {
+    // Fire-and-forget so a slow modelparameters.dev fetch can't delay
+    // app.listen() and trip Railway's healthcheck (see #1894). The MPS catalog
+    // falls back to its frozen default until the fetch lands.
+    void this.refreshCache().catch((err) => {
       this.logger.warn(`Startup modelparameters.dev refresh failed: ${err}`);
-    }
+    });
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_4AM)


### PR DESCRIPTION
### 💭 Why
Railway deploys could fail the boot healthcheck (#1894). Boot blocked on four third-party model-catalog fetches (OpenRouter, models.dev, GitHub, modelparameters.dev) awaited during module init. Two had no timeout, so a slow upstream could stall `app.listen()` for up to undici's ~300s default. Concurrent deploys made it worse.

### ✨ What changed
- All four startup syncs are now fire-and-forget, so they don't gate `app.listen()`.
- Added a 10s abort timeout to the OpenRouter and GitHub fetches (the two that lacked one).
- Pricing cache warmup moved off the boot path: it awaits the pricing/models.dev initial fetch in the background, then reloads.

### 🔧 For operators
Boot no longer waits on external APIs, so a slow or unreachable upstream can't fail a deploy. No config or migration changes.

### 📝 Notes
- Investigation also ruled out the #1694 `api_kind` migration as the cause (it runs in ~14ms on 100k rows).
- The healthcheck timeout was already raised 120s to 300s separately; this removes the root cause.
- Early requests in the first ~second after boot may see an empty pricing cache until warmup lands (same as prior happy-path behavior).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop deploy failures by making startup model-catalog syncs non-blocking and adding 10s timeouts for slow upstreams. The app starts listening immediately; slow or unreachable APIs no longer trip the Railway healthcheck.

- **Bug Fixes**
  - Startup syncs for OpenRouter, models.dev, GitHub, and modelparameters.dev now run in the background; they no longer block `app.listen()`.
  - Added 10s fetch timeouts to the OpenRouter and GitHub catalog fetches.
  - `ModelPricingCacheService` warms up after boot: waits for `PricingSyncService` and `ModelsDevSyncService` via `whenInitialized()`, then calls `reload()` off the boot path.
  - No config or migration changes. Early requests may briefly see an empty pricing cache until warmup completes.

<sup>Written for commit 680feca2a62f9d0a94bf6a2879229ea926eedee7. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1969?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

