### PR TITLE
fix(routing): collapse provider model groups

### DIFF
--- a/.changeset/sharp-models-fold.md
+++ b/.changeset/sharp-models-fold.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Allow routing model picker provider sections to collapse and keep sticky provider headers flush under the free-model filter.

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -295,7 +295,7 @@ const ModelPickerModal: Component<Props> = (props) => {
       }}
     >
       <div
-        class="modal-card"
+        class="modal-card routing-modal__card"
         style="max-width: 600px; padding: 0; display: flex; flex-direction: column; max-height: 80vh;"
         role="dialog"
         aria-modal="true"

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -515,7 +515,7 @@ const ModelPickerModal: Component<Props> = (props) => {
                   <span class="routing-modal__group-name">{group.name}</span>
                   <Show when={props.agentName && !group.provId.startsWith('custom:')}>
                     <button
-                      class="routing-modal__group-refresh"
+                      class="routing-modal__icon-btn routing-modal__group-refresh"
                       disabled={refreshingProvId() !== null}
                       onClick={(e) => {
                         e.stopPropagation();
@@ -546,7 +546,7 @@ const ModelPickerModal: Component<Props> = (props) => {
                   </Show>
                   <button
                     type="button"
-                    class="routing-modal__group-toggle"
+                    class="routing-modal__icon-btn routing-modal__group-toggle"
                     aria-expanded={!isGroupCollapsed(group.provId)}
                     aria-controls={groupPanelId(group.provId)}
                     aria-label={`${isGroupCollapsed(group.provId) ? 'Show' : 'Hide'} ${group.name} models`}

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -72,6 +72,24 @@ const ModelPickerModal: Component<Props> = (props) => {
   const [search, setSearch] = createSignal('');
   const [showFreeOnly, setShowFreeOnly] = createSignal(false);
   const [refreshingProvId, setRefreshingProvId] = createSignal<string | null>(null);
+  const [collapsedGroups, setCollapsedGroups] = createSignal<Set<string>>(new Set());
+
+  const groupCollapseKey = (provId: string) => `${activeTab()}:${provId}`;
+  const groupPanelId = (provId: string) =>
+    `routing-modal-models-${groupCollapseKey(provId).replace(/[^a-zA-Z0-9_-]/g, '-')}`;
+  const isGroupCollapsed = (provId: string) => collapsedGroups().has(groupCollapseKey(provId));
+  const toggleGroupCollapsed = (provId: string) => {
+    const key = groupCollapseKey(provId);
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
 
   const handleRefreshGroup = async (provId: string, displayName: string) => {
     if (!props.agentName) return;
@@ -526,44 +544,81 @@ const ModelPickerModal: Component<Props> = (props) => {
                       </svg>
                     </button>
                   </Show>
-                </div>
-                <For each={group.models}>
-                  {(model) => (
-                    <button
-                      class="routing-modal__model"
-                      onClick={() =>
-                        props.onSelect(props.tierId, model.value, group.provId, activeTab())
-                      }
+                  <button
+                    type="button"
+                    class="routing-modal__group-toggle"
+                    aria-expanded={!isGroupCollapsed(group.provId)}
+                    aria-controls={groupPanelId(group.provId)}
+                    aria-label={`${isGroupCollapsed(group.provId) ? 'Show' : 'Hide'} ${group.name} models`}
+                    title={`${isGroupCollapsed(group.provId) ? 'Show' : 'Hide'} ${group.name} models`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleGroupCollapsed(group.provId);
+                    }}
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2.2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      aria-hidden="true"
                     >
-                      <span class="routing-modal__model-label">
-                        {model.label}
-                        <Show when={isRecommended(model.value, group.provId, activeTab())}>
-                          <span class="routing-modal__recommended"> (recommended)</span>
-                        </Show>
-                        <Show when={modelRole(model.value, group.provId, activeTab())}>
-                          {(role) => <span class="routing-modal__role-tag">{role()}</span>}
-                        </Show>
-                      </span>
                       <Show
-                        when={isPaid()}
-                        fallback={
-                          <span class="routing-modal__model-id routing-modal__model-id--subscription">
-                            {isLocal() ? 'Runs on your machine' : 'Included in subscription'}
-                          </span>
+                        when={isGroupCollapsed(group.provId)}
+                        fallback={<path d="m18 15-6-6-6 6" />}
+                      >
+                        <path d="m6 9 6 6 6-6" />
+                      </Show>
+                    </svg>
+                  </button>
+                </div>
+                <div
+                  id={groupPanelId(group.provId)}
+                  class="routing-modal__group-models"
+                  hidden={isGroupCollapsed(group.provId)}
+                >
+                  <For each={group.models}>
+                    {(model) => (
+                      <button
+                        class="routing-modal__model"
+                        onClick={() =>
+                          props.onSelect(props.tierId, model.value, group.provId, activeTab())
                         }
                       >
-                        <Show when={model.pricing}>
-                          {(p) => (
-                            <span class="routing-modal__model-id">
-                              {pricePerM(p().input_price_per_token)} in ·{' '}
-                              {pricePerM(p().output_price_per_token)} out per 1M
+                        <span class="routing-modal__model-label">
+                          {model.label}
+                          <Show when={isRecommended(model.value, group.provId, activeTab())}>
+                            <span class="routing-modal__recommended"> (recommended)</span>
+                          </Show>
+                          <Show when={modelRole(model.value, group.provId, activeTab())}>
+                            {(role) => <span class="routing-modal__role-tag">{role()}</span>}
+                          </Show>
+                        </span>
+                        <Show
+                          when={isPaid()}
+                          fallback={
+                            <span class="routing-modal__model-id routing-modal__model-id--subscription">
+                              {isLocal() ? 'Runs on your machine' : 'Included in subscription'}
                             </span>
-                          )}
+                          }
+                        >
+                          <Show when={model.pricing}>
+                            {(p) => (
+                              <span class="routing-modal__model-id">
+                                {pricePerM(p().input_price_per_token)} in ·{' '}
+                                {pricePerM(p().output_price_per_token)} out per 1M
+                              </span>
+                            )}
+                          </Show>
                         </Show>
-                      </Show>
-                    </button>
-                  )}
-                </For>
+                      </button>
+                    )}
+                  </For>
+                </div>
               </div>
             )}
           </For>

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -261,6 +261,10 @@ const ModelPickerModal: Component<Props> = (props) => {
   };
 
   const totalVisibleModels = () => groupedModels().reduce((sum, g) => sum + g.models.length, 0);
+  const allVisibleGroupsCollapsed = () => {
+    const groups = groupedModels();
+    return groups.length > 0 && groups.every((group) => isGroupCollapsed(group.provId));
+  };
 
   /** Total models available (ignoring search) — used to decide whether to show search bar */
   const totalAvailableModels = () => {
@@ -482,7 +486,10 @@ const ModelPickerModal: Component<Props> = (props) => {
           </div>
         </Show>
 
-        <div class="routing-modal__list">
+        <div
+          class="routing-modal__list"
+          classList={{ 'routing-modal__list--all-collapsed': allVisibleGroupsCollapsed() }}
+        >
           <For each={groupedModels()}>
             {(group) => (
               <div class="routing-modal__group">

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -1,4 +1,8 @@
 /* ── Model picker modal ───────────────────────────── */
+.routing-modal__card {
+  overflow: hidden;
+}
+
 .routing-modal__header {
   display: flex;
   align-items: flex-start;

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -62,7 +62,7 @@
 
 .routing-modal__filter-bar {
   display: flex;
-  padding: 8px 24px 0;
+  padding: 8px 24px 8px;
   flex-shrink: 0;
 }
 

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -107,9 +107,14 @@
   overflow-y: auto;
   flex: 1;
   min-height: 0;
-  padding: 12px 0 0;
+  padding: 0;
   background: hsl(var(--card));
   border-top: 1px solid hsl(var(--border));
+}
+
+.routing-modal__list--all-collapsed {
+  flex: 0 0 auto;
+  overflow-y: visible;
 }
 
 .routing-modal__group {
@@ -124,7 +129,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 24px 6px;
+  padding: 12px 24px;
   position: sticky;
   top: 0;
   background: hsl(var(--card));

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -107,8 +107,8 @@
   overflow-y: auto;
   flex: 1;
   min-height: 0;
-  padding: 0;
-  margin-top: 12px;
+  padding: 12px 0 0;
+  background: hsl(var(--card));
   border-top: 1px solid hsl(var(--border));
 }
 
@@ -128,7 +128,7 @@
   position: sticky;
   top: 0;
   background: hsl(var(--card));
-  z-index: 1;
+  z-index: 2;
 }
 
 .routing-modal__group-icon {
@@ -174,6 +174,36 @@
 .routing-modal__group-refresh:disabled {
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+.routing-modal__group-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.routing-modal__group-toggle:hover {
+  color: hsl(var(--foreground));
+  border-color: hsl(var(--border));
+  background: hsl(var(--muted) / 0.6);
+}
+
+.routing-modal__group-toggle:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
 }
 
 .routing-modal__group-refresh-icon--spinning {

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -146,7 +146,7 @@
   flex: 1;
 }
 
-.routing-modal__group-refresh {
+.routing-modal__icon-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -165,45 +165,20 @@
     background 0.15s ease;
 }
 
-.routing-modal__group-refresh:hover:not(:disabled) {
+.routing-modal__icon-btn:hover:not(:disabled) {
   color: hsl(var(--foreground));
   border-color: hsl(var(--border));
   background: hsl(var(--muted) / 0.6);
 }
 
-.routing-modal__group-refresh:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.routing-modal__group-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  background: transparent;
-  color: hsl(var(--muted-foreground));
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease,
-    background 0.15s ease;
-}
-
-.routing-modal__group-toggle:hover {
-  color: hsl(var(--foreground));
-  border-color: hsl(var(--border));
-  background: hsl(var(--muted) / 0.6);
-}
-
-.routing-modal__group-toggle:focus-visible {
+.routing-modal__icon-btn:focus-visible {
   outline: 2px solid hsl(var(--ring));
   outline-offset: 1px;
+}
+
+.routing-modal__icon-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 
 .routing-modal__group-refresh-icon--spinning {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -409,6 +409,34 @@ describe("ModelPickerModal", () => {
     expect(modelButtons[0].textContent).toContain("GPT-4o mini");
   });
 
+  it("collapses and expands a provider's model rows from the group arrow", () => {
+    const { container } = render(() => (
+      <ModelPickerModal
+        tierId="simple"
+        models={baseModels}
+        tiers={tiers}
+        connectedProviders={apiKeyOnly}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+
+    const modelRows = container.querySelector(".routing-modal__group-models") as HTMLElement;
+    expect(modelRows.hasAttribute("hidden")).toBe(false);
+
+    const hideToggle = screen.getByLabelText("Hide OpenAI models");
+    expect(hideToggle.getAttribute("aria-expanded")).toBe("true");
+    fireEvent.click(hideToggle);
+
+    const showToggle = screen.getByLabelText("Show OpenAI models");
+    expect(showToggle.getAttribute("aria-expanded")).toBe("false");
+    expect(modelRows.hasAttribute("hidden")).toBe(true);
+
+    fireEvent.click(showToggle);
+    expect(screen.getByLabelText("Hide OpenAI models").getAttribute("aria-expanded")).toBe("true");
+    expect(modelRows.hasAttribute("hidden")).toBe(false);
+  });
+
   it("renders the recommendation tag for the auto-assigned route", () => {
     const { container } = render(() => (
       <ModelPickerModal

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -421,6 +421,8 @@ describe("ModelPickerModal", () => {
       />
     ));
 
+    const list = container.querySelector(".routing-modal__list") as HTMLElement;
+    expect(list.classList.contains("routing-modal__list--all-collapsed")).toBe(false);
     const modelRows = container.querySelector(".routing-modal__group-models") as HTMLElement;
     expect(modelRows.hasAttribute("hidden")).toBe(false);
 
@@ -431,10 +433,12 @@ describe("ModelPickerModal", () => {
     const showToggle = screen.getByLabelText("Show OpenAI models");
     expect(showToggle.getAttribute("aria-expanded")).toBe("false");
     expect(modelRows.hasAttribute("hidden")).toBe(true);
+    expect(list.classList.contains("routing-modal__list--all-collapsed")).toBe(true);
 
     fireEvent.click(showToggle);
     expect(screen.getByLabelText("Hide OpenAI models").getAttribute("aria-expanded")).toBe("true");
     expect(modelRows.hasAttribute("hidden")).toBe(false);
+    expect(list.classList.contains("routing-modal__list--all-collapsed")).toBe(false);
   });
 
   it("renders the recommendation tag for the auto-assigned route", () => {


### PR DESCRIPTION
## Summary

- add an accessible show/hide chevron to each provider section in the routing model picker
- keep collapsed provider model rows out of the scrollable list
- remove the visual gap between the sticky provider header and the free-model filter by moving the list spacing inside the scroll container
- add a focused regression test and patch changeset

## Why

Providers with long model catalogs make the picker awkward to scroll. Collapsing a noisy provider keeps the current provider visible without hiding other providers further down the list. The previous list margin also left a small transparent strip above the sticky provider header, so scrolled model text could show through near the filter bar.

## Validation

- `npm ci` (Node v23.7.0 emitted existing engine warnings for packages requiring Node 20/22/24)
- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/frontend -- ModelPickerModal.test.tsx`
- `npx tsc --noEmit` from `packages/frontend`
- `npm run lint --workspace=packages/frontend` (passes with existing warnings)
- `npm run build --workspace=packages/frontend` (passes with existing large chunk warning)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make provider sections in the routing model picker collapsible to cut scrolling. Tighten layout, fix sticky header/filter spacing, unify icon button styles, and clip the modal card corners to prevent content bleed.

- **New Features**
  - Accessible show/hide toggle per provider section.
  - Hide collapsed model rows; shrink the list when all visible groups are collapsed.

- **Bug Fixes**
  - Fix header/filter spacing: move list spacing inside the scroll container, add filter bar padding, set list background, raise sticky header z-index, and clip the modal card corners.
  - Unify icon button styles and add a focus-visible outline; add a regression test for collapse/expand behavior.

<sup>Written for commit 73739ea41c8616a8c9e85273cecb282b7d12743a. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2001?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

