### PR TITLE
fix: include custom tiers in message filters

### DIFF
--- a/.changeset/messages-tier-filter-custom.md
+++ b/.changeset/messages-tier-filter-custom.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show configured task-specific and custom tiers in the Messages tier filter and route those selections to the matching message-log filters.

--- a/packages/backend/src/analytics/controllers/messages.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.spec.ts
@@ -85,6 +85,9 @@ describe('MessagesController', () => {
       agent_name: undefined,
       status: undefined,
       recorded: undefined,
+      routing_tier: undefined,
+      specificity_category: undefined,
+      header_tier_id: undefined,
     });
   });
 
@@ -105,6 +108,9 @@ describe('MessagesController', () => {
       limit: 25,
       cursor: 'ts|id',
       agent_name: 'bot-1',
+      routing_tier: 'simple',
+      specificity_category: 'coding',
+      header_tier_id: 'ht-premium',
     };
     await controller.getMessages(query as never, user as never);
 
@@ -120,6 +126,9 @@ describe('MessagesController', () => {
       agent_name: 'bot-1',
       status: undefined,
       recorded: undefined,
+      routing_tier: 'simple',
+      specificity_category: 'coding',
+      header_tier_id: 'ht-premium',
     });
   });
 

--- a/packages/backend/src/analytics/controllers/messages.controller.ts
+++ b/packages/backend/src/analytics/controllers/messages.controller.ts
@@ -44,6 +44,8 @@ export class MessagesController {
       status: query.status,
       recorded: query.recorded,
       routing_tier: query.routing_tier,
+      specificity_category: query.specificity_category,
+      header_tier_id: query.header_tier_id,
     });
   }
 

--- a/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.spec.ts
@@ -103,4 +103,36 @@ describe('MessagesQueryDto', () => {
     const flat = errors.flatMap((e) => Object.values(e.constraints ?? {}));
     expect(flat.join('\n')).toMatch(/routing_tier must be one of/);
   });
