### PR TITLE
Fix model params dialog drag, cursor, and slider UX

### DIFF
--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -165,48 +165,42 @@ const ModelParamsDialog: Component<Props> = (props) => {
   );
 
   const SliderRow = (spec: ProviderParamSpec) => {
-    let sliderRef: HTMLDivElement | undefined;
+    let startX = 0;
+    let startValue = 0;
     const min = () => spec.range?.min ?? 0;
     const max = () => spec.range?.max ?? 100;
     const value = () => numericValue(spec);
-    const progress = () => {
-      const span = max() - min();
-      if (span <= 0) return 0;
-      return clampNumber(((value() - min()) / span) * 100, 0, 0, 100);
-    };
-    const setSliderValue = (next: number) => {
+    const setSliderVal = (next: number) => {
       if (isDisabled(spec)) return;
       setValue(spec, sliderValue(next, spec));
     };
-    const setFromPointer = (clientX: number) => {
-      if (!sliderRef) return;
-      const rect = sliderRef.getBoundingClientRect();
-      const ratio = clampNumber((clientX - rect.left) / rect.width, 0, 0, 1);
-      setSliderValue(min() + ratio * (max() - min()));
+    const pixelsPerUnit = () => {
+      const span = max() - min();
+      if (span <= 0) return 1;
+      return 120 / span;
     };
     const handleKeyDown = (e: KeyboardEvent) => {
       if (isDisabled(spec)) return;
       const step = sliderStep(spec);
       if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
         e.preventDefault();
-        setSliderValue(value() - step);
+        setSliderVal(value() - step);
       } else if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
         e.preventDefault();
-        setSliderValue(value() + step);
+        setSliderVal(value() + step);
       } else if (e.key === 'Home') {
         e.preventDefault();
-        setSliderValue(min());
+        setSliderVal(min());
       } else if (e.key === 'End') {
         e.preventDefault();
-        setSliderValue(max());
+        setSliderVal(max());
       }
     };
 
     return (
-      <div class="model-params__range">
+      <div class="model-params__scrub-field" classList={{ 'model-params__scrub-field--disabled': isDisabled(spec) }}>
         <div
-          ref={sliderRef}
-          class="model-params__slider"
+          class="model-params__scrub"
           role="slider"
           tabIndex={isDisabled(spec) ? -1 : 0}
           aria-label={spec.label}
@@ -215,28 +209,28 @@ const ModelParamsDialog: Component<Props> = (props) => {
           aria-valuenow={value()}
           aria-valuetext={String(value())}
           aria-disabled={isDisabled(spec)}
-          style={`--model-params-slider-progress: ${progress()}%;`}
           onPointerDown={(e) => {
             if (isDisabled(spec)) return;
             e.preventDefault();
+            startX = e.clientX;
+            startValue = value();
             e.currentTarget.setPointerCapture?.(e.pointerId);
-            setFromPointer(e.clientX);
           }}
           onPointerMove={(e) => {
             if (!e.currentTarget.hasPointerCapture?.(e.pointerId)) return;
-            setFromPointer(e.clientX);
+            const delta = (e.clientX - startX) / pixelsPerUnit();
+            setSliderVal(startValue + delta);
           }}
           onPointerUp={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
           onPointerCancel={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
           onKeyDown={handleKeyDown}
         >
-          <span class="model-params__slider-track" aria-hidden="true">
-            <span class="model-params__slider-fill" />
-          </span>
-          <span class="model-params__slider-thumb" aria-hidden="true" />
+          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M5 3a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4M5 10a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4M5 17a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7.33 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4" />
+          </svg>
         </div>
         <input
-          class="model-params__slider-input"
+          class="model-params__scrub-input"
           type="number"
           min={min()}
           max={max()}
@@ -244,7 +238,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
           value={value()}
           disabled={isDisabled(spec)}
           aria-label={`${spec.label} value`}
-          onInput={(e) => setSliderValue(Number.parseFloat(e.currentTarget.value))}
+          onInput={(e) => setSliderVal(Number.parseFloat(e.currentTarget.value))}
         />
       </div>
     );
@@ -330,18 +324,18 @@ const ModelParamsDialog: Component<Props> = (props) => {
         class="model-params__row"
         classList={{ 'model-params__row--disabled': !isApplicable(spec()) }}
       >
-        <div class="model-params__label">
+        <div class="model-params__row-top">
           <div class="model-params__label-title">
             <span>{spec().label}</span>
             <code class="model-params__param-key">{spec().path}</code>
           </div>
-          <div class="model-params__label-hint">
-            {isApplicable(spec())
-              ? `Provider default: ${spec().default === undefined ? 'unset' : String(spec().default)}`
-              : 'Unavailable with selected parameters'}
-          </div>
+          {renderControl(spec())}
         </div>
-        {renderControl(spec())}
+        <div class="model-params__label-hint">
+          {isApplicable(spec())
+            ? `Default: ${spec().default === undefined ? 'unset' : String(spec().default)}`
+            : 'Unavailable with selected parameters'}
+        </div>
       </div>
     );
   };
@@ -350,13 +344,15 @@ const ModelParamsDialog: Component<Props> = (props) => {
     <Show when={props.open}>
       <div
         class="modal-overlay"
+        draggable={false}
         onClick={(e) => {
           if (e.target === e.currentTarget && !saving()) props.onClose();
         }}
+        onDragStart={(e) => e.preventDefault()}
       >
         <div
           class="modal-card"
-          style="max-width: 460px;"
+          style="max-width: 460px; user-select: none;"
           role="dialog"
           aria-modal="true"
           aria-labelledby="model-params-dialog-title"

--- a/packages/frontend/src/styles/modals.css
+++ b/packages/frontend/src/styles/modals.css
@@ -148,6 +148,7 @@
   align-items: center;
   justify-content: center;
   padding: var(--gap-lg);
+  cursor: default;
   animation: fadeIn 150ms ease-out;
 }
 

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -568,10 +568,16 @@
 
 .model-params__row {
   display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 12px 0;
+}
+
+.model-params__row-top {
+  display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 12px 0;
 }
 
 .model-params__row--disabled .model-params__label-title,
@@ -590,13 +596,13 @@
 
 .model-params__group-header {
   padding: 6px 0 2px;
-  font-size: var(--font-size-xs);
+  font-size: var(--font-size-sm);
   font-weight: 600;
-  color: hsl(var(--muted-foreground));
+  color: hsl(var(--foreground));
 }
 
 .model-params__group .model-params__row {
-  padding: 10px 0;
+  padding: 8px 0;
 }
 
 .model-params__label-title {
@@ -629,6 +635,7 @@
   display: inline-flex;
   align-items: center;
   gap: 10px;
+  flex-shrink: 0;
   background: none;
   border: none;
   padding: 4px;
@@ -650,97 +657,79 @@
 }
 
 .model-params__field {
-  min-width: 150px;
+  flex-shrink: 0;
+  display: flex;
+  justify-content: flex-end;
 }
 
-.model-params__range {
-  display: grid;
-  grid-template-columns: 112px 54px;
+.model-params__scrub-field {
+  display: flex;
   align-items: center;
-  gap: 8px;
-  min-width: 174px;
-}
-
-.model-params__slider {
-  position: relative;
-  height: 24px;
-  cursor: pointer;
-  touch-action: none;
-}
-
-.model-params__slider-track {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 50%;
-  height: 4px;
-  overflow: hidden;
-  border-radius: 9999px;
-  background: hsl(var(--muted));
-  transform: translateY(-50%);
-}
-
-.model-params__slider-fill {
-  display: block;
-  width: var(--model-params-slider-progress, 100%);
-  height: 100%;
-  border-radius: inherit;
-  background: hsl(var(--success));
-}
-
-.model-params__slider-thumb {
-  position: absolute;
-  top: 50%;
-  left: var(--model-params-slider-progress, 100%);
-  width: 12px;
-  height: 12px;
-  border: 1.5px solid hsl(var(--card));
-  border-radius: 50%;
-  background: hsl(var(--success));
-  box-shadow: 0 1px 3px rgb(0 0 0 / 0.22);
-  transform: translate(-50%, -50%);
-  transition:
-    box-shadow var(--transition-fast),
-    transform var(--transition-fast);
-}
-
-.model-params__slider:hover .model-params__slider-thumb {
-  box-shadow:
-    0 1px 3px rgb(0 0 0 / 0.22),
-    0 0 0 3px hsl(var(--success) / 0.14);
-}
-
-.model-params__slider:focus-visible {
-  outline: 2px solid hsl(var(--success) / 0.45);
-  outline-offset: 1px;
-}
-
-.model-params__slider:focus-visible .model-params__slider-thumb {
-  transform: translate(-50%, -50%) scale(1.04);
-}
-
-.model-params__slider-input {
-  width: 54px;
+  width: 76px;
   height: 28px;
-  padding: 0 6px;
   border: 1px solid hsl(var(--border));
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius);
   background: hsl(var(--background));
+  overflow: hidden;
+}
+
+.model-params__scrub-field:focus-within {
+  border-color: hsl(var(--ring));
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+}
+
+.model-params__scrub-field--disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.model-params__scrub {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 24px;
+  height: 100%;
+  color: hsl(var(--muted-foreground) / 0.45);
+  cursor: ew-resize;
+  touch-action: none;
+  transition: color var(--transition-fast);
+}
+
+.model-params__scrub:hover {
+  color: hsl(var(--foreground));
+}
+
+.model-params__scrub:focus-visible {
+  outline: none;
+}
+
+.model-params__scrub-input {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  padding: 0 8px 0 0;
+  border: none;
+  background: transparent;
   color: hsl(var(--foreground));
   color-scheme: light;
   font-family: var(--font-family);
   font-size: var(--font-size-xs);
   font-variant-numeric: tabular-nums;
   text-align: right;
+  outline: none;
 }
 
-.model-params__slider-input:focus-visible {
-  outline: 2px solid hsl(var(--success) / 0.45);
-  outline-offset: 2px;
+.model-params__scrub-input::-webkit-outer-spin-button,
+.model-params__scrub-input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 
-.model-params__slider-input::-webkit-outer-spin-button,
-.model-params__slider-input::-webkit-inner-spin-button,
+.dark .model-params__scrub-input {
+  color-scheme: dark;
+}
+
 .model-params__number::-webkit-outer-spin-button,
 .model-params__number::-webkit-inner-spin-button {
   -webkit-appearance: none;
@@ -751,6 +740,7 @@
   width: 112px;
   height: 34px;
   padding: 0 10px;
+  text-align: right;
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   background: hsl(var(--background));
@@ -760,7 +750,6 @@
   font-size: var(--font-size-sm);
 }
 
-.dark .model-params__slider-input,
 .dark .model-params__number {
   color-scheme: dark;
 }
@@ -770,9 +759,7 @@
   outline-offset: 2px;
 }
 
-.model-params__number:disabled,
-.model-params__slider[aria-disabled='true'],
-.model-params__slider-input:disabled {
+.model-params__number:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -181,33 +181,25 @@ describe('ModelParamsDialog', () => {
     expect(input.value).toBe('1');
   });
 
-  it('updates slider controls from pointer input', () => {
+  it('updates scrub controls from pointer drag', () => {
     render(() => (
       <ModelParamsDialog {...baseProps} specs={anthropicSpecs} slotLabel="claude-sonnet-4-6" />
     ));
 
-    const slider = screen.getByRole('slider', { name: 'Temperature' }) as HTMLDivElement;
+    const scrub = screen.getByRole('slider', { name: 'Temperature' }) as HTMLDivElement;
     const input = screen.getByLabelText('Temperature value') as HTMLInputElement;
-    vi.spyOn(slider, 'getBoundingClientRect').mockReturnValue({
-      left: 0,
-      right: 100,
-      top: 0,
-      bottom: 20,
-      width: 100,
-      height: 20,
-      x: 0,
-      y: 0,
-      toJSON: () => ({}),
-    });
-    slider.setPointerCapture = vi.fn();
-    slider.hasPointerCapture = vi.fn(() => true);
-    slider.releasePointerCapture = vi.fn();
+    scrub.setPointerCapture = vi.fn();
+    scrub.hasPointerCapture = vi.fn(() => true);
+    scrub.releasePointerCapture = vi.fn();
 
-    fireEvent(slider, pointerEvent('pointerdown', 50));
+    // Default temperature is 1. pixelsPerUnit = 120 / (1 - 0) = 120.
+    // pointerdown at 100 sets startX=100, startValue=1.
+    fireEvent(scrub, pointerEvent('pointerdown', 100));
+    expect(input.value).toBe('1');
+
+    // pointermove to 40: delta = (40-100)/120 = -0.5, value = 1 + -0.5 = 0.5
+    fireEvent(scrub, pointerEvent('pointermove', 40));
     expect(input.value).toBe('0.5');
-
-    fireEvent(slider, pointerEvent('pointermove', 20));
-    expect(input.value).toBe('0.2');
   });
 
   it('stores integer number controls as parsed numeric values', async () => {


### PR DESCRIPTION
## ✨ What changed
- Fixed the model parameters dialog being draggable and showing a grab cursor
- Replaced the slider track with a compact scrub grip icon embedded inside the number field
- Right-aligned all number values for visual consistency
- Matched control widths across standalone numbers and scrub fields
- Reduced scrub field size for a cleaner, more compact layout

## 💭 Why
The model parameters dialog rendered inside a draggable model chip, so it inherited the chip's grab cursor and drag behavior. The slider controls were also visually inconsistent: different widths, mixed text alignment.

## 👤 For users
- The dialog no longer moves when clicking and dragging inside it
- Cursor is now a normal pointer instead of a grab hand
- Number fields with a range show a grip icon on the left: drag it horizontally to scrub the value
- All number controls are visually aligned and compact

## 🔧 For operators
No operator impact

## 🧪 How to test
1. Open the Routing page, connect a provider with models
2. Click the Parameters icon (sliders) on any model chip
3. Confirm the dialog has a normal cursor and cannot be dragged
4. For range fields (temperature, top_p): drag the grip dots icon left/right to change the value
5. Verify all number fields are right-aligned and controls have consistent width

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the model parameters dialog dragging and grab cursor. Replaces sliders with a compact scrub grip inside number fields and aligns numeric inputs for a cleaner, consistent layout.

- **Bug Fixes**
  - Dialog no longer inherits drag behavior; cursor is now default.
  - Range fields have a left grip you can drag to scrub values; keyboard arrows/Home/End still work.
  - Numbers are right-aligned with consistent widths; scrub field is smaller and more compact.

<sup>Written for commit 01a3f45a6998af1d262b369fb61d14cf3c033c99. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1971?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

