### PR TITLE
fix: stop dev CORS from blocking Wingman's SDK headers

### DIFF
--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -76,9 +76,11 @@ export async function bootstrap() {
   //
   // `credentials: false` is deliberate — Wingman uses bearer keys, never
   // cookies, and keeping credentials off the cross-origin path means a
-  // misconfigured allow-list can't leak session cookies. `allowedHeaders`
-  // is the minimum set the dashboard / Wingman send: bearer auth, JSON
-  // bodies, and the legacy `X-API-Key` header used by some operators.
+  // misconfigured allow-list can't leak session cookies. We omit
+  // `allowedHeaders` on purpose so the cors middleware reflects the
+  // request's `Access-Control-Request-Headers`: Wingman replays real SDK
+  // fingerprints (e.g. the OpenAI/Stainless `X-Stainless-*` family), and a
+  // fixed allow-list silently fails those preflights.
   if (isDev) {
     const configuredOrigin = process.env['CORS_ORIGIN'] || 'http://localhost:3000';
     const allowedOrigins = buildDevAllowedOrigins({
@@ -95,7 +97,6 @@ export async function bootstrap() {
     app.enableCors({
       origin: createCorsOriginHandler(allowedOrigins),
       credentials: false,
-      allowedHeaders: ['Authorization', 'Content-Type', 'X-API-Key'],
     });
   }
 


### PR DESCRIPTION
### 💭 Why
Main's dev CORS already allows the Wingman origin and answers Chrome's Private Network Access preflight. The remaining block: `allowedHeaders` is pinned to Authorization, Content-Type, X-API-Key. The OpenClaw, Hermes, and OpenAI SDK profiles replay `X-Stainless-*` headers to mimic the real SDK, so the preflight asks for headers the list omits and the request never leaves the browser.

### ✨ What changed
- Drop the fixed `allowedHeaders` list so the cors middleware reflects the request's `Access-Control-Request-Headers`.

### 👤 For users
The Wingman drawer's agent/SDK profiles (OpenClaw, Hermes, OpenAI SDK) now work against a local or self-hosted-dev Manifest. Dev-only; `credentials: false` is unchanged.
