### PR TITLE
feat: add OpenAI OAuth re-auth action

### DIFF
--- a/.changeset/oauth-reauth-existing-account.md
+++ b/.changeset/oauth-reauth-existing-account.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add a renew-auth-token action for existing OpenAI OAuth subscription accounts so re-authentication updates the selected account in place.

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.ts
@@ -42,12 +42,14 @@ export class OpenaiOauthController {
   @Get('authorize')
   async authorize(
     @Query('agentName') agentName: string,
+    @Query('label') label: string | string[] | undefined,
     @CurrentUser() user: AuthUser,
     @Req() req: Request,
   ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
     }
+    const keyLabel = optionalTrimmedStringQuery(label, 'label');
     const agent = await this.resolveAgent.resolve(user.id, agentName);
     // Prefer the operator-configured BETTER_AUTH_URL so a forged Host header
     // can't redirect the OAuth flow. Fall back to the request's host:port for
@@ -55,7 +57,12 @@ export class OpenaiOauthController {
     const trustedBackendUrl = this.configService.get<string>('BETTER_AUTH_URL');
     const backendUrl = trustedBackendUrl || `${req.protocol}://${req.get('host')}`;
     try {
-      const url = await this.oauthService.generateAuthorizationUrl(agent.id, user.id, backendUrl);
+      const url = await this.oauthService.generateAuthorizationUrl(
+        agent.id,
+        user.id,
+        backendUrl,
+        keyLabel,
+      );
       return { url };
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to start OAuth callback server';

--- a/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
@@ -151,6 +151,36 @@ describe('OpenaiOauthService', () => {
       expect(svc.getPendingCount()).toBe(0);
     });
 
+    it('stores re-authenticated tokens on the requested existing label', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, {
+          access_token: 'access-renewed',
+          refresh_token: 'refresh-renewed',
+          expires_in: 3600,
+        }),
+      );
+      const url = await svc.generateAuthorizationUrl(
+        'agent-1',
+        'user-1',
+        undefined,
+        'Work account',
+      );
+      const state = new URL(url).searchParams.get('state')!;
+
+      await svc.exchangeCode(state, 'auth-code');
+
+      expect(providerService.nextOAuthLabel).not.toHaveBeenCalled();
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'openai',
+        expect.stringContaining('"t":"access-renewed"'),
+        'subscription',
+        undefined,
+        'Work account',
+      );
+    });
+
     it('throws when the token endpoint returns an error', async () => {
       fetchMock.mockResolvedValue(mockResponse(400, {}, 'invalid_grant'));
       const url = await svc.generateAuthorizationUrl('a', 'u');
@@ -222,6 +252,31 @@ describe('OpenaiOauthService', () => {
         'openai',
         expect.stringContaining('"t":"new"'),
         'subscription',
+        undefined,
+        undefined,
+      );
+    });
+
+    it('persists refreshed blobs on the requested label', async () => {
+      const blob = { t: 'old', r: 'rf', e: Date.now() + 30_000 };
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
+      );
+      const token = await svc.unwrapToken(
+        JSON.stringify(blob),
+        'agent-1',
+        'user-1',
+        'Work account',
+      );
+      expect(token).toBe('new');
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'openai',
+        expect.stringContaining('"t":"new"'),
+        'subscription',
+        undefined,
+        'Work account',
       );
     });
 

