### PR TITLE
Replace routing pricing warning with toast

### DIFF
--- a/.changeset/routing-pricing-toast.md
+++ b/.changeset/routing-pricing-toast.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Replace the Routing page's empty pricing catalog panel with a concise warning toast that avoids naming implementation-specific upstream pricing sources.

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -1,4 +1,11 @@
-import { createSignal, createResource, createMemo, Show, type Component } from 'solid-js';
+import {
+  createSignal,
+  createResource,
+  createMemo,
+  createEffect,
+  Show,
+  type Component,
+} from 'solid-js';
 import { useLocation, useParams, useSearchParams } from '@solidjs/router';
 import { Title, Meta } from '@solidjs/meta';
 import RoutingModals from '../components/RoutingModals.js';
@@ -24,7 +31,6 @@ import {
   resetSpecificity,
   refreshModels,
   getPricingHealth,
-  refreshPricing,
   getComplexityStatus,
   toggleComplexity,
   listModelParams,
@@ -250,11 +256,22 @@ const Routing: Component = () => {
   const [instructionProvider, setInstructionProvider] = createSignal<string | null>(null);
   const [fallbackPickerTier, setFallbackPickerTier] = createSignal<string | null>(null);
   const [refreshingModels, setRefreshingModels] = createSignal(false);
-  const [pricingHealth, { refetch: refetchPricingHealth }] = createResource(getPricingHealth);
-  const [refreshingPricing, setRefreshingPricing] = createSignal(false);
-  const pricingCacheEmpty = () => (pricingHealth()?.model_count ?? 0) === 0;
+  const [pricingHealth] = createResource(getPricingHealth);
+  const [pricingWarningShown, setPricingWarningShown] = createSignal(false);
   const [wasEnabledBeforeModal, setWasEnabledBeforeModal] = createSignal(false);
   const [hadProvidersBeforeModal, setHadProvidersBeforeModal] = createSignal(false);
+
+  createEffect(() => {
+    const health = pricingHealth();
+    if (!health) return;
+    if (health.model_count > 0) {
+      setPricingWarningShown(false);
+      return;
+    }
+    if (pricingWarningShown()) return;
+    setPricingWarningShown(true);
+    toast.warning('Model pricing data is unavailable. Automatic tier defaults may be delayed.');
+  });
 
   const refetchAll = async () => {
     await Promise.all([
@@ -448,46 +465,6 @@ const Routing: Component = () => {
           </div>
         </Show>
       </div>
-
-      <Show when={pricingHealth() && pricingCacheEmpty()}>
-        <div
-          class="panel"
-          role="alert"
-          style="display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 16px; border-left: 3px solid var(--color-warning, #d97706);"
-        >
-          <div>
-            <strong>Pricing catalog is empty.</strong>{' '}
-            <span>
-              Manifest couldn't reach openrouter.ai at startup, so no models will be auto-assigned
-              to tiers. Retry below, or check outbound network access to openrouter.ai.
-            </span>
-          </div>
-          <button
-            class="btn btn--outline btn--sm"
-            disabled={refreshingPricing()}
-            onClick={async () => {
-              setRefreshingPricing(true);
-              try {
-                const res = await refreshPricing();
-                await refetchPricingHealth();
-                if (res.ok) {
-                  toast.success(`Pricing catalog loaded (${res.model_count} models)`);
-                  await refetchModels();
-                  await refetchTiers();
-                } else {
-                  toast.error('Pricing refresh failed — check backend logs');
-                }
-              } catch {
-                toast.error('Pricing refresh failed');
-              } finally {
-                setRefreshingPricing(false);
-              }
-            }}
-          >
-            {refreshingPricing() ? 'Retrying...' : 'Retry pricing sync'}
-          </button>
-        </div>
-      </Show>
 
       <Show when={!connectedProviders.loading} fallback={<RoutingLoadingSkeleton />}>
         <Show

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -13,7 +13,6 @@ const mockSetSpecificityFallbacks = vi.fn();
 const mockClearSpecificityFallbacks = vi.fn();
 const mockRefreshModels = vi.fn();
 const mockGetPricingHealth = vi.fn();
-const mockRefreshPricing = vi.fn();
 const mockGetComplexityStatus = vi.fn();
 const mockToggleComplexity = vi.fn();
 const mockSetTierResponseMode = vi.fn();
@@ -32,7 +31,6 @@ vi.mock('../../src/services/api.js', () => ({
   resetSpecificity: (...args: unknown[]) => mockResetSpecificity(...args),
   refreshModels: (...args: unknown[]) => mockRefreshModels(...args),
   getPricingHealth: (...args: unknown[]) => mockGetPricingHealth(...args),
-  refreshPricing: (...args: unknown[]) => mockRefreshPricing(...args),
   getComplexityStatus: (...args: unknown[]) => mockGetComplexityStatus(...args),
   toggleComplexity: (...args: unknown[]) => mockToggleComplexity(...args),
   setTierResponseMode: (...args: unknown[]) => mockSetTierResponseMode(...args),
@@ -56,11 +54,12 @@ vi.mock('../../src/services/api/header-tiers.js', () => ({
 
 const mockToastError = vi.fn();
 const mockToastSuccess = vi.fn();
+const mockToastWarning = vi.fn();
 vi.mock('../../src/services/toast-store.js', () => ({
   toast: {
     error: (...args: unknown[]) => mockToastError(...args),
     success: (...args: unknown[]) => mockToastSuccess(...args),
-    warning: vi.fn(),
+    warning: (...args: unknown[]) => mockToastWarning(...args),
   },
 }));
 
@@ -612,56 +611,24 @@ describe('Routing page', () => {
     });
   });
 
-  it('renders the empty pricing-cache warning when model_count is 0', async () => {
+  it('shows a pricing warning toast when model_count is 0', async () => {
     mockGetPricingHealth.mockResolvedValue({ model_count: 0, last_fetched_at: null });
     render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText(/Pricing catalog is empty/)).toBeDefined();
+      expect(mockToastWarning).toHaveBeenCalledWith(
+        'Model pricing data is unavailable. Automatic tier defaults may be delayed.',
+      );
     });
+    expect(screen.queryByText(/Pricing catalog is empty/)).toBeNull();
+    expect(screen.queryByText(/openrouter/i)).toBeNull();
   });
 
-  it('retries the pricing sync from the warning', async () => {
-    mockGetPricingHealth.mockResolvedValue({ model_count: 0, last_fetched_at: null });
-    mockRefreshPricing.mockResolvedValue({
-      ok: true,
-      model_count: 50,
-      last_fetched_at: '2025-01-01',
-    });
+  it('does not show a pricing warning when pricing data is loaded', async () => {
     render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText(/Retry pricing sync/)).toBeDefined();
+      expect(mockGetPricingHealth).toHaveBeenCalled();
     });
-    fireEvent.click(screen.getByText(/Retry pricing sync/));
-    await waitFor(() => {
-      expect(mockRefreshPricing).toHaveBeenCalled();
-      expect(mockToastSuccess).toHaveBeenCalledWith('Pricing catalog loaded (50 models)');
-    });
-  });
-
-  it('toasts a sync failure when refreshPricing rejects', async () => {
-    mockGetPricingHealth.mockResolvedValue({ model_count: 0, last_fetched_at: null });
-    mockRefreshPricing.mockRejectedValue(new Error('boom'));
-    render(() => <Routing />);
-    await waitFor(() => {
-      expect(screen.getByText(/Retry pricing sync/)).toBeDefined();
-    });
-    fireEvent.click(screen.getByText(/Retry pricing sync/));
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Pricing refresh failed');
-    });
-  });
-
-  it('toasts when pricing sync returns ok=false', async () => {
-    mockGetPricingHealth.mockResolvedValue({ model_count: 0, last_fetched_at: null });
-    mockRefreshPricing.mockResolvedValue({ ok: false, model_count: 0, last_fetched_at: null });
-    render(() => <Routing />);
-    await waitFor(() => {
-      expect(screen.getByText(/Retry pricing sync/)).toBeDefined();
-    });
-    fireEvent.click(screen.getByText(/Retry pricing sync/));
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Pricing refresh failed — check backend logs');
-    });
+    expect(mockToastWarning).not.toHaveBeenCalled();
   });
 
   it('toggles complexity and updates the resource on success', async () => {


### PR DESCRIPTION
## Summary
- Replace the Routing page empty pricing catalog panel with a one-time warning toast
- Remove OpenRouter-specific user-facing copy from the Routing page
- Update focused Routing page coverage and add a patch changeset

## Root cause
The Routing page rendered a persistent warning panel whenever pricing health returned `model_count: 0`. That exposed the upstream pricing catalog source and made a transient catalog sync issue look like a primary Routing page state.

## Validation
- `npm ci`
- `npm run build --workspace=packages/shared`
- `npm run test --workspace=packages/frontend -- Routing.test.tsx`
- `npx prettier --check packages/frontend/src/pages/Routing.tsx packages/frontend/tests/pages/Routing.test.tsx .changeset/routing-pricing-toast.md`
- `git diff --check -- packages/frontend/src/pages/Routing.tsx packages/frontend/tests/pages/Routing.test.tsx .changeset/routing-pricing-toast.md`
- `npx eslint packages/frontend/src/pages/Routing.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Routing page’s persistent pricing warning panel with a one‑time toast when pricing data is missing. This hides upstream implementation details and avoids a transient sync issue taking over the page.

- **Bug Fixes**
  - Show a single warning toast when pricing data is unavailable (`model_count: 0`); removes the panel and manual “Retry pricing sync” CTA.
  - Clear the warning state once pricing data loads again.
  - Remove OpenRouter-specific copy from the Routing page.

- **Refactors**
  - Drop `refreshPricing` usage and related UI/state in `packages/frontend/src/pages/Routing.tsx`; use `createEffect` to trigger the toast.
  - Update `packages/frontend/tests/pages/Routing.test.tsx` to assert toast behavior and remove panel/retry flows.
  - Add a patch changeset for `manifest`.

<sup>Written for commit 1a4063d8a2037e6b451564104bf8d712dbcf06d0. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2048?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

