### PR TITLE
fix: stop recording Railway proxy noise on every message

### DIFF
--- a/.changeset/filter-railway-noise-headers.md
+++ b/.changeset/filter-railway-noise-headers.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Stop recording Railway and proxy noise headers on every message. Headers injected by the hosting edge (x-railway-*, x-forwarded-*, x-real-ip, etc.) are dropped before storage, so the message Headers tab only shows headers the agent actually sent.

--- a/packages/backend/src/routing/proxy/request-headers.spec.ts
+++ b/packages/backend/src/routing/proxy/request-headers.spec.ts
@@ -41,6 +41,26 @@ describe('sanitizeRequestHeaders', () => {
     expect(result).toEqual({ 'x-safe': 'keep' });
   });
 
+  it('drops Railway/proxy/transport noise headers regardless of casing', () => {
+    const result = sanitizeRequestHeaders({
+      'X-Railway-Edge': 'railway/europe-west4-drams3a',
+      'X-Railway-Request-Id': 'm5e5d2NRQLKtNMov2JZdWA',
+      'X-Forwarded-For': '193.33.57.199',
+      'X-Forwarded-Host': 'app.manifest.build',
+      'X-Forwarded-Proto': 'https',
+      'X-Forwarded-Port': '443',
+      'X-Real-Ip': '193.33.57.199',
+      'X-Request-Start': '1779377596677',
+      'X-Envoy-External-Address': '193.33.57.199',
+      Host: 'app.manifest.build',
+      Connection: 'keep-alive',
+      'Accept-Encoding': 'gzip',
+      'Content-Length': '143',
+      'User-Agent': 'curl/8.18.0',
+    });
+    expect(result).toEqual({ 'user-agent': 'curl/8.18.0' });
+  });
+
   it('flattens array values with comma-space separator', () => {
     expect(sanitizeRequestHeaders({ 'x-multi': ['a', 'b', 'c'] })).toEqual({
       'x-multi': 'a, b, c',

--- a/packages/backend/src/routing/proxy/request-headers.ts
+++ b/packages/backend/src/routing/proxy/request-headers.ts
@@ -14,6 +14,25 @@ const SENSITIVE_HEADERS = new Set<string>([
   'x-api-key',
 ]);
 
+// Infrastructure noise injected by the hosting edge (Railway) and the
+// transport layer. None of it is meaningful for routing or display, so we
+// drop it before recording rather than persisting it on every message.
+const NOISE_HEADERS = new Set<string>([
+  'x-railway-edge',
+  'x-railway-request-id',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+  'x-forwarded-port',
+  'x-real-ip',
+  'x-request-start',
+  'x-envoy-external-address',
+  'host',
+  'connection',
+  'accept-encoding',
+  'content-length',
+]);
+
 export function sanitizeRequestHeaders(
   headers: IncomingHttpHeaders,
 ): Record<string, string> | null {
@@ -27,6 +46,7 @@ export function sanitizeRequestHeaders(
 
     const key = rawKey.toLowerCase();
     if (SENSITIVE_HEADERS.has(key)) continue;
+    if (NOISE_HEADERS.has(key)) continue;
 
     const joined = Array.isArray(rawVal) ? rawVal.join(', ') : String(rawVal);
     const cleaned = joined.replace(/[\x00-\x1f\x7f]/g, '').trim();

--- a/packages/backend/src/routing/proxy/request-headers.ts
+++ b/packages/backend/src/routing/proxy/request-headers.ts
@@ -15,8 +15,15 @@ const SENSITIVE_HEADERS = new Set<string>([
 ]);
 
 // Infrastructure noise injected by the hosting edge (Railway) and the
-// transport layer. None of it is meaningful for routing or display, so we
-// drop it before recording rather than persisting it on every message.
+// transport layer. None of it is meaningful for routing or studying an LLM
+// call, so we drop it before recording rather than persisting it on every
+// message.
+//
+// NOTE: `x-forwarded-for` and `x-real-ip` carry the end-user's IP. They are
+// dropped on purpose — not just as noise but because storing client IPs on
+// every message is PII we have no product use for (the telemetry policy
+// already lists "raw IPs" as never-sent). Do NOT re-add them for a "request
+// origin" feature without a deliberate retention/consent decision.
 const NOISE_HEADERS = new Set<string>([
   'x-railway-edge',
   'x-railway-request-id',


### PR DESCRIPTION
### 💭 Why
Every recorded message stored a pile of headers injected by Railway and the reverse proxy. They added noise to the Headers tab and bloated `request_headers` with infra metadata nobody reads.

### ✨ What changed
- Added a `NOISE_HEADERS` denylist in `sanitizeRequestHeaders()` covering `x-railway-*`, `x-forwarded-*`, `x-real-ip`, `x-request-start`, `x-envoy-external-address`, `host`, `connection`, `accept-encoding`, `content-length`.
- Dropped at the recording chokepoint, so they never hit the DB.

### 👤 For users
The message Headers tab now shows only headers the agent actually sent (e.g. `user-agent`, `content-type`), not Railway plumbing.

### 📝 Notes
Forward-only. Existing rows keep their stored noise; no backfill.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop storing Railway/proxy-injected headers on recorded messages to remove noise and cut `request_headers` bloat. The Headers tab now only shows agent-sent headers; client IP headers are dropped for privacy.

- **Bug Fixes**
  - Added `NOISE_HEADERS` denylist in `sanitizeRequestHeaders()` to drop `x-railway-*`, `x-forwarded-*`, `x-real-ip`, `x-request-start`, `x-envoy-external-address`, `host`, `connection`, `accept-encoding`, `content-length`.
  - Applied at the recording chokepoint before storage; case-insensitive filtering with tests. Documented why `x-forwarded-for`/`x-real-ip` are removed (PII not needed).

- **Migration**
  - Forward-only; existing rows are unchanged.

<sup>Written for commit de73ad694a934bb506e2eee167c93ecab7dbd643. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1988?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

