### PR TITLE
Enable message recording for all existing agents

### DIFF
--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -104,6 +104,7 @@ import { AddBenchmarkHistory1788000000000 } from './migrations/1788000000000-Add
 import { RenameBenchmarkToPlayground1789000000000 } from './migrations/1789000000000-RenameBenchmarkToPlayground';
 import { AddOAuthPendingFlows1789100000000 } from './migrations/1789100000000-AddOAuthPendingFlows';
 import { ScopeAgentModelParams1789200000000 } from './migrations/1789200000000-ScopeAgentModelParams';
+import { EnableRecordMessagesForAll1789300000000 } from './migrations/1789300000000-EnableRecordMessagesForAll';
 
 const entities = [
   AgentMessage,
@@ -209,6 +210,7 @@ const migrations = [
   RenameBenchmarkToPlayground1789000000000,
   AddOAuthPendingFlows1789100000000,
   ScopeAgentModelParams1789200000000,
+  EnableRecordMessagesForAll1789300000000,
 ];
 
 @Module({

--- a/packages/backend/src/database/migrations/1789300000000-EnableRecordMessagesForAll.spec.ts
+++ b/packages/backend/src/database/migrations/1789300000000-EnableRecordMessagesForAll.spec.ts
@@ -1,0 +1,27 @@
+import { EnableRecordMessagesForAll1789300000000 } from './1789300000000-EnableRecordMessagesForAll';
+
+describe('EnableRecordMessagesForAll1789300000000', () => {
+  let migration: EnableRecordMessagesForAll1789300000000;
+  let queryRunner: { query: jest.Mock };
+
+  beforeEach(() => {
+    migration = new EnableRecordMessagesForAll1789300000000();
+    queryRunner = { query: jest.fn().mockResolvedValue(undefined) };
+  });
+
+  it('sets record_messages to true for all agents', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await migration.up(queryRunner as any);
+
+    expect(queryRunner.query).toHaveBeenCalledWith(
+      'UPDATE agents SET record_messages = true WHERE record_messages = false',
+    );
+  });
+
+  it('down is a no-op', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await migration.down(queryRunner as any);
+
+    expect(queryRunner.query).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/database/migrations/1789300000000-EnableRecordMessagesForAll.ts
+++ b/packages/backend/src/database/migrations/1789300000000-EnableRecordMessagesForAll.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class EnableRecordMessagesForAll1789300000000 implements MigrationInterface {
+  name = 'EnableRecordMessagesForAll1789300000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `UPDATE agents SET record_messages = true WHERE record_messages = false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // No-op: we cannot know which agents had recording disabled before.
+  }
+}


### PR DESCRIPTION
## ✨ What changed
- Existing agents now have message recording turned on automatically
- A data migration flips `record_messages` from false to true for every agent that still had it off
- New agents were already defaulting to true, this catches up the rest

## 💭 Why
The advanced message logs feature shipped with recording enabled by default for new agents only. Anyone who created an agent before the feature existed had to manually go to Settings and toggle it on. Most users would never discover this.

## 👤 For users
Message recording is now active on all agents. Open any message from the Messages page to see the full request and response. You can still turn it off per agent in Settings.

## 🔧 For operators
One data migration runs on startup: `UPDATE agents SET record_messages = true WHERE record_messages = false`. Idempotent, no schema change, no downtime.

## 🧪 How to test
1. Start the app with an existing database that has agents created before the recording feature
2. Check that `record_messages` is true for all agents in the database
3. Open the Messages page and confirm the log drawer works on any message
4. Go to Settings and confirm the recording toggle shows "on"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically enable message recording for all existing agents so message logs are available by default. Users can still turn it off per agent in Settings.

- **Migration**
  - Run once on startup: `UPDATE agents SET record_messages = true WHERE record_messages = false`.
  - No schema changes; idempotent; no downtime.

<sup>Written for commit 07e9359cc8deb28b44cb93a94cb878c65030983a. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1984?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

