### PR TITLE
docs: show how to call Manifest from the OpenAI SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,27 @@ bash <(curl -sSL https://raw.githubusercontent.com/mnfst/manifest/main/docker/in
 
 Open [http://localhost:2099](http://localhost:2099) and sign up — the first account you create becomes the admin. Full self-hosting guide: [docker/DOCKER_README.md](docker/DOCKER_README.md).
 
-> The legacy `manifest` npm package is deprecated and no longer published.
+### Integrate from your code
+
+Manifest is OpenAI-compatible. Point any OpenAI SDK at it by changing two constructor args:
+
+```ts
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.MANIFEST_API_KEY,        // get one at app.manifest.build, starts with mnfst_
+  baseURL: 'https://app.manifest.build/v1',    // cloud; self-hosted: http://localhost:2099/v1
+});
+
+const completion = await client.chat.completions.create({
+  model: 'auto',                               // Manifest picks the provider
+  messages: [{ role: 'user', content: 'Say hi' }],
+});
+```
+
+That's the whole integration. The Python `openai` SDK works the same way. For Anthropic's `@anthropic-ai/sdk`, drop the trailing `/v1` from the base URL (the SDK appends it itself).
+
+> The legacy `manifest` npm package was the self-hosted *server* distribution, replaced by the [Docker image](docker/DOCKER_README.md). There is no client SDK to install: the OpenAI and Anthropic SDKs already work.
 
 ## Providers
 


### PR DESCRIPTION
### 💭 Why
README pitches Manifest but has zero integration code. An AI agent (or a dev) landing on the repo can't start a Node integration without chasing 3-4 follow-up fetches.

### ✨ What changed
- New `### Integrate from your code` subsection under `## Quick start`.
- Drop-in OpenAI SDK example using `model: 'auto'` (matches what `/v1/models` returns and what every in-app snippet uses).
- One-line note about dropping the trailing `/v1` for the Anthropic SDK, since `@anthropic-ai/sdk` appends `/v1/messages` itself.
- Old npm-deprecation line is folded into the same block, reframed as "server, not client".

### 👤 For users
Anyone with an existing `openai` SDK integration can swap two constructor args and be on Manifest. The `mnfst_` key prefix, the cloud base URL, and the `auto` model now all appear above the fold.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a drop-in `openai` SDK example to the README so developers can point existing clients at Manifest with two config changes. Also clarifies the base URL, `mnfst_` API key, `model: 'auto'`, the `@anthropic-ai/sdk` `/v1` note, and that the legacy `manifest` package was server-only.

- **New Features**
  - New “Integrate from your code” section under Quick start with a Node `openai` example.
  - Shows `baseURL` (`https://app.manifest.build/v1` or self-hosted), `apiKey` (`mnfst_...`), and `model: 'auto'`.
  - Notes Python `openai` works the same; `@anthropic-ai/sdk` should omit the `/v1` suffix. Clarifies there’s no client SDK; the old `manifest` npm package referred to the server and is replaced by Docker.

<sup>Written for commit 68476da78854cafed5ea8d35f619ca5b6a708b7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

