### PR TITLE
fix: highlight changed columns in PR schema diagrams

### DIFF
--- a/.github/scripts/db-diagram/__fixtures__/base.json
+++ b/.github/scripts/db-diagram/__fixtures__/base.json
@@ -37,6 +37,17 @@
       ],
       "primaryKeys": ["id"],
       "foreignKeys": []
+    },
+    "provider_keys": {
+      "columns": [
+        { "name": "id", "type": "varchar", "nullable": false },
+        { "name": "agent_id", "type": "varchar", "nullable": false },
+        { "name": "region", "type": "varchar", "nullable": false }
+      ],
+      "primaryKeys": ["id"],
+      "foreignKeys": [
+        { "column": "agent_id", "toTable": "agents", "toColumn": "id" }
+      ]
     }
   }
 }

--- a/.github/scripts/db-diagram/__fixtures__/expected-comment.md
+++ b/.github/scripts/db-diagram/__fixtures__/expected-comment.md
@@ -5,10 +5,11 @@
 - `1779000000000-AddRoutingTiers.ts`
 - `1779100000000-RefactorAgents.ts`
 - `1779200000000-DropLegacyMetrics.ts`
+- `1779300000000-RekeyProviderKeys.ts`
 
 ### Summary
 - 🟢 **Added tables:** `routing_tiers`
-- 🟡 **Modified tables:** `agent_api_keys` (+1 FK), `agents` (+1 col, ~1 col, -1 col)
+- 🟡 **Modified tables:** `agent_api_keys` (+1 FK), `agents` (+1 col, ~1 col, -1 col), `provider_keys` (-1 FK, PK changed)
 - 🔴 **Removed tables:** `legacy_metrics`
 
 ### Schema diagram
@@ -19,18 +20,24 @@ Showing only changed tables. 🟢 added, 🟡 modified, 🔴 removed. Changed co
 erDiagram
     agent_api_keys["🟡 agent_api_keys (modified)"] {
         varchar id PK
-        varchar agent_id FK
+        varchar agent_id FK "🟡 FK added"
         varchar_64_ key
     }
     agents["🟡 agents (modified)"] {
         varchar id PK
-        varchar name "modified"
+        varchar name "🟡 modified"
         varchar tenant_id FK
-        varchar_255_ display_name "added"
+        varchar_255_ display_name "🟢 added"
+        boolean legacy_flag "🔴 removed"
     }
     legacy_metrics["🔴 legacy_metrics (removed)"] {
         varchar id PK
         integer value
+    }
+    provider_keys["🟡 provider_keys (modified)"] {
+        varchar id PK
+        varchar agent_id "🟡 FK removed"
+        varchar region PK "🟡 PK changed"
     }
     routing_tiers["🟢 routing_tiers (added)"] {
         uuid id PK
@@ -60,6 +67,10 @@ erDiagram
 - 🔄 modified `name`: `varchar` NOT NULL → `varchar` NULL
 - ➕ added `display_name` `varchar(255)` NULL
 - ➖ dropped `legacy_flag` _(was `boolean`)_
+
+#### 🟡 `provider_keys`
+- 🔑 primary key changed: + `region`
+- 🔗 dropped FK `agent_id` → `agents.id`
 
 #### 🔴 `legacy_metrics` _(removed)_
 

--- a/.github/scripts/db-diagram/__fixtures__/head.json
+++ b/.github/scripts/db-diagram/__fixtures__/head.json
@@ -44,6 +44,15 @@
       "foreignKeys": [
         { "column": "agent_id", "toTable": "agents", "toColumn": "id" }
       ]
+    },
+    "provider_keys": {
+      "columns": [
+        { "name": "id", "type": "varchar", "nullable": false },
+        { "name": "agent_id", "type": "varchar", "nullable": false },
+        { "name": "region", "type": "varchar", "nullable": false }
+      ],
+      "primaryKeys": ["id", "region"],
+      "foreignKeys": []
     }
   }
 }

