### PR TITLE
Fix SSE comment parsing in streamed proxy responses

### DIFF
--- a/.changeset/sse-comment-parser.md
+++ b/.changeset/sse-comment-parser.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Parse provider SSE streams with a spec-compliant parser so keepalive comments remain comments instead of being forwarded as data payloads.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7686,6 +7686,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "dev": true,
@@ -14132,6 +14141,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "compression": "^1.8.1",
+        "eventsource-parser": "^3.1.0",
         "express-rate-limit": "^8.5.1",
         "helmet": "^8.1.0",
         "manifest-shared": "*",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -35,6 +35,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "compression": "^1.8.1",
+    "eventsource-parser": "^3.1.0",
     "express-rate-limit": "^8.5.1",
     "helmet": "^8.1.0",
     "pg": "^8.13.0",

--- a/packages/backend/src/playground/playground-stream.spec.ts
+++ b/packages/backend/src/playground/playground-stream.spec.ts
@@ -78,6 +78,7 @@ describe('consumeProviderStream', () => {
   it('skips empty data lines and unparseable JSON without throwing', async () => {
     const result = await consumeProviderStream(
       sseStream([
+        ': OPENROUTER PROCESSING\n\n',
         'data: \n\n',
         'data: not-json\n\n',
         'event: ping\n\n',
@@ -238,7 +239,7 @@ describe('consumeProviderStream', () => {
         () => undefined,
         Date.now(),
       ),
-    ).rejects.toThrow(/Stream buffer overflow/);
+    ).rejects.toThrow(/SSE buffer overflow/);
   });
 
   it('releases the reader lock even when the stream throws', async () => {

--- a/packages/backend/src/playground/playground-stream.ts
+++ b/packages/backend/src/playground/playground-stream.ts
@@ -1,5 +1,6 @@
 import type { ForwardResult, ProviderClient } from '../routing/proxy/provider-client';
-import { parseSseEvents, parseUsageObject, type StreamUsage } from '../routing/proxy/stream-writer';
+import { createSsePayloadParser } from '../routing/proxy/sse-parser';
+import { parseUsageObject, type StreamUsage } from '../routing/proxy/stream-writer';
 
 export interface ConsumeStreamResult {
   content: string;
@@ -11,7 +12,7 @@ export interface ConsumeStreamResult {
 }
 
 /**
- * One upstream SSE event (data: prefix already stripped by parseSseEvents) →
+ * One upstream SSE event (data prefix stripped by the SSE parser) →
  * an OpenAI-format `data: {...}\n\n` chunk string, or null to skip. Mirrors the
  * exact converter selection the production proxy uses in handleStreamResponse
  * so playground streaming inherits the same provider coverage instead of
@@ -87,11 +88,11 @@ export async function consumeProviderStream(
   const decoder = new TextDecoder();
   const transform = buildChunkTransform(forward, model, providerClient);
 
-  let buffer = '';
   let content = '';
   let usage: StreamUsage | null = null;
   let ttftMs: number | null = null;
   let lastDeltaAt = startedAt;
+  const parser = createSsePayloadParser({ maxBufferSize: MAX_STREAM_BUFFER });
 
   const apply = (event: string): void => {
     const sse = transform(event);
@@ -112,26 +113,16 @@ export async function consumeProviderStream(
       const result = await reader.read();
       done = result.done;
       if (result.value) {
-        buffer += decoder.decode(result.value, { stream: !done });
-        if (buffer.length > MAX_STREAM_BUFFER) {
-          throw new Error('Stream buffer overflow: provider sent data without event boundaries');
-        }
-        const { events, remaining } = parseSseEvents(buffer);
-        buffer = remaining;
-        for (const event of events) apply(event);
+        const text = decoder.decode(result.value, { stream: !done });
+        for (const event of parser.feed(text)) apply(event);
       }
     }
     // Flush any bytes the decoder held back from a multi-byte char split
     // across the last chunk boundary (the final read often has no value).
-    buffer += decoder.decode();
+    for (const event of parser.feed(decoder.decode())) apply(event);
     // The final usage chunk often arrives without a trailing blank line, so it
-    // sits unparsed in the buffer when the stream closes — flush it.
-    const tail = buffer
-      .split('\n')
-      .map((l) => (l.startsWith('data: ') ? l.slice(6) : l))
-      .join('\n')
-      .trim();
-    if (tail && tail !== '[DONE]') apply(tail);
+    // sits unparsed when the stream closes — flush it.
+    for (const event of parser.flush()) apply(event);
   } finally {
     reader.releaseLock();
   }

--- a/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/chatgpt-stream.spec.ts
@@ -91,7 +91,7 @@ describe('ChatGPT Adapter – transformResponsesStreamChunk', () => {
     expect(json.choices[0].delta.content).toBe('');
   });
 
-  it('handles pre-processed chunks (data: prefix stripped by parseSseEvents)', () => {
+  it('handles pre-processed chunks (data: prefix stripped by the payload parser)', () => {
     const chunk = 'event: response.output_text.delta\n{"delta":"Hi"}';
     const result = transformResponsesStreamChunk(chunk, 'gpt-5');
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.spec.ts
@@ -2105,8 +2105,8 @@ describe('ProxyController', () => {
 
     it('should transform Anthropic streaming through createAnthropicStreamTransformer', async () => {
       const mockProviderResp = createMockStreamResponse([
-        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":10}}}\n\n',
-        'event: content_block_delta\n{"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}\n\n',
+        'event: message_start\ndata: {"type":"message_start","message":{"usage":{"input_tokens":10}}}\n\n',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}\n\n',
       ]);
 
       proxyService.proxyRequest.mockResolvedValue({

--- a/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts
@@ -1,11 +1,11 @@
 import {
   initSseHeaders,
-  parseSseEvents,
   pipePassthrough,
   pipeStream,
   extractUsageFromSse,
   parseUsageObject,
 } from '../stream-writer';
+import { createSsePayloadParser } from '../sse-parser';
 
 function mockResponse(): {
   res: Record<string, jest.Mock | boolean | number>;
@@ -81,63 +81,88 @@ describe('initSseHeaders', () => {
   });
 });
 
-describe('parseSseEvents', () => {
+describe('createSsePayloadParser', () => {
   it('should parse a single SSE event', () => {
-    const result = parseSseEvents('data: {"text":"hello"}\n\n');
+    const parser = createSsePayloadParser();
 
-    expect(result.events).toEqual(['{"text":"hello"}']);
-    expect(result.remaining).toBe('');
+    expect(parser.feed('data: {"text":"hello"}\n\n')).toEqual(['{"text":"hello"}']);
+  });
+
+  it('should parse CRLF-delimited SSE events', () => {
+    const parser = createSsePayloadParser();
+
+    expect(parser.feed('data: {"text":"hello"}\r\n\r\n')).toEqual(['{"text":"hello"}']);
   });
 
   it('should parse multiple SSE events', () => {
+    const parser = createSsePayloadParser();
     const input = 'data: {"a":1}\n\ndata: {"b":2}\n\n';
-    const result = parseSseEvents(input);
 
-    expect(result.events).toEqual(['{"a":1}', '{"b":2}']);
-    expect(result.remaining).toBe('');
+    expect(parser.feed(input)).toEqual(['{"a":1}', '{"b":2}']);
   });
 
-  it('should preserve partial buffer in remaining', () => {
-    const input = 'data: {"done":true}\n\ndata: {"partial":';
-    const result = parseSseEvents(input);
+  it('should allow large batches of complete events under a small buffer cap', () => {
+    const parser = createSsePayloadParser({ maxBufferSize: 10 });
+    const input = 'data: x\n\ndata: y\n\ndata: z\n\n';
 
-    expect(result.events).toEqual(['{"done":true}']);
-    expect(result.remaining).toBe('data: {"partial":');
+    expect(parser.feed(input)).toEqual(['x', 'y', 'z']);
+  });
+
+  it('should buffer partial chunks until they complete', () => {
+    const parser = createSsePayloadParser();
+    const input = 'data: {"done":true}\n\ndata: {"partial":';
+
+    expect(parser.feed(input)).toEqual(['{"done":true}']);
+    expect(parser.feed('false}\n\n')).toEqual(['{"partial":false}']);
   });
 
   it('should skip [DONE] events', () => {
+    const parser = createSsePayloadParser();
     const input = 'data: {"text":"hi"}\n\ndata: [DONE]\n\n';
-    const result = parseSseEvents(input);
 
-    expect(result.events).toEqual(['{"text":"hi"}']);
+    expect(parser.feed(input)).toEqual(['{"text":"hi"}']);
   });
 
   it('should skip empty events', () => {
+    const parser = createSsePayloadParser();
     const input = '\n\ndata: {"a":1}\n\n\n\n';
-    const result = parseSseEvents(input);
 
-    expect(result.events).toEqual(['{"a":1}']);
+    expect(parser.feed(input)).toEqual(['{"a":1}']);
   });
 
   it('should handle multi-line data events', () => {
+    const parser = createSsePayloadParser();
     const input = 'data: line1\ndata: line2\n\n';
-    const result = parseSseEvents(input);
 
-    expect(result.events).toEqual(['line1\nline2']);
+    expect(parser.feed(input)).toEqual(['line1\nline2']);
   });
 
-  it('should return empty events for buffer with no complete events', () => {
-    const result = parseSseEvents('data: partial');
+  it('should ignore SSE comments instead of treating them as payload', () => {
+    const parser = createSsePayloadParser();
+    const input = ': OPENROUTER PROCESSING\n\ndata: {"a":1}\n\n';
 
-    expect(result.events).toEqual([]);
-    expect(result.remaining).toBe('data: partial');
+    expect(parser.feed(input)).toEqual(['{"a":1}']);
   });
 
-  it('should handle lines without data: prefix', () => {
+  it('should preserve event and id fields for protocol-specific transformers', () => {
+    const parser = createSsePayloadParser();
+    const input = 'event: response.completed\nid: evt_1\ndata: {"a":1}\n\n';
+
+    expect(parser.feed(input)).toEqual(['event: response.completed\nid: evt_1\n{"a":1}']);
+  });
+
+  it('should flush a trailing partial event when the stream closes', () => {
+    const parser = createSsePayloadParser();
+
+    expect(parser.feed('data: partial')).toEqual([]);
+    expect(parser.flush()).toEqual(['partial']);
+  });
+
+  it('should ignore unknown SSE fields', () => {
+    const parser = createSsePayloadParser();
     const input = 'raw content\n\n';
-    const result = parseSseEvents(input);
 
-    expect(result.events).toEqual(['raw content']);
+    expect(parser.feed(input)).toEqual([]);
   });
 });
 
@@ -191,6 +216,21 @@ describe('pipeStream', () => {
 
     expect(written).toContain('result:keep\n\n');
     expect(written.some((w) => w.includes('skip'))).toBe(false);
+  });
+
+  it('should preserve SSE keep-alive comments on transformed streams', async () => {
+    const { res, written } = mockResponse();
+    const stream = createReadableStream([
+      ': OPENROUTER PROCESSING\n\ndata: {"choices":[{"delta":{"content":"ok"}}]}\n\n',
+    ]);
+
+    const transform = (chunk: string) => `data: ${chunk}\n\n`;
+
+    await pipeStream(stream, res as never, transform);
+
+    expect(written).toContain(': OPENROUTER PROCESSING\n\n');
+    expect(written).toContain('data: {"choices":[{"delta":{"content":"ok"}}]}\n\n');
+    expect(written).not.toContain('data: : OPENROUTER PROCESSING\n\n');
   });
 
   it('should flush remaining buffer through transform', async () => {
@@ -451,9 +491,8 @@ describe('pipeStream', () => {
     expect(written).toContain('data: [DONE]\n\n');
   });
 
-  it('should flush remaining buffer line without data: prefix through transform', async () => {
+  it('should ignore trailing unknown raw lines when transforming SSE', async () => {
     const { res, written } = mockResponse();
-    // Remaining buffer has a line without "data: " prefix (e.g., raw JSON)
     const stream = createReadableStream(['data: first\n\n', '{"raw":"remaining"}']);
 
     const transform = (chunk: string) => `out:${chunk}\n\n`;
@@ -461,9 +500,7 @@ describe('pipeStream', () => {
     await pipeStream(stream, res as never, transform);
 
     expect(written).toContain('out:first\n\n');
-    // The remaining buffer '{"raw":"remaining"}' should be flushed through
-    // transform as-is (no "data: " prefix stripping)
-    expect(written).toContain('out:{"raw":"remaining"}\n\n');
+    expect(written).not.toContain('out:{"raw":"remaining"}\n\n');
     expect(written).toContain('data: [DONE]\n\n');
   });
 
@@ -708,6 +745,27 @@ describe('pipePassthrough', () => {
     expect(written.join('')).toBe(raw);
   });
 
+  it('passes upstream SSE comments through unchanged without tapping them as events', async () => {
+    const { res, written } = mockResponse();
+    const raw =
+      ': OPENROUTER PROCESSING\n\n' +
+      'data: {"usage":{"prompt_tokens":2,"completion_tokens":1}}\n\n';
+    const stream = createReadableStream([raw]);
+    const tap = jest.fn(() => 'data: {"usage":{"prompt_tokens":2,"completion_tokens":1}}\n\n');
+
+    const usage = await pipePassthrough(stream, res as never, tap);
+
+    expect(written.join('')).toBe(raw);
+    expect(tap).toHaveBeenCalledTimes(1);
+    expect(tap).toHaveBeenCalledWith('{"usage":{"prompt_tokens":2,"completion_tokens":1}}');
+    expect(usage).toEqual({
+      prompt_tokens: 2,
+      completion_tokens: 1,
+      cache_read_tokens: undefined,
+      cache_creation_tokens: undefined,
+    });
+  });
+
   it('passes raw upstream text to the capture callback', async () => {
     const { res } = mockResponse();
     const chunks = [
@@ -736,7 +794,7 @@ describe('pipePassthrough', () => {
 
     await pipePassthrough(stream, res as never, tap);
 
-    // parseSseEvents strips `data: ` per line — that's the same shape the
+    // The payload parser strips `data: ` per line — that's the same shape the
     // Anthropic stream transformer expects.
     expect(seen).toEqual([
       'event: message_start\n{"type":"a"}',

--- a/packages/backend/src/routing/proxy/sse-parser.ts
+++ b/packages/backend/src/routing/proxy/sse-parser.ts
@@ -1,0 +1,80 @@
+import { createParser, type EventSourceMessage, type ParseError } from 'eventsource-parser';
+
+export const DEFAULT_MAX_SSE_BUFFER_SIZE = 1_048_576;
+export const SSE_BUFFER_OVERFLOW_MESSAGE =
+  'SSE buffer overflow: provider sent data without event boundaries';
+
+export interface SsePayloadParser {
+  feed(chunk: string): string[];
+  flush(): string[];
+}
+
+interface SsePayloadParserOptions {
+  maxBufferSize?: number;
+  onComment?: (comment: string) => void;
+}
+
+function toTransformerPayload(event: EventSourceMessage): string | null {
+  if (!event.data || event.data === '[DONE]') return null;
+
+  const lines: string[] = [];
+  if (event.event) lines.push(`event: ${event.event}`);
+  if (event.id) lines.push(`id: ${event.id}`);
+  lines.push(event.data);
+  return lines.join('\n');
+}
+
+function createPayloadCollector(
+  events: string[],
+  onFatalError: (error: ParseError) => void,
+  options: SsePayloadParserOptions,
+) {
+  return createParser({
+    maxBufferSize: options.maxBufferSize,
+    onEvent(event) {
+      const payload = toTransformerPayload(event);
+      if (payload) events.push(payload);
+    },
+    onComment: options.onComment,
+    onError(error) {
+      if (error.type === 'max-buffer-size-exceeded') onFatalError(error);
+    },
+  });
+}
+
+export function createSsePayloadParser(options: SsePayloadParserOptions = {}): SsePayloadParser {
+  const maxBufferSize = options.maxBufferSize ?? DEFAULT_MAX_SSE_BUFFER_SIZE;
+  const events: string[] = [];
+  let fatalError: ParseError | null = null;
+  const parser = createPayloadCollector(
+    events,
+    (error) => {
+      fatalError = error;
+    },
+    { ...options, maxBufferSize },
+  );
+
+  const drain = (): string[] => {
+    if (fatalError) throw new Error(SSE_BUFFER_OVERFLOW_MESSAGE);
+    const drained = events.slice();
+    events.length = 0;
+    return drained;
+  };
+
+  const feed = (chunk: string): string[] => {
+    if (!chunk) return [];
+    parser.feed(chunk);
+    return drain();
+  };
+
+  const flush = (): string[] => {
+    parser.feed('\n\n');
+    return drain();
+  };
+
+  return { feed, flush };
+}
+
+export function formatSseComment(comment: string): string {
+  return comment ? `: ${comment}\n\n` : ':\n\n';
+}

--- a/packages/backend/src/routing/proxy/stream-writer.ts
+++ b/packages/backend/src/routing/proxy/stream-writer.ts
@@ -1,4 +1,9 @@
 import { Response as ExpressResponse } from 'express';
+import {
+  createSsePayloadParser,
+  DEFAULT_MAX_SSE_BUFFER_SIZE,
+  formatSseComment,
+} from './sse-parser';
 
 export interface StreamUsage {
   prompt_tokens: number;
@@ -117,39 +122,7 @@ export function initSseHeaders(
   res.flushHeaders();
 }
 
-/**
- * Parses an SSE text stream into individual event payloads.
- * Handles `data: ` prefixes, multi-event chunks, and partial
- * chunks that split across TCP reads.
- */
-export function parseSseEvents(buffer: string): { events: string[]; remaining: string } {
-  const events: string[] = [];
-  let remaining = buffer;
-
-  // Split on double-newline (SSE event boundary)
-  let idx: number;
-  while ((idx = remaining.indexOf('\n\n')) !== -1) {
-    const raw = remaining.slice(0, idx).trim();
-    remaining = remaining.slice(idx + 2);
-
-    if (!raw) continue;
-
-    // Strip "data: " prefix from each line and join
-    const payload = raw
-      .split('\n')
-      .map((line) => (line.startsWith('data: ') ? line.slice(6) : line))
-      .join('\n')
-      .trim();
-
-    if (payload && payload !== '[DONE]') {
-      events.push(payload);
-    }
-  }
-
-  return { events, remaining };
-}
-
-const MAX_SSE_BUFFER_SIZE = 1_048_576;
+const MAX_SSE_BUFFER_SIZE = DEFAULT_MAX_SSE_BUFFER_SIZE;
 
 /**
  * Forward an SSE stream byte-for-byte from `source` to `dest` while running a
@@ -172,8 +145,8 @@ export async function pipePassthrough(
 ): Promise<StreamUsage | null> {
   const reader = source.getReader();
   const decoder = new TextDecoder();
-  let sseBuffer = '';
   let capturedUsage: StreamUsage | null = null;
+  const parser = createSsePayloadParser({ maxBufferSize: MAX_SSE_BUFFER_SIZE });
 
   try {
     let done = false;
@@ -187,13 +160,7 @@ export async function pipePassthrough(
         dest.write(Buffer.from(result.value));
         const text = decoder.decode(result.value, { stream: !done });
         if (onClientChunk) onClientChunk(text);
-        sseBuffer += text;
-        if (sseBuffer.length > MAX_SSE_BUFFER_SIZE) {
-          throw new Error('SSE buffer overflow: provider sent data without event boundaries');
-        }
-        const { events, remaining } = parseSseEvents(sseBuffer);
-        sseBuffer = remaining;
-        for (const event of events) {
+        for (const event of parser.feed(text)) {
           const tapped = tap(event);
           if (tapped) {
             const usage = extractUsageFromSse(tapped);
@@ -202,20 +169,21 @@ export async function pipePassthrough(
         }
       }
     }
-    // Flush a trailing partial event through the tap so a final usage
-    // chunk that the upstream didn't terminate with \n\n isn't lost.
-    if (sseBuffer.trim()) {
-      const payload = sseBuffer
-        .split('\n')
-        .map((line) => (line.startsWith('data: ') ? line.slice(6) : line))
-        .join('\n')
-        .trim();
-      if (payload && payload !== '[DONE]') {
-        const tapped = tap(payload);
+    const finalText = decoder.decode();
+    if (finalText) {
+      for (const event of parser.feed(finalText)) {
+        const tapped = tap(event);
         if (tapped) {
           const usage = extractUsageFromSse(tapped);
           if (usage) capturedUsage = usage;
         }
+      }
+    }
+    for (const event of parser.flush()) {
+      const tapped = tap(event);
+      if (tapped) {
+        const usage = extractUsageFromSse(tapped);
+        if (usage) capturedUsage = usage;
       }
     }
   } finally {
@@ -235,13 +203,61 @@ export async function pipeStream(
 ): Promise<StreamUsage | null> {
   const reader = source.getReader();
   const decoder = new TextDecoder();
-  let sseBuffer = '';
-  let passthroughBuffer = '';
   let capturedUsage: StreamUsage | null = null;
 
   const writeOut = (s: string): void => {
     dest.write(s);
     if (onClientChunk) onClientChunk(s);
+  };
+  const transformParser = transform
+    ? createSsePayloadParser({
+        maxBufferSize: MAX_SSE_BUFFER_SIZE,
+        onComment: (comment) => {
+          if (!dest.writableEnded) writeOut(formatSseComment(comment));
+        },
+      })
+    : null;
+  const passthroughParser = transform
+    ? null
+    : createSsePayloadParser({ maxBufferSize: MAX_SSE_BUFFER_SIZE });
+
+  const applyTransformedEvents = (events: string[]): void => {
+    if (!transform) return;
+    for (const event of events) {
+      const transformed = transform(event);
+      if (transformed) {
+        writeOut(transformed);
+        const usage = extractUsageFromSse(transformed);
+        if (usage) capturedUsage = usage;
+      }
+    }
+  };
+
+  const capturePassthroughUsage = (events: string[]): void => {
+    for (const ev of events) {
+      try {
+        const obj = JSON.parse(ev);
+        const fromUsage = parseUsageObject(obj.usage);
+        if (fromUsage) {
+          capturedUsage = fromUsage;
+        } else {
+          const fromResponse = parseUsageObject(obj.response?.usage);
+          if (fromResponse) capturedUsage = fromResponse;
+        }
+      } catch {
+        /* ignore non-JSON events */
+      }
+    }
+  };
+
+  const consumeText = (text: string): void => {
+    if (!text) return;
+    if (transform && transformParser) {
+      applyTransformedEvents(transformParser.feed(text));
+      return;
+    }
+    writeOut(text);
+    if (passthroughParser) capturePassthroughUsage(passthroughParser.feed(text));
   };
 
   try {
@@ -254,89 +270,15 @@ export async function pipeStream(
 
       if (result.value) {
         const text = decoder.decode(result.value, { stream: !done });
-
-        if (transform) {
-          sseBuffer += text;
-          if (sseBuffer.length > MAX_SSE_BUFFER_SIZE) {
-            throw new Error('SSE buffer overflow: provider sent data without event boundaries');
-          }
-          const { events, remaining } = parseSseEvents(sseBuffer);
-          sseBuffer = remaining;
-
-          for (const event of events) {
-            const transformed = transform(event);
-            if (transformed) {
-              writeOut(transformed);
-              const usage = extractUsageFromSse(transformed);
-              if (usage) capturedUsage = usage;
-            }
-          }
-        } else {
-          writeOut(text);
-          passthroughBuffer += text;
-          if (passthroughBuffer.length > MAX_SSE_BUFFER_SIZE) {
-            throw new Error('SSE buffer overflow: provider sent data without event boundaries');
-          }
-          const { events: ptEvents, remaining } = parseSseEvents(passthroughBuffer);
-          passthroughBuffer = remaining;
-          for (const ev of ptEvents) {
-            try {
-              const obj = JSON.parse(ev);
-              const fromUsage = parseUsageObject(obj.usage);
-              if (fromUsage) {
-                capturedUsage = fromUsage;
-              } else {
-                const fromResponse = parseUsageObject(obj.response?.usage);
-                if (fromResponse) capturedUsage = fromResponse;
-              }
-            } catch {
-              /* ignore non-JSON events */
-            }
-          }
-        }
+        consumeText(text);
       }
     }
 
-    // Flush any remaining passthrough buffer content for usage extraction.
-    // The final SSE chunk (containing usage) may not end with \n\n,
-    // leaving it unparsed in passthroughBuffer.
-    if (!transform && passthroughBuffer.trim()) {
-      const payload = passthroughBuffer
-        .split('\n')
-        .map((line) => (line.startsWith('data: ') ? line.slice(6) : line))
-        .join('\n')
-        .trim();
-      if (payload && payload !== '[DONE]') {
-        try {
-          const obj = JSON.parse(payload);
-          const fromUsage = parseUsageObject(obj.usage);
-          if (fromUsage) {
-            capturedUsage = fromUsage;
-          } else {
-            const fromResponse = parseUsageObject(obj.response?.usage);
-            if (fromResponse) capturedUsage = fromResponse;
-          }
-        } catch {
-          /* ignore non-JSON remaining content */
-        }
-      }
-    }
-
-    // Flush any remaining buffer content through the transform
-    if (transform && sseBuffer.trim()) {
-      const payload = sseBuffer
-        .split('\n')
-        .map((line) => (line.startsWith('data: ') ? line.slice(6) : line))
-        .join('\n')
-        .trim();
-      if (payload && payload !== '[DONE]') {
-        const transformed = transform(payload);
-        if (transformed) {
-          writeOut(transformed);
-          const usage = extractUsageFromSse(transformed);
-          if (usage) capturedUsage = usage;
-        }
-      }
+    consumeText(decoder.decode());
+    if (transform && transformParser) {
+      applyTransformedEvents(transformParser.flush());
+    } else if (passthroughParser) {
+      capturePassthroughUsage(passthroughParser.flush());
     }
 
     if (transform && !dest.writableEnded) {


### PR DESCRIPTION
## Summary
- route provider SSE parsing through a small `eventsource-parser` wrapper
- preserve upstream keepalive comments as SSE comments instead of transforming them into `data:` payloads
- keep passthrough streams byte-for-byte while tapping only real data events for usage, and share the parser with playground streaming
- add regression coverage plus a patch changeset

Fixes #2053

## Validation
- `npm --workspace=manifest-shared run build`
- `npm --workspace=manifest-backend run build`
- `npm exec -- eslint packages/backend/src/routing/proxy/sse-parser.ts packages/backend/src/routing/proxy/stream-writer.ts packages/backend/src/playground/playground-stream.ts packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts packages/backend/src/playground/playground-stream.spec.ts`
- `npm exec -- prettier --check .changeset/sse-comment-parser.md packages/backend/src/routing/proxy/sse-parser.ts packages/backend/src/routing/proxy/stream-writer.ts packages/backend/src/playground/playground-stream.ts packages/backend/src/routing/proxy/__tests__/stream-writer.spec.ts packages/backend/src/playground/playground-stream.spec.ts packages/backend/package.json package-lock.json`
- `npm --workspace=manifest-backend test -- stream-writer.spec.ts playground-stream.spec.ts proxy-response-handler.spec.ts --runInBand`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route provider SSE through a spec-compliant parser. Keepalive comments are parsed and forwarded as comments; passthrough stays byte-for-byte and buffer overflow edge cases are reduced in proxy and playground.

- **Bug Fixes**
  - Preserve upstream SSE keep-alive comments; emit them as `: comment` when transforming, never as `data:`.
  - Use a shared SSE payload parser for proxy and playground; tap only real data events; passthrough remains byte-for-byte.
  - Better spec handling (CRLF, event/id fields, trailing flush) and a clearer overflow error ("SSE buffer overflow").

- **Dependencies**
  - Add `eventsource-parser@^3.1.0`.

<sup>Written for commit 259951e63c49a31510d9ca03be63b3e23283d5a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2055?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

