### PR TITLE
fix: limit OAuth callback URL tutorial video to OpenAI

### DIFF
--- a/.changeset/limit-oauth-callback-tutorial-video-to-openai.md
+++ b/.changeset/limit-oauth-callback-tutorial-video-to-openai.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Limit the OAuth callback-URL tutorial video on the provider sign-in screen to OpenAI. Other OAuth providers (Gemini, etc.) no longer show the OpenAI-specific video.

--- a/packages/frontend/src/components/OAuthDetailView.tsx
+++ b/packages/frontend/src/components/OAuthDetailView.tsx
@@ -74,6 +74,7 @@ const OAuthDetailView: Component<Props> = (props) => {
 
   const isMultiKey = () => (props.activeKeys?.() ?? []).length > 1;
   const isXaiProvider = () => props.provId === 'xai';
+  const isOpenAiProvider = () => props.provId === 'openai';
   const callbackPlaceholder = () =>
     isXaiProvider()
       ? 'Paste the xAI authorization code or callback URL'
@@ -300,21 +301,23 @@ const OAuthDetailView: Component<Props> = (props) => {
                   A login window has opened. If it does not close automatically after sign-in, paste
                   the callback URL below.
                 </p>
-                <p class="provider-detail__hint" style="margin-top: 8px;">
-                  Copy the full URL from the{' '}
-                  <span style="color: hsl(var(--foreground)); font-weight: 500;">
-                    popup's address bar
-                  </span>{' '}
-                  and paste it below:
-                </p>
-                <video
-                  src="/images/oauth-callback-example.mp4"
-                  autoplay
-                  loop
-                  muted
-                  playsinline
-                  style="width: 100%; border-radius: var(--radius); border: 1px solid hsl(var(--border)); margin-top: 12px;"
-                />
+                <Show when={isOpenAiProvider()}>
+                  <p class="provider-detail__hint" style="margin-top: 8px;">
+                    Copy the full URL from the{' '}
+                    <span style="color: hsl(var(--foreground)); font-weight: 500;">
+                      popup's address bar
+                    </span>{' '}
+                    and paste it below:
+                  </p>
+                  <video
+                    src="/images/oauth-callback-example.mp4"
+                    autoplay
+                    loop
+                    muted
+                    playsinline
+                    style="width: 100%; border-radius: var(--radius); border: 1px solid hsl(var(--border)); margin-top: 12px;"
+                  />
+                </Show>
               </>
             }
           >

--- a/packages/frontend/tests/components/OAuthDetailView.test.tsx
+++ b/packages/frontend/tests/components/OAuthDetailView.test.tsx
@@ -76,6 +76,14 @@ const xaiProvDef: ProviderDef = {
   subscriptionLabel: 'Grok subscription',
 };
 
+const geminiProvDef: ProviderDef = {
+  ...provDef,
+  id: 'gemini',
+  name: 'Gemini',
+  initial: 'G',
+  subscriptionLabel: 'Sign in with Google',
+};
+
 function makeKey(overrides: Partial<RoutingProvider> = {}): RoutingProvider {
   return {
     id: 'key-1',
@@ -400,6 +408,33 @@ describe('OAuthDetailView', () => {
         'Popup was blocked by your browser. Allow popups for this site, then try again.',
       );
     });
+  });
+
+  it('shows the callback-URL video tutorial for OpenAI after starting OAuth', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.openai.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    const { container } = renderView();
+    fireEvent.click(screen.getByText('Log in with OpenAI'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Copy the full URL/)).toBeDefined();
+    });
+    expect(container.querySelector('video[src="/images/oauth-callback-example.mp4"]')).not.toBeNull();
+  });
+
+  it('does not show the callback-URL video tutorial for non-OpenAI providers (e.g. Gemini)', async () => {
+    mockGetOpenaiOAuthUrl.mockResolvedValue({ url: 'https://oauth.google.com/authorize' });
+    vi.spyOn(window, 'open').mockReturnValue({ closed: false } as unknown as Window);
+
+    const { container } = renderView({ provId: 'gemini', provDef: geminiProvDef });
+    fireEvent.click(screen.getByText('Log in with Gemini'));
+
+    await waitFor(() => {
+      expect(mockGetOpenaiOAuthUrl).toHaveBeenCalled();
+    });
+    expect(screen.queryByText(/Copy the full URL/)).toBeNull();
+    expect(container.querySelector('video[src="/images/oauth-callback-example.mp4"]')).toBeNull();
   });
 
   it('Disconnect all revokes all OpenAI OAuth tokens', async () => {


### PR DESCRIPTION
## Summary

The provider sign-in screen surfaced an OpenAI-specific callback URL paste tutorial — including a short demo video — on every non-xAI OAuth provider, so Google sign-in (Gemini) was showing instructions and a video that only make sense for OpenAI. This made the Google login screen feel confusing and off-brand.

This PR gates the tutorial copy and the demo video on `provId === 'openai'` so only OpenAI shows them. Other popup-OAuth providers keep the generic *paste the callback URL below* hint without the OpenAI-specific block.

## Changes

- `OAuthDetailView.tsx`: wrap the *Copy the full URL from the popup's address bar* paragraph and the `<video>` tutorial in `<Show when={isOpenAiProvider()}>`.
- `OAuthDetailView.test.tsx`: add two tests covering both branches — the video is rendered for OpenAI and hidden for Gemini.
- Changeset: `patch` bump on `manifest`.

## Test plan

- `tsc --noEmit` — clean.
- `npm run lint` — 0 errors (warnings are pre-existing).
- New tests cover the OpenAI branch (video visible) and the Gemini branch (video hidden).
- Manual: open *Routing → connect provider → Gemini → Sign in with Google*; the OpenAI-specific tutorial and video are no longer shown.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit the OAuth callback-URL tutorial and demo video to OpenAI. Google/Gemini and other providers now show only the generic hint, fixing confusing OpenAI-specific instructions on their sign-in screens.

<sup>Written for commit db9d79e8fd6739bced16b97a73a7a0fe49e9318b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2063?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