--- a/packages/backend/src/routing/oauth/openai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.ts
@@ -53,6 +53,7 @@ export class OpenaiOauthService {
     agentId: string,
     userId: string,
     backendUrl?: string,
+    label?: string,
   ): Promise<string> {
     const state = generateState();
     const { verifier, challenge } = generatePkce();
@@ -63,6 +64,7 @@ export class OpenaiOauthService {
       verifier,
       agentId,
       userId,
+      label,
       backendUrl: safeBackendUrl,
     });
     if (this.useCallbackServer) {
@@ -114,7 +116,8 @@ export class OpenaiOauthService {
       r: data.refresh_token,
       e: Date.now() + data.expires_in * 1000,
     };
-    const label = await this.providerService.nextOAuthLabel(pending.agentId, 'openai');
+    const label =
+      pending.label ?? (await this.providerService.nextOAuthLabel(pending.agentId, 'openai'));
     const { provider: savedProvider } = await this.providerService.upsertProvider(
       pending.agentId,
       pending.userId,
@@ -162,7 +165,12 @@ export class OpenaiOauthService {
   }
 
   /** Parse an OAuth blob and return a valid access token, refreshing if expired. */
-  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
+  async unwrapToken(
+    rawValue: string,
+    agentId: string,
+    userId: string,
+    label?: string,
+  ): Promise<string | null> {
     const blob = parseOAuthTokenBlob(rawValue);
     if (!blob) return null;
     if (Date.now() < blob.e - 60_000) return blob.t;
@@ -174,6 +182,8 @@ export class OpenaiOauthService {
         'openai',
         serializeOAuthTokenBlob(refreshed),
         'subscription',
+        undefined,
+        label,
       );
       this.logger.log(`OpenAI OAuth token refreshed for agent=${agentId}`);
       return refreshed.t;

--- a/packages/backend/src/routing/oauth/openai-oauth.types.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.types.ts
@@ -16,6 +16,7 @@ export interface PendingOAuth {
   verifier: string;
   agentId: string;
   userId: string;
+  label?: string;
   backendUrl: string;
   expiresAt: number;
 }

--- a/packages/backend/src/routing/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.spec.ts
@@ -56,13 +56,19 @@ describe('OpenaiOauthController', () => {
         get: jest.fn().mockReturnValue('localhost:3001'),
       } as unknown as Request;
 
-      const result = await controller.authorize('my-agent', { id: 'user-1' } as never, req);
+      const result = await controller.authorize(
+        'my-agent',
+        undefined,
+        { id: 'user-1' } as never,
+        req,
+      );
 
       expect(resolveAgent.resolve).toHaveBeenCalledWith('user-1', 'my-agent');
       expect(oauthService.generateAuthorizationUrl).toHaveBeenCalledWith(
         'agent-id-1',
         'user-1',
         'http://localhost:3001',
+        undefined,
       );
       expect(result).toEqual({ url: 'https://auth.openai.com/oauth/...' });
     });
@@ -74,7 +80,12 @@ describe('OpenaiOauthController', () => {
       } as unknown as Request;
 
       await expect(
-        controller.authorize(undefined as unknown as string, { id: 'user-1' } as never, req),
+        controller.authorize(
+          undefined as unknown as string,
+          undefined,
+          { id: 'user-1' } as never,
+          req,
+        ),
       ).rejects.toThrow(HttpException);
     });
 
@@ -84,9 +95,9 @@ describe('OpenaiOauthController', () => {
         get: jest.fn().mockReturnValue('localhost:3001'),
       } as unknown as Request;
 
-      await expect(controller.authorize('', { id: 'user-1' } as never, req)).rejects.toThrow(
-        HttpException,
-      );
+      await expect(
+        controller.authorize('', undefined, { id: 'user-1' } as never, req),
+      ).rejects.toThrow(HttpException);
     });
 
     it('throws 503 when callback server port is unavailable', async () => {
@@ -101,7 +112,7 @@ describe('OpenaiOauthController', () => {
       } as unknown as Request;
 
       await expect(
-        controller.authorize('my-agent', { id: 'user-1' } as never, req),
+        controller.authorize('my-agent', undefined, { id: 'user-1' } as never, req),
       ).rejects.toThrow(HttpException);
     });
 
@@ -115,7 +126,7 @@ describe('OpenaiOauthController', () => {
       } as unknown as Request;
 
       await expect(
-        controller.authorize('my-agent', { id: 'user-1' } as never, req),
+        controller.authorize('my-agent', undefined, { id: 'user-1' } as never, req),
       ).rejects.toThrow('Failed to start OAuth callback server');
     });
 
