### PR TITLE
Add info tooltips to model params groups and standardize tooltip size

### DIFF
--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -1,4 +1,3 @@
-import { createEffect, createSignal, For, Show, type Component } from 'solid-js';
 import {
   compareProviderParamSpecs,
   getProviderParamValue,
@@ -8,6 +7,8 @@ import {
   type ModelParamGroup,
   type ProviderParamSpec,
 } from 'manifest-shared';
+import { createEffect, createSignal, For, Show, type Component } from 'solid-js';
+import { Portal } from 'solid-js/web';
 import type { RequestParamDefaults } from '../services/api.js';
 import Select from './Select.jsx';
 
@@ -33,6 +34,57 @@ const GROUP_LABELS: Record<ModelParamGroup, string> = {
   output_format: 'Output format',
   observability: 'Observability',
   provider_metadata: 'Provider metadata',
+};
+
+const GROUP_INTROS: Record<ModelParamGroup, string> = {
+  generation_length: 'Controls how much text the model can produce in a single response.',
+  sampling: 'Adjusts randomness and diversity in the generated output.',
+  reasoning: 'Controls extended thinking where the model reasons before answering.',
+  tooling: 'Configures how the model calls external tools and functions.',
+  output_format: 'Constrains the shape of the response.',
+  observability: 'Metadata fields for tracing and debugging requests.',
+  provider_metadata: 'Provider-specific options outside standard categories.',
+};
+
+const PARAM_HINTS: Record<string, string> = {
+  temperature:
+    'Low values give focused, deterministic answers. High values give more creative, varied responses.',
+  top_p:
+    'Limits token choices to the most probable ones whose cumulative probability reaches this threshold. Lower values make output more focused.',
+  top_k:
+    'Limits token choices to the top K most probable tokens at each step. Lower values make output more predictable.',
+  max_tokens:
+    'The model stops when it finishes or reaches this limit. A higher value allows longer answers but does not force them.',
+  'thinking.type':
+    'When enabled, the model reasons step by step before answering. Uses more tokens but improves accuracy on complex tasks.',
+  'thinking.budget_tokens':
+    'Maximum number of tokens the model can spend on its internal reasoning before producing the final answer.',
+  reasoning_effort:
+    'How much effort the model puts into reasoning. Lower values are faster and cheaper, higher values are more thorough.',
+  frequency_penalty:
+    'Penalizes tokens that already appeared in the output. Higher values reduce repetition.',
+  presence_penalty:
+    'Penalizes tokens that appeared at all in the conversation. Higher values encourage the model to cover new topics.',
+  tool_choice:
+    'Controls whether the model must call a tool, can optionally call one, or is prevented from calling tools.',
+  parallel_tool_use:
+    'When enabled, the model can call multiple tools in a single turn instead of one at a time.',
+  response_format: 'Forces the model to produce output in a specific format, such as valid JSON.',
+  stream:
+    'When enabled, the response arrives incrementally as it is generated instead of all at once.',
+  store: 'When enabled, the request and response are stored by the provider for later inspection.',
+  service_tier: 'Selects between standard and priority processing tiers offered by the provider.',
+};
+
+const paramHint = (spec: ProviderParamSpec): string => PARAM_HINTS[spec.path] ?? spec.description;
+
+const rangeLabel = (spec: ProviderParamSpec): string | null => {
+  if (!spec.range) return null;
+  const { min, max } = spec.range;
+  if (min !== undefined && max !== undefined) return `${min}–${max}`;
+  if (min !== undefined) return `min ${min}`;
+  if (max !== undefined) return `max ${max}`;
+  return null;
 };
 
 const GROUP_ORDER: readonly ModelParamGroup[] = [
@@ -354,78 +406,118 @@ const ModelParamsDialog: Component<Props> = (props) => {
   };
 
   return (
-    <Show when={props.open}>
-      <div
-        class="modal-overlay"
-        draggable={false}
-        onClick={(e) => {
-          if (e.target === e.currentTarget && !saving()) props.onClose();
-        }}
-        onDragStart={(e) => e.preventDefault()}
-      >
+    <Portal>
+      <Show when={props.open}>
         <div
-          class="modal-card"
-          style="max-width: 460px; user-select: none;"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="model-params-dialog-title"
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={handleKeyDown}
+          class="modal-overlay"
+          onClick={(e) => {
+            if (e.target === e.currentTarget && !saving()) props.onClose();
+          }}
         >
-          <h2 class="modal-card__title" id="model-params-dialog-title">
-            Model parameters
-          </h2>
-          <p class="modal-card__desc">Manifest parameters for {props.slotLabel}.</p>
-
-          <Show
-            when={!props.loading}
-            fallback={
-              <div class="model-params__status">
-                <span class="spinner" />
-                <span>Loading parameters…</span>
-              </div>
-            }
+          <div
+            class="modal-card"
+            style="max-width: 460px; user-select: none;"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="model-params-dialog-title"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={handleKeyDown}
           >
+            <h2 class="modal-card__title" id="model-params-dialog-title">
+              Model parameters
+            </h2>
+            <p class="modal-card__desc">Manifest parameters for {props.slotLabel}.</p>
+
             <Show
-              when={props.specs.length > 0}
+              when={!props.loading}
               fallback={
-                <p class="model-params__status">This model has no configurable parameters.</p>
+                <div class="model-params__status">
+                  <span class="spinner" />
+                  <span>Loading parameters…</span>
+                </div>
               }
             >
-              <For each={groupSpecs(props.specs)}>
-                {(group) => (
-                  <div class="model-params__group">
-                    <div class="model-params__group-header">{GROUP_LABELS[group.group]}</div>
-                    <For each={group.specs}>{(spec) => <ParamRow spec={spec} />}</For>
-                  </div>
-                )}
-              </For>
+              <Show
+                when={props.specs.length > 0}
+                fallback={
+                  <p class="model-params__status">This model has no configurable parameters.</p>
+                }
+              >
+                <For each={groupSpecs(props.specs)}>
+                  {(group) => (
+                    <div class="model-params__group">
+                      <div class="model-params__group-header">
+                        <span>{GROUP_LABELS[group.group]}</span>
+                        <span class="model-params__group-info">
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="13"
+                            height="13"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <circle cx="12" cy="12" r="10" />
+                            <path d="M12 16v-4" />
+                            <path d="M12 8h.01" />
+                          </svg>
+                          <span class="model-params__group-tooltip">
+                            <span class="model-params__tooltip-intro">
+                              {GROUP_INTROS[group.group]}
+                            </span>
+                            <For each={group.specs}>
+                              {(spec) => (
+                                <span class="model-params__tooltip-param">
+                                  <strong>{spec.label}</strong>
+                                  <Show when={rangeLabel(spec)}>
+                                    {' '}
+                                    <span class="model-params__tooltip-range">
+                                      {rangeLabel(spec)}
+                                    </span>
+                                  </Show>
+                                  <br />
+                                  {paramHint(spec)}
+                                </span>
+                              )}
+                            </For>
+                          </span>
+                        </span>
+                      </div>
+                      <For each={group.specs}>{(spec) => <ParamRow spec={spec} />}</For>
+                    </div>
+                  )}
+                </For>
+              </Show>
             </Show>
-          </Show>
 
-          <div class="modal-card__footer">
-            <button
-              class="btn btn--ghost btn--sm"
-              onClick={props.onClose}
-              disabled={saving()}
-              type="button"
-            >
-              {!props.loading && props.specs.length > 0 ? 'Cancel' : 'Close'}
-            </button>
-            <Show when={!props.loading && props.specs.length > 0}>
+            <div class="modal-card__footer">
               <button
-                class="btn btn--primary btn--sm"
-                onClick={handleSave}
+                class="btn btn--ghost btn--sm"
+                onClick={props.onClose}
                 disabled={saving()}
                 type="button"
               >
-                {saving() ? <span class="spinner" /> : 'Save'}
+                {!props.loading && props.specs.length > 0 ? 'Cancel' : 'Close'}
               </button>
-            </Show>
+              <Show when={!props.loading && props.specs.length > 0}>
+                <button
+                  class="btn btn--primary btn--sm"
+                  onClick={handleSave}
+                  disabled={saving()}
+                  type="button"
+                >
+                  {saving() ? <span class="spinner" /> : 'Save'}
+                </button>
+              </Show>
+            </div>
           </div>
         </div>
-      </div>
-    </Show>
+      </Show>
+    </Portal>
   );
 };
 

--- a/packages/frontend/src/styles/charts.css
+++ b/packages/frontend/src/styles/charts.css
@@ -75,7 +75,7 @@
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
   padding: 8px 12px;
-  font-size: var(--font-size-xs);
+  font-size: var(--tooltip-font-size);
   color: hsl(var(--popover-foreground));
   pointer-events: none;
   box-shadow:

--- a/packages/frontend/src/styles/data.css
+++ b/packages/frontend/src/styles/data.css
@@ -135,7 +135,7 @@
   color: hsl(var(--popover-foreground));
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
-  font-size: var(--font-size-xs);
+  font-size: var(--tooltip-font-size);
   font-weight: 400;
   line-height: 1.5;
   white-space: normal;
@@ -992,7 +992,7 @@
   border-radius: var(--radius);
   background: hsl(var(--foreground));
   color: hsl(var(--background));
-  font-size: var(--font-size-xs);
+  font-size: var(--tooltip-font-size);
   font-weight: 400;
   white-space: nowrap;
   opacity: 0;

--- a/packages/frontend/src/styles/recording.css
+++ b/packages/frontend/src/styles/recording.css
@@ -911,7 +911,7 @@
   transform: translateX(-50%);
   padding: 4px 10px;
   border-radius: var(--radius-sm, 6px);
-  font-size: 12px;
+  font-size: var(--tooltip-font-size);
   font-weight: 500;
   font-family: var(--font-family);
   white-space: nowrap;

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -82,7 +82,7 @@
   border: 1px solid hsl(var(--border));
   padding: 6px 10px;
   border-radius: 6px;
-  font-size: 12px;
+  font-size: var(--tooltip-font-size);
   line-height: 1.4;
   white-space: nowrap;
   z-index: 20;
@@ -595,10 +595,74 @@
 }
 
 .model-params__group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   padding: 6px 0 2px;
   font-size: var(--font-size-sm);
   font-weight: 600;
   color: hsl(var(--foreground));
