### PR TITLE
fix(recording): render Responses input in message log

### DIFF
--- a/.changeset/tender-keys-smile.md
+++ b/.changeset/tender-keys-smile.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Render recorded OpenAI Responses API request input in the message log conversation tab instead of falling back to the raw-body hint.

--- a/packages/frontend/src/components/RecordedMessageModal.tsx
+++ b/packages/frontend/src/components/RecordedMessageModal.tsx
@@ -115,7 +115,7 @@ const RecordedMessageModal: Component<Props> = (props) => {
     return d ? extractAssistantReply(d.recording?.response_body ?? null) : null;
   });
 
-  // Only the OpenAI chat-completion shape carries an inline `messages[]`
+  // Only OpenAI-compatible request shapes carry inline conversation turns
   // that the rail + Essentials can render meaningfully. For Claude / Gemini
   // / unknown / empty bodies we collapse the chrome so the user sees a
   // single "use the Raw tab" hint in the main pane instead of three

--- a/packages/frontend/tests/components/RecordedMessageModal.test.tsx
+++ b/packages/frontend/tests/components/RecordedMessageModal.test.tsx
@@ -148,6 +148,47 @@ describe("RecordedMessageModal (drawer)", () => {
     });
   });
 
+  it("surfaces OpenAI Responses input in the conversation turns", async () => {
+    mockGetMessageDetails.mockResolvedValue(
+      baseDetails({
+        recording: {
+          request_body: {
+            model: "gpt-5.4-mini",
+            instructions: "Be concise.",
+            input: [
+              {
+                role: "user",
+                content: [
+                  { type: "input_text", text: "look at this" },
+                  { type: "input_image", image_url: "https://example.test/image.png" },
+                ],
+              },
+              { role: "assistant", content: [{ type: "output_text", text: "noted" }] },
+            ],
+          },
+          response_body: { type: "json", body: { id: "resp_1", output: [] } },
+          response_headers: {},
+          size_bytes: 120,
+          created_at: "",
+        },
+      }),
+    );
+
+    render(() => <RecordedMessageModal open={true} messageId="msg-responses" onClose={vi.fn()} />);
+
+    await vi.waitFor(() => {
+      const tab = document.querySelector('[role="tab"][aria-selected="true"]');
+      expect(tab?.textContent).toContain("Conversation");
+      expect(tab?.textContent).toContain("3");
+      expect(document.querySelectorAll(".recorded-modal__turn").length).toBe(3);
+      expect(document.body.textContent).toContain("Be concise.");
+      expect(document.body.textContent).toContain("look at this");
+      expect(document.body.textContent).toContain("[image]");
+      expect(document.body.textContent).toContain("noted");
+    });
+    expect(document.body.textContent).not.toContain("Unrecognised request body shape");
+  });
+
   it("switches tabs when tab buttons are clicked", async () => {
     render(() => <RecordedMessageModal open={true} messageId="msg-1" onClose={vi.fn()} />);
     await vi.waitFor(() => {

--- a/packages/shared/__tests__/chat-message.spec.ts
+++ b/packages/shared/__tests__/chat-message.spec.ts
@@ -1,0 +1,197 @@
+import {
+  coerceContentToText,
+  detectRequestBodyFormat,
+  extractAssistantReply,
+  extractRequestMessages,
+  extractRequestTools,
+  normalizeRole,
+} from '../src/chat-message';
+
+describe('chat-message recording helpers', () => {
+  it('extracts OpenAI chat-completions messages unchanged', () => {
+    const messages = [{ role: 'user', content: 'hello' }];
+
+    expect(extractRequestMessages({ messages })).toBe(messages);
+    expect(detectRequestBodyFormat({ messages })).toBe('openai');
+  });
+
+  it('extracts OpenAI Responses string input and instructions as turns', () => {
+    expect(
+      extractRequestMessages({
+        instructions: 'Be concise.',
+        input: 'Summarize the request.',
+      }),
+    ).toEqual([
+      { role: 'system', content: 'Be concise.' },
+      { role: 'user', content: 'Summarize the request.' },
+    ]);
+    expect(detectRequestBodyFormat({ input: 'Summarize the request.' })).toBe('openai');
+  });
+
+  it('extracts OpenAI Responses input items, function calls, and tool outputs', () => {
+    const messages = extractRequestMessages({
+      input: [
+        'first',
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'look' },
+            { type: 'input_image', image_url: 'https://example.test/image.png' },
+          ],
+        },
+        { role: 'assistant', content: [{ type: 'output_text', text: 'done' }] },
+        { type: 'function_call', call_id: 'call_1', name: 'search', arguments: '{"q":"x"}' },
+        { type: 'function_call_output', call_id: 'call_1', output: { ok: true } },
+      ],
+    });
+
+    expect(messages).toEqual([
+      { role: 'user', content: 'first' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'look' },
+          { type: 'image_url', image_url: { url: 'https://example.test/image.png' } },
+        ],
+      },
+      { role: 'assistant', content: [{ type: 'text', text: 'done' }] },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'search', arguments: '{"q":"x"}' },
+          },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: '{"ok":true}' },
+    ]);
+    expect(detectRequestBodyFormat({ input: [] })).toBe('openai');
+  });
+
+  it('extracts Responses API function tools for the tools tab', () => {
+    expect(
+      extractRequestTools({
+        tools: [
+          {
+            type: 'function',
+            name: 'lookup',
+            description: 'Lookup data',
+            parameters: { type: 'object' },
+          },
+          { type: 'web_search_preview' },
+        ],
+      }),
+    ).toEqual([
+      { type: 'function', function: { name: 'lookup', description: 'Lookup data' } },
+      { type: 'web_search_preview', function: { name: 'web_search_preview' } },
+    ]);
+  });
+
+  it('coerces Responses image parts into readable placeholders', () => {
+    expect(
+      coerceContentToText([
+        { type: 'input_text', text: 'look' },
+        { type: 'input_image', image_url: 'https://example.test/image.png' },
+      ]),
+    ).toBe('look\n[image]');
+  });
+
+  it('normalizes known roles and rejects unknown role values', () => {
+    expect(normalizeRole('system')).toBe('system');
+    expect(normalizeRole('user')).toBe('user');
+    expect(normalizeRole('assistant')).toBe('assistant');
+    expect(normalizeRole('tool')).toBe('tool');
+    expect(normalizeRole('developer')).toBe('unknown');
+  });
+
+  it('coerces fallback content shapes to readable text', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(coerceContentToText(null)).toBe('');
+    expect(coerceContentToText('ready')).toBe('ready');
+    expect(coerceContentToText({ ok: true })).toBe('{"ok":true}');
+    expect(coerceContentToText(circular)).toBe('[object Object]');
+    expect(
+      coerceContentToText([undefined, 'ignored', { type: 'input_audio' }, { text: 123 }]),
+    ).toBe('');
+  });
+
+  it('handles compact and malformed Responses input items defensively', () => {
+    expect(
+      extractRequestMessages({
+        instructions: '   ',
+        input: [
+          { role: 'user', content: 'direct user text' },
+          { role: 'user', content: [{ type: 'input_text', text: 'single user text' }] },
+          { role: 'assistant', content: [{ type: 'file_search_call', id: 'fs_1' }] },
+          { role: 123, content: 7 },
+          { type: 'function_call' },
+          { type: 'function_call_output' },
+          { type: 'function_call_output', call_id: 'call_2', output: 'done' },
+          42,
+        ],
+      }),
+    ).toEqual([
+      { role: 'user', content: 'direct user text' },
+      { role: 'user', content: 'single user text' },
+      { role: 'assistant', content: [{ type: 'file_search_call', id: 'fs_1' }] },
+      { role: 'user', content: 7 },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: undefined,
+            type: 'function',
+            function: { name: 'unknown', arguments: '{}' },
+          },
+        ],
+      },
+      { role: 'tool', tool_call_id: undefined, content: '' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'done' },
+    ]);
+    expect(extractRequestMessages(null)).toEqual([]);
+  });
+
+  it('handles missing, existing, and malformed request tools', () => {
+    const existingTool = {
+      type: 'function',
+      function: { name: 'lookup', description: 'Lookup data' },
+    };
+
+    expect(extractRequestTools(null)).toEqual([]);
+    expect(extractRequestTools({ tools: 'invalid' as unknown as unknown[] })).toEqual([]);
+    expect(
+      extractRequestTools({
+        tools: [existingTool, { type: 'function' }, { label: 'unknown' }, 'invalid'],
+      }),
+    ).toEqual([
+      existingTool,
+      { type: 'function', function: { name: undefined, description: undefined } },
+      { type: undefined, function: { name: undefined } },
+    ]);
+  });
+
+  it('detects non-OpenAI request body formats and empty payloads', () => {
+    expect(detectRequestBodyFormat(null)).toBe('empty');
+    expect(detectRequestBodyFormat({ contents: [] })).toBe('gemini');
+    expect(detectRequestBodyFormat({ system: 'Be concise.' })).toBe('claude');
+    expect(detectRequestBodyFormat({ prompt: 'hello' })).toBe('unknown');
+  });
+
+  it('extracts assistant replies from JSON chat-completions responses', () => {
+    expect(extractAssistantReply(null)).toBeNull();
+    expect(extractAssistantReply({ type: 'text', body: 'ok' })).toBeNull();
+    expect(
+      extractAssistantReply({
+        type: 'json',
+        body: { choices: [{ message: { role: 'assistant', content: 'done' } }] },
+      }),
+    ).toEqual({ role: 'assistant', content: 'done' });
+    expect(extractAssistantReply({ type: 'json', body: {} })).toBeNull();
+  });
+});

