### PR TITLE
feat: split model selector modalities

### DIFF
--- a/.changeset/model-selector-modalities.md
+++ b/.changeset/model-selector-modalities.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Separate model selector capabilities from input and output modality columns.

--- a/packages/backend/src/database/models-dev-sync.service.spec.ts
+++ b/packages/backend/src/database/models-dev-sync.service.spec.ts
@@ -294,6 +294,8 @@ describe('ModelsDevSyncService', () => {
       expect(model!.maxOutputTokens).toBe(128000);
       expect(model!.reasoning).toBe(true);
       expect(model!.toolCall).toBe(true);
+      expect(model!.inputModalities).toEqual(['text', 'image']);
+      expect(model!.outputModalities).toEqual(['text']);
     });
 
     it('should find Google/Gemini models via our "gemini" provider ID', () => {
@@ -600,7 +602,10 @@ describe('ModelsDevSyncService', () => {
 
       await service.refreshCache();
 
-      expect(service.lookupModel('openai', 'empty-mod')).not.toBeNull();
+      const model = service.lookupModel('openai', 'empty-mod');
+      expect(model).not.toBeNull();
+      expect(model!.inputModalities).toEqual(['text']);
+      expect(model!.outputModalities).toEqual(['text']);
     });
 
     it('should include models with empty input and output arrays', async () => {
@@ -666,7 +671,9 @@ describe('ModelsDevSyncService', () => {
 
       await service.refreshCache();
 
-      expect(service.lookupModel('openai', 'mixed-output')).not.toBeNull();
+      const model = service.lookupModel('openai', 'mixed-output');
+      expect(model).not.toBeNull();
+      expect(model!.outputModalities).toEqual(['text', 'image']);
     });
 
     it('should exclude models with audio-only input', async () => {

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -1,8 +1,11 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
-import { normalizeProviderName, type ModelCapability } from 'manifest-shared';
+import { normalizeProviderName, type ModelCapability, type ModelModality } from 'manifest-shared';
 import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
-import { capabilitiesFromModelsDev } from '../model-discovery/model-capabilities';
+import {
+  capabilitiesFromModelsDev,
+  modelModalitiesFromModelsDev,
+} from '../model-discovery/model-capabilities';
 
 /**
  * Mapping from our internal provider IDs to models.dev provider directory names.
@@ -48,6 +51,8 @@ export interface ModelsDevModelEntry {
   cacheReadPricePerToken?: number | null;
   cacheWritePricePerToken?: number | null;
   capabilities: readonly ModelCapability[];
+  inputModalities: readonly ModelModality[];
+  outputModalities: readonly ModelModality[];
 }
 
 interface RawModelsDevModel {
@@ -388,6 +393,7 @@ export class ModelsDevSyncService implements OnModuleInit {
     const outputPerMillion = raw.cost?.output ?? null;
     const cacheReadPerMillion = raw.cost?.cache_read ?? null;
     const cacheWritePerMillion = raw.cost?.cache_write ?? null;
+    const modalities = modelModalitiesFromModelsDev(raw.modalities);
 
     return {
       id: modelId,
@@ -399,6 +405,8 @@ export class ModelsDevSyncService implements OnModuleInit {
       contextWindow: raw.limit?.context,
       maxOutputTokens: raw.limit?.output,
       capabilities: capabilitiesFromModelsDev(providerId, modelId, raw.modalities, raw.tool_call),
+      inputModalities: modalities.input,
+      outputModalities: modalities.output,
       inputPricePerToken: inputPerMillion !== null ? inputPerMillion / 1_000_000 : null,
       outputPricePerToken: outputPerMillion !== null ? outputPerMillion / 1_000_000 : null,
       cacheReadPricePerToken: cacheReadPerMillion !== null ? cacheReadPerMillion / 1_000_000 : null,

--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -1,9 +1,11 @@
 import { PROVIDER_BY_ID_OR_ALIAS } from '../common/constants/providers';
-import type { ModelCapability } from 'manifest-shared';
+import type { ModelCapability, ModelModality } from 'manifest-shared';
 
 type RawModalities = { input?: string[]; output?: string[] } | undefined;
 
-const MODALITY_CAPABILITIES: ReadonlyMap<string, ModelCapability> = new Map([
+const DEFAULT_MODALITIES: readonly ModelModality[] = ['text'];
+
+const MODALITY_CAPABILITIES: ReadonlyMap<string, ModelModality> = new Map([
   ['text', 'text'],
   ['image', 'image'],
   ['audio', 'audio'],
@@ -29,6 +31,11 @@ const STREAMING_ENDPOINT_PROVIDERS = new Set([
   'zai',
 ]);
 
+export interface ModelModalities {
+  input: readonly ModelModality[];
+  output: readonly ModelModality[];
+}
+
 export function mergeModelCapabilities(
   ...capabilityLists: Array<readonly ModelCapability[] | null | undefined>
 ): readonly ModelCapability[] | undefined {
@@ -44,6 +51,24 @@ export function mergeModelCapabilities(
   return merged.length > 0 ? merged : undefined;
 }
 
+export function modelModalitiesFromModelsDev(modalities: RawModalities): ModelModalities {
+  return {
+    input: normalizeModalities(modalities?.input),
+    output: normalizeModalities(modalities?.output),
+  };
+}
+
+export function inputModalitiesFromCapabilities(
+  capabilities: readonly ModelCapability[] | null | undefined,
+): readonly ModelModality[] {
+  const out: ModelModality[] = ['text'];
+  for (const capability of capabilities ?? []) {
+    if (capability === 'text' || capability === 'stream' || capability === 'tools') continue;
+    if (!out.includes(capability)) out.push(capability);
+  }
+  return out;
+}
+
 export function capabilitiesFromModelsDev(
   providerId: string,
   modelId: string,
@@ -54,12 +79,8 @@ export function capabilitiesFromModelsDev(
   const add = (capability: ModelCapability) => {
     if (!out.includes(capability)) out.push(capability);
   };
-  const modalValues = [...(modalities?.input ?? []), ...(modalities?.output ?? [])];
-  for (const modality of modalValues) {
-    const capability = MODALITY_CAPABILITIES.get(modality.toLowerCase());
-    if (capability) add(capability);
-  }
-  if (modalValues.length === 0) add('text');
+  const normalized = modelModalitiesFromModelsDev(modalities);
+  for (const modality of [...normalized.input, ...normalized.output]) add(modality);
   if (toolCall === true) add('tools');
   if (modelSupportsStreaming(providerId, modelId)) add('stream');
   return out;
@@ -76,6 +97,15 @@ function resolveProviderId(providerId: string): string {
   const lower = providerId.toLowerCase();
   const entry = PROVIDER_BY_ID_OR_ALIAS.get(lower);
   return entry?.id ?? lower;
+}
+
+function normalizeModalities(values: readonly string[] | undefined): readonly ModelModality[] {
+  const out: ModelModality[] = [];
+  for (const value of values ?? []) {
+    const modality = MODALITY_CAPABILITIES.get(value.toLowerCase());
+    if (modality && !out.includes(modality)) out.push(modality);
+  }
+  return out.length > 0 ? out : DEFAULT_MODALITIES;
 }
 
 function isOpenAiNonStreamingModel(modelId: string): boolean {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -427,6 +427,8 @@ export class ModelDiscoveryService {
           displayName: mdEntry.name || model.displayName,
           capabilityReasoning: mdEntry.reasoning ?? model.capabilityReasoning,
           capabilityCode: mdEntry.toolCall ?? model.capabilityCode,
+          ...(mdEntry.inputModalities ? { inputModalities: mdEntry.inputModalities } : {}),
+          ...(mdEntry.outputModalities ? { outputModalities: mdEntry.outputModalities } : {}),
           capabilities: mergeModelCapabilities(
             model.capabilities,
             mdEntry.capabilities,
@@ -475,6 +477,8 @@ export class ModelDiscoveryService {
       ...model,
       capabilityReasoning: mdEntry.reasoning ?? model.capabilityReasoning,
       capabilityCode: mdEntry.toolCall ?? model.capabilityCode,
+      ...(mdEntry.inputModalities ? { inputModalities: mdEntry.inputModalities } : {}),
+      ...(mdEntry.outputModalities ? { outputModalities: mdEntry.outputModalities } : {}),
       capabilities: mergeModelCapabilities(
         model.capabilities,
         mdEntry.capabilities,

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -10,7 +10,6 @@ import {
 } from 'manifest-shared';
 import { normalizeAnthropicShortModelId } from '../common/utils/anthropic-model-id';
 import { GOOGLE_VARIANT_RE } from '../model-prices/model-name-normalizer';
-import type { ModelsDevSyncService } from '../database/models-dev-sync.service';
 
 interface PricingLookup {
   lookupPricing(key: string): {
@@ -149,6 +148,8 @@ export function buildModelsDevFallback(
       outputPricePerToken: number | null;
       reasoning?: boolean;
       toolCall?: boolean;
+      inputModalities?: DiscoveredModel['inputModalities'];
+      outputModalities?: DiscoveredModel['outputModalities'];
     }[];
   } | null,
   providerId: string,
@@ -164,6 +165,8 @@ export function buildModelsDevFallback(
     outputPricePerToken: e.outputPricePerToken,
     capabilityReasoning: e.reasoning ?? false,
     capabilityCode: e.toolCall ?? false,
+    ...(e.inputModalities ? { inputModalities: e.inputModalities } : {}),
+    ...(e.outputModalities ? { outputModalities: e.outputModalities } : {}),
     qualityScore: 3,
   }));
 }

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -6,7 +6,7 @@
  * DiscoveredModel objects cached in user_providers.cached_models.
  */
 
-import type { AuthType, ModelCapability } from 'manifest-shared';
+import type { AuthType, ModelCapability, ModelModality } from 'manifest-shared';
 
 export interface DiscoveredModel {
   id: string;
@@ -18,6 +18,8 @@ export interface DiscoveredModel {
   capabilityReasoning: boolean;
   capabilityCode: boolean;
   capabilities?: readonly ModelCapability[];
+  inputModalities?: readonly ModelModality[];
+  outputModalities?: readonly ModelModality[];
   qualityScore: number;
   authType?: AuthType;
 }

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -272,7 +272,9 @@ describe('ModelController', () => {
         provider: 'openai',
         auth_type: 'api_key',
         input_price_per_token: 0.0000025,
+        input_modalities: ['text'],
         output_price_per_token: 0.00001,
+        output_modalities: ['text'],
         context_window: 128000,
         capability_reasoning: false,
         capability_code: true,
@@ -340,8 +342,10 @@ describe('ModelController', () => {
         'capability_reasoning',
         'context_window',
         'display_name',
+        'input_modalities',
         'input_price_per_token',
         'model_name',
+        'output_modalities',
         'output_price_per_token',
         'provider',
         'quality_score',
@@ -354,11 +358,15 @@ describe('ModelController', () => {
       ]);
       mockModelsDevSync.lookupModel.mockReturnValue({
         capabilities: ['text', 'image', 'tools', 'stream'],
+        inputModalities: ['text', 'image'],
+        outputModalities: ['text', 'image'],
       });
 
       const result = await controller.getAvailableModels(mockUser, mockAgentName);
 
       expect(result[0].capabilities).toEqual(['text', 'image', 'tools', 'stream']);
+      expect(result[0].input_modalities).toEqual(['text', 'image']);
+      expect(result[0].output_modalities).toEqual(['text']);
     });
 
     it('resolves gateway models to the underlying provider for capability metadata', async () => {

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -12,6 +12,7 @@ import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { resolveUnderlyingModelIdentity } from 'manifest-shared';
 import {
+  inputModalitiesFromCapabilities,
   mergeModelCapabilities,
   modelSupportsStreaming,
 } from '../model-discovery/model-capabilities';
@@ -112,16 +113,18 @@ export class ModelController {
         // already unwraps gateways internally, so it keeps the raw identity.
         const capId = resolveUnderlyingModelIdentity(m.provider, m.id);
         const capProvider = capId.provider ?? m.provider;
-        const modelsDevCapabilities = this.modelsDevSync.lookupModel(
-          capProvider,
-          capId.model,
-        )?.capabilities;
+        const modelsDevEntry = this.modelsDevSync.lookupModel(capProvider, capId.model);
+        const modelsDevCapabilities = modelsDevEntry?.capabilities;
         const modelCapabilities = mergeModelCapabilities(
           m.capabilities,
           modelsDevCapabilities,
           capabilities,
           modelSupportsStreaming(capProvider, capId.model) ? ['stream'] : undefined,
         );
+        const inputModalities =
+          modelsDevEntry?.inputModalities ??
+          m.inputModalities ??
+          inputModalitiesFromCapabilities(modelCapabilities);
         // OpenCode Go bills a per-request slice of its dollar quota rather than
         // per token, so surface that cost; other subscriptions stay flat-fee.
         const costPerRequest =
@@ -139,6 +142,8 @@ export class ModelController {
           capability_reasoning: m.capabilityReasoning,
           capability_code: m.capabilityCode,
           ...(modelCapabilities ? { capabilities: modelCapabilities } : {}),
+          input_modalities: inputModalities,
+          output_modalities: ['text'],
           quality_score: m.qualityScore,
           display_name: isCustom ? CustomProviderService.rawModelName(m.id) : m.displayName || null,
           ...(isCustom && {

--- a/packages/frontend/src/components/ModelCapabilityBadges.tsx
+++ b/packages/frontend/src/components/ModelCapabilityBadges.tsx
@@ -1,5 +1,5 @@
 import { For, Show, type Component } from 'solid-js';
-import type { ModelCapability } from '../services/api.js';
+import type { ModelCapability, ModelModality } from '../services/api.js';
 
 interface Props {
   capabilities?: readonly ModelCapability[];
@@ -17,7 +17,7 @@ export const CAPABILITY_LABELS: Record<ModelCapability, string> = {
 };
 
 export const CAPABILITY_ICONS: Record<ModelCapability, string> = {
-  text: '',
+  text: '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M4 4c0-1.1.9-2 2-2h12c1.1 0 2 .9 2 2v16c0 1.1-.9 2-2 2H6c-1.1 0-2-.9-2-2zm2 0v16h12V4zm2 4h8v2H8zm0 4h8v2H8zm0 4h5v2H8z"/></svg>',
   video:
     '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M18 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-4.33L22 17V7l-4 3.33zm-2 12H4V6h12z"/></svg>',
   image:
@@ -31,6 +31,16 @@ export const CAPABILITY_ICONS: Record<ModelCapability, string> = {
 };
 
 const DISPLAY_ORDER: readonly ModelCapability[] = ['stream', 'tools', 'image', 'audio', 'video'];
+const MODALITY_ORDER: readonly ModelModality[] = ['text', 'image', 'audio', 'video'];
+const unknownIcon =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M11 16h2v2h-2z"/><path d="M16.71 2.29A1 1 0 0 0 16 2H8c-.27 0-.52.11-.71.29l-5 5A1 1 0 0 0 2 8v8c0 .27.11.52.29.71l5 5c.19.19.44.29.71.29h8c.27 0 .52-.11.71-.29l5-5A1 1 0 0 0 22 16V8c0-.27-.11-.52-.29-.71zM20 15.58l-4.41 4.41H8.42l-4.41-4.41V8.41L8.42 4h7.17L20 8.41z"/><path d="M13.27 6.25c-2.08-.75-4.47.35-5.21 2.41l1.88.68c.18-.5.56-.9 1.07-1.13s1.08-.26 1.58-.08a2.01 2.01 0 0 1 1.32 1.86c0 1.04-1.66 1.86-2.24 2.07-.4.14-.67.52-.67.94v1h2v-.34c1.04-.51 2.91-1.69 2.91-3.68a4.015 4.015 0 0 0-2.64-3.73"/></svg>';
+
+interface ModalityProps {
+  modalities?: readonly ModelModality[];
+  compact?: boolean;
+  iconOnly?: boolean;
+  direction: 'input' | 'output';
+}
 
 const ModelCapabilityBadges: Component<Props> = (props) => {
   const hasMetadata = () => (props.capabilities?.length ?? 0) > 0;
@@ -45,9 +55,6 @@ const ModelCapabilityBadges: Component<Props> = (props) => {
       .map((capability) => CAPABILITY_LABELS[capability])
       .join(', ')}`;
   };
-
-  const unknownIcon =
-    '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" fill="currentColor" viewBox="0 0 24 24"><path d="M11 16h2v2h-2z"/><path d="M16.71 2.29A1 1 0 0 0 16 2H8c-.27 0-.52.11-.71.29l-5 5A1 1 0 0 0 2 8v8c0 .27.11.52.29.71l5 5c.19.19.44.29.71.29h8c.27 0 .52-.11.71-.29l5-5A1 1 0 0 0 22 16V8c0-.27-.11-.52-.29-.71zM20 15.58l-4.41 4.41H8.42l-4.41-4.41V8.41L8.42 4h7.17L20 8.41z"/><path d="M13.27 6.25c-2.08-.75-4.47.35-5.21 2.41l1.88.68c.18-.5.56-.9 1.07-1.13s1.08-.26 1.58-.08a2.01 2.01 0 0 1 1.32 1.86c0 1.04-1.66 1.86-2.24 2.07-.4.14-.67.52-.67.94v1h2v-.34c1.04-.51 2.91-1.69 2.91-3.68a4.015 4.015 0 0 0-2.64-3.73"/></svg>';
 
   return (
     <Show
@@ -90,6 +97,61 @@ const ModelCapabilityBadges: Component<Props> = (props) => {
                 />
               )}
               <Show when={!props.iconOnly}>{CAPABILITY_LABELS[capability]}</Show>
+            </span>
+          )}
+        </For>
+      </span>
+    </Show>
+  );
+};
+
+export const ModelModalityBadges: Component<ModalityProps> = (props) => {
+  const supported = () => {
+    const set = new Set(props.modalities ?? []);
+    return MODALITY_ORDER.filter((modality) => set.has(modality));
+  };
+  const directionLabel = () => (props.direction === 'input' ? 'Input' : 'Output');
+  const summary = () => {
+    if (supported().length === 0) return `${directionLabel()} modalities unknown`;
+    return `${directionLabel()}: ${supported()
+      .map((modality) => CAPABILITY_LABELS[modality])
+      .join(', ')}`;
+  };
+  const tooltip = (modality: ModelModality) => CAPABILITY_LABELS[modality];
+
+  return (
+    <Show
+      when={supported().length > 0}
+      fallback={
+        <span
+          class="model-capability-badges model-modality-badges"
+          classList={{ 'model-capability-badges--compact': !!props.compact }}
+          aria-label={summary()}
+        >
+          <span
+            class="model-capability-badge model-capability-badge--icon-only model-capability-badge--unknown"
+            data-tooltip={`${directionLabel()} modalities unknown`}
+          >
+            <span class="model-capability-badge__icon" innerHTML={unknownIcon} />
+          </span>
+        </span>
+      }
+    >
+      <span
+        class="model-capability-badges model-modality-badges"
+        classList={{ 'model-capability-badges--compact': !!props.compact }}
+        aria-label={summary()}
+      >
+        <For each={supported()}>
+          {(modality) => (
+            <span
+              class="model-capability-badge model-modality-badge"
+              classList={{ 'model-capability-badge--icon-only': !!props.iconOnly }}
+              title={props.iconOnly ? undefined : tooltip(modality)}
+              data-tooltip={tooltip(modality)}
+            >
+              <span class="model-capability-badge__icon" innerHTML={CAPABILITY_ICONS[modality]} />
+              <Show when={!props.iconOnly}>{CAPABILITY_LABELS[modality]}</Show>
             </span>
           )}
         </For>

--- a/packages/frontend/src/components/ModelPickerModal.tsx
+++ b/packages/frontend/src/components/ModelPickerModal.tsx
@@ -5,6 +5,7 @@ import {
   type AvailableModel,
   type CustomProviderData,
   type ModelCapability,
+  type ModelModality,
   type RoutingProvider,
   type TierAssignment,
 } from '../services/api.js';
@@ -16,6 +17,7 @@ import { toast } from '../services/toast-store.js';
 import ModelCapabilityBadges, {
   CAPABILITY_ICONS,
   CAPABILITY_LABELS,
+  ModelModalityBadges,
 } from './ModelCapabilityBadges.js';
 
 interface Props {
@@ -51,6 +53,10 @@ const isFreeModel = (m: AvailableModel): boolean =>
   m.output_price_per_token != null &&
   Number(m.input_price_per_token) === 0 &&
   Number(m.output_price_per_token) === 0;
+
+const ACTION_CAPABILITIES: readonly ModelCapability[] = ['stream', 'tools'];
+const MODALITY_ORDER: readonly ModelModality[] = ['text', 'image', 'audio', 'video'];
+const DEFAULT_MODALITIES: readonly ModelModality[] = ['text'];
 
 const unavailableCapabilityLabel = (capability: ModelCapability): string => {
   if (capability === 'stream') return 'Stream unavailable';
@@ -97,14 +103,13 @@ const ModelPickerModal: Component<Props> = (props) => {
 
   const isCapabilityRequired = (cap: ModelCapability) => requiredCapabilities().has(cap);
 
-  /** Capabilities that exist on at least one model in the current tab, including stream. */
+  /** Action capabilities that exist on at least one model in the current tab. */
   const availableCapabilities = (): ModelCapability[] => {
-    const capOrder: ModelCapability[] = ['stream', 'tools', 'image', 'audio', 'video'];
     const found = new Set<ModelCapability>();
     for (const m of props.models) {
       for (const c of m.capabilities ?? []) found.add(c);
     }
-    return capOrder.filter((c) => found.has(c));
+    return ACTION_CAPABILITIES.filter((c) => found.has(c));
   };
 
   const handleRefreshGroup = async (provId: string, displayName: string) => {
@@ -308,6 +313,23 @@ const ModelPickerModal: Component<Props> = (props) => {
       ? null
       : unavailableCapabilityLabel(required);
   };
+  const actionCapabilitiesFor = (model: AvailableModel): readonly ModelCapability[] => {
+    return ACTION_CAPABILITIES.filter((capability) =>
+      (model.capabilities ?? []).includes(capability),
+    );
+  };
+  const inputModalitiesFor = (model: AvailableModel): readonly ModelModality[] => {
+    if (model.input_modalities && model.input_modalities.length > 0) return model.input_modalities;
+    const caps = new Set(model.capabilities ?? []);
+    const modalities = MODALITY_ORDER.filter(
+      (modality) => modality === 'text' || caps.has(modality),
+    );
+    return modalities.length > 0 ? modalities : DEFAULT_MODALITIES;
+  };
+  const outputModalitiesFor = (model: AvailableModel): readonly ModelModality[] =>
+    model.output_modalities && model.output_modalities.length > 0
+      ? model.output_modalities
+      : DEFAULT_MODALITIES;
 
   // Resolve the routing-tier label for the subtitle. Callers outside the
   // routing context (e.g. the Playground) pass a non-tier id, so there is no
@@ -326,8 +348,7 @@ const ModelPickerModal: Component<Props> = (props) => {
       }}
     >
       <div
-        class="modal-card"
-        style="max-width: 600px; padding: 0; display: flex; flex-direction: column; max-height: 80vh;"
+        class="modal-card routing-modal__card"
         role="dialog"
         aria-modal="true"
         aria-labelledby="model-picker-title"
@@ -509,6 +530,15 @@ const ModelPickerModal: Component<Props> = (props) => {
         </div>
 
         <div class="routing-modal__list">
+          <Show when={groupedModels().length > 0}>
+            <div class="routing-modal__table-head" aria-hidden="true">
+              <span>Model</span>
+              <span>Capabilities</span>
+              <span>Input</span>
+              <span>Output</span>
+              <span>Price</span>
+            </div>
+          </Show>
           <For each={groupedModels()}>
             {(group) => (
               <div class="routing-modal__group">
@@ -595,32 +625,66 @@ const ModelPickerModal: Component<Props> = (props) => {
                               {(role) => <span class="routing-modal__role-tag">{role()}</span>}
                             </Show>
                           </span>
-                          <ModelCapabilityBadges
-                            capabilities={model.pricing.capabilities}
+                        </span>
+                        <span class="routing-modal__model-cell">
+                          <span class="routing-modal__model-cell-label">Capabilities</span>
+                          <Show
+                            when={actionCapabilitiesFor(model.pricing).length > 0}
+                            fallback={
+                              <span
+                                class="model-capability-badges model-capability-badges--compact"
+                                aria-label="No stream or tools"
+                              />
+                            }
+                          >
+                            <ModelCapabilityBadges
+                              capabilities={actionCapabilitiesFor(model.pricing)}
+                              compact
+                              iconOnly
+                            />
+                          </Show>
+                        </span>
+                        <span class="routing-modal__model-cell">
+                          <span class="routing-modal__model-cell-label">Input</span>
+                          <ModelModalityBadges
+                            modalities={inputModalitiesFor(model.pricing)}
+                            direction="input"
                             compact
                             iconOnly
                           />
                         </span>
-                        <Show
-                          when={isPaid()}
-                          fallback={
-                            <span class="routing-modal__model-price">
-                              {isLocal()
-                                ? 'Runs on your machine'
-                                : (formatPerRequestCost(model.pricing.cost_per_request) ??
-                                  'Included in subscription')}
-                            </span>
-                          }
-                        >
-                          <Show when={model.pricing}>
-                            {(p) => (
+                        <span class="routing-modal__model-cell">
+                          <span class="routing-modal__model-cell-label">Output</span>
+                          <ModelModalityBadges
+                            modalities={outputModalitiesFor(model.pricing)}
+                            direction="output"
+                            compact
+                            iconOnly
+                          />
+                        </span>
+                        <span class="routing-modal__model-cell routing-modal__model-cell--price">
+                          <span class="routing-modal__model-cell-label">Price</span>
+                          <Show
+                            when={isPaid()}
+                            fallback={
                               <span class="routing-modal__model-price">
-                                {pricePerM(p().input_price_per_token)} in ·{' '}
-                                {pricePerM(p().output_price_per_token)} out
+                                {isLocal()
+                                  ? 'Runs on your machine'
+                                  : (formatPerRequestCost(model.pricing.cost_per_request) ??
+                                    'Included in subscription')}
                               </span>
-                            )}
+                            }
+                          >
+                            <Show when={model.pricing}>
+                              {(p) => (
+                                <span class="routing-modal__model-price">
+                                  {pricePerM(p().input_price_per_token)} in ·{' '}
+                                  {pricePerM(p().output_price_per_token)} out
+                                </span>
+                              )}
+                            </Show>
                           </Show>
-                        </Show>
+                        </span>
                       </button>
                     );
                   }}

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -1,13 +1,14 @@
 import type {
   AuthType,
   ModelCapability,
+  ModelModality,
   ModelRoute,
   ResponseMode,
   OutputModality,
 } from 'manifest-shared';
 import { BASE_URL, fetchJson, fetchMutate, parseErrorMessage, routingPath } from './core.js';
 
-export type { AuthType, ModelCapability, ModelRoute, ResponseMode, OutputModality };
+export type { AuthType, ModelCapability, ModelModality, ModelRoute, ResponseMode, OutputModality };
 
 export interface RoutingProvider {
   id: string;
@@ -297,6 +298,8 @@ export interface AvailableModel {
   capability_reasoning: boolean;
   capability_code: boolean;
   capabilities?: ModelCapability[];
+  input_modalities?: ModelModality[];
+  output_modalities?: ModelModality[];
   quality_score: number;
   display_name?: string;
   provider_display_name?: string;

--- a/packages/frontend/src/styles/routing-modal.css
+++ b/packages/frontend/src/styles/routing-modal.css
@@ -1,4 +1,14 @@
 /* ── Model picker modal ───────────────────────────── */
+.routing-modal__card {
+  --routing-modal-model-grid: minmax(0, 1fr) 88px 72px 72px 172px;
+
+  max-width: 760px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  max-height: 80vh;
+}
+
 .routing-modal__header {
   display: flex;
   align-items: flex-start;
@@ -159,6 +169,31 @@
   border-top: 1px solid hsl(var(--border));
 }
 
+.routing-modal__table-head {
+  display: grid;
+  grid-template-columns: var(--routing-modal-model-grid);
+  align-items: center;
+  gap: 12px;
+  padding: 8px 24px 8px 48px;
+  border-bottom: 1px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.routing-modal__table-head > span:not(:first-child) {
+  justify-self: center;
+  text-align: center;
+}
+
+.routing-modal__table-head > span:last-child {
+  justify-self: end;
+  text-align: right;
+}
+
 .routing-modal__group {
   border-bottom: 1px solid hsl(var(--border));
 }
@@ -234,10 +269,10 @@
 }
 
 .routing-modal__model {
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--routing-modal-model-grid);
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  gap: 12px;
   width: 100%;
   padding: 9px 24px 9px 48px;
   background: none;
@@ -249,7 +284,7 @@
   transition: background var(--transition-fast);
 }
 
-.routing-modal__model:first-child {
+.routing-modal__group-header + .routing-modal__model {
   border-top: none;
 }
 
@@ -275,14 +310,13 @@
 }
 
 .routing-modal__model-left {
-  display: flex;
+  display: block;
   align-items: center;
-  gap: 8px;
   min-width: 0;
-  flex: 1 1 0;
 }
 
 .routing-modal__model-label {
+  display: block;
   min-width: 0;
   font-size: var(--font-size-sm);
   font-weight: 500;
@@ -290,6 +324,31 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.routing-modal__model-cell {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+
+.routing-modal__model-cell--price {
+  justify-content: flex-end;
+}
+
+.routing-modal__model-cell .model-modality-badges {
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.routing-modal__model-cell-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
 }
 
 .routing-modal__model-price {
@@ -416,7 +475,48 @@
 }
 
 @media (max-width: 640px) {
+  .routing-modal__card {
+    max-width: calc(100vw - 24px);
+  }
+
+  .routing-modal__table-head {
+    display: none;
+  }
+
   .routing-modal__model {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+    gap: 8px;
     padding: 10px 16px 10px 48px;
+  }
+
+  .routing-modal__model-cell {
+    justify-content: flex-start;
+    gap: 6px;
+  }
+
+  .routing-modal__model-cell--price {
+    justify-content: flex-start;
+  }
+
+  .routing-modal__model-cell-label {
+    position: static;
+    width: 72px;
+    height: auto;
+    overflow: visible;
+    clip: auto;
+    flex-shrink: 0;
+    color: hsl(var(--muted-foreground));
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .routing-modal__model-price {
+    white-space: normal;
+    text-align: left;
   }
 }

--- a/packages/frontend/tests/components/ModelCapabilityBadges.test.tsx
+++ b/packages/frontend/tests/components/ModelCapabilityBadges.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@solidjs/testing-library';
 import { describe, expect, it } from 'vitest';
 
-import ModelCapabilityBadges from '../../src/components/ModelCapabilityBadges';
+import ModelCapabilityBadges, {
+  ModelModalityBadges,
+} from '../../src/components/ModelCapabilityBadges';
 
 describe('ModelCapabilityBadges', () => {
   it('labels supported capabilities as read-only model metadata', () => {
@@ -27,5 +29,24 @@ describe('ModelCapabilityBadges', () => {
 
     expect(screen.getByLabelText('Capabilities unknown')).toBeTruthy();
     expect(container.querySelector('.model-capability-badge--unknown')).toBeTruthy();
+  });
+
+  it('labels input modalities separately from capabilities', () => {
+    const { container } = render(() => (
+      <ModelModalityBadges modalities={['text', 'image']} direction="input" iconOnly />
+    ));
+
+    expect(screen.getByLabelText('Input: Text, Image')).toBeTruthy();
+    const tooltips = Array.from(container.querySelectorAll('.model-modality-badge')).map((badge) =>
+      badge.getAttribute('data-tooltip'),
+    );
+    expect(tooltips).toEqual(['Text', 'Image']);
+    expect(screen.queryByText('Stream')).toBeNull();
+  });
+
+  it('labels output modalities separately from capabilities', () => {
+    render(() => <ModelModalityBadges modalities={['text']} direction="output" iconOnly />);
+
+    expect(screen.getByLabelText('Output: Text')).toBeTruthy();
   });
 });

--- a/packages/frontend/tests/components/ModelPickerModal.test.tsx
+++ b/packages/frontend/tests/components/ModelPickerModal.test.tsx
@@ -1068,7 +1068,12 @@ describe('ModelPickerModal', () => {
     const modelsWithCapabilities: AvailableModel[] = [
       { ...baseModels[0]!, capabilities: ['text', 'stream', 'tools'] },
       { ...baseModels[1]!, capabilities: ['text', 'stream'] },
-      { ...baseModels[2]!, capabilities: ['text', 'image'], auth_type: 'api_key', provider: 'OpenAI' },
+      {
+        ...baseModels[2]!,
+        capabilities: ['text', 'image'],
+        auth_type: 'api_key',
+        provider: 'OpenAI',
+      },
     ];
 
     it('renders capability filter pills for capabilities present in the model list', () => {
@@ -1082,12 +1087,14 @@ describe('ModelPickerModal', () => {
           onClose={vi.fn()}
         />
       ));
-      const pills = container.querySelectorAll('.routing-modal__filter-right .routing-modal__cap-pill');
-      // Should have pills for stream, tools, image (the caps found in models)
+      const pills = container.querySelectorAll(
+        '.routing-modal__filter-right .routing-modal__cap-pill',
+      );
+      // Modalities are shown in the row columns; filter pills stay action-focused.
       const pillTexts = Array.from(pills).map((p) => p.textContent?.trim());
       expect(pillTexts.some((t) => t?.includes('Stream'))).toBe(true);
       expect(pillTexts.some((t) => t?.includes('Tools'))).toBe(true);
-      expect(pillTexts.some((t) => t?.includes('Image'))).toBe(true);
+      expect(pillTexts.some((t) => t?.includes('Image'))).toBe(false);
     });
 
     it('toggles a capability filter on and off when clicking a pill', () => {
@@ -1101,9 +1108,13 @@ describe('ModelPickerModal', () => {
           onClose={vi.fn()}
         />
       ));
-      const pills = container.querySelectorAll('.routing-modal__filter-right .routing-modal__cap-pill');
+      const pills = container.querySelectorAll(
+        '.routing-modal__filter-right .routing-modal__cap-pill',
+      );
       // Find the "Tools" pill
-      const toolsPill = Array.from(pills).find((p) => p.textContent?.includes('Tools')) as HTMLButtonElement;
+      const toolsPill = Array.from(pills).find((p) =>
+        p.textContent?.includes('Tools'),
+      ) as HTMLButtonElement;
       expect(toolsPill).toBeDefined();
       // Toggle on
       fireEvent.click(toolsPill);
@@ -1128,11 +1139,38 @@ describe('ModelPickerModal', () => {
           onClose={vi.fn()}
         />
       ));
-      const pills = container.querySelectorAll('.routing-modal__filter-right .routing-modal__cap-pill');
-      // stream, tools, image should be present (text is not in capOrder so it is filtered out)
-      // audio and video are not in any model so they are not shown
-      expect(pills.length).toBe(3);
+      const pills = container.querySelectorAll(
+        '.routing-modal__filter-right .routing-modal__cap-pill',
+      );
+      expect(pills.length).toBe(2);
     });
+  });
+
+  it('renders capabilities, input modalities, and output modalities as separate columns', () => {
+    const { container } = render(() => (
+      <ModelPickerModal
+        tierId="simple"
+        models={[
+          {
+            ...baseModels[0]!,
+            capabilities: ['text', 'image', 'stream', 'tools'],
+            input_modalities: ['text', 'image'],
+            output_modalities: ['text'],
+          },
+        ]}
+        tiers={tiers}
+        connectedProviders={apiKeyOnly}
+        onSelect={vi.fn()}
+        onClose={vi.fn()}
+      />
+    ));
+
+    expect(container.querySelector('.routing-modal__table-head')?.textContent).toContain(
+      'Capabilities',
+    );
+    expect(container.querySelector('[aria-label="Capabilities: Stream, Tools"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Input: Text, Image"]')).toBeTruthy();
+    expect(container.querySelector('[aria-label="Output: Text"]')).toBeTruthy();
   });
 
   it('clicks the Local tab when local + api_key are both connected', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -50,6 +50,7 @@ export {
   isParamApplicability,
   isProviderParamPath,
   MODEL_CAPABILITIES,
+  MODEL_MODALITIES,
   normalizeProviderParamProviderId,
   omitProviderInapplicableParams,
   pickProviderCompatibleParams,
@@ -59,6 +60,7 @@ export {
 } from './provider-params-spec';
 export type {
   ModelCapability,
+  ModelModality,
   ModelParamGroup,
   ModelParamDefinition,
   ModelParamRange,

--- a/packages/shared/src/provider-params-spec.ts
+++ b/packages/shared/src/provider-params-spec.ts
@@ -3,7 +3,11 @@ import { resolveUnderlyingModelIdentity, underlyingGatewayModel } from './provid
 import { normalizeProviderName, SHARED_PROVIDER_BY_ID_OR_ALIAS } from './providers';
 import type { JsonPrimitive, JsonValue } from './request-params';
 
-export const MODEL_CAPABILITIES = ['text', 'image', 'audio', 'video', 'stream', 'tools'] as const;
+export const MODEL_MODALITIES = ['text', 'image', 'audio', 'video'] as const;
+
+export type ModelModality = (typeof MODEL_MODALITIES)[number];
+
+export const MODEL_CAPABILITIES = [...MODEL_MODALITIES, 'stream', 'tools'] as const;
 
 export type ModelCapability = (typeof MODEL_CAPABILITIES)[number];
 


### PR DESCRIPTION
### ✨ What changed
- Split Stream and Tools from modality badges in the model picker.
- Added Input and Output columns with Text, Image, Audio, Video icons.
- Plumbed input/output modalities through discovery and `/available-models`.
- Kept output modalities text-only until Manifest supports more outputs.
- Added focused backend and frontend coverage.

### 💭 Why
Capabilities and modalities describe different things. The selector now matches that shape and leaves room for non-text outputs later.

### 👤 For users
The model picker is easier to scan across providers.

### 📝 Notes
- Current manifests still report text output only.
- Local run is active on `http://localhost:3000`.
- Validated with focused tests, builds, lint, changeset status, and `git diff --check`.
