### PR TITLE
feat: auto-fill custom provider prices from models.dev

### DIFF
--- a/.changeset/modelsdev-custom-provider-prices.md
+++ b/.changeset/modelsdev-custom-provider-prices.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Auto-fill custom provider model prices from models.dev when the provider name and model IDs match.

--- a/.changeset/modelsdev-custom-provider-prices.md
+++ b/.changeset/modelsdev-custom-provider-prices.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Auto-fill custom provider model prices from models.dev, including estimated model-only fallback prices when the custom provider is not listed there.
+Auto-fill custom provider model prices from exact models.dev provider/model matches, and mark exact model-only matches as estimated when no provider match is available.

--- a/.changeset/modelsdev-custom-provider-prices.md
+++ b/.changeset/modelsdev-custom-provider-prices.md
@@ -2,4 +2,4 @@
 'manifest': patch
 ---
 
-Auto-fill custom provider model prices from models.dev when the provider name and model IDs match.
+Auto-fill custom provider model prices from models.dev, including estimated model-only fallback prices when the custom provider is not listed there.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -1015,4 +1015,32 @@ describe('ModelsDevSyncService', () => {
       expect(service.lookupCustomProviderModel('Kilo Gateway', 'missing-model')).toBeNull();
     });
   });
+
+  describe('lookupModelAcrossProviders', () => {
+    beforeEach(async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+    });
+
+    it('should match provider-prefixed model IDs against official provider catalogs first', () => {
+      const model = service.lookupModelAcrossProviders('openai/gpt-4o');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('GPT-4o');
+      expect(model!.inputPricePerToken).toBe(2.5 / 1_000_000);
+    });
+
+    it('should fall back to exact model IDs from non-native provider catalogs', () => {
+      const model = service.lookupModelAcrossProviders('openai/gpt-4o-mini');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('GPT-4o mini');
+      expect(model!.inputPricePerToken).toBe(0.15 / 1_000_000);
+    });
+
+    it('should return null when no provider contains the model ID', () => {
+      expect(service.lookupModelAcrossProviders('missing-model')).toBeNull();
+    });
+  });
 });

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -169,6 +169,19 @@ const MOCK_API_RESPONSE = {
       },
     },
   },
+  kilo: {
+    id: 'kilo',
+    name: 'Kilo Gateway',
+    models: {
+      'openai/gpt-4o-mini': {
+        id: 'openai/gpt-4o-mini',
+        name: 'GPT-4o mini',
+        cost: { input: 0.15, output: 0.6, cache_read: 0.075 },
+        limit: { context: 128000, output: 16384 },
+        modalities: { input: ['text'], output: ['text'] },
+      },
+    },
+  },
   'unknown-provider': {
     id: 'unknown-provider',
     name: 'Unknown',
@@ -965,6 +978,41 @@ describe('ModelsDevSyncService', () => {
       const upper = service.getModelsForProvider('ANTHROPIC');
       expect(lower).toEqual(upper);
       expect(lower.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('lookupCustomProviderModel', () => {
+    beforeEach(async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => MOCK_API_RESPONSE,
+      });
+      await service.refreshCache();
+    });
+
+    it('should find arbitrary models.dev providers by display name', () => {
+      const model = service.lookupCustomProviderModel('Kilo Gateway', 'openai/gpt-4o-mini');
+      expect(model).not.toBeNull();
+      expect(model!.name).toBe('GPT-4o mini');
+      expect(model!.inputPricePerToken).toBe(0.15 / 1_000_000);
+      expect(model!.outputPricePerToken).toBe(0.6 / 1_000_000);
+      expect(model!.contextWindow).toBe(128000);
+    });
+
+    it('should normalize custom provider names and IDs', () => {
+      expect(service.lookupCustomProviderModel('kilo', 'openai/gpt-4o-mini')).not.toBeNull();
+      expect(
+        service.lookupCustomProviderModel('kilo-gateway', 'openai/gpt-4o-mini'),
+      ).not.toBeNull();
+    });
+
+    it('should keep native provider support scoped to PROVIDER_ID_MAP', () => {
+      expect(service.getModelsForProvider('kilo')).toEqual([]);
+    });
+
+    it('should return null when provider or model is missing', () => {
+      expect(service.lookupCustomProviderModel('Mammouth', 'openai/gpt-4o-mini')).toBeNull();
+      expect(service.lookupCustomProviderModel('Kilo Gateway', 'missing-model')).toBeNull();
     });
   });
 });

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import type { ModelCapability } from 'manifest-shared';
+import { normalizeProviderName, type ModelCapability } from 'manifest-shared';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
 import { capabilitiesFromModelsDev } from '../model-discovery/model-capabilities';
 
