### PR TITLE
Remove recorded-only messages filter

### DIFF
--- a/.changeset/remove-recorded-only-filter.md
+++ b/.changeset/remove-recorded-only-filter.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Remove the recorded-only filter from the messages dashboard.

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -60,7 +60,6 @@ const MessageLog: Component = () => {
   const [tierFilter, setTierFilter] = createSignal('');
   const [costMin, setCostMin] = createSignal('');
   const [costMax, setCostMax] = createSignal('');
-  const [recordedOnly, setRecordedOnly] = createSignal(false);
   const [recordingModalId, setRecordingModalId] = createSignal<string | null>(null);
   const closeDr = () => setRecordingModalId(null);
   onMount(() => window.addEventListener('sidebar-navigate', closeDr));
@@ -155,7 +154,7 @@ const MessageLog: Component = () => {
   };
 
   createEffect(
-    on([providerFilter, tierFilter, costMin, costMax, recordedOnly], () => pager.resetPage(), {
+    on([providerFilter, tierFilter, costMin, costMax], () => pager.resetPage(), {
       defer: true,
     }),
   );
@@ -166,7 +165,6 @@ const MessageLog: Component = () => {
       tier: tierFilter(),
       costMin: costMin(),
       costMax: costMax(),
-      recordedOnly: recordedOnly(),
       agentName: params.agentName,
       _ping: messagePing(),
       cursor: pager.currentCursor(),
@@ -178,7 +176,6 @@ const MessageLog: Component = () => {
       if (p.tier) q.routing_tier = p.tier;
       if (p.costMin) q.cost_min = p.costMin;
       if (p.costMax) q.cost_max = p.costMax;
-      if (p.recordedOnly) q.recorded = 'true';
       if (p.agentName) q.agent_name = p.agentName;
       if (p.cursor) q.cursor = p.cursor;
       q.limit = String(p.limit);
@@ -205,11 +202,7 @@ const MessageLog: Component = () => {
   );
 
   const hasActiveFilters = () =>
-    providerFilter() !== '' ||
-    tierFilter() !== '' ||
-    costMin() !== '' ||
-    costMax() !== '' ||
-    recordedOnly();
+    providerFilter() !== '' || tierFilter() !== '' || costMin() !== '' || costMax() !== '';
 
   const hasNoData = () => {
     const d = data();
@@ -225,7 +218,6 @@ const MessageLog: Component = () => {
     setTierFilter('');
     setCostMin('');
     setCostMax('');
-    setRecordedOnly(false);
   };
 
   const tierOptions = [
@@ -281,15 +273,6 @@ const MessageLog: Component = () => {
               options={providerOptions()}
             />
             <Select value={tierFilter()} onChange={setTierFilter} options={tierOptions} />
-            <button
-              type="button"
-              class={`msg-recorded-filter${recordedOnly() ? ' msg-recorded-filter--active' : ''}`}
-              onClick={() => setRecordedOnly(!recordedOnly())}
-              aria-pressed={recordedOnly()}
-              title="Show only recorded messages"
-            >
-              Recorded only
-            </button>
             <div class="cost-range-filter">
               <input
                 type="number"

--- a/packages/frontend/src/styles/recording.css
+++ b/packages/frontend/src/styles/recording.css
@@ -61,35 +61,6 @@
   background: hsl(var(--destructive) / 0.08);
 }
 
-/* ── Recorded-only filter chip ─────────────────────────── */
-.msg-recorded-filter {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-radius: 9999px;
-  border: 1px solid hsl(var(--border));
-  background: hsl(var(--background));
-  color: hsl(var(--muted-foreground));
-  font-size: var(--font-size-xs);
-  cursor: pointer;
-  transition:
-    background var(--transition-fast),
-    color var(--transition-fast),
-    border-color var(--transition-fast);
-}
-
-.msg-recorded-filter:hover {
-  color: hsl(var(--foreground));
-  border-color: hsl(var(--border));
-}
-
-.msg-recorded-filter--active {
-  background: hsl(var(--destructive) / 0.12);
-  color: hsl(var(--destructive));
-  border-color: hsl(var(--destructive) / 0.4);
-}
-
 /* ── Recorded message modal ────────────────────────────── */
 .recorded-modal__header {
   display: flex;

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -239,6 +239,8 @@ describe("MessageLog", () => {
       const selects = container.querySelectorAll('[data-testid="select"]');
       expect(selects.length).toBeGreaterThanOrEqual(1);
     });
+    expect(container.textContent).not.toContain("Recorded only");
+    expect(container.querySelector(".msg-recorded-filter")).toBeNull();
   });
 
   it("renders provider display names in the filter dropdown", async () => {
@@ -1023,24 +1025,7 @@ describe("MessageLog", () => {
     });
   });
 
-  describe("Recording filter", () => {
-    it("toggles the recorded query param when the filter chip is clicked", async () => {
-      mockGetMessages.mockResolvedValue(messagesData);
-      const { container } = render(() => <MessageLog />);
-      await vi.waitFor(() => {
-        expect(container.querySelector(".msg-recorded-filter")).not.toBeNull();
-      });
-      const chip = container.querySelector(".msg-recorded-filter") as HTMLButtonElement;
-      mockGetMessages.mockClear();
-      fireEvent.click(chip);
-      await vi.waitFor(() => {
-        const calls = mockGetMessages.mock.calls;
-        const lastQ = calls[calls.length - 1]?.[0] ?? {};
-        expect(lastQ.recorded).toBe("true");
-      });
-      expect(chip.classList.contains("msg-recorded-filter--active")).toBe(true);
-    });
-
+  describe("Recording modal", () => {
     it("opens the recorded-message modal when the row is clicked", async () => {
       const withRecording = {
         ...messagesData,


### PR DESCRIPTION
## Summary

- Remove the `Recorded only` chip from the Messages dashboard header.
- Stop the dashboard from sending the `recorded=true` query param through local filter state.
- Remove the now-unused chip CSS and update MessageLog tests to assert the filter is absent while keeping recording modal coverage.
- Add a patch changeset for `manifest`.

## Validation

- `npm ci`
- `npm run build --workspace=manifest-shared`
- `npm run test --workspace=manifest-frontend -- MessageLog.test.tsx`
- `npx eslint packages/frontend/src/pages/MessageLog.tsx`
- `npx prettier --check packages/frontend/src/pages/MessageLog.tsx packages/frontend/src/styles/recording.css .changeset/remove-recorded-only-filter.md`
- `git diff --check`
- `npm run build --workspace=manifest-frontend`

Note: `npm ci` reported the existing Node engine warning under local Node v23.7.0 and 12 moderate audit findings; install completed successfully. The frontend build also emitted the existing large chunk warning.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Recorded only" filter from the Messages dashboard and stopped sending the recorded=true query param. Cleaned up unused CSS, updated MessageLog tests to confirm the filter is gone while keeping recording modal coverage, and added a patch changeset for `manifest`.

<sup>Written for commit 130eb3cfc682984d7884750d7b5d15f84fb4775b. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2002?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

