### PR TITLE
fix(proxy): persist reasoning_content cache

### DIFF
--- a/.changeset/shared-reasoning-content-cache.md
+++ b/.changeset/shared-reasoning-content-cache.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Persist cached `reasoning_content` for DeepSeek-compatible tool-call turns in Postgres so cloud deployments with multiple backend instances can re-inject the required field on follow-up requests.

--- a/packages/backend/src/database/database.module.ts
+++ b/packages/backend/src/database/database.module.ts
@@ -23,6 +23,7 @@ import { MessageRecording } from '../entities/message-recording.entity';
 import { AgentModelParams } from '../entities/agent-model-params.entity';
 import { PlaygroundRun } from '../entities/playground-run.entity';
 import { PlaygroundColumn } from '../entities/playground-column.entity';
+import { ReasoningContentCacheEntry } from '../entities/reasoning-content-cache-entry.entity';
 import { DatabaseSeederService } from './database-seeder.service';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { InitialSchema1771464895790 } from './migrations/1771464895790-InitialSchema';
@@ -106,6 +107,7 @@ import { AddOAuthPendingFlows1789100000000 } from './migrations/1789100000000-Ad
 import { ScopeAgentModelParams1789200000000 } from './migrations/1789200000000-ScopeAgentModelParams';
 import { EnableRecordMessagesForAll1789300000000 } from './migrations/1789300000000-EnableRecordMessagesForAll';
 import { AddAgentApiKeyPrefixActiveIndex1790000000000 } from './migrations/1790000000000-AddAgentApiKeyPrefixActiveIndex';
