### PR TITLE
Fix Anthropic streamed delta usage accounting

### DIFF
--- a/.changeset/anthropic-stream-delta-usage.md
+++ b/.changeset/anthropic-stream-delta-usage.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Record cumulative Anthropic streamed input and cache token counts when they are reported on `message_delta` events.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -1228,6 +1228,27 @@ describe('Anthropic Adapter', () => {
       expect(usage.usage.cache_creation_tokens).toBe(5);
       expect(usage.usage.prompt_tokens_details.cached_tokens).toBe(10);
     });
+
+    it('prefers cumulative input and cache tokens from message_delta usage when present', () => {
+      const transform = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+      transform(
+        'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":42,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}}',
+      );
+
+      const result = transform(
+        'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":100,"cache_read_input_tokens":20,"cache_creation_input_tokens":7,"output_tokens":30}}',
+      );
+
+      const parts = result!.split('\n\n').filter(Boolean);
+      const usage = JSON.parse(parts[1].replace('data: ', ''));
+      expect(usage.usage.prompt_tokens).toBe(127);
+      expect(usage.usage.completion_tokens).toBe(30);
+      expect(usage.usage.total_tokens).toBe(157);
+      expect(usage.usage.cache_read_tokens).toBe(20);
+      expect(usage.usage.cache_creation_tokens).toBe(7);
+      expect(usage.usage.prompt_tokens_details.cached_tokens).toBe(20);
+    });
   });
 
   describe('extended-thinking round-trip (Fix 3)', () => {

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -523,6 +523,20 @@ function handleMessageStart(state: StreamState, data: Record<string, unknown>): 
   return makeChunkSse(state.model, { role: 'assistant', content: '' }, null);
 }
 
+function applyMessageDeltaUsage(
+  state: StreamState,
+  usage: Record<string, unknown> | undefined,
+): void {
+  if (!usage) return;
+  if (typeof usage.input_tokens === 'number') state.inputTokens = usage.input_tokens;
+  if (typeof usage.cache_read_input_tokens === 'number') {
+    state.cacheReadTokens = usage.cache_read_input_tokens;
+  }
+  if (typeof usage.cache_creation_input_tokens === 'number') {
+    state.cacheCreationTokens = usage.cache_creation_input_tokens;
+  }
+}
+
 function handleContentBlockStart(state: StreamState, data: Record<string, unknown>): string | null {
   const block = data.content_block as Record<string, unknown> | undefined;
   const blockIndex = data.index as number;
@@ -620,8 +634,9 @@ function flushThinkingBlocks(state: StreamState): void {
 function handleMessageDelta(state: StreamState, data: Record<string, unknown>): string {
   flushThinkingBlocks(state);
   const delta = data.delta as Record<string, unknown> | undefined;
-  const usage = data.usage as Record<string, number> | undefined;
-  const outputTokens = usage?.output_tokens ?? 0;
+  const usage = data.usage as Record<string, unknown> | undefined;
+  applyMessageDeltaUsage(state, usage);
+  const outputTokens = typeof usage?.output_tokens === 'number' ? usage.output_tokens : 0;
   // inputTokens is non-cached only; total = non-cached + cache reads + cache creation
   const totalInput = state.inputTokens + state.cacheReadTokens + state.cacheCreationTokens;
 


### PR DESCRIPTION
## Summary
- Record cumulative Anthropic streamed input and cache token counts when they are present on `message_delta.usage`.
- Keep the existing `message_start` usage fallback for streams where Anthropic only sends `output_tokens` on `message_delta`.
- Add a regression covering updated input, cache-read, and cache-creation counts from the final delta event.

## Context
Anthropic's streaming API documents `message_delta` usage as cumulative, and the current TypeScript API reference includes `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` on `MessageDeltaUsage`: https://platform.claude.com/docs/en/api/messages-streaming

## Validation
- `npm run build --workspace=manifest-shared`
- `npm run build --workspace=packages/backend`
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/proxy/__tests__/anthropic-adapter.spec.ts src/routing/proxy/__tests__/stream-writer.spec.ts`
- `npm test --workspace=packages/backend -- --coverage --coverageReporters=text --runTestsByPath src/routing/proxy/__tests__/anthropic-adapter.spec.ts --collectCoverageFrom=routing/proxy/anthropic-adapter.ts` (100% for `anthropic-adapter.ts`)
- `npm run lint --workspace=packages/backend` (exits 0; existing warnings remain)
- `npx eslint packages/backend/src/routing/proxy/anthropic-adapter.ts packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts`
- `npx prettier --check .changeset/anthropic-stream-delta-usage.md packages/backend/src/routing/proxy/anthropic-adapter.ts packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts`
- `git diff --check`
- Live Anthropic smoke: streamed `/v1/messages` through compiled passthrough transformer using `claude-haiku-4-5-20251001`; captured nonzero prompt/completion usage and saw usage on `message_delta`.
- Synthetic passthrough smoke: preserved native Anthropic SSE bytes and captured final cumulative input/cache/output usage from `message_delta.usage`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Anthropic streaming usage accounting by reading cumulative input and cache tokens from `message_delta`. Ensures accurate prompt/total/completion tokens while keeping a safe fallback for older streams.

- **Bug Fixes**
  - Prefer cumulative `input_tokens`, `cache_read_input_tokens`, and `cache_creation_input_tokens` from `message_delta.usage`.
  - Keep `message_start` usage as a fallback when only `output_tokens` is sent on deltas.
  - Added a regression test to confirm final cumulative input/cache/output usage is emitted correctly.

<sup>Written for commit c86ab7504b7e7f79965b7210f8dd17c5f676c7a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2057?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

