### PR TITLE
fix: show recorded assistant response turns

### DIFF
--- a/.changeset/message-log-assistant-response.md
+++ b/.changeset/message-log-assistant-response.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Show captured assistant responses as the final turn in recorded OpenAI Chat and Responses API message log conversations.

--- a/packages/frontend/src/components/RecordedMessageModal.tsx
+++ b/packages/frontend/src/components/RecordedMessageModal.tsx
@@ -27,8 +27,7 @@ import {
   coerceContentToText,
   countMatches,
   detectRequestBodyFormat,
-  extractAssistantReply,
-  extractRequestMessages,
+  extractRecordedConversationMessages,
   extractRequestTools,
   normalizeRole,
   type Role,
@@ -49,7 +48,10 @@ interface Props {
 }
 
 const requestMessages = (d: MessageDetailResponse) =>
-  extractRequestMessages(d.recording?.request_body);
+  extractRecordedConversationMessages(
+    d.recording?.request_body,
+    d.recording?.response_body ?? null,
+  );
 const requestTools = (d: MessageDetailResponse) => extractRequestTools(d.recording?.request_body);
 
 /** Don't hijack '/' when the user is typing in any editable field. */
@@ -108,11 +110,6 @@ const RecordedMessageModal: Component<Props> = (props) => {
       if (normalizeRole(ms[i]!.role) === 'user') return { msg: ms[i]!, index: i };
     }
     return null;
-  });
-
-  const assistantReply = createMemo(() => {
-    const d = data();
-    return d ? extractAssistantReply(d.recording?.response_body ?? null) : null;
   });
 
   // Only OpenAI-compatible request shapes carry inline conversation turns