@@ -98,6 +98,10 @@ export class ModelsDevSyncService implements OnModuleInit {
   private readonly logger = new Logger(ModelsDevSyncService.name);
   /** Map: our provider ID → Map<model ID (native), entry> */
   private cache = new Map<string, Map<string, ModelsDevModelEntry>>();
+  /** Map: models.dev provider ID → Map<model ID, entry>. Includes providers Manifest does not natively know. */
+  private customProviderCache = new Map<string, Map<string, ModelsDevModelEntry>>();
+  /** Map: provider id/display-name aliases → models.dev provider ID. */
+  private customProviderIndex = new Map<string, string>();
   private lastFetchedAt: Date | null = null;
   private initialLoad: Promise<void> | null = null;
 
@@ -124,7 +128,24 @@ export class ModelsDevSyncService implements OnModuleInit {
     if (!raw) return 0;
 
     const newCache = new Map<string, Map<string, ModelsDevModelEntry>>();
+    const newCustomProviderCache = new Map<string, Map<string, ModelsDevModelEntry>>();
+    const newCustomProviderIndex = new Map<string, string>();
     let totalModels = 0;
+
+    for (const [modelsDevId, provider] of Object.entries(raw)) {
+      if (!provider?.models) continue;
+
+      const modelMap = new Map<string, ModelsDevModelEntry>();
+      for (const [modelId, model] of Object.entries(provider.models)) {
+        if (!this.isChatCompatible(model)) continue;
+        modelMap.set(modelId, this.parseModel(modelsDevId, modelId, model));
+      }
+
+      if (modelMap.size > 0) {
+        newCustomProviderCache.set(modelsDevId, modelMap);
+        this.indexCustomProvider(newCustomProviderIndex, modelsDevId, provider);
+      }
+    }
 
     for (const [ourId, modelsDevId] of Object.entries(PROVIDER_ID_MAP)) {
       const provider = raw[modelsDevId];
@@ -144,6 +165,8 @@ export class ModelsDevSyncService implements OnModuleInit {
     }
 
     this.cache = newCache;
+    this.customProviderCache = newCustomProviderCache;
+    this.customProviderIndex = newCustomProviderIndex;
     this.lastFetchedAt = new Date();
     this.logger.log(`models.dev cache loaded: ${newCache.size} providers, ${totalModels} models`);
 
@@ -165,7 +188,25 @@ export class ModelsDevSyncService implements OnModuleInit {
   lookupModel(providerId: string, modelId: string): ModelsDevModelEntry | null {
     const providerModels = this.cache.get(resolveProviderId(providerId));
     if (!providerModels) return null;
+    return this.lookupModelInProvider(providerModels, modelId);
+  }
 
+  /**
+   * Look up a model for a user-defined custom provider by matching the custom
+   * provider display name against models.dev provider IDs and names.
+   */
+  lookupCustomProviderModel(providerName: string, modelId: string): ModelsDevModelEntry | null {
+    const providerKey = this.resolveCustomProviderKey(providerName);
+    if (!providerKey) return null;
+    const providerModels = this.customProviderCache.get(providerKey);
+    if (!providerModels) return null;
+    return this.lookupModelInProvider(providerModels, modelId);
+  }
+
+  private lookupModelInProvider(
+    providerModels: Map<string, ModelsDevModelEntry>,
+    modelId: string,
+  ): ModelsDevModelEntry | null {
     // 1. Exact match
     const exact = providerModels.get(modelId);
     if (exact) return exact;
@@ -255,6 +296,16 @@ export class ModelsDevSyncService implements OnModuleInit {
     return null;
   }
 
+  private resolveCustomProviderKey(providerName: string): string | null {
+    const trimmed = providerName.trim();
+    if (!trimmed) return null;
+    return (
+      this.customProviderIndex.get(trimmed.toLowerCase()) ??
+      this.customProviderIndex.get(normalizeProviderName(trimmed)) ??
+      null
+    );
+  }
+
   /**
    * Get all models for a provider (by our internal provider ID).
    * Returns an empty array if the provider is not found.
@@ -272,6 +323,29 @@ export class ModelsDevSyncService implements OnModuleInit {
 
   getLastFetchedAt(): Date | null {
     return this.lastFetchedAt;
+  }
+
+  private indexCustomProvider(
+    index: Map<string, string>,
+    modelsDevId: string,
+    provider: RawModelsDevProvider,
+  ): void {
+    this.addCustomProviderIndexEntry(index, modelsDevId, modelsDevId);
+    if (provider.id) this.addCustomProviderIndexEntry(index, provider.id, modelsDevId);
+    if (provider.name) this.addCustomProviderIndexEntry(index, provider.name, modelsDevId);
+  }
+
+  private addCustomProviderIndexEntry(
+    index: Map<string, string>,
+    value: string,
+    modelsDevId: string,
+  ): void {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const lower = trimmed.toLowerCase();
+    if (!index.has(lower)) index.set(lower, modelsDevId);
+    const normalized = normalizeProviderName(trimmed);
+    if (!index.has(normalized)) index.set(normalized, modelsDevId);
   }
 
   private parseModel(

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -203,6 +203,36 @@ export class ModelsDevSyncService implements OnModuleInit {
     return this.lookupModelInProvider(providerModels, modelId);
   }
 
+  /**
+   * Conservative model-only fallback for custom providers that are not listed
+   * on models.dev. Prefer official provider catalogs, then exact IDs from
+   * aggregator catalogs. This is intentionally not fuzzy.
+   */
+  lookupModelAcrossProviders(modelId: string): ModelsDevModelEntry | null {
+    const providerScoped = this.lookupProviderScopedModel(modelId);
+    if (providerScoped) return providerScoped;
+
+    for (const providerModels of this.cache.values()) {
+      const found = this.lookupModelInProvider(providerModels, modelId);
+      if (found) return found;
+    }
+
+    for (const providerModels of this.customProviderCache.values()) {
+      const exact = providerModels.get(modelId);
+      if (exact) return exact;
+    }
+
+    return null;
+  }
+
+  private lookupProviderScopedModel(modelId: string): ModelsDevModelEntry | null {
+    const slash = modelId.indexOf('/');
+    if (slash <= 0 || slash === modelId.length - 1) return null;
+    const providerPart = modelId.slice(0, slash);
+    const nativeModelId = modelId.slice(slash + 1);
+    return this.lookupModel(providerPart, nativeModelId);
+  }
+
   private lookupModelInProvider(
     providerModels: Map<string, ModelsDevModelEntry>,
     modelId: string,

--- a/packages/backend/src/entities/custom-provider.entity.ts
+++ b/packages/backend/src/entities/custom-provider.entity.ts
@@ -7,6 +7,7 @@ export interface CustomProviderModel {
   input_price_per_million_tokens?: number;
   output_price_per_million_tokens?: number;
   context_window?: number;
+  price_estimated?: boolean;
 }
 
 export type CustomProviderApiKind = 'openai' | 'anthropic';

--- a/packages/backend/src/routing/custom-provider.controller.spec.ts
+++ b/packages/backend/src/routing/custom-provider.controller.spec.ts
@@ -261,6 +261,7 @@ describe('CustomProviderController', () => {
         'http://host.docker.internal:8000/v1',
         'sk-x',
         undefined,
+        undefined,
       );
       expect(result).toEqual({ models: [{ model_name: 'm1' }, { model_name: 'm2' }] });
     });
@@ -275,6 +276,21 @@ describe('CustomProviderController', () => {
         'https://api.anthropic.com',
         'sk-ant-x',
         'anthropic',
+        undefined,
+      );
+    });
+
+    it('forwards provider_name so probe results can be price-enriched', async () => {
+      await controller.probe(mockUser, 'test-agent', {
+        base_url: 'https://api.kilo.ai/api/gateway',
+        apiKey: 'kilo-x',
+        provider_name: 'Kilo Gateway',
+      } as never);
+      expect(mockCustomProviderService.probeModels).toHaveBeenCalledWith(
+        'https://api.kilo.ai/api/gateway',
+        'kilo-x',
+        undefined,
+        'Kilo Gateway',
       );
     });
 

--- a/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.controller.ts
@@ -56,6 +56,7 @@ export class CustomProviderController {
       body.base_url,
       body.apiKey,
       body.api_kind,
+      body.provider_name,
     );
     return { models };
   }

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -23,7 +23,8 @@ function makeDeps(overrides: {
   findOneResults?: (CustomProvider | null)[];
   findResult?: CustomProvider[];
   cached?: CustomProvider[] | null;
-  modelsDevSync?: Pick<ModelsDevSyncService, 'lookupCustomProviderModel'>;
+  modelsDevSync?: Pick<ModelsDevSyncService, 'lookupCustomProviderModel'> &
+    Partial<Pick<ModelsDevSyncService, 'lookupModelAcrossProviders'>>;
 }) {
   const findOne = jest.fn();
   const find = jest.fn().mockResolvedValue(overrides.findResult ?? []);
@@ -423,6 +424,37 @@ describe('CustomProviderService', () => {
       });
     });
 
+    it('marks model-only price fallbacks as estimated when provider is not on models.dev', async () => {
+      const modelsDevSync = {
+        lookupCustomProviderModel: jest.fn().mockReturnValue(null),
+        lookupModelAcrossProviders: jest.fn().mockReturnValue({
+          inputPricePerToken: 0.15 / 1_000_000,
+          outputPricePerToken: 0.6 / 1_000_000,
+          contextWindow: 128000,
+        }),
+      };
+      const { svc } = makeDeps({ findOneResults: [null], modelsDevSync });
+
+      const cp = await svc.create('agent-1', 'user-1', {
+        ...dto,
+        name: 'Mammouth AI',
+        models: [{ model_name: 'openai/gpt-4o-mini' }],
+      });
+
+      expect(modelsDevSync.lookupCustomProviderModel).toHaveBeenCalledWith(
+        'Mammouth AI',
+        'openai/gpt-4o-mini',
+      );
+      expect(modelsDevSync.lookupModelAcrossProviders).toHaveBeenCalledWith('openai/gpt-4o-mini');
+      expect(cp.models[0]).toEqual({
+        model_name: 'openai/gpt-4o-mini',
+        input_price_per_million_tokens: 0.15,
+        output_price_per_million_tokens: 0.6,
+        context_window: 128000,
+        price_estimated: true,
+      });
+    });
+
     it('preserves user-entered prices over models.dev matches', async () => {
       const modelsDevSync = {
         lookupCustomProviderModel: jest.fn().mockReturnValue({
@@ -741,6 +773,40 @@ describe('CustomProviderService', () => {
           input_price_per_million_tokens: 0.15,
           output_price_per_million_tokens: 0.6,
           context_window: 128000,
+        },
+      ]);
+    });
+
+    it('marks probed model-only price fallbacks as estimated', async () => {
+      const modelsDevSync = {
+        lookupCustomProviderModel: jest.fn().mockReturnValue(null),
+        lookupModelAcrossProviders: jest.fn().mockReturnValue({
+          inputPricePerToken: 0.15 / 1_000_000,
+          outputPricePerToken: 0.6 / 1_000_000,
+          contextWindow: 128000,
+        }),
+      };
+      const { svc } = makeDeps({ modelsDevSync });
+      global.fetch = jest.fn().mockResolvedValue(
+        jsonResponse({
+          data: [{ id: 'openai/gpt-4o-mini' }],
+        }),
+      ) as unknown as typeof fetch;
+
+      const result = await svc.probeModels(
+        'http://host.docker.internal:8000/v1',
+        'sk-x',
+        'openai',
+        'Mammouth AI',
+      );
+
+      expect(result).toEqual([
+        {
+          model_name: 'openai/gpt-4o-mini',
+          input_price_per_million_tokens: 0.15,
+          output_price_per_million_tokens: 0.6,
+          context_window: 128000,
+          price_estimated: true,
         },
       ]);
     });

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.spec.ts
@@ -13,6 +13,7 @@ import { ProviderService } from '../routing-core/provider.service';
 import { RoutingCacheService } from '../routing-core/routing-cache.service';
 import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
+import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { validatePublicUrl } = require('../../common/utils/url-validation');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -22,6 +23,7 @@ function makeDeps(overrides: {
   findOneResults?: (CustomProvider | null)[];
   findResult?: CustomProvider[];
   cached?: CustomProvider[] | null;
+  modelsDevSync?: Pick<ModelsDevSyncService, 'lookupCustomProviderModel'>;
 }) {
   const findOne = jest.fn();
   const find = jest.fn().mockResolvedValue(overrides.findResult ?? []);
@@ -64,6 +66,7 @@ function makeDeps(overrides: {
     routingCache,
     autoAssign,
     pricingCache,
+    overrides.modelsDevSync as ModelsDevSyncService | undefined,
   );
 
   return {
@@ -391,6 +394,64 @@ describe('CustomProviderService', () => {
       });
       expect(cp.api_kind).toBe('anthropic');
     });
+
+    it('fills missing prices and context from models.dev when provider and model match', async () => {
+      const modelsDevSync = {
+        lookupCustomProviderModel: jest.fn().mockReturnValue({
+          inputPricePerToken: 0.15 / 1_000_000,
+          outputPricePerToken: 0.6 / 1_000_000,
+          contextWindow: 128000,
+        }),
+      };
+      const { svc } = makeDeps({ findOneResults: [null], modelsDevSync });
+
+      const cp = await svc.create('agent-1', 'user-1', {
+        ...dto,
+        name: 'Kilo Gateway',
+        models: [{ model_name: 'openai/gpt-4o-mini' }],
+      });
+
+      expect(modelsDevSync.lookupCustomProviderModel).toHaveBeenCalledWith(
+        'Kilo Gateway',
+        'openai/gpt-4o-mini',
+      );
+      expect(cp.models[0]).toEqual({
+        model_name: 'openai/gpt-4o-mini',
+        input_price_per_million_tokens: 0.15,
+        output_price_per_million_tokens: 0.6,
+        context_window: 128000,
+      });
+    });
+
+    it('preserves user-entered prices over models.dev matches', async () => {
+      const modelsDevSync = {
+        lookupCustomProviderModel: jest.fn().mockReturnValue({
+          inputPricePerToken: 0.15 / 1_000_000,
+          outputPricePerToken: 0.6 / 1_000_000,
+          contextWindow: 128000,
+        }),
+      };
+      const { svc } = makeDeps({ findOneResults: [null], modelsDevSync });
+
+      const cp = await svc.create('agent-1', 'user-1', {
+        ...dto,
+        name: 'Kilo Gateway',
+        models: [
+          {
+            model_name: 'openai/gpt-4o-mini',
+            input_price_per_million_tokens: 9,
+            output_price_per_million_tokens: 10,
+            context_window: 64000,
+          },
+        ],
+      });
+
+      expect(cp.models[0]).toMatchObject({
+        input_price_per_million_tokens: 9,
+        output_price_per_million_tokens: 10,
+        context_window: 64000,
+      });
+    });
   });
 
   describe('update', () => {
@@ -479,6 +540,29 @@ describe('CustomProviderService', () => {
       // Edited prices must flow into the shared pricing cache so the next
       // proxied message picks up the new per-token cost.
       expect(reloadPricing).toHaveBeenCalledTimes(1);
+    });
+
+    it('fills missing model update prices from models.dev using the current provider name', async () => {
+      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'Kilo Gateway' } as CustomProvider;
+      const modelsDevSync = {
+        lookupCustomProviderModel: jest.fn().mockReturnValue({
+          inputPricePerToken: 0.15 / 1_000_000,
+          outputPricePerToken: 0.6 / 1_000_000,
+          contextWindow: 128000,
+        }),
+      };
+      const { svc } = makeDeps({ findOneResults: [existing], modelsDevSync });
+
+      await svc.update('agent-1', 'cp1', 'user-1', {
+        models: [{ model_name: 'openai/gpt-4o-mini' }],
+      });
+
+      expect(existing.models[0]).toEqual({
+        model_name: 'openai/gpt-4o-mini',
+        input_price_per_million_tokens: 0.15,
+        output_price_per_million_tokens: 0.6,
+        context_window: 128000,
+      });
     });
 
     it('updates api_kind when provided', async () => {
@@ -627,6 +711,38 @@ describe('CustomProviderService', () => {
       // a hostile endpoint could 3xx the probe to a cloud-metadata URL
       // that would bypass the pre-fetch validator.
       expect(init.redirect).toBe('error');
+    });
+
+    it('enriches probed models with models.dev pricing when provider name matches', async () => {
+      const modelsDevSync = {
+        lookupCustomProviderModel: jest.fn().mockReturnValue({
+          inputPricePerToken: 0.15 / 1_000_000,
+          outputPricePerToken: 0.6 / 1_000_000,
+          contextWindow: 128000,
+        }),
+      };
+      const { svc } = makeDeps({ modelsDevSync });
+      global.fetch = jest.fn().mockResolvedValue(
+        jsonResponse({
+          data: [{ id: 'openai/gpt-4o-mini' }],
+        }),
+      ) as unknown as typeof fetch;
+
+      const result = await svc.probeModels(
+        'http://host.docker.internal:8000/v1',
+        'sk-x',
+        'openai',
+        'Kilo Gateway',
+      );
+
+      expect(result).toEqual([
+        {
+          model_name: 'openai/gpt-4o-mini',
+          input_price_per_million_tokens: 0.15,
+          output_price_per_million_tokens: 0.6,
+          context_window: 128000,
+        },
+      ]);
     });
 
     it('strips trailing slashes from the base URL before appending /models', async () => {

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -436,16 +436,31 @@ export class CustomProviderService {
         providerName && this.modelsDevSync
           ? this.modelsDevSync.lookupCustomProviderModel(providerName, model.model_name)
           : null;
+      const modelOnlyMatch =
+        !modelsDevMatch && this.modelsDevSync
+          ? ((this.modelsDevSync as Partial<ModelsDevSyncService>).lookupModelAcrossProviders?.(
+              model.model_name,
+            ) ?? null)
+          : null;
+      const priceSource = modelsDevMatch ?? modelOnlyMatch;
+      const inputWasFilled =
+        model.input_price_per_million_tokens == null && priceSource?.inputPricePerToken != null;
+      const outputWasFilled =
+        model.output_price_per_million_tokens == null && priceSource?.outputPricePerToken != null;
       const inputPrice =
         model.input_price_per_million_tokens ??
-        this.toPricePerMillion(modelsDevMatch?.inputPricePerToken);
+        this.toPricePerMillion(priceSource?.inputPricePerToken);
       const outputPrice =
         model.output_price_per_million_tokens ??
-        this.toPricePerMillion(modelsDevMatch?.outputPricePerToken);
+        this.toPricePerMillion(priceSource?.outputPricePerToken);
       const contextWindow =
         model.context_window ??
-        modelsDevMatch?.contextWindow ??
+        priceSource?.contextWindow ??
         (options.defaultContextWindow === false ? undefined : 128000);
+      const priceEstimated =
+        !modelsDevMatch &&
+        (inputPrice !== undefined || outputPrice !== undefined) &&
+        (model.price_estimated === true || inputWasFilled || outputWasFilled);
 
       const enriched: CustomProviderModel = {
         model_name: model.model_name,
@@ -453,6 +468,7 @@ export class CustomProviderService {
       if (inputPrice !== undefined) enriched.input_price_per_million_tokens = inputPrice;
       if (outputPrice !== undefined) enriched.output_price_per_million_tokens = outputPrice;
       if (contextWindow !== undefined) enriched.context_window = contextWindow;
+      if (priceEstimated) enriched.price_estimated = true;
       return enriched;
     });
   }

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.ts
@@ -3,6 +3,8 @@ import {
   ConflictException,
   NotFoundException,
   BadRequestException,
+  Inject,
+  Optional,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -13,7 +15,11 @@ import {
   normalizeProviderName,
 } from 'manifest-shared';
 import type { AuthType } from 'manifest-shared';
-import { CustomProvider, CustomProviderApiKind } from '../../entities/custom-provider.entity';
+import {
+  CustomProvider,
+  CustomProviderApiKind,
+  CustomProviderModel,
+} from '../../entities/custom-provider.entity';
 import { ProviderService } from '../routing-core/provider.service';
 import { RoutingCacheService } from '../routing-core/routing-cache.service';
 import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service';
@@ -21,6 +27,7 @@ import { CreateCustomProviderDto, UpdateCustomProviderDto } from '../dto/custom-
 import { validatePublicUrl } from '../../common/utils/url-validation';
 import { isSelfHosted } from '../../common/utils/detect-self-hosted';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
+import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
 import { classifyProbeError } from './probe-error';
 
 const PROBE_TIMEOUT_MS = 5000;
@@ -68,6 +75,9 @@ export class CustomProviderService {
     private readonly routingCache: RoutingCacheService,
     private readonly autoAssign: TierAutoAssignService,
     private readonly pricingCache: ModelPricingCacheService,
+    @Optional()
+    @Inject(ModelsDevSyncService)
+    private readonly modelsDevSync: ModelsDevSyncService | null = null,
   ) {}
 
   /** Provider key used in UserProvider tables. */
@@ -203,12 +213,7 @@ export class CustomProviderService {
       name: dto.name,
       base_url: dto.base_url,
       api_kind: dto.api_kind ?? 'openai',
-      models: dto.models.map((m) => ({
-        model_name: m.model_name,
-        input_price_per_million_tokens: m.input_price_per_million_tokens,
-        output_price_per_million_tokens: m.output_price_per_million_tokens,
-        context_window: m.context_window ?? 128000,
-      })),
+      models: this.enrichCustomProviderModels(dto.name, dto.models),
       created_at: new Date().toISOString(),
     });
     await this.repo.insert(cp);
@@ -269,12 +274,7 @@ export class CustomProviderService {
     }
 
     if (dto.models !== undefined) {
-      cp.models = dto.models.map((m) => ({
-        model_name: m.model_name,
-        input_price_per_million_tokens: m.input_price_per_million_tokens,
-        output_price_per_million_tokens: m.output_price_per_million_tokens,
-        context_window: m.context_window ?? 128000,
-      }));
+      cp.models = this.enrichCustomProviderModels(cp.name, dto.models);
     }
 
     // Retag auth_type when the name changes categories (freeform ↔ canonical
@@ -364,7 +364,8 @@ export class CustomProviderService {
     baseUrl: string,
     apiKey?: string,
     apiKind: CustomProviderApiKind = 'openai',
-  ): Promise<{ model_name: string }[]> {
+    providerName?: string,
+  ): Promise<CustomProviderModel[]> {
     try {
       await validatePublicUrl(baseUrl, { allowPrivate: isSelfHosted() });
     } catch (err) {
@@ -412,12 +413,52 @@ export class CustomProviderService {
         (m): m is { id: string } =>
           typeof m.id === 'string' && m.id.length > 0 && !isEmbeddingModel(m.id),
       );
-      return filtered.map((m) => ({ model_name: m.id }));
+      return this.enrichCustomProviderModels(
+        providerName,
+        filtered.map((m) => ({ model_name: m.id })),
+        { defaultContextWindow: false },
+      );
     } catch (err) {
       if (err instanceof BadRequestException) throw err;
       throw new BadRequestException(classifyProbeError({ url, error: err as Error }).message);
     } finally {
       clearTimeout(timeout);
     }
+  }
+
+  private enrichCustomProviderModels(
+    providerName: string | undefined,
+    models: readonly CustomProviderModel[],
+    options: { defaultContextWindow?: boolean } = {},
+  ): CustomProviderModel[] {
+    return models.map((model) => {
+      const modelsDevMatch =
+        providerName && this.modelsDevSync
+          ? this.modelsDevSync.lookupCustomProviderModel(providerName, model.model_name)
+          : null;
+      const inputPrice =
+        model.input_price_per_million_tokens ??
+        this.toPricePerMillion(modelsDevMatch?.inputPricePerToken);
+      const outputPrice =
+        model.output_price_per_million_tokens ??
+        this.toPricePerMillion(modelsDevMatch?.outputPricePerToken);
+      const contextWindow =
+        model.context_window ??
+        modelsDevMatch?.contextWindow ??
+        (options.defaultContextWindow === false ? undefined : 128000);
+
+      const enriched: CustomProviderModel = {
+        model_name: model.model_name,
+      };
+      if (inputPrice !== undefined) enriched.input_price_per_million_tokens = inputPrice;
+      if (outputPrice !== undefined) enriched.output_price_per_million_tokens = outputPrice;
+      if (contextWindow !== undefined) enriched.context_window = contextWindow;
+      return enriched;
+    });
+  }
+
+  private toPricePerMillion(pricePerToken: number | null | undefined): number | undefined {
+    if (pricePerToken == null) return undefined;
+    return Number((pricePerToken * 1_000_000).toFixed(12));
   }
 }

--- a/packages/backend/src/routing/dto/custom-provider.dto.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.ts
@@ -13,6 +13,7 @@ import {
   IsUrl,
   IsIn,
   Min,
+  IsBoolean,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 
@@ -43,6 +44,10 @@ export class CustomProviderModelDto {
   @Min(1)
   @Type(() => Number)
   context_window?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  price_estimated?: boolean;
 }
 
 export class CreateCustomProviderDto {

--- a/packages/backend/src/routing/dto/custom-provider.dto.ts
+++ b/packages/backend/src/routing/dto/custom-provider.dto.ts
@@ -83,6 +83,11 @@ export class ProbeCustomProviderDto {
   base_url!: string;
 
   @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  provider_name?: string;
+
+  @IsOptional()
   @IsIn(CUSTOM_PROVIDER_API_KINDS, { message: 'api_kind must be "openai" or "anthropic"' })
   api_kind?: CustomProviderApiKindDto;
 

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -130,6 +130,7 @@ const CustomProviderForm: Component<Props> = (props) => {
   };
 
   const validModels = () => rows().filter((r) => r.model_name.trim());
+  const hasEstimatedPrices = () => rows().some((r) => r.price_estimated);
 
   const canSubmit = () => name().trim() && baseUrl().trim() && validModels().length > 0 && !busy();
 
@@ -399,8 +400,25 @@ const CustomProviderForm: Component<Props> = (props) => {
         </div>
 
         <div class="provider-detail__field">
-          <label class="provider-detail__label">Models</label>
-          <div class="custom-provider-models">
+          <div id="cp-models-label" class="provider-detail__label custom-provider-models__label">
+            Models
+            <Show when={hasEstimatedPrices()}>
+              <InfoTooltip text={ESTIMATED_PRICE_TOOLTIP} />
+            </Show>
+          </div>
+          <div class="custom-provider-models" aria-labelledby="cp-models-label">
+            <div class="custom-provider-models__columns" aria-hidden="true">
+              <span class="custom-provider-models__column custom-provider-models__column--name">
+                Model name
+              </span>
+              <span class="custom-provider-models__column custom-provider-models__column--price">
+                Input / 1M tokens
+              </span>
+              <span class="custom-provider-models__column custom-provider-models__column--price">
+                Output / 1M tokens
+              </span>
+              <span class="custom-provider-models__column-spacer" />
+            </div>
             <Index each={rows()}>
               {(row, i) => (
                 <div class="custom-provider-model-row">
@@ -430,11 +448,6 @@ const CustomProviderForm: Component<Props> = (props) => {
                     value={row().output_price}
                     onInput={(e) => updateRow(i, 'output_price', e.currentTarget.value)}
                   />
-                  <span class="custom-provider-model-row__price-info">
-                    <Show when={row().price_estimated}>
-                      <InfoTooltip text={ESTIMATED_PRICE_TOOLTIP} />
-                    </Show>
-                  </span>
                   <button
                     type="button"
                     class="custom-provider-model-row__remove"

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -88,12 +88,13 @@ const CustomProviderForm: Component<Props> = (props) => {
         url,
         apiKey().trim() || undefined,
         apiKind(),
+        name().trim() || undefined,
       );
       if (models.length === 0) {
         setProbeError('Server returned no models');
         return;
       }
-      setRows(models.map((m) => ({ model_name: m.model_name, input_price: '', output_price: '' })));
+      setRows(toModelRows(models));
     } catch (e) {
       setProbeError(e instanceof Error ? e.message : 'Probe failed');
     } finally {

--- a/packages/frontend/src/components/CustomProviderForm.tsx
+++ b/packages/frontend/src/components/CustomProviderForm.tsx
@@ -11,6 +11,7 @@ import {
 import { toast } from '../services/toast-store.js';
 import { checkIsSelfHosted } from '../services/setup-status.js';
 import type { CustomProviderPrefill } from '../services/routing-params.js';
+import InfoTooltip from './InfoTooltip.jsx';
 
 const BASE_URL_PLACEHOLDERS: Record<CustomProviderApiKind, string> = {
   openai: 'https://api.example.com/v1',
@@ -30,9 +31,17 @@ interface ModelRow {
   model_name: string;
   input_price: string;
   output_price: string;
+  price_estimated: boolean;
 }
 
-const emptyRow = (): ModelRow => ({ model_name: '', input_price: '', output_price: '' });
+const ESTIMATED_PRICE_TOOLTIP = 'Estimated price. This may not be accurate.';
+
+const emptyRow = (): ModelRow => ({
+  model_name: '',
+  input_price: '',
+  output_price: '',
+  price_estimated: false,
+});
 
 const toModelRows = (models: CustomProviderModel[]): ModelRow[] =>
   models.map((m) => ({
@@ -41,6 +50,7 @@ const toModelRows = (models: CustomProviderModel[]): ModelRow[] =>
       m.input_price_per_million_tokens != null ? String(m.input_price_per_million_tokens) : '',
     output_price:
       m.output_price_per_million_tokens != null ? String(m.output_price_per_million_tokens) : '',
+    price_estimated: m.price_estimated === true,
   }));
 
 const CustomProviderForm: Component<Props> = (props) => {
@@ -52,6 +62,7 @@ const CustomProviderForm: Component<Props> = (props) => {
       model_name: m.model_name,
       input_price: m.input_price ?? '',
       output_price: m.output_price ?? '',
+      price_estimated: false,
     }));
   };
 
@@ -102,8 +113,14 @@ const CustomProviderForm: Component<Props> = (props) => {
     }
   };
 
-  const updateRow = (index: number, field: keyof ModelRow, value: string) => {
-    setRows((prev) => prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+  const updateRow = (
+    index: number,
+    field: 'model_name' | 'input_price' | 'output_price',
+    value: string,
+  ) => {
+    setRows((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, [field]: value, price_estimated: false } : r)),
+    );
   };
 
   const addRow = () => setRows((prev) => [...prev, emptyRow()]);
@@ -126,6 +143,9 @@ const CustomProviderForm: Component<Props> = (props) => {
         : {}),
       ...(r.output_price !== ''
         ? { output_price_per_million_tokens: parsePrice(r.output_price) }
+        : {}),
+      ...(r.price_estimated && (r.input_price !== '' || r.output_price !== '')
+        ? { price_estimated: true }
         : {}),
     }));
 
@@ -410,6 +430,11 @@ const CustomProviderForm: Component<Props> = (props) => {
                     value={row().output_price}
                     onInput={(e) => updateRow(i, 'output_price', e.currentTarget.value)}
                   />
+                  <span class="custom-provider-model-row__price-info">
+                    <Show when={row().price_estimated}>
+                      <InfoTooltip text={ESTIMATED_PRICE_TOOLTIP} />
+                    </Show>
+                  </span>
                   <button
                     type="button"
                     class="custom-provider-model-row__remove"

--- a/packages/frontend/src/components/InfoTooltip.tsx
+++ b/packages/frontend/src/components/InfoTooltip.tsx
@@ -1,4 +1,5 @@
 import { createSignal, onCleanup, type Component } from 'solid-js';
+import { Portal } from 'solid-js/web';
 
 interface Props {
   text: string;
@@ -6,15 +7,22 @@ interface Props {
 
 const InfoTooltip: Component<Props> = (props) => {
   const [expanded, setExpanded] = createSignal(false);
-  const [pos, setPos] = createSignal<{ top: number; left: number } | null>(null);
+  const [pos, setPos] = createSignal<{
+    top: number;
+    left: number;
+    placement: 'above' | 'below';
+  } | null>(null);
   let iconRef: HTMLSpanElement | undefined;
 
   const updatePos = () => {
     if (!iconRef) return;
     const rect = iconRef.getBoundingClientRect();
+    const placement = rect.top < 72 ? 'below' : 'above';
+    const left = Math.min(Math.max(rect.left + rect.width / 2, 16), window.innerWidth - 16);
     setPos({
-      top: rect.top - 8,
-      left: rect.left + rect.width / 2,
+      top: placement === 'above' ? rect.top - 8 : rect.bottom + 8,
+      left,
+      placement,
     });
   };
 
@@ -70,18 +78,21 @@ const InfoTooltip: Component<Props> = (props) => {
         <line x1="12" y1="8" x2="12.01" y2="8" />
       </svg>
       {expanded() && pos() && (
-        <span
-          class="info-tooltip__bubble"
-          role="tooltip"
-          style={{
-            position: 'fixed',
-            top: `${pos()!.top}px`,
-            left: `${pos()!.left}px`,
-            transform: 'translate(-50%, -100%)',
-          }}
-        >
-          {props.text}
-        </span>
+        <Portal>
+          <span
+            class="info-tooltip__bubble"
+            role="tooltip"
+            style={{
+              position: 'fixed',
+              top: `${pos()!.top}px`,
+              left: `${pos()!.left}px`,
+              transform:
+                pos()!.placement === 'above' ? 'translate(-50%, -100%)' : 'translate(-50%, 0)',
+            }}
+          >
+            {props.text}
+          </span>
+        </Portal>
       )}
     </span>
   );

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -434,20 +434,21 @@ export async function probeCustomProvider(
   base_url: string,
   apiKey?: string,
   api_kind?: CustomProviderApiKind,
+  provider_name?: string,
 ) {
   const res = await fetch(`${BASE_URL}${routingPath(agentName, 'custom-providers/probe')}`, {
     method: 'POST',
     credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ base_url, apiKey, api_kind }),
+    body: JSON.stringify({ base_url, apiKey, api_kind, provider_name }),
   });
   if (!res.ok) {
     const message = await parseErrorMessage(res);
     throw new Error(message);
   }
   const text = await res.text();
-  if (!text) return { models: [] } as { models: { model_name: string }[] };
-  return JSON.parse(text) as { models: { model_name: string }[] };
+  if (!text) return { models: [] } as { models: CustomProviderModel[] };
+  return JSON.parse(text) as { models: CustomProviderModel[] };
 }
 
 export function deleteCustomProvider(agentName: string, id: string) {

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -350,6 +350,7 @@ export interface CustomProviderModel {
   input_price_per_million_tokens?: number;
   output_price_per_million_tokens?: number;
   context_window?: number;
+  price_estimated?: boolean;
 }
 
 export interface CustomProviderData {

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -731,6 +731,39 @@
   gap: 6px;
 }
 
+.custom-provider-models__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.custom-provider-models__columns {
+  display: flex;
+  gap: 6px;
+  align-items: flex-end;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.custom-provider-models__column {
+  min-width: 0;
+}
+
+.custom-provider-models__column--name {
+  flex: 2;
+}
+
+.custom-provider-models__column--price {
+  flex: 1;
+}
+
+.custom-provider-models__column-spacer {
+  width: 32px;
+  flex-shrink: 0;
+}
+
 .custom-provider-model-row {
   display: flex;
   gap: 6px;
@@ -756,13 +789,6 @@
 
 .custom-provider-model-row__price {
   -moz-appearance: textfield;
-}
-
-.custom-provider-model-row__price-info {
-  width: 18px;
-  display: inline-flex;
-  justify-content: center;
-  flex-shrink: 0;
 }
 
 .custom-provider-model-row__remove {

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -758,6 +758,13 @@
   -moz-appearance: textfield;
 }
 
+.custom-provider-model-row__price-info {
+  width: 18px;
+  display: inline-flex;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
 .custom-provider-model-row__remove {
   width: 32px;
   height: 32px;

--- a/packages/frontend/tests/components/CustomProviderForm.test.tsx
+++ b/packages/frontend/tests/components/CustomProviderForm.test.tsx
@@ -586,6 +586,57 @@ describe("CustomProviderForm — Fetch models probe", () => {
     });
   });
 
+  it("shows estimated price info for model-only price fallbacks", async () => {
+    mockProbeCustomProvider.mockResolvedValue({
+      models: [
+        {
+          model_name: "openai/gpt-4o-mini",
+          input_price_per_million_tokens: 0.15,
+          output_price_per_million_tokens: 0.6,
+          price_estimated: true,
+        },
+      ],
+    });
+
+    render(() => (
+      <CustomProviderForm agentName="test-agent" onCreated={onCreated} onBack={onBack} />
+    ));
+
+    fireEvent.input(screen.getByPlaceholderText("e.g. Groq, Together, Azure"), {
+      target: { value: "Mammouth AI" },
+    });
+    fireEvent.input(screen.getByPlaceholderText("https://api.example.com/v1"), {
+      target: { value: "https://api.mammouth.ai/v1" },
+    });
+
+    fireEvent.click(screen.getByText("Fetch models"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Info: Estimated price. This may not be accurate."),
+      ).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText("Connect"));
+
+    await waitFor(() => {
+      expect(mockCreateCustomProvider).toHaveBeenCalledWith("test-agent", {
+        name: "Mammouth AI",
+        base_url: "https://api.mammouth.ai/v1",
+        api_kind: "openai",
+        apiKey: undefined,
+        models: [
+          {
+            model_name: "openai/gpt-4o-mini",
+            input_price_per_million_tokens: 0.15,
+            output_price_per_million_tokens: 0.6,
+            price_estimated: true,
+          },
+        ],
+      });
+    });
+  });
+
   it("surfaces a 'no models' error when the server returns an empty list", async () => {
     mockProbeCustomProvider.mockResolvedValue({ models: [] });
 

--- a/packages/frontend/tests/components/CustomProviderForm.test.tsx
+++ b/packages/frontend/tests/components/CustomProviderForm.test.tsx
@@ -616,6 +616,19 @@ describe("CustomProviderForm — Fetch models probe", () => {
         screen.getByLabelText("Info: Estimated price. This may not be accurate."),
       ).toBeDefined();
     });
+    expect(screen.getByText("Input / 1M tokens")).toBeDefined();
+    expect(screen.getByText("Output / 1M tokens")).toBeDefined();
+    expect(
+      screen.getAllByLabelText("Info: Estimated price. This may not be accurate."),
+    ).toHaveLength(1);
+
+    fireEvent.mouseEnter(screen.getByLabelText("Info: Estimated price. This may not be accurate."));
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip").textContent).toBe(
+        "Estimated price. This may not be accurate.",
+      );
+    });
 
     fireEvent.click(screen.getByText("Connect"));
 

--- a/packages/frontend/tests/components/CustomProviderForm.test.tsx
+++ b/packages/frontend/tests/components/CustomProviderForm.test.tsx
@@ -491,6 +491,7 @@ describe("CustomProviderForm — Fetch models probe", () => {
         "http://host.docker.internal:8000/v1",
         undefined,
         "openai",
+        undefined,
       );
       const inputs = screen.getAllByPlaceholderText("Model name") as HTMLInputElement[];
       expect(inputs).toHaveLength(2);
@@ -514,6 +515,74 @@ describe("CustomProviderForm — Fetch models probe", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Connection refused")).toBeDefined();
+    });
+  });
+
+  it("populates probed models with models.dev prices", async () => {
+    mockProbeCustomProvider.mockResolvedValue({
+      models: [
+        {
+          model_name: "openai/gpt-4o-mini",
+          input_price_per_million_tokens: 0.15,
+          output_price_per_million_tokens: 0.6,
+        },
+      ],
+    });
+
+    render(() => (
+      <CustomProviderForm agentName="test-agent" onCreated={onCreated} onBack={onBack} />
+    ));
+
+    fireEvent.input(screen.getByPlaceholderText("e.g. Groq, Together, Azure"), {
+      target: { value: "Kilo Gateway" },
+    });
+    fireEvent.input(screen.getByPlaceholderText("https://api.example.com/v1"), {
+      target: { value: "https://api.kilo.ai/api/gateway" },
+    });
+
+    fireEvent.click(screen.getByText("Fetch models"));
+
+    await waitFor(() => {
+      expect(mockProbeCustomProvider).toHaveBeenCalledWith(
+        "test-agent",
+        "https://api.kilo.ai/api/gateway",
+        undefined,
+        "openai",
+        "Kilo Gateway",
+      );
+      expect(
+        (screen.getByLabelText("Model 1 input price per million tokens") as HTMLInputElement).value,
+      ).toBe("0.15");
+      expect(
+        (screen.getByLabelText("Model 1 output price per million tokens") as HTMLInputElement)
+          .value,
+      ).toBe("0.6");
+    });
+  });
+
+  it("keeps price fields blank when the probe returns models without pricing", async () => {
+    mockProbeCustomProvider.mockResolvedValue({
+      models: [{ model_name: "unknown-model" }],
+    });
+
+    render(() => (
+      <CustomProviderForm agentName="test-agent" onCreated={onCreated} onBack={onBack} />
+    ));
+
+    fireEvent.input(screen.getByPlaceholderText("https://api.example.com/v1"), {
+      target: { value: "http://host.docker.internal:8000/v1" },
+    });
+
+    fireEvent.click(screen.getByText("Fetch models"));
+
+    await waitFor(() => {
+      expect(
+        (screen.getByLabelText("Model 1 input price per million tokens") as HTMLInputElement).value,
+      ).toBe("");
+      expect(
+        (screen.getByLabelText("Model 1 output price per million tokens") as HTMLInputElement)
+          .value,
+      ).toBe("");
     });
   });
 
@@ -1210,6 +1279,7 @@ describe("CustomProviderForm — API format selector", () => {
         "https://api.anthropic.com",
         undefined,
         "anthropic",
+        undefined,
       );
     });
   });

--- a/packages/frontend/tests/components/InfoTooltip.test.tsx
+++ b/packages/frontend/tests/components/InfoTooltip.test.tsx
@@ -35,11 +35,17 @@ describe("InfoTooltip", () => {
   });
 
   it("has role=tooltip on bubble when expanded", () => {
-    const { container } = render(() => <InfoTooltip text="Bubble text" />);
+    render(() => <InfoTooltip text="Bubble text" />);
     fireEvent.click(screen.getByRole("button"));
-    const bubble = container.querySelector('[role="tooltip"]');
+    const bubble = screen.getByRole("tooltip");
     expect(bubble).not.toBeNull();
-    expect(bubble?.textContent).toBe("Bubble text");
+    expect(bubble.textContent).toBe("Bubble text");
+  });
+
+  it("shows tooltip text on hover", () => {
+    render(() => <InfoTooltip text="Hover text" />);
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    expect(screen.getByRole("tooltip").textContent).toBe("Hover text");
   });
 
   it("toggles expanded on click", () => {

--- a/packages/frontend/tests/services/api-extra.test.ts
+++ b/packages/frontend/tests/services/api-extra.test.ts
@@ -125,6 +125,25 @@ describe('api/routing', () => {
     expect(body.apiKey).toBeUndefined();
   });
 
+  it('probeCustomProvider can include a provider name for price enrichment', async () => {
+    mockOk({
+      models: [{ model_name: 'openai/gpt-4o-mini', input_price_per_million_tokens: 0.15 }],
+    });
+    await probeCustomProvider(
+      'demo-agent',
+      'https://api.kilo.ai/api/gateway',
+      undefined,
+      'openai',
+      'Kilo Gateway',
+    );
+    const [, init] = mockFetch.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({
+      base_url: 'https://api.kilo.ai/api/gateway',
+      api_kind: 'openai',
+      provider_name: 'Kilo Gateway',
+    });
+  });
+
   it('deleteCustomProvider DELETEs the custom provider by ID', async () => {
     mockOk({ ok: true });
     const out = await deleteCustomProvider('demo-agent', 'cp-123');

--- a/packages/frontend/tests/services/api/routing-extra.test.ts
+++ b/packages/frontend/tests/services/api/routing-extra.test.ts
@@ -299,6 +299,19 @@ describe('routing API client (additional coverage)', () => {
     expect(body.api_kind).toBe('anthropic');
   });
 
+  it('probeCustomProvider includes provider_name when provided', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ models: [] }),
+      text: async () => JSON.stringify({ models: [] }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    await routing.probeCustomProvider('demo', 'http://x', undefined, 'openai', 'Kilo Gateway');
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.provider_name).toBe('Kilo Gateway');
+  });
+
   it('probeCustomProvider throws using parseErrorMessage on non-ok response', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,


### PR DESCRIPTION
## Summary
- Index all chat-capable models.dev providers for custom-provider provider/model lookups.
- Auto-fill missing custom-provider input/output prices and context windows during probe/create/update when provider and model match models.dev.
- Fall back to exact model-ID matches from models.dev when the custom provider is not listed there, mark those imported prices as estimated, and show one estimate note beside the Models section.
- Pass `provider_name` from the frontend probe flow so detected models return imported prices in the custom-provider form.

## Context
This is the second step after the model catalog cap increase. It preserves manual prices/context, leaves unmatched model IDs on the existing blank-price/default-context path, and only uses exact models.dev matches. It does not fuzzy-match or invent prices.

As of 2026-05-26, models.dev has no Mammouth/Mammoth provider. A Mammouth-style custom provider can still prefill prices for exact model IDs that models.dev knows, such as `openai/gpt-4o-mini`; unknown Mammouth-native model IDs remain blank.

## Validation
- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/backend -- models-dev-sync.service.spec.ts custom-provider.service.spec.ts custom-provider.controller.spec.ts`
- `npm test --workspace=packages/frontend -- CustomProviderForm.test.tsx api-extra.test.ts routing-extra.test.ts`
- `npm test --workspace=packages/frontend -- CustomProviderForm.test.tsx InfoTooltip.test.tsx api-extra.test.ts routing-extra.test.ts`
- `npm run build --workspace=packages/backend`
- `npm run build --workspace=packages/frontend` (existing large Playground chunk warning)
- `npm exec eslint -- packages/frontend/src/components/CustomProviderForm.tsx packages/frontend/src/components/InfoTooltip.tsx packages/frontend/src/services/api/routing.ts`
- `npm exec prettier -- --check packages/frontend/src/components/CustomProviderForm.tsx packages/frontend/src/components/InfoTooltip.tsx packages/frontend/src/styles/routing-providers.css`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-fill custom provider model prices and context from models.dev using provider-name + model ID matches, with an exact model-only fallback marked as estimated. The form shows a single estimated-price tooltip beside Models, preserves user edits, and passes `price_estimated` through the API.

- **New Features**
  - Indexes all chat-capable models.dev providers (including non-native) for custom-provider lookups by display name/alias.
  - Fills missing `input_price_per_million_tokens`, `output_price_per_million_tokens`, and `context_window` on create/update/probe when matched; preserves user-entered values; leaves unmatched blank.
  - Adds exact model-only price fallback across providers (prefers official catalogs first) and flags these with `price_estimated: true`.
  - Adds `price_estimated` to DTO/entity and API in `packages/backend` and `packages/frontend`; probe accepts `provider_name` and returns enriched models.
  - Frontend sends `provider_name` during probe, renders one info tooltip for estimated prices, and submits `price_estimated` when applicable.

<sup>Written for commit 174d3298cf8cb4ae8d45351ed73915c2b7efebef. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2024?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