+import { AddReasoningContentCache1790100000000 } from './migrations/1790100000000-AddReasoningContentCache';
 
 const entities = [
   AgentMessage,
@@ -129,6 +131,7 @@ const entities = [
   AgentModelParams,
   PlaygroundRun,
   PlaygroundColumn,
+  ReasoningContentCacheEntry,
 ];
 
 const migrations = [
@@ -213,6 +216,7 @@ const migrations = [
   ScopeAgentModelParams1789200000000,
   EnableRecordMessagesForAll1789300000000,
   AddAgentApiKeyPrefixActiveIndex1790000000000,
+  AddReasoningContentCache1790100000000,
 ];
 
 @Module({
@@ -260,6 +264,7 @@ const migrations = [
       HeaderTier,
       MessageRecording,
       AgentModelParams,
+      ReasoningContentCacheEntry,
     ]),
     ModelPricesModule,
   ],

--- a/packages/backend/src/database/migrations/1790100000000-AddReasoningContentCache.ts
+++ b/packages/backend/src/database/migrations/1790100000000-AddReasoningContentCache.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReasoningContentCache1790100000000 implements MigrationInterface {
+  name = 'AddReasoningContentCache1790100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "reasoning_content_cache" (
+        "session_key" varchar NOT NULL,
+        "first_tool_call_id" varchar NOT NULL,
+        "content" text NOT NULL,
+        "expires_at" TIMESTAMP NOT NULL,
+        "created_at" TIMESTAMP NOT NULL DEFAULT NOW(),
+        "updated_at" TIMESTAMP NOT NULL DEFAULT NOW(),
+        CONSTRAINT "PK_reasoning_content_cache"
+          PRIMARY KEY ("session_key", "first_tool_call_id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_reasoning_content_cache_expires" ON "reasoning_content_cache" ("expires_at")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_reasoning_content_cache_expires"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "reasoning_content_cache"`);
+  }
+}

--- a/packages/backend/src/entities/reasoning-content-cache-entry.entity.ts
+++ b/packages/backend/src/entities/reasoning-content-cache-entry.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, Column, PrimaryColumn, Index } from 'typeorm';
+import { timestampType, timestampDefault } from '../common/utils/postgres-sql';
+
+/**
+ * Short-lived shared cache for OpenAI-compatible reasoning traces that must be
+ * replayed on tool-call follow-up turns.
+ */
+@Entity('reasoning_content_cache')
+@Index(['expires_at'])
+export class ReasoningContentCacheEntry {
+  @PrimaryColumn('varchar')
+  session_key!: string;
+
+  @PrimaryColumn('varchar')
+  first_tool_call_id!: string;
+
+  @Column('text')
+  content!: string;
+
+  @Column(timestampType())
+  expires_at!: string;
+
+  @Column(timestampType(), { default: timestampDefault() })
+  created_at!: string;
+
+  @Column(timestampType(), { default: timestampDefault() })
+  updated_at!: string;
+}

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -11,6 +11,7 @@ import { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
 import { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
+import { ReasoningContentCache } from '../reasoning-content-cache';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
 import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
 import { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
@@ -47,6 +48,7 @@ describe('ProxyFallbackService', () => {
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
   let modelParamsService: jest.Mocked<AgentModelParamsService>;
   let providerParamSpecs: jest.Mocked<ProviderParamSpecService>;
+  let reasoningCache: jest.Mocked<Pick<ReasoningContentCache, 'reinjectMissingReasoningContent'>>;
 
   beforeEach(() => {
     providerKeyService = {
@@ -99,6 +101,17 @@ describe('ProxyFallbackService', () => {
       list: jest.fn().mockResolvedValue(specCatalog),
     } as unknown as jest.Mocked<ProviderParamSpecService>;
 
+    reasoningCache = {
+      reinjectMissingReasoningContent: jest.fn(
+        async (
+          requestBody: Record<string, unknown>,
+          _sessionKey: string,
+          _endpointKey: string | null,
+          _model: string,
+        ) => requestBody,
+      ),
+    };
+
     service = new ProxyFallbackService(
       providerKeyService,
       customProviderRepo,
@@ -110,6 +123,7 @@ describe('ProxyFallbackService', () => {
       pricingCache,
       modelParamsService,
       providerParamSpecs,
+      reasoningCache as unknown as ReasoningContentCache,
     );
   });
 
@@ -274,6 +288,53 @@ describe('ProxyFallbackService', () => {
       });
 
       expect(modelParamsService.get).not.toHaveBeenCalled();
+    });
+
+    it('re-injects shared reasoning_content before forwarding to compatible providers', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+      const requestBody = {
+        messages: [
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+          },
+        ],
+      };
+      const enrichedBody = {
+        messages: [
+          {
+            ...requestBody.messages[0],
+            reasoning_content: 'shared thinking',
+          },
+        ],
+      };
+      reasoningCache.reinjectMissingReasoningContent.mockResolvedValueOnce(enrichedBody);
+
+      await service.tryForwardToProvider({
+        provider: 'deepseek',
+        apiKey: 'sk-test',
+        model: 'deepseek-chat',
+        body: requestBody,
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'api_key',
+      });
+
+      expect(reasoningCache.reinjectMissingReasoningContent).toHaveBeenCalledWith(
+        requestBody,
+        'sess-1',
+        'deepseek',
+        'deepseek-chat',
+      );
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({ body: enrichedBody }),
+      );
     });
 
     it('rethrows when signal is aborted', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/reasoning-content-cache.spec.ts
@@ -1,4 +1,13 @@
+import type { Repository } from 'typeorm';
+import { ReasoningContentCacheEntry } from '../../../entities/reasoning-content-cache-entry.entity';
 import { ReasoningContentCache } from '../reasoning-content-cache';
+
+const makeRepo = () =>
+  ({
+    upsert: jest.fn().mockResolvedValue(undefined),
+    find: jest.fn().mockResolvedValue([]),
+    delete: jest.fn().mockResolvedValue(undefined),
+  }) as unknown as jest.Mocked<Repository<ReasoningContentCacheEntry>>;
 
 describe('ReasoningContentCache', () => {
   let cache: ReasoningContentCache;
@@ -79,6 +88,101 @@ describe('ReasoningContentCache', () => {
     cache.store('session-1', 'call_1', 'new');
 
     expect(cache.retrieve('session-1', 'call_1')).toBe('new');
+  });
+
+  it('persists stored reasoning_content to the shared repository when available', () => {
+    const repo = makeRepo();
+    const sharedCache = new ReasoningContentCache(repo);
+
+    sharedCache.store('session-1', 'call_1', 'thinking');
+
+    expect(repo.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session_key: 'session-1',
+        first_tool_call_id: 'call_1',
+        content: 'thinking',
+      }),
+      ['session_key', 'first_tool_call_id'],
+    );
+  });
+
+  it('retrieves shared reasoning_content and warms the local cache', async () => {
+    const repo = makeRepo();
+    repo.find.mockResolvedValue([
+      {
+        session_key: 'session-1',
+        first_tool_call_id: 'call_2',
+        content: 'shared thinking',
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+    const sharedCache = new ReasoningContentCache(repo);
+
+    const result = await sharedCache.retrieveMany('session-1', ['call_2']);
+
+    expect(result.get('call_2')).toBe('shared thinking');
+    expect(sharedCache.retrieve('session-1', 'call_2')).toBe('shared thinking');
+  });
+
+  it('re-injects shared reasoning_content into compatible assistant tool-call messages', async () => {
+    const repo = makeRepo();
+    repo.find.mockResolvedValue([
+      {
+        session_key: 'session-1',
+        first_tool_call_id: 'call_1',
+        content: 'shared thinking',
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ]);
+    const sharedCache = new ReasoningContentCache(repo);
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await sharedCache.reinjectMissingReasoningContent(
+      body,
+      'session-1',
+      'deepseek',
+      'deepseek-chat',
+    );
+
+    const messages = result.messages as Array<Record<string, unknown>>;
+    const originalMessages = body.messages as Array<Record<string, unknown>>;
+    expect(messages[0].reasoning_content).toBe('shared thinking');
+    expect(originalMessages[0].reasoning_content).toBeUndefined();
+  });
+
+  it('does not query shared cache for strict providers', async () => {
+    const repo = makeRepo();
+    const sharedCache = new ReasoningContentCache(repo);
+    const body = {
+      messages: [
+        {
+          role: 'assistant',
+          tool_calls: [{ id: 'call_1', type: 'function', function: {} }],
+        },
+      ],
+    };
+
+    const result = await sharedCache.reinjectMissingReasoningContent(
+      body,
+      'session-1',
+      'mistral',
+      'mistral-large',
+    );
+
+    expect(result).toBe(body);
+    expect(repo.find).not.toHaveBeenCalled();
   });
 
   it('evicts expired entries lazily when cleanup interval has elapsed', () => {

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -36,6 +36,7 @@ import {
   resolveEndpointKey,
 } from './provider-endpoints';
 import { CopilotTokenService } from './copilot-token.service';
+import { ReasoningContentCache } from './reasoning-content-cache';
 import { buildProviderExtraHeaders } from './provider-hooks';
 import { shouldTriggerFallback } from './fallback-status-codes';
 import { inferProviderFromModelName } from '../../common/utils/provider-aliases';
@@ -80,6 +81,7 @@ export class ProxyFallbackService {
     private readonly pricingCache: ModelPricingCacheService,
     private readonly modelParamsService: AgentModelParamsService,
     private readonly providerParamSpecs: ProviderParamSpecService,
+    private readonly reasoningCache?: ReasoningContentCache,
   ) {}
 
   /**
@@ -348,14 +350,14 @@ export class ProxyFallbackService {
     // new agent_model_params table, so a primary OpenAI route with a
     // DeepSeek fallback no longer needs the old per-provider filter —
     // OpenAI's lookup returns null, DeepSeek's returns its own row.
-    const body = await this.applyParamMerge(
+    let body = await this.applyParamMerge(
       opts.body,
       opts.paramMergeContext,
       provider,
       authType,
       opts.model,
     );
-    const chatBody = opts.chatBody
+    let chatBody = opts.chatBody
       ? await this.applyParamMerge(
           opts.chatBody,
           opts.paramMergeContext,
@@ -424,6 +426,29 @@ export class ProxyFallbackService {
       } else if (providerRegion === 'cn') {
         const regionBaseUrl = `${MINIMAX_BASE_URLS.cn}/anthropic`;
         customEndpoint = buildEndpointOverride(regionBaseUrl, 'minimax-subscription');
+      }
+    }
+
+    const reasoningEndpointKey =
+      customEndpoint && customEndpoint.format !== 'openai'
+        ? null
+        : customEndpoint
+          ? 'custom'
+          : resolveEndpointKey(provider);
+    if (this.reasoningCache) {
+      body = await this.reasoningCache.reinjectMissingReasoningContent(
+        body,
+        opts.sessionKey,
+        reasoningEndpointKey,
+        forwardModel,
+      );
+      if (chatBody) {
+        chatBody = await this.reasoningCache.reinjectMissingReasoningContent(
+          chatBody,
+          opts.sessionKey,
+          reasoningEndpointKey,
+          forwardModel,
+        );
       }
     }
 

--- a/packages/backend/src/routing/proxy/proxy.module.ts
+++ b/packages/backend/src/routing/proxy/proxy.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { MessageRecording } from '../../entities/message-recording.entity';
+import { ReasoningContentCacheEntry } from '../../entities/reasoning-content-cache-entry.entity';
 import { RoutingCoreModule } from '../routing-core/routing-core.module';
 import { ModelPricesModule } from '../../model-prices/model-prices.module';
 import { ModelDiscoveryModule } from '../../model-discovery/model-discovery.module';
@@ -29,7 +30,12 @@ import { ProxyExceptionFilter } from './proxy-exception.filter';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AgentMessage, CustomProvider, MessageRecording]),
+    TypeOrmModule.forFeature([
+      AgentMessage,
+      CustomProvider,
+      MessageRecording,
+      ReasoningContentCacheEntry,
+    ]),
     RoutingCoreModule,
     ModelPricesModule,
     ModelDiscoveryModule,

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -1,3 +1,9 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { ReasoningContentCacheEntry } from '../../entities/reasoning-content-cache-entry.entity';
+import { supportsReasoningContent } from './provider-client-converters';
+
 interface CachedReasoningContent {
   content: string;
   expiresAt: number;
@@ -15,18 +21,28 @@ const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
  * rebuild conversation history, so Manifest caches it by the first tool call id
  * and restores it before forwarding the next turn to a compatible provider.
  */
+@Injectable()
 export class ReasoningContentCache {
+  private readonly logger = new Logger(ReasoningContentCache.name);
   private cache = new Map<string, CachedReasoningContent>();
   private lastCleanup = Date.now();
+
+  constructor(
+    @Optional()
+    @InjectRepository(ReasoningContentCacheEntry)
+    private readonly repo?: Repository<ReasoningContentCacheEntry>,
+  ) {}
 
   /** Store the reasoning_content string for an assistant tool-call turn. */
   store(sessionKey: string, firstToolCallId: string, content: string): void {
     if (!content) return;
     this.maybeCleanup();
+    const expiresAt = Date.now() + TTL_MS;
     this.cache.set(`${sessionKey}:${firstToolCallId}`, {
       content,
-      expiresAt: Date.now() + TTL_MS,
+      expiresAt,
     });
+    void this.persist(sessionKey, firstToolCallId, content, expiresAt);
   }
 
   /** Retrieve cached reasoning_content, or null if not found/expired. */
@@ -40,11 +56,91 @@ export class ReasoningContentCache {
     return entry.content;
   }
 
+  async retrieveMany(sessionKey: string, firstToolCallIds: string[]): Promise<Map<string, string>> {
+    this.maybeCleanup();
+    const result = new Map<string, string>();
+    const missing: string[] = [];
+
+    for (const id of [...new Set(firstToolCallIds)]) {
+      const local = this.retrieve(sessionKey, id);
+      if (local) {
+        result.set(id, local);
+      } else {
+        missing.push(id);
+      }
+    }
+
+    if (missing.length === 0 || !this.repo) return result;
+
+    try {
+      const rows = await this.repo.find({
+        where: {
+          session_key: sessionKey,
+          first_tool_call_id: In(missing),
+        },
+      });
+      const now = Date.now();
+      const expired: string[] = [];
+      for (const row of rows) {
+        if (new Date(row.expires_at).getTime() <= now) {
+          expired.push(row.first_tool_call_id);
+          continue;
+        }
+        result.set(row.first_tool_call_id, row.content);
+        this.cache.set(`${sessionKey}:${row.first_tool_call_id}`, {
+          content: row.content,
+          expiresAt: new Date(row.expires_at).getTime(),
+        });
+      }
+      if (expired.length > 0) void this.deleteExpired(sessionKey, expired);
+    } catch (err) {
+      this.logger.warn(`Failed to read shared reasoning_content cache: ${String(err)}`);
+    }
+
+    return result;
+  }
+
+  async reinjectMissingReasoningContent(
+    body: Record<string, unknown>,
+    sessionKey: string,
+    endpointKey: string | null,
+    model: string,
+  ): Promise<Record<string, unknown>> {
+    if (!endpointKey || !supportsReasoningContent(endpointKey, model)) return body;
+    const messages = body.messages;
+    if (!Array.isArray(messages)) return body;
+
+    const ids = messages
+      .map((message) => firstToolCallIdMissingReasoning(message))
+      .filter((id): id is string => typeof id === 'string');
+    if (ids.length === 0) return body;
+
+    const cached = await this.retrieveMany(sessionKey, ids);
+    if (cached.size === 0) return body;
+
+    let changed = false;
+    const nextMessages = messages.map((message) => {
+      const id = firstToolCallIdMissingReasoning(message);
+      if (!id) return message;
+      const content = cached.get(id);
+      if (!content) return message;
+      changed = true;
+      return { ...(message as Record<string, unknown>), reasoning_content: content };
+    });
+
+    return changed ? { ...body, messages: nextMessages } : body;
+  }
+
   /** Clear all cached reasoning_content for a session. */
   clearSession(sessionKey: string): void {
     const prefix = `${sessionKey}:`;
     for (const key of this.cache.keys()) {
       if (key.startsWith(prefix)) this.cache.delete(key);
+    }
+    if (this.repo) {
+      void this.repo.delete({ session_key: sessionKey }).catch((err) => {
+        this.logger.warn(`Failed to clear shared reasoning_content cache: ${String(err)}`);
+      });
     }
   }
 
@@ -56,5 +152,69 @@ export class ReasoningContentCache {
     for (const [key, entry] of this.cache) {
       if (now > entry.expiresAt) this.cache.delete(key);
     }
+    if (this.repo) void this.cleanupSharedExpired(now);
   }
+
+  private async persist(
+    sessionKey: string,
+    firstToolCallId: string,
+    content: string,
+    expiresAt: number,
+  ): Promise<void> {
+    if (!this.repo) return;
+    const now = new Date().toISOString();
+    try {
+      await this.repo.upsert(
+        {
+          session_key: sessionKey,
+          first_tool_call_id: firstToolCallId,
+          content,
+          expires_at: new Date(expiresAt).toISOString(),
+          created_at: now,
+          updated_at: now,
+        },
+        ['session_key', 'first_tool_call_id'],
+      );
+    } catch (err) {
+      this.logger.warn(`Failed to persist reasoning_content cache: ${String(err)}`);
+    }
+  }
+
+  private async deleteExpired(sessionKey: string, firstToolCallIds: string[]): Promise<void> {
+    if (!this.repo || firstToolCallIds.length === 0) return;
+    try {
+      await this.repo.delete({
+        session_key: sessionKey,
+        first_tool_call_id: In(firstToolCallIds),
+      });
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+
+  private async cleanupSharedExpired(now: number): Promise<void> {
+    if (!this.repo) return;
+    try {
+      await this.repo
+        .createQueryBuilder()
+        .delete()
+        .where('expires_at < :now', { now: new Date(now).toISOString() })
+        .execute();
+    } catch {
+      // Best-effort cleanup only.
+    }
+  }
+}
+
+function firstToolCallIdMissingReasoning(message: unknown): string | null {
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
+  const record = message as Record<string, unknown>;
+  if (typeof record.reasoning_content === 'string' && record.reasoning_content) return null;
+  if (!Array.isArray(record.tool_calls) || record.tool_calls.length === 0) return null;
+  const firstToolCall = record.tool_calls[0];
+  if (!firstToolCall || typeof firstToolCall !== 'object' || Array.isArray(firstToolCall)) {
+    return null;
+  }
+  const id = (firstToolCall as Record<string, unknown>).id;
+  return typeof id === 'string' && id ? id : null;
 }


### PR DESCRIPTION
## Summary
- persist DeepSeek-compatible `reasoning_content` cache entries in Postgres with a short TTL
- keep the existing in-memory cache as a fast path and re-inject shared cache hits before forwarding OpenAI-compatible tool-call turns
- add a migration, entity wiring, regression coverage, and a patch changeset

## Root cause
PR #1998 fixed local/single-instance replay by caching `reasoning_content` in process memory. In the cloud, a tool-call response and the follow-up request can land on different backend instances, so the second instance has no cached reasoning trace and DeepSeek rejects the request.

## Validation
- `npm test --workspace=manifest-backend -- routing/proxy/__tests__/reasoning-content-cache.spec.ts routing/proxy/__tests__/proxy-fallback.service.spec.ts routing/proxy/__tests__/proxy-fallback.routes.spec.ts routing/proxy/__tests__/proxy-response-handler.spec.ts routing/proxy/__tests__/provider-client-converters.spec.ts --runInBand`
- `npm run build --workspace=manifest-backend`
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist `reasoning_content` across backend instances to fix DeepSeek tool-call follow-ups in multi-node deployments. Adds a short-lived Postgres-backed shared cache and re-injects cached content before forwarding to compatible providers.

- **Bug Fixes**
  - Added shared cache in Postgres (`reasoning_content_cache`) with a short TTL, keeping the in-memory cache as the fast path.
  - Re-inject `reasoning_content` in OpenAI-format requests via `ProxyFallbackService` when forwarding to compatible models; skipped for strict providers.
  - Coverage added for persistence, reinjection, and fallback behavior.

- **Migration**
  - Introduces table `reasoning_content_cache` and index on `expires_at` via migration `1790100000000-AddReasoningContentCache`; entity wired in the backend.
  - Run database migrations on deploy.

<sup>Written for commit 86385517be22923c0fcd3279425cd2fcd0d0f403. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2008?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

