### PR TITLE
fix(routing): make Manifest model params authoritative

### DIFF
--- a/.changeset/manifest-params-authority.md
+++ b/.changeset/manifest-params-authority.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Make saved Manifest model parameters authoritative over overlapping client request parameters while preserving client parameters that Manifest does not configure.

--- a/docs/model-parameters-schema.md
+++ b/docs/model-parameters-schema.md
@@ -147,8 +147,11 @@ They do not store derived UI state or provider-specific rule state.
 The outbound proxy merge:
 
 1. expands needed nested defaults for configured nested roots
-2. merges client request body values last, so client body values win
+2. merges configured Manifest values last, so Manifest values win for the same provider path
 3. omits params that are not applicable under the final effective values
+
+Client request body values that do not overlap configured Manifest model
+params stay in the outbound provider request.
 
 ## Adding A New Rule
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -228,7 +228,7 @@ describe('ProxyFallbackService', () => {
       expect(forwarded.body.thinking).toBeUndefined();
     });
 
-    it('respects the inbound body field by presence (client wins over saved per-route params)', async () => {
+    it('lets saved Manifest params override inbound body fields at the same path', async () => {
       providerClient.forward.mockResolvedValue({
         response: new Response('{}', { status: 200 }),
         isGoogle: false,
@@ -252,7 +252,7 @@ describe('ProxyFallbackService', () => {
       });
 
       const forwarded = providerClient.forward.mock.calls[0][0];
-      expect(forwarded.body.thinking).toEqual({ type: 'enabled' });
+      expect(forwarded.body.thinking).toEqual({ type: 'disabled' });
     });
 
     it('skips the lookup when paramMergeContext is omitted (e.g. legacy callers)', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -438,8 +438,8 @@ describe('ProxyService — orchestration', () => {
           } as never,
         }),
       );
-      // The body still carries the client-supplied thinking field — the
-      // fallback service's merge respects that by presence.
+      // The body still carries the client-supplied thinking field; the
+      // fallback service applies the resolved Manifest params last.
       expect(fallbackService.tryForwardToProvider.mock.calls[0][0].body.thinking).toEqual({
         type: 'enabled',
       });

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -198,7 +198,10 @@ const ModelParamsDialog: Component<Props> = (props) => {
     };
 
     return (
-      <div class="model-params__scrub-field" classList={{ 'model-params__scrub-field--disabled': isDisabled(spec) }}>
+      <div
+        class="model-params__scrub-field"
+        classList={{ 'model-params__scrub-field--disabled': isDisabled(spec) }}
+      >
         <div
           class="model-params__scrub"
           role="slider"
@@ -225,7 +228,14 @@ const ModelParamsDialog: Component<Props> = (props) => {
           onPointerCancel={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
           onKeyDown={handleKeyDown}
         >
-          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="12"
+            height="12"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
             <path d="M5 3a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4M5 10a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4M5 17a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7.33 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4" />
           </svg>
         </div>
@@ -362,7 +372,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
           <h2 class="modal-card__title" id="model-params-dialog-title">
             Model parameters
           </h2>
-          <p class="modal-card__desc">Defaults for {props.slotLabel}. Client requests override.</p>
+          <p class="modal-card__desc">Manifest parameters for {props.slotLabel}.</p>
 
           <For each={groupSpecs(props.specs)}>
             {(group) => (

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -136,6 +136,12 @@ describe('ModelParamsDialog', () => {
     expect(q('.provider-toggle__switch--on')).not.toBeNull();
   });
 
+  it('describes params as Manifest-owned rather than client-overridden defaults', () => {
+    render(() => <ModelParamsDialog {...baseProps} slotLabel="GPT-5 Nano" />);
+    expect(screen.getByText('Manifest parameters for GPT-5 Nano.')).toBeTruthy();
+    expect(screen.queryByText(/Client requests override/)).toBeNull();
+  });
+
   it('reflects the configured override when present', () => {
     render(() => <ModelParamsDialog {...baseProps} current={{ thinking: { type: 'disabled' } }} />);
     const toggle = q('.model-params__toggle') as HTMLButtonElement;

--- a/packages/shared/__tests__/request-params-snapshot.spec.ts
+++ b/packages/shared/__tests__/request-params-snapshot.spec.ts
@@ -88,11 +88,21 @@ describe('snapshotRequestParams', () => {
     ).toEqual({ thinking: { type: 'enabled', budget_tokens: 4096 } });
   });
 
-  it('lets client body values win over saved params', () => {
+  it('records saved Manifest params over client body values at the same path', () => {
     expect(
       snapshotRequestParams({
         body: { temperature: 0.4, messages: [] },
         modelParams: { temperature: 0.8 },
+        specs,
+      }),
+    ).toEqual({ temperature: 0.8, thinking: { type: 'disabled' } });
+  });
+
+  it('records client body params that are not configured in Manifest', () => {
+    expect(
+      snapshotRequestParams({
+        body: { temperature: 0.4, messages: [] },
+        modelParams: { thinking: { type: 'disabled' } },
         specs,
       }),
     ).toEqual({ temperature: 0.4, thinking: { type: 'disabled' } });

--- a/packages/shared/__tests__/request-params.spec.ts
+++ b/packages/shared/__tests__/request-params.spec.ts
@@ -79,13 +79,37 @@ describe('applyRequestParamDefaults', () => {
     });
   });
 
-  it('lets the request body win by presence, including nested values', () => {
+  it('lets configured Manifest params win over request body values at the same path', () => {
     const body: Record<string, unknown> = {
       messages: [],
-      thinking: { budget_tokens: 8192 },
+      temperature: 0.4,
     };
-    const merged = applyRequestParamDefaults(body, { thinking: { type: 'enabled' } }, specs);
-    expect(merged.thinking).toEqual({ type: 'enabled', budget_tokens: 8192 });
+    const merged = applyRequestParamDefaults(body, { temperature: 0.8 }, specs);
+    expect(merged).toEqual({ messages: [], temperature: 0.8 });
+  });
+
+  it('keeps request body params that are not configured in Manifest', () => {
+    const body: Record<string, unknown> = {
+      messages: [],
+      temperature: 0.4,
+      max_tokens: 2048,
+    };
+    const merged = applyRequestParamDefaults(body, { thinking: { type: 'disabled' } }, specs);
+    expect(merged).toEqual({
+      messages: [],
+      temperature: 0.4,
+      max_tokens: 2048,
+      thinking: { type: 'disabled' },
+    });
+  });
+
+  it('lets configured nested Manifest params win while preserving unconfigured nested siblings', () => {
+    const body: Record<string, unknown> = {
+      messages: [],
+      thinking: { type: 'enabled', vendor_note: 'client-only' },
+    };
+    const merged = applyRequestParamDefaults(body, { thinking: { type: 'disabled' } }, specs);
+    expect(merged.thinking).toEqual({ type: 'disabled', vendor_note: 'client-only' });
   });
 
   it('omits defaults that are unavailable under selected values', () => {

--- a/packages/shared/src/request-params-snapshot.ts
+++ b/packages/shared/src/request-params-snapshot.ts
@@ -34,16 +34,16 @@ export function snapshotRequestParams(
   let out: RequestParamDefaults = {};
 
   for (const spec of orderedSpecs) {
-    if (hasPath(body, spec.path)) {
-      out = setProviderParamValue(out, spec.path, getPath(body, spec.path) as JsonValue);
-      continue;
-    }
     if (expandedParams && hasPath(expandedParams, spec.path)) {
       out = setProviderParamValue(
         out,
         spec.path,
         getProviderParamValue(expandedParams, spec.path) as JsonValue,
       );
+      continue;
+    }
+    if (hasPath(body, spec.path)) {
+      out = setProviderParamValue(out, spec.path, getPath(body, spec.path) as JsonValue);
       continue;
     }
     if (spec.default !== undefined && providerParamIsApplicable(spec, out)) {

--- a/packages/shared/src/request-params.ts
+++ b/packages/shared/src/request-params.ts
@@ -14,9 +14,9 @@ export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue
 export type RequestParamDefaults = Record<string, JsonValue>;
 
 /**
- * Merge configured defaults into a request body using the route's param
- * specs. Storage stays as UI values. The provider wire shape is the same
- * path shape unless a future provider needs a dedicated transformer.
+ * Merge configured Manifest params into a request body using the route's
+ * param specs. Storage stays as UI values. The provider wire shape is the
+ * same path shape unless a future provider needs a dedicated transformer.
  */
 export function applyRequestParamDefaults<T extends Record<string, unknown>>(
   body: T,
@@ -34,15 +34,15 @@ export function applyRequestParamDefaults<T extends Record<string, unknown>>(
     merged = setProviderParamValue(merged, spec.path, getPath(expanded, spec.path) as JsonValue);
   }
 
-  return omitProviderInapplicableParams(deepMerge(merged, body), orderedSpecs) as T;
+  return omitProviderInapplicableParams(deepMerge(body, merged), orderedSpecs) as T;
 }
 
 function deepMerge(
-  defaults: Record<string, unknown>,
-  body: Record<string, unknown>,
+  base: Record<string, unknown>,
+  overrides: Record<string, unknown>,
 ): Record<string, unknown> {
-  const out = structuredCloneRecord(defaults);
-  for (const [key, value] of Object.entries(body)) {
+  const out = structuredCloneRecord(base);
+  for (const [key, value] of Object.entries(overrides)) {
     if (isRecord(value) && isRecord(out[key])) {
       out[key] = deepMerge(out[key] as Record<string, unknown>, value);
     } else {


### PR DESCRIPTION
## Summary
- make saved Manifest model parameters override overlapping client request body parameters before provider forwarding
- keep client request parameters that Manifest does not configure
- align request parameter telemetry, model-parameter docs, modal copy, tests, and changeset with the new precedence

## Validation
- npm test --workspace=manifest-shared -- request-params.spec.ts request-params-snapshot.spec.ts
- npm run build --workspace=manifest-shared
- npm test --workspace=manifest-backend -- proxy-fallback.service.spec.ts proxy.service.spec.ts
- npm test --workspace=manifest-frontend -- ModelParamsDialog.test.tsx
- npm exec -- eslint packages/shared/src/request-params.ts packages/shared/src/request-params-snapshot.ts packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts packages/frontend/src/components/ModelParamsDialog.tsx
- npm exec -- prettier --check docs/model-parameters-schema.md packages/shared/src/request-params.ts packages/shared/src/request-params-snapshot.ts packages/shared/__tests__/request-params.spec.ts packages/shared/__tests__/request-params-snapshot.spec.ts packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts packages/frontend/src/components/ModelParamsDialog.tsx packages/frontend/tests/components/ModelParamsDialog.test.tsx .changeset/manifest-params-authority.md
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make saved Manifest model parameters authoritative. Overlapping client request body values no longer override; unconfigured client fields are preserved.

- **Bug Fixes**
  - Apply Manifest params last in the provider merge (`applyRequestParamDefaults`), overriding overlapping client values while keeping unconfigured client fields and nested siblings.
  - Update snapshot/telemetry precedence to record Manifest values over client values.
  - Refresh docs and `ModelParamsDialog` copy to reflect Manifest-owned parameters.
  - Update tests across backend, shared, and frontend to assert the new precedence.

<sup>Written for commit 4e780bea1dab5d74237476860e5e7dd0d7d45fa2. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1977?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

