### PR TITLE
Fix Claude Code Manifest auto model setup

### DIFF
--- a/.changeset/claude-code-auto-model.md
+++ b/.changeset/claude-code-auto-model.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Set Claude Code setup snippets to use Manifest's `auto` model by default and expose it through `/v1/models`.

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -173,6 +173,23 @@ describe('ProxyController', () => {
     recorder.onModuleDestroy();
   });
 
+  it('should expose /v1/models with the Manifest auto route', () => {
+    expect(controller.models()).toEqual({
+      object: 'list',
+      data: [
+        {
+          id: 'auto',
+          object: 'model',
+          type: 'model',
+          display_name: 'Manifest Auto',
+        },
+      ],
+      has_more: false,
+      first_id: 'auto',
+      last_id: 'auto',
+    });
+  });
+
   it('should return JSON response for non-streaming OpenAI provider', async () => {
     const responseBody = { choices: [{ message: { content: 'hello' } }] };
     const mockProviderResp = new Response(JSON.stringify(responseBody), {

--- a/packages/backend/src/routing/proxy/proxy.controller.ts
+++ b/packages/backend/src/routing/proxy/proxy.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  Get,
   Post,
   Req,
   Res,
@@ -59,6 +60,24 @@ export class ProxyController {
     private readonly reasoningCache: ReasoningContentCache,
     private readonly recordingCache: AgentRecordingCacheService,
   ) {}
+
+  @Get('models')
+  models(): Record<string, unknown> {
+    return {
+      object: 'list',
+      data: [
+        {
+          id: 'auto',
+          object: 'model',
+          type: 'model',
+          display_name: 'Manifest Auto',
+        },
+      ],
+      has_more: false,
+      first_id: 'auto',
+      last_id: 'auto',
+    };
+  }
 
   @Post('chat/completions')
   async chatCompletions(

--- a/packages/frontend/src/components/ClaudeCodeSetup.tsx
+++ b/packages/frontend/src/components/ClaudeCodeSetup.tsx
@@ -53,7 +53,8 @@ const ClaudeCodeSetup: Component<Props> = (props) => {
     <div class="setup-agents-card">
       <p class="setup-method__hint">
         Add this block to <code class="setup-model-hint__code">~/.claude/settings.json</code> —
-        every <code class="setup-model-hint__code">claude</code> run will route through Manifest.
+        every <code class="setup-model-hint__code">claude</code> run will route through Manifest
+        with <code class="setup-model-hint__code">auto</code>.
       </p>
 
       <div class="setup-cli-block">

--- a/packages/frontend/src/services/framework-snippets.ts
+++ b/packages/frontend/src/services/framework-snippets.ts
@@ -339,12 +339,15 @@ openclaw gateway restart`;
  * The JSON block to paste into ~/.claude/settings.json. Claude Code reads
  * `env` keys from settings.json on every startup, so this is the persistent
  * configuration path — no shell rc edits, no Node required, no command-line
- * gymnastics. Anthropic SDK auto-appends /v1/messages to baseURL, so we
- * strip a trailing /v1 from the rendered URL.
+ * gymnastics. Pin the default model to Manifest's `auto` route so Claude
+ * Code does not send its built-in Anthropic model IDs to the gateway.
+ * Anthropic SDK auto-appends /v1/messages to baseURL, so we strip a trailing
+ * /v1 from the rendered URL.
  */
 export function getClaudeCodeSettingsSnippet(baseUrl: string, apiKey: string): string {
   const url = stripV1Suffix(baseUrl);
   return `{
+  "model": "auto",
   "env": {
     "ANTHROPIC_BASE_URL": "${url}",
     "ANTHROPIC_AUTH_TOKEN": "${apiKey}"

--- a/packages/frontend/tests/components/ClaudeCodeSetup.test.tsx
+++ b/packages/frontend/tests/components/ClaudeCodeSetup.test.tsx
@@ -24,11 +24,13 @@ describe("ClaudeCodeSetup", () => {
     const labels = Array.from(codes).map((c) => c.textContent);
     expect(labels).toContain("~/.claude/settings.json");
     expect(labels).toContain("claude");
+    expect(labels).toContain("auto");
   });
 
-  it("renders the JSON env block with ANTHROPIC vars", () => {
+  it("renders the JSON settings block with Manifest auto model and ANTHROPIC vars", () => {
     const { container } = render(() => <ClaudeCodeSetup {...baseProps} />);
     const text = container.textContent ?? "";
+    expect(text).toContain('"model": "auto"');
     expect(text).toContain('"env"');
     expect(text).toContain("ANTHROPIC_BASE_URL");
     expect(text).toContain("ANTHROPIC_AUTH_TOKEN");
@@ -92,6 +94,7 @@ describe("ClaudeCodeSetup", () => {
     fireEvent.click(copyButton!);
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText.mock.calls[0][0]).toContain("mnfst_full_secret_value");
+    expect(writeText.mock.calls[0][0]).toContain('"model": "auto"');
     void copyBtn;
   });
 

--- a/packages/frontend/tests/services/framework-snippets.test.ts
+++ b/packages/frontend/tests/services/framework-snippets.test.ts
@@ -283,6 +283,7 @@ describe("getClaudeCodeSettingsSnippet", () => {
     // Strict-parse to make sure it's valid JSON and shaped correctly.
     const parsed = JSON.parse(snippet);
     expect(parsed).toEqual({
+      model: "auto",
       env: {
         ANTHROPIC_BASE_URL: "http://localhost:38240",
         ANTHROPIC_AUTH_TOKEN: "mnfst_key",


### PR DESCRIPTION
## Summary

- set the Claude Code setup snippet to persist `"model": "auto"` alongside the Manifest gateway env vars
- mention `auto` in the Claude Code setup UI copy
- expose `GET /v1/models` with Manifest Auto so Claude Code gateway discovery does not receive a 404

## Why

Claude Code can keep or discover built-in Anthropic model IDs such as `claude-opus-4-7[1m]`. When it is configured to use Manifest as an Anthropic-compatible gateway, those IDs can be sent to Manifest instead of the intended `auto` route. The setup snippet now pins new sessions to `auto`, and `/v1/models` advertises the supported Manifest model.

## Validation

- `npm ci`
- `npm run build --workspace packages/shared`
- `npm run test --workspace packages/frontend -- ClaudeCodeSetup.test.tsx`
- `npm run test --workspace packages/backend -- proxy.controller.spec.ts`
- `npm exec --workspace packages/frontend -- eslint src/components/ClaudeCodeSetup.tsx src/services/framework-snippets.ts`
- `npm exec --workspace packages/backend -- eslint src/routing/proxy/proxy.controller.ts src/routing/proxy/__tests__/proxy.controller.spec.ts` (passes with two existing `no-explicit-any` warnings in the backend proxy test)
- `npx prettier --check packages/backend/src/routing/proxy/proxy.controller.ts packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts packages/frontend/src/components/ClaudeCodeSetup.tsx packages/frontend/src/services/framework-snippets.ts .changeset/claude-code-auto-model.md`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Claude Code to Manifest’s `auto` model and expose `/v1/models` so gateway discovery works without 404s. Prevents Anthropic model IDs from bypassing the `auto` route.

- **Bug Fixes**
  - Default `"model": "auto"` in the settings snippet for `~/.claude/settings.json`.
  - Update setup UI copy to mention `auto`.
  - Add `GET /v1/models` returning the `auto` model.
  - Update backend and frontend tests to cover the settings snippet and `/v1/models`.

<sup>Written for commit bf641a12e3935cea7189296df6f9fab347a511e3. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2021?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

