### PR TITLE
feat: show OpenCode Go per-request cost in the model picker

### DIFF
--- a/.changeset/opencode-go-per-request-pricing-label.md
+++ b/.changeset/opencode-go-per-request-pricing-label.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Show OpenCode Go's per-request cost in the model picker and tier cards. OpenCode Go bills a per-request slice of its dollar quota rather than a flat fee, so models with a published cost now display e.g. `$0.0136/req` instead of the generic "Included in subscription" label. The `available-models` API surfaces `cost_per_request` (from the OpenCode Go catalog) for gateway models; flat-fee subscriptions are unchanged.

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -3,6 +3,7 @@ import { ProviderService } from './routing-core/provider.service';
 import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { CustomProviderService } from './custom-provider/custom-provider.service';
 import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
+import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog.service';
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
@@ -39,6 +40,7 @@ describe('ModelController', () => {
   let mockPricingSync: Record<string, jest.Mock>;
   let mockProviderParamSpecs: Record<string, jest.Mock>;
   let mockModelsDevSync: Record<string, jest.Mock>;
+  let mockOpencodeGoCatalog: Record<string, jest.Mock>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -75,6 +77,9 @@ describe('ModelController', () => {
     mockModelsDevSync = {
       lookupModel: jest.fn().mockReturnValue(null),
     };
+    mockOpencodeGoCatalog = {
+      resolveCostPerRequest: jest.fn().mockResolvedValue(null),
+    };
 
     controller = new ModelController(
       mockProviderService as unknown as ProviderService,
@@ -85,6 +90,7 @@ describe('ModelController', () => {
       mockPricingSync as unknown as PricingSyncService,
       mockProviderParamSpecs as unknown as ProviderParamSpecService,
       mockModelsDevSync as unknown as ModelsDevSyncService,
+      mockOpencodeGoCatalog as unknown as OpencodeGoCatalogService,
     );
   });
 
@@ -274,6 +280,50 @@ describe('ModelController', () => {
         quality_score: 3,
         display_name: 'GPT-4o',
       });
+    });
+
+    it('includes the per-request cost for OpenCode Go subscription models', async () => {
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
+        makeDiscovered({
+          id: 'opencode-go/glm-5.1',
+          provider: 'opencode-go',
+          authType: 'subscription',
+        }),
+      ]);
+      mockOpencodeGoCatalog.resolveCostPerRequest.mockResolvedValue(0.013636);
+
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
+
+      expect(mockOpencodeGoCatalog.resolveCostPerRequest).toHaveBeenCalledWith(
+        'opencode-go/glm-5.1',
+      );
+      expect(result[0].cost_per_request).toBe(0.013636);
+    });
+
+    it('omits cost_per_request when OpenCode Go has no published limit', async () => {
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
+        makeDiscovered({
+          id: 'opencode-go/mimo-v25',
+          provider: 'opencode-go',
+          authType: 'subscription',
+        }),
+      ]);
+      mockOpencodeGoCatalog.resolveCostPerRequest.mockResolvedValue(null);
+
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
+
+      expect(result[0]).not.toHaveProperty('cost_per_request');
+    });
+
+    it('does not query OpenCode Go cost for non-gateway providers', async () => {
+      mockDiscoveryService.getModelsForAgent.mockResolvedValue([
+        makeDiscovered({ id: 'gpt-4o', provider: 'openai' }),
+      ]);
+
+      const result = await controller.getAvailableModels(mockUser, mockAgentName);
+
+      expect(mockOpencodeGoCatalog.resolveCostPerRequest).not.toHaveBeenCalled();
+      expect(result[0]).not.toHaveProperty('cost_per_request');
     });
 
     it('should return only whitelisted fields for non-custom models', async () => {

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -6,6 +6,7 @@ import { ResolveAgentService } from './routing-core/resolve-agent.service';
 import { CustomProviderService } from './custom-provider/custom-provider.service';
 import { ProviderParamSpecService } from './routing-core/provider-param-spec.service';
 import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
+import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog.service';
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
@@ -30,6 +31,7 @@ export class ModelController {
     private readonly pricingSync: PricingSyncService,
     private readonly providerParamSpecs: ProviderParamSpecService,
     private readonly modelsDevSync: ModelsDevSyncService,
+    private readonly opencodeGoCatalog: OpencodeGoCatalogService,
   ) {}
 
   @Get('pricing-health')
@@ -112,12 +114,19 @@ export class ModelController {
           capabilities,
           modelSupportsStreaming(m.provider, m.id) ? ['stream'] : undefined,
         );
+        // OpenCode Go bills a per-request slice of its dollar quota rather than
+        // per token, so surface that cost; other subscriptions stay flat-fee.
+        const costPerRequest =
+          m.provider === 'opencode-go'
+            ? await this.opencodeGoCatalog.resolveCostPerRequest(m.id)
+            : null;
         return {
           model_name: m.id,
           provider: m.provider,
           auth_type: authType,
           input_price_per_token: m.inputPricePerToken,
           output_price_per_token: m.outputPricePerToken,
+          ...(costPerRequest != null ? { cost_per_request: costPerRequest } : {}),
           context_window: m.contextWindow,
           capability_reasoning: m.capabilityReasoning,
           capability_code: m.capabilityCode,

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -17,7 +17,7 @@ import {
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
 import { authBadgeFor } from './AuthBadge.js';
 import { resolveProviderId, inferProviderFromModel, pricePerM } from '../services/routing-utils.js';
-import { customProviderColor } from '../services/formatters.js';
+import { customProviderColor, formatPerRequestCost } from '../services/formatters.js';
 import { PROVIDERS } from '../services/providers.js';
 import FallbackList from './FallbackList.js';
 import ModelParamsAffordance from './ModelParamsAffordance.jsx';
@@ -388,7 +388,10 @@ const HeaderTierCard: Component<Props> = (props) => {
                   when={effectiveAuth() !== 'subscription'}
                   fallback={
                     <span class="routing-card__chip-meta">
-                      <span class="routing-card__chip-price">Included in subscription</span>
+                      <span class="routing-card__chip-price">
+                        {formatPerRequestCost(modelInfo()?.cost_per_request) ??
+                          'Included in subscription'}
+                      </span>
                       <ModelCapabilityBadges capabilities={modelInfo()?.capabilities} compact />
                       <Show when={primarySkipped()}>
                         <span class="routing-card__skipped-badge">Skipped in Stream</span>

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -9,7 +9,7 @@ import {
   type TierAssignment,
 } from '../services/api.js';
 import { PROVIDERS, STAGES, SPECIFICITY_STAGES, DEFAULT_STAGE } from '../services/providers.js';
-import { customProviderColor } from '../services/formatters.js';
+import { customProviderColor, formatPerRequestCost } from '../services/formatters.js';
 import { inferProviderFromModel, pricePerM, resolveProviderId } from '../services/routing-utils.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
 import { toast } from '../services/toast-store.js';
@@ -570,7 +570,10 @@ const ModelPickerModal: Component<Props> = (props) => {
                           fallback={
                             <span class="routing-modal__model-meta">
                               <span class="routing-modal__model-id routing-modal__model-id--subscription">
-                                {isLocal() ? 'Runs on your machine' : 'Included in subscription'}
+                                {isLocal()
+                                  ? 'Runs on your machine'
+                                  : (formatPerRequestCost(model.pricing.cost_per_request) ??
+                                    'Included in subscription')}
                               </span>
                               <ModelCapabilityBadges
                                 capabilities={model.pricing.capabilities}

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -10,7 +10,7 @@ import {
   inferProviderFromModel,
   usedKeyLabelsForModelInTier,
 } from '../services/routing-utils.js';
-import { customProviderColor } from '../services/formatters.js';
+import { customProviderColor, formatPerRequestCost } from '../services/formatters.js';
 import FallbackList from '../components/FallbackList.js';
 import ModelParamsAffordance from '../components/ModelParamsAffordance.jsx';
 import ModelCapabilityBadges from '../components/ModelCapabilityBadges.js';
@@ -580,7 +580,10 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                           when={effectiveAuth() !== 'subscription'}
                           fallback={
                             <span class="routing-card__chip-meta">
-                              <span class="routing-card__chip-price">Included in subscription</span>
+                              <span class="routing-card__chip-price">
+                                {formatPerRequestCost(modelInfo(modelName())?.cost_per_request) ??
+                                  'Included in subscription'}
+                              </span>
                               <ModelCapabilityBadges
                                 capabilities={modelCapabilities(modelName())}
                                 compact

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -291,6 +291,8 @@ export interface AvailableModel {
   auth_type?: AuthType;
   input_price_per_token: number | null;
   output_price_per_token: number | null;
+  /** Per-request USD cost for per-request subscriptions (e.g. OpenCode Go). */
+  cost_per_request?: number | null;
   context_window: number;
   capability_reasoning: boolean;
   capability_code: boolean;

--- a/packages/frontend/src/services/formatters.ts
+++ b/packages/frontend/src/services/formatters.ts
@@ -27,6 +27,19 @@ export function formatCost(n: number): string | null {
 }
 
 /**
+ * Format a per-request subscription cost (e.g. OpenCode Go's docs-attributed
+ * USD per call) as a compact `$0.0136/req` label. Returns null for a missing,
+ * zero, or negative value so callers fall back to a flat-fee label.
+ */
+export function formatPerRequestCost(cost: number | null | undefined): string | null {
+  if (cost == null) return null;
+  const n = Number(cost);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  if (n < 0.0001) return '< $0.0001/req';
+  return `$${n.toFixed(4)}/req`;
+}
+
+/**
  * Format a trend percentage (e.g., +18%, -7%).
  */
 export function formatTrend(pct: number): string {

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -51,7 +51,8 @@ vi.mock('../../src/services/providers.js', () => ({
   ],
 }));
 
-vi.mock('../../src/services/formatters.js', () => ({
+vi.mock('../../src/services/formatters.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/services/formatters.js')>()),
   customProviderColor: () => '#000',
 }));
 
@@ -357,6 +358,40 @@ describe('HeaderTierCard', () => {
     ));
     expect(container.querySelector('[data-testid="auth-subscription"]')).not.toBeNull();
     expect(container.textContent).toContain('Included in subscription');
+  });
+
+  it('shows the per-request cost for per-request subscriptions', () => {
+    const tierSub = {
+      ...baseTier,
+      override_route: {
+        provider: 'opencode-go',
+        authType: 'subscription',
+        model: 'opencode-go/glm-5.1',
+      } as const,
+    };
+    const gatewayModels: AvailableModel[] = [
+      {
+        ...models[0],
+        model_name: 'opencode-go/glm-5.1',
+        provider: 'opencode-go',
+        auth_type: 'subscription',
+        display_name: 'GLM-5.1',
+        cost_per_request: 0.013636,
+      },
+    ];
+    const { container } = render(() => (
+      <HeaderTierCard
+        agentName="demo"
+        tier={tierSub}
+        models={gatewayModels}
+        customProviders={customProviders}
+        connectedProviders={connectedProviders}
+        onOverride={vi.fn()}
+        onFallbacksUpdate={vi.fn()}
+      />
+    ));
+    expect(container.textContent).toContain('$0.0136/req');
+    expect(container.textContent).not.toContain('Included in subscription');
   });
 
   it('renders a + Add model button when override_route is null', () => {

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -40,7 +40,8 @@ vi.mock('../../src/services/routing-utils.js', () => ({
   pricePerM: (n: number) => `$${(Number(n) * 1_000_000).toFixed(2)}`,
 }));
 
-vi.mock('../../src/services/formatters.js', () => ({
+vi.mock('../../src/services/formatters.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/services/formatters.js')>()),
   customProviderColor: () => '#000',
 }));
 
@@ -716,6 +717,41 @@ describe('ModelPickerModal', () => {
       />
     ));
     expect(container.textContent).toContain('Runs on your machine');
+  });
+
+  it('renders the per-request cost instead of "Included in subscription" when present', () => {
+    const gatewayProviders: RoutingProvider[] = [
+      {
+        id: 'p4',
+        provider: 'opencode-go',
+        auth_type: 'subscription',
+        is_active: true,
+        has_api_key: false,
+        connected_at: '2025-01-01',
+      },
+    ];
+    const gatewayModels: AvailableModel[] = [
+      {
+        ...baseModels[2],
+        model_name: 'opencode-go/glm-5.1',
+        provider: 'opencode-go',
+        auth_type: 'subscription',
+        display_name: 'GLM-5.1',
+        cost_per_request: 0.013636,
+      },
+    ];
+    const { container } = render(() => (
+      <ModelPickerModal
+        tierId="simple"
+        models={gatewayModels}
+        tiers={tiers}
+        connectedProviders={gatewayProviders}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(container.textContent).toContain('$0.0136/req');
+    expect(container.textContent).not.toContain('Included in subscription');
   });
 
   it('filters the list by group name when search matches the group label', () => {

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -67,7 +67,8 @@ vi.mock('../../src/services/routing-utils.js', () => ({
   usedKeyLabelsForModelInTier: () => new Set<string>(),
 }));
 
-vi.mock('../../src/services/formatters.js', () => ({
+vi.mock('../../src/services/formatters.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/services/formatters.js')>()),
   customProviderColor: () => '#000',
 }));
 
@@ -629,6 +630,48 @@ describe('RoutingTierCard', () => {
       />
     ));
     expect(container.textContent).toContain('Included in subscription');
+  });
+
+  it('renders the per-request cost for per-request subscriptions', () => {
+    const tier = {
+      ...baseTier,
+      override_route: {
+        provider: 'opencode-go',
+        authType: 'subscription' as const,
+        model: 'opencode-go/glm-5.1',
+      },
+    };
+    const subProviders: RoutingProvider[] = [
+      {
+        id: 'p4',
+        provider: 'opencode-go',
+        auth_type: 'subscription',
+        is_active: true,
+        has_api_key: false,
+        connected_at: '2025-01-01',
+      },
+    ];
+    const gatewayModels: AvailableModel[] = [
+      {
+        ...models[0],
+        model_name: 'opencode-go/glm-5.1',
+        provider: 'opencode-go',
+        auth_type: 'subscription',
+        display_name: 'GLM-5.1',
+        cost_per_request: 0.013636,
+      },
+    ];
+    const { container } = render(() => (
+      <RoutingTierCard
+        {...makeProps({
+          tier: () => tier,
+          activeProviders: () => subProviders,
+          models: () => gatewayModels,
+        })}
+      />
+    ));
+    expect(container.textContent).toContain('$0.0136/req');
+    expect(container.textContent).not.toContain('Included in subscription');
   });
 
   it('renders the custom-provider letter in the chip when override_route is custom', () => {

--- a/packages/frontend/tests/services/formatters.test.ts
+++ b/packages/frontend/tests/services/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatNumber, formatCost, formatTrend, formatStatus, formatMetricType, formatErrorMessage, formatRelativeTime, formatTime, formatDuration, formatTimeAgo } from "../../src/services/formatters";
+import { formatNumber, formatCost, formatPerRequestCost, formatTrend, formatStatus, formatMetricType, formatErrorMessage, formatRelativeTime, formatTime, formatDuration, formatTimeAgo } from "../../src/services/formatters";
 
 describe("formatNumber", () => {
   it("formats millions", () => {
@@ -36,6 +36,23 @@ describe("formatCost", () => {
   it("formats costs at or above one cent normally", () => {
     expect(formatCost(0.01)).toBe("$0.01");
     expect(formatCost(0.05)).toBe("$0.05");
+  });
+});
+
+describe("formatPerRequestCost", () => {
+  it("formats a per-request cost with 4 decimals", () => {
+    expect(formatPerRequestCost(0.013636)).toBe("$0.0136/req");
+    expect(formatPerRequestCost(0.05)).toBe("$0.0500/req");
+  });
+  it("returns a floor label for tiny positive costs", () => {
+    expect(formatPerRequestCost(0.00001)).toBe("< $0.0001/req");
+  });
+  it("returns null for missing, zero, negative, or non-finite values", () => {
+    expect(formatPerRequestCost(null)).toBeNull();
+    expect(formatPerRequestCost(undefined)).toBeNull();
+    expect(formatPerRequestCost(0)).toBeNull();
+    expect(formatPerRequestCost(-1)).toBeNull();
+    expect(formatPerRequestCost(Number.NaN)).toBeNull();
   });
 });
 


### PR DESCRIPTION
### ✨ What changed
- The `available-models` endpoint now returns `cost_per_request` for OpenCode Go models, sourced from `OpencodeGoCatalogService`.
- The model picker (`ModelPickerModal`) and routing tier cards (`HeaderTierCard`, `RoutingTierCard`) render that cost (e.g. `$0.0136/req`) via a new `formatPerRequestCost` helper, instead of the flat "Included in subscription" label.

### 💭 Why
OpenCode Go bills a per-request slice of its dollar quota ($12 / 5h), not a flat fee. The per-request cost was already computed and recorded per message (#1885), but the routing UI still showed every subscription model as "Included in subscription", which is misleading for OpenCode Go.

### 👤 For users
OpenCode Go models in the picker and tier cards now show their real per-request cost (e.g. `$0.0136/req` for GLM-5.1). Flat-fee subscriptions (Claude Max, ChatGPT Plus, GLM Coding, Copilot) are unchanged — they still show "Included in subscription".

### 📝 Notes
- Pricing **follows the transport**: the cost comes from the gateway's own catalog, scoped to `provider === 'opencode-go'` so no other provider triggers the lookup. (Capabilities, by contrast, follow the provenance — see #2030.)
- `formatPerRequestCost` returns null for missing/zero/negative costs, so the "Included in subscription" fallback is preserved everywhere.
- Backend `model.controller` + shared formatter + all three components covered at 100% line coverage on changed files; backend/frontend `tsc` clean; full frontend suite (3426 tests) green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the per-request cost for OpenCode Go models in the model picker and routing tier cards. The backend now surfaces `cost_per_request`, so users see accurate `$X/req` pricing instead of the generic "Included in subscription" label.

- New Features
  - `available-models` now returns `cost_per_request` for `opencode-go` models using `OpencodeGoCatalogService`.
  - `ModelPickerModal`, `HeaderTierCard`, and `RoutingTierCard` render `$0.0136/req` via `formatPerRequestCost`, falling back to "Included in subscription" when missing or non-positive.
  - Added `cost_per_request` to the `AvailableModel` API type; flat-fee subscriptions are unchanged.

<sup>Written for commit f71c741b265fc84bf668742789b301250d1e7ffe. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2032?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