+}
+
+.model-params__group-info {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  color: hsl(var(--muted-foreground) / 0.5);
+  cursor: default;
+  transition: color var(--transition-fast);
+}
+
+.model-params__group-info:hover {
+  color: hsl(var(--muted-foreground));
+}
+
+.model-params__group-tooltip {
+  display: none;
+  flex-direction: column;
+  gap: 8px;
+  position: absolute;
+  top: calc(100% + 8px);
+  left: -4px;
+  width: 280px;
+  padding: 10px 12px;
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: 8px;
+  font-size: var(--tooltip-font-size);
+  font-weight: 400;
+  line-height: 1.5;
+  white-space: normal;
+  box-shadow: 0 4px 12px hsl(var(--foreground) / 0.08);
+  z-index: 10;
+}
+
+.model-params__group-info:hover .model-params__group-tooltip {
+  display: flex;
+}
+
+.model-params__tooltip-intro {
+  color: hsl(var(--muted-foreground));
+}
+
+.model-params__tooltip-param {
+  display: block;
+}
+
+.model-params__tooltip-param strong {
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.model-params__tooltip-range {
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--muted) / 0.45);
+  border: 1px solid hsl(var(--border) / 0.7);
+  border-radius: 3px;
+  padding: 0 4px;
 }
 
 .model-params__group .model-params__row {
@@ -787,7 +851,7 @@
   transform: translateX(-50%) scale(0.95);
   background: #fff;
   color: #1a1a1a;
-  font-size: 11px;
+  font-size: var(--tooltip-font-size);
   font-weight: 500;
   padding: 4px 8px;
   border-radius: 6px;

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -129,6 +129,7 @@
   --font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, monospace;
   --font-size-xs: 0.75rem;
   --font-size-sm: 0.875rem;
+  --tooltip-font-size: var(--font-size-sm);
   --font-size-base: 0.9375rem;
   --font-size-lg: 1.125rem;
   --font-size-xl: 1.5rem;

--- a/packages/frontend/src/styles/tooltip.css
+++ b/packages/frontend/src/styles/tooltip.css
@@ -31,7 +31,7 @@
   color: hsl(var(--popover-foreground));
   border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
-  font-size: var(--font-size-xs);
+  font-size: var(--tooltip-font-size);
   font-weight: 400;
   line-height: 1.5;
   white-space: normal;

--- a/packages/frontend/tests/components/FallbackList.test.tsx
+++ b/packages/frontend/tests/components/FallbackList.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@solidjs/testing-library';
 import type { ProviderParamSpecCatalog } from 'manifest-shared';
+
+vi.mock('solid-js/web', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('solid-js/web')>();
+  return { ...mod, Portal: (props: any) => props.children };
+});
+
 import { getModelParamSpecs } from '../../src/services/api/model-params.js';
 
 const mockSetFallbacks = vi.fn();

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@solidjs/testing-library';
 
