### PR TITLE
fix(proxy): emit full Responses API lifecycle for /v1/responses over Chat Completions upstreams (#2064)

### DIFF
--- a/.changeset/fix-responses-stream-lifecycle.md
+++ b/.changeset/fix-responses-stream-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix `/v1/responses` streaming to emit the full OpenAI Responses API event lifecycle when bridging a Chat Completions upstream. The converter now opens a message item and content part (`response.output_item.added` / `response.content_part.added`) before the text deltas and closes them (`response.output_text.done` / `response.content_part.done` / `response.output_item.done`) with a populated `response.completed`, instead of emitting bare `output_text.delta` + `response.completed{output:[]}`. Strict Responses API clients (Pi, OpenClaw-style) previously dropped the deltas and rendered empty assistant messages.

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -851,15 +851,22 @@ describe('proxy-response-handler', () => {
       );
     });
 
-    it('should convert chat completion streams when serving Responses clients', async () => {
+    it('should convert chat completion streams into the full Responses lifecycle (issue #2064)', async () => {
       const { res } = mockResponse();
       const forward = mockForward();
       const client = mockProviderClient();
       const meta = makeMeta();
       let capturedTransform: ((chunk: string) => string | null) | undefined;
+      let capturedFinalize: (() => string | null) | undefined;
       pipeStreamSpy.mockImplementation(
-        async (_body: unknown, _res: unknown, transform?: (chunk: string) => string | null) => {
+        async (
+          _body: unknown,
+          _res: unknown,
+          transform?: (chunk: string) => string | null,
+          finalize?: () => string | null,
+        ) => {
           capturedTransform = transform;
+          capturedFinalize = finalize;
           return null;
         },
       );
@@ -876,11 +883,24 @@ describe('proxy-response-handler', () => {
         'responses',
       );
 
+      // The converter must be stateful: the message item + content part are
+      // opened ahead of the first delta so strict clients keep the text.
       expect(capturedTransform).toBeDefined();
-      const converted = capturedTransform!(
+      const opened = capturedTransform!(
         'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}\n\n',
-      );
-      expect(converted).toContain('event: response.output_text.delta');
+      )!;
+      expect(opened).toContain('event: response.output_item.added');
+      expect(opened).toContain('event: response.content_part.added');
+      expect(opened).toContain('event: response.output_text.delta');
+
+      // finalize must close the item and terminate the stream itself, since
+      // pipeStream skips its own [DONE] when a finalize is supplied.
+      expect(capturedFinalize).toBeDefined();
+      const tail = capturedFinalize!()!;
+      expect(tail).toContain('event: response.output_item.done');
+      expect(tail).toContain('event: response.completed');
+      expect(tail).toContain('"text":"Hi"');
+      expect(tail.trimEnd().endsWith('data: [DONE]')).toBe(true);
     });
 
     it('should cache thought_signatures from Google stream chunks', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -1,10 +1,46 @@
 import {
-  chatCompletionStreamChunkToResponses,
   collectResponsesSseResponse,
+  createResponsesStreamTransformer,
   fromChatCompletionResponse,
   toChatCompletionsRequest,
   toNativeResponsesRequest,
 } from '../responses-adapter';
+
+/** Ordered list of every event payload's `type` in a concatenated SSE string. */
+function eventTypes(sse: string): string[] {
+  const types: string[] = [];
+  for (const line of sse.split('\n')) {
+    if (!line.startsWith('data: ')) continue;
+    const json = line.slice(6).trim();
+    if (json === '[DONE]') {
+      types.push('[DONE]');
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(json);
+      if (typeof parsed?.type === 'string') types.push(parsed.type);
+    } catch {
+      /* ignore */
+    }
+  }
+  return types;
+}
+
+/** Parses the data payload of the first event with the given `type`. */
+function firstEventData(sse: string, type: string): Record<string, any> | null {
+  for (const line of sse.split('\n')) {
+    if (!line.startsWith('data: ')) continue;
+    const json = line.slice(6).trim();
+    if (json === '[DONE]') continue;
+    try {
+      const parsed = JSON.parse(json);
+      if (parsed?.type === type) return parsed;
+    } catch {
+      /* ignore */
+    }
+  }
+  return null;
+}
 
 describe('Responses adapter', () => {
   describe('toChatCompletionsRequest', () => {
@@ -606,48 +642,136 @@ describe('Responses adapter', () => {
     });
   });
 
-  describe('chatCompletionStreamChunkToResponses', () => {
-    it('converts chat completion content deltas to Responses SSE events', () => {
-      const result = chatCompletionStreamChunkToResponses(
-        'data: {"choices":[{"delta":{"content":"Hi"},"finish_reason":null}]}\n\n',
-      );
+  describe('createResponsesStreamTransformer', () => {
+    it('opens the message item and content part before the first text delta', () => {
+      const t = createResponsesStreamTransformer('gpt-4o');
+      const out =
+        t.transform('{"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}') ?? '';
 
-      expect(result).toContain('event: response.output_text.delta');
-      expect(result).toContain('"delta":"Hi"');
+      // Lifecycle envelope must precede the delta so strict Responses clients
+      // (Pi/OpenClaw) accept the text instead of rendering an empty message.
+      expect(eventTypes(out)).toEqual([
+        'response.created',
+        'response.in_progress',
+        'response.output_item.added',
+        'response.content_part.added',
+        'response.output_text.delta',
+      ]);
+
+      const added = firstEventData(out, 'response.output_item.added')!;
+      expect(added.item).toMatchObject({
+        type: 'message',
+        role: 'assistant',
+        status: 'in_progress',
+      });
+      expect(added.item.content).toEqual([]);
+
+      // The delta must reference the same item_id the item was opened with.
+      const delta = firstEventData(out, 'response.output_text.delta')!;
+      expect(delta.item_id).toBe(added.item.id);
+      expect(delta.delta).toBe('Hello');
     });
 
-    it('converts finish chunks to response.completed events', () => {
-      const result = chatCompletionStreamChunkToResponses(
-        JSON.stringify({
-          model: 'gpt-4o',
-          choices: [{ delta: {}, finish_reason: 'stop' }],
-          usage: { prompt_tokens: 1, completion_tokens: 2, total_tokens: 3 },
+    it('opens the item exactly once across multiple deltas', () => {
+      const t = createResponsesStreamTransformer('gpt-4o');
+      t.transform('{"choices":[{"delta":{"content":"Hel"}}]}');
+      const second = t.transform('{"choices":[{"delta":{"content":"lo"}}]}') ?? '';
+
+      expect(eventTypes(second)).toEqual(['response.output_text.delta']);
+      expect(firstEventData(second, 'response.output_text.delta')!.delta).toBe('lo');
+    });
+
+    it('closes the part and item and emits a populated completed event with [DONE]', () => {
+      const t = createResponsesStreamTransformer('gpt-4o');
+      const opened = t.transform('{"choices":[{"delta":{"content":"Hello"}}]}') ?? '';
+      t.transform('{"choices":[{"delta":{"content":"!"}}]}');
+      const tail =
+        t.transform(
+          '{"model":"gpt-4o","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1576,"completion_tokens":32,"total_tokens":1608}}',
+        ) ?? '';
+      const end = t.finalize() ?? '';
+
+      expect(eventTypes(end)).toEqual([
+        'response.output_text.done',
+        'response.content_part.done',
+        'response.output_item.done',
+        'response.completed',
+        '[DONE]',
+      ]);
+
+      const itemId = firstEventData(opened, 'response.output_item.added')!.item.id;
+      const textDone = firstEventData(end, 'response.output_text.done')!;
+      expect(textDone.text).toBe('Hello!');
+      expect(textDone.item_id).toBe(itemId);
+
+      const itemDone = firstEventData(end, 'response.output_item.done')!;
+      expect(itemDone.item.id).toBe(itemId);
+      expect(itemDone.item.status).toBe('completed');
+      expect(itemDone.item.content).toEqual([
+        { type: 'output_text', text: 'Hello!', annotations: [] },
+      ]);
+
+      // The completed event must carry the assembled message in `output`
+      // (the bug: it shipped `output: []`), plus usage and a matching id.
+      const completed = firstEventData(end, 'response.completed')!;
+      expect(completed.response.status).toBe('completed');
+      expect(completed.response.output).toEqual([
+        expect.objectContaining({
+          id: itemId,
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello!', annotations: [] }],
         }),
-      );
-
-      expect(result).toContain('event: response.completed');
-      expect(result).toContain('"input_tokens":1');
+      ]);
+      expect(completed.response.usage).toMatchObject({
+        input_tokens: 1576,
+        output_tokens: 32,
+        total_tokens: 1608,
+      });
+      // `finish_reason` chunk carried no text delta, so the tail before finalize
+      // is empty.
+      expect(tail).toBe('');
     });
 
-    it('converts usage-only stream chunks to response.completed events', () => {
-      const result = chatCompletionStreamChunkToResponses(
-        JSON.stringify({
-          model: 'gpt-4o',
-          choices: [],
-          usage: { prompt_tokens: 5, completion_tokens: 7, total_tokens: 12 },
-        }),
-      );
+    it('emits no item events and an empty output for usage-only streams', () => {
+      const t = createResponsesStreamTransformer('gpt-4o');
+      const out =
+        t.transform(
+          '{"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":0,"total_tokens":5}}',
+        ) ?? '';
+      const end = t.finalize() ?? '';
 
-      expect(result).toContain('event: response.completed');
-      expect(result).toContain('"input_tokens":5');
-      expect(result).toContain('"output_tokens":7');
+      expect(eventTypes(out)).toEqual(['response.created', 'response.in_progress']);
+      expect(eventTypes(end)).toEqual(['response.completed', '[DONE]']);
+      expect(firstEventData(end, 'response.completed')!.response.output).toEqual([]);
+      expect(firstEventData(end, 'response.completed')!.response.usage).toMatchObject({
+        input_tokens: 5,
+      });
     });
 
-    it('ignores done, empty, malformed, and irrelevant chunks', () => {
-      expect(chatCompletionStreamChunkToResponses('data: [DONE]\n\n')).toBeNull();
-      expect(chatCompletionStreamChunkToResponses('')).toBeNull();
-      expect(chatCompletionStreamChunkToResponses('data: not-json\n\n')).toBeNull();
-      expect(chatCompletionStreamChunkToResponses('{"choices":[]}')).toBeNull();
+    it('still emits created, completed, and [DONE] when the stream is empty', () => {
+      const t = createResponsesStreamTransformer('gpt-4o');
+      const end = t.finalize() ?? '';
+
+      expect(eventTypes(end)).toEqual([
+        'response.created',
+        'response.in_progress',
+        'response.completed',
+        '[DONE]',
+      ]);
+    });
+
+    it('finalize is idempotent and returns null after the stream is closed', () => {
+      const t = createResponsesStreamTransformer('gpt-4o');
+      expect(t.finalize()).not.toBeNull();
+      expect(t.finalize()).toBeNull();
+    });
+
+    it('ignores done, empty, malformed, and irrelevant payloads', () => {
+      const t = createResponsesStreamTransformer('gpt-4o');
+      expect(t.transform('data: [DONE]\n\n')).toBeNull();
+      expect(t.transform('')).toBeNull();
+      expect(t.transform('data: not-json\n\n')).toBeNull();
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -788,6 +788,9 @@ describe('Responses adapter', () => {
         const completed = firstEventData(end, 'response.completed')!;
         expect(completed.response.id).toBe(created.response.id);
         expect(completed.response.created_at).toBe(created.response.created_at);
+        // completed_at must reflect the actual finalize time, not the
+        // stream-start timestamp reused for created_at.
+        expect(completed.response.completed_at).toBeGreaterThan(completed.response.created_at);
       } finally {
         nowSpy.mockRestore();
       }

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -773,5 +773,24 @@ describe('Responses adapter', () => {
       expect(t.transform('')).toBeNull();
       expect(t.transform('data: not-json\n\n')).toBeNull();
     });
+
+    it('keeps created_at stable across created and completed as the clock advances', () => {
+      // Advance the wall clock on every Date.now() so a re-derived timestamp
+      // would drift between the opening and closing snapshots of the same id.
+      let now = 1_700_000_000_000;
+      const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => (now += 1000));
+      try {
+        const t = createResponsesStreamTransformer('gpt-4o');
+        const opened = t.transform('{"choices":[{"delta":{"content":"Hi"}}]}') ?? '';
+        const end = t.finalize() ?? '';
+
+        const created = firstEventData(opened, 'response.created')!;
+        const completed = firstEventData(end, 'response.completed')!;
+        expect(completed.response.id).toBe(created.response.id);
+        expect(completed.response.created_at).toBe(created.response.created_at);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
   });
 });

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -15,8 +15,8 @@ import {
 } from './stream-writer';
 import { sanitizeProviderError } from './proxy-error-sanitizer';
 import {
-  chatCompletionStreamChunkToResponses,
   collectResponsesSseResponse,
+  createResponsesStreamTransformer,
   fromChatCompletionResponse,
 } from './responses-adapter';
 import {
@@ -296,13 +296,18 @@ export async function handleStreamResponse(
 
   const messagesTransformer =
     apiMode === 'messages' ? createMessagesStreamTransformer(meta.model) : null;
-  const finalize = messagesTransformer ? () => messagesTransformer.finalize() : undefined;
-  const toClientChunk =
-    apiMode === 'responses'
-      ? chatCompletionStreamChunkToResponses
-      : messagesTransformer
-        ? messagesTransformer.transform
-        : (chunk: string) => chunk;
+  // Responses inbound over a Chat Completions upstream needs a stateful
+  // converter so the message-item lifecycle events frame the text deltas
+  // (issue #2064). It shares the messages transformer's {transform, finalize}
+  // shape, and likewise owns stream termination via `finalize` (which emits
+  // the trailing `[DONE]` that pipeStream then skips).
+  const responsesTransformer =
+    apiMode === 'responses' ? createResponsesStreamTransformer(meta.model) : null;
+  const streamTransformer = messagesTransformer ?? responsesTransformer;
+  const finalize = streamTransformer ? () => streamTransformer.finalize() : undefined;
+  const toClientChunk = streamTransformer
+    ? (chunk: string) => streamTransformer.transform(chunk)
+    : (chunk: string) => chunk;
 
   if (apiMode === 'responses' && forward.isResponses) {
     return pipeStream(forward.response.body!, res, undefined, undefined, onClient);

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -499,65 +499,194 @@ function safeParse(data: string): JsonRecord | null {
   }
 }
 
-export function chatCompletionStreamChunkToResponses(chunk: string): string | null {
-  const payloads = extractDataPayloads(chunk);
+export interface ResponsesStreamTransformer {
+  transform: (chunk: string) => string | null;
+  finalize: () => string | null;
+}
+
+interface ResponsesStreamState {
+  responseId: string;
+  itemId: string;
+  model: string;
+  usage: unknown;
+  text: string;
+  createdEmitted: boolean;
+  itemOpened: boolean;
+  completed: boolean;
+}
+
+/**
+ * Converts an upstream Chat Completions SSE stream into a spec-compliant
+ * OpenAI Responses API event stream.
+ *
+ * Unlike a per-chunk mapper, this is stateful: the Responses API requires a
+ * message item and content part to be *opened* (`response.output_item.added`
+ * + `response.content_part.added`) before any `response.output_text.delta`,
+ * and *closed* (`...output_text.done` / `...content_part.done` /
+ * `...output_item.done`) before `response.completed`. Strict clients (Pi,
+ * OpenClaw-style) silently drop text deltas that arrive without an open item,
+ * which surfaced as empty assistant messages (issue #2064).
+ *
+ * `transform` runs per upstream event; `finalize` closes the stream and emits
+ * the terminal `data: [DONE]`. When a `finalize` is supplied, `pipeStream`
+ * delegates termination to it (it does not add its own `[DONE]`).
+ */
+export function createResponsesStreamTransformer(model: string): ResponsesStreamTransformer {
+  const state: ResponsesStreamState = {
+    responseId: `resp_${randomUUID().replace(/-/g, '')}`,
+    itemId: `msg_${randomUUID().replace(/-/g, '')}`,
+    model,
+    usage: undefined,
+    text: '',
+    createdEmitted: false,
+    itemOpened: false,
+    completed: false,
+  };
+
+  return {
+    transform: (chunk: string) => transformResponsesStreamChunk(chunk, state),
+    finalize: () => finalizeResponsesStream(state),
+  };
+}
+
+function inProgressResponse(state: ResponsesStreamState): JsonRecord {
+  const response = fromChatCompletionResponse(
+    { model: state.model, choices: [{ message: { content: '' } }] },
+    state.model,
+  );
+  response.id = state.responseId;
+  response.status = 'in_progress';
+  response.completed_at = null;
+  response.usage = null;
+  return response;
+}
+
+function emitCreated(state: ResponsesStreamState): string[] {
+  if (state.createdEmitted) return [];
+  state.createdEmitted = true;
+  const response = inProgressResponse(state);
+  return [
+    formatResponsesEvent('response.created', { type: 'response.created', response }),
+    formatResponsesEvent('response.in_progress', { type: 'response.in_progress', response }),
+  ];
+}
+
+function emitItemOpen(state: ResponsesStreamState): string[] {
+  if (state.itemOpened) return [];
+  state.itemOpened = true;
+  return [
+    formatResponsesEvent('response.output_item.added', {
+      type: 'response.output_item.added',
+      output_index: 0,
+      item: {
+        id: state.itemId,
+        type: 'message',
+        status: 'in_progress',
+        role: 'assistant',
+        content: [],
+      },
+    }),
+    formatResponsesEvent('response.content_part.added', {
+      type: 'response.content_part.added',
+      item_id: state.itemId,
+      output_index: 0,
+      content_index: 0,
+      part: { type: 'output_text', text: '', annotations: [] },
+    }),
+  ];
+}
+
+function transformResponsesStreamChunk(chunk: string, state: ResponsesStreamState): string | null {
   const events: string[] = [];
 
-  for (const payload of payloads) {
+  for (const payload of extractDataPayloads(chunk)) {
     if (payload === '[DONE]') continue;
     const data = safeParse(payload);
     if (!data) continue;
-    const choices = Array.isArray(data.choices) ? data.choices : [];
-    if (choices.length === 0 && isRecord(data.usage)) {
-      events.push(
-        formatResponsesEvent('response.completed', {
-          type: 'response.completed',
-          response: fromChatCompletionResponse(
-            {
-              model: typeof data.model === 'string' ? data.model : undefined,
-              usage: data.usage,
-              choices: [{ message: { content: '' } }],
-            },
-            typeof data.model === 'string' ? data.model : 'unknown',
-          ),
-        }),
-      );
-      continue;
-    }
 
+    if (typeof data.model === 'string') state.model = data.model;
+    if (isRecord(data.usage)) state.usage = data.usage;
+
+    events.push(...emitCreated(state));
+
+    const choices = Array.isArray(data.choices) ? data.choices : [];
     const choice = isRecord(choices[0]) ? choices[0] : null;
     const delta = isRecord(choice?.delta) ? choice.delta : {};
 
     if (typeof delta.content === 'string' && delta.content.length > 0) {
+      events.push(...emitItemOpen(state));
+      state.text += delta.content;
       events.push(
         formatResponsesEvent('response.output_text.delta', {
           type: 'response.output_text.delta',
-          item_id: 'msg_0',
+          item_id: state.itemId,
           output_index: 0,
           content_index: 0,
           delta: delta.content,
         }),
       );
     }
-
-    if (choice?.finish_reason) {
-      events.push(
-        formatResponsesEvent('response.completed', {
-          type: 'response.completed',
-          response: fromChatCompletionResponse(
-            {
-              model: typeof data.model === 'string' ? data.model : undefined,
-              usage: data.usage,
-              choices: [{ message: { content: '' } }],
-            },
-            typeof data.model === 'string' ? data.model : 'unknown',
-          ),
-        }),
-      );
-    }
   }
 
   return events.length > 0 ? events.join('') : null;
+}
+
+function finalizeResponsesStream(state: ResponsesStreamState): string | null {
+  if (state.completed) return null;
+  state.completed = true;
+
+  const events: string[] = [...emitCreated(state)];
+
+  if (state.itemOpened) {
+    events.push(
+      formatResponsesEvent('response.output_text.done', {
+        type: 'response.output_text.done',
+        item_id: state.itemId,
+        output_index: 0,
+        content_index: 0,
+        text: state.text,
+      }),
+      formatResponsesEvent('response.content_part.done', {
+        type: 'response.content_part.done',
+        item_id: state.itemId,
+        output_index: 0,
+        content_index: 0,
+        part: { type: 'output_text', text: state.text, annotations: [] },
+      }),
+      formatResponsesEvent('response.output_item.done', {
+        type: 'response.output_item.done',
+        output_index: 0,
+        item: {
+          id: state.itemId,
+          type: 'message',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: state.text, annotations: [] }],
+        },
+      }),
+    );
+  }
+
+  const response = fromChatCompletionResponse(
+    {
+      model: state.model,
+      usage: isRecord(state.usage) ? state.usage : undefined,
+      choices: [{ message: { content: state.text } }],
+    },
+    state.model,
+  );
+  response.id = state.responseId;
+  if (state.itemOpened && Array.isArray(response.output)) {
+    const message = response.output.find((item) => isRecord(item) && item.type === 'message');
+    if (isRecord(message)) message.id = state.itemId;
+  }
+
+  events.push(
+    formatResponsesEvent('response.completed', { type: 'response.completed', response }),
+    'data: [DONE]\n\n',
+  );
+
+  return events.join('');
 }
 
 function extractDataPayloads(chunk: string): string[] {

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -508,6 +508,7 @@ interface ResponsesStreamState {
   responseId: string;
   itemId: string;
   model: string;
+  createdAt: number;
   usage: unknown;
   text: string;
   createdEmitted: boolean;
@@ -536,6 +537,10 @@ export function createResponsesStreamTransformer(model: string): ResponsesStream
     responseId: `resp_${randomUUID().replace(/-/g, '')}`,
     itemId: `msg_${randomUUID().replace(/-/g, '')}`,
     model,
+    // Stamp the creation time once so every response snapshot for this id
+    // (`response.created`, `.in_progress`, `.completed`) reports the same
+    // `created_at`, even on streams that span more than one second.
+    createdAt: Math.floor(Date.now() / 1000),
     usage: undefined,
     text: '',
     createdEmitted: false,
@@ -551,7 +556,7 @@ export function createResponsesStreamTransformer(model: string): ResponsesStream
 
 function inProgressResponse(state: ResponsesStreamState): JsonRecord {
   const response = fromChatCompletionResponse(
-    { model: state.model, choices: [{ message: { content: '' } }] },
+    { model: state.model, created: state.createdAt, choices: [{ message: { content: '' } }] },
     state.model,
   );
   response.id = state.responseId;
@@ -670,6 +675,7 @@ function finalizeResponsesStream(state: ResponsesStreamState): string | null {
   const response = fromChatCompletionResponse(
     {
       model: state.model,
+      created: state.createdAt,
       usage: isRecord(state.usage) ? state.usage : undefined,
       choices: [{ message: { content: state.text } }],
     },

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -682,6 +682,10 @@ function finalizeResponsesStream(state: ResponsesStreamState): string | null {
     state.model,
   );
   response.id = state.responseId;
+  // `created_at` is the stream-start stamp (shared across every snapshot for
+  // this id), but `completed_at` must reflect when the stream actually
+  // finished — fromChatCompletionResponse defaults it to `created`.
+  response.completed_at = Math.floor(Date.now() / 1000);
   if (state.itemOpened && Array.isArray(response.output)) {
     const message = response.output.find((item) => isRecord(item) && item.type === 'message');
     if (isRecord(message)) message.id = state.itemId;


### PR DESCRIPTION
Fixes #2064.

## Problem

When a client uses `/v1/responses` (`api: "openai-responses"`) but the routed upstream only speaks Chat Completions (llama.cpp, Groq, etc.), the SSE converter emitted only:

```
response.output_text.delta
response.completed        ← output: []
```

This is well-formed SSE, but it is **semantically incomplete** for the Responses API: a client must see a message item and content part *opened* before it will attach text. Strict Responses clients (Pi `@mariozechner/pi-coding-agent`, OpenClaw-style) therefore dropped every delta and rendered an **empty assistant message**, keeping only usage.

## Fix

Replace the stateless per-chunk converter with a stateful `createResponsesStreamTransformer(model)` (`{ transform, finalize }`, mirroring the Anthropic messages transformer) wired through `handleStreamResponse` for `apiMode === 'responses'`. It now emits the full lifecycle:

```
response.created
response.in_progress
response.output_item.added      ← opens the assistant message (once)
response.content_part.added     ← opens the output_text part (once)
response.output_text.delta ...
response.output_text.done
response.content_part.done
response.output_item.done        ← assembled message
response.completed               ← output populated + usage
data: [DONE]
```

Like the messages transformer, it owns stream termination via `finalize` (emits the trailing `[DONE]`, which `pipeStream` then skips). This also removes a latent duplicate `response.completed` the old path emitted (one on `finish_reason`, one on the usage chunk).

## Testing

- New unit tests for the transformer (lifecycle ordering, single-open invariant, populated `completed`, usage-only streams, empty stream, idempotent `finalize`, malformed payloads) + an expanded `handleStreamResponse` integration test asserting the client-facing bytes. Full backend suite green (5322 tests), 100% patch coverage, tsc/lint clean.
- **End-to-end against a real Groq (chat-completions) upstream**, using the actual `pi-coding-agent` client configured exactly as in the issue (`api: "openai-responses"`):

| | before (this fix) | after |
|---|---|---|
| Pi `text_start/delta/end` | none | present |
| assistant `content` | `[]` | `[{ "text": "Hello from pi." }]` |
| rendered output | **empty bubble** | **"Hello from pi."** |

Requests were attributed to the OpenClaw-platform agent in the dashboard, confirming the full chain: Pi → Manifest `/v1/responses` → tier routing → Groq → spec-compliant lifecycle stream back.