### PR TITLE
Normalize OpenCode Go MPS model IDs

### DIFF
--- a/.changeset/opencode-go-mps-model-normalization.md
+++ b/.changeset/opencode-go-mps-model-normalization.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Match OpenCode Go provider-prefixed route model IDs to bare modelparams.dev catalog entries when loading configurable model parameters.

--- a/packages/shared/__tests__/provider-params-spec.spec.ts
+++ b/packages/shared/__tests__/provider-params-spec.spec.ts
@@ -94,6 +94,22 @@ const catalog: ProviderParamSpecCatalog = [
       },
     ],
   },
+  {
+    provider: 'opencode-go',
+    authType: 'subscription',
+    model: 'mimo-v2.5',
+    params: [
+      {
+        path: 'temperature',
+        type: 'number',
+        label: 'Temperature',
+        description: 'Controls sampling randomness.',
+        default: 1,
+        range: { min: 0, max: 2, step: 0.1 },
+        group: 'sampling',
+      },
+    ],
+  },
 ];
 
 const anthropicSpecs = getProviderParamSpecs(catalog, 'anthropic', 'api_key', 'claude-sonnet-4-6');
@@ -131,6 +147,23 @@ describe('provider-params-spec', () => {
 
       expect(specs).toHaveLength(1);
       expect(specs[0].provider).toBe('zai');
+    });
+
+    it('matches OpenCode Go route model IDs against bare catalog model IDs', () => {
+      const specs = getProviderParamSpecs(
+        catalog,
+        'opencode-go',
+        'subscription',
+        'opencode-go/mimo-v2.5',
+      );
+
+      expect(specs).toHaveLength(1);
+      expect(specs[0]).toMatchObject({
+        provider: 'opencode-go',
+        authType: 'subscription',
+        model: 'mimo-v2.5',
+        path: 'temperature',
+      });
     });
 
     it('exports provider alias normalization through the shared package barrel', () => {

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -97,6 +97,16 @@ export function normalizeProviderParamProviderId(providerId: string): string {
   return lower;
 }
 
+function normalizeProviderParamModelId(providerId: string, model: string): string {
+  const provider = normalizeProviderParamProviderId(providerId);
+  // Manifest route IDs for OpenCode Go include the provider prefix, while the
+  // MPS catalog keeps provider and model in separate fields.
+  if (provider === 'opencode-go' && model.toLowerCase().startsWith('opencode-go/')) {
+    return model.slice('opencode-go/'.length);
+  }
+  return model;
+}
+
 export function getProviderParamSpecs(
   catalog: ProviderParamSpecCatalog,
   providerId: string | undefined,
@@ -105,11 +115,12 @@ export function getProviderParamSpecs(
 ): readonly ProviderParamSpec[] {
   if (!providerId || !authType || !model) return [];
   const provider = normalizeProviderParamProviderId(providerId);
+  const modelId = normalizeProviderParamModelId(provider, model);
   const entry = catalog.find(
     (spec) =>
       normalizeProviderParamProviderId(spec.provider) === provider &&
       spec.authType === authType &&
-      spec.model === model,
+      normalizeProviderParamModelId(spec.provider, spec.model) === modelId,
   );
   if (!entry) return [];
   return entry.params


### PR DESCRIPTION
## Summary
- Match `opencode-go/<model-id>` route model strings against bare modelparams.dev catalog model IDs for OpenCode Go.
- Keep saved route identities unchanged, so existing per-route params remain scoped to the actual Manifest route.
- Add a patch changeset and a focused shared regression test.

## Why
The modelparams.dev catalog cannot store slash-delimited model IDs. The companion catalog PR adds `provider: opencode-go`, `model: mimo-v2.5`, but Manifest discovers/routes OpenCode Go models as `opencode-go/mimo-v2.5`. Without this normalization, the catalog row exists but the app cannot load it for the routed model.

Companion catalog PR: https://github.com/mnfst/modelparams.dev/pull/32

## Validation
- `npm ci`
- `npm --workspace packages/shared test -- provider-params-spec.spec.ts`
- `npm --workspace packages/shared run build`
- `npm --workspace packages/backend test -- model-params.controller.spec.ts proxy.service.spec.ts proxy-fallback.service.spec.ts`
- `npx eslint packages/shared/src/provider-params-spec.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize OpenCode Go model IDs so routed IDs like `opencode-go/mimo-v2.5` match the catalog’s bare model IDs and load configurable params correctly. Route identities remain unchanged.

- **Bug Fixes**
  - Strip the `opencode-go/` prefix during spec lookup to match modelparams.dev entries.
  - Preserve saved route IDs so per-route params stay scoped to the actual Manifest route.
  - Added a focused regression test and a patch changeset.

<sup>Written for commit 11c3aa6d80c7d0e08be18b56e9d61eed03d2246d. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2020?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

