### PR TITLE
fix(proxy): preserve reasoning_content across turns

### DIFF
--- a/.changeset/reasoning-content-reinject.md
+++ b/.changeset/reasoning-content-reinject.md
@@ -1,0 +1,7 @@
+---
+'manifest': patch
+---
+
+fix(proxy): re-inject cached reasoning_content for OpenAI-compatible tool turns
+
+When reasoning providers return `reasoning_content` alongside tool calls, Manifest now caches the field and restores it on the next request if an OpenAI-compatible client dropped it from the assistant history. The replay is guarded to DeepSeek/Kimi/OpenCode Go-compatible targets and strict providers still have the field stripped.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -1,4 +1,7 @@
-import { sanitizeOpenAiBody } from '../provider-client-converters';
+import {
+  createReasoningContentStreamTransformer,
+  sanitizeOpenAiBody,
+} from '../provider-client-converters';
 
 describe('provider-client-converters', () => {
   describe('sanitizeOpenAiBody', () => {
@@ -167,12 +170,45 @@ describe('provider-client-converters', () => {
       expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
     });
 
+    it('normalizes provider casing when preserving reasoning_content', () => {
+      const body = {
+        messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'DeepSeek', 'deepseek-chat');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
+    });
+
+    it('should preserve reasoning_content for native moonshot provider', () => {
+      const body = {
+        messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'moonshot', 'kimi-k2');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
+    });
+
     it('should preserve reasoning_content for openrouter deepseek models', () => {
       const body = {
         messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
       };
 
       const result = sanitizeOpenAiBody(body, 'openrouter', 'deepseek/deepseek-r1');
+      const messages = result.messages as any[];
+
+      expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
+    });
+
+    it('should preserve reasoning_content for openrouter moonshot models', () => {
+      const body = {
+        messages: [{ role: 'assistant', content: 'Hi', reasoning_content: 'thought' }],
+      };
+
+      const result = sanitizeOpenAiBody(body, 'openrouter', 'moonshotai/kimi-k2');
       const messages = result.messages as any[];
 
       expect(messages[0]).toHaveProperty('reasoning_content', 'thought');
@@ -290,6 +326,83 @@ describe('provider-client-converters', () => {
         const messages = result.messages as any[];
         expect(messages[0]).not.toHaveProperty('reasoning_content');
       }
+    });
+
+    it('re-injects cached reasoning_content for compatible assistant tool-call messages', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' },
+              },
+            ],
+          },
+        ],
+      };
+
+      const lookup = jest.fn((id: string) => (id === 'call_1' ? 'cached reasoning' : null));
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).toHaveBeenCalledWith('call_1');
+      expect(messages[0]).toHaveProperty('reasoning_content', 'cached reasoning');
+    });
+
+    it('does not re-inject cached reasoning_content for strict providers', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const lookup = jest.fn(() => 'cached reasoning');
+      const result = sanitizeOpenAiBody(body, 'mistral', 'mistral-large', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).not.toHaveBeenCalled();
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+
+    it('does not replace existing reasoning_content during re-injection', () => {
+      const body = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            reasoning_content: 'client reasoning',
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+
+      const lookup = jest.fn(() => 'cached reasoning');
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).not.toHaveBeenCalled();
+      expect(messages[0]).toHaveProperty('reasoning_content', 'client reasoning');
+    });
+
+    it('does not re-inject cached reasoning_content without tool calls', () => {
+      const body = {
+        messages: [{ role: 'assistant', content: 'Hi' }],
+      };
+
+      const lookup = jest.fn(() => 'cached reasoning');
+      const result = sanitizeOpenAiBody(body, 'deepseek', 'deepseek-chat', lookup);
+      const messages = result.messages as any[];
+
+      expect(lookup).not.toHaveBeenCalled();
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
     });
 
     /* ── Message sanitization: reasoning_details ── */