+vi.mock('solid-js/web', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('solid-js/web')>();
+  return { ...mod, Portal: (props: any) => props.children };
+});
+
 const mockResetHeaderTier = vi.fn();
 const mockSetHeaderTierFallbacks = vi.fn();
 const mockClearHeaderTierFallbacks = vi.fn();

--- a/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsAffordance.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@solidjs/testing-library';
 import type { ProviderParamSpec } from 'manifest-shared';
+
+vi.mock('solid-js/web', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('solid-js/web')>();
+  return { ...mod, Portal: (props: any) => props.children };
+});
+
 import ModelParamsAffordance from '../../src/components/ModelParamsAffordance';
 import { getModelParamSpecs } from '../../src/services/api/model-params.js';
 

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -2,6 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, screen, waitFor } from '@solidjs/testing-library';
 import type { ProviderParamSpec, RequestParamDefaults } from 'manifest-shared';
 
+vi.mock('solid-js/web', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('solid-js/web')>();
+  return { ...mod, Portal: (props: any) => props.children };
+});
+
 import ModelParamsDialog from '../../src/components/ModelParamsDialog';
 
 const q = (sel: string) => document.querySelector(sel);
@@ -153,7 +158,7 @@ describe('ModelParamsDialog', () => {
     render(() => (
       <ModelParamsDialog {...baseProps} specs={anthropicSpecs} slotLabel="claude-sonnet-4-6" />
     ));
-    expect(screen.getByText('Max tokens')).toBeTruthy();
+    expect(screen.getAllByText('Max tokens').length).toBeGreaterThan(0);
     expect(screen.getByText('max_tokens')).toBeTruthy();
   });
 

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent, waitFor } from '@solidjs/testing-library';
+
+vi.mock('solid-js/web', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('solid-js/web')>();
+  return { ...mod, Portal: (props: any) => props.children };
+});
+
 import { getModelParamSpecs } from '../../src/services/api/model-params.js';
 
 const mockSetFallbacks = vi.fn();


