### PR TITLE
feat: upgrade MiniMax subscription models to M3

### DIFF
--- a/.changeset/minimax-m3-subscription.md
+++ b/.changeset/minimax-m3-subscription.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add MiniMax M3 to the minimax subscription provider's known models (with `-highspeed`) and retire the M2.5 / M2.1 / M2 / M1 entries from the curated list. M2.7 stays as the legacy option.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Manifest connects to **300+ models across 16 providers** plus any custom provide
   | [**Mistral**](https://mistral.ai/) | ✅ | — | mistral-large, codestral, magistral |
   | [**Qwen** (Alibaba Cloud)](https://www.alibabacloud.com/en/solutions/generative-ai/qwen) | ✅ | — | qwen3-max, qwen3-coder, qwq-32b |
   | [**Moonshot** (Kimi)](https://kimi.ai/) | ✅ | ✅ Kimi Coding Plan | kimi-k2, kimi-for-coding, moonshot-v1-128k |
-  | [**MiniMax**](https://www.minimax.io/) | ✅ | ✅ MiniMax Coding Plan | minimax-m2, abab7-chat-preview |
+  | [**MiniMax**](https://www.minimax.io/) | ✅ | ✅ MiniMax Coding Plan | minimax-m3, minimax-m2.7 |
   | [**Z.ai** (Zhipu)](https://z.ai/) | ✅ | ✅ GLM Coding Plan | glm-4.6, glm-4.5-air |
   | [**OpenCode**](https://opencode.ai/) | — | ✅ Go subscription | Routes via OpenCode Go catalog |
   | [**Ollama**](https://ollama.com/) | 🖥️ Local | ✅ Ollama Cloud | Any GGUF model, port `11434` |

--- a/packages/backend/src/common/utils/provider-inference.spec.ts
+++ b/packages/backend/src/common/utils/provider-inference.spec.ts
@@ -54,7 +54,7 @@ describe('inferProviderFromModel', () => {
   });
 
   it('returns "minimax" for minimax- prefix', () => {
-    expect(inferProviderFromModel('MiniMax-M2.5')).toBe('minimax');
+    expect(inferProviderFromModel('MiniMax-M3')).toBe('minimax');
   });
 
   it('returns "zai" for glm- prefix', () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -2155,13 +2155,10 @@ describe('ModelDiscoveryService', () => {
       const result = buildSubscriptionFallbackModels(null as never, 'minimax');
 
       expect(result.map((m) => m.id)).toEqual([
+        'MiniMax-M3',
+        'MiniMax-M3-highspeed',
         'MiniMax-M2.7',
         'MiniMax-M2.7-highspeed',
-        'MiniMax-M2.5',
-        'MiniMax-M2.5-highspeed',
-        'MiniMax-M2.1',
-        'MiniMax-M2.1-highspeed',
-        'MiniMax-M2',
       ]);
     });
 
@@ -2362,9 +2359,10 @@ describe('ModelDiscoveryService', () => {
 
       const result = supplementWithKnownModels(raw, 'minimax');
 
-      expect(result.map((m) => m.id)).toContain('MiniMax-M2.1');
-      expect(result.map((m) => m.id)).toContain('MiniMax-M2');
-      expect(result.map((m) => m.id)).not.toContain('MiniMax-M2.5');
+      expect(result.map((m) => m.id)).toContain('MiniMax-M3');
+      expect(result.map((m) => m.id)).toContain('MiniMax-M3-highspeed');
+      expect(result.map((m) => m.id)).toContain('MiniMax-M2.7');
+      expect(result.map((m) => m.id)).not.toContain('MiniMax-M2');
     });
 
     it('should supplement Z.ai known models including glm-5.1', () => {

--- a/packages/backend/src/model-prices/model-name-normalizer.spec.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.spec.ts
@@ -136,11 +136,11 @@ describe('model-name-normalizer', () => {
     });
 
     it('includes MiniMax mixed-case aliases', () => {
-      const map = buildAliasMap(['minimax-m2.7', 'minimax-m2.5', 'minimax-m1']);
+      const map = buildAliasMap(['minimax-m3', 'minimax-m2.7']);
+      expect(map.get('MiniMax-M3')).toBe('minimax-m3');
+      expect(map.get('MiniMax-M3-highspeed')).toBe('minimax-m3-highspeed');
       expect(map.get('MiniMax-M2.7')).toBe('minimax-m2.7');
       expect(map.get('MiniMax-M2.7-highspeed')).toBe('minimax-m2.7-highspeed');
-      expect(map.get('MiniMax-M2.5')).toBe('minimax-m2.5');
-      expect(map.get('MiniMax-M1')).toBe('minimax-m1');
     });
 
     it('indexes by bare name without version suffix', () => {
@@ -236,15 +236,15 @@ describe('model-name-normalizer', () => {
     });
 
     it('resolves MiniMax mixed-case alias', () => {
-      const map = buildAliasMap(['minimax-m2.7', 'minimax-m2.5', 'minimax-m1']);
+      const map = buildAliasMap(['minimax-m3', 'minimax-m2.7']);
+      expect(resolveModelName('MiniMax-M3', map)).toBe('minimax-m3');
+      expect(resolveModelName('MiniMax-M3-highspeed', map)).toBe('minimax-m3-highspeed');
       expect(resolveModelName('MiniMax-M2.7', map)).toBe('minimax-m2.7');
-      expect(resolveModelName('MiniMax-M2.7-highspeed', map)).toBe('minimax-m2.7-highspeed');
-      expect(resolveModelName('MiniMax-M2.5', map)).toBe('minimax-m2.5');
     });
 
     it('resolves minimax/ prefixed model', () => {
-      const map = buildAliasMap(['minimax-m2.5']);
-      expect(resolveModelName('minimax/minimax-m2.5', map)).toBe('minimax-m2.5');
+      const map = buildAliasMap(['minimax-m3']);
+      expect(resolveModelName('minimax/minimax-m3', map)).toBe('minimax-m3');
     });
 
     it('resolves dot-variant to dash-canonical via normalization', () => {

--- a/packages/backend/src/model-prices/model-name-normalizer.ts
+++ b/packages/backend/src/model-prices/model-name-normalizer.ts
@@ -30,14 +30,10 @@ const KNOWN_ALIASES: ReadonlyArray<readonly [string, string]> = [
   ['deepseek-chat-v3-0324', 'deepseek-chat'],
   ['deepseek-r1', 'deepseek-reasoner'],
   // MiniMax mixed-case aliases
+  ['MiniMax-M3', 'minimax-m3'],
+  ['MiniMax-M3-highspeed', 'minimax-m3-highspeed'],
   ['MiniMax-M2.7', 'minimax-m2.7'],
   ['MiniMax-M2.7-highspeed', 'minimax-m2.7-highspeed'],
-  ['MiniMax-M2.5', 'minimax-m2.5'],
-  ['MiniMax-M2.5-highspeed', 'minimax-m2.5-highspeed'],
-  ['MiniMax-M2.1', 'minimax-m2.1'],
-  ['MiniMax-M2.1-highspeed', 'minimax-m2.1-highspeed'],
-  ['MiniMax-M2', 'minimax-m2'],
-  ['MiniMax-M1', 'minimax-m1'],
   // Mistral version aliases
   ['mistral-large', 'mistral-large-latest'],
   ['codestral', 'codestral-latest'],

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -2716,7 +2716,7 @@ describe('ProviderClient', () => {
       ['deepseek', 'deepseek-chat'],
       ['moonshot', 'kimi-k2-0905-preview'],
       ['kilo', 'kilo-auto/free'],
-      ['minimax', 'MiniMax-M2'],
+      ['minimax', 'MiniMax-M3'],
       ['nvidia', 'nvidia/nemotron-3-super-120b-a12b'],
       ['qwen', 'qwen-max'],
       ['xai', 'grok-3'],

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -518,7 +518,7 @@ describe('ProxyFallbackService', () => {
       await service.tryForwardToProvider({
         provider: 'minimax',
         apiKey: 'token',
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
         body,
         stream: false,
         sessionKey: 'sess-1',
@@ -529,7 +529,7 @@ describe('ProxyFallbackService', () => {
       expect(providerClient.forward).toHaveBeenCalledWith({
         provider: 'minimax',
         apiKey: 'token',
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
         body,
         stream: false,
         customEndpoint: expect.objectContaining({
@@ -551,7 +551,7 @@ describe('ProxyFallbackService', () => {
       await service.tryForwardToProvider({
         provider: 'minimax',
         apiKey: 'token',
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
         body,
         stream: false,
         sessionKey: 'sess-1',
@@ -563,7 +563,7 @@ describe('ProxyFallbackService', () => {
       expect(providerClient.forward).toHaveBeenCalledWith({
         provider: 'minimax',
         apiKey: 'token',
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
         body,
         stream: false,
         authType: 'subscription',
@@ -581,7 +581,7 @@ describe('ProxyFallbackService', () => {
       await service.tryForwardToProvider({
         provider: 'minimax',
         apiKey: 'sk-cp-cn-token',
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
         body,
         stream: false,
         sessionKey: 'sess-1',
@@ -637,7 +637,7 @@ describe('ProxyFallbackService', () => {
       await service.tryForwardToProvider({
         provider: 'minimax',
         apiKey: 'sk-cp-global-token',
-        model: 'MiniMax-M2.5',
+        model: 'MiniMax-M3',
         body,
         stream: false,
         sessionKey: 'sess-1',

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -183,7 +183,7 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   },
   minimax: {
     initial: 'Mm',
-    subtitle: 'MiniMax M2.7, M2.5, M1',
+    subtitle: 'MiniMax M3, M2.7',
     supportsSubscription: true,
     subscriptionLabel: 'MiniMax Coding Plan',
     subscriptionAuthMode: 'device_code',

--- a/packages/frontend/tests/services/routing-utils.test.ts
+++ b/packages/frontend/tests/services/routing-utils.test.ts
@@ -142,8 +142,8 @@ describe("inferProviderFromModel", () => {
   });
 
   it("detects MiniMax models", () => {
-    expect(inferProviderFromModel("minimax-m2.5")).toBe("minimax");
-    expect(inferProviderFromModel("MiniMax-M1")).toBe("minimax");
+    expect(inferProviderFromModel("minimax-m3")).toBe("minimax");
+    expect(inferProviderFromModel("MiniMax-M3")).toBe("minimax");
   });
 
   it("detects Z.ai GLM models", () => {
@@ -201,7 +201,7 @@ describe("inferProviderName", () => {
   });
 
   it("returns MiniMax for minimax models", () => {
-    expect(inferProviderName("minimax-m2.5")).toBe("MiniMax");
+    expect(inferProviderName("minimax-m3")).toBe("MiniMax");
   });
 
   it("returns Z.ai for GLM models", () => {

--- a/packages/shared/__tests__/provider-inference.spec.ts
+++ b/packages/shared/__tests__/provider-inference.spec.ts
@@ -35,7 +35,7 @@ describe('inferProviderFromModel', () => {
     ['open-mistral-nemo', 'mistral'],
     ['kimi-k2', 'moonshot'],
     ['moonshot-v1', 'moonshot'],
-    ['MiniMax-M2.5', 'minimax'],
+    ['MiniMax-M3', 'minimax'],
     ['glm-4', 'zai'],
     ['qwen2.5-coder', 'qwen'],
     ['qwq-32b', 'qwen'],

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -220,11 +220,11 @@ describe('getSubscriptionKnownModels', () => {
     expect(models).toContain('copilot/gpt-5.4');
   });
 
-  it('returns known models for minimax including M2.7', () => {
+  it('returns known models for minimax including M3', () => {
     const models = getSubscriptionKnownModels('minimax');
+    expect(models).toContain('MiniMax-M3');
+    expect(models).toContain('MiniMax-M3-highspeed');
     expect(models).toContain('MiniMax-M2.7');
-    expect(models).toContain('MiniMax-M2.7-highspeed');
-    expect(models).toContain('MiniMax-M2.5');
   });
 
   it('returns the fixed model id for moonshot Kimi Coding Plan', () => {

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -43,13 +43,10 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     subscriptionLabel: 'MiniMax Coding Plan',
     subscriptionAuthMode: 'device_code' as const,
     knownModels: Object.freeze([
+      'MiniMax-M3',
+      'MiniMax-M3-highspeed',
       'MiniMax-M2.7',
       'MiniMax-M2.7-highspeed',
-      'MiniMax-M2.5',
-      'MiniMax-M2.5-highspeed',
-      'MiniMax-M2.1',
-      'MiniMax-M2.1-highspeed',
-      'MiniMax-M2',
     ]),
     subscriptionCapabilities: Object.freeze({
       maxContextWindow: 200000,


### PR DESCRIPTION
## Summary

Refresh the curated minimax subscription model list so newly-connected MiniMax Coding Plan accounts surface the latest M3 model alongside the existing M2.7 fallback.

## Changes

- `packages/shared/src/subscription/configs.ts` — add `MiniMax-M3` and `MiniMax-M3-highspeed` to the curated `knownModels`, drop `M2.5` / `M2.5-highspeed` / `M2.1` / `M2.1-highspeed` / `M2`. Keeps `M2.7` and `M2.7-highspeed` as legacy options.
- `packages/backend/src/model-prices/model-name-normalizer.ts` — add the matching mixed-case aliases for the M3 / M3-highspeed pair so OpenRouter's lowercase `minimax-m3` rows resolve correctly.
- `README.md` and `packages/frontend/src/services/providers.ts` — update the README provider table and the routing tile subtitle to reference the M3 / M2.7 lineup.
- Updated tests: `packages/shared/__tests__/subscription.spec.ts`, `packages/shared/__tests__/provider-inference.spec.ts`, `packages/backend/src/common/utils/provider-inference.spec.ts`, `packages/backend/src/model-prices/model-name-normalizer.spec.ts`, `packages/backend/src/model-discovery/model-discovery.service.spec.ts`, `packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts`, `packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts`, and `packages/frontend/tests/services/routing-utils.test.ts` so the curated-list and inference assertions reflect the M3 default.
- Added a `.changeset/minimax-m3-subscription.md` patch entry per repo guidelines.

The proxy-fallback edits are pure fixture renames (the routing tests pass any model id straight through `tryForwardToProvider`), so they don't change behavior — they just stop tests from reading like the M2.5 era.

## Why

`MiniMax-M3` is the new flagship in the minimax catalog (512K context, 128K max output, image input across both OpenAI- and Anthropic-compatible interfaces). Without it in `knownModels` the subscription tile only fills with M2.7 entries when the live `/models` lookup is empty, so users on Coding Plan keys can't pick the newer model without manually typing the id. M2.7 stays in the list as the legacy path; the older M2.5 / M2.1 / M2 / M1 IDs are no longer surfaced in the upstream catalog so the curated list drops them.

## Testing

Local from `repos/manifest`:

- `cd packages/shared && npm run build`
- `cd packages/shared && npx jest` — 251 passed
- `cd packages/backend && npx jest src/model-prices/model-name-normalizer.spec.ts src/common/utils/provider-inference.spec.ts` — 77 passed
- `cd packages/backend && npx jest src/model-discovery/model-discovery.service.spec.ts` — 121 passed
- `cd packages/backend && npx jest src/routing/proxy/__tests__/proxy-fallback.service.spec.ts src/routing/proxy/__tests__/provider-client.spec.ts` — 217 passed
- `cd packages/frontend && npx vitest run tests/services/routing-utils.test.ts tests/services/providers.test.ts` — 130 passed
- `cd packages/frontend && npx vitest run tests/components/ProviderSelectModal.test.tsx` — 96 passed
- `cd packages/backend && npx tsc --noEmit` and `cd packages/frontend && npx tsc --noEmit` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade MiniMax subscription defaults to M3 so Coding Plan users see `MiniMax-M3` by default, with `M2.7` kept as a fallback. Adds alias normalization so `MiniMax-M3` resolves to `minimax-m3` in price and routing logic.

- New Features
  - Added `MiniMax-M3` and `MiniMax-M3-highspeed` to curated `knownModels`; removed M2.5/M2.1/M2/M1; kept `M2.7` and `M2.7-highspeed`.
  - Added mixed-case aliases for M3 in the model-name normalizer to map to `minimax-m3`/`minimax-m3-highspeed`.
  - Updated README provider table and the MiniMax UI subtitle to “MiniMax M3, M2.7”.
  - Updated tests to reflect M3 as the default; proxy-fallback changes are fixture renames only (no behavior change).

<sup>Written for commit ea1e78361733eb2e46b72bda990a0629e46387ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