--- a/packages/shared/src/chat-message.ts
+++ b/packages/shared/src/chat-message.ts
@@ -19,6 +19,12 @@ export interface ChatTool {
   function?: { name?: string; description?: string };
 }
 
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 export function normalizeRole(role: unknown): Role {
   if (role === 'system' || role === 'user' || role === 'assistant' || role === 'tool') return role;
   return 'unknown';
@@ -33,7 +39,7 @@ export function coerceContentToText(content: unknown): string {
         if (part && typeof part === 'object') {
           const p = part as { text?: unknown; type?: unknown };
           if (typeof p.text === 'string') return p.text;
-          if (p.type === 'image_url') return '[image]';
+          if (p.type === 'image_url' || p.type === 'input_image') return '[image]';
         }
         return '';
       })
@@ -47,32 +53,130 @@ export function coerceContentToText(content: unknown): string {
   }
 }
 
+function responsesContentToChatContent(content: unknown, role: string): unknown {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return content;
+
+  const converted = content.filter(isRecord).map((part) => {
+    if (typeof part.text === 'string') {
+      return { type: 'text', text: part.text };
+    }
+    if (part.type === 'input_image' && typeof part.image_url === 'string') {
+      return { type: 'image_url', image_url: { url: part.image_url } };
+    }
+    return part;
+  });
+
+  if (converted.length === 1 && converted[0]?.type === 'text' && role !== 'assistant') {
+    return converted[0].text;
+  }
+  return converted;
+}
+
+function responsesInputItemToMessages(item: JsonRecord): ChatMessage[] {
+  if (item.type === 'function_call') {
+    return [
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: typeof item.call_id === 'string' ? item.call_id : undefined,
+            type: 'function',
+            function: {
+              name: typeof item.name === 'string' ? item.name : 'unknown',
+              arguments: typeof item.arguments === 'string' ? item.arguments : '{}',
+            },
+          },
+        ],
+      },
+    ];
+  }
+
+  if (item.type === 'function_call_output') {
+    return [
+      {
+        role: 'tool',
+        tool_call_id: typeof item.call_id === 'string' ? item.call_id : undefined,
+        content:
+          item.output == null
+            ? ''
+            : typeof item.output === 'string'
+              ? item.output
+              : JSON.stringify(item.output),
+      },
+    ];
+  }
+
+  const role = typeof item.role === 'string' ? item.role : 'user';
+  return [{ role, content: responsesContentToChatContent(item.content, role) }];
+}
+
 export function extractRequestMessages(
   requestBody: Record<string, unknown> | null | undefined,
 ): ChatMessage[] {
-  const rb = requestBody as { messages?: ChatMessage[] } | null | undefined;
-  return Array.isArray(rb?.messages) ? rb!.messages! : [];
+  if (!requestBody) return [];
+  const rb = requestBody as { messages?: ChatMessage[]; input?: unknown; instructions?: unknown };
+  if (Array.isArray(rb.messages)) return rb.messages;
+
+  const messages: ChatMessage[] = [];
+  if (typeof rb.instructions === 'string' && rb.instructions.trim()) {
+    messages.push({ role: 'system', content: rb.instructions });
+  }
+
+  if (typeof rb.input === 'string') {
+    messages.push({ role: 'user', content: rb.input });
+  } else if (Array.isArray(rb.input)) {
+    for (const item of rb.input) {
+      if (typeof item === 'string') {
+        messages.push({ role: 'user', content: item });
+      } else if (isRecord(item)) {
+        messages.push(...responsesInputItemToMessages(item));
+      }
+    }
+  }
+
+  return messages;
 }
 
 export function extractRequestTools(
   requestBody: Record<string, unknown> | null | undefined,
 ): ChatTool[] {
-  const rb = requestBody as { tools?: ChatTool[] } | null | undefined;
-  return Array.isArray(rb?.tools) ? rb!.tools! : [];
+  const rb = requestBody as { tools?: unknown[] } | null | undefined;
+  if (!Array.isArray(rb?.tools)) return [];
+  return rb.tools.filter(isRecord).map((tool) => {
+    if (isRecord(tool.function)) return tool as ChatTool;
+    if (tool.type === 'function') {
+      return {
+        type: 'function',
+        function: {
+          name: typeof tool.name === 'string' ? tool.name : undefined,
+          description: typeof tool.description === 'string' ? tool.description : undefined,
+        },
+      };
+    }
+    return {
+      type: typeof tool.type === 'string' ? tool.type : undefined,
+      function: { name: typeof tool.type === 'string' ? tool.type : undefined },
+    };
+  });
 }
 
 export type RequestBodyFormat = 'openai' | 'claude' | 'gemini' | 'empty' | 'unknown';
 
 /**
- * The drawer only renders OpenAI chat-completion shapes inline; Claude/Gemini
- * payloads route to the Raw tab. Returning `empty`/`unknown` lets callers
- * surface a hint instead of silently rendering zero turns.
+ * The drawer renders OpenAI chat-completion and Responses request shapes
+ * inline; Claude/Gemini payloads route to the Raw tab. Returning
+ * `empty`/`unknown` lets callers surface a hint instead of silently rendering
+ * zero turns.
  */
 export function detectRequestBodyFormat(
   requestBody: Record<string, unknown> | null | undefined,
 ): RequestBodyFormat {
   if (!requestBody) return 'empty';
   if (Array.isArray((requestBody as { messages?: unknown }).messages)) return 'openai';
+  const input = (requestBody as { input?: unknown }).input;
+  if (typeof input === 'string' || Array.isArray(input)) return 'openai';
   if (Array.isArray((requestBody as { contents?: unknown }).contents)) return 'gemini';
   if (typeof (requestBody as { system?: unknown }).system === 'string') return 'claude';
   return 'unknown';


### PR DESCRIPTION
## Summary
- Render recorded OpenAI Responses API `input` payloads in the message log Conversation tab.
- Normalize Responses text/image parts, function calls, tool outputs, and function tool definitions for the existing drawer UI.
- Add shared parser coverage, a drawer regression for `Conversation (3)`, and a patch changeset.

## Root Cause
The recording drawer only classified request bodies with `messages[]` as OpenAI-compatible. Responses API calls record `input` instead, so successful calls opened as `Conversation (0)` with the unknown request body hint.

## Validation
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npx tsc --noEmit` in `packages/frontend`
- `npm test --workspace manifest-shared -- chat-message.spec.ts`
- `npm test --workspace manifest-shared -- --coverage --coverageReporters=lcov --runTestsByPath __tests__/chat-message.spec.ts`
- `npm test --workspace manifest-frontend -- RecordedMessageModal.test.tsx`
- `npx prettier --check packages/shared/src/chat-message.ts packages/shared/__tests__/chat-message.spec.ts packages/frontend/src/components/RecordedMessageModal.tsx .changeset/tender-keys-smile.md`
- `git diff --check`

Closes #1990.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render OpenAI Responses API `input` and `instructions` as conversation turns in the Conversation tab so recordings show real messages instead of “Conversation (0)”. Fixes #1990.

- **Bug Fixes**
  - Parse Responses `instructions` and `input` (text/image parts) into turns; show `[image]` for `input_image`.
  - Convert `function_call` and `function_call_output` into assistant tool_calls and tool messages; surface function tools in the Tools tab.
  - Detect Responses requests as OpenAI-compatible to remove the “Unrecognised request body shape” hint; add shared parser tests and a drawer regression for “Conversation (3)”.

<sup>Written for commit 2bf3734852450aa862ccabe08f5b7a53ce702ee2. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1992?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

