### PR TITLE
fix: resolve gateway model params via the underlying provider

### DIFF
--- a/.changeset/gateway-model-params.md
+++ b/.changeset/gateway-model-params.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show model parameters for gateway models (e.g. OpenCode Go). A model like `opencode-go/deepseek-v4-pro` now resolves its parameters and capabilities from the underlying provider's catalog entry (`deepseek` / `deepseek-v4-pro`), so the params dialog, request snapshot, and outbound param defaults work the same as connecting the provider directly.

--- a/packages/shared/__tests__/provider-inference.spec.ts
+++ b/packages/shared/__tests__/provider-inference.spec.ts
@@ -1,4 +1,8 @@
-import { MODEL_PREFIX_MAP, inferProviderFromModel } from '../src/provider-inference';
+import {
+  MODEL_PREFIX_MAP,
+  inferProviderFromModel,
+  underlyingGatewayModel,
+} from '../src/provider-inference';
 
 describe('MODEL_PREFIX_MAP', () => {
   it('is a non-empty array of [RegExp, string] entries', () => {
@@ -68,5 +72,17 @@ describe('inferProviderFromModel', () => {
 
   it('returns undefined for unrecognized models', () => {
     expect(inferProviderFromModel('unknown-model')).toBeUndefined();
+  });
+});
+
+describe('underlyingGatewayModel', () => {
+  it('strips the gateway prefix from gateway model ids', () => {
+    expect(underlyingGatewayModel('opencode-go/deepseek-v4-pro')).toBe('deepseek-v4-pro');
+    expect(underlyingGatewayModel('opencode-go/kimi-k2.6')).toBe('kimi-k2.6');
+  });
+
+  it('returns null for non-gateway model ids', () => {
+    expect(underlyingGatewayModel('deepseek-v4-pro')).toBeNull();
+    expect(underlyingGatewayModel('openrouter/anthropic/claude-sonnet-4')).toBeNull();
   });
 });

--- a/packages/shared/__tests__/provider-params-spec.spec.ts
+++ b/packages/shared/__tests__/provider-params-spec.spec.ts
@@ -96,6 +96,23 @@ const catalog: ProviderParamSpecCatalog = [
       },
     ],
   },
+  {
+    provider: 'deepseek',
+    authType: 'api_key',
+    model: 'deepseek-v4-pro',
+    capabilities: ['text', 'stream'],
+    params: [
+      {
+        path: 'reasoning_effort',
+        type: 'enum',
+        label: 'Reasoning effort',
+        description: 'Controls DeepSeek reasoning effort.',
+        default: 'medium',
+        values: ['low', 'medium', 'high'],
+        group: 'reasoning',
+      },
+    ],
+  },
 ];
 
 const anthropicSpecs = getProviderParamSpecs(catalog, 'anthropic', 'api_key', 'claude-sonnet-4-6');
@@ -126,6 +143,30 @@ describe('provider-params-spec', () => {
       expect(getProviderParamSpecs(catalog, 'anthropic', 'api_key', 'claude:sonnet/4-6')).toEqual(
         [],
       );
+    });
+
+    it('resolves gateway models to the underlying provider specs', () => {
+      // OpenCode Go (subscription gateway) -> DeepSeek's native api_key specs.
+      const specs = getProviderParamSpecs(
+        catalog,
+        'opencode-go',
+        'subscription',
+        'opencode-go/deepseek-v4-pro',
+      );
+      expect(specs.map((spec) => spec.path)).toEqual(['reasoning_effort']);
+      expect(specs[0].provider).toBe('deepseek');
+      expect(specs[0].model).toBe('deepseek-v4-pro');
+    });
+
+    it('returns [] for gateway models whose underlying provider is absent from the catalog', () => {
+      // moonshot (kimi) is not in the catalog.
+      expect(
+        getProviderParamSpecs(catalog, 'opencode-go', 'subscription', 'opencode-go/kimi-k2.6'),
+      ).toEqual([]);
+      // mimo-v2.5 infers no provider at all.
+      expect(
+        getProviderParamSpecs(catalog, 'opencode-go', 'subscription', 'opencode-go/mimo-v2.5'),
+      ).toEqual([]);
     });
 
     it('matches catalog provider aliases against Manifest provider IDs', () => {
@@ -173,6 +214,17 @@ describe('provider-params-spec', () => {
       expect(getProviderModelCapabilities(catalog, 'openai', 'api_key', undefined)).toBeNull();
       expect(getProviderModelCapabilities(catalog, 'openai', 'api_key', 'missing')).toBeNull();
       expect(getProviderModelCapabilities(catalog, 'openai', 'api_key', 'gpt-5')).toBeNull();
+    });
+
+    it('resolves gateway models to the underlying provider capabilities', () => {
+      expect(
+        getProviderModelCapabilities(
+          catalog,
+          'opencode-go',
+          'subscription',
+          'opencode-go/deepseek-v4-pro',
+        ),
+      ).toEqual(['text', 'stream']);
     });
   });
 

--- a/packages/shared/src/provider-inference.ts
+++ b/packages/shared/src/provider-inference.ts
@@ -23,6 +23,25 @@ const MODEL_PREFIX_MAP: [RegExp, string][] = [
 
 export { MODEL_PREFIX_MAP };
 
+/**
+ * Gateway model-id prefixes. A gateway transparently proxies another
+ * provider's API, so the id after the prefix is the underlying provider's
+ * own model id (e.g. `opencode-go/deepseek-v4-pro` -> `deepseek-v4-pro`).
+ */
+const GATEWAY_MODEL_PREFIXES = ['opencode-go/'] as const;
+
+/**
+ * If `model` is a gateway model id, return the underlying provider's model
+ * id; otherwise return `null`. Used to resolve gateway models to the
+ * provenance provider whose parameters and capabilities they inherit.
+ */
+export function underlyingGatewayModel(model: string): string | null {
+  for (const prefix of GATEWAY_MODEL_PREFIXES) {
+    if (model.startsWith(prefix)) return model.slice(prefix.length);
+  }
+  return null;
+}
+
 export function inferProviderFromModel(model: string): string | undefined {
   if (model.startsWith('custom:')) return 'custom';
   if (!model.includes('/') && /:/.test(model) && !model.endsWith(':free')) return 'ollama';

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -1,4 +1,5 @@
 import type { AuthType } from './auth-types';
+import { inferProviderFromModel, underlyingGatewayModel } from './provider-inference';
 import { normalizeProviderName, SHARED_PROVIDER_BY_ID_OR_ALIAS } from './providers';
 import type { JsonPrimitive, JsonValue } from './request-params';
 
@@ -102,19 +103,41 @@ export function normalizeProviderParamProviderId(providerId: string): string {
   return lower;
 }
 
+/**
+ * Resolve the catalog lookup identity for a model.
+ *
+ * Gateways (e.g. OpenCode Go) are transparent transports: a model like
+ * `opencode-go/deepseek-v4-pro` exposes the underlying provider's native
+ * parameters, so it resolves to `(deepseek, api_key, deepseek-v4-pro)`. The
+ * gateway's own subscription billing is irrelevant to which knobs the
+ * model's API accepts, so authType collapses to `api_key`. Non-gateway ids
+ * are returned unchanged.
+ */
+function paramLookupIdentity(
+  providerId: string | undefined,
+  authType: AuthType | undefined,
+  model: string | undefined,
+): { providerId: string | undefined; authType: AuthType | undefined; model: string | undefined } {
+  if (!model) return { providerId, authType, model };
+  const underlying = underlyingGatewayModel(model);
+  if (underlying === null) return { providerId, authType, model };
+  return { providerId: inferProviderFromModel(underlying), authType: 'api_key', model: underlying };
+}
+
 export function getProviderParamSpecs(
   catalog: ProviderParamSpecCatalog,
   providerId: string | undefined,
   authType: AuthType | undefined,
   model: string | undefined,
 ): readonly ProviderParamSpec[] {
-  if (!providerId || !authType || !model) return [];
-  const provider = normalizeProviderParamProviderId(providerId);
+  const id = paramLookupIdentity(providerId, authType, model);
+  if (!id.providerId || !id.authType || !id.model) return [];
+  const provider = normalizeProviderParamProviderId(id.providerId);
   const entry = catalog.find(
     (spec) =>
       normalizeProviderParamProviderId(spec.provider) === provider &&
-      spec.authType === authType &&
-      spec.model === model,
+      spec.authType === id.authType &&
+      spec.model === id.model,
   );
   if (!entry) return [];
   return entry.params
@@ -136,13 +159,14 @@ export function getProviderModelCapabilities(
   authType: AuthType | undefined,
   model: string | undefined,
 ): readonly ModelCapability[] | null {
-  if (!providerId || !authType || !model) return null;
-  const provider = providerId.toLowerCase();
+  const id = paramLookupIdentity(providerId, authType, model);
+  if (!id.providerId || !id.authType || !id.model) return null;
+  const provider = normalizeProviderParamProviderId(id.providerId);
   const entry = catalog.find(
     (spec) =>
-      spec.provider.toLowerCase() === provider &&
-      spec.authType === authType &&
-      spec.model === model,
+      normalizeProviderParamProviderId(spec.provider) === provider &&
+      spec.authType === id.authType &&
+      spec.model === id.model,
   );
   return entry?.capabilities ?? null;
 }


### PR DESCRIPTION
### ✨ What changed
- New `underlyingGatewayModel()` strips the `opencode-go/` prefix to the underlying model id.
- New `paramLookupIdentity()` maps a gateway tuple to its provenance tuple before the catalog lookup.
- Both `getProviderParamSpecs` and `getProviderModelCapabilities` route through it.

### 💭 Why
The MPS catalog lookup is exact on `(provider, authType, model)` and has no `opencode-go` entries, so gateway models resolved to `[]`. A gateway is a transparent transport: `opencode-go/deepseek-v4-pro` should expose DeepSeek's native params.

### 👤 For users
OpenCode Go models that map to a catalogued provider now show parameters instead of "no parameter controls". Today that lights up `opencode-go/deepseek-*` (DeepSeek is the only catalog provider OpenCode Go also serves). Others stay empty until their provider is in the catalog.

### 📝 Notes
- Resolution: `(opencode-go, subscription, opencode-go/deepseek-v4-pro)` -> `(deepseek, api_key, deepseek-v4-pro)`. authType collapses to `api_key` because params are the model's native-API knobs, not a billing property.
- One fix covers all four paths (dialog, snapshot, outbound defaults, capabilities) since they share the two lookups.
- `getProviderModelCapabilities` now normalizes the provider id like its sibling (was raw `.toLowerCase()`), so gateway-resolved providers match aliases consistently.
- Params complement to #1885 (OpenCode Go per-request cost). Pricing follows the transport; params follow the provenance.
- Shared package: 233 tests pass, 100% line coverage on changed files, `tsc` clean. Backend/frontend suites not run locally; CI covers them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parameter and capability resolution for gateway models by resolving them to the underlying provider before catalog lookups. `opencode-go/*` models now show native params (e.g., `opencode-go/deepseek-v4-pro` exposes DeepSeek controls) across the params dialog, request snapshot, and outbound defaults.

- **Bug Fixes**
  - Added `underlyingGatewayModel()` to strip the `opencode-go/` prefix.
  - Added `paramLookupIdentity()` to map `(opencode-go, subscription, opencode-go/deepseek-v4-pro)` to `(deepseek, api_key, deepseek-v4-pro)`.
  - Routed `getProviderParamSpecs` and `getProviderModelCapabilities` through this mapping and normalized provider IDs consistently.
  - When the underlying provider isn’t in the catalog, returns no specs/capabilities as before.
  - Updated tests to cover gateway resolution.

<sup>Written for commit a446d3e7579c7b2870803f67570f8b30581f3a9c. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2028?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

