### PR TITLE
Fix OpenAI fallback tool-call history sanitization

### DIFF
--- a/.changeset/opencode-go-reasoning-routing.md
+++ b/.changeset/opencode-go-reasoning-routing.md
@@ -1,5 +1,5 @@
 ---
-"manifest": patch
+'manifest': patch
 ---
 
-Fix OpenCode Go reasoning-tier routing by sending qwen3.7 models through the provider's Anthropic-compatible endpoint, keeping Mimo on the OpenAI-compatible endpoint, and hardening streamed reasoning_content caching for tool-call continuations.
+Fix OpenCode Go reasoning-tier routing by sending qwen3.7 models through the provider's Anthropic-compatible endpoint, keeping Mimo on the OpenAI-compatible endpoint, hardening streamed reasoning_content caching for tool-call continuations, and preventing native OpenAI fallbacks from rejecting incomplete DeepSeek tool-call history.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2472,6 +2472,127 @@ describe('ProviderClient', () => {
       expect(sentBody.messages[3].tool_call_id).toBe(validToolCallId);
     });
 
+    it('preserves complete OpenAI tool-call blocks', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithToolCalls = {
+        messages: [
+          { role: 'user', content: 'Check both tools.' },
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_search',
+                type: 'function',
+                function: { name: 'search', arguments: '{}' },
+              },
+              {
+                id: 'call_lookup',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' },
+              },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_search', content: '{"ok":true}' },
+          { role: 'tool', tool_call_id: 'call_lookup', content: '{"ok":true}' },
+          { role: 'user', content: 'Continue.' },
+        ],
+      };
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: bodyWithToolCalls as unknown as Record<string, unknown>,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toEqual(bodyWithToolCalls.messages);
+    });
+
+    it('strips incomplete OpenAI tool-call blocks before fallback forwarding', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithIncompleteToolCalls = {
+        messages: [
+          { role: 'user', content: 'Check both tools.' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_search',
+                type: 'function',
+                function: { name: 'search', arguments: '{}' },
+              },
+              {
+                id: 'call_lookup',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' },
+              },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_search', content: '{"ok":true}' },
+          { role: 'tool', tool_call_id: 'call_extra', content: '{"ok":true}' },
+          { role: 'user', content: 'Continue.' },
+        ],
+      };
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: bodyWithIncompleteToolCalls as unknown as Record<string, unknown>,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toEqual([
+        { role: 'user', content: 'Check both tools.' },
+        { role: 'assistant', content: '' },
+        { role: 'user', content: 'Continue.' },
+      ]);
+    });
+
+    it('strips later orphan OpenAI tool messages before fallback forwarding', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const bodyWithLaterToolResult = {
+        messages: [
+          { role: 'user', content: 'Check both tools.' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_search',
+                type: 'function',
+                function: { name: 'search', arguments: '{}' },
+              },
+            ],
+          },
+          { role: 'user', content: 'Continue.' },
+          { role: 'tool', tool_call_id: 'call_search', content: '{"ok":true}' },
+          { role: 'user', content: 'Next.' },
+        ],
+      };
+
+      await client.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body: bodyWithLaterToolResult as unknown as Record<string, unknown>,
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toEqual([
+        { role: 'user', content: 'Check both tools.' },
+        { role: 'assistant', content: '' },
+        { role: 'user', content: 'Continue.' },
+        { role: 'user', content: 'Next.' },
+      ]);
+    });
+
     it('preserves all fields for OpenAI', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
       await client.forward({

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -102,6 +102,7 @@ const OPENAI_ONLY_FIELDS = new Set([
  * Nested message fields may still need target-aware cleanup.
  */
 const PASSTHROUGH_PROVIDERS = new Set(['openai', 'openrouter']);
+const STRICT_TOOL_SEQUENCE_ENDPOINTS = new Set(['openai']);
 const MISTRAL_TOOL_CALL_ID_REGEX = /^[A-Za-z0-9]{9}$/;
 const DEEPSEEK_MAX_TOKENS_LIMIT = 8192;
 
@@ -241,6 +242,90 @@ function supportsReasoningDetails(endpointKey: string): boolean {
   return endpointKey === 'openrouter';
 }
 
+function toolCallIds(toolCalls: unknown): string[] {
+  if (!Array.isArray(toolCalls)) return [];
+  return toolCalls
+    .map((toolCall) => {
+      if (!toolCall || typeof toolCall !== 'object' || Array.isArray(toolCall)) return null;
+      const id = (toolCall as Record<string, unknown>).id;
+      return typeof id === 'string' && id ? id : null;
+    })
+    .filter((id): id is string => id !== null);
+}
+
+function hasCompleteImmediateToolResponses(
+  messages: unknown[],
+  index: number,
+  ids: string[],
+): boolean {
+  const pending = new Set(ids);
+  for (let i = index + 1; i < messages.length; i++) {
+    const message = messages[i];
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return false;
+    const record = message as Record<string, unknown>;
+    if (record.role !== 'tool') return false;
+    if (typeof record.tool_call_id !== 'string') return false;
+    if (!pending.has(record.tool_call_id)) return false;
+    pending.delete(record.tool_call_id);
+    if (pending.size === 0) {
+      const next = messages[i + 1];
+      if (!next || typeof next !== 'object' || Array.isArray(next)) return true;
+      return (next as Record<string, unknown>).role !== 'tool';
+    }
+  }
+  return false;
+}
+
+function stripIncompleteToolCallBlocks(messages: unknown[], endpointKey: string): unknown[] {
+  if (!STRICT_TOOL_SEQUENCE_ENDPOINTS.has(endpointKey)) return messages;
+
+  const expectedToolCallIds = new Set<string>();
+  const result: unknown[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+      result.push(message);
+      continue;
+    }
+
+    const record = message as Record<string, unknown>;
+    if (record.role === 'tool' && typeof record.tool_call_id === 'string') {
+      if (!expectedToolCallIds.has(record.tool_call_id)) continue;
+      expectedToolCallIds.delete(record.tool_call_id);
+      result.push(message);
+      continue;
+    }
+
+    const hasToolCallsArray = Array.isArray(record.tool_calls) && record.tool_calls.length > 0;
+    const ids = toolCallIds(record.tool_calls);
+    if (record.role !== 'assistant' || !hasToolCallsArray) {
+      result.push(message);
+      continue;
+    }
+
+    if (ids.length > 0 && hasCompleteImmediateToolResponses(messages, i, ids)) {
+      for (const id of ids) expectedToolCallIds.add(id);
+      result.push(message);
+      continue;
+    }
+
+    const cleaned = { ...record };
+    delete cleaned.tool_calls;
+    if (cleaned.content === null || cleaned.content === undefined) cleaned.content = '';
+    result.push(cleaned);
+
+    while (i + 1 < messages.length) {
+      const next = messages[i + 1];
+      if (!next || typeof next !== 'object' || Array.isArray(next)) break;
+      if ((next as Record<string, unknown>).role !== 'tool') break;
+      i += 1;
+    }
+  }
+
+  return result;
+}
+
 function sanitizeOpenAiMessages(
   messages: unknown,
   endpointKey: string,
@@ -249,6 +334,7 @@ function sanitizeOpenAiMessages(
 ): unknown {
   if (!Array.isArray(messages)) return messages;
 
+  const normalizedMessages = stripIncompleteToolCallBlocks(messages, endpointKey);
   const preserveReasoningContent = supportsReasoningContent(endpointKey, model);
   const preserveReasoningDetails = supportsReasoningDetails(endpointKey);
   const isMistral = endpointKey === 'mistral';
@@ -264,7 +350,7 @@ function sanitizeOpenAiMessages(
   };
 
   if (isMistral) {
-    for (const message of messages) {
+    for (const message of normalizedMessages) {
       if (!message || typeof message !== 'object' || Array.isArray(message)) {
         continue;
       }
@@ -308,7 +394,7 @@ function sanitizeOpenAiMessages(
     return rewritten;
   };
 
-  return messages.map((message) => {
+  return normalizedMessages.map((message) => {
     if (!message || typeof message !== 'object' || Array.isArray(message)) {
       return message;
     }


### PR DESCRIPTION
## Summary
- strip incomplete native OpenAI tool-call history blocks before fallback forwarding
- preserve complete assistant/tool-result blocks unchanged
- cover the DeepSeek-primary/OpenAI-fallback invalid_request_error path

## Testing
- npm --workspace=packages/backend test -- provider-client.spec.ts --runInBand
- npm --workspace=packages/backend run build
- npx prettier --check .changeset/opencode-go-reasoning-routing.md packages/backend/src/routing/proxy/provider-client-converters.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
- git diff --check
- npx eslint packages/backend/src/routing/proxy/provider-client-converters.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts (passes with two pre-existing no-explicit-any warnings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenAI fallback failures by sanitizing tool-call history. We strip incomplete tool-call blocks and orphan tool results, keeping complete assistant/tool results so DeepSeek→OpenAI fallback no longer throws invalid_request_error.

- **Bug Fixes**
  - Normalize `openai` messages by removing assistant `tool_calls` without immediate complete `tool` responses and by dropping later orphan `tool` messages; set empty assistant content when needed.
  - Preserve complete assistant/tool blocks and other messages unchanged.
  - Integrate normalization into `sanitizeOpenAiMessages` via `stripIncompleteToolCallBlocks`, guarded by `STRICT_TOOL_SEQUENCE_ENDPOINTS` for `openai`; added tests for preserve/strip and orphan cases.

<sup>Written for commit 527981e80f60c8696a36d21705205c01b11eafaf. Summary will update on new commits. <a href="https://cubic.dev/pr/mnfst/manifest/pull/2050?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