+
+  it('accepts each known specificity_category value', async () => {
+    for (const category of [
+      'coding',
+      'web_browsing',
+      'data_analysis',
+      'image_generation',
+      'video_generation',
+      'social_media',
+      'email_management',
+      'calendar_management',
+      'trading',
+    ]) {
+      const dto = plainToInstance(MessagesQueryDto, { specificity_category: category });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('rejects an unknown specificity_category value', async () => {
+    const dto = plainToInstance(MessagesQueryDto, { specificity_category: 'gardening' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    const flat = errors.flatMap((e) => Object.values(e.constraints ?? {}));
+    expect(flat.join('\n')).toMatch(/specificity_category must be one of/);
+  });
+
+  it('accepts custom header tier ids', async () => {
+    const dto = plainToInstance(MessagesQueryDto, { header_tier_id: 'ht-premium' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
 });

--- a/packages/backend/src/analytics/dto/messages-query.dto.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.ts
@@ -1,6 +1,11 @@
 import { Transform, Type } from 'class-transformer';
 import { IsBoolean, IsIn, IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
-import { ALL_TIERS, type MessageTier } from 'manifest-shared';
+import {
+  ALL_TIERS,
+  SPECIFICITY_CATEGORIES,
+  type MessageTier,
+  type SpecificityCategory,
+} from 'manifest-shared';
 
 export const MESSAGE_STATUS_FILTER_VALUES = [
   'ok',
@@ -67,4 +72,14 @@ export class MessagesQueryDto {
     message: `routing_tier must be one of: ${ALL_TIERS.join(', ')}`,
   })
   routing_tier?: MessageTier;
+
+  @IsOptional()
+  @IsIn(SPECIFICITY_CATEGORIES, {
+    message: `specificity_category must be one of: ${SPECIFICITY_CATEGORIES.join(', ')}`,
+  })
+  specificity_category?: SpecificityCategory;
+
+  @IsOptional()
+  @IsString()
+  header_tier_id?: string;
 }

--- a/packages/backend/src/analytics/services/messages-query.service.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.spec.ts
@@ -598,6 +598,64 @@ describe('MessagesQueryService', () => {
     expect(tierCall?.[1]).toEqual({ tierFilter: 'playground' });
   });
 
+  it('passes specificity_category filter through to the query builder', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 1 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-1', timestamp: '2026-04-24 10:00:00', model: 'gpt-4o-mini', cost: 0 },
+      ])
+      .mockResolvedValueOnce([{ model: 'gpt-4o-mini' }]);
+
+    const mockQb = (
+      service as unknown as { turnRepo: { createQueryBuilder: jest.Mock } }
+    ).turnRepo.createQueryBuilder();
+    const andWhereSpy = mockQb.andWhere as jest.Mock;
+    andWhereSpy.mockClear();
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      specificity_category: 'coding',
+    });
+
+    expect(result.total_count).toBe(1);
+    const specificityCall = andWhereSpy.mock.calls.find(
+      ([clause]) => typeof clause === 'string' && clause.includes('specificity_category'),
+    );
+    expect(specificityCall).toBeDefined();
+    expect(specificityCall?.[1]).toEqual({ specificityFilter: 'coding' });
+  });
+
+  it('passes header_tier_id filter through to the query builder', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 1 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-1', timestamp: '2026-04-24 10:00:00', model: 'gpt-4o-mini', cost: 0 },
+      ])
+      .mockResolvedValueOnce([{ model: 'gpt-4o-mini' }]);
+
+    const mockQb = (
+      service as unknown as { turnRepo: { createQueryBuilder: jest.Mock } }
+    ).turnRepo.createQueryBuilder();
+    const andWhereSpy = mockQb.andWhere as jest.Mock;
+    andWhereSpy.mockClear();
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      header_tier_id: 'ht-premium',
+    });
+
+    expect(result.total_count).toBe(1);
+    const headerTierCall = andWhereSpy.mock.calls.find(
+      ([clause]) => typeof clause === 'string' && clause.includes('header_tier_id'),
+    );
+    expect(headerTierCall).toBeDefined();
+    expect(headerTierCall?.[1]).toEqual({ headerTierFilter: 'ht-premium' });
+  });
+
   it('different routing_tier values produce different count cache keys', async () => {
     mockGetRawOne.mockResolvedValueOnce({ total: 3 });
     mockGetRawMany

--- a/packages/backend/src/analytics/services/messages-query.service.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.ts
@@ -47,6 +47,8 @@ export class MessagesQueryService {
     status?: MessageStatusFilter;
     recorded?: boolean;
     routing_tier?: string;
+    specificity_category?: string;
+    header_tier_id?: string;
   }) {
     const tenantId = (await this.tenantCache.resolve(params.userId)) ?? undefined;
     const baseQb = await this.buildBaseMessageQuery(params, tenantId);
@@ -110,6 +112,8 @@ export class MessagesQueryService {
       status?: MessageStatusFilter;
       recorded?: boolean;
       routing_tier?: string;
+      specificity_category?: string;
+      header_tier_id?: string;
     },
     tenantId: string | undefined,
   ): Promise<SelectQueryBuilder<AgentMessage>> {
@@ -150,6 +154,18 @@ export class MessagesQueryService {
 
     if (params.routing_tier) {
       qb.andWhere('at.routing_tier = :tierFilter', { tierFilter: params.routing_tier });
+    }
+
+    if (params.specificity_category) {
+      qb.andWhere('at.specificity_category = :specificityFilter', {
+        specificityFilter: params.specificity_category,
+      });
+    }
+
+    if (params.header_tier_id) {
+      qb.andWhere('at.header_tier_id = :headerTierFilter', {
+        headerTierFilter: params.header_tier_id,
+      });
     }
 
     if (params.provider) {
@@ -302,6 +318,8 @@ export class MessagesQueryService {
     status?: MessageStatusFilter;
     recorded?: boolean;
     routing_tier?: string;
+    specificity_category?: string;
+    header_tier_id?: string;
   }): string {
     return [
       params.userId,
@@ -314,6 +332,8 @@ export class MessagesQueryService {
       params.status ?? '',
       params.recorded ? '1' : '',
       params.routing_tier ?? '',
+      params.specificity_category ?? '',
+      params.header_tier_id ?? '',
     ].join(':');
   }
 }

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -24,15 +24,17 @@ import { agentDisplayName } from '../services/agent-display-name.js';
 import { agentPlatform, agentCategory } from '../services/agent-platform-store.js';
 import {
   getCustomProviders,
+  getSpecificityAssignments,
   getMessages,
   getRoutingStatus,
+  listHeaderTiers,
   setMessageFeedback,
   clearMessageFeedback,
   type CustomProviderData,
 } from '../services/api.js';
 import { createCursorPagination } from '../services/cursor-pagination.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
-import { PROVIDERS } from '../services/providers.js';
+import { PROVIDERS, SPECIFICITY_STAGES } from '../services/providers.js';
 import { ALL_TIERS, TIER_LABELS_ALL } from 'manifest-shared';
 import { checkIsSelfHosted } from '../services/setup-status.js';
 import { messagePing } from '../services/sse.js';
@@ -44,6 +46,9 @@ interface MessagesData {
   total_count: number;
   providers: string[];
 }
+
+const SPECIFICITY_FILTER_PREFIX = 'specificity:';
+const HEADER_TIER_FILTER_PREFIX = 'header:';
 
 const MessageLog: Component = () => {
   const params = useParams<{ agentName: string }>();
@@ -126,6 +131,16 @@ const MessageLog: Component = () => {
     (name) => getRoutingStatus(decodeURIComponent(name)),
   );
 
+  const [specificityAssignments] = createResource(
+    () => params.agentName,
+    (name) => getSpecificityAssignments(decodeURIComponent(name)),
+  );
+
+  const [headerTiers] = createResource(
+    () => params.agentName,
+    (name) => listHeaderTiers(decodeURIComponent(name)),
+  );
+
   const hasProviders = () => routingStatus()?.enabled === true;
 
   /** Map custom:<uuid> → provider display name */
@@ -173,7 +188,15 @@ const MessageLog: Component = () => {
     (p) => {
       const q: Record<string, string> = {};
       if (p.provider) q.provider = p.provider;
-      if (p.tier) q.routing_tier = p.tier;
+      if (p.tier) {
+        if (p.tier.startsWith(SPECIFICITY_FILTER_PREFIX)) {
+          q.specificity_category = p.tier.slice(SPECIFICITY_FILTER_PREFIX.length);
+        } else if (p.tier.startsWith(HEADER_TIER_FILTER_PREFIX)) {
+          q.header_tier_id = p.tier.slice(HEADER_TIER_FILTER_PREFIX.length);
+        } else {
+          q.routing_tier = p.tier;
+        }
+      }
       if (p.costMin) q.cost_min = p.costMin;
       if (p.costMax) q.cost_max = p.costMax;
       if (p.agentName) q.agent_name = p.agentName;
@@ -220,10 +243,29 @@ const MessageLog: Component = () => {
     setCostMax('');
   };
 
-  const tierOptions = [
+  const activeSpecificityCategories = createMemo(
+    () =>
+      new Set(
+        (specificityAssignments() ?? [])
+          .filter((assignment) => assignment.is_active)
+          .map((assignment) => assignment.category),
+      ),
+  );
+
+  const tierOptions = createMemo(() => [
     { label: 'All tiers', value: '' },
     ...ALL_TIERS.map((t) => ({ label: TIER_LABELS_ALL[t], value: t })),
-  ];
+    ...SPECIFICITY_STAGES.filter((stage) => activeSpecificityCategories().has(stage.id)).map(
+      (stage) => ({
+        label: stage.label,
+        value: `${SPECIFICITY_FILTER_PREFIX}${stage.id}`,
+      }),
+    ),
+    ...(headerTiers() ?? []).map((tier) => ({
+      label: tier.name,
+      value: `${HEADER_TIER_FILTER_PREFIX}${tier.id}`,
+    })),
+  ]);
 
   /** Resolve provider ID to display name */
   const providerDisplayName = (id: string): string => {
@@ -272,7 +314,7 @@ const MessageLog: Component = () => {
               onChange={setProviderFilter}
               options={providerOptions()}
             />
-            <Select value={tierFilter()} onChange={setTierFilter} options={tierOptions} />
+            <Select value={tierFilter()} onChange={setTierFilter} options={tierOptions()} />
             <div class="cost-range-filter">
               <input
                 type="number"

--- a/packages/frontend/src/services/api.ts
+++ b/packages/frontend/src/services/api.ts
@@ -4,6 +4,7 @@ export * from './api/messages.js';
 export * from './api/analytics.js';
 export * from './api/routing.js';
 export * from './api/specificity.js';
+export * from './api/header-tiers.js';
 export * from './api/notifications.js';
 export * from './api/oauth.js';
 export * from './api/free-models.js';

--- a/packages/frontend/src/services/api/messages.ts
+++ b/packages/frontend/src/services/api/messages.ts
@@ -112,6 +112,8 @@ export function getMessages(
     cost_max?: string;
     recorded?: string;
     routing_tier?: string;
+    specificity_category?: string;
+    header_tier_id?: string;
   } = {},
 ) {
   return fetchJson('/messages', params);

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -16,16 +16,20 @@ vi.mock("@solidjs/meta", () => ({
 
 const mockGetMessages = vi.fn();
 const mockGetCustomProviders = vi.fn();
+const mockGetSpecificityAssignments = vi.fn();
 const mockGetMessageDetails = vi.fn();
 const mockGetRoutingStatus = vi.fn();
+const mockListHeaderTiers = vi.fn();
 const mockSetMessageFeedback = vi.fn();
 const mockClearMessageFeedback = vi.fn();
 const mockDeleteMessageRecording = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getMessages: (...args: unknown[]) => mockGetMessages(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
+  getSpecificityAssignments: (...args: unknown[]) => mockGetSpecificityAssignments(...args),
   getMessageDetails: (...args: unknown[]) => mockGetMessageDetails(...args),
   getRoutingStatus: (...args: unknown[]) => mockGetRoutingStatus(...args),
+  listHeaderTiers: (...args: unknown[]) => mockListHeaderTiers(...args),
   setMessageFeedback: (...args: unknown[]) => mockSetMessageFeedback(...args),
   clearMessageFeedback: (...args: unknown[]) => mockClearMessageFeedback(...args),
   deleteMessageRecording: (...args: unknown[]) => mockDeleteMessageRecording(...args),
@@ -129,7 +133,9 @@ describe("MessageLog", () => {
     localStorage.clear();
     mockAgentName = "test-agent";
     mockGetCustomProviders.mockResolvedValue([]);
+    mockGetSpecificityAssignments.mockResolvedValue([]);
     mockGetRoutingStatus.mockResolvedValue({ enabled: false });
+    mockListHeaderTiers.mockResolvedValue([]);
   });
 
   it("renders Messages heading", () => {
@@ -1154,6 +1160,35 @@ describe("MessageLog", () => {
       expect(tierSelect.textContent).toContain("Simple");
     });
 
+    it("adds active task-specific categories and defined custom tiers to the tier options", async () => {
+      mockGetMessages.mockResolvedValue(messagesData);
+      mockGetSpecificityAssignments.mockResolvedValue([
+        { category: "coding", is_active: true },
+        { category: "trading", is_active: false },
+      ]);
+      mockListHeaderTiers.mockResolvedValue([
+        { id: "ht-premium", name: "Premium", enabled: true, sort_order: 0 },
+        { id: "ht-legacy", name: "Legacy", enabled: false, sort_order: 1 },
+      ]);
+
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const tierSelect = container.querySelectorAll(
+          '[data-testid="select"]',
+        )[1] as HTMLSelectElement;
+        expect(tierSelect.textContent).toContain("Coding");
+        expect(tierSelect.textContent).toContain("Premium");
+      });
+
+      const tierSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[1] as HTMLSelectElement;
+      expect(tierSelect.textContent).not.toContain("Trading");
+      expect(tierSelect.textContent).toContain("Legacy");
+      expect(tierSelect.textContent).not.toContain("Task:");
+      expect(tierSelect.textContent).not.toContain("Custom:");
+    });
+
     it("sends routing_tier in the query when a tier is selected", async () => {
       mockGetMessages.mockResolvedValue(messagesData);
       const { container } = render(() => <MessageLog />);
@@ -1171,6 +1206,56 @@ describe("MessageLog", () => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
         expect(lastQ.routing_tier).toBe("playground");
+      });
+    });
+
+    it("sends specificity_category in the query when a task category is selected", async () => {
+      mockGetMessages.mockResolvedValue(messagesData);
+      mockGetSpecificityAssignments.mockResolvedValue([{ category: "coding", is_active: true }]);
+
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelectorAll('[data-testid="select"]').length).toBeGreaterThanOrEqual(
+          2,
+        );
+      });
+
+      const tierSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[1] as HTMLSelectElement;
+      mockGetMessages.mockClear();
+      fireEvent.change(tierSelect, { target: { value: "specificity:coding" } });
+
+      await vi.waitFor(() => {
+        const calls = mockGetMessages.mock.calls;
+        const lastQ = calls[calls.length - 1]?.[0] ?? {};
+        expect(lastQ.specificity_category).toBe("coding");
+        expect(lastQ.routing_tier).toBeUndefined();
+      });
+    });
+
+    it("sends header_tier_id in the query when a custom tier is selected", async () => {
+      mockGetMessages.mockResolvedValue(messagesData);
+      mockListHeaderTiers.mockResolvedValue([{ id: "ht-premium", name: "Premium" }]);
+
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelectorAll('[data-testid="select"]').length).toBeGreaterThanOrEqual(
+          2,
+        );
+      });
+
+      const tierSelect = container.querySelectorAll(
+        '[data-testid="select"]',
+      )[1] as HTMLSelectElement;
+      mockGetMessages.mockClear();
+      fireEvent.change(tierSelect, { target: { value: "header:ht-premium" } });
+
+      await vi.waitFor(() => {
+        const calls = mockGetMessages.mock.calls;
+        const lastQ = calls[calls.length - 1]?.[0] ?? {};
+        expect(lastQ.header_tier_id).toBe("ht-premium");
+        expect(lastQ.routing_tier).toBeUndefined();
       });
     });
   });


### PR DESCRIPTION
## Summary
- show active task-specific categories and configured custom header tiers in the Messages tier filter using their normal UI labels
- send task/custom tier selections as `specificity_category` or `header_tier_id` instead of `routing_tier`
- apply the new filters in backend message queries and count cache keys
- add focused frontend/backend coverage plus a patch changeset

## Validation
- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/frontend -- MessageLog.test.tsx`
- `npm test --workspace=packages/backend -- --runInBand analytics/dto/messages-query.dto.spec.ts analytics/controllers/messages.controller.spec.ts analytics/services/messages-query.service.spec.ts`
- `npx tsc --noEmit` in `packages/frontend`
- `npx tsc --noEmit` in `packages/backend`
- `npx eslint packages/frontend/src/pages/MessageLog.tsx packages/frontend/src/services/api.ts packages/frontend/src/services/api/messages.ts packages/backend/src/analytics/controllers/messages.controller.ts packages/backend/src/analytics/dto/messages-query.dto.ts packages/backend/src/analytics/services/messages-query.service.ts`
- `git diff --check`

## Notes
- Includes `.changeset/messages-tier-filter-custom.md` as a patch changeset.
- Browser smoke against seeded local demo confirmed unprefixed labels: `Coding`, `Data Analysis`, `Priority Support`, `Internal Tools`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Messages tier filter to include task-specific categories and custom header tiers, and sends the right params to the backend. This makes filtering accurate and keeps UI labels clean.

- Bug Fixes
  - UI: show active task categories and defined header tiers in the tier dropdown with normal labels (e.g., “Coding”, “Premium”).
  - Frontend/API: map selections to `specificity_category` or `header_tier_id` (fallback to `routing_tier`); update `getMessages` query params.
  - Backend: accept/validate `specificity_category` and `header_tier_id`, apply them in queries, and include them in count cache keys.

<sup>Written for commit 58dd78ca244c07062cfbcb799834fa77cc7c45ef. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2016?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

