### PR TITLE
fix: resolve gateway model capabilities via the underlying provider

### DIFF
--- a/.changeset/gateway-model-capabilities.md
+++ b/.changeset/gateway-model-capabilities.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show capability badges for gateway models in the model picker. A gateway model like `opencode-go/glm-5.1` now resolves its capabilities from the underlying provider's models.dev metadata (`zai` / `glm-5.1`) instead of showing "Capabilities unknown". The resolution is gateway-generic — it keys off the shared gateway-prefix abstraction, so any gateway added later inherits it automatically.

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -311,6 +311,42 @@ describe('ModelController', () => {
       expect(result[0].capabilities).toEqual(['text', 'image', 'tools', 'stream']);
     });
 
+    it('resolves gateway models to the underlying provider for capability metadata', async () => {
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
+        makeDiscovered({
+          id: 'opencode-go/glm-5.1',
+          provider: 'opencode-go',
+          authType: 'subscription',
+        }),
+      ]);
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        capabilities: ['text', 'tools', 'stream'],
+      });
+
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
+
+      // The gateway prefix is stripped and the provider inferred from the
+      // underlying id, so models.dev is queried as the real provider.
+      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith('zai', 'glm-5.1');
+      expect(result[0].capabilities).toEqual(['text', 'tools', 'stream']);
+    });
+
+    it('falls back to the gateway provider when the underlying id is unknown', async () => {
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
+        makeDiscovered({
+          id: 'opencode-go/mimo-v25',
+          provider: 'opencode-go',
+          authType: 'subscription',
+        }),
+      ]);
+
+      await controller.getAvailableModels(mockUser, mockAgentName);
+
+      // `mimo-v25` matches no known provider, so the lookup keeps the gateway
+      // provider rather than passing `undefined`.
+      expect(mockModelsDevSync.lookupModel).toHaveBeenCalledWith('opencode-go', 'mimo-v25');
+    });
+
     it('should use null for display_name when displayName is empty', async () => {
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([
         makeDiscovered({ id: 'some-model', provider: 'openai', displayName: '' }),

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -9,6 +9,7 @@ import { ModelDiscoveryService } from '../model-discovery/model-discovery.servic
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
+import { resolveUnderlyingModelIdentity } from 'manifest-shared';
 import {
   mergeModelCapabilities,
   modelSupportsStreaming,
@@ -102,15 +103,22 @@ export class ModelController {
           authType,
           m.id,
         );
+        // Gateway models (e.g. `opencode-go/glm-5.1`) proxy another provider's
+        // API, so their capabilities live under the underlying provider on
+        // models.dev. Resolve the provenance before the metadata lookups; this
+        // is gateway-generic, not OpenCode Go-specific. `getCapabilities` (MPS)
+        // already unwraps gateways internally, so it keeps the raw identity.
+        const capId = resolveUnderlyingModelIdentity(m.provider, m.id);
+        const capProvider = capId.provider ?? m.provider;
         const modelsDevCapabilities = this.modelsDevSync.lookupModel(
-          m.provider,
-          m.id,
+          capProvider,
+          capId.model,
         )?.capabilities;
         const modelCapabilities = mergeModelCapabilities(
           m.capabilities,
           modelsDevCapabilities,
           capabilities,
-          modelSupportsStreaming(m.provider, m.id) ? ['stream'] : undefined,
+          modelSupportsStreaming(capProvider, capId.model) ? ['stream'] : undefined,
         );
         return {
           model_name: m.id,

--- a/packages/shared/__tests__/provider-inference.spec.ts
+++ b/packages/shared/__tests__/provider-inference.spec.ts
@@ -1,6 +1,7 @@
 import {
   MODEL_PREFIX_MAP,
   inferProviderFromModel,
+  resolveUnderlyingModelIdentity,
   underlyingGatewayModel,
 } from '../src/provider-inference';
 
@@ -84,5 +85,36 @@ describe('underlyingGatewayModel', () => {
   it('returns null for non-gateway model ids', () => {
     expect(underlyingGatewayModel('deepseek-v4-pro')).toBeNull();
     expect(underlyingGatewayModel('openrouter/anthropic/claude-sonnet-4')).toBeNull();
+  });
+});
+
+describe('resolveUnderlyingModelIdentity', () => {
+  it('resolves a gateway model id to its provenance provider and bare model', () => {
+    expect(resolveUnderlyingModelIdentity('opencode-go', 'opencode-go/glm-5.1')).toEqual({
+      provider: 'zai',
+      model: 'glm-5.1',
+    });
+    expect(resolveUnderlyingModelIdentity('opencode-go', 'opencode-go/kimi-k2.6')).toEqual({
+      provider: 'moonshot',
+      model: 'kimi-k2.6',
+    });
+  });
+
+  it('returns an undefined provider when the underlying id matches no known provider', () => {
+    expect(resolveUnderlyingModelIdentity('opencode-go', 'opencode-go/mimo-v25')).toEqual({
+      provider: undefined,
+      model: 'mimo-v25',
+    });
+  });
+
+  it('returns non-gateway pairs unchanged', () => {
+    expect(resolveUnderlyingModelIdentity('zai', 'glm-5.1')).toEqual({
+      provider: 'zai',
+      model: 'glm-5.1',
+    });
+    expect(resolveUnderlyingModelIdentity(undefined, 'deepseek-v4-pro')).toEqual({
+      provider: undefined,
+      model: 'deepseek-v4-pro',
+    });
   });
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -83,7 +83,12 @@ export {
   encodeFallbackEntry,
 } from './fallback-encoding';
 export type { FallbackEntry } from './fallback-encoding';
-export { MODEL_PREFIX_MAP, inferProviderFromModel } from './provider-inference';
+export {
+  MODEL_PREFIX_MAP,
+  inferProviderFromModel,
+  underlyingGatewayModel,
+  resolveUnderlyingModelIdentity,
+} from './provider-inference';
 export {
   SHARED_PROVIDERS,
   SHARED_PROVIDER_BY_ID,

--- a/packages/shared/src/provider-inference.ts
+++ b/packages/shared/src/provider-inference.ts
@@ -51,3 +51,23 @@ export function inferProviderFromModel(model: string): string | undefined {
   }
   return undefined;
 }
+
+/**
+ * Resolve a `(provider, model)` pair to the underlying provider and model that
+ * own its metadata, transparently unwrapping gateway transports. For a gateway
+ * model id (e.g. `opencode-go/glm-5.1`) this returns the provenance provider
+ * inferred from the underlying id and that bare id
+ * (`{ provider: 'zai', model: 'glm-5.1' }`); non-gateway pairs are returned
+ * unchanged. The provider is `undefined` when the underlying id matches no
+ * known provider, so callers decide whether to fall back. Capability and
+ * parameter lookups route through this so any gateway model inherits the
+ * underlying model's metadata, not just OpenCode Go's.
+ */
+export function resolveUnderlyingModelIdentity(
+  provider: string | undefined,
+  model: string,
+): { provider: string | undefined; model: string } {
+  const underlying = underlyingGatewayModel(model);
+  if (underlying === null) return { provider, model };
+  return { provider: inferProviderFromModel(underlying), model: underlying };
+}

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -1,5 +1,5 @@
 import type { AuthType } from './auth-types';
-import { inferProviderFromModel, underlyingGatewayModel } from './provider-inference';
+import { resolveUnderlyingModelIdentity, underlyingGatewayModel } from './provider-inference';
 import { normalizeProviderName, SHARED_PROVIDER_BY_ID_OR_ALIAS } from './providers';
 import type { JsonPrimitive, JsonValue } from './request-params';
 
@@ -118,10 +118,9 @@ function paramLookupIdentity(
   authType: AuthType | undefined,
   model: string | undefined,
 ): { providerId: string | undefined; authType: AuthType | undefined; model: string | undefined } {
-  if (!model) return { providerId, authType, model };
-  const underlying = underlyingGatewayModel(model);
-  if (underlying === null) return { providerId, authType, model };
-  return { providerId: inferProviderFromModel(underlying), authType: 'api_key', model: underlying };
+  if (!model || underlyingGatewayModel(model) === null) return { providerId, authType, model };
+  const resolved = resolveUnderlyingModelIdentity(providerId, model);
+  return { providerId: resolved.provider, authType: 'api_key', model: resolved.model };
 }
 
 export function getProviderParamSpecs(


### PR DESCRIPTION
### ✨ What changed
- New shared `resolveUnderlyingModelIdentity(provider, model)` unwraps any registered gateway prefix to its provenance `(provider, model)` — e.g. `(opencode-go, opencode-go/glm-5.1)` → `(zai, glm-5.1)`.
- The `available-models` endpoint routes its **models.dev capability lookup** and **streaming-support floor** through it, so gateway models inherit the underlying model's capabilities.
- `paramLookupIdentity()` (params, #2028) now reuses the same helper, so params and capabilities share one resolution seam.

### 💭 Why
A gateway is a transparent transport. `opencode-go/glm-5.1` is really z.ai's GLM-5.1, but the endpoint looked capabilities up under the gateway provider id `opencode-go`, which models.dev has no entry for. Every source came back empty, so the model picker showed **"Capabilities unknown"** for all OpenCode Go models.

### 👤 For users
OpenCode Go models now show capability badges (Text / Tools / Stream / Image…) sourced from the underlying provider's models.dev metadata, instead of "Capabilities unknown". Today that covers `opencode-go/*` models whose underlying id maps to a known provider (GLM→zai, Kimi→moonshot, MiniMax→minimax); ids with no known provider (e.g. MiMo) stay unknown.

### 📝 Notes
- **Gateway-generic, not OpenCode Go-specific.** The resolution keys off the shared `GATEWAY_MODEL_PREFIXES` abstraction. Any gateway added to that list inherits capability (and, via #2028, parameter) resolution with zero per-gateway code.
- `getCapabilities()` (MPS catalog) already unwraps gateways internally, so it keeps the raw identity — only the models.dev lookup and streaming floor needed the change.
- Complements #2028 (params) and #1885 (per-request cost). Capabilities follow the provenance; pricing follows the transport.
- Shared + backend `model.controller` suites pass with 100% line coverage on changed files; `tsc` clean. Frontend untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix capability detection for gateway models by resolving to the underlying provider/model before lookup. The model picker now shows correct capability badges for `opencode-go/*` and future gateways instead of "Capabilities unknown".

- **Bug Fixes**
  - Added `resolveUnderlyingModelIdentity(provider, model)` in `manifest-shared` to unwrap gateway ids (e.g. `opencode-go/glm-5.1` → `zai` / `glm-5.1`); non-gateway pairs stay the same.
  - `available-models` now queries models.dev capabilities and streaming support using the resolved identity, falling back to the gateway provider when the underlying provider is unknown.
  - Parameter resolution now reuses the same helper so params and capabilities resolve through one path.

<sup>Written for commit 8061e86ed24a0e0678596729a0e9501224c3c516. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2030?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