@@ -825,6 +938,64 @@ describe('provider-client-converters', () => {
       expect(result).toHaveProperty('max_completion_tokens', 4096);
       expect(result).not.toHaveProperty('store');
       expect(result).not.toHaveProperty('service_tier');
+    });
+  });
+
+  describe('createReasoningContentStreamTransformer', () => {
+    it('accumulates reasoning_content and fires callback on tool-call finish', () => {
+      const callback = jest.fn();
+      const transform = createReasoningContentStreamTransformer(callback);
+
+      expect(
+        transform(
+          JSON.stringify({
+            choices: [{ delta: { reasoning_content: 'I should ' }, finish_reason: null }],
+          }),
+        ),
+      ).toContain('reasoning_content');
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { reasoning_content: 'use a tool.' }, finish_reason: null }],
+        }),
+      );
+      transform(
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'lookup' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        }),
+      );
+      transform(JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] }));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith('call_1', 'I should use a tool.');
+    });
+
+    it('does not fire without a tool call id', () => {
+      const callback = jest.fn();
+      const transform = createReasoningContentStreamTransformer(callback);
+
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { reasoning_content: 'thinking' }, finish_reason: null }],
+        }),
+      );
+      transform(JSON.stringify({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] }));
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('passes malformed chunks through unchanged as SSE data', () => {
+      const callback = jest.fn();
+      const transform = createReasoningContentStreamTransformer(callback);
+
+      expect(transform('not json')).toBe('data: not json\n\n');
+      expect(callback).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -488,6 +488,7 @@ describe('proxy-response-handler', () => {
       return {
         convertGoogleStreamChunk: jest.fn(),
         createAnthropicStreamTransformer: jest.fn().mockReturnValue(jest.fn()),
+        createReasoningContentStreamTransformer: jest.fn().mockReturnValue(jest.fn()),
         convertChatGptStreamChunk: jest.fn(),
       };
     }
@@ -951,6 +952,47 @@ describe('proxy-response-handler', () => {
 
       // Should not throw — just drops the signatures silently.
       expect(() => capturedTransform!('{}')).not.toThrow();
+    });
+
+    it('caches reasoning_content from compatible OpenAI-compatible streams', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'deepseek', model: 'deepseek-chat' });
+      const reasoningCache = { store: jest.fn() };
+      const sessionKey = 'sess-reasoning-stream';
+      const transformer = jest.fn((chunk: string) => `data: ${chunk}\n\n`);
+      client.createReasoningContentStreamTransformer.mockReturnValue(transformer);
+
+      await handleStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        sessionKey,
+        undefined,
+        'chat_completions',
+        undefined,
+        reasoningCache as any,
+      );
+
+      const callback = client.createReasoningContentStreamTransformer.mock.calls[0][0];
+      expect(typeof callback).toBe('function');
+      callback('call_1', 'streamed reasoning');
+      expect(reasoningCache.store).toHaveBeenCalledWith(
+        'sess-reasoning-stream',
+        'call_1',
+        'streamed reasoning',
+      );
+      expect(pipeStreamSpy).toHaveBeenCalledWith(
+        forward.response.body,
+        res,
+        expect.any(Function),
+        undefined,
+        undefined,
+      );
     });
   });
 