--- a/packages/frontend/src/components/recorded-drawer-state.ts
+++ b/packages/frontend/src/components/recorded-drawer-state.ts
@@ -1,6 +1,6 @@
 import { createEffect, createSignal, on, type Accessor, type Setter } from 'solid-js';
 import {
-  extractRequestMessages,
+  extractRecordedConversationMessages,
   normalizeRole,
   shouldCollapseByDefault,
   type ChatMessage,
@@ -62,7 +62,10 @@ export function createRecordedDrawerState(
       (d) => {
         if (!d?.recording?.request_body) return;
         const next = new Set<number>();
-        extractRequestMessages(d.recording.request_body).forEach((m: ChatMessage, i) => {
+        extractRecordedConversationMessages(
+          d.recording.request_body,
+          d.recording.response_body ?? null,
+        ).forEach((m: ChatMessage, i) => {
           const role = normalizeRole(m.role);
           const tokens = estimateMessageTokens(m);
           if (!shouldCollapseByDefault(role, tokens)) next.add(i);

--- a/packages/frontend/src/components/recorded-message-helpers.ts
+++ b/packages/frontend/src/components/recorded-message-helpers.ts
@@ -7,7 +7,9 @@ export {
   coerceContentToText,
   detectRequestBodyFormat,
   extractAssistantReply,
+  extractRecordedConversationMessages,
   extractRequestMessages,
+  extractResponseMessages,
   extractRequestTools,
   normalizeRole,
 } from 'manifest-shared';

--- a/packages/frontend/tests/components/RecordedMessageModal.test.tsx
+++ b/packages/frontend/tests/components/RecordedMessageModal.test.tsx
@@ -68,7 +68,6 @@ function baseDetails(overrides: Record<string, unknown> = {}) {
         messages: [
           { role: "system", content: "You are helpful." },
           { role: "user", content: "hi there" },
-          { role: "assistant", content: "hello back" },
         ],
       },
       response_body: {
@@ -187,6 +186,49 @@ describe("RecordedMessageModal (drawer)", () => {
       expect(document.body.textContent).toContain("noted");
     });
     expect(document.body.textContent).not.toContain("Unrecognised request body shape");
+  });
+
+  it("appends OpenAI Responses output as the final assistant turn", async () => {
+    mockGetMessageDetails.mockResolvedValue(
+      baseDetails({
+        recording: {
+          request_body: {
+            model: "gpt-5-mini",
+            input: [
+              {
+                role: "user",
+                content: [{ type: "input_text", text: "latest user question" }],
+              },
+            ],
+          },
+          response_body: {
+            type: "json",
+            body: {
+              id: "resp_1",
+              output: [
+                {
+                  type: "message",
+                  role: "assistant",
+                  content: [{ type: "output_text", text: "latest assistant answer" }],
+                },
+              ],
+            },
+          },
+          response_headers: {},
+          size_bytes: 120,
+          created_at: "",
+        },
+      }),
+    );
+
+    render(() => <RecordedMessageModal open={true} messageId="msg-responses" onClose={vi.fn()} />);
+
+    await vi.waitFor(() => {
+      const turns = Array.from(document.querySelectorAll(".recorded-modal__turn"));
+      expect(turns.length).toBe(2);
+      expect(turns.map((t) => t.getAttribute("data-role"))).toEqual(["user", "assistant"]);
+      expect(turns[turns.length - 1]?.textContent).toContain("latest assistant answer");
+    });
   });
 
   it("switches tabs when tab buttons are clicked", async () => {

--- a/packages/shared/__tests__/chat-message.spec.ts
+++ b/packages/shared/__tests__/chat-message.spec.ts
@@ -2,7 +2,9 @@ import {
   coerceContentToText,
   detectRequestBodyFormat,
   extractAssistantReply,
+  extractRecordedConversationMessages,
   extractRequestMessages,
+  extractResponseMessages,
   extractRequestTools,
   normalizeRole,
 } from '../src/chat-message';
@@ -192,6 +194,112 @@ describe('chat-message recording helpers', () => {
         body: { choices: [{ message: { role: 'assistant', content: 'done' } }] },
       }),
     ).toEqual({ role: 'assistant', content: 'done' });
+    expect(extractResponseMessages({ type: 'json', body: { choices: [{}] } })).toEqual([]);
     expect(extractAssistantReply({ type: 'json', body: {} })).toBeNull();
+  });
+
+  it('extracts OpenAI Responses output messages as response turns', () => {
+    const response = {
+      type: 'json',
+      body: {
+        output: [
+          { type: 'reasoning', summary: [] },
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'final answer' }],
+          },
+          {
+            type: 'message',
+            content: [{ type: 'output_text', text: 'implicit assistant answer' }],
+          },
+          { type: 'function_call', call_id: 'call_1', name: 'lookup', arguments: '{"id":1}' },
+          { type: 'function_call', id: 'call_2' },
+          { type: 'function_call' },
+        ],
+      },
+    };
+
+    expect(extractResponseMessages(response)).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'final answer' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'implicit assistant answer' }] },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{"id":1}' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call_2',
+            type: 'function',
+            function: { name: 'unknown', arguments: '{}' },
+          },
+        ],
+      },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: undefined,
+            type: 'function',
+            function: { name: 'unknown', arguments: '{}' },
+          },
+        ],
+      },
+    ]);
+    expect(extractAssistantReply(response)).toEqual({
+      role: 'assistant',
+      content: [{ type: 'text', text: 'final answer' }],
+    });
+  });
+
+  it('appends captured OpenAI responses after request turns', () => {
+    expect(
+      extractRecordedConversationMessages(
+        { input: 'hello' },
+        {
+          type: 'json',
+          body: {
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'hi back' }],
+              },
+            ],
+          },
+        },
+      ),
+    ).toEqual([
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: [{ type: 'text', text: 'hi back' }] },
+    ]);
+    expect(
+      extractRecordedConversationMessages(
+        { system: 'Claude system prompt' },
+        {
+          type: 'json',
+          body: {
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'do not append' }],
+              },
+            ],
+          },
+        },
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/shared/src/chat-message.ts
+++ b/packages/shared/src/chat-message.ts
@@ -20,6 +20,7 @@ export interface ChatTool {
 }
 
 type JsonRecord = Record<string, unknown>;
