### PR TITLE
feat: add Kimi Coding Plan subscription

### DIFF
--- a/.changeset/kimi-coding-plan.md
+++ b/.changeset/kimi-coding-plan.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Kimi Coding Plan subscription routing for Moonshot/Kimi with the `kimi-for-coding` model.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Manifest connects to **300+ models across 16 providers** plus any custom provide
   | [**DeepSeek**](https://www.deepseek.com/) | ✅ | — | deepseek-v3.2, deepseek-r1 |
   | [**Mistral**](https://mistral.ai/) | ✅ | — | mistral-large, codestral, magistral |
   | [**Qwen** (Alibaba Cloud)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) | ✅ | — | qwen3-max, qwen3-coder, qwq-32b |
-  | [**Moonshot** (Kimi)](https://kimi.ai/) | ✅ | — | kimi-k2, moonshot-v1-128k |
+  | [**Moonshot** (Kimi)](https://kimi.ai/) | ✅ | ✅ Kimi Coding Plan | kimi-k2, kimi-for-coding, moonshot-v1-128k |
   | [**MiniMax**](https://www.minimax.io/) | ✅ | ✅ MiniMax Coding Plan | minimax-m2, abab7-chat-preview |
   | [**Z.ai** (Zhipu)](https://z.ai/) | ✅ | ✅ GLM Coding Plan | glm-4.6, glm-4.5-air |
   | [**OpenCode**](https://opencode.ai/) | — | ✅ Go subscription | Routes via OpenCode Go catalog |

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -45,7 +45,7 @@ Manifest is a smart model router for **AI agents** like OpenClaw, Hermes, or any
 
 ## Supported providers
 
-Works with 300+ models across OpenAI, Anthropic, Google Gemini, DeepSeek, xAI, Mistral, Qwen, MiniMax, Kimi, Amazon Nova, Z.ai, OpenRouter, Ollama, and any provider with an OpenAI-compatible API. Connect with an API key, or reuse an existing paid subscription (ChatGPT Plus/Pro, Claude Max/Pro, GLM Coding Plan, etc.) where supported.
+Works with 300+ models across OpenAI, Anthropic, Google Gemini, DeepSeek, xAI, Mistral, Qwen, MiniMax, Kimi, Amazon Nova, Z.ai, OpenRouter, Ollama, and any provider with an OpenAI-compatible API. Connect with an API key, or reuse an existing paid subscription (ChatGPT Plus/Pro, Claude Max/Pro, Kimi Coding Plan, GLM Coding Plan, etc.) where supported.
 
 ## Manifest vs OpenRouter
 

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -632,6 +632,15 @@ describe('ProviderModelFetcherService', () => {
     );
   });
 
+  /* ── Kimi Coding Plan subscription routing ── */
+
+  it('should skip live model fetching for moonshot subscription auth', async () => {
+    const result = await service.fetch('moonshot', 'kimi-code-key', 'subscription');
+
+    expect(result).toEqual([]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   /* ── Kiro subscription provider ── */
 
   it('should fetch Kiro models dynamically through the Kiro model-list operation', async () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -585,6 +585,10 @@ export class ProviderModelFetcherService {
       configKey = 'openai-subscription';
     } else if (configKey === 'minimax' && authType === 'subscription') {
       configKey = 'minimax-subscription';
+    } else if (configKey === 'moonshot' && authType === 'subscription') {
+      // Kimi Code documents a fixed subscription model id (`kimi-for-coding`)
+      // rather than a subscription-scoped /models endpoint.
+      return [];
     } else if (configKey === 'zai' && authType === 'subscription') {
       configKey = 'zai-subscription';
     } else if (configKey === 'opencode-go') {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1178,6 +1178,54 @@ describe('ProviderClient', () => {
     });
   });
 
+  describe('Kimi Coding Plan subscription provider', () => {
+    it('routes Moonshot subscription auth to Kimi Code Anthropic endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'moonshot',
+        apiKey: 'kimi-code-key',
+        model: 'kimi-for-coding',
+        body,
+        stream: false,
+        authType: 'subscription',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.kimi.com/coding/v1/messages',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            'x-api-key': 'kimi-code-key',
+            'Content-Type': 'application/json',
+            'anthropic-version': '2023-06-01',
+          },
+        }),
+      );
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('kimi-for-coding');
+      expect(sentBody.stream).toBeUndefined();
+      expect(sentBody.system).toBeUndefined();
+      expect(result.isAnthropic).toBe(true);
+    });
+
+    it('keeps standard Moonshot API-key auth on the Moonshot OpenAI endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'moonshot',
+        apiKey: 'sk-moon',
+        model: 'kimi-k2',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.moonshot.ai/v1/chat/completions');
+    });
+  });
+
   describe('Kilo API-key provider', () => {
     it('routes to the Kilo Gateway and preserves provider-prefixed model IDs', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -352,6 +352,24 @@ describe('PROVIDER_ENDPOINTS', () => {
     });
   });
 
+  it('moonshot-subscription uses Kimi Coding Plan Anthropic-compatible endpoint', () => {
+    const ep = PROVIDER_ENDPOINTS['moonshot-subscription'];
+    expect(ep.baseUrl).toBe('https://api.kimi.com/coding');
+    expect(ep.format).toBe('anthropic');
+    expect(ep.buildPath('kimi-for-coding')).toBe('/v1/messages');
+    expect(ep.skipSubscriptionIdentity).toBe(true);
+  });
+
+  it('moonshot-subscription uses Kimi Code API key headers', () => {
+    const headers = PROVIDER_ENDPOINTS['moonshot-subscription'].buildHeaders('kimi-code-key');
+    expect(headers).toEqual({
+      'x-api-key': 'kimi-code-key',
+      'Content-Type': 'application/json',
+      'anthropic-version': '2023-06-01',
+    });
+    expect(headers.Authorization).toBeUndefined();
+  });
+
   it('ollama-cloud points at ollama.com with OpenAI format', () => {
     const ep = PROVIDER_ENDPOINTS['ollama-cloud'];
     expect(ep.baseUrl).toBe('https://ollama.com');
@@ -506,6 +524,10 @@ describe('resolveSubscriptionEndpointKey', () => {
 
   it('returns minimax-subscription for minimax', () => {
     expect(resolveSubscriptionEndpointKey('minimax')).toBe('minimax-subscription');
+  });
+
+  it('returns moonshot-subscription for moonshot', () => {
+    expect(resolveSubscriptionEndpointKey('moonshot')).toBe('moonshot-subscription');
   });
 
   it('returns undefined for providers with no subscription override', () => {

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -286,6 +286,7 @@ export class ProviderClient {
 
     if (endpoint.format === 'anthropic') {
       const isSubscription = authType === 'subscription';
+      const injectSubscriptionIdentity = isSubscription && !endpoint.skipSubscriptionIdentity;
       // When the inbound request is already Anthropic Messages
       // (`POST /v1/messages`) and the resolved upstream is also Anthropic,
       // skip the OpenAI translation round-trip and apply only the additive
@@ -299,12 +300,12 @@ export class ProviderClient {
         ctx.apiMode === 'messages'
           ? applyAnthropicMessagesMutations(body, {
               injectCacheControl: !isSubscription,
-              injectSubscriptionIdentity: isSubscription,
+              injectSubscriptionIdentity,
               thinkingLookup: ctx.thinkingLookup,
             })
           : toAnthropicRequest(requestSource, bareModel, {
               injectCacheControl: !isSubscription,
-              injectSubscriptionIdentity: isSubscription,
+              injectSubscriptionIdentity,
               thinkingLookup: ctx.thinkingLookup,
             });
       requestBody.model = bareModel;

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -45,6 +45,12 @@ export interface ProviderEndpoint {
    * the OAuth blob's `u` field. Only valid alongside `format: 'google'`.
    */
   codeAssistEnvelope?: boolean;
+  /**
+   * Subscription routes using the Anthropic wire format usually need the
+   * Claude-agent identity prompt. Disable it for API-key based third-party
+   * endpoints that only reuse the Anthropic protocol shape.
+   */
+  skipSubscriptionIdentity?: boolean;
 }
 
 const openaiStreamUsage = { streamUsageReporting: 'openai_stream_options' as const };
@@ -76,10 +82,9 @@ const anthropicBearerHeaders = (apiKey: string): Record<string, string> => ({
   'anthropic-version': '2023-06-01',
 });
 
-// OpenCode Go's /v1/messages endpoint follows the native Anthropic protocol
-// and authenticates via the `x-api-key` header, not `Authorization: Bearer`.
-// Sending a Bearer token yields a "Missing API key" 401 from the upstream.
-const opencodeGoAnthropicHeaders = (apiKey: string): Record<string, string> => ({
+// Some Anthropic-compatible /v1/messages endpoints authenticate via the
+// `x-api-key` header, not `Authorization: Bearer`.
+const anthropicApiKeyHeaders = (apiKey: string): Record<string, string> => ({
   'x-api-key': apiKey,
   'Content-Type': 'application/json',
   'anthropic-version': '2023-06-01',
@@ -92,6 +97,7 @@ const opencodeGoAnthropicHeaders = (apiKey: string): Record<string, string> => (
  * endpoint to accept requests, but may break if OpenAI changes validation.
  */
 const CHATGPT_SUBSCRIPTION_BASE = 'https://chatgpt.com/backend-api';
+const KIMI_CODING_SUBSCRIPTION_BASE = 'https://api.kimi.com/coding';
 const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
 const ZAI_SUBSCRIPTION_BASE = 'https://open.bigmodel.cn/api/coding/paas/v4';
 const OPENCODE_GO_BASE = 'https://opencode.ai/zen/go';
@@ -199,6 +205,13 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: openaiPath,
     format: 'openai',
     ...openaiStreamUsage,
+  },
+  'moonshot-subscription': {
+    baseUrl: KIMI_CODING_SUBSCRIPTION_BASE,
+    buildHeaders: anthropicApiKeyHeaders,
+    buildPath: () => '/v1/messages',
+    format: 'anthropic',
+    skipSubscriptionIdentity: true,
   },
   nvidia: {
     baseUrl: NVIDIA_NIM_BASE,
@@ -325,7 +338,7 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
   },
   'opencode-go-anthropic': {
     baseUrl: OPENCODE_GO_BASE,
-    buildHeaders: opencodeGoAnthropicHeaders,
+    buildHeaders: anthropicApiKeyHeaders,
     buildPath: () => '/v1/messages',
     format: 'anthropic',
   },

--- a/packages/backend/src/routing/proxy/provider-hooks.ts
+++ b/packages/backend/src/routing/proxy/provider-hooks.ts
@@ -15,6 +15,7 @@
 const SUBSCRIPTION_ENDPOINT_OVERRIDES: Record<string, string> = {
   openai: 'openai-subscription',
   minimax: 'minimax-subscription',
+  moonshot: 'moonshot-subscription',
   zai: 'zai-subscription',
   // Gemini's per-API-key endpoint is registered under the legacy key
   // `'google'`, so the override is keyed there too. The OAuth flow shifts

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -65,8 +65,12 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   const isApiKeyCredential = () =>
     !props.isSubMode() || props.provDef.subscriptionCredentialKind === 'api-key';
   const credentialNoun = () => (isApiKeyCredential() ? 'API key' : 'setup token');
-  const inputAriaLabel = () => `${props.provDef.name} ${credentialNoun()}`;
-  const editAriaLabel = () => `New ${props.provDef.name} ${credentialNoun()}`;
+  const credentialOwnerName = () =>
+    props.isSubMode() && props.provDef.subscriptionCredentialName
+      ? props.provDef.subscriptionCredentialName
+      : props.provDef.name;
+  const inputAriaLabel = () => `${credentialOwnerName()} ${credentialNoun()}`;
+  const editAriaLabel = () => `New ${credentialOwnerName()} ${credentialNoun()}`;
   const placeholder = () =>
     props.isSubMode()
       ? (props.provDef.subscriptionKeyPlaceholder ?? 'Paste token')
@@ -229,7 +233,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Get {props.provDef.name} {credentialNoun()}
+                Get {credentialOwnerName()} {credentialNoun()}
               </a>
             </p>
           </Show>
@@ -305,6 +309,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
                 placeholder={placeholder() ?? 'Paste API key'}
                 whereToGetUrl={whereToGetUrl}
                 credentialNoun={credentialNoun}
+                credentialOwnerName={credentialOwnerName}
                 existingLabels={() => activeKeys().map((k) => k.label)}
                 open={props.addKeyOpen}
                 setOpen={props.setAddKeyOpen}
@@ -340,7 +345,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Get {props.provDef.name} {credentialNoun()}
+                  Get {credentialOwnerName()} {credentialNoun()}
                 </a>
               </p>
             </Show>
@@ -368,6 +373,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
           setBusy={props.setBusy}
           placeholder={placeholder() ?? 'Paste API key'}
           credentialNoun={credentialNoun}
+          credentialOwnerName={credentialOwnerName}
           whereToGetUrl={whereToGetUrl}
           addKeyOpen={props.addKeyOpen}
           setAddKeyOpen={props.setAddKeyOpen}
@@ -422,6 +428,7 @@ export interface AddAnotherKeyActionProps {
   placeholder: string;
   whereToGetUrl: () => string | undefined;
   credentialNoun: () => string;
+  credentialOwnerName: () => string;
   existingLabels: () => string[];
   open?: Accessor<boolean>;
   setOpen?: Setter<boolean>;
@@ -509,7 +516,7 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
           onInput={(e) => setLabel(e.currentTarget.value)}
         />
         <label class="provider-detail__label" for="add-key-value" style="margin-top: 8px;">
-          {props.provDef.name} {props.credentialNoun()}
+          {props.credentialOwnerName()} {props.credentialNoun()}
         </label>
         <input
           ref={apiKeyInputRef}
@@ -517,7 +524,7 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
           class="provider-detail__input provider-detail__input--masked"
           type="text"
           autocomplete="off"
-          aria-label={`New ${props.provDef.name} ${props.credentialNoun()}`}
+          aria-label={`New ${props.credentialOwnerName()} ${props.credentialNoun()}`}
           placeholder={props.placeholder}
           value={apiKey()}
           onInput={(e) => setApiKey(e.currentTarget.value)}
@@ -533,7 +540,7 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
               target="_blank"
               rel="noopener noreferrer"
             >
-              Get {props.provDef.name} {props.credentialNoun()}
+              Get {props.credentialOwnerName()} {props.credentialNoun()}
             </a>
           </p>
         </Show>
@@ -570,6 +577,7 @@ interface KeyChainViewProps {
   setBusy: Setter<boolean>;
   placeholder: string;
   credentialNoun: () => string;
+  credentialOwnerName: () => string;
   whereToGetUrl: () => string | undefined;
   addKeyOpen?: Accessor<boolean>;
   setAddKeyOpen?: Setter<boolean>;
@@ -730,6 +738,7 @@ const KeyChainView: Component<KeyChainViewProps> = (props) => {
           placeholder={props.placeholder}
           whereToGetUrl={props.whereToGetUrl}
           credentialNoun={props.credentialNoun}
+          credentialOwnerName={props.credentialOwnerName}
           existingLabels={() => props.activeKeys().map((k) => k.label)}
           open={props.addKeyOpen}
           setOpen={props.setAddKeyOpen}

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -29,6 +29,7 @@ export const getRoutingProviderApiKeyUrl = (providerId: string): string | undefi
  * Anthropic setup-tokens come from the Claude Code CLI, not the API console).
  */
 export const SUBSCRIPTION_PROVIDER_KEY_URLS: Record<string, string> = {
+  moonshot: 'https://www.kimi.com/code/console',
   'ollama-cloud': 'https://ollama.com/settings/keys',
   kiro: 'https://app.kiro.dev',
   zai: 'https://z.ai/manage-apikey/apikey-list',

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -26,6 +26,8 @@ export interface ProviderDef {
    * for providers that historically used the Anthropic-style setup-token flow.
    */
   subscriptionCredentialKind?: 'setup-token' | 'api-key';
+  /** Optional product name used when the subscription credential differs from the provider brand. */
+  subscriptionCredentialName?: string;
   /** Instructions text shown in the subscription detail view. */
   subscriptionCommand?: string;
   /** Provider uses GitHub device login instead of token paste. */
@@ -73,6 +75,7 @@ interface ProviderUIOverlay {
   subscriptionLabel?: string;
   subscriptionKeyPlaceholder?: string;
   subscriptionCredentialKind?: 'setup-token' | 'api-key';
+  subscriptionCredentialName?: string;
   subscriptionCommand?: string;
   deviceLogin?: boolean;
   subscriptionAuthMode?: 'popup_oauth' | 'popup_paste' | 'device_code' | 'token';
@@ -199,6 +202,12 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   moonshot: {
     initial: 'Mo',
     subtitle: 'Kimi k2, Moonshot v1',
+    supportsSubscription: true,
+    subscriptionLabel: 'Kimi Coding Plan',
+    subscriptionAuthMode: 'token',
+    subscriptionCredentialKind: 'api-key',
+    subscriptionCredentialName: 'Kimi Code',
+    subscriptionKeyPlaceholder: 'Paste your Kimi Code API key',
     models: [],
   },
   nvidia: {

--- a/packages/frontend/tests/components/ProviderKeyForm.test.tsx
+++ b/packages/frontend/tests/components/ProviderKeyForm.test.tsx
@@ -884,6 +884,7 @@ describe('ProviderKeyForm', () => {
           placeholder="sk-..."
           whereToGetUrl={() => undefined}
           credentialNoun={() => 'API key'}
+          credentialOwnerName={() => 'OpenAI'}
           existingLabels={() => ['Default']}
           isSubscription={overrides.isSubscription}
         />

--- a/packages/frontend/tests/components/ProviderSelectContent.test.tsx
+++ b/packages/frontend/tests/components/ProviderSelectContent.test.tsx
@@ -223,6 +223,18 @@ describe("ProviderSelectContent", () => {
     expect(screen.getAllByText("GLM Coding Plan").length).toBeGreaterThan(0);
   });
 
+  it("shows Moonshot Kimi Coding Plan in the subscription tab", () => {
+    render(() => (
+      <ProviderSelectContent
+        agentName="test-agent"
+        providers={[]}
+        onUpdate={onUpdate}
+      />
+    ));
+    expect(screen.getByText("Moonshot")).toBeDefined();
+    expect(screen.getAllByText("Kimi Coding Plan").length).toBeGreaterThan(0);
+  });
+
   it("opens token paste detail view when Z.ai is clicked in subscription tab", async () => {
     const { container } = render(() => (
       <ProviderSelectContent
@@ -255,6 +267,24 @@ describe("ProviderSelectContent", () => {
       );
       expect(link).not.toBeNull();
       expect(link!.textContent).toContain("Z.ai");
+    });
+  });
+
+  it("shows 'Get Kimi Code API key' link to the Kimi Code console in subscription detail view", async () => {
+    const { container } = render(() => (
+      <ProviderSelectContent
+        agentName="test-agent"
+        providers={[]}
+        onUpdate={onUpdate}
+      />
+    ));
+    fireEvent.click(screen.getByText("Moonshot"));
+    await waitFor(() => {
+      const link = container.querySelector<HTMLAnchorElement>(
+        'a[href="https://www.kimi.com/code/console"]',
+      );
+      expect(link).not.toBeNull();
+      expect(link!.textContent).toContain("Kimi Code");
     });
   });
 

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -369,6 +369,16 @@ describe("PROVIDERS", () => {
     expect(minimax.subscriptionAuthMode).toBe("device_code");
   });
 
+  it("Moonshot supports Kimi Coding Plan subscription with token flow", () => {
+    const moonshot = PROVIDERS.find((p) => p.id === "moonshot")!;
+    expect(moonshot.supportsSubscription).toBe(true);
+    expect(moonshot.subscriptionLabel).toBe("Kimi Coding Plan");
+    expect(moonshot.subscriptionAuthMode).toBe("token");
+    expect(moonshot.subscriptionKeyPlaceholder).toBe("Paste your Kimi Code API key");
+    expect(moonshot.subscriptionCredentialKind).toBe("api-key");
+    expect(moonshot.subscriptionCredentialName).toBe("Kimi Code");
+  });
+
   it("Ollama Cloud is subscription-only with token paste flow", () => {
     const cloud = PROVIDERS.find((p) => p.id === "ollama-cloud")!;
     expect(cloud).toBeDefined();
@@ -401,6 +411,12 @@ describe("PROVIDERS", () => {
     );
     expect(getSubscriptionProviderKeyUrl("ollama-cloud")).toBe(
       "https://ollama.com/settings/keys",
+    );
+  });
+
+  it("provides a subscription-key URL for Moonshot/Kimi pointing at the Kimi Code console", () => {
+    expect(getSubscriptionProviderKeyUrl("moonshot")).toBe(
+      "https://www.kimi.com/code/console",
     );
   });
 

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -15,6 +15,7 @@ describe('SUBSCRIPTION_PROVIDER_CONFIGS', () => {
         'anthropic',
         'openai',
         'minimax',
+        'moonshot',
         'copilot',
         'ollama-cloud',
         'zai',
@@ -67,6 +68,17 @@ describe('getSubscriptionProviderConfig', () => {
     const config = getSubscriptionProviderConfig('minimax');
     expect(config).toMatchObject({
       subscriptionAuthMode: 'device_code',
+    });
+  });
+
+  it('returns config for moonshot Kimi Coding Plan', () => {
+    const config = getSubscriptionProviderConfig('moonshot');
+    expect(config).toMatchObject({
+      supportsSubscription: true,
+      subscriptionLabel: 'Kimi Coding Plan',
+      subscriptionAuthMode: 'token',
+      subscriptionKeyPlaceholder: 'Paste your Kimi Code API key',
+      knownModelsMatch: 'exact',
     });
   });
 
@@ -179,6 +191,7 @@ describe('supportsSubscriptionProvider', () => {
     expect(supportsSubscriptionProvider('anthropic')).toBe(true);
     expect(supportsSubscriptionProvider('openai')).toBe(true);
     expect(supportsSubscriptionProvider('minimax')).toBe(true);
+    expect(supportsSubscriptionProvider('moonshot')).toBe(true);
     expect(supportsSubscriptionProvider('copilot')).toBe(true);
     expect(supportsSubscriptionProvider('ollama-cloud')).toBe(true);
     expect(supportsSubscriptionProvider('zai')).toBe(true);
@@ -212,6 +225,10 @@ describe('getSubscriptionKnownModels', () => {
     expect(models).toContain('MiniMax-M2.7');
     expect(models).toContain('MiniMax-M2.7-highspeed');
     expect(models).toContain('MiniMax-M2.5');
+  });
+
+  it('returns the fixed model id for moonshot Kimi Coding Plan', () => {
+    expect(getSubscriptionKnownModels('moonshot')).toEqual(['kimi-for-coding']);
   });
 
   it('returns null known models for ollama-cloud (relies on live /api/tags discovery)', () => {
@@ -266,6 +283,10 @@ describe('getSubscriptionKnownModelsMatch', () => {
     expect(getSubscriptionKnownModelsMatch('gemini')).toBe('exact');
   });
 
+  it('returns exact for moonshot Kimi Coding Plan', () => {
+    expect(getSubscriptionKnownModelsMatch('moonshot')).toBe('exact');
+  });
+
   it('returns prefix for unsupported providers (graceful fallback)', () => {
     expect(getSubscriptionKnownModelsMatch('unknown')).toBe('prefix');
   });
@@ -309,6 +330,15 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('zai');
     expect(caps).toMatchObject({
       maxContextWindow: 204800,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    });
+  });
+
+  it('returns capabilities for moonshot Kimi Coding Plan', () => {
+    const caps = getSubscriptionCapabilities('moonshot');
+    expect(caps).toMatchObject({
+      maxContextWindow: 262144,
       supportsPromptCaching: false,
       supportsBatching: false,
     });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -57,6 +57,19 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       supportsBatching: false,
     }),
   }),
+  moonshot: Object.freeze({
+    supportsSubscription: true as const,
+    subscriptionLabel: 'Kimi Coding Plan',
+    subscriptionAuthMode: 'token' as const,
+    subscriptionKeyPlaceholder: 'Paste your Kimi Code API key',
+    knownModels: Object.freeze(['kimi-for-coding']),
+    knownModelsMatch: 'exact' as const,
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 262144,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
   'ollama-cloud': Object.freeze({
     supportsSubscription: true as const,
     subscriptionLabel: 'Ollama Cloud subscription',


### PR DESCRIPTION
## Summary

- add Moonshot/Kimi subscription support for Kimi Coding Plan using the documented `kimi-for-coding` model
- route subscription traffic through Kimi Code's Anthropic-compatible endpoint at `https://api.kimi.com/coding/v1/messages` with `x-api-key` auth
- skip Claude subscription identity injection for this third-party Anthropic-protocol endpoint
- wire the frontend subscription tab, Kimi Code API key wording, Kimi Code Console link, docs, focused tests, and changeset

## Validation

- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/shared -- subscription.spec.ts --runInBand`
- `npm test --workspace=packages/backend -- provider-endpoints.spec.ts provider-client.spec.ts provider-model-fetcher.service.spec.ts --runInBand`
- `npm test --workspace=packages/frontend -- ProviderSelectContent.test.tsx ProviderKeyForm.test.tsx providers.test.ts`
- `npm run build --workspace=packages/backend`
- `npm run build --workspace=packages/frontend`
- `npm run lint` (passes with existing warnings)
- `git diff --check`
- `npx changeset status --since=upstream/main --verbose`

## Live smoke

- Connected a real Kimi Code API key locally without exposing the secret
- Verified the active provider row as `moonshot` / `subscription` with one cached model
- `POST http://127.0.0.1:3001/v1/chat/completions` with `model: auto` returned HTTP 200
- Response headers included `X-Manifest-Provider: moonshot` and `X-Manifest-Model: kimi-for-coding`
- Response content was `KIMI_SMOKE_OK` with usage `22` prompt, `10` completion, `32` total tokens
- Backend log confirmed forwarding to `moonshot-subscription: https://api.kimi.com/coding/v1/messages`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Kimi Coding Plan subscription support for Moonshot/Kimi by routing to Kimi Code’s Anthropic-compatible endpoint and exposing it in the subscription UI. This enables `kimi-for-coding` via a Kimi Code API key.

- New Features
  - Routes Moonshot subscription traffic to https://api.kimi.com/coding/v1/messages with `x-api-key` auth and `anthropic-version: 2023-06-01`.
  - Uses fixed model `kimi-for-coding`; skips live model fetch for Moonshot subscription auth.
  - Disables Claude subscription identity injection for this third‑party Anthropic endpoint.
  - Adds “Kimi Coding Plan” to the subscription tab with “Kimi Code” labeling, API key paste flow, and console link: https://www.kimi.com/code/console.
  - Updates README/docs/tests; shared config sets known models to exact match and adds capabilities.

- Refactors
  - Consolidates Anthropic `x-api-key` header builder for reuse (also applied to OpenCode Go).

<sup>Written for commit d439884a0e2488cb18fbe62cd8f14d8ebc6678bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

