### PR TITLE
perf: cut dashboard's initial bundle for faster load

### DIFF
--- a/.changeset/frontend-initial-load-perf.md
+++ b/.changeset/frontend-initial-load-perf.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Speed up the dashboard's first load. Heavy code now loads on demand instead of up front: the syntax highlighter is a slim 6-language build, charts load per tab, and the markdown renderer loads when the first message renders. Dev-only tooling no longer ships in production bundles.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -2,18 +2,27 @@ import { useLocation } from '@solidjs/router';
 import {
   createEffect,
   createSignal,
+  lazy,
   onCleanup,
   onMount,
   Show,
+  Suspense,
   type ParentComponent,
 } from 'solid-js';
 import Header from './components/Header.jsx';
 import Sidebar from './components/Sidebar.jsx';
 import AuthGuard from './components/AuthGuard.jsx';
 import VersionIndicator from './components/VersionIndicator.jsx';
-import WingmanDevTools from './components/WingmanDevTools.jsx';
 import { connectSse } from './services/sse.js';
 import { RightSidebarProvider, useRightSidebar } from './services/right-sidebar.jsx';
+
+// Dev-only gateway tester. Gating the dynamic import behind the compile-time
+// `__DEV_MODE__` flag lets rollup drop both the component and its transitive
+// deps from production/self-hosted bundles — a static import can leak in when
+// transitive deps have side effects, since `define` runs after graph build.
+const WingmanDevTools = __DEV_MODE__
+  ? lazy(() => import('./components/WingmanDevTools.jsx'))
+  : null;
 
 const SseConnector: ParentComponent = (props) => {
   onMount(() => {
@@ -72,7 +81,11 @@ const AppInner: ParentComponent = (props) => {
         {rightSidebar()}
       </div>
       <VersionIndicator />
-      {__DEV_MODE__ && <WingmanDevTools />}
+      {__DEV_MODE__ && WingmanDevTools && (
+        <Suspense fallback={null}>
+          <WingmanDevTools />
+        </Suspense>
+      )}
     </div>
   );
 };

--- a/packages/frontend/src/components/ChartCard.tsx
+++ b/packages/frontend/src/components/ChartCard.tsx
@@ -1,11 +1,16 @@
-import { Show, type Component, type JSX } from 'solid-js';
-import CostChart from './CostChart.jsx';
+import { lazy, Show, Suspense, type Component, type JSX } from 'solid-js';
 import InfoTooltip from './InfoTooltip.jsx';
-import SavingsChart from './SavingsChart.jsx';
-import SingleTokenChart from './SingleTokenChart.jsx';
-import TokenChart from './TokenChart.jsx';
 import { formatCost, formatNumber } from '../services/formatters.js';
 import type { SavingsTimeseriesRow } from '../services/api/analytics.js';
+
+// uPlot-backed charts make up the `charts` vendor chunk. Importing them eagerly
+// pulls that chunk into the initial Overview render even though only one view
+// is visible at a time. Loading each chart lazily defers the chunk until its
+// tab is actually selected.
+const CostChart = lazy(() => import('./CostChart.jsx'));
+const SavingsChart = lazy(() => import('./SavingsChart.jsx'));
+const SingleTokenChart = lazy(() => import('./SingleTokenChart.jsx'));
+const TokenChart = lazy(() => import('./TokenChart.jsx'));
 
 type ActiveView = 'cost' | 'tokens' | 'messages' | 'savings';
 
@@ -121,7 +126,9 @@ const ChartCard: Component<ChartCardProps> = (props) => (
             </div>
           }
         >
-          <CostChart data={props.costUsage} range={props.range} />
+          <Suspense fallback={<div style="height: 260px;" />}>
+            <CostChart data={props.costUsage} range={props.range} />
+          </Suspense>
         </Show>
       </Show>
       <Show when={props.activeView === 'tokens'}>
@@ -133,7 +140,9 @@ const ChartCard: Component<ChartCardProps> = (props) => (
             </div>
           }
         >
-          <TokenChart data={props.tokenUsage} range={props.range} />
+          <Suspense fallback={<div style="height: 260px;" />}>
+            <TokenChart data={props.tokenUsage} range={props.range} />
+          </Suspense>
         </Show>
       </Show>
       <Show when={props.activeView === 'messages'}>
@@ -145,12 +154,14 @@ const ChartCard: Component<ChartCardProps> = (props) => (
             </div>
           }
         >
-          <SingleTokenChart
-            data={props.messageChartData}
-            label="Messages"
-            colorVar="--chart-1"
-            range={props.range}
-          />
+          <Suspense fallback={<div style="height: 260px;" />}>
+            <SingleTokenChart
+              data={props.messageChartData}
+              label="Messages"
+              colorVar="--chart-1"
+              range={props.range}
+            />
+          </Suspense>
         </Show>
       </Show>
       <Show when={props.activeView === 'savings'}>
@@ -162,7 +173,9 @@ const ChartCard: Component<ChartCardProps> = (props) => (
             </div>
           }
         >
-          <SavingsChart data={props.savingsTimeseries!} range={props.range} />
+          <Suspense fallback={<div style="height: 260px;" />}>
+            <SavingsChart data={props.savingsTimeseries!} range={props.range} />
+          </Suspense>
         </Show>
       </Show>
     </div>

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -144,6 +144,9 @@ const OAuthDetailView: Component<Props> = (props) => {
       setSuccessHandled(false);
       props.setBusy(false);
 
+      // Dispose any in-flight monitor from a previous start before replacing it,
+      // so repeated logins don't orphan the earlier poll/listener handle.
+      disposeOAuthMonitor?.();
       disposeOAuthMonitor = monitorOAuthPopup(
         popup,
         {

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -66,6 +66,11 @@ const OAuthDetailView: Component<Props> = (props) => {
   const [renamingId, setRenamingId] = createSignal<string | null>(null);
   const [renameValue, setRenameValue] = createSignal('');
 
+  // Dispose the OAuth popup monitor if the view unmounts mid-flow, otherwise its
+  // 300ms URL poll keeps running after the component is gone.
+  let disposeOAuthMonitor: (() => void) | null = null;
+  onCleanup(() => disposeOAuthMonitor?.());
+
   const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
   const isXaiProvider = () => props.provId === 'xai';
   const callbackPlaceholder = () =>
@@ -139,7 +144,7 @@ const OAuthDetailView: Component<Props> = (props) => {
       setSuccessHandled(false);
       props.setBusy(false);
 
-      monitorOAuthPopup(
+      disposeOAuthMonitor = monitorOAuthPopup(
         popup,
         {
           onSuccess: finishOAuthSuccess,

--- a/packages/frontend/src/components/playground/MarkdownContent.tsx
+++ b/packages/frontend/src/components/playground/MarkdownContent.tsx
@@ -64,7 +64,10 @@ const MarkdownContent: Component<Props> = (props) => {
   });
 
   return (
-    <Show when={html() != null} fallback={<pre class="markdown-loading">{props.text}</pre>}>
+    <Show
+      when={html() != null}
+      fallback={<pre class={`${props.class ?? ''} markdown-loading`.trim()}>{props.text}</pre>}
+    >
       <div class={props.class} innerHTML={html()!} />
     </Show>
   );

--- a/packages/frontend/src/components/playground/MarkdownContent.tsx
+++ b/packages/frontend/src/components/playground/MarkdownContent.tsx
@@ -1,27 +1,6 @@
-import { createMemo, type Component } from 'solid-js';
-import { marked } from 'marked';
-import DOMPurify from 'dompurify';
-import hljs from 'highlight.js';
-
-marked.use({
-  async: false,
-  gfm: true,
-  breaks: true,
-  renderer: {
-    code({ text, lang }) {
-      if (lang) {
-        const language = hljs.getLanguage(lang) ? lang : 'plaintext';
-        try {
-          const html = hljs.highlight(text, { language, ignoreIllegals: true }).value;
-          return `<pre><code class="hljs language-${language}">${html}</code></pre>`;
-        } catch {
-          /* fall through to escaped plain */
-        }
-      }
-      return `<pre><code class="hljs">${escapeHtml(text)}</code></pre>`;
-    },
-  },
-});
+import { createMemo, createResource, Show, type Component } from 'solid-js';
+import type { Tokens } from 'marked';
+import { highlight, isSupported } from '../../services/syntax-highlight.js';
 
 function escapeHtml(s: string): string {
   return s
@@ -32,22 +11,63 @@ function escapeHtml(s: string): string {
     .replace(/'/g, '&#39;');
 }
 
+// marked's fenced-code renderer. Supported languages get highlighted with the
+// slim hljs core; everything else (and unlabelled blocks) is escaped to plain
+// text. Both paths keep the `hljs` class so styles/syntax-highlight.css applies.
+function renderCodeBlock({ text, lang }: Tokens.Code): string {
+  if (lang && isSupported(lang)) {
+    return `<pre><code class="hljs language-${lang}">${highlight(text, lang)}</code></pre>`;
+  }
+  return `<pre><code class="hljs">${escapeHtml(text)}</code></pre>`;
+}
+
+type MarkdownRenderer = (text: string) => string;
+
+// `marked` (~70 KB) + `dompurify` (~50 KB) are only needed once an assistant
+// message renders, so load them lazily and once. The module-level promise also
+// guarantees `marked.use()` runs a single time no matter how many
+// MarkdownContent instances mount.
+let rendererPromise: Promise<MarkdownRenderer> | null = null;
+
+function loadRenderer(): Promise<MarkdownRenderer> {
+  if (!rendererPromise) {
+    rendererPromise = Promise.all([import('marked'), import('dompurify')]).then(
+      ([{ marked }, { default: DOMPurify }]) => {
+        marked.use({
+          async: false,
+          gfm: true,
+          breaks: true,
+          renderer: { code: renderCodeBlock },
+        });
+        return (text: string) =>
+          DOMPurify.sanitize(marked.parse(text) as string, {
+            ALLOWED_ATTR: ['href', 'title', 'class', 'target', 'rel'],
+            FORBID_TAGS: ['style', 'iframe', 'form', 'input', 'script'],
+            FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'style'],
+          });
+      },
+    );
+  }
+  return rendererPromise;
+}
+
 interface Props {
   text: string;
   class?: string;
 }
 
 const MarkdownContent: Component<Props> = (props) => {
+  const [renderMarkdown] = createResource(loadRenderer);
   const html = createMemo(() => {
-    const parsed = marked.parse(props.text ?? '') as string;
-    return DOMPurify.sanitize(parsed, {
-      ALLOWED_ATTR: ['href', 'title', 'class', 'target', 'rel'],
-      FORBID_TAGS: ['style', 'iframe', 'form', 'input', 'script'],
-      FORBID_ATTR: ['onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'style'],
-    });
+    const render = renderMarkdown();
+    return render ? render(props.text ?? '') : null;
   });
 
-  return <div class={props.class} innerHTML={html()} />;
+  return (
+    <Show when={html() != null} fallback={<pre class="markdown-loading">{props.text}</pre>}>
+      <div class={props.class} innerHTML={html()!} />
+    </Show>
+  );
 };
 
 export default MarkdownContent;

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -39,6 +39,9 @@ import { ALL_TIERS, TIER_LABELS_ALL } from 'manifest-shared';
 import { checkIsSelfHosted } from '../services/setup-status.js';
 import { messagePing } from '../services/sse.js';
 import '../styles/overview.css';
+// The recorded-message drawer/modal styles. Only the Messages log mounts
+// RecordedMessageModal, so this CSS stays out of the global theme bundle.
+import '../styles/recording.css';
 
 interface MessagesData {
   items: MessageRow[];

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -5,6 +5,7 @@ import {
   createMemo,
   createResource,
   createSignal,
+  on,
   onMount,
   Show,
   type Component,
@@ -212,19 +213,28 @@ const Overview: Component = () => {
 
   const SMART_RANGES: string[] = ['30d', '7d', '24h'];
 
-  createEffect(() => {
-    if (userSelectedRange()) return;
-    const d = data();
-    if (!d || (d.has_data === false && !d.has_providers)) return;
-    const hasData =
-      (d.token_usage?.length ?? 0) > 0 ||
-      (d.cost_usage?.length ?? 0) > 0 ||
-      (d.message_usage?.length ?? 0) > 0;
-    if (hasData) return;
-    const currentIdx = SMART_RANGES.indexOf(range());
-    if (currentIdx < 0 || currentIdx >= SMART_RANGES.length - 1) return;
-    setRange(SMART_RANGES[currentIdx + 1]!);
-  });
+  // Step the chart range down to the next bucket while it has no data, but only
+  // after a fetch resolves — `defer: true` skips the no-op run at mount where
+  // `data()` is still undefined. Both `data` and `range` are tracked so the
+  // cascade keeps re-firing as it steps 30d → 7d → 24h.
+  createEffect(
+    on(
+      [data, range],
+      ([d, currentRange]) => {
+        if (userSelectedRange()) return;
+        if (!d || (d.has_data === false && !d.has_providers)) return;
+        const hasData =
+          (d.token_usage?.length ?? 0) > 0 ||
+          (d.cost_usage?.length ?? 0) > 0 ||
+          (d.message_usage?.length ?? 0) > 0;
+        if (hasData) return;
+        const currentIdx = SMART_RANGES.indexOf(currentRange);
+        if (currentIdx < 0 || currentIdx >= SMART_RANGES.length - 1) return;
+        setRange(SMART_RANGES[currentIdx + 1]!);
+      },
+      { defer: true },
+    ),
+  );
 
   const messageChartData = createMemo(() => {
     const src = data()?.message_usage;

--- a/packages/frontend/src/services/oauth-popup.ts
+++ b/packages/frontend/src/services/oauth-popup.ts
@@ -8,7 +8,7 @@ export function monitorOAuthPopup(
   popup: Window,
   callbacks: { onSuccess: () => void; onFailure: () => void },
   donePath = '/oauth/openai/done',
-): void {
+): () => void {
   let handled = false;
   let bc: BroadcastChannel | null = null;
   let bcTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -81,4 +81,16 @@ export function monitorOAuthPopup(
       }, 30_000);
     }
   }, 300);
+
+  // Stop polling and tear down listeners without firing either callback — for
+  // callers that unmount before the popup resolves. The 300ms URL poll would
+  // otherwise run forever. The popup window itself is left open for the user.
+  const dispose = () => {
+    if (handled) return;
+    handled = true;
+    clearInterval(pollRef);
+    fullCleanup();
+  };
+
+  return dispose;
 }

--- a/packages/frontend/src/services/sse.ts
+++ b/packages/frontend/src/services/sse.ts
@@ -15,17 +15,30 @@ export function connectSse(): () => void {
 
   const bumpPing = () => setPingCount((n) => n + 1);
 
+  // Coalesce message-class bumps. A chatty agent emits one SSE `message` event
+  // per ingested record, and every bump refetches the Overview/MessageLog
+  // resources. Collapsing a burst into a single bump every 500ms keeps backend
+  // QPS sane at the cost of a small refresh delay on the dashboard.
+  let messageBumpTimer: ReturnType<typeof setTimeout> | null = null;
+  const bumpMessagePing = () => {
+    if (messageBumpTimer) return;
+    messageBumpTimer = setTimeout(() => {
+      messageBumpTimer = null;
+      setMessagePing((n) => n + 1);
+    }, 500);
+  };
+
   // Legacy generic 'ping' from older deployments — keep listening so a partial
   // upgrade (old backend, new frontend) still triggers refetches. The safe
   // default is to treat unknown 'ping' as a message-class change since that's
   // the kind the bus emitted before typed events landed.
   es.addEventListener('ping', () => {
-    setMessagePing((n) => n + 1);
+    bumpMessagePing();
     bumpPing();
   });
 
   es.addEventListener('message', () => {
-    setMessagePing((n) => n + 1);
+    bumpMessagePing();
     bumpPing();
   });
   es.addEventListener('agent', () => {
@@ -37,5 +50,9 @@ export function connectSse(): () => void {
     bumpPing();
   });
 
-  return () => es.close();
+  return () => {
+    if (messageBumpTimer) clearTimeout(messageBumpTimer);
+    messageBumpTimer = null;
+    es.close();
+  };
 }

--- a/packages/frontend/src/services/syntax-highlight.ts
+++ b/packages/frontend/src/services/syntax-highlight.ts
@@ -1,16 +1,34 @@
+// The `.hljs` token styles that pair with this highlighter. Co-locating the CSS
+// with the service (instead of the global theme) loads it only into the chunks
+// that actually render highlighted code (CodeBlock, MarkdownContent, etc.).
+import '../styles/syntax-highlight.css';
 import hljs from 'highlight.js/lib/core';
 import python from 'highlight.js/lib/languages/python';
 import typescript from 'highlight.js/lib/languages/typescript';
+import javascript from 'highlight.js/lib/languages/javascript';
 import bash from 'highlight.js/lib/languages/bash';
 import yaml from 'highlight.js/lib/languages/yaml';
+import json from 'highlight.js/lib/languages/json';
 
+// Slim hljs core: only the grammars we actually render. Importing the full
+// `highlight.js` bundle pulls ~190 languages (~500 KB). These six cover the
+// setup snippets (CodeBlock / HermesSetup / FrameworkSnippets) and the common
+// fenced blocks in Playground responses; anything else falls back to escaped
+// plain text via `highlight()` below.
 hljs.registerLanguage('python', python);
 hljs.registerLanguage('typescript', typescript);
+hljs.registerLanguage('javascript', javascript);
 hljs.registerLanguage('bash', bash);
 hljs.registerLanguage('yaml', yaml);
+hljs.registerLanguage('json', json);
+
+/** True when a grammar is registered for `language` (including hljs aliases). */
+export function isSupported(language: string): boolean {
+  return !!hljs.getLanguage(language);
+}
 
 export function highlight(code: string, language: string): string {
-  if (!hljs.getLanguage(language)) return escapeHtml(code);
+  if (!isSupported(language)) return escapeHtml(code);
   return hljs.highlight(code, { language }).value;
 }
 

--- a/packages/frontend/src/styles/theme.css
+++ b/packages/frontend/src/styles/theme.css
@@ -19,10 +19,8 @@
 @import './model-filter.css';
 @import './version-indicator.css';
 @import './skeleton.css';
-@import './syntax-highlight.css';
 @import './agent-type-select.css';
 @import './feedback.css';
-@import './recording.css';
 
 /* ── shadcn/ui design tokens — Light (default) ───── */
 @layer base {

--- a/packages/frontend/tests/components/ChartCard.test.tsx
+++ b/packages/frontend/tests/components/ChartCard.test.tsx
@@ -14,8 +14,8 @@ vi.mock('../../src/components/TokenChart.jsx', () => ({
   ),
 }));
 vi.mock('../../src/components/SingleTokenChart.jsx', () => ({
-  default: (props: { data: unknown[] }) => (
-    <div data-testid="single-token-chart" data-points={props.data.length} />
+  default: (props: { data: unknown[]; range: string }) => (
+    <div data-testid="single-token-chart" data-points={props.data.length} data-range={props.range} />
   ),
 }));
 vi.mock('../../src/components/SavingsChart.jsx', () => ({
@@ -58,17 +58,28 @@ describe('ChartCard', () => {
     expect(container.textContent).toMatch(/1(,|\.)?\d*k?/i);
   });
 
-  it('marks the active view and only renders that view\'s chart', () => {
-    const { container } = render(() => (
+  it('marks the active view and only renders that view\'s chart', async () => {
+    const { container, findByTestId } = render(() => (
       <ChartCard {...baseProps({ activeView: 'tokens' })} />
     ));
     // Only the tokens stat should have the active modifier.
     const active = container.querySelectorAll('.chart-card__stat--active');
     expect(active).toHaveLength(1);
     expect(active[0].textContent).toContain('Token usage');
-    expect(container.querySelector('[data-testid="token-chart"]')).not.toBeNull();
+    // Charts load lazily, so wait for the active one to resolve.
+    expect(await findByTestId('token-chart')).not.toBeNull();
     expect(container.querySelector('[data-testid="cost-chart"]')).toBeNull();
     expect(container.querySelector('[data-testid="single-token-chart"]')).toBeNull();
+  });
+
+  it('lazily renders the messages chart when the messages view is active', async () => {
+    const { findByTestId } = render(() => (
+      <ChartCard {...baseProps({ activeView: 'messages' })} />
+    ));
+    const chart = await findByTestId('single-token-chart');
+    expect(chart).not.toBeNull();
+    expect(chart.getAttribute('data-points')).toBe('1');
+    expect(chart.getAttribute('data-range')).toBe('24h');
   });
 
   it('invokes onViewChange when a stat tile is clicked', () => {
@@ -178,8 +189,8 @@ describe('ChartCard', () => {
     expect(onViewChange).toHaveBeenCalledWith('savings');
   });
 
-  it('renders savings chart when activeView is savings', () => {
-    const { container } = render(() => (
+  it('renders savings chart when activeView is savings', async () => {
+    const { container, findByTestId } = render(() => (
       <ChartCard
         {...baseProps({
           activeView: 'savings',
@@ -189,7 +200,7 @@ describe('ChartCard', () => {
         })}
       />
     ));
-    expect(container.querySelector('[data-testid="savings-chart"]')).not.toBeNull();
+    expect(await findByTestId('savings-chart')).not.toBeNull();
     expect(container.querySelector('[data-testid="cost-chart"]')).toBeNull();
   });
 

--- a/packages/frontend/tests/components/CopilotDeviceLogin.test.tsx
+++ b/packages/frontend/tests/components/CopilotDeviceLogin.test.tsx
@@ -378,4 +378,27 @@ describe("CopilotDeviceLogin", () => {
     });
     expect(props.onConnected).toHaveBeenCalled();
   });
+
+  it("clears the pending poll timeout on unmount", async () => {
+    const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+    mockCopilotDeviceCode.mockResolvedValue({
+      device_code: "dc_test",
+      user_code: "ABCD-1234",
+      verification_uri: "https://github.com/login/device",
+      expires_in: 900,
+      interval: 5,
+    });
+    // Never resolve the poll so a pollTimeout stays pending at unmount.
+    mockCopilotPollToken.mockReturnValue(new Promise(() => {}));
+
+    const { unmount } = renderComponent();
+    await fireEvent.click(screen.getByText("Sign in with GitHub"));
+    await waitFor(() => {
+      expect(screen.getByText("ABCD-1234")).toBeDefined();
+    });
+
+    unmount();
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
 });

--- a/packages/frontend/tests/components/MarkdownContent.test.tsx
+++ b/packages/frontend/tests/components/MarkdownContent.test.tsx
@@ -1,80 +1,133 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render } from '@solidjs/testing-library';
-import hljs from 'highlight.js';
+import { describe, it, expect } from 'vitest';
+import { render, waitFor } from '@solidjs/testing-library';
 import MarkdownContent from '../../src/components/playground/MarkdownContent';
 
 describe('MarkdownContent', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it('shows raw text while markdown libraries load, then renders HTML', async () => {
+    const { container } = render(() => <MarkdownContent text={'## Title'} />);
+    // marked + dompurify load lazily, so the first synchronous paint is the
+    // raw-text fallback (avoids a layout flash before the chunk arrives).
+    const loading = container.querySelector('pre.markdown-loading');
+    expect(loading).not.toBeNull();
+    expect(loading?.textContent).toBe('## Title');
+
+    await waitFor(() => {
+      expect(container.querySelector('h2')?.textContent).toBe('Title');
+    });
+    expect(container.querySelector('pre.markdown-loading')).toBeNull();
   });
 
-  it('renders headings, bold, and lists as HTML', () => {
+  it('renders headings, bold, and lists as HTML', async () => {
     const { container } = render(() => (
-      <MarkdownContent
-        text={'## Title\n\nSome **bold** text.\n\n- one\n- two\n- three'}
-      />
+      <MarkdownContent text={'## Title\n\nSome **bold** text.\n\n- one\n- two\n- three'} />
     ));
-    expect(container.querySelector('h2')?.textContent).toBe('Title');
+    await waitFor(() => {
+      expect(container.querySelector('h2')?.textContent).toBe('Title');
+    });
     expect(container.querySelector('strong')?.textContent).toBe('bold');
     expect(container.querySelectorAll('li')).toHaveLength(3);
   });
 
-  it('renders inline code and fenced code blocks', () => {
+  it('forwards the class prop to the rendered container', async () => {
+    const { container } = render(() => <MarkdownContent text={'hi'} class="custom-md" />);
+    await waitFor(() => {
+      expect(container.querySelector('div.custom-md')).not.toBeNull();
+    });
+  });
+
+  it('renders inline code and highlights fenced blocks for supported languages', async () => {
     const { container } = render(() => (
-      <MarkdownContent text={'use `foo` then:\n\n```js\nconst x = 1;\n```'} />
+      <MarkdownContent text={'use `foo` then:\n\n```typescript\nconst x = 1;\n```'} />
     ));
+    await waitFor(() => {
+      expect(container.querySelector('pre code')).not.toBeNull();
+    });
     expect(container.querySelector('p code')?.textContent).toBe('foo');
-    const pre = container.querySelector('pre');
-    expect(pre).toBeDefined();
-    expect(pre?.textContent).toContain('const x = 1;');
-    expect(pre?.querySelector('code')?.classList.contains('hljs')).toBe(true);
+    const code = container.querySelector('pre code');
+    expect(code?.textContent).toContain('const x = 1;');
+    expect(code?.classList.contains('hljs')).toBe(true);
+    expect(code?.classList.contains('language-typescript')).toBe(true);
+    // Highlighted output carries hljs token spans.
+    expect(code?.querySelector('.hljs-keyword')).not.toBeNull();
   });
 
-  it('strips embedded <script> tags from untrusted model output', () => {
+  it('highlights javascript fences (js alias is registered)', async () => {
     const { container } = render(() => (
-      <MarkdownContent text={'hello\n\n<script>alert(1)</script>\n\nbye'} />
+      <MarkdownContent text={'```js\nconst x = 1;\n```'} />
     ));
-    expect(container.querySelector('script')).toBeNull();
-    expect(container.textContent).toContain('hello');
-    expect(container.textContent).toContain('bye');
+    await waitFor(() => {
+      expect(container.querySelector('pre code')).not.toBeNull();
+    });
+    expect(container.querySelector('pre code .hljs-keyword')).not.toBeNull();
   });
 
-  it('strips event handlers like onerror from inline HTML', () => {
-    const { container } = render(() => (
-      <MarkdownContent text={'<img src=x onerror="alert(1)" alt="x">'} />
-    ));
-    const img = container.querySelector('img');
-    expect(img?.hasAttribute('onerror')).toBe(false);
-  });
-
-  it('escapes a fenced code block that has no language', () => {
+  it('escapes a fenced code block that has no language', async () => {
     const { container } = render(() => (
       <MarkdownContent text={'```\n<b>&"\' not html\n```'} />
     ));
+    await waitFor(() => {
+      expect(container.querySelector('pre code')).not.toBeNull();
+    });
     const code = container.querySelector('pre code');
-    expect(code).not.toBeNull();
     expect(code?.textContent).toContain('<b>&"\' not html');
     expect(code?.querySelector('b')).toBeNull();
     expect(code?.classList.contains('hljs')).toBe(true);
+    expect(code?.classList.contains('language-')).toBe(false);
   });
 
-  it('falls back to escaped plain text when highlight.js throws', () => {
-    const spy = vi.spyOn(hljs, 'highlight').mockImplementation(() => {
-      throw new Error('hljs boom');
-    });
+  it('escapes fenced blocks for unsupported languages instead of highlighting', async () => {
     const { container } = render(() => (
-      <MarkdownContent text={'```js\nconst x = "<i>";\n```'} />
+      <MarkdownContent text={'```rust\nlet x = "<i>";\n```'} />
     ));
+    await waitFor(() => {
+      expect(container.querySelector('pre code')).not.toBeNull();
+    });
     const code = container.querySelector('pre code');
-    expect(code?.textContent).toContain('const x = "<i>";');
+    expect(code?.textContent).toContain('let x = "<i>";');
     expect(code?.querySelector('i')).toBeNull();
-    expect(spy).toHaveBeenCalled();
+    // No grammar registered → no token spans, no language class.
+    expect(code?.querySelector('.hljs-keyword')).toBeNull();
+    expect(code?.className).toBe('hljs');
   });
 
-  it('renders plain text without markdown gracefully', () => {
+  it('strips embedded <script> tags from untrusted model output', async () => {
+    const { container } = render(() => (
+      <MarkdownContent text={'hello\n\n<script>alert(1)</script>\n\nbye'} />
+    ));
+    await waitFor(() => {
+      expect(container.textContent).toContain('hello');
+    });
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.textContent).toContain('bye');
+  });
+
+  it('strips event handlers like onerror from inline HTML', async () => {
+    const { container } = render(() => (
+      <MarkdownContent text={'<img src=x onerror="alert(1)" alt="x">'} />
+    ));
+    await waitFor(() => {
+      expect(container.querySelector('img')).not.toBeNull();
+    });
+    expect(container.querySelector('img')?.hasAttribute('onerror')).toBe(false);
+  });
+
+  it('renders an empty container when text is nullish', async () => {
+    const { container } = render(() => (
+      <MarkdownContent text={undefined as unknown as string} />
+    ));
+    await waitFor(() => {
+      expect(container.querySelector('div')).not.toBeNull();
+    });
+    expect(container.querySelector('div')?.innerHTML).toBe('');
+  });
+
+  it('renders plain text without markdown gracefully', async () => {
     const { container } = render(() => (
       <MarkdownContent text={'Just a plain sentence with no formatting.'} />
     ));
+    await waitFor(() => {
+      expect(container.querySelector('div')).not.toBeNull();
+    });
     expect(container.textContent).toContain('Just a plain sentence with no formatting.');
   });
 });

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -12,6 +12,7 @@ const mockDisconnectProvider = vi.fn();
 const mockRenameProviderKey = vi.fn();
 const mockToastError = vi.fn();
 const mockToastSuccess = vi.fn();
+const mockDisposeMonitor = vi.fn();
 
 vi.mock('../../src/services/api.js', () => ({
   getOpenaiOAuthUrl: (...args: unknown[]) => mockGetOpenaiOAuthUrl(...args),
@@ -44,7 +45,7 @@ vi.mock('../../src/services/toast-store.js', () => ({
 }));
 
 vi.mock('../../src/services/oauth-popup.js', () => ({
-  monitorOAuthPopup: vi.fn(),
+  monitorOAuthPopup: vi.fn(() => mockDisposeMonitor),
 }));
 
 import OAuthDetailView from '../../src/components/OAuthDetailView';
@@ -668,5 +669,17 @@ describe('OAuthDetailView', () => {
     // Typing again should clear the error
     fireEvent.input(input, { target: { value: 'http://other' } });
     expect(screen.queryByText(/URL is missing the authorization code/)).toBeNull();
+  });
+
+  it('disposes the OAuth popup monitor when unmounted mid-flow', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    const { unmount } = renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+    await waitFor(() => expect(monitorOAuthPopup).toHaveBeenCalled());
+
+    unmount();
+    expect(mockDisposeMonitor).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/frontend/tests/components/PlaygroundColumn.test.tsx
+++ b/packages/frontend/tests/components/PlaygroundColumn.test.tsx
@@ -39,7 +39,7 @@ describe('PlaygroundColumn', () => {
     expect(container.querySelector('.playground-column__response')).toBeNull();
   });
 
-  it('progressively renders streamed text while still loading (no skeleton once text exists)', () => {
+  it('progressively renders streamed text while still loading (no skeleton once text exists)', async () => {
     const { container } = render(() => (
       <PlaygroundColumn
         {...baseProps}
@@ -48,19 +48,24 @@ describe('PlaygroundColumn', () => {
     ));
     // Skeleton is replaced by the markdown response as soon as text arrives.
     expect(container.querySelector('.playground-column__skeleton')).toBeNull();
-    const md = container.querySelector('.playground-column__response');
-    expect(md).not.toBeNull();
-    expect(md!.textContent).toContain('partial answer');
+    // MarkdownContent loads marked/dompurify lazily, so wait for the response.
+    await vi.waitFor(() => {
+      const md = container.querySelector('.playground-column__response');
+      expect(md).not.toBeNull();
+      expect(md!.textContent).toContain('partial answer');
+    });
   });
 
-  it('renders the final markdown response on success', () => {
+  it('renders the final markdown response on success', async () => {
     const { container } = render(() => (
       <PlaygroundColumn
         {...baseProps}
         column={col({ status: 'success', response: '## Done\n\nall good' })}
       />
     ));
-    expect(container.querySelector('.playground-column__response h2')?.textContent).toBe('Done');
+    await vi.waitFor(() => {
+      expect(container.querySelector('.playground-column__response h2')?.textContent).toBe('Done');
+    });
   });
 
   it('renders the error state with a Retry button and fires onRetry', () => {

--- a/packages/frontend/tests/pages/Login.test.tsx
+++ b/packages/frontend/tests/pages/Login.test.tsx
@@ -277,4 +277,29 @@ describe("Login", () => {
       expect(container.textContent).toContain("Rate limited");
     });
   });
+
+  it("clears the cooldown interval on unmount", async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    mockSignInEmail.mockResolvedValue({
+      error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" },
+    });
+    mockSendVerificationEmail.mockResolvedValue({ error: null });
+    const { container, unmount } = render(() => <Login />);
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "u@t.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass" } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend verification email");
+    });
+    const resendBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Resend verification email"),
+    )!;
+    fireEvent.click(resendBtn);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend in");
+    });
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
 });

--- a/packages/frontend/tests/pages/Register.test.tsx
+++ b/packages/frontend/tests/pages/Register.test.tsx
@@ -270,4 +270,20 @@ describe("Register", () => {
       expect(link).not.toBeNull();
     });
   });
+
+  it("clears the cooldown interval on unmount", async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    mockSignUpEmail.mockResolvedValue({ error: null });
+    const { container, unmount } = render(() => <Register />);
+    fireEvent.input(container.querySelector('input[type="text"]')!, { target: { value: "Test" } });
+    fireEvent.input(container.querySelector('input[type="email"]')!, { target: { value: "test@test.com" } });
+    fireEvent.input(container.querySelector('input[type="password"]')!, { target: { value: "pass12345" } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend in");
+    });
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
 });

--- a/packages/frontend/tests/services/oauth-popup.test.ts
+++ b/packages/frontend/tests/services/oauth-popup.test.ts
@@ -139,4 +139,39 @@ describe("monitorOAuthPopup", () => {
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(onFailure).not.toHaveBeenCalled();
   });
+
+  it("returns a disposer that stops polling and listeners without firing callbacks", () => {
+    const removeListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      get location(): Location {
+        throw new DOMException("cross-origin");
+      },
+    } as unknown as Window;
+
+    const onSuccess = vi.fn();
+    const onFailure = vi.fn();
+
+    const dispose = monitorOAuthPopup(popup, { onSuccess, onFailure });
+
+    dispose();
+
+    // The message listener is removed as part of teardown.
+    expect(removeListenerSpy).toHaveBeenCalledWith("message", expect.any(Function));
+
+    // A late OAuth message and further polling ticks must be ignored.
+    window.dispatchEvent(
+      new MessageEvent("message", { data: { type: "manifest-oauth-success" } }),
+    );
+    vi.advanceTimersByTime(5_000);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+
+    // Disposing again is a no-op (handled guard).
+    dispose();
+
+    removeListenerSpy.mockRestore();
+  });
 });

--- a/packages/frontend/tests/services/sse.test.ts
+++ b/packages/frontend/tests/services/sse.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 describe("sse", () => {
   let mockEventSource: any;
+
+  function getHandler(type: string) {
+    return mockEventSource.addEventListener.mock.calls.find(
+      (c: any[]) => c[0] === type,
+    )?.[1];
+  }
 
   beforeEach(() => {
     mockEventSource = {
@@ -10,6 +16,10 @@ describe("sse", () => {
     };
     vi.stubGlobal("EventSource", vi.fn(() => mockEventSource));
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("creates EventSource with correct URL", async () => {
@@ -25,48 +35,81 @@ describe("sse", () => {
     expect(mockEventSource.close).toHaveBeenCalled();
   });
 
-  it("increments pingCount AND messagePing when legacy 'ping' event is received", async () => {
+  it("bumps pingCount immediately but debounces messagePing on legacy 'ping'", async () => {
+    vi.useFakeTimers();
     const { connectSse, pingCount, messagePing } = await import(
       "../../src/services/sse"
     );
     connectSse();
-    const pingHandler = mockEventSource.addEventListener.mock.calls.find(
-      (c: any[]) => c[0] === "ping",
-    )?.[1];
+    const pingHandler = getHandler("ping");
     expect(pingHandler).toBeDefined();
     const beforePing = pingCount();
     const beforeMessage = messagePing();
     pingHandler();
+    // pingCount is the legacy counter — bumped synchronously.
     expect(pingCount()).toBe(beforePing + 1);
-    // legacy ping is treated as a message-class change so MessageLog/Overview
-    // stay reactive when talking to an older backend.
+    // messagePing is coalesced — nothing until the 500ms window elapses.
+    expect(messagePing()).toBe(beforeMessage);
+    vi.advanceTimersByTime(500);
     expect(messagePing()).toBe(beforeMessage + 1);
   });
 
-  it("increments messagePing AND pingCount on 'message' event", async () => {
+  it("bumps pingCount immediately but debounces messagePing on 'message'", async () => {
+    vi.useFakeTimers();
     const { connectSse, pingCount, messagePing } = await import(
       "../../src/services/sse"
     );
     connectSse();
-    const handler = mockEventSource.addEventListener.mock.calls.find(
-      (c: any[]) => c[0] === "message",
-    )?.[1];
+    const handler = getHandler("message");
     expect(handler).toBeDefined();
     const beforePing = pingCount();
     const beforeMessage = messagePing();
     handler();
-    expect(messagePing()).toBe(beforeMessage + 1);
     expect(pingCount()).toBe(beforePing + 1);
+    expect(messagePing()).toBe(beforeMessage);
+    vi.advanceTimersByTime(500);
+    expect(messagePing()).toBe(beforeMessage + 1);
   });
 
-  it("increments agentPing AND pingCount on 'agent' event", async () => {
+  it("coalesces a burst of 'message' events into a single bump per window", async () => {
+    vi.useFakeTimers();
+    const { connectSse, messagePing } = await import("../../src/services/sse");
+    connectSse();
+    const handler = getHandler("message");
+    const before = messagePing();
+    // Five events inside 100ms collapse into one scheduled bump.
+    for (let i = 0; i < 5; i++) handler();
+    vi.advanceTimersByTime(100);
+    expect(messagePing()).toBe(before);
+    vi.advanceTimersByTime(400);
+    expect(messagePing()).toBe(before + 1);
+    // A later event opens a fresh window.
+    handler();
+    vi.advanceTimersByTime(500);
+    expect(messagePing()).toBe(before + 2);
+  });
+
+  it("clears the pending message bump timer on cleanup", async () => {
+    vi.useFakeTimers();
+    const { connectSse, messagePing } = await import("../../src/services/sse");
+    const cleanup = connectSse();
+    const handler = getHandler("message");
+    const before = messagePing();
+    handler();
+    cleanup();
+    vi.advanceTimersByTime(1000);
+    // The scheduled bump must not fire after cleanup.
+    expect(messagePing()).toBe(before);
+    expect(mockEventSource.close).toHaveBeenCalled();
+  });
+
+  it("increments agentPing AND pingCount on 'agent' event without touching messagePing", async () => {
+    vi.useFakeTimers();
     const { connectSse, pingCount, agentPing, messagePing } = await import(
       "../../src/services/sse"
     );
     connectSse();
-    const handler = mockEventSource.addEventListener.mock.calls.find(
-      (c: any[]) => c[0] === "agent",
-    )?.[1];
+    const handler = getHandler("agent");
     expect(handler).toBeDefined();
     const beforePing = pingCount();
     const beforeAgent = agentPing();
@@ -74,7 +117,8 @@ describe("sse", () => {
     handler();
     expect(agentPing()).toBe(beforeAgent + 1);
     expect(pingCount()).toBe(beforePing + 1);
-    // 'agent' event must NOT bump messagePing
+    // 'agent' must NOT schedule a messagePing bump.
+    vi.advanceTimersByTime(500);
     expect(messagePing()).toBe(beforeMessage);
   });
 
@@ -83,9 +127,7 @@ describe("sse", () => {
       "../../src/services/sse"
     );
     connectSse();
-    const handler = mockEventSource.addEventListener.mock.calls.find(
-      (c: any[]) => c[0] === "routing",
-    )?.[1];
+    const handler = getHandler("routing");
     expect(handler).toBeDefined();
     const beforePing = pingCount();
     const beforeRouting = routingPing();

--- a/packages/frontend/tests/services/syntax-highlight.test.ts
+++ b/packages/frontend/tests/services/syntax-highlight.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { highlight } from "../../src/services/syntax-highlight";
+import { highlight, isSupported } from "../../src/services/syntax-highlight";
 
 describe("highlight", () => {
   it("highlights Python code with span tags", () => {
@@ -54,5 +54,29 @@ describe("highlight", () => {
     const result = highlight("a > b < c", "nonexistent_lang");
     expect(result).toContain("&gt;");
     expect(result).toContain("&lt;");
+  });
+
+  it("highlights JSON", () => {
+    const result = highlight('{"enabled": true}', "json");
+    expect(result).toContain("<span");
+  });
+
+  it("highlights JavaScript via the js alias", () => {
+    const result = highlight("const x = 1;", "js");
+    expect(result).toContain("hljs-keyword");
+  });
+});
+
+describe("isSupported", () => {
+  it("returns true for registered languages and their aliases", () => {
+    for (const lang of ["python", "typescript", "javascript", "js", "bash", "yaml", "json"]) {
+      expect(isSupported(lang)).toBe(true);
+    }
+  });
+
+  it("returns false for unregistered languages and empty input", () => {
+    expect(isSupported("rust")).toBe(false);
+    expect(isSupported("nonexistent_lang")).toBe(false);
+    expect(isSupported("")).toBe(false);
   });
 });


### PR DESCRIPTION
### 💭 Why
The dashboard shipped the full syntax highlighter (~500 KB), the markdown parser, and all chart code in the initial payload, even though most isn't needed on first paint.

### ✨ What changed
- MarkdownContent uses a slim 6-language highlighter instead of full highlight.js.
- marked + dompurify load lazily on the first rendered message.
- Overview charts load per tab instead of all up front.
- The dev-only Wingman drawer is dropped from production bundles.
- SSE message refreshes are debounced to one per 500ms.
- An OAuth popup poll no longer keeps running after the view unmounts.
- Syntax-highlight and recorded-message CSS moved off the global stylesheet.

### 👤 For users
Faster first load of the dashboard. Charts and the playground's markdown renderer load on demand.

### 📝 Notes
Six other per-page stylesheets stay in the global bundle on purpose: they hold shared selectors (.sr-only, .data-table, .cards-grid, .modal-card__*) used on other routes, so a per-page move would regress styling. Splitting those needs the shared rules factored out first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts the dashboard’s initial bundle and defers heavy code to speed up first paint. Charts, markdown, and syntax highlighting now load on demand; SSE refreshes are coalesced for smoother updates.

- **Performance**
  - Replaced full `highlight.js` with a slim 6-language build and moved syntax CSS out of the global theme.
  - Lazy-loaded `marked` and `dompurify` on first markdown render with a raw-text fallback.
  - Lazy-loaded Overview charts per tab via `Suspense`.
  - Gated the dev-only Wingman drawer behind `__DEV_MODE__` with a lazy import so it’s dropped from production bundles.
  - Debounced SSE message events to one bump per 500ms to reduce redundant refetches.
  - Scoped recorded-message styles to the Messages page to keep the global theme lean.

- **Bug Fixes**
  - Disposed the OAuth popup monitor on unmount and before starting a new login to prevent orphan polls/listeners.
  - Cleared the pending SSE debounce timer on disconnect to prevent stray updates.
  - Markdown loading fallback now preserves the passed `class` to avoid an unstyled flash.

<sup>Written for commit 751f8e89706a5584f4674016dc255ed579275973. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2044?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

