### PR TITLE
fix(proxy): support xAI Responses API routing

### DIFF
--- a/.changeset/xai-responses-routing.md
+++ b/.changeset/xai-responses-routing.md
@@ -1,0 +1,8 @@
+---
+'manifest': patch
+---
+
+fix(proxy): route xAI Responses API requests to xAI's native /v1/responses endpoint
+
+Adds native xAI Responses API forwarding and routes xAI multi-agent Grok models
+through /v1/responses instead of filtering them out of model discovery.

--- a/packages/backend/src/common/constants/xai-models.ts
+++ b/packages/backend/src/common/constants/xai-models.ts
@@ -1,0 +1,7 @@
+/**
+ * xAI models that only accept /v1/responses, not /v1/chat/completions.
+ *
+ * xAI documents the multi-agent Grok variant as Responses API-only. Keep the
+ * matcher model-family based so dated snapshots are routed with their alias.
+ */
+export const XAI_RESPONSES_ONLY_RE = /^grok-.*multi-agent(?:-|$)/i;

--- a/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
+++ b/packages/backend/src/model-discovery/filter-non-chat-models.spec.ts
@@ -305,16 +305,16 @@ describe('filterNonChatModels', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('filters multi-agent models', () => {
+    it('keeps xAI multi-agent models because the proxy routes them to Responses API', () => {
       const models = [makeModel('grok-4.20-multi-agent-0309'), makeModel('grok-3')];
       const result = filterNonChatModels(models, 'xai');
-      expect(result.map((m) => m.id)).toEqual(['grok-3']);
+      expect(result.map((m) => m.id)).toEqual(['grok-4.20-multi-agent-0309', 'grok-3']);
     });
 
-    it('filters any future multi-agent model', () => {
+    it('keeps future xAI multi-agent models for Responses API routing', () => {
       const models = [makeModel('grok-5-multi-agent-0612'), makeModel('grok-3')];
       const result = filterNonChatModels(models, 'xai');
-      expect(result.map((m) => m.id)).toEqual(['grok-3']);
+      expect(result.map((m) => m.id)).toEqual(['grok-5-multi-agent-0612', 'grok-3']);
     });
   });
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -129,7 +129,7 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
   // Note: do NOT block "safeguard" — Groq's gpt-oss-safeguard-20b is a chat
   // model the user can call.
   groq: /(?:(?:^|\/|-)compound|prompt-guard|orpheus)/i,
-  xai: /(?:imagine|multi-agent)/i,
+  xai: /imagine/i,
   copilot: /accounts\/[^/]+\/routers\//i,
 };
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -137,6 +137,49 @@ describe('ProviderClient', () => {
       );
     });
 
+    it('routes public Responses API requests for xAI to /v1/responses', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'grok-4.3',
+        body: {
+          input: [{ role: 'user', content: 'Hello' }],
+          reasoning: { effort: 'low' },
+          stream: false,
+        },
+        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/responses',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer sk-xai',
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody).toMatchObject({
+        model: 'grok-4.3',
+        reasoning: { effort: 'low' },
+        stream: false,
+        store: false,
+      });
+      expect(sentBody.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ]);
+      expect(sentBody.messages).toBeUndefined();
+      expect(result.isResponses).toBe(true);
+      expect(result.isChatGpt).toBe(false);
+    });
+
     it('builds correct URL for openrouter', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({
@@ -1302,6 +1345,91 @@ describe('ProviderClient', () => {
 
       const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
       expect(typeof sentBody.messages[0].content).toBe('string');
+    });
+  });
+
+  describe('resolveEndpoint - xAI Responses-only routing', () => {
+    const multiAgentModels = ['grok-4.20-multi-agent', 'grok-4.20-multi-agent-0309'];
+
+    it.each(multiAgentModels)(
+      'routes xAI multi-agent model %s to /v1/responses with chatgpt conversion',
+      async (model) => {
+        mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+        const result = await client.forward({
+          provider: 'xai',
+          apiKey: 'sk-xai',
+          model,
+          body,
+          stream: false,
+        });
+
+        expect(mockFetch).toHaveBeenCalledWith('https://api.x.ai/v1/responses', expect.any(Object));
+
+        const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(sentBody.model).toBe(model);
+        expect(sentBody.input).toEqual([
+          { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+        ]);
+        expect(sentBody.store).toBe(false);
+        expect(sentBody.messages).toBeUndefined();
+        expect(result.isChatGpt).toBe(true);
+        expect(result.isResponses).toBe(false);
+      },
+    );
+
+    it('detects xAI Responses-only models after stripping a vendor prefix', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'xai/grok-4.20-multi-agent-0309',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.x.ai/v1/responses');
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('grok-4.20-multi-agent-0309');
+    });
+
+    it('maps max_tokens to max_output_tokens for xAI multi-agent requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'grok-4.20-multi-agent',
+        body: { ...body, max_tokens: 1536 },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(mockFetch).toHaveBeenCalledWith('https://api.x.ai/v1/responses', expect.any(Object));
+      expect(sentBody.max_output_tokens).toBe(1536);
+      expect(sentBody.max_tokens).toBeUndefined();
+    });
+
+    it('leaves regular xAI models on /v1/chat/completions for Chat Completions requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'xai',
+        apiKey: 'sk-xai',
+        model: 'grok-4.3',
+        body,
+        stream: false,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/chat/completions',
+        expect.any(Object),
+      );
+      expect(result.isChatGpt).toBe(false);
+      expect(result.isResponses).toBe(false);
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -220,6 +220,17 @@ describe('PROVIDER_ENDPOINTS', () => {
     });
   });
 
