### PR TITLE
fix: show account labels on custom routing tiers

### DIFF
--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -364,6 +364,28 @@ describe('HeaderTierService', () => {
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
     });
 
+    it('persists keyLabel on explicit header-tier overrides', async () => {
+      const row = { id: 'h1', agent_id: 'agent-1', override_route: null } as HeaderTier;
+      repo.findOne.mockResolvedValue(row);
+
+      const result = await svc.setOverride(
+        'agent-1',
+        'h1',
+        'gpt-4o',
+        'openai',
+        'subscription',
+        'Personal',
+      );
+
+      expect(discoveryService.getModelsForAgent).not.toHaveBeenCalled();
+      expect(result.override_route).toEqual({
+        provider: 'openai',
+        authType: 'subscription',
+        model: 'gpt-4o',
+        keyLabel: 'Personal',
+      });
+    });
+
     it('resolves via discovery when only the model is given', async () => {
       const row = { id: 'h1', agent_id: 'agent-1', override_route: null } as HeaderTier;
       repo.findOne.mockResolvedValue(row);

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.spec.ts
@@ -114,6 +114,30 @@ describe('HeaderTierController', () => {
       'gpt-4o',
       'OpenAI',
       'api_key',
+      undefined,
+    );
+  });
+
+  it('setOverride forwards route keyLabel when present', async () => {
+    const { controller, service } = makeController();
+    await controller.setOverride(user, 'my-agent', 'ht-1', {
+      model: 'gpt-4o',
+      provider: 'OpenAI',
+      authType: 'api_key',
+      route: {
+        model: 'gpt-4o',
+        provider: 'openai',
+        authType: 'api_key',
+        keyLabel: 'Personal',
+      },
+    });
+    expect(service.setOverride).toHaveBeenCalledWith(
+      'agent-1',
+      'ht-1',
+      'gpt-4o',
+      'openai',
+      'api_key',
+      'Personal',
     );
   });
 

--- a/packages/backend/src/routing/header-tiers/header-tier.controller.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.controller.ts
@@ -16,14 +16,20 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  MaxLength,
   ValidateNested,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 import { CurrentUser } from '../../auth/current-user.decorator';
 import type { AuthUser } from '../../auth/auth.instance';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
-import { ModelRouteDto, SetResponseModeDto, responseModeFromDto } from '../dto/routing.dto';
+import {
+  MAX_PROVIDER_KEY_LABEL_LENGTH,
+  ModelRouteDto,
+  SetResponseModeDto,
+  responseModeFromDto,
+} from '../dto/routing.dto';
 import { HeaderTierService } from './header-tier.service';
 import { AUTH_TYPES, type TierColor } from 'manifest-shared';
 
@@ -58,6 +64,13 @@ class OverrideBody {
   @IsOptional()
   @IsIn(AUTH_TYPES)
   authType?: 'api_key' | 'subscription' | 'local';
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(MAX_PROVIDER_KEY_LABEL_LENGTH)
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  providerKeyLabel?: string;
 
   // Validate the nested route shape so a malformed payload can't bypass the
   // legacy field validators above by being smuggled in through `route`.
@@ -176,7 +189,15 @@ export class HeaderTierController {
     const model = body.route?.model ?? body.model;
     const provider = body.route?.provider ?? body.provider;
     const authType = body.route?.authType ?? body.authType;
-    return this.headerTierService.setOverride(agent.id, id, model, provider, authType);
+    const providerKeyLabel = body.route?.keyLabel ?? body.providerKeyLabel;
+    return this.headerTierService.setOverride(
+      agent.id,
+      id,
+      model,
+      provider,
+      authType,
+      providerKeyLabel,
+    );
   }
 
   @Delete(':agentName/header-tiers/:id/override')

--- a/packages/backend/src/routing/header-tiers/header-tier.service.ts
+++ b/packages/backend/src/routing/header-tiers/header-tier.service.ts
@@ -200,14 +200,19 @@ export class HeaderTierService {
     model: string,
     provider?: string,
     authType?: AuthType,
+    providerKeyLabel?: string | null,
   ): Promise<HeaderTier> {
     const row = await this.findOrThrow(agentId, id);
     // When the caller passes an explicit (provider, authType) the route is
     // already unambiguous — skip the discovery fetch.
-    const explicit = explicitRoute(model, provider, authType);
+    const explicit = explicitRoute(model, provider, authType, providerKeyLabel);
     const route =
       explicit ??
-      unambiguousRoute(model, await this.discoveryService.getModelsForAgent(row.agent_id));
+      unambiguousRoute(
+        model,
+        await this.discoveryService.getModelsForAgent(row.agent_id),
+        providerKeyLabel,
+      );
     assertStreamableResponseMode(
       row.response_mode,
       `custom tier "${row.name}"`,

--- a/packages/frontend/src/components/FallbackList.tsx
+++ b/packages/frontend/src/components/FallbackList.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, onCleanup, For, Show, type Component } from 'solid-js';
+import { createSignal, For, Show, type Component } from 'solid-js';
 import {
   clearFallbacks,
   setFallbacks,
@@ -9,7 +9,6 @@ import {
   type RequestParamDefaults,
   type ResponseMode,
   type RoutingProvider,
-  type TierAssignment,
 } from '../services/api.js';
 import { customProviderColor } from '../services/formatters.js';
 import { getModelLabel } from '../services/provider-utils.js';
@@ -17,18 +16,20 @@ import { PROVIDERS } from '../services/providers.js';
 import {
   resolveProviderId,
   stripCustomPrefix,
+  type RouteSlots,
   usedKeyLabelsForModelInTier,
 } from '../services/routing-utils.js';
 import { toast } from '../services/toast-store.js';
 import { authBadgeFor } from './AuthBadge.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
 import ModelParamsAffordance from './ModelParamsAffordance.jsx';
+import RouteKeyChip from './RouteKeyChip.js';
 import { modelParamsScopeForTier } from 'manifest-shared';
 
 interface FallbackListProps {
   agentName: string;
   tier: string;
-  tierData?: () => TierAssignment | undefined;
+  tierData?: () => RouteSlots | undefined;
   fallbacks: string[];
   // Optional structured route per fallback. When present (length matches
   // fallbacks), each row renders provider/auth from the route instead of
@@ -468,13 +469,20 @@ const FallbackList: Component<FallbackListProps> = (props) => {
                         <span class="routing-card__skipped-badge">Skipped in Stream</span>
                       </Show>
                       <Show when={keys().length > 1}>
-                        <FallbackKeyChip
+                        <RouteKeyChip
                           keys={keys()}
                           currentLabel={pinnedLabel() ?? undefined}
                           modelLabel={modelLabel(model())}
-                          modelName={model()}
-                          tier={props.tierData ?? (() => undefined)}
-                          fallbackIndex={i()}
+                          usedLabels={() =>
+                            usedKeyLabelsForModelInTier(
+                              (props.tierData ?? (() => undefined))(),
+                              model(),
+                              i(),
+                              keys()[0]?.label,
+                            )
+                          }
+                          buttonClass="fallback-list__key-chip"
+                          allowClear
                           onPick={(label) => setLabelAt(i(), label)}
                         />
                       </Show>
@@ -582,123 +590,6 @@ const FallbackList: Component<FallbackListProps> = (props) => {
         </Show>
       </Show>
     </div>
-  );
-};
-
-/**
- * Compact inline pill that shows the currently-pinned API key for a fallback
- * row and lets the user pick a different one. Renders only when the row's
- * provider has 2+ active keys, so single-key users never see it.
- */
-interface FallbackKeyChipProps {
-  keys: RoutingProvider[];
-  currentLabel: string | undefined;
-  modelLabel: string;
-  modelName: string;
-  tier: () => TierAssignment | undefined;
-  fallbackIndex: number;
-  onPick: (label: string | null) => void;
-}
-
-const FallbackKeyChip: Component<FallbackKeyChipProps> = (props) => {
-  const [open, setOpen] = createSignal(false);
-  let containerRef: HTMLSpanElement | undefined;
-  createEffect(() => {
-    if (open()) {
-      const handler = (e: MouseEvent) => {
-        if (containerRef && !containerRef.contains(e.target as Node)) setOpen(false);
-      };
-      document.addEventListener('mousedown', handler);
-      onCleanup(() => document.removeEventListener('mousedown', handler));
-    }
-  });
-  const displayLabel = () => props.currentLabel ?? props.keys[0]?.label ?? '';
-  const usedKeys = () =>
-    usedKeyLabelsForModelInTier(
-      props.tier(),
-      props.modelName,
-      props.fallbackIndex,
-      props.keys[0]?.label,
-    );
-
-  return (
-    <span ref={containerRef} style="position: relative; display: inline-flex; flex-shrink: 0;">
-      <button
-        type="button"
-        class="fallback-list__key-chip"
-        aria-haspopup="listbox"
-        aria-expanded={open()}
-        aria-label={`API key for ${props.modelLabel}: currently ${displayLabel()}. Click to change.`}
-        title={displayLabel()}
-        onClick={() => setOpen(!open())}
-        style="background: hsl(var(--muted) / 0.5); border: 1px solid hsl(var(--border)); border-radius: 999px; padding: 2px 8px; font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); cursor: pointer; max-width: 96px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-flex; align-items: center; gap: 3px;"
-      >
-        <span style="overflow: hidden; text-overflow: ellipsis;">{displayLabel()}</span>
-        <span aria-hidden="true">▾</span>
-      </button>
-      <Show when={open()}>
-        <ul
-          role="listbox"
-          aria-label="Choose API key"
-          style="position: absolute; top: 100%; right: 0; margin-top: 4px; list-style: none; padding: 4px; min-width: 160px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--background)); box-shadow: 0 4px 12px hsl(var(--foreground) / 0.08); z-index: 10; display: flex; flex-direction: column; gap: 2px;"
-        >
-          <Show when={props.currentLabel}>
-            <li>
-              <button
-                type="button"
-                role="option"
-                aria-selected={false}
-                onClick={() => {
-                  setOpen(false);
-                  props.onPick(null);
-                }}
-                style="width: 100%; text-align: left; background: none; border: none; padding: 4px 6px; cursor: pointer; border-radius: 4px; font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); border-bottom: 1px solid hsl(var(--border)); margin-bottom: 2px; padding-bottom: 6px;"
-              >
-                Clear pin
-              </button>
-            </li>
-          </Show>
-          <For each={props.keys}>
-            {(k) => {
-              const isUsed = () => usedKeys().has(k.label.toLowerCase());
-              const isSelected = () =>
-                props.currentLabel
-                  ? props.currentLabel.toLowerCase() === k.label.toLowerCase()
-                  : displayLabel().toLowerCase() === k.label.toLowerCase();
-              return (
-                <li>
-                  <button
-                    type="button"
-                    role="option"
-                    aria-selected={isSelected()}
-                    disabled={isUsed()}
-                    onClick={() => {
-                      setOpen(false);
-                      if ((props.currentLabel ?? '').toLowerCase() !== k.label.toLowerCase()) {
-                        props.onPick(k.label);
-                      }
-                    }}
-                    style={`width: 100%; text-align: left; background: none; border: none; padding: 4px 6px; cursor: pointer; border-radius: 4px; font-size: var(--font-size-xs); color: hsl(var(--foreground)); display: flex; align-items: center; gap: 6px;${isUsed() ? ' opacity: 0.4; cursor: not-allowed;' : ''}`}
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="8"
-                      height="8"
-                      fill="currentColor"
-                      viewBox="0 0 24 24"
-                      style={`visibility: ${isSelected() ? 'visible' : 'hidden'}`}
-                    >
-                      <path d="M12 5a7 7 0 1 0 0 14 7 7 0 1 0 0-14" />
-                    </svg>
-                    {k.label}
-                  </button>
-                </li>
-              );
-            }}
-          </For>
-        </ul>
-      </Show>
-    </span>
   );
 };
 

--- a/packages/frontend/src/components/HeaderTierCard.tsx
+++ b/packages/frontend/src/components/HeaderTierCard.tsx
@@ -16,17 +16,24 @@ import {
 } from '../services/api/header-tiers.js';
 import { providerIcon, customProviderLogo } from './ProviderIcon.js';
 import { authBadgeFor } from './AuthBadge.js';
-import { resolveProviderId, inferProviderFromModel, pricePerM } from '../services/routing-utils.js';
+import {
+  resolveProviderId,
+  inferProviderFromModel,
+  pricePerM,
+  usedKeyLabelsForModelInTier,
+  activeRouteKeys,
+  routeKeySelectionForModel,
+} from '../services/routing-utils.js';
 import { customProviderColor, formatPerRequestCost } from '../services/formatters.js';
 import { PROVIDERS } from '../services/providers.js';
 import FallbackList from './FallbackList.js';
 import ModelParamsAffordance from './ModelParamsAffordance.jsx';
 import ModelPickerModal from './ModelPickerModal.js';
 import HeaderTierSnippetModal from './HeaderTierSnippetModal.js';
+import RouteKeyChip from './RouteKeyChip.js';
+import KeyPickerModal from './KeyPickerModal.js';
 import { toast } from '../services/toast-store.js';
 import { modelParamsScopeForHeaderTier } from 'manifest-shared';
-import OutputControls from './OutputControls.js';
-import ModelCapabilityBadges from './ModelCapabilityBadges.js';
 
 function providerIdForModel(model: string, apiModels: AvailableModel[]): string | undefined {
   const m =
@@ -44,13 +51,27 @@ function providerIdForModel(model: string, apiModels: AvailableModel[]): string 
   return undefined;
 }
 
+function providerDisplayName(providerId: string, customProviders: CustomProviderData[]): string {
+  if (providerId.startsWith('custom:')) {
+    const id = providerId.slice('custom:'.length);
+    const cp = customProviders.find((p) => p.id === id);
+    if (cp) return cp.name;
+  }
+  return PROVIDERS.find((p) => p.id === providerId)?.name ?? providerId;
+}
+
 interface Props {
   agentName: string;
   tier: HeaderTier;
   models: AvailableModel[];
   customProviders: CustomProviderData[];
   connectedProviders: RoutingProvider[];
-  onOverride: (model: string, provider: string, authType?: AuthType) => void | Promise<void>;
+  onOverride: (
+    model: string,
+    provider: string,
+    authType?: AuthType,
+    providerKeyLabel?: string,
+  ) => void | Promise<void>;
   onFallbacksUpdate: (fallbacks: string[], routes?: ModelRoute[] | null) => void;
   onEdit?: () => void;
   onDisable?: () => void;
@@ -80,7 +101,15 @@ interface Props {
 
 const HeaderTierCard: Component<Props> = (props) => {
   type PickerMode = 'primary' | 'fallback' | null;
+  interface PendingKeyPick {
+    mode: Exclude<PickerMode, null>;
+    model: string;
+    provider: string;
+    authType?: AuthType;
+    keys: RoutingProvider[];
+  }
   const [pickerMode, setPickerMode] = createSignal<PickerMode>(null);
+  const [pendingKeyPick, setPendingKeyPick] = createSignal<PendingKeyPick | null>(null);
   const [snippetOpen, setSnippetOpen] = createSignal(false);
   const [menuOpen, setMenuOpen] = createSignal(false);
   const [resetting, setResetting] = createSignal(false);
@@ -139,6 +168,58 @@ const HeaderTierCard: Component<Props> = (props) => {
     return props.customProviders.find((p) => `custom:${p.id}` === id);
   };
 
+  const primaryKeys = (): RoutingProvider[] => {
+    const id = providerId();
+    const auth = effectiveAuth();
+    if (!id || !auth || auth === 'local') return [];
+    return activeRouteKeys(props.connectedProviders, id, auth);
+  };
+
+  const handlePrimaryKeyPick = async (label: string | null): Promise<void> => {
+    const route = props.tier.override_route;
+    const provider = providerId() ?? route?.provider;
+    const auth = effectiveAuth() ?? route?.authType;
+    if (!route || !provider || !auth) return;
+    await props.onOverride(route.model, provider, auth, label ?? undefined);
+  };
+
+  const addFallbackRoute = async (
+    model: string,
+    provider: string,
+    authType: AuthType | undefined,
+    keyLabel?: string,
+  ): Promise<void> => {
+    const next = [...fallbacks(), model];
+    const currentRoutes = props.tier.fallback_routes ?? [];
+    const effectiveAuth = authType ?? 'api_key';
+    const nextRoute: ModelRoute = keyLabel
+      ? { provider, authType: effectiveAuth, model, keyLabel }
+      : { provider, authType: effectiveAuth, model };
+    const nextRoutes = [...currentRoutes, nextRoute];
+    try {
+      await setHeaderTierFallbacks(props.agentName, props.tier.id, next, nextRoutes);
+      props.onFallbacksUpdate(next, nextRoutes);
+      toast.success('Fallback added');
+    } catch {
+      toast.error('Failed to add fallback');
+    }
+  };
+
+  const completePickerSelection = async (
+    mode: Exclude<PickerMode, null>,
+    model: string,
+    provider: string,
+    authType?: AuthType,
+    keyLabel?: string,
+  ): Promise<void> => {
+    if (mode === 'primary') {
+      if (keyLabel === undefined) await props.onOverride(model, provider, authType);
+      else await props.onOverride(model, provider, authType, keyLabel);
+      return;
+    }
+    await addFallbackRoute(model, provider, authType, keyLabel);
+  };
+
   const handlePickerSelect = async (
     _tierId: string,
     model: string,
@@ -147,21 +228,39 @@ const HeaderTierCard: Component<Props> = (props) => {
   ): Promise<void> => {
     const mode = pickerMode();
     setPickerMode(null);
-    if (mode === 'primary') {
-      await props.onOverride(model, provider, authType);
-    } else if (mode === 'fallback') {
-      const next = [...fallbacks(), model];
-      const currentRoutes = props.tier.fallback_routes ?? [];
-      const nextRoutes =
-        authType !== undefined ? [...currentRoutes, { provider, authType, model }] : undefined;
-      try {
-        await setHeaderTierFallbacks(props.agentName, props.tier.id, next, nextRoutes);
-        props.onFallbacksUpdate(next, nextRoutes ?? null);
-        toast.success('Fallback added');
-      } catch {
-        toast.error('Failed to add fallback');
-      }
+    if (!mode) return;
+    const effectiveAuth = authType ?? 'api_key';
+    const selection = routeKeySelectionForModel({
+      providers: props.connectedProviders,
+      tier: props.tier,
+      modelName: model,
+      providerId: provider,
+      authType: effectiveAuth,
+      slot: mode,
+    });
+    if (selection.exhausted) return;
+    if (selection.autoLabel) {
+      await completePickerSelection(mode, model, provider, authType, selection.autoLabel);
+      return;
     }
+    if (!selection.needsChoice) {
+      await completePickerSelection(mode, model, provider, authType);
+      return;
+    }
+    setPendingKeyPick({ mode, model, provider, authType, keys: selection.keys });
+  };
+
+  const handlePendingKeyPick = (label: string | null): void => {
+    const pending = pendingKeyPick();
+    if (!pending) return;
+    setPendingKeyPick(null);
+    void completePickerSelection(
+      pending.mode,
+      pending.model,
+      pending.provider,
+      pending.authType,
+      label ?? undefined,
+    );
   };
 
   const handleReset = async () => {
@@ -334,6 +433,25 @@ const HeaderTierCard: Component<Props> = (props) => {
                   <span class="routing-card__main">{modelLabel() || modelName()}</span>
                 </div>
                 <div style="display: flex; align-items: center; gap: 4px; flex-shrink: 0;">
+                  <Show when={primaryKeys().length > 1}>
+                    <RouteKeyChip
+                      keys={primaryKeys()}
+                      currentLabel={props.tier.override_route?.keyLabel ?? undefined}
+                      modelLabel={modelLabel() || modelName()}
+                      usedLabels={() =>
+                        usedKeyLabelsForModelInTier(
+                          props.tier,
+                          modelName(),
+                          'primary',
+                          primaryKeys()[0]?.label,
+                        )
+                      }
+                      buttonClass="routing-card__key-chip"
+                      leadingMargin
+                      stopPropagation
+                      onPick={handlePrimaryKeyPick}
+                    />
+                  </Show>
                   <Show
                     when={
                       props.getModelParams &&
@@ -411,6 +529,7 @@ const HeaderTierCard: Component<Props> = (props) => {
             tier={props.tier.id}
             fallbacks={fallbacks()}
             fallbackRoutes={props.tier.fallback_routes ?? null}
+            tierData={() => props.tier}
             models={props.models}
             customProviders={props.customProviders}
             connectedProviders={props.connectedProviders}
@@ -441,6 +560,18 @@ const HeaderTierCard: Component<Props> = (props) => {
           onClose={() => setPickerMode(null)}
           onSelect={handlePickerSelect}
         />
+      </Show>
+
+      <Show when={pendingKeyPick()}>
+        {(pending) => (
+          <KeyPickerModal
+            providerName={providerDisplayName(pending().provider, props.customProviders)}
+            modelName={pending().model}
+            keys={pending().keys}
+            onPick={handlePendingKeyPick}
+            onClose={() => setPendingKeyPick(null)}
+          />
+        )}
       </Show>
 
       <Show when={snippetOpen()}>

--- a/packages/frontend/src/components/RouteKeyChip.tsx
+++ b/packages/frontend/src/components/RouteKeyChip.tsx
@@ -1,0 +1,126 @@
+import { createEffect, createSignal, For, onCleanup, Show, type Component } from 'solid-js';
+import type { RoutingProvider } from '../services/api.js';
+
+interface RouteKeyChipProps {
+  keys: RoutingProvider[];
+  currentLabel?: string | null;
+  modelLabel: string;
+  usedLabels?: () => Set<string>;
+  onPick: (label: string | null) => void | Promise<void>;
+  buttonClass: string;
+  disabled?: boolean;
+  allowClear?: boolean;
+  leadingMargin?: boolean;
+  menuMinWidth?: number;
+  stopPropagation?: boolean;
+}
+
+const RouteKeyChip: Component<RouteKeyChipProps> = (props) => {
+  const [open, setOpen] = createSignal(false);
+  let containerRef: HTMLSpanElement | undefined;
+
+  createEffect(() => {
+    if (!open()) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef && !containerRef.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    onCleanup(() => document.removeEventListener('mousedown', handler));
+  });
+
+  const stop = (event: Event) => {
+    if (props.stopPropagation) event.stopPropagation();
+  };
+  const displayLabel = () => props.currentLabel ?? props.keys[0]?.label ?? '';
+  const usedLabels = () => props.usedLabels?.() ?? new Set<string>();
+  const buttonStyle = () =>
+    `background: hsl(var(--muted) / 0.5); border: 1px solid hsl(var(--border)); border-radius: 999px; padding: 2px 8px; font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); cursor: pointer; max-width: 96px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-flex; align-items: center; gap: 3px;${props.leadingMargin ? ' margin-left: 4px;' : ''}`;
+  const menuStyle = () =>
+    `position: absolute; top: 100%; right: 0; margin-top: 4px; list-style: none; padding: 4px; min-width: ${props.menuMinWidth ?? 160}px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--background)); box-shadow: 0 4px 12px hsl(var(--foreground) / 0.08); z-index: 10; display: flex; flex-direction: column; gap: 2px;`;
+
+  return (
+    <span ref={containerRef} style="position: relative; display: inline-flex; flex-shrink: 0;">
+      <button
+        type="button"
+        class={props.buttonClass}
+        aria-haspopup="listbox"
+        aria-expanded={open()}
+        aria-label={`API key for ${props.modelLabel}: currently ${displayLabel()}. Click to change.`}
+        title={displayLabel()}
+        disabled={props.disabled}
+        onClick={(event) => {
+          stop(event);
+          setOpen(!open());
+        }}
+        style={buttonStyle()}
+      >
+        <span style="overflow: hidden; text-overflow: ellipsis;">{displayLabel()}</span>
+        <span aria-hidden="true">▾</span>
+      </button>
+      <Show when={open()}>
+        <ul role="listbox" aria-label="Choose API key" onClick={stop} style={menuStyle()}>
+          <Show when={props.allowClear && props.currentLabel}>
+            <li>
+              <button
+                type="button"
+                role="option"
+                aria-selected={false}
+                onClick={(event) => {
+                  stop(event);
+                  setOpen(false);
+                  void props.onPick(null);
+                }}
+                style="width: 100%; text-align: left; background: none; border: none; padding: 4px 6px; cursor: pointer; border-radius: 4px; font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); border-bottom: 1px solid hsl(var(--border)); margin-bottom: 2px; padding-bottom: 6px;"
+              >
+                Clear pin
+              </button>
+            </li>
+          </Show>
+          <For each={props.keys}>
+            {(key) => {
+              const isUsedElsewhere = () => usedLabels().has(key.label.toLowerCase());
+              const isSelected = () =>
+                props.currentLabel
+                  ? props.currentLabel.toLowerCase() === key.label.toLowerCase()
+                  : displayLabel().toLowerCase() === key.label.toLowerCase();
+              const shouldPick = () =>
+                (props.currentLabel ?? '').toLowerCase() !== key.label.toLowerCase();
+              return (
+                <li>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected()}
+                    disabled={props.disabled || isUsedElsewhere()}
+                    onClick={(event) => {
+                      stop(event);
+                      setOpen(false);
+                      if (shouldPick()) {
+                        void props.onPick(key.label);
+                      }
+                    }}
+                    style={`width: 100%; text-align: left; background: none; border: none; padding: 4px 6px; cursor: pointer; border-radius: 4px; font-size: var(--font-size-xs); color: hsl(var(--foreground)); display: flex; align-items: center; gap: 6px;${isUsedElsewhere() ? ' opacity: 0.4; cursor: not-allowed;' : ''}`}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="8"
+                      height="8"
+                      fill="currentColor"
+                      viewBox="0 0 24 24"
+                      style={`visibility: ${isSelected() ? 'visible' : 'hidden'}`}
+                    >
+                      <path d="M12 5a7 7 0 1 0 0 14 7 7 0 1 0 0-14" />
+                    </svg>
+                    {key.label}
+                  </button>
+                </li>
+              );
+            }}
+          </For>
+        </ul>
+      </Show>
+    </span>
+  );
+};
+
+export default RouteKeyChip;

--- a/packages/frontend/src/components/RoutingModals.tsx
+++ b/packages/frontend/src/components/RoutingModals.tsx
@@ -15,7 +15,11 @@ import type {
   ResponseMode,
 } from '../services/api.js';
 import type { CustomProviderPrefill, ProviderDeepLink } from '../services/routing-params.js';
-import { usedKeyLabelsForModelInTier } from '../services/routing-utils.js';
+import {
+  activeRouteKeys,
+  availableRouteKeysForModel,
+  routeKeySelectionForModel,
+} from '../services/routing-utils.js';
 
 interface RoutingModalsProps {
   agentName: () => string;
@@ -71,30 +75,6 @@ interface PendingOverride {
   isFallback?: boolean;
 }
 
-/**
- * All active credential rows for a (provider, auth_type) tuple, sorted by
- * priority. Used to decide whether to show the "Which key?" picker. Local
- * providers (Ollama) don't carry keys, so they're excluded — the chain
- * concept doesn't apply.
- */
-function activeKeysFor(
-  providers: RoutingProvider[],
-  providerId: string,
-  authType: AuthType,
-): RoutingProvider[] {
-  if (authType === 'local') return [];
-  return providers
-    .filter(
-      (p) =>
-        p.provider.toLowerCase() === providerId.toLowerCase() &&
-        p.auth_type === authType &&
-        p.is_active &&
-        p.has_api_key,
-    )
-    .slice()
-    .sort((a, b) => a.priority - b.priority);
-}
-
 function providerDisplayName(providerId: string, customProviders: CustomProviderData[]): string {
   if (providerId.startsWith('custom:')) {
     const id = providerId.slice('custom:'.length);
@@ -124,13 +104,20 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
     authType?: AuthType,
   ) => {
     const effectiveAuth = authType ?? 'api_key';
-    const keys = activeKeysFor(props.connectedProviders(), providerId, effectiveAuth);
-    if (keys.length <= 1) {
+    const selection = routeKeySelectionForModel({
+      providers: props.connectedProviders(),
+      tier: props.getTier(tierId),
+      modelName,
+      providerId,
+      authType: effectiveAuth,
+      slot: 'primary',
+    });
+    if (!selection.needsChoice) {
       props.onOverride(tierId, modelName, providerId, authType);
       return;
     }
     // 2+ keys → ask the user which one before persisting.
-    setPendingOverride({ tierId, modelName, providerId, authType, keys });
+    setPendingOverride({ tierId, modelName, providerId, authType, keys: selection.keys });
   };
 
   const resolvePending = (label: string | null) => {
@@ -201,32 +188,12 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
 
       <Show when={props.fallbackPickerTier()}>
         {(tierId) => {
-          const usedKeysForModel = (
-            modelName: string,
-            providerId?: string,
-            authType?: AuthType,
-          ) => {
-            // The default key (priority 0) is implicitly used when the primary has no pin
-            let defaultLabel: string | undefined;
-            if (providerId) {
-              const effectiveAuth = authType ?? 'api_key';
-              const keys = activeKeysFor(props.connectedProviders(), providerId, effectiveAuth);
-              defaultLabel = keys[0]?.label;
-            }
-            return usedKeyLabelsForModelInTier(
-              props.getTier(tierId()),
-              modelName,
-              undefined,
-              defaultLabel,
-            );
-          };
-
           const filteredModels = () => {
             return props.models().filter((m) => {
               // Find how many keys exist for this model's provider
               const providerId = m.provider;
               const authType = m.auth_type ?? 'api_key';
-              const keys = activeKeysFor(props.connectedProviders(), providerId, authType);
+              const keys = activeRouteKeys(props.connectedProviders(), providerId, authType);
               if (keys.length <= 1) {
                 // Single-key model: hide if already used as primary or fallback
                 // (matched on the full route tuple — same model on a different
@@ -250,8 +217,15 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
                 );
               }
               // Multi-key model: hide only if ALL keys are already used
-              const used = usedKeysForModel(m.model_name, providerId, authType);
-              return used.size < keys.length;
+              return (
+                availableRouteKeysForModel(
+                  props.connectedProviders(),
+                  props.getTier(tierId()),
+                  m.model_name,
+                  providerId,
+                  authType,
+                ).length > 0
+              );
             });
           };
 
@@ -262,24 +236,29 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
             authType?: AuthType,
           ) => {
             const effectiveAuth = authType ?? 'api_key';
-            const allKeys = activeKeysFor(props.connectedProviders(), providerId, effectiveAuth);
+            const allKeys = activeRouteKeys(props.connectedProviders(), providerId, effectiveAuth);
             if (allKeys.length <= 1) {
               // Single-key (or no-key) provider: add fallback without key selection
               props.onFallbackPickerClose();
               props.onAddFallback(tid, modelName, providerId, authType);
               return;
             }
-            // Filter out keys already used for this model
-            const used = usedKeysForModel(modelName, providerId, authType);
-            const availableKeys = allKeys.filter((k) => !used.has(k.label.toLowerCase()));
-            if (availableKeys.length === 0) {
+            const selection = routeKeySelectionForModel({
+              providers: props.connectedProviders(),
+              tier: props.getTier(tierId()),
+              modelName,
+              providerId,
+              authType: effectiveAuth,
+              slot: 'fallback',
+            });
+            if (selection.exhausted) {
               // All keys exhausted — shouldn't happen since filteredModels hides it
               return;
             }
-            if (availableKeys.length === 1) {
+            if (selection.autoLabel) {
               // Only one key left — auto-select it, close picker for fresh data
               props.onFallbackPickerClose();
-              props.onAddFallback(tid, modelName, providerId, authType, availableKeys[0]!.label);
+              props.onAddFallback(tid, modelName, providerId, authType, selection.autoLabel);
               return;
             }
             // 2+ keys available → ask which one
@@ -288,7 +267,7 @@ const RoutingModals: Component<RoutingModalsProps> = (props) => {
               modelName,
               providerId,
               authType,
-              keys: availableKeys,
+              keys: selection.keys,
               isFallback: true,
             });
           };

--- a/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
+++ b/packages/frontend/src/pages/RoutingHeaderTiersSection.tsx
@@ -101,9 +101,10 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
     model: string,
     provider: string,
     authType?: AuthType,
+    providerKeyLabel?: string,
   ): Promise<void> => {
     try {
-      await overrideHeaderTier(props.agentName(), id, model, provider, authType);
+      await overrideHeaderTier(props.agentName(), id, model, provider, authType, providerKeyLabel);
       await refetch();
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to update tier');
@@ -201,7 +202,7 @@ const RoutingHeaderTiersSection: Component<Props> = (props) => {
                 models={props.models()}
                 customProviders={props.customProviders()}
                 connectedProviders={props.connectedProviders()}
-                onOverride={(m, p, a) => handleOverride(tier.id, m, p, a)}
+                onOverride={(m, p, a, label) => handleOverride(tier.id, m, p, a, label)}
                 onFallbacksUpdate={(_fallbacks, updatedRoutes) =>
                   applyFallbackUpdate(tier.id, updatedRoutes)
                 }

--- a/packages/frontend/src/pages/RoutingTierCard.tsx
+++ b/packages/frontend/src/pages/RoutingTierCard.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, onCleanup, For, Show, type Component } from 'solid-js';
+import { createSignal, Show, type Component } from 'solid-js';
 import { PROVIDERS } from '../services/providers.js';
 import type { StageDef } from '../services/providers.js';
 import { getModelLabel } from '../services/provider-utils.js';
@@ -13,7 +13,7 @@ import {
 import { customProviderColor, formatPerRequestCost } from '../services/formatters.js';
 import FallbackList from '../components/FallbackList.js';
 import ModelParamsAffordance from '../components/ModelParamsAffordance.jsx';
-import ModelCapabilityBadges from '../components/ModelCapabilityBadges.js';
+import RouteKeyChip from '../components/RouteKeyChip.js';
 import { setFallbacks as setFallbacksApi } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import { modelParamsScopeForTier } from 'manifest-shared';
@@ -707,18 +707,6 @@ interface PrimaryKeyChipProps {
 }
 
 const PrimaryKeyChip: Component<PrimaryKeyChipProps> = (props) => {
-  const [open, setOpen] = createSignal(false);
-  let containerRef: HTMLSpanElement | undefined;
-  createEffect(() => {
-    if (open()) {
-      const handler = (e: MouseEvent) => {
-        if (containerRef && !containerRef.contains(e.target as Node)) setOpen(false);
-      };
-      document.addEventListener('mousedown', handler);
-      onCleanup(() => document.removeEventListener('mousedown', handler));
-    }
-  });
-
   const keys = () => {
     const id = props.provId();
     const auth = props.effectiveAuth();
@@ -744,75 +732,25 @@ const PrimaryKeyChip: Component<PrimaryKeyChipProps> = (props) => {
     const effective = t?.override_route ?? t?.auto_assigned_route ?? null;
     return effective?.keyLabel ?? null;
   };
-  const displayLabel = () => pinned() ?? keys()[0]?.label ?? '';
 
   const usedByFallbacks = () =>
-    usedKeyLabelsForModelInTier(props.tier(), props.modelName(), 'primary');
+    usedKeyLabelsForModelInTier(props.tier(), props.modelName(), 'primary', keys()[0]?.label);
 
   return (
     <Show when={keys().length > 1}>
-      <span ref={containerRef} style="position: relative; display: inline-flex; flex-shrink: 0;">
-        <button
-          type="button"
-          class="routing-card__key-chip"
-          aria-haspopup="listbox"
-          aria-expanded={open()}
-          aria-label={`API key for ${props.modelLabel}: currently ${displayLabel()}. Click to change.`}
-          title={displayLabel()}
-          disabled={props.disabled()}
-          onClick={() => setOpen(!open())}
-          style="background: hsl(var(--muted) / 0.5); border: 1px solid hsl(var(--border)); border-radius: 999px; padding: 2px 8px; font-size: var(--font-size-xs); color: hsl(var(--muted-foreground)); cursor: pointer; max-width: 96px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; display: inline-flex; align-items: center; gap: 3px; margin-left: 4px;"
-        >
-          <span style="overflow: hidden; text-overflow: ellipsis;">{displayLabel()}</span>
-          <span aria-hidden="true">▾</span>
-        </button>
-        <Show when={open()}>
-          <ul
-            role="listbox"
-            aria-label="Choose API key"
-            style="position: absolute; top: 100%; right: 0; margin-top: 4px; list-style: none; padding: 4px; min-width: 140px; border: 1px solid hsl(var(--border)); border-radius: 6px; background: hsl(var(--background)); box-shadow: 0 4px 12px hsl(var(--foreground) / 0.08); z-index: 10; display: flex; flex-direction: column; gap: 2px;"
-          >
-            <For each={keys()}>
-              {(k) => {
-                const isUsedElsewhere = () => usedByFallbacks().has(k.label.toLowerCase());
-                const isSelected = () =>
-                  pinned()
-                    ? pinned()!.toLowerCase() === k.label.toLowerCase()
-                    : displayLabel().toLowerCase() === k.label.toLowerCase();
-                return (
-                  <li>
-                    <button
-                      type="button"
-                      role="option"
-                      aria-selected={isSelected()}
-                      disabled={props.disabled() || isUsedElsewhere()}
-                      onClick={() => {
-                        setOpen(false);
-                        if (pinned()?.toLowerCase() !== k.label.toLowerCase()) {
-                          props.onPinKey(k.label);
-                        }
-                      }}
-                      style={`width: 100%; text-align: left; background: none; border: none; padding: 4px 6px; cursor: pointer; border-radius: 4px; font-size: var(--font-size-xs); color: hsl(var(--foreground)); display: flex; align-items: center; gap: 6px;${isUsedElsewhere() ? ' opacity: 0.4; cursor: not-allowed;' : ''}`}
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="8"
-                        height="8"
-                        fill="currentColor"
-                        viewBox="0 0 24 24"
-                        style={`visibility: ${isSelected() ? 'visible' : 'hidden'}`}
-                      >
-                        <path d="M12 5a7 7 0 1 0 0 14 7 7 0 1 0 0-14" />
-                      </svg>
-                      {k.label}
-                    </button>
-                  </li>
-                );
-              }}
-            </For>
-          </ul>
-        </Show>
-      </span>
+      <RouteKeyChip
+        keys={keys()}
+        currentLabel={pinned()}
+        modelLabel={props.modelLabel}
+        usedLabels={usedByFallbacks}
+        buttonClass="routing-card__key-chip"
+        disabled={props.disabled()}
+        leadingMargin
+        menuMinWidth={140}
+        onPick={(label) => {
+          if (label) props.onPinKey(label);
+        }}
+      />
     </Show>
   );
 };

--- a/packages/frontend/src/services/api/header-tiers.ts
+++ b/packages/frontend/src/services/api/header-tiers.ts
@@ -108,12 +108,16 @@ export function overrideHeaderTier(
   model: string,
   provider: string,
   authType?: AuthType,
+  providerKeyLabel?: string,
 ) {
   const body: Record<string, unknown> = { model, provider };
   if (authType) {
     body.authType = authType;
-    body.route = { provider, authType, model };
+    body.route = providerKeyLabel
+      ? { provider, authType, model, keyLabel: providerKeyLabel }
+      : { provider, authType, model };
   }
+  if (providerKeyLabel) body.providerKeyLabel = providerKeyLabel;
   return fetchMutate<HeaderTier>(
     routingPath(agentName, `header-tiers/${encodeURIComponent(id)}/override`),
     {

--- a/packages/frontend/src/services/routing-utils.ts
+++ b/packages/frontend/src/services/routing-utils.ts
@@ -1,6 +1,12 @@
 import { PROVIDERS } from './providers.js';
 import { inferProviderFromModel, SHARED_PROVIDERS } from 'manifest-shared';
-import type { TierAssignment } from './api.js';
+import type { AuthType, ModelRoute, RoutingProvider } from './api.js';
+
+export interface RouteSlots {
+  override_route?: ModelRoute | null;
+  auto_assigned_route?: ModelRoute | null;
+  fallback_routes?: ModelRoute[] | null;
+}
 
 /**
  * Collect all key labels already used for a given model within a tier
@@ -13,10 +19,10 @@ import type { TierAssignment } from './api.js';
  *   own dropdown), or a fallback index to skip that fallback (for its dropdown).
  */
 export function usedKeyLabelsForModelInTier(
-  tier: TierAssignment | undefined,
+  tier: RouteSlots | undefined,
   modelName: string,
   excludeSlot?: 'primary' | number,
-  /** When the primary has no explicit key pin, the proxy uses the first key
+  /** When a route has no explicit key pin, the proxy uses the first key
    *  by priority. Pass that label here so it gets counted as "used". */
   defaultKeyLabel?: string,
 ): Set<string> {
@@ -36,11 +42,93 @@ export function usedKeyLabelsForModelInTier(
     if (excludeSlot === i) continue;
     const r = routes[i];
     if (!r) continue;
-    if (r.model === modelName && r.keyLabel) {
-      used.add(r.keyLabel.toLowerCase());
+    if (r.model === modelName) {
+      const label = r.keyLabel ?? defaultKeyLabel;
+      if (label) used.add(label.toLowerCase());
     }
   }
   return used;
+}
+
+/**
+ * All active credential rows for a (provider, auth_type) tuple, sorted by
+ * priority. Local providers do not expose account keys, so they are excluded.
+ */
+export function activeRouteKeys(
+  providers: RoutingProvider[],
+  providerId: string,
+  authType: AuthType,
+): RoutingProvider[] {
+  if (authType === 'local') return [];
+  return providers
+    .filter(
+      (p) =>
+        p.provider.toLowerCase() === providerId.toLowerCase() &&
+        p.auth_type === authType &&
+        p.is_active &&
+        p.has_api_key,
+    )
+    .slice()
+    .sort((a, b) => a.priority - b.priority);
+}
+
+/**
+ * Remaining credential rows that can still be used for a model in one tier.
+ * Unpinned matching routes count as the first key by priority because that is
+ * how the proxy resolves them at runtime.
+ */
+export function availableRouteKeysForModel(
+  providers: RoutingProvider[],
+  tier: RouteSlots | undefined,
+  modelName: string,
+  providerId: string,
+  authType: AuthType,
+  excludeSlot?: 'primary' | number,
+): RoutingProvider[] {
+  const keys = activeRouteKeys(providers, providerId, authType);
+  if (keys.length === 0) return keys;
+  const used = usedKeyLabelsForModelInTier(tier, modelName, excludeSlot, keys[0]?.label);
+  return keys.filter((key) => !used.has(key.label.toLowerCase()));
+}
+
+export interface RouteKeySelection {
+  /** Keys the user may choose from when a picker is needed. */
+  keys: RoutingProvider[];
+  /** A single key that can be applied without showing a picker. */
+  autoLabel?: string;
+  needsChoice: boolean;
+  exhausted: boolean;
+}
+
+export function routeKeySelectionForModel(input: {
+  providers: RoutingProvider[];
+  tier: RouteSlots | undefined;
+  modelName: string;
+  providerId: string;
+  authType: AuthType;
+  slot: 'primary' | 'fallback';
+}): RouteKeySelection {
+  const keys = activeRouteKeys(input.providers, input.providerId, input.authType);
+  if (keys.length <= 1) return { keys, needsChoice: false, exhausted: false };
+  if (input.slot === 'primary') return { keys, needsChoice: true, exhausted: false };
+
+  const availableKeys = availableRouteKeysForModel(
+    input.providers,
+    input.tier,
+    input.modelName,
+    input.providerId,
+    input.authType,
+  );
+  if (availableKeys.length === 0) return { keys: [], needsChoice: false, exhausted: true };
+  if (availableKeys.length === 1) {
+    return {
+      keys: availableKeys,
+      autoLabel: availableKeys[0]!.label,
+      needsChoice: false,
+      exhausted: false,
+    };
+  }
+  return { keys: availableKeys, needsChoice: true, exhausted: false };
 }
 
 /** Format per-million token price: $0.15 */

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -30,17 +30,21 @@ vi.mock('../../src/components/AuthBadge.js', () => ({
     authType === 'subscription' ? 'Subscription' : 'API Key',
 }));
 
-vi.mock('../../src/services/routing-utils.js', () => ({
-  resolveProviderId: (p: string) => p.toLowerCase(),
-  inferProviderFromModel: (m: string) => {
-    if (m.startsWith('gpt')) return 'openai';
-    if (m.startsWith('claude')) return 'anthropic';
-    if (/^[a-z][\w-]*\//.test(m)) return 'openrouter';
-    return undefined;
-  },
-  pricePerM: (n: number) => `$${(n * 1_000_000).toFixed(2)}`,
-  stripCustomPrefix: (m: string) => m,
-}));
+vi.mock('../../src/services/routing-utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/services/routing-utils.js')>();
+  return {
+    ...actual,
+    resolveProviderId: (p: string) => p.toLowerCase(),
+    inferProviderFromModel: (m: string) => {
+      if (m.startsWith('gpt')) return 'openai';
+      if (m.startsWith('claude')) return 'anthropic';
+      if (/^[a-z][\w-]*\//.test(m)) return 'openrouter';
+      return undefined;
+    },
+    pricePerM: (n: number) => `$${(n * 1_000_000).toFixed(2)}`,
+    stripCustomPrefix: (m: string) => m,
+  };
+});
 
 vi.mock('../../src/services/providers.js', () => ({
   PROVIDERS: [
@@ -71,6 +75,7 @@ vi.mock('../../src/components/FallbackList.js', () => ({
       props.models,
       props.customProviders,
       props.connectedProviders,
+      props.tierData,
       props.getModelParams,
       props.setModelParams,
       props.modelHasParams,
@@ -153,6 +158,26 @@ vi.mock('../../src/components/ModelPickerModal.js', () => ({
           pick
         </button>
         <button data-testid="picker-close" onClick={() => (props.onClose as () => void)()}>
+          close
+        </button>
+      </div>
+    );
+  },
+}));
+
+vi.mock('../../src/components/KeyPickerModal.js', () => ({
+  default: (props: Record<string, unknown>) => {
+    const _read = [props.providerName, props.modelName, props.keys];
+    void _read;
+    return (
+      <div data-testid="key-picker-modal">
+        <button
+          data-testid="key-picker-pick-personal"
+          onClick={() => (props.onPick as (label: string | null) => void)('Personal')}
+        >
+          pick Personal
+        </button>
+        <button data-testid="key-picker-close" onClick={() => (props.onClose as () => void)()}>
           close
         </button>
       </div>
@@ -252,6 +277,8 @@ const connectedProviders: RoutingProvider[] = [
     auth_type: 'api_key',
     is_active: true,
     has_api_key: true,
+    label: 'Default',
+    priority: 0,
     connected_at: '2025-01-01',
   },
 ];
@@ -358,6 +385,90 @@ describe('HeaderTierCard', () => {
     ));
     expect(container.querySelector('[data-testid="auth-subscription"]')).not.toBeNull();
     expect(container.textContent).toContain('Included in subscription');
+  });
+
+  it('shows the primary account chip for multi-account header tier routes', () => {
+    const onOverride = vi.fn();
+    const tierSub = {
+      ...baseTier,
+      override_route: { provider: 'openai', authType: 'subscription', model: 'gpt-4o' } as const,
+    };
+    const providers: RoutingProvider[] = [
+      {
+        ...connectedProviders[0],
+        id: 'sub-1',
+        auth_type: 'subscription',
+        label: 'Default',
+        priority: 0,
+      },
+      {
+        ...connectedProviders[0],
+        id: 'sub-2',
+        auth_type: 'subscription',
+        label: 'Personal',
+        priority: 1,
+      },
+    ];
+    const { container, getByRole, queryByTestId } = render(() => (
+      <HeaderTierCard
+        agentName="demo"
+        tier={tierSub}
+        models={models}
+        customProviders={customProviders}
+        connectedProviders={providers}
+        onOverride={onOverride}
+        onFallbacksUpdate={vi.fn()}
+      />
+    ));
+
+    const chip = container.querySelector('.routing-card__key-chip') as HTMLButtonElement;
+    expect(chip.textContent).toContain('Default');
+    fireEvent.click(chip);
+    fireEvent.click(getByRole('option', { name: /Personal/ }));
+
+    expect(onOverride).toHaveBeenCalledWith('gpt-4o', 'openai', 'subscription', 'Personal');
+    expect(queryByTestId('model-picker')).toBeNull();
+  });
+
+  it('shows an explicit primary account pin on header tier routes', () => {
+    const tierSub = {
+      ...baseTier,
+      override_route: {
+        provider: 'openai',
+        authType: 'subscription',
+        model: 'gpt-4o',
+        keyLabel: 'Personal',
+      } as const,
+    };
+    const providers: RoutingProvider[] = [
+      {
+        ...connectedProviders[0],
+        id: 'sub-1',
+        auth_type: 'subscription',
+        label: 'Default',
+        priority: 0,
+      },
+      {
+        ...connectedProviders[0],
+        id: 'sub-2',
+        auth_type: 'subscription',
+        label: 'Personal',
+        priority: 1,
+      },
+    ];
+    const { container } = render(() => (
+      <HeaderTierCard
+        agentName="demo"
+        tier={tierSub}
+        models={models}
+        customProviders={customProviders}
+        connectedProviders={providers}
+        onOverride={vi.fn()}
+        onFallbacksUpdate={vi.fn()}
+      />
+    ));
+
+    expect(container.querySelector('.routing-card__key-chip')?.textContent).toContain('Personal');
   });
 
   it('shows the per-request cost for per-request subscriptions', () => {
@@ -708,6 +819,98 @@ describe('HeaderTierCard', () => {
           { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
         ],
       );
+    });
+  });
+
+  it('auto-pins the next available account when adding the same model as a custom fallback', async () => {
+    const providers: RoutingProvider[] = [
+      {
+        ...connectedProviders[0],
+        id: 'p-default',
+        label: 'Default',
+        priority: 0,
+      },
+      {
+        ...connectedProviders[0],
+        id: 'p-personal',
+        label: 'Personal',
+        priority: 1,
+      },
+    ];
+    const onFallbacksUpdate = vi.fn();
+    const { getByTestId, queryByTestId } = render(() => (
+      <HeaderTierCard
+        agentName="demo"
+        tier={baseTier}
+        models={models}
+        customProviders={customProviders}
+        connectedProviders={providers}
+        onOverride={vi.fn()}
+        onFallbacksUpdate={onFallbacksUpdate}
+      />
+    ));
+
+    fireEvent.click(getByTestId('fb-add') as HTMLButtonElement);
+    fireEvent.click(getByTestId('picker-pick') as HTMLButtonElement);
+
+    await waitFor(() => {
+      const expectedRoutes = [
+        { provider: 'openai', authType: 'api_key', model: 'gpt-4o', keyLabel: 'Personal' },
+      ];
+      expect(mockSetHeaderTierFallbacks).toHaveBeenCalledWith(
+        'demo',
+        'ht-1',
+        ['gpt-4o'],
+        expectedRoutes,
+      );
+      expect(onFallbacksUpdate).toHaveBeenCalledWith(['gpt-4o'], expectedRoutes);
+      expect(queryByTestId('key-picker-modal')).toBeNull();
+    });
+  });
+
+  it('opens account picker when replacing the primary with a multi-account model', async () => {
+    const providers: RoutingProvider[] = [
+      {
+        ...connectedProviders[0],
+        id: 'p-default',
+        label: 'Default',
+        priority: 0,
+      },
+      {
+        ...connectedProviders[0],
+        id: 'p-personal',
+        label: 'Personal',
+        priority: 1,
+      },
+    ];
+    const onOverride = vi.fn();
+    const { container, getByTestId, queryByTestId } = render(() => (
+      <HeaderTierCard
+        agentName="demo"
+        tier={{ ...baseTier, override_route: null }}
+        models={models}
+        customProviders={customProviders}
+        connectedProviders={providers}
+        onOverride={onOverride}
+        onFallbacksUpdate={vi.fn()}
+      />
+    ));
+
+    fireEvent.click(
+      Array.from(container.querySelectorAll('button')).find((b) =>
+        b.textContent?.includes('+ Add model'),
+      ) as HTMLButtonElement,
+    );
+    fireEvent.click(getByTestId('picker-pick') as HTMLButtonElement);
+
+    expect(onOverride).not.toHaveBeenCalled();
+    expect(queryByTestId('key-picker-modal')).not.toBeNull();
+
+    fireEvent.click(getByTestId('key-picker-pick-personal') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(onOverride).toHaveBeenCalledWith('gpt-4o', 'openai', 'api_key', 'Personal');
+      expect(queryByTestId('key-picker-modal')).toBeNull();
     });
   });
 

--- a/packages/frontend/tests/components/RoutingModals.test.tsx
+++ b/packages/frontend/tests/components/RoutingModals.test.tsx
@@ -9,11 +9,15 @@ vi.mock('../../src/components/ModelPickerModal.js', () => ({
   default: (props: Record<string, unknown>) => {
     pickerCalls.push({
       tierId: props.tierId,
+      agentName: props.agentName,
       modelsCount: (props.models as { length: number } | undefined)?.length ?? 0,
       modelsList: ((props.models as { model_name: string }[] | undefined) ?? []).map(
         (m) => `${m.model_name}:${(m as { auth_type?: string }).auth_type ?? ''}`,
       ),
       tiersCount: (props.tiers as { length: number } | undefined)?.length ?? 0,
+      customProvidersCount: (props.customProviders as { length: number } | undefined)?.length ?? 0,
+      connectedProvidersCount:
+        (props.connectedProviders as { length: number } | undefined)?.length ?? 0,
       requiredCapability: props.requiredCapability,
       providerRefreshed: props.onProviderRefreshed,
     });
@@ -682,6 +686,38 @@ describe('RoutingModals', () => {
         'api_key',
         'Personal',
       );
+    });
+
+    it('does nothing if a stale fallback selection has no available keys left', () => {
+      const tierWithEveryKeyUsed: TierAssignment = {
+        ...tiers[0]!,
+        override_route: {
+          provider: 'openai',
+          authType: 'api_key',
+          model: 'gpt-4o',
+          keyLabel: 'Work',
+        },
+        fallback_routes: [
+          { provider: 'openai', authType: 'api_key', model: 'gpt-4o', keyLabel: 'Personal' },
+        ],
+      };
+      const onAddFallback = vi.fn();
+      const { getByTestId, queryByTestId } = render(() => (
+        <RoutingModals
+          {...makeProps({
+            fallbackPickerTier: () => 'simple',
+            tiers: () => [tierWithEveryKeyUsed],
+            getTier: (id: string) => [tierWithEveryKeyUsed].find((t) => t.tier === id),
+            connectedProviders: () => multiKeyProviders,
+            onAddFallback,
+          })}
+        />
+      ));
+
+      fireEvent.click(getByTestId('picker-simple'));
+
+      expect(onAddFallback).not.toHaveBeenCalled();
+      expect(queryByTestId('key-picker-modal')).toBeNull();
     });
 
     it('closes the picker without calling onOverride when the user cancels', () => {

--- a/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
+++ b/packages/frontend/tests/pages/RoutingHeaderTiersSection.test.tsx
@@ -269,6 +269,7 @@ describe('RoutingHeaderTiersSection', () => {
         'gpt-4o',
         'openai',
         'api_key',
+        undefined,
       );
     });
   });

--- a/packages/frontend/tests/services/header-tiers-api.test.ts
+++ b/packages/frontend/tests/services/header-tiers-api.test.ts
@@ -100,6 +100,14 @@ describe('header-tiers API client', () => {
       authType: 'api_key',
       route: { provider: 'OpenAI', authType: 'api_key', model: 'gpt-4o' },
     });
+    await api.overrideHeaderTier('my-agent', 'ht-1', 'gpt-4o', 'OpenAI', 'api_key', 'Personal');
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body)).toEqual({
+      model: 'gpt-4o',
+      provider: 'OpenAI',
+      authType: 'api_key',
+      providerKeyLabel: 'Personal',
+      route: { provider: 'OpenAI', authType: 'api_key', model: 'gpt-4o', keyLabel: 'Personal' },
+    });
   });
 
   it('resetHeaderTier DELETEs the override', async () => {

--- a/packages/frontend/tests/services/routing-utils.test.ts
+++ b/packages/frontend/tests/services/routing-utils.test.ts
@@ -6,8 +6,11 @@ import {
   inferProviderName,
   stripCustomPrefix,
   usedKeyLabelsForModelInTier,
+  activeRouteKeys,
+  availableRouteKeysForModel,
+  routeKeySelectionForModel,
 } from "../../src/services/routing-utils";
-import type { TierAssignment } from "../../src/services/api";
+import type { RoutingProvider, TierAssignment } from "../../src/services/api";
 
 /* ── pricePerM ─────────────────────────────────── */
 
@@ -307,6 +310,18 @@ describe("usedKeyLabelsForModelInTier", () => {
     expect(usedKeyLabelsForModelInTier(tier, "gpt-4o")).toEqual(new Set(["work", "personal"]));
   });
 
+  it("counts unpinned matching fallback routes as the default key when provided", () => {
+    const tier = baseTier({
+      fallback_routes: [
+        { provider: "openai", authType: "api_key", model: "gpt-4o" },
+        { provider: "openai", authType: "api_key", model: "gpt-4o", keyLabel: "Work" },
+      ],
+    });
+    expect(usedKeyLabelsForModelInTier(tier, "gpt-4o", undefined, "Default")).toEqual(
+      new Set(["default", "work"]),
+    );
+  });
+
   it("excludes a specific fallback index from collection", () => {
     const tier = baseTier({
       fallback_routes: [
@@ -330,5 +345,112 @@ describe("usedKeyLabelsForModelInTier", () => {
       ],
     });
     expect(usedKeyLabelsForModelInTier(tier, "gpt-4o")).toEqual(new Set(["work", "personal"]));
+  });
+});
+
+/* ── route key selection ──────────────────────── */
+
+describe("route key selection", () => {
+  const providers: RoutingProvider[] = [
+    {
+      id: "p2",
+      provider: "openai",
+      auth_type: "api_key",
+      is_active: true,
+      has_api_key: true,
+      label: "Personal",
+      priority: 1,
+      connected_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "p1",
+      provider: "openai",
+      auth_type: "api_key",
+      is_active: true,
+      has_api_key: true,
+      label: "Default",
+      priority: 0,
+      connected_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "inactive",
+      provider: "openai",
+      auth_type: "api_key",
+      is_active: false,
+      has_api_key: true,
+      label: "Inactive",
+      priority: 2,
+      connected_at: "2026-01-01T00:00:00Z",
+    },
+  ];
+
+  it("returns active provider keys sorted by priority", () => {
+    expect(activeRouteKeys(providers, "openai", "api_key").map((p) => p.label)).toEqual([
+      "Default",
+      "Personal",
+    ]);
+  });
+
+  it("treats an unpinned primary as using the default key", () => {
+    const tier: TierAssignment = {
+      id: "t1",
+      agent_id: "a1",
+      tier: "simple",
+      override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      auto_assigned_route: null,
+      fallback_routes: null,
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    expect(
+      availableRouteKeysForModel(providers, tier, "gpt-4o", "openai", "api_key").map(
+        (p) => p.label,
+      ),
+    ).toEqual(["Personal"]);
+  });
+
+  it("returns no available keys once every account is used for the model", () => {
+    const tier: TierAssignment = {
+      id: "t1",
+      agent_id: "a1",
+      tier: "simple",
+      override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      auto_assigned_route: null,
+      fallback_routes: [
+        { provider: "openai", authType: "api_key", model: "gpt-4o", keyLabel: "Personal" },
+      ],
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    expect(availableRouteKeysForModel(providers, tier, "gpt-4o", "openai", "api_key")).toEqual(
+      [],
+    );
+  });
+
+  it("auto-selects the only remaining fallback key", () => {
+    const tier: TierAssignment = {
+      id: "t1",
+      agent_id: "a1",
+      tier: "simple",
+      override_route: { provider: "openai", authType: "api_key", model: "gpt-4o" },
+      auto_assigned_route: null,
+      fallback_routes: null,
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+
+    expect(
+      routeKeySelectionForModel({
+        providers,
+        tier,
+        modelName: "gpt-4o",
+        providerId: "openai",
+        authType: "api_key",
+        slot: "fallback",
+      }),
+    ).toMatchObject({
+      autoLabel: "Personal",
+      needsChoice: false,
+      exhausted: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary

- show the multi-account key chip on custom header-tier primary routes
- persist `route.keyLabel` / `providerKeyLabel` through the header-tier override API and backend service
- let shared route-slot key-label detection work for header tiers and unpinned default-account fallback routes

## Root cause

Custom header-tier primary cards did not render the account chip used by default routing cards, and the header-tier override path dropped `keyLabel`, so existing routing models from the first connected subscription account had no visible or persisted account selection after another account was connected.

Fixes #2068.

## Validation

- `npm --workspace packages/shared run build`
- `npm --workspace packages/frontend test -- HeaderTierCard.test.tsx RoutingTierCard.test.tsx routing-utils.test.ts header-tiers-api.test.ts RoutingHeaderTiersSection.test.tsx`
- `npm --workspace packages/backend test -- header-tier.controller.spec.ts header-tier.service.spec.ts`
- `npm --workspace packages/frontend run build`
- `npm --workspace packages/backend run build`
- touched-source ESLint + `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the account chip on custom header-tier primary routes and keep the chosen account when overriding or adding fallbacks. Fixes #2068.

- **Bug Fixes**
  - Frontend: added shared `RouteKeyChip`. `HeaderTierCard` now shows and updates the account for multi-account providers, opening a key picker when needed. Reused in `RoutingTierCard` and `FallbackList`. Fallback picker now hides exhausted models and auto-pins or asks to choose. Updated `routing-utils` with `activeRouteKeys`, `availableRouteKeysForModel`, `routeKeySelectionForModel`, and default-key counting for unpinned routes.
  - API/Backend: `overrideHeaderTier` accepts an optional `providerKeyLabel`. Controller trims and enforces `MAX_PROVIDER_KEY_LABEL_LENGTH` and forwards `route.keyLabel`. Service persists `keyLabel` for explicit and discovery paths.

<sup>Written for commit 4e4a6886bd30196372948e0b12178e0a8422ec58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