--- a/.github/scripts/db-diagram/render-diagram.cjs
+++ b/.github/scripts/db-diagram/render-diagram.cjs
@@ -141,17 +141,37 @@ function buildMermaid(headSnap, baseSnap, added, modMap, dropped) {
     const modCols = new Set(
       changes.filter((c) => c.kind === 'modified').map((c) => c.column),
     );
+    const fkAddedCols = new Set(
+      changes.filter((c) => c.kind === 'fk-added').map((c) => c.fk.column),
+    );
+    const fkDroppedCols = new Set(
+      changes.filter((c) => c.kind === 'fk-dropped').map((c) => c.fk.column),
+    );
+    const pkChange = changes.find((c) => c.kind === 'pk-changed');
+    const pkChangedCols = new Set(
+      pkChange ? [...pkChange.added, ...pkChange.dropped] : [],
+    );
+    const droppedCols = changes.filter((c) => c.kind === 'dropped');
 
     for (const col of table.columns) {
       const safeType = sanitizeMermaidType(col.type);
       const pk = table.primaryKeys.includes(col.name) ? ' PK' : '';
       const fk = !pk && table.foreignKeys.some((f) => f.column === col.name) ? ' FK' : '';
-      let note = '';
-      if (isModified) {
-        if (addedCols.has(col.name)) note = ' "added"';
-        else if (modCols.has(col.name)) note = ' "modified"';
-      }
+      const note = isModified
+        ? columnNote(col.name, {
+            addedCols,
+            modCols,
+            fkAddedCols,
+            fkDroppedCols,
+            pkChangedCols,
+          })
+        : '';
       lines.push(`        ${safeType} ${col.name}${pk}${fk}${note}`);
+    }
+    // Columns removed by this PR no longer exist in the head snapshot, so render
+    // them as trailing rows (with their pre-drop type) flagged 🔴 removed.
+    for (const c of droppedCols) {
+      lines.push(`        ${sanitizeMermaidType(c.type)} ${c.column} "🔴 removed"`);
     }
     lines.push('    }');
     rendered.add(name);
@@ -168,6 +188,20 @@ function buildMermaid(headSnap, baseSnap, added, modMap, dropped) {
   }
 
   return lines.join('\n');
+}
+
+// Builds the inline annotation for a single column of a modified table.
+// 🟢 for a newly added column, 🟡 for any in-place change (type/nullable, FK,
+// or PK membership). Dropped columns are annotated separately as trailing rows.
+function columnNote(colName, sets) {
+  if (sets.addedCols.has(colName)) return ' "🟢 added"';
+  const parts = [];
+  if (sets.modCols.has(colName)) parts.push('modified');
+  if (sets.fkAddedCols.has(colName)) parts.push('FK added');
+  if (sets.fkDroppedCols.has(colName)) parts.push('FK removed');
+  if (sets.pkChangedCols.has(colName)) parts.push('PK changed');
+  if (!parts.length) return '';
+  return ` "🟡 ${parts.join(', ')}"`;
 }
 
 function buildSummary(added, modified, dropped) {

--- a/.github/scripts/db-diagram/smoke-test.cjs
+++ b/.github/scripts/db-diagram/smoke-test.cjs
@@ -12,6 +12,7 @@ const MIGRATION_FILES = [
   'packages/backend/src/database/migrations/1779000000000-AddRoutingTiers.ts',
   'packages/backend/src/database/migrations/1779100000000-RefactorAgents.ts',
   'packages/backend/src/database/migrations/1779200000000-DropLegacyMetrics.ts',
+  'packages/backend/src/database/migrations/1779300000000-RekeyProviderKeys.ts',
 ].join('\n');
 
 const result = spawnSync(


### PR DESCRIPTION
### 💭 Why
The schema-diagram PR comment flagged a table as modified but never showed which column changed. A migration that only adds a foreign key (like #1973) left reviewers seeing "table modified" with no column highlighted.

### ✨ What changed
- Annotate columns touched by FK add/remove and primary-key changes, not just type/nullable edits.
- Render dropped columns as trailing rows instead of hiding them.
- Color every column note 🟢 added / 🟡 modified / 🔴 removed to match the legend.

### 📝 Notes
- Smoke-test fixture extended to cover FK-drop and PK-change cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlight changed columns in PR schema diagrams, including FK and PK updates. Dropped columns are now visible, and notes use consistent 🟢/🟡/🔴 labels.

- **Bug Fixes**
  - Annotate columns for FK added/removed and PK membership changes.
  - Render dropped columns as trailing rows with "🔴 removed".
  - Apply consistent column notes: 🟢 added, 🟡 modified, 🔴 removed; extend fixtures and smoke test for FK-drop/PK-change cases.

<sup>Written for commit 22cb911a72073e22ada15461a68ec8b58324b940. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1978?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