+  it('xai-responses targets /v1/responses with OpenAI-compatible auth headers', () => {
+    const ep = PROVIDER_ENDPOINTS['xai-responses'];
+    expect(ep.baseUrl).toBe('https://api.x.ai');
+    expect(ep.format).toBe('chatgpt');
+    expect(ep.buildPath('grok-4.20-multi-agent')).toBe('/v1/responses');
+    expect(ep.buildHeaders('xai-test-key')).toEqual({
+      Authorization: 'Bearer xai-test-key',
+      'Content-Type': 'application/json',
+    });
+  });
+
   it('anthropic buildPath returns /v1/messages', () => {
     const path = PROVIDER_ENDPOINTS['anthropic'].buildPath('claude-sonnet-4');
     expect(path).toBe('/v1/messages');

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
+import { XAI_RESPONSES_ONLY_RE } from '../../common/constants/xai-models';
 import { PROVIDER_ENDPOINTS, ProviderEndpoint, resolveEndpointKey } from './provider-endpoints';
 import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
@@ -172,9 +173,17 @@ export class ProviderClient {
     if (apiMode === 'responses' && resolved === 'openai') {
       resolved = 'openai-responses';
     }
+    if (apiMode === 'responses' && resolved === 'xai') {
+      resolved = 'xai-responses';
+    }
     // OpenAI rejects these models on /v1/chat/completions; forward to /v1/responses.
     if (resolved === 'openai' && OPENAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
       resolved = 'openai-responses';
+    }
+    // xAI multi-agent models are Responses API-only; route them to /v1/responses
+    // while still accepting Chat Completions-shaped client requests.
+    if (resolved === 'xai' && XAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
+      resolved = 'xai-responses';
     }
     // Copilot serves Codex variants only at /responses; /chat/completions returns
     // "Unsupported API for model" (gh issue mnfst/manifest#1849).
@@ -277,7 +286,9 @@ export class ProviderClient {
               // The ChatGPT subscription backend rejects max_output_tokens with
               // unsupported_parameter; only opt in for the API-key paths.
               mapMaxOutputTokens:
-                endpointKey === 'openai-responses' || endpointKey === 'copilot-responses',
+                endpointKey === 'openai-responses' ||
+                endpointKey === 'copilot-responses' ||
+                endpointKey === 'xai-responses',
             });
       // Force upstream streaming for copilot-responses so the SSE collector in
       // handleNonStreamResponse stays the single source of truth. Without this,

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -129,6 +129,12 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: openaiPath,
     format: 'openai',
   },
+  'xai-responses': {
+    baseUrl: 'https://api.x.ai',
+    buildHeaders: openaiHeaders,
+    buildPath: () => '/v1/responses',
+    format: 'chatgpt',
+  },
   minimax: {
     baseUrl: 'https://api.minimax.io',
     buildHeaders: openaiHeaders,


### PR DESCRIPTION
## Summary
- add an `xai-responses` provider endpoint for `https://api.x.ai/v1/responses`
- route Manifest `/v1/responses` requests for xAI to the native xAI Responses API
- route xAI multi-agent Grok models to `/v1/responses` and keep them discoverable instead of filtering them as non-chat

## Source docs
- xAI Multi Agent docs: https://docs.x.ai/developers/model-capabilities/text/multi-agent
- xAI Chat Completions vs Responses comparison: https://docs.x.ai/developers/model-capabilities/text/comparison

## Validation
- `npm ci`
- `npm --workspace packages/shared run build`
- `npm --workspace packages/backend test -- --runInBand routing/proxy/__tests__/provider-client.spec.ts routing/proxy/__tests__/provider-endpoints.spec.ts model-discovery/filter-non-chat-models.spec.ts`
- `npm --workspace packages/backend run build`
- `npm --workspace packages/backend run lint` (passes with existing warnings)
- `git diff --check`
- live xAI smoke: `POST https://api.x.ai/v1/responses` with `grok-4.20-multi-agent`, `reasoning.effort=low`, `store=false`; returned HTTP 200 and output `OK` (13,098 total tokens, 0 server-side tools).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native routing for xAI’s Responses API. Multi‑agent Grok models now hit `/v1/responses` and remain visible in model discovery.

- **New Features**
  - Added `xai-responses` provider endpoint pointing to `https://api.x.ai/v1/responses` with OpenAI-style headers and `chatgpt` format.
  - Forward xAI requests with `apiMode='responses'` to `xai-responses`, and map `max_tokens` to `max_output_tokens`.
  - Auto-route xAI multi-agent Grok models (`/^grok-.*multi-agent(?:-|$)/i`) to `/v1/responses` while accepting Chat Completions-shaped inputs; handles vendor-prefixed IDs like `xai/grok-...`.
  - Stop filtering xAI multi-agent models from discovery to keep them selectable.

<sup>Written for commit d06146166d499f77d6bf1102827334b18aaf6b50. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2005?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

