### PR TITLE
fix: keep provider-specific models selectable

### DIFF
--- a/.changeset/deepseek-model-picker-dedupe.md
+++ b/.changeset/deepseek-model-picker-dedupe.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Keep same-name models from different providers available in the routing model picker.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -580,7 +580,7 @@ describe('ModelDiscoveryService', () => {
       expect(result[0].authType).toBe('local');
     });
 
-    it('should deduplicate models by id', async () => {
+    it('should deduplicate duplicate models for the same provider and auth type', async () => {
       const providers = [
         makeProvider({
           id: 'p1',
@@ -589,7 +589,7 @@ describe('ModelDiscoveryService', () => {
         }),
         makeProvider({
           id: 'p2',
-          provider: 'deepseek',
+          provider: 'openai',
           cached_models: [makeModel({ id: 'gpt-4' })],
         }),
       ];
@@ -598,6 +598,31 @@ describe('ModelDiscoveryService', () => {
 
       const result = await service.getModelsForAgent('agent-1');
       expect(result).toHaveLength(1);
+    });
+
+    it('should keep the same model id from different providers as separate routes', async () => {
+      const providers = [
+        makeProvider({
+          id: 'p1',
+          provider: 'openrouter',
+          cached_models: [makeModel({ id: 'deepseek-chat', provider: 'openrouter' })],
+        }),
+        makeProvider({
+          id: 'p2',
+          provider: 'deepseek',
+          cached_models: [makeModel({ id: 'deepseek-chat', provider: 'deepseek' })],
+        }),
+      ];
+      providerRepo.find.mockResolvedValue(providers);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelsForAgent('agent-1');
+
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => `${m.provider}:${m.authType}:${m.id}`)).toEqual([
+        'openrouter:api_key:deepseek-chat',
+        'deepseek:api_key:deepseek-chat',
+      ]);
     });
 
     it('should skip providers with no cached_models', async () => {
@@ -720,6 +745,23 @@ describe('ModelDiscoveryService', () => {
       const result = await service.getModelForAgent('agent-1', 'gpt-4');
       expect(result).toBeDefined();
       expect(result!.id).toBe('gpt-4');
+    });
+
+    it('should not infer a provider when the model id is shared by multiple routes', async () => {
+      providerRepo.find.mockResolvedValue([
+        makeProvider({
+          provider: 'openrouter',
+          cached_models: [makeModel({ id: 'deepseek-chat', provider: 'openrouter' })],
+        }),
+        makeProvider({
+          provider: 'deepseek',
+          cached_models: [makeModel({ id: 'deepseek-chat', provider: 'deepseek' })],
+        }),
+      ]);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelForAgent('agent-1', 'deepseek-chat');
+      expect(result).toBeUndefined();
     });
 
     it('should return undefined for missing model', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -315,14 +315,16 @@ export class ModelDiscoveryService {
       if (!Array.isArray(rawCached)) continue;
       const cached = filterNonChatModels(rawCached, p.provider.toLowerCase());
       const providerAuthType: AuthType = p.auth_type;
+      const providerId = p.provider.toLowerCase();
       for (const m of cached) {
         const effectiveAuthType = m.authType ?? providerAuthType;
-        // Deduplicate by model ID + auth type so subscription and API key
-        // versions of the same model are kept as independent entries.
-        const dedupeKey = `${m.id}::${effectiveAuthType}`;
+        // Deduplicate by the routable tuple, not just model ID. Multiple
+        // providers can expose the same native model name, and the picker must
+        // keep each provider-specific route selectable.
+        const dedupeKey = `${providerId}::${effectiveAuthType}::${m.id}`;
         if (!seen.has(dedupeKey)) {
           seen.set(dedupeKey, models.length);
-          models.push({ ...m, authType: effectiveAuthType });
+          models.push({ ...m, provider: p.provider, authType: effectiveAuthType });
         }
       }
     }
@@ -374,7 +376,10 @@ export class ModelDiscoveryService {
 
   async getModelForAgent(agentId: string, modelName: string): Promise<DiscoveredModel | undefined> {
     const all = await this.getModelsForAgent(agentId);
-    return all.find((m) => m.id === modelName);
+    const matches = all.filter((m) => m.id === modelName);
+    // Provider-less lookups are legacy fallbacks. Once multiple providers can
+    // expose the same model ID, only a single matching route is safe to infer.
+    return matches.length === 1 ? matches[0] : undefined;
   }
 
   private enrichModel(model: DiscoveredModel, providerId: string): DiscoveredModel {


### PR DESCRIPTION
### ✨ What changed
- Deduplicate discovered models by provider, auth type, and model ID.
- Return cached model rows with the active user provider ID.
- Add a regression for OpenRouter and DeepSeek sharing `deepseek-chat`.

### 💭 Why
The model picker is fed by `/available-models`. Same-name models from different providers were collapsed before the UI could show native DeepSeek.

### 👤 For users
DeepSeek stays selectable in routing fallbacks when another provider exposes the same model ID.

### 🔧 For operators
No migration or env changes.
Changeset: patch for `manifest`.

### 📝 Notes
Closes #2078.
Validation: `npm run lint` (warnings only), `npm run build`, full `model-discovery.service.spec.ts`, focused red/green regression, backend build, Prettier, `git diff --check`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the model picker collapsing same-name models across providers so each provider route stays selectable. DeepSeek now remains selectable alongside OpenRouter when both expose `deepseek-chat` (closes #2078).

- **Bug Fixes**
  - Deduplicate models by provider + auth type + model ID.
  - Preserve provider on discovered model rows and apply the effective auth type.
  - Do not infer a provider when a model ID is shared; add tests for separate routes and ambiguous lookups.

<sup>Written for commit 0eff607c5be3d6449b311d735c986fbf08c0ad11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

