### PR TITLE
fix(proxy): guard DeepSeek image inputs

### DIFF
--- a/.changeset/deepseek-image-input-guard.md
+++ b/.changeset/deepseek-image-input-guard.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Avoid forwarding image-bearing requests to DeepSeek; use configured fallbacks when available and otherwise return a Manifest error explaining that the selected route does not support image input.

--- a/packages/backend/src/common/errors/error-codes.ts
+++ b/packages/backend/src/common/errors/error-codes.ts
@@ -58,6 +58,11 @@ export const MANIFEST_ERRORS = {
     title: 'Messages array too long',
     template: '`messages` array exceeds maximum length of {max}.',
   },
+  M302: {
+    title: 'Image input unsupported by provider',
+    template:
+      '{provider} model {model} does not support image inputs. Pick a vision-capable route or add a fallback here: {dashboardUrl}',
+  },
   M500: {
     title: 'Internal server error',
     template: 'Something broke on our end. Try again in a moment.',

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -275,6 +275,81 @@ describe('ProxyService — orchestration', () => {
     });
   });
 
+  describe('image input compatibility', () => {
+    const anthropicImageBody = {
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1024,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            { type: 'image', source: { type: 'url', url: 'https://example.test/image.png' } },
+          ],
+        },
+      ],
+      stream: false,
+    };
+
+    it('returns a friendly error instead of forwarding Anthropic image input to DeepSeek', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('deepseek', 'api_key', 'deepseek-v4-flash'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+
+      const result = await svc.proxyRequest(
+        baseOpts({ body: anthropicImageBody as never, apiMode: 'messages' }),
+      );
+      const body = await result.forward.response.text();
+
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(fallbackService.tryFallbacks).not.toHaveBeenCalled();
+      expect(body).toContain('M302');
+      expect(body).toContain('deepseek');
+      expect(body).toContain('deepseek-v4-flash');
+    });
+
+    it('skips the DeepSeek primary and tries configured fallbacks for image input', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('deepseek', 'api_key', 'deepseek-v4-flash'),
+        fallback_routes: [route('openai', 'api_key', 'gpt-4o')],
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      fallbackService.tryFallbacks.mockResolvedValue({
+        success: {
+          forward: {
+            response: okResponse(),
+            isGoogle: false,
+            isAnthropic: false,
+            isChatGpt: false,
+          },
+          model: 'gpt-4o',
+          provider: 'openai',
+          fallbackIndex: 0,
+          authType: 'api_key',
+        },
+        failures: [],
+      } as never);
+
+      const result = await svc.proxyRequest(
+        baseOpts({ body: anthropicImageBody as never, apiMode: 'messages' }),
+      );
+
+      expect(fallbackService.tryForwardToProvider).not.toHaveBeenCalled();
+      expect(fallbackService.tryFallbacks).toHaveBeenCalled();
+      expect(result.meta.fallbackFromModel).toBe('deepseek-v4-flash');
+      expect(result.meta.provider).toBe('openai');
+      expect(result.meta.auth_type).toBe('api_key');
+    });
+  });
+
   describe('happy path forward', () => {
     it('returns the forward result and records tier momentum on a 200 non-stream response', async () => {
       resolveService.resolve.mockResolvedValue({

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -24,6 +24,7 @@ import {
   normalizeProviderModel,
   resolveApiKey,
 } from './proxy-fallback.service';
+import { resolveEndpointKey } from './provider-endpoints';
 import {
   ProxyApiMode,
   ProxyRequestOptions,
@@ -227,6 +228,32 @@ export class ProxyService {
       modelParams: primaryModelParams,
       specs: primarySpecs,
     });
+
+    if (containsImageInput(routingBody) && isDeepSeekRoute(route.provider)) {
+      this.logger.warn(
+        `Skipping DeepSeek image input: provider=${route.provider} model=${primaryModel}`,
+      );
+      const unsupportedForward = this.buildUnsupportedImageForward(route.provider, primaryModel);
+      const fallbackResult = await this.tryFallbackChain({
+        agentId,
+        userId,
+        resolved,
+        primaryModel,
+        forward: unsupportedForward,
+        body,
+        chatBody,
+        stream,
+        sessionKey,
+        signal,
+        signatureLookup,
+        thinkingLookup,
+        reasoningContentLookup,
+        apiMode,
+        paramMergeContext,
+      });
+      if (fallbackResult?.meta.fallbackFromModel) return fallbackResult;
+      return this.buildUnsupportedImageResult(stream, route.provider, primaryModel, agentName);
+    }
 
     const forward = await this.fallbackService.tryForwardToProvider({
       provider: route.provider,
@@ -659,6 +686,34 @@ export class ProxyService {
     const content = formatManifestError('M101', { dashboardUrl });
     return buildFriendlyResponse(content, stream, 'no_provider');
   }
+
+  private buildUnsupportedImageForward(provider: string, model: string): ForwardResult {
+    return {
+      response: new Response(
+        JSON.stringify({
+          error: {
+            message: `${provider} model ${model} does not support image inputs.`,
+            type: 'unsupported_image_input',
+          },
+        }),
+        { status: 400, headers: { 'content-type': 'application/json' } },
+      ),
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+    };
+  }
+
+  private buildUnsupportedImageResult(
+    stream: boolean,
+    provider: string,
+    model: string,
+    agentName?: string,
+  ): ProxyResult {
+    const dashboardUrl = getDashboardUrl(this.config, agentName, 'routing');
+    const content = formatManifestError('M302', { provider, model, dashboardUrl });
+    return buildFriendlyResponse(content, stream, 'unsupported_image_input');
+  }
 }
 
 /** Replace null content fields with empty string to avoid upstream rejections. */
@@ -666,4 +721,26 @@ function sanitizeNullContent(messages: Record<string, unknown>[]): void {
   for (const msg of messages) {
     if (msg && typeof msg === 'object' && msg.content === null) msg.content = '';
   }
+}
+
+function containsImageInput(body: Record<string, unknown>): boolean {
+  const messages = body.messages;
+  if (!Array.isArray(messages)) return false;
+  return messages.some((message) => {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return false;
+    return contentContainsImageInput((message as Record<string, unknown>).content);
+  });
+}
+
+function contentContainsImageInput(content: unknown): boolean {
+  if (!Array.isArray(content)) return false;
+  return content.some((part) => {
+    if (!part || typeof part !== 'object' || Array.isArray(part)) return false;
+    const type = (part as Record<string, unknown>).type;
+    return type === 'image_url' || type === 'input_image' || type === 'image';
+  });
+}
+
+function isDeepSeekRoute(provider: string): boolean {
+  return resolveEndpointKey(provider) === 'deepseek';
 }


### PR DESCRIPTION
## Summary
- detect image-bearing routed requests before forwarding to native DeepSeek
- skip the invalid DeepSeek primary and try configured fallback routes when present
- return a Manifest M302 friendly error when no fallback can handle the image request

## Validation
- npm ci
- npm run build --workspace=manifest-shared
- npm test --workspace=manifest-backend -- routing/proxy/__tests__/proxy.service.spec.ts common/errors/__tests__/error-codes.spec.ts --runInBand
- npm run build --workspace=manifest-backend
- npx eslint packages/backend/src/routing/proxy/proxy.service.ts packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts packages/backend/src/common/errors/error-codes.ts
- npx prettier --check packages/backend/src/routing/proxy/proxy.service.ts packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts packages/backend/src/common/errors/error-codes.ts .changeset/deepseek-image-input-guard.md
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent image-bearing requests from being sent to DeepSeek. If fallbacks exist, use them; otherwise return a friendly M302 explaining image input isn’t supported.

- **Bug Fixes**
  - Detect image inputs in `messages` and skip DeepSeek routes.
  - Try `fallback_routes` for vision-capable providers; include provider/model in meta on success.
  - Return M302 “Image input unsupported by provider” with a dashboard link when no fallback can handle it.
  - Added tests for both fallback and error paths; introduced M302 in `MANIFEST_ERRORS`.

<sup>Written for commit cc72b0dc13af6675bc914f72c88319ba45f1e9f3. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2009?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

