### PR TITLE
Add Grok subscription OAuth provider

### DIFF
--- a/.changeset/grok-subscription-provider.md
+++ b/.changeset/grok-subscription-provider.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add Grok subscription provider support with xAI OAuth login and dynamic xAI model discovery.

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -76,7 +76,7 @@ export class ModelDiscoveryService {
     // OAuth-backed subscription providers store an encrypted token blob.
     // Unwrap it so model discovery can call the provider-native /models endpoint.
     if (provider.auth_type === 'subscription' && apiKey) {
-      if (lowerProvider === 'openai' || lowerProvider === 'minimax') {
+      if (lowerProvider === 'openai' || lowerProvider === 'minimax' || lowerProvider === 'xai') {
         const blob = parseOAuthTokenBlob(apiKey);
         if (blob?.t) {
           apiKey = blob.t;

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -290,6 +290,30 @@ describe('ProviderModelFetcherService', () => {
     });
   });
 
+  /* ── xAI provider ── */
+
+  describe('xai provider', () => {
+    it('uses the dynamic xAI models endpoint for subscription auth', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'grok-3' }, { id: 'grok-4' }],
+        }),
+      });
+
+      const result = await service.fetch('xai', 'xai-test-key', 'subscription');
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.x.ai/v1/models',
+        expect.objectContaining({
+          headers: { Authorization: 'Bearer xai-test-key' },
+        }),
+      );
+      expect(result.map((m) => m.id)).toEqual(['grok-3', 'grok-4']);
+      expect(result.every((m) => m.provider === 'xai')).toBe(true);
+    });
+  });
+
   /* ── Mistral-specific filter ── */
 
   describe('parseMistralChatOnly (via mistral provider)', () => {

--- a/packages/backend/src/routing/oauth/core/callback-page.ts
+++ b/packages/backend/src/routing/oauth/core/callback-page.ts
@@ -18,7 +18,7 @@ export function oauthDoneHtml(success: boolean, nonce?: string, providerLabel = 
 <p id="hint" style="font-size:13px;color:#888;display:none;">You can close this window.</p>
 <script${nonceAttr}>
 try{var bc=new BroadcastChannel('manifest-oauth');bc.postMessage({type:'${message}'});bc.close();}catch(e){}
-if(window.opener){window.opener.postMessage({type:'${message}'},window.location.origin);}
+if(window.opener){window.opener.postMessage({type:'${message}'},'*');}
 setTimeout(function(){window.close();document.getElementById('hint').style.display='block';},1500);
 </script>
 </body>

--- a/packages/backend/src/routing/oauth/oauth.module.ts
+++ b/packages/backend/src/routing/oauth/oauth.module.ts
@@ -10,6 +10,8 @@ import { AnthropicOauthService } from './anthropic/anthropic-oauth.service';
 import { AnthropicOauthController } from './anthropic/anthropic-oauth.controller';
 import { KiroOauthService } from './kiro-oauth.service';
 import { KiroOauthController } from './kiro-oauth.controller';
+import { XaiOauthController } from './xai/xai-oauth.controller';
+import { XaiOauthService } from './xai/xai-oauth.service';
 import { OAuthPendingFlowStore } from './core';
 import { GeminiOauthService } from './gemini-oauth.service';
 import { GeminiOauthController } from './gemini-oauth.controller';
@@ -23,6 +25,7 @@ import { CodeAssistClientService } from './codeassist-client.service';
     AnthropicOauthController,
     GeminiOauthController,
     KiroOauthController,
+    XaiOauthController,
   ],
   providers: [
     OpenaiOauthService,
@@ -30,6 +33,7 @@ import { CodeAssistClientService } from './codeassist-client.service';
     CopilotDeviceAuthService,
     AnthropicOauthService,
     KiroOauthService,
+    XaiOauthService,
     OAuthPendingFlowStore,
     GeminiOauthService,
     CodeAssistClientService,
@@ -41,6 +45,7 @@ import { CodeAssistClientService } from './codeassist-client.service';
     AnthropicOauthService,
     GeminiOauthService,
     KiroOauthService,
+    XaiOauthService,
   ],
 })
 export class OAuthModule {}

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.controller.ts
@@ -1,0 +1,126 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  Logger,
+  Post,
+  Query,
+  Req,
+  Res,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { randomBytes } from 'crypto';
+import { Request, Response } from 'express';
+import { AuthUser } from '../../../auth/auth.instance';
+import { CurrentUser } from '../../../auth/current-user.decorator';
+import { Public } from '../../../common/decorators/public.decorator';
+import { ResolveAgentService } from '../../routing-core/resolve-agent.service';
+import { ProviderKeyService } from '../../routing-core/provider-key.service';
+import { ProviderService } from '../../routing-core/provider.service';
+import { oauthDoneHtml, type OAuthTokenBlob } from '../core';
+import { optionalTrimmedStringQuery } from '../query-params';
+import { XaiOauthService } from './xai-oauth.service';
+
+@Controller('api/v1/oauth/xai')
+export class XaiOauthController {
+  private readonly logger = new Logger(XaiOauthController.name);
+
+  constructor(
+    private readonly oauthService: XaiOauthService,
+    private readonly resolveAgent: ResolveAgentService,
+    private readonly providerKeyService: ProviderKeyService,
+    private readonly providerService: ProviderService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  @Get('authorize')
+  async authorize(
+    @Query('agentName') agentName: string,
+    @CurrentUser() user: AuthUser,
+    @Req() req: Request,
+  ) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    const trustedBackendUrl = this.configService.get<string>('BETTER_AUTH_URL');
+    const backendUrl = trustedBackendUrl || `${req.protocol}://${req.get('host')}`;
+    try {
+      const url = await this.oauthService.generateAuthorizationUrl(agent.id, user.id, backendUrl);
+      return { url };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to start OAuth callback server';
+      throw new HttpException(message, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  @Post('callback')
+  async callback(
+    @Body('code') code: string,
+    @Body('state') state: string,
+    @CurrentUser() _user: AuthUser,
+  ) {
+    if (!code || !state) {
+      throw new HttpException('code and state are required', HttpStatus.BAD_REQUEST);
+    }
+
+    try {
+      await this.oauthService.exchangeCode(state, code);
+      return { ok: true };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Token exchange failed';
+      this.logger.error(`xAI OAuth callback exchange failed: ${message}`);
+      throw new HttpException(message, HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  @Post('revoke')
+  async revoke(
+    @Query('agentName') agentName: string,
+    @Query('label') label: string | string[] | undefined,
+    @CurrentUser() user: AuthUser,
+  ) {
+    if (!agentName) {
+      throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
+    }
+    const keyLabel = optionalTrimmedStringQuery(label, 'label');
+    const agent = await this.resolveAgent.resolve(user.id, agentName);
+    const keys = await this.providerKeyService.getProviderKeys(agent.id, 'xai', 'subscription');
+    const keysToRevoke = keyLabel
+      ? keys.filter((key) => key.label.toLowerCase() === keyLabel.toLowerCase())
+      : keys;
+
+    for (const key of keysToRevoke) {
+      if (!key.apiKey) continue;
+      try {
+        const blob = JSON.parse(key.apiKey) as OAuthTokenBlob;
+        if (blob.t) await this.oauthService.revokeToken(blob.t);
+        if (blob.r) await this.oauthService.revokeToken(blob.r);
+      } catch {
+        this.logger.warn('Could not parse xAI OAuth token blob for revocation');
+      }
+    }
+
+    const { notifications } = await this.providerService.removeProvider(
+      agent.id,
+      'xai',
+      'subscription',
+      keyLabel,
+    );
+
+    return { ok: true, notifications };
+  }
+
+  @Get('done')
+  @Public()
+  done(@Query('ok') ok: string, @Res() res: Response) {
+    const success = ok === '1';
+
+    const nonce = randomBytes(16).toString('base64');
+    res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Content-Security-Policy', `default-src 'none'; script-src 'nonce-${nonce}'`);
+    res.send(oauthDoneHtml(success, nonce, 'xAI Login'));
+  }
+}

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
@@ -1,0 +1,204 @@
+import { ConfigService } from '@nestjs/config';
+import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
+import { ProviderService } from '../../routing-core/provider.service';
+import { XaiOauthService } from './xai-oauth.service';
+
+const originalFetch = global.fetch;
+
+function mockResponse(status: number, body: unknown, text = ''): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => text || JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function createConfig(nodeEnv = 'production'): ConfigService {
+  return {
+    get: (key: string) => {
+      if (key === 'app.nodeEnv') return nodeEnv;
+      if (key === 'XAI_OAUTH_CLIENT_ID') return undefined;
+      return undefined;
+    },
+  } as unknown as ConfigService;
+}
+
+function createProviderService() {
+  const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
+  const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  const nextOAuthLabel = jest.fn().mockResolvedValue('X Account');
+  return {
+    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    upsertProvider,
+    recalculateTiers,
+    nextOAuthLabel,
+  };
+}
+
+function createDiscovery(): { svc: ModelDiscoveryService; discoverModels: jest.Mock } {
+  const discoverModels = jest.fn().mockResolvedValue(undefined);
+  return { svc: { discoverModels } as unknown as ModelDiscoveryService, discoverModels };
+}
+
+describe('XaiOauthService', () => {
+  let fetchMock: jest.Mock;
+  let providerService: ReturnType<typeof createProviderService>;
+  let discovery: ReturnType<typeof createDiscovery>;
+  let svc: XaiOauthService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-26T12:00:00Z'));
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    providerService = createProviderService();
+    discovery = createDiscovery();
+    svc = new XaiOauthService(providerService.svc, createConfig('production'), discovery.svc);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('builds an xAI OAuth URL with PKCE and the subscription scopes', async () => {
+    const url = await svc.generateAuthorizationUrl('agent-1', 'user-1', 'http://localhost:3001');
+    const parsed = new URL(url);
+
+    expect(parsed.origin + parsed.pathname).toBe('https://auth.x.ai/oauth2/authorize');
+    expect(parsed.searchParams.get('response_type')).toBe('code');
+    expect(parsed.searchParams.get('client_id')).toBe('b1a00492-073a-47ea-816f-4c329264a828');
+    expect(parsed.searchParams.get('redirect_uri')).toBe('http://127.0.0.1:56121/callback');
+    expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(parsed.searchParams.get('code_challenge')?.length).toBeGreaterThan(0);
+    expect(parsed.searchParams.get('scope')).toContain('grok-cli:access');
+    expect(parsed.searchParams.get('scope')).toContain('api:access');
+    expect(parsed.searchParams.has('plan')).toBe(false);
+    expect(parsed.searchParams.has('referrer')).toBe(false);
+    expect(parsed.searchParams.get('state')?.length).toBeGreaterThan(0);
+    expect(svc.getPendingCount()).toBe(1);
+  });
+
+  it('uses a custom xAI client id from ConfigService when provided', async () => {
+    const config = {
+      get: (key: string) =>
+        key === 'XAI_OAUTH_CLIENT_ID'
+          ? 'custom-xai-client'
+          : key === 'app.nodeEnv'
+            ? 'production'
+            : undefined,
+    } as unknown as ConfigService;
+    const customSvc = new XaiOauthService(providerService.svc, config, discovery.svc);
+    const url = await customSvc.generateAuthorizationUrl('a', 'u');
+    expect(new URL(url).searchParams.get('client_id')).toBe('custom-xai-client');
+  });
+
+  it('exchanges a valid code, stores the OAuth blob, and triggers model discovery', async () => {
+    fetchMock.mockResolvedValue(
+      mockResponse(200, {
+        access_token: 'access-1',
+        refresh_token: 'refresh-1',
+        expires_in: 3600,
+      }),
+    );
+    const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+    const parsed = new URL(url);
+    const state = parsed.searchParams.get('state')!;
+
+    await svc.exchangeCode(state, 'auth-code');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [tokenUrl, init] = fetchMock.mock.calls[0];
+    expect(tokenUrl).toBe('https://auth.x.ai/oauth2/token');
+    const body = new URLSearchParams(init.body.toString());
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('auth-code');
+    expect(body.get('redirect_uri')).toBe('http://127.0.0.1:56121/callback');
+    expect(body.get('code_verifier')?.length).toBeGreaterThan(0);
+    expect(body.has('code_challenge')).toBe(false);
+    expect(body.has('code_challenge_method')).toBe(false);
+
+    expect(providerService.nextOAuthLabel).toHaveBeenCalledWith('agent-1', 'xai');
+    expect(providerService.upsertProvider).toHaveBeenCalledWith(
+      'agent-1',
+      'user-1',
+      'xai',
+      expect.stringContaining('"t":"access-1"'),
+      'subscription',
+      undefined,
+      'X Account',
+    );
+    expect(discovery.discoverModels).toHaveBeenCalledWith({ id: 'p1' });
+    expect(providerService.recalculateTiers).toHaveBeenCalledWith('agent-1');
+    expect(svc.getPendingCount()).toBe(0);
+  });
+
+  it('rejects unknown and expired states', async () => {
+    await expect(svc.exchangeCode('bogus-state', 'code')).rejects.toThrow(
+      'Invalid or expired OAuth state',
+    );
+
+    const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+    const state = new URL(url).searchParams.get('state')!;
+    jest.advanceTimersByTime(10 * 60 * 1000 + 1);
+
+    await expect(svc.exchangeCode(state, 'code')).rejects.toThrow('OAuth state expired');
+    expect(svc.getPendingCount()).toBe(0);
+  });
+
+  it('throws when the token endpoint returns an error', async () => {
+    fetchMock.mockResolvedValue(mockResponse(400, {}, 'invalid_grant'));
+    const url = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+    const state = new URL(url).searchParams.get('state')!;
+
+    await expect(svc.exchangeCode(state, 'bad-code')).rejects.toThrow('Token exchange failed');
+  });
+
+  it('refreshes and persists a fresh access token when the stored token is near expiry', async () => {
+    const blob = { t: 'old', r: 'refresh-old', e: Date.now() + 30_000 };
+    fetchMock.mockResolvedValue(
+      mockResponse(200, {
+        access_token: 'new-access',
+        refresh_token: 'refresh-new',
+        expires_in: 3600,
+      }),
+    );
+
+    const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+
+    expect(token).toBe('new-access');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://auth.x.ai/oauth2/token',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(providerService.upsertProvider).toHaveBeenCalledWith(
+      'agent-1',
+      'user-1',
+      'xai',
+      expect.stringContaining('"t":"new-access"'),
+      'subscription',
+    );
+  });
+
+  it('returns cached token while still valid and null for malformed blobs', async () => {
+    const blob = { t: 'access', r: 'refresh', e: Date.now() + 10 * 60 * 1000 };
+    expect(await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1')).toBe('access');
+    expect(await svc.unwrapToken('not-json', 'agent-1', 'user-1')).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('POSTs tokens to the xAI revoke endpoint', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, {}));
+
+    await svc.revokeToken('tok');
+
+    const [revokeUrl, init] = fetchMock.mock.calls[0];
+    expect(revokeUrl).toBe('https://auth.x.ai/oauth2/revoke');
+    const body = new URLSearchParams(init.body.toString());
+    expect(body.get('token')).toBe('tok');
+  });
+});

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.service.ts
@@ -1,0 +1,305 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createServer, IncomingMessage, Server, ServerResponse } from 'http';
+import { ProviderService } from '../../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
+import { scrubSecrets } from '../../../common/utils/secret-scrub';
+import {
+  generatePkce,
+  generateState,
+  oauthDoneHtml,
+  parseOAuthTokenBlob,
+  PendingStore,
+  serializeOAuthTokenBlob,
+  type OAuthTokenBlob,
+} from '../core';
+
+interface PendingXaiOAuth {
+  verifier: string;
+  agentId: string;
+  userId: string;
+  backendUrl: string;
+  expiresAt: number;
+}
+
+const DEFAULT_CLIENT_ID = 'b1a00492-073a-47ea-816f-4c329264a828';
+const AUTHORIZE_URL = 'https://auth.x.ai/oauth2/authorize';
+const TOKEN_URL = 'https://auth.x.ai/oauth2/token';
+const REVOKE_URL = 'https://auth.x.ai/oauth2/revoke';
+const SCOPE = 'openid profile email offline_access grok-cli:access api:access';
+const CALLBACK_PORT = 56121;
+const REDIRECT_URI = `http://127.0.0.1:${CALLBACK_PORT}/callback`;
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+@Injectable()
+export class XaiOauthService {
+  private readonly logger = new Logger(XaiOauthService.name);
+  private readonly pending = new PendingStore<PendingXaiOAuth>(STATE_TTL_MS);
+  private callbackServer: Server | null = null;
+  private serverReady: Promise<void> | null = null;
+  private readonly clientId: string;
+  private readonly useCallbackServer: boolean;
+
+  constructor(
+    private readonly providerService: ProviderService,
+    private readonly configService: ConfigService,
+    private readonly discoveryService: ModelDiscoveryService,
+  ) {
+    this.clientId = this.configService.get<string>('XAI_OAUTH_CLIENT_ID') ?? DEFAULT_CLIENT_ID;
+    this.useCallbackServer =
+      (this.configService.get<string>('app.nodeEnv') ?? 'development') !== 'production';
+  }
+
+  async generateAuthorizationUrl(
+    agentId: string,
+    userId: string,
+    backendUrl?: string,
+  ): Promise<string> {
+    const state = generateState();
+    const nonce = generateState(16);
+    const { verifier, challenge } = generatePkce();
+    const safeBackendUrl = backendUrl && this.isAllowedRedirectOrigin(backendUrl) ? backendUrl : '';
+    this.pending.set(state, {
+      verifier,
+      agentId,
+      userId,
+      backendUrl: safeBackendUrl,
+    });
+    if (this.useCallbackServer) {
+      await this.ensureCallbackServer();
+    }
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: this.clientId,
+      redirect_uri: REDIRECT_URI,
+      scope: SCOPE,
+      state,
+      nonce,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    });
+    return `${AUTHORIZE_URL}?${params.toString()}`;
+  }
+
+  async exchangeCode(state: string, code: string): Promise<void> {
+    const pending = this.pending.peek(state);
+    if (!pending) throw new Error('Invalid or expired OAuth state');
+    if (pending.expiresAt < Date.now()) {
+      this.pending.delete(state);
+      throw new Error('OAuth state expired');
+    }
+    this.pending.delete(state);
+
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT_URI,
+        client_id: this.clientId,
+        code_verifier: pending.verifier,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`xAI token exchange failed: ${scrubSecrets(text)}`);
+      throw new Error('Token exchange failed');
+    }
+
+    const data = (await response.json()) as {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    };
+    const blob: OAuthTokenBlob = {
+      t: data.access_token,
+      r: data.refresh_token,
+      e: Date.now() + data.expires_in * 1000,
+    };
+    const label = await this.providerService.nextOAuthLabel(pending.agentId, 'xai');
+    const { provider: savedProvider } = await this.providerService.upsertProvider(
+      pending.agentId,
+      pending.userId,
+      'xai',
+      serializeOAuthTokenBlob(blob),
+      'subscription',
+      undefined,
+      label,
+    );
+    try {
+      await this.discoveryService.discoverModels(savedProvider);
+      await this.providerService.recalculateTiers(pending.agentId);
+    } catch (err) {
+      this.logger.warn(`Model discovery after xAI OAuth failed: ${err}`);
+    }
+    this.logger.log(`xAI OAuth token stored for agent=${pending.agentId}`);
+    this.shutdownCallbackServerIfIdle();
+  }
+
+  async refreshAccessToken(refreshToken: string): Promise<OAuthTokenBlob> {
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Accept: 'application/json',
+      },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: this.clientId,
+      }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      this.logger.error(`xAI token refresh failed: ${scrubSecrets(text)}`);
+      throw new Error('Token refresh failed');
+    }
+    const data = (await response.json()) as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in: number;
+    };
+    return {
+      t: data.access_token,
+      r: data.refresh_token || refreshToken,
+      e: Date.now() + data.expires_in * 1000,
+    };
+  }
+
+  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
+    const blob = parseOAuthTokenBlob(rawValue);
+    if (!blob) return null;
+    if (Date.now() < blob.e - 60_000) return blob.t;
+    try {
+      const refreshed = await this.refreshAccessToken(blob.r);
+      await this.providerService.upsertProvider(
+        agentId,
+        userId,
+        'xai',
+        serializeOAuthTokenBlob(refreshed),
+        'subscription',
+      );
+      this.logger.log(`xAI OAuth token refreshed for agent=${agentId}`);
+      return refreshed.t;
+    } catch (err) {
+      this.logger.error(`Failed to refresh xAI token for agent=${agentId}: ${err}`);
+      return null;
+    }
+  }
+
+  async revokeToken(token: string): Promise<void> {
+    try {
+      const response = await fetch(REVOKE_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Accept: 'application/json',
+        },
+        body: new URLSearchParams({ token, client_id: this.clientId }),
+      });
+      if (!response.ok) {
+        const text = await response.text();
+        this.logger.warn(`xAI token revocation failed: ${scrubSecrets(text)}`);
+      } else {
+        this.logger.log('xAI OAuth token revoked');
+      }
+    } catch (err) {
+      this.logger.warn(`xAI token revocation error: ${err}`);
+    }
+  }
+
+  getPendingCount(): number {
+    return this.pending.size();
+  }
+
+  private ensureCallbackServer(): Promise<void> {
+    if (this.callbackServer) return Promise.resolve();
+    if (this.serverReady) return this.serverReady;
+    this.serverReady = new Promise<void>((resolve, reject) => {
+      const server = createServer((req, res) => this.handleCallbackRequest(req, res));
+      server.on('error', (err: NodeJS.ErrnoException) => {
+        this.callbackServer = null;
+        this.serverReady = null;
+        if (err.code === 'EADDRINUSE') {
+          this.logger.warn(`Port ${CALLBACK_PORT} in use - xAI callback server not started`);
+          reject(
+            new Error(
+              `Port ${CALLBACK_PORT} is already in use. Run 'lsof -i :${CALLBACK_PORT}' to find the process.`,
+            ),
+          );
+        } else {
+          this.logger.error(`xAI callback server error: ${err.message}`);
+          reject(new Error(`Callback server failed: ${err.message}`));
+        }
+      });
+      server.listen(CALLBACK_PORT, '127.0.0.1', () => {
+        this.logger.log(`xAI OAuth callback server listening on port ${CALLBACK_PORT}`);
+        this.callbackServer = server;
+        resolve();
+      });
+      server.unref();
+    });
+    return this.serverReady;
+  }
+
+  private handleCallbackRequest(req: IncomingMessage, res: ServerResponse): void {
+    const url = new URL(req.url ?? '/', `http://127.0.0.1:${CALLBACK_PORT}`);
+    if (url.pathname !== '/callback') {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const code = url.searchParams.get('code') ?? '';
+    const state = url.searchParams.get('state') ?? '';
+    const error = url.searchParams.get('error');
+    const appUrl = this.pending.peek(state)?.backendUrl || '';
+    if (error) {
+      const desc = url.searchParams.get('error_description') ?? error;
+      this.logger.error(`xAI OAuth callback error from provider: ${desc}`);
+      this.pending.delete(state);
+      this.shutdownCallbackServerIfIdle();
+      this.sendDoneResponse(res, false, appUrl);
+      return;
+    }
+    this.exchangeCode(state, code)
+      .then(() => this.sendDoneResponse(res, true, appUrl))
+      .catch((err) => {
+        this.logger.error(`xAI OAuth callback failed: ${err}`);
+        this.sendDoneResponse(res, false, appUrl);
+      });
+  }
+
+  private isAllowedRedirectOrigin(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      const hostname = parsed.hostname;
+      return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    } catch {
+      return false;
+    }
+  }
+
+  private sendDoneResponse(res: ServerResponse, success: boolean, appUrl: string): void {
+    if (appUrl && this.isAllowedRedirectOrigin(appUrl)) {
+      const ok = success ? '1' : '0';
+      res.writeHead(302, { Location: `${appUrl}/api/v1/oauth/xai/done?ok=${ok}` });
+      res.end();
+    } else {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end(oauthDoneHtml(success, undefined, 'xAI Login'));
+    }
+  }
+
+  private shutdownCallbackServerIfIdle(): void {
+    if (this.pending.isEmpty() && this.callbackServer) {
+      this.callbackServer.close();
+      this.callbackServer = null;
+      this.serverReady = null;
+      this.logger.log('xAI OAuth callback server shut down (no pending flows)');
+    }
+  }
+}

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
@@ -8,6 +8,7 @@ import { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
 import { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
 import { GeminiOauthService } from '../../oauth/gemini-oauth.service';
 import { KiroOauthService } from '../../oauth/kiro-oauth.service';
+import { XaiOauthService } from '../../oauth/xai/xai-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
 import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
@@ -38,6 +39,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
   let anthropicOauth: jest.Mocked<AnthropicOauthService>;
   let geminiOauth: jest.Mocked<GeminiOauthService>;
   let kiroOauth: jest.Mocked<KiroOauthService>;
+  let xaiOauth: jest.Mocked<XaiOauthService>;
   let providerClient: jest.Mocked<ProviderClient>;
   let copilotToken: jest.Mocked<CopilotTokenService>;
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
@@ -74,6 +76,9 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
     kiroOauth = {
       unwrapToken: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<KiroOauthService>;
+    xaiOauth = {
+      unwrapToken: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<XaiOauthService>;
 
     providerClient = {
       forward: jest.fn(),
@@ -107,6 +112,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
       anthropicOauth,
       geminiOauth,
       kiroOauth,
+      xaiOauth,
       providerClient,
       copilotToken,
       pricingCache,

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -11,6 +11,7 @@ import { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
 import { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
 import { GeminiOauthService } from '../../oauth/gemini-oauth.service';
 import { KiroOauthService } from '../../oauth/kiro-oauth.service';
+import { XaiOauthService } from '../../oauth/xai/xai-oauth.service';
 import { ProviderClient } from '../provider-client';
 import { CopilotTokenService } from '../copilot-token.service';
 import { ReasoningContentCache } from '../reasoning-content-cache';
@@ -47,6 +48,7 @@ describe('ProxyFallbackService', () => {
   let anthropicOauth: jest.Mocked<AnthropicOauthService>;
   let geminiOauth: jest.Mocked<GeminiOauthService>;
   let kiroOauth: jest.Mocked<KiroOauthService>;
+  let xaiOauth: jest.Mocked<XaiOauthService>;
   let providerClient: jest.Mocked<ProviderClient>;
   let copilotToken: jest.Mocked<CopilotTokenService>;
   let pricingCache: jest.Mocked<ModelPricingCacheService>;
@@ -85,6 +87,9 @@ describe('ProxyFallbackService', () => {
     kiroOauth = {
       unwrapToken: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<KiroOauthService>;
+    xaiOauth = {
+      unwrapToken: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<XaiOauthService>;
 
     providerClient = {
       forward: jest.fn(),
@@ -131,6 +136,7 @@ describe('ProxyFallbackService', () => {
       anthropicOauth,
       geminiOauth,
       kiroOauth,
+      xaiOauth,
       providerClient,
       copilotToken,
       pricingCache,
@@ -1012,6 +1018,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('access-token');
@@ -1037,6 +1044,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('mm-token');
@@ -1055,6 +1063,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('sk-key');
@@ -1075,6 +1084,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('blob');
@@ -1094,6 +1104,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('access-claude');
@@ -1114,6 +1125,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('sk-ant-legacy');
@@ -1134,6 +1146,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('kiro-access');
@@ -1152,6 +1165,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('qwen-key');
@@ -1159,6 +1173,28 @@ describe('ProxyFallbackService', () => {
       expect(minimaxOauth.unwrapToken).not.toHaveBeenCalled();
       expect(anthropicOauth.unwrapToken).not.toHaveBeenCalled();
       expect(kiroOauth.unwrapToken).not.toHaveBeenCalled();
+      expect(xaiOauth.unwrapToken).not.toHaveBeenCalled();
+    });
+
+    it('unwraps xAI OAuth subscription tokens', async () => {
+      xaiOauth.unwrapToken.mockResolvedValue('xai-access');
+
+      const result = await resolveApiKey(
+        'xai',
+        'blob',
+        'subscription',
+        'agent-1',
+        'user-1',
+        openaiOauth,
+        minimaxOauth,
+        anthropicOauth,
+        geminiOauth,
+        kiroOauth,
+        xaiOauth,
+      );
+
+      expect(result.apiKey).toBe('xai-access');
+      expect(xaiOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1');
     });
 
     it('returns original key when MiniMax unwrap returns null', async () => {
@@ -1175,6 +1211,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('blob');
@@ -1192,6 +1229,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('zai-sub-key');
@@ -1200,6 +1238,7 @@ describe('ProxyFallbackService', () => {
       expect(minimaxOauth.unwrapToken).not.toHaveBeenCalled();
       expect(anthropicOauth.unwrapToken).not.toHaveBeenCalled();
       expect(kiroOauth.unwrapToken).not.toHaveBeenCalled();
+      expect(xaiOauth.unwrapToken).not.toHaveBeenCalled();
     });
 
     it('unwraps Gemini subscription token and reads project id from blob.u', async () => {
@@ -1222,6 +1261,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('fresh-access-token');
@@ -1244,6 +1284,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe(blob);
@@ -1263,6 +1304,7 @@ describe('ProxyFallbackService', () => {
         anthropicOauth,
         geminiOauth,
         kiroOauth,
+        xaiOauth,
       );
 
       expect(result.apiKey).toBe('fresh-token');

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -15,6 +15,7 @@ import type { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
 import type { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
 import type { GeminiOauthService } from '../../oauth/gemini-oauth.service';
 import type { KiroOauthService } from '../../oauth/kiro-oauth.service';
+import type { XaiOauthService } from '../../oauth/xai/xai-oauth.service';
 import type { SessionMomentumService } from '../session-momentum.service';
 import type { LimitCheckService } from '../../../notifications/services/limit-check.service';
 import type { ProxyFallbackService } from '../proxy-fallback.service';
@@ -74,6 +75,7 @@ describe('ProxyService — orchestration', () => {
   let anthropicOauth: jest.Mocked<Pick<AnthropicOauthService, 'unwrapToken'>>;
   let geminiOauth: jest.Mocked<Pick<GeminiOauthService, 'unwrapToken'>>;
   let kiroOauth: jest.Mocked<Pick<KiroOauthService, 'unwrapToken'>>;
+  let xaiOauth: jest.Mocked<Pick<XaiOauthService, 'unwrapToken'>>;
   let momentum: jest.Mocked<
     Pick<
       SessionMomentumService,
@@ -109,6 +111,7 @@ describe('ProxyService — orchestration', () => {
     anthropicOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     geminiOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     kiroOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
+    xaiOauth = { unwrapToken: jest.fn().mockResolvedValue(null) };
     momentum = {
       recordTier: jest.fn(),
       recordCategory: jest.fn(),
@@ -151,6 +154,7 @@ describe('ProxyService — orchestration', () => {
       anthropicOauth as unknown as AnthropicOauthService,
       geminiOauth as unknown as GeminiOauthService,
       kiroOauth as unknown as KiroOauthService,
+      xaiOauth as unknown as XaiOauthService,
       momentum as unknown as SessionMomentumService,
       limitCheck as unknown as LimitCheckService,
       fallbackService as unknown as ProxyFallbackService,

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -30,6 +30,7 @@ import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.servic
 import { GeminiOauthService } from '../oauth/gemini-oauth.service';
 import { parseOAuthTokenBlob } from '../oauth/core';
 import { KiroOauthService } from '../oauth/kiro-oauth.service';
+import { XaiOauthService } from '../oauth/xai/xai-oauth.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ProviderClient, ForwardResult } from './provider-client';
 import {
@@ -81,6 +82,7 @@ export class ProxyFallbackService {
     private readonly anthropicOauth: AnthropicOauthService,
     private readonly geminiOauth: GeminiOauthService,
     private readonly kiroOauth: KiroOauthService,
+    private readonly xaiOauth: XaiOauthService,
     private readonly providerClient: ProviderClient,
     private readonly copilotToken: CopilotTokenService,
     private readonly pricingCache: ModelPricingCacheService,
@@ -226,6 +228,7 @@ export class ProxyFallbackService {
         this.anthropicOauth,
         this.geminiOauth,
         this.kiroOauth,
+        this.xaiOauth,
       );
       const providerRegion = await this.providerKeyService.getProviderRegion(
         agentId,
@@ -504,6 +507,7 @@ export async function resolveApiKey(
   anthropicOauth: AnthropicOauthService,
   geminiOauth: GeminiOauthService,
   kiroOauth: KiroOauthService,
+  xaiOauth: XaiOauthService,
 ): Promise<{ apiKey: string; resourceUrl?: string }> {
   if (authType === 'subscription') {
     const lower = provider.toLowerCase();
@@ -530,6 +534,10 @@ export async function resolveApiKey(
     }
     if (lower === 'kiro') {
       const unwrapped = await kiroOauth.unwrapToken(apiKey, agentId, userId);
+      if (unwrapped) return { apiKey: unwrapped };
+    }
+    if (lower === 'xai') {
+      const unwrapped = await xaiOauth.unwrapToken(apiKey, agentId, userId);
       if (unwrapped) return { apiKey: unwrapped };
     }
   }

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -8,6 +8,7 @@ import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
 import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.service';
 import { GeminiOauthService } from '../oauth/gemini-oauth.service';
 import { KiroOauthService } from '../oauth/kiro-oauth.service';
+import { XaiOauthService } from '../oauth/xai/xai-oauth.service';
 import { ForwardResult } from './provider-client';
 import { SessionMomentumService } from './session-momentum.service';
 import { LimitCheckService } from '../../notifications/services/limit-check.service';
@@ -131,6 +132,7 @@ export class ProxyService {
     private readonly anthropicOauth: AnthropicOauthService,
     private readonly geminiOauth: GeminiOauthService,
     private readonly kiroOauth: KiroOauthService,
+    private readonly xaiOauth: XaiOauthService,
     private readonly momentum: SessionMomentumService,
     private readonly limitCheck: LimitCheckService,
     private readonly fallbackService: ProxyFallbackService,
@@ -440,6 +442,7 @@ export class ProxyService {
       this.anthropicOauth,
       this.geminiOauth,
       this.kiroOauth,
+      this.xaiOauth,
     );
     const providerRegion = await this.providerKeyService.getProviderRegion(
       agentId,

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -46,6 +46,10 @@ const OAuthDetailView: Component<Props> = (props) => {
   const [renameValue, setRenameValue] = createSignal('');
 
   const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
+  const callbackPlaceholder = () =>
+    props.provId === 'xai'
+      ? 'http://127.0.0.1:56121/callback?code=...'
+      : 'http://localhost:1455/auth/callback?code=...';
   const activeKeyCount = () => (props.activeKeys?.() ?? []).length;
   const flowHasConnected = () => {
     const baseline = flowKeyCount();
@@ -106,12 +110,16 @@ const OAuthDetailView: Component<Props> = (props) => {
       setSuccessHandled(false);
       props.setBusy(false);
 
-      monitorOAuthPopup(popup, {
-        onSuccess: finishOAuthSuccess,
-        onFailure: () => {
-          // Popup closed without auto-redirect — user needs to paste the URL
+      monitorOAuthPopup(
+        popup,
+        {
+          onSuccess: finishOAuthSuccess,
+          onFailure: () => {
+            // Popup closed without auto-redirect — user needs to paste the URL
+          },
         },
-      });
+        `/oauth/${props.provId}/done`,
+      );
     } catch {
       props.setBusy(false);
     }
@@ -229,8 +237,8 @@ const OAuthDetailView: Component<Props> = (props) => {
           }
         >
           <p class="provider-detail__hint">
-            A login window has opened. After you sign in, the popup will show a "can't be reached"
-            page. This is expected.
+            A login window has opened. If it does not close automatically after sign-in, paste the
+            callback URL below.
           </p>
           <p class="provider-detail__hint" style="margin-top: 8px;">
             Copy the full URL from the{' '}
@@ -253,7 +261,7 @@ const OAuthDetailView: Component<Props> = (props) => {
               classList={{ 'provider-detail__input--error': !!pasteError() }}
               type="text"
               autocomplete="off"
-              placeholder="http://localhost:1455/auth/callback?code=..."
+              placeholder={callbackPlaceholder()}
               value={pasteUrl()}
               onInput={(e) => {
                 setPasteUrl(e.currentTarget.value);

--- a/packages/frontend/src/services/api/oauth.ts
+++ b/packages/frontend/src/services/api/oauth.ts
@@ -22,8 +22,22 @@ export function getOpenaiOAuthUrl(agentName: string) {
   });
 }
 
+export function getXaiOAuthUrl(agentName: string) {
+  return fetchJson<{ url: string }>(`/oauth/xai/authorize`, {
+    agentName,
+  });
+}
+
 export function submitOpenaiOAuthCallback(code: string, state: string) {
   return fetchMutate<{ ok: boolean }>('/oauth/openai/callback', {
+    method: 'POST',
+    body: JSON.stringify({ code, state }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+export function submitXaiOAuthCallback(code: string, state: string) {
+  return fetchMutate<{ ok: boolean }>('/oauth/xai/callback', {
     method: 'POST',
     body: JSON.stringify({ code, state }),
     headers: { 'Content-Type': 'application/json' },
@@ -35,6 +49,15 @@ export function revokeOpenaiOAuth(agentName: string, label?: string) {
   if (label) params.set('label', label);
   return fetchMutate<{ ok: boolean; notifications?: string[] }>(
     `/oauth/openai/revoke?${params.toString()}`,
+    { method: 'POST' },
+  );
+}
+
+export function revokeXaiOAuth(agentName: string, label?: string) {
+  const params = new URLSearchParams({ agentName });
+  if (label) params.set('label', label);
+  return fetchMutate<{ ok: boolean; notifications?: string[] }>(
+    `/oauth/xai/revoke?${params.toString()}`,
     { method: 'POST' },
   );
 }
@@ -154,6 +177,11 @@ const POPUP_OAUTH_PROVIDERS: Record<string, PopupOauthApi> = {
     getUrl: getGeminiOAuthUrl,
     submitCallback: submitGeminiOAuthCallback,
     revoke: revokeGeminiOAuth,
+  },
+  xai: {
+    getUrl: getXaiOAuthUrl,
+    submitCallback: submitXaiOAuthCallback,
+    revoke: revokeXaiOAuth,
   },
 };
 

--- a/packages/frontend/src/services/oauth-popup.ts
+++ b/packages/frontend/src/services/oauth-popup.ts
@@ -7,6 +7,7 @@
 export function monitorOAuthPopup(
   popup: Window,
   callbacks: { onSuccess: () => void; onFailure: () => void },
+  donePath = '/oauth/openai/done',
 ): void {
   let handled = false;
   let bc: BroadcastChannel | null = null;
@@ -62,7 +63,7 @@ export function monitorOAuthPopup(
   pollRef = setInterval(() => {
     try {
       const doneUrl = popup.location?.href;
-      if (doneUrl?.includes('/oauth/openai/done')) {
+      if (doneUrl?.includes(donePath)) {
         const ok = new URL(doneUrl).searchParams.get('ok') === '1';
         handleResult(ok);
       }

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -259,6 +259,9 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   xai: {
     initial: 'X',
     subtitle: 'Grok 3, Grok 2',
+    supportsSubscription: true,
+    subscriptionLabel: 'Grok subscription',
+    subscriptionAuthMode: 'popup_oauth',
     models: [],
   },
   zai: {

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -5,6 +5,9 @@ import { createSignal } from 'solid-js';
 const mockGetOpenaiOAuthUrl = vi.fn();
 const mockSubmitOpenaiOAuthCallback = vi.fn();
 const mockRevokeOpenaiOAuth = vi.fn();
+const mockGetXaiOAuthUrl = vi.fn();
+const mockSubmitXaiOAuthCallback = vi.fn();
+const mockRevokeXaiOAuth = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockRenameProviderKey = vi.fn();
 const mockToastError = vi.fn();
@@ -14,11 +17,21 @@ vi.mock('../../src/services/api.js', () => ({
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
   submitOpenaiOAuthCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
   revokeOpenaiOAuth: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
-  getPopupOauthApi: () => ({
-    getUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
-    submitCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
-    revoke: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
-  }),
+  getXaiOAuthUrl: (...args: unknown[]) => mockGetXaiOAuthUrl(...args),
+  submitXaiOAuthCallback: (...args: unknown[]) => mockSubmitXaiOAuthCallback(...args),
+  revokeXaiOAuth: (...args: unknown[]) => mockRevokeXaiOAuth(...args),
+  getPopupOauthApi: (providerId: string) =>
+    providerId === 'xai'
+      ? {
+          getUrl: (...args: unknown[]) => mockGetXaiOAuthUrl(...args),
+          submitCallback: (...args: unknown[]) => mockSubmitXaiOAuthCallback(...args),
+          revoke: (...args: unknown[]) => mockRevokeXaiOAuth(...args),
+        }
+      : {
+          getUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+          submitCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
+          revoke: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
+        },
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   renameProviderKey: (...args: unknown[]) => mockRenameProviderKey(...args),
 }));
@@ -37,6 +50,7 @@ vi.mock('../../src/services/oauth-popup.js', () => ({
 import OAuthDetailView from '../../src/components/OAuthDetailView';
 import type { ProviderDef } from '../../src/services/providers.js';
 import type { RoutingProvider } from '../../src/services/api.js';
+import { monitorOAuthPopup } from '../../src/services/oauth-popup.js';
 
 const provDef: ProviderDef = {
   id: 'openai',
@@ -51,6 +65,14 @@ const provDef: ProviderDef = {
   supportsSubscription: true,
   subscriptionLabel: 'ChatGPT Plus subscription',
   subscriptionAuthMode: 'oauth',
+};
+
+const xaiProvDef: ProviderDef = {
+  ...provDef,
+  id: 'xai',
+  name: 'xAI',
+  initial: 'X',
+  subscriptionLabel: 'Grok subscription',
 };
 
 function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
@@ -74,6 +96,8 @@ function renderView(
     connected?: boolean;
     activeKeys?: RoutingProvider[];
     addKeyOpen?: boolean;
+    provId?: string;
+    provDef?: ProviderDef;
   } = {},
 ) {
   const [busy, setBusy] = createSignal(false);
@@ -82,10 +106,11 @@ function renderView(
   const onUpdate = vi.fn();
   const onClose = vi.fn();
   const keys = opts.activeKeys ?? [];
+  const providerId = opts.provId ?? 'openai';
   const result = render(() => (
     <OAuthDetailView
-      provDef={provDef}
-      provId="openai"
+      provDef={opts.provDef ?? provDef}
+      provId={providerId}
       agentName="test-agent"
       connected={() => opts.connected ?? false}
       selectedAuthType={() => 'subscription'}
@@ -225,6 +250,46 @@ describe('OAuthDetailView', () => {
         screen.getByPlaceholderText('http://localhost:1455/auth/callback?code=...'),
       ).toBeDefined();
     });
+  });
+
+  it('starts xAI OAuth with the xAI callback path and placeholder', async () => {
+    mockGetXaiOAuthUrl.mockResolvedValue({ url: 'https://auth.x.ai/oauth2/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView({ provId: 'xai', provDef: xaiProvDef });
+    fireEvent.click(screen.getByText('Log in with xAI'));
+
+    await waitFor(() => {
+      expect(mockGetXaiOAuthUrl).toHaveBeenCalledWith('test-agent');
+    });
+    expect(screen.getByPlaceholderText('http://127.0.0.1:56121/callback?code=...')).toBeDefined();
+    expect(monitorOAuthPopup).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      '/oauth/xai/done',
+    );
+  });
+
+  it('submits an xAI pasted callback URL through the xAI OAuth API', async () => {
+    mockGetXaiOAuthUrl.mockResolvedValue({ url: 'https://auth.x.ai/oauth2/authorize' });
+    mockSubmitXaiOAuthCallback.mockResolvedValue({ ok: true });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    const { onUpdate } = renderView({ provId: 'xai', provDef: xaiProvDef });
+    fireEvent.click(screen.getByText('Log in with xAI'));
+    const input = await waitFor(() =>
+      screen.getByPlaceholderText('http://127.0.0.1:56121/callback?code=...'),
+    );
+    fireEvent.input(input, {
+      target: { value: 'http://127.0.0.1:56121/callback?code=xai-code&state=xai-state' },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(mockSubmitXaiOAuthCallback).toHaveBeenCalledWith('xai-code', 'xai-state');
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith('xAI subscription connected');
+    expect(onUpdate).toHaveBeenCalled();
   });
 
   it('shows popup-blocked toast when window.open returns null', async () => {

--- a/packages/frontend/tests/components/ProviderSelectModal-commandonly.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal-commandonly.test.tsx
@@ -4,16 +4,25 @@ import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockGetXaiOAuthUrl = vi.fn();
+const mockSubmitOpenaiOAuthCallback = vi.fn();
+const mockSubmitXaiOAuthCallback = vi.fn();
 const mockPollMinimaxOAuth = vi.fn();
 const mockStartMinimaxOAuth = vi.fn();
+const mockRenameProviderKey = vi.fn();
 
 vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  getXaiOAuthUrl: (...args: unknown[]) => mockGetXaiOAuthUrl(...args),
+  submitOpenaiOAuthCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
+  submitXaiOAuthCallback: (...args: unknown[]) => mockSubmitXaiOAuthCallback(...args),
   pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: () => Promise.resolve({ ok: true }),
+  revokeXaiOAuth: () => Promise.resolve({ ok: true }),
   startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
+  renameProviderKey: (...args: unknown[]) => mockRenameProviderKey(...args),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({
@@ -23,7 +32,6 @@ vi.mock("../../src/services/toast-store.js", () => ({
 vi.mock("../../src/components/ProviderIcon.js", () => ({
   providerIcon: () => null, customProviderLogo: () => null,
 }));
-
 
 // Mock providers to include a "command-only" subscription provider:
 // has subscriptionCommand but NO subscriptionKeyPlaceholder and NO popup_oauth mode

--- a/packages/frontend/tests/components/ProviderSelectModal-opencode-go.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal-opencode-go.test.tsx
@@ -4,16 +4,25 @@ import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockGetXaiOAuthUrl = vi.fn();
+const mockSubmitOpenaiOAuthCallback = vi.fn();
+const mockSubmitXaiOAuthCallback = vi.fn();
 const mockPollMinimaxOAuth = vi.fn();
 const mockStartMinimaxOAuth = vi.fn();
+const mockRenameProviderKey = vi.fn();
 
 vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  getXaiOAuthUrl: (...args: unknown[]) => mockGetXaiOAuthUrl(...args),
+  submitOpenaiOAuthCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
+  submitXaiOAuthCallback: (...args: unknown[]) => mockSubmitXaiOAuthCallback(...args),
   pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: () => Promise.resolve({ ok: true }),
+  revokeXaiOAuth: () => Promise.resolve({ ok: true }),
   startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
+  renameProviderKey: (...args: unknown[]) => mockRenameProviderKey(...args),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({

--- a/packages/frontend/tests/components/ProviderSelectModal-subscription.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal-subscription.test.tsx
@@ -4,16 +4,25 @@ import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockGetXaiOAuthUrl = vi.fn();
+const mockSubmitOpenaiOAuthCallback = vi.fn();
+const mockSubmitXaiOAuthCallback = vi.fn();
 const mockPollMinimaxOAuth = vi.fn();
 const mockStartMinimaxOAuth = vi.fn();
+const mockRenameProviderKey = vi.fn();
 
 vi.mock("../../src/services/api.js", () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  getXaiOAuthUrl: (...args: unknown[]) => mockGetXaiOAuthUrl(...args),
+  submitOpenaiOAuthCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
+  submitXaiOAuthCallback: (...args: unknown[]) => mockSubmitXaiOAuthCallback(...args),
   pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: () => Promise.resolve({ ok: true }),
+  revokeXaiOAuth: () => Promise.resolve({ ok: true }),
   startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
+  renameProviderKey: (...args: unknown[]) => mockRenameProviderKey(...args),
 }));
 
 vi.mock("../../src/services/toast-store.js", () => ({

--- a/packages/frontend/tests/components/ProviderSelectModal.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectModal.test.tsx
@@ -32,15 +32,19 @@ class MockBroadcastChannel {
 const mockConnectProvider = vi.fn();
 const mockDisconnectProvider = vi.fn();
 const mockGetOpenaiOAuthUrl = vi.fn();
+const mockGetXaiOAuthUrl = vi.fn();
+const mockSubmitOpenaiOAuthCallback = vi.fn();
+const mockSubmitXaiOAuthCallback = vi.fn();
 const mockPollMinimaxOAuth = vi.fn();
 const mockRevokeOpenaiOAuth = vi.fn();
+const mockRevokeXaiOAuth = vi.fn();
 const mockRevokeMinimaxOAuth = vi.fn();
-const mockSubmitOpenaiOAuthCallback = vi.fn();
 const mockStartMinimaxOAuth = vi.fn();
 const mockStartAnthropicOAuth = vi.fn();
 const mockSubmitAnthropicOAuth = vi.fn();
 const mockRevokeAnthropicOAuth = vi.fn();
 const mockGetAnthropicOAuthPending = vi.fn().mockResolvedValue({ state: null });
+const mockRenameProviderKey = vi.fn();
 const mockCreateCustomProvider = vi.fn();
 const mockUpdateCustomProvider = vi.fn();
 const mockDeleteCustomProvider = vi.fn();
@@ -49,26 +53,34 @@ vi.mock('../../src/services/api.js', () => ({
   connectProvider: (...args: unknown[]) => mockConnectProvider(...args),
   disconnectProvider: (...args: unknown[]) => mockDisconnectProvider(...args),
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+  getXaiOAuthUrl: (...args: unknown[]) => mockGetXaiOAuthUrl(...args),
+  submitOpenaiOAuthCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
+  submitXaiOAuthCallback: (...args: unknown[]) => mockSubmitXaiOAuthCallback(...args),
   pollMinimaxOAuth: (...args: unknown[]) => mockPollMinimaxOAuth(...args),
   revokeOpenaiOAuth: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
+  revokeXaiOAuth: (...args: unknown[]) => mockRevokeXaiOAuth(...args),
   revokeMinimaxOAuth: (...args: unknown[]) => mockRevokeMinimaxOAuth(...args),
   startMinimaxOAuth: (...args: unknown[]) => mockStartMinimaxOAuth(...args),
   startAnthropicOAuth: (...args: unknown[]) => mockStartAnthropicOAuth(...args),
   submitAnthropicOAuth: (...args: unknown[]) => mockSubmitAnthropicOAuth(...args),
   revokeAnthropicOAuth: (...args: unknown[]) => mockRevokeAnthropicOAuth(...args),
   getAnthropicOAuthPending: (...args: unknown[]) => mockGetAnthropicOAuthPending(...args),
+  renameProviderKey: (...args: unknown[]) => mockRenameProviderKey(...args),
   createCustomProvider: (...args: unknown[]) => mockCreateCustomProvider(...args),
   updateCustomProvider: (...args: unknown[]) => mockUpdateCustomProvider(...args),
   deleteCustomProvider: (...args: unknown[]) => mockDeleteCustomProvider(...args),
-  // Dispatch table consumed by OAuthDetailView. Returns the same mocked
-  // OpenAI/Gemini funcs so the existing tests keep working unchanged.
-  getPopupOauthApi: (providerId: string) => ({
-    getUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
-    submitCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
-    revoke: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
-    _provider: providerId,
-  }),
-  submitOpenaiOAuthCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
+  getPopupOauthApi: (providerId: string) =>
+    providerId === 'xai'
+      ? {
+          getUrl: (...args: unknown[]) => mockGetXaiOAuthUrl(...args),
+          submitCallback: (...args: unknown[]) => mockSubmitXaiOAuthCallback(...args),
+          revoke: (...args: unknown[]) => mockRevokeXaiOAuth(...args),
+        }
+      : {
+          getUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
+          submitCallback: (...args: unknown[]) => mockSubmitOpenaiOAuthCallback(...args),
+          revoke: (...args: unknown[]) => mockRevokeOpenaiOAuth(...args),
+        },
 }));
 
 vi.mock('../../src/services/toast-store.js', () => ({

--- a/packages/frontend/tests/services/api/oauth.test.ts
+++ b/packages/frontend/tests/services/api/oauth.test.ts
@@ -35,11 +35,39 @@ describe('oauth API client', () => {
     expect(url).toContain('agentName=demo');
   });
 
+  it('getXaiOAuthUrl forwards agentName as a query param', async () => {
+    const fetchMock = setupFetch({ url: 'https://auth.x.ai/oauth2/authorize?state=s' });
+    const out = await oauth.getXaiOAuthUrl('demo');
+    expect(out).toEqual({ url: 'https://auth.x.ai/oauth2/authorize?state=s' });
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/oauth/xai/authorize');
+    expect(url).toContain('agentName=demo');
+  });
+
+  it('submitXaiOAuthCallback POSTs code + state as JSON', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.submitXaiOAuthCallback('code-1', 'state-1');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/xai/callback');
+    const req = init as RequestInit;
+    expect(req.method).toBe('POST');
+    expect(req.body).toBe(JSON.stringify({ code: 'code-1', state: 'state-1' }));
+    expect((req.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
   it('revokeOpenaiOAuth POSTs with the encoded agent name in the URL', async () => {
     const fetchMock = setupFetch({ ok: true });
     await oauth.revokeOpenaiOAuth('my agent');
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toContain('/api/v1/oauth/openai/revoke?agentName=my+agent');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('revokeXaiOAuth POSTs with the encoded agent name and label in the URL', async () => {
+    const fetchMock = setupFetch({ ok: true });
+    await oauth.revokeXaiOAuth('my agent', 'X Account');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/oauth/xai/revoke?agentName=my+agent&label=X+Account');
     expect((init as RequestInit).method).toBe('POST');
   });
 

--- a/packages/frontend/tests/services/oauth-popup.test.ts
+++ b/packages/frontend/tests/services/oauth-popup.test.ts
@@ -33,7 +33,10 @@ describe("monitorOAuthPopup", () => {
     vi.advanceTimersByTime(30_000);
 
     // fullCleanup should have been called — removeEventListener is evidence
-    expect(removeListenerSpy).toHaveBeenCalledWith("message", expect.any(Function));
+    expect(removeListenerSpy).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function),
+    );
 
     // Popup closed without a result — onFailure should be called to unblock UI
     expect(onSuccess).not.toHaveBeenCalled();
@@ -63,7 +66,7 @@ describe("monitorOAuthPopup", () => {
 
     // Simulate postMessage arriving before the 5-minute timeout
     window.dispatchEvent(
-      new MessageEvent("message", { data: { type: "manifest-oauth-success" } })
+      new MessageEvent("message", { data: { type: "manifest-oauth-success" } }),
     );
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
@@ -96,7 +99,7 @@ describe("monitorOAuthPopup", () => {
 
     // Send a non-OAuth message
     window.dispatchEvent(
-      new MessageEvent("message", { data: { type: "unrelated-event" } })
+      new MessageEvent("message", { data: { type: "unrelated-event" } }),
     );
 
     vi.advanceTimersByTime(300);
@@ -110,6 +113,30 @@ describe("monitorOAuthPopup", () => {
     vi.advanceTimersByTime(300);
 
     expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+  });
+
+  it("recognizes custom provider done paths during URL polling", () => {
+    let href = "https://auth.x.ai/oauth2/authorize";
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      location: {
+        get href() {
+          return href;
+        },
+      },
+    } as unknown as Window;
+
+    const onSuccess = vi.fn();
+    const onFailure = vi.fn();
+
+    monitorOAuthPopup(popup, { onSuccess, onFailure }, "/oauth/xai/done");
+
+    href = "http://127.0.0.1:38284/api/v1/oauth/xai/done?ok=1";
+    vi.advanceTimersByTime(300);
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(onFailure).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -398,6 +398,17 @@ describe("PROVIDERS", () => {
     expect(zai.subscriptionOnly).toBeUndefined();
   });
 
+  it("xAI supports Grok subscription with OAuth flow and dynamic models", () => {
+    const xai = PROVIDERS.find((p) => p.id === "xai")!;
+    expect(xai.supportsSubscription).toBe(true);
+    expect(xai.subscriptionLabel).toBe("Grok subscription");
+    expect(xai.subscriptionAuthMode).toBe("popup_oauth");
+    expect(xai.subscriptionCredentialKind).toBeUndefined();
+    expect(xai.subscriptionKeyPlaceholder).toBeUndefined();
+    expect(xai.subscriptionOnly).toBeUndefined();
+    expect(xai.models).toEqual([]);
+  });
+
   it("provides a subscription-key URL for Z.ai pointing at the API key dashboard", () => {
     expect(getSubscriptionProviderKeyUrl("zai")).toBe(
       "https://z.ai/manage-apikey/apikey-list",

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -20,6 +20,7 @@ describe('SUBSCRIPTION_PROVIDER_CONFIGS', () => {
         'zai',
         'opencode-go',
         'gemini',
+        'xai',
       ]),
     );
   });
@@ -119,6 +120,20 @@ describe('getSubscriptionProviderConfig', () => {
     expect(config?.knownModels).toBeUndefined();
   });
 
+  it('returns config for xai', () => {
+    const config = getSubscriptionProviderConfig('xai');
+    expect(config).toMatchObject({
+      supportsSubscription: true,
+      subscriptionLabel: 'Grok subscription',
+      subscriptionAuthMode: 'popup_oauth',
+    });
+  });
+
+  it('does not publish a hardcoded known-models list for xai', () => {
+    const config = getSubscriptionProviderConfig('xai');
+    expect(config?.knownModels).toBeUndefined();
+  });
+
   it('returns config for gemini', () => {
     const config = getSubscriptionProviderConfig('gemini');
     expect(config).toMatchObject({
@@ -169,6 +184,7 @@ describe('supportsSubscriptionProvider', () => {
     expect(supportsSubscriptionProvider('zai')).toBe(true);
     expect(supportsSubscriptionProvider('opencode-go')).toBe(true);
     expect(supportsSubscriptionProvider('gemini')).toBe(true);
+    expect(supportsSubscriptionProvider('xai')).toBe(true);
   });
 
   it('returns false for unsupported providers', () => {
@@ -223,6 +239,10 @@ describe('getSubscriptionKnownModels', () => {
     expect(models).toContain('gemini-2.5-pro');
     expect(models).toContain('gemini-2.5-flash');
     expect(models).toContain('gemini-2.5-flash-lite');
+  });
+
+  it('returns null for xai (dynamic provider discovery, no hardcoded list)', () => {
+    expect(getSubscriptionKnownModels('xai')).toBeNull();
   });
 
   it('returns null for unsupported providers', () => {
@@ -289,6 +309,15 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('zai');
     expect(caps).toMatchObject({
       maxContextWindow: 204800,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    });
+  });
+
+  it('returns capabilities for xai', () => {
+    const caps = getSubscriptionCapabilities('xai');
+    expect(caps).toMatchObject({
+      maxContextWindow: 128000,
       supportsPromptCaching: false,
       supportsBatching: false,
     });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -149,6 +149,17 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       supportsBatching: false,
     }),
   }),
+  xai: Object.freeze({
+    supportsSubscription: true as const,
+    subscriptionLabel: 'Grok subscription',
+    subscriptionAuthMode: 'popup_oauth' as const,
+    // Model list is fetched dynamically from xAI's OpenAI-compatible /v1/models endpoint.
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 128000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
   copilot: Object.freeze({
     supportsSubscription: true as const,
     subscriptionLabel: 'GitHub Copilot subscription',


### PR DESCRIPTION
## What
- Adds xAI/Grok as a subscription provider using popup OAuth and X account login.
- Stores and refreshes xAI OAuth tokens, unwraps them for proxy/model discovery, and discovers models dynamically from xAI `/v1/models`.
- Wires the frontend subscription flow, callback polling, provider metadata, and focused coverage.

## Validation
- `npm test --workspace=packages/shared -- subscription.spec.ts`
- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/backend -- xai-oauth.service.spec.ts proxy-fallback.service.spec.ts proxy-fallback.routes.spec.ts proxy.service.spec.ts provider-model-fetcher.service.spec.ts`
- `npm run build --workspace=packages/backend`
- `npm test --workspace=packages/frontend -- providers.test.ts oauth.test.ts oauth-popup.test.ts OAuthDetailView.test.tsx ProviderSelectModal.test.tsx ProviderSelectModal-subscription.test.tsx ProviderSelectModal-opencode-go.test.tsx ProviderSelectModal-commandonly.test.tsx`
- `npm run build --workspace=packages/frontend`
- `git diff --check HEAD~1 HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds xAI/Grok as a subscription provider with popup OAuth (X login), dynamic model discovery, and proxy token unwrapping so users can connect Grok subscriptions and use discovered models immediately.

- **New Features**
  - Added `xai` subscription provider with popup OAuth: authorize, callback, revoke.
  - Stores OAuth token blob and auto-refreshes access tokens; unwraps in proxy fallback.
  - Fetches models dynamically from xAI `/v1/models`; model discovery updated to handle `xai`.
  - Frontend updates: provider UI, popup flow with custom done path, callback paste support, and tests.
  - Backend: `xai` OAuth controller/service, local callback server on port 56121 (non-prod), and revoke endpoint.
  - Comprehensive tests across backend, frontend, and shared configs.

<sup>Written for commit b13ac3d7b8909899219fa693f5fd391ce0225c13. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2037?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