@@ -129,13 +140,49 @@ describe('OpenaiOauthController', () => {
         get: jest.fn().mockReturnValue('evil.example'),
       } as unknown as Request;
 
-      await controller.authorize('my-agent', { id: 'user-1' } as never, req);
+      await controller.authorize('my-agent', undefined, { id: 'user-1' } as never, req);
 
       expect(oauthService.generateAuthorizationUrl).toHaveBeenCalledWith(
         'agent-id-1',
         'user-1',
         'https://manifest.example.com',
+        undefined,
       );
+    });
+
+    it('passes an optional label for re-authenticating an existing OAuth key', async () => {
+      resolveAgent.resolve.mockResolvedValue({ id: 'agent-id-1' } as never);
+      oauthService.generateAuthorizationUrl.mockResolvedValue('https://auth.openai.com/oauth/...');
+
+      const req = {
+        protocol: 'http',
+        get: jest.fn().mockReturnValue('localhost:3001'),
+      } as unknown as Request;
+
+      await controller.authorize('my-agent', 'Work account', { id: 'user-1' } as never, req);
+
+      expect(oauthService.generateAuthorizationUrl).toHaveBeenCalledWith(
+        'agent-id-1',
+        'user-1',
+        'http://localhost:3001',
+        'Work account',
+      );
+    });
+
+    it('rejects repeated label query parameters', async () => {
+      const req = {
+        protocol: 'http',
+        get: jest.fn().mockReturnValue('localhost:3001'),
+      } as unknown as Request;
+
+      await expect(
+        controller.authorize('my-agent', ['Default', 'Work'], { id: 'user-1' } as never, req),
+      ).rejects.toMatchObject({
+        message: 'label query parameter must be a string',
+        status: HttpStatus.BAD_REQUEST,
+      });
+      expect(resolveAgent.resolve).not.toHaveBeenCalled();
+      expect(oauthService.generateAuthorizationUrl).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -770,6 +770,59 @@ describe('ProxyFallbackService', () => {
       );
     });
 
+    it('passes structured OpenAI fallback key labels into token unwrap', async () => {
+      providerKeyService.getProviderApiKey.mockResolvedValue('oauth-blob');
+      openaiOauth.unwrapToken.mockResolvedValue('access-token');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      });
+
+      const result = await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['gpt-5.2-codex'],
+        body,
+        false,
+        'sess-1',
+        'gpt-4o',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            provider: 'openai',
+            authType: 'subscription',
+            model: 'gpt-5.2-codex',
+            keyLabel: 'Work account',
+          },
+        ],
+      );
+
+      expect(result.success).not.toBeNull();
+      expect(providerKeyService.getProviderApiKey).toHaveBeenCalledWith(
+        'agent-1',
+        'openai',
+        'subscription',
+        'Work account',
+      );
+      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith(
+        'oauth-blob',
+        'agent-1',
+        'user-1',
+        'Work account',
+      );
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'access-token' }),
+      );
+    });
+
     it('does not exclude auth types for different provider', async () => {
       providerKeyService.getAuthType.mockResolvedValue('api_key');
       providerKeyService.getProviderApiKey.mockResolvedValue('sk-test');
@@ -939,7 +992,31 @@ describe('ProxyFallbackService', () => {
       );
 
       expect(result.apiKey).toBe('access-token');
-      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1');
+      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1', undefined);
+    });
+
+    it('passes key labels through to OpenAI subscription unwrap', async () => {
+      openaiOauth.unwrapToken.mockResolvedValue('access-token');
+
+      const result = await resolveApiKey(
+        'openai',
+        'blob',
+        'subscription',
+        'agent-1',
+        'user-1',
+        openaiOauth,
+        minimaxOauth,
+        anthropicOauth,
+        'Work account',
+      );
+
+      expect(result.apiKey).toBe('access-token');
+      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith(
+        'blob',
+        'agent-1',
+        'user-1',
+        'Work account',
+      );
     });
 
     it('unwraps MiniMax subscription token with resource URL', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -299,6 +299,42 @@ describe('ProxyService — orchestration', () => {
       expect(momentum.recordTier).toHaveBeenCalledWith('sess-1', 'standard');
     });
 
+    it('passes the primary OpenAI subscription key label into token unwrap', async () => {
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: {
+          provider: 'openai',
+          authType: 'subscription',
+          model: 'gpt-5.2-codex',
+          keyLabel: 'Work account',
+        },
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.getProviderApiKey.mockResolvedValue('oauth-blob');
+      openaiOauth.unwrapToken.mockResolvedValue('access-token');
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      });
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith(
+        'oauth-blob',
+        'agent-1',
+        'user-1',
+        'Work account',
+      );
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'access-token' }),
+      );
+    });
+
     it('records the specificity category when the route originates from specificity', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -217,6 +217,7 @@ export class ProxyFallbackService {
         this.openaiOauth,
         this.minimaxOauth,
         this.anthropicOauth,
+        providerKeyLabel,
       );
       const providerRegion = await this.providerKeyService.getProviderRegion(
         agentId,
@@ -463,11 +464,12 @@ export async function resolveApiKey(
   openaiOauth: OpenaiOauthService,
   minimaxOauth: MinimaxOauthService,
   anthropicOauth: AnthropicOauthService,
+  providerKeyLabel?: string,
 ): Promise<{ apiKey: string; resourceUrl?: string }> {
   if (authType === 'subscription') {
     const lower = provider.toLowerCase();
     if (lower === 'openai') {
-      const unwrapped = await openaiOauth.unwrapToken(apiKey, agentId, userId);
+      const unwrapped = await openaiOauth.unwrapToken(apiKey, agentId, userId, providerKeyLabel);
       if (unwrapped) return { apiKey: unwrapped };
     }
     if (lower === 'minimax') {

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -418,6 +418,7 @@ export class ProxyService {
       this.openaiOauth,
       this.minimaxOauth,
       this.anthropicOauth,
+      resolved.provider_key_label,
     );
     const providerRegion = await this.providerKeyService.getProviderRegion(
       agentId,

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -41,6 +41,7 @@ const OAuthDetailView: Component<Props> = (props) => {
   const [popupOpened, setPopupOpened] = createSignal(false);
   const [pasteUrl, setPasteUrl] = createSignal('');
   const [pasteError, setPasteError] = createSignal<string | null>(null);
+  const [pendingRenewLabel, setPendingRenewLabel] = createSignal<string | null>(null);
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameValue, setRenameValue] = createSignal('');
 
@@ -54,17 +55,26 @@ const OAuthDetailView: Component<Props> = (props) => {
     }
   });
 
-  const handleOAuthLogin = async () => {
+  const successMessage = (label?: string | null) =>
+    label
+      ? `${props.provDef.name} auth token renewed`
+      : `${props.provDef.name} subscription connected`;
+
+  const handleOAuthLogin = async (label?: string) => {
     props.setBusy(true);
     setPasteUrl('');
     setPasteError(null);
+    setPendingRenewLabel(label ?? null);
     try {
-      const { url } = await getOpenaiOAuthUrl(props.agentName);
+      const { url } = label
+        ? await getOpenaiOAuthUrl(props.agentName, label)
+        : await getOpenaiOAuthUrl(props.agentName);
       const popup = window.open(url, 'manifest-oauth', 'width=500,height=700');
       if (!popup) {
         toast.error(
           'Popup was blocked by your browser. Allow popups for this site, then try again.',
         );
+        setPendingRenewLabel(null);
         props.setBusy(false);
         return;
       }
@@ -74,7 +84,9 @@ const OAuthDetailView: Component<Props> = (props) => {
 
       monitorOAuthPopup(popup, {
         onSuccess: () => {
-          toast.success(`${props.provDef.name} subscription connected`);
+          toast.success(successMessage(label));
+          setPopupOpened(false);
+          setPendingRenewLabel(null);
           props.onUpdate();
         },
         onFailure: () => {
@@ -82,6 +94,7 @@ const OAuthDetailView: Component<Props> = (props) => {
         },
       });
     } catch {
+      setPendingRenewLabel(null);
       props.setBusy(false);
     }
   };
@@ -102,7 +115,9 @@ const OAuthDetailView: Component<Props> = (props) => {
       props.setBusy(true);
       setPasteError(null);
       await submitOpenaiOAuthCallback(code, state);
-      toast.success(`${props.provDef.name} subscription connected`);
+      toast.success(successMessage(pendingRenewLabel()));
+      setPopupOpened(false);
+      setPendingRenewLabel(null);
       props.onUpdate();
     } catch {
       setPasteError('Failed to exchange token. The URL may have expired — try logging in again.');
@@ -178,26 +193,22 @@ const OAuthDetailView: Component<Props> = (props) => {
 
   return (
     <>
-      <Show when={!props.connected()}>
-        <Show
-          when={popupOpened()}
-          fallback={
-            <>
-              <p class="provider-detail__hint">
-                Log in with your {props.provDef.name} account to connect your subscription.
-              </p>
-              <button
-                class="btn btn--primary provider-detail__action"
-                disabled={props.busy()}
-                onClick={handleOAuthLogin}
-              >
-                <Show when={!props.busy()} fallback={<span class="spinner" />}>
-                  Log in with {props.provDef.name}
-                </Show>
-              </button>
-            </>
-          }
+      <Show when={!props.connected() && !popupOpened()}>
+        <p class="provider-detail__hint">
+          Log in with your {props.provDef.name} account to connect your subscription.
+        </p>
+        <button
+          class="btn btn--primary provider-detail__action"
+          disabled={props.busy()}
+          onClick={() => handleOAuthLogin()}
         >
+          <Show when={!props.busy()} fallback={<span class="spinner" />}>
+            Log in with {props.provDef.name}
+          </Show>
+        </button>
+      </Show>
+      <Show when={popupOpened()}>
+        <>
           <p class="provider-detail__hint">
             A login window has opened. After you sign in, the popup will show a "can't be reached"
             page. This is expected.
@@ -247,7 +258,7 @@ const OAuthDetailView: Component<Props> = (props) => {
               </Show>
             </button>
           </div>
-        </Show>
+        </>
       </Show>
       <Show when={props.connected()}>
         {/* Multi-key list */}
@@ -274,6 +285,16 @@ const OAuthDetailView: Component<Props> = (props) => {
                               Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
                             </div>
                           </div>
+                          <button
+                            class="btn btn--outline btn--sm"
+                            style="flex-shrink: 0;"
+                            disabled={props.busy()}
+                            onClick={() => handleOAuthLogin(k.label)}
+                            aria-label={`Renew auth token for ${k.label}`}
+                            title="Renew auth token"
+                          >
+                            Renew
+                          </button>
                           <button
                             class="btn btn--outline btn--sm"
                             style="flex-shrink: 0;"
@@ -357,6 +378,15 @@ const OAuthDetailView: Component<Props> = (props) => {
               Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
             </span>
           </div>
+          <button
+            class="btn btn--outline provider-detail__action"
+            disabled={props.busy()}
+            onClick={() => handleOAuthLogin((props.activeKeys?.() ?? [])[0]?.label ?? 'Default')}
+          >
+            <Show when={!props.busy()} fallback={<span class="spinner" />}>
+              Renew auth token
+            </Show>
+          </button>
           <button
             class="btn btn--outline provider-detail__action provider-detail__disconnect"
             disabled={props.busy()}

--- a/packages/frontend/src/services/api/oauth.ts
+++ b/packages/frontend/src/services/api/oauth.ts
@@ -16,9 +16,10 @@ export interface MinimaxOAuthPollResponse {
   pollIntervalMs?: number;
 }
 
-export function getOpenaiOAuthUrl(agentName: string) {
+export function getOpenaiOAuthUrl(agentName: string, label?: string) {
   return fetchJson<{ url: string }>(`/oauth/openai/authorize`, {
     agentName,
+    ...(label ? { label } : {}),
   });
 }
 

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -64,11 +64,13 @@ function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
   };
 }
 
-function renderView(opts: {
-  connected?: boolean;
-  activeKeys?: RoutingProvider[];
-  addKeyOpen?: boolean;
-} = {}) {
+function renderView(
+  opts: {
+    connected?: boolean;
+    activeKeys?: RoutingProvider[];
+    addKeyOpen?: boolean;
+  } = {},
+) {
   const [busy, setBusy] = createSignal(false);
   const [addKeyOpen, setAddKeyOpen] = createSignal(opts.addKeyOpen ?? false);
   const onBack = vi.fn();
@@ -108,6 +110,7 @@ describe('OAuthDetailView', () => {
   it('shows "Connected via" text and Disconnect button for single-key connected state', () => {
     renderView({ connected: true, activeKeys: [makeKey()] });
     expect(screen.getByText(/Connected via ChatGPT Plus subscription/)).toBeDefined();
+    expect(screen.getByText('Renew auth token')).toBeDefined();
     expect(screen.getByText('Disconnect')).toBeDefined();
   });
 
@@ -123,20 +126,14 @@ describe('OAuthDetailView', () => {
   });
 
   it('shows "Disconnect all" button in multi-key mode', () => {
-    const keys = [
-      makeKey({ id: 'k1', label: 'A' }),
-      makeKey({ id: 'k2', label: 'B' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'A' }), makeKey({ id: 'k2', label: 'B' })];
     renderView({ connected: true, activeKeys: keys });
     expect(screen.getByText('Disconnect all')).toBeDefined();
   });
 
   it('clicking Rename shows input and saving calls renameProviderKey', async () => {
     mockRenameProviderKey.mockResolvedValue({ id: 'k1', label: 'New name', priority: 1 });
-    const keys = [
-      makeKey({ id: 'k1', label: 'Old name' }),
-      makeKey({ id: 'k2', label: 'Other' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Old name' }), makeKey({ id: 'k2', label: 'Other' })];
     const { onUpdate } = renderView({ connected: true, activeKeys: keys });
 
     const renameButtons = screen.getAllByText('Rename');
@@ -176,6 +173,34 @@ describe('OAuthDetailView', () => {
     expect(onUpdate).toHaveBeenCalled();
   });
 
+  it('single-key Renew auth token re-authenticates the existing labeled account', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView({ connected: true, activeKeys: [makeKey({ label: 'Primary' })] });
+    fireEvent.click(screen.getByText('Renew auth token'));
+
+    await waitFor(() => {
+      expect(mockGetOpenaiOAuthUrl).toHaveBeenCalledWith('test-agent', 'Primary');
+    });
+  });
+
+  it('multi-key Renew auth token targets the clicked account label', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+    const keys = [
+      makeKey({ id: 'k1', label: 'Primary' }),
+      makeKey({ id: 'k2', label: 'Secondary' }),
+    ];
+
+    renderView({ connected: true, activeKeys: keys });
+    fireEvent.click(screen.getByLabelText('Renew auth token for Secondary'));
+
+    await waitFor(() => {
+      expect(mockGetOpenaiOAuthUrl).toHaveBeenCalledWith('test-agent', 'Secondary');
+    });
+  });
+
   it('addKeyOpen effect triggers getOpenaiOAuthUrl when connected', async () => {
     mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
     vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
@@ -201,10 +226,7 @@ describe('OAuthDetailView', () => {
 
   it('Disconnect all revokes all OpenAI OAuth tokens', async () => {
     mockRevokeOpenaiOAuth.mockResolvedValue({ ok: true, notifications: [] });
-    const keys = [
-      makeKey({ id: 'k1', label: 'A' }),
-      makeKey({ id: 'k2', label: 'B' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'A' }), makeKey({ id: 'k2', label: 'B' })];
     const { onBack, onUpdate } = renderView({ connected: true, activeKeys: keys });
 
     fireEvent.click(screen.getByText('Disconnect all'));
@@ -218,10 +240,7 @@ describe('OAuthDetailView', () => {
   });
 
   it('commitRename cancels if new label is same as old', async () => {
-    const keys = [
-      makeKey({ id: 'k1', label: 'Same' }),
-      makeKey({ id: 'k2', label: 'Other' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Same' }), makeKey({ id: 'k2', label: 'Other' })];
     renderView({ connected: true, activeKeys: keys });
 
     const renameButtons = screen.getAllByText('Rename');
@@ -275,6 +294,27 @@ describe('OAuthDetailView', () => {
       expect(screen.getByText(/URL is missing the authorization code/)).toBeDefined();
     });
     expect(mockSubmitOpenaiOAuthCallback).not.toHaveBeenCalled();
+  });
+
+  it('handlePasteSubmit shows renewed-token toast for a re-auth flow', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    mockSubmitOpenaiOAuthCallback.mockResolvedValue({ ok: true });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView({ connected: true, activeKeys: [makeKey({ label: 'Primary' })] });
+    fireEvent.click(screen.getByText('Renew auth token'));
+    await waitFor(() => expect(mockGetOpenaiOAuthUrl).toHaveBeenCalled());
+
+    const input = await waitFor(() => screen.getByPlaceholderText(/localhost:1455/));
+    fireEvent.input(input, {
+      target: { value: 'http://localhost:1455/auth/callback?code=abc&state=xyz' },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(mockSubmitOpenaiOAuthCallback).toHaveBeenCalledWith('abc', 'xyz');
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith('OpenAI auth token renewed');
   });
 
   it('handlePasteSubmit shows error when exchange fails', async () => {
@@ -409,10 +449,7 @@ describe('OAuthDetailView', () => {
 
   it('commitRename catch branch when renameProviderKey fails', async () => {
     mockRenameProviderKey.mockRejectedValue(new Error('network'));
-    const keys = [
-      makeKey({ id: 'k1', label: 'Old name' }),
-      makeKey({ id: 'k2', label: 'Other' }),
-    ];
+    const keys = [makeKey({ id: 'k1', label: 'Old name' }), makeKey({ id: 'k2', label: 'Other' })];
     const { onUpdate } = renderView({ connected: true, activeKeys: keys });
 
     const renameButtons = screen.getAllByText('Rename');

--- a/packages/frontend/tests/services/api/oauth.test.ts
+++ b/packages/frontend/tests/services/api/oauth.test.ts
@@ -34,6 +34,14 @@ describe('oauth API client', () => {
     expect(url).toContain('agentName=demo');
   });
 
+  it('getOpenaiOAuthUrl forwards the optional provider key label', async () => {
+    const fetchMock = setupFetch({ url: 'https://example.com' });
+    await oauth.getOpenaiOAuthUrl('demo', 'Work account');
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('agentName=demo');
+    expect(url).toContain('label=Work+account');
+  });
+
   it('revokeOpenaiOAuth POSTs with the encoded agent name in the URL', async () => {
     const fetchMock = setupFetch({ ok: true });
     await oauth.revokeOpenaiOAuth('my agent');


### PR DESCRIPTION
## Summary

- Adds a `Renew auth token` action for existing OpenAI OAuth subscription accounts.
- Carries an optional provider key label through the OpenAI OAuth authorize state so callback exchange updates that account in place instead of creating a new connection.
- Keeps automatic OpenAI OAuth access-token refresh on expiry, and persists refreshed blobs back to the selected label for primary and fallback routes.
- Keeps the existing add-connection flow unchanged when no label is supplied.
- Makes the manual callback URL paste fallback available during connected-account re-auth flows.

Closes #2012.

## Validation

- `npm ci` (local Node v23.7.0 shows the existing engine warning because CI uses Node 24)
- `npm --workspace packages/shared run build --if-present`
- `npm --workspace packages/frontend test -- tests/services/api/oauth.test.ts tests/components/OAuthDetailView.test.tsx`
- `npm --workspace packages/backend test -- openai-oauth.controller.spec.ts oauth/openai-oauth.service.spec.ts --runInBand`
- `npm --workspace packages/backend test -- oauth/openai-oauth.service.spec.ts proxy/__tests__/proxy.service.spec.ts proxy/__tests__/proxy-fallback.service.spec.ts --runInBand`
- `npx tsc --noEmit` in `packages/backend`
- `npx tsc --noEmit` in `packages/frontend`
- `npm run build --workspace=packages/backend`
- `npm run build --workspace=packages/frontend`
- `npm run lint` (exits 0 with pre-existing warnings)
- `git diff --check`
- Local cloud-mode stack booted with fresh DB `manifest_2012_e74f88cd`; `http://localhost:3001/api/v1/health` returned healthy and `http://localhost:3000/api/v1/setup/status` returned setup status.

## Notes

The in-app browser automation tool was unavailable in this session, so local verification used the running dev stack plus HTTP smoke checks and focused UI tests.