### PR TITLE
fix(proxy): preserve Google generation config

### DIFF
--- a/.changeset/google-native-generation-config.md
+++ b/.changeset/google-native-generation-config.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Preserve native Google `generationConfig` fields when routing requests to Gemini, while keeping existing OpenAI-compatible generation aliases as explicit overrides.

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -68,6 +68,57 @@ describe('Google Adapter', () => {
       });
     });
 
+    it('preserves native Google generationConfig params', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        generationConfig: {
+          topK: 40,
+          thinkingConfig: {
+            thinkingBudget: 128,
+            includeThoughts: true,
+          },
+          responseMimeType: 'application/json',
+        },
+      };
+      const result = toGoogleRequest(body, 'gemini-2.5-flash');
+
+      expect(result.generationConfig).toEqual({
+        topK: 40,
+        thinkingConfig: {
+          thinkingBudget: 128,
+          includeThoughts: true,
+        },
+        responseMimeType: 'application/json',
+      });
+    });
+
+    it('lets OpenAI-style generation aliases override native generationConfig fields', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Hi' }],
+        generationConfig: {
+          maxOutputTokens: 256,
+          temperature: 0.2,
+          topP: 0.4,
+          thinkingConfig: {
+            thinkingLevel: 'high',
+          },
+        },
+        max_tokens: 1000,
+        temperature: 0.7,
+        top_p: 0.9,
+      };
+      const result = toGoogleRequest(body, 'gemini-3.5-flash');
+
+      expect(result.generationConfig).toEqual({
+        maxOutputTokens: 1000,
+        temperature: 0.7,
+        topP: 0.9,
+        thinkingConfig: {
+          thinkingLevel: 'high',
+        },
+      });
+    });
+
     it('converts tools to functionDeclarations', () => {
       const body = {
         messages: [{ role: 'user', content: 'Search for cats' }],

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -103,6 +103,14 @@ function safeParseArgs(args: string | undefined): Record<string, unknown> {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cloneRecord(value: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(value)) as Record<string, unknown>;
+}
+
 /* ── Request conversion ── */
 
 function mapRole(role: string): string {
@@ -249,8 +257,9 @@ export function toGoogleRequest(
   const tools = convertTools(body.tools as Record<string, unknown>[] | undefined);
   if (tools) result.tools = tools;
 
-  // Map generation config
-  const genConfig: Record<string, unknown> = {};
+  const genConfig: Record<string, unknown> = isRecord(body.generationConfig)
+    ? cloneRecord(body.generationConfig)
+    : {};
   if (body.max_tokens !== undefined) genConfig.maxOutputTokens = body.max_tokens;
   if (body.temperature !== undefined) genConfig.temperature = body.temperature;
   if (body.top_p !== undefined) genConfig.topP = body.top_p;


### PR DESCRIPTION
## Summary
- preserve native Google generationConfig fields when converting OpenAI-compatible requests to Gemini generateContent
- keep max_tokens, temperature, and top_p aliases as explicit overrides
- add focused Google adapter coverage and a patch changeset

## Validation
- npm test -- google-adapter.spec.ts
- npx eslint packages/backend/src/routing/proxy/google-adapter.ts packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
- npx prettier --check packages/backend/src/routing/proxy/google-adapter.ts packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
- git diff --check
- npm run build in packages/shared
- npm run build in packages/backend

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves native Google `generationConfig` when converting OpenAI-compatible requests to Gemini. `max_tokens`, `temperature`, and `top_p` now override native fields when present.

- **Bug Fixes**
  - Deep-clone incoming `generationConfig` (via `isRecord` and `cloneRecord`) and apply aliases as explicit overrides.
  - Added focused tests in `google-adapter.spec.ts` to ensure nested fields (e.g., `thinkingConfig`, `responseMimeType`) are preserved and override precedence works.

<sup>Written for commit 045907d5ec3be3654f42b499034ec40d4acbde7d. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1972?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

