### PR TITLE
Refresh Model parameters dialog UI

### DIFF
--- a/.changeset/model-params-dialog-refresh.md
+++ b/.changeset/model-params-dialog-refresh.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Refresh the Model parameters dialog with grouped cards, inline descriptions, a compact slider with min/max markers, and a synced number field. Disabled parameters now keep their description and gain a help icon explaining how to enable them, while remembering the last user value for when they become available again.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14901,7 +14901,7 @@
       }
     },
     "packages/manifest": {
-      "version": "6.5.0"
+      "version": "6.6.1"
     },
     "packages/shared": {
       "name": "manifest-shared",

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -306,8 +306,7 @@ const ModelParamsDialog: Component<Props> = (props) => {
       }
       const parsed = Number.parseFloat(normalized);
       if (!Number.isFinite(parsed)) return;
-      const clamped = clampNumber(parsed, numberDefault(spec), spec.range?.min, spec.range?.max);
-      setValue(spec, spec.type === 'integer' ? Math.trunc(clamped) : clamped);
+      setValue(spec, sliderValue(parsed, spec));
     };
 
     return (

--- a/packages/frontend/src/components/ModelParamsDialog.tsx
+++ b/packages/frontend/src/components/ModelParamsDialog.tsx
@@ -36,15 +36,7 @@ const GROUP_LABELS: Record<ModelParamGroup, string> = {
   provider_metadata: 'Provider metadata',
 };
 
-const GROUP_INTROS: Record<ModelParamGroup, string> = {
-  generation_length: 'Controls how much text the model can produce in a single response.',
-  sampling: 'Adjusts randomness and diversity in the generated output.',
-  reasoning: 'Controls extended thinking where the model reasons before answering.',
-  tooling: 'Configures how the model calls external tools and functions.',
-  output_format: 'Constrains the shape of the response.',
-  observability: 'Metadata fields for tracing and debugging requests.',
-  provider_metadata: 'Provider-specific options outside standard categories.',
-};
+const trimTrailingPunct = (text: string): string => text.replace(/[.\s]+$/, '');
 
 const PARAM_HINTS: Record<string, string> = {
   temperature:
@@ -60,7 +52,7 @@ const PARAM_HINTS: Record<string, string> = {
   'thinking.budget_tokens':
     'Maximum number of tokens the model can spend on its internal reasoning before producing the final answer.',
   reasoning_effort:
-    'How much effort the model puts into reasoning. Lower values are faster and cheaper, higher values are more thorough.',
+    'It defines how much effort the model puts into reasoning. Lower values are faster and cheaper, higher values are more thorough.',
   frequency_penalty:
     'Penalizes tokens that already appeared in the output. Higher values reduce repetition.',
   presence_penalty:
@@ -77,15 +69,6 @@ const PARAM_HINTS: Record<string, string> = {
 };
 
 const paramHint = (spec: ProviderParamSpec): string => PARAM_HINTS[spec.path] ?? spec.description;
-
-const rangeLabel = (spec: ProviderParamSpec): string | null => {
-  if (!spec.range) return null;
-  const { min, max } = spec.range;
-  if (min !== undefined && max !== undefined) return `${min}–${max}`;
-  if (min !== undefined) return `min ${min}`;
-  if (max !== undefined) return `max ${max}`;
-  return null;
-};
 
 const GROUP_ORDER: readonly ModelParamGroup[] = [
   'generation_length',
@@ -152,6 +135,9 @@ const ModelParamsDialog: Component<Props> = (props) => {
   });
 
   const valueFor = (spec: ProviderParamSpec): JsonValue | undefined => {
+    if (!providerParamIsApplicable(spec, draft())) {
+      return spec.default as JsonValue | undefined;
+    }
     const value = getProviderParamValue(draft(), spec.path);
     return (value === undefined ? spec.default : value) as JsonValue | undefined;
   };
@@ -163,6 +149,63 @@ const ModelParamsDialog: Component<Props> = (props) => {
   const isApplicable = (spec: ProviderParamSpec): boolean =>
     providerParamIsApplicable(spec, draft());
   const isDisabled = (spec: ProviderParamSpec): boolean => saving() || !isApplicable(spec);
+
+  const labelForPath = (path: string): string =>
+    props.specs.find((s) => s.path === path)?.label ?? path;
+
+  const formatValueList = (values: readonly JsonValue[]): string => {
+    const quoted = values.map((v) => `"${String(v)}"`);
+    if (quoted.length === 1) return quoted[0]!;
+    if (quoted.length === 2) return `${quoted[0]} or ${quoted[1]}`;
+    return `${quoted.slice(0, -1).join(', ')}, or ${quoted[quoted.length - 1]}`;
+  };
+
+  const describeBlocker = (spec: ProviderParamSpec): string | null => {
+    if (!spec.applicability) return null;
+    const { only, except } = spec.applicability;
+    if (only) {
+      const rules = Array.isArray(only) ? only : [only];
+      const rule = rules[0];
+      if (!rule) return null;
+      const parts = Object.entries(rule).map(([path, value]) => {
+        const label = labelForPath(path);
+        const list = Array.isArray(value) ? (value as readonly JsonValue[]) : [value as JsonValue];
+        return `set ${label} to ${formatValueList(list)}`;
+      });
+      return `To configure this parameter, ${parts.join(' and ')}.`;
+    }
+    if (except) {
+      const draftSnapshot = draft();
+      const rules = Array.isArray(except) ? except : [except];
+      const active = rules.find((rule) =>
+        Object.entries(rule).every(([path, value]) => {
+          const current = getProviderParamValue(draftSnapshot, path);
+          if (Array.isArray(value))
+            return (value as readonly JsonValue[]).includes(current as JsonValue);
+          if (value !== null && typeof value === 'object' && 'not' in value) {
+            const notVal = (value as { not: JsonValue | readonly JsonValue[] }).not;
+            if (Array.isArray(notVal))
+              return !(notVal as readonly JsonValue[]).includes(current as JsonValue);
+            return current !== notVal;
+          }
+          return current === value;
+        }),
+      );
+      if (!active) return null;
+      const parts = Object.entries(active).map(([path, value]) => {
+        const label = labelForPath(path);
+        if (Array.isArray(value)) {
+          return `${label} is ${formatValueList(value as readonly JsonValue[])}`;
+        }
+        if (value !== null && typeof value === 'object' && 'not' in value) {
+          return `${label} is set to a custom value`;
+        }
+        return `${label} is "${String(value)}"`;
+      });
+      return `Unavailable while ${parts.join(' and ')}.`;
+    }
+    return null;
+  };
 
   const stringValue = (spec: ProviderParamSpec): string => {
     const value = valueFor(spec);
@@ -220,19 +263,12 @@ const ModelParamsDialog: Component<Props> = (props) => {
   );
 
   const SliderRow = (spec: ProviderParamSpec) => {
-    let startX = 0;
-    let startValue = 0;
     const min = () => spec.range?.min ?? 0;
     const max = () => spec.range?.max ?? 100;
     const value = () => numericValue(spec);
     const setSliderVal = (next: number) => {
       if (isDisabled(spec)) return;
       setValue(spec, sliderValue(next, spec));
-    };
-    const pixelsPerUnit = () => {
-      const span = max() - min();
-      if (span <= 0) return 1;
-      return 120 / span;
     };
     const handleKeyDown = (e: KeyboardEvent) => {
       if (isDisabled(spec)) return;
@@ -252,59 +288,74 @@ const ModelParamsDialog: Component<Props> = (props) => {
       }
     };
 
+    let numberInputRef: HTMLInputElement | undefined;
+    createEffect(() => {
+      const next = value();
+      if (numberInputRef && document.activeElement !== numberInputRef) {
+        numberInputRef.value = String(next);
+      }
+    });
+
+    const commitFromText = (raw: string) => {
+      if (isDisabled(spec)) return;
+      const normalized = raw.replace(',', '.').trim();
+      if (normalized === '' || normalized === '-' || normalized === '.' || normalized === '-.') {
+        return;
+      }
+      const parsed = Number.parseFloat(normalized);
+      if (!Number.isFinite(parsed)) return;
+      const clamped = clampNumber(parsed, numberDefault(spec), spec.range?.min, spec.range?.max);
+      setValue(spec, spec.type === 'integer' ? Math.trunc(clamped) : clamped);
+    };
+
     return (
       <div
-        class="model-params__scrub-field"
-        classList={{ 'model-params__scrub-field--disabled': isDisabled(spec) }}
+        class="model-params__slider-control"
+        classList={{ 'model-params__slider-field--disabled': isDisabled(spec) }}
       >
-        <div
-          class="model-params__scrub"
-          role="slider"
-          tabIndex={isDisabled(spec) ? -1 : 0}
-          aria-label={spec.label}
-          aria-valuemin={min()}
-          aria-valuemax={max()}
-          aria-valuenow={value()}
-          aria-valuetext={String(value())}
-          aria-disabled={isDisabled(spec)}
-          onPointerDown={(e) => {
-            if (isDisabled(spec)) return;
-            e.preventDefault();
-            startX = e.clientX;
-            startValue = value();
-            e.currentTarget.setPointerCapture?.(e.pointerId);
-          }}
-          onPointerMove={(e) => {
-            if (!e.currentTarget.hasPointerCapture?.(e.pointerId)) return;
-            const delta = (e.clientX - startX) / pixelsPerUnit();
-            setSliderVal(startValue + delta);
-          }}
-          onPointerUp={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
-          onPointerCancel={(e) => e.currentTarget.releasePointerCapture?.(e.pointerId)}
-          onKeyDown={handleKeyDown}
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="12"
-            height="12"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path d="M5 3a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4M5 10a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4M5 17a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4m7.33 0a2 2 0 1 0 0 4 2 2 0 1 0 0-4" />
-          </svg>
-        </div>
         <input
-          class="model-params__scrub-input"
-          type="number"
-          min={min()}
-          max={max()}
-          step={sliderStep(spec)}
-          value={value()}
+          ref={(el) => {
+            numberInputRef = el;
+            if (el) el.value = String(value());
+          }}
+          type="text"
+          inputmode="decimal"
+          class="model-params__number model-params__number--slider"
           disabled={isDisabled(spec)}
           aria-label={`${spec.label} value`}
-          onInput={(e) => setSliderVal(Number.parseFloat(e.currentTarget.value))}
+          onBlur={(e) => (e.currentTarget.value = String(value()))}
+          onInput={(e) => commitFromText(e.currentTarget.value)}
         />
+        <div class="model-params__slider-field">
+          <div class="model-params__slider-track-wrapper">
+            <div class="model-params__slider-track-bg" />
+            <For each={[0, 25, 50, 75, 100]}>
+              {(pct) => (
+                <span
+                  class="model-params__slider-tick"
+                  style={`left: calc(6px + (100% - 12px) * ${pct} / 100)`}
+                />
+              )}
+            </For>
+            <input
+              type="range"
+              class="model-params__slider"
+              min={min()}
+              max={max()}
+              step={sliderStep(spec)}
+              value={value()}
+              disabled={isDisabled(spec)}
+              aria-label={spec.label}
+              aria-disabled={isDisabled(spec)}
+              onInput={(e) => setSliderVal(Number.parseFloat(e.currentTarget.value))}
+              onKeyDown={handleKeyDown}
+            />
+          </div>
+          <div class="model-params__slider-bounds">
+            <span class="model-params__slider-bound">{min()}</span>
+            <span class="model-params__slider-bound">{max()}</span>
+          </div>
+        </div>
       </div>
     );
   };
@@ -384,23 +435,42 @@ const ModelParamsDialog: Component<Props> = (props) => {
 
   const ParamRow = (rowProps: { spec: ProviderParamSpec }) => {
     const spec = () => rowProps.spec;
+    const description = () => trimTrailingPunct(paramHint(spec())) + '.';
+    const defaultLabel = () => (spec().default === undefined ? 'unset' : String(spec().default));
     return (
       <div
         class="model-params__row"
         classList={{ 'model-params__row--disabled': !isApplicable(spec()) }}
       >
-        <div class="model-params__row-top">
+        <div class="model-params__row-text">
           <div class="model-params__label-title">
             <span>{spec().label}</span>
             <code class="model-params__param-key">{spec().path}</code>
+            <Show when={!isApplicable(spec()) && describeBlocker(spec())}>
+              {(message) => (
+                <span class="model-params__help" tabIndex={0} aria-label={message()}>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="14"
+                    height="14"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path d="M12 2C6.49 2 2 6.49 2 12s4.49 10 10 10 10-4.49 10-10S17.51 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8" />
+                    <path d="M11 16h2v2h-2zm2.27-9.75c-2.08-.75-4.47.35-5.21 2.41l1.88.68c.18-.5.56-.9 1.07-1.13s1.08-.26 1.58-.08a2.01 2.01 0 0 1 1.32 1.86c0 1.04-1.66 1.86-2.24 2.07-.4.14-.67.52-.67.94v1h2v-.34c1.04-.51 2.91-1.69 2.91-3.68a4.015 4.015 0 0 0-2.64-3.73" />
+                  </svg>
+                  <span class="model-params__help-tooltip" role="tooltip">
+                    {message()}
+                  </span>
+                </span>
+              )}
+            </Show>
           </div>
-          {renderControl(spec())}
+          <div class="model-params__label-hint">{description()}</div>
+          <div class="model-params__default-hint">Default: {defaultLabel()}</div>
         </div>
-        <div class="model-params__label-hint">
-          {isApplicable(spec())
-            ? `Default: ${spec().default === undefined ? 'unset' : String(spec().default)}`
-            : 'Unavailable with selected parameters'}
-        </div>
+        <div class="model-params__row-control">{renderControl(spec())}</div>
       </div>
     );
   };
@@ -415,8 +485,8 @@ const ModelParamsDialog: Component<Props> = (props) => {
           }}
         >
           <div
-            class="modal-card"
-            style="max-width: 460px; user-select: none;"
+            class="modal-card model-params__dialog"
+            style="max-width: 600px; user-select: none;"
             role="dialog"
             aria-modal="true"
             aria-labelledby="model-params-dialog-title"
@@ -428,71 +498,46 @@ const ModelParamsDialog: Component<Props> = (props) => {
             </h2>
             <p class="modal-card__desc">Manifest parameters for {props.slotLabel}.</p>
 
-            <Show
-              when={!props.loading}
-              fallback={
-                <div class="model-params__status">
-                  <span class="spinner" />
-                  <span>Loading parameters…</span>
-                </div>
-              }
-            >
+            <div class="model-params__body">
               <Show
-                when={props.specs.length > 0}
+                when={!props.loading}
                 fallback={
-                  <p class="model-params__status">This model has no configurable parameters.</p>
+                  <div class="model-params__status">
+                    <span class="spinner" />
+                    <span>Loading parameters…</span>
+                  </div>
                 }
               >
-                <For each={groupSpecs(props.specs)}>
-                  {(group) => (
-                    <div class="model-params__group">
-                      <div class="model-params__group-header">
-                        <span>{GROUP_LABELS[group.group]}</span>
-                        <span class="model-params__group-info">
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="13"
-                            height="13"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            viewBox="0 0 24 24"
-                            aria-hidden="true"
-                          >
-                            <circle cx="12" cy="12" r="10" />
-                            <path d="M12 16v-4" />
-                            <path d="M12 8h.01" />
-                          </svg>
-                          <span class="model-params__group-tooltip">
-                            <span class="model-params__tooltip-intro">
-                              {GROUP_INTROS[group.group]}
-                            </span>
-                            <For each={group.specs}>
-                              {(spec) => (
-                                <span class="model-params__tooltip-param">
-                                  <strong>{spec.label}</strong>
-                                  <Show when={rangeLabel(spec)}>
-                                    {' '}
-                                    <span class="model-params__tooltip-range">
-                                      {rangeLabel(spec)}
-                                    </span>
-                                  </Show>
-                                  <br />
-                                  {paramHint(spec)}
-                                </span>
-                              )}
-                            </For>
-                          </span>
-                        </span>
+                <Show
+                  when={props.specs.length > 0}
+                  fallback={
+                    <p class="model-params__status">This model has no configurable parameters.</p>
+                  }
+                >
+                  <For each={groupSpecs(props.specs)}>
+                    {(group) => (
+                      <div class="model-params__group">
+                        <div class="model-params__group-header">
+                          <span>{GROUP_LABELS[group.group]}</span>
+                        </div>
+                        <div class="model-params__group-card">
+                          <For each={group.specs}>
+                            {(spec, index) => (
+                              <>
+                                <Show when={index() > 0}>
+                                  <div class="model-params__separator" />
+                                </Show>
+                                <ParamRow spec={spec} />
+                              </>
+                            )}
+                          </For>
+                        </div>
                       </div>
-                      <For each={group.specs}>{(spec) => <ParamRow spec={spec} />}</For>
-                    </div>
-                  )}
-                </For>
+                    )}
+                  </For>
+                </Show>
               </Show>
-            </Show>
+            </div>
 
             <div class="modal-card__footer">
               <button

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -544,18 +544,56 @@
   color: hsl(var(--success));
 }
 
-.model-params__row {
+.model-params__dialog {
   display: flex;
   flex-direction: column;
-  gap: 0;
-  padding: 12px 0;
+  max-height: calc(100vh - 64px);
 }
 
-.model-params__row-top {
+.model-params__dialog .modal-card__title,
+.model-params__dialog .modal-card__desc {
+  flex-shrink: 0;
+}
+
+.model-params__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  margin: 0 -32px;
+  padding: 0 32px;
+}
+
+.model-params__dialog .modal-card__footer {
+  flex-shrink: 0;
+  padding-top: 16px;
+}
+
+.model-params__row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+  padding: 8px 0;
+}
+
+.model-params__row-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.model-params__row-control {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+}
+
+.model-params__default-hint {
+  font-size: var(--font-size-xs);
+  line-height: 1.4;
+  color: hsl(var(--muted-foreground));
 }
 
 .model-params__row--disabled .model-params__label-title,
@@ -564,87 +602,37 @@
 }
 
 .model-params__group {
-  padding: 8px 0;
-  border-top: 1px solid hsl(var(--border) / 0.65);
+  padding: 0;
 }
 
-.model-params__group:first-of-type {
-  border-top: none;
+.model-params__group + .model-params__group {
+  margin-top: 16px;
 }
 
 .model-params__group-header {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 0 2px;
-  font-size: var(--font-size-sm);
+  padding: 0 16px 8px;
+  font-size: var(--font-size-base);
   font-weight: 600;
   color: hsl(var(--foreground));
 }
 
-.model-params__group-info {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  color: hsl(var(--muted-foreground) / 0.5);
-  cursor: default;
-  transition: color var(--transition-fast);
-}
-
-.model-params__group-info:hover {
-  color: hsl(var(--muted-foreground));
-}
-
-.model-params__group-tooltip {
-  display: none;
-  flex-direction: column;
-  gap: 8px;
-  position: absolute;
-  top: calc(100% + 8px);
-  left: -4px;
-  width: 280px;
-  padding: 10px 12px;
-  background: hsl(var(--popover));
-  color: hsl(var(--popover-foreground));
+.model-params__group-card {
+  background: hsl(var(--background));
   border: 1px solid hsl(var(--border));
-  border-radius: 8px;
-  font-size: var(--tooltip-font-size);
-  font-weight: 400;
-  line-height: 1.5;
-  white-space: normal;
-  box-shadow: 0 4px 12px hsl(var(--foreground) / 0.08);
-  z-index: 10;
+  border-radius: var(--radius);
+  padding: 4px 16px;
 }
 
-.model-params__group-info:hover .model-params__group-tooltip {
-  display: flex;
-}
-
-.model-params__tooltip-intro {
-  color: hsl(var(--muted-foreground));
-}
-
-.model-params__tooltip-param {
-  display: block;
-}
-
-.model-params__tooltip-param strong {
-  font-weight: 600;
-  color: hsl(var(--foreground));
-}
-
-.model-params__tooltip-range {
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-xs);
-  color: hsl(var(--muted-foreground));
-  background: hsl(var(--muted) / 0.45);
-  border: 1px solid hsl(var(--border) / 0.7);
-  border-radius: 3px;
-  padding: 0 4px;
+.model-params__separator {
+  height: 1px;
+  background: hsl(var(--border));
 }
 
 .model-params__group .model-params__row {
-  padding: 8px 0;
+  padding: 12px 0;
 }
 
 /* Loading / "no configurable parameters" placeholder shown while the per-model
@@ -679,10 +667,53 @@
   padding: 1px 5px;
 }
 
+.model-params__help {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  margin-top: 2px;
+  color: hsl(var(--muted-foreground));
+  cursor: help;
+  transition: color var(--transition-fast);
+  outline: none;
+}
+
+.model-params__help:hover,
+.model-params__help:focus-visible {
+  color: hsl(var(--foreground));
+}
+
+.model-params__help-tooltip {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  display: none;
+  width: max-content;
+  max-width: 240px;
+  padding: 8px 10px;
+  background: hsl(var(--popover, var(--card)));
+  color: hsl(var(--popover-foreground, var(--foreground)));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+  line-height: 1.5;
+  white-space: normal;
+  box-shadow: 0 4px 12px hsl(var(--foreground) / 0.08);
+  pointer-events: none;
+}
+
+.model-params__help:hover .model-params__help-tooltip,
+.model-params__help:focus-visible .model-params__help-tooltip {
+  display: block;
+}
+
 .model-params__label-hint {
   font-size: var(--font-size-xs);
+  line-height: 1.4;
   color: hsl(var(--muted-foreground));
-  margin-top: 2px;
 }
 
 .model-params__toggle {
@@ -716,72 +747,173 @@
   justify-content: flex-end;
 }
 
-.model-params__scrub-field {
+.model-params__slider-control {
   display: flex;
-  align-items: center;
-  width: 76px;
-  height: 28px;
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius);
-  background: hsl(var(--background));
-  overflow: hidden;
-}
-
-.model-params__scrub-field:focus-within {
-  border-color: hsl(var(--ring));
-  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
-}
-
-.model-params__scrub-field--disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.model-params__scrub {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
   flex-shrink: 0;
-  width: 24px;
-  height: 100%;
-  color: hsl(var(--muted-foreground) / 0.45);
-  cursor: ew-resize;
-  touch-action: none;
-  transition: color var(--transition-fast);
 }
 
-.model-params__scrub:hover {
-  color: hsl(var(--foreground));
+.model-params__slider-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 88px;
+  flex-shrink: 0;
 }
 
-.model-params__scrub:focus-visible {
-  outline: none;
+.model-params__slider-field--disabled {
+  opacity: 0.5;
 }
 
-.model-params__scrub-input {
-  flex: 1;
-  min-width: 0;
-  height: 100%;
-  padding: 0 8px 0 0;
-  border: none;
-  background: transparent;
-  color: hsl(var(--foreground));
-  color-scheme: light;
-  font-family: var(--font-family);
+.model-params__slider-track-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 20px;
+  width: 100%;
+}
+
+.model-params__slider-track-bg {
+  position: absolute;
+  top: 50%;
+  left: 6px;
+  right: 6px;
+  z-index: 0;
+  height: 4px;
+  background: hsl(var(--border));
+  border-radius: 2px;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.model-params__slider-tick {
+  position: absolute;
+  top: 50%;
+  z-index: 1;
+  width: 2px;
+  height: 8px;
+  background: hsl(var(--muted-foreground) / 0.55);
+  border-radius: 2px;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+.model-params__slider-bounds {
+  position: relative;
+  height: 14px;
   font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
   font-variant-numeric: tabular-nums;
-  text-align: right;
-  outline: none;
+  user-select: none;
 }
 
-.model-params__scrub-input::-webkit-outer-spin-button,
-.model-params__scrub-input::-webkit-inner-spin-button {
+.model-params__slider-bound {
+  position: absolute;
+  top: 0;
+  transform: translateX(-50%);
+}
+
+.model-params__slider-bound:first-child {
+  left: 6px;
+}
+
+.model-params__slider-bound:last-child {
+  left: calc(100% - 6px);
+}
+
+.model-params__slider {
+  display: block;
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   -webkit-appearance: none;
+  appearance: none;
+  height: 20px;
+  background: transparent;
+  cursor: pointer;
+  outline: none;
+  padding: 0;
   margin: 0;
 }
 
-.dark .model-params__scrub-input {
-  color-scheme: dark;
+.model-params__slider:disabled {
+  cursor: not-allowed;
+}
+
+.model-params__slider::-webkit-slider-runnable-track {
+  height: 4px;
+  background: transparent;
+  border-radius: 2px;
+}
+
+.model-params__slider::-moz-range-track {
+  height: 4px;
+  background: transparent;
+  border-radius: 2px;
+}
+
+.model-params__slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 20px;
+  margin-top: -8px;
+  background: #ffffff;
+  border: 1px solid hsl(var(--foreground) / 0.22);
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow:
+    0 2px 6px hsl(var(--foreground) / 0.18),
+    inset 0 0 0 0.5px hsl(var(--foreground) / 0.04);
+  transition:
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+.model-params__slider::-moz-range-thumb {
+  width: 12px;
+  height: 20px;
+  background: #ffffff;
+  border: 1px solid hsl(var(--foreground) / 0.22);
+  border-radius: 6px;
+  cursor: pointer;
+  box-shadow:
+    0 2px 6px hsl(var(--foreground) / 0.18),
+    inset 0 0 0 0.5px hsl(var(--foreground) / 0.04);
+}
+
+.dark .model-params__slider::-webkit-slider-thumb {
+  background: #1a1a1a;
+}
+
+.dark .model-params__slider::-moz-range-thumb {
+  background: #1a1a1a;
+}
+
+.model-params__slider:hover:not(:disabled)::-webkit-slider-thumb {
+  border-color: hsl(var(--foreground) / 0.35);
+}
+
+.model-params__slider:hover:not(:disabled)::-moz-range-thumb {
+  border-color: hsl(var(--foreground) / 0.35);
+}
+
+.model-params__slider:focus-visible::-webkit-slider-thumb {
+  border-color: hsl(var(--ring));
+  box-shadow:
+    0 2px 6px hsl(var(--foreground) / 0.18),
+    0 0 0 3px hsl(var(--ring) / 0.2);
+}
+
+.model-params__slider:focus-visible::-moz-range-thumb {
+  border-color: hsl(var(--ring));
+  box-shadow:
+    0 2px 6px hsl(var(--foreground) / 0.18),
+    0 0 0 3px hsl(var(--ring) / 0.2);
 }
 
 .model-params__number::-webkit-outer-spin-button,
@@ -792,7 +924,7 @@
 
 .model-params__number {
   width: 112px;
-  height: 34px;
+  height: 32px;
   padding: 0 10px;
   text-align: right;
   border: 1px solid hsl(var(--border));
@@ -802,6 +934,16 @@
   color-scheme: light;
   font-family: var(--font-family);
   font-size: var(--font-size-sm);
+}
+
+.model-params__number--slider {
+  width: 50px;
+  height: 32px;
+  padding: 0 6px;
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  flex-shrink: 0;
 }
 
 .dark .model-params__number {

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -11,15 +11,6 @@ import ModelParamsDialog from '../../src/components/ModelParamsDialog';
 
 const q = (sel: string) => document.querySelector(sel);
 
-const pointerEvent = (type: string, clientX: number) => {
-  const event = new Event(type, { bubbles: true, cancelable: true }) as PointerEvent;
-  Object.defineProperties(event, {
-    clientX: { value: clientX },
-    pointerId: { value: 1 },
-  });
-  return event;
-};
-
 const deepseekSpecs: readonly ProviderParamSpec[] = [
   {
     provider: 'deepseek',
@@ -176,41 +167,205 @@ describe('ModelParamsDialog', () => {
       <ModelParamsDialog {...baseProps} specs={anthropicSpecs} slotLabel="claude-sonnet-4-6" />
     ));
 
-    const slider = screen.getByRole('slider', { name: 'Temperature' });
-    const input = screen.getByLabelText('Temperature value') as HTMLInputElement;
+    const slider = screen.getByRole('slider', { name: 'Temperature' }) as HTMLInputElement;
 
     fireEvent.keyDown(slider, { key: 'ArrowDown' });
-    expect(input.value).toBe('0.9');
+    expect(slider.value).toBe('0.9');
 
     fireEvent.keyDown(slider, { key: 'ArrowUp' });
-    expect(input.value).toBe('1');
+    expect(slider.value).toBe('1');
 
     fireEvent.keyDown(slider, { key: 'Home' });
-    expect(input.value).toBe('0');
+    expect(slider.value).toBe('0');
 
     fireEvent.keyDown(slider, { key: 'End' });
-    expect(input.value).toBe('1');
+    expect(slider.value).toBe('1');
   });
 
-  it('updates scrub controls from pointer drag', () => {
+  it('updates slider value from native input event', () => {
     render(() => (
       <ModelParamsDialog {...baseProps} specs={anthropicSpecs} slotLabel="claude-sonnet-4-6" />
     ));
 
-    const scrub = screen.getByRole('slider', { name: 'Temperature' }) as HTMLDivElement;
-    const input = screen.getByLabelText('Temperature value') as HTMLInputElement;
-    scrub.setPointerCapture = vi.fn();
-    scrub.hasPointerCapture = vi.fn(() => true);
-    scrub.releasePointerCapture = vi.fn();
+    const slider = screen.getByRole('slider', { name: 'Temperature' }) as HTMLInputElement;
+    fireEvent.input(slider, { target: { value: '0.5' } });
+    expect(slider.value).toBe('0.5');
+  });
 
-    // Default temperature is 1. pixelsPerUnit = 120 / (1 - 0) = 120.
-    // pointerdown at 100 sets startX=100, startValue=1.
-    fireEvent(scrub, pointerEvent('pointerdown', 100));
-    expect(input.value).toBe('1');
+  it('updates slider value when typing in the companion number input', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        specs={anthropicSpecs}
+        slotLabel="claude-sonnet-4-6"
+        onSave={onSave}
+      />
+    ));
 
-    // pointermove to 40: delta = (40-100)/120 = -0.5, value = 1 + -0.5 = 0.5
-    fireEvent(scrub, pointerEvent('pointermove', 40));
-    expect(input.value).toBe('0.5');
+    const numberInput = screen.getByLabelText('Temperature value') as HTMLInputElement;
+    fireEvent.input(numberInput, { target: { value: '0,3' } });
+    fireEvent.input(numberInput, { target: { value: '' } });
+    fireEvent.input(numberInput, { target: { value: '.' } });
+    fireEvent.input(numberInput, { target: { value: 'abc' } });
+    fireEvent.input(numberInput, { target: { value: '0.6' } });
+    fireEvent.blur(numberInput);
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ temperature: 0.6 }));
+  });
+
+  it('keeps integer slider values truncated when the number input is edited', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const integerSliderSpec: readonly ProviderParamSpec[] = [
+      {
+        provider: 'anthropic',
+        authType: 'api_key',
+        model: 'claude-sonnet-4-6',
+        path: 'thinking.budget_tokens',
+        type: 'integer',
+        label: 'Thinking budget',
+        description: 'Budget.',
+        default: 4096,
+        range: { min: 1024, max: 32768, step: 1024 },
+        group: 'reasoning',
+      },
+    ];
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        specs={integerSliderSpec}
+        slotLabel="claude-sonnet-4-6"
+        onSave={onSave}
+      />
+    ));
+
+    const numberInput = screen.getByLabelText('Thinking budget value') as HTMLInputElement;
+    fireEvent.input(numberInput, { target: { value: '8192.9' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ thinking: { budget_tokens: 8192 } }));
+  });
+
+  it('renders a tooltip explaining how to enable a blocked param (only-rule case)', () => {
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        specs={anthropicSpecs}
+        slotLabel="claude-sonnet-4-6"
+        current={{ thinking: { type: 'disabled' } }}
+      />
+    ));
+
+    const helps = document.querySelectorAll('.model-params__help');
+    const messages = Array.from(helps).map((el) => el.getAttribute('aria-label'));
+    expect(messages.some((m) => m && m.includes('To configure this parameter'))).toBe(true);
+    expect(messages.some((m) => m && m.includes('Thinking mode'))).toBe(true);
+  });
+
+  it('formats lists of three or more required values in the help tooltip', () => {
+    const specs: readonly ProviderParamSpec[] = [
+      {
+        provider: 'test',
+        authType: 'api_key',
+        model: 'test',
+        path: 'mode',
+        type: 'enum',
+        label: 'Mode',
+        description: 'Mode.',
+        default: 'off',
+        values: ['off', 'low', 'medium', 'high'],
+        group: 'reasoning',
+      },
+      {
+        provider: 'test',
+        authType: 'api_key',
+        model: 'test',
+        path: 'effort',
+        type: 'integer',
+        label: 'Effort',
+        description: 'Effort.',
+        default: 1,
+        range: { min: 0, max: 10, step: 1 },
+        group: 'reasoning',
+        applicability: { only: { mode: ['low', 'medium', 'high'] } },
+      },
+    ];
+    render(() => <ModelParamsDialog {...baseProps} specs={specs} slotLabel="test" />);
+
+    const messages = Array.from(document.querySelectorAll('.model-params__help')).map((el) =>
+      el.getAttribute('aria-label'),
+    );
+    expect(messages.some((m) => m && m.includes('"low", "medium", or "high"'))).toBe(true);
+  });
+
+  it('describes blockers for primitive except rules and custom not rules', () => {
+    const blockedSpecs: readonly ProviderParamSpec[] = [
+      {
+        provider: 'test',
+        authType: 'api_key',
+        model: 'test',
+        path: 'mode',
+        type: 'enum',
+        label: 'Mode',
+        description: 'Mode.',
+        default: 'fast',
+        values: ['fast', 'slow'],
+        group: 'reasoning',
+      },
+      {
+        provider: 'test',
+        authType: 'api_key',
+        model: 'test',
+        path: 'noise',
+        type: 'number',
+        label: 'Noise',
+        description: 'Noise.',
+        default: 0.5,
+        range: { min: 0, max: 1, step: 0.1 },
+        group: 'sampling',
+        applicability: { except: { mode: 'slow' } },
+      },
+      {
+        provider: 'test',
+        authType: 'api_key',
+        model: 'test',
+        path: 'jitter',
+        type: 'number',
+        label: 'Jitter',
+        description: 'Jitter.',
+        default: 0.5,
+        range: { min: 0, max: 1, step: 0.1 },
+        group: 'sampling',
+        applicability: { except: { mode: { not: 'fast' } } },
+      },
+    ];
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        specs={blockedSpecs}
+        slotLabel="test"
+        current={{ mode: 'slow' }}
+      />
+    ));
+
+    const messages = Array.from(document.querySelectorAll('.model-params__help')).map((el) =>
+      el.getAttribute('aria-label'),
+    );
+    expect(messages.some((m) => m && m.includes('Mode is "slow"'))).toBe(true);
+    expect(messages.some((m) => m && m.includes('Mode is set to a custom value'))).toBe(true);
+  });
+
+  it('shows the slider min and max bounds', () => {
+    render(() => (
+      <ModelParamsDialog {...baseProps} specs={anthropicSpecs} slotLabel="claude-sonnet-4-6" />
+    ));
+
+    const slider = screen.getByRole('slider', { name: 'Temperature' });
+    const field = slider.closest('.model-params__slider-field') as HTMLElement;
+    const bounds = field.querySelectorAll('.model-params__slider-bound');
+    expect(bounds[0]?.textContent).toBe('0');
+    expect(bounds[1]?.textContent).toBe('1');
   });
 
   it('stores integer number controls as parsed numeric values', async () => {

--- a/packages/frontend/tests/components/ModelParamsDialog.test.tsx
+++ b/packages/frontend/tests/components/ModelParamsDialog.test.tsx
@@ -265,6 +265,24 @@ describe('ModelParamsDialog', () => {
     await waitFor(() => expect(onSave).toHaveBeenCalledWith({ temperature: 0.6 }));
   });
 
+  it('snaps companion number input values to the slider step before saving', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(() => (
+      <ModelParamsDialog
+        {...baseProps}
+        specs={anthropicSpecs}
+        slotLabel="claude-sonnet-4-6"
+        onSave={onSave}
+      />
+    ));
+
+    const numberInput = screen.getByLabelText('Temperature value') as HTMLInputElement;
+    fireEvent.input(numberInput, { target: { value: '0.36' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ temperature: 0.4 }));
+  });
+
   it('keeps integer slider values truncated when the number input is edited', async () => {
     const onSave = vi.fn().mockResolvedValue(undefined);
     const integerSliderSpec: readonly ProviderParamSpec[] = [


### PR DESCRIPTION
✨ What changed
- Group params into cards with inline descriptions and Default lines.
- Replace the dot-scrub with a compact slider, tick markers and a synced number field.
- Modal caps at 90vh with a scrollable body and a sticky footer.
- Disabled params keep their description and get a help icon. The tooltip explains which other param to flip to enable the row, built from the spec applicability data.
- Remember the last user value while a param is disabled so it returns when the param becomes available again.

💭 Why
The previous Model parameters modal hid descriptions behind an info icon tooltip, used a scrub-dot control most users did not recognise, and dropped the user's value as soon as a dependency disabled a row. Long lists scrolled the whole modal so the Save button could disappear off-screen.

👤 For users
Every parameter now shows its full description by default. Disabled rows still show their description and offer a clear hover tip explaining how to unlock them. Edits to a disabled row are kept and restored when the row reopens. The slider accepts both period and comma decimals.

Cons 
the modal is providing a lot of information in the first screen. It's not smooth to read

🔧 For operators
No operator impact.

🧪 How to test
1. Open the Routing page, pick a model with rich params (Anthropic Claude Sonnet works well), open Model parameters. Expect grouped cards, each with title, description and Default line.
2. Toggle Thinking mode off then on, watch Top P become enabled or disabled. Hover the help icon on a disabled row, expect a tooltip naming the param to flip.
3. Set Top P to 0.6, disable it via Thinking mode, then re-enable. Expect Top P to return to 0.6.
4. Drag the slider, type 0,3 in the number field, then 0.7. Both should sync the slider and accept the comma as a decimal.
5. Open Model parameters on a model with many groups, expect the modal to scroll inside while title and Save stay visible.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshed the Model parameters dialog with grouped cards, inline descriptions, and a compact slider plus synced number input. Disabled params now show how to unlock them and keep your last value; the modal is wider and scrolls while actions stay visible.

- New Features
  - Card layout per group with titles, inline descriptions, and a Default line per parameter.
  - Replaced scrubber with a compact slider: min/max labels, quartile ticks, keyboard support; number input stays in sync, accepts “.” and “,” decimals, snaps to step, and truncates integer params.
  - Disabled rows keep descriptions and add a help icon with messages derived from applicability rules (names the blocker and required values), while preserving the last user value.
  - Modal max-width 600px; caps at 90vh with an internal scroll area and sticky footer.

- Dependencies
  - Bump `manifest` to 6.6.1.

<sup>Written for commit 63d2633fe91fb4c69300d3fd758a64e78680e374. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2004?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



**Currently on the platform:** 
<img width="1072" height="1028" alt="Screenshot 2026-05-22 at 15 09 28" src="https://github.com/user-attachments/assets/287aadac-828a-4913-b4fa-97ec135e8d47" />
<img width="1034" height="996" alt="Screenshot 2026-05-22 at 15 09 23" src="https://github.com/user-attachments/assets/730442ca-cb0f-4ce8-9185-15282c329b42" />

**UI in this PR:**
<img width="1238" height="1638" alt="Screenshot 2026-05-22 at 15 08 38" src="https://github.com/user-attachments/assets/41f3df85-5400-43c8-8cff-4c24619330c0" />


