### PR TITLE
revert: rollback model parameter descriptions

### DIFF
--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -389,19 +389,18 @@ const ModelParamsDialog: Component<Props> = (props) => {
         class="model-params__row"
         classList={{ 'model-params__row--disabled': !isApplicable(spec()) }}
       >
-        <div class="model-params__row-copy">
+        <div class="model-params__row-top">
           <div class="model-params__label-title">
             <span>{spec().label}</span>
             <code class="model-params__param-key">{spec().path}</code>
           </div>
-          <div class="model-params__description">{spec().description}</div>
-          <div class="model-params__label-hint">
-            {isApplicable(spec())
-              ? `Default: ${spec().default === undefined ? 'unset' : String(spec().default)}`
-              : 'Unavailable with selected parameters'}
-          </div>
+          {renderControl(spec())}
         </div>
-        <div class="model-params__row-control">{renderControl(spec())}</div>
+        <div class="model-params__label-hint">
+          {isApplicable(spec())
+            ? `Default: ${spec().default === undefined ? 'unset' : String(spec().default)}`
+            : 'Unavailable with selected parameters'}
+        </div>
       </div>
     );
   };

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -545,25 +545,20 @@
 }
 
 .model-params__row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) max-content;
-  align-items: start;
-  column-gap: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
   padding: 12px 0;
 }
 
-.model-params__row-copy {
-  min-width: 0;
-}
-
-.model-params__row-control {
+.model-params__row-top {
   display: flex;
-  justify-content: flex-end;
-  min-width: max-content;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
 }
 
 .model-params__row--disabled .model-params__label-title,
-.model-params__row--disabled .model-params__description,
 .model-params__row--disabled .model-params__label-hint {
   color: hsl(var(--muted-foreground));
 }
@@ -688,13 +683,6 @@
   font-size: var(--font-size-xs);
   color: hsl(var(--muted-foreground));
   margin-top: 2px;
-}
-
-.model-params__description {
-  margin-top: 4px;
-  color: hsl(var(--foreground) / 0.78);
-  font-size: var(--font-size-xs);
-  line-height: 1.45;
 }
 
 .model-params__toggle {
@@ -1361,16 +1349,5 @@
 
   .provider-toggle__expand {
     padding-left: 24px;
-  }
-}
-
-@media (max-width: 600px) {
-  .model-params__row {
-    grid-template-columns: 1fr;
-    row-gap: 10px;
-  }
-
-  .model-params__row-control {
-    justify-content: flex-start;
   }
 }

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -160,8 +160,6 @@ describe('ModelParamsDialog', () => {
     ));
     expect(screen.getAllByText('Max tokens').length).toBeGreaterThan(0);
     expect(screen.getByText('max_tokens')).toBeTruthy();
-    expect(screen.getByText('Maximum number of output tokens.')).toBeTruthy();
-    expect(screen.getByText('Default: 4096')).toBeTruthy();
   });
 
   it('renders derived select, slider, and number controls from specs', () => {


### PR DESCRIPTION
## Summary
- Reverts #1976 to roll back the current production deployment.
- Removes the inline MPS parameter description UI changes introduced by the merged PR.

## Validation
- npm ci
- npm run build --workspace manifest-shared
- npm test --workspace manifest-frontend -- ModelParamsDialog
- npm run lint --workspace manifest-frontend (0 errors, existing upstream warnings only)
- git diff --check HEAD~1 HEAD

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts #1976 to remove inline model parameter descriptions and restore the previous Model Params dialog layout. Simplifies styles and updates tests to match the reverted UI.

- **Refactors**
  - Restore top row with label/key and control; keep availability hint below; remove per-parameter description.
  - Replace grid with a simple flex layout; remove `.model-params__description` and mobile grid overrides.
  - Update tests to drop assertions for description and specific default text.

<sup>Written for commit c1b7a1818e92c60b058ee9261d2ec1603e5258f6. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1997?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

