### PR TITLE
Fix xAI manual OAuth code paste

### DIFF
--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -20,6 +20,26 @@ import { monitorOAuthPopup } from '../services/oauth-popup.js';
 
 const MAX_LABEL_LENGTH = 50;
 
+function parseOAuthCallbackInput(raw: string, fallbackState: string | null) {
+  let code: string | null = null;
+  let state: string | null = fallbackState;
+  const parts = raw.split(/\s+/).filter(Boolean);
+
+  for (const part of parts) {
+    try {
+      const url = new URL(part);
+      code = code ?? url.searchParams.get('code');
+      state = state ?? url.searchParams.get('state');
+    } catch {
+      if (!code && /^[A-Za-z0-9._~-]{20,}$/.test(part)) {
+        code = part;
+      }
+    }
+  }
+
+  return { code, state };
+}
+
 interface Props {
   provDef: ProviderDef;
   provId: string;
@@ -42,13 +62,15 @@ const OAuthDetailView: Component<Props> = (props) => {
   const [successHandled, setSuccessHandled] = createSignal(false);
   const [pasteUrl, setPasteUrl] = createSignal('');
   const [pasteError, setPasteError] = createSignal<string | null>(null);
+  const [oauthState, setOauthState] = createSignal<string | null>(null);
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameValue, setRenameValue] = createSignal('');
 
   const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
+  const isXaiProvider = () => props.provId === 'xai';
   const callbackPlaceholder = () =>
-    props.provId === 'xai'
-      ? 'http://127.0.0.1:56121/callback?code=...'
+    isXaiProvider()
+      ? 'Paste the xAI authorization code or callback URL'
       : 'http://localhost:1455/auth/callback?code=...';
   const activeKeyCount = () => (props.activeKeys?.() ?? []).length;
   const flowHasConnected = () => {
@@ -64,6 +86,7 @@ const OAuthDetailView: Component<Props> = (props) => {
     setFlowKeyCount(null);
     setPasteUrl('');
     setPasteError(null);
+    setOauthState(null);
     toast.success(`${props.provDef.name} subscription connected`);
     props.onUpdate();
   };
@@ -96,11 +119,17 @@ const OAuthDetailView: Component<Props> = (props) => {
     setPasteError(null);
     try {
       const { url } = await oauthApi().getUrl(props.agentName);
+      try {
+        setOauthState(new URL(url).searchParams.get('state'));
+      } catch {
+        setOauthState(null);
+      }
       const popup = window.open(url, 'manifest-oauth', 'width=500,height=700');
       if (!popup) {
         toast.error(
           'Popup was blocked by your browser. Allow popups for this site, then try again.',
         );
+        setOauthState(null);
         props.setBusy(false);
         return;
       }
@@ -130,11 +159,13 @@ const OAuthDetailView: Component<Props> = (props) => {
     if (!raw) return;
 
     try {
-      const url = new URL(raw);
-      const code = url.searchParams.get('code');
-      const state = url.searchParams.get('state');
+      const { code, state } = parseOAuthCallbackInput(raw, oauthState());
       if (!code || !state) {
-        setPasteError('URL is missing the authorization code. Make sure you copied the full URL.');
+        setPasteError(
+          props.provId === 'xai'
+            ? 'Paste the authorization code shown by xAI, or paste the full callback URL after approval.'
+            : 'URL is missing the authorization code. Make sure you copied the full URL.',
+        );
         return;
       }
 
@@ -236,32 +267,45 @@ const OAuthDetailView: Component<Props> = (props) => {
             </>
           }
         >
-          <p class="provider-detail__hint">
-            A login window has opened. If it does not close automatically after sign-in, paste the
-            callback URL below.
-          </p>
-          <p class="provider-detail__hint" style="margin-top: 8px;">
-            Copy the full URL from the{' '}
-            <span style="color: hsl(var(--foreground)); font-weight: 500;">
-              popup's address bar
-            </span>{' '}
-            and paste it below:
-          </p>
-          <video
-            src="/images/oauth-callback-example.mp4"
-            autoplay
-            loop
-            muted
-            playsinline
-            style="width: 100%; border-radius: var(--radius); border: 1px solid hsl(var(--border)); margin-top: 12px;"
-          />
+          <Show
+            when={isXaiProvider()}
+            fallback={
+              <>
+                <p class="provider-detail__hint">
+                  A login window has opened. If it does not close automatically after sign-in, paste
+                  the callback URL below.
+                </p>
+                <p class="provider-detail__hint" style="margin-top: 8px;">
+                  Copy the full URL from the{' '}
+                  <span style="color: hsl(var(--foreground)); font-weight: 500;">
+                    popup's address bar
+                  </span>{' '}
+                  and paste it below:
+                </p>
+                <video
+                  src="/images/oauth-callback-example.mp4"
+                  autoplay
+                  loop
+                  muted
+                  playsinline
+                  style="width: 100%; border-radius: var(--radius); border: 1px solid hsl(var(--border)); margin-top: 12px;"
+                />
+              </>
+            }
+          >
+            <p class="provider-detail__hint">
+              A login window has opened. After approving access, paste the authorization code xAI
+              shows. If your browser lands on a callback URL, paste that URL instead.
+            </p>
+          </Show>
           <div class="provider-detail__field" style="margin-top: 12px;">
-            <input
+            <textarea
               class="provider-detail__input"
               classList={{ 'provider-detail__input--error': !!pasteError() }}
-              type="text"
               autocomplete="off"
               placeholder={callbackPlaceholder()}
+              rows={3}
+              style="resize: vertical;"
               value={pasteUrl()}
               onInput={(e) => {
                 setPasteUrl(e.currentTarget.value);

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -252,7 +252,7 @@ describe('OAuthDetailView', () => {
     });
   });
 
-  it('starts xAI OAuth with the xAI callback path and placeholder', async () => {
+  it('starts xAI OAuth with the xAI callback path and manual-code placeholder', async () => {
     mockGetXaiOAuthUrl.mockResolvedValue({ url: 'https://auth.x.ai/oauth2/authorize' });
     vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
 
@@ -262,7 +262,9 @@ describe('OAuthDetailView', () => {
     await waitFor(() => {
       expect(mockGetXaiOAuthUrl).toHaveBeenCalledWith('test-agent');
     });
-    expect(screen.getByPlaceholderText('http://127.0.0.1:56121/callback?code=...')).toBeDefined();
+    expect(
+      screen.getByPlaceholderText('Paste the xAI authorization code or callback URL'),
+    ).toBeDefined();
     expect(monitorOAuthPopup).toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
@@ -278,7 +280,7 @@ describe('OAuthDetailView', () => {
     const { onUpdate } = renderView({ provId: 'xai', provDef: xaiProvDef });
     fireEvent.click(screen.getByText('Log in with xAI'));
     const input = await waitFor(() =>
-      screen.getByPlaceholderText('http://127.0.0.1:56121/callback?code=...'),
+      screen.getByPlaceholderText('Paste the xAI authorization code or callback URL'),
     );
     fireEvent.input(input, {
       target: { value: 'http://127.0.0.1:56121/callback?code=xai-code&state=xai-state' },
@@ -290,6 +292,79 @@ describe('OAuthDetailView', () => {
     });
     expect(mockToastSuccess).toHaveBeenCalledWith('xAI subscription connected');
     expect(onUpdate).toHaveBeenCalled();
+  });
+
+  it('submits an xAI raw authorization code with the pending OAuth state', async () => {
+    mockGetXaiOAuthUrl.mockResolvedValue({
+      url: 'https://auth.x.ai/oauth2/authorize?state=pending-xai-state',
+    });
+    mockSubmitXaiOAuthCallback.mockResolvedValue({ ok: true });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView({ provId: 'xai', provDef: xaiProvDef });
+    fireEvent.click(screen.getByText('Log in with xAI'));
+    const input = await waitFor(() =>
+      screen.getByPlaceholderText('Paste the xAI authorization code or callback URL'),
+    );
+    fireEvent.input(input, {
+      target: { value: 'raw-xai-code-from-consent-page' },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(mockSubmitXaiOAuthCallback).toHaveBeenCalledWith(
+        'raw-xai-code-from-consent-page',
+        'pending-xai-state',
+      );
+    });
+  });
+
+  it('submits an xAI consent URL and displayed code pasted together', async () => {
+    mockGetXaiOAuthUrl.mockResolvedValue({ url: 'https://auth.x.ai/oauth2/authorize' });
+    mockSubmitXaiOAuthCallback.mockResolvedValue({ ok: true });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView({ provId: 'xai', provDef: xaiProvDef });
+    fireEvent.click(screen.getByText('Log in with xAI'));
+    const input = await waitFor(() =>
+      screen.getByPlaceholderText('Paste the xAI authorization code or callback URL'),
+    );
+    fireEvent.input(input, {
+      target: {
+        value:
+          'https://accounts.x.ai/oauth2/consent?response_type=code&state=consent-state\nmanual-xai-code-from-page',
+      },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(mockSubmitXaiOAuthCallback).toHaveBeenCalledWith(
+        'manual-xai-code-from-page',
+        'consent-state',
+      );
+    });
+  });
+
+  it('asks xAI users for the displayed code when only the consent URL is pasted', async () => {
+    mockGetXaiOAuthUrl.mockResolvedValue({
+      url: 'https://auth.x.ai/oauth2/authorize?state=pending-xai-state',
+    });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    renderView({ provId: 'xai', provDef: xaiProvDef });
+    fireEvent.click(screen.getByText('Log in with xAI'));
+    const input = await waitFor(() =>
+      screen.getByPlaceholderText('Paste the xAI authorization code or callback URL'),
+    );
+    fireEvent.input(input, {
+      target: { value: 'https://accounts.x.ai/oauth2/consent?state=pending-xai-state' },
+    });
+    fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Paste the authorization code shown by xAI/)).toBeDefined();
+    });
+    expect(mockSubmitXaiOAuthCallback).not.toHaveBeenCalled();
   });
 
   it('shows popup-blocked toast when window.open returns null', async () => {


### PR DESCRIPTION
## Summary
- allow the OAuth paste field to accept raw xAI authorization codes using the pending state from the opened auth URL
- keep full callback URL support and handle consent URL plus displayed code pasted together
- update xAI-specific fallback copy and use a multiline paste field for long OAuth payloads

## Validation
- npm ci
- npm test --workspace=packages/frontend -- OAuthDetailView.test.tsx
- npx prettier --check packages/frontend/src/components/OAuthDetailView.tsx packages/frontend/tests/components/OAuthDetailView.test.tsx
- npm run lint --workspace=packages/frontend (existing warnings only)
- git diff --check HEAD~1 HEAD
- npm run build --workspace=packages/shared && npm run build --workspace=packages/frontend


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables pasting xAI authorization codes directly during OAuth while keeping full callback URL support. Improves parsing, guidance, and input for the xAI flow.

- **New Features**
  - Accepts raw xAI codes and callback URLs, including consent URL + code pasted together.
  - Captures pending OAuth state from the opened auth URL and uses it when submitting manual codes.
  - Updates xAI-specific hints and placeholder; switches to a multiline input for long payloads. Other providers remain unchanged.

<sup>Written for commit 7f6bb8626f9903dc5d364bd3bacd786314b9fb3a. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2039?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

