### PR TITLE
fix setup model selector

### DIFF
--- a/.changeset/calm-models-wave.md
+++ b/.changeset/calm-models-wave.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Clarify generic provider setup copy to use the `auto` Manifest model selector.

--- a/packages/frontend/src/components/SetupStepProviders.tsx
+++ b/packages/frontend/src/components/SetupStepProviders.tsx
@@ -12,12 +12,12 @@ const SetupStepProviders: Component<Props> = (props) => {
       <h3 class="setup-step__heading">Connect your LLM providers</h3>
       <p class="setup-step__desc">
         Manifest routes each request to the best model for the job. Connect at least one provider so{' '}
-        <code class="api-key-display__code">manifest/auto</code> can resolve requests.
+        <code class="api-key-display__code">auto</code> can resolve requests.
       </p>
 
       <div class="api-key-display__warning" style="margin-bottom: 16px;">
-        Without a connected provider, requests to{' '}
-        <code class="api-key-display__code">manifest/auto</code> will return an error.
+        Without a connected provider, requests to <code class="api-key-display__code">auto</code>{' '}
+        will return an error.
       </div>
 
       <div style="display: flex; align-items: center; gap: 12px;">

--- a/packages/frontend/tests/components/SetupStepProviders.test.tsx
+++ b/packages/frontend/tests/components/SetupStepProviders.test.tsx
@@ -27,11 +27,11 @@ describe("SetupStepProviders", () => {
     expect(container.textContent).toContain("will return an error");
   });
 
-  it("mentions manifest/auto", () => {
+  it("mentions auto", () => {
     const { container } = render(() => (
       <SetupStepProviders agentName="test-agent" onGoToRouting={onGoToRouting} />
     ));
-    expect(container.textContent).toContain("manifest/auto");
+    expect(container.textContent).toContain("auto");
   });
 
   it("renders connect a provider button", () => {


### PR DESCRIPTION
## Summary
- change the generic provider setup step to describe Manifest requests using the `auto` model selector
- keep OpenClaw/OpenCode provider-qualified configuration strings such as `manifest/auto` intact
- add a patch changeset for the published `manifest` package

## Validation
- `npm --workspace=manifest-frontend test -- tests/components/SetupStepProviders.test.tsx`
- `git diff --check upstream/main..HEAD`
- `npx eslint packages/frontend/src/components/SetupStepProviders.tsx`
