### PR TITLE
Fix OpenCode Go catalog routing and reasoning cache

### DIFF
--- a/.changeset/opencode-go-reasoning-routing.md
+++ b/.changeset/opencode-go-reasoning-routing.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix OpenCode Go reasoning-tier routing by sending qwen3.7 models through the provider's Anthropic-compatible endpoint, keeping Mimo on the OpenAI-compatible endpoint, and hardening streamed reasoning_content caching for tool-call continuations.

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -22,6 +22,7 @@ const STREAMING_ENDPOINT_PROVIDERS = new Set([
   'ollama',
   'ollama-cloud',
   'openai',
+  'opencode-go',
   'openrouter',
   'qwen',
   'xai',

--- a/packages/backend/src/model-discovery/opencode-go-catalog.service.spec.ts
+++ b/packages/backend/src/model-discovery/opencode-go-catalog.service.spec.ts
@@ -16,6 +16,7 @@ const ENDPOINTS_TABLE = [
   `| Kimi K2.5    | kimi-k2.5    | ${OAI} | ${OAI_SDK} |`,
   `| MiMo-V2-Pro  | mimo-v2-pro  | ${OAI} | ${OAI_SDK} |`,
   `| MiMo-V2-Omni | mimo-v2-omni | ${OAI} | ${OAI_SDK} |`,
+  `| Qwen3.7 Max  | qwen3.7-max  | ${ANT} | ${ANT_SDK} |`,
   `| MiniMax M2.7 | minimax-m2.7 | ${ANT} | ${ANT_SDK} |`,
   `| MiniMax M2.5 | minimax-m2.5 | ${ANT} | ${ANT_SDK} |`,
   '',
@@ -31,6 +32,7 @@ const LIMITS_TABLE = [
   '| Kimi K2.5          | 1,850               | 4,630             | 9,250              |',
   '| MiMo-V2-Pro        | 1,290               | 3,225             | 6,450              |',
   '| MiMo-V2-Omni (≤ 256K) | 2,150            | 5,450             | 10,900             |',
+  '| Qwen3.7 Max        | 770                 | 1,925             | 3,850              |',
   '| MiniMax M2.7       | 3,400               | 8,500             | 17,000             |',
   '| MiniMax M2.5       | 6,300               | 15,900            | 31,800             |',
   '',
@@ -68,6 +70,7 @@ describe('OpencodeGoCatalogService', () => {
         'kimi-k2.5',
         'mimo-v2-pro',
         'mimo-v2-omni',
+        'qwen3.7-max',
         'minimax-m2.7',
         'minimax-m2.5',
       ]);
@@ -79,15 +82,17 @@ describe('OpencodeGoCatalogService', () => {
       expect(labels['glm-5.1']).toBe('GLM-5.1');
       expect(labels['kimi-k2.5']).toBe('Kimi K2.5');
       expect(labels['mimo-v2-omni']).toBe('MiMo-V2-Omni');
+      expect(labels['qwen3.7-max']).toBe('Qwen3.7 Max');
       expect(labels['minimax-m2.7']).toBe('MiniMax M2.7');
     });
 
-    it('tags MiniMax rows as anthropic and everything else as openai', () => {
+    it('tags docs rows with the endpoint format they declare', () => {
       const entries = service.parse(SAMPLE_MDX);
       const byId = Object.fromEntries(entries.map((e) => [e.id, e.format]));
       expect(byId['glm-5.1']).toBe('openai');
       expect(byId['kimi-k2.5']).toBe('openai');
       expect(byId['mimo-v2-pro']).toBe('openai');
+      expect(byId['qwen3.7-max']).toBe('anthropic');
       expect(byId['minimax-m2.5']).toBe('anthropic');
       expect(byId['minimax-m2.7']).toBe('anthropic');
     });
@@ -182,6 +187,29 @@ describe('OpencodeGoCatalogService', () => {
       const prefixed = service.getCostPerRequest('opencode-go/glm-5.1');
       expect(bare).toBeCloseTo(OPENCODE_GO_BUDGET_5H_USD / 880, 12);
       expect(prefixed).toBe(bare);
+    });
+
+    it('resolves both bare and prefixed model formats after list()', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => SAMPLE_MDX,
+      } as Response);
+      await service.list();
+      expect(service.getFormat('qwen3.7-max')).toBe('anthropic');
+      expect(service.getFormat('opencode-go/qwen3.7-max')).toBe('anthropic');
+      expect(service.getFormat('opencode-go/mimo-v2-pro')).toBe('openai');
+    });
+
+    it('warms the catalog for async format lookup', async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => SAMPLE_MDX,
+      } as Response);
+
+      await expect(service.resolveFormat('opencode-go/qwen3.7-max')).resolves.toBe('anthropic');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
     it('returns null for a known model with no published limit', async () => {
@@ -288,7 +316,7 @@ describe('OpencodeGoCatalogService', () => {
       } as Response);
 
       const first = await service.list();
-      expect(first).toHaveLength(7);
+      expect(first).toHaveLength(8);
       expect(fetchSpy).toHaveBeenCalledTimes(1);
 
       const second = await service.list();
@@ -303,7 +331,7 @@ describe('OpencodeGoCatalogService', () => {
         text: async () => SAMPLE_MDX,
       } as Response);
       const good = await service.list();
-      expect(good).toHaveLength(7);
+      expect(good).toHaveLength(8);
 
       // Force the success cache to look expired, but keep lastGood populated.
       (service as unknown as { cache: unknown }).cache = null;

--- a/packages/backend/src/model-discovery/opencode-go-catalog.service.ts
+++ b/packages/backend/src/model-discovery/opencode-go-catalog.service.ts
@@ -46,6 +46,7 @@ export class OpencodeGoCatalogService implements OnModuleInit {
   private cache: { entries: OpencodeGoCatalogEntry[]; expiresAt: number } | null = null;
   private lastGood: OpencodeGoCatalogEntry[] | null = null;
   private costByModelId = new Map<string, number>();
+  private formatByModelId = new Map<string, OpencodeGoCatalogEntry['format']>();
   /**
    * In-flight fetch promise — concurrent callers (e.g. the onModuleInit
    * warmup plus the first proxy request) share the same fetch instead of
@@ -101,7 +102,7 @@ export class OpencodeGoCatalogService implements OnModuleInit {
       }
       this.cache = { entries, expiresAt: now + CACHE_TTL_MS };
       this.lastGood = entries;
-      this.rebuildCostIndex(entries);
+      this.rebuildIndexes(entries);
       this.logger.log(`OpenCode Go catalog loaded: ${entries.length} models`);
       return entries;
     } catch (err) {
@@ -119,11 +120,19 @@ export class OpencodeGoCatalogService implements OnModuleInit {
    * (`opencode-go/glm-5.1`) — callers don't need to strip the prefix.
    */
   getCostPerRequest(modelId: string | null | undefined): number | null {
-    if (!modelId) return null;
-    const bare = modelId.startsWith('opencode-go/')
-      ? modelId.slice('opencode-go/'.length)
-      : modelId;
+    const bare = bareOpencodeGoModelId(modelId);
+    if (!bare) return null;
     return this.costByModelId.get(bare) ?? null;
+  }
+
+  /**
+   * Sync lookup for the API format an OpenCode Go model expects. Returns
+   * `null` before the docs catalog has loaded or when the model is unknown.
+   */
+  getFormat(modelId: string | null | undefined): OpencodeGoCatalogEntry['format'] | null {
+    const bare = bareOpencodeGoModelId(modelId);
+    if (!bare) return null;
+    return this.formatByModelId.get(bare) ?? null;
   }
 
   /**
@@ -140,6 +149,20 @@ export class OpencodeGoCatalogService implements OnModuleInit {
       await this.list();
     }
     return this.getCostPerRequest(modelId);
+  }
+
+  /**
+   * Async format lookup for cold processes. Shares the same cached docs fetch
+   * as list()/resolveCostPerRequest(), so concurrent first calls coalesce.
+   */
+  async resolveFormat(
+    modelId: string | null | undefined,
+  ): Promise<OpencodeGoCatalogEntry['format'] | null> {
+    if (!modelId) return null;
+    if (this.formatByModelId.size === 0) {
+      await this.list();
+    }
+    return this.getFormat(modelId);
   }
 
   /**
@@ -200,14 +223,17 @@ export class OpencodeGoCatalogService implements OnModuleInit {
     return out;
   }
 
-  private rebuildCostIndex(entries: OpencodeGoCatalogEntry[]): void {
-    const next = new Map<string, number>();
+  private rebuildIndexes(entries: OpencodeGoCatalogEntry[]): void {
+    const nextCosts = new Map<string, number>();
+    const nextFormats = new Map<string, OpencodeGoCatalogEntry['format']>();
     for (const entry of entries) {
+      nextFormats.set(entry.id, entry.format);
       if (entry.costPerRequestUsd != null) {
-        next.set(entry.id, entry.costPerRequestUsd);
+        nextCosts.set(entry.id, entry.costPerRequestUsd);
       }
     }
-    this.costByModelId = next;
+    this.costByModelId = nextCosts;
+    this.formatByModelId = nextFormats;
   }
 
   /** Test hook: clear in-memory state. */
@@ -215,8 +241,14 @@ export class OpencodeGoCatalogService implements OnModuleInit {
     this.cache = null;
     this.lastGood = null;
     this.costByModelId = new Map();
+    this.formatByModelId = new Map();
     this.inflight = null;
   }
+}
+
+function bareOpencodeGoModelId(modelId: string | null | undefined): string | null {
+  if (!modelId) return null;
+  return modelId.startsWith('opencode-go/') ? modelId.slice('opencode-go/'.length) : modelId;
 }
 
 /**

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -976,6 +976,63 @@ describe('provider-client-converters', () => {
       expect(callback).toHaveBeenCalledWith('call_1', 'I should use a tool.');
     });
 
+    it('stores reasoning_content once a tool call id appears even without a tool-call finish marker', () => {
+      const callback = jest.fn();
+      const transform = createReasoningContentStreamTransformer(callback);
+
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { reasoning_content: 'I should use a tool.' }, finish_reason: null }],
+        }),
+      );
+      transform(
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'lookup' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        }),
+      );
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith('call_1', 'I should use a tool.');
+    });
+
+    it('updates cached reasoning_content if more reasoning arrives after the tool call id', () => {
+      const callback = jest.fn();
+      const transform = createReasoningContentStreamTransformer(callback);
+
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { reasoning_content: 'plan A' }, finish_reason: null }],
+        }),
+      );
+      transform(
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'lookup' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        }),
+      );
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { reasoning_content: ' then plan B' }, finish_reason: null }],
+        }),
+      );
+
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenLastCalledWith('call_1', 'plan A then plan B');
+    });
+
     it('does not fire without a tool call id', () => {
       const callback = jest.fn();
       const transform = createReasoningContentStreamTransformer(callback);

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1338,6 +1338,95 @@ describe('ProviderClient', () => {
       expect(url).toBe('https://opencode.ai/zen/go/v1/messages');
     });
 
+    it('routes qwen3.7 models to Anthropic /v1/messages', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'opencode-go',
+        apiKey: 'og-token',
+        model: 'opencode-go/qwen3.7-max',
+        body,
+        stream: true,
+        authType: 'subscription',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://opencode.ai/zen/go/v1/messages',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'x-api-key': 'og-token',
+            'anthropic-version': '2023-06-01',
+          }),
+        }),
+      );
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('qwen3.7-max');
+      expect(sentBody.stream).toBe(true);
+      expect(result.isAnthropic).toBe(true);
+    });
+
+    it('routes catalog-declared Anthropic models to /v1/messages', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const catalogClient = new ProviderClient({
+        getFormat: jest.fn().mockReturnValue(null),
+        resolveFormat: jest.fn().mockResolvedValue('anthropic'),
+      } as any);
+
+      await catalogClient.forward({
+        provider: 'opencode-go',
+        apiKey: 'og-token',
+        model: 'opencode-go/future-model',
+        body,
+        stream: true,
+        authType: 'subscription',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://opencode.ai/zen/go/v1/messages');
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('future-model');
+    });
+
+    it('uses catalog format over family fallback when available', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const catalogClient = new ProviderClient({
+        resolveFormat: jest.fn().mockResolvedValue('openai'),
+      } as any);
+
+      await catalogClient.forward({
+        provider: 'opencode-go',
+        apiKey: 'og-token',
+        model: 'opencode-go/minimax-experimental',
+        body,
+        stream: true,
+        authType: 'subscription',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://opencode.ai/zen/go/v1/chat/completions');
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('minimax-experimental');
+    });
+
+    it('keeps mimo models on the OpenAI-compatible endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'opencode-go',
+        apiKey: 'og-token',
+        model: 'opencode-go/mimo-v2.5-pro',
+        body,
+        stream: true,
+        authType: 'subscription',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://opencode.ai/zen/go/v1/chat/completions');
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('mimo-v2.5-pro');
+      expect(sentBody.stream).toBe(true);
+    });
+
     it('routes kimi-k2.5 through the OpenAI endpoint', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -183,12 +183,17 @@ export function createReasoningContentStreamTransformer(
 ): (chunk: string) => string | null {
   let accumulatedReasoning = '';
   let firstToolCallId: string | null = null;
-  let fired = false;
+  let storedReasoning = '';
 
-  const tryFire = (): void => {
-    if (!fired && onReasoningContent && accumulatedReasoning && firstToolCallId) {
+  const storeIfReady = (): void => {
+    if (
+      onReasoningContent &&
+      accumulatedReasoning &&
+      firstToolCallId &&
+      accumulatedReasoning !== storedReasoning
+    ) {
       onReasoningContent(firstToolCallId, accumulatedReasoning);
-      fired = true;
+      storedReasoning = accumulatedReasoning;
     }
   };
 
@@ -201,6 +206,7 @@ export function createReasoningContentStreamTransformer(
       if (delta) {
         if (typeof delta.reasoning_content === 'string') {
           accumulatedReasoning += delta.reasoning_content;
+          storeIfReady();
         }
         const toolCalls = delta.tool_calls as Array<Record<string, unknown>> | undefined;
         if (Array.isArray(toolCalls)) {
@@ -210,10 +216,11 @@ export function createReasoningContentStreamTransformer(
               firstToolCallId = toolCall.id;
             }
           }
+          storeIfReady();
         }
       }
 
-      if (choice?.finish_reason === 'tool_calls') tryFire();
+      if (choice?.finish_reason === 'tool_calls') storeIfReady();
     } catch {
       // Pass malformed/non-JSON chunks through unchanged.
     }

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { OPENAI_RESPONSES_ONLY_RE, stripVendorPrefix } from '../../common/constants/openai-models';
 import { XAI_RESPONSES_ONLY_RE } from '../../common/constants/xai-models';
 import { PROVIDER_ENDPOINTS, ProviderEndpoint, resolveEndpointKey } from './provider-endpoints';
@@ -25,6 +25,7 @@ import {
 import { ForwardOptions } from './proxy-types';
 import { toNativeResponsesRequest } from './responses-adapter';
 import { forwardKiroChat } from './kiro-adapter';
+import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
 
 export interface ForwardResult {
   response: Response;
@@ -99,6 +100,11 @@ function stripModelPrefix(model: string, endpointKey: string): string {
 export class ProviderClient {
   private readonly logger = new Logger(ProviderClient.name);
 
+  constructor(
+    @Optional()
+    private readonly opencodeGoCatalog?: OpencodeGoCatalogService,
+  ) {}
+
   async forward(opts: ForwardOptions): Promise<ForwardResult> {
     const {
       provider,
@@ -112,7 +118,7 @@ export class ProviderClient {
       authType,
     } = opts;
 
-    const { endpoint, endpointKey } = this.resolveEndpoint(
+    const { endpoint, endpointKey } = await this.resolveEndpoint(
       customEndpoint,
       provider,
       authType,
@@ -188,13 +194,13 @@ export class ProviderClient {
     });
   }
 
-  private resolveEndpoint(
+  private async resolveEndpoint(
     customEndpoint: ProviderEndpoint | undefined,
     provider: string,
     authType: string | undefined,
     model: string,
     apiMode: ForwardOptions['apiMode'],
-  ): { endpoint: ProviderEndpoint; endpointKey: string } {
+  ): Promise<{ endpoint: ProviderEndpoint; endpointKey: string }> {
     if (customEndpoint) {
       return { endpoint: customEndpoint, endpointKey: 'custom' };
     }
@@ -227,13 +233,29 @@ export class ProviderClient {
       resolved = 'copilot-responses';
     }
     if (resolved === 'opencode-go') {
-      // OpenCode Go uses two different API formats depending on the model:
-      // MiniMax models use Anthropic /v1/messages, all others use OpenAI /v1/chat/completions.
-      if (stripVendorPrefix(model).toLowerCase().startsWith('minimax-')) {
+      const bareOpenCodeModel = stripVendorPrefix(model).toLowerCase();
+      const knownAnthropicFamily = this.isKnownOpencodeGoAnthropicFamily(bareOpenCodeModel);
+      const catalogFormat = await this.resolveOpencodeGoFormat(bareOpenCodeModel);
+      if (catalogFormat === 'anthropic' || (!catalogFormat && knownAnthropicFamily)) {
         resolved = 'opencode-go-anthropic';
       }
     }
     return { endpoint: PROVIDER_ENDPOINTS[resolved], endpointKey: resolved };
+  }
+
+  private async resolveOpencodeGoFormat(bareModel: string): Promise<'openai' | 'anthropic' | null> {
+    if (!this.opencodeGoCatalog) return null;
+    try {
+      return await this.opencodeGoCatalog.resolveFormat(bareModel);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`OpenCode Go catalog format lookup failed: ${message}`);
+      return null;
+    }
+  }
+
+  private isKnownOpencodeGoAnthropicFamily(bareModel: string): boolean {
+    return bareModel.startsWith('minimax-') || bareModel.startsWith('qwen3.7');
   }
 
   private buildRequest(ctx: {

--- a/packages/backend/src/routing/routing-core/__tests__/response-mode-guard.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/response-mode-guard.spec.ts
@@ -40,6 +40,14 @@ describe('assertStreamableResponseMode', () => {
       assertStreamableResponseMode('stream', 'tier "default"', openai, [custom]),
     ).not.toThrow();
   });
+
+  it('allows OpenCode Go routes in stream mode', () => {
+    const opencodeGo = route('opencode-go', 'opencode-go/qwen3.7-max');
+
+    expect(() =>
+      assertStreamableResponseMode('stream', 'tier "reasoning"', opencodeGo, null),
+    ).not.toThrow();
+  });
 });
 
 describe('effectiveRoutesForResponseMode', () => {


### PR DESCRIPTION
## Summary

Fixes OpenCode Go model routing by using the docs catalog's declared endpoint format per model. Anthropic-format models now route to OpenCode Go's `/v1/messages` endpoint, while OpenAI-compatible models continue to use `/v1/chat/completions`.

Live provider probing confirmed `qwen3.7-max` rejects OpenAI-compatible requests with `Model qwen3.7-max is not supported for format oa-compat`, but succeeds through the Anthropic-compatible endpoint. `mimo-v2.5-pro` and `deepseek-v4-pro` continue to work on the OpenAI-compatible endpoint.

Also marks `opencode-go` as stream-capable for response-mode routing and hardens streamed `reasoning_content` caching so Manifest stores the cache entry as soon as both reasoning text and the first tool call id are known, instead of depending only on a final `finish_reason: "tool_calls"` chunk.

Fixes #2045.
Refs #2047.

## Validation

- `npm --workspace packages/shared run build`
- `npm --workspace packages/backend test -- provider-client.spec.ts --runInBand`
- `npm --workspace packages/backend test -- provider-client-converters.spec.ts --runInBand`
- `npm --workspace packages/backend test -- opencode-go-catalog.service.spec.ts --runInBand`
- `npm --workspace packages/backend test -- proxy-response-handler.spec.ts --runInBand`
- `npm --workspace packages/backend test -- reasoning-content-cache.spec.ts --runInBand`
- `npm --workspace packages/backend test -- response-mode-guard.spec.ts --runInBand`
- `npm --workspace packages/backend run build`
- `npx prettier --check packages/backend/src/model-discovery/opencode-go-catalog.service.ts packages/backend/src/model-discovery/opencode-go-catalog.service.spec.ts packages/backend/src/routing/proxy/provider-client.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts`
- `git diff --check`

## Notes

The native DeepSeek key available during investigation returned insufficient balance, so #2047 was validated through the OpenCode Go DeepSeek smoke plus focused cache tests rather than a native DeepSeek live repro.