### PR DESCRIPTION
## ✨ What changed
- Added an info icon next to each parameter group header (Sampling, Reasoning, etc.) with a rich tooltip
- Each tooltip shows a group intro, then lists every parameter with its name, range badge, and a plain-English description
- Descriptions are provider-aware: the range shown matches the actual model (e.g. temperature 0-1 for Anthropic, 0-2 for DeepSeek)
- Rendered the dialog via Portal so it can no longer be dragged from inside a draggable model chip
- Introduced a `--tooltip-font-size` design token (14px) and applied it to every tooltip in the app

## 💭 Why
Users configuring model parameters had no guidance on what each setting does or what values to use. Group headers like "Sampling" or "Reasoning" were labels without explanation. Tooltip font sizes were inconsistent across the app (11px, 12px, variable).

## 👤 For users
- Hovering the (i) icon next to any group header shows what each parameter does and its valid range
- All tooltips across the app are now 14px for better readability
- The params dialog no longer drags when opened from a model chip

## 🔧 For operators
No operator impact

## 🧪 How to test
1. Open the Routing page, connect a provider (e.g. DeepSeek or Anthropic)
2. Click the Parameters icon on any model chip
3. Hover the (i) icon next to a group header (e.g. Sampling)
4. Verify the tooltip shows the group intro + each param with description and range
5. Try to drag the dialog from the overlay: it should not move

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added info tooltips to each model parameter group and standardized tooltip font size across the app. The model params dialog now renders via `Portal` to prevent dragging when opened from a draggable model chip.

- **New Features**
  - Added an info icon next to each group header (Sampling, Reasoning, etc.) with a rich tooltip showing a short intro plus each parameter’s name, range badge, and a plain-English description.
  - Tooltips are provider-aware; ranges match the selected model’s spec (e.g., temperature 0–1 for Anthropic, 0–2 for DeepSeek).
  - Introduced `--tooltip-font-size` (14px) and applied it to all tooltips for consistent readability.

- **Bug Fixes**
  - Rendered the params dialog via `Portal` from `solid-js/web` so it can’t be dragged from inside a draggable model chip; tests updated to mock `Portal`.

<sup>Written for commit 57d8244921400606edd7b9915bff45862e42350a. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1993?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