+type RecordingResponseBody = { type?: string; body?: unknown };
 
 function isRecord(value: unknown): value is JsonRecord {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -112,6 +113,37 @@ function responsesInputItemToMessages(item: JsonRecord): ChatMessage[] {
   return [{ role, content: responsesContentToChatContent(item.content, role) }];
 }
 
+function responsesOutputItemToMessages(item: JsonRecord): ChatMessage[] {
+  if (item.type === 'function_call') {
+    return [
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id:
+              typeof item.call_id === 'string'
+                ? item.call_id
+                : typeof item.id === 'string'
+                  ? item.id
+                  : undefined,
+            type: 'function',
+            function: {
+              name: typeof item.name === 'string' ? item.name : 'unknown',
+              arguments: typeof item.arguments === 'string' ? item.arguments : '{}',
+            },
+          },
+        ],
+      },
+    ];
+  }
+
+  if (item.type !== 'message') return [];
+
+  const role = typeof item.role === 'string' ? item.role : 'assistant';
+  return [{ role, content: responsesContentToChatContent(item.content, role) }];
+}
+
 export function extractRequestMessages(
   requestBody: Record<string, unknown> | null | undefined,
 ): ChatMessage[] {
@@ -183,12 +215,41 @@ export function detectRequestBodyFormat(
 }
 
 export function extractAssistantReply(
-  responseBody: { type?: string; body?: unknown } | null | undefined,
+  responseBody: RecordingResponseBody | null | undefined,
 ): ChatMessage | null {
-  if (!responseBody || responseBody.type !== 'json') return null;
-  const chat = (responseBody as { body?: unknown }).body as
-    | { choices?: Array<{ message?: ChatMessage }> }
-    | null
-    | undefined;
-  return chat?.choices?.[0]?.message ?? null;
+  return (
+    extractResponseMessages(responseBody).find((m) => normalizeRole(m.role) === 'assistant') ?? null
+  );
+}
+
+export function extractResponseMessages(
+  responseBody: RecordingResponseBody | null | undefined,
+): ChatMessage[] {
+  if (!responseBody || responseBody.type !== 'json' || !isRecord(responseBody.body)) return [];
+
+  const body = responseBody.body;
+  if (Array.isArray(body.choices)) {
+    for (const choice of body.choices) {
+      if (!isRecord(choice) || !isRecord(choice.message)) continue;
+      return [choice.message as ChatMessage];
+    }
+    return [];
+  }
+
+  if (!Array.isArray(body.output)) return [];
+
+  const messages: ChatMessage[] = [];
+  for (const item of body.output) {
+    if (isRecord(item)) messages.push(...responsesOutputItemToMessages(item));
+  }
+  return messages;
+}
+
+export function extractRecordedConversationMessages(
+  requestBody: Record<string, unknown> | null | undefined,
+  responseBody: RecordingResponseBody | null | undefined,
+): ChatMessage[] {
+  const requestMessages = extractRequestMessages(requestBody);
+  if (detectRequestBodyFormat(requestBody) !== 'openai') return requestMessages;
+  return [...requestMessages, ...extractResponseMessages(responseBody)];
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -99,7 +99,9 @@ export {
   coerceContentToText,
   detectRequestBodyFormat,
   extractAssistantReply,
+  extractRecordedConversationMessages,
   extractRequestMessages,
+  extractResponseMessages,
   extractRequestTools,
   normalizeRole,
 } from './chat-message';


### PR DESCRIPTION
## Summary
- append recorded assistant response turns from Chat Completions responses and Responses API outputs to recorded conversation logs
- render Responses API function-call output items as assistant tool calls while keeping non-OpenAI request bodies request-only
- seed recorded drawer expansion state from the combined request/response conversation

Fixes #1990

## Validation
- `npm ci` (completed with Node v23.7.0 engine warning; `npm audit` reports 12 moderate existing vulnerabilities)
- `npm run build -w manifest-shared`
- `npm test -w manifest-shared -- chat-message.spec.ts --runInBand`
- `npm test -w manifest-shared -- chat-message.spec.ts --runInBand --coverage --collectCoverageFrom=src/chat-message.ts` (100% for `chat-message.ts`)
- `npm test -w manifest-frontend -- RecordedMessageModal.test.tsx`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npm run build`
