### PR TITLE
Improve model picker with capability icons, filters, and response mode modal

### DIFF
--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -280,13 +280,6 @@ const HeaderTierCard: Component<Props> = (props) => {
         {props.tier.header_key}: {props.tier.header_value}
       </code>
 
-      <OutputControls
-        compact
-        responseMode={() => props.tier.response_mode ?? 'buffered'}
-        disabled={() => !!props.changingResponseMode || !props.onResponseModeChange}
-        onResponseModeChange={(mode) => props.onResponseModeChange?.(mode)}
-      />
-
       <div class="routing-card__body">
         <Show when={currentModel()}>
           {(modelName) => (
@@ -392,7 +385,6 @@ const HeaderTierCard: Component<Props> = (props) => {
                         {formatPerRequestCost(modelInfo()?.cost_per_request) ??
                           'Included in subscription'}
                       </span>
-                      <ModelCapabilityBadges capabilities={modelInfo()?.capabilities} compact />
                       <Show when={primarySkipped()}>
                         <span class="routing-card__skipped-badge">Skipped in Stream</span>
                       </Show>
@@ -401,7 +393,6 @@ const HeaderTierCard: Component<Props> = (props) => {
                 >
                   <span class="routing-card__chip-meta">
                     <span class="routing-card__chip-price">{priceLabel()}</span>
-                    <ModelCapabilityBadges capabilities={modelInfo()?.capabilities} compact />
                     <Show when={primarySkipped()}>
                       <span class="routing-card__skipped-badge">Skipped in Stream</span>
                     </Show>

--- a/packages/frontend/src/components/HeaderTierModal.tsx
+++ b/packages/frontend/src/components/HeaderTierModal.tsx
@@ -4,11 +4,13 @@ import HeaderComboBox, { type HeaderSuggestion } from './HeaderComboBox.js';
 import {
   createHeaderTier,
   getSeenHeaders,
+  setHeaderTierResponseMode,
   updateHeaderTier,
   type HeaderTier,
   type SeenHeader,
 } from '../services/api/header-tiers.js';
 import { toast } from '../services/toast-store.js';
+import type { AvailableModel, ModelCapability, ResponseMode } from '../services/api.js';
 
 const RESERVED_KEYS = new Set([
   'authorization',
@@ -32,6 +34,8 @@ interface Props {
   onBack?: () => void;
   /** When set and editing, shows a Delete tier button. */
   onDelete?: (id: string) => void;
+  /** Available models for stream compatibility check. */
+  models?: AvailableModel[];
 }
 
 const HeaderTierModal: Component<Props> = (props) => {
@@ -42,6 +46,9 @@ const HeaderTierModal: Component<Props> = (props) => {
   const [headerValue, setHeaderValue] = createSignal(editingTier?.header_value ?? '');
   const [badgeColor, setBadgeColor] = createSignal<TierColor>(
     (editingTier?.badge_color as TierColor | undefined) ?? 'indigo',
+  );
+  const [streamMode, setStreamMode] = createSignal<boolean>(
+    editingTier?.response_mode === 'stream',
   );
   const [submitting, setSubmitting] = createSignal(false);
   const [triedSubmit, setTriedSubmit] = createSignal(false);
@@ -55,6 +62,28 @@ const HeaderTierModal: Component<Props> = (props) => {
   const otherTiers = createMemo(() =>
     editingTier ? props.existingTiers.filter((t) => t.id !== editingTier.id) : props.existingTiers,
   );
+
+  /** Models in this tier that don't support streaming. */
+  const incompatibleModels = () => {
+    if (!editingTier) return [];
+    const caps = new Map<string, readonly ModelCapability[]>();
+    for (const m of props.models ?? []) {
+      if (m.capabilities) caps.set(m.model_name, m.capabilities);
+    }
+    const hasStream = (model: string) => caps.get(model)?.includes('stream') ?? false;
+    const result: { model: string; position: string }[] = [];
+    const route = editingTier.override_route;
+    if (route && !hasStream(route.model)) {
+      result.push({ model: route.model, position: 'Primary' });
+    }
+    for (const [i, fb] of (editingTier.fallback_routes ?? []).entries()) {
+      if (!hasStream(fb.model)) {
+        result.push({ model: fb.model, position: `Fallback ${i + 1}` });
+      }
+    }
+    return result;
+  };
+  const canEnableStream = () => incompatibleModels().length === 0;
 
   const keySuggestions = (): HeaderSuggestion[] => {
     const rows = seen() ?? [];
@@ -141,9 +170,14 @@ const HeaderTierModal: Component<Props> = (props) => {
         header_value: headerValue().trim(),
         badge_color: badgeColor(),
       };
-      const saved = editingTier
+      let saved = editingTier
         ? await updateHeaderTier(props.agentName, editingTier.id, payload)
         : await createHeaderTier(props.agentName, payload);
+      // Persist response mode change if toggled
+      const newMode: ResponseMode = streamMode() ? 'stream' : 'buffered';
+      if (saved.response_mode !== newMode) {
+        saved = await setHeaderTierResponseMode(props.agentName, saved.id, newMode);
+      }
       props.onSaved(saved);
       props.onClose();
     } catch (err) {
@@ -286,6 +320,57 @@ const HeaderTierModal: Component<Props> = (props) => {
             )}
           </For>
         </div>
+
+        <div class="response-mode-modal__field-header" style="margin-top: 16px;">
+          <span class="response-mode-modal__field-title">Stream mode</span>
+          <button
+            class="routing-switch"
+            classList={{
+              'routing-switch--on': streamMode(),
+              'routing-switch--disabled': !streamMode() && !canEnableStream(),
+            }}
+            disabled={!streamMode() && !canEnableStream()}
+            onClick={() => {
+              if (streamMode()) setStreamMode(false);
+              else if (canEnableStream()) setStreamMode(true);
+            }}
+          >
+            <span class="routing-switch__track">
+              <span class="routing-switch__thumb" />
+            </span>
+          </button>
+        </div>
+        <Show
+          when={streamMode()}
+          fallback={
+            <p class="response-mode-modal__desc">
+              Responses are returned as a single payload once the model finishes generating.
+            </p>
+          }
+        >
+          <p class="response-mode-modal__desc">
+            Responses are streamed token by token as the model generates them.
+          </p>
+        </Show>
+        <Show when={!streamMode() && incompatibleModels().length > 0}>
+          <div class="response-mode-modal__blocker" style="margin-top: 8px;">
+            <p class="response-mode-modal__blocker-text">
+              {incompatibleModels().length === 1 ? 'This model does' : 'These models do'} not
+              support streaming. Change {incompatibleModels().length === 1 ? 'it' : 'them'} to
+              enable stream mode.
+            </p>
+            <div class="response-mode-modal__blocker-list">
+              <For each={incompatibleModels()}>
+                {(item) => (
+                  <div class="response-mode-modal__blocker-row">
+                    <span class="response-mode-modal__blocker-model">{item.model}</span>
+                    <span class="response-mode-modal__blocker-meta">{item.position}</span>
+                  </div>
+                )}
+              </For>
+            </div>
+          </div>
+        </Show>
 
         <div class="header-tier-modal__footer">
           <Show when={editingTier && props.onDelete}>

--- a/packages/frontend/src/components/ModelCapabilityBadges.tsx
+++ b/packages/frontend/src/components/ModelCapabilityBadges.tsx
@@ -4,15 +4,30 @@ import type { ModelCapability } from '../services/api.js';
 interface Props {
   capabilities?: readonly ModelCapability[];
   compact?: boolean;
+  iconOnly?: boolean;
 }
 
-const CAPABILITY_LABELS: Record<ModelCapability, string> = {
+export const CAPABILITY_LABELS: Record<ModelCapability, string> = {
   text: 'Text',
   image: 'Image',
   audio: 'Audio',
   video: 'Video',
   stream: 'Stream',
   tools: 'Tools',
+};
+
+export const CAPABILITY_ICONS: Record<ModelCapability, string> = {
+  text: '',
+  video:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M18 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-4.33L22 17V7l-4 3.33zm-2 12H4V6h12z"/></svg>',
+  image:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="m5 17.41 3-3 1.29 1.29c.39.39 1.02.39 1.41 0l5.29-5.29 3 3V14h2V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H5zM19 5v5.59L16.71 8.3a.996.996 0 0 0-1.41 0l-5.29 5.29-1.29-1.29a.996.996 0 0 0-1.41 0l-2.29 2.29V5h14Z"/><path d="M8.5 7a1.5 1.5 0 1 0 0 3 1.5 1.5 0 1 0 0-3m13.22 11.07-1.94-.86-.86-1.94a.46.46 0 0 0-.42-.28c-.19-.02-.35.1-.43.27l-.86 1.87-1.95.94c-.16.08-.27.25-.26.43 0 .18.11.35.28.42l1.94.86.86 1.94a.471.471 0 0 0 .86 0l.86-1.94 1.94-.86a.471.471 0 0 0 0-.86Z"/></svg>',
+  stream:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M12 8c-1.1 0-2 .9-2 2 0 .85.53 1.57 1.28 1.86l-.53 10.13h2.5l-.53-10.13C13.47 11.57 14 10.85 14 10c0-1.1-.9-2-2-2m-2.83-.83L7.76 5.75A5.97 5.97 0 0 0 6 9.99c0 1.6.62 3.11 1.76 4.25l1.41-1.41A3.96 3.96 0 0 1 8 10c0-1.07.42-2.07 1.17-2.82Zm7.07-1.41-1.41 1.41C15.59 7.93 16 8.93 16 10s-.42 2.07-1.17 2.83l1.41 1.41C17.37 13.11 18 11.6 18 10s-.62-3.11-1.76-4.24"/><path d="M6.34 4.34 4.93 2.92C3.04 4.81 2 7.32 2 9.99s1.04 5.18 2.93 7.07l1.41-1.41c-1.51-1.51-2.35-3.52-2.35-5.66s.83-4.15 2.34-5.65Zm11.32 0c3.12 3.12 3.12 8.2 0 11.31l1.41 1.41c3.9-3.9 3.9-10.24 0-14.14l-1.41 1.41Z"/></svg>',
+  tools:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M20.71 6.04a.99.99 0 0 0-.9.27l-3.18 3.18-2.12-2.12 3.18-3.18a.98.98 0 0 0 .27-.9c-.07-.33-.29-.6-.6-.73A7.47 7.47 0 0 0 9.2 4.19a7.49 7.49 0 0 0-1.86 7.52L2.3 16.75c-.19.19-.29.44-.29.71s.11.52.29.71l3.54 3.54c.19.19.44.29.71.29s.52-.11.71-.29l5.04-5.04c2.64.82 5.53.12 7.52-1.86a7.47 7.47 0 0 0 1.63-8.16c-.13-.31-.4-.53-.73-.6Zm-2.32 7.34a5.51 5.51 0 0 1-5.98 1.2c-.37-.15-.8-.07-1.09.22l-4.78 4.78-2.12-2.12 4.78-4.78c.29-.29.37-.71.22-1.09a5.47 5.47 0 0 1 1.2-5.98 5.5 5.5 0 0 1 4.41-1.59l-2.65 2.65a.996.996 0 0 0 0 1.41l3.54 3.54c.19.19.44.29.71.29s.52-.11.71-.29l2.65-2.65c.16 1.61-.4 3.23-1.59 4.42Z"/></svg>',
+  audio:
+    '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M16 12V6c0-2.21-1.79-4-4-4S8 3.79 8 6v6c0 2.21 1.79 4 4 4s4-1.79 4-4m-6 0V6c0-1.1.9-2 2-2s2 .9 2 2v6c0 1.1-.9 2-2 2s-2-.9-2-2"/><path d="M18 12c0 3.31-2.69 6-6 6s-6-2.69-6-6H4c0 4.07 3.06 7.44 7 7.93V22h2v-2.07c3.94-.49 7-3.86 7-7.93z"/></svg>',
 };
 
 const DISPLAY_ORDER: readonly ModelCapability[] = ['stream', 'tools', 'image', 'audio', 'video'];
@@ -31,17 +46,26 @@ const ModelCapabilityBadges: Component<Props> = (props) => {
       .join(', ')}`;
   };
 
+  const unknownIcon =
+    '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M11 16h2v2h-2z"/><path d="M16.71 2.29A1 1 0 0 0 16 2H8c-.27 0-.52.11-.71.29l-5 5A1 1 0 0 0 2 8v8c0 .27.11.52.29.71l5 5c.19.19.44.29.71.29h8c.27 0 .52-.11.71-.29l5-5A1 1 0 0 0 22 16V8c0-.27-.11-.52-.29-.71zM20 15.58l-4.41 4.41H8.42l-4.41-4.41V8.41L8.42 4h7.17L20 8.41z"/><path d="M13.27 6.25c-2.08-.75-4.47.35-5.21 2.41l1.88.68c.18-.5.56-.9 1.07-1.13s1.08-.26 1.58-.08a2.01 2.01 0 0 1 1.32 1.86c0 1.04-1.66 1.86-2.24 2.07-.4.14-.67.52-.67.94v1h2v-.34c1.04-.51 2.91-1.69 2.91-3.68a4.015 4.015 0 0 0-2.64-3.73"/></svg>';
+
   return (
     <Show
       when={supported().length > 0}
       fallback={
         <span
-          class="model-capability-badges model-capability-badges--empty"
+          class="model-capability-badges"
           classList={{ 'model-capability-badges--compact': !!props.compact }}
           aria-label={summary()}
-          title="Model capability metadata. This is not a selected setting."
         >
-          {summary()}
+          <Show when={!hasMetadata()}>
+            <span
+              class="model-capability-badge model-capability-badge--icon-only model-capability-badge--unknown"
+              data-tooltip="Capabilities unknown"
+            >
+              <span class="model-capability-badge__icon" innerHTML={unknownIcon} />
+            </span>
+          </Show>
         </span>
       }
     >
@@ -53,7 +77,20 @@ const ModelCapabilityBadges: Component<Props> = (props) => {
       >
         <For each={supported()}>
           {(capability) => (
-            <span class="model-capability-badge">{CAPABILITY_LABELS[capability]}</span>
+            <span
+              class="model-capability-badge"
+              classList={{ 'model-capability-badge--icon-only': !!props.iconOnly }}
+              title={props.iconOnly ? undefined : CAPABILITY_LABELS[capability]}
+              data-tooltip={CAPABILITY_LABELS[capability]}
+            >
+              {CAPABILITY_ICONS[capability] && (
+                <span
+                  class="model-capability-badge__icon"
+                  innerHTML={CAPABILITY_ICONS[capability]}
+                />
+              )}
+              <Show when={!props.iconOnly}>{CAPABILITY_LABELS[capability]}</Show>
+            </span>
           )}
         </For>
       </span>

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -13,7 +13,10 @@ import { customProviderColor, formatPerRequestCost } from '../services/formatter
 import { inferProviderFromModel, pricePerM, resolveProviderId } from '../services/routing-utils.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
 import { toast } from '../services/toast-store.js';
-import ModelCapabilityBadges from './ModelCapabilityBadges.js';
+import ModelCapabilityBadges, {
+  CAPABILITY_ICONS,
+  CAPABILITY_LABELS,
+} from './ModelCapabilityBadges.js';
 
 interface Props {
   tierId: string;
@@ -79,7 +82,30 @@ const ModelPickerModal: Component<Props> = (props) => {
   const [activeTab, setActiveTab] = createSignal<AuthType>(resolveInitialTab());
   const [search, setSearch] = createSignal('');
   const [showFreeOnly, setShowFreeOnly] = createSignal(false);
+  /** Required capabilities: only show models that have ALL of these. */
+  const [requiredCapabilities, setRequiredCapabilities] = createSignal<Set<ModelCapability>>(
+    props.requiredCapability ? new Set([props.requiredCapability]) : new Set(),
+  );
   const [refreshingProvId, setRefreshingProvId] = createSignal<string | null>(null);
+
+  const toggleCapability = (cap: ModelCapability) => {
+    const current = new Set(requiredCapabilities());
+    if (current.has(cap)) current.delete(cap);
+    else current.add(cap);
+    setRequiredCapabilities(current);
+  };
+
+  const isCapabilityRequired = (cap: ModelCapability) => requiredCapabilities().has(cap);
+
+  /** Capabilities that exist on at least one model in the current tab, including stream. */
+  const availableCapabilities = (): ModelCapability[] => {
+    const capOrder: ModelCapability[] = ['stream', 'tools', 'image', 'audio', 'video'];
+    const found = new Set<ModelCapability>();
+    for (const m of props.models) {
+      for (const c of m.capabilities ?? []) found.add(c);
+    }
+    return capOrder.filter((c) => found.has(c));
+  };
 
   const handleRefreshGroup = async (provId: string, displayName: string) => {
     if (!props.agentName) return;
@@ -151,6 +177,18 @@ const ModelPickerModal: Component<Props> = (props) => {
       // different model access levels).
       if (showTabs() && m.auth_type && m.auth_type !== tab) continue;
       if (freeOnly && !isFreeModel(m)) continue;
+      const required = requiredCapabilities();
+      if (required.size > 0) {
+        const caps = m.capabilities ?? [];
+        let pass = true;
+        for (const r of required) {
+          if (!caps.includes(r)) {
+            pass = false;
+            break;
+          }
+        }
+        if (!pass) continue;
+      }
       const dbProvId = resolveProviderId(m.provider);
       const prefixProvId = inferProviderFromModel(m.model_name);
       // OpenRouter is the one provider where the vendor prefix is genuinely
@@ -438,46 +476,37 @@ const ModelPickerModal: Component<Props> = (props) => {
           </div>
         </Show>
 
-        <Show when={isPaid()}>
-          <div class="routing-modal__filter-bar">
-            <button
-              type="button"
-              class="routing-modal__filter-pill"
-              classList={{ 'routing-modal__filter-pill--active': showFreeOnly() }}
-              onClick={() => setShowFreeOnly(!showFreeOnly())}
-            >
-              <svg
-                class="routing-modal__filter-check"
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
+        <div class="routing-modal__filter-bar">
+          <div class="routing-modal__filter-left">
+            <Show when={isPaid()}>
+              <button
+                type="button"
+                class="routing-modal__cap-pill"
+                classList={{ 'routing-modal__cap-pill--active': showFreeOnly() }}
+                onClick={() => setShowFreeOnly(!showFreeOnly())}
               >
-                <Show
-                  when={showFreeOnly()}
-                  fallback={<rect x="3" y="3" width="18" height="18" rx="3" stroke-width="2" />}
-                >
-                  <rect
-                    x="3"
-                    y="3"
-                    width="18"
-                    height="18"
-                    rx="3"
-                    stroke-width="2"
-                    fill="currentColor"
-                  />
-                  <path d="m9 12 2 2 4-4" stroke="hsl(var(--card))" />
-                </Show>
-              </svg>
-              Free models only
-            </button>
+                Free models only
+              </button>
+            </Show>
           </div>
-        </Show>
+          <div class="routing-modal__filter-right">
+            <For each={availableCapabilities()}>
+              {(cap) => (
+                <button
+                  type="button"
+                  class="routing-modal__cap-pill"
+                  classList={{
+                    'routing-modal__cap-pill--active': isCapabilityRequired(cap),
+                  }}
+                  onClick={() => toggleCapability(cap)}
+                >
+                  <span class="routing-modal__filter-pill-icon" innerHTML={CAPABILITY_ICONS[cap]} />
+                  {CAPABILITY_LABELS[cap]}
+                </button>
+              )}
+            </For>
+          </div>
+        </div>
 
         <div class="routing-modal__list">
           <For each={groupedModels()}>
@@ -556,48 +585,41 @@ const ModelPickerModal: Component<Props> = (props) => {
                           props.onSelect(props.tierId, model.value, group.provId, activeTab())
                         }
                       >
-                        <span class="routing-modal__model-label">
-                          {model.label}
-                          <Show when={isRecommended(model.value, group.provId, activeTab())}>
-                            <span class="routing-modal__recommended"> (recommended)</span>
-                          </Show>
-                          <Show when={modelRole(model.value, group.provId, activeTab())}>
-                            {(role) => <span class="routing-modal__role-tag">{role()}</span>}
-                          </Show>
+                        <span class="routing-modal__model-left">
+                          <span class="routing-modal__model-label">
+                            {model.label}
+                            <Show when={isRecommended(model.value, group.provId, activeTab())}>
+                              <span class="routing-modal__recommended"> (recommended)</span>
+                            </Show>
+                            <Show when={modelRole(model.value, group.provId, activeTab())}>
+                              {(role) => <span class="routing-modal__role-tag">{role()}</span>}
+                            </Show>
+                          </span>
+                          <ModelCapabilityBadges
+                            capabilities={model.pricing.capabilities}
+                            compact
+                            iconOnly
+                          />
                         </span>
                         <Show
                           when={isPaid()}
                           fallback={
-                            <span class="routing-modal__model-meta">
-                              <span class="routing-modal__model-id routing-modal__model-id--subscription">
-                                {isLocal()
-                                  ? 'Runs on your machine'
-                                  : (formatPerRequestCost(model.pricing.cost_per_request) ??
-                                    'Included in subscription')}
-                              </span>
-                              <ModelCapabilityBadges
-                                capabilities={model.pricing.capabilities}
-                                compact
-                              />
+                            <span class="routing-modal__model-price">
+                              {isLocal()
+                                ? 'Runs on your machine'
+                                : (formatPerRequestCost(model.pricing.cost_per_request) ??
+                                  'Included in subscription')}
                             </span>
                           }
                         >
                           <Show when={model.pricing}>
                             {(p) => (
-                              <span class="routing-modal__model-meta">
-                                <span class="routing-modal__model-id">
-                                  {pricePerM(p().input_price_per_token)} in ·{' '}
-                                  {pricePerM(p().output_price_per_token)} out per 1M
-                                </span>
-                                <ModelCapabilityBadges capabilities={p().capabilities} compact />
+                              <span class="routing-modal__model-price">
+                                {pricePerM(p().input_price_per_token)} in ·{' '}
+                                {pricePerM(p().output_price_per_token)} out
                               </span>
                             )}
                           </Show>
-                        </Show>
-                        <Show when={disabledReason()}>
-                          {(reason) => (
-                            <span class="routing-modal__model-disabled-reason">{reason()}</span>
-                          )}
                         </Show>
                       </button>
                     );

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -422,15 +422,21 @@ const OAuthDetailView: Component<Props> = (props) => {
               </For>
             </ul>
           </div>
-          <button
-            class="btn btn--outline provider-detail__action provider-detail__disconnect"
-            disabled={props.busy()}
-            onClick={handleDisconnect}
-          >
-            <Show when={!props.busy()} fallback={<span class="spinner" />}>
-              Disconnect all
-            </Show>
-          </button>
+          <div class="provider-detail__footer">
+            <button
+              class="btn btn--outline provider-detail__disconnect"
+              disabled={props.busy()}
+              onClick={handleDisconnect}
+            >
+              <Show when={!props.busy()} fallback={<span class="spinner" />}>
+                Disconnect all
+              </Show>
+            </button>
+            <div style="flex: 1;" />
+            <button class="btn btn--primary btn--sm" onClick={() => props.onClose()}>
+              Done
+            </button>
+          </div>
         </Show>
         {/* Single key — original view */}
         <Show when={!isMultiKey()}>
@@ -439,15 +445,21 @@ const OAuthDetailView: Component<Props> = (props) => {
               Connected via {props.provDef.subscriptionLabel ?? 'subscription'}
             </span>
           </div>
-          <button
-            class="btn btn--outline provider-detail__action provider-detail__disconnect"
-            disabled={props.busy()}
-            onClick={handleDisconnect}
-          >
-            <Show when={!props.busy()} fallback={<span class="spinner" />}>
-              Disconnect
-            </Show>
-          </button>
+          <div class="provider-detail__footer">
+            <button
+              class="btn btn--outline provider-detail__disconnect"
+              disabled={props.busy()}
+              onClick={handleDisconnect}
+            >
+              <Show when={!props.busy()} fallback={<span class="spinner" />}>
+                Disconnect
+              </Show>
+            </button>
+            <div style="flex: 1;" />
+            <button class="btn btn--primary btn--sm" onClick={() => props.onClose()}>
+              Done
+            </button>
+          </div>
         </Show>
       </Show>
     </>

--- a/packages/frontend/src/components/ResponseModeModal.tsx
+++ b/packages/frontend/src/components/ResponseModeModal.tsx
@@ -1,0 +1,195 @@
+import { For, Show, type Accessor, type Component } from 'solid-js';
+import type {
+  AvailableModel,
+  ModelCapability,
+  ResponseMode,
+  TierAssignment,
+} from '../services/api.js';
+import { STAGES, DEFAULT_STAGE } from '../services/providers.js';
+
+export interface IncompatibleModel {
+  model: string;
+  tier: string;
+  tierLabel: string;
+  position: string;
+}
+
+interface Props {
+  responseMode: Accessor<ResponseMode>;
+  onResponseModeChange: (mode: ResponseMode) => void | Promise<void>;
+  disabled?: Accessor<boolean>;
+  tiers: TierAssignment[];
+  models: AvailableModel[];
+  onClose: () => void;
+  onReplace?: (
+    tierId: string,
+    position: 'primary' | number,
+    requiredCapability: ModelCapability,
+  ) => void;
+}
+
+function tierLabel(tierId: string): string {
+  const stage = [DEFAULT_STAGE, ...STAGES].find((s) => s.id === tierId);
+  return stage?.label ?? tierId;
+}
+
+function getIncompatibleModels(
+  tiers: TierAssignment[],
+  models: AvailableModel[],
+): IncompatibleModel[] {
+  const caps = new Map<string, readonly ModelCapability[]>();
+  for (const m of models) {
+    if (m.capabilities) caps.set(m.model_name, m.capabilities);
+  }
+  const hasStream = (model: string) => caps.get(model)?.includes('stream') ?? false;
+
+  const result: IncompatibleModel[] = [];
+  for (const t of tiers) {
+    const route = t.override_route ?? t.auto_assigned_route;
+    if (route && !hasStream(route.model)) {
+      result.push({
+        model: route.model,
+        tier: t.tier,
+        tierLabel: tierLabel(t.tier),
+        position: 'Primary',
+      });
+    }
+    for (const [i, fb] of (t.fallback_routes ?? []).entries()) {
+      if (!hasStream(fb.model)) {
+        result.push({
+          model: fb.model,
+          tier: t.tier,
+          tierLabel: tierLabel(t.tier),
+          position: `Fallback ${i + 1}`,
+        });
+      }
+    }
+  }
+  return result;
+}
+
+const ResponseModeModal: Component<Props> = (props) => {
+  const isStream = () => props.responseMode() === 'stream';
+  const incompatible = () => getIncompatibleModels(props.tiers, props.models);
+  const canEnableStream = () => incompatible().length === 0;
+
+  const handleToggle = () => {
+    if (isStream()) {
+      void props.onResponseModeChange('buffered');
+    } else if (canEnableStream()) {
+      void props.onResponseModeChange('stream');
+    }
+  };
+
+  return (
+    <div
+      class="modal-overlay"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) props.onClose();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') props.onClose();
+      }}
+    >
+      <div
+        class="modal-card response-mode-modal"
+        style="max-width: 520px;"
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div class="routing-modal__header">
+          <div class="routing-modal__title">Response mode</div>
+          <button class="modal__close" onClick={() => props.onClose()} aria-label="Close">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M18 6 6 18" />
+              <path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div class="response-mode-modal__body">
+          <div class="response-mode-modal__field-header">
+            <span class="response-mode-modal__field-title">Stream mode</span>
+            <button
+              class="routing-switch"
+              classList={{
+                'routing-switch--on': isStream(),
+                'routing-switch--disabled': !isStream() && !canEnableStream(),
+              }}
+              disabled={props.disabled?.() || (!isStream() && !canEnableStream())}
+              onClick={handleToggle}
+            >
+              <span class="routing-switch__track">
+                <span class="routing-switch__thumb" />
+              </span>
+            </button>
+          </div>
+          <Show
+            when={isStream()}
+            fallback={
+              <p class="response-mode-modal__desc">
+                Responses are returned as a single payload once the model finishes generating.
+                Compatible with all models.
+              </p>
+            }
+          >
+            <p class="response-mode-modal__desc">
+              Responses are streamed token by token as the model generates them. Only models with
+              streaming support are used.
+            </p>
+          </Show>
+
+          <Show when={!isStream() && incompatible().length > 0}>
+            <div class="response-mode-modal__blocker">
+              <p class="response-mode-modal__blocker-text">
+                Stream mode is unavailable because{' '}
+                {incompatible().length === 1 ? 'this model does' : 'these models do'} not support
+                streaming. Change {incompatible().length === 1 ? 'it' : 'them'} to enable stream
+                mode.
+              </p>
+              <div class="response-mode-modal__blocker-list">
+                <For each={incompatible()}>
+                  {(item) => (
+                    <div class="response-mode-modal__blocker-row">
+                      <span class="response-mode-modal__blocker-model">{item.model}</span>
+                      <span class="response-mode-modal__blocker-meta">
+                        {item.tierLabel} · {item.position}
+                      </span>
+                      <button
+                        class="btn btn--outline btn--sm"
+                        onClick={() =>
+                          props.onReplace?.(
+                            item.tier,
+                            item.position === 'Primary'
+                              ? 'primary'
+                              : parseInt(item.position.replace('Fallback ', '')) - 1,
+                            'stream',
+                          )
+                        }
+                      >
+                        Change
+                      </button>
+                    </div>
+                  )}
+                </For>
+              </div>
+            </div>
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResponseModeModal;

--- a/packages/frontend/src/components/RoutingTabs.tsx
+++ b/packages/frontend/src/components/RoutingTabs.tsx
@@ -12,6 +12,10 @@ export interface RoutingTabsProps {
   specificityEnabled: () => boolean;
   customEnabled: () => boolean;
   pipelineHelp?: () => JSX.Element | null;
+  /** Slot rendered to the right of the tabs (e.g. response mode toggle). */
+  headerRight?: JSX.Element;
+  /** When set, the help button is removed from the header. The parent manages the modal. */
+  onShowHelp?: () => void;
   children: {
     default: JSX.Element;
     specificity: JSX.Element;
@@ -56,27 +60,8 @@ const RoutingTabs: Component<RoutingTabsProps> = (props) => {
             </button>
           ))}
         </div>
-        <Show when={props.pipelineHelp?.()}>
-          <button
-            class="routing-pipeline-help"
-            onClick={() => setHelpOpen(true)}
-            aria-label="How routing works"
-            title="How routing works"
-          >
-            <span class="routing-pipeline-help__label">How routing works</span>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="16"
-              height="16"
-              fill="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path d="M12 15A1 1 0 1 0 12 17 1 1 0 1 0 12 15z" />
-              <path d="m9.65,10.5c.4,0,.81-.2.96-.57.07-.18.18-.34.33-.49.57-.57,1.55-.57,2.12,0,.28.28.44.66.44,1.06s-.16.78-.44,1.06c-.28.28-.64.43-1.03.44-.56,0-1.03.44-1.03,1v.5h0c0,.13.03.26.08.38.05.12.12.23.21.33.19.19.44.29.71.29s.52-.1.71-.29c.11-.11.18-.24.23-.38.53-.17,1.14-.45,1.54-.85.66-.66,1.03-1.54,1.03-2.47,0-1.19-.59-2.28-1.62-2.96-1.12-.73-2.63-.73-3.75,0-.65.42-1.13,1.02-1.39,1.7-.24.61.27,1.26.92,1.26Z" />
-              <path d="m2.72,19.65c-.32.46-.36,1.05-.1,1.55.26.5.77.8,1.33.8h8.05c4.35,0,8.26-2.81,9.51-6.82,1.06-3.41.4-6.9-1.81-9.56-2.18-2.62-5.5-3.94-8.91-3.54C6.07,2.63,2.3,6.63,2.02,11.39c-.14,2.34.55,4.66,1.91,6.51l-1.21,1.75Zm1.29-8.14c.23-3.81,3.24-7.01,7.01-7.45,2.73-.32,5.39.74,7.13,2.83,1.77,2.13,2.3,4.94,1.44,7.69-.99,3.19-4.12,5.42-7.6,5.42h-7.09l.67-.96c.49-.7.48-1.63-.02-2.3-1.12-1.52-1.66-3.33-1.55-5.23Z" />
-            </svg>
-          </button>
+        <Show when={props.headerRight}>
+          <div class="routing-tabs__header-right">{props.headerRight}</div>
         </Show>
       </div>
       <div
@@ -89,42 +74,6 @@ const RoutingTabs: Component<RoutingTabsProps> = (props) => {
         <Show when={activeTab() === 'specificity'}>{props.children.specificity}</Show>
         <Show when={activeTab() === 'custom'}>{props.children.custom}</Show>
       </div>
-
-      <Show when={helpOpen() && props.pipelineHelp?.()}>
-        {(content) => (
-          <div
-            class="modal-overlay"
-            onClick={(e) => {
-              if (e.target === e.currentTarget) setHelpOpen(false);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') setHelpOpen(false);
-            }}
-          >
-            <div
-              class="modal-card"
-              style="max-width: 480px;"
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="pipeline-help-title"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <h2
-                id="pipeline-help-title"
-                style="margin: 0 0 16px; font-size: var(--font-size-lg); font-weight: 600;"
-              >
-                How routing works
-              </h2>
-              {content()}
-              <div style="display: flex; justify-content: flex-end; margin-top: 16px;">
-                <button class="btn btn--primary btn--sm" onClick={() => setHelpOpen(false)}>
-                  Got it
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-      </Show>
     </div>
   );
 };

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -4,6 +4,7 @@ import { Title, Meta } from '@solidjs/meta';
 import RoutingModals from '../components/RoutingModals.js';
 import { buildPipelineHelp } from '../components/RoutingPipelineCard.js';
 import RoutingTabs from '../components/RoutingTabs.js';
+import ResponseModeModal from '../components/ResponseModeModal.js';
 import { toast } from '../services/toast-store.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import RoutingDefaultTierSection from './RoutingDefaultTierSection.js';
@@ -246,6 +247,8 @@ const Routing: Component = () => {
       !!customProviderPrefill() ||
       !!providerDeepLink(),
   );
+  const [helpOpen, setHelpOpen] = createSignal(false);
+  const [responseModeModalOpen, setResponseModeModalOpen] = createSignal(false);
   const [instructionModal, setInstructionModal] = createSignal<'enable' | 'disable' | null>(null);
   const [instructionProvider, setInstructionProvider] = createSignal<string | null>(null);
   const [fallbackPickerTier, setFallbackPickerTier] = createSignal<string | null>(null);
@@ -532,6 +535,27 @@ const Routing: Component = () => {
                 complexityEnabled(),
               )
             }
+            headerRight={
+              <button class="response-mode-btn" onClick={() => setResponseModeModalOpen(true)}>
+                <span class="response-mode-btn__icon">
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                </span>
+                Response mode: {defaultResponseMode() === 'stream' ? 'Stream' : 'Buffered'}
+              </button>
+            }
           >
             {{
               default: (
@@ -638,8 +662,66 @@ const Routing: Component = () => {
             resettingTier={actions.resettingTier}
             onResetAll={actions.handleResetAll}
             onShowInstructions={() => setInstructionModal('enable')}
+            onShowHowRoutingWorks={() => setHelpOpen(true)}
           />
+
+          <Show when={helpOpen()}>
+            {(() => {
+              const content = buildPipelineHelp(
+                hasAnySpecificityActive(),
+                hasCustomTiersEnabled(),
+                complexityEnabled(),
+              );
+              if (!content) return null;
+              return (
+                <div
+                  class="modal-overlay"
+                  onClick={(e) => {
+                    if (e.target === e.currentTarget) setHelpOpen(false);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Escape') setHelpOpen(false);
+                  }}
+                >
+                  <div
+                    class="modal-card"
+                    style="max-width: 480px;"
+                    role="dialog"
+                    aria-modal="true"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <h2 style="margin: 0 0 16px; font-size: var(--font-size-lg); font-weight: 600;">
+                      How routing works
+                    </h2>
+                    {content}
+                    <div style="display: flex; justify-content: flex-end; margin-top: 16px;">
+                      <button class="btn btn--primary btn--sm" onClick={() => setHelpOpen(false)}>
+                        Got it
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })()}
+          </Show>
         </Show>
+      </Show>
+
+      <Show when={responseModeModalOpen()}>
+        <ResponseModeModal
+          responseMode={defaultResponseMode}
+          onResponseModeChange={async (mode) => {
+            await handleDefaultResponseModeChange(mode);
+          }}
+          disabled={changingDefaultResponseMode}
+          tiers={tiers() ?? []}
+          models={models() ?? []}
+          onClose={() => setResponseModeModalOpen(false)}
+          onReplace={(tierId) => {
+            setResponseModeModalOpen(false);
+            setDropdownTier(tierId);
+          }}
+        />
       </Show>
 
       <RoutingModals

--- a/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
+++ b/packages/frontend/src/pages/RoutingDefaultTierSection.tsx
@@ -155,16 +155,7 @@ const RoutingDefaultTierSection: Component<RoutingDefaultTierSectionProps> = (pr
       ? 'Analyzes the complexity of each request on the fly and routes it to the matching tier.'
       : 'Pick one model and up to 5 fallbacks as your default routing.';
 
-  const controls = () => (
-    <div class="routing-section__controls">
-      <OutputControls
-        responseMode={props.responseMode}
-        disabled={props.changingResponseMode}
-        onResponseModeChange={props.onResponseModeChange}
-      />
-      {switchButton()}
-    </div>
-  );
+  const controls = () => <div class="routing-section__controls">{switchButton()}</div>;
 
   if (props.embedded) {
     return (

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -327,6 +327,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
             agentName={props.agentName()}
             existingTiers={tiers()}
             editing={state === 'new' ? undefined : state}
+            models={props.models()}
             onClose={() => setModalTier(null)}
             onSaved={(saved) => {
               const wasCreate = state === 'new';

--- a/packages/frontend/src/pages/RoutingPanels.tsx
+++ b/packages/frontend/src/pages/RoutingPanels.tsx
@@ -191,6 +191,7 @@ export interface RoutingFooterProps {
   resettingTier: () => string | null;
   onResetAll: () => void;
   onShowInstructions: () => void;
+  onShowHowRoutingWorks?: () => void;
 }
 
 /** Footer bar with reset-all and setup instructions buttons. */
@@ -206,6 +207,12 @@ export const RoutingFooter: Component<RoutingFooterProps> = (props) => (
       </button>
     </Show>
     <div style="flex: 1;" />
+    <Show when={props.onShowHowRoutingWorks}>
+      <button class="routing-footer__instructions" onClick={() => props.onShowHowRoutingWorks?.()}>
+        How routing works
+      </button>
+      <span class="routing-footer__sep">|</span>
+    </Show>
     <button class="routing-footer__instructions" onClick={() => props.onShowInstructions()}>
       Setup instructions
     </button>

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -584,10 +584,6 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                                 {formatPerRequestCost(modelInfo(modelName())?.cost_per_request) ??
                                   'Included in subscription'}
                               </span>
-                              <ModelCapabilityBadges
-                                capabilities={modelCapabilities(modelName())}
-                                compact
-                              />
                               <Show when={primarySkipped()}>
                                 <span class="routing-card__skipped-badge">Skipped in Stream</span>
                               </Show>
@@ -596,10 +592,6 @@ const RoutingTierCard: Component<RoutingTierCardProps> = (props) => {
                         >
                           <span class="routing-card__chip-meta">
                             <span class="routing-card__chip-price">{priceLabel(modelName())}</span>
-                            <ModelCapabilityBadges
-                              capabilities={modelCapabilities(modelName())}
-                              compact
-                            />
                             <Show when={primarySkipped()}>
                               <span class="routing-card__skipped-badge">Skipped in Stream</span>
                             </Show>

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -62,8 +62,55 @@
 
 .routing-modal__filter-bar {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   padding: 8px 24px 0;
   flex-shrink: 0;
+}
+
+.routing-modal__filter-left,
+.routing-modal__filter-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.routing-modal__filter-pill-icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.routing-modal__cap-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-family);
+  font-weight: 500;
+  color: hsl(var(--muted-foreground));
+  background: transparent;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.routing-modal__cap-pill:hover {
+  background: hsl(var(--muted) / 0.5);
+  color: hsl(var(--foreground));
+}
+
+.routing-modal__cap-pill--active {
+  color: hsl(var(--foreground));
+  background: hsl(var(--muted) / 0.7);
+  border-color: hsl(var(--foreground) / 0.3);
 }
 
 .routing-modal__filter-pill {
@@ -189,10 +236,8 @@
 .routing-modal__model {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
-  flex-wrap: wrap;
-  column-gap: 10px;
-  row-gap: 4px;
+  justify-content: space-between;
+  gap: 8px;
   width: 100%;
   padding: 9px 24px 9px 48px;
   background: none;
@@ -229,11 +274,31 @@
   outline-offset: -2px;
 }
 
+.routing-modal__model-left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  flex: 1 1 0;
+}
+
 .routing-modal__model-label {
   min-width: 0;
   font-size: var(--font-size-sm);
   font-weight: 500;
   color: hsl(var(--foreground));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.routing-modal__model-price {
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  font-family: var(--font-mono, monospace);
+  line-height: 1.35;
+  white-space: nowrap;
+  text-align: right;
 }
 
 .routing-modal__model-id {

--- a/packages/frontend/src/styles/routing-providers.css
+++ b/packages/frontend/src/styles/routing-providers.css
@@ -593,6 +593,17 @@
 .provider-detail__disconnect {
   color: hsl(var(--destructive));
   border-color: hsl(var(--destructive) / 0.3);
+  float: none;
+  margin-top: 0;
+}
+
+.provider-detail__footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid hsl(var(--border));
 }
 
 /* AnthropicOAuthDetailView layout. Stacks primary OAuth above the

--- a/packages/frontend/src/styles/routing-tabs.css
+++ b/packages/frontend/src/styles/routing-tabs.css
@@ -127,6 +127,12 @@
   margin-bottom: 20px;
 }
 
+.routing-tabs__header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
 .routing-tabs .panel__tab {
   gap: 8px;
 }

--- a/packages/frontend/src/styles/routing.css
+++ b/packages/frontend/src/styles/routing.css
@@ -313,9 +313,8 @@
   display: inline-flex;
   align-items: center;
   padding: 2px;
-  border: 1px solid hsl(var(--border));
   border-radius: var(--radius);
-  background: hsl(var(--background));
+  background: hsl(var(--muted));
 }
 
 .output-controls__segment {
@@ -344,9 +343,9 @@
 }
 
 .output-controls__segment--active {
-  background: hsl(var(--foreground));
-  color: hsl(var(--background));
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.06);
 }
 
 .output-controls__segment:disabled {
@@ -358,6 +357,120 @@
   justify-content: space-between;
   width: 100%;
   padding: 6px 0 10px;
+}
+
+/* ── Response mode modal ─────────────────────────── */
+
+.response-mode-modal .routing-modal__header {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.response-mode-modal__body {
+  padding: 0;
+}
+
+.response-mode-modal__blocker {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--muted) / 0.3);
+}
+
+.response-mode-modal__field-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.response-mode-modal__field-title {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.response-mode-modal__desc {
+  margin: 4px 0 0;
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.4;
+}
+
+.response-mode-modal__blocker-text {
+  margin: 0 0 8px;
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  line-height: 1.4;
+}
+
+.response-mode-modal__blocker-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.response-mode-modal__blocker-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 0;
+  border-top: 1px solid hsl(var(--border) / 0.5);
+}
+
+.response-mode-modal__blocker-row:first-child {
+  border-top: none;
+}
+
+.response-mode-modal__blocker-model {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.response-mode-modal__blocker-meta {
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.routing-switch--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Response mode settings button ───────────────── */
+
+.response-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: hsl(var(--muted));
+  border: none;
+  border-radius: var(--radius);
+  color: hsl(var(--muted-foreground));
+  font-family: var(--font-family);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.response-mode-btn:hover {
+  background: hsl(var(--muted) / 0.8);
+  color: hsl(var(--foreground));
+}
+
+.response-mode-btn__icon {
+  display: inline-flex;
+  align-items: center;
 }
 
 /* ── Complexity empty state ───────────────────────── */
@@ -583,6 +696,7 @@
 
 .model-capability-badges {
   flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .model-capability-badges--compact {
@@ -599,6 +713,7 @@
 .model-capability-badge {
   display: inline-flex;
   align-items: center;
+  gap: 3px;
   height: 18px;
   padding: 0 6px;
   border: 1px solid hsl(var(--border));
@@ -608,6 +723,49 @@
   font-size: 10px;
   font-weight: 600;
   line-height: 1;
+}
+
+.model-capability-badge--icon-only {
+  padding: 0;
+  width: 18px;
+  justify-content: center;
+  position: relative;
+}
+
+.model-capability-badge--icon-only::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 3px 8px;
+  border-radius: 4px;
+  background: hsl(var(--card));
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 2px 6px hsl(var(--foreground) / 0.08);
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.1s;
+  z-index: 10;
+}
+
+.model-capability-badge--icon-only:hover::after {
+  opacity: 1;
+}
+
+.model-capability-badge--unknown {
+  border-style: dashed;
+  opacity: 0.5;
+}
+
+.model-capability-badge__icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .dark .routing-card__model-chip {
@@ -1406,6 +1564,12 @@
 .routing-footer__instructions:focus-visible {
   outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
+}
+
+.routing-footer__sep {
+  color: hsl(var(--border));
+  font-size: var(--font-size-sm);
+  user-select: none;
 }
 
 /* ── Routing footer ───────────────────────────────── */

--- a/packages/frontend/tests/components/HeaderTierModal.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierModal.test.tsx
@@ -544,6 +544,178 @@ describe("HeaderTierModal", () => {
     });
   });
 
+  describe("stream mode toggle", () => {
+    it("renders the stream mode switch in edit mode, defaults to off for buffered tier", () => {
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[existingTier]}
+          editing={existingTier}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      const sw = container.querySelector(".routing-switch") as HTMLButtonElement;
+      expect(sw).not.toBeNull();
+      expect(sw.classList.contains("routing-switch--on")).toBe(false);
+    });
+
+    it("toggles stream mode on when clicked and all models support streaming", () => {
+      const streamTier: HeaderTier = {
+        ...existingTier,
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      };
+      const models = [{ model_name: "gpt-4o", capabilities: ["text", "stream"] as const }];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[streamTier]}
+          editing={streamTier}
+          models={models as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      const sw = container.querySelector(".routing-switch") as HTMLButtonElement;
+      fireEvent.click(sw);
+      expect(sw.classList.contains("routing-switch--on")).toBe(true);
+      // Clicking again toggles it off
+      fireEvent.click(sw);
+      expect(sw.classList.contains("routing-switch--on")).toBe(false);
+    });
+
+    it("disables the stream toggle when models don't support streaming", () => {
+      const noStreamTier: HeaderTier = {
+        ...existingTier,
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        fallback_routes: [{ provider: "openai", authType: "api_key", model: "gpt-3.5" }],
+      };
+      const models = [
+        { model_name: "gpt-4o", capabilities: ["text"] as const },
+        { model_name: "gpt-3.5", capabilities: ["text"] as const },
+      ];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[noStreamTier]}
+          editing={noStreamTier}
+          models={models as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      const sw = container.querySelector(".routing-switch") as HTMLButtonElement;
+      expect(sw.disabled).toBe(true);
+      expect(sw.classList.contains("routing-switch--disabled")).toBe(true);
+    });
+
+    it("shows incompatible models blocker when models lack stream capability", () => {
+      const noStreamTier: HeaderTier = {
+        ...existingTier,
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        fallback_routes: [{ provider: "openai", authType: "api_key", model: "gpt-3.5" }],
+      };
+      const models = [
+        { model_name: "gpt-4o", capabilities: ["text"] as const },
+        { model_name: "gpt-3.5", capabilities: ["text"] as const },
+      ];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[noStreamTier]}
+          editing={noStreamTier}
+          models={models as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      const blocker = container.querySelector(".response-mode-modal__blocker");
+      expect(blocker).not.toBeNull();
+      expect(blocker?.textContent).toContain("These models do");
+      expect(blocker?.textContent).toContain("them");
+      const rows = container.querySelectorAll(".response-mode-modal__blocker-row");
+      expect(rows.length).toBe(2);
+      expect(rows[0].textContent).toContain("gpt-4o");
+      expect(rows[0].textContent).toContain("Primary");
+      expect(rows[1].textContent).toContain("gpt-3.5");
+      expect(rows[1].textContent).toContain("Fallback 1");
+    });
+
+    it("shows singular blocker text when only one model is incompatible", () => {
+      const singleNoStream: HeaderTier = {
+        ...existingTier,
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      };
+      const models = [{ model_name: "gpt-4o", capabilities: ["text"] as const }];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[singleNoStream]}
+          editing={singleNoStream}
+          models={models as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      const blocker = container.querySelector(".response-mode-modal__blocker");
+      expect(blocker?.textContent).toContain("This model does");
+      expect(blocker?.textContent).toContain(" it ");
+    });
+
+    it("persists stream mode change via setHeaderTierResponseMode on save", async () => {
+      const streamTier: HeaderTier = {
+        ...existingTier,
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      };
+      const models = [{ model_name: "gpt-4o", capabilities: ["text", "stream"] as const }];
+      const onSaved = vi.fn();
+      const onClose = vi.fn();
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[streamTier]}
+          editing={streamTier}
+          models={models as any}
+          onClose={onClose}
+          onSaved={onSaved}
+        />
+      ));
+      // Toggle stream mode on
+      fireEvent.click(container.querySelector(".routing-switch") as HTMLButtonElement);
+      // Submit
+      fireEvent.click(
+        Array.from(container.querySelectorAll("button")).find((b) =>
+          b.textContent?.includes("Save changes"),
+        ) as HTMLButtonElement,
+      );
+      await waitFor(() => {
+        expect(mockUpdateHeaderTier).toHaveBeenCalled();
+        expect(mockSetHeaderTierResponseMode).toHaveBeenCalledWith("demo", existingTier.id, "stream");
+      });
+      expect(onSaved).toHaveBeenCalled();
+    });
+
+    it("shows stream description when stream mode is active", () => {
+      const streamTier: HeaderTier = {
+        ...existingTier,
+        response_mode: "stream",
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      };
+      const models = [{ model_name: "gpt-4o", capabilities: ["text", "stream"] as const }];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[streamTier]}
+          editing={streamTier}
+          models={models as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      expect(container.textContent).toContain("streamed token by token");
+    });
+  });
+
   describe("badge color picker", () => {
     it("renders one swatch per TIER_COLORS entry", () => {
       const { container } = render(() => (

--- a/packages/frontend/tests/components/HeaderTierModal.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierModal.test.tsx
@@ -4,10 +4,12 @@ import { render, fireEvent, waitFor } from "@solidjs/testing-library";
 const mockCreateHeaderTier = vi.fn();
 const mockUpdateHeaderTier = vi.fn();
 const mockGetSeenHeaders = vi.fn();
+const mockSetHeaderTierResponseMode = vi.fn();
 vi.mock("../../src/services/api/header-tiers.js", () => ({
   createHeaderTier: (...args: unknown[]) => mockCreateHeaderTier(...args),
   updateHeaderTier: (...args: unknown[]) => mockUpdateHeaderTier(...args),
   getSeenHeaders: (...args: unknown[]) => mockGetSeenHeaders(...args),
+  setHeaderTierResponseMode: (...args: unknown[]) => mockSetHeaderTierResponseMode(...args),
 }));
 
 const mockToastError = vi.fn();
@@ -65,6 +67,7 @@ const existingTier: HeaderTier = {
   enabled: true,
   override_route: null,
   fallback_routes: null,
+  response_mode: "buffered",
   created_at: "2025-01-01",
   updated_at: "2025-01-01",
 };
@@ -74,8 +77,9 @@ describe("HeaderTierModal", () => {
     vi.clearAllMocks();
     comboCalls.length = 0;
     mockGetSeenHeaders.mockResolvedValue([]);
-    mockCreateHeaderTier.mockResolvedValue({ ...existingTier, id: "ht-new", name: "Created" });
-    mockUpdateHeaderTier.mockResolvedValue({ ...existingTier });
+    mockCreateHeaderTier.mockResolvedValue({ ...existingTier, id: "ht-new", name: "Created", response_mode: "buffered" });
+    mockUpdateHeaderTier.mockResolvedValue({ ...existingTier, response_mode: "buffered" });
+    mockSetHeaderTierResponseMode.mockResolvedValue({ ...existingTier, response_mode: "stream" });
   });
 
   describe("create mode", () => {

--- a/packages/frontend/tests/components/HeaderTierModal.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierModal.test.tsx
@@ -706,6 +706,171 @@ describe("HeaderTierModal", () => {
     });
   });
 
+  describe("stream mode and incompatible models", () => {
+    const tierWithRoute: HeaderTier = {
+      ...existingTier,
+      override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      fallback_routes: [{ provider: "anthropic", authType: "api_key", model: "claude-3" }],
+    };
+
+    it("lists incompatible models that do not support streaming (primary + fallbacks)", () => {
+      const modelsWithCaps = [
+        { model_name: "gpt-4o", capabilities: ["text"] as const },
+        { model_name: "claude-3", capabilities: ["text"] as const },
+      ];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[tierWithRoute]}
+          editing={tierWithRoute}
+          models={modelsWithCaps as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      // Stream toggle should be disabled since models lack stream capability
+      const switchBtn = container.querySelector(".routing-switch") as HTMLButtonElement;
+      expect(switchBtn.classList.contains("routing-switch--disabled")).toBe(true);
+      // Blocker text should show plural form
+      expect(container.textContent).toContain("These models do");
+      expect(container.textContent).toContain("not support streaming");
+      // Blocker rows should be rendered
+      const blockerRows = container.querySelectorAll(".response-mode-modal__blocker-row");
+      expect(blockerRows.length).toBe(2);
+      expect(blockerRows[0].textContent).toContain("gpt-4o");
+      expect(blockerRows[0].textContent).toContain("Primary");
+      expect(blockerRows[1].textContent).toContain("claude-3");
+      expect(blockerRows[1].textContent).toContain("Fallback 1");
+    });
+
+    it("shows singular blocker text when only one model is incompatible", () => {
+      const tierSingleRoute: HeaderTier = {
+        ...existingTier,
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        fallback_routes: [],
+      };
+      const modelsWithCaps = [
+        { model_name: "gpt-4o", capabilities: ["text"] as const },
+      ];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[tierSingleRoute]}
+          editing={tierSingleRoute}
+          models={modelsWithCaps as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      expect(container.textContent).toContain("This model does");
+      expect(container.textContent).toContain("Change it to");
+    });
+
+    it("enables the stream toggle when all models support streaming", () => {
+      const modelsWithStream = [
+        { model_name: "gpt-4o", capabilities: ["text", "stream"] as const },
+        { model_name: "claude-3", capabilities: ["text", "stream"] as const },
+      ];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[tierWithRoute]}
+          editing={tierWithRoute}
+          models={modelsWithStream as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      const switchBtn = container.querySelector(".routing-switch") as HTMLButtonElement;
+      expect(switchBtn.classList.contains("routing-switch--disabled")).toBe(false);
+    });
+
+    it("toggles stream mode on and off when clicked", () => {
+      const modelsWithStream = [
+        { model_name: "gpt-4o", capabilities: ["text", "stream"] as const },
+        { model_name: "claude-3", capabilities: ["text", "stream"] as const },
+      ];
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[tierWithRoute]}
+          editing={tierWithRoute}
+          models={modelsWithStream as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      const switchBtn = container.querySelector(".routing-switch") as HTMLButtonElement;
+      // Initially buffered (existingTier.response_mode = "buffered")
+      expect(switchBtn.classList.contains("routing-switch--on")).toBe(false);
+      // Click to enable stream
+      fireEvent.click(switchBtn);
+      expect(switchBtn.classList.contains("routing-switch--on")).toBe(true);
+      // Shows streaming description
+      expect(container.textContent).toContain("streamed token by token");
+      // Click to disable stream
+      fireEvent.click(switchBtn);
+      expect(switchBtn.classList.contains("routing-switch--on")).toBe(false);
+      expect(container.textContent).toContain("returned as a single payload");
+    });
+
+    it("calls setHeaderTierResponseMode when stream mode changed during submit", async () => {
+      const modelsWithStream = [
+        { model_name: "gpt-4o", capabilities: ["text", "stream"] as const },
+        { model_name: "claude-3", capabilities: ["text", "stream"] as const },
+      ];
+      const onSaved = vi.fn();
+      const onClose = vi.fn();
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[tierWithRoute]}
+          editing={tierWithRoute}
+          models={modelsWithStream as any}
+          onClose={onClose}
+          onSaved={onSaved}
+        />
+      ));
+      // Toggle stream on
+      const switchBtn = container.querySelector(".routing-switch") as HTMLButtonElement;
+      fireEvent.click(switchBtn);
+      // Submit the form
+      const submitBtn = Array.from(container.querySelectorAll("button")).find((b) =>
+        b.textContent?.includes("Save changes"),
+      ) as HTMLButtonElement;
+      fireEvent.click(submitBtn);
+      await waitFor(() => {
+        expect(mockUpdateHeaderTier).toHaveBeenCalled();
+        expect(mockSetHeaderTierResponseMode).toHaveBeenCalledWith("demo", existingTier.id, "stream");
+        expect(onSaved).toHaveBeenCalled();
+      });
+    });
+
+    it("handles models with capabilities set on available models (caps.set path)", () => {
+      const modelsWithCaps = [
+        { model_name: "gpt-4o", capabilities: ["text", "stream"] as const },
+      ];
+      const tierOneRoute: HeaderTier = {
+        ...existingTier,
+        override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        fallback_routes: [],
+      };
+      const { container } = render(() => (
+        <HeaderTierModal
+          agentName="demo"
+          existingTiers={[tierOneRoute]}
+          editing={tierOneRoute}
+          models={modelsWithCaps as any}
+          onClose={vi.fn()}
+          onSaved={vi.fn()}
+        />
+      ));
+      // Stream toggle should be enabled
+      const switchBtn = container.querySelector(".routing-switch") as HTMLButtonElement;
+      expect(switchBtn.classList.contains("routing-switch--disabled")).toBe(false);
+    });
+  });
+
   describe("keyboard shortcuts", () => {
     it("submits when Enter is pressed on the name input", async () => {
       const onSaved = vi.fn();

--- a/packages/frontend/tests/components/ModelCapabilityBadges.test.tsx
+++ b/packages/frontend/tests/components/ModelCapabilityBadges.test.tsx
@@ -18,13 +18,14 @@ describe('ModelCapabilityBadges', () => {
   it('shows text-only metadata without rendering unchecked capabilities', () => {
     render(() => <ModelCapabilityBadges capabilities={['text']} />);
 
-    expect(screen.getByText('Text only')).toBeTruthy();
+    expect(screen.getByLabelText('Text only')).toBeTruthy();
     expect(screen.queryByText('Stream')).toBeNull();
   });
 
   it('shows unknown state when no capability metadata is present', () => {
-    render(() => <ModelCapabilityBadges />);
+    const { container } = render(() => <ModelCapabilityBadges />);
 
-    expect(screen.getByText('Capabilities unknown')).toBeTruthy();
+    expect(screen.getByLabelText('Capabilities unknown')).toBeTruthy();
+    expect(container.querySelector('.model-capability-badge--unknown')).toBeTruthy();
   });
 });

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -215,7 +215,7 @@ describe('ModelPickerModal', () => {
     expect(container.querySelector('.routing-modal__subtitle')).toBeNull();
   });
 
-  it('disables models that do not support the required stream capability', () => {
+  it('filters out models that do not support the required stream capability', () => {
     const onSelect = vi.fn();
     const modelsWithCapabilities: AvailableModel[] = [
       { ...baseModels[0]!, capabilities: ['text', 'stream'] },
@@ -234,21 +234,18 @@ describe('ModelPickerModal', () => {
     ));
 
     const buttons = Array.from(container.querySelectorAll('.routing-modal__model'));
+    // requiredCapability pre-selects the capability filter, so models without
+    // stream are filtered out entirely rather than shown as disabled.
     const streamModel = buttons.find((button) => button.textContent?.includes('GPT-4o'));
     const blockedModel = buttons.find((button) => button.textContent?.includes('GPT-4o mini'));
     expect(streamModel).toBeDefined();
-    expect(blockedModel).toBeDefined();
-    expect((streamModel as HTMLButtonElement).disabled).toBe(false);
-    expect((blockedModel as HTMLButtonElement).disabled).toBe(true);
-    expect(blockedModel?.textContent).toContain('Stream unavailable');
+    expect(blockedModel).toBeUndefined();
 
-    fireEvent.click(blockedModel as HTMLButtonElement);
-    expect(onSelect).not.toHaveBeenCalled();
     fireEvent.click(streamModel as HTMLButtonElement);
     expect(onSelect).toHaveBeenCalledWith('default', 'gpt-4o', 'openai', 'api_key');
   });
 
-  it('uses a generic unavailable label for future output capabilities', () => {
+  it('filters out all models when none support the required capability', () => {
     const { container } = render(() => (
       <ModelPickerModal
         tierId="default"
@@ -261,9 +258,9 @@ describe('ModelPickerModal', () => {
       />
     ));
 
-    const blockedModel = container.querySelector('.routing-modal__model') as HTMLButtonElement;
-    expect(blockedModel.disabled).toBe(true);
-    expect(blockedModel.textContent).toContain('Image unavailable');
+    // No models have the image capability, so all are filtered out
+    const models = container.querySelectorAll('.routing-modal__model');
+    expect(models.length).toBe(0);
   });
 
   describe('per-group refresh button', () => {
@@ -445,10 +442,10 @@ describe('ModelPickerModal', () => {
         onClose={vi.fn()}
       />
     ));
-    const pill = container.querySelector('.routing-modal__filter-pill') as HTMLButtonElement;
+    const pill = container.querySelector('.routing-modal__cap-pill') as HTMLButtonElement;
     expect(pill).not.toBeNull();
     fireEvent.click(pill);
-    expect(pill.classList.contains('routing-modal__filter-pill--active')).toBe(true);
+    expect(pill.classList.contains('routing-modal__cap-pill--active')).toBe(true);
     // Only gpt-4o-mini is free → only one model rendered
     const modelButtons = container.querySelectorAll('.routing-modal__model');
     expect(modelButtons.length).toBe(1);
@@ -958,7 +955,7 @@ describe('ModelPickerModal', () => {
         onClose={vi.fn()}
       />
     ));
-    const pill = container.querySelector('.routing-modal__filter-pill') as HTMLButtonElement;
+    const pill = container.querySelector('.routing-modal__cap-pill') as HTMLButtonElement;
     fireEvent.click(pill);
     expect(container.textContent).toContain(
       'No free models available from your connected providers',
@@ -1056,9 +1053,9 @@ describe('ModelPickerModal', () => {
       t.textContent?.includes('API Keys'),
     ) as HTMLButtonElement;
     fireEvent.click(apiTab);
-    const pill = container.querySelector('.routing-modal__filter-pill') as HTMLButtonElement;
+    const pill = container.querySelector('.routing-modal__cap-pill') as HTMLButtonElement;
     fireEvent.click(pill);
-    expect(pill.classList.contains('routing-modal__filter-pill--active')).toBe(true);
+    expect(pill.classList.contains('routing-modal__cap-pill--active')).toBe(true);
     // Click Subscription tab — the click handler sets activeTab + resets free-only.
     const subTab = Array.from(container.querySelectorAll('[role="tab"]')).find((t) =>
       t.textContent?.includes('Subscription'),

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -1064,6 +1064,77 @@ describe('ModelPickerModal', () => {
     expect(subTab.getAttribute('aria-selected')).toBe('true');
   });
 
+  describe('capability filter pills', () => {
+    const modelsWithCapabilities: AvailableModel[] = [
+      { ...baseModels[0]!, capabilities: ['text', 'stream', 'tools'] },
+      { ...baseModels[1]!, capabilities: ['text', 'stream'] },
+      { ...baseModels[2]!, capabilities: ['text', 'image'], auth_type: 'api_key', provider: 'OpenAI' },
+    ];
+
+    it('renders capability filter pills for capabilities present in the model list', () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="simple"
+          models={modelsWithCapabilities}
+          tiers={tiers}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      const pills = container.querySelectorAll('.routing-modal__filter-right .routing-modal__cap-pill');
+      // Should have pills for stream, tools, image (the caps found in models)
+      const pillTexts = Array.from(pills).map((p) => p.textContent?.trim());
+      expect(pillTexts.some((t) => t?.includes('Stream'))).toBe(true);
+      expect(pillTexts.some((t) => t?.includes('Tools'))).toBe(true);
+      expect(pillTexts.some((t) => t?.includes('Image'))).toBe(true);
+    });
+
+    it('toggles a capability filter on and off when clicking a pill', () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="simple"
+          models={modelsWithCapabilities}
+          tiers={tiers}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      const pills = container.querySelectorAll('.routing-modal__filter-right .routing-modal__cap-pill');
+      // Find the "Tools" pill
+      const toolsPill = Array.from(pills).find((p) => p.textContent?.includes('Tools')) as HTMLButtonElement;
+      expect(toolsPill).toBeDefined();
+      // Toggle on
+      fireEvent.click(toolsPill);
+      expect(toolsPill.classList.contains('routing-modal__cap-pill--active')).toBe(true);
+      // Only one model has tools capability (gpt-4o)
+      const modelButtons = container.querySelectorAll('.routing-modal__model');
+      expect(modelButtons.length).toBe(1);
+      expect(modelButtons[0].textContent).toContain('GPT-4o');
+      // Toggle off
+      fireEvent.click(toolsPill);
+      expect(toolsPill.classList.contains('routing-modal__cap-pill--active')).toBe(false);
+    });
+
+    it('availableCapabilities returns correct set from model list', () => {
+      const { container } = render(() => (
+        <ModelPickerModal
+          tierId="simple"
+          models={modelsWithCapabilities}
+          tiers={tiers}
+          connectedProviders={apiKeyOnly}
+          onSelect={vi.fn()}
+          onClose={vi.fn()}
+        />
+      ));
+      const pills = container.querySelectorAll('.routing-modal__filter-right .routing-modal__cap-pill');
+      // stream, tools, image should be present (text is not in capOrder so it is filtered out)
+      // audio and video are not in any model so they are not shown
+      expect(pills.length).toBe(3);
+    });
+  });
+
   it('clicks the Local tab when local + api_key are both connected', () => {
     const localAndApi: RoutingProvider[] = [
       ...apiKeyOnly,

--- a/packages/frontend/tests/components/ResponseModeModal.test.tsx
+++ b/packages/frontend/tests/components/ResponseModeModal.test.tsx
@@ -1,0 +1,436 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import { createSignal } from 'solid-js';
+
+vi.mock('../../src/services/providers.js', () => ({
+  STAGES: [
+    { id: 'simple', label: 'Simple' },
+    { id: 'standard', label: 'Standard' },
+    { id: 'complex', label: 'Complex' },
+  ],
+  DEFAULT_STAGE: { id: 'default', label: 'Default' },
+}));
+
+import ResponseModeModal from '../../src/components/ResponseModeModal';
+import type { AvailableModel, TierAssignment } from '../../src/services/api/routing';
+
+const streamCapableModel: AvailableModel = {
+  model_name: 'gpt-4o',
+  provider: 'OpenAI',
+  auth_type: 'api_key',
+  input_price_per_token: 0.000005,
+  output_price_per_token: 0.000015,
+  context_window: 128000,
+  capability_reasoning: false,
+  capability_code: true,
+  capabilities: ['text', 'stream'],
+  quality_score: 8,
+  display_name: 'GPT-4o',
+};
+
+const noStreamModel: AvailableModel = {
+  model_name: 'o1-preview',
+  provider: 'OpenAI',
+  auth_type: 'api_key',
+  input_price_per_token: 0.00001,
+  output_price_per_token: 0.00003,
+  context_window: 128000,
+  capability_reasoning: true,
+  capability_code: true,
+  capabilities: ['text'],
+  quality_score: 9,
+  display_name: 'o1-preview',
+};
+
+const allStreamModels: AvailableModel[] = [streamCapableModel];
+const mixedModels: AvailableModel[] = [streamCapableModel, noStreamModel];
+
+function makeTier(overrides?: Partial<TierAssignment>): TierAssignment {
+  return {
+    id: 't1',
+    agent_id: 'a1',
+    tier: 'simple',
+    override_route: null,
+    auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+    fallback_routes: null,
+    updated_at: '2025-01-01',
+    ...overrides,
+  };
+}
+
+describe('ResponseModeModal', () => {
+  it('renders with stream mode off (buffered) and shows buffered description', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[makeTier()]}
+        models={allStreamModels}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(container.textContent).toContain(
+      'Responses are returned as a single payload once the model finishes generating',
+    );
+    const toggle = container.querySelector('.routing-switch') as HTMLButtonElement;
+    expect(toggle.classList.contains('routing-switch--on')).toBe(false);
+  });
+
+  it('renders with stream mode on and shows stream description', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('stream');
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[makeTier()]}
+        models={allStreamModels}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(container.textContent).toContain(
+      'Responses are streamed token by token as the model generates them',
+    );
+    const toggle = container.querySelector('.routing-switch') as HTMLButtonElement;
+    expect(toggle.classList.contains('routing-switch--on')).toBe(true);
+  });
+
+  it('toggle calls onResponseModeChange with stream when no incompatible models', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const onChange = vi.fn();
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={onChange}
+        tiers={[makeTier()]}
+        models={allStreamModels}
+        onClose={vi.fn()}
+      />
+    ));
+    const toggle = container.querySelector('.routing-switch') as HTMLButtonElement;
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith('stream');
+  });
+
+  it('toggle calls onResponseModeChange with buffered when currently streaming', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('stream');
+    const onChange = vi.fn();
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={onChange}
+        tiers={[makeTier()]}
+        models={allStreamModels}
+        onClose={vi.fn()}
+      />
+    ));
+    const toggle = container.querySelector('.routing-switch') as HTMLButtonElement;
+    fireEvent.click(toggle);
+    expect(onChange).toHaveBeenCalledWith('buffered');
+  });
+
+  it('toggle is disabled when incompatible models exist and mode is buffered', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const onChange = vi.fn();
+    const tier = makeTier({
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'o1-preview' },
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={onChange}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+      />
+    ));
+    const toggle = container.querySelector('.routing-switch') as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+    expect(toggle.classList.contains('routing-switch--disabled')).toBe(true);
+    fireEvent.click(toggle);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('toggle is disabled when disabled prop is true', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const [disabled] = createSignal(true);
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        disabled={disabled}
+        tiers={[makeTier()]}
+        models={allStreamModels}
+        onClose={vi.fn()}
+      />
+    ));
+    const toggle = container.querySelector('.routing-switch') as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+  });
+
+  it('lists incompatible models with model name, tier label, and position', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const tier = makeTier({
+      tier: 'simple',
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'o1-preview' },
+      fallback_routes: [{ provider: 'openai', authType: 'api_key', model: 'o1-preview' }],
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+      />
+    ));
+    const rows = container.querySelectorAll('.response-mode-modal__blocker-row');
+    expect(rows.length).toBe(2);
+
+    // Primary model
+    const firstModel = rows[0].querySelector('.response-mode-modal__blocker-model');
+    const firstMeta = rows[0].querySelector('.response-mode-modal__blocker-meta');
+    expect(firstModel?.textContent).toBe('o1-preview');
+    expect(firstMeta?.textContent).toContain('Simple');
+    expect(firstMeta?.textContent).toContain('Primary');
+
+    // Fallback model
+    const secondMeta = rows[1].querySelector('.response-mode-modal__blocker-meta');
+    expect(secondMeta?.textContent).toContain('Fallback 1');
+  });
+
+  it('shows singular copy when exactly one model is incompatible', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const tier = makeTier({
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'o1-preview' },
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(container.textContent).toContain('this model does');
+    expect(container.textContent).toContain('Change it to enable');
+  });
+
+  it('shows plural copy when multiple models are incompatible', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const tier = makeTier({
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'o1-preview' },
+      fallback_routes: [{ provider: 'openai', authType: 'api_key', model: 'o1-preview' }],
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(container.textContent).toContain('these models do');
+    expect(container.textContent).toContain('Change them to enable');
+  });
+
+  it('Change button calls onReplace with tier, primary position, and stream capability', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const onReplace = vi.fn();
+    const tier = makeTier({
+      tier: 'complex',
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'o1-preview' },
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+        onReplace={onReplace}
+      />
+    ));
+    const changeBtn = container.querySelector(
+      '.response-mode-modal__blocker-row .btn--outline',
+    ) as HTMLButtonElement;
+    fireEvent.click(changeBtn);
+    expect(onReplace).toHaveBeenCalledWith('complex', 'primary', 'stream');
+  });
+
+  it('Change button calls onReplace with fallback index for fallback models', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const onReplace = vi.fn();
+    const tier = makeTier({
+      tier: 'simple',
+      override_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+      auto_assigned_route: null,
+      fallback_routes: [{ provider: 'openai', authType: 'api_key', model: 'o1-preview' }],
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+        onReplace={onReplace}
+      />
+    ));
+    const changeBtn = container.querySelector(
+      '.response-mode-modal__blocker-row .btn--outline',
+    ) as HTMLButtonElement;
+    fireEvent.click(changeBtn);
+    // Fallback 1 → index 0
+    expect(onReplace).toHaveBeenCalledWith('simple', 0, 'stream');
+  });
+
+  it('close button calls onClose', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const onClose = vi.fn();
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[]}
+        models={[]}
+        onClose={onClose}
+      />
+    ));
+    const closeBtn = container.querySelector('.modal__close') as HTMLButtonElement;
+    fireEvent.click(closeBtn);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('overlay click calls onClose', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const onClose = vi.fn();
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[]}
+        models={[]}
+        onClose={onClose}
+      />
+    ));
+    fireEvent.click(container.querySelector('.modal-overlay') as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking inside the modal card does not call onClose', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const onClose = vi.fn();
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[]}
+        models={[]}
+        onClose={onClose}
+      />
+    ));
+    fireEvent.click(container.querySelector('.response-mode-modal') as HTMLElement);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('Escape key on overlay calls onClose', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const onClose = vi.fn();
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[]}
+        models={[]}
+        onClose={onClose}
+      />
+    ));
+    fireEvent.keyDown(container.querySelector('.modal-overlay') as HTMLElement, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses override_route when present instead of auto_assigned_route', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const tier = makeTier({
+      override_route: { provider: 'openai', authType: 'api_key', model: 'o1-preview' },
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+      />
+    ));
+    // o1-preview (override) should be listed as incompatible, not gpt-4o (auto)
+    const modelNames = container.querySelectorAll('.response-mode-modal__blocker-model');
+    expect(modelNames.length).toBe(1);
+    expect(modelNames[0].textContent).toBe('o1-preview');
+  });
+
+  it('does not show blocker section when in stream mode even if models lack streaming', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('stream');
+    const tier = makeTier({
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'o1-preview' },
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+      />
+    ));
+    expect(container.querySelector('.response-mode-modal__blocker')).toBeNull();
+  });
+
+  it('falls back to tier id when tier does not match any stage', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const tier = makeTier({
+      tier: 'unknown-tier',
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'o1-preview' },
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={mixedModels}
+        onClose={vi.fn()}
+      />
+    ));
+    const meta = container.querySelector('.response-mode-modal__blocker-meta');
+    expect(meta?.textContent).toContain('unknown-tier');
+  });
+
+  it('treats models without capabilities metadata as not supporting stream', () => {
+    const [mode] = createSignal<'buffered' | 'stream'>('buffered');
+    const noCapsModel: AvailableModel = {
+      ...noStreamModel,
+      model_name: 'mystery-model',
+      capabilities: undefined,
+    };
+    const tier = makeTier({
+      auto_assigned_route: { provider: 'openai', authType: 'api_key', model: 'mystery-model' },
+    });
+    const { container } = render(() => (
+      <ResponseModeModal
+        responseMode={mode}
+        onResponseModeChange={vi.fn()}
+        tiers={[tier]}
+        models={[noCapsModel]}
+        onClose={vi.fn()}
+      />
+    ));
+    // Model without capabilities → hasStream returns false (via ?? false) → listed as incompatible
+    const modelNames = container.querySelectorAll('.response-mode-modal__blocker-model');
+    expect(modelNames.length).toBe(1);
+    expect(modelNames[0].textContent).toBe('mystery-model');
+  });
+});

--- a/packages/frontend/tests/components/RoutingTabs.test.tsx
+++ b/packages/frontend/tests/components/RoutingTabs.test.tsx
@@ -107,7 +107,7 @@ describe('RoutingTabs', () => {
 
   /* ---- Pipeline help modal ---- */
 
-  it('shows help button when pipelineHelp returns content', () => {
+  it('accepts pipelineHelp prop without rendering help button or modal', () => {
     render(() => (
       <RoutingTabs
         specificityEnabled={() => false}
@@ -121,7 +121,9 @@ describe('RoutingTabs', () => {
         }}
       </RoutingTabs>
     ));
-    expect(screen.getByLabelText('How routing works')).toBeDefined();
+    // Help button and modal are now managed by the parent (Routing.tsx)
+    expect(screen.queryByLabelText('How routing works')).toBeNull();
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 
   it('does not show help button when pipelineHelp returns null', () => {
@@ -141,12 +143,12 @@ describe('RoutingTabs', () => {
     expect(screen.queryByLabelText('How routing works')).toBeNull();
   });
 
-  it('opens help modal on button click and shows content', async () => {
+  it('renders headerRight slot when provided', () => {
     render(() => (
       <RoutingTabs
         specificityEnabled={() => false}
         customEnabled={() => false}
-        pipelineHelp={() => <div data-testid="help-content">Pipeline info</div>}
+        headerRight={<div data-testid="header-right-content">Right content</div>}
       >
         {{
           default: <div>Default</div>,
@@ -155,15 +157,45 @@ describe('RoutingTabs', () => {
         }}
       </RoutingTabs>
     ));
-    fireEvent.click(screen.getByLabelText('How routing works'));
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeDefined();
-      expect(screen.getByText('How routing works', { selector: 'h2' })).toBeDefined();
-      expect(screen.getByTestId('help-content')).toBeDefined();
-    });
+    expect(screen.getByTestId('header-right-content')).toBeDefined();
   });
 
-  it('closes help modal on "Got it" click', async () => {
+  it('does not render headerRight wrapper when no slot is provided', () => {
+    const { container } = render(() => (
+      <RoutingTabs
+        specificityEnabled={() => false}
+        customEnabled={() => false}
+      >
+        {{
+          default: <div>Default</div>,
+          specificity: <div>Specificity</div>,
+          custom: <div>Custom</div>,
+        }}
+      </RoutingTabs>
+    ));
+    expect(container.querySelector('.routing-tabs__header-right')).toBeNull();
+  });
+
+  it('accepts onShowHelp prop for parent-managed help modal', () => {
+    const onShowHelp = vi.fn();
+    render(() => (
+      <RoutingTabs
+        specificityEnabled={() => false}
+        customEnabled={() => false}
+        onShowHelp={onShowHelp}
+      >
+        {{
+          default: <div>Default</div>,
+          specificity: <div>Specificity</div>,
+          custom: <div>Custom</div>,
+        }}
+      </RoutingTabs>
+    ));
+    // The component accepts the prop but does not render a help button itself
+    expect(screen.queryByLabelText('How routing works')).toBeNull();
+  });
+
+  it('does not render a help modal internally even with pipelineHelp', () => {
     render(() => (
       <RoutingTabs
         specificityEnabled={() => false}
@@ -177,71 +209,6 @@ describe('RoutingTabs', () => {
         }}
       </RoutingTabs>
     ));
-    fireEvent.click(screen.getByLabelText('How routing works'));
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeDefined());
-    fireEvent.click(screen.getByText('Got it'));
-    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
-  });
-
-  it('closes help modal on overlay click', async () => {
-    render(() => (
-      <RoutingTabs
-        specificityEnabled={() => false}
-        customEnabled={() => false}
-        pipelineHelp={() => <div>Help</div>}
-      >
-        {{
-          default: <div>Default</div>,
-          specificity: <div>Specificity</div>,
-          custom: <div>Custom</div>,
-        }}
-      </RoutingTabs>
-    ));
-    fireEvent.click(screen.getByLabelText('How routing works'));
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeDefined());
-    const overlay = screen.getByRole('dialog').parentElement!;
-    fireEvent.click(overlay);
-    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
-  });
-
-  it('closes help modal on Escape key', async () => {
-    render(() => (
-      <RoutingTabs
-        specificityEnabled={() => false}
-        customEnabled={() => false}
-        pipelineHelp={() => <div>Help</div>}
-      >
-        {{
-          default: <div>Default</div>,
-          specificity: <div>Specificity</div>,
-          custom: <div>Custom</div>,
-        }}
-      </RoutingTabs>
-    ));
-    fireEvent.click(screen.getByLabelText('How routing works'));
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeDefined());
-    const overlay = screen.getByRole('dialog').parentElement!;
-    fireEvent.keyDown(overlay, { key: 'Escape' });
-    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
-  });
-
-  it('does not close help modal when clicking inside the dialog card', async () => {
-    render(() => (
-      <RoutingTabs
-        specificityEnabled={() => false}
-        customEnabled={() => false}
-        pipelineHelp={() => <div>Help</div>}
-      >
-        {{
-          default: <div>Default</div>,
-          specificity: <div>Specificity</div>,
-          custom: <div>Custom</div>,
-        }}
-      </RoutingTabs>
-    ));
-    fireEvent.click(screen.getByLabelText('How routing works'));
-    await waitFor(() => expect(screen.getByRole('dialog')).toBeDefined());
-    fireEvent.click(screen.getByRole('dialog'));
-    expect(screen.getByRole('dialog')).toBeDefined();
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 });

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -1635,6 +1635,27 @@ describe('Routing page', () => {
     });
   });
 
+  it('fires onResponseModeChange on the ResponseModeModal which calls handleDefaultResponseModeChange', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      const headerRight = screen.getByTestId('tab-header-right');
+      expect(headerRight.querySelector('.response-mode-btn')).not.toBeNull();
+    });
+    fireEvent.click(screen.getByTestId('tab-header-right').querySelector('.response-mode-btn') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(screen.getByTestId('response-mode-modal')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('response-mode-modal-change'));
+    await waitFor(() => {
+      // Complexity is enabled, so it calls setTierResponseMode for each stage
+      expect(mockSetTierResponseMode).toHaveBeenCalled();
+      const calls = mockSetTierResponseMode.mock.calls;
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[0][0]).toBe('demo');
+      expect(calls[0][2]).toBe('stream');
+    });
+  });
+
   it('closes the help modal via Escape key', async () => {
     render(() => <Routing />);
     await waitFor(() => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -108,6 +108,8 @@ vi.mock('../../src/components/RoutingTabs.js', () => ({
     };
     return (
       <div data-testid="routing-tabs">
+        {/* Render headerRight so lines 538-556 (response-mode-btn JSX) are covered */}
+        <div data-testid="tab-header-right">{props.headerRight as unknown as Element}</div>
         <div data-testid="tab-default">{children.default as unknown as Element}</div>
         <div data-testid="tab-specificity">{children.specificity as unknown as Element}</div>
         <div data-testid="tab-custom">{children.custom as unknown as Element}</div>
@@ -117,7 +119,7 @@ vi.mock('../../src/components/RoutingTabs.js', () => ({
 }));
 
 vi.mock('../../src/components/RoutingPipelineCard.js', () => ({
-  buildPipelineHelp: () => ({ summary: 'summary', steps: [] }),
+  buildPipelineHelp: () => <div data-testid="pipeline-help-content">Help content</div>,
 }));
 
 let lastModalsProps: Record<string, unknown> | null = null;
@@ -473,7 +475,57 @@ vi.mock('../../src/pages/RoutingSpecificitySection.js', () => ({
 }));
 
 vi.mock('../../src/pages/RoutingHeaderTiersSection.js', () => ({
-  default: () => <div data-testid="custom-section" />,
+  default: (props: Record<string, unknown>) => {
+    // Read props so models={props.models()} (line 330) is covered.
+    const _read = [
+      props.agentName,
+      props.models,
+      props.customProviders,
+      props.connectedProviders,
+      props.externalTiers,
+      props.externalRefetch,
+      props.externalMutate,
+      props.getModelParams,
+      props.setModelParams,
+    ];
+    void _read;
+    return <div data-testid="custom-section" />;
+  },
+}));
+
+vi.mock('../../src/components/ResponseModeModal.js', () => ({
+  default: (props: Record<string, unknown>) => {
+    // Read every prop so JSX attribute lines 711-723 are covered.
+    const _read = [
+      props.responseMode,
+      props.disabled,
+      props.tiers,
+      props.models,
+    ];
+    void _read;
+    return (
+      <div data-testid="response-mode-modal">
+        <button
+          data-testid="response-mode-modal-change"
+          onClick={() => (props.onResponseModeChange as (m: string) => void)('stream')}
+        >
+          change
+        </button>
+        <button
+          data-testid="response-mode-modal-close"
+          onClick={() => (props.onClose as () => void)()}
+        >
+          close
+        </button>
+        <button
+          data-testid="response-mode-modal-replace"
+          onClick={() => (props.onReplace as (tierId: string) => void)('simple')}
+        >
+          replace
+        </button>
+      </div>
+    );
+  },
 }));
 
 vi.mock('../../src/pages/RoutingPanels.js', () => ({
@@ -494,6 +546,12 @@ vi.mock('../../src/pages/RoutingPanels.js', () => ({
           onClick={() => (props.onShowInstructions as () => void)()}
         >
           instructions
+        </button>
+        <button
+          data-testid="show-how-routing-works"
+          onClick={() => (props.onShowHowRoutingWorks as () => void)?.()}
+        >
+          how-routing-works
         </button>
       </div>
     );
@@ -1485,5 +1543,111 @@ describe('Routing page', () => {
     });
     fireEvent.click(screen.getByTestId('spec-saved-params'));
     expect(true).toBe(true);
+  });
+
+  it('renders the response mode button in headerRight (lines 538-556)', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId('tab-header-right')).toBeDefined();
+    });
+    // The response-mode-btn is rendered inside headerRight via the RoutingTabs mock
+    const headerRight = screen.getByTestId('tab-header-right');
+    const btn = headerRight.querySelector('.response-mode-btn');
+    expect(btn).not.toBeNull();
+    expect(btn?.textContent).toContain('Response mode');
+  });
+
+  it('opens the ResponseModeModal when clicking the response mode button', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      const headerRight = screen.getByTestId('tab-header-right');
+      expect(headerRight.querySelector('.response-mode-btn')).not.toBeNull();
+    });
+    fireEvent.click(screen.getByTestId('tab-header-right').querySelector('.response-mode-btn') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(screen.getByTestId('response-mode-modal')).toBeDefined();
+    });
+  });
+
+  it('closes the ResponseModeModal via onClose', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      const headerRight = screen.getByTestId('tab-header-right');
+      expect(headerRight.querySelector('.response-mode-btn')).not.toBeNull();
+    });
+    fireEvent.click(screen.getByTestId('tab-header-right').querySelector('.response-mode-btn') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(screen.getByTestId('response-mode-modal')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('response-mode-modal-close'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('response-mode-modal')).toBeNull();
+    });
+  });
+
+  it('calls onReplace on the ResponseModeModal which closes it and opens dropdown', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      const headerRight = screen.getByTestId('tab-header-right');
+      expect(headerRight.querySelector('.response-mode-btn')).not.toBeNull();
+    });
+    fireEvent.click(screen.getByTestId('tab-header-right').querySelector('.response-mode-btn') as HTMLButtonElement);
+    await waitFor(() => {
+      expect(screen.getByTestId('response-mode-modal')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('response-mode-modal-replace'));
+    // Modal closes, dropdown tier is set to 'simple'
+    await waitFor(() => {
+      expect(screen.queryByTestId('response-mode-modal')).toBeNull();
+    });
+  });
+
+  it('opens the help modal and closes it via Got it button (lines 665-705)', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId('show-how-routing-works')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('show-how-routing-works'));
+    await waitFor(() => {
+      expect(screen.getByText('How routing works')).toBeDefined();
+      expect(screen.getByText('Got it')).toBeDefined();
+      expect(screen.getByTestId('pipeline-help-content')).toBeDefined();
+    });
+    fireEvent.click(screen.getByText('Got it'));
+    await waitFor(() => {
+      expect(screen.queryByText('Got it')).toBeNull();
+    });
+  });
+
+  it('closes the help modal by clicking the overlay', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId('show-how-routing-works')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('show-how-routing-works'));
+    await waitFor(() => {
+      expect(screen.getByText('How routing works')).toBeDefined();
+    });
+    const overlay = document.querySelector('.modal-overlay') as HTMLElement;
+    fireEvent.click(overlay);
+    await waitFor(() => {
+      expect(screen.queryByText('Got it')).toBeNull();
+    });
+  });
+
+  it('closes the help modal via Escape key', async () => {
+    render(() => <Routing />);
+    await waitFor(() => {
+      expect(screen.getByTestId('show-how-routing-works')).toBeDefined();
+    });
+    fireEvent.click(screen.getByTestId('show-how-routing-works'));
+    await waitFor(() => {
+      expect(screen.getByText('How routing works')).toBeDefined();
+    });
+    const overlay = document.querySelector('.modal-overlay') as HTMLElement;
+    fireEvent.keyDown(overlay, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByText('Got it')).toBeNull();
+    });
   });
 });

--- a/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingDefaultTierSection.test.tsx
@@ -122,18 +122,17 @@ describe('RoutingDefaultTierSection', () => {
     expect(screen.getByText(/Analyzes the complexity/)).toBeDefined();
   });
 
-  it('renders the Response mode control without an output selector', () => {
+  it('does not render a Response mode control (moved to parent)', () => {
     render(() => <RoutingDefaultTierSection {...makeProps()} />);
-    expect(screen.getByRole('group', { name: 'Response mode' })).toBeDefined();
-    expect(screen.queryByLabelText('Output')).toBeNull();
+    expect(screen.queryByRole('group', { name: 'Response mode' })).toBeNull();
   });
 
-  it('forwards response mode changes from the Response mode control', async () => {
+  it('accepts responseMode and onResponseModeChange props without rendering them', () => {
     const onResponseModeChange = vi.fn().mockResolvedValue(undefined);
     render(() => <RoutingDefaultTierSection {...makeProps({ onResponseModeChange })} />);
-    fireEvent.click(screen.getByText('Stream'));
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(onResponseModeChange).toHaveBeenCalledWith('stream');
+    // OutputControls is no longer rendered inside this component,
+    // so clicking 'Stream' is not possible here.
+    expect(screen.queryByText('Stream')).toBeNull();
   });
 
   it('invokes onToggleComplexity when the toggle is clicked', () => {

--- a/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
@@ -109,8 +109,9 @@ vi.mock('../../src/components/HeaderTierCard.js', () => ({
 vi.mock('../../src/components/HeaderTierModal.js', () => ({
   default: (props: Record<string, unknown>) => {
     const editing = props.editing as { id: string; name: string } | undefined;
-    // Read every prop including agentName + existingTiers so JSX getters fire.
-    const _read = [props.agentName, props.existingTiers];
+    // Read every prop including agentName, existingTiers, models so JSX getters fire
+    // (covers line 330: models={props.models()}).
+    const _read = [props.agentName, props.existingTiers, props.models];
     void _read;
     return (
       <div data-testid="tier-modal">

--- a/packages/frontend/tests/pages/RoutingPanels.test.tsx
+++ b/packages/frontend/tests/pages/RoutingPanels.test.tsx
@@ -126,6 +126,37 @@ describe('RoutingFooter', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Setup instructions' }));
     expect(onShowInstructions).toHaveBeenCalled();
   });
+
+  it('renders and fires onShowHowRoutingWorks when provided', () => {
+    const onShowHowRoutingWorks = vi.fn();
+    render(() => (
+      <RoutingFooter
+        hasOverrides={() => false}
+        resettingAll={() => false}
+        resettingTier={() => null}
+        onResetAll={vi.fn()}
+        onShowInstructions={vi.fn()}
+        onShowHowRoutingWorks={onShowHowRoutingWorks}
+      />
+    ));
+    const btn = screen.getByRole('button', { name: 'How routing works' });
+    expect(btn).toBeDefined();
+    fireEvent.click(btn);
+    expect(onShowHowRoutingWorks).toHaveBeenCalled();
+  });
+
+  it('does not render How routing works button when handler is not provided', () => {
+    render(() => (
+      <RoutingFooter
+        hasOverrides={() => false}
+        resettingAll={() => false}
+        resettingTier={() => null}
+        onResetAll={vi.fn()}
+        onShowInstructions={vi.fn()}
+      />
+    ));
+    expect(screen.queryByRole('button', { name: 'How routing works' })).toBeNull();
+  });
 });
 
 describe('RoutingLoadingSkeleton', () => {


### PR DESCRIPTION
## ✨ What changed
- Model capability badges now show SVG icons (stream, tools, image, audio, video) with instant tooltips instead of text labels
- Model picker modal has capability filter pills to narrow models by stream, tools, image, audio, or video support
- Response mode (Buffered/Stream) moved into a dedicated settings modal that blocks stream activation when incompatible models are in the routing
- Custom tier edit modal now includes the stream mode toggle with the same blocker behavior
- Provider detail footer shows Disconnect on the left and Done (primary) on the right

## 💭 Why
- Capability badges took too much horizontal space with text labels, especially in the model picker where space is tight
- Switching to stream mode was too easy: users could activate it without realizing some of their routed models don't support streaming, causing silent skips
- The model picker had no way to filter by capability, making it hard to find stream-compatible models

## 👤 For users
- Cleaner model picker rows with icon-only capability badges and price on the right
- Filter models by capability (Stream, Tools, Image, etc.) directly in the picker
- Response mode settings modal explains what streaming does and lists incompatible models with a "Change" button for each
- Unknown capabilities show a "?" icon instead of "Capabilities unknown" text

## 🔧 For operators
No operator impact.

## 🧪 How to test
1. Open the Routing page for any agent with connected providers
2. Click "Response mode: Buffered" button next to the routing tabs, verify the modal opens with stream mode toggle and description
3. Click "Select a model" on any tier card, verify capability icons appear next to model names and filter pills work at the top
4. Edit a custom tier, verify the stream mode toggle appears after Badge color
5. Open a connected provider detail, verify Disconnect is on the left and Done button on the right

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the routing UI with icon-only capability badges, capability filters in the model picker, and a Response mode modal that blocks Stream when routed models don’t support it. Also cleans up the custom tier editor, tabs header/footer, and provider detail footer.

- New Features
  - Capability badges use SVG icons with instant tooltips; unknown shows a “?” icon.
  - Model picker adds capability filter pills (Stream, Tools, Image, Audio, Video), aligns name left with price right, and hides models that don’t meet required capabilities.
  - Response mode modal explains streaming, blocks enabling when incompatible models are routed, and lists them with “Change” actions.
  - Custom tier edit modal includes the Stream toggle with the same compatibility checks.
  - “Response mode” button moved to the Routing tabs header; “How routing works” moved to the footer; inline response toggles removed from tier cards and the default tier section.
  - Provider detail footer shows Disconnect on the left and Done on the right.

<sup>Written for commit 9f5500d89ce76e339787c403de3d1f82bf5fc6c1. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2046?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

