### PR TITLE
chore: rename Alibaba provider display name to Alibaba Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Manifest connects to **300+ models across 16 providers** plus any custom provide
   | [**xAI**](https://x.ai/) | ✅ | — | grok-4, grok-3, grok-code-fast |
   | [**DeepSeek**](https://www.deepseek.com/) | ✅ | — | deepseek-v3.2, deepseek-r1 |
   | [**Mistral**](https://mistral.ai/) | ✅ | — | mistral-large, codestral, magistral |
-  | [**Qwen** (Alibaba)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) | ✅ | — | qwen3-max, qwen3-coder, qwq-32b |
+  | [**Qwen** (Alibaba Cloud)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) | ✅ | — | qwen3-max, qwen3-coder, qwq-32b |
   | [**Moonshot** (Kimi)](https://kimi.ai/) | ✅ | — | kimi-k2, moonshot-v1-128k |
   | [**MiniMax**](https://www.minimax.io/) | ✅ | ✅ MiniMax Coding Plan | minimax-m2, abab7-chat-preview |
   | [**Z.ai** (Zhipu)](https://z.ai/) | ✅ | ✅ GLM Coding Plan | glm-4.6, glm-4.5-air |

--- a/packages/backend/src/common/constants/providers.spec.ts
+++ b/packages/backend/src/common/constants/providers.spec.ts
@@ -118,7 +118,7 @@ describe('PROVIDER_BY_ID_OR_ALIAS', () => {
     const entry = PROVIDER_BY_ID_OR_ALIAS.get('alibaba') as ProviderRegistryEntry;
     expect(entry).toBeDefined();
     expect(entry.id).toBe('qwen');
-    expect(entry.displayName).toBe('Alibaba');
+    expect(entry.displayName).toBe('Alibaba Cloud');
   });
 
   it('resolves kimi alias to moonshot entry', () => {

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -401,8 +401,8 @@ describe('ProviderSelectModal', () => {
       ));
 
       fireEvent.click(screen.getByText('API Keys'));
-      fireEvent.click(screen.getByText('Alibaba'));
-      fireEvent.input(screen.getByLabelText('Alibaba API key'), {
+      fireEvent.click(screen.getByText('Alibaba Cloud'));
+      fireEvent.input(screen.getByLabelText('Alibaba Cloud API key'), {
         target: { value: VALID_QWEN_KEY },
       });
       fireEvent.click(screen.getByText('Connect'));

--- a/packages/shared/src/providers.ts
+++ b/packages/shared/src/providers.ts
@@ -46,7 +46,7 @@ export interface SharedProviderEntry {
 export const SHARED_PROVIDERS: readonly SharedProviderEntry[] = [
   {
     id: 'qwen',
-    displayName: 'Alibaba',
+    displayName: 'Alibaba Cloud',
     aliases: ['alibaba'],
     openRouterPrefixes: ['qwen', 'alibaba'],
     requiresApiKey: true,


### PR DESCRIPTION
## Summary
- Rename the `qwen` provider's user-facing `displayName` from **Alibaba** to **Alibaba Cloud** in `packages/shared/src/providers.ts` (the single source of truth shared by backend and frontend).
- Update the two test fixtures that pinned the literal string (`providers.spec.ts`, `ProviderSelectModal.test.tsx`) and the README provider table entry.
- Internal lowercase tokens (`aliases: ['alibaba']`, `openRouterPrefixes`, `isQwenProvider` checks, `Alibaba/Qwen` error message strings) are intentionally left as-is — they are ID-style or describe the technical pair, not the brand label.

## Test plan
- [x] `cd packages/shared && npx jest` — 215/215 pass
- [x] `cd packages/backend && npx jest` — 4956/4956 pass
- [x] `cd packages/frontend && npx vitest run` — 3340/3340 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the `qwen` provider display name from Alibaba to Alibaba Cloud, using `packages/shared/src/providers.ts` as the source of truth so both backend and frontend show the correct brand. Updated README and tests that referenced the old label.

<sup>Written for commit 7a3491ac08e7d74c8896a06d7613e6ea812ad872. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2011?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

