### PR TITLE
fix: price cached input tokens correctly

### DIFF
--- a/.changeset/deepseek-cache-read-cost.md
+++ b/.changeset/deepseek-cache-read-cost.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix token-cost calculation for providers that report cache-read prompt tokens. Manifest now uses models.dev cache-read/cache-write prices when available, so cached DeepSeek input tokens are billed at the cache-hit rate instead of the full input-token rate.

--- a/packages/backend/src/common/utils/cost-calculator.spec.ts
+++ b/packages/backend/src/common/utils/cost-calculator.spec.ts
@@ -76,6 +76,62 @@ describe('computeTokenCost', () => {
     expect(result).toBeCloseTo(0.0075, 10);
   });
 
+  it('prices cache-read input tokens with the cache-read price when available', () => {
+    const deepseekPricing: PricingEntry = {
+      model_name: 'deepseek-v4-pro',
+      provider: 'DeepSeek',
+      input_price_per_token: 0.435 / 1_000_000,
+      output_price_per_token: 0.87 / 1_000_000,
+      cache_read_price_per_token: 0.003625 / 1_000_000,
+      display_name: 'DeepSeek V4 Pro',
+    };
+
+    const result = computeTokenCost({
+      inputTokens: 36_100,
+      outputTokens: 1_200,
+      cacheReadTokens: 21_600,
+      model: 'deepseek-v4-pro',
+      pricing: deepseekPricing,
+    });
+
+    expect(result).toBeCloseTo(0.0074298, 10);
+  });
+
+  it('falls back to input price for cache-read tokens without cache-read pricing', () => {
+    const result = computeTokenCost({
+      inputTokens: 1000,
+      outputTokens: 500,
+      cacheReadTokens: 400,
+      model: 'gpt-4o',
+      pricing,
+    });
+
+    expect(result).toBeCloseTo(0.0075, 10);
+  });
+
+  it('uses cache-write pricing for cache-creation tokens when available', () => {
+    const cachePricing: PricingEntry = {
+      model_name: 'claude-opus-4-6',
+      provider: 'Anthropic',
+      input_price_per_token: 3 / 1_000_000,
+      output_price_per_token: 15 / 1_000_000,
+      cache_read_price_per_token: 0.3 / 1_000_000,
+      cache_write_price_per_token: 3.75 / 1_000_000,
+      display_name: 'Claude Opus 4.6',
+    };
+
+    const result = computeTokenCost({
+      inputTokens: 1000,
+      outputTokens: 100,
+      cacheReadTokens: 300,
+      cacheCreationTokens: 200,
+      model: 'claude-opus-4-6',
+      pricing: cachePricing,
+    });
+
+    expect(result).toBeCloseTo(0.00384, 12);
+  });
+
   it('computes cost with only input tokens', () => {
     const result = computeTokenCost({
       inputTokens: 2000,

--- a/packages/backend/src/common/utils/cost-calculator.ts
+++ b/packages/backend/src/common/utils/cost-calculator.ts
@@ -3,6 +3,8 @@ import { PricingEntry } from '../../model-prices/model-pricing-cache.service';
 export interface CostInput {
   inputTokens: number;
   outputTokens: number;
+  cacheReadTokens?: number;
+  cacheCreationTokens?: number;
   model: string | null | undefined;
   pricing: PricingEntry | undefined;
   /**
@@ -47,9 +49,31 @@ export function computeTokenCost(input: CostInput): number | null {
     return null;
   }
 
+  const inputPrice = Number(pricing.input_price_per_token);
+  const outputPrice = Number(pricing.output_price_per_token);
+  const cacheReadTokens = Math.min(input.inputTokens, Math.max(0, input.cacheReadTokens ?? 0));
+  const cacheCreationTokens = Math.min(
+    input.inputTokens - cacheReadTokens,
+    Math.max(0, input.cacheCreationTokens ?? 0),
+  );
+  const uncachedInputTokens = Math.max(
+    0,
+    input.inputTokens - cacheReadTokens - cacheCreationTokens,
+  );
+  const cacheReadPrice =
+    pricing.cache_read_price_per_token != null
+      ? Number(pricing.cache_read_price_per_token)
+      : inputPrice;
+  const cacheWritePrice =
+    pricing.cache_write_price_per_token != null
+      ? Number(pricing.cache_write_price_per_token)
+      : inputPrice;
+
   const cost =
-    input.inputTokens * Number(pricing.input_price_per_token) +
-    input.outputTokens * Number(pricing.output_price_per_token);
+    uncachedInputTokens * inputPrice +
+    cacheReadTokens * cacheReadPrice +
+    cacheCreationTokens * cacheWritePrice +
+    input.outputTokens * outputPrice;
 
   return cost < 0 ? null : cost;
 }

--- a/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.spec.ts
@@ -457,6 +457,32 @@ describe('ModelPricingCacheService', () => {
       expect(entry!.source).toBe('models.dev');
     });
 
+    it('should preserve models.dev cache pricing on pricing entries', async () => {
+      mockGetAll.mockReturnValue(new Map());
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'deepseek') {
+          return [
+            {
+              id: 'deepseek-v4-pro',
+              name: 'DeepSeek V4 Pro',
+              inputPricePerToken: 0.435 / 1_000_000,
+              outputPricePerToken: 0.87 / 1_000_000,
+              cacheReadPricePerToken: 0.003625 / 1_000_000,
+              cacheWritePricePerToken: 0.435 / 1_000_000,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('deepseek-v4-pro');
+      expect(entry).toBeDefined();
+      expect(entry!.cache_read_price_per_token).toBe(0.003625 / 1_000_000);
+      expect(entry!.cache_write_price_per_token).toBe(0.435 / 1_000_000);
+    });
+
     it('should set display_name to null when models.dev entry has no name', async () => {
       mockGetAll.mockReturnValue(new Map());
       mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {

--- a/packages/backend/src/model-prices/model-pricing-cache.service.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.service.ts
@@ -25,6 +25,8 @@ export interface PricingEntry {
   provider: string;
   input_price_per_token: number | null;
   output_price_per_token: number | null;
+  cache_read_price_per_token?: number | null;
+  cache_write_price_per_token?: number | null;
   display_name: string | null;
   /** True if confirmed via provider-native API, false if unverified, undefined if no data. */
   validated?: boolean;
@@ -200,6 +202,8 @@ export class ModelPricingCacheService implements OnApplicationBootstrap {
           provider: registryEntry.displayName,
           input_price_per_token: model.inputPricePerToken,
           output_price_per_token: model.outputPricePerToken,
+          cache_read_price_per_token: model.cacheReadPricePerToken ?? null,
+          cache_write_price_per_token: model.cacheWritePricePerToken ?? null,
           display_name: model.name || null,
           validated: this.resolveValidatedForModelsDev(providerId, model.id),
           source: 'models.dev',

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -177,6 +177,8 @@ export class PlaygroundService {
       const cost = computeTokenCost({
         inputTokens,
         outputTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
         model: dto.model,
         pricing: this.pricingCache.getByModel(dto.model),
         isSubscription: authType === 'subscription',

--- a/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts
@@ -175,6 +175,30 @@ describe('ProxyMessageRecorder', () => {
       expect(inserted.cost_usd).toBeCloseTo(0.0075, 10);
     });
 
+    it('computes cost_usd with cache-read pricing when usage has cached tokens', async () => {
+      getByModelMock.mockReturnValue({
+        model_name: 'deepseek-v4-pro',
+        provider: 'DeepSeek',
+        input_price_per_token: 0.435 / 1_000_000,
+        output_price_per_token: 0.87 / 1_000_000,
+        cache_read_price_per_token: 0.003625 / 1_000_000,
+        display_name: 'DeepSeek V4 Pro',
+      });
+
+      await recorder.recordFallbackSuccess(ctx, 'deepseek-v4-pro', 'standard', {
+        authType: 'api_key',
+        usage: {
+          prompt_tokens: 36_100,
+          completion_tokens: 1_200,
+          cache_read_tokens: 21_600,
+        },
+      });
+
+      const inserted = insertMock.mock.calls[0][0];
+      expect(inserted.cache_read_tokens).toBe(21_600);
+      expect(inserted.cost_usd).toBeCloseTo(0.0074298, 10);
+    });
+
     it('sets cost_usd to 0 for subscription auth type', async () => {
       getByModelMock.mockReturnValue({
         model_name: 'gpt-4o',

--- a/packages/backend/src/routing/proxy/proxy-message-recorder.ts
+++ b/packages/backend/src/routing/proxy/proxy-message-recorder.ts
@@ -408,6 +408,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     const costUsd = computeTokenCost({
       inputTokens,
       outputTokens,
+      cacheReadTokens: usage?.cache_read_tokens ?? 0,
+      cacheCreationTokens: usage?.cache_creation_tokens ?? 0,
       model,
       pricing: usage ? this.pricingCache.getByModel(model) : undefined,
       isSubscription: authType === 'subscription',
@@ -487,6 +489,8 @@ export class ProxyMessageRecorder implements OnModuleDestroy {
     const costUsd = computeTokenCost({
       inputTokens: usage.prompt_tokens,
       outputTokens: usage.completion_tokens,
+      cacheReadTokens: usage.cache_read_tokens ?? 0,
+      cacheCreationTokens: usage.cache_creation_tokens ?? 0,
       model,
       pricing: this.pricingCache.getByModel(model),
       isSubscription: authType === 'subscription',


### PR DESCRIPTION
## Summary
- preserve models.dev cache-read/cache-write prices in the pricing cache
- price uncached input, cache-read input, cache-creation input, and output tokens separately
- pass recorded cache token counters into proxy and Playground cost calculation

## Root cause
Manifest recorded and displayed `cache_read_tokens`, but `computeTokenCost` still multiplied total prompt tokens by the full input-token price. Providers with cheaper cache-hit pricing, like DeepSeek, were therefore overcharged whenever cache reads were present.

## Impact
This fixes the reported DeepSeek V4 Pro case and applies generically to any model with cache-read/cache-write pricing from models.dev. Models without cache-specific pricing keep the previous input-price fallback behavior.

Closes #2051

## Validation
- `npm ci` (Node v23.7.0 engine warning only)
- `npm --workspace manifest-shared run build`
- `npm --workspace manifest-backend test -- cost-calculator.spec.ts model-pricing-cache.service.spec.ts proxy-message-recorder.spec.ts --runInBand`
- `npm --workspace manifest-backend run build`
- `npx eslint packages/backend/src/common/utils/cost-calculator.ts packages/backend/src/common/utils/cost-calculator.spec.ts packages/backend/src/model-prices/model-pricing-cache.service.ts packages/backend/src/model-prices/model-pricing-cache.service.spec.ts packages/backend/src/routing/proxy/proxy-message-recorder.ts packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts packages/backend/src/playground/playground.service.ts`
- `npx prettier --check packages/backend/src/common/utils/cost-calculator.ts packages/backend/src/common/utils/cost-calculator.spec.ts packages/backend/src/model-prices/model-pricing-cache.service.ts packages/backend/src/model-prices/model-pricing-cache.service.spec.ts packages/backend/src/routing/proxy/proxy-message-recorder.ts packages/backend/src/routing/proxy/__tests__/proxy-message-recorder.spec.ts packages/backend/src/playground/playground.service.ts .changeset/deepseek-cache-read-cost.md`
- `npx changeset status`
- `git diff --check HEAD~1 HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes token cost calculation by pricing cached input tokens at models.dev cache-read/write rates. Prevents overcharging for providers like DeepSeek while keeping fallback behavior for models without cache pricing. Closes #2051.

- **Bug Fixes**
  - Compute costs separately for uncached input, cache-read, cache-creation, and output tokens.
  - Preserve models.dev cache-read/write prices in the pricing cache and expose them on PricingEntry.
  - Pass `cache_read_tokens` and `cache_creation_tokens` through the proxy and Playground to the cost calculator.
  - Fallback to input price when cache prices are missing; subscription requests remain $0.
  - Add tests for DeepSeek and cache-pricing scenarios.

<sup>Written for commit 65bca08fa4a95c837f2beec1e871efff5e5ecab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

