### PR TITLE
fix: refresh rejected OAuth subscription tokens

### DIFF
--- a/.changeset/openai-oauth-invalidated-refresh.md
+++ b/.changeset/openai-oauth-invalidated-refresh.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Refresh OAuth subscription credentials once when the upstream rejects a stored access token.

--- a/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
@@ -249,6 +249,14 @@ export abstract class RedirectPkceOauthBaseService {
     // still produce a usable short-lived access token.
     if (Date.now() < blob.e - 60_000) return blob.t;
     if (!blob.r) return null;
+    return this.refreshAndPersistToken(blob, agentId, userId);
+  }
+
+  private async refreshAndPersistToken(
+    blob: OAuthTokenBlob,
+    agentId: string,
+    userId: string,
+  ): Promise<string | null> {
     try {
       const refreshed = await this.refreshAccessToken(blob.r, blob.u);
       await this.providerService.upsertProvider(

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -169,6 +169,191 @@ describe('ProxyFallbackService', () => {
       expect(result.response.ok).toBe(true);
     });
 
+    it.each([
+      {
+        provider: 'openai',
+        rawBlob: JSON.stringify({
+          t: 'old-access-token',
+          r: 'refresh-token',
+          e: Date.now() + 10 * 60 * 1000,
+        }),
+        setup: () => openaiOauth.unwrapToken.mockResolvedValue('fresh-openai-token'),
+        unwrap: () => openaiOauth.unwrapToken,
+        expectedApiKey: 'fresh-openai-token',
+      },
+      {
+        provider: 'minimax',
+        rawBlob: JSON.stringify({
+          t: 'old-access-token',
+          r: 'refresh-token',
+          e: Date.now() + 10 * 60 * 1000,
+          u: 'https://api.minimax.io/anthropic',
+        }),
+        setup: () =>
+          minimaxOauth.unwrapToken.mockResolvedValue({
+            t: 'fresh-minimax-token',
+            r: 'refresh-token',
+            e: Date.now() + 60 * 60 * 1000,
+            u: 'https://api.minimax.io/anthropic',
+          }),
+        unwrap: () => minimaxOauth.unwrapToken,
+        expectedApiKey: 'fresh-minimax-token',
+      },
+      {
+        provider: 'anthropic',
+        rawBlob: JSON.stringify({
+          t: 'old-access-token',
+          r: 'refresh-token',
+          e: Date.now() + 10 * 60 * 1000,
+        }),
+        setup: () => anthropicOauth.unwrapToken.mockResolvedValue('fresh-anthropic-token'),
+        unwrap: () => anthropicOauth.unwrapToken,
+        expectedApiKey: 'fresh-anthropic-token',
+      },
+      {
+        provider: 'gemini',
+        rawBlob: JSON.stringify({
+          t: 'old-access-token',
+          r: 'refresh-token',
+          e: Date.now() + 10 * 60 * 1000,
+          u: 'project-123',
+        }),
+        setup: () => geminiOauth.unwrapToken.mockResolvedValue('fresh-gemini-token'),
+        unwrap: () => geminiOauth.unwrapToken,
+        expectedApiKey: 'fresh-gemini-token',
+        expectedProviderResource: 'project-123',
+      },
+      {
+        provider: 'kiro',
+        rawBlob: JSON.stringify({
+          source: 'kiro-oidc',
+          t: 'old-access-token',
+          r: 'refresh-token',
+          e: Date.now() + 10 * 60 * 1000,
+          cid: 'client-id',
+          cs: 'client-secret',
+          region: 'us-east-1',
+        }),
+        setup: () => kiroOauth.unwrapToken.mockResolvedValue('fresh-kiro-token'),
+        unwrap: () => kiroOauth.unwrapToken,
+        expectedApiKey: 'fresh-kiro-token',
+      },
+      {
+        provider: 'xai',
+        rawBlob: JSON.stringify({
+          t: 'old-access-token',
+          r: 'refresh-token',
+          e: Date.now() + 10 * 60 * 1000,
+        }),
+        setup: () => xaiOauth.unwrapToken.mockResolvedValue('fresh-xai-token'),
+        unwrap: () => xaiOauth.unwrapToken,
+        expectedApiKey: 'fresh-xai-token',
+      },
+    ])(
+      'refreshes and retries rejected $provider OAuth subscription tokens',
+      async ({ provider, rawBlob, setup, unwrap, expectedApiKey, expectedProviderResource }) => {
+        setup();
+        providerClient.forward
+          .mockResolvedValueOnce({
+            response: new Response('unauthorized', { status: 401 }),
+            isGoogle: false,
+            isAnthropic: false,
+            isChatGpt: provider === 'openai',
+          })
+          .mockResolvedValueOnce({
+            response: new Response('{"ok":true}', { status: 200 }),
+            isGoogle: false,
+            isAnthropic: false,
+            isChatGpt: provider === 'openai',
+          });
+
+        const result = await service.tryForwardToProvider({
+          provider,
+          apiKey: 'old-access-token',
+          rawApiKey: rawBlob,
+          agentId: 'agent-1',
+          userId: 'user-1',
+          model: `${provider}-model`,
+          body,
+          stream: false,
+          sessionKey: 'sess-1',
+          authType: 'subscription',
+        });
+
+        expect(result.response.status).toBe(200);
+        expect(providerClient.forward).toHaveBeenCalledTimes(2);
+        expect(providerClient.forward.mock.calls[0][0].apiKey).toBe('old-access-token');
+        expect(providerClient.forward.mock.calls[1][0].apiKey).toBe(expectedApiKey);
+        expect(providerClient.forward.mock.calls[1][0].providerResource).toBe(
+          expectedProviderResource,
+        );
+
+        const expiredBlob = JSON.parse(unwrap().mock.calls[0][0] as string) as {
+          e: number;
+          source?: string;
+        };
+        expect(expiredBlob.e).toBe(0);
+        if (provider === 'kiro') expect(expiredBlob.source).toBe('kiro-oidc');
+      },
+    );
+
+    it('does not refresh non-OAuth subscription strings after an upstream 401', async () => {
+      providerClient.forward.mockResolvedValueOnce({
+        response: new Response('unauthorized', { status: 401 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      });
+
+      const result = await service.tryForwardToProvider({
+        provider: 'openai',
+        apiKey: 'sk-plain-subscription-token',
+        rawApiKey: 'sk-plain-subscription-token',
+        agentId: 'agent-1',
+        userId: 'user-1',
+        model: 'gpt-5.3-codex',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'subscription',
+      });
+
+      expect(result.response.status).toBe(401);
+      expect(openaiOauth.unwrapToken).not.toHaveBeenCalled();
+      expect(providerClient.forward).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the original rejected-token response readable when refresh cannot recover', async () => {
+      const errorBody = 'unauthorized';
+      providerClient.forward.mockResolvedValue({
+        response: new Response(errorBody, { status: 401 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      });
+
+      const result = await service.tryForwardToProvider({
+        provider: 'openai',
+        apiKey: 'invalidated-access',
+        rawApiKey: JSON.stringify({
+          t: 'invalidated-access',
+          r: 'refresh-token',
+          e: Date.now() + 10 * 60 * 1000,
+        }),
+        agentId: 'agent-1',
+        userId: 'user-1',
+        model: 'gpt-5.3-codex',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'subscription',
+      });
+
+      expect(result.response.status).toBe(401);
+      await expect(result.response.text()).resolves.toBe(errorBody);
+      expect(providerClient.forward).toHaveBeenCalledTimes(1);
+    });
+
     it('catches transport errors and returns synthetic response', async () => {
       providerClient.forward.mockRejectedValue(new Error('fetch failed'));
 
@@ -1070,12 +1255,13 @@ describe('ProxyFallbackService', () => {
       expect(openaiOauth.unwrapToken).not.toHaveBeenCalled();
     });
 
-    it('returns original key when unwrap returns null', async () => {
+    it('returns null for an OpenAI OAuth blob when unwrap returns null', async () => {
       openaiOauth.unwrapToken.mockResolvedValue(null);
+      const blob = JSON.stringify({ t: 'old', r: 'refresh', e: Date.now() - 1000 });
 
       const result = await resolveApiKey(
         'openai',
-        'blob',
+        blob,
         'subscription',
         'agent-1',
         'user-1',
@@ -1087,7 +1273,7 @@ describe('ProxyFallbackService', () => {
         xaiOauth,
       );
 
-      expect(result.apiKey).toBe('blob');
+      expect(result.apiKey).toBeNull();
     });
 
     it('unwraps Anthropic subscription token via the OAuth blob path', async () => {
@@ -1269,7 +1455,7 @@ describe('ProxyFallbackService', () => {
       expect(geminiOauth.unwrapToken).toHaveBeenCalledWith(blob, 'agent-1', 'user-1');
     });
 
-    it('returns original key when Gemini unwrapToken returns null', async () => {
+    it('returns null when Gemini unwrapToken cannot recover a stored OAuth blob', async () => {
       geminiOauth.unwrapToken.mockResolvedValue(null);
       const blob = JSON.stringify({ t: 'token', r: 'r', e: Date.now() + 1000, u: 'proj-x' });
 
@@ -1287,7 +1473,7 @@ describe('ProxyFallbackService', () => {
         xaiOauth,
       );
 
-      expect(result.apiKey).toBe(blob);
+      expect(result.apiKey).toBeNull();
     });
 
     it('returns resourceUrl as undefined when the Gemini blob is not parseable JSON', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -311,6 +311,43 @@ describe('ProxyService — orchestration', () => {
       expect(momentum.recordTier).toHaveBeenCalledWith('sess-1', 'standard');
     });
 
+    it('passes the raw stored OpenAI OAuth blob alongside the unwrapped access token', async () => {
+      const rawBlob = JSON.stringify({
+        t: 'cached-access',
+        r: 'refresh-token',
+        e: Date.now() + 10 * 60 * 1000,
+      });
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: route('openai', 'subscription', 'gpt-5.3-codex'),
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.getProviderApiKey.mockResolvedValue(rawBlob);
+      openaiOauth.unwrapToken.mockResolvedValue('cached-access');
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      });
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai',
+          authType: 'subscription',
+          apiKey: 'cached-access',
+          rawApiKey: rawBlob,
+          agentId: 'agent-1',
+          userId: 'user-1',
+        }),
+      );
+    });
+
     it('records the specificity category when the route originates from specificity', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -21,6 +21,28 @@ export interface ParamMergeContext {
   scopeKey: string;
 }
 
+interface ForwardProviderOptions {
+  provider: string;
+  apiKey: string;
+  model: string;
+  body: Record<string, unknown>;
+  chatBody?: Record<string, unknown>;
+  stream: boolean;
+  sessionKey: string;
+  signal?: AbortSignal;
+  authType?: string;
+  rawApiKey?: string;
+  agentId?: string;
+  userId?: string;
+  resourceUrl?: string;
+  providerRegion?: string | null;
+  apiMode?: ProxyApiMode;
+  signatureLookup?: SignatureLookup;
+  thinkingLookup?: ThinkingBlockLookup;
+  reasoningContentLookup?: ReasoningContentLookup;
+  paramMergeContext?: ParamMergeContext;
+}
+
 import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
@@ -230,6 +252,12 @@ export class ProxyFallbackService {
         this.kiroOauth,
         this.xaiOauth,
       );
+      if (resolvedCredentials.apiKey === null) {
+        this.logger.debug(
+          `Fallback ${i}: skipping model=${model} provider=${provider} (OAuth token unavailable)`,
+        );
+        continue;
+      }
       const providerRegion = await this.providerKeyService.getProviderRegion(
         agentId,
         provider,
@@ -250,6 +278,9 @@ export class ProxyFallbackService {
         stream,
         sessionKey,
         signal,
+        agentId,
+        userId,
+        rawApiKey: apiKey,
         authType,
         apiMode,
         resourceUrl: resolvedCredentials.resourceUrl,
@@ -287,26 +318,10 @@ export class ProxyFallbackService {
     return { success: null, failures };
   }
 
-  async tryForwardToProvider(opts: {
-    provider: string;
-    apiKey: string;
-    model: string;
-    body: Record<string, unknown>;
-    chatBody?: Record<string, unknown>;
-    stream: boolean;
-    sessionKey: string;
-    signal?: AbortSignal;
-    authType?: string;
-    resourceUrl?: string;
-    providerRegion?: string | null;
-    apiMode?: ProxyApiMode;
-    signatureLookup?: SignatureLookup;
-    thinkingLookup?: ThinkingBlockLookup;
-    reasoningContentLookup?: ReasoningContentLookup;
-    paramMergeContext?: ParamMergeContext;
-  }): Promise<ForwardResult> {
+  async tryForwardToProvider(opts: ForwardProviderOptions): Promise<ForwardResult> {
     try {
-      return await this.forwardToProvider(opts);
+      const forward = await this.forwardToProvider(opts);
+      return await this.retryOAuthSubscriptionAfterRejectedToken(opts, forward);
     } catch (error) {
       if (opts.signal?.aborted) throw error;
       if (!isTransportError(error)) throw error;
@@ -326,24 +341,47 @@ export class ProxyFallbackService {
     }
   }
 
-  private async forwardToProvider(opts: {
-    provider: string;
-    apiKey: string;
-    model: string;
-    body: Record<string, unknown>;
-    chatBody?: Record<string, unknown>;
-    stream: boolean;
-    sessionKey: string;
-    signal?: AbortSignal;
-    authType?: string;
-    resourceUrl?: string;
-    providerRegion?: string | null;
-    apiMode?: ProxyApiMode;
-    signatureLookup?: SignatureLookup;
-    thinkingLookup?: ThinkingBlockLookup;
-    reasoningContentLookup?: ReasoningContentLookup;
-    paramMergeContext?: ParamMergeContext;
-  }): Promise<ForwardResult> {
+  private async retryOAuthSubscriptionAfterRejectedToken(
+    opts: ForwardProviderOptions,
+    forward: ForwardResult,
+  ): Promise<ForwardResult> {
+    if (
+      opts.authType !== 'subscription' ||
+      forward.response.status !== 401 ||
+      !opts.rawApiKey ||
+      !opts.agentId ||
+      !opts.userId
+    ) {
+      return forward;
+    }
+
+    const refreshed = await refreshRejectedOAuthCredential(
+      opts.provider,
+      opts.rawApiKey,
+      opts.agentId,
+      opts.userId,
+      {
+        openaiOauth: this.openaiOauth,
+        minimaxOauth: this.minimaxOauth,
+        anthropicOauth: this.anthropicOauth,
+        geminiOauth: this.geminiOauth,
+        kiroOauth: this.kiroOauth,
+        xaiOauth: this.xaiOauth,
+      },
+    );
+    if (!refreshed?.apiKey || refreshed.apiKey === opts.apiKey) return forward;
+
+    this.logger.log(
+      `OAuth token rejected upstream; refreshed provider=${opts.provider} agent=${opts.agentId}`,
+    );
+    return this.forwardToProvider({
+      ...opts,
+      apiKey: refreshed.apiKey,
+      resourceUrl: refreshed.resourceUrl ?? opts.resourceUrl,
+    });
+  }
+
+  private async forwardToProvider(opts: ForwardProviderOptions): Promise<ForwardResult> {
     const {
       provider,
       stream,
@@ -496,6 +534,73 @@ export function normalizeProviderModel(provider: string, model: string): string 
   return provider.toLowerCase() === 'anthropic' ? normalizeAnthropicShortModelId(model) : model;
 }
 
+interface OAuthServiceSet {
+  openaiOauth: OpenaiOauthService;
+  minimaxOauth: MinimaxOauthService;
+  anthropicOauth: AnthropicOauthService;
+  geminiOauth: GeminiOauthService;
+  kiroOauth: KiroOauthService;
+  xaiOauth: XaiOauthService;
+}
+
+interface ResolvedCredentials {
+  apiKey: string | null;
+  resourceUrl?: string;
+}
+
+function expireRefreshableOAuthBlob(rawValue: string): string | null {
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const blob = parsed as Record<string, unknown>;
+    if (typeof blob.t !== 'string' || typeof blob.r !== 'string' || typeof blob.e !== 'number') {
+      return null;
+    }
+    if (!blob.r) return null;
+    return JSON.stringify({ ...blob, e: 0 });
+  } catch {
+    return null;
+  }
+}
+
+async function refreshRejectedOAuthCredential(
+  provider: string,
+  rawValue: string,
+  agentId: string,
+  userId: string,
+  services: OAuthServiceSet,
+): Promise<ResolvedCredentials | null> {
+  const expiredRawValue = expireRefreshableOAuthBlob(rawValue);
+  if (!expiredRawValue) return null;
+
+  const lower = provider.toLowerCase();
+  if (lower === 'openai') {
+    const unwrapped = await services.openaiOauth.unwrapToken(expiredRawValue, agentId, userId);
+    return unwrapped ? { apiKey: unwrapped } : null;
+  }
+  if (lower === 'minimax') {
+    const unwrapped = await services.minimaxOauth.unwrapToken(expiredRawValue, agentId, userId);
+    return unwrapped ? { apiKey: unwrapped.t, resourceUrl: unwrapped.u } : null;
+  }
+  if (lower === 'anthropic') {
+    const unwrapped = await services.anthropicOauth.unwrapToken(expiredRawValue, agentId, userId);
+    return unwrapped ? { apiKey: unwrapped } : null;
+  }
+  if (lower === 'gemini') {
+    const unwrapped = await services.geminiOauth.unwrapToken(expiredRawValue, agentId, userId);
+    return unwrapped ? { apiKey: unwrapped, resourceUrl: parseOAuthTokenBlob(rawValue)?.u } : null;
+  }
+  if (lower === 'kiro') {
+    const unwrapped = await services.kiroOauth.unwrapToken(expiredRawValue, agentId, userId);
+    return unwrapped ? { apiKey: unwrapped } : null;
+  }
+  if (lower === 'xai') {
+    const unwrapped = await services.xaiOauth.unwrapToken(expiredRawValue, agentId, userId);
+    return unwrapped ? { apiKey: unwrapped } : null;
+  }
+  return null;
+}
+
 export async function resolveApiKey(
   provider: string,
   apiKey: string,
@@ -508,20 +613,23 @@ export async function resolveApiKey(
   geminiOauth: GeminiOauthService,
   kiroOauth: KiroOauthService,
   xaiOauth: XaiOauthService,
-): Promise<{ apiKey: string; resourceUrl?: string }> {
+): Promise<ResolvedCredentials> {
   if (authType === 'subscription') {
     const lower = provider.toLowerCase();
     if (lower === 'openai') {
       const unwrapped = await openaiOauth.unwrapToken(apiKey, agentId, userId);
       if (unwrapped) return { apiKey: unwrapped };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'minimax') {
       const unwrapped = await minimaxOauth.unwrapToken(apiKey, agentId, userId);
       if (unwrapped) return { apiKey: unwrapped.t, resourceUrl: unwrapped.u };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'anthropic') {
       const unwrapped = await anthropicOauth.unwrapToken(apiKey, agentId, userId);
       if (unwrapped) return { apiKey: unwrapped };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'gemini') {
       const unwrapped = await geminiOauth.unwrapToken(apiKey, agentId, userId);
@@ -531,14 +639,17 @@ export async function resolveApiKey(
         const projectId = parseOAuthTokenBlob(apiKey)?.u;
         return { apiKey: unwrapped, resourceUrl: projectId };
       }
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'kiro') {
       const unwrapped = await kiroOauth.unwrapToken(apiKey, agentId, userId);
       if (unwrapped) return { apiKey: unwrapped };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'xai') {
       const unwrapped = await xaiOauth.unwrapToken(apiKey, agentId, userId);
       if (unwrapped) return { apiKey: unwrapped };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
   }
   return { apiKey };

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -257,6 +257,9 @@ export class ProxyService {
       stream,
       sessionKey,
       signal,
+      agentId,
+      userId,
+      rawApiKey: credentials.rawApiKey,
       authType: route.authType,
       apiMode,
       resourceUrl: credentials.resourceUrl,
@@ -422,7 +425,12 @@ export class ProxyService {
     agentId: string,
     userId: string,
     resolved: { provider: string; auth_type?: AuthType; provider_key_label?: string },
-  ): Promise<{ apiKey: string; resourceUrl?: string; providerRegion?: string | null } | null> {
+  ): Promise<{
+    apiKey: string;
+    rawApiKey: string;
+    resourceUrl?: string;
+    providerRegion?: string | null;
+  } | null> {
     const apiKey = await this.providerKeyService.getProviderApiKey(
       agentId,
       resolved.provider,
@@ -444,13 +452,20 @@ export class ProxyService {
       this.kiroOauth,
       this.xaiOauth,
     );
+    const unwrappedApiKey = unwrapped.apiKey;
+    if (unwrappedApiKey === null) return null;
     const providerRegion = await this.providerKeyService.getProviderRegion(
       agentId,
       resolved.provider,
       resolved.auth_type,
       resolved.provider_key_label,
     );
-    return { ...unwrapped, providerRegion };
+    return {
+      apiKey: unwrappedApiKey,
+      rawApiKey: apiKey,
+      resourceUrl: unwrapped.resourceUrl,
+      providerRegion,
+    };
   }
 
   private async tryFallbackChain(args: {


### PR DESCRIPTION
## Summary
- retry OAuth subscription requests once when upstream returns `401` for a stored OAuth access token
- reuse each provider's existing unwrap/refresh path by expiring a copy of the stored blob, preserving provider-specific blob fields
- stop forwarding parseable OAuth JSON blobs as bearer tokens when unwrap/refresh cannot recover

Closes #2012.

## Root cause
Manifest refreshed OAuth access tokens only when the locally stored expiry was near or past expiry. If an upstream provider rejected the access token before that local expiry elapsed, Manifest forwarded the cached token and returned the upstream 401. Separately, when unwrap returned null for a stored OAuth blob, credential resolution fell back to the raw JSON blob and sent it as `Authorization: Bearer ...`.

## Validation
- `npm ci`
- `npm run build --workspace=packages/shared`
- `npm test --workspace=packages/backend -- --runInBand routing/oauth/openai-oauth.service.spec.ts routing/proxy/__tests__/proxy-fallback.service.spec.ts routing/proxy/__tests__/proxy.service.spec.ts`
- `npx tsc --noEmit` in `packages/backend`
- `npm run build --workspace=packages/backend`
- `npx prettier --check` on touched files
- `git diff --check`

Note: local `npm ci` ran under Node v23.7.0 and emitted the existing engine warning for packages requiring Node >=24.