### PR TITLE
fix: resolve modelparams provider aliases

### DIFF
--- a/.changeset/mps-provider-aliases.md
+++ b/.changeset/mps-provider-aliases.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Resolve modelparams.dev provider aliases such as Z.ai's `z-ai` catalog ID when loading configurable model parameters.

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -122,6 +122,39 @@ describe('ProviderParamSpecService', () => {
     ]);
   });
 
+  it('canonicalizes provider aliases when listing model identities', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({
+        models: [
+          {
+            provider: 'z-ai',
+            authType: 'subscription',
+            model: 'glm-5',
+            params: [
+              {
+                path: 'max_tokens',
+                type: 'integer',
+                label: 'Max tokens',
+                description: 'Upper bound on generated tokens.',
+                group: 'generation_length',
+                range: { min: 1 },
+              },
+            ],
+          },
+        ],
+      }),
+    } as unknown as Response);
+    const service = new ProviderParamSpecService();
+    await service.refreshCache();
+
+    expect(service.listModelIds()).toEqual([
+      { provider: 'zai', authType: 'subscription', model: 'glm-5' },
+    ]);
+  });
+
   it('sends If-None-Match and keeps the cache on a 304 response', async () => {
     mockRemoteCatalog('"v1"');
     const service = new ProviderParamSpecService();

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -6,6 +6,7 @@ import {
   getProviderParamSpecs,
   isParamApplicability,
   isProviderParamPath,
+  normalizeProviderParamProviderId,
   providerParamValueIsValid,
   type AuthType,
   type JsonValue,
@@ -100,11 +101,14 @@ export class ProviderParamSpecService implements OnModuleInit {
    * downloading the whole catalog.
    */
   listModelIds(): Array<{ provider: string; authType: AuthType; model: string }> {
-    return this.specs.map((entry) => ({
-      provider: entry.provider,
-      authType: entry.authType,
-      model: entry.model,
-    }));
+    return this.specs.map((entry) => {
+      const provider = normalizeProviderParamProviderId(entry.provider);
+      return {
+        provider,
+        authType: entry.authType,
+        model: entry.model,
+      };
+    });
   }
 
   async getSpecs(

--- a/packages/shared/__tests__/provider-params-spec.spec.ts
+++ b/packages/shared/__tests__/provider-params-spec.spec.ts
@@ -13,6 +13,7 @@ import {
   setProviderParamValue,
   type ProviderParamSpecCatalog,
 } from '../src/provider-params-spec';
+import { normalizeProviderParamProviderId as normalizeProviderParamProviderIdFromBarrel } from '../src';
 
 const catalog: ProviderParamSpecCatalog = [
   {
@@ -79,6 +80,20 @@ const catalog: ProviderParamSpecCatalog = [
       },
     ],
   },
+  {
+    provider: 'z-ai',
+    authType: 'subscription',
+    model: 'glm-5.1',
+    params: [
+      {
+        path: 'max_tokens',
+        type: 'integer',
+        label: 'Max tokens',
+        description: 'Maximum tokens.',
+        group: 'generation_length',
+      },
+    ],
+  },
 ];
 
 const anthropicSpecs = getProviderParamSpecs(catalog, 'anthropic', 'api_key', 'claude-sonnet-4-6');
@@ -108,6 +123,21 @@ describe('provider-params-spec', () => {
       ).toHaveLength(4);
       expect(getProviderParamSpecs(catalog, 'anthropic', 'api_key', 'claude:sonnet/4-6')).toEqual(
         [],
+      );
+    });
+
+    it('matches catalog provider aliases against Manifest provider IDs', () => {
+      const specs = getProviderParamSpecs(catalog, 'zai', 'subscription', 'glm-5.1');
+
+      expect(specs).toHaveLength(1);
+      expect(specs[0].provider).toBe('zai');
+    });
+
+    it('exports provider alias normalization through the shared package barrel', () => {
+      expect(normalizeProviderParamProviderIdFromBarrel('zai')).toBe('zai');
+      expect(normalizeProviderParamProviderIdFromBarrel('z-ai')).toBe('zai');
+      expect(normalizeProviderParamProviderIdFromBarrel('unknown-provider')).toBe(
+        'unknown-provider',
       );
     });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -44,6 +44,7 @@ export {
   getProviderParamSpecs,
   isParamApplicability,
   isProviderParamPath,
+  normalizeProviderParamProviderId,
   omitProviderInapplicableParams,
   pickProviderCompatibleParams,
   providerParamIsApplicable,

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -1,4 +1,5 @@
 import type { AuthType } from './auth-types';
+import { normalizeProviderName, SHARED_PROVIDER_BY_ID_OR_ALIAS } from './providers';
 import type { JsonPrimitive, JsonValue } from './request-params';
 
 export type ModelParamType = 'boolean' | 'enum' | 'integer' | 'number' | 'string';
@@ -87,6 +88,15 @@ const GROUP_ORDER: readonly ModelParamGroup[] = [
 
 const UNSAFE_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
 
+export function normalizeProviderParamProviderId(providerId: string): string {
+  const lower = providerId.toLowerCase();
+  const exact = SHARED_PROVIDER_BY_ID_OR_ALIAS.get(lower);
+  if (exact) return exact.id;
+  const normalized = SHARED_PROVIDER_BY_ID_OR_ALIAS.get(normalizeProviderName(lower));
+  if (normalized) return normalized.id;
+  return lower;
+}
+
 export function getProviderParamSpecs(
   catalog: ProviderParamSpecCatalog,
   providerId: string | undefined,
@@ -94,21 +104,24 @@ export function getProviderParamSpecs(
   model: string | undefined,
 ): readonly ProviderParamSpec[] {
   if (!providerId || !authType || !model) return [];
-  const provider = providerId.toLowerCase();
+  const provider = normalizeProviderParamProviderId(providerId);
   const entry = catalog.find(
     (spec) =>
-      spec.provider.toLowerCase() === provider &&
+      normalizeProviderParamProviderId(spec.provider) === provider &&
       spec.authType === authType &&
       spec.model === model,
   );
   if (!entry) return [];
   return entry.params
-    .map((param) => ({
-      provider: entry.provider,
-      authType: entry.authType,
-      model: entry.model,
-      ...param,
-    }))
+    .map((param) => {
+      const provider = normalizeProviderParamProviderId(entry.provider);
+      return {
+        provider,
+        authType: entry.authType,
+        model: entry.model,
+        ...param,
+      };
+    })
     .sort(compareProviderParamSpecs);
 }
 


### PR DESCRIPTION
Summary
- Canonicalize modelparams.dev provider IDs with shared provider aliases during MPS lookup and model ID listing.
- Add `z-ai` as a Z.ai alias so modelparams rows resolve to Manifest `zai` routes.
- Add regression coverage and a patch changeset.

Validation
- `npm test --workspace=manifest-shared -- provider-params-spec`
- `npm run build --workspace=manifest-shared`
- `npm run build --workspace=manifest-backend`
- `npm run lint` passes with existing warnings only
- `npx prettier --check` on touched files
- `git diff --check`
- Companion lookup smoke with modelparams branch: 14 MiniMax/Z.ai known subscription routes, 0 missing specs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes provider IDs and aliases across model-params loading and listing so `z-ai` catalog entries resolve to `zai` routes and specs no longer go missing.

- Bug Fixes
  - Normalize provider IDs in `getProviderParamSpecs` (inputs and returned specs) and in backend `ProviderParamSpecService.listModelIds` via shared `normalizeProviderParamProviderId` (exported from the barrel).
  - Map `z-ai` -> `zai` using the shared provider alias map; add backend/shared regression tests and a patch changeset.

<sup>Written for commit 6cd59c7cfc7c6425fb7597fa5480fb2cc9c3d76f. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2019?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

