### PR TITLE
fix: block SSRF to internal hosts via custom provider URLs

### DIFF
--- a/.changeset/ssrf-mapped-ipv6-and-oauth-log-scrub.md
+++ b/.changeset/ssrf-mapped-ipv6-and-oauth-log-scrub.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Close an SSRF hole where a custom provider URL written as an IPv4-mapped IPv6 literal (for example `https://[::ffff:169.254.169.254]`) slipped past the guard and could reach cloud metadata or private hosts. The carrier-grade NAT range (100.64.0.0/10, used by managed Kubernetes and Tailscale) is now blocked too. Separately, MiniMax, Kiro, and Copilot OAuth errors no longer echo refresh tokens or client secrets into logs.

--- a/packages/backend/src/common/utils/secret-scrub.spec.ts
+++ b/packages/backend/src/common/utils/secret-scrub.spec.ts
@@ -131,6 +131,39 @@ describe('scrubSecrets', () => {
     expect(twice).toBe(once);
   });
 
+  it('redacts JSON refresh_token values', () => {
+    const out = scrubSecrets('{"error":"invalid_grant","refresh_token":"rt-abcdef123456789"}');
+    expect(out).not.toContain('rt-abcdef123456789');
+    expect(out).toContain('"refresh_token":"[REDACTED]"');
+  });
+
+  it('redacts JSON client_secret values', () => {
+    const out = scrubSecrets('{"client_secret":"cs-supersecretvalue","client_id":"public"}');
+    expect(out).not.toContain('cs-supersecretvalue');
+    expect(out).toContain('"client_secret":"[REDACTED]"');
+    // Non-secret fields are left intact.
+    expect(out).toContain('"client_id":"public"');
+  });
+
+  it('redacts form-encoded credential params without bleeding past &', () => {
+    const out = scrubSecrets('grant_type=refresh_token&refresh_token=rt-opaque999&client_id=abc');
+    expect(out).not.toContain('rt-opaque999');
+    expect(out).toContain('refresh_token=[REDACTED]');
+    expect(out).toContain('client_id=abc');
+  });
+
+  it('redacts a realistic Kiro device-authorization error body echoing the client secret', () => {
+    const body = JSON.stringify({
+      error: 'invalid_client',
+      client_secret: 'kiro-cs-LEAKEDSECRET12345',
+      device_code: 'dc-LEAKEDDEVICECODE67890',
+    });
+    const out = scrubSecrets(body);
+    expect(out).not.toContain('LEAKEDSECRET12345');
+    expect(out).not.toContain('LEAKEDDEVICECODE67890');
+    expect(out).toContain('[REDACTED]');
+  });
+
   it('redacts a realistic Anthropic 401 body', () => {
     const body = JSON.stringify({
       type: 'error',

--- a/packages/backend/src/common/utils/secret-scrub.ts
+++ b/packages/backend/src/common/utils/secret-scrub.ts
@@ -24,6 +24,16 @@ const PATTERNS: Pattern[] = [
     re: /(["']?)(x-api-key|authorization|api-key)\1(\s*[:=]\s*)(["']?)[^"',}\r\n]+\4/gi,
     replacement: '$1$2$1$3$4[REDACTED]$4',
   },
+  // OAuth credential fields. Unlike vendor API keys, refresh/access tokens and
+  // client secrets are opaque (no recognizable prefix), so the vendor regexes
+  // below never catch them. Providers' token endpoints (MiniMax, Kiro, Copilot)
+  // can echo the submitted token back inside an error body — redact the value
+  // of these keys in both JSON ("refresh_token":"…") and form (client_secret=…)
+  // shapes. The value class excludes & so form-encoded params don't bleed.
+  {
+    re: /(["']?)(refresh_token|client_secret|access_token|device_code)\1(\s*[:=]\s*)(["']?)[^"',}&\s]+\4/gi,
+    replacement: '$1$2$1$3$4[REDACTED]$4',
+  },
   { re: /Bearer\s+[A-Za-z0-9_\-.=+/]{8,}/gi, replacement: 'Bearer [REDACTED]' },
   { re: /([?&])key=[^&\s"']+/g, replacement: '$1key=[REDACTED]' },
   { re: /\bsk-ant-[A-Za-z0-9_\-]{10,}/g, replacement: '[REDACTED]' },

--- a/packages/backend/src/common/utils/url-validation.spec.ts
+++ b/packages/backend/src/common/utils/url-validation.spec.ts
@@ -85,8 +85,52 @@ describe('isPrivateIp', () => {
     expect(isPrivateIp('::ffff:8.8.8.8')).toBe(false);
   });
 
+  // Regression: Node's URL parser emits the *hex* form of IPv4-mapped IPv6
+  // literals (e.g. [::ffff:127.0.0.1] -> ::ffff:7f00:1). The old dotted-only
+  // regex missed these, letting a private/loopback target slip through.
+  it('detects ::ffff:7f00:1 (hex-form mapped loopback) as private', () => {
+    expect(isPrivateIp('::ffff:7f00:1')).toBe(true);
+  });
+
+  it('detects ::ffff:a00:5 (hex-form mapped 10.0.0.5) as private', () => {
+    expect(isPrivateIp('::ffff:a00:5')).toBe(true);
+  });
+
+  it('detects ::ffff:a9fe:a9fe (hex-form mapped 169.254.169.254) as private', () => {
+    expect(isPrivateIp('::ffff:a9fe:a9fe')).toBe(true);
+  });
+
+  it('allows ::ffff:808:808 (hex-form mapped public 8.8.8.8)', () => {
+    expect(isPrivateIp('::ffff:808:808')).toBe(false);
+  });
+
+  // RFC 6598 carrier-grade NAT — routes to internal cloud fabric.
+  it('detects 100.64.0.5 as private (CGNAT)', () => {
+    expect(isPrivateIp('100.64.0.5')).toBe(true);
+  });
+
+  it('detects 100.127.255.255 as private (CGNAT upper bound)', () => {
+    expect(isPrivateIp('100.127.255.255')).toBe(true);
+  });
+
+  it('allows 100.63.255.255 (just below CGNAT)', () => {
+    expect(isPrivateIp('100.63.255.255')).toBe(false);
+  });
+
+  it('allows 100.128.0.1 (just above CGNAT)', () => {
+    expect(isPrivateIp('100.128.0.1')).toBe(false);
+  });
+
   it('returns false for invalid IP format', () => {
     expect(isPrivateIp('not-an-ip')).toBe(false);
+  });
+
+  it('returns false for a malformed IPv6-shaped string', () => {
+    expect(isPrivateIp('1:2:3:4:5:6:7:8:9')).toBe(false);
+  });
+
+  it('handles a full (uncompressed) IPv6 literal as public', () => {
+    expect(isPrivateIp('2001:db8:0:0:0:0:0:1')).toBe(false);
   });
 });
 
@@ -122,6 +166,10 @@ describe('isCloudMetadataIp', () => {
 
   it('detects IPv4-mapped metadata IP', () => {
     expect(isCloudMetadataIp('::ffff:169.254.169.254')).toBe(true);
+  });
+
+  it('detects hex-form IPv4-mapped metadata IP (::ffff:a9fe:a9fe)', () => {
+    expect(isCloudMetadataIp('::ffff:a9fe:a9fe')).toBe(true);
   });
 
   it('allows public IPs', () => {
@@ -245,6 +293,32 @@ describe('validatePublicUrl', () => {
 
   it('rejects IP literal 192.168.x.x', async () => {
     await expect(validatePublicUrl('https://192.168.1.100:3000')).rejects.toThrow(
+      'private or internal',
+    );
+  });
+
+  it('rejects CGNAT literal 100.64.x.x (RFC 6598)', async () => {
+    await expect(validatePublicUrl('https://100.64.0.5:8080')).rejects.toThrow(
+      'private or internal',
+    );
+  });
+
+  // Regression (SSRF guard bypass): a bracketed IPv4-mapped IPv6 literal is
+  // normalized by URL to its hex form, which previously slipped past the guard.
+  it('rejects IPv4-mapped IPv6 literal pointing to cloud metadata', async () => {
+    await expect(validatePublicUrl('https://[::ffff:169.254.169.254]/latest')).rejects.toThrow(
+      'cloud metadata endpoints',
+    );
+  });
+
+  it('rejects IPv4-mapped IPv6 literal pointing to a private host', async () => {
+    await expect(validatePublicUrl('https://[::ffff:10.0.0.5]:6443')).rejects.toThrow(
+      'private or internal',
+    );
+  });
+
+  it('rejects IPv4-mapped IPv6 literal pointing to loopback', async () => {
+    await expect(validatePublicUrl('https://[::ffff:127.0.0.1]:8200')).rejects.toThrow(
       'private or internal',
     );
   });

--- a/packages/backend/src/common/utils/url-validation.ts
+++ b/packages/backend/src/common/utils/url-validation.ts
@@ -7,6 +7,7 @@ const PRIVATE_RANGES: { addr: bigint; mask: bigint }[] = [
   cidr('172.16.0.0', 12), // Class B private
   cidr('192.168.0.0', 16), // Class C private
   cidr('169.254.0.0', 16), // Link-local
+  cidr('100.64.0.0', 10), // Carrier-grade NAT (RFC 6598) — routes to cloud fabric (EKS/GKE pods, Tailscale)
   cidr('0.0.0.0', 8), // Current network
 ];
 
@@ -32,10 +33,50 @@ export function isIpLiteral(host: string): boolean {
   return isIP(host) !== 0;
 }
 
+// Collapse an IPv4-mapped IPv6 address to its dotted-quad IPv4 form so the
+// IPv4 range checks can see it. Node's URL parser normalizes
+// `[::ffff:169.254.169.254]` to the *hex* form `::ffff:a9fe:a9fe`, which a
+// dotted-only regex misses — that gap let a mapped literal smuggle a private
+// or cloud-metadata target past the SSRF guard. We expand the (already
+// isIP-validated) literal to its 8 hextets and, when it is IPv4-mapped
+// (`::ffff:0:0/96`), rebuild the embedded IPv4. Non-mapped hosts pass through.
+function unwrapMappedIpv4(host: string): string {
+  if (isIP(host) !== 6) return host;
+  // host is a valid IPv6 literal, so `::` appears at most once and every
+  // group is valid hex (or a single dotted-quad tail) — no defensive parsing.
+  const parseGroups = (segment: string): number[] =>
+    segment === ''
+      ? []
+      : segment.split(':').flatMap((part) => {
+          const dotted = part.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+          if (dotted) {
+            const o = dotted.slice(1).map(Number);
+            return [(o[0] << 8) | o[1], (o[2] << 8) | o[3]];
+          }
+          return [parseInt(part, 16)];
+        });
+
+  const [head, tail] = host.toLowerCase().split('::');
+  const left = parseGroups(head);
+  const right = tail === undefined ? [] : parseGroups(tail);
+  const hextets = [...left, ...Array<number>(8 - left.length - right.length).fill(0), ...right];
+
+  const mapped =
+    hextets[0] === 0 &&
+    hextets[1] === 0 &&
+    hextets[2] === 0 &&
+    hextets[3] === 0 &&
+    hextets[4] === 0 &&
+    hextets[5] === 0xffff;
+  if (!mapped) return host;
+  const hi = hextets[6];
+  const lo = hextets[7];
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
 export function isPrivateIp(ip: string): boolean {
-  // Handle IPv4-mapped IPv6 addresses (::ffff:a.b.c.d)
-  const mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
-  const normalizedIp = mapped ? mapped[1] : ip;
+  // Collapse IPv4-mapped IPv6 (any textual form) to dotted IPv4 first.
+  const normalizedIp = unwrapMappedIpv4(ip);
 
   // Check IPv6 private ranges
   if (normalizedIp.includes(':')) {
@@ -71,8 +112,7 @@ const CLOUD_METADATA_RANGES: { addr: bigint; mask: bigint }[] = [
 const CLOUD_METADATA_V6 = ['fd00:ec2::254'];
 
 export function isCloudMetadataIp(ip: string): boolean {
-  const mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
-  const normalizedIp = mapped ? mapped[1] : ip;
+  const normalizedIp = unwrapMappedIpv4(ip);
 
   if (normalizedIp.includes(':')) {
     const lower = normalizedIp.toLowerCase();

--- a/packages/backend/src/routing/oauth/kiro-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { randomBytes } from 'node:crypto';
 import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
 import {
   KIRO_CLIENT_NAME,
   KIRO_CLIENT_TYPE,
@@ -280,7 +281,7 @@ export class KiroOauthService {
     });
     if (!response.ok) {
       const text = await response.text();
-      this.logger.error(`Kiro device authorization failed: ${text}`);
+      this.logger.error(`Kiro device authorization failed: ${scrubSecrets(text)}`);
       throw new Error('Failed to start Kiro login');
     }
     const payload = (await response.json()) as KiroDeviceAuthorizationResponse;
@@ -312,7 +313,7 @@ export class KiroOauthService {
     });
     if (!response.ok) {
       const text = await response.text();
-      this.logger.error(`Kiro token refresh failed: ${text}`);
+      this.logger.error(`Kiro token refresh failed: ${scrubSecrets(text)}`);
       throw new Error('Token refresh failed');
     }
     const payload = (await response.json()) as KiroTokenResponse;

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { createHash, randomBytes, randomUUID } from 'crypto';
 import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
 import { OAuthTokenBlob } from './openai-oauth.types';
 import {
   MinimaxRegion,
@@ -240,7 +241,7 @@ export class MinimaxOauthService {
     });
     if (!response.ok) {
       const text = await response.text();
-      this.logger.error(`MiniMax token refresh failed: ${text}`);
+      this.logger.error(`MiniMax token refresh failed: ${scrubSecrets(text)}`);
       throw new Error('Token refresh failed');
     }
     const payload = (await response.json()) as MinimaxTokenResponse;

--- a/packages/backend/src/routing/proxy/copilot-token.service.ts
+++ b/packages/backend/src/routing/proxy/copilot-token.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
+import { scrubSecrets } from '../../common/utils/secret-scrub';
 
 const TOKEN_ENDPOINT = 'https://api.github.com/copilot_internal/v2/token';
 
@@ -63,7 +64,7 @@ export class CopilotTokenService {
 
     if (!res.ok) {
       const body = await res.text().catch(() => '');
-      this.logger.warn(`Copilot token exchange failed: ${res.status} ${body}`);
+      this.logger.warn(`Copilot token exchange failed: ${res.status} ${scrubSecrets(body)}`);
       throw new Error(`Copilot token exchange failed: ${res.status}`);
     }
 


### PR DESCRIPTION
### 💭 Why
An OWASP audit found a custom provider URL could reach cloud metadata and internal hosts through the proxy, and three OAuth flows could leak secrets into logs.

### ✨ What changed
- SSRF guard now canonicalizes IPv4-mapped IPv6 literals before its range checks. The hex form (`::ffff:a9fe:a9fe`, what `URL` emits for `[::ffff:169.254.169.254]`) used to slip past the dotted-only check.
- Block the carrier-grade NAT range `100.64.0.0/10` (managed Kubernetes pods, Tailscale).
- Scrub MiniMax, Kiro, and Copilot OAuth error bodies before logging, so echoed refresh tokens and client secrets stay out of logs.

### 👤 For users
Self-hosted is unaffected (private destinations stay allowed there). In cloud, a custom provider can no longer point at these internal addresses.

### 📝 Notes
Follow-up: pin the validated IP at connect time to close the DNS-rebinding race (tracked separately).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks SSRF via custom provider URLs by normalizing IPv4-mapped IPv6 literals and treating CGNAT as internal. Also scrubs OAuth secrets from MiniMax, Kiro, and Copilot error logs.

- **Bug Fixes**
  - Normalize IPv4-mapped IPv6 (`::ffff:...`) to dotted IPv4 before checks, including hex forms like `::ffff:a9fe:a9fe`.
  - Block `100.64.0.0/10` (CGNAT) as private/internal.
  - Redact `refresh_token`, `client_secret`, `access_token`, and `device_code` in JSON and form bodies; applied to Kiro, MiniMax, and Copilot OAuth error logging.

- **Migration**
  - No action needed. Self-hosted remains unchanged; cloud now blocks internal destinations for custom providers.

<sup>Written for commit 3434f64ea1bf729904cd4a9c0f055f24dab89043. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2040?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

