### PR TITLE
fix: raise custom provider model cap

### DIFF
--- a/.changeset/custom-provider-model-cap.md
+++ b/.changeset/custom-provider-model-cap.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Increase the custom provider model catalog limit from 50 to 500 models.

--- a/packages/backend/src/routing/dto/custom-provider.dto.spec.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.spec.ts
@@ -6,6 +6,7 @@ import {
   ProbeCustomProviderDto,
   UpdateCustomProviderDto,
   CustomProviderModelDto,
+  CUSTOM_PROVIDER_MODEL_LIMIT,
 } from './custom-provider.dto';
 
 function toDto(data: Record<string, unknown>): CreateCustomProviderDto {
@@ -14,6 +15,10 @@ function toDto(data: Record<string, unknown>): CreateCustomProviderDto {
 
 function toUpdateDto(data: Record<string, unknown>): UpdateCustomProviderDto {
   return plainToInstance(UpdateCustomProviderDto, data);
+}
+
+function makeModels(count: number): CustomProviderModelDto[] {
+  return Array.from({ length: count }, (_, i) => ({ model_name: `model-${i + 1}` }));
 }
 
 describe('CreateCustomProviderDto', () => {
@@ -107,6 +112,26 @@ describe('CreateCustomProviderDto', () => {
     expect(errors.length).toBeGreaterThan(0);
   });
 
+  it('accepts large custom provider catalogs', async () => {
+    const dto = toDto({
+      name: 'Mammouth',
+      base_url: 'https://api.mammouth.ai/v1',
+      models: makeModels(73),
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects custom provider catalogs above the configured limit', async () => {
+    const dto = toDto({
+      name: 'Too Large',
+      base_url: 'https://api.example.com/v1',
+      models: makeModels(CUSTOM_PROVIDER_MODEL_LIMIT + 1),
+    });
+    const errors = await validate(dto);
+    expect(errors.some((e) => e.property === 'models')).toBe(true);
+  });
+
   it('rejects missing base_url', async () => {
     const dto = toDto({
       name: 'Test',
@@ -148,6 +173,14 @@ describe('UpdateCustomProviderDto', () => {
   it('accepts partial update with only models', async () => {
     const dto = toUpdateDto({
       models: [{ model_name: 'model-a' }],
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts large model catalog updates', async () => {
+    const dto = toUpdateDto({
+      models: makeModels(73),
     });
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);

--- a/packages/backend/src/routing/dto/custom-provider.dto.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.ts
@@ -18,6 +18,8 @@ import { Type } from 'class-transformer';
 
 export const CUSTOM_PROVIDER_API_KINDS = ['openai', 'anthropic'] as const;
 export type CustomProviderApiKindDto = (typeof CUSTOM_PROVIDER_API_KINDS)[number];
+export const CUSTOM_PROVIDER_MODEL_LIMIT = 500;
+
 export class CustomProviderModelDto {
   @IsString()
   @IsNotEmpty()
@@ -68,7 +70,7 @@ export class CreateCustomProviderDto {
 
   @IsArray()
   @ArrayMinSize(1)
-  @ArrayMaxSize(50)
+  @ArrayMaxSize(CUSTOM_PROVIDER_MODEL_LIMIT)
   @ValidateNested({ each: true })
   @Type(() => CustomProviderModelDto)
   models!: CustomProviderModelDto[];
@@ -117,7 +119,7 @@ export class UpdateCustomProviderDto {
   @IsOptional()
   @IsArray()
   @ArrayMinSize(1)
-  @ArrayMaxSize(50)
+  @ArrayMaxSize(CUSTOM_PROVIDER_MODEL_LIMIT)
   @ValidateNested({ each: true })
   @Type(() => CustomProviderModelDto)
   models?: CustomProviderModelDto[];


### PR DESCRIPTION
## Summary
- increase the custom provider model catalog limit from 50 to 500
- reuse the exported limit for create and update DTO validation
- add focused DTO coverage for 73-model catalogs and over-limit rejection

## Context
Discussion #973 raised that providers such as Mammouth.ai can expose more than 50 models, which makes the current custom provider cap too low for bulk model imports.

## Validation
- `npm test --workspace=packages/backend -- custom-provider.dto.spec.ts`
- `npx prettier --check packages/backend/src/routing/dto/custom-provider.dto.ts packages/backend/src/routing/dto/custom-provider.dto.spec.ts .changeset/custom-provider-model-cap.md`
- `npx eslint packages/backend/src/routing/dto/custom-provider.dto.ts packages/backend/src/routing/dto/custom-provider.dto.spec.ts`
- `npm run build --workspace=packages/shared`
- `npm run build --workspace=packages/backend`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the custom provider model catalog limit from 50 to 500 to support bulk imports from providers with large model lists. Applies to both create and update DTO validation in `packages/backend`.

- **Bug Fixes**
  - Centralize the limit in `CUSTOM_PROVIDER_MODEL_LIMIT` and use it in both DTOs.
  - Add DTO tests for 73-model catalogs and over-limit rejection.

<sup>Written for commit 802869f98ddd534a6eafd7fd8e110b053a866661. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2023?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