@@ -1496,6 +1538,89 @@ describe('proxy-response-handler', () => {
       // _extractedSignatures should be deleted from the response body
       const sentBody = res.json.mock.calls[0][0];
       expect(sentBody._extractedSignatures).toBeUndefined();
+    });
+
+    it('caches reasoning_content from compatible non-stream responses with tool calls', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const reasoningCache = { store: jest.fn() };
+      const sessionKey = 'sess-reasoning-json';
+      const body = {
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '',
+              reasoning_content: 'I should call the tool.',
+              tool_calls: [
+                {
+                  id: 'call_1',
+                  type: 'function',
+                  function: { name: 'lookup', arguments: '{}' },
+                },
+              ],
+            },
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta({ provider: 'deepseek', model: 'deepseek-chat' });
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        sessionKey,
+        undefined,
+        'chat_completions',
+        undefined,
+        reasoningCache as any,
+      );
+
+      expect(reasoningCache.store).toHaveBeenCalledWith(
+        'sess-reasoning-json',
+        'call_1',
+        'I should call the tool.',
+      );
+      expect(res.json).toHaveBeenCalledWith(body);
+    });
+
+    it('does not cache reasoning_content from strict provider responses', async () => {
+      const { res } = mockResponse();
+      const client = mockProviderClient();
+      const reasoningCache = { store: jest.fn() };
+      const body = {
+        choices: [
+          {
+            message: {
+              reasoning_content: 'unsupported',
+              tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+            },
+          },
+        ],
+      };
+      const forward = mockForward(body);
+      const meta = makeMeta({ provider: 'mistral', model: 'mistral-large' });
+
+      await handleNonStreamResponse(
+        res as any,
+        forward as any,
+        meta,
+        {},
+        client as any,
+        undefined,
+        'sess-strict',
+        undefined,
+        'chat_completions',
+        undefined,
+        reasoningCache as any,
+      );
+
+      expect(reasoningCache.store).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -5,6 +5,7 @@ import { ProxyMessageDedup } from '../proxy-message-dedup';
 import { IngestEventBusService } from '../../../common/services/ingest-event-bus.service';
 import { ThoughtSignatureCache } from '../thought-signature-cache';
 import { ThinkingBlockCache } from '../thinking-block-cache';
+import { ReasoningContentCache } from '../reasoning-content-cache';
 
 /**
  * Flush enough microtasks for the recorder's fire-and-forget chain to
@@ -163,6 +164,7 @@ describe('ProxyController', () => {
       recorder,
       new ThoughtSignatureCache(),
       new ThinkingBlockCache(),
+      new ReasoningContentCache(),
       { isRecording: jest.fn().mockResolvedValue(false), invalidate: jest.fn() } as never,
     );
   });

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -18,6 +18,7 @@ import type { LimitCheckService } from '../../../notifications/services/limit-ch
 import type { ProxyFallbackService } from '../proxy-fallback.service';
 import type { ThoughtSignatureCache } from '../thought-signature-cache';
 import type { ThinkingBlockCache } from '../thinking-block-cache';
+import type { ReasoningContentCache } from '../reasoning-content-cache';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
 import type { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
 
@@ -82,6 +83,7 @@ describe('ProxyService — orchestration', () => {
   let configService: ConfigService;
   let signatureCache: ThoughtSignatureCache;
   let thinkingCache: ThinkingBlockCache;
+  let reasoningCache: ReasoningContentCache;
   let modelParamsService: { get: jest.Mock; list: jest.Mock; set: jest.Mock; delete: jest.Mock };
   let providerParamSpecs: { getSpecs: jest.Mock; list: jest.Mock };
   let svc: ProxyService;
@@ -117,6 +119,9 @@ describe('ProxyService — orchestration', () => {
       retrieve: jest.fn().mockReturnValue(null),
     } as unknown as ThoughtSignatureCache;
     thinkingCache = { retrieve: jest.fn().mockReturnValue(null) } as unknown as ThinkingBlockCache;
+    reasoningCache = {
+      retrieve: jest.fn().mockReturnValue(null),
+    } as unknown as ReasoningContentCache;
 
     modelParamsService = {
       get: jest.fn().mockResolvedValue(null),
@@ -144,6 +149,7 @@ describe('ProxyService — orchestration', () => {
       configService,
       signatureCache,
       thinkingCache,
+      reasoningCache,
       modelParamsService as unknown as AgentModelParamsService,
       providerParamSpecs as unknown as ProviderParamSpecService,
     );
@@ -1069,7 +1075,7 @@ describe('ProxyService — orchestration', () => {
       expect(resolveService.resolve).toHaveBeenCalled();
     });
 
-    it('exercises the per-request signature and thinking lookup closures', async () => {
+    it('exercises the per-request signature, thinking, and reasoning lookup closures', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
         route: route('openai', 'api_key', 'gpt-4o'),
@@ -1082,6 +1088,7 @@ describe('ProxyService — orchestration', () => {
         // Invoke the lookups so coverage hits the closure bodies.
         opts.signatureLookup?.('tool-call-1');
         opts.thinkingLookup?.('first-use-1');
+        opts.reasoningContentLookup?.('reasoning-call-1');
         return {
           response: okResponse(),
           isGoogle: false,
@@ -1093,6 +1100,7 @@ describe('ProxyService — orchestration', () => {
       await svc.proxyRequest(baseOpts());
       expect(signatureCache.retrieve).toHaveBeenCalledWith('sess-1', 'tool-call-1');
       expect(thinkingCache.retrieve).toHaveBeenCalledWith('sess-1', 'first-use-1');
+      expect(reasoningCache.retrieve).toHaveBeenCalledWith('sess-1', 'reasoning-call-1');
     });
 
     it('strips system / developer roles when scoring', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -1,0 +1,100 @@
+import { ReasoningContentCache } from '../reasoning-content-cache';
+
+describe('ReasoningContentCache', () => {
+  let cache: ReasoningContentCache;
+
+  beforeEach(() => {
+    cache = new ReasoningContentCache();
+    jest.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('stores and retrieves reasoning_content', () => {
+    cache.store('session-1', 'call_1', 'thinking');
+    expect(cache.retrieve('session-1', 'call_1')).toBe('thinking');
+  });
+
+  it('returns null for a non-existent key', () => {
+    expect(cache.retrieve('no-session', 'no-call')).toBeNull();
+  });
+
+  it('ignores empty reasoning_content', () => {
+    cache.store('session-1', 'call_1', '');
+    expect(cache.retrieve('session-1', 'call_1')).toBeNull();
+  });
+
+  it('returns null for an expired entry', () => {
+    const realNow = Date.now;
+    const baseTime = 1000000000000;
+
+    Date.now = () => baseTime;
+    cache.store('session-1', 'call_1', 'expired');
+
+    Date.now = () => baseTime + 31 * 60 * 1000;
+    expect(cache.retrieve('session-1', 'call_1')).toBeNull();
+
+    Date.now = realNow;
+  });
+
+  it('returns content when it has not yet expired', () => {
+    const realNow = Date.now;
+    const baseTime = 1000000000000;
+
+    Date.now = () => baseTime;
+    cache.store('session-1', 'call_1', 'valid');
+
+    Date.now = () => baseTime + 29 * 60 * 1000;
+    expect(cache.retrieve('session-1', 'call_1')).toBe('valid');
+
+    Date.now = realNow;
+  });
+
+  it('clearSession removes all entries for a given session', () => {
+    cache.store('session-A', 'call_1', 'a');
+    cache.store('session-A', 'call_2', 'b');
+    cache.store('session-B', 'call_1', 'c');
+
+    cache.clearSession('session-A');
+
+    expect(cache.retrieve('session-A', 'call_1')).toBeNull();
+    expect(cache.retrieve('session-A', 'call_2')).toBeNull();
+    expect(cache.retrieve('session-B', 'call_1')).toBe('c');
+  });
+
+  it('stores entries for multiple sessions independently', () => {
+    cache.store('s1', 'call_1', 'a');
+    cache.store('s2', 'call_1', 'b');
+    cache.store('s3', 'call_2', 'c');
+
+    expect(cache.retrieve('s1', 'call_1')).toBe('a');
+    expect(cache.retrieve('s2', 'call_1')).toBe('b');
+    expect(cache.retrieve('s3', 'call_2')).toBe('c');
+  });
+
+  it('overwrites existing entry for the same session and tool call', () => {
+    cache.store('session-1', 'call_1', 'old');
+    cache.store('session-1', 'call_1', 'new');
+
+    expect(cache.retrieve('session-1', 'call_1')).toBe('new');
+  });
+
+  it('evicts expired entries lazily when cleanup interval has elapsed', () => {
+    const realNow = Date.now;
+    const baseTime = 1000000000000;
+
+    Date.now = () => baseTime;
+    const localCache = new ReasoningContentCache();
+    localCache.store('s1', 'call_1', 'first');
+
+    Date.now = () => baseTime + 31 * 60 * 1000;
+    localCache.store('s2', 'call_2', 'second');
+
+    expect(localCache.retrieve('s1', 'call_1')).toBeNull();
+    expect(localCache.retrieve('s2', 'call_2')).toBe('second');
+
+    Date.now = realNow;
+  });
+});

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -78,7 +78,7 @@ export {
 };
 export type { GoogleStreamChunkResult } from './google-adapter';
 export type { ThinkingBlocksCallback } from './anthropic-adapter';
-export type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
+export type { SignatureLookup, ThinkingBlockLookup, ReasoningContentLookup } from './proxy-types';
 
 // ─── OpenAI body sanitization (used by ProviderClient.forward) ───────────────
 
@@ -140,16 +140,20 @@ const OPENCODE_GO_REASONING_MODEL_FAMILY_RE =
 /**
  * Some reasoning APIs reject follow-up turns that don't echo back the previous
  * assistant's `reasoning_content`. Preserve it for:
- *  - the native `deepseek` endpoint (always)
+ *  - the native `deepseek` and `moonshot` endpoints (always)
  *  - OpenCode Go's known reasoning model families
  *  - aggregator/proxy endpoints whose `deepseek-*` slugs forward to a DeepSeek
- *    engine (OpenRouter `deepseek/*` and user-supplied custom providers).
+ *    engine, or whose `moonshotai/*` slugs forward to Kimi
+ *    (OpenRouter `deepseek/*` / `moonshotai/*` and DeepSeek custom providers).
  * Strict OpenAI-compatible endpoints (Mistral, native OpenAI, etc.) keep
  * stripping the field even if a community fine-tune slug contains "deepseek".
  */
-function supportsReasoningContent(endpointKey: string, model: string): boolean {
-  if (endpointKey === 'deepseek') return true;
-  if (!REASONING_CONTENT_AWARE_ENDPOINTS.has(endpointKey)) return false;
+export function supportsReasoningContent(endpointKey: string, model: string): boolean {
+  const normalizedEndpoint = endpointKey.toLowerCase();
+  const key = normalizedEndpoint.startsWith('custom:') ? 'custom' : normalizedEndpoint;
+  if (key === 'deepseek') return true;
+  if (key === 'moonshot') return true;
+  if (!REASONING_CONTENT_AWARE_ENDPOINTS.has(key)) return false;
   // Bare model id after stripping any vendor/aggregator prefix:
   //   "deepseek/r1"             → "r1"            — OpenRouter, not deepseek-family
   //   "openrouter" + "deepseek/deepseek-r1" → "deepseek-r1" ✓
@@ -159,10 +163,63 @@ function supportsReasoningContent(endpointKey: string, model: string): boolean {
   // practice the custom path passes the already-bare model — both shapes
   // are handled.)
   const bare = model.toLowerCase().split('/').pop() ?? '';
-  if (endpointKey === 'opencode-go') {
+  if (key === 'opencode-go') {
     return OPENCODE_GO_REASONING_MODEL_FAMILY_RE.test(bare);
   }
+  if (key === 'openrouter' && model.toLowerCase().startsWith('moonshotai/')) {
+    return true;
+  }
   return bare.includes('deepseek');
+}
+
+export type ReasoningContentCallback = (firstToolCallId: string, content: string) => void;
+
+/**
+ * Creates a stateful OpenAI-compatible stream transformer that passes chunks
+ * through unchanged while accumulating reasoning_content for tool-call turns.
+ */
+export function createReasoningContentStreamTransformer(
+  onReasoningContent?: ReasoningContentCallback,
+): (chunk: string) => string | null {
+  let accumulatedReasoning = '';
+  let firstToolCallId: string | null = null;
+  let fired = false;
+
+  const tryFire = (): void => {
+    if (!fired && onReasoningContent && accumulatedReasoning && firstToolCallId) {
+      onReasoningContent(firstToolCallId, accumulatedReasoning);
+      fired = true;
+    }
+  };
+
+  return (chunk: string): string | null => {
+    try {
+      const parsed = JSON.parse(chunk) as Record<string, unknown>;
+      const choice = (parsed.choices as Array<Record<string, unknown>> | undefined)?.[0];
+      const delta = choice?.delta as Record<string, unknown> | undefined;
+
+      if (delta) {
+        if (typeof delta.reasoning_content === 'string') {
+          accumulatedReasoning += delta.reasoning_content;
+        }
+        const toolCalls = delta.tool_calls as Array<Record<string, unknown>> | undefined;
+        if (Array.isArray(toolCalls)) {
+          for (const toolCall of toolCalls) {
+            if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) continue;
+            if (firstToolCallId === null && typeof toolCall.id === 'string' && toolCall.id) {
+              firstToolCallId = toolCall.id;
+            }
+          }
+        }
+      }
+
+      if (choice?.finish_reason === 'tool_calls') tryFire();
+    } catch {
+      // Pass malformed/non-JSON chunks through unchanged.
+    }
+
+    return `data: ${chunk}\n\n`;
+  };
 }
 
 /**
@@ -177,7 +234,12 @@ function supportsReasoningDetails(endpointKey: string): boolean {
   return endpointKey === 'openrouter';
 }
 
-function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: string): unknown {
+function sanitizeOpenAiMessages(
+  messages: unknown,
+  endpointKey: string,
+  model: string,
+  reasoningContentLookup?: (firstToolCallId: string) => string | null,
+): unknown {
   if (!Array.isArray(messages)) return messages;
 
   const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
@@ -252,6 +314,24 @@ function sanitizeOpenAiMessages(messages: unknown, endpointKey: string, model: s
       delete cleaned.reasoning_details;
     }
 
+    if (
+      preserveReasoningContent &&
+      !cleaned.reasoning_content &&
+      Array.isArray(cleaned.tool_calls) &&
+      cleaned.tool_calls.length > 0 &&
+      reasoningContentLookup
+    ) {
+      const firstToolCall = cleaned.tool_calls[0];
+      const firstToolCallId =
+        firstToolCall && typeof firstToolCall === 'object' && !Array.isArray(firstToolCall)
+          ? (firstToolCall as Record<string, unknown>).id
+          : undefined;
+      if (typeof firstToolCallId === 'string') {
+        const cached = reasoningContentLookup(firstToolCallId);
+        if (cached) cleaned.reasoning_content = cached;
+      }
+    }
+
     if (isMistral && Array.isArray(cleaned.tool_calls)) {
       cleaned.tool_calls = cleaned.tool_calls.map((toolCall) => {
         if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) {
@@ -294,6 +374,7 @@ export function sanitizeOpenAiBody(
   body: Record<string, unknown>,
   endpointKey: string,
   model: string,
+  reasoningContentLookup?: (firstToolCallId: string) => string | null,
 ): Record<string, unknown> {
   const passthroughTopLevel = PASSTHROUGH_PROVIDERS.has(endpointKey);
 
@@ -306,7 +387,7 @@ export function sanitizeOpenAiBody(
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
     if (key === 'messages') {
-      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model);
+      cleaned[key] = sanitizeOpenAiMessages(value, endpointKey, model, reasoningContentLookup);
       continue;
     }
     // Rewrite max_tokens → max_completion_tokens for OpenAI-backed endpoints that

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -19,6 +19,7 @@ import {
   convertAnthropicResponse as anthropicResponseConverter,
   convertAnthropicStreamChunk as anthropicStreamChunkConverter,
   createAnthropicTransformer,
+  createReasoningContentStreamTransformer as reasoningContentStreamTransformer,
 } from './provider-client-converters';
 import { ForwardOptions } from './proxy-types';
 import { toNativeResponsesRequest } from './responses-adapter';
@@ -122,6 +123,7 @@ export class ProviderClient {
       stream,
       signatureLookup: opts.signatureLookup,
       thinkingLookup: opts.thinkingLookup,
+      reasoningContentLookup: opts.reasoningContentLookup,
     });
 
     const finalHeaders = extraHeaders ? { ...headers, ...extraHeaders } : headers;
@@ -202,6 +204,7 @@ export class ProviderClient {
     stream: boolean;
     signatureLookup?: ForwardOptions['signatureLookup'];
     thinkingLookup?: ForwardOptions['thinkingLookup'];
+    reasoningContentLookup?: ForwardOptions['reasoningContentLookup'];
   }): { url: string; headers: Record<string, string>; requestBody: Record<string, unknown> } {
     const { endpoint, endpointKey, bareModel, apiKey, authType, body, chatBody, stream } = ctx;
     // For non-chat_completions inbound modes ('responses', 'messages'), the
@@ -291,7 +294,12 @@ export class ProviderClient {
     }
 
     // OpenAI-compatible path (default)
-    const sanitized = sanitizeOpenAiBody(requestSource, endpointKey, ctx.model);
+    const sanitized = sanitizeOpenAiBody(
+      requestSource,
+      endpointKey,
+      ctx.model,
+      ctx.reasoningContentLookup,
+    );
     if (stream && SUPPORTS_USAGE_STREAM_OPTIONS.has(endpointKey)) {
       const existing =
         typeof sanitized.stream_options === 'object' && sanitized.stream_options !== null
@@ -356,5 +364,6 @@ export class ProviderClient {
   readonly convertAnthropicResponse = anthropicResponseConverter;
   readonly convertAnthropicStreamChunk = anthropicStreamChunkConverter;
   readonly createAnthropicStreamTransformer = createAnthropicTransformer;
+  readonly createReasoningContentStreamTransformer = reasoningContentStreamTransformer;
   readonly collectChatGptSseResponse = chatGptSseCollector;
 }

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -48,7 +48,7 @@ import {
   buildTransportErrorResponse,
   describeTransportError,
 } from './proxy-transport';
-import type { SignatureLookup, ThinkingBlockLookup } from './proxy-types';
+import type { SignatureLookup, ThinkingBlockLookup, ReasoningContentLookup } from './proxy-types';
 import type { ProxyApiMode } from './proxy-types';
 
 export interface FailedFallback {
@@ -128,6 +128,7 @@ export class ProxyFallbackService {
     chatBody?: Record<string, unknown>,
     fallbackRoutes?: ModelRoute[] | null,
     paramMergeContext?: ParamMergeContext,
+    reasoningContentLookup?: ReasoningContentLookup,
   ): Promise<{
     success: {
       forward: ForwardResult;
@@ -243,6 +244,7 @@ export class ProxyFallbackService {
         providerRegion,
         signatureLookup,
         thinkingLookup,
+        reasoningContentLookup,
         paramMergeContext,
       });
 
@@ -288,6 +290,7 @@ export class ProxyFallbackService {
     apiMode?: ProxyApiMode;
     signatureLookup?: SignatureLookup;
     thinkingLookup?: ThinkingBlockLookup;
+    reasoningContentLookup?: ReasoningContentLookup;
     paramMergeContext?: ParamMergeContext;
   }): Promise<ForwardResult> {
     try {
@@ -326,6 +329,7 @@ export class ProxyFallbackService {
     apiMode?: ProxyApiMode;
     signatureLookup?: SignatureLookup;
     thinkingLookup?: ThinkingBlockLookup;
+    reasoningContentLookup?: ReasoningContentLookup;
     paramMergeContext?: ParamMergeContext;
   }): Promise<ForwardResult> {
     const {
@@ -337,6 +341,7 @@ export class ProxyFallbackService {
       providerRegion,
       signatureLookup,
       thinkingLookup,
+      reasoningContentLookup,
     } = opts;
     // Per-attempt merge: ask the model-params service for this iteration's
     // (provider, auth_type, model) config. Storage is model-scoped on the
@@ -436,6 +441,7 @@ export class ProxyFallbackService {
       apiMode: opts.apiMode,
       signatureLookup,
       thinkingLookup,
+      reasoningContentLookup,
     });
   }
 }

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -26,11 +26,13 @@ import {
 import type { ProxyApiMode } from './proxy-types';
 import type { ThoughtSignatureCache } from './thought-signature-cache';
 import type { ThinkingBlockCache, ThinkingBlock } from './thinking-block-cache';
+import type { ReasoningContentCache } from './reasoning-content-cache';
 import type { ExtractedSignature } from './google-adapter';
 import {
   extractThinkingBlocksFromMessagesResponse,
   type ExtractedThinkingBlocks,
 } from './anthropic-adapter';
+import { supportsReasoningContent } from './provider-client-converters';
 import type { CallerAttribution } from './caller-classifier';
 import type { CaptureSink } from './recording-capture';
 import { sanitizeResponseHeaders } from './recording-capture';
@@ -277,6 +279,7 @@ export async function handleStreamResponse(
   thinkingCache?: ThinkingBlockCache,
   apiMode: ProxyApiMode = 'chat_completions',
   capture?: CaptureSink,
+  reasoningCache?: ReasoningContentCache,
 ): Promise<StreamUsage | null> {
   initSseHeaders(res, metaHeaders);
 
@@ -364,10 +367,57 @@ export async function handleStreamResponse(
       onClient,
     );
   }
+  if (supportsReasoningContent(meta.provider, meta.model)) {
+    const onReasoningContent =
+      reasoningCache && sessionKey
+        ? (firstToolCallId: string, content: string) => {
+            reasoningCache.store(sessionKey, firstToolCallId, content);
+          }
+        : undefined;
+    const transformer = providerClient.createReasoningContentStreamTransformer(onReasoningContent);
+    return pipeStream(
+      forward.response.body!,
+      res,
+      (chunk) => {
+        const out = transformer(chunk);
+        return out ? toClientChunk(out) : null;
+      },
+      finalize,
+      onClient,
+    );
+  }
   if (apiMode === 'responses' || apiMode === 'messages') {
     return pipeStream(forward.response.body!, res, toClientChunk, finalize, onClient);
   }
   return pipeStream(forward.response.body!, res, undefined, undefined, onClient);
+}
+
+function cacheReasoningContent(
+  responseBody: unknown,
+  cache: ReasoningContentCache | undefined,
+  sessionKey: string | undefined,
+): void {
+  if (!cache || !sessionKey) return;
+  const body = responseBody as Record<string, unknown> | undefined;
+  const choices = body?.choices;
+  if (!Array.isArray(choices) || choices.length === 0) return;
+  const firstChoice = choices[0];
+  if (!firstChoice || typeof firstChoice !== 'object' || Array.isArray(firstChoice)) return;
+  const message = (firstChoice as Record<string, unknown>).message as
+    | Record<string, unknown>
+    | undefined;
+  if (!message) return;
+  const reasoningContent = message.reasoning_content;
+  if (typeof reasoningContent !== 'string' || !reasoningContent) return;
+  const toolCalls = message.tool_calls;
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return;
+  const firstToolCall = toolCalls[0];
+  const firstToolCallId =
+    firstToolCall && typeof firstToolCall === 'object' && !Array.isArray(firstToolCall)
+      ? (firstToolCall as Record<string, unknown>).id
+      : undefined;
+  if (typeof firstToolCallId !== 'string' || !firstToolCallId) return;
+  cache.store(sessionKey, firstToolCallId, reasoningContent);
 }
 
 export async function handleNonStreamResponse(
@@ -381,6 +431,7 @@ export async function handleNonStreamResponse(
   thinkingCache?: ThinkingBlockCache,
   apiMode: ProxyApiMode = 'chat_completions',
   capture?: CaptureSink,
+  reasoningCache?: ReasoningContentCache,
 ): Promise<StreamUsage | null> {
   if (capture) {
     capture.setHeaders(sanitizeResponseHeaders(forward.response.headers));
@@ -430,6 +481,9 @@ export async function handleNonStreamResponse(
     responseBody = providerClient.collectChatGptSseResponse(sseText, meta.model);
   } else {
     responseBody = await forward.response.json();
+    if (supportsReasoningContent(meta.provider, meta.model)) {
+      cacheReasoningContent(responseBody, reasoningCache, sessionKey);
+    }
   }
 
   if (apiMode === 'responses' && !forward.isResponses) {

--- a/packages/backend/src/routing/proxy/proxy-types.ts
+++ b/packages/backend/src/routing/proxy/proxy-types.ts
@@ -16,6 +16,14 @@ export type SignatureLookup = (toolCallId: string) => string | null;
  * assistant turn; returns the ordered block sequence or null.
  */
 export type ThinkingBlockLookup = (firstToolUseId: string) => ThinkingBlock[] | null;
+
+/**
+ * Optional lookup to re-inject cached reasoning_content strings that were
+ * stripped by OpenAI-compatible clients. Called with the first tool_call id
+ * from the assistant turn; returns the cached reasoning_content or null.
+ */
+export type ReasoningContentLookup = (firstToolCallId: string) => string | null;
+
 export type ProxyApiMode = 'chat_completions' | 'responses' | 'messages';
 
 export interface OpenAIMessage {
@@ -47,6 +55,8 @@ export interface ForwardOptions {
   signatureLookup?: SignatureLookup;
   /** Lookup for re-injecting cached thinking blocks (Anthropic only). */
   thinkingLookup?: ThinkingBlockLookup;
+  /** Lookup for re-injecting cached reasoning_content (DeepSeek-compatible providers). */
+  reasoningContentLookup?: ReasoningContentLookup;
 }
 
 /** Options for ProxyService.proxyRequest. */

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -19,6 +19,7 @@ import { ProviderClient } from './provider-client';
 import { ProxyMessageRecorder } from './proxy-message-recorder';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
+import { ReasoningContentCache } from './reasoning-content-cache';
 import { classifyCaller } from './caller-classifier';
 import { sanitizeRequestHeaders } from './request-headers';
 import { createCaptureSink, CaptureSink } from './recording-capture';
@@ -55,6 +56,7 @@ export class ProxyController {
     private readonly recorder: ProxyMessageRecorder,
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
+    private readonly reasoningCache: ReasoningContentCache,
     private readonly recordingCache: AgentRecordingCacheService,
   ) {}
 
@@ -170,6 +172,7 @@ export class ProxyController {
           this.thinkingCache,
           apiMode,
           capture,
+          this.reasoningCache,
         );
       } else {
         streamUsage = await handleNonStreamResponse(
@@ -183,6 +186,7 @@ export class ProxyController {
           this.thinkingCache,
           apiMode,
           capture,
+          this.reasoningCache,
         );
       }
 

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -24,6 +24,7 @@ import { SessionMomentumService } from './session-momentum.service';
 import { CopilotTokenService } from './copilot-token.service';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
+import { ReasoningContentCache } from './reasoning-content-cache';
 import { ProxyExceptionFilter } from './proxy-exception.filter';
 
 @Module({
@@ -51,6 +52,7 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
     CopilotTokenService,
     ThoughtSignatureCache,
     ThinkingBlockCache,
+    ReasoningContentCache,
     ProxyExceptionFilter,
     MessageRecordingService,
   ],

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -29,9 +29,11 @@ import {
   ProxyRequestOptions,
   SignatureLookup,
   ThinkingBlockLookup,
+  ReasoningContentLookup,
 } from './proxy-types';
 import { ThoughtSignatureCache } from './thought-signature-cache';
 import { ThinkingBlockCache } from './thinking-block-cache';
+import { ReasoningContentCache } from './reasoning-content-cache';
 import { AgentModelParamsService } from '../routing-core/agent-model-params.service';
 import { ProviderParamSpecService } from '../routing-core/provider-param-spec.service';
 import { buildFriendlyResponse, getDashboardUrl } from './proxy-friendly-response';
@@ -118,6 +120,7 @@ export class ProxyService {
     private readonly config: ConfigService,
     private readonly signatureCache: ThoughtSignatureCache,
     private readonly thinkingCache: ThinkingBlockCache,
+    private readonly reasoningCache: ReasoningContentCache,
     private readonly modelParamsService: AgentModelParamsService,
     private readonly providerParamSpecs: ProviderParamSpecService,
   ) {}
@@ -186,6 +189,8 @@ export class ProxyService {
       this.signatureCache.retrieve(sessionKey, toolCallId);
     const thinkingLookup = (firstToolUseId: string) =>
       this.thinkingCache.retrieve(sessionKey, firstToolUseId);
+    const reasoningContentLookup = (firstToolCallId: string) =>
+      this.reasoningCache.retrieve(sessionKey, firstToolCallId);
 
     // Per-attempt param-defaults merge happens inside the fallback service
     // so each forward (primary + every fallback iteration) looks up its
@@ -238,6 +243,7 @@ export class ProxyService {
       providerRegion: credentials.providerRegion,
       signatureLookup,
       thinkingLookup,
+      reasoningContentLookup,
       paramMergeContext,
     });
 
@@ -255,6 +261,7 @@ export class ProxyService {
         signal,
         signatureLookup,
         thinkingLookup,
+        reasoningContentLookup,
         apiMode,
         paramMergeContext,
       });
@@ -315,6 +322,7 @@ export class ProxyService {
         signal,
         signatureLookup,
         thinkingLookup,
+        reasoningContentLookup,
         apiMode,
         paramMergeContext,
       });
@@ -433,6 +441,7 @@ export class ProxyService {
     signal?: AbortSignal;
     signatureLookup: SignatureLookup;
     thinkingLookup: ThinkingBlockLookup;
+    reasoningContentLookup: ReasoningContentLookup;
     apiMode: ProxyApiMode;
     paramMergeContext: ParamMergeContext;
   }): Promise<ProxyResult | null> {
@@ -482,6 +491,7 @@ export class ProxyService {
       chatBody,
       fallbackRoutes,
       args.paramMergeContext,
+      args.reasoningContentLookup,
     );
 
     this.recordTierIfScoring(sessionKey, resolved.tier);

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -1,0 +1,60 @@
+interface CachedReasoningContent {
+  content: string;
+  expiresAt: number;
+}
+
+const TTL_MS = 30 * 60 * 1000; // 30 minutes
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * In-memory cache for OpenAI-compatible `reasoning_content` strings.
+ *
+ * DeepSeek-compatible reasoning providers require assistant tool-call turns to
+ * be replayed with the same `reasoning_content` they returned. Generic
+ * OpenAI-compatible SDKs often drop that provider-specific field when they
+ * rebuild conversation history, so Manifest caches it by the first tool call id
+ * and restores it before forwarding the next turn to a compatible provider.
+ */
+export class ReasoningContentCache {
+  private cache = new Map<string, CachedReasoningContent>();
+  private lastCleanup = Date.now();
+
+  /** Store the reasoning_content string for an assistant tool-call turn. */
+  store(sessionKey: string, firstToolCallId: string, content: string): void {
+    if (!content) return;
+    this.maybeCleanup();
+    this.cache.set(`${sessionKey}:${firstToolCallId}`, {
+      content,
+      expiresAt: Date.now() + TTL_MS,
+    });
+  }
+
+  /** Retrieve cached reasoning_content, or null if not found/expired. */
+  retrieve(sessionKey: string, firstToolCallId: string): string | null {
+    const entry = this.cache.get(`${sessionKey}:${firstToolCallId}`);
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(`${sessionKey}:${firstToolCallId}`);
+      return null;
+    }
+    return entry.content;
+  }
+
+  /** Clear all cached reasoning_content for a session. */
+  clearSession(sessionKey: string): void {
+    const prefix = `${sessionKey}:`;
+    for (const key of this.cache.keys()) {
+      if (key.startsWith(prefix)) this.cache.delete(key);
+    }
+  }
+
+  /** Lazily evict expired entries to avoid unbounded growth. */
+  private maybeCleanup(): void {
+    const now = Date.now();
+    if (now - this.lastCleanup < CLEANUP_INTERVAL_MS) return;
+    this.lastCleanup = now;
+    for (const [key, entry] of this.cache) {
+      if (now > entry.expiresAt) this.cache.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add an in-memory `ReasoningContentCache` keyed by session + first tool call id
- cache `reasoning_content` from compatible OpenAI-style stream and non-stream tool-call responses
- re-inject cached `reasoning_content` when clients replay assistant tool-call messages without it, guarded to DeepSeek/Kimi/OpenCode Go-compatible targets while strict providers still strip it

## Context
This keeps the useful part of #1811 but avoids the larger/stale MPS/provider-params changes. It focuses on the concrete client bug: OpenAI-compatible clients can drop provider-specific `reasoning_content` between tool-use turns even though some reasoning providers require it to be replayed.

Closes #1811.

## Verification
- `npm run build --workspace=packages/shared`
- `npm run test --workspace=packages/backend -- --runInBand src/routing/proxy/__tests__/provider-client-converters.spec.ts src/routing/proxy/__tests__/reasoning-content-cache.spec.ts src/routing/proxy/__tests__/proxy-response-handler.spec.ts src/routing/proxy/__tests__/proxy.service.spec.ts src/routing/proxy/__tests__/proxy.controller.spec.ts`
- `npm run build --workspace=packages/backend`
- `npm run lint --workspace=packages/backend` (passes with existing warnings)
- `npx prettier --check ...touched files...`
- `git diff --check`
- local synthetic smoke: fake compatible upstream JSON response cached `reasoning_content`, then a follow-up custom OpenAI-compatible forward re-injected it before sending upstream

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves and re-injects provider-specific `reasoning_content` across tool-call turns so OpenAI-compatible clients don’t break DeepSeek/Moonshot (Kimi)/OpenCode Go conversations. Strict providers remain unchanged.

- **Bug Fixes**
  - Added in-memory `ReasoningContentCache` (30m TTL) keyed by session + first tool_call id.
  - Captures `reasoning_content` from OpenAI-style streams (via a new stream transformer) and JSON responses; stores on tool-call finish.
  - Re-injects cached `reasoning_content` for assistant tool-call messages when missing, without overriding existing values.
  - Guarded to native `deepseek` and `moonshot`, OpenRouter `deepseek/*` and `moonshotai/*`, and `opencode-go` reasoning families; strict providers still strip it.
  - Wired through proxy controller/service/fallback and OpenAI body sanitizer; added targeted tests.

<sup>Written for commit 261769d0dfd6544dda1e24db5deb439bed976ce3. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/1998?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->
