### PR TITLE
Request exact streamed usage by endpoint capability

### DIFF
--- a/.changeset/stream-usage-endpoint-capability.md
+++ b/.changeset/stream-usage-endpoint-capability.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Request exact token usage for every supported OpenAI-compatible streamed provider by moving `stream_options.include_usage` behind endpoint capability metadata, including Kilo and NVIDIA NIM.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1,4 +1,5 @@
 import { ProviderClient } from '../provider-client';
+import { buildCustomEndpoint } from '../provider-endpoints';
 
 const mockFetch = jest.fn();
 (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
@@ -2593,7 +2594,9 @@ describe('ProviderClient', () => {
       ['mistral', 'mistral-small'],
       ['deepseek', 'deepseek-chat'],
       ['moonshot', 'kimi-k2-0905-preview'],
+      ['kilo', 'kilo-auto/free'],
       ['minimax', 'MiniMax-M2'],
+      ['nvidia', 'nvidia/nemotron-3-super-120b-a12b'],
       ['qwen', 'qwen-max'],
       ['xai', 'grok-3'],
       ['zai', 'glm-4.6'],
@@ -2688,15 +2691,7 @@ describe('ProviderClient', () => {
     it('uses custom endpoint with streaming', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 
-      const customEndpoint = {
-        baseUrl: 'http://localhost:8000',
-        buildHeaders: (key: string) => ({
-          Authorization: `Bearer ${key}`,
-          'Content-Type': 'application/json',
-        }),
-        buildPath: () => '/v1/chat/completions',
-        format: 'openai' as const,
-      };
+      const customEndpoint = buildCustomEndpoint('http://localhost:8000');
 
       await client.forward({
         provider: 'custom:uuid',

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -37,6 +37,12 @@ describe('buildCustomEndpoint', () => {
     expect(path).toBe('/v1/chat/completions');
   });
 
+  it('requests exact streamed usage for OpenAI-compatible custom providers', () => {
+    const endpoint = buildCustomEndpoint('http://localhost:8000');
+
+    expect(endpoint.streamUsageReporting).toBe('openai_stream_options');
+  });
+
   it('returns an Anthropic-shaped endpoint when apiKind="anthropic"', () => {
     const endpoint = buildCustomEndpoint('https://api.anthropic.com', 'anthropic');
 
@@ -406,6 +412,51 @@ describe('PROVIDER_ENDPOINTS', () => {
       'anthropic-version': '2023-06-01',
     });
     expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('marks OpenAI-compatible streaming endpoints that support usage chunks', () => {
+    const endpointKeys = [
+      'openai',
+      'deepseek',
+      'groq',
+      'kilo',
+      'mistral',
+      'xai',
+      'minimax',
+      'moonshot',
+      'nvidia',
+      'qwen',
+      'zai',
+      'zai-subscription',
+      'copilot',
+      'openrouter',
+      'ollama',
+      'ollama-cloud',
+      'opencode-go',
+    ];
+
+    for (const key of endpointKeys) {
+      expect(PROVIDER_ENDPOINTS[key].streamUsageReporting).toBe('openai_stream_options');
+    }
+  });
+
+  it('does not send OpenAI stream usage options to native or Responses endpoints', () => {
+    const endpointKeys = [
+      'anthropic',
+      'google',
+      'gemini-subscription',
+      'kiro',
+      'openai-subscription',
+      'openai-responses',
+      'xai-responses',
+      'copilot-responses',
+      'minimax-subscription',
+      'opencode-go-anthropic',
+    ];
+
+    for (const key of endpointKeys) {
+      expect(PROVIDER_ENDPOINTS[key].streamUsageReporting).toBeUndefined();
+    }
   });
 });
 

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -164,6 +164,17 @@ describe('createSsePayloadParser', () => {
 
     expect(parser.feed(input)).toEqual([]);
   });
+
+  it('preserves named event metadata while stripping data prefixes', () => {
+    const parser = createSsePayloadParser();
+    const input =
+      'event: response.completed\n' +
+      'data: {"response":{"usage":{"input_tokens":12,"output_tokens":2}}}\n\n';
+
+    expect(parser.feed(input)).toEqual([
+      'event: response.completed\n{"response":{"usage":{"input_tokens":12,"output_tokens":2}}}',
+    ]);
+  });
 });
 
 describe('pipeStream', () => {
@@ -583,6 +594,38 @@ describe('pipeStream', () => {
     });
   });
 
+  it('captures usage from native Responses API named SSE events', async () => {
+    const { res, written } = mockResponse();
+    const completed =
+      'event: response.completed\n' +
+      `data: ${JSON.stringify({
+        type: 'response.completed',
+        response: {
+          usage: {
+            input_tokens: 12,
+            input_tokens_details: { cached_tokens: 3 },
+            output_tokens: 2,
+            total_tokens: 14,
+          },
+        },
+      })}\n\n`;
+    const stream = createReadableStream([
+      'event: response.created\n' +
+        `data: ${JSON.stringify({ type: 'response.created', response: { usage: null } })}\n\n`,
+      completed,
+    ]);
+
+    const usage = await pipeStream(stream, res as never);
+
+    expect(written.join('')).toContain(completed);
+    expect(usage).toEqual({
+      prompt_tokens: 12,
+      completion_tokens: 2,
+      cache_read_tokens: 3,
+      cache_creation_tokens: 0,
+    });
+  });
+
   it('should return null usage when stream has no usage data', async () => {
     const { res } = mockResponse();
     const stream = createReadableStream([
@@ -619,7 +662,7 @@ describe('pipeStream', () => {
       choices: [],
       usage: { prompt_tokens: 31, completion_tokens: 10, cache_read_tokens: 5 },
     });
-    // Final chunk with usage does NOT end with \n\n — stays in passthroughBuffer
+    // Final chunk with usage does NOT end with \n\n — stays buffered until stream close.
     const stream = createReadableStream([
       `data: ${JSON.stringify({ choices: [{ delta: { content: 'hi' } }] })}\n\n`,
       `data: ${usagePayload}`,
@@ -657,6 +700,33 @@ describe('pipeStream', () => {
       prompt_tokens: 7,
       completion_tokens: 9,
       cache_read_tokens: 2,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  it('captures response.usage from a leftover native Responses API named event', async () => {
+    const { res } = mockResponse();
+    const usagePayload = JSON.stringify({
+      type: 'response.completed',
+      response: {
+        usage: {
+          input_tokens: 8,
+          output_tokens: 5,
+          input_tokens_details: { cached_tokens: 1 },
+        },
+      },
+    });
+    const stream = createReadableStream([
+      `data: ${JSON.stringify({ choices: [{ delta: { content: 'hi' } }] })}\n\n`,
+      `event: response.completed\ndata: ${usagePayload}`,
+    ]);
+
+    const usage = await pipeStream(stream, res as never);
+
+    expect(usage).toEqual({
+      prompt_tokens: 8,
+      completion_tokens: 5,
+      cache_read_tokens: 1,
       cache_creation_tokens: 0,
     });
   });

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -52,30 +52,6 @@ const PROVIDER_TIMEOUT_MS =
     : 180_000;
 
 /**
- * Endpoint keys (OpenAI-compatible format) whose streaming responses support
- * `stream_options.include_usage`. Token usage is needed for DB logging and for
- * downstream clients (e.g. OpenClaw context management).
- */
-const SUPPORTS_USAGE_STREAM_OPTIONS = new Set([
-  'openai',
-  'openrouter',
-  'ollama',
-  'ollama-cloud',
-  'mistral',
-  'deepseek',
-  'moonshot',
-  'minimax',
-  'qwen',
-  'xai',
-  'zai',
-  'zai-subscription',
-  'copilot',
-  'opencode-go',
-  'custom',
-  'groq',
-]);
-
-/**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").
  * Models synced from OpenRouter use vendor prefixes, but native APIs expect bare names.
  */
@@ -382,7 +358,7 @@ export class ProviderClient {
       ctx.model,
       ctx.reasoningContentLookup,
     );
-    if (stream && SUPPORTS_USAGE_STREAM_OPTIONS.has(endpointKey)) {
+    if (stream && endpoint.streamUsageReporting === 'openai_stream_options') {
       const existing =
         typeof sanitized.stream_options === 'object' && sanitized.stream_options !== null
           ? (sanitized.stream_options as Record<string, unknown>)

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -24,6 +24,12 @@ export interface ProviderEndpoint {
   buildStreamPath?: (model: string) => string;
   format: 'openai' | 'google' | 'anthropic' | 'chatgpt' | 'kiro';
   /**
+   * How this endpoint can report exact token usage for streaming responses.
+   * `openai_stream_options` means the proxy should request a final usage event
+   * by sending `stream_options.include_usage`.
+   */
+  streamUsageReporting?: 'openai_stream_options';
+  /**
    * Set to `true` for endpoints whose `baseUrl` is user-supplied (custom
    * providers, subscription resource URLs). The proxy re-runs SSRF
    * validation against this URL immediately before each forward to defend
@@ -40,6 +46,8 @@ export interface ProviderEndpoint {
    */
   codeAssistEnvelope?: boolean;
 }
+
+const openaiStreamUsage = { streamUsageReporting: 'openai_stream_options' as const };
 
 const openaiHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
@@ -102,6 +110,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   'openai-subscription': {
     baseUrl: CHATGPT_SUBSCRIPTION_BASE,
@@ -128,30 +137,35 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   groq: {
     baseUrl: 'https://api.groq.com/openai',
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   kilo: {
     baseUrl: KILO_GATEWAY_BASE,
     buildHeaders: openaiHeaders,
     buildPath: () => '/chat/completions',
     format: 'openai',
+    ...openaiStreamUsage,
   },
   mistral: {
     baseUrl: 'https://api.mistral.ai',
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   xai: {
     baseUrl: 'https://api.x.ai',
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   'xai-responses': {
     baseUrl: 'https://api.x.ai',
@@ -164,6 +178,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   'minimax-subscription': {
     baseUrl: MINIMAX_SUBSCRIPTION_BASE,
@@ -176,30 +191,35 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   nvidia: {
     baseUrl: NVIDIA_NIM_BASE,
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   qwen: {
     baseUrl: getQwenCompatibleBaseUrl('beijing'),
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   zai: {
     baseUrl: 'https://api.z.ai',
     buildHeaders: openaiHeaders,
     buildPath: () => '/api/paas/v4/chat/completions',
     format: 'openai',
+    ...openaiStreamUsage,
   },
   'zai-subscription': {
     baseUrl: ZAI_SUBSCRIPTION_BASE,
     buildHeaders: openaiHeaders,
     buildPath: () => '/chat/completions',
     format: 'openai',
+    ...openaiStreamUsage,
   },
   google: {
     baseUrl: 'https://generativelanguage.googleapis.com',
@@ -241,6 +261,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     }),
     buildPath: () => '/chat/completions',
     format: 'openai',
+    ...openaiStreamUsage,
   },
   // Codex variants (e.g. gpt-5-codex, gpt-5.2-codex, gpt-5.3-codex) only accept
   // /responses on Copilot — /chat/completions returns "Unsupported API for model".
@@ -266,18 +287,21 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     }),
     buildPath: () => '/api/v1/chat/completions',
     format: 'openai',
+    ...openaiStreamUsage,
   },
   ollama: {
     baseUrl: OLLAMA_HOST,
     buildHeaders: () => ({ 'Content-Type': 'application/json' }),
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   'ollama-cloud': {
     baseUrl: OLLAMA_CLOUD_HOST,
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   kiro: {
     baseUrl: KIRO_BASE_URL,
@@ -290,6 +314,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
   },
   'opencode-go-anthropic': {
     baseUrl: OPENCODE_GO_BASE,
@@ -320,6 +345,7 @@ export function buildCustomEndpoint(
     buildHeaders: openaiHeaders,
     buildPath: openaiPath,
     format: 'openai',
+    ...openaiStreamUsage,
     requiresSsrfRevalidation: true,
   };
 }

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -84,24 +84,61 @@ export function parseUsageObject(usage: unknown): StreamUsage | null {
   return null;
 }
 
-/** Extract usage data from an SSE-formatted text chunk (e.g. `data: {...}\n\n`). */
+function extractUsageFromObject(obj: unknown): StreamUsage | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const record = obj as Record<string, unknown>;
+  const fromUsage = parseUsageObject(record.usage);
+  if (fromUsage) return fromUsage;
+  const response = record.response;
+  if (response && typeof response === 'object') {
+    return parseUsageObject((response as Record<string, unknown>).usage);
+  }
+  return null;
+}
+
+function extractUsageFromJsonPayload(payload: string): StreamUsage | null {
+  const trimmed = payload.trim();
+  if (!trimmed || trimmed === '[DONE]') return null;
+  try {
+    return extractUsageFromObject(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
+function extractJsonPayloadFromParsedEvent(eventText: string): string {
+  return eventText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(
+      (line) =>
+        line &&
+        !line.startsWith('event:') &&
+        !line.startsWith('id:') &&
+        !line.startsWith('retry:') &&
+        !line.startsWith(':'),
+    )
+    .map((line) => (line.startsWith('data:') ? line.slice(5).trim() : line))
+    .join('\n')
+    .trim();
+}
+
+/** Extract usage data from SSE text, parsed SSE event text, or raw JSON. */
 export function extractUsageFromSse(sseText: string): StreamUsage | null {
   for (const line of sseText.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed.startsWith('data:')) continue;
     const json = trimmed.slice(5).trim();
-    if (json === '[DONE]') continue;
-    try {
-      const obj = JSON.parse(json);
-      const fromUsage = parseUsageObject(obj.usage);
-      if (fromUsage) return fromUsage;
-      const fromResponse = parseUsageObject(obj.response?.usage);
-      if (fromResponse) return fromResponse;
-    } catch {
-      /* ignore parse errors */
-    }
+    const usage = extractUsageFromJsonPayload(json);
+    if (usage) return usage;
   }
-  return null;
+
+  const usage = extractUsageFromJsonPayload(sseText);
+  if (usage) return usage;
+
+  const payload = extractJsonPayloadFromParsedEvent(sseText);
+  if (!payload || payload === sseText.trim()) return null;
+  return extractUsageFromJsonPayload(payload);
 }
 
 export function initSseHeaders(
@@ -235,18 +272,8 @@ export async function pipeStream(
 
   const capturePassthroughUsage = (events: string[]): void => {
     for (const ev of events) {
-      try {
-        const obj = JSON.parse(ev);
-        const fromUsage = parseUsageObject(obj.usage);
-        if (fromUsage) {
-          capturedUsage = fromUsage;
-        } else {
-          const fromResponse = parseUsageObject(obj.response?.usage);
-          if (fromResponse) capturedUsage = fromResponse;
-        }
-      } catch {
-        /* ignore non-JSON events */
-      }
+      const usage = extractUsageFromSse(ev);
+      if (usage) capturedUsage = usage;
     }
   };
 


### PR DESCRIPTION
## Summary
- Move `stream_options.include_usage` opt-in from a hard-coded provider-name set to endpoint capability metadata.
- Mark every supported OpenAI-compatible Chat Completions streaming endpoint for exact usage reporting, including Kilo and NVIDIA NIM.
- Keep native Anthropic/Gemini/Kiro and Responses-style endpoints unmarked for `stream_options`, while preserving custom OpenAI-compatible providers.
- Capture exact usage from native Responses API named SSE events (`response.completed -> response.usage`) so OpenAI Responses streaming no longer records zero tokens.

## Impact
- Streamed Chat Completions responses can now record exact output token usage for providers that emit usage chunks.
- Native OpenAI Responses streaming now records the final usage already present in the upstream stream; no extra request parameter is needed.
- Expected runtime impact is negligible: compatible Chat Completions providers may send one final usage event, while Responses already sends `response.completed`.
- Providers that still do not report usage continue to fall back to the existing missing-usage UI behavior.

## Validation
- Official OpenAI API reference confirms Responses streaming emits final usage on `response.completed`.
- Live direct OpenAI Responses streaming smoke with local `.env.keys`: `response.created` had `usage: null`; final `response.completed` included `{ input_tokens: 12, output_tokens: 2, total_tokens: 14 }`.
- Live direct-provider smoke with local `.env.keys` confirmed exact streamed usage from OpenAI Chat Completions, Mistral, Groq, xAI, Moonshot, OpenRouter, Z.AI, Gemini, and Anthropic.
- Live smoke confirmed OpenAI Chat Completions needs `stream_options.include_usage`; Mistral and Groq reported usage even without it. DeepSeek, MiniMax, and Ollama Cloud were blocked by account/key state, not request shape.
- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/proxy/__tests__/provider-endpoints.spec.ts src/routing/proxy/__tests__/provider-client.spec.ts src/routing/proxy/__tests__/stream-writer.spec.ts`
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/proxy/__tests__/provider-endpoints.spec.ts src/routing/proxy/__tests__/provider-client.spec.ts src/routing/proxy/__tests__/stream-writer.spec.ts --coverage --collectCoverageFrom='routing/proxy/provider-endpoints.ts' --collectCoverageFrom='routing/proxy/provider-client.ts' --collectCoverageFrom='routing/proxy/stream-writer.ts'`
- `npx eslint packages/backend/src/routing/proxy/provider-endpoints.ts packages/backend/src/routing/proxy/provider-client.ts packages/backend/src/routing/proxy/stream-writer.ts packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts` (only pre-existing `no-explicit-any` warnings in the spec)
- `npm run build --workspace=packages/backend`
- `npx prettier --check .changeset/stream-usage-endpoint-capability.md packages/backend/src/routing/proxy/provider-endpoints.ts packages/backend/src/routing/proxy/provider-client.ts packages/backend/src/routing/proxy/stream-writer.ts packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts`
- `git diff --check`
