### PR TITLE
test: cover OAuth, SSRF, and tenant-isolation gaps

### DIFF
--- a/packages/backend/src/analytics/services/messages-query.service.cost-filter.spec.ts
+++ b/packages/backend/src/analytics/services/messages-query.service.cost-filter.spec.ts
@@ -1,0 +1,243 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Brackets } from 'typeorm';
+import { MessagesQueryService } from './messages-query.service';
+import { AgentMessage } from '../../entities/agent-message.entity';
+import { TenantCacheService } from '../../common/services/tenant-cache.service';
+
+/**
+ * Cost-filter edge cases for MessagesQueryService.
+ *
+ * The buildBaseMessageQuery method applies cost_min/cost_max filters to raw
+ * `at.cost_usd` without sanitization (only `>=` / `<=` comparisons). If a row
+ * has a negative cost (data corruption, bug, refund-style entry, etc.), the
+ * filter must still apply the comparison literally rather than coerce or
+ * skip the value.
+ *
+ * These tests pin both the SQL clause + the parameter that gets bound, so a
+ * future refactor (e.g. swapping the raw column for `sqlSanitizeCost`) is
+ * caught by a failing test instead of a silent behavior change.
+ */
+describe('MessagesQueryService — cost filter edge cases', () => {
+  let service: MessagesQueryService;
+  let mockGetRawOne: jest.Mock;
+  let mockGetRawMany: jest.Mock;
+  let mockTenantResolve: jest.Mock;
+
+  beforeEach(async () => {
+    mockGetRawOne = jest.fn().mockResolvedValue({ total: 0 });
+    mockGetRawMany = jest.fn().mockResolvedValue([]);
+    mockTenantResolve = jest.fn().mockResolvedValue('tenant-123');
+
+    const mockQb: Record<string, jest.Mock> = {
+      select: jest.fn(),
+      addSelect: jest.fn(),
+      distinct: jest.fn(),
+      leftJoin: jest.fn(),
+      where: jest.fn(),
+      andWhere: jest.fn(),
+      orWhere: jest.fn(),
+      groupBy: jest.fn(),
+      orderBy: jest.fn(),
+      addOrderBy: jest.fn(),
+      limit: jest.fn(),
+      clone: jest.fn(),
+      getRawOne: mockGetRawOne,
+      getRawMany: mockGetRawMany,
+    };
+
+    const chainableMethods = [
+      'select',
+      'addSelect',
+      'distinct',
+      'leftJoin',
+      'where',
+      'andWhere',
+      'orWhere',
+      'groupBy',
+      'orderBy',
+      'addOrderBy',
+      'limit',
+      'clone',
+    ];
+    for (const method of chainableMethods) {
+      mockQb[method].mockImplementation((...args: unknown[]) => {
+        const arg = args[0];
+        if (arg instanceof Brackets && typeof (arg as any).whereFactory === 'function') {
+          (arg as any).whereFactory(mockQb);
+        }
+        return mockQb;
+      });
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MessagesQueryService,
+        {
+          provide: getRepositoryToken(AgentMessage),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(mockQb) },
+        },
+        {
+          provide: TenantCacheService,
+          useValue: { resolve: mockTenantResolve },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MessagesQueryService>(MessagesQueryService);
+  });
+
+  const findCostCall = (calls: unknown[][], paramKey: 'costMin' | 'costMax') => {
+    const op = paramKey === 'costMin' ? 'cost_usd >=' : 'cost_usd <=';
+    return calls.find(([clause]) => typeof clause === 'string' && clause.includes(op));
+  };
+
+  it('passes a negative cost_min through to the cost_usd >= clause', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 1 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-neg', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o', cost: -0.5 },
+      ])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    const repo = (service as unknown as { turnRepo: { createQueryBuilder: jest.Mock } }).turnRepo;
+    const qb = repo.createQueryBuilder();
+    const andWhereSpy = qb.andWhere as jest.Mock;
+    andWhereSpy.mockClear();
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      cost_min: -1,
+    });
+
+    const call = findCostCall(andWhereSpy.mock.calls, 'costMin');
+    // The negative bound must be forwarded literally — no coercion to 0 or
+    // dropping the filter altogether (which would silently change semantics).
+    expect(call).toBeDefined();
+    expect(call?.[1]).toEqual({ costMin: -1 });
+    // The mocked row with cost=-0.5 is returned as-is (the assertion above
+    // proves the filter would include it at the SQL level since -0.5 >= -1).
+    expect(result.items).toHaveLength(1);
+  });
+
+  it('passes cost_min of 0 to the query so negative-cost rows are excluded', async () => {
+    // Database returns no rows because cost_usd >= 0 filters them out. We
+    // assert the SQL parameter (the database is the ground truth, but here
+    // we lock the contract sent to it).
+    mockGetRawOne.mockResolvedValueOnce({ total: 0 });
+    mockGetRawMany.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const repo = (service as unknown as { turnRepo: { createQueryBuilder: jest.Mock } }).turnRepo;
+    const qb = repo.createQueryBuilder();
+    const andWhereSpy = qb.andWhere as jest.Mock;
+    andWhereSpy.mockClear();
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      cost_min: 0,
+    });
+
+    const call = findCostCall(andWhereSpy.mock.calls, 'costMin');
+    expect(call).toBeDefined();
+    expect(call?.[1]).toEqual({ costMin: 0 });
+    expect(result.items).toEqual([]);
+  });
+
+  it('passes a negative cost_max through to the cost_usd <= clause', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 1 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-neg', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o', cost: -0.5 },
+      ])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    const repo = (service as unknown as { turnRepo: { createQueryBuilder: jest.Mock } }).turnRepo;
+    const qb = repo.createQueryBuilder();
+    const andWhereSpy = qb.andWhere as jest.Mock;
+    andWhereSpy.mockClear();
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      cost_max: -0.1,
+    });
+
+    const call = findCostCall(andWhereSpy.mock.calls, 'costMax');
+    expect(call).toBeDefined();
+    expect(call?.[1]).toEqual({ costMax: -0.1 });
+    expect(result.items).toHaveLength(1);
+  });
+
+  it('passes both negative cost_min and cost_max for inclusive negative ranges', async () => {
+    mockGetRawOne.mockResolvedValueOnce({ total: 1 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-neg', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o', cost: -0.5 },
+      ])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    const repo = (service as unknown as { turnRepo: { createQueryBuilder: jest.Mock } }).turnRepo;
+    const qb = repo.createQueryBuilder();
+    const andWhereSpy = qb.andWhere as jest.Mock;
+    andWhereSpy.mockClear();
+
+    await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      cost_min: -1,
+      cost_max: -0.1,
+    });
+
+    const minCall = findCostCall(andWhereSpy.mock.calls, 'costMin');
+    const maxCall = findCostCall(andWhereSpy.mock.calls, 'costMax');
+    // Both bounds must be present and forwarded literally; without this,
+    // a future "guard against negative input" change would silently widen
+    // the filter window.
+    expect(minCall?.[1]).toEqual({ costMin: -1 });
+    expect(maxCall?.[1]).toEqual({ costMax: -0.1 });
+  });
+
+  it('uses different cache keys for opposite-sign cost bounds', async () => {
+    // Negative and positive bounds with the same magnitude must NOT collide
+    // in the count-cache key (else a paginated request with cost_min=-1
+    // could return a cached count from a previous cost_min=1 request).
+    mockGetRawOne.mockResolvedValueOnce({ total: 7 });
+    mockGetRawMany
+      .mockResolvedValueOnce([
+        { id: 'msg-pos', timestamp: '2026-02-16 10:00:00', model: 'gpt-4o', cost: 0.5 },
+      ])
+      .mockResolvedValueOnce([{ model: 'gpt-4o' }]);
+
+    await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      cost_min: 1,
+    });
+
+    mockGetRawOne.mockResolvedValueOnce({ total: 99 });
+    mockGetRawMany.mockResolvedValueOnce([
+      { id: 'msg-neg', timestamp: '2026-02-16 11:00:00', model: 'gpt-4o', cost: -0.5 },
+    ]);
+
+    const result = await service.getMessages({
+      range: '24h',
+      userId: 'test-user',
+      limit: 20,
+      cost_min: -1,
+      cursor: '2026-02-16 10:00:00|msg-pos',
+    });
+
+    // The second call uses a cursor, so a cache hit would reuse the first
+    // call's total (7). We assert it ran a fresh COUNT and returned 99,
+    // proving the cache key correctly distinguishes the sign of cost_min.
+    expect(result.total_count).toBe(99);
+    expect(mockGetRawOne).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
+++ b/packages/backend/src/analytics/services/timeseries-queries.service.spec.ts
@@ -4,6 +4,7 @@ import { TimeseriesQueriesService } from './timeseries-queries.service';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { Agent } from '../../entities/agent.entity';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
+import { MESSAGE_ROW_SELECT_ALIASES } from './query-helpers';
 
 describe('TimeseriesQueriesService', () => {
   let service: TimeseriesQueriesService;
@@ -214,17 +215,31 @@ describe('TimeseriesQueriesService', () => {
       expect(rows[0]!['specificity_category']).toBe('coding');
     });
 
-    it('projects specificity_category through the shared helper (regression: dashboard badge drift)', async () => {
+    it('projects exactly the columns declared in MESSAGE_ROW_SELECT_ALIASES (regression: helper drift)', async () => {
       mockGetRawMany.mockResolvedValue([]);
       await service.getRecentActivity('24h', 'u1');
 
+      // getRecentActivity routes its column projection through the shared
+      // selectMessageRowColumns helper. Any divergence between the helper
+      // and this endpoint silently breaks the dashboard message badges, so
+      // pin the projected alias set to MESSAGE_ROW_SELECT_ALIASES exactly.
       const projectedAliases = [
-        ...mockTurnQb.select.mock.calls.map((call) => call[1]),
-        ...mockTurnQb.addSelect.mock.calls.map((call) => call[1]),
+        ...mockTurnQb.select.mock.calls.map((call) => call[1] as string),
+        ...mockTurnQb.addSelect.mock.calls.map((call) => call[1] as string),
       ];
-      expect(projectedAliases).toContain('specificity_category');
-      expect(projectedAliases).toContain('routing_tier');
-      expect(projectedAliases).toContain('routing_reason');
+
+      expect(mockTurnQb.select).toHaveBeenCalledTimes(1);
+      expect(mockTurnQb.addSelect).toHaveBeenCalledTimes(MESSAGE_ROW_SELECT_ALIASES.length - 1);
+      expect(projectedAliases).toEqual([...MESSAGE_ROW_SELECT_ALIASES]);
+    });
+
+    it('applies tenant isolation via addTenantFilter so cross-tenant data cannot leak', async () => {
+      mockGetRawMany.mockResolvedValue([]);
+      await service.getRecentActivity('24h', 'u1', 5, undefined, 'tenant-123');
+
+      // When a tenantId is provided the helper filters by tenant_id (not user_id).
+      const andWhereCalls = mockTurnQb.andWhere.mock.calls.map((call) => call[0] as string);
+      expect(andWhereCalls).toContain('at.tenant_id = :tenantId');
     });
   });
 

--- a/packages/backend/src/auth/session.guard.cache.spec.ts
+++ b/packages/backend/src/auth/session.guard.cache.spec.ts
@@ -1,0 +1,229 @@
+jest.mock('better-auth/node', () => ({
+  fromNodeHeaders: jest.fn((headers: Record<string, string>) => headers),
+}));
+
+jest.mock('./auth.instance', () => ({
+  auth: {
+    api: {
+      getSession: jest.fn(),
+    },
+  },
+}));
+
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { SessionGuard } from './session.guard';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { auth } = require('./auth.instance');
+
+function createMockContext(overrides: { ip?: string; headers?: Record<string, string> }): {
+  context: ExecutionContext;
+  request: Record<string, unknown>;
+} {
+  const peerIp = overrides.ip ?? '127.0.0.1';
+  const request: Record<string, unknown> = {
+    ip: peerIp,
+    socket: { remoteAddress: peerIp },
+    headers: overrides.headers ?? {},
+  };
+
+  const context = {
+    getHandler: jest.fn(),
+    getClass: jest.fn(),
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as unknown as ExecutionContext;
+
+  return { context, request };
+}
+
+describe('SessionGuard — cache edge cases', () => {
+  let guard: SessionGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new SessionGuard(reflector);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    guard.onModuleDestroy();
+  });
+
+  describe('whitespace-only cookie header', () => {
+    it('hashes whitespace-only cookies (length > 0) and reuses the cache entry', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const mockSession = {
+        user: { id: 'u-ws', name: 'WS', email: 'ws@test.com' },
+        session: { id: 's-ws' },
+      };
+      (auth.api.getSession as jest.Mock).mockResolvedValue(mockSession);
+      const headers = { cookie: '   ' };
+
+      // First call: no cache, hits getSession and stores under the hashed key
+      await guard.canActivate(createMockContext({ headers }).context);
+      expect(auth.api.getSession).toHaveBeenCalledTimes(1);
+
+      // Second call with the same whitespace cookie: should hit the cache.
+      // This documents the current behavior — the guard only checks length > 0,
+      // so a whitespace-only header is a valid cache key (just like any other
+      // non-empty cookie). It is NOT treated as "no cookie".
+      const second = createMockContext({ headers });
+      const result = await guard.canActivate(second.context);
+
+      expect(result).toBe(true);
+      expect(auth.api.getSession).toHaveBeenCalledTimes(1);
+      expect(second.request['user']).toEqual(mockSession.user);
+      expect(second.request['authMethod']).toBe('session');
+    });
+
+    it('produces a different cache key than an empty cookie header', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      const mockSession = {
+        user: { id: 'u-x', name: 'X', email: 'x@test.com' },
+        session: { id: 's-x' },
+      };
+      (auth.api.getSession as jest.Mock).mockResolvedValue(mockSession);
+
+      // Empty string: skips cache entirely (length === 0 → cacheKey is null)
+      await guard.canActivate(createMockContext({ headers: { cookie: '' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: '' } }).context);
+      expect(auth.api.getSession).toHaveBeenCalledTimes(2);
+
+      // Whitespace-only: cached (length > 0)
+      await guard.canActivate(createMockContext({ headers: { cookie: '   ' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: '   ' } }).context);
+
+      // Only one additional getSession call for whitespace (first stores, second hits cache)
+      expect(auth.api.getSession).toHaveBeenCalledTimes(3);
+    });
+
+    it('treats different whitespace patterns as distinct cache keys', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      (auth.api.getSession as jest.Mock).mockResolvedValue({
+        user: { id: 'u-ws2', name: 'WS2', email: 'ws2@test.com' },
+        session: { id: 's-ws2' },
+      });
+
+      await guard.canActivate(createMockContext({ headers: { cookie: ' ' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: '\t' } }).context);
+      await guard.canActivate(createMockContext({ headers: { cookie: '\n' } }).context);
+
+      // Each is a different non-empty string → different hash → different cache key
+      expect(auth.api.getSession).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('concurrent cache eviction (parallel canActivate)', () => {
+    it('preserves cache size <= MAX_CACHE_SIZE under parallel calls that trigger eviction', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      (auth.api.getSession as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          user: { id: 'u-par', name: 'P', email: 'p@test.com' },
+          session: { id: 's-par' },
+        }),
+      );
+
+      // Shrink the cap so the test is fast and deterministic. The eviction
+      // logic is the same regardless of cap (`while (size >= MAX) delete first`).
+      type WritableMax = { MAX_CACHE_SIZE: number };
+      const MAX = 50;
+      (guard as unknown as WritableMax).MAX_CACHE_SIZE = MAX;
+
+      // Pre-fill the cache to exactly MAX entries.
+      for (let i = 0; i < MAX; i++) {
+        await guard.canActivate(createMockContext({ headers: { cookie: `pre-${i}` } }).context);
+      }
+      type WithCache = { cache: Map<string, unknown> };
+      expect((guard as unknown as WithCache).cache.size).toBe(MAX);
+
+      // Now fire many parallel calls with DISTINCT cookies. Each will await
+      // getSession (resolved on the microtask queue), then synchronously
+      // call storeInCache. Because async functions interleave between
+      // awaits, multiple storeInCache calls can be pending at once — this
+      // exercises the eviction loop under interleaved scheduling.
+      const PARALLEL = 100;
+      const contexts = Array.from(
+        { length: PARALLEL },
+        (_, i) => createMockContext({ headers: { cookie: `par-${i}` } }).context,
+      );
+      await Promise.all(contexts.map((c) => guard.canActivate(c)));
+
+      // Invariant: the cache must never exceed its cap, even under parallel
+      // eviction pressure. If the while loop or `keys().next()` ever skipped
+      // a key, size would drift above MAX.
+      expect((guard as unknown as WithCache).cache.size).toBeLessThanOrEqual(MAX);
+
+      // Stronger: after the dust settles, the cache should be exactly at
+      // (or below) cap. We inserted PARALLEL new keys on top of a full
+      // cache, so the cap is the upper bound.
+      expect((guard as unknown as WithCache).cache.size).toBe(MAX);
+    });
+
+    it('does not throw when storeInCache is called from many parallel awaiters', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      (auth.api.getSession as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          user: { id: 'u-safe', name: 'S', email: 's@test.com' },
+          session: { id: 's-safe' },
+        }),
+      );
+
+      type WritableMax = { MAX_CACHE_SIZE: number };
+      (guard as unknown as WritableMax).MAX_CACHE_SIZE = 10;
+
+      // Fire 50 distinct parallel requests against a cap of 10. The
+      // `while (size >= MAX_CACHE_SIZE)` loop with `keys().next()` must
+      // remain stable even when many writers are interleaved between awaits.
+      const contexts = Array.from(
+        { length: 50 },
+        (_, i) => createMockContext({ headers: { cookie: `safe-${i}` } }).context,
+      );
+
+      await expect(Promise.all(contexts.map((c) => guard.canActivate(c)))).resolves.toEqual(
+        Array(50).fill(true),
+      );
+
+      type WithCache = { cache: Map<string, unknown> };
+      expect((guard as unknown as WithCache).cache.size).toBeLessThanOrEqual(10);
+    });
+
+    it('keeps a recently-touched entry when parallel new inserts evict the oldest', async () => {
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      (auth.api.getSession as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          user: { id: 'u-lru', name: 'L', email: 'l@test.com' },
+          session: { id: 's-lru' },
+        }),
+      );
+
+      type WritableMax = { MAX_CACHE_SIZE: number };
+      const MAX = 5;
+      (guard as unknown as WritableMax).MAX_CACHE_SIZE = MAX;
+
+      // Fill the cache and capture a "recent" key by touching it last.
+      for (let i = 0; i < MAX; i++) {
+        await guard.canActivate(createMockContext({ headers: { cookie: `lru-${i}` } }).context);
+      }
+      // Touch lru-0 so it moves to the tail of insertion order.
+      await guard.canActivate(createMockContext({ headers: { cookie: 'lru-0' } }).context);
+
+      const callsBefore = (auth.api.getSession as jest.Mock).mock.calls.length;
+
+      // Now fire parallel new inserts that should evict the now-oldest entries
+      // (lru-1, lru-2, ...), NOT lru-0.
+      const contexts = Array.from(
+        { length: 3 },
+        (_, i) => createMockContext({ headers: { cookie: `new-${i}` } }).context,
+      );
+      await Promise.all(contexts.map((c) => guard.canActivate(c)));
+
+      // lru-0 should still be cached: hitting it must NOT add a getSession call.
+      await guard.canActivate(createMockContext({ headers: { cookie: 'lru-0' } }).context);
+      expect((auth.api.getSession as jest.Mock).mock.calls.length).toBe(callsBefore + 3);
+    });
+  });
+});

--- a/packages/backend/src/common/guards/api-key.guard.spec.ts
+++ b/packages/backend/src/common/guards/api-key.guard.spec.ts
@@ -202,4 +202,63 @@ describe('ApiKeyGuard', () => {
 
     await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
   });
+
+  it('rejects x-api-key header when provided as an array', async () => {
+    // Express returns an array when multiple values are supplied for the
+    // same header (e.g. duplicate `X-API-Key: ...` lines). `typeof` an
+    // array is 'object', so the guard's `typeof apiKey !== 'string'` check
+    // must reject this case rather than coerce / pick a value silently.
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: { 'x-api-key': ['key1', 'key2'] },
+          ip: '127.0.0.1',
+        }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow('X-API-Key header required');
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  it('rejects x-api-key header when provided as a single-element array', async () => {
+    // Even when only one value is present, an array shape must not pass —
+    // otherwise downstream `apiKey.substring(...)` / hash lookups would
+    // explode at runtime on `array.substring is not a function`.
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: { 'x-api-key': ['only-key'] },
+          ip: '127.0.0.1',
+        }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    await expect(guard.canActivate(ctx)).rejects.toThrow('X-API-Key header required');
+    expect(mockFind).not.toHaveBeenCalled();
+  });
+
+  it('rejects x-api-key header when provided as an empty array', async () => {
+    // Falsy short-circuit (`!apiKey`) handles `[]` because empty arrays
+    // are truthy in JS — the explicit type guard is what catches this.
+    const ctx = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: { 'x-api-key': [] as string[] },
+          ip: '127.0.0.1',
+        }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+
+    await expect(guard.canActivate(ctx)).rejects.toThrow(UnauthorizedException);
+    expect(mockFind).not.toHaveBeenCalled();
+  });
 });

--- a/packages/backend/src/common/utils/cost-calculator.numeric-edges.spec.ts
+++ b/packages/backend/src/common/utils/cost-calculator.numeric-edges.spec.ts
@@ -1,0 +1,289 @@
+import { computeTokenCost } from './cost-calculator';
+import { PricingEntry } from '../../model-prices/model-pricing-cache.service';
+
+/**
+ * These tests pin the current behavior of `computeTokenCost` when pricing
+ * values resolve to non-finite numbers (NaN / Infinity / -Infinity).
+ *
+ * The function performs `Number(pricing.x_price_per_token)` and then guards
+ * the result only with `cost < 0`. Non-finite numbers slip through because:
+ *  - `NaN < 0` is `false`
+ *  - `Infinity < 0` is `false`
+ *  - `-Infinity < 0` is `true` (returns null)
+ *
+ * Until the source is hardened to reject NaN / +Infinity, these tests
+ * document the gap so any future change to the guard is intentional.
+ */
+describe('computeTokenCost — non-finite pricing edges', () => {
+  const basePricing: PricingEntry = {
+    model_name: 'gpt-4o',
+    provider: 'OpenAI',
+    input_price_per_token: 0.0000025,
+    output_price_per_token: 0.00001,
+    display_name: 'GPT-4o',
+  };
+
+  describe('NaN in pricing fields', () => {
+    it('returns NaN when input_price_per_token is the literal NaN', () => {
+      const nanPricing: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.NaN,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'gpt-4o',
+        pricing: nanPricing,
+      });
+
+      // Documented gap: the `cost < 0` guard does NOT reject NaN.
+      // Tightening should change this to `.toBeNull()`.
+      expect(result).not.toBeNull();
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it('returns NaN when output_price_per_token is the literal NaN', () => {
+      const nanPricing: PricingEntry = {
+        ...basePricing,
+        output_price_per_token: Number.NaN,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'gpt-4o',
+        pricing: nanPricing,
+      });
+
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it('returns NaN when input_price_per_token is a non-numeric string', () => {
+      // Models real-world malformed JSON: a string that Number() turns into NaN.
+      const malformed: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: 'not-a-number' as unknown as number,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'gpt-4o',
+        pricing: malformed,
+      });
+
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it('returns NaN when cache_read_price_per_token resolves to NaN', () => {
+      const malformed: PricingEntry = {
+        ...basePricing,
+        cache_read_price_per_token: 'oops' as unknown as number,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheReadTokens: 400,
+        model: 'gpt-4o',
+        pricing: malformed,
+      });
+
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it('returns NaN when cache_write_price_per_token resolves to NaN', () => {
+      const malformed: PricingEntry = {
+        ...basePricing,
+        cache_write_price_per_token: 'bad' as unknown as number,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 1000,
+        outputTokens: 500,
+        cacheCreationTokens: 200,
+        model: 'gpt-4o',
+        pricing: malformed,
+      });
+
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it('returns 0 for subscription even when pricing fields are NaN (short-circuit)', () => {
+      // Subscription short-circuit happens before Number() coercion is touched,
+      // so the NaN never reaches the math.
+      const nanPricing: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.NaN,
+        output_price_per_token: Number.NaN,
+      };
+
+      expect(
+        computeTokenCost({
+          inputTokens: 100,
+          outputTokens: 50,
+          model: 'gpt-4o',
+          pricing: nanPricing,
+          isSubscription: true,
+        }),
+      ).toBe(0);
+    });
+  });
+
+  describe('Infinity in pricing fields', () => {
+    it('returns NaN when input_price_per_token is +Infinity (0 * Inf in fallback cache pricing)', () => {
+      // inputPrice = +Inf leaks into cacheReadPrice / cacheWritePrice fallbacks.
+      // Both cache token counts default to 0, so `0 * Infinity = NaN` poisons
+      // the sum. The `cost < 0` guard cannot reject NaN.
+      const infinitePricing: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.POSITIVE_INFINITY,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'gpt-4o',
+        pricing: infinitePricing,
+      });
+
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it('returns +Infinity when input_price_per_token is +Infinity and cache prices are explicitly finite', () => {
+      // Pinning down the path where +Infinity is preserved: supply explicit
+      // finite cache prices so the `0 * cacheReadPrice` term is `0 * finite = 0`
+      // instead of `0 * Infinity = NaN`. The output term then dominates.
+      const infinitePricing: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.POSITIVE_INFINITY,
+        cache_read_price_per_token: 0,
+        cache_write_price_per_token: 0,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'gpt-4o',
+        pricing: infinitePricing,
+      });
+
+      // Documented gap: `Infinity < 0` is false, so the guard lets +Infinity through.
+      expect(result).toBe(Number.POSITIVE_INFINITY);
+      expect(Number.isFinite(result)).toBe(false);
+    });
+
+    it('returns Infinity when output_price_per_token is +Infinity', () => {
+      const infinitePricing: PricingEntry = {
+        ...basePricing,
+        output_price_per_token: Number.POSITIVE_INFINITY,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'gpt-4o',
+        pricing: infinitePricing,
+      });
+
+      expect(result).toBe(Number.POSITIVE_INFINITY);
+    });
+
+    it('returns null when input_price_per_token is -Infinity with finite cache prices', () => {
+      // With explicit finite cache prices, `0 * finite = 0`, so the cost
+      // is `100 * (-Inf) + 0 + 0 + 50 * finite = -Inf`. `-Inf < 0` is true
+      // → returns null (the existing negative-cost guard catches this).
+      const negInfinite: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.NEGATIVE_INFINITY,
+        cache_read_price_per_token: 0,
+        cache_write_price_per_token: 0,
+      };
+
+      expect(
+        computeTokenCost({
+          inputTokens: 100,
+          outputTokens: 50,
+          model: 'gpt-4o',
+          pricing: negInfinite,
+        }),
+      ).toBeNull();
+    });
+
+    it('returns NaN when input_price_per_token is -Infinity and cache prices fall back (0 * -Inf = NaN)', () => {
+      // Without explicit cache prices, the `0 * (-Infinity)` terms produce
+      // NaN which leaks past the negative-cost guard. Documented gap.
+      const negInfinite: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.NEGATIVE_INFINITY,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'gpt-4o',
+        pricing: negInfinite,
+      });
+
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it('returns NaN when one price is +Infinity and the other is -Infinity', () => {
+      // +Infinity * input + (-Infinity) * output = NaN when both terms contribute
+      const mixedInfinite: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.POSITIVE_INFINITY,
+        output_price_per_token: Number.NEGATIVE_INFINITY,
+      };
+
+      const result = computeTokenCost({
+        inputTokens: 100,
+        outputTokens: 50,
+        model: 'gpt-4o',
+        pricing: mixedInfinite,
+      });
+
+      // +Inf + (-Inf) = NaN; NaN < 0 is false, so we get NaN back.
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it('returns 0 for subscription even when pricing is +Infinity (short-circuit)', () => {
+      const infinitePricing: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.POSITIVE_INFINITY,
+        output_price_per_token: Number.POSITIVE_INFINITY,
+      };
+
+      expect(
+        computeTokenCost({
+          inputTokens: 100,
+          outputTokens: 50,
+          model: 'gpt-4o',
+          pricing: infinitePricing,
+          isSubscription: true,
+        }),
+      ).toBe(0);
+    });
+
+    it('returns the per-request cost for subscriptions even with Infinity pricing', () => {
+      // Subscription branch never touches the token math, so Infinity is irrelevant.
+      const infinitePricing: PricingEntry = {
+        ...basePricing,
+        input_price_per_token: Number.POSITIVE_INFINITY,
+        output_price_per_token: Number.POSITIVE_INFINITY,
+      };
+
+      expect(
+        computeTokenCost({
+          inputTokens: 100,
+          outputTokens: 50,
+          model: 'gpt-4o',
+          pricing: infinitePricing,
+          isSubscription: true,
+          perRequestCostUsd: 0.02,
+        }),
+      ).toBeCloseTo(0.02, 10);
+    });
+  });
+});

--- a/packages/backend/src/common/utils/crypto.util.spec.ts
+++ b/packages/backend/src/common/utils/crypto.util.spec.ts
@@ -54,6 +54,23 @@ describe('encrypt / decrypt', () => {
     expect(decrypt(ciphertext, secret)).toBe(plaintext);
   });
 
+  it('round-trips empty plaintext', () => {
+    // AES-GCM must accept zero-length messages — cipher.update('', 'utf8') and
+    // cipher.final() should produce a valid (empty) ciphertext + auth tag that
+    // round-trips cleanly. Regression guard for any future refactor that
+    // mishandles empty input (e.g. short-circuiting before final()).
+    const ciphertext = encrypt('', secret);
+    // Even an empty plaintext must produce the 4-part envelope.
+    expect(ciphertext.split(':').length).toBe(4);
+    expect(decrypt(ciphertext, secret)).toBe('');
+  });
+
+  it('round-trips unicode and multi-byte plaintext', () => {
+    const plaintext = 'café — 日本語 — 🚀';
+    const ciphertext = encrypt(plaintext, secret);
+    expect(decrypt(ciphertext, secret)).toBe(plaintext);
+  });
+
   it('produces different ciphertext each call (random salt/iv)', () => {
     const plaintext = 'deterministic?';
     const a = encrypt(plaintext, secret);
@@ -71,6 +88,12 @@ describe('encrypt / decrypt', () => {
     // Flip a character in the encrypted portion
     parts[3] = 'AAAA' + parts[3].slice(4);
     expect(() => decrypt(parts.join(':'), secret)).toThrow();
+  });
+
+  it('decrypt throws when the wrong secret is used', () => {
+    const ciphertext = encrypt('payload', secret);
+    const wrongSecret = 'different-secret-also-long-enough-for-scrypt';
+    expect(() => decrypt(ciphertext, wrongSecret)).toThrow();
   });
 });
 
@@ -95,6 +118,12 @@ describe('isEncrypted', () => {
   });
 
   it('returns false when Buffer.from throws (catch branch)', () => {
+    // The catch branch in isEncrypted only fires if Buffer.from itself throws.
+    // We stub it to throw on any base64 decode call, then assert (a) the
+    // function still returns false (i.e. the catch is actually entered) and
+    // (b) our mock was invoked with the 'base64' encoding — without (b), a
+    // refactor that stopped calling Buffer.from would pass silently and leave
+    // the catch branch uncovered.
     const originalFrom = Buffer.from.bind(Buffer);
     const mockFrom = jest.fn().mockImplementation((value: unknown, encoding?: string) => {
       if (encoding === 'base64') throw new Error('mocked');
@@ -104,8 +133,20 @@ describe('isEncrypted', () => {
 
     try {
       expect(isEncrypted('a:b:c:d')).toBe(false);
+      // Confirm the catch branch was actually exercised — at least one
+      // base64 decode attempt must have happened before the throw.
+      const base64Calls = mockFrom.mock.calls.filter((args) => args[1] === 'base64');
+      expect(base64Calls.length).toBeGreaterThan(0);
     } finally {
       Buffer.from = originalFrom as unknown as typeof Buffer.from;
     }
+  });
+
+  it('returns false when a part round-trips to a different base64 string', () => {
+    // Buffer.from('AB', 'base64').toString('base64') === 'AA==' (re-encoded
+    // form), so a non-canonical base64 part that does not round-trip cleanly
+    // must be rejected as not-encrypted. This guards the
+    // `buf.toString('base64') !== part` branch inside isEncrypted.
+    expect(isEncrypted('AB:AB:AB:AB')).toBe(false);
   });
 });

--- a/packages/backend/src/database/ollama-sync.service.spec.ts
+++ b/packages/backend/src/database/ollama-sync.service.spec.ts
@@ -202,6 +202,48 @@ describe('OllamaSyncService', () => {
 
       expect(result).toEqual({ count: 6 });
     });
+
+    /* ── Discovery service rejection (fail-fast) ── */
+
+    it('should rethrow when discoverModels rejects for a single provider', async () => {
+      const provider = { id: 'p1', provider: 'ollama', is_active: true };
+      mockProviderRepo.find.mockResolvedValue([provider]);
+      const discoveryError = new Error('discovery failed');
+      mockDiscovery.discoverModels.mockRejectedValueOnce(discoveryError);
+
+      await expect(service.sync()).rejects.toThrow('discovery failed');
+      expect(mockDiscovery.discoverModels).toHaveBeenCalledTimes(1);
+    });
+
+    it('should halt loop on first provider rejection and not invoke later providers', async () => {
+      const provider1 = { id: 'p1', provider: 'ollama', is_active: true };
+      const provider2 = { id: 'p2', provider: 'ollama', is_active: true };
+      mockProviderRepo.find.mockResolvedValue([provider1, provider2]);
+      mockDiscovery.discoverModels
+        .mockRejectedValueOnce(new Error('first failed'))
+        .mockResolvedValueOnce([{ id: 'm1' }]);
+
+      await expect(service.sync()).rejects.toThrow('first failed');
+      // Fail-fast: loop halts immediately; second provider is never queried
+      expect(mockDiscovery.discoverModels).toHaveBeenCalledTimes(1);
+      expect(mockDiscovery.discoverModels).toHaveBeenCalledWith(provider1);
+      expect(mockDiscovery.discoverModels).not.toHaveBeenCalledWith(provider2);
+    });
+
+    it('should rethrow even if some providers already succeeded (no partial count)', async () => {
+      const provider1 = { id: 'p1', provider: 'ollama', is_active: true };
+      const provider2 = { id: 'p2', provider: 'ollama', is_active: true };
+      const provider3 = { id: 'p3', provider: 'ollama', is_active: true };
+      mockProviderRepo.find.mockResolvedValue([provider1, provider2, provider3]);
+      mockDiscovery.discoverModels
+        .mockResolvedValueOnce([{ id: 'm1' }, { id: 'm2' }])
+        .mockRejectedValueOnce(new Error('second failed'))
+        .mockResolvedValueOnce([{ id: 'm3' }]);
+
+      // sync() rejects rather than returning a partial { count: 2 }
+      await expect(service.sync()).rejects.toThrow('second failed');
+      expect(mockDiscovery.discoverModels).toHaveBeenCalledTimes(2);
+    });
   });
 
   /* ── Provider repo query ── */
@@ -215,6 +257,41 @@ describe('OllamaSyncService', () => {
       expect(mockProviderRepo.find).toHaveBeenCalledWith({
         where: { provider: 'ollama', is_active: true },
       });
+    });
+
+    it('should query with exact where shape (toStrictEqual)', async () => {
+      global.fetch = mockFetchSuccess([]);
+
+      await service.sync();
+
+      expect(mockProviderRepo.find).toHaveBeenCalledTimes(1);
+      const callArg = mockProviderRepo.find.mock.calls[0][0];
+      // Exact structural match catches accidental field additions/removals
+      // (e.g., an inverted is_active or a missing provider filter).
+      expect(callArg).toStrictEqual({
+        where: { provider: 'ollama', is_active: true },
+      });
+      expect(callArg).toEqual(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            provider: 'ollama',
+            is_active: true,
+          }),
+        }),
+      );
+    });
+
+    it('should fall through to API ping when find returns empty (simulates is_active=false filter)', async () => {
+      // If is_active were inverted to false, no rows would match — the service
+      // should hit the API ping branch instead of calling discoverModels.
+      mockProviderRepo.find.mockResolvedValue([]);
+      global.fetch = mockFetchSuccess([{ name: 'llama3' }]);
+
+      const result = await service.sync();
+
+      expect(result).toEqual({ count: 1 });
+      expect(mockDiscovery.discoverModels).not.toHaveBeenCalled();
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/backend/src/database/pricing-sync.service.edge.spec.ts
+++ b/packages/backend/src/database/pricing-sync.service.edge.spec.ts
@@ -1,0 +1,245 @@
+import { PricingSyncService } from './pricing-sync.service';
+
+// Edge-case coverage for PricingSyncService that does not fit cleanly into the
+// main spec file (which is already long). Split out per the test-file size cap
+// in CLAUDE.md. The primary spec is `pricing-sync.service.spec.ts`.
+
+let fetchSpy: jest.SpyInstance;
+
+describe('PricingSyncService edge cases', () => {
+  let service: PricingSyncService;
+
+  beforeEach(() => {
+    service = new PricingSyncService();
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  describe('refreshCache fetch timeout', () => {
+    // The fetch helper sets up `setTimeout(() => controller.abort(), 10_000)`.
+    // If anything during the fetch+parse pipeline times out, the abort signal
+    // fires and the in-flight fetch/json promise rejects with an AbortError.
+    // The catch handler logs and returns null → refreshCache resolves with 0.
+    //
+    // Without this test, a regression that drops the abort signal (e.g. a
+    // refactor that re-fetches without forwarding `controller.signal`) would
+    // silently allow the request to hang for the undici default header
+    // timeout — exactly the class of bug that motivated the non-blocking
+    // startup fix (#1894).
+    it('passes the AbortController signal to fetch so it can be aborted on stall', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      fetchSpy.mockImplementation(async (_url, options) => {
+        const init = options as { signal: AbortSignal };
+        capturedSignal = init.signal;
+        return {
+          ok: true,
+          json: async () => ({ data: [] }),
+        } as unknown as Response;
+      });
+
+      await service.refreshCache();
+
+      // The signal must be an AbortSignal so the surrounding setTimeout(abort)
+      // can actually terminate a stalled upstream connection. If a refactor
+      // dropped the signal, the test fails immediately.
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      // It should not already be aborted right after a clean request — the
+      // timer is cleared in the finally block.
+      expect(capturedSignal!.aborted).toBe(false);
+    });
+
+    // Simulates a real upstream stall: the signal fires (because the abort
+    // timer expired upstream) and res.json() rejects with AbortError. We pin
+    // the exact contract that the catch handler:
+    //  - returns null from fetchOpenRouterModels
+    //  - causes refreshCache to return 0
+    //  - logs an error
+    //  - does not mutate cache or lastFetchedAt
+    it('returns 0 and logs when res.json() rejects with AbortError mid-parse', async () => {
+      const abortErr = new Error('The operation was aborted');
+      abortErr.name = 'AbortError';
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw abortErr;
+        },
+      } as unknown as Response);
+
+      const loggerSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+      try {
+        const count = await service.refreshCache();
+
+        expect(count).toBe(0);
+        expect(loggerSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/Failed to fetch OpenRouter models.*AbortError/),
+        );
+        // No cache mutation on abort.
+        expect(service.getAll().size).toBe(0);
+        expect(service.getLastFetchedAt()).toBeNull();
+      } finally {
+        loggerSpy.mockRestore();
+      }
+    });
+
+    // Belt-and-suspenders: if fetch itself rejects with AbortError (network
+    // stall *before* headers, not after), refreshCache must still resolve 0
+    // and log the error. This guards the other branch of the catch.
+    it('returns 0 and logs when fetch itself rejects with AbortError', async () => {
+      const abortErr = new Error('The operation was aborted');
+      abortErr.name = 'AbortError';
+      fetchSpy.mockRejectedValue(abortErr);
+
+      const loggerSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+      try {
+        const count = await service.refreshCache();
+        expect(count).toBe(0);
+        expect(loggerSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/Failed to fetch OpenRouter models.*AbortError/),
+        );
+      } finally {
+        loggerSpy.mockRestore();
+      }
+    });
+
+    // Verify clearTimeout is called on the abort timer regardless of which
+    // branch wins (success or thrown). If clearTimeout was moved out of
+    // finally and the throw branch leaked the timer, the test below would
+    // see a missing call.
+    it('clears the abort timer on successful fetch (no leaked handles)', async () => {
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      } as unknown as Response);
+
+      try {
+        await service.refreshCache();
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+      } finally {
+        clearTimeoutSpy.mockRestore();
+      }
+    });
+
+    it('clears the abort timer when fetch throws (no leaked handles)', async () => {
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      fetchSpy.mockRejectedValue(new Error('network down'));
+
+      const loggerSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+      try {
+        const count = await service.refreshCache();
+        expect(count).toBe(0);
+        expect(clearTimeoutSpy).toHaveBeenCalled();
+      } finally {
+        loggerSpy.mockRestore();
+        clearTimeoutSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('refreshCache concurrency', () => {
+    // The service is invoked by both the @Cron decorator (daily) and by
+    // manual triggers so concurrent calls are possible. Two parallel calls
+    // each compute their own newCache, and the last assignment to
+    // `this.cache` wins. This test pins the contract: the final cache is
+    // one of the two complete result sets — never a half-merged
+    // intermediate. If a future change introduces shared mutable state
+    // inside refreshCache, this test will start failing.
+    it('handles two parallel refreshCache calls without corrupting the cache', async () => {
+      const respA = {
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'openai/gpt-A', pricing: { prompt: '0.001', completion: '0.002' } }],
+        }),
+      } as unknown as Response;
+      const respB = {
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'openai/gpt-B', pricing: { prompt: '0.003', completion: '0.004' } }],
+        }),
+      } as unknown as Response;
+
+      fetchSpy.mockResolvedValueOnce(respA).mockResolvedValueOnce(respB);
+
+      const [countA, countB] = await Promise.all([service.refreshCache(), service.refreshCache()]);
+
+      expect(countA).toBe(1);
+      expect(countB).toBe(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      // Whichever assignment landed last owns the cache. The other entry
+      // must not be present, and the cache size must equal the size of one
+      // complete fetch (never the union — that would prove the cache was
+      // mutated mid-flight).
+      const all = service.getAll();
+      expect(all.size).toBe(1);
+      const hasA = all.has('openai/gpt-A');
+      const hasB = all.has('openai/gpt-B');
+      expect(hasA !== hasB).toBe(true);
+    });
+
+    // When both calls return the same dataset, the result must be identical
+    // to a single call. Catches a race where one writer could clear the
+    // cache after the other populated it.
+    it('is idempotent when called twice in parallel with identical responses', async () => {
+      fetchSpy.mockImplementation(
+        async () =>
+          ({
+            ok: true,
+            json: async () => ({
+              data: [
+                { id: 'openai/gpt-4o', pricing: { prompt: '0.001', completion: '0.002' } },
+                { id: 'anthropic/claude-x', pricing: { prompt: '0.003', completion: '0.006' } },
+              ],
+            }),
+          }) as unknown as Response,
+      );
+
+      const [countA, countB] = await Promise.all([service.refreshCache(), service.refreshCache()]);
+
+      expect(countA).toBe(2);
+      expect(countB).toBe(2);
+
+      const all = service.getAll();
+      expect(all.size).toBe(2);
+      expect(all.has('openai/gpt-4o')).toBe(true);
+      expect(all.has('anthropic/claude-x')).toBe(true);
+      expect(all.get('openai/gpt-4o')!.input).toBe(0.001);
+      expect(all.get('anthropic/claude-x')!.output).toBe(0.006);
+    });
+
+    // If one of two concurrent refreshes fails (e.g. transient 503), the
+    // other must still populate the cache. The failure must not clobber a
+    // successful sibling's writes because the failure branch returns early
+    // before assigning this.cache.
+    it('does not clobber the cache when a concurrent refresh fails', async () => {
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [{ id: 'openai/gpt-good', pricing: { prompt: '0.001', completion: '0.002' } }],
+        }),
+      } as unknown as Response);
+      fetchSpy.mockResolvedValueOnce({ ok: false, status: 503 } as unknown as Response);
+
+      const loggerSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+      try {
+        const [countA, countB] = await Promise.all([
+          service.refreshCache(),
+          service.refreshCache(),
+        ]);
+
+        // One call saw the good response (count=1), the other saw 503 (count=0).
+        expect(new Set([countA, countB])).toEqual(new Set([0, 1]));
+
+        // The good model must be present regardless of completion order —
+        // the 503 branch returns early before reassigning this.cache.
+        expect(service.getAll().has('openai/gpt-good')).toBe(true);
+        expect(service.getAll().size).toBe(1);
+      } finally {
+        loggerSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/packages/backend/src/database/quality-score.util.edge-cases.spec.ts
+++ b/packages/backend/src/database/quality-score.util.edge-cases.spec.ts
@@ -1,0 +1,157 @@
+import { computeQualityScore, QualityScoreInput } from './quality-score.util';
+
+type ScoreInput = QualityScoreInput;
+
+function makeModel(overrides: Partial<ScoreInput> = {}): ScoreInput {
+  return {
+    model_name: 'test-model',
+    input_price_per_token: 0.000005,
+    output_price_per_token: 0.000015,
+    capability_reasoning: false,
+    capability_code: false,
+    context_window: 128000,
+    ...overrides,
+  };
+}
+
+/**
+ * Edge cases around negative / mixed-sign prices.
+ *
+ * Background (finding): the zero-price branch is gated on `totalPerM === 0`
+ * (strict equality), not `<= 0`. If one of the two prices is negative and the
+ * other is zero, totalPerM is negative, so the zero-price branch is bypassed
+ * and the function falls through to the paid-model tree, where every
+ * `>=` threshold check fails. The result is a degraded score (1 or 2),
+ * NOT the zero-price scoring path. These tests pin that behavior so any
+ * accidental relaxation of the gate (e.g. `<= 0`) is caught.
+ */
+describe('computeQualityScore — negative / mixed-sign prices', () => {
+  describe('one negative + one zero (the finding scenario)', () => {
+    it('treats input=-0.001, output=0 as paid-model with no caps → score 1', () => {
+      // totalPerM = (-0.001 + 0) * 1_000_000 = -1000 (NOT === 0)
+      // Falls through to price-only fallback; every >= check fails → return 1
+      const model = makeModel({
+        model_name: 'corrupt-pricing-model',
+        input_price_per_token: -0.001,
+        output_price_per_token: 0,
+        capability_reasoning: false,
+        capability_code: false,
+      });
+      expect(computeQualityScore(model)).toBe(1);
+    });
+
+    it('treats input=0, output=-0.001 as paid-model with no caps → score 1', () => {
+      const model = makeModel({
+        model_name: 'corrupt-pricing-model',
+        input_price_per_token: 0,
+        output_price_per_token: -0.001,
+        capability_reasoning: false,
+        capability_code: false,
+      });
+      expect(computeQualityScore(model)).toBe(1);
+    });
+
+    it('does NOT promote a corrupt-priced reasoning+code model to score 3', () => {
+      // If the zero-price branch were entered (e.g. via `<= 0`), this model
+      // would score 3 (hasBoth && !isMini). The strict `=== 0` gate keeps
+      // it on the paid branch, where -1000/M cannot satisfy any >= check,
+      // and hasCode triggers `return 2`.
+      const model = makeModel({
+        model_name: 'corrupt-dual-cap',
+        input_price_per_token: -0.001,
+        output_price_per_token: 0,
+        capability_reasoning: true,
+        capability_code: true,
+      });
+      expect(computeQualityScore(model)).toBe(2);
+      expect(computeQualityScore(model)).not.toBe(3);
+    });
+
+    it('does NOT promote a corrupt-priced reasoning-only model to score 3', () => {
+      // Zero-price logic would return 3 for non-mini reasoning. Paid branch
+      // returns 1 because hasCode is false and every >= threshold fails.
+      const model = makeModel({
+        model_name: 'corrupt-reasoner',
+        input_price_per_token: 0,
+        output_price_per_token: -0.001,
+        capability_reasoning: true,
+        capability_code: false,
+      });
+      expect(computeQualityScore(model)).toBe(1);
+      expect(computeQualityScore(model)).not.toBe(3);
+    });
+
+    it('does NOT promote a corrupt-priced code-only model above score 2', () => {
+      const model = makeModel({
+        model_name: 'corrupt-coder',
+        input_price_per_token: -0.001,
+        output_price_per_token: 0,
+        capability_reasoning: false,
+        capability_code: true,
+      });
+      // Zero-price branch would also return 2 here, but via a different
+      // path. Pin the paid-branch result so we notice if the gate changes.
+      expect(computeQualityScore(model)).toBe(2);
+    });
+  });
+
+  describe('both prices negative', () => {
+    it('scores a doubly-negative no-cap model at the lowest tier', () => {
+      const model = makeModel({
+        model_name: 'doubly-corrupt',
+        input_price_per_token: -0.000005,
+        output_price_per_token: -0.000015,
+        capability_reasoning: false,
+        capability_code: false,
+      });
+      // totalPerM = -20 → paid-model branches all fail → 1
+      expect(computeQualityScore(model)).toBe(1);
+    });
+
+    it('scores a doubly-negative reasoning+code model at the lowest tier', () => {
+      // Without the strict gate this would also pass `=== 0` checks if it
+      // were broadened. Make sure the paid branch keeps us low.
+      const model = makeModel({
+        model_name: 'doubly-corrupt-dual',
+        input_price_per_token: -0.000005,
+        output_price_per_token: -0.000015,
+        capability_reasoning: true,
+        capability_code: true,
+      });
+      expect(computeQualityScore(model)).toBe(2);
+    });
+  });
+
+  describe('negative inputs canceling to exactly zero (defensive)', () => {
+    it('routes input=-0.001 + output=+0.001 (sum exactly 0) into zero-price branch', () => {
+      // (-0.001 + 0.001) * 1_000_000 = 0 EXACTLY → enters Ollama-style branch.
+      // This documents a genuine edge case in the strict `=== 0` gate: it
+      // accepts mixed-sign prices that happen to cancel. Treat as a pinned
+      // behavior, not a recommendation.
+      const model = makeModel({
+        model_name: 'sum-zero-model',
+        input_price_per_token: -0.001,
+        output_price_per_token: 0.001,
+        capability_reasoning: true,
+        capability_code: true,
+      });
+      // hasBoth && !isMini → 3 (Ollama-style scoring)
+      expect(computeQualityScore(model)).toBe(3);
+    });
+  });
+
+  describe('override precedence is unaffected by corrupt prices', () => {
+    it('still returns override score when input price is negative', () => {
+      // Overrides are looked up before any price math, so corrupt prices
+      // on an override-listed model don't degrade its score.
+      const model = makeModel({
+        model_name: 'openrouter/auto',
+        input_price_per_token: -0.001,
+        output_price_per_token: 0,
+        capability_reasoning: false,
+        capability_code: false,
+      });
+      expect(computeQualityScore(model)).toBe(5);
+    });
+  });
+});

--- a/packages/backend/src/database/seed-messages.determinism.spec.ts
+++ b/packages/backend/src/database/seed-messages.determinism.spec.ts
@@ -1,0 +1,213 @@
+import { Logger } from '@nestjs/common';
+import { seedAgentMessages } from './seed-messages';
+
+/**
+ * Determinism-focused tests that pin Date.now() to a fixed value so the seed
+ * generator is fully reproducible across runs.
+ *
+ * Without mocking Date.now(), two consecutive runs of seedAgentMessages can
+ * legitimately produce different output because:
+ *   1. The msgCount for h=0 depends on `new Date(now).getUTCHours()` and the
+ *      runs may straddle an hour boundary.
+ *   2. Each timestamp is capped via Math.min(rawTs, now), so a later `now`
+ *      shifts the cap and changes the ISO string.
+ *   3. The 7-day window is anchored at `now`, so the earliest hour shifts
+ *      by the wall-clock delta between runs.
+ *
+ * Pinning Date.now() removes those sources of drift and lets us assert
+ * exact equality across runs and across different anchor timestamps.
+ */
+
+function makeMockRepo() {
+  return {
+    count: jest.fn().mockResolvedValue(0),
+    insert: jest.fn().mockResolvedValue({}),
+  };
+}
+
+function makeMockLogger(): Logger & { log: jest.Mock } {
+  return { log: jest.fn() } as unknown as Logger & { log: jest.Mock };
+}
+
+function collectInsertedMessages(
+  mockRepo: ReturnType<typeof makeMockRepo>,
+): Array<Record<string, unknown>> {
+  const messages: Array<Record<string, unknown>> = [];
+  for (const call of mockRepo.insert.mock.calls) {
+    const batch = call[0] as Array<Record<string, unknown>>;
+    messages.push(...batch);
+  }
+  return messages;
+}
+
+describe('seedAgentMessages determinism with pinned clock', () => {
+  // A weekday at mid-afternoon UTC. Inside the day-window (8..22) so h=0
+  // generates the busy-hour msgCount path.
+  const DAY_ANCHOR = new Date('2026-06-02T15:30:00.000Z').getTime();
+  // A weekday at 04:00 UTC. Inside the night-window (0..7) so h=0 generates
+  // the quiet-hour msgCount path. Used to verify the window selection logic.
+  const NIGHT_ANCHOR = new Date('2026-06-02T04:00:00.000Z').getTime();
+  // A timestamp that exercises the Math.min(rawTs, now) cap at h=0: rawTs
+  // can land between now-3500000ms and now-3499999ms, so the cap matters.
+  const CAP_ANCHOR = new Date('2026-06-02T12:00:00.000Z').getTime();
+
+  let logger: Logger & { log: jest.Mock };
+  let dateNowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logger = makeMockLogger();
+  });
+
+  afterEach(() => {
+    if (dateNowSpy) {
+      dateNowSpy.mockRestore();
+    }
+    jest.clearAllMocks();
+  });
+
+  it('produces byte-identical message arrays when Date.now() is pinned', async () => {
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(DAY_ANCHOR);
+
+    const repo1 = makeMockRepo();
+    await seedAgentMessages(repo1 as never, 'user-1', logger);
+    const msgs1 = collectInsertedMessages(repo1);
+
+    const repo2 = makeMockRepo();
+    await seedAgentMessages(repo2 as never, 'user-1', logger);
+    const msgs2 = collectInsertedMessages(repo2);
+
+    expect(msgs1.length).toBe(msgs2.length);
+    // Compare every field that gets persisted. JSON.stringify gives us a
+    // single failure point with the full diff if anything drifts.
+    expect(JSON.stringify(msgs1)).toBe(JSON.stringify(msgs2));
+  });
+
+  it('produces stable timestamps across runs when Date.now() is pinned', async () => {
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(DAY_ANCHOR);
+
+    const repo1 = makeMockRepo();
+    await seedAgentMessages(repo1 as never, 'user-1', logger);
+    const msgs1 = collectInsertedMessages(repo1);
+
+    const repo2 = makeMockRepo();
+    await seedAgentMessages(repo2 as never, 'user-1', logger);
+    const msgs2 = collectInsertedMessages(repo2);
+
+    for (let i = 0; i < msgs1.length; i++) {
+      expect(msgs1[i].timestamp).toBe(msgs2[i].timestamp);
+    }
+  });
+
+  it('caps timestamps at the pinned now value (no future timestamps)', async () => {
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(CAP_ANCHOR);
+
+    const repo = makeMockRepo();
+    await seedAgentMessages(repo as never, 'user-1', logger);
+    const msgs = collectInsertedMessages(repo);
+
+    // Without the Math.min(rawTs, now) cap, h=0 could produce rawTs values
+    // up to ~3.5 minutes in the future. The cap must clamp them to now.
+    expect(msgs.length).toBeGreaterThan(0);
+    for (const msg of msgs) {
+      const ts = new Date(msg.timestamp as string).getTime();
+      expect(ts).toBeLessThanOrEqual(CAP_ANCHOR);
+    }
+  });
+
+  it('keeps every timestamp within the 7-day window anchored at pinned now', async () => {
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(DAY_ANCHOR);
+
+    const repo = makeMockRepo();
+    await seedAgentMessages(repo as never, 'user-1', logger);
+    const msgs = collectInsertedMessages(repo);
+
+    const sevenDaysMs = 7 * 24 * 3600000;
+    const lowerBound = DAY_ANCHOR - sevenDaysMs - 3600000; // tolerate one-hour edge
+    for (const msg of msgs) {
+      const ts = new Date(msg.timestamp as string).getTime();
+      expect(ts).toBeGreaterThanOrEqual(lowerBound);
+      expect(ts).toBeLessThanOrEqual(DAY_ANCHOR);
+    }
+  });
+
+  it('uses the busy-hour msgCount path at h=0 when pinned now is a day hour', async () => {
+    // DAY_ANCHOR is 15:30 UTC, so utcHour=15 which is within 8..22.
+    // The busy-hour branch yields 4..8 messages for h=0. Because hourBase=now
+    // at h=0 and rawTs = now + offset, the Math.min(rawTs, now) cap clamps
+    // every h=0 message to exactly the ISO string of now.
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(DAY_ANCHOR);
+
+    const repo = makeMockRepo();
+    await seedAgentMessages(repo as never, 'user-1', logger);
+    const msgs = collectInsertedMessages(repo);
+
+    const nowIso = new Date(DAY_ANCHOR).toISOString();
+    const h0Messages = msgs.filter((m) => m.timestamp === nowIso);
+    // Busy hour produces 4..8 messages (4 + floor(seededRandom(0)*5) ∈ [4,8]).
+    expect(h0Messages.length).toBeGreaterThanOrEqual(4);
+    expect(h0Messages.length).toBeLessThanOrEqual(8);
+  });
+
+  it('uses the quiet-hour msgCount path at h=0 when pinned now is a night hour', async () => {
+    // NIGHT_ANCHOR is 04:00 UTC, so utcHour=4 which is within 0..7.
+    // The quiet-hour branch yields 0..2 messages for h=0. All h=0 timestamps
+    // get capped to exactly the ISO string of now (see test above).
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(NIGHT_ANCHOR);
+
+    const repo = makeMockRepo();
+    await seedAgentMessages(repo as never, 'user-1', logger);
+    const msgs = collectInsertedMessages(repo);
+
+    const nowIso = new Date(NIGHT_ANCHOR).toISOString();
+    const h0Messages = msgs.filter((m) => m.timestamp === nowIso);
+    // Quiet hour produces 0..2 messages (floor(seededRandom(500)*3) ∈ [0,2]).
+    expect(h0Messages.length).toBeLessThanOrEqual(2);
+  });
+
+  it('shifts the entire 7-day window when the pinned now changes', async () => {
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(DAY_ANCHOR);
+    const repoA = makeMockRepo();
+    await seedAgentMessages(repoA as never, 'user-1', logger);
+    const msgsA = collectInsertedMessages(repoA);
+
+    // Re-pin to one day later. The 7-day window should slide forward by 24h.
+    const SHIFTED = DAY_ANCHOR + 24 * 3600000;
+    dateNowSpy.mockReturnValue(SHIFTED);
+    const repoB = makeMockRepo();
+    await seedAgentMessages(repoB as never, 'user-1', logger);
+    const msgsB = collectInsertedMessages(repoB);
+
+    expect(msgsA.length).toBeGreaterThan(0);
+    expect(msgsB.length).toBeGreaterThan(0);
+
+    const maxA = Math.max(...msgsA.map((m) => new Date(m.timestamp as string).getTime()));
+    const maxB = Math.max(...msgsB.map((m) => new Date(m.timestamp as string).getTime()));
+    // The latest timestamp in run B should be later than in run A by roughly
+    // the 24h shift (allow a generous tolerance for the random offset).
+    expect(maxB).toBeGreaterThan(maxA);
+    expect(maxB - maxA).toBeGreaterThan(20 * 3600000);
+  });
+
+  it('produces deterministic IDs and models independent of pinned now', async () => {
+    // The id and model assignments use seededRandom(idx) and idx % models.length;
+    // neither depends on `now`. Verify by running with two different anchors.
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(DAY_ANCHOR);
+    const repoA = makeMockRepo();
+    await seedAgentMessages(repoA as never, 'user-1', logger);
+    const msgsA = collectInsertedMessages(repoA);
+
+    dateNowSpy.mockReturnValue(NIGHT_ANCHOR);
+    const repoB = makeMockRepo();
+    await seedAgentMessages(repoB as never, 'user-1', logger);
+    const msgsB = collectInsertedMessages(repoB);
+
+    // The total count differs (different msgCount at h=0 across day/night),
+    // but where both runs produce a message at the same index, the id and
+    // model must match because idx is allocated identically in both runs
+    // for matching (h, m) pairs only when msgCounts agree at every h.
+    // We can at least assert the first id is 'seed-msg-0001' in both.
+    expect(msgsA[0].id).toBe('seed-msg-0001');
+    expect(msgsB[0].id).toBe('seed-msg-0001');
+    expect(msgsA[0].model).toBe(msgsB[0].model);
+  });
+});

--- a/packages/backend/src/entities/agent.entity.spec.ts
+++ b/packages/backend/src/entities/agent.entity.spec.ts
@@ -63,4 +63,139 @@ describe('Agent entity', () => {
       expect(inverseFn(apiKey)).toBe(apiKey.agent);
     });
   });
+
+  describe('TypeORM table metadata', () => {
+    it('is mapped to the "agents" table', () => {
+      const table = getMetadataArgsStorage().tables.find((t) => t.target === Agent);
+      expect(table).toBeDefined();
+      expect(table!.name).toBe('agents');
+      // Regular table (not view/junction/closure) — used by the schema sync.
+      expect(table!.type).toBe('regular');
+    });
+  });
+
+  describe('TypeORM index metadata', () => {
+    const agentIndices = () => getMetadataArgsStorage().indices.filter((i) => i.target === Agent);
+
+    it('declares the partial unique index on (tenant_id, name) WHERE deleted_at IS NULL', () => {
+      const indices = agentIndices();
+      expect(indices.length).toBeGreaterThan(0);
+
+      // Find the composite (tenant_id, name) index. `columns` is a string[] when
+      // declared at class-level via @Index(['tenant_id', 'name'], { ... }).
+      const composite = indices.find((idx) => {
+        const cols = idx.columns;
+        return (
+          Array.isArray(cols) && cols.length === 2 && cols[0] === 'tenant_id' && cols[1] === 'name'
+        );
+      });
+
+      expect(composite).toBeDefined();
+      expect(composite!.unique).toBe(true);
+      // The partial predicate gates uniqueness so soft-deleted rows don't
+      // collide with a freshly created agent of the same name.
+      expect(composite!.where).toBe('"deleted_at" IS NULL');
+    });
+
+    it('does not silently drop the partial WHERE clause to a full unique index', () => {
+      // Regression guard: a full unique index on (tenant_id, name) would block
+      // recreating an agent with the same name after a soft delete. Make sure
+      // no Agent index claims uniqueness on those columns without `where`.
+      const indices = agentIndices();
+      const offending = indices.find((idx) => {
+        const cols = idx.columns;
+        return (
+          Array.isArray(cols) &&
+          cols.length === 2 &&
+          cols[0] === 'tenant_id' &&
+          cols[1] === 'name' &&
+          idx.unique === true &&
+          (idx.where === undefined || idx.where === null || idx.where === '')
+        );
+      });
+      expect(offending).toBeUndefined();
+    });
+  });
+
+  describe('TypeORM column metadata', () => {
+    const agentColumns = () => getMetadataArgsStorage().columns.filter((c) => c.target === Agent);
+
+    it('declares "id" as the primary column (varchar)', () => {
+      const id = agentColumns().find((c) => c.propertyName === 'id');
+      expect(id).toBeDefined();
+      // PrimaryColumn registers with mode "regular" and primary: true in options.
+      expect(id!.options.primary).toBe(true);
+      expect(id!.options.type).toBe('varchar');
+    });
+
+    it('declares boolean defaults that match the source-of-truth migrations', () => {
+      const cols = agentColumns();
+
+      const isActive = cols.find((c) => c.propertyName === 'is_active');
+      expect(isActive).toBeDefined();
+      expect(isActive!.options.type).toBe('boolean');
+      // Agents default to enabled when created from the dashboard.
+      expect(isActive!.options.default).toBe(true);
+
+      const complexity = cols.find((c) => c.propertyName === 'complexity_routing_enabled');
+      expect(complexity).toBeDefined();
+      expect(complexity!.options.type).toBe('boolean');
+      // Opt-in feature — must default to false so existing agents are unaffected.
+      expect(complexity!.options.default).toBe(false);
+
+      const record = cols.find((c) => c.propertyName === 'record_messages');
+      expect(record).toBeDefined();
+      expect(record!.options.type).toBe('boolean');
+      // Recording defaults ON; opt-out via UI toggles this to false.
+      expect(record!.options.default).toBe(true);
+    });
+
+    it('marks the expected fields as nullable and the required ones as non-null', () => {
+      const cols = agentColumns();
+      const byName = (name: string) => cols.find((c) => c.propertyName === name);
+
+      // Required columns: name, tenant_id (and the boolean flags above).
+      expect(byName('name')!.options.nullable).toBeFalsy();
+      expect(byName('tenant_id')!.options.nullable).toBeFalsy();
+
+      // Nullable columns — these may legitimately be missing on legacy rows.
+      expect(byName('display_name')!.options.nullable).toBe(true);
+      expect(byName('description')!.options.nullable).toBe(true);
+      expect(byName('agent_category')!.options.nullable).toBe(true);
+      expect(byName('agent_platform')!.options.nullable).toBe(true);
+      expect(byName('savings_baseline_model')!.options.nullable).toBe(true);
+
+      // Soft-delete column: NULL for live rows, set on delete.
+      expect(byName('deleted_at')!.options.nullable).toBe(true);
+      expect(byName('deleted_at')!.options.default).toBeNull();
+    });
+  });
+
+  describe('TypeORM relation options', () => {
+    const agentRelations = () =>
+      getMetadataArgsStorage().relations.filter((r) => r.target === Agent);
+
+    it('cascades agent deletes when the parent tenant is removed', () => {
+      const manyToOne = agentRelations().find((r) => r.relationType === 'many-to-one');
+      expect(manyToOne).toBeDefined();
+      // FK to tenants(id) must cascade — orphaned agents would break tenant filtering.
+      expect(manyToOne!.options.onDelete).toBe('CASCADE');
+    });
+
+    it('cascades inserts/updates through the agent → apiKey OneToOne', () => {
+      const oneToOne = agentRelations().find((r) => r.relationType === 'one-to-one');
+      expect(oneToOne).toBeDefined();
+      // `cascade: true` lets `agentRepo.save(agent)` persist the attached apiKey
+      // in the same transaction as ApiKeyGeneratorService.onboardAgent.
+      expect(oneToOne!.options.cascade).toBe(true);
+    });
+
+    it('wires the tenant join column to the "tenant_id" foreign key', () => {
+      const joinColumns = getMetadataArgsStorage().joinColumns.filter((jc) => jc.target === Agent);
+      const tenantJoin = joinColumns.find((jc) => jc.propertyName === 'tenant');
+      expect(tenantJoin).toBeDefined();
+      // Mismatched names here would silently break ManyToOne loading.
+      expect(tenantJoin!.name).toBe('tenant_id');
+    });
+  });
 });

--- a/packages/backend/src/github/github.controller.spec.ts
+++ b/packages/backend/src/github/github.controller.spec.ts
@@ -2,9 +2,11 @@ const fetchMock = jest.fn();
 (global as unknown as Record<string, unknown>).fetch = fetchMock;
 
 describe('GithubController', () => {
-  let controller: InstanceType<
-    typeof import('./github.controller').GithubController
-  >;
+  let controller: InstanceType<typeof import('./github.controller').GithubController>;
+  // Capture the real Date.now once at module load so individual tests can
+  // overwrite Date.now safely. afterEach restores it unconditionally so a
+  // failing test cannot leak a fake Date.now into sibling tests.
+  const realDateNow = Date.now;
 
   /** Re-imports the module with fresh module-level cache variables. */
   async function freshImport() {
@@ -16,6 +18,11 @@ describe('GithubController', () => {
     jest.resetModules();
     fetchMock.mockReset();
     controller = await freshImport();
+  });
+
+  afterEach(() => {
+    // Restore Date.now even when a test throws before its inline restore.
+    Date.now = realDateNow;
   });
 
   // ── Happy path ────────────────────────────────────────────────
@@ -30,10 +37,9 @@ describe('GithubController', () => {
 
     expect(result).toEqual({ stars: 42 });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.github.com/repos/mnfst/manifest',
-      { headers: { Accept: 'application/vnd.github.v3+json' } },
-    );
+    expect(fetchMock).toHaveBeenCalledWith('https://api.github.com/repos/mnfst/manifest', {
+      headers: { Accept: 'application/vnd.github.v3+json' },
+    });
   });
 
   it('should return cached stars within TTL without fetching', async () => {
@@ -62,8 +68,7 @@ describe('GithubController', () => {
     await controller.getStars();
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    // Advance time past the 10-minute TTL
-    const realDateNow = Date.now;
+    // Advance time past the 10-minute TTL. afterEach restores Date.now.
     Date.now = () => realDateNow() + 11 * 60 * 1000;
 
     fetchMock.mockResolvedValue({
@@ -75,8 +80,6 @@ describe('GithubController', () => {
 
     expect(result).toEqual({ stars: 75 });
     expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    Date.now = realDateNow;
   });
 
   // ── Error handling ────────────────────────────────────────────
@@ -96,8 +99,7 @@ describe('GithubController', () => {
     });
     await controller.getStars();
 
-    // Expire the cache
-    const realDateNow = Date.now;
+    // Expire the cache. afterEach restores Date.now.
     Date.now = () => realDateNow() + 11 * 60 * 1000;
 
     fetchMock.mockResolvedValue({ ok: false, status: 503 });
@@ -105,8 +107,6 @@ describe('GithubController', () => {
     const result = await controller.getStars();
 
     expect(result).toEqual({ stars: 200 });
-
-    Date.now = realDateNow;
   });
 
   it('should return null when fetch throws on first call', async () => {
@@ -124,8 +124,7 @@ describe('GithubController', () => {
     });
     await controller.getStars();
 
-    // Expire the cache
-    const realDateNow = Date.now;
+    // Expire the cache. afterEach restores Date.now.
     Date.now = () => realDateNow() + 11 * 60 * 1000;
 
     fetchMock.mockRejectedValue(new Error('timeout'));
@@ -133,8 +132,6 @@ describe('GithubController', () => {
     const result = await controller.getStars();
 
     expect(result).toEqual({ stars: 300 });
-
-    Date.now = realDateNow;
   });
 
   // ── Edge cases ────────────────────────────────────────────────
@@ -170,5 +167,63 @@ describe('GithubController', () => {
     const result = await controller.getStars();
 
     expect(result).toEqual({ stars: 0 });
+  });
+
+  // ── Concurrency ───────────────────────────────────────────────
+
+  it('should deduplicate concurrent requests during cache expiry', async () => {
+    // Step 1: prime the cache with a known value so we can exercise the
+    // "expired cache + many concurrent callers" code path.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stargazers_count: 100 }),
+    });
+    await controller.getStars();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Step 2: expire the cache by advancing Date.now past the 10-minute TTL.
+    Date.now = () => realDateNow() + 11 * 60 * 1000;
+
+    // Step 3: fire 10 concurrent calls while a single fetch is in flight.
+    // The fetch resolution is gated by a manual trigger so all 10 callers
+    // observe the in-flight request before it completes.
+    let triggerFetchResolve: (value: {
+      ok: boolean;
+      json: () => Promise<{ stargazers_count: number }>;
+    }) => void = () => undefined;
+    const pendingFetch = new Promise<{
+      ok: boolean;
+      json: () => Promise<{ stargazers_count: number }>;
+    }>((resolve) => {
+      triggerFetchResolve = resolve;
+    });
+    fetchMock.mockReturnValue(pendingFetch);
+
+    const concurrentCalls = Array.from({ length: 10 }, () => controller.getStars());
+
+    // Yield to the microtask queue so each call has a chance to enter the
+    // controller and either share or trigger its own fetch.
+    await Promise.resolve();
+
+    // Documents the current behavior: the module-level cache has NO in-flight
+    // request coalescing, so every concurrent caller past TTL triggers its
+    // own fetch (thundering herd). This test pins the existing semantics so a
+    // future deduplication patch shows up as an intentional change here.
+    // Total includes the 1 priming call + 10 concurrent calls = 11.
+    expect(fetchMock).toHaveBeenCalledTimes(11);
+
+    // Step 4: release the gated fetch and verify all 10 concurrent callers
+    // resolve to the same, consistent star count.
+    triggerFetchResolve({
+      ok: true,
+      json: async () => ({ stargazers_count: 250 }),
+    });
+
+    const results = await Promise.all(concurrentCalls);
+
+    expect(results).toHaveLength(10);
+    for (const result of results) {
+      expect(result).toEqual({ stars: 250 });
+    }
   });
 });

--- a/packages/backend/src/health/health.controller.spec.ts
+++ b/packages/backend/src/health/health.controller.spec.ts
@@ -7,6 +7,10 @@ describe('HealthController', () => {
     controller = new HealthController();
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('returns healthy status', () => {
     const result = controller.getHealth();
     expect(result.status).toBe('healthy');
@@ -23,5 +27,88 @@ describe('HealthController', () => {
     expect(result).not.toHaveProperty('mode');
     expect(result).not.toHaveProperty('devMode');
     expect(result).not.toHaveProperty('version');
+  });
+
+  describe('uptime calculation', () => {
+    it('returns 0 uptime on the first call immediately after construction', () => {
+      // Pin Date.now() to a fixed point before construction so the constructor
+      // and the first getHealth() call see the same timestamp.
+      const fixedNow = 1_700_000_000_000;
+      jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+
+      const freshController = new HealthController();
+      const result = freshController.getHealth();
+
+      expect(result.uptime_seconds).toBe(0);
+    });
+
+    it('returns uptime that increases with each call as wall-clock time advances', () => {
+      // Construct at t=0, then advance the mocked clock for each subsequent call.
+      const constructionTime = 1_700_000_000_000;
+      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(constructionTime);
+
+      const freshController = new HealthController();
+
+      dateNowSpy.mockReturnValue(constructionTime + 5_000);
+      const firstCall = freshController.getHealth();
+      expect(firstCall.uptime_seconds).toBe(5);
+
+      dateNowSpy.mockReturnValue(constructionTime + 12_500);
+      const secondCall = freshController.getHealth();
+      expect(secondCall.uptime_seconds).toBe(12);
+
+      expect(secondCall.uptime_seconds).toBeGreaterThan(firstCall.uptime_seconds);
+    });
+
+    it('reflects the correct wall-clock delta using Math.floor (sub-second deltas truncate to 0)', () => {
+      const constructionTime = 1_700_000_000_000;
+      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(constructionTime);
+
+      const freshController = new HealthController();
+
+      // 999ms after construction is still less than 1s — floor to 0.
+      dateNowSpy.mockReturnValue(constructionTime + 999);
+      expect(freshController.getHealth().uptime_seconds).toBe(0);
+
+      // Exactly 1s elapsed.
+      dateNowSpy.mockReturnValue(constructionTime + 1_000);
+      expect(freshController.getHealth().uptime_seconds).toBe(1);
+
+      // Exactly 1 hour elapsed.
+      dateNowSpy.mockReturnValue(constructionTime + 3_600_000);
+      expect(freshController.getHealth().uptime_seconds).toBe(3_600);
+    });
+
+    it('handles a clock that jumps backward without throwing', () => {
+      // Construct at a later time, then simulate the system clock jumping
+      // backward (NTP correction, VM resume, manual change). The getter must
+      // not throw — uptime_seconds will be negative, which documents the
+      // current behavior and pins it against silent regression.
+      const constructionTime = 1_700_000_000_000;
+      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(constructionTime);
+
+      const freshController = new HealthController();
+
+      // Clock jumps backward by 10s.
+      dateNowSpy.mockReturnValue(constructionTime - 10_000);
+
+      expect(() => freshController.getHealth()).not.toThrow();
+      const result = freshController.getHealth();
+      expect(typeof result.uptime_seconds).toBe('number');
+      expect(Number.isFinite(result.uptime_seconds)).toBe(true);
+      expect(result.uptime_seconds).toBe(-10);
+      expect(result.status).toBe('healthy');
+    });
+
+    it('returns 0 when the clock has not advanced since construction', () => {
+      const constructionTime = 1_700_000_000_000;
+      const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(constructionTime);
+
+      const freshController = new HealthController();
+
+      // Clock has not advanced at all between construction and call.
+      dateNowSpy.mockReturnValue(constructionTime);
+      expect(freshController.getHealth().uptime_seconds).toBe(0);
+    });
   });
 });

--- a/packages/backend/src/model-discovery/anthropic-subscription-probe.timeout.spec.ts
+++ b/packages/backend/src/model-discovery/anthropic-subscription-probe.timeout.spec.ts
@@ -1,0 +1,129 @@
+// Tests that exercise the real PROBE_TIMEOUT_MS (5000ms) abort path inside
+// probeModel(). The sibling spec mocks fetch to resolve immediately or to
+// reject synchronously, so the AbortController never actually fires — the
+// "signal aborts a hung request after 5s" contract is untested there.
+//
+// Here we use Jest fake timers + a fetch mock that hangs until init.signal
+// aborts. Advancing fake time past PROBE_TIMEOUT_MS forces the
+// setTimeout(abort, 5000) inside probeModel to run; the listener on the
+// mocked fetch observes abort and rejects, simulating real fetch behavior.
+// We then verify (1) the signal really aborted, (2) the function returned
+// the model (caught error → keep, since transient failures are not
+// deterministic subscription rejections), and (3) clearTimeout fires on
+// the success path so the abort callback never runs after a clean response.
+
+import { filterBySubscriptionAccess } from './anthropic-subscription-probe';
+import { DiscoveredModel } from './model-fetcher';
+
+function makeModel(id: string): DiscoveredModel {
+  return {
+    id,
+    displayName: id,
+    provider: 'anthropic',
+    contextWindow: 200000,
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 3,
+  };
+}
+
+describe('filterBySubscriptionAccess — real abort/timeout behavior', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.useRealTimers();
+  });
+
+  it('aborts the in-flight fetch after PROBE_TIMEOUT_MS and keeps the model', async () => {
+    jest.useFakeTimers();
+
+    const signals: AbortSignal[] = [];
+    let aborted = false;
+    global.fetch = jest.fn().mockImplementation((_url: string, init: RequestInit) => {
+      const sig = init.signal as AbortSignal;
+      signals.push(sig);
+      // Mirror real fetch: hang forever, then reject with AbortError when
+      // the signal aborts. If the setTimeout inside probeModel never fires
+      // this promise stays pending and the test would hang past Jest's
+      // per-test timeout — a clear failure mode.
+      return new Promise((_resolve, reject) => {
+        sig.addEventListener('abort', () => {
+          aborted = true;
+          const err = new Error('The operation was aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    });
+
+    const pending = filterBySubscriptionAccess([makeModel('claude-sonnet-4-6')], 'test-key');
+
+    // Let the fetch call start so the listener is attached before we advance time.
+    await Promise.resolve();
+    expect(signals).toHaveLength(1);
+    expect(signals[0].aborted).toBe(false);
+    expect(aborted).toBe(false);
+
+    // Advance just past the 5s probe timeout — setTimeout(abort, 5000) fires.
+    await jest.advanceTimersByTimeAsync(5000);
+
+    const result = await pending;
+    expect(aborted).toBe(true);
+    expect(signals[0].aborted).toBe(true);
+    // Caught error path returns true → model is preserved (transient ≠ rejection).
+    expect(result.map((m) => m.id)).toEqual(['claude-sonnet-4-6']);
+  });
+
+  it('does NOT abort fetch when it resolves before PROBE_TIMEOUT_MS, and clears the timer', async () => {
+    jest.useFakeTimers();
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    let observedAbort = false;
+
+    global.fetch = jest.fn().mockImplementation((_url: string, init: RequestInit) => {
+      const sig = init.signal as AbortSignal;
+      sig.addEventListener('abort', () => {
+        observedAbort = true;
+      });
+      // Resolve immediately on the microtask queue — well before 5s elapses.
+      return Promise.resolve({ ok: true, status: 200 });
+    });
+
+    const result = await filterBySubscriptionAccess([makeModel('claude-sonnet-4-6')], 'test-key');
+
+    expect(result.map((m) => m.id)).toEqual(['claude-sonnet-4-6']);
+    // The success path must clear the abort timer so the queued abort never runs.
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+
+    // Push fake time past PROBE_TIMEOUT_MS — if clearTimeout did its job the
+    // abort callback never fires and observedAbort stays false. If a future
+    // refactor drops the clearTimeout, this assertion catches it.
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect(observedAbort).toBe(false);
+
+    clearTimeoutSpy.mockRestore();
+  });
+
+  it('passes a fresh AbortSignal (not already aborted) to each fetch call', async () => {
+    // Each probe must own its own AbortController so one family's timeout
+    // never cancels another family's in-flight probe. Without this, slow
+    // upstream responses for sonnet could erroneously kill the opus probe.
+    const capturedSignals: AbortSignal[] = [];
+    global.fetch = jest.fn().mockImplementation((_url: string, init: RequestInit) => {
+      capturedSignals.push(init.signal as AbortSignal);
+      return Promise.resolve({ ok: true, status: 200 });
+    });
+
+    await filterBySubscriptionAccess(
+      [makeModel('claude-haiku-4-5-20251001'), makeModel('claude-sonnet-4-6')],
+      'test-key',
+    );
+
+    expect(capturedSignals).toHaveLength(2);
+    expect(capturedSignals[0]).not.toBe(capturedSignals[1]);
+    expect(capturedSignals[0].aborted).toBe(false);
+    expect(capturedSignals[1].aborted).toBe(false);
+  });
+});

--- a/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.boundary.spec.ts
@@ -1,0 +1,401 @@
+import { ModelDiscoveryService } from './model-discovery.service';
+import { ProviderModelFetcherService } from './provider-model-fetcher.service';
+import { ProviderModelRegistryService } from './provider-model-registry.service';
+import { UserProvider } from '../entities/user-provider.entity';
+import { CustomProvider } from '../entities/custom-provider.entity';
+import { DiscoveredModel } from './model-fetcher';
+
+jest.mock('../common/utils/crypto.util', () => ({
+  decrypt: jest.fn(),
+  getEncryptionSecret: jest.fn(),
+}));
+
+jest.mock('../database/quality-score.util', () => ({
+  computeQualityScore: jest.fn().mockReturnValue(3),
+}));
+
+jest.mock('./anthropic-subscription-probe', () => ({
+  filterBySubscriptionAccess: jest.fn().mockImplementation((models: unknown[]) => models),
+}));
+
+import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
+import { computeQualityScore } from '../database/quality-score.util';
+
+const mockDecrypt = decrypt as jest.MockedFunction<typeof decrypt>;
+const mockGetSecret = getEncryptionSecret as jest.MockedFunction<typeof getEncryptionSecret>;
+const mockComputeScore = computeQualityScore as jest.MockedFunction<typeof computeQualityScore>;
+
+function makeModel(overrides: Partial<DiscoveredModel> = {}): DiscoveredModel {
+  return {
+    id: 'test-model',
+    displayName: 'Test Model',
+    provider: 'openai',
+    contextWindow: 128000,
+    inputPricePerToken: null,
+    outputPricePerToken: null,
+    capabilityReasoning: false,
+    capabilityCode: false,
+    qualityScore: 3,
+    ...overrides,
+  };
+}
+
+function makeProvider(overrides: Partial<UserProvider> = {}): UserProvider {
+  return {
+    id: 'prov-1',
+    user_id: 'user-1',
+    agent_id: 'agent-1',
+    provider: 'openai',
+    api_key_encrypted: 'encrypted-key',
+    key_prefix: 'sk-',
+    auth_type: 'api_key',
+    is_active: true,
+    connected_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    cached_models: null,
+    models_fetched_at: null,
+    ...overrides,
+  } as UserProvider;
+}
+
+function makeCustomProvider(overrides: Partial<CustomProvider> = {}): CustomProvider {
+  return {
+    id: 'cp-1',
+    agent_id: 'agent-1',
+    user_id: 'user-1',
+    name: 'My Custom',
+    base_url: 'http://localhost:8000',
+    models: [{ model_name: 'custom-llm' }],
+    created_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  } as CustomProvider;
+}
+
+function makeMockRepo() {
+  return {
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn().mockResolvedValue(null),
+    save: jest.fn().mockImplementation((e: unknown) => Promise.resolve(e)),
+  };
+}
+
+describe('ModelDiscoveryService — boundary conditions', () => {
+  let service: ModelDiscoveryService;
+  let providerRepo: ReturnType<typeof makeMockRepo>;
+  let customProviderRepo: ReturnType<typeof makeMockRepo>;
+  let fetcher: { fetch: jest.Mock };
+  let mockPricingSync: { lookupPricing: jest.Mock; getAll: jest.Mock };
+  let mockModelRegistry: { registerModels: jest.Mock; getConfirmedModels: jest.Mock };
+  let mockModelsDevSync: { lookupModel: jest.Mock; getModelsForProvider: jest.Mock };
+  let mockCopilotTokenService: { getCopilotToken: jest.Mock };
+
+  beforeEach(() => {
+    providerRepo = makeMockRepo();
+    customProviderRepo = makeMockRepo();
+    fetcher = { fetch: jest.fn().mockResolvedValue([]) };
+    mockPricingSync = {
+      lookupPricing: jest.fn().mockReturnValue(null),
+      getAll: jest.fn().mockReturnValue(new Map()),
+    };
+    mockModelsDevSync = {
+      lookupModel: jest.fn().mockReturnValue(null),
+      getModelsForProvider: jest.fn().mockReturnValue([]),
+    };
+    mockModelRegistry = {
+      registerModels: jest.fn(),
+      getConfirmedModels: jest.fn().mockReturnValue(null),
+    };
+    mockCopilotTokenService = { getCopilotToken: jest.fn().mockResolvedValue('tid=x') };
+    mockDecrypt.mockReturnValue('decrypted-key');
+    mockGetSecret.mockReturnValue('secret-32-chars-long-xxxxxxxxxx');
+    // Explicit reset — jest.clearAllMocks() in afterEach clears call data but
+    // NOT mockReturnValue, so without this re-assignment a prior test's
+    // mockReturnValue(5) would bleed into this one and cause order-dependent
+    // failures.
+    mockComputeScore.mockReturnValue(3);
+
+    service = new ModelDiscoveryService(
+      providerRepo as never,
+      customProviderRepo as never,
+      fetcher as unknown as ProviderModelFetcherService,
+      mockPricingSync as never,
+      mockModelsDevSync as never,
+      mockModelRegistry as unknown as ProviderModelRegistryService,
+      mockCopilotTokenService as never,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /* ── pricing boundary conditions ── */
+
+  describe('enrichModel pricing boundary conditions', () => {
+    it('triggers enrichment when outputPricePerToken is negative', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'neg-out',
+        name: 'Neg Out',
+        inputPricePerToken: 0.001,
+        outputPricePerToken: 0.002,
+        contextWindow: 128000,
+      });
+      fetcher.fetch.mockResolvedValue([
+        makeModel({ id: 'neg-out', inputPricePerToken: 0.0001, outputPricePerToken: -0.5 }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider());
+      // Output is < 0 → >= 0 guard fails → re-priced from models.dev.
+      expect(result[0].inputPricePerToken).toBe(0.001);
+      expect(result[0].outputPricePerToken).toBe(0.002);
+    });
+
+    it('produces a finite quality score for zero-price models', async () => {
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'zero-price',
+          inputPricePerToken: 0,
+          outputPricePerToken: 0,
+          capabilityCode: true,
+        }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(result[0].qualityScore).toBeDefined();
+      expect(Number.isFinite(result[0].qualityScore)).toBe(true);
+      expect(result[0].qualityScore).toBeGreaterThanOrEqual(1);
+      expect(result[0].qualityScore).toBeLessThanOrEqual(5);
+    });
+
+    it('produces a finite quality score for near-zero (epsilon) pricing', async () => {
+      fetcher.fetch.mockResolvedValue([
+        makeModel({
+          id: 'tiny-price',
+          inputPricePerToken: 1e-10,
+          outputPricePerToken: 1e-10,
+          capabilityReasoning: true,
+        }),
+      ]);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(result[0].qualityScore).toBeDefined();
+      expect(Number.isFinite(result[0].qualityScore)).toBe(true);
+      expect(result[0].qualityScore).toBeGreaterThanOrEqual(1);
+      expect(result[0].qualityScore).toBeLessThanOrEqual(5);
+    });
+  });
+
+  /* ── custom provider tenant isolation ── */
+
+  describe('getModelsForAgent — custom provider tenant isolation', () => {
+    it('namespaces custom provider model ids by provider UUID', async () => {
+      // Same model_name under two different agents must map to two distinct
+      // ids (the provider UUID is embedded in the dedupe key + model id), so
+      // cross-tenant deduplication cannot bleed routes across users.
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValueOnce([
+        makeCustomProvider({
+          id: 'cp-agent-a',
+          agent_id: 'agent-a',
+          models: [{ model_name: 'shared' }],
+        }),
+      ]);
+      const resultA = await service.getModelsForAgent('agent-a');
+
+      customProviderRepo.find.mockResolvedValueOnce([
+        makeCustomProvider({
+          id: 'cp-agent-b',
+          agent_id: 'agent-b',
+          models: [{ model_name: 'shared' }],
+        }),
+      ]);
+      const resultB = await service.getModelsForAgent('agent-b');
+
+      expect(resultA[0].id).toBe('custom:cp-agent-a/shared');
+      expect(resultA[0].provider).toBe('custom:cp-agent-a');
+      expect(resultB[0].id).toBe('custom:cp-agent-b/shared');
+      expect(resultB[0].provider).toBe('custom:cp-agent-b');
+      expect(resultA[0].id).not.toBe(resultB[0].id);
+    });
+
+    it('scopes the custom provider repository query by agent_id', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      await service.getModelsForAgent('agent-isolated');
+
+      expect(customProviderRepo.find).toHaveBeenCalledWith({
+        where: { agent_id: 'agent-isolated' },
+      });
+    });
+  });
+
+  describe('getModelForAgent — custom provider tenant isolation', () => {
+    it('returns undefined for a custom model id that belongs to a different agent', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([]);
+
+      const result = await service.getModelForAgent('agent-b', 'custom:cp-agent-a/exclusive-model');
+      expect(result).toBeUndefined();
+      expect(customProviderRepo.find).toHaveBeenCalledWith({
+        where: { agent_id: 'agent-b' },
+      });
+    });
+  });
+
+  /* ── custom provider price arithmetic on degenerate inputs ── */
+
+  describe('getModelsForAgent — custom provider price division edge cases', () => {
+    it('passes NaN through (current behavior — division applied to non-null value)', async () => {
+      // `NaN != null` is true, so the source divides NaN by 1_000_000 → NaN.
+      // Documents current behavior; entity-layer validation is a separate
+      // hardening task.
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([
+        makeCustomProvider({
+          models: [
+            {
+              model_name: 'nan-priced',
+              input_price_per_million_tokens: Number.NaN,
+              output_price_per_million_tokens: Number.NaN,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await service.getModelsForAgent('agent-1');
+      expect(Number.isNaN(result[0].inputPricePerToken as number)).toBe(true);
+      expect(Number.isNaN(result[0].outputPricePerToken as number)).toBe(true);
+    });
+
+    it('passes Infinity through (current behavior)', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([
+        makeCustomProvider({
+          models: [
+            {
+              model_name: 'inf-priced',
+              input_price_per_million_tokens: Number.POSITIVE_INFINITY,
+              output_price_per_million_tokens: Number.POSITIVE_INFINITY,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await service.getModelsForAgent('agent-1');
+      expect(result[0].inputPricePerToken).toBe(Number.POSITIVE_INFINITY);
+      expect(result[0].outputPricePerToken).toBe(Number.POSITIVE_INFINITY);
+    });
+
+    it('produces NaN when a string slips through the entity layer (current behavior)', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([
+        makeCustomProvider({
+          models: [
+            {
+              model_name: 'string-priced',
+              input_price_per_million_tokens: 'not-a-number' as unknown as number,
+              output_price_per_million_tokens: 'also-not' as unknown as number,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await service.getModelsForAgent('agent-1');
+      expect(Number.isNaN(result[0].inputPricePerToken as number)).toBe(true);
+      expect(Number.isNaN(result[0].outputPricePerToken as number)).toBe(true);
+    });
+
+    it('returns null when both per-million prices are null (no division)', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      customProviderRepo.find.mockResolvedValue([
+        makeCustomProvider({
+          models: [
+            {
+              model_name: 'null-priced',
+              input_price_per_million_tokens: null as unknown as undefined,
+              output_price_per_million_tokens: null as unknown as undefined,
+            },
+          ],
+        }),
+      ]);
+
+      const result = await service.getModelsForAgent('agent-1');
+      expect(result[0].inputPricePerToken).toBeNull();
+      expect(result[0].outputPricePerToken).toBeNull();
+    });
+  });
+
+  /* ── contextWindow boundary handling ── */
+
+  describe('enrichModel — contextWindow boundary inputs', () => {
+    // The source uses `mdEntry.contextWindow ?? model.contextWindow` (nullish
+    // coalescing), which only short-circuits on null/undefined. Zero, NaN,
+    // and Infinity all pass through. These tests document the current
+    // behavior — a future sanitization PR should clamp to a safe range and
+    // flip the `.toBe(...)` assertions to `.toBe(128_000)` / `.toBe(32_000_000)`.
+
+    it('passes a zero contextWindow from models.dev through (current behavior)', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'zero-ctx',
+        name: 'Zero',
+        inputPricePerToken: 0.0001,
+        outputPricePerToken: 0.0001,
+        contextWindow: 0,
+      });
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'zero-ctx' })]);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(result[0].contextWindow).toBe(0);
+    });
+
+    it('falls back to model.contextWindow when models.dev contextWindow is undefined', async () => {
+      mockModelsDevSync.lookupModel.mockReturnValue({
+        id: 'no-ctx',
+        name: 'No Ctx',
+        inputPricePerToken: 0.0001,
+        outputPricePerToken: 0.0001,
+      });
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'no-ctx', contextWindow: 64000 })]);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(result[0].contextWindow).toBe(64000);
+    });
+
+    it('passes Infinity contextWindow from OpenRouter through (current behavior)', async () => {
+      mockPricingSync.lookupPricing.mockReturnValue({
+        input: 0.0001,
+        output: 0.0001,
+        contextWindow: Number.POSITIVE_INFINITY,
+      });
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'inf-ctx' })]);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(result[0].contextWindow).toBe(Number.POSITIVE_INFINITY);
+    });
+
+    it('passes NaN contextWindow from OpenRouter through (current behavior)', async () => {
+      mockPricingSync.lookupPricing.mockReturnValue({
+        input: 0.0001,
+        output: 0.0001,
+        contextWindow: Number.NaN,
+      });
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'nan-ctx' })]);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(Number.isNaN(result[0].contextWindow)).toBe(true);
+    });
+
+    it('preserves a sane contextWindow value from OpenRouter', async () => {
+      mockPricingSync.lookupPricing.mockReturnValue({
+        input: 0.0001,
+        output: 0.0001,
+        contextWindow: 256000,
+      });
+      fetcher.fetch.mockResolvedValue([makeModel({ id: 'sane-ctx' })]);
+
+      const result = await service.discoverModels(makeProvider());
+      expect(result[0].contextWindow).toBe(256000);
+    });
+  });
+});

--- a/packages/backend/src/model-discovery/model-fallback.resolution-order.spec.ts
+++ b/packages/backend/src/model-discovery/model-fallback.resolution-order.spec.ts
@@ -1,0 +1,289 @@
+import { lookupWithVariants } from './model-fallback';
+
+/**
+ * Pin down the *resolution order* of lookupWithVariants — i.e. which variant
+ * is tried first, second, third, and that null is only returned after every
+ * transformation has been exhausted. The chained tests in
+ * `model-fallback.spec.ts` exercise each step in isolation; these tests
+ * exercise the *chain* by populating the cache so that multiple steps could
+ * resolve, then asserting which one wins.
+ */
+
+function makePricingSync(
+  entries: Map<
+    string,
+    { input: number; output: number; contextWindow?: number; displayName?: string }
+  >,
+) {
+  return {
+    lookupPricing: jest.fn((key: string) => entries.get(key) ?? null),
+    getAll: jest.fn(() => entries),
+  };
+}
+
+describe('lookupWithVariants resolution order', () => {
+  describe('exact match wins', () => {
+    it('short-circuits before alias / :free / dot are tried', () => {
+      const cache = new Map([
+        ['mistralai/open-mistral-nemo', { input: 1, output: 1 }],
+        ['mistralai/mistral-nemo', { input: 2, output: 2 }],
+        ['mistralai/open-mistral-nemo:free', { input: 3, output: 3 }],
+      ]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'mistralai', 'open-mistral-nemo');
+
+      expect(result).toEqual({ input: 1, output: 1 });
+      expect(sync.lookupPricing).toHaveBeenNthCalledWith(1, 'mistralai/open-mistral-nemo');
+    });
+
+    it('wins over date-stripped variant', () => {
+      const cache = new Map([
+        ['anthropic/claude-opus-4-6-20260301', { input: 5, output: 5 }],
+        ['anthropic/claude-opus-4-6', { input: 99, output: 99 }],
+      ]);
+
+      const result = lookupWithVariants(
+        makePricingSync(cache),
+        'anthropic',
+        'claude-opus-4-6-20260301',
+      );
+
+      expect(result).toEqual({ input: 5, output: 5 });
+    });
+  });
+
+  describe('alias path runs before dot/dash/date', () => {
+    it('falls through exact miss and resolves via OPENROUTER_NAME_ALIASES', () => {
+      const cache = new Map([['mistralai/mistral-nemo', { input: 7, output: 7 }]]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'mistralai', 'open-mistral-nemo');
+
+      expect(result).toEqual({ input: 7, output: 7 });
+      expect(sync.lookupPricing).toHaveBeenNthCalledWith(1, 'mistralai/open-mistral-nemo');
+      expect(sync.lookupPricing).toHaveBeenNthCalledWith(2, 'mistralai/mistral-nemo');
+    });
+
+    it('alias success short-circuits before dot/dash variants are tried', () => {
+      const cache = new Map([['mistralai/open-mistral-7b', { input: 9, output: 9 }]]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'mistralai', 'mistral-tiny');
+
+      expect(result).toEqual({ input: 9, output: 9 });
+      expect(sync.lookupPricing).toHaveBeenNthCalledWith(1, 'mistralai/mistral-tiny');
+      expect(sync.lookupPricing).toHaveBeenNthCalledWith(2, 'mistralai/open-mistral-7b');
+    });
+
+    it('tries every alias before falling through to dot variant', () => {
+      // 'voxtral-small-2507' contains alias 'voxtral-small' → 'voxtral-small-24b'.
+      // Other aliases ('open-mistral-nemo', 'mistral-tiny') do not match.
+      const cache = new Map([['mistralai/voxtral-small-24b-2507', { input: 33, output: 33 }]]);
+
+      const result = lookupWithVariants(makePricingSync(cache), 'mistralai', 'voxtral-small-2507');
+
+      expect(result).toEqual({ input: 33, output: 33 });
+    });
+  });
+
+  describe('dot variant runs before date-strip', () => {
+    it('succeeds when exact and alias both miss', () => {
+      const cache = new Map([['anthropic/claude-sonnet-4.6', { input: 11, output: 11 }]]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'anthropic', 'claude-sonnet-4-6');
+
+      expect(result).toEqual({ input: 11, output: 11 });
+      expect(sync.lookupPricing).toHaveBeenNthCalledWith(1, 'anthropic/claude-sonnet-4-6');
+      expect(sync.lookupPricing).toHaveBeenNthCalledWith(2, 'anthropic/claude-sonnet-4.6');
+    });
+
+    it('wins over date-strip when both could match', () => {
+      const cache = new Map([
+        ['anthropic/claude-sonnet-4.6-20260301', { input: 13, output: 13 }],
+        ['anthropic/claude-sonnet-4-6', { input: 99, output: 99 }],
+      ]);
+
+      const result = lookupWithVariants(
+        makePricingSync(cache),
+        'anthropic',
+        'claude-sonnet-4-6-20260301',
+      );
+
+      // Dot variant runs *before* date strip — that hit must win.
+      expect(result).toEqual({ input: 13, output: 13 });
+    });
+  });
+
+  describe('date-strip runs before :free and Google variant', () => {
+    it('succeeds when exact / alias / dot / dash all miss', () => {
+      const cache = new Map([['openai/gpt-5-turbo', { input: 17, output: 17 }]]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'openai', 'gpt-5-turbo-20260101');
+
+      expect(result).toEqual({ input: 17, output: 17 });
+      const calls = sync.lookupPricing.mock.calls.map((c) => c[0]);
+      const exactIdx = calls.indexOf('openai/gpt-5-turbo-20260101');
+      const strippedIdx = calls.indexOf('openai/gpt-5-turbo');
+      expect(exactIdx).toBe(0);
+      expect(strippedIdx).toBeGreaterThan(exactIdx);
+    });
+
+    it('wins over :free fallback when both could match', () => {
+      const cache = new Map([
+        ['anthropic/claude-3-haiku', { input: 19, output: 19 }],
+        ['anthropic/claude-3-haiku-20260101:free', { input: 99, output: 99 }],
+      ]);
+
+      const result = lookupWithVariants(
+        makePricingSync(cache),
+        'anthropic',
+        'claude-3-haiku-20260101',
+      );
+
+      expect(result).toEqual({ input: 19, output: 19 });
+    });
+  });
+
+  describe(':free fallback runs after date-strip, before Google variant', () => {
+    it('succeeds when no earlier transformation matched', () => {
+      const cache = new Map([['google/gemma-3n-e2b-it:free', { input: 0, output: 0 }]]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'google', 'gemma-3n-e2b-it');
+
+      expect(result).toEqual({ input: 0, output: 0 });
+      const calls = sync.lookupPricing.mock.calls.map((c) => c[0]);
+      expect(calls[0]).toBe('google/gemma-3n-e2b-it');
+      expect(calls).toContain('google/gemma-3n-e2b-it:free');
+    });
+
+    it('wins over Google variant strip when both could match', () => {
+      const cache = new Map([
+        ['google/gemma-it-latest:free', { input: 21, output: 21 }],
+        ['google/gemma-it', { input: 99, output: 99 }],
+      ]);
+
+      const result = lookupWithVariants(makePricingSync(cache), 'google', 'gemma-it-latest');
+
+      expect(result).toEqual({ input: 21, output: 21 });
+    });
+  });
+
+  describe('-latest cache scan is the last resort', () => {
+    it('finds dated cache entry when nothing else matched', () => {
+      const cache = new Map([['mistralai/ministral-14b-2512', { input: 23, output: 23 }]]);
+
+      const result = lookupWithVariants(
+        makePricingSync(cache),
+        'mistralai',
+        'ministral-14b-latest',
+      );
+
+      expect(result).toEqual({ input: 23, output: 23 });
+    });
+
+    it('does NOT run when an earlier step already matched', () => {
+      const cache = new Map([
+        ['mistralai/voxtral-small-24b-latest', { input: 25, output: 25 }],
+        ['mistralai/voxtral-small-24b-2507', { input: 99, output: 99 }],
+      ]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'mistralai', 'voxtral-small-latest');
+
+      // Alias path matched first; cache-scan path never reached.
+      expect(result).toEqual({ input: 25, output: 25 });
+      expect(sync.getAll).not.toHaveBeenCalled();
+    });
+
+    it('runs only after Google-variant strip misses', () => {
+      // 'mistral-7b-latest' triggers BOTH Google-variant strip
+      // (gives 'mistral-7b') and -latest scan (gives 'mistral-7b-*').
+      // Cache has only the dated form — order must reach scan path.
+      const cache = new Map([
+        ['mistralai/mistral-7b-2503', { input: 29, output: 29 }],
+        ['mistralai/mistral-7b-2401', { input: 31, output: 31 }],
+      ]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'mistralai', 'mistral-7b-latest');
+
+      // First dated entry wins (Map iteration = insertion order).
+      expect(result).toEqual({ input: 29, output: 29 });
+      expect(sync.getAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('exhaustion returns null', () => {
+    it('returns null when every transformation misses', () => {
+      const cache = new Map<
+        string,
+        { input: number; output: number; contextWindow?: number; displayName?: string }
+      >();
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'anthropic', 'claude-opus-4-6-20260301');
+
+      expect(result).toBeNull();
+      const calls = sync.lookupPricing.mock.calls.map((c) => c[0]);
+      // Several transformation steps were attempted.
+      expect(calls[0]).toBe('anthropic/claude-opus-4-6-20260301');
+      expect(calls).toContain('anthropic/claude-opus-4.6-20260301');
+      expect(calls).toContain('anthropic/claude-opus-4-6');
+      expect(calls).toContain('anthropic/claude-opus-4.6');
+      expect(calls).toContain('anthropic/claude-opus-4-6-20260301:free');
+    });
+
+    it('returns null even after -latest scan finds zero starting-with matches', () => {
+      const cache = new Map([
+        ['openai/gpt-4o', { input: 99, output: 99 }],
+        ['mistralai/other-model-2512', { input: 99, output: 99 }],
+      ]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'mistralai', 'ministral-14b-latest');
+
+      expect(result).toBeNull();
+      // Confirm the -latest scan path WAS reached.
+      expect(sync.getAll).toHaveBeenCalled();
+    });
+
+    it('returns null when alias would apply but the aliased key is also missing', () => {
+      const cache = new Map<string, { input: number; output: number }>();
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'mistralai', 'open-mistral-nemo');
+
+      expect(result).toBeNull();
+      const calls = sync.lookupPricing.mock.calls.map((c) => c[0]);
+      expect(calls).toContain('mistralai/open-mistral-nemo');
+      expect(calls).toContain('mistralai/mistral-nemo');
+    });
+
+    it('returns null when only an unrelated provider has a similar entry', () => {
+      // Cross-provider isolation: prefix must be respected at every step.
+      const cache = new Map([['anthropic/claude-sonnet-4.6', { input: 99, output: 99 }]]);
+
+      const result = lookupWithVariants(makePricingSync(cache), 'openai', 'claude-sonnet-4-6');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('Google-variant-strip reachability', () => {
+    it('is only reached after every prior step missed', () => {
+      const cache = new Map([['google/gemini-2.5-pro', { input: 27, output: 27 }]]);
+      const sync = makePricingSync(cache);
+
+      const result = lookupWithVariants(sync, 'google', 'gemini-2.5-pro-preview-03-25');
+
+      expect(result).toEqual({ input: 27, output: 27 });
+      const calls = sync.lookupPricing.mock.calls.map((c) => c[0]);
+      expect(calls[0]).toBe('google/gemini-2.5-pro-preview-03-25');
+      expect(calls.indexOf('google/gemini-2.5-pro')).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/backend/src/model-discovery/opencode-go-catalog.service.malformed.spec.ts
+++ b/packages/backend/src/model-discovery/opencode-go-catalog.service.malformed.spec.ts
@@ -1,0 +1,292 @@
+import { OPENCODE_GO_BUDGET_5H_USD, OpencodeGoCatalogService } from './opencode-go-catalog.service';
+
+const BT = String.fromCharCode(96);
+const OAI = BT + 'https://opencode.ai/zen/go/v1/chat/completions' + BT;
+const ANT = BT + 'https://opencode.ai/zen/go/v1/messages' + BT;
+const OAI_SDK = BT + '@ai-sdk/openai-compatible' + BT;
+const ANT_SDK = BT + '@ai-sdk/anthropic' + BT;
+
+const ENDPOINTS_TABLE = [
+  '## Endpoints',
+  '',
+  '| Model        | Model ID     | Endpoint                                         | AI SDK Package              |',
+  '| ------------ | ------------ | ------------------------------------------------ | --------------------------- |',
+  `| GLM-5.1      | glm-5.1      | ${OAI} | ${OAI_SDK} |`,
+  `| GLM-5        | glm-5        | ${OAI} | ${OAI_SDK} |`,
+  `| Kimi K2.5    | kimi-k2.5    | ${OAI} | ${OAI_SDK} |`,
+  `| Qwen3.7 Max  | qwen3.7-max  | ${ANT} | ${ANT_SDK} |`,
+  '',
+].join('\n');
+
+describe('OpencodeGoCatalogService — malformed MDX edge cases', () => {
+  let service: OpencodeGoCatalogService;
+
+  beforeEach(() => {
+    service = new OpencodeGoCatalogService();
+  });
+
+  describe('non-numeric request counts in Usage Limits table', () => {
+    it('skips rows where the request column is "N/A" but keeps other rows', () => {
+      const mdx = [
+        '## Usage limits',
+        '',
+        '| Model     | requests per 5 hour | requests per week | requests per month |',
+        '| --------- | ------------------- | ----------------- | ------------------ |',
+        '| GLM-5.1   | N/A                 | N/A               | N/A                |',
+        '| GLM-5     | 1,150               | 2,880             | 5,750              |',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const entries = service.parse(mdx);
+      const cost = Object.fromEntries(entries.map((e) => [e.id, e.costPerRequestUsd]));
+
+      // GLM-5.1 row had "N/A" — regex rejects it, so cost stays null.
+      expect(cost['glm-5.1']).toBeNull();
+      // GLM-5 row had a real number — cost is computed normally.
+      expect(cost['glm-5']).toBeCloseTo(OPENCODE_GO_BUDGET_5H_USD / 1150, 12);
+    });
+
+    it('skips rows where the request column is "--" placeholder', () => {
+      const mdx = [
+        '## Usage limits',
+        '',
+        '| Model     | requests per 5 hour | requests per week | requests per month |',
+        '| --------- | ------------------- | ----------------- | ------------------ |',
+        '| GLM-5.1   | --                  | --                | --                 |',
+        '| GLM-5     | 1,150               | 2,880             | 5,750              |',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const entries = service.parse(mdx);
+      const glm51 = entries.find((e) => e.id === 'glm-5.1');
+      const glm5 = entries.find((e) => e.id === 'glm-5');
+
+      expect(glm51?.costPerRequestUsd).toBeNull();
+      expect(glm5?.costPerRequestUsd).toBeCloseTo(OPENCODE_GO_BUDGET_5H_USD / 1150, 12);
+    });
+
+    it('does not crash and still returns all endpoint models when every limits row is non-numeric', () => {
+      const mdx = [
+        '## Usage limits',
+        '',
+        '| Model     | requests per 5 hour | requests per week | requests per month |',
+        '| --------- | ------------------- | ----------------- | ------------------ |',
+        '| GLM-5.1   | N/A                 | N/A               | N/A                |',
+        '| GLM-5     | --                  | --                | --                 |',
+        '| Kimi K2.5 | TBD                 | TBD               | TBD                |',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const entries = service.parse(mdx);
+      // All 4 endpoint models still returned.
+      expect(entries.map((e) => e.id).sort()).toEqual([
+        'glm-5',
+        'glm-5.1',
+        'kimi-k2.5',
+        'qwen3.7-max',
+      ]);
+      // Every cost is null — no NaN, no Infinity, no crash.
+      for (const entry of entries) {
+        expect(entry.costPerRequestUsd).toBeNull();
+      }
+    });
+
+    it('does not populate the cost index with NaN or Infinity', async () => {
+      const mdx = [
+        '## Usage limits',
+        '',
+        '| Model     | requests per 5 hour | requests per week | requests per month |',
+        '| --------- | ------------------- | ----------------- | ------------------ |',
+        '| GLM-5.1   | N/A                 | N/A               | N/A                |',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: async () => mdx,
+      } as Response);
+
+      try {
+        await service.list();
+        const cost = service.getCostPerRequest('glm-5.1');
+        // Must be exactly null — not NaN, not Infinity, not 0.
+        expect(cost).toBeNull();
+        // Sanity: also confirm getFormat still works (only cost was dropped).
+        expect(service.getFormat('glm-5.1')).toBe('openai');
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('skips rows where the request column is empty/whitespace', () => {
+      const mdx = [
+        '## Usage limits',
+        '',
+        '| Model     | requests per 5 hour | requests per week | requests per month |',
+        '| --------- | ------------------- | ----------------- | ------------------ |',
+        '| GLM-5.1   |                     | 2,150             | 4,300              |',
+        '| GLM-5     | 1,150               | 2,880             | 5,750              |',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const entries = service.parse(mdx);
+      const glm51 = entries.find((e) => e.id === 'glm-5.1');
+      const glm5 = entries.find((e) => e.id === 'glm-5');
+
+      // Empty cell — regex anchored on [0-9] rejects it.
+      expect(glm51?.costPerRequestUsd).toBeNull();
+      expect(glm5?.costPerRequestUsd).toBeCloseTo(OPENCODE_GO_BUDGET_5H_USD / 1150, 12);
+    });
+  });
+
+  describe('partially malformed MDX (one table broken)', () => {
+    it('returns all models with null cost when Usage Limits table is entirely missing', () => {
+      // Endpoints table valid, no Usage Limits section at all.
+      const entries = service.parse(ENDPOINTS_TABLE);
+      expect(entries).toHaveLength(4);
+      for (const entry of entries) {
+        expect(entry.costPerRequestUsd).toBeNull();
+      }
+      // IDs still parsed correctly.
+      expect(entries.map((e) => e.id).sort()).toEqual([
+        'glm-5',
+        'glm-5.1',
+        'kimi-k2.5',
+        'qwen3.7-max',
+      ]);
+    });
+
+    it('returns models with null cost when Usage Limits formatting is broken (no numeric columns)', () => {
+      // Limits "table" exists but no row matches the 3-numeric-column anchor.
+      const broken = [
+        '## Usage limits',
+        '',
+        'These limits are TBD pending pricing review.',
+        '',
+        '- GLM-5.1: see docs',
+        '- GLM-5: see docs',
+        '- Kimi K2.5: see docs',
+        '',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const entries = service.parse(broken);
+      expect(entries).toHaveLength(4);
+      for (const entry of entries) {
+        expect(entry.costPerRequestUsd).toBeNull();
+      }
+    });
+
+    it('returns models with null cost when Usage Limits names do not match any Endpoints name', () => {
+      // Limits table has valid numeric rows, but the names are completely
+      // different from the endpoints names (e.g. legacy model names).
+      const mismatch = [
+        '## Usage limits',
+        '',
+        '| Model           | requests per 5 hour | requests per week | requests per month |',
+        '| --------------- | ------------------- | ----------------- | ------------------ |',
+        '| Legacy Model A  | 880                 | 2,150             | 4,300              |',
+        '| Legacy Model B  | 1,150               | 2,880             | 5,750              |',
+        '| Unknown Codename| 1,850               | 4,630             | 9,250              |',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const entries = service.parse(mismatch);
+      // All endpoint models still parsed.
+      expect(entries).toHaveLength(4);
+      // None matched — every cost is null, but no crash.
+      for (const entry of entries) {
+        expect(entry.costPerRequestUsd).toBeNull();
+      }
+      // IDs still correct.
+      expect(entries.map((e) => e.id).sort()).toEqual([
+        'glm-5',
+        'glm-5.1',
+        'kimi-k2.5',
+        'qwen3.7-max',
+      ]);
+    });
+
+    it('matches the subset that aligns and leaves the rest null when Endpoints/Limits partially overlap', () => {
+      // Half the endpoints match Usage Limits rows, half don't.
+      const partial = [
+        '## Usage limits',
+        '',
+        '| Model     | requests per 5 hour | requests per week | requests per month |',
+        '| --------- | ------------------- | ----------------- | ------------------ |',
+        '| GLM-5.1   | 880                 | 2,150             | 4,300              |',
+        '| Totally Different Name | 1,150     | 2,880             | 5,750              |',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const entries = service.parse(partial);
+      const cost = Object.fromEntries(entries.map((e) => [e.id, e.costPerRequestUsd]));
+
+      // Only GLM-5.1 matched cross-table.
+      expect(cost['glm-5.1']).toBeCloseTo(OPENCODE_GO_BUDGET_5H_USD / 880, 12);
+      // Rest of the endpoint models got null, not NaN or crash.
+      expect(cost['glm-5']).toBeNull();
+      expect(cost['kimi-k2.5']).toBeNull();
+      expect(cost['qwen3.7-max']).toBeNull();
+    });
+
+    it('returns [] when both tables are malformed beyond recognition', () => {
+      const garbage = [
+        '## Usage limits',
+        '',
+        'totally not a table',
+        '',
+        '## Endpoints',
+        '',
+        'also not a table',
+      ].join('\n');
+
+      const entries = service.parse(garbage);
+      expect(entries).toEqual([]);
+    });
+
+    it('returns [] when the Endpoints table is missing but Usage Limits is intact', () => {
+      // Inverse of the above — limits table present, endpoints missing.
+      // Without Endpoints, there are no models to attribute costs to.
+      const limitsOnly = [
+        '## Usage limits',
+        '',
+        '| Model     | requests per 5 hour | requests per week | requests per month |',
+        '| --------- | ------------------- | ----------------- | ------------------ |',
+        '| GLM-5.1   | 880                 | 2,150             | 4,300              |',
+        '| GLM-5     | 1,150               | 2,880             | 5,750              |',
+      ].join('\n');
+
+      const entries = service.parse(limitsOnly);
+      expect(entries).toEqual([]);
+    });
+
+    it('still maps format correctly when only some endpoint rows have matching limits', () => {
+      const partial = [
+        '## Usage limits',
+        '',
+        '| Model     | requests per 5 hour | requests per week | requests per month |',
+        '| --------- | ------------------- | ----------------- | ------------------ |',
+        '| Qwen3.7 Max | 770               | 1,925             | 3,850              |',
+        ENDPOINTS_TABLE,
+      ].join('\n');
+
+      const entries = service.parse(partial);
+      const byId = Object.fromEntries(entries.map((e) => [e.id, e]));
+
+      // Cost attached only to qwen3.7-max.
+      expect(byId['qwen3.7-max']?.costPerRequestUsd).toBeCloseTo(
+        OPENCODE_GO_BUDGET_5H_USD / 770,
+        12,
+      );
+      expect(byId['glm-5.1']?.costPerRequestUsd).toBeNull();
+
+      // But formats still correct for all endpoint rows.
+      expect(byId['glm-5.1']?.format).toBe('openai');
+      expect(byId['glm-5']?.format).toBe('openai');
+      expect(byId['kimi-k2.5']?.format).toBe('openai');
+      expect(byId['qwen3.7-max']?.format).toBe('anthropic');
+    });
+  });
+});

--- a/packages/backend/src/model-prices/model-pricing-cache.zero-pricing.spec.ts
+++ b/packages/backend/src/model-prices/model-pricing-cache.zero-pricing.spec.ts
@@ -1,0 +1,231 @@
+import { ModelPricingCacheService } from './model-pricing-cache.service';
+import { PricingSyncService, OpenRouterPricingEntry } from '../database/pricing-sync.service';
+import { ModelsDevSyncService } from '../database/models-dev-sync.service';
+import { ProviderModelRegistryService } from '../model-discovery/provider-model-registry.service';
+
+/**
+ * Tests for the zero-pricing override protection in
+ * `ModelPricingCacheService.loadModelsDevEntries()` (see source lines 217-222).
+ *
+ * Some providers (e.g. GitHub Copilot) ship a models.dev catalog that lists
+ * popular third-party models like `gemini-2.5-pro` as $0. Without the guard,
+ * those entries would erase the real pricing that came in either from
+ * OpenRouter or from an earlier iteration of the models.dev loop. These
+ * tests pin the cross-source behavior so the conditional cannot regress
+ * silently.
+ */
+
+function makeEntry(input: number, output: number): OpenRouterPricingEntry {
+  return { input, output };
+}
+
+function makeMockRegistry() {
+  return {
+    isModelConfirmed: jest.fn().mockReturnValue(null),
+    getConfirmedModels: jest.fn().mockReturnValue(null),
+    registerModels: jest.fn(),
+  };
+}
+
+function makeMockModelsDevSync() {
+  return {
+    lookupModel: jest.fn().mockReturnValue(null),
+    getModelsForProvider: jest.fn().mockReturnValue([]),
+    isProviderSupported: jest.fn().mockReturnValue(false),
+    whenInitialized: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('ModelPricingCacheService — zero-pricing override protection', () => {
+  let service: ModelPricingCacheService;
+  let mockGetAll: jest.Mock;
+  let mockRegistry: ReturnType<typeof makeMockRegistry>;
+  let mockModelsDevSync: ReturnType<typeof makeMockModelsDevSync>;
+  let mockPricingSync: { getAll: jest.Mock; whenInitialized: jest.Mock };
+
+  beforeEach(() => {
+    mockGetAll = jest.fn().mockReturnValue(new Map<string, OpenRouterPricingEntry>());
+    mockPricingSync = {
+      getAll: mockGetAll,
+      whenInitialized: jest.fn().mockResolvedValue(undefined),
+    };
+    mockModelsDevSync = makeMockModelsDevSync();
+    mockRegistry = makeMockRegistry();
+    service = new ModelPricingCacheService(
+      mockPricingSync as unknown as PricingSyncService,
+      mockModelsDevSync as unknown as ModelsDevSyncService,
+      mockRegistry as unknown as ProviderModelRegistryService,
+    );
+  });
+
+  describe('OpenRouter real pricing vs models.dev zero pricing', () => {
+    it('keeps OpenRouter pricing on the bare key when models.dev lists $0 for the same model', async () => {
+      // OpenRouter: real pricing for google/gemini-2.5-pro
+      mockGetAll.mockReturnValue(
+        new Map<string, OpenRouterPricingEntry>([
+          ['google/gemini-2.5-pro', makeEntry(0.001, 0.01)],
+        ]),
+      );
+
+      // models.dev: GitHub Copilot exposes gemini-2.5-pro as $0 (acts as a
+      // proxy — its own pricing for the same model is not relevant).
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'copilot') {
+          return [
+            {
+              id: 'gemini-2.5-pro',
+              name: 'Gemini 2.5 Pro',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      // The bare key (used by cost lookup on ingested messages that only
+      // carry the model name) must still resolve to OpenRouter's real
+      // pricing — NOT the $0 entry from copilot's models.dev catalog.
+      const bare = service.getByModel('gemini-2.5-pro');
+      expect(bare).toBeDefined();
+      expect(bare!.source).toBe('openrouter');
+      expect(bare!.provider).toBe('Google');
+      expect(bare!.input_price_per_token).toBe(0.001);
+      expect(bare!.output_price_per_token).toBe(0.01);
+    });
+
+    it('lets models.dev override OpenRouter when the new pricing is non-zero', async () => {
+      // Inverse case: OpenRouter has zero pricing, models.dev has real
+      // pricing. The guard should NOT block this — zero is the bad data,
+      // not the good data.
+      mockGetAll.mockReturnValue(
+        new Map<string, OpenRouterPricingEntry>([['google/gemini-2.5-pro', makeEntry(0, 0)]]),
+      );
+
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'gemini') {
+          return [
+            {
+              id: 'gemini-2.5-pro',
+              name: 'Gemini 2.5 Pro',
+              inputPricePerToken: 0.00000125,
+              outputPricePerToken: 0.00001,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const bare = service.getByModel('gemini-2.5-pro');
+      expect(bare).toBeDefined();
+      expect(bare!.source).toBe('models.dev');
+      expect(bare!.provider).toBe('Google');
+      expect(bare!.input_price_per_token).toBe(0.00000125);
+      expect(bare!.output_price_per_token).toBe(0.00001);
+    });
+
+    it('lets models.dev override OpenRouter when both have real pricing', async () => {
+      // Sanity: the guard ONLY kicks in for $0 incoming pricing. When
+      // models.dev has its own real pricing for a model, it should still
+      // win over OpenRouter (curated > broad).
+      mockGetAll.mockReturnValue(
+        new Map<string, OpenRouterPricingEntry>([
+          ['anthropic/claude-opus-4-6', makeEntry(0.000015, 0.000075)],
+        ]),
+      );
+
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'anthropic') {
+          return [
+            {
+              id: 'claude-opus-4-6',
+              name: 'Claude Opus 4.6',
+              inputPricePerToken: 0.000005,
+              outputPricePerToken: 0.000025,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const bare = service.getByModel('claude-opus-4-6');
+      expect(bare).toBeDefined();
+      expect(bare!.source).toBe('models.dev');
+      expect(bare!.input_price_per_token).toBe(0.000005);
+    });
+
+    it('treats a single zero side (input=0 but output>0) as NOT zero-pricing', async () => {
+      // The guard requires BOTH input and output to be zero for the
+      // "isZeroPricing" check. A model with one side non-zero is real
+      // pricing and should be allowed to overwrite.
+      mockGetAll.mockReturnValue(
+        new Map<string, OpenRouterPricingEntry>([
+          ['anthropic/claude-half', makeEntry(0.001, 0.002)],
+        ]),
+      );
+
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'anthropic') {
+          return [
+            {
+              id: 'claude-half',
+              name: 'Claude Half',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0.005,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('claude-half');
+      expect(entry).toBeDefined();
+      // models.dev wins because output is non-zero → not "zero pricing".
+      expect(entry!.source).toBe('models.dev');
+      expect(entry!.input_price_per_token).toBe(0);
+      expect(entry!.output_price_per_token).toBe(0.005);
+    });
+
+    it('treats OpenRouter zero-input pricing as NOT "real pricing" so models.dev can win', async () => {
+      // hasRealPricing = (existing.input ?? 0) > 0. So if OpenRouter
+      // already has input=0 (regardless of output), the guard considers
+      // it "no real pricing" and models.dev — even at $0 — overwrites.
+      // This pins that boundary so the conditional doesn't drift.
+      mockGetAll.mockReturnValue(
+        new Map<string, OpenRouterPricingEntry>([
+          ['anthropic/claude-free-input', makeEntry(0, 0.002)],
+        ]),
+      );
+
+      mockModelsDevSync.getModelsForProvider.mockImplementation((providerId: string) => {
+        if (providerId === 'anthropic') {
+          return [
+            {
+              id: 'claude-free-input',
+              name: 'Claude Free Input',
+              inputPricePerToken: 0,
+              outputPricePerToken: 0,
+            },
+          ];
+        }
+        return [];
+      });
+
+      await service.reload();
+
+      const entry = service.getByModel('claude-free-input');
+      expect(entry).toBeDefined();
+      expect(entry!.source).toBe('models.dev');
+      expect(entry!.input_price_per_token).toBe(0);
+      expect(entry!.output_price_per_token).toBe(0);
+    });
+  });
+});

--- a/packages/backend/src/notifications/dto/notification-rule.dto.spec.ts
+++ b/packages/backend/src/notifications/dto/notification-rule.dto.spec.ts
@@ -36,6 +36,72 @@ describe('CreateNotificationRuleDto', () => {
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
   });
+
+  it.each([['hour'], ['day'], ['week'], ['month']])('accepts valid period "%s"', async (period) => {
+    const dto = plainToInstance(CreateNotificationRuleDto, {
+      agent_name: 'demo-agent',
+      metric_type: 'tokens',
+      threshold: 1000,
+      period,
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it.each([['invalid'], ['daily'], ['yearly'], ['HOUR'], ['Day'], ['minute'], ['second'], ['']])(
+    'rejects invalid period "%s"',
+    async (period) => {
+      const dto = plainToInstance(CreateNotificationRuleDto, {
+        agent_name: 'demo-agent',
+        metric_type: 'tokens',
+        threshold: 1000,
+        period,
+      });
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      const periodError = errors.find((e) => e.property === 'period');
+      expect(periodError).toBeDefined();
+      expect(periodError?.constraints).toHaveProperty('isIn');
+    },
+  );
+
+  it('rejects missing period (required field)', async () => {
+    const dto = plainToInstance(CreateNotificationRuleDto, {
+      agent_name: 'demo-agent',
+      metric_type: 'tokens',
+      threshold: 1000,
+    });
+    const errors = await validate(dto);
+    const periodError = errors.find((e) => e.property === 'period');
+    expect(periodError).toBeDefined();
+    expect(periodError?.constraints).toHaveProperty('isIn');
+  });
+
+  it('rejects numeric period', async () => {
+    const dto = plainToInstance(CreateNotificationRuleDto, {
+      agent_name: 'demo-agent',
+      metric_type: 'tokens',
+      threshold: 1000,
+      period: 1,
+    });
+    const errors = await validate(dto);
+    const periodError = errors.find((e) => e.property === 'period');
+    expect(periodError).toBeDefined();
+    expect(periodError?.constraints).toHaveProperty('isIn');
+  });
+
+  it('rejects null period', async () => {
+    const dto = plainToInstance(CreateNotificationRuleDto, {
+      agent_name: 'demo-agent',
+      metric_type: 'tokens',
+      threshold: 1000,
+      period: null,
+    });
+    const errors = await validate(dto);
+    const periodError = errors.find((e) => e.property === 'period');
+    expect(periodError).toBeDefined();
+    expect(periodError?.constraints).toHaveProperty('isIn');
+  });
 });
 
 describe('UpdateNotificationRuleDto', () => {
@@ -59,6 +125,31 @@ describe('UpdateNotificationRuleDto', () => {
     });
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it.each([['hour'], ['day'], ['week'], ['month']])('accepts valid period "%s"', async (period) => {
+    const dto = plainToInstance(UpdateNotificationRuleDto, { period });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it.each([['invalid'], ['daily'], ['HOUR'], ['Day'], ['minute'], ['second'], ['']])(
+    'rejects invalid period "%s" with isIn constraint',
+    async (period) => {
+      const dto = plainToInstance(UpdateNotificationRuleDto, { period });
+      const errors = await validate(dto);
+      const periodError = errors.find((e) => e.property === 'period');
+      expect(periodError).toBeDefined();
+      expect(periodError?.constraints).toHaveProperty('isIn');
+    },
+  );
+
+  it('rejects numeric period', async () => {
+    const dto = plainToInstance(UpdateNotificationRuleDto, { period: 7 });
+    const errors = await validate(dto);
+    const periodError = errors.find((e) => e.property === 'period');
+    expect(periodError).toBeDefined();
+    expect(periodError?.constraints).toHaveProperty('isIn');
   });
 
   it('transforms is_active via @Type(() => Boolean)', async () => {

--- a/packages/backend/src/notifications/notifications.controller.email-validation.spec.ts
+++ b/packages/backend/src/notifications/notifications.controller.email-validation.spec.ts
@@ -1,0 +1,187 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { DataSource } from 'typeorm';
+import { NotificationsController } from './notifications.controller';
+import { NotificationRulesService } from './services/notification-rules.service';
+import { NotificationLogService } from './services/notification-log.service';
+import { EmailProviderConfigService } from './services/email-provider-config.service';
+import { NotificationCronService } from './services/notification-cron.service';
+import { LimitCheckService } from './services/limit-check.service';
+
+const mockUser = { id: 'user-1', email: 'test@test.com', name: 'Test' } as never;
+
+describe('NotificationsController setNotificationEmail validation', () => {
+  let module: TestingModule;
+  let controller: NotificationsController;
+  let emailProviderConfigService: jest.Mocked<EmailProviderConfigService>;
+
+  beforeEach(async () => {
+    const mockEmailProviderConfigService = {
+      getConfig: jest.fn(),
+      upsert: jest.fn(),
+      remove: jest.fn(),
+      testConfig: jest.fn(),
+      testSavedConfig: jest.fn(),
+      getNotificationEmail: jest.fn(),
+      setNotificationEmail: jest.fn(),
+    };
+
+    module = await Test.createTestingModule({
+      controllers: [NotificationsController],
+      providers: [
+        {
+          provide: NotificationRulesService,
+          useValue: {
+            listRules: jest.fn(),
+            createRule: jest.fn(),
+            updateRule: jest.fn(),
+            deleteRule: jest.fn(),
+            getRule: jest.fn(),
+            getOwnedRule: jest.fn(),
+          },
+        },
+        { provide: NotificationLogService, useValue: { getLogsForAgent: jest.fn() } },
+        { provide: EmailProviderConfigService, useValue: mockEmailProviderConfigService },
+        { provide: NotificationCronService, useValue: { checkThresholds: jest.fn() } },
+        { provide: LimitCheckService, useValue: { invalidateCache: jest.fn() } },
+      ],
+    }).compile();
+
+    controller = module.get(NotificationsController);
+    emailProviderConfigService = module.get(EmailProviderConfigService);
+  });
+
+  it('propagates BadRequestException when email is an empty string', async () => {
+    emailProviderConfigService.setNotificationEmail.mockRejectedValue(
+      new BadRequestException('Notification email must be a non-empty string'),
+    );
+
+    await expect(controller.setNotificationEmail(mockUser, { email: '' })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+
+    expect(emailProviderConfigService.setNotificationEmail).toHaveBeenCalledWith('user-1', '');
+  });
+
+  it('propagates BadRequestException when email is whitespace only (spaces)', async () => {
+    emailProviderConfigService.setNotificationEmail.mockRejectedValue(
+      new BadRequestException('Notification email must be a non-empty string'),
+    );
+
+    await expect(
+      controller.setNotificationEmail(mockUser, { email: '   ' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(emailProviderConfigService.setNotificationEmail).toHaveBeenCalledWith('user-1', '   ');
+  });
+
+  it('propagates BadRequestException when email is whitespace only (tabs and newlines)', async () => {
+    emailProviderConfigService.setNotificationEmail.mockRejectedValue(
+      new BadRequestException('Notification email must be a non-empty string'),
+    );
+
+    await expect(
+      controller.setNotificationEmail(mockUser, { email: '\t\n\r ' }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(emailProviderConfigService.setNotificationEmail).toHaveBeenCalledWith(
+      'user-1',
+      '\t\n\r ',
+    );
+  });
+
+  it('does not call setNotificationEmail with persisted writes after rejection', async () => {
+    emailProviderConfigService.setNotificationEmail.mockRejectedValue(
+      new BadRequestException('Notification email must be a non-empty string'),
+    );
+
+    await expect(controller.setNotificationEmail(mockUser, { email: '' })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+
+    // The controller should not have returned a saved:true payload — assert that
+    // a rejected promise short-circuits the `return { saved: true }` line.
+    expect(emailProviderConfigService.setNotificationEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a valid non-empty email and returns saved: true', async () => {
+    emailProviderConfigService.setNotificationEmail.mockResolvedValue(undefined);
+
+    const result = await controller.setNotificationEmail(mockUser, { email: 'alerts@test.com' });
+
+    expect(emailProviderConfigService.setNotificationEmail).toHaveBeenCalledWith(
+      'user-1',
+      'alerts@test.com',
+    );
+    expect(result).toEqual({ saved: true });
+  });
+});
+
+describe('EmailProviderConfigService.setNotificationEmail empty/whitespace handling', () => {
+  // Direct unit tests on the service method that the controller delegates to.
+  // The controller-level tests above only assert propagation; these assert
+  // that the service itself rejects empty/whitespace input before touching
+  // the database.
+
+  function createMockDataSource() {
+    return {
+      query: jest.fn().mockResolvedValue([]),
+      options: { type: 'postgres' },
+    } as unknown as DataSource;
+  }
+
+  const mockConfigService = {
+    get: (_key: string, fallback?: string) => fallback,
+  } as unknown as ConfigService;
+
+  it('throws BadRequestException for empty string without querying the database', async () => {
+    const ds = createMockDataSource();
+    const service = new EmailProviderConfigService(ds, mockConfigService);
+
+    await expect(service.setNotificationEmail('user-1', '')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(ds.query).not.toHaveBeenCalled();
+  });
+
+  it('throws BadRequestException for whitespace-only input without querying the database', async () => {
+    const ds = createMockDataSource();
+    const service = new EmailProviderConfigService(ds, mockConfigService);
+
+    await expect(service.setNotificationEmail('user-1', '   \t\n')).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+    expect(ds.query).not.toHaveBeenCalled();
+  });
+
+  it('throws BadRequestException for non-string (cast) input without querying the database', async () => {
+    const ds = createMockDataSource();
+    const service = new EmailProviderConfigService(ds, mockConfigService);
+
+    await expect(
+      service.setNotificationEmail('user-1', undefined as unknown as string),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(ds.query).not.toHaveBeenCalled();
+  });
+
+  it('still updates the DB when a valid trimmed email is provided', async () => {
+    // First query returns an existing row, second is the UPDATE.
+    const ds = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce([{ id: 'existing-1' }])
+        .mockResolvedValueOnce([]),
+      options: { type: 'postgres' },
+    } as unknown as DataSource;
+    const service = new EmailProviderConfigService(ds, mockConfigService);
+
+    await service.setNotificationEmail('user-1', '  Alerts@Test.COM  ');
+
+    expect(ds.query).toHaveBeenCalledTimes(2);
+    // Second call is the UPDATE — confirm the email was lowercased & trimmed.
+    const updateCall = (ds.query as jest.Mock).mock.calls[1];
+    expect(updateCall[1][0]).toBe('alerts@test.com');
+    expect(updateCall[1][2]).toBe('user-1');
+  });
+});

--- a/packages/backend/src/notifications/services/email-provider-config.service.ts
+++ b/packages/backend/src/notifications/services/email-provider-config.service.ts
@@ -175,6 +175,11 @@ export class EmailProviderConfigService {
   }
 
   async setNotificationEmail(userId: string, email: string): Promise<void> {
+    const normalized = typeof email === 'string' ? email.trim().toLowerCase() : '';
+    if (!normalized) {
+      throw new BadRequestException('Notification email must be a non-empty string');
+    }
+
     const existing = await this.ds.query(
       `SELECT id FROM email_provider_configs WHERE user_id = $1`,
       [userId],
@@ -184,7 +189,7 @@ export class EmailProviderConfigService {
     if (existing.length > 0) {
       await this.ds.query(
         `UPDATE email_provider_configs SET notification_email = $1, updated_at = $2 WHERE user_id = $3`,
-        [email.trim().toLowerCase(), now, userId],
+        [normalized, now, userId],
       );
     }
   }

--- a/packages/backend/src/notifications/services/email-providers/mailgun.provider.spec.ts
+++ b/packages/backend/src/notifications/services/email-providers/mailgun.provider.spec.ts
@@ -17,7 +17,7 @@ describe('MailgunProvider', () => {
     fromEmail: 'noreply@test.com',
   };
 
-  it('sends email and returns true on success', async () => {
+  it('sends email and returns true on success with all required body fields', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
     const provider = new MailgunProvider(config);
 
@@ -28,9 +28,38 @@ describe('MailgunProvider', () => {
       'https://api.mailgun.net/v3/mg.test.com/messages',
       expect.objectContaining({ method: 'POST' }),
     );
+
+    const body = (global.fetch as jest.Mock).mock.calls[0][1].body;
+    expect(body).toBeInstanceOf(URLSearchParams);
+    expect(body.get('from')).toBe('Manifest <noreply@test.com>');
+    expect(body.get('to')).toBe('user@test.com');
+    expect(body.get('subject')).toBe('Test');
+    expect(body.get('html')).toBe('<p>Hi</p>');
+    expect(body.get('h:Reply-To')).toBe('noreply@test.com');
+    expect(body.get('o:tag')).toBe('manifest');
+    expect(body.has('text')).toBe(false);
   });
 
-  it('uses Basic auth with base64-encoded credentials', async () => {
+  it('serializes body as URL-encoded form (not JSON)', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const provider = new MailgunProvider(config);
+
+    await provider.send({
+      to: 'user@test.com',
+      subject: 'Subject with spaces & symbols',
+      html: '<p>Hi & bye</p>',
+    });
+
+    const body = (global.fetch as jest.Mock).mock.calls[0][1].body as URLSearchParams;
+    expect(body).toBeInstanceOf(URLSearchParams);
+    const encoded = body.toString();
+    expect(encoded).toContain('subject=Subject+with+spaces+%26+symbols');
+    expect(encoded).toContain('html=%3Cp%3EHi+%26+bye%3C%2Fp%3E');
+    // Ensure body is NOT a JSON string
+    expect(typeof body).not.toBe('string');
+  });
+
+  it('uses Basic auth with base64-encoded credentials and no Content-Type override', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
     const provider = new MailgunProvider(config);
 
@@ -39,6 +68,8 @@ describe('MailgunProvider', () => {
     const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers;
     const expected = `Basic ${Buffer.from('api:test-key').toString('base64')}`;
     expect(headers.Authorization).toBe(expected);
+    // fetch() should infer Content-Type: application/x-www-form-urlencoded from URLSearchParams
+    expect(headers['Content-Type']).toBeUndefined();
   });
 
   it('returns false when apiKey is empty', async () => {
@@ -82,7 +113,7 @@ describe('MailgunProvider', () => {
     expect(result).toBe(false);
   });
 
-  it('uses custom from address when provided', async () => {
+  it('uses custom from address when provided and preserves all other fields', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
     const provider = new MailgunProvider(config);
 
@@ -95,9 +126,25 @@ describe('MailgunProvider', () => {
 
     const body = (global.fetch as jest.Mock).mock.calls[0][1].body as URLSearchParams;
     expect(body.get('from')).toBe('Custom <custom@test.com>');
+    expect(body.get('to')).toBe('user@test.com');
+    expect(body.get('subject')).toBe('Test');
+    expect(body.get('html')).toBe('<p>Hi</p>');
+    expect(body.get('h:Reply-To')).toBe('noreply@test.com');
+    expect(body.get('o:tag')).toBe('manifest');
   });
 
-  it('includes text param when provided', async () => {
+  it('uses default from when fromEmail not configured', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const provider = new MailgunProvider({ ...config, fromEmail: undefined });
+
+    await provider.send({ to: 'user@test.com', subject: 'Test', html: '<p>Hi</p>' });
+
+    const body = (global.fetch as jest.Mock).mock.calls[0][1].body as URLSearchParams;
+    expect(body.get('from')).toBe('Manifest <noreply@manifest.build>');
+    expect(body.get('h:Reply-To')).toBe('noreply@manifest.build');
+  });
+
+  it('includes text param when provided alongside all required fields', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
     const provider = new MailgunProvider(config);
 
@@ -110,6 +157,12 @@ describe('MailgunProvider', () => {
 
     const body = (global.fetch as jest.Mock).mock.calls[0][1].body as URLSearchParams;
     expect(body.get('text')).toBe('Hi plain');
+    expect(body.get('from')).toBe('Manifest <noreply@test.com>');
+    expect(body.get('to')).toBe('user@test.com');
+    expect(body.get('subject')).toBe('Test');
+    expect(body.get('html')).toBe('<p>Hi</p>');
+    expect(body.get('h:Reply-To')).toBe('noreply@test.com');
+    expect(body.get('o:tag')).toBe('manifest');
   });
 
   it('omits text param when not provided', async () => {
@@ -122,6 +175,17 @@ describe('MailgunProvider', () => {
     expect(body.has('text')).toBe(false);
   });
 
+  it('omits text param when explicitly empty string', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const provider = new MailgunProvider(config);
+
+    await provider.send({ to: 'user@test.com', subject: 'Test', html: '<p>Hi</p>', text: '' });
+
+    const body = (global.fetch as jest.Mock).mock.calls[0][1].body as URLSearchParams;
+    // empty string is falsy, so text should not be appended
+    expect(body.has('text')).toBe(false);
+  });
+
   it('includes Reply-To header and tag', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
     const provider = new MailgunProvider(config);
@@ -131,6 +195,32 @@ describe('MailgunProvider', () => {
     const body = (global.fetch as jest.Mock).mock.calls[0][1].body as URLSearchParams;
     expect(body.get('h:Reply-To')).toBe('noreply@test.com');
     expect(body.get('o:tag')).toBe('manifest');
+  });
+
+  it('preserves unicode characters in subject and html', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    const provider = new MailgunProvider(config);
+
+    await provider.send({
+      to: 'user@test.com',
+      subject: 'Alert: spend > €100 (你好)',
+      html: '<p>Hello 你好 🚨</p>',
+    });
+
+    const body = (global.fetch as jest.Mock).mock.calls[0][1].body as URLSearchParams;
+    expect(body.get('subject')).toBe('Alert: spend > €100 (你好)');
+    expect(body.get('html')).toBe('<p>Hello 你好 🚨</p>');
+  });
+
+  it('encodes domain in URL path to prevent injection', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+    // valid domain that contains a hyphen — exercise encodeURIComponent path
+    const provider = new MailgunProvider({ ...config, domain: 'mg-prod.test.com' });
+
+    await provider.send({ to: 'user@test.com', subject: 'Test', html: '<p>Hi</p>' });
+
+    const url = (global.fetch as jest.Mock).mock.calls[0][0];
+    expect(url).toBe('https://api.mailgun.net/v3/mg-prod.test.com/messages');
   });
 
   it('rejects domain with path traversal characters', async () => {

--- a/packages/backend/src/notifications/services/limit-check.service.edge-cases.spec.ts
+++ b/packages/backend/src/notifications/services/limit-check.service.edge-cases.spec.ts
@@ -1,0 +1,294 @@
+/**
+ * Edge-case tests for LimitCheckService — complements limit-check.service.spec.ts.
+ *
+ * Covers:
+ *   1. Concurrent invocations (double-submit race in dedup logic)
+ *   2. insertLog() failure leaving the dedup guard unset
+ *   3. Graceful degradation when resolveUserEmail returns null
+ *   4. Very large numeric consumption values (overflow / precision)
+ *
+ * Split out from limit-check.service.spec.ts to keep each file under the 300-line cap.
+ */
+import { Subject } from 'rxjs';
+import { LimitCheckService } from './limit-check.service';
+import { NotificationRulesService } from './notification-rules.service';
+import { NotificationEmailService } from './notification-email.service';
+import { EmailProviderConfigService } from './email-provider-config.service';
+import { NotificationLogService } from './notification-log.service';
+import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
+import { ManifestRuntimeService } from '../../common/services/manifest-runtime.service';
+
+const TENANT = 'tenant-1';
+const AGENT = 'my-agent';
+
+const BLOCK_RULE = {
+  id: 'r1',
+  tenant_id: TENANT,
+  agent_name: AGENT,
+  user_id: 'u1',
+  metric_type: 'tokens' as const,
+  threshold: 50000,
+  period: 'day' as const,
+};
+
+describe('LimitCheckService — edge cases', () => {
+  let service: LimitCheckService;
+  let mockGetActiveBlockRules: jest.Mock;
+  let mockGetConsumption: jest.Mock;
+  let mockSendThresholdAlert: jest.Mock;
+  let mockGetFullConfig: jest.Mock;
+  let mockHasAlreadySent: jest.Mock;
+  let mockInsertLog: jest.Mock;
+  let mockResolveUserEmail: jest.Mock;
+  let ingestSubject: Subject<string>;
+
+  beforeEach(() => {
+    mockGetActiveBlockRules = jest.fn().mockResolvedValue([BLOCK_RULE]);
+    mockGetConsumption = jest.fn().mockResolvedValue(60000);
+
+    const rulesService = {
+      getActiveBlockRules: mockGetActiveBlockRules,
+      getConsumption: mockGetConsumption,
+    } as unknown as NotificationRulesService;
+
+    mockSendThresholdAlert = jest.fn().mockResolvedValue(true);
+    const emailService = {
+      sendThresholdAlert: mockSendThresholdAlert,
+    } as unknown as NotificationEmailService;
+
+    mockGetFullConfig = jest.fn().mockResolvedValue(null);
+    const emailProviderConfig = {
+      getFullConfig: mockGetFullConfig,
+    } as unknown as EmailProviderConfigService;
+
+    const runtime = {
+      getAuthBaseUrl: jest.fn().mockReturnValue('http://localhost:3001'),
+    } as unknown as ManifestRuntimeService;
+
+    ingestSubject = new Subject<string>();
+    const ingestBus = {
+      all: () => ingestSubject.asObservable(),
+    } as unknown as IngestEventBusService;
+
+    mockHasAlreadySent = jest.fn().mockResolvedValue(false);
+    mockInsertLog = jest.fn().mockResolvedValue(undefined);
+    mockResolveUserEmail = jest.fn().mockResolvedValue(null);
+    const notificationLog = {
+      hasAlreadySent: mockHasAlreadySent,
+      insertLog: mockInsertLog,
+      resolveUserEmail: mockResolveUserEmail,
+    } as unknown as NotificationLogService;
+
+    service = new LimitCheckService(
+      rulesService,
+      emailService,
+      emailProviderConfig,
+      ingestBus,
+      runtime,
+      notificationLog,
+    );
+    service.onModuleInit();
+  });
+
+  afterEach(() => {
+    service.onModuleDestroy();
+    ingestSubject.complete();
+    jest.restoreAllMocks();
+  });
+
+  /* ── 1. Concurrent double-submit race ────────────────────────── */
+
+  describe('email notification on block — concurrency', () => {
+    it('handles concurrent requests without crashing (race demonstrates dedup gap)', async () => {
+      mockResolveUserEmail.mockResolvedValue('test@example.com');
+
+      // Fire two concurrent checks before either has resolved insertLog.
+      const [a, b] = await Promise.all([
+        service.checkLimits(TENANT, AGENT),
+        service.checkLimits(TENANT, AGENT),
+      ]);
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Both calls observe the limit exceeded.
+      expect(a).not.toBeNull();
+      expect(b).not.toBeNull();
+      expect(a!.ruleId).toBe('r1');
+      expect(b!.ruleId).toBe('r1');
+
+      // Both pass the dedup check because neither write has committed yet.
+      // This pins the documented race: without a transaction or ON CONFLICT
+      // guard, both branches call insertLog + sendThresholdAlert.
+      expect(mockHasAlreadySent).toHaveBeenCalledTimes(2);
+      expect(mockInsertLog).toHaveBeenCalledTimes(2);
+      expect(mockSendThresholdAlert).toHaveBeenCalledTimes(2);
+    });
+
+    it('subsequent invocation after committed log is deduped', async () => {
+      mockResolveUserEmail.mockResolvedValue('test@example.com');
+
+      await service.checkLimits(TENANT, AGENT);
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockSendThresholdAlert).toHaveBeenCalledTimes(1);
+
+      // Once the log row is persisted, the next call must short-circuit.
+      mockHasAlreadySent.mockResolvedValue(true);
+      await service.checkLimits(TENANT, AGENT);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockSendThresholdAlert).toHaveBeenCalledTimes(1);
+      expect(mockInsertLog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /* ── 2. insertLog failure → dedup guard not updated ──────────── */
+
+  describe('email notification on block — insertLog failure', () => {
+    it('re-evaluates rule on next invocation if insertLog throws', async () => {
+      // Silence the error logger so the test output stays clean.
+      const loggerSpy = jest.spyOn(service['logger'], 'error').mockImplementation(() => undefined);
+
+      mockResolveUserEmail.mockResolvedValue('test@example.com');
+
+      // First call: insertLog fails.
+      mockInsertLog.mockRejectedValueOnce(new Error('DB connection lost'));
+      await service.checkLimits(TENANT, AGENT);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // insertLog was attempted once and failed.
+      expect(mockInsertLog).toHaveBeenCalledTimes(1);
+      // Dedup guard was consulted once.
+      expect(mockHasAlreadySent).toHaveBeenCalledTimes(1);
+      // No alert email since insertLog throws before sendThresholdAlert.
+      expect(mockSendThresholdAlert).not.toHaveBeenCalled();
+      // Error was surfaced via the logger.
+      expect(loggerSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to send block notification for rule r1'),
+      );
+
+      // Second call: insertLog succeeds.
+      mockInsertLog.mockResolvedValueOnce(undefined);
+      mockHasAlreadySent.mockResolvedValueOnce(false);
+      await service.checkLimits(TENANT, AGENT);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Both insertLog attempts were made (one fail, one succeed).
+      expect(mockInsertLog).toHaveBeenCalledTimes(2);
+      // Rule was re-evaluated: hasAlreadySent called twice total.
+      expect(mockHasAlreadySent).toHaveBeenCalledTimes(2);
+      // Second attempt makes it to the email send.
+      expect(mockSendThresholdAlert).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /* ── 3. Graceful degradation: config exists but email is null ── */
+
+  describe('email notification on block — null email fallback', () => {
+    it('skips email but still logs when notificationEmail is null and user has no email', async () => {
+      // Provider config exists but provides no override.
+      mockGetFullConfig.mockResolvedValue({
+        provider: 'resend',
+        apiKey: 'key',
+        notificationEmail: null,
+      });
+      // User row exists but has no email either.
+      mockResolveUserEmail.mockResolvedValue(null);
+
+      const result = await service.checkLimits(TENANT, AGENT);
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Rule still triggers the block.
+      expect(result).not.toBeNull();
+
+      // No email was sent — nothing to send to.
+      expect(mockSendThresholdAlert).not.toHaveBeenCalled();
+
+      // But the log row IS recorded so we don't retry every cron tick.
+      expect(mockInsertLog).toHaveBeenCalledTimes(1);
+      expect(mockInsertLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ruleId: 'r1',
+          actualValue: 60000,
+          thresholdValue: 50000,
+          metricType: 'tokens',
+          agentName: AGENT,
+        }),
+      );
+
+      // resolveUserEmail was invoked with the null override, exercising the
+      // full fallback path inside notification-log.service.
+      expect(mockResolveUserEmail).toHaveBeenCalledWith('u1', null);
+    });
+  });
+
+  /* ── 4. Very large numeric consumption values ────────────────── */
+
+  describe('numeric edge cases for consumption / threshold comparison', () => {
+    it('handles MAX_SAFE_INTEGER consumption against finite threshold', async () => {
+      mockGetConsumption.mockResolvedValue(Number.MAX_SAFE_INTEGER);
+      mockResolveUserEmail.mockResolvedValue('test@example.com');
+
+      const result = await service.checkLimits(TENANT, AGENT);
+
+      expect(result).not.toBeNull();
+      expect(result!.actual).toBe(Number.MAX_SAFE_INTEGER);
+      expect(result!.threshold).toBe(50000);
+      // Comparison is well-defined for safe integers.
+      expect(result!.actual >= result!.threshold).toBe(true);
+    });
+
+    it('handles 999_999_999 tokens without precision loss', async () => {
+      mockGetActiveBlockRules.mockResolvedValue([{ ...BLOCK_RULE, threshold: 999_999_999 }]);
+      mockGetConsumption.mockResolvedValue(999_999_999);
+      mockResolveUserEmail.mockResolvedValue('test@example.com');
+
+      const result = await service.checkLimits(TENANT, AGENT);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(result).not.toBeNull();
+      expect(result!.actual).toBe(999_999_999);
+      expect(result!.threshold).toBe(999_999_999);
+      expect(mockSendThresholdAlert).toHaveBeenCalledWith(
+        'test@example.com',
+        expect.objectContaining({
+          actualValue: 999_999_999,
+          threshold: 999_999_999,
+        }),
+        undefined,
+      );
+    });
+
+    it('handles very large cost values (999999.99) without precision loss', async () => {
+      const costRule = {
+        ...BLOCK_RULE,
+        metric_type: 'cost' as const,
+        threshold: 999_999.99,
+        period: 'month' as const,
+      };
+      mockGetActiveBlockRules.mockResolvedValue([costRule]);
+      mockGetConsumption.mockResolvedValue(999_999.99);
+      mockResolveUserEmail.mockResolvedValue('test@example.com');
+
+      const result = await service.checkLimits(TENANT, AGENT);
+
+      expect(result).not.toBeNull();
+      expect(result!.metricType).toBe('cost');
+      expect(result!.actual).toBe(999_999.99);
+      expect(result!.threshold).toBe(999_999.99);
+      expect(result!.period).toBe('month');
+    });
+
+    it('does not trigger when consumption is just below threshold (boundary)', async () => {
+      mockGetActiveBlockRules.mockResolvedValue([
+        { ...BLOCK_RULE, threshold: Number.MAX_SAFE_INTEGER },
+      ]);
+      mockGetConsumption.mockResolvedValue(Number.MAX_SAFE_INTEGER - 1);
+
+      const result = await service.checkLimits(TENANT, AGENT);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(result).toBeNull();
+      expect(mockSendThresholdAlert).not.toHaveBeenCalled();
+      expect(mockInsertLog).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/notifications/services/notification-cron.service.edge-cases.spec.ts
+++ b/packages/backend/src/notifications/services/notification-cron.service.edge-cases.spec.ts
@@ -1,0 +1,299 @@
+/**
+ * Edge-case tests for NotificationCronService — complements
+ * notification-cron.service.spec.ts. Split out to stay under the 300-line cap.
+ *
+ * Pins the non-atomic period-boundary race: checkThresholds() computes
+ * (periodStart, periodEnd) once for consumption, then evaluateRule() calls
+ * computePeriodBoundaries() again for dedup + insertLog. If wall-clock crosses
+ * a period boundary between the two, the dedup key written to notification_logs
+ * no longer matches the period whose consumption was measured.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationCronService } from './notification-cron.service';
+import { NotificationRulesService } from './notification-rules.service';
+import { NotificationEmailService } from './notification-email.service';
+import { EmailProviderConfigService } from './email-provider-config.service';
+import { NotificationLogService } from './notification-log.service';
+import { ManifestRuntimeService } from '../../common/services/manifest-runtime.service';
+
+const baseRule = {
+  id: 'rule-1',
+  tenant_id: 'tenant-1',
+  agent_name: 'my-agent',
+  user_id: 'user-1',
+  metric_type: 'tokens' as const,
+  threshold: 100_000,
+  period: 'day' as const,
+};
+
+describe('NotificationCronService — edge cases', () => {
+  let service: NotificationCronService;
+  let mockGetAllActiveRules: jest.Mock;
+  let mockGetActiveRulesForUser: jest.Mock;
+  let mockGetConsumption: jest.Mock;
+  let mockSendThresholdAlert: jest.Mock;
+  let mockHasAlreadySent: jest.Mock;
+  let mockInsertLog: jest.Mock;
+  let mockResolveUserEmail: jest.Mock;
+  let mockGetFullConfig: jest.Mock;
+
+  beforeEach(async () => {
+    mockGetAllActiveRules = jest.fn();
+    mockGetActiveRulesForUser = jest.fn();
+    mockGetConsumption = jest.fn();
+    mockSendThresholdAlert = jest.fn().mockResolvedValue(true);
+    mockHasAlreadySent = jest.fn().mockResolvedValue(false);
+    mockInsertLog = jest.fn().mockResolvedValue(undefined);
+    mockResolveUserEmail = jest.fn().mockResolvedValue('user@test.com');
+    mockGetFullConfig = jest.fn().mockResolvedValue(null);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationCronService,
+        {
+          provide: NotificationRulesService,
+          useValue: {
+            getAllActiveRules: mockGetAllActiveRules,
+            getActiveRulesForUser: mockGetActiveRulesForUser,
+            getConsumption: mockGetConsumption,
+          },
+        },
+        {
+          provide: NotificationEmailService,
+          useValue: { sendThresholdAlert: mockSendThresholdAlert },
+        },
+        {
+          provide: EmailProviderConfigService,
+          useValue: { getFullConfig: mockGetFullConfig },
+        },
+        {
+          provide: NotificationLogService,
+          useValue: {
+            hasAlreadySent: mockHasAlreadySent,
+            insertLog: mockInsertLog,
+            resolveUserEmail: mockResolveUserEmail,
+          },
+        },
+        {
+          provide: ManifestRuntimeService,
+          useValue: { getAuthBaseUrl: jest.fn().mockReturnValue('http://localhost:3001') },
+        },
+      ],
+    }).compile();
+
+    service = module.get(NotificationCronService);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  /* ── 1. Non-atomic period boundary (documented race) ───────────── */
+
+  describe('period boundary drift between consumption fetch and dedup check', () => {
+    it('passes the SAME periodStart string to hasAlreadySent and insertLog when wall-clock is steady', async () => {
+      // Pin time so both computePeriodBoundaries() calls inside checkThresholds()
+      // observe the identical Date.now(). This is the happy path: dedup key and
+      // log row agree on period_start. Hardcoded to mid-day to avoid boundary noise.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-06-15T12:00:00Z'));
+
+      mockGetAllActiveRules.mockResolvedValue([baseRule]);
+      mockGetConsumption.mockResolvedValue(150_000);
+
+      const result = await service.checkThresholds();
+      expect(result).toBe(1);
+
+      // hasAlreadySent (line 107) reads its own computePeriodBoundaries result.
+      // insertLog (line 116) does too. With time pinned, both align with the
+      // value passed to getConsumption (line 63 inside checkThresholds).
+      expect(mockHasAlreadySent).toHaveBeenCalledTimes(1);
+      const dedupPeriodStart = mockHasAlreadySent.mock.calls[0][1];
+      const consumptionPeriodStart = mockGetConsumption.mock.calls[0][3];
+      const insertedPeriodStart = mockInsertLog.mock.calls[0][0].periodStart;
+
+      expect(dedupPeriodStart).toBe(consumptionPeriodStart);
+      expect(insertedPeriodStart).toBe(consumptionPeriodStart);
+      // Day period: midnight UTC. Fixed expectation.
+      expect(consumptionPeriodStart).toBe('2026-06-15 00:00:00');
+    });
+
+    it('emits an "hour" period that recomputes consistently within the same tick', async () => {
+      // Fixed timestamp away from hour boundary so the two computePeriodBoundaries
+      // calls cannot diverge. This proves the dedup key is reproducible under
+      // steady time — the failure mode is *clock drift between the two calls*.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-06-15T12:30:00Z'));
+
+      const hourRule = { ...baseRule, period: 'hour' as const };
+      mockGetAllActiveRules.mockResolvedValue([hourRule]);
+      mockGetConsumption.mockResolvedValue(150_000);
+
+      await service.checkThresholds();
+
+      const consumptionPeriodStart = mockGetConsumption.mock.calls[0][3];
+      const dedupPeriodStart = mockHasAlreadySent.mock.calls[0][1];
+      // hour period: previous hour boundary (UTC).
+      expect(consumptionPeriodStart).toBe('2026-06-15 11:00:00');
+      expect(dedupPeriodStart).toBe(consumptionPeriodStart);
+    });
+
+    it('demonstrates the gap: if clock crosses an hour boundary between the two calls, dedup key drifts', async () => {
+      // Start 1s before an hour boundary so the FIRST computePeriodBoundaries
+      // (inside checkThresholds, line 63) sees 11:00 as the previous-hour start.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-06-15T11:59:59Z'));
+
+      const hourRule = { ...baseRule, period: 'hour' as const };
+      mockGetAllActiveRules.mockResolvedValue([hourRule]);
+
+      // Advance the clock past the hour boundary before evaluateRule() runs its own
+      // computePeriodBoundaries(). After advance, "previous hour" rolls forward,
+      // so periodStart shifts to the new hour.
+      mockGetConsumption.mockImplementation(async () => {
+        jest.setSystemTime(new Date('2026-06-15T12:00:01Z'));
+        return 150_000;
+      });
+
+      await service.checkThresholds();
+
+      const consumptionPeriodStart = mockGetConsumption.mock.calls[0][3];
+      const dedupPeriodStart = mockHasAlreadySent.mock.calls[0][1];
+      const insertedPeriodStart = mockInsertLog.mock.calls[0][0].periodStart;
+
+      // The drift is real and observable: consumption was measured against the
+      // 10:00 start, but the dedup key + log row were written under the 11:00 start.
+      // This documents the current behaviour. When the source is refactored to
+      // capture periodStart once (e.g. pass it from checkThresholds into
+      // evaluateRule, or use a fixed epoch-modulo derivation), update these
+      // expectations to equality.
+      expect(consumptionPeriodStart).toBe('2026-06-15 10:00:00');
+      expect(dedupPeriodStart).toBe('2026-06-15 11:00:00');
+      expect(insertedPeriodStart).toBe('2026-06-15 11:00:00');
+      expect(dedupPeriodStart).not.toBe(consumptionPeriodStart);
+    });
+  });
+
+  /* ── 2. Grouping: shared consumption query across rules ────────── */
+
+  describe('rule grouping by (tenant, agent, period)', () => {
+    it('fetches consumption ONCE per (group, metric) even with many same-group rules', async () => {
+      const r1 = { ...baseRule, id: 'r1', threshold: 100_000 };
+      const r2 = { ...baseRule, id: 'r2', threshold: 200_000 };
+      const r3 = { ...baseRule, id: 'r3', threshold: 50_000 };
+      mockGetAllActiveRules.mockResolvedValue([r1, r2, r3]);
+      mockGetConsumption.mockResolvedValue(75_000);
+
+      const result = await service.checkThresholds();
+
+      // Only r3 (50k threshold) trips at consumption=75k. r1 and r2 do not.
+      expect(result).toBe(1);
+      // Three rules, same group, same metric — single getConsumption call.
+      expect(mockGetConsumption).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches consumption per metric type within the same group', async () => {
+      const tokensRule = {
+        ...baseRule,
+        id: 'tk',
+        metric_type: 'tokens' as const,
+        threshold: 50_000,
+      };
+      const costRule = { ...baseRule, id: 'cs', metric_type: 'cost' as const, threshold: 1.0 };
+      mockGetAllActiveRules.mockResolvedValue([tokensRule, costRule]);
+      mockGetConsumption.mockImplementation(async (_t: string, _a: string, metric: string) =>
+        metric === 'tokens' ? 100_000 : 5.0,
+      );
+
+      const result = await service.checkThresholds();
+
+      expect(result).toBe(2);
+      // One fetch per metric type, same group.
+      expect(mockGetConsumption).toHaveBeenCalledTimes(2);
+      const metrics = mockGetConsumption.mock.calls.map((c) => c[2]).sort();
+      expect(metrics).toEqual(['cost', 'tokens']);
+    });
+
+    it('separates consumption queries when rules differ in (agent, period)', async () => {
+      const ruleDay = { ...baseRule, id: 'd1', period: 'day' as const };
+      const ruleHour = { ...baseRule, id: 'h1', period: 'hour' as const };
+      const ruleOtherAgent = { ...baseRule, id: 'o1', agent_name: 'other-agent' };
+      mockGetAllActiveRules.mockResolvedValue([ruleDay, ruleHour, ruleOtherAgent]);
+      mockGetConsumption.mockResolvedValue(10);
+
+      await service.checkThresholds();
+
+      // Three distinct groups → three getConsumption calls.
+      expect(mockGetConsumption).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  /* ── 3. Per-user invocation path ───────────────────────────────── */
+
+  describe('checkThresholds(userId)', () => {
+    it('uses getActiveRulesForUser when userId is provided', async () => {
+      mockGetActiveRulesForUser.mockResolvedValue([baseRule]);
+      mockGetConsumption.mockResolvedValue(200_000);
+
+      const result = await service.checkThresholds('user-1');
+
+      expect(result).toBe(1);
+      expect(mockGetActiveRulesForUser).toHaveBeenCalledWith('user-1');
+      expect(mockGetAllActiveRules).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 when per-user query yields no rules', async () => {
+      mockGetActiveRulesForUser.mockResolvedValue([]);
+
+      const result = await service.checkThresholds('user-1');
+
+      expect(result).toBe(0);
+      expect(mockGetConsumption).not.toHaveBeenCalled();
+    });
+  });
+
+  /* ── 4. Cost metric path ───────────────────────────────────────── */
+
+  describe('cost metric', () => {
+    it('triggers for cost metric at boundary (consumption == threshold)', async () => {
+      const costRule = {
+        ...baseRule,
+        id: 'cost-rule',
+        metric_type: 'cost' as const,
+        threshold: 12.5,
+        period: 'month' as const,
+      };
+      mockGetAllActiveRules.mockResolvedValue([costRule]);
+      // Exact equality must trip (actual >= threshold).
+      mockGetConsumption.mockResolvedValue(12.5);
+
+      const result = await service.checkThresholds();
+
+      expect(result).toBe(1);
+      expect(mockInsertLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ruleId: 'cost-rule',
+          actualValue: 12.5,
+          thresholdValue: 12.5,
+          metricType: 'cost',
+        }),
+      );
+    });
+
+    it('does not trigger when cost falls 0.01 below threshold', async () => {
+      const costRule = {
+        ...baseRule,
+        metric_type: 'cost' as const,
+        threshold: 10.0,
+        period: 'month' as const,
+      };
+      mockGetAllActiveRules.mockResolvedValue([costRule]);
+      mockGetConsumption.mockResolvedValue(9.99);
+
+      const result = await service.checkThresholds();
+      expect(result).toBe(0);
+      expect(mockInsertLog).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/notifications/services/notification-rules.service.consumption.spec.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.consumption.spec.ts
@@ -1,0 +1,201 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotificationRulesService } from './notification-rules.service';
+import { NotificationRule } from '../../entities/notification-rule.entity';
+import { NotificationLog } from '../../entities/notification-log.entity';
+import { AgentMessage } from '../../entities/agent-message.entity';
+import { Agent } from '../../entities/agent.entity';
+import { Tenant } from '../../entities/tenant.entity';
+
+describe('NotificationRulesService.getConsumption', () => {
+  let service: NotificationRulesService;
+  let messageRepo: { createQueryBuilder: jest.Mock };
+
+  const makeQb = <T>(rawOne: T | null = null) => {
+    const qb: Record<string, jest.Mock> = {};
+    qb.select = jest.fn().mockReturnValue(qb);
+    qb.addSelect = jest.fn().mockReturnValue(qb);
+    qb.where = jest.fn().mockReturnValue(qb);
+    qb.andWhere = jest.fn().mockReturnValue(qb);
+    qb.groupBy = jest.fn().mockReturnValue(qb);
+    qb.innerJoin = jest.fn().mockReturnValue(qb);
+    qb.getRawOne = jest.fn().mockResolvedValue(rawOne);
+    qb.getRawMany = jest.fn().mockResolvedValue([]);
+    qb.getOne = jest.fn().mockResolvedValue(rawOne);
+    return qb;
+  };
+
+  beforeEach(async () => {
+    messageRepo = { createQueryBuilder: jest.fn().mockReturnValue(makeQb()) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationRulesService,
+        {
+          provide: getRepositoryToken(NotificationRule),
+          useValue: {
+            find: jest.fn(),
+            findOneBy: jest.fn(),
+            insert: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+            count: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(NotificationLog),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(makeQb()) },
+        },
+        { provide: getRepositoryToken(AgentMessage), useValue: messageRepo },
+        {
+          provide: getRepositoryToken(Agent),
+          useValue: { createQueryBuilder: jest.fn().mockReturnValue(makeQb()) },
+        },
+        { provide: getRepositoryToken(Tenant), useValue: {} },
+      ],
+    }).compile();
+
+    service = module.get(NotificationRulesService);
+  });
+
+  it('sums input+output tokens for tokens metric', async () => {
+    const qb = makeQb({ total: '12345' });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    const result = await service.getConsumption(
+      't1',
+      'a1',
+      'tokens',
+      '2026-02-17 00:00:00',
+      '2026-02-17 14:00:00',
+    );
+
+    expect(result).toBe(12345);
+    expect(qb.select).toHaveBeenCalledWith(
+      expect.stringContaining('SUM(at.input_tokens + at.output_tokens)'),
+      'total',
+    );
+  });
+
+  it('sums cost_usd for cost metric', async () => {
+    const qb = makeQb({ total: '3.45' });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    const result = await service.getConsumption(
+      't1',
+      'a1',
+      'cost',
+      '2026-02-01 00:00:00',
+      '2026-02-17 14:00:00',
+    );
+
+    expect(result).toBe(3.45);
+    expect(qb.select).toHaveBeenCalledWith(expect.stringContaining('SUM(at.cost_usd)'), 'total');
+  });
+
+  it('returns 0 when no rows match', async () => {
+    messageRepo.createQueryBuilder.mockReturnValueOnce(makeQb(null));
+
+    const result = await service.getConsumption('t1', 'a1', 'tokens', '', '');
+    expect(result).toBe(0);
+  });
+
+  it('returns exact cost value for cost metric (boundary equality)', async () => {
+    const qb = makeQb({ total: '50.00' });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    const result = await service.getConsumption(
+      't1',
+      'a1',
+      'cost',
+      '2026-02-01 00:00:00',
+      '2026-02-17 14:00:00',
+    );
+
+    expect(result).toBe(50);
+    expect(qb.select).toHaveBeenCalledWith(expect.stringContaining('SUM(at.cost_usd)'), 'total');
+  });
+
+  it('returns exact cost value when SUM returns a numeric (not string) at threshold boundary', async () => {
+    const qb = makeQb({ total: 10 });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    const result = await service.getConsumption(
+      't1',
+      'a1',
+      'cost',
+      '2026-02-01 00:00:00',
+      '2026-02-17 14:00:00',
+    );
+
+    expect(result).toBe(10);
+    expect(Number.isFinite(result)).toBe(true);
+  });
+
+  it('does not round sub-cent floating-point values away from the threshold', async () => {
+    // 10.000001 is just above a $10 threshold; ensure we return exactly that, not 10.
+    const qb = makeQb({ total: '10.000001' });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    const result = await service.getConsumption(
+      't1',
+      'a1',
+      'cost',
+      '2026-02-01 00:00:00',
+      '2026-02-17 14:00:00',
+    );
+
+    expect(result).toBe(10.000001);
+    expect(result > 10).toBe(true);
+  });
+
+  it('returns a value just under threshold without snapping to it', async () => {
+    // 9.999999 is just below $10; must NOT round up to 10 (would falsely trigger an alert).
+    const qb = makeQb({ total: '9.999999' });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    const result = await service.getConsumption(
+      't1',
+      'a1',
+      'cost',
+      '2026-02-01 00:00:00',
+      '2026-02-17 14:00:00',
+    );
+
+    expect(result).toBe(9.999999);
+    expect(result < 10).toBe(true);
+  });
+
+  it('enforces tenant isolation in the WHERE clause', async () => {
+    const qb = makeQb({ total: '0' });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    await service.getConsumption(
+      'tenant-A',
+      'agent-1',
+      'cost',
+      '2026-02-01 00:00:00',
+      '2026-02-17 14:00:00',
+    );
+
+    expect(qb.where).toHaveBeenCalledWith('at.tenant_id = :tenantId', { tenantId: 'tenant-A' });
+    // The agent subquery must also be filtered by the same tenant_id (preventing cross-tenant access).
+    const andWhereCalls = qb.andWhere.mock.calls.map((c) => String(c[0]));
+    expect(andWhereCalls.some((sql) => sql.includes('tenant_id = at.tenant_id'))).toBe(true);
+    expect(andWhereCalls.some((sql) => sql.includes('deleted_at IS NULL'))).toBe(true);
+  });
+
+  it('passes the period boundaries as inclusive-start, exclusive-end', async () => {
+    const qb = makeQb({ total: '0' });
+    messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
+
+    await service.getConsumption('t1', 'a1', 'cost', '2026-02-01 00:00:00', '2026-02-17 14:00:00');
+
+    expect(qb.andWhere).toHaveBeenCalledWith('at.timestamp >= :periodStart', {
+      periodStart: '2026-02-01 00:00:00',
+    });
+    expect(qb.andWhere).toHaveBeenCalledWith('at.timestamp < :periodEnd', {
+      periodEnd: '2026-02-17 14:00:00',
+    });
+  });
+});

--- a/packages/backend/src/notifications/services/notification-rules.service.spec.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.spec.ts
@@ -219,49 +219,8 @@ describe('NotificationRulesService', () => {
     });
   });
 
-  describe('getConsumption', () => {
-    it('sums input+output tokens for tokens metric', async () => {
-      const qb = makeQb({ total: '12345' });
-      messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
-
-      const result = await service.getConsumption(
-        't1',
-        'a1',
-        'tokens',
-        '2026-02-17 00:00:00',
-        '2026-02-17 14:00:00',
-      );
-
-      expect(result).toBe(12345);
-      expect(qb.select).toHaveBeenCalledWith(
-        expect.stringContaining('SUM(at.input_tokens + at.output_tokens)'),
-        'total',
-      );
-    });
-
-    it('sums cost_usd for cost metric', async () => {
-      const qb = makeQb({ total: '3.45' });
-      messageRepo.createQueryBuilder.mockReturnValueOnce(qb);
-
-      const result = await service.getConsumption(
-        't1',
-        'a1',
-        'cost',
-        '2026-02-01 00:00:00',
-        '2026-02-17 14:00:00',
-      );
-
-      expect(result).toBe(3.45);
-      expect(qb.select).toHaveBeenCalledWith(expect.stringContaining('SUM(at.cost_usd)'), 'total');
-    });
-
-    it('returns 0 when no rows match', async () => {
-      messageRepo.createQueryBuilder.mockReturnValueOnce(makeQb(null));
-
-      const result = await service.getConsumption('t1', 'a1', 'tokens', '', '');
-      expect(result).toBe(0);
-    });
-  });
+  // getConsumption tests live in notification-rules.service.consumption.spec.ts
+  // (split to keep this file under the 300-line limit; see CLAUDE.md "File Size Limits").
 
   describe('getAllActiveRules', () => {
     it('returns active notify+both rules', async () => {

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.edge.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.edge.spec.ts
@@ -1,0 +1,263 @@
+import { ExecutionContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AgentKeyAuthGuard } from './agent-key-auth.guard';
+import { hashKey } from '../../common/utils/hash.util';
+
+// Edge-case coverage for AgentKeyAuthGuard that does not fit into the main
+// spec file (which is already at the per-file size cap from CLAUDE.md). The
+// primary spec is `agent-key-auth.guard.spec.ts`. These tests document
+// behavior at the boundary of missing relations and DB failures during the
+// dev-loopback seed-tenant lookup.
+
+function makeContext(headers: Record<string, string | undefined>, ip = '203.0.113.1') {
+  const request: Record<string, unknown> = { headers, ip, socket: { remoteAddress: ip } };
+  return {
+    req: request,
+    ctx: {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as unknown as ExecutionContext,
+  };
+}
+
+function createMockConfig(overrides: Record<string, string> = {}): ConfigService {
+  const values: Record<string, string> = {
+    'app.nodeEnv': 'test',
+    ...overrides,
+  };
+  return {
+    get: (key: string, fallback?: string) => values[key] ?? fallback,
+  } as unknown as ConfigService;
+}
+
+describe('AgentKeyAuthGuard edge cases', () => {
+  let guard: AgentKeyAuthGuard;
+  let mockGetMany: jest.Mock;
+  let mockGetOne: jest.Mock;
+  let mockCreateQueryBuilder: jest.Mock;
+  let mockExecute: jest.Mock;
+  let mockFindOne: jest.Mock;
+  let mockConfig: ConfigService;
+
+  function buildMockRepo() {
+    mockGetMany = jest.fn().mockResolvedValue([]);
+    mockGetOne = jest.fn().mockResolvedValue(null);
+    const mockSelectQb = {
+      select: jest.fn().mockReturnThis(),
+      leftJoin: jest.fn().mockReturnThis(),
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getCount: jest.fn().mockResolvedValue(0),
+      getMany: mockGetMany,
+      getOne: mockGetOne,
+    };
+    mockExecute = jest.fn().mockResolvedValue({});
+    const mockUpdateQb = {
+      update: jest.fn().mockReturnThis(),
+      set: jest.fn().mockImplementation((setObj) => {
+        if (setObj) {
+          for (const val of Object.values(setObj)) {
+            if (typeof val === 'function') (val as () => unknown)();
+          }
+        }
+        return mockUpdateQb;
+      }),
+      where: jest.fn().mockReturnThis(),
+      execute: mockExecute,
+    };
+    mockCreateQueryBuilder = jest.fn().mockImplementation((alias?: string) => {
+      return alias ? mockSelectQb : mockUpdateQb;
+    });
+    mockFindOne = jest.fn().mockResolvedValue(null);
+    return {
+      createQueryBuilder: mockCreateQueryBuilder,
+      findOne: mockFindOne,
+    } as never;
+  }
+
+  function createGuard(configOverrides: Record<string, string> = {}) {
+    mockConfig = createMockConfig(configOverrides);
+    const repo = buildMockRepo();
+    const g = new AgentKeyAuthGuard(repo, mockConfig);
+    g.clearCache();
+    return g;
+  }
+
+  beforeEach(() => {
+    guard = createGuard();
+  });
+
+  afterEach(() => {
+    guard.onModuleDestroy();
+  });
+
+  describe('validateMnfstToken with broken relations', () => {
+    // Lines 206-207 of the source dereference keyRecord.agent.name and
+    // keyRecord.tenant.name without null checks. If either relation fails
+    // to hydrate (race during a delete, foreign-key drift, missing JOIN
+    // result), the code throws a TypeError when assembling the cache entry.
+    // These tests pin that behavior so future refactors can intentionally
+    // tighten it (e.g. throwing UnauthorizedException instead) without
+    // silently regressing.
+    it('throws when keyRecord.agent is null', async () => {
+      const token = 'mnfst_missing-agent-key';
+      mockGetMany.mockResolvedValue([
+        {
+          id: 'key-no-agent',
+          tenant_id: 'tenant-1',
+          agent_id: 'agent-orphan',
+          key_hash: hashKey(token),
+          expires_at: null,
+          agent: null,
+          tenant: { name: 'user-1' },
+        },
+      ]);
+
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      // Source accesses keyRecord.agent.name without null-check on line 206.
+      // Assert on a generic Error so the test does not couple to a specific
+      // V8 TypeError wording.
+      await expect(guard.canActivate(ctx)).rejects.toThrow();
+    });
+
+    it('throws when keyRecord.tenant is null', async () => {
+      const token = 'mnfst_missing-tenant-key';
+      mockGetMany.mockResolvedValue([
+        {
+          id: 'key-no-tenant',
+          tenant_id: 'tenant-orphan',
+          agent_id: 'agent-1',
+          key_hash: hashKey(token),
+          expires_at: null,
+          agent: { name: 'orphan-agent' },
+          tenant: null,
+        },
+      ]);
+
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      // Source accesses keyRecord.tenant.name without null-check on line 207.
+      await expect(guard.canActivate(ctx)).rejects.toThrow();
+    });
+
+    it('throws when both keyRecord.agent and keyRecord.tenant are null', async () => {
+      const token = 'mnfst_both-null-key';
+      mockGetMany.mockResolvedValue([
+        {
+          id: 'key-both-null',
+          tenant_id: 'tenant-orphan',
+          agent_id: 'agent-orphan',
+          key_hash: hashKey(token),
+          expires_at: null,
+          agent: null,
+          tenant: null,
+        },
+      ]);
+
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      await expect(guard.canActivate(ctx)).rejects.toThrow();
+    });
+
+    it('does not cache the entry when agent is null (cache write fails before set)', async () => {
+      const token = 'mnfst_no-cache-on-fail-key';
+      mockGetMany.mockResolvedValue([
+        {
+          id: 'key-uncached',
+          tenant_id: 'tenant-1',
+          agent_id: 'agent-1',
+          key_hash: hashKey(token),
+          expires_at: null,
+          agent: null,
+          tenant: { name: 'user-1' },
+        },
+      ]);
+
+      const { ctx } = makeContext({ authorization: `Bearer ${token}` });
+      await expect(guard.canActivate(ctx)).rejects.toThrow();
+
+      // The cache.set call is on the same statement that dereferences the
+      // null relation, so the entry never lands in the cache. A retry must
+      // still hit the DB rather than serving a poisoned cache entry.
+      const internalCache = (guard as unknown as { cache: Map<string, unknown> }).cache;
+      expect(internalCache.size).toBe(0);
+    });
+  });
+
+  describe('dev loopback seed-tenant lookup failure', () => {
+    beforeEach(() => {
+      guard.onModuleDestroy();
+      guard = createGuard({ 'app.nodeEnv': 'development' });
+    });
+
+    // The seed-tenant lookup at lines 229-235 of the source has no try/catch.
+    // If the DB connection drops or the query rejects, the rejection
+    // propagates up through resolveDevContext -> handleDevLoopback ->
+    // canActivate. The current fallback (`seedKey ?? findOne(...)`) only
+    // covers the case where getOne() resolves to null — it does NOT cover
+    // a rejected promise. This test pins that propagation so a future fix
+    // (e.g. wrapping getOne in try/catch and falling back to findOne) has a
+    // failing assertion to flip.
+    it('propagates the error when seed-tenant getOne() rejects (no fallback today)', async () => {
+      const dbError = new Error('Connection lost');
+      mockGetOne.mockRejectedValue(dbError);
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'dev-tenant',
+        agent_id: 'dev-agent',
+        agent: { name: 'demo-agent' },
+        tenant: { name: 'dev-user' },
+      });
+
+      const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '127.0.0.1');
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Connection lost');
+
+      // The findOne fallback is never reached because getOne rejected first.
+      // If a future patch adds try/catch around getOne and falls through to
+      // findOne, this assertion will fail loudly and force the test author
+      // to update both this expectation and the one above.
+      expect(mockFindOne).not.toHaveBeenCalled();
+    });
+
+    it('does not poison the devContext cache when seed-tenant getOne() rejects', async () => {
+      mockGetOne.mockRejectedValue(new Error('Connection lost'));
+
+      const { ctx } = makeContext({ authorization: 'Bearer dev-no-auth' }, '127.0.0.1');
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Connection lost');
+
+      // devContext must remain unset so a subsequent successful call resolves
+      // fresh. A poisoned cache would short-circuit future requests.
+      const devContext = (
+        guard as unknown as { devContext: { context: unknown; expiresAt: number } | null }
+      ).devContext;
+      expect(devContext).toBeNull();
+    });
+
+    it('falls back to findOne when seed-tenant getOne() resolves to null', async () => {
+      // This covers the documented happy path of the `seedKey ?? findOne(...)`
+      // fallback at line 237-242 — getOne returns null (seed tenant doesn't
+      // exist in this DB), so the guard uses the first active key from
+      // findOne. Pinned here because the rejection test above is the
+      // pathological sibling — both branches need explicit assertions.
+      mockGetOne.mockResolvedValue(null);
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'first-tenant',
+        agent_id: 'first-agent',
+        agent: { name: 'first-agent-name' },
+        tenant: { name: 'first-user' },
+      });
+
+      const { ctx, req } = makeContext({ authorization: 'Bearer dev-no-auth' }, '127.0.0.1');
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(req.ingestionContext).toEqual({
+        tenantId: 'first-tenant',
+        agentId: 'first-agent',
+        agentName: 'first-agent-name',
+        userId: 'first-user',
+      });
+      expect(mockGetOne).toHaveBeenCalledTimes(1);
+      expect(mockFindOne).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/backend/src/otlp/services/api-key.service.edge-cases.spec.ts
+++ b/packages/backend/src/otlp/services/api-key.service.edge-cases.spec.ts
@@ -1,0 +1,290 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { ApiKeyGeneratorService } from './api-key.service';
+import { Tenant } from '../../entities/tenant.entity';
+import { Agent } from '../../entities/agent.entity';
+import { AgentApiKey } from '../../entities/agent-api-key.entity';
+import { AgentKeyAuthGuard } from '../guards/agent-key-auth.guard';
+
+jest.mock('uuid', () => ({ v4: jest.fn() }));
+jest.mock('crypto', () => {
+  const actual = jest.requireActual('crypto');
+  return {
+    ...actual,
+    randomBytes: jest.fn(),
+  };
+});
+
+const TEST_SECRET = 'a'.repeat(32);
+jest.mock('../../common/utils/crypto.util', () => {
+  const actual = jest.requireActual('../../common/utils/crypto.util');
+  return {
+    ...actual,
+    getEncryptionSecret: () => TEST_SECRET,
+  };
+});
+
+import { v4 as uuidv4 } from 'uuid';
+import { randomBytes } from 'crypto';
+
+const mockedUuidv4 = uuidv4 as jest.Mock;
+const mockedRandomBytes = randomBytes as jest.Mock;
+
+describe('ApiKeyGeneratorService — edge cases', () => {
+  let service: ApiKeyGeneratorService;
+  let mockTenantFindOne: jest.Mock;
+  let mockTenantInsert: jest.Mock;
+  let mockAgentInsert: jest.Mock;
+  let mockKeyInsert: jest.Mock;
+  let mockKeyDelete: jest.Mock;
+  let mockKeyGetOne: jest.Mock;
+  let mockKeyQb: Record<string, jest.Mock>;
+  let mockAgentGetOne: jest.Mock;
+  let mockAgentQb: Record<string, jest.Mock>;
+  let mockClearCache: jest.Mock;
+
+  beforeEach(async () => {
+    mockTenantFindOne = jest.fn();
+    mockTenantInsert = jest.fn().mockResolvedValue({});
+    mockAgentInsert = jest.fn().mockResolvedValue({});
+    mockKeyInsert = jest.fn().mockResolvedValue({});
+    mockKeyDelete = jest.fn().mockResolvedValue({});
+    mockKeyGetOne = jest.fn();
+    mockAgentGetOne = jest.fn();
+    mockClearCache = jest.fn();
+
+    mockKeyQb = {
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: mockKeyGetOne,
+    };
+
+    mockAgentQb = {
+      leftJoin: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      getOne: mockAgentGetOne,
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ApiKeyGeneratorService,
+        {
+          provide: getRepositoryToken(Tenant),
+          useValue: { findOne: mockTenantFindOne, insert: mockTenantInsert },
+        },
+        {
+          provide: getRepositoryToken(Agent),
+          useValue: {
+            insert: mockAgentInsert,
+            createQueryBuilder: jest.fn().mockReturnValue(mockAgentQb),
+          },
+        },
+        {
+          provide: getRepositoryToken(AgentApiKey),
+          useValue: {
+            insert: mockKeyInsert,
+            delete: mockKeyDelete,
+            createQueryBuilder: jest.fn().mockReturnValue(mockKeyQb),
+          },
+        },
+        {
+          provide: AgentKeyAuthGuard,
+          useValue: { clearCache: mockClearCache },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ApiKeyGeneratorService>(ApiKeyGeneratorService);
+
+    mockedUuidv4.mockReset();
+    mockedRandomBytes.mockReset();
+    mockedRandomBytes.mockReturnValue(Buffer.from('a'.repeat(32), 'utf8'));
+    mockedUuidv4
+      .mockReturnValueOnce('uuid-tenant-1')
+      .mockReturnValueOnce('uuid-agent-1')
+      .mockReturnValueOnce('uuid-key-1');
+  });
+
+  // ──────────────────────────────────────────────
+  // onboardAgent — duplicate / constraint violations
+  // ──────────────────────────────────────────────
+
+  describe('onboardAgent duplicates and constraints', () => {
+    const defaultParams = { tenantName: 'user-42', agentName: 'my-agent' };
+
+    it('should propagate unique constraint violation when same agent name re-onboarded', async () => {
+      mockTenantFindOne.mockResolvedValue({
+        id: 'existing-tenant-id',
+        name: 'user-42',
+      });
+      const constraintError = new Error('duplicate key value violates unique constraint');
+      constraintError.name = 'QueryFailedError';
+      mockAgentInsert.mockRejectedValueOnce(constraintError);
+
+      await expect(service.onboardAgent(defaultParams)).rejects.toThrow(
+        'duplicate key value violates unique constraint',
+      );
+    });
+
+    it('should not insert API key when agent insert fails with unique constraint', async () => {
+      mockTenantFindOne.mockResolvedValue({
+        id: 'existing-tenant-id',
+        name: 'user-42',
+      });
+      mockAgentInsert.mockRejectedValueOnce(new Error('duplicate key'));
+
+      await expect(service.onboardAgent(defaultParams)).rejects.toThrow();
+      expect(mockKeyInsert).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // onboardAgent — agentCategory + agentPlatform
+  // ──────────────────────────────────────────────
+
+  describe('onboardAgent optional category and platform', () => {
+    const defaultParams = { tenantName: 'user-42', agentName: 'my-agent' };
+
+    it('should store agentCategory and agentPlatform when provided', async () => {
+      mockTenantFindOne.mockResolvedValue(null);
+
+      await service.onboardAgent({
+        ...defaultParams,
+        agentCategory: 'coding',
+        agentPlatform: 'openclaw',
+      });
+
+      expect(mockAgentInsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent_category: 'coding',
+          agent_platform: 'openclaw',
+        }),
+      );
+    });
+
+    it('should default agent_category to null when omitted', async () => {
+      mockTenantFindOne.mockResolvedValue(null);
+
+      await service.onboardAgent(defaultParams);
+
+      expect(mockAgentInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ agent_category: null }),
+      );
+    });
+
+    it('should default agent_platform to null when omitted', async () => {
+      mockTenantFindOne.mockResolvedValue(null);
+
+      await service.onboardAgent(defaultParams);
+
+      expect(mockAgentInsert).toHaveBeenCalledWith(
+        expect.objectContaining({ agent_platform: null }),
+      );
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // getKeyForAgent — soft-delete filter + cross-tenant
+  // ──────────────────────────────────────────────
+
+  describe('getKeyForAgent isolation and soft-delete', () => {
+    it('should apply deleted_at IS NULL filter (soft-delete)', async () => {
+      mockKeyGetOne.mockResolvedValue({ key_prefix: 'mnfst_xxx' });
+
+      await service.getKeyForAgent('user-99', 'bot-x');
+
+      expect(mockKeyQb.andWhere).toHaveBeenCalledWith('a.deleted_at IS NULL');
+    });
+
+    it('should throw NotFoundException when wrong userId for valid agent (cross-tenant)', async () => {
+      // Wrong userId for an agent that exists under a different tenant — the
+      // join on t.name forces a null result, never a leak.
+      mockKeyGetOne.mockResolvedValue(null);
+
+      await expect(service.getKeyForAgent('attacker-user', 'agent-a')).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(mockKeyQb.where).toHaveBeenCalledWith('t.name = :userId', {
+        userId: 'attacker-user',
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // rotateKey — soft-delete + cross-tenant
+  // ──────────────────────────────────────────────
+
+  describe('rotateKey isolation and soft-delete', () => {
+    it('should apply deleted_at IS NULL filter when looking up agent', async () => {
+      mockAgentGetOne.mockResolvedValue({
+        id: 'agent-id-1',
+        name: 'my-agent',
+        tenant_id: 'tenant-id-1',
+      });
+
+      await service.rotateKey('user-1', 'my-agent');
+
+      expect(mockAgentQb.andWhere).toHaveBeenCalledWith('a.deleted_at IS NULL');
+    });
+
+    it('should throw NotFoundException when cross-tenant userId does not own the agent', async () => {
+      // Wrong user trying to rotate someone else's agent — query returns null.
+      mockAgentGetOne.mockResolvedValue(null);
+
+      await expect(service.rotateKey('attacker-user', 'someone-elses-agent')).rejects.toThrow(
+        NotFoundException,
+      );
+      // Ensure we never deleted the key for an agent we couldn't look up.
+      expect(mockKeyDelete).not.toHaveBeenCalled();
+      expect(mockClearCache).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────────
+  // onboardAgent + rotateKey — empty / whitespace inputs
+  // ──────────────────────────────────────────────
+
+  describe('input edge cases (empty strings)', () => {
+    it('should still call tenant lookup when tenantName is an empty string', async () => {
+      // Service does not validate empty strings — DTO does. Pins current
+      // behaviour so a silent regression inside the service is caught.
+      mockTenantFindOne.mockResolvedValue(null);
+
+      await service.onboardAgent({ tenantName: '', agentName: 'my-agent' });
+
+      expect(mockTenantFindOne).toHaveBeenCalledWith({ where: { name: '' } });
+      expect(mockTenantInsert).toHaveBeenCalledWith(expect.objectContaining({ name: '' }));
+    });
+
+    it('should pass empty agentName through to agent insert', async () => {
+      mockTenantFindOne.mockResolvedValue(null);
+
+      await service.onboardAgent({ tenantName: 'user-42', agentName: '' });
+
+      expect(mockAgentInsert).toHaveBeenCalledWith(expect.objectContaining({ name: '' }));
+      // Label still concatenates even for empty agent name.
+      expect(mockKeyInsert).toHaveBeenCalledWith(expect.objectContaining({ label: ' ingest key' }));
+    });
+
+    it('rotateKey should throw NotFoundException when called with empty agentName', async () => {
+      mockAgentGetOne.mockResolvedValue(null);
+
+      await expect(service.rotateKey('user-1', '')).rejects.toThrow(NotFoundException);
+      expect(mockAgentQb.where).toHaveBeenCalledWith('a.name = :agentName', {
+        agentName: '',
+      });
+    });
+
+    it('rotateKey should throw NotFoundException when called with empty userId', async () => {
+      mockAgentGetOne.mockResolvedValue(null);
+
+      await expect(service.rotateKey('', 'my-agent')).rejects.toThrow(NotFoundException);
+      expect(mockAgentQb.andWhere).toHaveBeenCalledWith('t.name = :userId', {
+        userId: '',
+      });
+    });
+  });
+});

--- a/packages/backend/src/playground/playground-response-headers.spec.ts
+++ b/packages/backend/src/playground/playground-response-headers.spec.ts
@@ -1,0 +1,181 @@
+import { whitelistResponseHeaders } from './playground-response-headers';
+
+const EXACT_HEADERS = [
+  'content-type',
+  'date',
+  'x-request-id',
+  'request-id',
+  'openai-model',
+  'openai-organization',
+  'openai-processing-ms',
+  'openai-version',
+  'anthropic-ratelimit-requests-limit',
+  'anthropic-ratelimit-requests-remaining',
+  'anthropic-ratelimit-requests-reset',
+  'anthropic-ratelimit-tokens-limit',
+  'anthropic-ratelimit-tokens-remaining',
+  'anthropic-ratelimit-tokens-reset',
+];
+
+describe('whitelistResponseHeaders', () => {
+  it('allows all exact-match headers', () => {
+    const h = new Headers();
+    for (const name of EXACT_HEADERS) h.append(name, `value-for-${name}`);
+
+    const out = whitelistResponseHeaders(h);
+
+    for (const name of EXACT_HEADERS) {
+      expect(out[name]).toBe(`value-for-${name}`);
+    }
+    expect(Object.keys(out).sort()).toEqual([...EXACT_HEADERS].sort());
+  });
+
+  it('blocks authorization, cookie, set-cookie, and host headers', () => {
+    const h = new Headers();
+    h.append('authorization', 'Bearer sk-secret');
+    h.append('cookie', 'session=abc');
+    h.append('set-cookie', 'session=xyz; HttpOnly');
+    h.append('host', 'api.openai.com');
+    // Keep one allowed header so we can confirm the function still works.
+    h.append('content-type', 'application/json');
+
+    const out = whitelistResponseHeaders(h);
+
+    expect(out['authorization']).toBeUndefined();
+    expect(out['cookie']).toBeUndefined();
+    expect(out['set-cookie']).toBeUndefined();
+    expect(out['host']).toBeUndefined();
+    expect(out['content-type']).toBe('application/json');
+  });
+
+  it('allows x-ratelimit-, x-manifest-, and ratelimit- prefixes (case-insensitive)', () => {
+    const h = new Headers();
+    // Mix of casings — Headers normalizes to lowercase internally, but we
+    // also rely on the function's defensive .toLowerCase() call.
+    h.append('X-RateLimit-Remaining', '99');
+    h.append('X-MANIFEST-Tier', 'standard');
+    h.append('RateLimit-Reset', '60');
+    h.append('x-ratelimit-limit', '100');
+    h.append('x-manifest-specificity', 'coding');
+    h.append('ratelimit-policy', '100;w=60');
+
+    const out = whitelistResponseHeaders(h);
+
+    // Keys come out lowercased.
+    expect(out['x-ratelimit-remaining']).toBe('99');
+    expect(out['x-manifest-tier']).toBe('standard');
+    expect(out['ratelimit-reset']).toBe('60');
+    expect(out['x-ratelimit-limit']).toBe('100');
+    expect(out['x-manifest-specificity']).toBe('coding');
+    expect(out['ratelimit-policy']).toBe('100;w=60');
+  });
+
+  it('lowercases all output header keys for case-insensitive matching', () => {
+    // Headers normalizes incoming keys to lowercase on storage, so the
+    // .toLowerCase() in the function is defensive. Confirm the contract:
+    // every key emitted is already lowercase regardless of input casing.
+    const h = new Headers();
+    h.append('Content-Type', 'application/json');
+    h.append('X-Request-ID', 'req-123');
+    h.append('X-RateLimit-Limit', '1000');
+
+    const out = whitelistResponseHeaders(h);
+
+    for (const key of Object.keys(out)) {
+      expect(key).toBe(key.toLowerCase());
+    }
+    expect(out['content-type']).toBe('application/json');
+    expect(out['x-request-id']).toBe('req-123');
+    expect(out['x-ratelimit-limit']).toBe('1000');
+  });
+
+  it('returns an empty object for empty headers', () => {
+    expect(whitelistResponseHeaders(new Headers())).toEqual({});
+  });
+
+  it('returns an empty object when no headers match the allow-list', () => {
+    const h = new Headers();
+    h.append('authorization', 'Bearer sk-secret');
+    h.append('cookie', 'session=abc');
+    h.append('server', 'cloudflare');
+    h.append('x-fingerprint', 'browser-id');
+
+    expect(whitelistResponseHeaders(h)).toEqual({});
+  });
+
+  it('deduplicates headers with different casing via Headers normalization', () => {
+    // The Headers API normalizes keys to lowercase and merges duplicate
+    // values with ", ". Confirm we never emit two object keys for the
+    // same logical header — even if a provider sends multiple cases.
+    const h = new Headers();
+    h.append('X-Request-Id', 'first');
+    h.append('x-request-id', 'second');
+    h.append('X-REQUEST-ID', 'third');
+
+    const out = whitelistResponseHeaders(h);
+
+    // Exactly one lowercase entry — no per-casing duplicates leak through.
+    expect(Object.keys(out)).toEqual(['x-request-id']);
+    // Headers concatenates duplicate-key appends with ", ".
+    expect(out['x-request-id']).toBe('first, second, third');
+  });
+
+  it('preserves header values verbatim, including empty strings', () => {
+    const h = new Headers();
+    h.append('content-type', '');
+    h.append('x-request-id', 'req-abc-123');
+    h.append('x-ratelimit-remaining', '0');
+
+    const out = whitelistResponseHeaders(h);
+
+    expect(out['content-type']).toBe('');
+    expect(out['x-request-id']).toBe('req-abc-123');
+    expect(out['x-ratelimit-remaining']).toBe('0');
+  });
+
+  it('does not match prefixes mid-string (startsWith only)', () => {
+    // "my-x-ratelimit-remaining" must NOT match the "x-ratelimit-" prefix.
+    // The startsWith() check is the security boundary — a substring match
+    // would let custom-prefixed headers leak through.
+    const h = new Headers();
+    h.append('my-x-ratelimit-remaining', '50');
+    h.append('foo-x-manifest-tier', 'cheap');
+    h.append('not-ratelimit-policy', 'spoof');
+
+    expect(whitelistResponseHeaders(h)).toEqual({});
+  });
+
+  it('does not match exact-list headers via a partial substring', () => {
+    // Only exact lowercase matches should pass. "openai-model-foo" must
+    // not slip through just because "openai-model" is whitelisted.
+    const h = new Headers();
+    h.append('openai-model-foo', 'leak');
+    h.append('content-type-extra', 'leak');
+    h.append('xx-date', 'leak');
+
+    expect(whitelistResponseHeaders(h)).toEqual({});
+  });
+
+  it('mixes allowed and blocked headers correctly in one pass', () => {
+    const h = new Headers();
+    // Allowed (exact)
+    h.append('content-type', 'application/json');
+    h.append('openai-model', 'gpt-4o');
+    // Allowed (prefix)
+    h.append('x-ratelimit-remaining', '99');
+    h.append('x-manifest-tier', 'standard');
+    // Blocked
+    h.append('authorization', 'Bearer sk-secret');
+    h.append('cookie', 'session=abc');
+    h.append('server', 'cloudflare');
+
+    const out = whitelistResponseHeaders(h);
+
+    expect(out).toEqual({
+      'content-type': 'application/json',
+      'openai-model': 'gpt-4o',
+      'x-ratelimit-remaining': '99',
+      'x-manifest-tier': 'standard',
+    });
+  });
+});

--- a/packages/backend/src/playground/playground.service.truncation.spec.ts
+++ b/packages/backend/src/playground/playground.service.truncation.spec.ts
@@ -1,0 +1,256 @@
+import type { Response as ExpressResponse } from 'express';
+import { PlaygroundService } from './playground.service';
+import type { ProviderClient } from '../routing/proxy/provider-client';
+import type { ProviderKeyService } from '../routing/routing-core/provider-key.service';
+import type { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import type { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
+import type { IngestEventBusService } from '../common/services/ingest-event-bus.service';
+import type { PlaygroundHistoryService } from './playground-history.service';
+import type { Repository } from 'typeorm';
+import type { AgentMessage } from '../entities/agent-message.entity';
+import type { CustomProvider } from '../entities/custom-provider.entity';
+import type { RunPlaygroundDto } from './dto/run-playground.dto';
+
+const USER_ID = 'user-1';
+const AGENT = { id: 'agent-1', tenant_id: 'tenant-1', name: 'demo' };
+
+function makeDto(overrides: Partial<RunPlaygroundDto> = {}): RunPlaygroundDto {
+  return {
+    agentName: 'demo',
+    model: 'openai/gpt-4o',
+    provider: 'openai',
+    authType: 'api_key',
+    messages: [{ role: 'user', content: 'hi' }],
+    ...overrides,
+  } as RunPlaygroundDto;
+}
+
+interface MockRes {
+  status: jest.Mock;
+  json: jest.Mock;
+  setHeader: jest.Mock;
+  flushHeaders: jest.Mock;
+  write: jest.Mock;
+  end: jest.Mock;
+  on: jest.Mock;
+  headersSent: boolean;
+  writableEnded: boolean;
+  _written: string[];
+  _json: unknown;
+  _status: number | null;
+  _closeHandler: (() => void) | null;
+}
+
+function mockRes(): MockRes {
+  const res: MockRes = {
+    status: jest.fn((code: number) => {
+      res._status = code;
+      return res;
+    }),
+    json: jest.fn((body: unknown) => {
+      res._json = body;
+      return res;
+    }),
+    setHeader: jest.fn(),
+    flushHeaders: jest.fn(),
+    write: jest.fn((chunk: string) => {
+      res._written.push(chunk);
+      return true;
+    }),
+    end: jest.fn(() => {
+      res.writableEnded = true;
+      return res;
+    }),
+    on: jest.fn((event: string, handler: () => void) => {
+      if (event === 'close') res._closeHandler = handler;
+      return res;
+    }),
+    headersSent: false,
+    writableEnded: false,
+    _written: [],
+    _json: undefined,
+    _status: null,
+    _closeHandler: null,
+  };
+  return res;
+}
+
+const asRes = (r: MockRes): ExpressResponse => r as unknown as ExpressResponse;
+
+interface Mocks {
+  resolveAgent: { resolve: jest.Mock };
+  providerKeyService: {
+    hasActiveProvider: jest.Mock;
+    getAuthType: jest.Mock;
+    getProviderApiKey: jest.Mock;
+  };
+  providerClient: {
+    forward: jest.Mock;
+    convertGoogleStreamChunk: jest.Mock;
+    createAnthropicStreamTransformer: jest.Mock;
+    convertChatGptStreamChunk: jest.Mock;
+  };
+  pricingCache: { getByModel: jest.Mock };
+  eventBus: { emit: jest.Mock };
+  history: { saveColumn: jest.Mock };
+  messageRepo: { insert: jest.Mock };
+  customProviderRepo: { findOne: jest.Mock };
+}
+
+function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService; mocks: Mocks } {
+  const full: Mocks = {
+    resolveAgent: {
+      resolve: jest.fn().mockResolvedValue(AGENT),
+    },
+    providerKeyService: {
+      hasActiveProvider: jest.fn().mockResolvedValue(true),
+      getAuthType: jest.fn().mockResolvedValue('api_key'),
+      getProviderApiKey: jest.fn().mockResolvedValue('sk-test'),
+    },
+    providerClient: {
+      forward: jest.fn(),
+      convertGoogleStreamChunk: jest.fn(),
+      createAnthropicStreamTransformer: jest.fn(),
+      convertChatGptStreamChunk: jest.fn(),
+    },
+    pricingCache: {
+      getByModel: jest.fn().mockReturnValue({
+        input_price_per_token: 0.000001,
+        output_price_per_token: 0.000002,
+      }),
+    },
+    eventBus: { emit: jest.fn() },
+    history: { saveColumn: jest.fn().mockResolvedValue('col-1') },
+    messageRepo: { insert: jest.fn().mockResolvedValue(undefined) },
+    customProviderRepo: { findOne: jest.fn().mockResolvedValue(null) },
+    ...mocks,
+  };
+  const service = new PlaygroundService(
+    full.resolveAgent as unknown as ResolveAgentService,
+    full.providerKeyService as unknown as ProviderKeyService,
+    full.providerClient as unknown as ProviderClient,
+    full.pricingCache as unknown as ModelPricingCacheService,
+    full.eventBus as unknown as IngestEventBusService,
+    full.history as unknown as PlaygroundHistoryService,
+    full.messageRepo as unknown as Repository<AgentMessage>,
+    full.customProviderRepo as unknown as Repository<CustomProvider>,
+  );
+  return { service, mocks: full };
+}
+
+describe('PlaygroundService.runStream — error body truncation', () => {
+  it('truncates long error bodies to a safe length for SSE response and history column', async () => {
+    const { service, mocks } = buildService();
+    // 10KB body — 10,000 'A's. The service should:
+    //   1) truncate to 500 chars for the JSON response + history error message
+    //   2) truncate to 2000 chars for the persisted agent_messages.error_message
+    const longBody = 'A'.repeat(10_000);
+    mocks.providerClient.forward.mockResolvedValue({
+      response: {
+        ok: false,
+        status: 502,
+        headers: new Headers(),
+        text: jest.fn().mockResolvedValue(longBody),
+        body: null,
+      },
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+    });
+    const res = mockRes();
+
+    await service.runStream(USER_ID, makeDto(), asRes(res));
+
+    // --- 1. The user-facing JSON response must NOT contain the full body. ---
+    expect(res._status).toBe(502);
+    const message = (res._json as { message: string }).message;
+    expect(message.startsWith('Provider returned 502: ')).toBe(true);
+    // Prefix "Provider returned 502: " (23 chars) + max 500 chars snippet
+    // = at most 523 chars. The full 10KB body must NOT leak through.
+    expect(message.length).toBeLessThanOrEqual(523);
+    expect(message.length).toBeLessThan(longBody.length);
+    // Snippet content after the prefix should be exactly 500 chars of 'A'.
+    const snippet = message.slice('Provider returned 502: '.length);
+    expect(snippet.length).toBe(500);
+    expect(snippet).toBe('A'.repeat(500));
+
+    // --- 2. The history column receives the same truncated error message. ---
+    expect(mocks.history.saveColumn).toHaveBeenCalledTimes(1);
+    const column = mocks.history.saveColumn.mock.calls[0][0];
+    expect(column.status).toBe('error');
+    expect(column.errorMessage).toBe(message);
+    expect((column.errorMessage as string).length).toBeLessThanOrEqual(523);
+
+    // --- 3. The agent_messages row caps error_message to 2000 chars. ---
+    // recordError uses errorBody.slice(0, 2000) on the raw body — the original
+    // body is 10K 'A's, so the persisted value is exactly 2000 'A's.
+    expect(mocks.messageRepo.insert).toHaveBeenCalledTimes(1);
+    const row = mocks.messageRepo.insert.mock.calls[0][0];
+    expect(row.status).toBe('error');
+    expect(row.error_http_status).toBe(502);
+    expect((row.error_message as string).length).toBe(2000);
+    expect(row.error_message).toBe('A'.repeat(2000));
+    // Crucially, the full 10KB body never made it to the DB row either.
+    expect((row.error_message as string).length).toBeLessThan(longBody.length);
+  });
+
+  it('trims whitespace from the truncated snippet so 500 trailing spaces collapse', async () => {
+    const { service, mocks } = buildService();
+    // 500 leading/trailing spaces + a payload in the middle. After slice(0,500)
+    // the snippet is all whitespace and .trim() collapses it to '' — the
+    // service must fall back to the status-only message form.
+    const body = ' '.repeat(600) + 'real error text after the slice window';
+    mocks.providerClient.forward.mockResolvedValue({
+      response: {
+        ok: false,
+        status: 500,
+        headers: new Headers(),
+        text: jest.fn().mockResolvedValue(body),
+        body: null,
+      },
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+    });
+    const res = mockRes();
+
+    await service.runStream(USER_ID, makeDto(), asRes(res));
+
+    const message = (res._json as { message: string }).message;
+    expect(message).toBe('Provider returned 500');
+    // The history column gets the same status-only message — no whitespace
+    // soup, and definitely none of the "real error text after the slice
+    // window" payload that sits beyond the 500-char window.
+    const column = mocks.history.saveColumn.mock.calls[0][0];
+    expect(column.errorMessage).toBe('Provider returned 500');
+    expect(column.errorMessage).not.toContain('real error text');
+  });
+
+  it('preserves short error bodies verbatim (no over-truncation)', async () => {
+    const { service, mocks } = buildService();
+    const shortBody = 'quota exceeded';
+    mocks.providerClient.forward.mockResolvedValue({
+      response: {
+        ok: false,
+        status: 429,
+        headers: new Headers(),
+        text: jest.fn().mockResolvedValue(shortBody),
+        body: null,
+      },
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+    });
+    const res = mockRes();
+
+    await service.runStream(USER_ID, makeDto(), asRes(res));
+
+    const message = (res._json as { message: string }).message;
+    expect(message).toBe('Provider returned 429: quota exceeded');
+    const column = mocks.history.saveColumn.mock.calls[0][0];
+    expect(column.errorMessage).toBe('Provider returned 429: quota exceeded');
+    const row = mocks.messageRepo.insert.mock.calls[0][0];
+    // Short bodies are stored verbatim (< 2000 char cap).
+    expect(row.error_message).toBe(shortBody);
+  });
+});

--- a/packages/backend/src/public-stats/public-stats.controller.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.spec.ts
@@ -1,3 +1,22 @@
+// IMPORTANT: PublicStatsController uses module-level cache variables (cachedUsage,
+// cachedFree, cachedProviderTokens, cachedAgentTokens, cachedFreeProviders) plus the
+// matching `*Timestamp` and `*Inflight` lets. These survive between `it()` blocks
+// because they live in the module closure, not on the controller instance.
+//
+// We reset them by calling `jest.resetModules()` in beforeEach() and then
+// re-importing the controller via freshImport(). This drops the cached module
+// from Jest's module registry so the next `import()` re-evaluates the file with
+// all module-level lets back at their initial value (`null` / `0`).
+//
+// When adding a new describe block: either inherit the parent describe's
+// beforeEach (preferred) or, if you override beforeEach, you MUST call
+// `jest.resetModules()` and use `freshImport()` to obtain the controller.
+// Skipping this leaks cached values across tests and produces nondeterministic
+// passes/failures depending on test order.
+//
+// Future refactor: hoist the caches into an injectable service (e.g. a
+// PublicStatsCacheService) so NestJS DI can give each test a fresh instance
+// without needing module reimport gymnastics.
 import type { ConfigService } from '@nestjs/config';
 import type {
   PublicStatsService,
@@ -63,6 +82,10 @@ describe('PublicStatsController', () => {
   }
 
   beforeEach(async () => {
+    // Reset module to clear module-level cache state (cachedUsage, cachedFree,
+    // cachedProviderTokens, cachedAgentTokens, cachedFreeProviders) plus the
+    // matching `*Timestamp` and `*Inflight` lets. Without this, cached values
+    // from a previous test would leak into the next one.
     jest.resetModules();
     Object.values(mockService).forEach((m) => m.mockReset());
     controller = await freshImport();
@@ -708,6 +731,74 @@ describe('PublicStatsController', () => {
       expect(json).not.toContain('user_id');
       expect(json).not.toContain('email');
       expect(json).not.toContain('password');
+    });
+  });
+
+  // Regression: module-level caches MUST be reset between tests. If the
+  // beforeEach loses its jest.resetModules() + freshImport() pair, these
+  // assertions will fail because state from previous tests would leak in.
+  describe('module-level cache isolation (regression)', () => {
+    it('cachedUsage starts as null in every test (no leak from sibling tests)', async () => {
+      // The parent beforeEach already ran freshImport() and reset mocks.
+      // The mock is unconfigured, so the first call hits refreshUsage(),
+      // the service throws (no mock return value), and the fallback runs.
+      // If the cache leaked, total_messages would be whatever the previous
+      // test stored (e.g. 100 from STATS_FIXTURE).
+      mockService.getUsageStats.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await controller.getUsage();
+
+      expect(result.total_messages).toBe(0);
+      expect(result.top_models).toEqual([]);
+    });
+
+    it('cachedProviderTokens starts as null in every test', async () => {
+      mockService.getProviderDailyTokens.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await controller.getProviderTokens();
+
+      expect(result.providers).toEqual([]);
+    });
+
+    it('cachedAgentTokens starts as null in every test', async () => {
+      mockService.getAgentDailyTokens.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await controller.getAgentTokens();
+
+      expect(result.agents).toEqual([]);
+    });
+
+    it('cachedFreeProviders starts as null in every test', () => {
+      mockFreeModelsService.getAll.mockReset();
+      mockFreeModelsService.getAll.mockReturnValue({ providers: [], last_synced_at: null });
+
+      const result = controller.getFreeProviders();
+
+      // Fresh import means the cache is empty, so the service MUST be called.
+      // If the cache leaked, getAll would be skipped and we'd see a stale list.
+      expect(mockFreeModelsService.getAll).toHaveBeenCalledTimes(1);
+      expect(result.providers).toEqual([]);
+    });
+
+    it('freshImport() returns a controller whose getUsage refetches from scratch', async () => {
+      // Seed the first controller's cache, then verify a freshly imported
+      // controller does NOT see that cached value.
+      mockService.getUsageStats.mockResolvedValue(STATS_FIXTURE);
+      const first = await controller.getUsage();
+      expect(first.total_messages).toBe(100);
+
+      // freshImport() calls jest.resetModules() implicitly? No — only the
+      // parent beforeEach does. So we re-do the dance manually here to prove
+      // the pattern.
+      jest.resetModules();
+      Object.values(mockService).forEach((m) => m.mockReset());
+      mockService.getUsageStats.mockRejectedValueOnce(new Error('boom'));
+      const fresh = await freshImport();
+
+      const second = await fresh.getUsage();
+
+      // Fresh controller + fresh module = empty cache + failed fetch = fallback.
+      expect(second.total_messages).toBe(0);
     });
   });
 });

--- a/packages/backend/src/public-stats/public-stats.service.pricing-edges.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.pricing-edges.spec.ts
@@ -1,0 +1,282 @@
+import { PublicStatsService } from './public-stats.service';
+import {
+  ModelPricingCacheService,
+  PricingEntry,
+} from '../model-prices/model-pricing-cache.service';
+
+/**
+ * Pricing-edge regression tests for PublicStatsService.
+ *
+ * The main spec covers the happy paths and the `getByModel() === null` branch.
+ * This file pins behavior for the "object returned but key fields missing" cases:
+ * a stale cache row, a partial models.dev response, or a custom provider entry
+ * that never resolved its pricing/provider columns. Without these tests the
+ * pricing-derivation branches (lines 154-173, 228-230 of the source) silently
+ * change shape.
+ */
+
+function mockQueryBuilder(result: unknown) {
+  const qb: Record<string, jest.Mock> = {};
+  qb.select = jest.fn().mockReturnValue(qb);
+  qb.addSelect = jest.fn().mockReturnValue(qb);
+  qb.where = jest.fn().mockReturnValue(qb);
+  qb.andWhere = jest.fn().mockReturnValue(qb);
+  qb.groupBy = jest.fn().mockReturnValue(qb);
+  qb.orderBy = jest.fn().mockReturnValue(qb);
+  qb.limit = jest.fn().mockReturnValue(qb);
+  qb.innerJoin = jest.fn().mockReturnValue(qb);
+  qb.addGroupBy = jest.fn().mockReturnValue(qb);
+  qb.getRawOne = jest.fn().mockResolvedValue(result);
+  qb.getRawMany = jest.fn().mockResolvedValue(result);
+  return qb;
+}
+
+function makePricingEntry(overrides: Partial<PricingEntry> = {}): PricingEntry {
+  return {
+    model_name: 'test-model',
+    provider: 'TestProvider',
+    input_price_per_token: 0.000001,
+    output_price_per_token: 0.000002,
+    display_name: 'Test Model',
+    ...overrides,
+  };
+}
+
+describe('PublicStatsService — pricing edge cases', () => {
+  let service: PublicStatsService;
+  let mockRepo: { createQueryBuilder: jest.Mock };
+  let mockPricingCache: { getAll: jest.Mock; getByModel: jest.Mock };
+
+  beforeEach(() => {
+    mockRepo = { createQueryBuilder: jest.fn() };
+    mockPricingCache = {
+      getAll: jest.fn().mockReturnValue([]),
+      getByModel: jest.fn().mockReturnValue(null),
+    };
+    service = new PublicStatsService(
+      mockRepo as never,
+      mockPricingCache as unknown as ModelPricingCacheService,
+    );
+  });
+
+  function setupUsageQueries(
+    count: unknown,
+    top: unknown,
+    tokens7d: unknown,
+    tokensPrev7d: unknown = [],
+    tokens30d: unknown = [],
+  ) {
+    mockRepo.createQueryBuilder
+      .mockReturnValueOnce(mockQueryBuilder(count))
+      .mockReturnValueOnce(mockQueryBuilder(top))
+      .mockReturnValueOnce(mockQueryBuilder(tokens7d))
+      .mockReturnValueOnce(mockQueryBuilder(tokensPrev7d))
+      .mockReturnValueOnce(mockQueryBuilder(tokens30d));
+  }
+
+  function setupProviderDailyQuery(rows: unknown) {
+    mockRepo.createQueryBuilder.mockReturnValueOnce(mockQueryBuilder(rows));
+  }
+
+  function setupAgentDailyQuery(rows: unknown) {
+    mockRepo.createQueryBuilder.mockReturnValueOnce(mockQueryBuilder(rows));
+  }
+
+  describe('getUsageStats — partial pricing entries', () => {
+    it('excludes models when getByModel returns provider=null + undefined/null prices', async () => {
+      // Simulates a stale or partial cache row: object exists but provider is
+      // falsy. `pricing?.provider || 'Unknown'` then collapses to 'Unknown',
+      // which is in EXCLUDED_PROVIDERS, so the model must be skipped entirely.
+      setupUsageQueries(
+        { total: '1' },
+        [{ model: 'stale-model', usage_count: '1' }],
+        [{ model: 'stale-model', tokens: '5000' }],
+      );
+      mockPricingCache.getByModel.mockReturnValue({
+        model_name: 'stale-model',
+        provider: null,
+        input_price_per_token: undefined,
+        output_price_per_token: null,
+        display_name: null,
+      } as unknown as PricingEntry);
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(0);
+      // Token map still reflects the row — only the top-models projection
+      // filters by provider, the raw 7d token map is unfiltered.
+      expect(result.token_map.get('stale-model')).toBe(5000);
+    });
+
+    it('excludes models when provider is the empty string', async () => {
+      setupUsageQueries(
+        { total: '1' },
+        [{ model: 'empty-provider', usage_count: '1' }],
+        [{ model: 'empty-provider', tokens: '1' }],
+      );
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: '' }));
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(0);
+    });
+
+    it('returns null price_per_million when prices are missing but provider is known', async () => {
+      // Provider is OK, so the row survives the EXCLUDED_PROVIDERS gate.
+      // The price fields must coerce undefined and null into null (not NaN,
+      // not 0). The source uses `!= null` which catches both undefined and
+      // null — this test pins that contract.
+      setupUsageQueries(
+        { total: '1' },
+        [{ model: 'priceless-model', usage_count: '1' }],
+        [{ model: 'priceless-model', tokens: '2000' }],
+      );
+      mockPricingCache.getByModel.mockReturnValue({
+        model_name: 'priceless-model',
+        provider: 'OpenAI',
+        input_price_per_token: undefined,
+        output_price_per_token: null,
+        display_name: null,
+      } as unknown as PricingEntry);
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(1);
+      expect(result.top_models[0].provider).toBe('OpenAI');
+      expect(result.top_models[0].input_price_per_million).toBeNull();
+      expect(result.top_models[0].output_price_per_million).toBeNull();
+      expect(result.top_models[0].tokens_7d).toBe(2000);
+    });
+
+    it('keeps explicit zero prices as 0, not null', async () => {
+      // Free-tier models legitimately price at 0. The `!= null` check must
+      // let zero through so the UI can distinguish "free" from "unknown".
+      setupUsageQueries(
+        { total: '1' },
+        [{ model: 'free-model', usage_count: '1' }],
+        [{ model: 'free-model', tokens: '100' }],
+      );
+      mockPricingCache.getByModel.mockReturnValue(
+        makePricingEntry({
+          provider: 'Google',
+          input_price_per_token: 0,
+          output_price_per_token: 0,
+        }),
+      );
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(1);
+      expect(result.top_models[0].input_price_per_million).toBe(0);
+      expect(result.top_models[0].output_price_per_million).toBe(0);
+    });
+
+    it('handles mixed-presence price fields (input set, output missing)', async () => {
+      setupUsageQueries(
+        { total: '1' },
+        [{ model: 'half-priced', usage_count: '1' }],
+        [{ model: 'half-priced', tokens: '50' }],
+      );
+      mockPricingCache.getByModel.mockReturnValue({
+        model_name: 'half-priced',
+        provider: 'Anthropic',
+        input_price_per_token: 0.000003,
+        output_price_per_token: undefined,
+        display_name: null,
+      } as unknown as PricingEntry);
+
+      const result = await service.getUsageStats();
+
+      expect(result.top_models).toHaveLength(1);
+      expect(result.top_models[0].input_price_per_million).toBeCloseTo(3);
+      expect(result.top_models[0].output_price_per_million).toBeNull();
+    });
+  });
+
+  describe('getProviderDailyTokens — partial pricing entries', () => {
+    it('excludes rows when getByModel returns provider=null', async () => {
+      setupProviderDailyQuery([
+        {
+          model: 'stale-model',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: 'api_key',
+          cost: '0.10',
+        },
+      ]);
+      mockPricingCache.getByModel.mockReturnValue({
+        model_name: 'stale-model',
+        provider: null,
+        input_price_per_token: undefined,
+        output_price_per_token: null,
+        display_name: null,
+      } as unknown as PricingEntry);
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toEqual([]);
+    });
+
+    it('includes rows when provider is set even if price fields are missing', async () => {
+      // The provider-daily endpoint does not project prices, so missing
+      // price fields should not affect grouping at all.
+      setupProviderDailyQuery([
+        {
+          model: 'priceless-model',
+          date: '2026-04-07',
+          tokens: '2000',
+          auth_type: 'api_key',
+          cost: '0.25',
+        },
+      ]);
+      mockPricingCache.getByModel.mockReturnValue({
+        model_name: 'priceless-model',
+        provider: 'OpenAI',
+        input_price_per_token: undefined,
+        output_price_per_token: null,
+        display_name: null,
+      } as unknown as PricingEntry);
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].provider).toBe('OpenAI');
+      expect(result[0].total_tokens).toBe(2000);
+      expect(result[0].models[0].total_cost).toBeCloseTo(0.25);
+    });
+  });
+
+  describe('getAgentDailyTokens — partial pricing entries', () => {
+    // getAgentDailyTokens does not consult pricingCache at all (its provider
+    // axis is the agent, not the LLM provider), but we pin that here so a
+    // future refactor that adds pricing-cache lookups is forced to revisit
+    // these edge cases.
+    it('ignores pricing cache state entirely (does not call getByModel)', async () => {
+      setupAgentDailyQuery([
+        {
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '1000',
+          auth_type: 'api_key',
+          cost: '0.10',
+        },
+      ]);
+      mockPricingCache.getByModel.mockReturnValue({
+        model_name: 'gpt-4o',
+        provider: null,
+        input_price_per_token: undefined,
+        output_price_per_token: null,
+        display_name: null,
+      } as unknown as PricingEntry);
+
+      const result = await service.getAgentDailyTokens();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].agent_platform).toBe('openclaw');
+      expect(result[0].total_tokens).toBe(1000);
+      expect(mockPricingCache.getByModel).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/routing/custom-provider/custom-provider.service.edge-cases.spec.ts
+++ b/packages/backend/src/routing/custom-provider/custom-provider.service.edge-cases.spec.ts
@@ -1,0 +1,279 @@
+// Edge-case coverage for CustomProviderService. Lives alongside the main
+// spec to keep individual files under the 300-line limit. Focuses on
+// scenarios that the broader spec doesn't already pin down:
+//   - cache-eviction races where a custom provider reference outlives the
+//     custom_providers row
+//   - URL-validation failure surfaces propagating through every entry
+//     point (create / update / probeModels) for malformed URLs, http-in-
+//     cloud-mode rejections, and private-IP rejections
+jest.mock('../../common/utils/url-validation', () => ({
+  validatePublicUrl: jest.fn(),
+}));
+jest.mock('../../common/utils/detect-self-hosted', () => ({
+  isSelfHosted: jest.fn().mockReturnValue(false),
+}));
+
+import { BadRequestException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { CustomProviderService } from './custom-provider.service';
+import { CustomProvider } from '../../entities/custom-provider.entity';
+import { ProviderService } from '../routing-core/provider.service';
+import { RoutingCacheService } from '../routing-core/routing-cache.service';
+import { TierAutoAssignService } from '../routing-core/tier-auto-assign.service';
+import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
+import { ModelsDevSyncService } from '../../database/models-dev-sync.service';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { validatePublicUrl } = require('../../common/utils/url-validation');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { isSelfHosted } = require('../../common/utils/detect-self-hosted');
+
+function makeDeps(overrides: {
+  findOneResults?: (CustomProvider | null)[];
+  findResult?: CustomProvider[];
+  cached?: CustomProvider[] | null;
+}) {
+  const findOne = jest.fn();
+  const find = jest.fn().mockResolvedValue(overrides.findResult ?? []);
+  const insert = jest.fn().mockResolvedValue(undefined);
+  const save = jest.fn().mockResolvedValue(undefined);
+  const remove = jest.fn().mockResolvedValue(undefined);
+
+  const results = overrides.findOneResults ?? [];
+  findOne.mockImplementation(() => Promise.resolve(results.shift() ?? null));
+
+  const repo = { findOne, find, insert, save, remove } as unknown as Repository<CustomProvider>;
+  const providerService = {
+    upsertProvider: jest.fn().mockResolvedValue({ provider: {} }),
+    removeProvider: jest.fn().mockResolvedValue(undefined),
+    retagAuthType: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ProviderService;
+  const getCustomProviders = jest.fn().mockReturnValue(overrides.cached ?? null);
+  const setCustomProviders = jest.fn();
+  const routingCache = {
+    getCustomProviders,
+    setCustomProviders,
+    invalidateAgent: jest.fn(),
+  } as unknown as RoutingCacheService;
+  const autoAssign = {
+    recalculate: jest.fn().mockResolvedValue(undefined),
+  } as unknown as TierAutoAssignService;
+  const pricingCache = {
+    reload: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ModelPricingCacheService;
+
+  const svc = new CustomProviderService(
+    repo,
+    providerService,
+    routingCache,
+    autoAssign,
+    pricingCache,
+    undefined as unknown as ModelsDevSyncService,
+  );
+
+  return { svc, find, findOne, getCustomProviders, setCustomProviders };
+}
+
+describe('CustomProviderService edge cases', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (validatePublicUrl as jest.Mock).mockReset();
+    (validatePublicUrl as jest.Mock).mockResolvedValue(undefined);
+    (isSelfHosted as jest.Mock).mockReset();
+    (isSelfHosted as jest.Mock).mockReturnValue(false);
+  });
+
+  describe('canonicalizeAgentMessageKeys with stale references', () => {
+    it('handles a true cache miss (cache null + DB empty) by falling through to passthrough', async () => {
+      // Distinct from `cached: []`: the cache itself returned no entry at all
+      // (e.g. just after `invalidateAgent`), so list() has to hit the DB.
+      // The DB also returns nothing — the provider was deleted from under
+      // a still-pending message. The canonicalizer must pass the keys
+      // through untouched rather than throw or invent canonical names.
+      const { svc, find, setCustomProviders } = makeDeps({
+        cached: null,
+        findResult: [],
+      });
+
+      const result = await svc.canonicalizeAgentMessageKeys(
+        'agent-1',
+        'custom:deleted-uuid',
+        'custom:deleted-uuid/some-model',
+      );
+
+      expect(result).toEqual({
+        provider: 'custom:deleted-uuid',
+        model: 'custom:deleted-uuid/some-model',
+      });
+      // The cache miss path must actually hit the DB and repopulate the
+      // cache (with the empty result) so the next lookup is also cheap.
+      expect(find).toHaveBeenCalledWith({ where: { agent_id: 'agent-1' } });
+      expect(setCustomProviders).toHaveBeenCalledWith('agent-1', []);
+    });
+
+    it('passes through when cache miss + DB has unrelated providers (UUID still gone)', async () => {
+      // Cache cold, DB has *other* custom providers for the agent but not
+      // the one being canonicalized. This is the realistic stale-pointer
+      // case after a delete + invalidateAgent.
+      const otherRow = {
+        id: 'cp-still-here',
+        agent_id: 'agent-1',
+        name: 'llama.cpp',
+      } as CustomProvider;
+      const { svc } = makeDeps({
+        cached: null,
+        findResult: [otherRow],
+      });
+
+      const result = await svc.canonicalizeAgentMessageKeys(
+        'agent-1',
+        'custom:deleted-uuid',
+        'custom:deleted-uuid/foo',
+      );
+
+      // Other providers in the result must not bleed onto the deleted ID.
+      expect(result).toEqual({
+        provider: 'custom:deleted-uuid',
+        model: 'custom:deleted-uuid/foo',
+      });
+    });
+
+    it('passes through fallback_from_model when cache miss + DB empty (null provider)', async () => {
+      // fallback_from_model branch (provider null, model carries custom:
+      // prefix) under a true cache miss. Same passthrough contract.
+      const { svc, find } = makeDeps({
+        cached: null,
+        findResult: [],
+      });
+
+      const result = await svc.canonicalizeAgentMessageKeys(
+        'agent-1',
+        null,
+        'custom:evicted/legacy-model',
+      );
+
+      expect(result).toEqual({ provider: null, model: 'custom:evicted/legacy-model' });
+      expect(find).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('URL validation failures', () => {
+    const baseDto = {
+      name: 'my-provider',
+      base_url: 'http://bad.example',
+      apiKey: 'sk-x',
+      models: [
+        {
+          model_name: 'm1',
+          input_price_per_million_tokens: 1,
+          output_price_per_million_tokens: 1,
+        },
+      ],
+    };
+
+    it('rejects malformed URLs on create with BadRequestException carrying the validator message', async () => {
+      (validatePublicUrl as jest.Mock).mockRejectedValue(new Error('Invalid URL format'));
+      const { svc } = makeDeps({ findOneResults: [null] });
+      // The service must wrap whatever the validator throws in a
+      // BadRequestException — leaking the raw Error type would surface as
+      // a 500 to the client, hiding the underlying user-input problem.
+      await expect(svc.create('agent-1', 'user-1', baseDto)).rejects.toThrow(BadRequestException);
+      await expect(svc.create('agent-1', 'user-1', baseDto)).rejects.toThrow(/Invalid URL format/);
+    });
+
+    it('rejects http URLs in cloud mode on create (cleartext credentials risk)', async () => {
+      (validatePublicUrl as jest.Mock).mockRejectedValue(
+        new Error('Only https URLs are allowed in cloud mode.'),
+      );
+      const { svc } = makeDeps({ findOneResults: [null] });
+      await expect(
+        svc.create('agent-1', 'user-1', { ...baseDto, base_url: 'http://api.example.com' }),
+      ).rejects.toThrow(/Only https URLs are allowed/);
+      // allowPrivate must be false in non-self-hosted runs — the validator
+      // can't make that decision on its own without this option.
+      expect(validatePublicUrl).toHaveBeenLastCalledWith('http://api.example.com', {
+        allowPrivate: false,
+      });
+    });
+
+    it('rejects private-IP URLs in cloud mode on create (SSRF guard)', async () => {
+      (validatePublicUrl as jest.Mock).mockRejectedValue(
+        new Error('URLs pointing to private or internal networks are not allowed'),
+      );
+      const { svc } = makeDeps({ findOneResults: [null] });
+      await expect(
+        svc.create('agent-1', 'user-1', { ...baseDto, base_url: 'http://10.0.0.5:11434' }),
+      ).rejects.toThrow(/private or internal networks/);
+    });
+
+    it('rejects cloud-metadata URLs on create even in self-hosted mode', async () => {
+      // Cloud metadata is the one destination that's always blocked, even
+      // when allowPrivate is on — the validator throws and the service
+      // must still wrap it as a BadRequestException.
+      (isSelfHosted as jest.Mock).mockReturnValue(true);
+      (validatePublicUrl as jest.Mock).mockRejectedValue(
+        new Error('URLs pointing to cloud metadata endpoints are not allowed'),
+      );
+      const { svc } = makeDeps({ findOneResults: [null] });
+      await expect(
+        svc.create('agent-1', 'user-1', {
+          ...baseDto,
+          base_url: 'http://169.254.169.254/latest/meta-data',
+        }),
+      ).rejects.toThrow(/cloud metadata endpoints/);
+      expect(validatePublicUrl).toHaveBeenLastCalledWith(
+        'http://169.254.169.254/latest/meta-data',
+        { allowPrivate: true },
+      );
+    });
+
+    it('rejects malformed URLs on update with BadRequestException', async () => {
+      (validatePublicUrl as jest.Mock).mockRejectedValue(new Error('Invalid URL format'));
+      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const { svc } = makeDeps({ findOneResults: [existing] });
+      await expect(
+        svc.update('agent-1', 'cp1', 'user-1', { base_url: 'ht!tp://broken' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects private-IP URLs on update in cloud mode', async () => {
+      (validatePublicUrl as jest.Mock).mockRejectedValue(
+        new Error('URLs pointing to private or internal networks are not allowed'),
+      );
+      const existing = { id: 'cp1', agent_id: 'agent-1', name: 'n' } as CustomProvider;
+      const { svc } = makeDeps({ findOneResults: [existing] });
+      await expect(
+        svc.update('agent-1', 'cp1', 'user-1', { base_url: 'http://192.168.1.10' }),
+      ).rejects.toThrow(/private or internal networks/);
+    });
+
+    it('propagates malformed URL errors from probeModels as BadRequestException', async () => {
+      (validatePublicUrl as jest.Mock).mockRejectedValue(new Error('Invalid URL format'));
+      const { svc } = makeDeps({});
+      await expect(svc.probeModels('not a url')).rejects.toThrow(BadRequestException);
+      await expect(svc.probeModels('not a url')).rejects.toThrow(/Invalid URL format/);
+    });
+
+    it('propagates cloud-metadata rejection from probeModels (SSRF defense in depth)', async () => {
+      (validatePublicUrl as jest.Mock).mockRejectedValue(
+        new Error('URLs pointing to cloud metadata endpoints are not allowed'),
+      );
+      const { svc } = makeDeps({});
+      await expect(svc.probeModels('http://169.254.169.254')).rejects.toThrow(BadRequestException);
+      await expect(svc.probeModels('http://169.254.169.254')).rejects.toThrow(
+        /cloud metadata endpoints/,
+      );
+    });
+
+    it('passes allowPrivate=true to probeModels in self-hosted mode but still blocks bad URLs', async () => {
+      (isSelfHosted as jest.Mock).mockReturnValue(true);
+      (validatePublicUrl as jest.Mock).mockRejectedValue(
+        new Error('Only http and https URLs are allowed'),
+      );
+      const { svc } = makeDeps({});
+      await expect(svc.probeModels('ftp://internal.host/v1')).rejects.toThrow(BadRequestException);
+      expect(validatePublicUrl).toHaveBeenLastCalledWith('ftp://internal.host/v1', {
+        allowPrivate: true,
+      });
+    });
+  });
+});

--- a/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
+++ b/packages/backend/src/routing/header-tiers/__tests__/header-tier.service.spec.ts
@@ -141,11 +141,21 @@ describe('HeaderTierService', () => {
       ).rejects.toThrow(/Header key is required/);
     });
 
-    it('rejects reserved header keys', async () => {
-      const reserved = [...RESERVED_HEADER_KEYS][0];
-      await expect(
-        svc.create('agent-1', 'user-1', null, validInput({ header_key: reserved })),
-      ).rejects.toThrow(/stripped for security/);
+    it('rejects all reserved header keys', async () => {
+      for (const key of RESERVED_HEADER_KEYS) {
+        await expect(
+          svc.create('agent-1', 'user-1', null, validInput({ header_key: key })),
+        ).rejects.toThrow(/stripped for security/);
+      }
+    });
+
+    it('rejects reserved header keys with mixed case and whitespace', async () => {
+      for (const key of RESERVED_HEADER_KEYS) {
+        const mutated = `  ${key.toUpperCase()}  `;
+        await expect(
+          svc.create('agent-1', 'user-1', null, validInput({ header_key: mutated })),
+        ).rejects.toThrow(/stripped for security/);
+      }
     });
 
     it('rejects empty header values', async () => {
@@ -280,6 +290,24 @@ describe('HeaderTierService', () => {
       await expect(svc.update('agent-1', 'h1', { header_value: 'b' })).rejects.toThrow(
         /already matches/,
       );
+    });
+
+    it('rejects reserved header keys when updating header_key field', async () => {
+      const row = {
+        id: 'h1',
+        agent_id: 'agent-1',
+        name: 'A',
+        header_key: 'x-tier',
+        header_value: 'v',
+      } as HeaderTier;
+      for (const key of RESERVED_HEADER_KEYS) {
+        repo.findOne.mockResolvedValue(row);
+        repo.find.mockResolvedValue([row]);
+        await expect(svc.update('agent-1', 'h1', { header_key: key })).rejects.toThrow(
+          /stripped for security/,
+        );
+      }
+      expect(repo.save).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.security.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.security.spec.ts
@@ -1,0 +1,300 @@
+import { ProviderService } from '../../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
+import { AnthropicOauthService } from './anthropic-oauth.service';
+import {
+  OAuthPendingFlowStore,
+  type OAuthPendingFlowInput,
+  type OAuthPendingFlowRecord,
+} from '../core';
+
+const originalFetch = global.fetch;
+
+function mockResponse(status: number, body: unknown, text = ''): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => text || JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function createProviderService() {
+  const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
+  const recalculateTiers = jest.fn().mockResolvedValue(undefined);
+  const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
+  return {
+    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    upsertProvider,
+    recalculateTiers,
+    nextOAuthLabel,
+  };
+}
+
+function createDiscovery(): { svc: ModelDiscoveryService; discoverModels: jest.Mock } {
+  const discoverModels = jest.fn().mockResolvedValue(undefined);
+  return { svc: { discoverModels } as unknown as ModelDiscoveryService, discoverModels };
+}
+
+function createPendingStore() {
+  const flows = new Map<string, OAuthPendingFlowRecord>();
+  const key = (p: string, s: string) => `${p}:${s}`;
+  const cleanup = () => {
+    for (const [k, f] of flows) if (f.expiresAt < Date.now()) flows.delete(k);
+  };
+  const svc = {
+    create: jest.fn(async (provider: string, input: OAuthPendingFlowInput, ttlMs: number) => {
+      cleanup();
+      for (const [k, f] of flows) {
+        if (f.provider === provider && f.agentId === input.agentId && f.userId === input.userId) {
+          flows.delete(k);
+        }
+      }
+      const record = { provider, ...input, expiresAt: Date.now() + ttlMs };
+      flows.set(key(provider, input.state), record);
+      return record;
+    }),
+    consume: jest.fn(async (provider: string, state: string, agentId: string, userId: string) => {
+      const flow = flows.get(key(provider, state));
+      if (!flow || flow.agentId !== agentId || flow.userId !== userId) return null;
+      flows.delete(key(provider, state));
+      return flow;
+    }),
+    findLatestForAgent: jest.fn(async (provider: string, agentId: string, userId: string) => {
+      cleanup();
+      for (const f of flows.values()) {
+        if (f.provider === provider && f.agentId === agentId && f.userId === userId) return f;
+      }
+      return null;
+    }),
+    clear: jest.fn(async (provider: string, state: string) => {
+      flows.delete(key(provider, state));
+    }),
+    count: jest.fn(async (provider: string) => {
+      cleanup();
+      let t = 0;
+      for (const f of flows.values()) if (f.provider === provider) t += 1;
+      return t;
+    }),
+  } as unknown as OAuthPendingFlowStore;
+  return { svc, flows };
+}
+
+describe('AnthropicOauthService - security & edge cases', () => {
+  let fetchMock: jest.Mock;
+  let providerService: ReturnType<typeof createProviderService>;
+  let discovery: ReturnType<typeof createDiscovery>;
+  let pendingStore: ReturnType<typeof createPendingStore>;
+  let svc: AnthropicOauthService;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-01T12:00:00Z'));
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    providerService = createProviderService();
+    discovery = createDiscovery();
+    pendingStore = createPendingStore();
+    svc = new AnthropicOauthService(providerService.svc, discovery.svc, pendingStore.svc);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe('exchangeCode tenant boundaries', () => {
+    it('rejects exchange when state belongs to a different user', async () => {
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+
+      await expect(
+        svc.exchangeCode(`code#${state}`, undefined, 'agent-1', 'user-2'),
+      ).rejects.toThrow('Invalid or expired OAuth state');
+
+      // Boundary check is enforced by the store, not the service.
+      expect(pendingStore.svc.consume).toHaveBeenCalledWith(
+        'anthropic',
+        state,
+        'agent-1',
+        'user-2',
+      );
+      // Original owner's pending flow stays intact so user-1 can still finish.
+      await expect(svc.findPendingForAgent('agent-1', 'user-1')).resolves.toEqual({ state });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+    });
+
+    it('rejects exchange when state belongs to a different agent', async () => {
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+
+      await expect(
+        svc.exchangeCode(`code#${state}`, undefined, 'agent-2', 'user-1'),
+      ).rejects.toThrow('Invalid or expired OAuth state');
+
+      expect(pendingStore.svc.consume).toHaveBeenCalledWith(
+        'anthropic',
+        state,
+        'agent-2',
+        'user-1',
+      );
+      await expect(svc.findPendingForAgent('agent-1', 'user-1')).resolves.toEqual({ state });
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+    });
+
+    it('rejects state reuse after first successful exchange', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a', refresh_token: 'r', expires_in: 3600 }),
+      );
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+
+      await svc.exchangeCode(`first-code#${state}`, undefined, 'agent-1', 'user-1');
+      expect(providerService.upsertProvider).toHaveBeenCalledTimes(1);
+      await expect(svc.getPendingCount()).resolves.toBe(0);
+
+      // Replaying the same state with a different code must fail — one-time token.
+      await expect(
+        svc.exchangeCode(`replayed-code#${state}`, undefined, 'agent-1', 'user-1'),
+      ).rejects.toThrow('Invalid or expired OAuth state');
+      expect(providerService.upsertProvider).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('token endpoint error handling', () => {
+    it('throws when the token endpoint returns malformed JSON', async () => {
+      const badResponse = {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('Unexpected token < in JSON at position 0');
+        },
+        text: async () => '<html>oops</html>',
+      } as unknown as Response;
+      fetchMock.mockResolvedValue(badResponse);
+      const logger = { error: jest.fn(), log: jest.fn(), warn: jest.fn() };
+      (svc as unknown as { logger: typeof logger }).logger = logger;
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+
+      await expect(
+        svc.exchangeCode(`c#${state}`, undefined, 'agent-1', 'user-1'),
+      ).rejects.toBeInstanceOf(SyntaxError);
+
+      // State is consumed before JSON parsing — no rollback path today.
+      await expect(svc.getPendingCount()).resolves.toBe(0);
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+    });
+
+    it('throws and logs when the token endpoint returns 503 Service Unavailable', async () => {
+      fetchMock.mockResolvedValue(mockResponse(503, {}, 'Service Unavailable'));
+      const logger = { error: jest.fn(), log: jest.fn(), warn: jest.fn() };
+      (svc as unknown as { logger: typeof logger }).logger = logger;
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+
+      const err = await svc
+        .exchangeCode(`bad#${state}`, undefined, 'agent-1', 'user-1')
+        .catch((e: Error) => e);
+      // Generic Token exchange failed — no internal status text leakage.
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe('Token exchange failed');
+      expect((err as Error).message).not.toContain('Service Unavailable');
+      expect((err as Error).message).not.toContain('503');
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+    });
+
+    it('propagates the network error when fetch() itself throws', async () => {
+      fetchMock.mockRejectedValue(new Error('Network error'));
+      const { state } = await svc.generateAuthorizationUrl('agent-1', 'user-1');
+
+      await expect(svc.exchangeCode(`c#${state}`, undefined, 'agent-1', 'user-1')).rejects.toThrow(
+        'Network error',
+      );
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unwrapToken expiry boundaries', () => {
+    it('returns the cached access token at exactly 61s before expiry', async () => {
+      // 61_000 > 60_000 → Date.now() < blob.e - 60_000 holds → return blob.t.
+      const blob = JSON.stringify({ t: 'cached', r: 'rf', e: Date.now() + 61_000 });
+      expect(await svc.unwrapToken(blob, 'agent-1', 'user-1')).toBe('cached');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('refreshes at exactly 59s before expiry', async () => {
+      // 59_000 < 60_000 → Date.now() < blob.e - 60_000 is FALSE → refresh path.
+      const blob = JSON.stringify({ t: 'old', r: 'rf', e: Date.now() + 59_000 });
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
+      );
+      expect(await svc.unwrapToken(blob, 'agent-1', 'user-1')).toBe('new');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes when the token expires exactly now', async () => {
+      const blob = JSON.stringify({ t: 'old', r: 'rf', e: Date.now() });
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'refreshed', refresh_token: 'rf2', expires_in: 3600 }),
+      );
+      expect(await svc.unwrapToken(blob, 'agent-1', 'user-1')).toBe('refreshed');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      // New expiry is computed from Date.now() at the time of the refresh
+      // response, not carried from the stale blob.
+      const stored = providerService.upsertProvider.mock.calls[0][3] as string;
+      expect(JSON.parse(stored).e).toBe(Date.now() + 3600 * 1000);
+    });
+
+    it('refresh updates the expiry from Date.now() rather than carrying the old e', async () => {
+      // Pin a stale expiry 100s in the past so the refresh path runs.
+      const staleExpiry = Date.now() - 100_000;
+      const blob = JSON.stringify({ t: 'old', r: 'rf', e: staleExpiry });
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'fresh', refresh_token: 'rf2', expires_in: 1800 }),
+      );
+      await svc.unwrapToken(blob, 'agent-1', 'user-1');
+      const stored = providerService.upsertProvider.mock.calls[0][3] as string;
+      const parsed = JSON.parse(stored) as { t: string; r: string; e: number };
+      expect(parsed.e).toBe(Date.now() + 1800 * 1000);
+      expect(parsed.e).not.toBe(staleExpiry);
+    });
+  });
+
+  describe('unwrapToken refresh-token fallbacks', () => {
+    it('returns access_token when blob has empty refresh and is past the refresh threshold', async () => {
+      // e = Date.now() + 30s puts us inside the 60s refresh window. With r='',
+      // the service must short-circuit and return blob.t — no fetch attempt.
+      const blob = JSON.stringify({ t: 'access', r: '', e: Date.now() + 30_000 });
+      expect(await svc.unwrapToken(blob, 'agent-1', 'user-1')).toBe('access');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+    });
+
+    it('rejects a JSON blob whose r field is null (type system enforces string)', async () => {
+      // parseOAuthTokenBlob requires r: string, so r: null fails isOAuthTokenBlob
+      // and the value is treated as a legacy paste token (returned as-is).
+      const raw = JSON.stringify({ t: 'access', r: null, e: Date.now() + 30_000 });
+      expect(await svc.unwrapToken(raw, 'agent-1', 'user-1')).toBe(raw);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a JSON blob whose r field is missing entirely', async () => {
+      // Missing r → not an OAuth blob → legacy paste fallback.
+      const raw = JSON.stringify({ t: 'access', e: Date.now() + 30_000 });
+      expect(await svc.unwrapToken(raw, 'agent-1', 'user-1')).toBe(raw);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('refreshAccessToken expiry computation', () => {
+    it('computes the new expiry from the refresh-response time, not the prior token', async () => {
+      fetchMock.mockResolvedValue(
+        mockResponse(200, { access_token: 'a2', refresh_token: 'r2', expires_in: 1800 }),
+      );
+      const before = Date.now();
+      const blob = await svc.refreshAccessToken('old-refresh');
+      expect(blob.e).toBe(before + 1800 * 1000);
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/core/pending-store.spec.ts
+++ b/packages/backend/src/routing/oauth/core/pending-store.spec.ts
@@ -82,4 +82,140 @@ describe('PendingStore', () => {
     jest.advanceTimersByTime(1_500);
     expect([...store.entries()]).toEqual([]);
   });
+
+  // Regression: ensure cleanup actually drains the internal map rather than
+  // just hiding entries from iteration. `peek()` is the only public read that
+  // does NOT trigger cleanup, so peek-after-iterate proves the map was
+  // mutated, not just filtered on the way out.
+  it('entries() skips expired entries AND cleanup removes them from internal map', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('a', { payload: '1' });
+    store.set('b', { payload: '2' });
+    jest.advanceTimersByTime(1_500);
+    // Trigger cleanup via entries() iteration.
+    const seen = [...store.entries()];
+    expect(seen).toEqual([]);
+    // peek() does not clean up, so if either key is still findable the
+    // internal map was never drained.
+    expect(store.peek('a')).toBeUndefined();
+    expect(store.peek('b')).toBeUndefined();
+  });
+
+  // 10 entries expire at the same instant — confirms the cleanup loop drains
+  // every match in one pass rather than just the first one (a common
+  // map-iteration bug when deleting in place).
+  it('cleanup drains all expired entries in a single pass (rapid expirations)', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    for (let i = 0; i < 10; i++) {
+      store.set(`k${i}`, { payload: `p${i}` });
+    }
+    expect(store.size()).toBe(10);
+    jest.advanceTimersByTime(1_001);
+    // size() triggers cleanup — all 10 should be gone.
+    expect(store.size()).toBe(0);
+    // Direct peek confirms each key was removed from the map.
+    for (let i = 0; i < 10; i++) {
+      expect(store.peek(`k${i}`)).toBeUndefined();
+    }
+  });
+
+  // Staggered TTLs: only the expired half should be drained. Guards against
+  // a regression where cleanup accidentally deletes fresh entries.
+  it('cleanup preserves fresh entries while removing expired ones', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('old1', { payload: 'old1' });
+    store.set('old2', { payload: 'old2' });
+    // Advance halfway through the TTL, then add fresh entries.
+    jest.advanceTimersByTime(700);
+    store.set('fresh1', { payload: 'fresh1' });
+    store.set('fresh2', { payload: 'fresh2' });
+    // Advance past the original TTL — old1/old2 expire, fresh1/fresh2 don't.
+    jest.advanceTimersByTime(400);
+    expect(store.size()).toBe(2);
+    expect(store.peek('old1')).toBeUndefined();
+    expect(store.peek('old2')).toBeUndefined();
+    expect(store.get('fresh1')?.payload).toBe('fresh1');
+    expect(store.get('fresh2')?.payload).toBe('fresh2');
+  });
+
+  // entries() runs cleanup BEFORE yielding, then iterates the underlying Map
+  // directly. Mutating that Map mid-iteration must not crash — per the JS
+  // spec, deleted-before-visit keys are skipped and added-during-iteration
+  // keys are visited.
+  it('entries() iteration is safe even when the store mutates mid-loop', () => {
+    const store = new PendingStore<FakeEntry>(10_000);
+    store.set('a', { payload: '1' });
+    store.set('b', { payload: '2' });
+    store.set('c', { payload: '3' });
+    const collected: string[] = [];
+    for (const [key] of store.entries()) {
+      collected.push(key);
+      // Delete an unvisited key — it should be skipped, not crash.
+      if (key === 'a') store.delete('b');
+      // Add a fresh key — it should be visited after 'c'.
+      if (key === 'c') store.set('d', { payload: '4' });
+    }
+    expect(collected).toEqual(['a', 'c', 'd']);
+    expect(store.peek('d')?.payload).toBe('4');
+  });
+
+  // Repeated set() of the same key must replace (not duplicate) the entry,
+  // and the latest expiresAt should win. Important because the pending-OAuth
+  // flow could conceivably re-issue the same state under odd retry conditions.
+  it('set() with the same key replaces the entry with a fresh TTL', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    const first = store.set('k', { payload: 'v1' });
+    jest.advanceTimersByTime(500);
+    const second = store.set('k', { payload: 'v2' });
+    expect(second.payload).toBe('v2');
+    expect(second.expiresAt).toBe(first.expiresAt + 500);
+    expect(store.size()).toBe(1);
+    expect(store.get('k')?.payload).toBe('v2');
+  });
+
+  // consume() on an expired entry behaves like a miss (no return value) and
+  // still removes the entry — verifies the consume/get composition does not
+  // leave stale entries in the map after time passes.
+  it('consume() returns undefined and removes an expired entry', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('k', { payload: 'x' });
+    jest.advanceTimersByTime(1_500);
+    expect(store.consume('k')).toBeUndefined();
+    expect(store.peek('k')).toBeUndefined();
+  });
+
+  // isEmpty() must trigger cleanup so a store full of expired entries reports
+  // empty rather than non-empty. Without this, `shutdownCallbackServerIfIdle`
+  // in redirect-pkce-oauth.base.ts would never shut the server down.
+  it('isEmpty() reports true after every entry expires', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('a', { payload: '1' });
+    store.set('b', { payload: '2' });
+    expect(store.isEmpty()).toBe(false);
+    jest.advanceTimersByTime(1_500);
+    expect(store.isEmpty()).toBe(true);
+  });
+
+  // delete() on an unknown key should not throw (Map.delete returns false,
+  // but the public API hides that — verify the contract is "best-effort no-op").
+  it('delete() on an unknown key is a no-op', () => {
+    const store = new PendingStore<FakeEntry>(10_000);
+    store.set('a', { payload: '1' });
+    expect(() => store.delete('does-not-exist')).not.toThrow();
+    expect(store.size()).toBe(1);
+  });
+
+  // TTL boundary: an entry exactly at expiresAt is treated as still fresh
+  // because the check is `expiresAt < now` (strict less-than). Pin this so a
+  // refactor to <= doesn't silently invalidate tokens one ms early.
+  it('treats an entry exactly at its expiresAt boundary as still fresh', () => {
+    const store = new PendingStore<FakeEntry>(1_000);
+    store.set('k', { payload: 'x' });
+    // Advance to exactly the expiresAt timestamp.
+    jest.advanceTimersByTime(1_000);
+    expect(store.get('k')?.payload).toBe('x');
+    // One more tick should push it over the edge.
+    jest.advanceTimersByTime(1);
+    expect(store.get('k')).toBeUndefined();
+  });
 });

--- a/packages/backend/src/routing/oauth/core/pkce.spec.ts
+++ b/packages/backend/src/routing/oauth/core/pkce.spec.ts
@@ -18,6 +18,53 @@ describe('pkce', () => {
       expect(a.verifier).not.toBe(b.verifier);
       expect(a.challenge).not.toBe(b.challenge);
     });
+
+    it('verifier is exactly 43 base64url chars (no padding) — 32 bytes of entropy', () => {
+      // 32 bytes encoded as base64url = ceil(32 * 4 / 3) = 43 chars (no '=' padding).
+      // This pins the entropy floor at 256 bits and rejects any future
+      // `randomBytes(n)` change where n < 32.
+      const { verifier } = generatePkce();
+      expect(verifier).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(verifier).not.toContain('=');
+    });
+
+    it('verifier base64url-decodes to exactly 32 bytes (256 bits of entropy)', () => {
+      const { verifier } = generatePkce();
+      const decoded = Buffer.from(verifier, 'base64url');
+      expect(decoded.length).toBe(32);
+    });
+
+    it('challenge is exactly 43 base64url chars (no padding) — SHA-256 output', () => {
+      // SHA-256 emits 32 bytes → 43 base64url chars, identical shape to the verifier.
+      const { challenge } = generatePkce();
+      expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(challenge).not.toContain('=');
+    });
+
+    it('challenge base64url-decodes to exactly 32 bytes (SHA-256 digest size)', () => {
+      const { challenge } = generatePkce();
+      const decoded = Buffer.from(challenge, 'base64url');
+      expect(decoded.length).toBe(32);
+    });
+
+    it('verifier and challenge contain no base64 (non-url) characters "+" or "/"', () => {
+      // Defends against regressions that switch encoding to base64 (which uses + and /
+      // instead of - and _, and adds = padding) — illegal in RFC 7636 §4.1.
+      const { verifier, challenge } = generatePkce();
+      expect(verifier).not.toMatch(/[+/=]/);
+      expect(challenge).not.toMatch(/[+/=]/);
+    });
+
+    it('verifiers are unique across many invocations (entropy smoke test)', () => {
+      // Hardcoded sample size: with 256 bits of entropy a collision is astronomically
+      // unlikely; this still catches a regression where someone wires up a stub.
+      const sampleSize = 64;
+      const seen = new Set<string>();
+      for (let i = 0; i < sampleSize; i += 1) {
+        seen.add(generatePkce().verifier);
+      }
+      expect(seen.size).toBe(sampleSize);
+    });
   });
 
   describe('generateState', () => {

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.spec.ts
@@ -1,0 +1,298 @@
+import { HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request, Response } from 'express';
+import { OpenaiOauthController } from './openai-oauth.controller';
+import { OpenaiOauthService } from './openai-oauth.service';
+import { ResolveAgentService } from '../routing-core/resolve-agent.service';
+import { ProviderService } from '../routing-core/provider.service';
+import { ProviderKeyService } from '../routing-core/provider-key.service';
+
+const user = { id: 'user-1', email: 'u@example.com', name: 'U' } as never;
+
+const buildRequest = (): Request =>
+  ({ protocol: 'http', get: jest.fn().mockReturnValue('localhost:3001') }) as unknown as Request;
+
+function build() {
+  const oauth = {
+    generateAuthorizationUrl: jest.fn(),
+    exchangeCode: jest.fn(),
+    revokeToken: jest.fn().mockResolvedValue(undefined),
+  } as unknown as OpenaiOauthService;
+  const resolveAgent = {
+    resolve: jest.fn().mockResolvedValue({ id: 'agent-1' }),
+  } as unknown as ResolveAgentService;
+  const providerKeyService = {
+    getProviderKeys: jest.fn().mockResolvedValue([]),
+  } as unknown as ProviderKeyService;
+  const providerService = {
+    removeProvider: jest.fn().mockResolvedValue({ notifications: [] }),
+  } as unknown as ProviderService;
+  const configService = {
+    get: jest.fn().mockReturnValue(undefined),
+  } as unknown as ConfigService;
+  return {
+    ctrl: new OpenaiOauthController(
+      oauth,
+      resolveAgent,
+      providerKeyService,
+      providerService,
+      configService,
+    ),
+    oauth,
+    resolveAgent,
+    providerKeyService,
+    providerService,
+    configService,
+  };
+}
+
+type MockedRes = Response & { setHeader: jest.Mock; send: jest.Mock };
+const buildResponse = () => ({ setHeader: jest.fn(), send: jest.fn() }) as unknown as MockedRes;
+
+const blobKey = (label: string, t: string, r: string) => ({
+  id: `id-${label}`,
+  label,
+  priority: 0,
+  apiKey: JSON.stringify({ t, r, e: 0 }),
+  region: null,
+});
+
+describe('OpenaiOauthController', () => {
+  describe('authorize', () => {
+    it('returns 400 when agentName is empty (and skips agent lookup)', async () => {
+      const { ctrl, resolveAgent } = build();
+      await expect(ctrl.authorize('', user, buildRequest())).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+      });
+      expect(resolveAgent.resolve).not.toHaveBeenCalled();
+    });
+
+    it('propagates NotFoundException when agent does not exist', async () => {
+      const { ctrl, resolveAgent, oauth } = build();
+      (resolveAgent.resolve as jest.Mock).mockRejectedValue(
+        new NotFoundException('Agent "ghost" not found'),
+      );
+      await expect(ctrl.authorize('ghost', user, buildRequest())).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(oauth.generateAuthorizationUrl).not.toHaveBeenCalled();
+    });
+
+    it('uses BETTER_AUTH_URL from config when set', async () => {
+      const { ctrl, oauth, configService } = build();
+      (configService.get as jest.Mock).mockImplementation((key: string) =>
+        key === 'BETTER_AUTH_URL' ? 'https://app.example.com' : undefined,
+      );
+      (oauth.generateAuthorizationUrl as jest.Mock).mockResolvedValue('https://openai/oauth?x=1');
+      const result = await ctrl.authorize('demo-agent', user, buildRequest());
+      expect(result).toEqual({ url: 'https://openai/oauth?x=1' });
+      expect(oauth.generateAuthorizationUrl).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'https://app.example.com',
+      );
+    });
+
+    it('falls back to request host:port when BETTER_AUTH_URL is not set', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.generateAuthorizationUrl as jest.Mock).mockResolvedValue('https://openai/oauth?y=2');
+      await ctrl.authorize('demo-agent', user, buildRequest());
+      expect(oauth.generateAuthorizationUrl).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'http://localhost:3001',
+      );
+    });
+
+    it('wraps service errors in a 503 carrying the original message', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.generateAuthorizationUrl as jest.Mock).mockRejectedValue(new Error('bind failed'));
+      await expect(ctrl.authorize('demo-agent', user, buildRequest())).rejects.toMatchObject({
+        status: HttpStatus.SERVICE_UNAVAILABLE,
+        message: 'bind failed',
+      });
+    });
+
+    it('wraps non-Error throws with a generic message', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.generateAuthorizationUrl as jest.Mock).mockRejectedValue('boom');
+      await expect(ctrl.authorize('agent', user, buildRequest())).rejects.toThrow(
+        'Failed to start OAuth callback server',
+      );
+    });
+  });
+
+  describe('revoke', () => {
+    it('rejects missing agentName', async () => {
+      const { ctrl } = build();
+      await expect(ctrl.revoke('', undefined, user)).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('rejects repeated label query parameters', async () => {
+      const { ctrl, resolveAgent, providerService } = build();
+      await expect(ctrl.revoke('agent', ['Key 1', 'Key 2'], user)).rejects.toMatchObject({
+        message: 'label query parameter must be a string',
+        status: 400,
+      });
+      expect(resolveAgent.resolve).not.toHaveBeenCalled();
+      expect(providerService.removeProvider).not.toHaveBeenCalled();
+    });
+
+    it('propagates NotFoundException (cross-tenant guard) and skips removeProvider', async () => {
+      const { ctrl, resolveAgent, providerService } = build();
+      (resolveAgent.resolve as jest.Mock).mockRejectedValue(
+        new NotFoundException('Agent "other-tenant-agent" not found'),
+      );
+      await expect(ctrl.revoke('other-tenant-agent', undefined, user)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(providerService.removeProvider).not.toHaveBeenCalled();
+    });
+
+    it('removes provider when no stored OAuth keys exist', async () => {
+      const { ctrl, providerService } = build();
+      await expect(ctrl.revoke('agent', undefined, user)).resolves.toEqual({
+        ok: true,
+        notifications: [],
+      });
+      expect(providerService.removeProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'openai',
+        'subscription',
+        undefined,
+      );
+    });
+
+    it('revokes both access and refresh tokens for stored keys', async () => {
+      const { ctrl, oauth, providerKeyService, providerService } = build();
+      (providerKeyService.getProviderKeys as jest.Mock).mockResolvedValue([
+        blobKey('Default', 'access-1', 'refresh-1'),
+      ]);
+      await ctrl.revoke('agent', undefined, user);
+      expect(oauth.revokeToken).toHaveBeenCalledWith('access-1');
+      expect(oauth.revokeToken).toHaveBeenCalledWith('refresh-1');
+      expect(providerService.removeProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'openai',
+        'subscription',
+        undefined,
+      );
+    });
+
+    it('filters keys by label (case-insensitive) when provided', async () => {
+      const { ctrl, oauth, providerKeyService, providerService } = build();
+      (providerKeyService.getProviderKeys as jest.Mock).mockResolvedValue([
+        blobKey('Default', 'a1', 'r1'),
+        blobKey('Work', 'a2', 'r2'),
+      ]);
+      await ctrl.revoke('agent', 'work', user);
+      expect(oauth.revokeToken).toHaveBeenCalledWith('a2');
+      expect(oauth.revokeToken).toHaveBeenCalledWith('r2');
+      expect(oauth.revokeToken).not.toHaveBeenCalledWith('a1');
+      expect(providerService.removeProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'openai',
+        'subscription',
+        'work',
+      );
+    });
+
+    it.each([
+      ['null apiKey', null],
+      ['malformed JSON', 'not-json{'],
+    ])('skips revokeToken for %s but still calls removeProvider', async (_label, apiKey) => {
+      const { ctrl, oauth, providerKeyService, providerService } = build();
+      (providerKeyService.getProviderKeys as jest.Mock).mockResolvedValue([
+        { id: 'p1', label: 'Default', priority: 0, apiKey, region: null },
+      ]);
+      await expect(ctrl.revoke('agent', undefined, user)).resolves.toEqual({
+        ok: true,
+        notifications: [],
+      });
+      expect(oauth.revokeToken).not.toHaveBeenCalled();
+      expect(providerService.removeProvider).toHaveBeenCalled();
+    });
+
+    it('forwards notifications from provider service', async () => {
+      const { ctrl, providerService } = build();
+      (providerService.removeProvider as jest.Mock).mockResolvedValue({
+        notifications: ['some-warning'],
+      });
+      await expect(ctrl.revoke('agent', undefined, user)).resolves.toEqual({
+        ok: true,
+        notifications: ['some-warning'],
+      });
+    });
+  });
+
+  describe('callback', () => {
+    it('returns 400 when code is missing and skips exchangeCode', async () => {
+      const { ctrl, oauth } = build();
+      await expect(ctrl.callback('', 'state', user)).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+      });
+      expect(oauth.exchangeCode).not.toHaveBeenCalled();
+    });
+
+    it('rejects when state is missing', async () => {
+      const { ctrl } = build();
+      await expect(ctrl.callback('code', '', user)).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('exchanges code via the service and returns ok', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.exchangeCode as jest.Mock).mockResolvedValue(undefined);
+      await expect(ctrl.callback('auth-code', 'state-1', user)).resolves.toEqual({ ok: true });
+      expect(oauth.exchangeCode).toHaveBeenCalledWith('state-1', 'auth-code');
+    });
+
+    it('wraps service errors in a 400 carrying the original message', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.exchangeCode as jest.Mock).mockRejectedValue(new Error('Token exchange failed'));
+      await expect(ctrl.callback('code', 'state', user)).rejects.toMatchObject({
+        status: HttpStatus.BAD_REQUEST,
+        message: 'Token exchange failed',
+      });
+    });
+
+    it('wraps non-Error throws with a generic message', async () => {
+      const { ctrl, oauth } = build();
+      (oauth.exchangeCode as jest.Mock).mockRejectedValue('boom');
+      await expect(ctrl.callback('code', 'state', user)).rejects.toThrow('Token exchange failed');
+    });
+  });
+
+  describe('done', () => {
+    const getCsp = (res: MockedRes) =>
+      res.setHeader.mock.calls.find(([n]) => n === 'Content-Security-Policy')![1] as string;
+
+    it('renders HTML success page with a CSP nonce when ok=1', () => {
+      const { ctrl } = build();
+      const res = buildResponse();
+      ctrl.done('1', res);
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+      expect(getCsp(res)).toMatch(/^default-src 'none'; script-src 'nonce-[A-Za-z0-9+/=]+'$/);
+      const html = res.send.mock.calls[0][0] as string;
+      expect(html).toContain('Login successful!');
+      expect(html).toContain('manifest-oauth-success');
+    });
+
+    it('renders HTML failure page when ok is not "1"', () => {
+      const { ctrl } = build();
+      const res = buildResponse();
+      ctrl.done('0', res);
+      const html = res.send.mock.calls[0][0] as string;
+      expect(html).toContain('Login failed');
+      expect(html).toContain('manifest-oauth-error');
+    });
+
+    it('generates a unique nonce on every render', () => {
+      const { ctrl } = build();
+      const r1 = buildResponse();
+      const r2 = buildResponse();
+      ctrl.done('1', r1);
+      ctrl.done('1', r2);
+      expect(getCsp(r1)).not.toEqual(getCsp(r2));
+    });
+  });
+});

--- a/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.callback.spec.ts
+++ b/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.callback.spec.ts
@@ -1,0 +1,250 @@
+/**
+ * Callback-handler tests for RedirectPkceOauthBaseService — specifically the
+ * sendDoneResponse logic that decides between a 302 redirect to the SPA
+ * (only when the stored backendUrl is loopback) and the inline HTML page.
+ *
+ * These tests do NOT spin up a real HTTP server; they invoke the private
+ * handleCallbackRequest directly with stub req/res objects so the assertions
+ * are deterministic.
+ */
+import { ConfigService } from '@nestjs/config';
+import { ProviderService } from '../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import {
+  RedirectPkceOauthBaseService,
+  type RedirectPkceOauthConfig,
+} from './redirect-pkce-oauth.base';
+
+class TestPkceOauthService extends RedirectPkceOauthBaseService {
+  constructor(
+    providerService: ProviderService,
+    configService: ConfigService,
+    discoveryService: ModelDiscoveryService,
+    config?: Partial<RedirectPkceOauthConfig>,
+  ) {
+    super(providerService, configService, discoveryService, {
+      providerId: 'test-provider',
+      serviceName: 'TestPkceOauthService',
+      defaultClientId: 'test-client-id',
+      clientIdEnvVar: 'TEST_OAUTH_CLIENT_ID',
+      authorizeUrl: 'https://auth.example.com/oauth/authorize',
+      tokenUrl: 'https://auth.example.com/oauth/token',
+      revokeUrl: 'https://auth.example.com/oauth/revoke',
+      scope: 'openid profile email',
+      callbackPort: 1455,
+      ...config,
+    });
+  }
+}
+
+function createConfig(): ConfigService {
+  return {
+    get: (key: string) => (key === 'app.nodeEnv' ? 'production' : undefined),
+  } as unknown as ConfigService;
+}
+
+function createProviderService(): ProviderService {
+  return {
+    upsertProvider: jest.fn().mockResolvedValue({ provider: { id: 'p1' } }),
+    recalculateTiers: jest.fn().mockResolvedValue(undefined),
+    nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ProviderService;
+}
+
+function createDiscovery(): ModelDiscoveryService {
+  return {
+    discoverModels: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ModelDiscoveryService;
+}
+
+function buildSvc(): TestPkceOauthService {
+  return new TestPkceOauthService(createProviderService(), createConfig(), createDiscovery());
+}
+
+interface CallbackPair {
+  req: { url: string };
+  res: { writeHead: jest.Mock; end: jest.Mock };
+  done: Promise<void>;
+  writeHead: jest.Mock;
+  end: jest.Mock;
+}
+
+function buildCallbackPair(callbackUrl: string): CallbackPair {
+  const req = { url: callbackUrl };
+  let resolveDone!: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+  const writeHead = jest.fn();
+  const end = jest.fn(resolveDone);
+  const res = { writeHead, end };
+  return { req, res, done, writeHead, end };
+}
+
+function invokeHandler(svc: TestPkceOauthService, req: unknown, res: unknown): void {
+  (
+    svc as unknown as {
+      handleCallbackRequest: (request: unknown, response: unknown) => void;
+    }
+  ).handleCallbackRequest(req, res);
+}
+
+describe('RedirectPkceOauthBaseService — sendDoneResponse', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('falls back to the inline HTML page when no backendUrl was stored', async () => {
+    const svc = buildSvc();
+    const url = await svc.generateAuthorizationUrl('a', 'u');
+    const state = new URL(url).searchParams.get('state')!;
+
+    const { req, res, done, writeHead, end } = buildCallbackPair(
+      `/auth/callback?state=${state}&error=access_denied`,
+    );
+    invokeHandler(svc, req, res);
+    await done;
+
+    expect(writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    const html = end.mock.calls[0][0] as string;
+    expect(html).toContain('Login failed');
+    // No 302 redirect was issued.
+    expect(writeHead).not.toHaveBeenCalledWith(302, expect.anything());
+  });
+
+  it('falls back to inline HTML when the stored backendUrl was sanitised away (attacker.com)', async () => {
+    const svc = buildSvc();
+    // attacker.com URL is rejected at storage, so backendUrl=''. The callback
+    // handler must NOT redirect to attacker.com.
+    const url = await svc.generateAuthorizationUrl('a', 'u', 'http://attacker.com');
+    const state = new URL(url).searchParams.get('state')!;
+
+    const { req, res, done, writeHead } = buildCallbackPair(
+      `/auth/callback?state=${state}&error=access_denied`,
+    );
+    invokeHandler(svc, req, res);
+    await done;
+
+    expect(writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'text/html' });
+    expect(writeHead).not.toHaveBeenCalledWith(302, expect.anything());
+  });
+
+  it('redirects to the stored localhost backendUrl on error', async () => {
+    const svc = buildSvc();
+    const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost:3001');
+    const state = new URL(url).searchParams.get('state')!;
+
+    const { req, res, done, writeHead } = buildCallbackPair(
+      `/auth/callback?state=${state}&error=access_denied`,
+    );
+    invokeHandler(svc, req, res);
+    await done;
+
+    expect(writeHead).toHaveBeenCalledWith(302, {
+      Location: 'http://localhost:3001/api/v1/oauth/test-provider/done?ok=0',
+    });
+  });
+
+  it('redirects to localhost backendUrl with ok=0 when exchange fails', async () => {
+    const svc = buildSvc();
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({}),
+      text: async () => 'bad',
+    } as unknown as Response) as unknown as typeof fetch;
+
+    try {
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://127.0.0.1:3001');
+      const state = new URL(url).searchParams.get('state')!;
+
+      const { req, res, done, writeHead } = buildCallbackPair(
+        `/auth/callback?state=${state}&code=bad-code`,
+      );
+      invokeHandler(svc, req, res);
+      await done;
+
+      expect(writeHead).toHaveBeenCalledWith(302, {
+        Location: 'http://127.0.0.1:3001/api/v1/oauth/test-provider/done?ok=0',
+      });
+    } finally {
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('returns 404 for paths other than /auth/callback', () => {
+    const svc = buildSvc();
+    const { req, res } = buildCallbackPair('/other-path');
+    invokeHandler(svc, req, res);
+    expect(res.writeHead).toHaveBeenCalledWith(404);
+    expect(res.end).toHaveBeenCalledWith('Not found');
+  });
+
+  it('treats a request with no URL as the root path and returns 404', () => {
+    const svc = buildSvc();
+    const { res } = buildCallbackPair('');
+    // Pass through req with no .url property to exercise the `req.url ?? '/'`
+    // fallback in handleCallbackRequest.
+    invokeHandler(svc, {}, res);
+    expect(res.writeHead).toHaveBeenCalledWith(404);
+    expect(res.end).toHaveBeenCalledWith('Not found');
+  });
+
+  it('uses the provider id from config in the redirect Location', async () => {
+    const svc = new TestPkceOauthService(
+      createProviderService(),
+      createConfig(),
+      createDiscovery(),
+      { providerId: 'custom-provider' },
+    );
+    const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost:3001');
+    const state = new URL(url).searchParams.get('state')!;
+
+    const { req, res, done, writeHead } = buildCallbackPair(
+      `/auth/callback?state=${state}&error=access_denied`,
+    );
+    invokeHandler(svc, req, res);
+    await done;
+
+    expect(writeHead).toHaveBeenCalledWith(302, {
+      Location: 'http://localhost:3001/api/v1/oauth/custom-provider/done?ok=0',
+    });
+  });
+
+  it('redirects with ok=0 (not ok=1) on provider-side error', async () => {
+    const svc = buildSvc();
+    const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost:3001');
+    const state = new URL(url).searchParams.get('state')!;
+
+    const { req, res, done, writeHead } = buildCallbackPair(
+      `/auth/callback?state=${state}&error=access_denied&error_description=user%20refused`,
+    );
+    invokeHandler(svc, req, res);
+    await done;
+
+    const [, headers] = writeHead.mock.calls[0];
+    expect(headers.Location).toContain('ok=0');
+    expect(headers.Location).not.toContain('ok=1');
+  });
+
+  it('clears the pending state when the provider returns an error', async () => {
+    const svc = buildSvc();
+    const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost:3001');
+    const state = new URL(url).searchParams.get('state')!;
+    expect(svc.getPendingCount()).toBe(1);
+
+    const { req, res, done } = buildCallbackPair(
+      `/auth/callback?state=${state}&error=access_denied`,
+    );
+    invokeHandler(svc, req, res);
+    await done;
+
+    expect(svc.getPendingCount()).toBe(0);
+  });
+});

--- a/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.spec.ts
+++ b/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * Security-focused tests for RedirectPkceOauthBaseService — specifically the
+ * backendUrl/redirect_uri validation that protects the callback server's 302
+ * redirect from being forged to an attacker-controlled host.
+ *
+ * The base class is abstract; we instantiate it through a minimal concrete
+ * subclass that mirrors the real OpenAI/Gemini wiring without touching any
+ * external network or DI.
+ */
+import { ConfigService } from '@nestjs/config';
+import { ProviderService } from '../routing-core/provider.service';
+import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
+import {
+  RedirectPkceOauthBaseService,
+  type RedirectPkceOauthConfig,
+} from './redirect-pkce-oauth.base';
+
+interface PendingFlowState {
+  verifier: string;
+  agentId: string;
+  userId: string;
+  backendUrl: string;
+  expiresAt: number;
+}
+
+class TestPkceOauthService extends RedirectPkceOauthBaseService {
+  constructor(
+    providerService: ProviderService,
+    configService: ConfigService,
+    discoveryService: ModelDiscoveryService,
+    config?: Partial<RedirectPkceOauthConfig>,
+  ) {
+    super(providerService, configService, discoveryService, {
+      providerId: 'test-provider',
+      serviceName: 'TestPkceOauthService',
+      defaultClientId: 'test-client-id',
+      clientIdEnvVar: 'TEST_OAUTH_CLIENT_ID',
+      authorizeUrl: 'https://auth.example.com/oauth/authorize',
+      tokenUrl: 'https://auth.example.com/oauth/token',
+      revokeUrl: 'https://auth.example.com/oauth/revoke',
+      scope: 'openid profile email',
+      callbackPort: 1455,
+      ...config,
+    });
+  }
+}
+
+function createConfig(nodeEnv = 'production'): ConfigService {
+  return {
+    get: (key: string) => {
+      if (key === 'app.nodeEnv') return nodeEnv;
+      return undefined;
+    },
+  } as unknown as ConfigService;
+}
+
+function createProviderService(): ProviderService {
+  return {
+    upsertProvider: jest.fn().mockResolvedValue({ provider: { id: 'p1' } }),
+    recalculateTiers: jest.fn().mockResolvedValue(undefined),
+    nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ProviderService;
+}
+
+function createDiscovery(): ModelDiscoveryService {
+  return {
+    discoverModels: jest.fn().mockResolvedValue(undefined),
+  } as unknown as ModelDiscoveryService;
+}
+
+// Read the pending store's stored backendUrl for an issued state without
+// exposing a public API. The real services don't expose this; tests need it
+// to confirm the validator sanitised the value at storage time.
+function readPendingBackendUrl(svc: RedirectPkceOauthBaseService, state: string): string {
+  const internals = svc as unknown as {
+    pending: { peek: (key: string) => PendingFlowState | undefined };
+  };
+  return internals.pending.peek(state)?.backendUrl ?? '';
+}
+
+function buildSvc(): TestPkceOauthService {
+  return new TestPkceOauthService(
+    createProviderService(),
+    createConfig('production'),
+    createDiscovery(),
+  );
+}
+
+describe('RedirectPkceOauthBaseService — backendUrl validation', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-01T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('generateAuthorizationUrl — sanitises backendUrl on storage', () => {
+    it('stores a valid http://localhost backendUrl verbatim', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost:3001');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('http://localhost:3001');
+    });
+
+    it('stores a valid http://127.0.0.1 backendUrl verbatim', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://127.0.0.1:8080');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('http://127.0.0.1:8080');
+    });
+
+    it('rejects http://[::1]:port (current isAllowedRedirectOrigin compares to "::1", not "[::1]")', async () => {
+      // The URL parser returns hostname='[::1]' for IPv6 literals, and the
+      // check uses === '::1'. This documents the current behaviour: the
+      // IPv6 loopback path is effectively dead code today. A future patch
+      // that strips the brackets should flip this test.
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://[::1]:3001');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('accepts loopback hosts on non-standard ports', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost:54321');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('http://localhost:54321');
+    });
+
+    it('accepts https://localhost without rewriting the scheme', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'https://localhost:3001');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('https://localhost:3001');
+    });
+
+    it('replaces a non-loopback http origin with empty string', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://attacker.com');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('replaces a non-loopback https origin with empty string', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'https://evil.example.com');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('rejects an origin that LOOKS like localhost via subdomain trickery', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost.attacker.com');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('rejects an origin that embeds localhost in user-info', async () => {
+      const svc = buildSvc();
+      // The URL parser puts "localhost" in userinfo, hostname is "attacker.com".
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://localhost@attacker.com');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('stores empty string when backendUrl is undefined', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', undefined);
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('stores empty string when backendUrl is an empty string', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', '');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('stores empty string when backendUrl is a malformed URL', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'not-a-url');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('stores empty string for a missing-scheme URL', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', '//localhost:3001');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('stores empty string for a javascript: URL', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'javascript:alert(document.cookie)');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('stores empty string for a file:// URL', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'file:///etc/passwd');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('stores empty string for a data: URL with embedded localhost', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl(
+        'a',
+        'u',
+        'data:text/html,<script>fetch("http://localhost:1234")</script>',
+      );
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+
+    it('stores empty string for an attacker URL where localhost appears in the path', async () => {
+      const svc = buildSvc();
+      const url = await svc.generateAuthorizationUrl('a', 'u', 'http://attacker.com/localhost');
+      const state = new URL(url).searchParams.get('state')!;
+      expect(readPendingBackendUrl(svc, state)).toBe('');
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.concurrency.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.concurrency.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * Concurrent / interleaved use of createAnthropicStreamTransformer.
+ *
+ * The transformer is stateful (per-instance StreamState held in closure). These
+ * tests exercise multiple transformers in parallel and interleave their event
+ * handling to verify state isolation — no cross-stream bleeding of usage
+ * counters, tool-call indices, or thinking-block accumulators.
+ */
+import { createAnthropicStreamTransformer } from '../anthropic-adapter';
+
+describe('createAnthropicStreamTransformer concurrent use', () => {
+  it('keeps tool_use indices isolated between two interleaved transformers', () => {
+    const a = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+    const b = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+    a('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":1}}}');
+    b('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":1}}}');
+
+    // First tool on each — both should be index 0, not 0 and 1.
+    const aTool = a(
+      'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a1","name":"x"}}',
+    );
+    const bTool = b(
+      'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_b1","name":"y"}}',
+    );
+
+    const aData = JSON.parse(aTool!.replace('data: ', '').trim());
+    const bData = JSON.parse(bTool!.replace('data: ', '').trim());
+
+    expect(aData.choices[0].delta.tool_calls[0].index).toBe(0);
+    expect(aData.choices[0].delta.tool_calls[0].id).toBe('toolu_a1');
+    expect(bData.choices[0].delta.tool_calls[0].index).toBe(0);
+    expect(bData.choices[0].delta.tool_calls[0].id).toBe('toolu_b1');
+
+    // Second tool only on transformer a — should be index 1 on a, b unaffected.
+    const aTool2 = a(
+      'event: content_block_start\n{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_a2","name":"z"}}',
+    );
+    const aData2 = JSON.parse(aTool2!.replace('data: ', '').trim());
+    expect(aData2.choices[0].delta.tool_calls[0].index).toBe(1);
+
+    // A subsequent input_json_delta on b for its first tool stays at index 0.
+    const bDelta = b(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{}"}}',
+    );
+    const bDeltaData = JSON.parse(bDelta!.replace('data: ', '').trim());
+    expect(bDeltaData.choices[0].delta.tool_calls[0].index).toBe(0);
+  });
+
+  it('attributes usage tokens to the transformer that received the events', () => {
+    const a = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+    const b = createAnthropicStreamTransformer('claude-haiku-4-5-20251001');
+
+    a(
+      'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":100,"cache_read_input_tokens":10,"cache_creation_input_tokens":5}}}',
+    );
+    b(
+      'event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":7,"cache_read_input_tokens":2,"cache_creation_input_tokens":1}}}',
+    );
+
+    // Finalize a — its usage should reflect a's message_start counts only.
+    const aEnd = a(
+      'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":20}}',
+    );
+    const aParts = aEnd!.split('\n\n').filter(Boolean);
+    const aUsage = JSON.parse(aParts[1].replace('data: ', '')).usage;
+    expect(aUsage.prompt_tokens).toBe(115); // 100 + 10 + 5
+    expect(aUsage.completion_tokens).toBe(20);
+    expect(aUsage.cache_read_tokens).toBe(10);
+    expect(aUsage.cache_creation_tokens).toBe(5);
+
+    // b's state is untouched by a's finalize.
+    const bEnd = b(
+      'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}',
+    );
+    const bParts = bEnd!.split('\n\n').filter(Boolean);
+    const bUsage = JSON.parse(bParts[1].replace('data: ', '')).usage;
+    expect(bUsage.prompt_tokens).toBe(10); // 7 + 2 + 1
+    expect(bUsage.completion_tokens).toBe(3);
+    expect(bUsage.cache_read_tokens).toBe(2);
+    expect(bUsage.cache_creation_tokens).toBe(1);
+  });
+
+  it('keeps the model tag isolated to each transformer in interleaved chunks', () => {
+    const a = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+    const b = createAnthropicStreamTransformer('claude-haiku-4-5-20251001');
+
+    const textEvent =
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}';
+
+    a('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":1}}}');
+    b('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":1}}}');
+
+    const aChunk = a(textEvent);
+    const bChunk = b(textEvent);
+
+    const aData = JSON.parse(aChunk!.replace('data: ', '').trim());
+    const bData = JSON.parse(bChunk!.replace('data: ', '').trim());
+    expect(aData.model).toBe('claude-sonnet-4-20250514');
+    expect(bData.model).toBe('claude-haiku-4-5-20251001');
+    expect(aData.choices[0].delta.content).toBe('hi');
+    expect(bData.choices[0].delta.content).toBe('hi');
+  });
+
+  it('isolates thinking-block accumulators between concurrent transformers', () => {
+    const callbackA = jest.fn();
+    const callbackB = jest.fn();
+    const a = createAnthropicStreamTransformer('claude-sonnet-4-20250514', callbackA);
+    const b = createAnthropicStreamTransformer('claude-sonnet-4-20250514', callbackB);
+
+    // Interleave: both start, both seed thinking blocks at index 0, both
+    // append different text via thinking_delta, both add a tool_use, both
+    // finalize. The callbacks must fire with each transformer's own data.
+    a('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":5}}}');
+    b('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":5}}}');
+
+    a(
+      'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}',
+    );
+    b(
+      'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}',
+    );
+
+    a(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"A-think"}}',
+    );
+    b(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"B-think"}}',
+    );
+
+    a(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sigA"}}',
+    );
+    b(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sigB"}}',
+    );
+
+    a(
+      'event: content_block_start\n{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_A","name":"search"}}',
+    );
+    b(
+      'event: content_block_start\n{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_B","name":"search"}}',
+    );
+
+    a(
+      'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":2}}',
+    );
+    b(
+      'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":2}}',
+    );
+
+    expect(callbackA).toHaveBeenCalledTimes(1);
+    expect(callbackB).toHaveBeenCalledTimes(1);
+    expect(callbackA).toHaveBeenCalledWith('toolu_A', [
+      { type: 'thinking', thinking: 'A-think', signature: 'sigA' },
+    ]);
+    expect(callbackB).toHaveBeenCalledWith('toolu_B', [
+      { type: 'thinking', thinking: 'B-think', signature: 'sigB' },
+    ]);
+  });
+
+  it('keeps state isolated when one transformer is finalized while another keeps streaming', () => {
+    const callbackA = jest.fn();
+    const callbackB = jest.fn();
+    const a = createAnthropicStreamTransformer('claude-sonnet-4-20250514', callbackA);
+    const b = createAnthropicStreamTransformer('claude-sonnet-4-20250514', callbackB);
+
+    // Start both.
+    a('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":50}}}');
+    b('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":50}}}');
+
+    // a accumulates a thinking block + tool_use + finalizes.
+    a(
+      'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}',
+    );
+    a(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"A reasoning"}}',
+    );
+    a(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sigA"}}',
+    );
+    a(
+      'event: content_block_start\n{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_first_A","name":"search"}}',
+    );
+    a(
+      'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":10}}',
+    );
+
+    // Now b continues — its state must be unaffected by a's flush.
+    b(
+      'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}',
+    );
+    b(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"B reasoning"}}',
+    );
+    b(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sigB"}}',
+    );
+    b(
+      'event: content_block_start\n{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_first_B","name":"search"}}',
+    );
+    b(
+      'event: message_delta\n{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":7}}',
+    );
+
+    expect(callbackA).toHaveBeenCalledTimes(1);
+    expect(callbackA).toHaveBeenCalledWith('toolu_first_A', [
+      { type: 'thinking', thinking: 'A reasoning', signature: 'sigA' },
+    ]);
+    expect(callbackB).toHaveBeenCalledTimes(1);
+    expect(callbackB).toHaveBeenCalledWith('toolu_first_B', [
+      { type: 'thinking', thinking: 'B reasoning', signature: 'sigB' },
+    ]);
+  });
+
+  it('does not cross-pollinate input_json_delta args between two interleaved tool_use streams', () => {
+    const a = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+    const b = createAnthropicStreamTransformer('claude-sonnet-4-20250514');
+
+    a('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":5}}}');
+    b('event: message_start\n{"type":"message_start","message":{"usage":{"input_tokens":5}}}');
+
+    a(
+      'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_A","name":"fnA"}}',
+    );
+    b(
+      'event: content_block_start\n{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_B","name":"fnB"}}',
+    );
+
+    const aArg = a(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"a\\":1}"}}',
+    );
+    const bArg = b(
+      'event: content_block_delta\n{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"b\\":2}"}}',
+    );
+
+    const aData = JSON.parse(aArg!.replace('data: ', '').trim());
+    const bData = JSON.parse(bArg!.replace('data: ', '').trim());
+    expect(aData.choices[0].delta.tool_calls[0].function.arguments).toBe('{"a":1}');
+    expect(bData.choices[0].delta.tool_calls[0].function.arguments).toBe('{"b":2}');
+  });
+
+  it('runs many concurrent transformers without any state leaking', () => {
+    // Smoke test for a higher-concurrency case — 10 transformers running
+    // in interleaved lockstep. Each must finalize with its own usage figures.
+    const N = 10;
+    const transformers = Array.from({ length: N }, (_, i) =>
+      createAnthropicStreamTransformer(`claude-model-${i}`),
+    );
+
+    transformers.forEach((t, i) => {
+      t(
+        `event: message_start\n${JSON.stringify({
+          type: 'message_start',
+          message: { usage: { input_tokens: i + 1 } },
+        })}`,
+      );
+    });
+
+    transformers.forEach((t, i) => {
+      t(
+        `event: content_block_start\n${JSON.stringify({
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: `toolu_${i}`, name: 'fn' },
+        })}`,
+      );
+    });
+
+    transformers.forEach((t, i) => {
+      const result = t(
+        `event: message_delta\n${JSON.stringify({
+          type: 'message_delta',
+          delta: { stop_reason: 'tool_use' },
+          usage: { output_tokens: (i + 1) * 10 },
+        })}`,
+      );
+      const parts = result!.split('\n\n').filter(Boolean);
+      const finish = JSON.parse(parts[0].replace('data: ', ''));
+      const usage = JSON.parse(parts[1].replace('data: ', ''));
+
+      expect(finish.model).toBe(`claude-model-${i}`);
+      expect(finish.choices[0].finish_reason).toBe('tool_calls');
+      expect(usage.usage.prompt_tokens).toBe(i + 1);
+      expect(usage.usage.completion_tokens).toBe((i + 1) * 10);
+    });
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-messages-adapter.spec.ts
@@ -545,6 +545,44 @@ describe('Anthropic Messages adapter', () => {
         cache_read_input_tokens: 0,
       });
     });
+
+    it('skips nullish text/tool blocks without dropping valid sibling blocks', () => {
+      // Defensive: an upstream provider could send a content array where some
+      // blocks have `text: null` or a tool_call where `id`/`function.arguments`
+      // are null. These must not cause valid sibling blocks to be lost or the
+      // converter to crash.
+      const result = chatCompletionsResponseToMessages(
+        {
+          choices: [
+            {
+              message: {
+                content: [
+                  { type: 'text', text: null },
+                  { type: 'text', text: 'real text' },
+                ],
+                tool_calls: [
+                  { id: null, function: { name: 'tn', arguments: null } },
+                  { id: 'tc_ok', function: { name: 'ok', arguments: '{"a":1}' } },
+                ],
+              },
+              finish_reason: 'tool_calls',
+            },
+          ],
+        },
+        'fallback',
+      );
+
+      // text block: null text contributes nothing; "real text" survives.
+      expect(result.content).toEqual([
+        { type: 'text', text: 'real text' },
+        // tool_call with null id gets a synthesized toolu_* id; null arguments
+        // resolve via safeParseJson(undefined) → {} (no crash).
+        expect.objectContaining({ type: 'tool_use', name: 'tn', input: {} }),
+        { type: 'tool_use', id: 'tc_ok', name: 'ok', input: { a: 1 } },
+      ]);
+      const synthesized = (result.content as Array<Record<string, unknown>>)[1];
+      expect(synthesized.id).toMatch(/^toolu_[0-9a-f]{32}$/);
+    });
   });
 
   describe('createMessagesStreamTransformer', () => {
@@ -1001,6 +1039,91 @@ describe('Anthropic Messages adapter', () => {
       const out = t.transform('{"choices":[{"delta":{"content":"raw"}}]}');
       expect(out).toContain('event: message_start');
       expect(out).toContain('"text":"raw"');
+    });
+
+    it('treats sequential zero-length deltas as no-ops and only opens a block on the first real content', () => {
+      // Realistic heartbeat / status pattern: providers can send several deltas
+      // with empty `reasoning_content`/`content` strings before any real text
+      // arrives. Empty deltas must not open blocks, consume block indices, or
+      // otherwise mutate state — so when "hello" finally lands, it opens
+      // text@0 (not text@2 or higher) and the stream stays valid.
+      const t = createMessagesStreamTransformer('m');
+      const sse = flushChunks(t, [
+        'data: {"choices":[{"delta":{"reasoning_content":""}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":""}}]}\n\n',
+        'data: {"choices":[{"delta":{"reasoning_content":""}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":"hello"}}]}\n\n',
+        'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+      ]);
+
+      const events = sse
+        .split('\n\n')
+        .filter(Boolean)
+        .map((block) => {
+          const [eventLine, dataLine] = block.split('\n');
+          return {
+            event: eventLine!.replace('event: ', ''),
+            data: JSON.parse(dataLine!.replace('data: ', '')),
+          };
+        });
+
+      // No thinking block was ever opened (all reasoning_content was empty),
+      // and exactly one text block opens at the first non-empty content.
+      expect(events.map((e) => e.event)).toEqual([
+        'message_start',
+        'content_block_start',
+        'content_block_delta',
+        'content_block_stop',
+        'message_delta',
+        'message_stop',
+      ]);
+      expect(events[1].data).toEqual({
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'text', text: '' },
+      });
+      expect(events[2].data).toEqual({
+        type: 'content_block_delta',
+        index: 0,
+        delta: { type: 'text_delta', text: 'hello' },
+      });
+    });
+
+    it('finalize closes an incomplete tool_use block opened mid-stream', () => {
+      // The stream opens a tool_use and emits a partial input_json_delta, then
+      // the upstream cuts off (no finish_reason, no second arg chunk, no usage).
+      // finalize() must emit the matching content_block_stop for the open
+      // tool_use plus the terminal message_delta / message_stop so clients
+      // don't hang on an orphan content_block_start.
+      const t = createMessagesStreamTransformer('m');
+      const opened = t.transform(
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"tc_partial","function":{"name":"search","arguments":"{\\"arg\\""}}]}}]}\n\n',
+      );
+      expect(opened).toContain('"content_block":{"type":"tool_use"');
+      expect(opened).toContain('"partial_json":"{\\"arg\\""');
+
+      const tail = t.finalize();
+      expect(tail).not.toBeNull();
+      const events = tail!
+        .split('\n\n')
+        .filter(Boolean)
+        .map((block) => {
+          const [eventLine, dataLine] = block.split('\n');
+          return {
+            event: eventLine!.replace('event: ', ''),
+            data: JSON.parse(dataLine!.replace('data: ', '')),
+          };
+        });
+
+      expect(events.map((e) => e.event)).toEqual([
+        'content_block_stop',
+        'message_delta',
+        'message_stop',
+      ]);
+      // Stop must reference the tool_use's index (0, the first/only block).
+      expect(events[0].data).toEqual({ type: 'content_block_stop', index: 0 });
+      // No finish_reason was ever seen, so stop_reason defaults to end_turn.
+      expect(events[1].data.delta.stop_reason).toBe('end_turn');
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -358,6 +358,312 @@ describe('Google Adapter', () => {
       expect(tools[0].functionDeclarations[0].parameters).toBeUndefined();
     });
 
+    describe('sanitizeSchema deep recursion and reference handling', () => {
+      // Builds a `depth`-level nested object schema. Each level has a `child`
+      // property whose schema carries an unsupported field set (title, default,
+      // additionalProperties, $schema, $ref) plus a valid `type`. The innermost
+      // leaf is a primitive string with the same unsupported set. Used to
+      // verify recursive stripping fires at every layer with no early exit.
+      function buildDeepSchema(depth: number): Record<string, unknown> {
+        let leaf: Record<string, unknown> = {
+          type: 'string',
+          title: 'leaf-title',
+          default: 'leaf-default',
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          $ref: '#/definitions/Leaf',
+        };
+        for (let i = 0; i < depth; i++) {
+          leaf = {
+            type: 'object',
+            title: `level-${i}-title`,
+            default: { placeholder: true },
+            additionalProperties: false,
+            $ref: `#/definitions/Level${i}`,
+            properties: { child: leaf },
+          };
+        }
+        return leaf;
+      }
+
+      it('strips unsupported fields at every level of a 12-level nested schema', () => {
+        const depth = 12;
+        const body = {
+          messages: [{ role: 'user', content: 'do' }],
+          tools: [
+            {
+              type: 'function',
+              function: { name: 'deep_tool', parameters: buildDeepSchema(depth) },
+            },
+          ],
+        };
+
+        const result = toGoogleRequest(body, 'gemini-2.0-flash');
+        const tools = result.tools as Array<{
+          functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+        }>;
+        let node: Record<string, unknown> | undefined = tools[0].functionDeclarations[0].parameters;
+
+        for (let i = depth - 1; i >= 0; i--) {
+          // The wrapping object at this level must keep `type` and `properties`
+          // but all banned keywords must be gone.
+          expect(node).toBeDefined();
+          expect(node!.type).toBe('object');
+          expect(node).not.toHaveProperty('title');
+          expect(node).not.toHaveProperty('default');
+          expect(node).not.toHaveProperty('additionalProperties');
+          expect(node).not.toHaveProperty('$ref');
+          const props = node!.properties as Record<string, Record<string, unknown>>;
+          expect(props).toBeDefined();
+          expect(props).toHaveProperty('child');
+          node = props.child;
+        }
+
+        // The leaf is the original primitive level with its own unsupported set.
+        expect(node).toBeDefined();
+        expect(node!.type).toBe('string');
+        expect(node).not.toHaveProperty('title');
+        expect(node).not.toHaveProperty('default');
+        expect(node).not.toHaveProperty('$schema');
+        expect(node).not.toHaveProperty('$ref');
+      });
+
+      it('strips deeply nested allOf composition with nested additionalProperties', () => {
+        // allOf carries object sub-schemas that themselves contain unsupported
+        // keys. The whole allOf branch should be removed; the surviving fields
+        // (properties, type) should sanitize cleanly without leaking allOf data.
+        const body = {
+          messages: [{ role: 'user', content: 'do' }],
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'composed_tool',
+                parameters: {
+                  type: 'object',
+                  allOf: [
+                    {
+                      type: 'object',
+                      additionalProperties: false,
+                      properties: {
+                        nested: {
+                          type: 'object',
+                          allOf: [{ type: 'object', additionalProperties: true }],
+                          additionalProperties: { type: 'string' },
+                          properties: { inner: { type: 'string', title: 'Inner' } },
+                        },
+                      },
+                    },
+                  ],
+                  properties: {
+                    keep: { type: 'string' },
+                  },
+                },
+              },
+            },
+          ],
+        };
+
+        const result = toGoogleRequest(body, 'gemini-2.0-flash');
+        const tools = result.tools as Array<{
+          functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+        }>;
+        const params = tools[0].functionDeclarations[0].parameters;
+
+        // allOf must be fully stripped — its contents do not survive.
+        expect(params).not.toHaveProperty('allOf');
+        // Surviving properties branch must still sanitize correctly.
+        const props = params.properties as Record<string, Record<string, unknown>>;
+        expect(props).toEqual({ keep: { type: 'string' } });
+      });
+
+      it('strips JSON Schema $ref that points to itself without infinite recursion', () => {
+        // The standard JSON Schema way to express a self-cycle is a string
+        // $ref pointing back to the root. Because `$ref` is in the unsupported
+        // set, the key is removed and no recursion follows the pointer.
+        const body = {
+          messages: [{ role: 'user', content: 'do' }],
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'self_ref',
+                parameters: {
+                  type: 'object',
+                  $ref: '#',
+                  properties: {
+                    self: { $ref: '#' },
+                    next: { type: 'object', $ref: '#/definitions/Node' },
+                  },
+                  definitions: {
+                    Node: {
+                      type: 'object',
+                      properties: { next: { $ref: '#/definitions/Node' } },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        };
+
+        const result = toGoogleRequest(body, 'gemini-2.0-flash');
+        const tools = result.tools as Array<{
+          functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+        }>;
+        const params = tools[0].functionDeclarations[0].parameters;
+
+        expect(params).not.toHaveProperty('$ref');
+        // definitions is in the unsupported set and must be stripped wholesale.
+        expect(params).not.toHaveProperty('definitions');
+        const props = params.properties as Record<string, Record<string, unknown>>;
+        expect(props).toHaveProperty('self');
+        expect(props).toHaveProperty('next');
+        // Per-property $ref keys must also be stripped at every level. The
+        // surviving non-$ref keywords (like `type`) on each property survive.
+        expect(props.self).not.toHaveProperty('$ref');
+        expect(props.next).not.toHaveProperty('$ref');
+        expect(props.next.type).toBe('object');
+        // The `self` property had only $ref — after stripping, it sanitizes to
+        // an empty object (no leftover keys), which is still a valid Gemini
+        // sub-schema.
+        expect(props.self).toEqual({});
+      });
+
+      it('strips $defs containing mutual $ref cycles without recursing through the cycle', () => {
+        // $defs and definitions are both in the unsupported set. Mutual cycles
+        // inside them never get walked because the parent key is removed before
+        // recursion. This guards against future regressions that might allow
+        // these keywords through (which would then re-enter the cycle forever).
+        const body = {
+          messages: [{ role: 'user', content: 'do' }],
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'mutual_cycle',
+                parameters: {
+                  type: 'object',
+                  $defs: {
+                    A: { type: 'object', properties: { b: { $ref: '#/$defs/B' } } },
+                    B: { type: 'object', properties: { a: { $ref: '#/$defs/A' } } },
+                  },
+                  properties: { kind: { type: 'string' } },
+                },
+              },
+            },
+          ],
+        };
+
+        const result = toGoogleRequest(body, 'gemini-2.0-flash');
+        const tools = result.tools as Array<{
+          functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+        }>;
+        const params = tools[0].functionDeclarations[0].parameters;
+        expect(params).not.toHaveProperty('$defs');
+        expect(params.properties).toEqual({ kind: { type: 'string' } });
+      });
+
+      it('strips a $ref chain that nests 15 levels deep without losing valid fields', () => {
+        // Build a chain of objects where every level has both a $ref keyword
+        // (to be stripped) and a `description` (to be kept). This verifies
+        // recursion processes every layer rather than short-circuiting once
+        // the first $ref is removed.
+        const depth = 15;
+        let chain: Record<string, unknown> = {
+          type: 'object',
+          description: 'leaf',
+          $ref: '#/definitions/Leaf',
+        };
+        for (let i = 0; i < depth; i++) {
+          chain = {
+            type: 'object',
+            description: `link-${i}`,
+            $ref: `#/definitions/Link${i}`,
+            properties: { next: chain },
+          };
+        }
+
+        const body = {
+          messages: [{ role: 'user', content: 'do' }],
+          tools: [{ type: 'function', function: { name: 'chain_tool', parameters: chain } }],
+        };
+
+        const result = toGoogleRequest(body, 'gemini-2.0-flash');
+        const tools = result.tools as Array<{
+          functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+        }>;
+        let node: Record<string, unknown> | undefined = tools[0].functionDeclarations[0].parameters;
+        for (let i = depth - 1; i >= 0; i--) {
+          expect(node).toBeDefined();
+          expect(node).not.toHaveProperty('$ref');
+          expect(node!.description).toBe(`link-${i}`);
+          node = (node!.properties as Record<string, Record<string, unknown>>).next;
+        }
+        // Leaf preserved with description intact and $ref gone.
+        expect(node).toBeDefined();
+        expect(node!.description).toBe('leaf');
+        expect(node).not.toHaveProperty('$ref');
+      });
+
+      it('strips unsupported keywords inside arrays of sub-schemas at depth', () => {
+        // Arrays of schemas (as you'd find in `prefixItems` or custom keyword
+        // arrays the helper does not strip) still need to recurse so banned
+        // keywords inside the items don't leak through.
+        const body = {
+          messages: [{ role: 'user', content: 'do' }],
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'array_tool',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    rows: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          cells: {
+                            type: 'array',
+                            items: {
+                              type: 'object',
+                              additionalProperties: false,
+                              $ref: '#/definitions/Cell',
+                              properties: {
+                                value: { type: 'string', title: 'v', default: '' },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        };
+
+        const result = toGoogleRequest(body, 'gemini-2.0-flash');
+        const tools = result.tools as Array<{
+          functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+        }>;
+        const params = tools[0].functionDeclarations[0].parameters;
+        const rows = (params.properties as Record<string, Record<string, unknown>>).rows;
+        const cellItems = (
+          (rows.items as Record<string, unknown>).properties as Record<
+            string,
+            Record<string, unknown>
+          >
+        ).cells.items as Record<string, unknown>;
+        expect(cellItems).not.toHaveProperty('additionalProperties');
+        expect(cellItems).not.toHaveProperty('$ref');
+        const cellProps = cellItems.properties as Record<string, Record<string, unknown>>;
+        expect(cellProps.value).toEqual({ type: 'string' });
+      });
+    });
+
     it('skips system messages with non-string content from systemInstruction', () => {
       const body = {
         messages: [

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.headers.spec.ts
@@ -1,0 +1,201 @@
+// Strict header contract tests for ProviderClient's auth-critical paths.
+//
+// Existing tests in provider-client.spec.ts often assert headers with
+// `expect.any(Object)` or only check one or two fields. That leaves room
+// for regressions in the auth header *shape* — e.g. Anthropic silently
+// switching from `x-api-key` to `Authorization: Bearer`, or the
+// ChatGPT subscription path losing the Codex-CLI spoof. This file pins
+// the *exact* header set on every auth-critical path so any drift
+// fails loudly.
+
+import { ProviderClient } from '../provider-client';
+
+const mockFetch = jest.fn();
+(globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
+
+const body = {
+  messages: [{ role: 'user', content: 'Hello' }],
+  temperature: 0.7,
+};
+
+describe('ProviderClient — strict header contract on auth-critical paths', () => {
+  let client: ProviderClient;
+
+  beforeEach(() => {
+    client = new ProviderClient();
+    mockFetch.mockReset();
+  });
+
+  it('Anthropic api_key path sends exactly x-api-key (no Authorization Bearer leak)', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'anthropic',
+      apiKey: 'sk-ant-key',
+      model: 'claude-sonnet-4-20250514',
+      body,
+      stream: false,
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    // Pin every header on this path so we'd notice a Bearer/x-api-key swap.
+    expect(sentHeaders).toEqual({
+      'x-api-key': 'sk-ant-key',
+      'Content-Type': 'application/json',
+      'anthropic-version': '2023-06-01',
+    });
+    expect(sentHeaders).not.toHaveProperty('Authorization');
+    expect(sentHeaders).not.toHaveProperty('anthropic-beta');
+  });
+
+  it('Anthropic subscription path sends Authorization Bearer + oauth beta (and NO x-api-key)', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'anthropic',
+      apiKey: 'sk-ant-oat-token',
+      model: 'claude-sonnet-4-20250514',
+      body,
+      stream: false,
+      authType: 'subscription',
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders).toEqual({
+      Authorization: 'Bearer sk-ant-oat-token',
+      'Content-Type': 'application/json',
+      'anthropic-version': '2023-06-01',
+      'anthropic-beta': 'oauth-2025-04-20',
+    });
+    expect(sentHeaders).not.toHaveProperty('x-api-key');
+  });
+
+  it('OpenAI api_key path sends exactly Authorization Bearer (and never x-api-key)', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'openai',
+      apiKey: 'sk-test',
+      model: 'gpt-4o',
+      body,
+      stream: false,
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders).toEqual({
+      Authorization: 'Bearer sk-test',
+      'Content-Type': 'application/json',
+    });
+    expect(sentHeaders).not.toHaveProperty('x-api-key');
+    expect(sentHeaders).not.toHaveProperty('originator');
+  });
+
+  it('xAI api_key path sends exactly Authorization Bearer (no leaked Anthropic-style headers)', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'xai',
+      apiKey: 'sk-xai-key',
+      model: 'grok-3',
+      body,
+      stream: false,
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders).toEqual({
+      Authorization: 'Bearer sk-xai-key',
+      'Content-Type': 'application/json',
+    });
+    expect(sentHeaders).not.toHaveProperty('x-api-key');
+    expect(sentHeaders).not.toHaveProperty('anthropic-version');
+  });
+
+  it('Kimi (moonshot subscription) Anthropic-compatible path sends x-api-key (NOT Bearer)', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'moonshot',
+      apiKey: 'kimi-code-key',
+      model: 'kimi-for-coding',
+      body,
+      stream: false,
+      authType: 'subscription',
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders).toEqual({
+      'x-api-key': 'kimi-code-key',
+      'Content-Type': 'application/json',
+      'anthropic-version': '2023-06-01',
+    });
+    expect(sentHeaders).not.toHaveProperty('Authorization');
+  });
+
+  it('Google api_key path sends exactly x-goog-api-key (NOT Authorization Bearer)', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'google',
+      apiKey: 'AIza-secret',
+      model: 'gemini-2.0-flash',
+      body,
+      stream: false,
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders).toEqual({
+      'Content-Type': 'application/json',
+      'x-goog-api-key': 'AIza-secret',
+    });
+    expect(sentHeaders).not.toHaveProperty('Authorization');
+    // Key must not appear in URL either.
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).not.toContain('AIza-secret');
+  });
+
+  it('OpenRouter sends Bearer + HTTP-Referer + X-Title attribution headers', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'openrouter',
+      apiKey: 'sk-or-key',
+      model: 'openrouter/auto',
+      body,
+      stream: false,
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders).toEqual({
+      Authorization: 'Bearer sk-or-key',
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://manifest.build',
+      'X-Title': 'Manifest',
+    });
+    expect(sentHeaders).not.toHaveProperty('x-api-key');
+  });
+
+  it('ChatGPT subscription path pins Codex-CLI spoof headers exactly', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'openai',
+      apiKey: 'oauth-token',
+      model: 'gpt-5',
+      body,
+      stream: false,
+      authType: 'subscription',
+    });
+
+    const sentHeaders = mockFetch.mock.calls[0][1].headers as Record<string, string>;
+    expect(sentHeaders.Authorization).toBe('Bearer oauth-token');
+    expect(sentHeaders['Content-Type']).toBe('application/json');
+    expect(sentHeaders.originator).toBe('codex_cli_rs');
+    // user-agent is the spoofed Codex CLI agent — must be present (any
+    // missing field would change upstream behavior since chatgpt.com
+    // rejects non-Codex shaped requests).
+    expect(typeof sentHeaders['user-agent']).toBe('string');
+    expect(sentHeaders['user-agent'].length).toBeGreaterThan(0);
+    expect(sentHeaders).not.toHaveProperty('x-api-key');
+    expect(sentHeaders).not.toHaveProperty('anthropic-version');
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.ssrf.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.ssrf.spec.ts
@@ -1,0 +1,170 @@
+// SSRF revalidation tests for ProviderClient.
+//
+// The provider-client.ts implements a defense-in-depth check
+// (`requiresSsrfRevalidation` → validatePublicUrl at forward time) so
+// that user-supplied custom-provider URLs can't be flipped to private /
+// metadata addresses via DNS rebinding *after* registration. The real
+// validator is a no-op when NODE_ENV === 'test' (see
+// `common/utils/url-validation.ts`), so we jest.mock both modules to
+// force the security branch to execute.
+
+jest.mock('../../../common/utils/url-validation', () => ({
+  validatePublicUrl: jest.fn(),
+}));
+jest.mock('../../../common/utils/detect-self-hosted', () => ({
+  isSelfHosted: jest.fn().mockReturnValue(false),
+}));
+
+import { ProviderClient } from '../provider-client';
+import { buildCustomEndpoint, ProviderEndpoint } from '../provider-endpoints';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { validatePublicUrl } = require('../../../common/utils/url-validation');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { isSelfHosted } = require('../../../common/utils/detect-self-hosted');
+
+const mockFetch = jest.fn();
+(globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
+
+const body = {
+  messages: [{ role: 'user', content: 'Hello' }],
+  temperature: 0.7,
+};
+
+describe('ProviderClient — SSRF revalidation for custom endpoints', () => {
+  let client: ProviderClient;
+
+  beforeEach(() => {
+    client = new ProviderClient();
+    mockFetch.mockReset();
+    (validatePublicUrl as jest.Mock).mockReset();
+    (isSelfHosted as jest.Mock).mockReset().mockReturnValue(false);
+  });
+
+  it('re-validates URL through validatePublicUrl when endpoint requires revalidation', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+    (validatePublicUrl as jest.Mock).mockResolvedValue(undefined);
+
+    // buildCustomEndpoint sets requiresSsrfRevalidation: true.
+    const customEndpoint = buildCustomEndpoint('https://upstream.example.com/v1');
+
+    await client.forward({
+      provider: 'custom:abc',
+      apiKey: 'sk-cust',
+      model: 'my-model',
+      body,
+      stream: false,
+      customEndpoint,
+    });
+
+    expect(validatePublicUrl).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledOpts] = (validatePublicUrl as jest.Mock).mock.calls[0];
+    // normalizeProviderBaseUrl strips trailing /v1, then buildPath adds /v1/chat/completions.
+    expect(calledUrl).toBe('https://upstream.example.com/v1/chat/completions');
+    expect(calledOpts).toEqual({ allowPrivate: false });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards allowPrivate=true to validatePublicUrl in self-hosted mode', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+    (validatePublicUrl as jest.Mock).mockResolvedValue(undefined);
+    (isSelfHosted as jest.Mock).mockReturnValue(true);
+
+    const customEndpoint = buildCustomEndpoint('http://localhost:8000');
+
+    await client.forward({
+      provider: 'custom:local',
+      apiKey: 'k',
+      model: 'm',
+      body,
+      stream: false,
+      customEndpoint,
+    });
+
+    const [, calledOpts] = (validatePublicUrl as jest.Mock).mock.calls[0];
+    expect(calledOpts).toEqual({ allowPrivate: true });
+  });
+
+  it('refuses to forward and never calls fetch when revalidation throws (DNS rebinding sim)', async () => {
+    // Simulates the URL passing initial registration but the hostname
+    // rebinding to a private/metadata address by the time we forward.
+    (validatePublicUrl as jest.Mock).mockRejectedValue(
+      new Error('URLs pointing to cloud metadata endpoints are not allowed'),
+    );
+
+    const customEndpoint = buildCustomEndpoint('https://victim.example.com');
+
+    await expect(
+      client.forward({
+        provider: 'custom:rebound',
+        apiKey: 'sk-cust',
+        model: 'm',
+        body,
+        stream: false,
+        customEndpoint,
+      }),
+    ).rejects.toThrow(
+      /Refusing to forward to disallowed URL.*cloud metadata endpoints are not allowed/,
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('wraps non-Error rejections from validatePublicUrl with Refusing-to-forward prefix', async () => {
+    (validatePublicUrl as jest.Mock).mockRejectedValue('private-network-blocked');
+
+    const customEndpoint = buildCustomEndpoint('https://rebound.example.com');
+
+    await expect(
+      client.forward({
+        provider: 'custom:x',
+        apiKey: 'k',
+        model: 'm',
+        body,
+        stream: false,
+        customEndpoint,
+      }),
+    ).rejects.toThrow('Refusing to forward to disallowed URL: private-network-blocked');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call validatePublicUrl for built-in endpoints (no revalidation flag)', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await client.forward({
+      provider: 'openai',
+      apiKey: 'sk-test',
+      model: 'gpt-4o',
+      body,
+      stream: false,
+    });
+
+    expect(validatePublicUrl).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call validatePublicUrl when a custom endpoint omits requiresSsrfRevalidation', async () => {
+    mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+    // Hand-built endpoint without the revalidation flag — exercises the
+    // `!endpoint.requiresSsrfRevalidation` branch.
+    const customEndpoint: ProviderEndpoint = {
+      baseUrl: 'https://trusted-template.example.com',
+      buildHeaders: (key: string) => ({
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+      }),
+      buildPath: () => '/chat/completions',
+      format: 'openai',
+    };
+
+    await client.forward({
+      provider: 'custom:no-revalidate',
+      apiKey: 'sk',
+      model: 'm',
+      body,
+      stream: false,
+      customEndpoint,
+    });
+
+    expect(validatePublicUrl).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.timeout.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.timeout.spec.ts
@@ -1,0 +1,148 @@
+// Tests that the PROVIDER_TIMEOUT_MS abort signal actually fires and
+// aborts the in-flight fetch. The existing AbortSignal passthrough
+// tests in provider-client.spec.ts only verify the signal is *created*
+// and combined — they mock fetch to resolve immediately, so the timeout
+// behavior is never exercised.
+//
+// PROVIDER_TIMEOUT_MS is captured at module import time, so each test
+// imports a fresh copy of the module under jest.isolateModulesAsync
+// with a short timeout override. The fetch mock returns a promise that
+// only settles when the signal aborts — if the timeout doesn't fire,
+// the test would block until Jest's per-test timeout (still a clear
+// failure, but we keep the per-test cap at 5 seconds for speed).
+
+import { ProviderClient } from '../provider-client';
+
+const mockFetch = jest.fn();
+(globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
+
+const body = {
+  messages: [{ role: 'user', content: 'Hello' }],
+  temperature: 0.7,
+};
+
+describe('ProviderClient — timeout signal actually aborts the in-flight fetch', () => {
+  const originalEnv = process.env.PROVIDER_TIMEOUT_MS;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.PROVIDER_TIMEOUT_MS;
+    else process.env.PROVIDER_TIMEOUT_MS = originalEnv;
+  });
+
+  it('fires PROVIDER_TIMEOUT_MS abort on pending fetch and surfaces the error', async () => {
+    process.env.PROVIDER_TIMEOUT_MS = '25';
+
+    let abortObserved = false;
+    mockFetch.mockImplementation((_url: string, init: RequestInit) => {
+      const sig = init.signal as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        sig.addEventListener('abort', () => {
+          abortObserved = true;
+          // Mirror real fetch behavior: reject with an abort-flavored error.
+          reject(new Error('The operation was aborted'));
+        });
+      });
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { ProviderClient: FreshClient } = await import('../provider-client');
+      const fresh = new FreshClient();
+      await expect(
+        fresh.forward({
+          provider: 'openai',
+          apiKey: 'sk-test',
+          model: 'gpt-4o',
+          body,
+          stream: false,
+        }),
+      ).rejects.toThrow(/aborted/i);
+    });
+
+    expect(abortObserved).toBe(true);
+    // Sanity-check that the signal we received was the one that aborted.
+    const finalSignal = (mockFetch.mock.calls[0][1] as RequestInit).signal as AbortSignal;
+    expect(finalSignal.aborted).toBe(true);
+  }, 5000);
+
+  it('does NOT abort fetch when neither client signal nor timeout has elapsed', async () => {
+    // Long timeout so it never fires inside the assertion window.
+    process.env.PROVIDER_TIMEOUT_MS = '60000';
+
+    let aborted = false;
+    mockFetch.mockImplementation((_url: string, init: RequestInit) => {
+      const sig = init.signal as AbortSignal;
+      return new Promise(() => {
+        sig.addEventListener('abort', () => {
+          aborted = true;
+        });
+      });
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { ProviderClient: FreshClient } = await import('../provider-client');
+      const fresh = new FreshClient();
+      const pending = fresh.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+      });
+      // Swallow the eventual rejection so the dangling forward (the real
+      // 60s timeout fires after the test ends) doesn't trip Node's
+      // unhandledRejection warning. We attach catch to BOTH the original
+      // and the .then chain since both will reject when the timeout fires.
+      const raced = pending.then(() => 'forwarded').catch(() => 'errored');
+      // Race the pending forward against a short tick — the forward must NOT
+      // win because neither client nor timeout signal has aborted yet.
+      const winner = await Promise.race([
+        raced,
+        new Promise<string>((r) => setTimeout(() => r('still-pending'), 30)),
+      ]);
+      expect(winner).toBe('still-pending');
+      expect(aborted).toBe(false);
+    });
+  }, 5000);
+
+  it('caller-initiated AbortController.abort() propagates through combined signal', async () => {
+    process.env.PROVIDER_TIMEOUT_MS = '60000';
+
+    let abortObserved = false;
+    mockFetch.mockImplementation((_url: string, init: RequestInit) => {
+      const sig = init.signal as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        const onAbort = () => {
+          abortObserved = true;
+          reject(new Error('The operation was aborted'));
+        };
+        // Handle both already-aborted (synchronous) and not-yet-aborted (event) cases.
+        if (sig.aborted) onAbort();
+        else sig.addEventListener('abort', onAbort);
+      });
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { ProviderClient: FreshClient } = await import('../provider-client');
+      const fresh = new FreshClient();
+      const ac = new AbortController();
+      const pending = fresh.forward({
+        provider: 'openai',
+        apiKey: 'sk-test',
+        model: 'gpt-4o',
+        body,
+        stream: false,
+        signal: ac.signal,
+      });
+      // Yield to the microtask queue so forward() reaches fetch() before we abort.
+      await new Promise((r) => setImmediate(r));
+      ac.abort();
+      await expect(pending).rejects.toThrow(/aborted/i);
+    });
+
+    expect(abortObserved).toBe(true);
+  }, 5000);
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.failures.spec.ts
@@ -1,0 +1,276 @@
+import { Repository } from 'typeorm';
+import type { ModelRoute } from 'manifest-shared';
+import { ProxyFallbackService } from '../proxy-fallback.service';
+import { ProviderKeyService } from '../../routing-core/provider-key.service';
+import { CustomProvider } from '../../../entities/custom-provider.entity';
+import { OpenaiOauthService } from '../../oauth/openai-oauth.service';
+import { MinimaxOauthService } from '../../oauth/minimax-oauth.service';
+import { AnthropicOauthService } from '../../oauth/anthropic/anthropic-oauth.service';
+import { GeminiOauthService } from '../../oauth/gemini-oauth.service';
+import { KiroOauthService } from '../../oauth/kiro-oauth.service';
+import { XaiOauthService } from '../../oauth/xai/xai-oauth.service';
+import { ProviderClient } from '../provider-client';
+import { CopilotTokenService } from '../copilot-token.service';
+import { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
+import { AgentModelParamsService } from '../../routing-core/agent-model-params.service';
+import { ProviderParamSpecService } from '../../routing-core/provider-param-spec.service';
+
+/**
+ * Status-code-driven fallback chain behavior for tryFallbacks().
+ *
+ * `shouldTriggerFallback(status)` currently returns true for ANY status >= 400,
+ * so every upstream error (401 auth, 404 not-found, 429 rate limit, 5xx) keeps
+ * the loop going to the next route. These tests pin that contract per status
+ * code so a future change that re-introduces auth-failure short-circuit (or
+ * any other selective stop) cannot land silently.
+ */
+
+describe('ProxyFallbackService.tryFallbacks — failure chain by status code', () => {
+  let service: ProxyFallbackService;
+  let providerKeyService: jest.Mocked<ProviderKeyService>;
+  let providerClient: jest.Mocked<ProviderClient>;
+
+  const body = { messages: [{ role: 'user', content: 'Hello' }], stream: false };
+
+  // Helper: build a structured ModelRoute. Keeps call-sites readable since
+  // tryFallbacks takes the route array at positional arg 16.
+  const route = (
+    provider: string,
+    model: string,
+    authType: 'api_key' | 'subscription' = 'api_key',
+  ): ModelRoute => ({ provider, authType, model });
+
+  // Helper: invoke tryFallbacks with the 16-arg signature. Trailing args we
+  // don't care about are passed as undefined.
+  const runFallbacks = (models: string[], routes: ModelRoute[] | null, primaryModel = 'gpt-4o') =>
+    service.tryFallbacks(
+      'agent-1',
+      'user-1',
+      models,
+      body,
+      false,
+      'sess-1',
+      primaryModel,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      routes,
+    );
+
+  beforeEach(() => {
+    providerKeyService = {
+      getProviderApiKey: jest.fn().mockResolvedValue('sk-test'),
+      getAuthType: jest.fn().mockResolvedValue('api_key'),
+      findProviderForModel: jest.fn().mockResolvedValue(undefined),
+      getProviderRegion: jest.fn().mockResolvedValue(null),
+      hasActiveProvider: jest.fn().mockResolvedValue(true),
+    } as unknown as jest.Mocked<ProviderKeyService>;
+
+    providerClient = {
+      forward: jest.fn(),
+    } as unknown as jest.Mocked<ProviderClient>;
+
+    const customProviderRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<Repository<CustomProvider>>;
+
+    const oauthStub = { unwrapToken: jest.fn().mockResolvedValue(null) };
+
+    service = new ProxyFallbackService(
+      providerKeyService,
+      customProviderRepo,
+      oauthStub as unknown as OpenaiOauthService,
+      oauthStub as unknown as MinimaxOauthService,
+      oauthStub as unknown as AnthropicOauthService,
+      oauthStub as unknown as GeminiOauthService,
+      oauthStub as unknown as KiroOauthService,
+      oauthStub as unknown as XaiOauthService,
+      providerClient,
+      {
+        getCopilotToken: jest.fn().mockResolvedValue('tid=copilot-session'),
+      } as unknown as CopilotTokenService,
+      {
+        getByModel: jest.fn().mockReturnValue(null),
+      } as unknown as ModelPricingCacheService,
+      {
+        get: jest.fn().mockResolvedValue(null),
+        list: jest.fn().mockResolvedValue([]),
+      } as unknown as AgentModelParamsService,
+      {
+        getSpecs: jest.fn().mockResolvedValue([]),
+        list: jest.fn().mockResolvedValue([]),
+      } as unknown as ProviderParamSpecService,
+    );
+  });
+
+  it('tries all three routes when first returns 429, second returns 429, third returns 200', async () => {
+    // Rate-limit → rate-limit → success is the canonical "retry across
+    // providers when the cheap one is throttled" path. All three must run
+    // and the third's success is what tryFallbacks returns.
+    providerClient.forward
+      .mockResolvedValueOnce({
+        response: new Response('rate limit', { status: 429 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response('rate limit', { status: 429 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: true,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+    const routes: ModelRoute[] = [
+      route('openai', 'gpt-4o-mini'),
+      route('anthropic', 'claude-haiku-3.5'),
+      route('gemini', 'gemini-2.5-flash'),
+    ];
+    const result = await runFallbacks(
+      ['gpt-4o-mini', 'claude-haiku-3.5', 'gemini-2.5-flash'],
+      routes,
+    );
+
+    expect(providerClient.forward).toHaveBeenCalledTimes(3);
+    expect(result.success).not.toBeNull();
+    expect(result.success!.fallbackIndex).toBe(2);
+    expect(result.success!.provider).toBe('gemini');
+    expect(result.success!.model).toBe('gemini-2.5-flash');
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures.map((f) => f.status)).toEqual([429, 429]);
+    expect(result.failures.map((f) => f.provider)).toEqual(['openai', 'anthropic']);
+  });
+
+  it('does NOT short-circuit on 401 auth errors — continues to next route (current contract)', async () => {
+    // shouldTriggerFallback(401) === true, so an auth failure on the first
+    // route keeps the loop going. This test pins that behavior: if anyone
+    // later wants 401 to halt the chain they need to change
+    // fallback-status-codes.ts AND update this test deliberately.
+    providerClient.forward
+      .mockResolvedValueOnce({
+        response: new Response('invalid api key', { status: 401 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response('rate limit', { status: 429 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: true,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+    const routes: ModelRoute[] = [
+      route('openai', 'gpt-4o-mini'),
+      route('anthropic', 'claude-haiku-3.5'),
+      route('gemini', 'gemini-2.5-flash'),
+    ];
+    const result = await runFallbacks(
+      ['gpt-4o-mini', 'claude-haiku-3.5', 'gemini-2.5-flash'],
+      routes,
+    );
+
+    expect(providerClient.forward).toHaveBeenCalledTimes(3);
+    expect(result.success).not.toBeNull();
+    expect(result.success!.provider).toBe('gemini');
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0]).toMatchObject({ status: 401, provider: 'openai' });
+    expect(result.failures[1]).toMatchObject({ status: 429, provider: 'anthropic' });
+  });
+
+  it('returns success=null with all-404 failures when every fallback lacks the model (no 503 collapse)', async () => {
+    // The "model not available on any provider" chain. tryFallbacks must
+    // preserve each per-attempt 404 status + body, NOT synthesize a
+    // generic 503 — the caller decides how to surface this.
+    providerClient.forward.mockImplementation(async () => ({
+      // Fresh Response per call — bodies can only be read once.
+      response: new Response('{"error":"model not found on this provider"}', {
+        status: 404,
+      }),
+      isGoogle: false,
+      isAnthropic: false,
+      isChatGpt: false,
+    }));
+
+    const routes: ModelRoute[] = [
+      route('openai', 'unknown-model-x'),
+      route('anthropic', 'unknown-model-x'),
+      route('gemini', 'unknown-model-x'),
+    ];
+    const result = await runFallbacks(
+      ['unknown-model-x', 'unknown-model-x', 'unknown-model-x'],
+      routes,
+    );
+
+    expect(providerClient.forward).toHaveBeenCalledTimes(3);
+    expect(result.success).toBeNull();
+    expect(result.failures).toHaveLength(3);
+    for (const failure of result.failures) {
+      expect(failure.status).toBe(404);
+      expect(failure.errorBody).toBe('{"error":"model not found on this provider"}');
+    }
+    expect(result.failures.map((f) => f.fallbackIndex)).toEqual([0, 1, 2]);
+    expect(result.failures.map((f) => f.provider)).toEqual(['openai', 'anthropic', 'gemini']);
+  });
+
+  it('preserves the LAST fallback errorBody/status when all return 404 (caller surfaces final 404 verbatim)', async () => {
+    // Same scenario as above with distinct per-provider error bodies. The
+    // final failure entry holds the last attempt's body verbatim — that
+    // is what proxy.service projects back to the agent as the user-facing
+    // response when the chain exhausts.
+    providerClient.forward
+      .mockResolvedValueOnce({
+        response: new Response('{"error":"openai: model_not_found"}', { status: 404 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response('{"error":"anthropic: not_found_error"}', { status: 404 }),
+        isGoogle: false,
+        isAnthropic: true,
+        isChatGpt: false,
+      })
+      .mockResolvedValueOnce({
+        response: new Response('{"error":"gemini: NOT_FOUND"}', { status: 404 }),
+        isGoogle: true,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+    const routes: ModelRoute[] = [
+      route('openai', 'unknown-model-x'),
+      route('anthropic', 'unknown-model-x'),
+      route('gemini', 'unknown-model-x'),
+    ];
+    const result = await runFallbacks(
+      ['unknown-model-x', 'unknown-model-x', 'unknown-model-x'],
+      routes,
+    );
+
+    expect(result.success).toBeNull();
+    const last = result.failures[result.failures.length - 1];
+    expect(last.status).toBe(404);
+    expect(last.errorBody).toBe('{"error":"gemini: NOT_FOUND"}');
+    expect(last.provider).toBe('gemini');
+    // Sanity: middle entries retain their own bodies — no overwrite.
+    expect(result.failures[0].errorBody).toContain('openai: model_not_found');
+    expect(result.failures[1].errorBody).toContain('anthropic: not_found_error');
+  });
+});

--- a/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.controller.streaming-abort.spec.ts
@@ -1,0 +1,261 @@
+import { ProxyController } from '../proxy.controller';
+import { ProxyMessageRecorder } from '../proxy-message-recorder';
+import { ProxyMessageDedup } from '../proxy-message-dedup';
+import { IngestEventBusService } from '../../../common/services/ingest-event-bus.service';
+import { ThoughtSignatureCache } from '../thought-signature-cache';
+import { ThinkingBlockCache } from '../thinking-block-cache';
+import { ReasoningContentCache } from '../reasoning-content-cache';
+
+/**
+ * Tests for client abort during ACTIVE streaming. The base spec covers the
+ * case where the service throws immediately after abort, but does not cover
+ * the case where the service is mid-stream when the client disconnects.
+ * This file isolates that scenario so we can rigorously assert:
+ *   - res.end is called exactly once (no double-close)
+ *   - no JSON envelope is written (no leaked error frame)
+ *   - the rate-limit slot is still released
+ *   - no error is thrown to the caller (handleProxyError swallows on abort)
+ */
+
+function mockResponse(): {
+  res: Record<string, jest.Mock | boolean | number>;
+  written: string[];
+  headers: Record<string, string>;
+} {
+  const written: string[] = [];
+  const headers: Record<string, string> = {};
+  const res: Record<string, jest.Mock | boolean | number> = {
+    setHeader: jest.fn((k: string, v: string) => {
+      headers[k] = v;
+    }),
+    flushHeaders: jest.fn(),
+    write: jest.fn((chunk: string) => {
+      written.push(chunk);
+    }),
+    end: jest.fn(),
+    send: jest.fn(),
+    json: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    once: jest.fn(),
+    writableEnded: false,
+  };
+  return { res, written, headers };
+}
+
+function mockRequest(
+  body: Record<string, unknown>,
+  userId = 'user-1',
+  headers: Record<string, string> = {},
+) {
+  return {
+    ingestionContext: {
+      userId,
+      tenantId: 'tenant-1',
+      agentId: 'agent-1',
+      agentName: 'test-agent',
+    },
+    body,
+    headers,
+    ip: '127.0.0.1',
+  };
+}
+
+function makeRecorder(repo: { insert: jest.Mock; findOne: jest.Mock; find: jest.Mock }) {
+  const pricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
+  return new ProxyMessageRecorder(
+    repo as never,
+    pricingCache as never,
+    new ProxyMessageDedup(),
+    { emit: jest.fn() } as unknown as IngestEventBusService,
+    {
+      canonicalizeAgentMessageKeys: jest
+        .fn()
+        .mockImplementation(async (_a: string, provider: string | null, model: string | null) => ({
+          provider: provider ?? null,
+          model: model ?? null,
+        })),
+    } as never,
+    { getProviders: jest.fn().mockResolvedValue([]) } as never,
+    { getTiers: jest.fn().mockResolvedValue([]) } as never,
+    { getAssignments: jest.fn().mockResolvedValue([]) } as never,
+    { list: jest.fn().mockResolvedValue([]) } as never,
+    {
+      getCostPerRequest: jest.fn().mockReturnValue(null),
+      resolveCostPerRequest: jest.fn().mockResolvedValue(null),
+    } as never,
+    { save: jest.fn() } as never,
+  );
+}
+
+describe('ProxyController streaming abort', () => {
+  let controller: ProxyController;
+  let proxyService: { proxyRequest: jest.Mock };
+  let rateLimiter: {
+    checkLimit: jest.Mock;
+    checkIpLimit: jest.Mock;
+    recordSuccess: jest.Mock;
+    acquireSlot: jest.Mock;
+    releaseSlot: jest.Mock;
+  };
+  let providerClient: Record<string, jest.Mock>;
+  let mockMessageRepo: { insert: jest.Mock; findOne: jest.Mock; find: jest.Mock };
+  let recorder: ProxyMessageRecorder;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    proxyService = { proxyRequest: jest.fn() };
+    rateLimiter = {
+      checkLimit: jest.fn(),
+      checkIpLimit: jest.fn(),
+      recordSuccess: jest.fn(),
+      acquireSlot: jest.fn(),
+      releaseSlot: jest.fn(),
+    };
+    providerClient = {
+      convertGoogleResponse: jest.fn(),
+      convertGoogleStreamChunk: jest.fn(),
+      convertAnthropicResponse: jest.fn(),
+      convertAnthropicStreamChunk: jest.fn(),
+    };
+    mockMessageRepo = {
+      insert: jest.fn().mockResolvedValue({}),
+      findOne: jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    recorder = makeRecorder(mockMessageRepo);
+    controller = new ProxyController(
+      proxyService as never,
+      rateLimiter as never,
+      providerClient as never,
+      recorder,
+      new ThoughtSignatureCache(),
+      new ThinkingBlockCache(),
+      new ReasoningContentCache(),
+      { isRecording: jest.fn().mockResolvedValue(false), invalidate: jest.fn() } as never,
+    );
+  });
+
+  afterEach(() => {
+    recorder.onModuleDestroy();
+  });
+
+  it('ends response once and swallows error when abort fires while proxyRequest is pending', async () => {
+    // proxyService returns a Promise that resolves only when the abort signal
+    // fires — modeling an in-flight request that gets cancelled mid-pipe.
+    proxyService.proxyRequest.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            reject(new Error('aborted'));
+          });
+        }),
+    );
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }], stream: true });
+    const { res } = mockResponse();
+
+    // Capture the controller's close listener so we can fire it manually
+    // mid-flight (simulating the client socket closing during streaming).
+    let closeListener: (() => void) | undefined;
+    (res.once as jest.Mock).mockImplementation((event: string, cb: () => void) => {
+      if (event === 'close') closeListener = cb;
+    });
+
+    const handlerPromise = controller.chatCompletions(req as never, res as never);
+
+    // Wait for the controller to wire up the listener and call proxyRequest.
+    await new Promise((r) => setImmediate(r));
+    expect(closeListener).toBeDefined();
+    expect(proxyService.proxyRequest).toHaveBeenCalled();
+
+    // Verify the controller actually passed an AbortSignal and it has not
+    // fired yet — i.e. we are mid-flight when the client disconnects.
+    const opts = proxyService.proxyRequest.mock.calls[0][0] as { signal: AbortSignal };
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+    expect(opts.signal.aborted).toBe(false);
+
+    // Fire the 'close' event — this should trigger clientAbort.abort()
+    // inside the controller, which rejects the in-flight proxyRequest
+    // promise via the listener we registered above.
+    closeListener!();
+
+    // The handler must resolve (no thrown error escapes to the caller)
+    // and not deadlock waiting on the never-resolving promise.
+    await expect(handlerPromise).resolves.toBeUndefined();
+
+    // res.end called exactly once, no JSON envelope written, no status set
+    // (the controller silently ends the stream on abort).
+    expect(res.end).toHaveBeenCalledTimes(1);
+    expect(res.json).not.toHaveBeenCalled();
+    expect(opts.signal.aborted).toBe(true);
+
+    // Slot must still be released even though the request was aborted.
+    expect(rateLimiter.releaseSlot).toHaveBeenCalledWith('user-1');
+  });
+
+  it('does not call res.end again when writableEnded is true at abort time', async () => {
+    // Same flow, but the response has already been ended (e.g. by pipeStream's
+    // finally block) before the catch block runs. The controller must NOT
+    // double-close, which would throw "write after end" in real Express.
+    proxyService.proxyRequest.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            reject(new Error('aborted'));
+          });
+        }),
+    );
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }], stream: true });
+    const { res } = mockResponse();
+    res.writableEnded = true;
+
+    let closeListener: (() => void) | undefined;
+    (res.once as jest.Mock).mockImplementation((event: string, cb: () => void) => {
+      if (event === 'close') closeListener = cb;
+    });
+
+    const handlerPromise = controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setImmediate(r));
+    closeListener!();
+
+    await expect(handlerPromise).resolves.toBeUndefined();
+
+    expect(res.end).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(rateLimiter.releaseSlot).toHaveBeenCalledWith('user-1');
+  });
+
+  it('records no error message when request was aborted mid-flight', async () => {
+    // When the client cancels, we should NOT persist an agent_message with
+    // status='error' — the abort is normal client behavior, not a failure
+    // we want surfaced in analytics.
+    proxyService.proxyRequest.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            reject(new Error('aborted'));
+          });
+        }),
+    );
+
+    const req = mockRequest({ messages: [{ role: 'user', content: 'hi' }], stream: true });
+    const { res } = mockResponse();
+
+    let closeListener: (() => void) | undefined;
+    (res.once as jest.Mock).mockImplementation((event: string, cb: () => void) => {
+      if (event === 'close') closeListener = cb;
+    });
+
+    const handlerPromise = controller.chatCompletions(req as never, res as never);
+    await new Promise((r) => setImmediate(r));
+    closeListener!();
+    await handlerPromise;
+
+    // Flush microtasks for any fire-and-forget recorder chain.
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+
+    // No agent_message rows written for the abort path
+    expect(mockMessageRepo.insert).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.streaming.spec.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.streaming.spec.ts
@@ -1,0 +1,235 @@
+/**
+ * Streaming edge-case tests for the ChatGPT Responses adapter.
+ *
+ * Focus: tool-call argument deltas that arrive as truncated JSON fragments
+ * across multiple SSE chunks. The transformer must NEVER attempt to parse the
+ * inner `delta` string — it is meant to be concatenated verbatim into the
+ * tool_calls[].function.arguments string and reassembled by the client only
+ * once the stream completes.
+ *
+ * Split out of chatgpt-adapter.spec.ts to keep each file under 300 lines.
+ */
+
+import { collectChatGptSseResponse, transformResponsesStreamChunk } from './chatgpt-adapter';
+
+function parseFrame(frame: string | null): Record<string, unknown> | null {
+  if (!frame) return null;
+  const first = frame.split('\n\n')[0];
+  return JSON.parse(first.replace(/^data: /, '')) as Record<string, unknown>;
+}
+
+function deltaFromFrame(frame: string | null): string {
+  const parsed = parseFrame(frame);
+  if (!parsed) throw new Error('expected frame to parse');
+  const choices = parsed.choices as Array<Record<string, unknown>>;
+  const delta = choices[0].delta as Record<string, unknown>;
+  const toolCalls = delta.tool_calls as Array<Record<string, unknown>>;
+  const fn = toolCalls[0].function as Record<string, unknown>;
+  return fn.arguments as string;
+}
+
+describe('chatgpt-adapter streaming: truncated tool-call argument JSON', () => {
+  describe('transformResponsesStreamChunk forwards partial deltas verbatim', () => {
+    it('forwards an incomplete JSON argument fragment unchanged on a single delta', () => {
+      // The upstream chunk boundary lands mid-string: '{"arg":"val' has an
+      // unterminated string. The transformer must NOT try to parse it — it
+      // should just pass the partial text through.
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"arg\\":\\"val"}';
+      expect(deltaFromFrame(transformResponsesStreamChunk(chunk, 'gpt-5'))).toBe('{"arg":"val');
+    });
+
+    it('forwards the completing fragment on a subsequent delta', () => {
+      // The next chunk closes the string + object. The transformer must again
+      // forward the literal text — concatenation is the consumer's job.
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"ue\\"}"}';
+      expect(deltaFromFrame(transformResponsesStreamChunk(chunk, 'gpt-5'))).toBe('ue"}');
+    });
+
+    it('forwards a delta that splits a Unicode escape sequence (\\u00...)', () => {
+      // é ('é') split mid-escape: first chunk ends with "\u00".
+      // The transformer must pass the half-escape through without throwing.
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"q\\":\\"caf\\\\u00"}';
+      expect(deltaFromFrame(transformResponsesStreamChunk(chunk, 'gpt-5'))).toBe('{"q":"caf\\u00');
+    });
+
+    it('forwards the completing half of the Unicode escape on the next delta', () => {
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"e9\\"}"}';
+      expect(deltaFromFrame(transformResponsesStreamChunk(chunk, 'gpt-5'))).toBe('e9"}');
+    });
+
+    it('preserves backslash characters in deltas (escape-only fragment)', () => {
+      // A fragment that is literally just a backslash. JSON-encoded as "\\\\"
+      // on the wire (envelope JSON encodes one backslash as two characters).
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"\\\\"}';
+      expect(deltaFromFrame(transformResponsesStreamChunk(chunk, 'gpt-5'))).toBe('\\');
+    });
+
+    it('returns null when the SSE envelope JSON itself is malformed (not the delta)', () => {
+      // Truncating the outer envelope (the line after `data: `) is a different
+      // failure mode from a truncated delta. The transformer's safeParse catches
+      // it and returns null instead of throwing.
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":';
+      expect(transformResponsesStreamChunk(chunk, 'gpt-5')).toBeNull();
+    });
+
+    it('treats a non-string delta as empty without throwing', () => {
+      // If the upstream ever drops the string type (e.g. delta: null), the
+      // transformer must coerce to '' rather than emit `null` into the
+      // arguments stream — that would otherwise inject the literal string
+      // "null" into the consumer's concatenation.
+      const chunk =
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":null}';
+      expect(deltaFromFrame(transformResponsesStreamChunk(chunk, 'gpt-5'))).toBe('');
+    });
+  });
+
+  describe('collectChatGptSseResponse reassembles tool-call arguments correctly', () => {
+    it('concatenates a JSON fragment that was split mid-string', () => {
+      // Reassembles to {"arg":"value"}. Each chunk on its own is invalid JSON
+      // because the string is unterminated, but concatenation yields valid
+      // JSON. The collector must NOT attempt to parse intermediate state.
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c1","name":"foo"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"arg\\":\\"val"}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"ue\\"}"}',
+        'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
+      ].join('\n\n');
+
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+      expect(message.tool_calls).toEqual([
+        {
+          id: 'c1',
+          type: 'function',
+          function: { name: 'foo', arguments: '{"arg":"value"}' },
+        },
+      ]);
+      // The reassembled arguments string must itself be parseable JSON.
+      const fnArgs = (
+        (message.tool_calls as Array<Record<string, unknown>>)[0].function as Record<
+          string,
+          unknown
+        >
+      ).arguments as string;
+      expect(JSON.parse(fnArgs)).toEqual({ arg: 'value' });
+    });
+
+    it('concatenates a fragment split across a Unicode escape sequence', () => {
+      // The escape é ('é') is split: ..."caf\u00 | e9"...
+      // The collector must keep the bytes intact so the final string is
+      // {"q":"café"} after JSON parsing by the consumer.
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c2","name":"search"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"q\\":\\"caf\\\\u00"}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"e9\\"}"}',
+        'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
+      ].join('\n\n');
+
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+      const toolCalls = message.tool_calls as Array<Record<string, unknown>>;
+      const fnArgs = (toolCalls[0].function as Record<string, unknown>).arguments as string;
+      // Concatenated literal text first.
+      expect(fnArgs).toBe('{"q":"caf\\u00e9"}');
+      // Then verify the consumer can parse it into 'café'.
+      expect(JSON.parse(fnArgs)).toEqual({ q: 'café' });
+    });
+
+    it('reassembles many small (1-3 char) fragments into valid JSON', () => {
+      // Stress: every chunk boundary is intentionally inside JSON syntax — a
+      // worst-case streaming scenario.
+      const parts = ['{', '"a"', ':', '[', '1', ',', '2', ',', '3', ']', '}'];
+      const events = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"cN","name":"f"}}',
+        ...parts.map((p) => {
+          // Each part must be JSON-encoded inside the envelope. Use
+          // JSON.stringify on the envelope itself to handle escaping correctly.
+          return `event: response.function_call_arguments.delta\ndata: ${JSON.stringify({
+            output_index: 0,
+            delta: p,
+          })}`;
+        }),
+        'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
+      ];
+
+      const out = collectChatGptSseResponse(events.join('\n\n'), 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+      const toolCalls = message.tool_calls as Array<Record<string, unknown>>;
+      const fnArgs = (toolCalls[0].function as Record<string, unknown>).arguments as string;
+      expect(fnArgs).toBe('{"a":[1,2,3]}');
+      expect(JSON.parse(fnArgs)).toEqual({ a: [1, 2, 3] });
+    });
+
+    it('keeps empty-string deltas as no-ops (does not append "undefined" or "null")', () => {
+      // An empty delta between two real deltas must contribute nothing — the
+      // final arguments string must be {"x":1}, not {"x":1}undefined.
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c3","name":"foo"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"x\\":"}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":""}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"1}"}',
+        'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
+      ].join('\n\n');
+
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+      const toolCalls = message.tool_calls as Array<Record<string, unknown>>;
+      const fnArgs = (toolCalls[0].function as Record<string, unknown>).arguments as string;
+      expect(fnArgs).toBe('{"x":1}');
+      expect(JSON.parse(fnArgs)).toEqual({ x: 1 });
+    });
+
+    it('coerces a non-string delta value to empty when concatenating', () => {
+      // If upstream sends `"delta": null` between two real deltas, the
+      // arguments string must still be valid JSON. The risk: a naive
+      // implementation might concatenate the literal "null".
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c4","name":"foo"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"y\\":"}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":null}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"2}"}',
+        'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
+      ].join('\n\n');
+
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+      const toolCalls = message.tool_calls as Array<Record<string, unknown>>;
+      const fnArgs = (toolCalls[0].function as Record<string, unknown>).arguments as string;
+      expect(fnArgs).toBe('{"y":2}');
+      expect(JSON.parse(fnArgs)).toEqual({ y: 2 });
+    });
+
+    it('drops only the envelope-malformed delta and keeps surrounding deltas intact', () => {
+      // If the outer SSE envelope JSON is broken on one event, that event is
+      // discarded by safeParse but the surrounding deltas must still arrive
+      // intact. This is the recovery path for occasional upstream corruption.
+      const sse = [
+        'event: response.output_item.added\ndata: {"output_index":0,"item":{"type":"function_call","call_id":"c5","name":"foo"}}',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"{\\"k\\":"}',
+        'event: response.function_call_arguments.delta\ndata: this-is-not-json',
+        'event: response.function_call_arguments.delta\ndata: {"output_index":0,"delta":"42}"}',
+        'event: response.completed\ndata: {"response":{"output":[{"type":"function_call"}]}}',
+      ].join('\n\n');
+
+      const out = collectChatGptSseResponse(sse, 'gpt-5');
+      const choices = out.choices as Array<Record<string, unknown>>;
+      const message = choices[0].message as Record<string, unknown>;
+      const toolCalls = message.tool_calls as Array<Record<string, unknown>>;
+      const fnArgs = (toolCalls[0].function as Record<string, unknown>).arguments as string;
+      // The middle event is dropped; the two valid deltas still concatenate.
+      expect(fnArgs).toBe('{"k":42}');
+      expect(JSON.parse(fnArgs)).toEqual({ k: 42 });
+    });
+  });
+});

--- a/packages/backend/src/routing/resolve/__tests__/resolve.controller.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.controller.spec.ts
@@ -1,0 +1,284 @@
+import type { Request } from 'express';
+import { ResolveController, RegisterSubscriptionsDto } from '../resolve.controller';
+import type { ResolveService } from '../resolve.service';
+import type { ProviderService } from '../../routing-core/provider.service';
+import type { IngestionContext } from '../../../otlp/interfaces/ingestion-context.interface';
+import type { ResolveRequestDto } from '../../dto/resolve-request.dto';
+import type { ResolveResponse } from '../../dto/resolve-response';
+
+type ReqWithCtx = Request & { ingestionContext: IngestionContext };
+
+const ingestionContext: IngestionContext = {
+  tenantId: 'tenant-1',
+  agentId: 'agent-1',
+  agentName: 'test-agent',
+  userId: 'user-1',
+};
+
+function mockReq(overrides: Partial<IngestionContext> = {}): ReqWithCtx {
+  return {
+    ingestionContext: { ...ingestionContext, ...overrides },
+  } as unknown as ReqWithCtx;
+}
+
+const baseResponse: ResolveResponse = {
+  tier: 'standard',
+  confidence: 0.9,
+  score: 5,
+  reason: 'scored',
+  route: { provider: 'openai', authType: 'api_key', model: 'gpt-4o' },
+  fallback_routes: null,
+};
+
+describe('ResolveController', () => {
+  let controller: ResolveController;
+  let resolveService: jest.Mocked<Pick<ResolveService, 'resolve'>>;
+  let providerService: jest.Mocked<
+    Pick<ProviderService, 'upsertProvider' | 'registerSubscriptionProvider'>
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveService = {
+      resolve: jest.fn().mockResolvedValue(baseResponse),
+    };
+    providerService = {
+      upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
+      registerSubscriptionProvider: jest.fn().mockResolvedValue({ isNew: true }),
+    };
+    controller = new ResolveController(
+      resolveService as unknown as ResolveService,
+      providerService as unknown as ProviderService,
+    );
+  });
+
+  describe('resolve', () => {
+    it('delegates to ResolveService and returns the response', async () => {
+      const body: ResolveRequestDto = {
+        messages: [{ role: 'user', content: 'hello' }],
+      };
+
+      const result = await controller.resolve(body, mockReq());
+
+      expect(result).toBe(baseResponse);
+      expect(resolveService.resolve).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes agentId from ingestionContext and all body params through', async () => {
+      const body: ResolveRequestDto = {
+        messages: [{ role: 'user', content: 'route me' }],
+        tools: [{ type: 'function', function: { name: 'search' } }],
+        tool_choice: 'auto',
+        max_tokens: 1024,
+        recentTiers: ['simple', 'standard'],
+        specificity: 'coding',
+      };
+
+      await controller.resolve(body, mockReq());
+
+      expect(resolveService.resolve).toHaveBeenCalledWith(
+        'agent-1',
+        body.messages,
+        body.tools,
+        body.tool_choice,
+        body.max_tokens,
+        body.recentTiers,
+        body.specificity,
+      );
+    });
+
+    it('forwards undefined optional fields when omitted', async () => {
+      const body: ResolveRequestDto = {
+        messages: [{ role: 'user', content: 'minimal' }],
+      };
+
+      await controller.resolve(body, mockReq());
+
+      expect(resolveService.resolve).toHaveBeenCalledWith(
+        'agent-1',
+        body.messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('uses the agentId from ingestionContext, not the body', async () => {
+      const body: ResolveRequestDto = {
+        messages: [{ role: 'user', content: 'cross-tenant attempt' }],
+      };
+      // Even if body somehow carried an agent reference, only ingestionContext
+      // wins — the guard is the only authority on tenancy. This pins that
+      // contract so a regression that reads agent from the body fails loudly.
+      const req = mockReq({ agentId: 'agent-from-context' });
+
+      await controller.resolve(body, req);
+
+      expect(resolveService.resolve).toHaveBeenCalledWith(
+        'agent-from-context',
+        body.messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    it('propagates errors thrown by ResolveService', async () => {
+      resolveService.resolve.mockRejectedValueOnce(new Error('boom'));
+      const body: ResolveRequestDto = {
+        messages: [{ role: 'user', content: 'fail' }],
+      };
+      await expect(controller.resolve(body, mockReq())).rejects.toThrow('boom');
+    });
+  });
+
+  describe('registerSubscriptions', () => {
+    it('returns 0 registered for an empty providers array', async () => {
+      const body: RegisterSubscriptionsDto = { providers: [] };
+
+      const result = await controller.registerSubscriptions(body, mockReq());
+
+      expect(result).toEqual({ registered: 0 });
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+      expect(providerService.registerSubscriptionProvider).not.toHaveBeenCalled();
+    });
+
+    it('uses upsertProvider when an item carries a token', async () => {
+      providerService.upsertProvider.mockResolvedValueOnce({
+        provider: {} as never,
+        isNew: true,
+      });
+      const body: RegisterSubscriptionsDto = {
+        providers: [{ provider: 'minimax', token: 'sk-token-123' }],
+      };
+
+      const result = await controller.registerSubscriptions(body, mockReq());
+
+      expect(providerService.upsertProvider).toHaveBeenCalledTimes(1);
+      expect(providerService.upsertProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'minimax',
+        'sk-token-123',
+        'subscription',
+      );
+      expect(providerService.registerSubscriptionProvider).not.toHaveBeenCalled();
+      expect(result).toEqual({ registered: 1 });
+    });
+
+    it('uses registerSubscriptionProvider when no token is provided', async () => {
+      providerService.registerSubscriptionProvider.mockResolvedValueOnce({ isNew: true });
+      const body: RegisterSubscriptionsDto = {
+        providers: [{ provider: 'anthropic' }],
+      };
+
+      const result = await controller.registerSubscriptions(body, mockReq());
+
+      expect(providerService.registerSubscriptionProvider).toHaveBeenCalledTimes(1);
+      expect(providerService.registerSubscriptionProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'anthropic',
+      );
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+      expect(result).toEqual({ registered: 1 });
+    });
+
+    it('only counts items where isNew is true', async () => {
+      providerService.upsertProvider.mockResolvedValueOnce({
+        provider: {} as never,
+        isNew: false,
+      });
+      providerService.registerSubscriptionProvider
+        .mockResolvedValueOnce({ isNew: true })
+        .mockResolvedValueOnce({ isNew: false });
+      const body: RegisterSubscriptionsDto = {
+        providers: [
+          { provider: 'minimax', token: 'tok-already-saved' },
+          { provider: 'anthropic' },
+          { provider: 'openai' },
+        ],
+      };
+
+      const result = await controller.registerSubscriptions(body, mockReq());
+
+      expect(result).toEqual({ registered: 1 });
+    });
+
+    it('treats an empty string token as tokenless and uses subscription registration', async () => {
+      // Falsy token (`''`) hits the `else` branch — verifies the truthiness
+      // check on item.token, not just an `undefined` check.
+      providerService.registerSubscriptionProvider.mockResolvedValueOnce({ isNew: true });
+      const body: RegisterSubscriptionsDto = {
+        providers: [{ provider: 'anthropic', token: '' }],
+      };
+
+      const result = await controller.registerSubscriptions(body, mockReq());
+
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+      expect(providerService.registerSubscriptionProvider).toHaveBeenCalledWith(
+        'agent-1',
+        'user-1',
+        'anthropic',
+      );
+      expect(result).toEqual({ registered: 1 });
+    });
+
+    it('uses agentId and userId from the ingestionContext', async () => {
+      // Pin tenancy: the controller must use the guard-attached context, not
+      // any body field, for both agent and user scope.
+      providerService.registerSubscriptionProvider.mockResolvedValueOnce({ isNew: true });
+      const body: RegisterSubscriptionsDto = {
+        providers: [{ provider: 'anthropic' }],
+      };
+
+      await controller.registerSubscriptions(
+        body,
+        mockReq({ agentId: 'agent-X', userId: 'user-Y' }),
+      );
+
+      expect(providerService.registerSubscriptionProvider).toHaveBeenCalledWith(
+        'agent-X',
+        'user-Y',
+        'anthropic',
+      );
+    });
+
+    it('propagates errors from the provider service (both paths)', async () => {
+      providerService.upsertProvider.mockRejectedValueOnce(new Error('upstream fail'));
+      await expect(
+        controller.registerSubscriptions(
+          { providers: [{ provider: 'minimax', token: 'sk-tok' }] },
+          mockReq(),
+        ),
+      ).rejects.toThrow('upstream fail');
+
+      providerService.registerSubscriptionProvider.mockRejectedValueOnce(new Error('reg fail'));
+      await expect(
+        controller.registerSubscriptions({ providers: [{ provider: 'anthropic' }] }, mockReq()),
+      ).rejects.toThrow('reg fail');
+    });
+
+    it('processes providers sequentially in submission order', async () => {
+      // Order of calls matters when a duplicate label triggers a conflict —
+      // pin the dispatch order so a refactor to Promise.all (which would
+      // change error semantics) gets caught.
+      const order: string[] = [];
+      providerService.registerSubscriptionProvider.mockImplementation(async (_a, _u, prov) => {
+        order.push(prov);
+        return { isNew: true };
+      });
+      const body: RegisterSubscriptionsDto = {
+        providers: [{ provider: 'anthropic' }, { provider: 'minimax' }, { provider: 'gemini' }],
+      };
+
+      await controller.registerSubscriptions(body, mockReq());
+
+      expect(order).toEqual(['anthropic', 'minimax', 'gemini']);
+    });
+  });
+});

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.edge.spec.ts
@@ -1,0 +1,282 @@
+import type { Repository } from 'typeorm';
+import type { ModelRoute } from 'manifest-shared';
+import { ResolveService } from '../resolve.service';
+import { Agent } from '../../../entities/agent.entity';
+import type { TierAssignment } from '../../../entities/tier-assignment.entity';
+import type { SpecificityAssignment } from '../../../entities/specificity-assignment.entity';
+import type { HeaderTier } from '../../../entities/header-tier.entity';
+import type { TierService } from '../../routing-core/tier.service';
+import type { ProviderKeyService } from '../../routing-core/provider-key.service';
+import type { SpecificityService } from '../../routing-core/specificity.service';
+import type { SpecificityPenaltyService } from '../../routing-core/specificity-penalty.service';
+import type { HeaderTierService } from '../../header-tiers/header-tier.service';
+import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
+import type { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
+
+/**
+ * Edge-case tests for ResolveService. Mirrors resolve.service.spec.ts mocking.
+ * Covers: header passthrough when the required header key is absent;
+ * specificity confidence boundary at exactly MIN_SPECIFICITY_CONFIDENCE;
+ * logger output for orphaned overrides and low-confidence specificity.
+ */
+jest.mock('../../../scoring', () => ({
+  scoreRequest: jest.fn(),
+  scanMessages: jest.fn(),
+}));
+jest.mock('../../../common/utils/provider-aliases', () => {
+  const actual = jest.requireActual('../../../common/utils/provider-aliases');
+  return { ...actual, inferProviderFromModelName: jest.fn(actual.inferProviderFromModelName) };
+});
+
+import { scoreRequest, scanMessages } from '../../../scoring';
+import { inferProviderFromModelName } from '../../../common/utils/provider-aliases';
+import { Logger } from '@nestjs/common';
+
+const mockedScore = scoreRequest as jest.MockedFunction<typeof scoreRequest>;
+const mockedScan = scanMessages as jest.MockedFunction<typeof scanMessages>;
+const mockedInferProvider = inferProviderFromModelName as jest.MockedFunction<
+  typeof inferProviderFromModelName
+>;
+
+const route = (provider: string, authType: ModelRoute['authType'], model: string): ModelRoute => ({
+  provider,
+  authType,
+  model,
+});
+
+const fallbackTierAssignment = (): TierAssignment =>
+  ({
+    tier: 'standard',
+    override_route: null,
+    auto_assigned_route: route('openai', 'api_key', 'fallback'),
+    fallback_routes: null,
+  }) as TierAssignment;
+
+const codingSpecificity = (overrideModel = 'gpt-4o'): SpecificityAssignment =>
+  ({
+    category: 'coding',
+    is_active: true,
+    override_route: route('openai', 'api_key', overrideModel),
+    auto_assigned_route: null,
+    fallback_routes: null,
+  }) as unknown as SpecificityAssignment;
+
+const headerTierFixture = (overrides: Partial<HeaderTier> = {}): HeaderTier =>
+  ({
+    id: 'h1',
+    name: 'Premium',
+    header_key: 'x-tier',
+    header_value: 'gold',
+    enabled: true,
+    badge_color: 'red',
+    override_route: route('openai', 'api_key', 'gpt-4o'),
+    fallback_routes: null,
+    ...overrides,
+  }) as unknown as HeaderTier;
+
+describe('ResolveService — edge cases', () => {
+  let tierService: jest.Mocked<Pick<TierService, 'getTiers'>>;
+  let providerKeyService: jest.Mocked<
+    Pick<
+      ProviderKeyService,
+      'isModelAvailable' | 'hasActiveProvider' | 'getAuthType' | 'getDefaultKeyLabel'
+    >
+  >;
+  let specificityService: jest.Mocked<Pick<SpecificityService, 'getActiveAssignments'>>;
+  let pricingCache: jest.Mocked<Pick<ModelPricingCacheService, 'getByModel'>>;
+  let discoveryService: jest.Mocked<
+    Pick<ModelDiscoveryService, 'getModelForAgent' | 'getModelsForAgent'>
+  >;
+  let penaltyService: jest.Mocked<Pick<SpecificityPenaltyService, 'getPenaltiesForAgent'>>;
+  let headerTierService: jest.Mocked<Pick<HeaderTierService, 'list'>>;
+  let agentRepo: { findOne: jest.Mock };
+  let svc: ResolveService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tierService = { getTiers: jest.fn().mockResolvedValue([]) };
+    providerKeyService = {
+      isModelAvailable: jest.fn().mockResolvedValue(true),
+      hasActiveProvider: jest.fn().mockResolvedValue(true),
+      getAuthType: jest.fn().mockResolvedValue('api_key'),
+      getDefaultKeyLabel: jest.fn().mockResolvedValue(undefined),
+    };
+    specificityService = { getActiveAssignments: jest.fn().mockResolvedValue([]) };
+    pricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
+    discoveryService = {
+      getModelForAgent: jest.fn().mockResolvedValue(null),
+      getModelsForAgent: jest.fn().mockResolvedValue([]),
+    };
+    penaltyService = { getPenaltiesForAgent: jest.fn().mockResolvedValue(new Map()) };
+    headerTierService = { list: jest.fn().mockResolvedValue([]) };
+    agentRepo = {
+      findOne: jest.fn().mockResolvedValue({ id: 'agent-1', complexity_routing_enabled: true }),
+    };
+    mockedScore.mockReturnValue({
+      tier: 'standard',
+      confidence: 0.9,
+      score: 5,
+      reason: 'scored',
+    } as unknown as ReturnType<typeof scoreRequest>);
+    mockedScan.mockReturnValue(null);
+    mockedInferProvider.mockReturnValue(undefined);
+    svc = new ResolveService(
+      tierService as unknown as TierService,
+      providerKeyService as unknown as ProviderKeyService,
+      specificityService as unknown as SpecificityService,
+      pricingCache as unknown as ModelPricingCacheService,
+      discoveryService as unknown as ModelDiscoveryService,
+      penaltyService as unknown as SpecificityPenaltyService,
+      headerTierService as unknown as HeaderTierService,
+      agentRepo as unknown as Repository<Agent>,
+    );
+  });
+
+  const messages = [{ role: 'user' as const, content: 'hello' }];
+
+  describe('header tier — missing header key', () => {
+    it('falls through when the required header key is absent from the request', async () => {
+      headerTierService.list.mockResolvedValue([headerTierFixture()]);
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'standard',
+          override_route: null,
+          auto_assigned_route: route('openai', 'api_key', 'gpt-4o-mini'),
+          fallback_routes: null,
+        } as TierAssignment,
+      ]);
+
+      // Headers object exists but lacks the configured header_key — the rule
+      // should not match and we should fall through to scored routing.
+      const result = await svc.resolve(
+        'agent-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'other-header': 'value' },
+      );
+
+      expect(result.reason).not.toBe('header-match');
+      expect(result.reason).toBe('scored');
+      expect(result.route).toEqual(route('openai', 'api_key', 'gpt-4o-mini'));
+    });
+  });
+
+  describe('specificity confidence boundary at 0.4', () => {
+    beforeEach(() => {
+      specificityService.getActiveAssignments.mockResolvedValue([codingSpecificity()]);
+      tierService.getTiers.mockResolvedValue([fallbackTierAssignment()]);
+    });
+
+    it('falls through when confidence is just below the gate (0.399 < 0.4)', async () => {
+      mockedScan.mockReturnValue({ category: 'coding', confidence: 0.399 } as never);
+      const result = await svc.resolve('agent-1', messages);
+      expect(result.reason).toBe('scored');
+    });
+
+    it('routes via specificity when confidence equals the gate exactly (0.4)', async () => {
+      // `< 0.4` is false when value equals 0.4 — boundary is inclusive on the
+      // accepting side, so this must route as specificity, not fall through.
+      mockedScan.mockReturnValue({ category: 'coding', confidence: 0.4 } as never);
+      const result = await svc.resolve('agent-1', messages);
+      expect(result.reason).toBe('specificity');
+      expect(result.specificity_category).toBe('coding');
+      expect(result.confidence).toBe(0.4);
+    });
+
+    it('routes via specificity when confidence is just above the gate (0.401)', async () => {
+      mockedScan.mockReturnValue({ category: 'coding', confidence: 0.401 } as never);
+      const result = await svc.resolve('agent-1', messages);
+      expect(result.reason).toBe('specificity');
+      expect(result.confidence).toBe(0.401);
+    });
+  });
+
+  describe('logger diagnostics', () => {
+    let debugSpy: jest.SpyInstance;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      debugSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+      warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      debugSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    /**
+     * Assert that at least one call to the given spy passed a first-argument
+     * string containing `needle`. Using mock.calls (not toHaveBeenCalledWith)
+     * because NestJS Logger.debug/warn are variadic and the matcher would
+     * otherwise need to model every optional param.
+     */
+    const expectMessageLogged = (spy: jest.SpyInstance, needle: string): void => {
+      const logged = spy.mock.calls.map((call) => String(call[0]));
+      const matched = logged.some((msg) => msg.includes(needle));
+      expect(matched).toBe(true);
+    };
+
+    it('emits a debug log when specificity confidence is below the gate', async () => {
+      specificityService.getActiveAssignments.mockResolvedValue([codingSpecificity()]);
+      mockedScan.mockReturnValue({ category: 'coding', confidence: 0.3 } as never);
+      tierService.getTiers.mockResolvedValue([fallbackTierAssignment()]);
+
+      await svc.resolve('agent-1', messages);
+
+      expectMessageLogged(debugSpy, 'below 0.4');
+      expectMessageLogged(debugSpy, 'coding');
+    });
+
+    it('emits a warn log when a specificity override points to an unavailable model', async () => {
+      specificityService.getActiveAssignments.mockResolvedValue([codingSpecificity('orphaned')]);
+      mockedScan.mockReturnValue({ category: 'coding', confidence: 0.9 } as never);
+      providerKeyService.isModelAvailable.mockResolvedValue(false);
+      tierService.getTiers.mockResolvedValue([fallbackTierAssignment()]);
+
+      await svc.resolve('agent-1', messages);
+
+      expectMessageLogged(warnSpy, 'Specificity override orphaned is unavailable');
+    });
+
+    it('emits a warn log when a tier override points to an unavailable model', async () => {
+      tierService.getTiers.mockResolvedValue([
+        {
+          tier: 'standard',
+          override_route: route('openai', 'api_key', 'orphaned'),
+          auto_assigned_route: route('openai', 'api_key', 'auto'),
+          fallback_routes: null,
+        } as unknown as TierAssignment,
+      ]);
+      providerKeyService.isModelAvailable.mockResolvedValue(false);
+
+      await svc.resolve('agent-1', messages);
+
+      expectMessageLogged(warnSpy, 'Override orphaned unavailable for agent=agent-1');
+    });
+
+    it('emits a debug log when a header tier matches but has no override route', async () => {
+      headerTierService.list.mockResolvedValue([headerTierFixture({ override_route: null })]);
+      tierService.getTiers.mockResolvedValue([fallbackTierAssignment()]);
+
+      await svc.resolve(
+        'agent-1',
+        messages,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { 'x-tier': 'gold' },
+      );
+
+      expectMessageLogged(debugSpy, 'Header tier "Premium" matched but has no model configured');
+    });
+  });
+});

--- a/packages/backend/src/scoring/__tests__/envelope-peeler.spec.ts
+++ b/packages/backend/src/scoring/__tests__/envelope-peeler.spec.ts
@@ -103,4 +103,93 @@ describe('peelEnvelope', () => {
     const wrapped = 'Sender (untrusted metadata):\n```json\n{"k":"v"}\n```\n\nline one\nline two';
     expect(peelEnvelope(wrapped)).toBe('line one\nline two');
   });
+
+  // ---------------------------------------------------------------------------
+  // looksLikeStructuredData heuristic — exercised via peelEnvelope on unlabeled
+  // fences. The body must independently look structured (>=2 yaml-shaped lines
+  // or balanced { } / [ ]) for an unlabeled fence to be treated as an envelope.
+  // ---------------------------------------------------------------------------
+
+  it('peels an unlabeled YAML fence with blank lines interleaved between valid keys', () => {
+    // Blank lines are skipped by the heuristic; the two `key: value` lines
+    // still satisfy the >=2 yamlLines threshold.
+    const wrapped = '```\nlabel: openclaw\n\nid: tui\n```\n\nhello';
+    expect(peelEnvelope(wrapped)).toBe('hello');
+  });
+
+  it('peels an unlabeled fence that uses YAML list-item syntax', () => {
+    // The `^- ` branch of the heuristic — two list items count as structure.
+    const wrapped = '```\n- one\n- two\n```\n\nlist follows';
+    expect(peelEnvelope(wrapped)).toBe('list follows');
+  });
+
+  it('does not peel a fence with a bare key followed by list items (no value on the key)', () => {
+    // `labels:` has no value after the colon, so the key-value regex rejects
+    // it and the line is also not a `- ` list item. The heuristic short-
+    // circuits to false on the first non-matching line.
+    const text = '```\nlabels:\n- a\n- b\nid: tui\n```\n\nmixed shape';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('peels an unlabeled fence whose YAML keys carry value content', () => {
+    const wrapped = '```\nname: agent\nversion: 1\n- item\n```\n\nhi';
+    expect(peelEnvelope(wrapped)).toBe('hi');
+  });
+
+  it('does not peel a fence that mixes one YAML line with prose', () => {
+    // First line is YAML-shaped; the prose line breaks the structure check
+    // and the heuristic short-circuits to false.
+    const text = '```\nlabel: openclaw\nbut also some prose here\n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('does not peel a fence whose key has no value after the colon', () => {
+    // The regex requires `\s*:\s*\S` — bare `key:` lines must not count.
+    const text = '```\nlabel:\nid:\n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('does not peel a fence whose lines look like prose with a colon (no leading identifier)', () => {
+    // The identifier anchor `^[A-Za-z_]` rejects lines starting with punctuation,
+    // digits, or whitespace — useful for sentences that happen to contain ":".
+    const text = '```\n1: skip\n2: skip\n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('peels keys containing dots, dashes, and underscores', () => {
+    // `\w.-` in the identifier tail must accept these characters.
+    const wrapped = '```\nmodel.id: gpt-4\nagent-name: cli_v2\n```\n\ngo';
+    expect(peelEnvelope(wrapped)).toBe('go');
+  });
+
+  it('peels a balanced JSON object with surrounding whitespace inside the fence', () => {
+    // The structural check trims before inspecting first/last chars, so
+    // padding inside the fence must not defeat detection.
+    const wrapped = '```\n   { "k": "v" }   \n```\n\nhi';
+    expect(peelEnvelope(wrapped)).toBe('hi');
+  });
+
+  it('peels a balanced JSON array body', () => {
+    const wrapped = '```\n[1, 2, 3]\n```\n\nhi';
+    expect(peelEnvelope(wrapped)).toBe('hi');
+  });
+
+  it('does not peel a fence whose body is only whitespace', () => {
+    // An all-whitespace inner body trims to empty and short-circuits to false.
+    const text = '```\n   \n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('does not peel JSON-ish content that is unbalanced (opens but never closes)', () => {
+    // First char is `{` but last is not `}` — the bracket shortcut must not fire.
+    const text = '```\n{ not really json\n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
+
+  it('does not peel an array opener with a non-matching closer', () => {
+    // `[` opens but the last meaningful char is `}` — the disjunction fails
+    // and the YAML fallback also rejects (no valid key/value lines).
+    const text = '```\n[ foo: bar }\n```\n\nhi';
+    expect(peelEnvelope(text)).toBe(text);
+  });
 });

--- a/packages/backend/src/scoring/__tests__/keyword-trie.spec.ts
+++ b/packages/backend/src/scoring/__tests__/keyword-trie.spec.ts
@@ -1,4 +1,4 @@
-import { KeywordTrie } from '../keyword-trie';
+import { KeywordTrie, isWordCharCode } from '../keyword-trie';
 
 describe('KeywordTrie', () => {
   it('builds from empty config with size 0', () => {
@@ -152,5 +152,101 @@ describe('KeywordTrie', () => {
     }
     const elapsed = performance.now() - start;
     expect(elapsed).toBeLessThan(500);
+  });
+
+  it('does NOT match keyword beyond MAX_SCAN_LENGTH (100k char boundary)', () => {
+    const trie = new KeywordTrie([{ name: 'test', keywords: ['target'] }]);
+    // 'target' starts at position 100,500 — entirely past the 100,000 truncation point.
+    const text = ''.padEnd(100500, 'x') + 'target' + 'y'.repeat(400);
+    expect(text.length).toBe(100906);
+    const matches = trie.scan(text);
+    expect(matches).toEqual([]);
+  });
+
+  it('matches keyword that fits entirely within MAX_SCAN_LENGTH boundary', () => {
+    const trie = new KeywordTrie([{ name: 'test', keywords: ['target'] }]);
+    // 'target' (6 chars) starts at position 99,994 — last char lands at index 99,999.
+    // Preceded by a space (non-word char) so the word-boundary check passes.
+    // afterIdx = 100,000 === len, so the trailing word-char check is skipped → match.
+    const text = 'x'.repeat(99993) + ' ' + 'target' + 'y'.repeat(100);
+    expect(text.length).toBe(100100);
+    const matches = trie.scan(text);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].keyword).toBe('target');
+    expect(matches[0].position).toBe(99994);
+  });
+
+  it('does NOT match keyword spanning MAX_SCAN_LENGTH boundary', () => {
+    const trie = new KeywordTrie([{ name: 'test', keywords: ['target'] }]);
+    // 'target' straddles position 99,997..100,002 — last 3 chars are past the cap so
+    // the inner loop exits before reaching a terminal node.
+    const text = 'x'.repeat(99996) + ' ' + 'target' + 'y'.repeat(100);
+    expect(text.length).toBe(100103);
+    const matches = trie.scan(text);
+    expect(matches).toEqual([]);
+  });
+
+  describe('isWordCharCode', () => {
+    it('returns true for digits 0-9 (codes 48-57)', () => {
+      for (let code = 48; code <= 57; code++) {
+        expect(isWordCharCode(code)).toBe(true);
+      }
+    });
+
+    it('returns true for uppercase A-Z (codes 65-90)', () => {
+      for (let code = 65; code <= 90; code++) {
+        expect(isWordCharCode(code)).toBe(true);
+      }
+    });
+
+    it('returns true for lowercase a-z (codes 97-122)', () => {
+      for (let code = 97; code <= 122; code++) {
+        expect(isWordCharCode(code)).toBe(true);
+      }
+    });
+
+    it('returns true for underscore (code 95)', () => {
+      expect(isWordCharCode(95)).toBe(true);
+      expect(isWordCharCode('_'.charCodeAt(0))).toBe(true);
+    });
+
+    it('returns false for space (32) and hyphen (45)', () => {
+      expect(isWordCharCode(32)).toBe(false);
+      expect(isWordCharCode(45)).toBe(false);
+      expect(isWordCharCode(' '.charCodeAt(0))).toBe(false);
+      expect(isWordCharCode('-'.charCodeAt(0))).toBe(false);
+    });
+
+    it('returns false at boundaries just outside digit range (47 and 58)', () => {
+      // 47 = '/', 58 = ':' — one below '0' and one above '9'.
+      expect(isWordCharCode(47)).toBe(false);
+      expect(isWordCharCode(58)).toBe(false);
+    });
+
+    it('returns false at boundaries just outside uppercase range (64 and 91)', () => {
+      // 64 = '@', 91 = '[' — one below 'A' and one above 'Z'.
+      expect(isWordCharCode(64)).toBe(false);
+      expect(isWordCharCode(91)).toBe(false);
+    });
+
+    it('returns false at boundaries just outside lowercase range (96 and 123)', () => {
+      // 96 = '`', 123 = '{' — one below 'a' and one above 'z'.
+      expect(isWordCharCode(96)).toBe(false);
+      expect(isWordCharCode(123)).toBe(false);
+    });
+
+    it('returns false for code 94 (just below underscore)', () => {
+      // 94 = '^' — verifies the underscore check is exact, not a range.
+      expect(isWordCharCode(94)).toBe(false);
+    });
+
+    it('returns false for common punctuation and whitespace', () => {
+      expect(isWordCharCode('.'.charCodeAt(0))).toBe(false);
+      expect(isWordCharCode(','.charCodeAt(0))).toBe(false);
+      expect(isWordCharCode('!'.charCodeAt(0))).toBe(false);
+      expect(isWordCharCode('?'.charCodeAt(0))).toBe(false);
+      expect(isWordCharCode('\t'.charCodeAt(0))).toBe(false);
+      expect(isWordCharCode('\n'.charCodeAt(0))).toBe(false);
+    });
   });
 });

--- a/packages/backend/src/scoring/__tests__/sigmoid.spec.ts
+++ b/packages/backend/src/scoring/__tests__/sigmoid.spec.ts
@@ -34,6 +34,98 @@ describe('computeConfidence', () => {
     expect(computeConfidence(0.1, boundaries)).toBeGreaterThanOrEqual(0.5);
     expect(computeConfidence(0.35, boundaries)).toBeGreaterThanOrEqual(0.5);
   });
+
+  it('returns exactly 0.5 at the nearest boundary (zero distance)', () => {
+    // Distance is Math.abs(score - boundary); at the boundary distance == 0 and sigmoid(0) == 0.5
+    expect(computeConfidence(-0.1, boundaries)).toBe(0.5);
+    expect(computeConfidence(0.1, boundaries)).toBe(0.5);
+    expect(computeConfidence(0.35, boundaries)).toBe(0.5);
+  });
+
+  it('returns 0.5 when k=0 regardless of distance (sigmoid degenerates)', () => {
+    // With k=0, the exponent is 0 → 1 / (1 + 1) === 0.5 for any score.
+    expect(computeConfidence(-10, boundaries, 0)).toBe(0.5);
+    expect(computeConfidence(0, boundaries, 0)).toBe(0.5);
+    expect(computeConfidence(10, boundaries, 0)).toBe(0.5);
+  });
+
+  it('with k=0.1 produces a shallow curve far from boundaries', () => {
+    // Shallow k → confidence rises slowly with distance.
+    // Distance from 10 to nearest boundary (0.35) is ~9.65; 1 / (1 + e^(-0.1 * 9.65)) ≈ 0.724.
+    const conf = computeConfidence(10, boundaries, 0.1);
+    expect(conf).toBeGreaterThan(0.7);
+    expect(conf).toBeLessThan(0.75);
+  });
+
+  it('with k=100 produces a steep curve far from boundaries', () => {
+    // Steep k → confidence saturates near 1 very quickly.
+    // Even at distance 0.5 (score=0.85, nearest=0.35): 1 / (1 + e^(-50)) is indistinguishable from 1.
+    const conf = computeConfidence(0.85, boundaries, 100);
+    expect(conf).toBeGreaterThan(0.999);
+    expect(conf).toBeLessThanOrEqual(1);
+  });
+
+  it('with k=0.1 vs k=100 at the same score: steep curve > shallow curve far from boundary', () => {
+    const score = 1.0;
+    const shallow = computeConfidence(score, boundaries, 0.1);
+    const steep = computeConfidence(score, boundaries, 100);
+    expect(steep).toBeGreaterThan(shallow);
+  });
+
+  it('approaches 1 as distance grows large (positive direction)', () => {
+    // 1 / (1 + e^(-k * d)) → 1 as d → +∞.
+    const conf = computeConfidence(1e6, boundaries);
+    expect(conf).toBeGreaterThan(0.9999);
+    expect(conf).toBeLessThanOrEqual(1);
+  });
+
+  it('approaches 1 as score goes to very large negative (Math.abs makes distance large)', () => {
+    // minDistance uses Math.abs, so score = -1e6 yields huge distance and confidence → 1.
+    const conf = computeConfidence(-1e6, boundaries);
+    expect(conf).toBeGreaterThan(0.9999);
+    expect(conf).toBeLessThanOrEqual(1);
+  });
+
+  it('remains numerically stable (no NaN/Infinity) at extreme positive distance', () => {
+    // Math.exp(-k * d) underflows to 0 for very large k*d; result must clamp at 1, not blow up.
+    const conf = computeConfidence(1e9, boundaries, 100);
+    expect(Number.isFinite(conf)).toBe(true);
+    expect(Number.isNaN(conf)).toBe(false);
+    expect(conf).toBeLessThanOrEqual(1);
+    expect(conf).toBeGreaterThan(0.999);
+  });
+
+  it('remains numerically stable at extreme negative score with extreme k', () => {
+    const conf = computeConfidence(-1e9, boundaries, 100);
+    expect(Number.isFinite(conf)).toBe(true);
+    expect(Number.isNaN(conf)).toBe(false);
+    expect(conf).toBeLessThanOrEqual(1);
+    expect(conf).toBeGreaterThan(0.999);
+  });
+
+  it('uses the closest boundary (not the first) to compute distance', () => {
+    // score=0.34 is 0.44 from simpleMax(-0.1), 0.24 from standardMax(0.1), 0.01 from complexMax(0.35).
+    // The minimum distance is 0.01, so confidence should be very close to 0.5.
+    const conf = computeConfidence(0.34, boundaries);
+    const expected = 1 / (1 + Math.exp(-8 * 0.01));
+    expect(conf).toBeCloseTo(expected, 10);
+  });
+
+  it('produces deterministic numeric output for the default k=8 formula', () => {
+    // Pin the exact computation so refactors that change the formula are caught.
+    // score=0.5, nearest boundary complexMax=0.35, distance=0.15, k=8 → sigmoid(1.2).
+    const conf = computeConfidence(0.5, boundaries);
+    const expected = 1 / (1 + Math.exp(-8 * 0.15));
+    expect(conf).toBeCloseTo(expected, 12);
+  });
+
+  it('is symmetric around each boundary (|score - b| drives the result)', () => {
+    // Equal distances on either side of the same boundary yield the same confidence.
+    // Distance 0.05 below simpleMax(-0.1) → score=-0.15; distance 0.05 above → score=-0.05.
+    const below = computeConfidence(-0.15, boundaries);
+    const above = computeConfidence(-0.05, boundaries);
+    expect(below).toBeCloseTo(above, 12);
+  });
 });
 
 describe('scoreToTier', () => {

--- a/packages/backend/src/scoring/__tests__/specificity-detector.spec.ts
+++ b/packages/backend/src/scoring/__tests__/specificity-detector.spec.ts
@@ -97,6 +97,57 @@ describe('detectSpecificity', () => {
       expect(result).not.toBeNull();
       expect(result!.category).toBe('data_analysis');
     });
+
+    it('should detect image_generation with imageGeneration dimension matches', () => {
+      const matches = [
+        match('generate', 'imageGeneration', 0),
+        match('create', 'imageGeneration', 10),
+      ];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('image_generation');
+    });
+
+    it('should detect video_generation with videoGeneration dimension matches', () => {
+      const matches = [
+        match('generate', 'videoGeneration', 0),
+        match('edit', 'videoGeneration', 10),
+      ];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('video_generation');
+    });
+
+    it('should detect social_media with socialMedia dimension matches', () => {
+      const matches = [match('post', 'socialMedia', 0), match('tweet', 'socialMedia', 10)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('social_media');
+    });
+
+    it('should detect email_management with emailManagement dimension matches', () => {
+      const matches = [match('send', 'emailManagement', 0), match('draft', 'emailManagement', 10)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('email_management');
+    });
+
+    it('should detect calendar_management with calendarManagement dimension matches', () => {
+      const matches = [
+        match('schedule', 'calendarManagement', 0),
+        match('meeting', 'calendarManagement', 10),
+      ];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('calendar_management');
+    });
+
+    it('should detect trading with trading dimension matches', () => {
+      const matches = [match('buy', 'trading', 0), match('sell', 'trading', 10)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('trading');
+    });
   });
 
   describe('no detection', () => {
@@ -236,6 +287,169 @@ describe('detectSpecificity', () => {
       const matches = [match('function', 'codeGeneration', 0)];
       const result = detectSpecificity(matches, [], undefined, 2);
       expect(result).toBeNull();
+    });
+
+    // For categories with threshold=1.0, a single tool-prefix match (TOOL_MATCH_WEIGHT=3)
+    // is enough to activate on its own — no keyword matches required.
+    it('should boost image_generation for image_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'image_generate' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('image_generation');
+    });
+
+    it('should boost image_generation for midjourney_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'midjourney_imagine' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('image_generation');
+    });
+
+    it('should boost image_generation for firefly_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'firefly_generate' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('image_generation');
+    });
+
+    it('should boost image_generation for leonardo_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'leonardo_generate' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('image_generation');
+    });
+
+    it('should boost video_generation for video_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'video_create' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('video_generation');
+    });
+
+    it('should boost video_generation for runway_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'runway_gen' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('video_generation');
+    });
+
+    it('should boost video_generation for sora_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'sora_generate' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('video_generation');
+    });
+
+    it('should boost social_media for social_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'social_post' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('social_media');
+    });
+
+    it('should boost social_media for hootsuite_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'hootsuite_schedule' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('social_media');
+    });
+
+    it('should boost social_media for buffer_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'buffer_post' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('social_media');
+    });
+
+    it('should boost email_management for email_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'email_send' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('email_management');
+    });
+
+    it('should boost email_management for gmail_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'gmail_send' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('email_management');
+    });
+
+    it('should boost email_management for outlook_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'outlook_send' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('email_management');
+    });
+
+    it('should boost email_management for superhuman_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'superhuman_send' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('email_management');
+    });
+
+    it('should boost calendar_management for calendar_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'calendar_create_event' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('calendar_management');
+    });
+
+    it('should boost calendar_management for gcal_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'gcal_create' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('calendar_management');
+    });
+
+    it('should boost calendar_management for calendly_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'calendly_book' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('calendar_management');
+    });
+
+    it('should boost calendar_management for reclaim_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'reclaim_schedule' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('calendar_management');
+    });
+
+    it('should boost trading for trade_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'trade_execute' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('trading');
+    });
+
+    it('should boost trading for exchange_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'exchange_order' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('trading');
+    });
+
+    it('should boost trading for robinhood_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'robinhood_buy' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('trading');
+    });
+
+    it('should boost trading for kalshi_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'kalshi_trade' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('trading');
+    });
+
+    it('should boost trading for coinbase_ prefixed tool', () => {
+      const tools: ScorerTool[] = [{ name: 'coinbase_buy' }];
+      const result = detectSpecificity([], tools);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('trading');
     });
   });
 
@@ -417,6 +631,118 @@ describe('detectSpecificity', () => {
     it('should still honor header override regardless of threshold', () => {
       const result = detectSpecificity([], undefined, 'coding', 100);
       expect(result).toEqual({ category: 'coding', confidence: 1.0 });
+    });
+  });
+
+  describe('ACTIVATION_THRESHOLDS per-category boundaries', () => {
+    // These tests exercise the REAL ACTIVATION_THRESHOLDS map (no override) to
+    // pin the per-category activation floor. web_browsing is intentionally high
+    // (3.0) vs every other category (1.0); regressions in those values would
+    // silently change routing behavior.
+
+    it('web_browsing requires score >= 3.0 to activate (real threshold)', () => {
+      // 'navigate' has weight 3 → score = 3.0 exactly = threshold → activates.
+      const matches = [match('navigate', 'webBrowsing', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('web_browsing');
+    });
+
+    it('web_browsing does NOT activate at score 2.0 (below 3.0 threshold)', () => {
+      // 'click the' has weight 2 → score = 2.0 < 3.0 → no activation.
+      const matches = [match('click the', 'webBrowsing', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).toBeNull();
+    });
+
+    it('web_browsing does NOT activate at score 1.5 (single weak noun)', () => {
+      // 'website' has weight 1.5 → 1.5 < 3.0 → no activation.
+      const matches = [match('website', 'webBrowsing', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).toBeNull();
+    });
+
+    it('coding activates at score 1.0 (single default-weight match)', () => {
+      // Unknown keyword → weight 1 → score = 1.0 = threshold → activates.
+      const matches = [match('anything', 'codeGeneration', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('coding');
+    });
+
+    it('data_analysis activates at score 1.0 (single default-weight match)', () => {
+      const matches = [match('anything', 'dataAnalysis', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('data_analysis');
+    });
+
+    it('image_generation activates at score 1.0 (single default-weight match)', () => {
+      const matches = [match('anything', 'imageGeneration', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('image_generation');
+    });
+
+    it('video_generation activates at score 1.0 (single default-weight match)', () => {
+      const matches = [match('anything', 'videoGeneration', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('video_generation');
+    });
+
+    it('social_media activates at score 1.0 (single default-weight match)', () => {
+      const matches = [match('anything', 'socialMedia', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('social_media');
+    });
+
+    it('email_management activates at score 1.0 (single default-weight match)', () => {
+      const matches = [match('anything', 'emailManagement', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('email_management');
+    });
+
+    it('calendar_management activates at score 1.0 (single default-weight match)', () => {
+      const matches = [match('anything', 'calendarManagement', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('calendar_management');
+    });
+
+    it('trading activates at score 1.0 (single default-weight match)', () => {
+      const matches = [match('anything', 'trading', 0)];
+      const result = detectSpecificity(matches);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('trading');
+    });
+
+    it('thresholdOverride uniformly raises the bar for every category', () => {
+      // Override of 4 — coding match (1.0) and web_browsing strong anchor (3.0)
+      // both fall below, so no category activates.
+      const matches = [
+        match('function', 'codeGeneration', 0),
+        match('navigate', 'webBrowsing', 10),
+      ];
+      const result = detectSpecificity(matches, undefined, undefined, 4);
+      expect(result).toBeNull();
+    });
+
+    it('thresholdOverride applies the >= comparison at the exact boundary', () => {
+      // Score = 3.0 (from 'navigate'); override = 3.0; should activate.
+      const matches = [match('navigate', 'webBrowsing', 0)];
+      const result = detectSpecificity(matches, undefined, undefined, 3);
+      expect(result).not.toBeNull();
+      expect(result!.category).toBe('web_browsing');
+    });
+
+    it('thresholdOverride just above score does not activate', () => {
+      // Score = 3.0 (from 'navigate'); override = 3.01 → 3.0 < 3.01 → null.
+      const matches = [match('navigate', 'webBrowsing', 0)];
+      const result = detectSpecificity(matches, undefined, undefined, 3.01);
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/backend/src/scoring/__tests__/specificity-weights.spec.ts
+++ b/packages/backend/src/scoring/__tests__/specificity-weights.spec.ts
@@ -1,0 +1,255 @@
+import { ACTIVATION_THRESHOLDS, KEYWORD_WEIGHTS, weightFor } from '../specificity-weights';
+
+describe('weightFor', () => {
+  describe('returns correct weight for known keywords', () => {
+    it('returns 4 for strong anchor "navigate to"', () => {
+      expect(weightFor('navigate to')).toBe(4);
+    });
+
+    it('returns 4 for "scrape"', () => {
+      expect(weightFor('scrape')).toBe(4);
+    });
+
+    it('returns 4 for "crawl"', () => {
+      expect(weightFor('crawl')).toBe(4);
+    });
+
+    it('returns 4 for "open url"', () => {
+      expect(weightFor('open url')).toBe(4);
+    });
+
+    it('returns 4 for "take a screenshot"', () => {
+      expect(weightFor('take a screenshot')).toBe(4);
+    });
+
+    it('returns 3 for "browse"', () => {
+      expect(weightFor('browse')).toBe(3);
+    });
+
+    it('returns 3 for "visit"', () => {
+      expect(weightFor('visit')).toBe(3);
+    });
+
+    it('returns 3 for "navigate"', () => {
+      expect(weightFor('navigate')).toBe(3);
+    });
+
+    it('returns 3 for "go to"', () => {
+      expect(weightFor('go to')).toBe(3);
+    });
+
+    it('returns 3 for context phrase "this website"', () => {
+      expect(weightFor('this website')).toBe(3);
+    });
+
+    it('returns 3 for "this page"', () => {
+      expect(weightFor('this page')).toBe(3);
+    });
+
+    it('returns 2 for "this domain"', () => {
+      expect(weightFor('this domain')).toBe(2);
+    });
+
+    it('returns 2 for "click on"', () => {
+      expect(weightFor('click on')).toBe(2);
+    });
+
+    it('returns 2 for "webpage"', () => {
+      expect(weightFor('webpage')).toBe(2);
+    });
+
+    it('returns 1.5 for weak noun "website"', () => {
+      expect(weightFor('website')).toBe(1.5);
+    });
+
+    it('returns 1.5 for "web page"', () => {
+      expect(weightFor('web page')).toBe(1.5);
+    });
+  });
+
+  describe('returns 1.0 fallback for unknown keywords', () => {
+    it('returns 1 for completely unknown keyword', () => {
+      expect(weightFor('unknown-keyword-xyz')).toBe(1);
+    });
+
+    it('returns 1 for empty string', () => {
+      expect(weightFor('')).toBe(1);
+    });
+
+    it('returns 1 for arbitrary phrase not in map', () => {
+      expect(weightFor('plot a chart')).toBe(1);
+    });
+
+    it('returns 1 for a single word not in map', () => {
+      expect(weightFor('refactor')).toBe(1);
+    });
+
+    it('returns 1 for keyword that looks similar but has different spacing', () => {
+      expect(weightFor('navigateto')).toBe(1);
+    });
+  });
+
+  describe('is case-sensitive', () => {
+    it('does not match "Navigate To" (titlecase)', () => {
+      expect(weightFor('Navigate To')).toBe(1);
+      expect(weightFor('Navigate To')).not.toBe(4);
+    });
+
+    it('does not match "BROWSE" (uppercase)', () => {
+      expect(weightFor('BROWSE')).toBe(1);
+      expect(weightFor('BROWSE')).not.toBe(3);
+    });
+
+    it('does not match "Website" (titlecase)', () => {
+      expect(weightFor('Website')).toBe(1);
+      expect(weightFor('Website')).not.toBe(1.5);
+    });
+
+    it('does not match "Scrape" (titlecase)', () => {
+      expect(weightFor('Scrape')).toBe(1);
+    });
+  });
+
+  describe('does not match keywords with leading/trailing whitespace', () => {
+    it('returns 1 for " navigate to" (leading space)', () => {
+      expect(weightFor(' navigate to')).toBe(1);
+    });
+
+    it('returns 1 for "browse " (trailing space)', () => {
+      expect(weightFor('browse ')).toBe(1);
+    });
+  });
+
+  describe('weight tiers reflect spec', () => {
+    it('strong anchors (4) outweigh strong verbs (3)', () => {
+      expect(weightFor('navigate to')).toBeGreaterThan(weightFor('navigate'));
+    });
+
+    it('strong verbs (3) outweigh medium context (2)', () => {
+      expect(weightFor('browse')).toBeGreaterThan(weightFor('click on'));
+    });
+
+    it('medium context (2) outweighs weak nouns (1.5)', () => {
+      expect(weightFor('click on')).toBeGreaterThan(weightFor('website'));
+    });
+
+    it('weak nouns (1.5) outweigh the unknown fallback (1)', () => {
+      expect(weightFor('website')).toBeGreaterThan(weightFor('not-a-real-keyword'));
+    });
+  });
+
+  describe('map integrity', () => {
+    it('every key in KEYWORD_WEIGHTS resolves via weightFor', () => {
+      for (const [keyword, weight] of Object.entries(KEYWORD_WEIGHTS)) {
+        expect(weightFor(keyword)).toBe(weight);
+      }
+    });
+
+    it('all weights are positive numbers', () => {
+      for (const weight of Object.values(KEYWORD_WEIGHTS)) {
+        expect(typeof weight).toBe('number');
+        expect(weight).toBeGreaterThan(0);
+        expect(Number.isFinite(weight)).toBe(true);
+      }
+    });
+
+    it('all keys are non-empty strings', () => {
+      for (const keyword of Object.keys(KEYWORD_WEIGHTS)) {
+        expect(typeof keyword).toBe('string');
+        expect(keyword.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('all keys are lowercased (case-sensitive lookup contract)', () => {
+      for (const keyword of Object.keys(KEYWORD_WEIGHTS)) {
+        expect(keyword).toBe(keyword.toLowerCase());
+      }
+    });
+  });
+
+  describe('spot-check anchor phrases from KEYWORD_WEIGHTS', () => {
+    const anchorSamples: Array<[string, number]> = [
+      ['navigate to', 4],
+      ['browse to', 4],
+      ['scrape', 4],
+      ['crawl', 4],
+      ['open url', 4],
+      ['fetch url', 4],
+      ['fetch the url', 4],
+      ['take a screenshot', 4],
+      ['web search', 4],
+      ['bookmark this', 4],
+      ['fill out the form', 4],
+      ['browse', 3],
+      ['visit', 3],
+      ['this website', 3],
+      ['this webpage', 3],
+      ['this site', 3],
+      ['this url', 3],
+      ['on this page', 3],
+      ['this page', 3],
+      ['this domain', 2],
+      ['open the url', 2],
+      ['click the', 2],
+      ['screenshot of', 2],
+      ['webpage', 2],
+      ['website', 1.5],
+      ['web page', 1.5],
+    ];
+
+    it.each(anchorSamples)('weightFor(%j) === %s', (keyword, expectedWeight) => {
+      expect(weightFor(keyword)).toBe(expectedWeight);
+    });
+  });
+});
+
+describe('ACTIVATION_THRESHOLDS', () => {
+  it('web_browsing threshold (3) matches the strong-anchor weight tier', () => {
+    expect(ACTIVATION_THRESHOLDS.web_browsing).toBe(3);
+  });
+
+  it('all non-web_browsing categories use the 1.0 threshold', () => {
+    expect(ACTIVATION_THRESHOLDS.coding).toBe(1);
+    expect(ACTIVATION_THRESHOLDS.data_analysis).toBe(1);
+    expect(ACTIVATION_THRESHOLDS.image_generation).toBe(1);
+    expect(ACTIVATION_THRESHOLDS.video_generation).toBe(1);
+    expect(ACTIVATION_THRESHOLDS.social_media).toBe(1);
+    expect(ACTIVATION_THRESHOLDS.email_management).toBe(1);
+    expect(ACTIVATION_THRESHOLDS.calendar_management).toBe(1);
+    expect(ACTIVATION_THRESHOLDS.trading).toBe(1);
+  });
+
+  it('web_browsing threshold is the highest of all categories', () => {
+    const webBrowsing = ACTIVATION_THRESHOLDS.web_browsing;
+    for (const [category, threshold] of Object.entries(ACTIVATION_THRESHOLDS)) {
+      if (category !== 'web_browsing') {
+        expect(threshold).toBeLessThanOrEqual(webBrowsing);
+      }
+    }
+  });
+
+  it('every threshold is a positive finite number', () => {
+    for (const threshold of Object.values(ACTIVATION_THRESHOLDS)) {
+      expect(typeof threshold).toBe('number');
+      expect(threshold).toBeGreaterThan(0);
+      expect(Number.isFinite(threshold)).toBe(true);
+    }
+  });
+
+  it('contains an entry for every documented specificity category', () => {
+    const expected = [
+      'coding',
+      'web_browsing',
+      'data_analysis',
+      'image_generation',
+      'video_generation',
+      'social_media',
+      'email_management',
+      'calendar_management',
+      'trading',
+    ];
+    for (const key of expected) {
+      expect(ACTIVATION_THRESHOLDS).toHaveProperty(key);
+    }
+  });
+});

--- a/packages/backend/src/setup/setup.service.spec.ts
+++ b/packages/backend/src/setup/setup.service.spec.ts
@@ -384,6 +384,35 @@ describe('SetupService', () => {
         await expect(service.createFirstAdmin(dto)).rejects.toThrow(ConflictException);
         expect(auth.api.signUpEmail).not.toHaveBeenCalled();
       });
+
+      it('throws ConflictException when count=1 but unverified SELECT returns 2+ rows', async () => {
+        // Defensive: count check says one user, but the unverified+email
+        // SELECT returns multiple rows (e.g., race with another insert or
+        // schema corruption). The recovery branch only fires when
+        // unverified.length === 1, so this MUST fall through to 409 —
+        // never silently mark all matches verified.
+        runnerQuery
+          .mockResolvedValueOnce(undefined) // lock
+          .mockResolvedValueOnce([{ count: '1' }]) // count = 1
+          .mockResolvedValueOnce([
+            { email: 'founder@example.com' },
+            { email: 'founder@example.com' },
+          ]) // unverified SELECT returns 2 rows — length !== 1
+          .mockResolvedValueOnce(undefined); // unlock
+
+        const caught = await service.createFirstAdmin(dto).catch((e: unknown) => e);
+        expect(caught).toBeInstanceOf(ConflictException);
+        expect((caught as Error).message).toMatch(/already completed/i);
+        expect(auth.api.signUpEmail).not.toHaveBeenCalled();
+        // No UPDATE emailVerified statement should have been issued.
+        const updateCall = runnerQuery.mock.calls.find(
+          (c) =>
+            typeof c[0] === 'string' &&
+            c[0].includes('UPDATE "user"') &&
+            c[0].includes('emailVerified'),
+        );
+        expect(updateCall).toBeUndefined();
+      });
     });
 
     it('treats an empty count result as count=0 and proceeds with signup', async () => {

--- a/packages/backend/src/telemetry/telemetry.service.spec.ts
+++ b/packages/backend/src/telemetry/telemetry.service.spec.ts
@@ -112,6 +112,60 @@ describe('TelemetryService', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
+    it('skips when first_send_at is one millisecond in the future (boundary)', async () => {
+      const { service, install, payloadBuilder } = makeService();
+      const now = new Date('2026-04-20T12:00:00.000Z');
+      const oneMsAhead = new Date(now.getTime() + 1).toISOString();
+      install.getOrCreate.mockResolvedValue({
+        ...baseInstall,
+        first_send_at: oneMsAhead,
+        last_sent_at: null,
+      });
+
+      await service.tick(now);
+
+      expect(payloadBuilder.build).not.toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(install.markSent).not.toHaveBeenCalled();
+    });
+
+    it('sends when first_send_at is exactly now (boundary uses strict greater-than)', async () => {
+      const { service, install, payloadBuilder } = makeService();
+      const now = new Date('2026-04-20T12:00:00.000Z');
+      install.getOrCreate.mockResolvedValue({
+        ...baseInstall,
+        first_send_at: now.toISOString(),
+        last_sent_at: null,
+      });
+      payloadBuilder.build.mockResolvedValue(payloadStub());
+      fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await service.tick(now);
+
+      expect(payloadBuilder.build).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(install.markSent).toHaveBeenCalledWith(now);
+    });
+
+    it('sends when first_send_at is one millisecond in the past (boundary)', async () => {
+      const { service, install, payloadBuilder } = makeService();
+      const now = new Date('2026-04-20T12:00:00.000Z');
+      const oneMsAgo = new Date(now.getTime() - 1).toISOString();
+      install.getOrCreate.mockResolvedValue({
+        ...baseInstall,
+        first_send_at: oneMsAgo,
+        last_sent_at: null,
+      });
+      payloadBuilder.build.mockResolvedValue(payloadStub());
+      fetchSpy.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await service.tick(now);
+
+      expect(payloadBuilder.build).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(install.markSent).toHaveBeenCalledTimes(1);
+    });
+
     it('skips when the last send was less than 24h ago', async () => {
       const { service, install, payloadBuilder } = makeService();
       const now = new Date('2026-04-20T12:00:00');

--- a/packages/backend/test/costs.e2e-spec.ts
+++ b/packages/backend/test/costs.e2e-spec.ts
@@ -1,13 +1,35 @@
 import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import request from 'supertest';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { createTestApp, TEST_API_KEY, TEST_USER_ID, TEST_TENANT_ID } from './helpers';
 import { sqlNow } from '../src/common/utils/postgres-sql';
 import { v4 as uuid } from 'uuid';
 import { PricingSyncService } from '../src/database/pricing-sync.service';
 import { ModelPricingCacheService } from '../src/model-prices/model-pricing-cache.service';
 
+interface CacheLike {
+  del?: (key: string) => Promise<unknown> | unknown;
+  reset?: () => Promise<unknown> | unknown;
+  clear?: () => Promise<unknown> | unknown;
+  store?: { reset?: () => Promise<unknown> | unknown };
+}
+
 let app: INestApplication;
+
+async function clearCache(): Promise<void> {
+  const cache = app.get<CacheLike>(CACHE_MANAGER);
+  // cache-manager v5 exposes reset(); v6 exposes clear(); legacy versions
+  // tucked it under .store.reset(). Try whichever the runtime provides so
+  // the test stays resilient across the upstream API churn.
+  if (typeof cache.clear === 'function') {
+    await cache.clear();
+  } else if (typeof cache.reset === 'function') {
+    await cache.reset();
+  } else if (cache.store && typeof cache.store.reset === 'function') {
+    await cache.store.reset();
+  }
+}
 
 beforeAll(async () => {
   app = await createTestApp();
@@ -109,5 +131,146 @@ describe('GET /api/v1/costs', () => {
 
   it('should reject request without auth with 401', async () => {
     await api().get('/api/v1/costs?range=24h').expect(401);
+  });
+});
+
+describe('GET /api/v1/costs - range validation edge cases', () => {
+  // RangeQueryDto uses class-validator @IsIn(['1h','6h','24h','7d','30d']).
+  // Anything outside that fixed set must fail validation with 400.
+  it('should reject range=0h (zero-magnitude)', async () => {
+    await auth(api().get('/api/v1/costs?range=0h')).expect(400);
+  });
+
+  it('should reject range=-1h (negative)', async () => {
+    await auth(api().get('/api/v1/costs?range=-1h')).expect(400);
+  });
+
+  it('should reject range=24h30m (trailing garbage)', async () => {
+    await auth(api().get('/api/v1/costs?range=24h30m')).expect(400);
+  });
+
+  it('should reject range=24H (case-sensitive whitelist)', async () => {
+    // @IsIn is case-sensitive: '24H' is not in the lowercase whitelist.
+    await auth(api().get('/api/v1/costs?range=24H')).expect(400);
+  });
+});
+
+describe('GET /api/v1/costs - numeric edge cases', () => {
+  // Seed extra rows that exercise the zero-token and large-token boundaries.
+  // These run AFTER the main describe so the existing tests' assertions
+  // (which only check shape or `> 0`) remain valid.
+  beforeAll(async () => {
+    const ds = app.get(DataSource);
+    const now = sqlNow();
+
+    // Row with all zeros — must not crash the query nor poison cost summary.
+    await ds.query(
+      `INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      [
+        '11111111-1111-4111-8111-111111111111',
+        now,
+        'Zero tokens edge case',
+        'agent',
+        'ok',
+        'gpt-4o',
+        0,
+        0,
+        0,
+        TEST_USER_ID,
+        TEST_TENANT_ID,
+        null,
+      ],
+    );
+
+    // Row with the max value PostgreSQL `integer` columns accept (2^31 - 1).
+    // Anything larger would error at the driver level — verifying the upper
+    // boundary is what the column type allows.
+    await ds.query(
+      `INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      [
+        '22222222-2222-4222-8222-222222222222',
+        now,
+        'Max int32 tokens edge case',
+        'agent',
+        'ok',
+        'gpt-4o',
+        2147483647,
+        0,
+        1.5,
+        TEST_USER_ID,
+        TEST_TENANT_ID,
+        null,
+      ],
+    );
+
+    // Cross-tenant row — must NEVER appear in the test user's results.
+    await ds.query(
+      `INSERT INTO tenants (id, name, organization_name, is_active, created_at, updated_at) VALUES ($1,$2,$3,true,$4,$5)`,
+      ['other-tenant-001', 'other-user-001', 'Other Org', now, now],
+    );
+    await ds.query(
+      `INSERT INTO agent_messages (id, timestamp, description, service_type, status, model, input_tokens, output_tokens, cost_usd, user_id, tenant_id, agent_name)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+      [
+        '33333333-3333-4333-8333-333333333333',
+        now,
+        'Other tenant cost',
+        'agent',
+        'ok',
+        'gpt-4o',
+        1000,
+        500,
+        99.99,
+        'other-user-001',
+        'other-tenant-001',
+        null,
+      ],
+    );
+
+    // UserCacheInterceptor caches GET /costs responses for 30s keyed by
+    // userId+URL. Earlier tests in this file populated that cache with the
+    // pre-seed state; wipe it so the new rows are reflected.
+    await clearCache();
+  });
+
+  it('should include zero-token rows without producing NaN/null cost', async () => {
+    const res = await auth(api().get('/api/v1/costs?range=24h')).expect(200);
+
+    const value = res.body.summary.weekly_cost.value;
+    expect(value).not.toBeNull();
+    expect(value).not.toBeUndefined();
+    expect(Number.isNaN(Number(value))).toBe(false);
+    expect(Number.isFinite(Number(value))).toBe(true);
+    expect(Number(value)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should sum max int32 token rows without numeric overflow', async () => {
+    const res = await auth(api().get('/api/v1/costs?range=24h')).expect(200);
+
+    // by_model aggregates SUM(input_tokens + output_tokens). With one row at
+    // 2^31-1 plus seeded rows (5000+2000 + 3000+1000 = 11000) plus the zero
+    // row (0), the gpt-4o total is 2_147_494_647. JS Number can represent
+    // this exactly (well below 2^53).
+    const gpt4o = (
+      res.body.by_model as Array<{ model: string; tokens: number; estimated_cost: number }>
+    ).find((m) => m.model === 'gpt-4o');
+    expect(gpt4o).toBeDefined();
+    expect(Number.isFinite(gpt4o!.tokens)).toBe(true);
+    expect(gpt4o!.tokens).toBe(2147483647 + 11000);
+    expect(Number.isFinite(gpt4o!.estimated_cost)).toBe(true);
+    // 0.0325 + 0.0175 + 0 + 1.5 = 1.55 with floating-point tolerance.
+    expect(gpt4o!.estimated_cost).toBeCloseTo(1.55, 5);
+  });
+
+  it('should not leak rows from other tenants in cost summary', async () => {
+    const res = await auth(api().get('/api/v1/costs?range=24h')).expect(200);
+
+    const totalCost = Number(res.body.summary.weekly_cost.value);
+    // Cross-tenant row had cost_usd=99.99. If isolation broke, total would
+    // exceed 99. Sum of our rows is 0.0325 + 0.0175 + 0 + 1.5 = 1.55.
+    expect(totalCost).toBeLessThan(50);
+    expect(totalCost).toBeCloseTo(1.55, 5);
   });
 });

--- a/packages/backend/test/custom-providers.url-validation.e2e-spec.ts
+++ b/packages/backend/test/custom-providers.url-validation.e2e-spec.ts
@@ -1,0 +1,272 @@
+import request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createTestApp, TEST_API_KEY } from './helpers';
+
+// URL-validation boundary tests for the custom-providers HTTP surface.
+//
+// The DTO uses class-validator's `IsUrl({ require_tld: false,
+// require_protocol: true })` so malformed inputs and schemeless hostnames
+// are rejected at the ValidationPipe layer (HTTP 400) before the service
+// runs. The service then calls `validatePublicUrl()` for SSRF/HTTPS-only
+// checks. `createTestApp()` boots with `NODE_ENV=test`, which makes
+// `validatePublicUrl()` short-circuit unless `SKIP_SSRF_VALIDATION=false`
+// is set per-request — the validator reads the env at call time (not boot)
+// so tests flip it just-in-time.
+
+describe('Custom Providers URL validation (e2e)', () => {
+  let app: INestApplication;
+  const agentName = 'test-agent';
+  const headers = { 'x-api-key': TEST_API_KEY };
+  const baseModels = [{ model_name: 'm1' }];
+
+  beforeAll(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  // Per-test cleanup keeps the (agent_id, name) unique constraint clear.
+  async function deleteByName(name: string): Promise<void> {
+    const list = await request(app.getHttpServer())
+      .get(`/api/v1/routing/${agentName}/custom-providers`)
+      .set(headers);
+    const match = list.body.find((p: { name: string; id: string }) => p.name === name);
+    if (match) {
+      await request(app.getHttpServer())
+        .delete(`/api/v1/routing/${agentName}/custom-providers/${match.id}`)
+        .set(headers);
+    }
+  }
+
+  function messagesOf(body: unknown): string[] {
+    const m = (body as { message?: string | string[] }).message;
+    if (Array.isArray(m)) return m.filter((x): x is string => typeof x === 'string');
+    return typeof m === 'string' ? [m] : [];
+  }
+
+  describe('POST — malformed input rejected by ValidationPipe', () => {
+    it('rejects a plain string with no scheme or host as 400', async () => {
+      // IsUrl(require_protocol:true) demands a real scheme — "not-a-url"
+      // has no scheme, no host, no path, so the DTO never reaches service.
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({ name: 'Malformed1', base_url: 'not-a-url', models: baseModels })
+        .expect(400);
+
+      // Pin the DTO's "Must be a valid URL" message so the rejection is
+      // base_url-specific and not e.g. a missing-name false positive.
+      expect(messagesOf(res.body).some((m) => m.includes('valid URL'))).toBe(true);
+    });
+
+    it('rejects host:port without a scheme as 400 (require_protocol)', async () => {
+      // "localhost:9000" looks like a URL to humans but validator.js
+      // rejects it without an http(s):// prefix.
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({ name: 'NoScheme', base_url: 'localhost:9000', models: baseModels })
+        .expect(400);
+
+      expect(messagesOf(res.body).some((m) => m.includes('valid URL'))).toBe(true);
+    });
+
+    it('rejects an empty base_url as 400', async () => {
+      // Caught by IsNotEmpty before IsUrl. Explicit assertion catches a
+      // regression where "" silently becomes a default value.
+      await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({ name: 'EmptyUrl', base_url: '', models: baseModels })
+        .expect(400);
+    });
+  });
+
+  describe('POST — dev/local URLs allowed in test mode', () => {
+    afterEach(async () => {
+      await deleteByName('Dev Localhost');
+      await deleteByName('Long Path');
+    });
+
+    it('accepts http://localhost:9000 with explicit scheme', async () => {
+      // Local LLM servers (Ollama, LM Studio, vLLM, llama.cpp) all bind
+      // to localhost. NODE_ENV=test skips SSRF, mirroring the real
+      // selfhosted allowPrivate path.
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({ name: 'Dev Localhost', base_url: 'http://localhost:9000/v1', models: baseModels })
+        .expect(201);
+
+      expect(res.body.base_url).toBe('http://localhost:9000/v1');
+    });
+
+    it('accepts a long but valid URL (>200 chars, no MaxLength on DTO)', async () => {
+      // The DTO has no MaxLength on base_url. Pin that a long valid URL
+      // (well past the 64-char string in the finding) still lands at 201,
+      // guarding against a regression that clips long-but-legal URLs.
+      const longPath = 'x'.repeat(200);
+      const longUrl = `https://api.example.com/v1/${longPath}`;
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({ name: 'Long Path', base_url: longUrl, models: baseModels })
+        .expect(201);
+
+      expect(res.body.base_url).toBe(longUrl);
+    });
+  });
+
+  describe('POST — service-layer SSRF guard (cloud mode)', () => {
+    // Flip SKIP_SSRF_VALIDATION per-test so the NODE_ENV=test short-circuit
+    // is bypassed and the real cloud-mode behavior runs. MANIFEST_MODE is
+    // forced to "cloud" so a Docker auto-detect doesn't switch modes.
+    let originalSkip: string | undefined;
+    let originalMode: string | undefined;
+
+    beforeEach(() => {
+      originalSkip = process.env['SKIP_SSRF_VALIDATION'];
+      originalMode = process.env['MANIFEST_MODE'];
+      process.env['SKIP_SSRF_VALIDATION'] = 'false';
+      process.env['MANIFEST_MODE'] = 'cloud';
+    });
+
+    afterEach(() => {
+      if (originalSkip === undefined) delete process.env['SKIP_SSRF_VALIDATION'];
+      else process.env['SKIP_SSRF_VALIDATION'] = originalSkip;
+      if (originalMode === undefined) delete process.env['MANIFEST_MODE'];
+      else process.env['MANIFEST_MODE'] = originalMode;
+    });
+
+    it('rejects plaintext http:// to a public host in cloud mode as 400', async () => {
+      // AC-2 in the Mine paper: forwarding API keys + completions over
+      // http leaks credentials to passive wire-sniffers.
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({
+          name: 'Plaintext HTTP',
+          base_url: 'http://api.example.com/v1',
+          models: baseModels,
+        })
+        .expect(400);
+
+      // The error message hints at MANIFEST_MODE=selfhosted; the "https"
+      // substring is the user-actionable key. Loose-match it so message
+      // refactors that preserve intent don't fail the test.
+      const body = res.body as { message?: string };
+      expect(typeof body.message === 'string' && body.message.includes('https')).toBe(true);
+    });
+
+    it('rejects private-IP URLs in cloud mode as 400 (SSRF)', async () => {
+      // RFC 1918 private space must never be reachable from the cloud
+      // proxy — that's how attackers pivot to internal services.
+      await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({ name: 'Private IP', base_url: 'https://10.0.0.5/v1', models: baseModels })
+        .expect(400);
+    });
+
+    it('rejects 127.0.0.1 loopback URLs in cloud mode as 400', async () => {
+      // Loopback is the classic SSRF target (admin consoles bound there).
+      // Even with https://, cloud mode must refuse it.
+      await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({ name: 'Loopback', base_url: 'https://127.0.0.1:8080/v1', models: baseModels })
+        .expect(400);
+    });
+
+    it('rejects cloud-metadata IMDS URL even when self-hosted', async () => {
+      // The one URL family blocked in both modes: cloud metadata
+      // (169.254.169.254 etc.). Flipping into self-hosted proves the
+      // override path doesn't reopen the IMDS hole.
+      process.env['MANIFEST_MODE'] = 'selfhosted';
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({
+          name: 'IMDS',
+          base_url: 'http://169.254.169.254/latest/meta-data',
+          models: baseModels,
+        })
+        .expect(400);
+
+      const body = res.body as { message?: string };
+      expect(typeof body.message === 'string' && body.message.includes('metadata')).toBe(true);
+    });
+  });
+
+  describe('PUT — same URL rules on update', () => {
+    let createdId: string;
+
+    beforeEach(async () => {
+      // Fresh row per test so a 400 update doesn't poison the next test.
+      const res = await request(app.getHttpServer())
+        .post(`/api/v1/routing/${agentName}/custom-providers`)
+        .set(headers)
+        .send({
+          name: 'Update Target',
+          base_url: 'https://api.example.com/v1',
+          models: baseModels,
+        })
+        .expect(201);
+      createdId = res.body.id;
+    });
+
+    afterEach(async () => {
+      await deleteByName('Update Target');
+    });
+
+    it('rejects a malformed base_url on update as 400', async () => {
+      // Same DTO rules as POST — IsUrl fires on update too.
+      await request(app.getHttpServer())
+        .put(`/api/v1/routing/${agentName}/custom-providers/${createdId}`)
+        .set(headers)
+        .send({ base_url: 'not-a-url' })
+        .expect(400);
+    });
+
+    it('rejects schemeless host:port on update as 400', async () => {
+      await request(app.getHttpServer())
+        .put(`/api/v1/routing/${agentName}/custom-providers/${createdId}`)
+        .set(headers)
+        .send({ base_url: 'localhost:9000' })
+        .expect(400);
+    });
+
+    it('rejects plaintext http to a public host on update in cloud mode', async () => {
+      const originalSkip = process.env['SKIP_SSRF_VALIDATION'];
+      const originalMode = process.env['MANIFEST_MODE'];
+      process.env['SKIP_SSRF_VALIDATION'] = 'false';
+      process.env['MANIFEST_MODE'] = 'cloud';
+      try {
+        await request(app.getHttpServer())
+          .put(`/api/v1/routing/${agentName}/custom-providers/${createdId}`)
+          .set(headers)
+          .send({ base_url: 'http://api.example.com/v1' })
+          .expect(400);
+      } finally {
+        if (originalSkip === undefined) delete process.env['SKIP_SSRF_VALIDATION'];
+        else process.env['SKIP_SSRF_VALIDATION'] = originalSkip;
+        if (originalMode === undefined) delete process.env['MANIFEST_MODE'];
+        else process.env['MANIFEST_MODE'] = originalMode;
+      }
+    });
+
+    it('accepts a fresh valid https URL on update (sanity)', async () => {
+      // Negative-space control: a well-formed public URL must succeed
+      // and the new base_url must persist.
+      const res = await request(app.getHttpServer())
+        .put(`/api/v1/routing/${agentName}/custom-providers/${createdId}`)
+        .set(headers)
+        .send({ base_url: 'https://api.example.com/openai/v1' })
+        .expect(200);
+
+      expect(res.body.base_url).toBe('https://api.example.com/openai/v1');
+    });
+  });
+});

--- a/packages/backend/test/messages.e2e-spec.ts
+++ b/packages/backend/test/messages.e2e-spec.ts
@@ -94,7 +94,7 @@ describe('GET /api/v1/messages', () => {
     expect(res.body.items.length).toBeLessThanOrEqual(1);
   });
 
-  it('supports cursor-based pagination', async () => {
+  it('supports cursor-based pagination without page overlap', async () => {
     const res1 = await request(app.getHttpServer())
       .get('/api/v1/messages?range=24h&limit=1')
       .set('x-api-key', TEST_API_KEY)
@@ -108,6 +108,11 @@ describe('GET /api/v1/messages', () => {
 
       expect(res2.body.items.length).toBeGreaterThan(0);
       expect(res2.body.items[0].id).not.toBe(res1.body.items[0].id);
+
+      // Pages must not overlap: ids across page1 ∪ page2 should be unique.
+      const ids1 = res1.body.items.map((it: { id: string }) => it.id);
+      const ids2 = res2.body.items.map((it: { id: string }) => it.id);
+      expect(new Set([...ids1, ...ids2]).size).toBe(ids1.length + ids2.length);
     }
   });
 
@@ -177,7 +182,7 @@ describe('PATCH /api/v1/messages/:id/feedback', () => {
     messageId = res.body.items[0].id;
   });
 
-  it('sets like feedback', async () => {
+  it('sets like feedback and persists it to the database row', async () => {
     await request(app.getHttpServer())
       .patch(`/api/v1/messages/${messageId}/feedback`)
       .set('x-api-key', TEST_API_KEY)
@@ -192,6 +197,20 @@ describe('PATCH /api/v1/messages/:id/feedback', () => {
     expect(details.body.message.feedback_rating).toBe('like');
     expect(details.body.message.feedback_tags).toBeNull();
     expect(details.body.message.feedback_details).toBeNull();
+
+    // Verify persistence by reading the row directly instead of trusting the
+    // controller projection — guards against an ORM .update() being silently
+    // dropped or projected from cache.
+    const ds = app.get(DataSource);
+    const dbRow = await ds.query(
+      `SELECT feedback_rating, feedback_tags, feedback_details
+         FROM agent_messages WHERE id = $1`,
+      [messageId],
+    );
+    expect(dbRow).toHaveLength(1);
+    expect(dbRow[0].feedback_rating).toBe('like');
+    expect(dbRow[0].feedback_tags).toBeNull();
+    expect(dbRow[0].feedback_details).toBeNull();
   });
 
   it('sets dislike feedback with tags and details', async () => {

--- a/packages/backend/test/messages.isolation.e2e-spec.ts
+++ b/packages/backend/test/messages.isolation.e2e-spec.ts
@@ -1,0 +1,166 @@
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import request from 'supertest';
+import { createTestApp, TEST_API_KEY, TEST_TENANT_ID, TEST_AGENT_ID } from './helpers';
+
+// Cross-tenant isolation boundary test for /api/v1/messages.
+//
+// The MockSessionGuard in test/helpers.ts authenticates every request as
+// TEST_USER_ID ("test-user-001"). We seed agent_messages owned by a SECOND
+// tenant/user ("attacker-tenant-002" / "attacker-user-002") and assert that
+// the authenticated user can never see those rows.
+//
+// This pins the addTenantFilter() contract in
+// packages/backend/src/analytics/services/query-helpers.ts: queries must scope
+// by tenant_id (resolved from the user's tenant), not just user_id, so a row
+// inserted with a different tenant_id and a different user_id never leaks.
+
+let app: INestApplication;
+let ds: DataSource;
+
+const ATTACKER_TENANT_ID = 'attacker-tenant-002';
+const ATTACKER_USER_ID = 'attacker-user-002';
+const ATTACKER_AGENT_ID = 'attacker-agent-002';
+const ATTACKER_MESSAGE_ID = 'attacker-message-002';
+const VICTIM_MESSAGE_ID = 'victim-message-001';
+
+async function insertMessage(
+  id: string,
+  tenantId: string,
+  agentId: string,
+  agentName: string,
+  userId: string,
+  description: string,
+  now: string,
+): Promise<void> {
+  await ds.query(
+    `INSERT INTO agent_messages
+       (id, tenant_id, agent_id, timestamp, status, model,
+        input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+        description, service_type, agent_name, user_id)
+     VALUES ($1,$2,$3,$4,'ok','gpt-4o',100,50,0,0,$5,'agent',$6,$7)`,
+    [id, tenantId, agentId, now, description, agentName, userId],
+  );
+}
+
+beforeAll(async () => {
+  app = await createTestApp();
+  ds = app.get(DataSource);
+
+  // Use a "recent" timestamp so the data falls inside the analytics service's
+  // default cutoff windows (1h/6h/24h/7d/30d). The existing messages.e2e-spec
+  // file also seeds with new Date(), so we mirror that pattern.
+  const now = new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+
+  // Seed a second tenant + agent that DO NOT belong to TEST_USER_ID. The
+  // tenants table's `name` column is the user id (per onboarding flow), so
+  // TenantCacheService.resolve(TEST_USER_ID) keeps resolving to
+  // TEST_TENANT_ID, never to ATTACKER_TENANT_ID.
+  await ds.query(
+    `INSERT INTO tenants (id, name, organization_name, is_active, created_at, updated_at)
+     VALUES ($1, $2, $3, true, $4, $4)`,
+    [ATTACKER_TENANT_ID, ATTACKER_USER_ID, 'Attacker Org', now],
+  );
+  await ds.query(
+    `INSERT INTO agents
+       (id, name, display_name, description, is_active, complexity_routing_enabled,
+        tenant_id, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, true, true, $5, $6, $6)`,
+    [
+      ATTACKER_AGENT_ID,
+      'attacker-agent',
+      'Attacker Agent',
+      'Owned by another tenant',
+      ATTACKER_TENANT_ID,
+      now,
+    ],
+  );
+
+  await insertMessage(
+    VICTIM_MESSAGE_ID,
+    TEST_TENANT_ID,
+    TEST_AGENT_ID,
+    'test-agent',
+    'test-user-001',
+    'Victim message',
+    now,
+  );
+  await insertMessage(
+    ATTACKER_MESSAGE_ID,
+    ATTACKER_TENANT_ID,
+    ATTACKER_AGENT_ID,
+    'attacker-agent',
+    ATTACKER_USER_ID,
+    'SECRET attacker payload',
+    now,
+  );
+});
+
+afterAll(async () => {
+  await app?.close();
+});
+
+describe('Cross-tenant isolation: GET /api/v1/messages', () => {
+  it('omits messages owned by a different tenant from the list response', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h&limit=200')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    expect(Array.isArray(res.body.items)).toBe(true);
+
+    // Confirm the victim's own row IS returned, otherwise the assertion below
+    // could trivially pass on an empty result. This guards against a future
+    // refactor that breaks the legitimate read path.
+    const returnedIds: string[] = res.body.items.map((it: { id: string }) => it.id);
+    expect(returnedIds).toContain(VICTIM_MESSAGE_ID);
+
+    // The attacker's row must not leak through the projection.
+    expect(returnedIds).not.toContain(ATTACKER_MESSAGE_ID);
+
+    // Belt-and-braces: agent_name is in the shared MessageRow projection, so
+    // any cross-tenant leak via a missing WHERE clause would surface here.
+    for (const item of res.body.items as Record<string, unknown>[]) {
+      expect(item['agent_name']).not.toBe('attacker-agent');
+    }
+  });
+
+  it('does not return another tenant\'s messages when filtering by attacker agent name', async () => {
+    // Even an explicit agent_name filter for the attacker's agent must NOT
+    // reveal cross-tenant data — addTenantFilter() resolves agent_name within
+    // the caller's tenant scope only.
+    const res = await request(app.getHttpServer())
+      .get('/api/v1/messages?range=24h&agent_name=attacker-agent')
+      .set('x-api-key', TEST_API_KEY)
+      .expect(200);
+
+    const returnedIds: string[] = res.body.items.map((it: { id: string }) => it.id);
+    expect(returnedIds).not.toContain(ATTACKER_MESSAGE_ID);
+  });
+
+  it('blocks PATCH /:id/feedback against a message owned by a different tenant', async () => {
+    // Even when the attacker's row id is known, the authenticated user must
+    // not be able to mutate it. The feedback service uses tenant scoping in
+    // findOwnedMessage(); a leak would return 204 instead of 404.
+    await request(app.getHttpServer())
+      .patch(`/api/v1/messages/${ATTACKER_MESSAGE_ID}/feedback`)
+      .set('x-api-key', TEST_API_KEY)
+      .send({ rating: 'like' })
+      .expect(404);
+
+    // Confirm at the DB layer that the attacker row was NOT mutated.
+    const dbRow = await ds.query(
+      `SELECT feedback_rating FROM agent_messages WHERE id = $1`,
+      [ATTACKER_MESSAGE_ID],
+    );
+    expect(dbRow).toHaveLength(1);
+    expect(dbRow[0].feedback_rating).toBeNull();
+  });
+
+  it('blocks GET /:id/details against a message owned by a different tenant', async () => {
+    await request(app.getHttpServer())
+      .get(`/api/v1/messages/${ATTACKER_MESSAGE_ID}/details`)
+      .set('x-api-key', TEST_API_KEY)
+      .expect(404);
+  });
+});

--- a/packages/backend/test/proxy.e2e-spec.ts
+++ b/packages/backend/test/proxy.e2e-spec.ts
@@ -146,19 +146,64 @@ describe('Proxy E2E — /v1/chat/completions', () => {
         stream: false,
       });
 
-    // The response should NOT be our AgentKeyAuthGuard 401 (which has a specific format).
-    // It will be either a provider error (401/403 from OpenAI) or a network error (500).
-    // Either way, we passed auth and resolved a model successfully.
+    // Whitelist of intentionally-handled status codes. If a status outside this
+    // set surfaces (e.g., a stray 404, 405, 501), the test should fail loudly
+    // instead of silently passing — that signals a real regression in the
+    // proxy pipeline. Forcing the assertion BEFORE the header check also
+    // prevents the original bug where a provider-returned 403 would skip the
+    // header verification entirely and be misread as success.
+    expect([200, 400, 401, 403, 429, 500, 502, 503, 504]).toContain(res.status);
+
+    // The AgentKeyAuthGuard rejects requests BEFORE the proxy resolves a model,
+    // so guard-emitted responses never carry X-Manifest-* headers. If the
+    // status is in the 4xx range that the guard could plausibly emit (401/403),
+    // we must prove that this response came from the provider — i.e., the
+    // proxy successfully passed auth and forwarded — by asserting that the
+    // routing meta headers are present. A guard rejection here would mean the
+    // setup in beforeAll is broken (TEST_OTLP_KEY no longer valid).
+    if (res.status === 401 || res.status === 403) {
+      expect(res.headers['x-manifest-tier']).toBeDefined();
+      expect(res.headers['x-manifest-model']).toBeDefined();
+      expect(res.headers['x-manifest-provider']).toBeDefined();
+      // Body shape from handleProviderError() — upstream_error envelope with
+      // the forwarded status echoed in `error.status`. A guard 401 would have
+      // type='auth_error' so this also discriminates the two paths.
+      expect(res.body?.error?.type).toBe('upstream_error');
+      expect(res.body?.error?.status).toBe(res.status);
+    } else if (res.status >= 500) {
+      // Two failure modes converge here:
+      //  - handleProviderError (provider returned 5xx)  → type: 'upstream_error', X-Manifest-* present
+      //  - handleProxyError    (network/throw in proxy) → type: 'server_error',   no X-Manifest-* headers
+      // Whichever path fires, the envelope must be one of the two known shapes —
+      // a 5xx with no `error` object would indicate a regression.
+      expect(['upstream_error', 'server_error']).toContain(res.body?.error?.type);
+    } else if (res.status === 200) {
+      // Unlikely in CI (the fake key would be rejected), but if it succeeds
+      // we still expect the routing meta headers on the response.
+      expect(res.headers['x-manifest-tier']).toBeDefined();
+      expect(res.headers['x-manifest-model']).toBeDefined();
+    }
+  });
+
+  it('does not return guard 401 envelope when a valid agent key is supplied', async () => {
+    // Regression guard: if the AgentKeyAuthGuard ever rejects TEST_OTLP_KEY,
+    // the entire suite above silently degrades into "always 401, no headers"
+    // territory. Pin the contract explicitly so that a broken seed/key setup
+    // fails this single test instead of corrupting the meaning of every other
+    // assertion in the file.
+    const res = await bearer(api().post('/v1/chat/completions'))
+      .send({
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      });
+
     if (res.status === 401) {
-      // If 401, verify it's from the provider (not our guard)
-      // Our guard returns { message: '...', statusCode: 401 }
-      // Provider errors are forwarded with X-Manifest-* headers
-      const hasManifestHeaders =
-        res.headers['x-manifest-tier'] || res.headers['x-manifest-model'];
-      expect(hasManifestHeaders).toBeTruthy();
-    } else {
-      // Network error or other — proxy attempted the forward
-      expect(res.status).toBeDefined();
+      // Guard 401s pass through ProxyExceptionFilter and are wrapped with
+      // type: 'auth_error', code: 'manifest_auth'. Provider 401s come from
+      // handleProviderError() with type: 'upstream_error'. Asserting type
+      // discriminates the two, even before headers are checked.
+      expect(res.body?.error?.type).not.toBe('auth_error');
+      expect(res.body?.error?.code).not.toBe('manifest_auth');
     }
   });
 

--- a/packages/backend/test/setup.e2e-spec.ts
+++ b/packages/backend/test/setup.e2e-spec.ts
@@ -103,6 +103,63 @@ describe('First-run setup wizard', () => {
       expect(res.body.message).toBeDefined();
     });
 
+    // Email format edge cases — class-validator's @IsEmail() wraps
+    // validator.js's isEmail with default options (require_tld: true,
+    // allow_display_name: false, ignore_max_length: false). These tests
+    // pin the validator behaviour so an upstream change can't silently
+    // accept malformed addresses on the first-run setup endpoint.
+    it.each([
+      ['test@', 'missing domain'],
+      ['test@.com', 'domain starts with dot'],
+      ['test @example.com', 'space in local part'],
+      ['a@b', 'single-label domain (no TLD)'],
+      ['@example.com', 'missing local part'],
+      ['plainaddress', 'no @ symbol at all'],
+    ])('rejects email %p (%s)', async (email) => {
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({ email, name: 'Founder', password: 'secret-password' })
+        .expect(400);
+      expect(res.body.message).toBeDefined();
+    });
+
+    it('rejects email exceeding the 254-character MaxLength', async () => {
+      // Total > 254 triggers @MaxLength(254). validator.js also enforces
+      // a 254-char default cap (ignore_max_length: false) — either layer
+      // is sufficient to reject this address; we want both to keep it out.
+      const longEmail = `${'a'.repeat(64)}@${'b'.repeat(63)}.${'c'.repeat(63)}.${'d'.repeat(63)}.com`;
+      expect(longEmail.length).toBeGreaterThan(254);
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({ email: longEmail, name: 'Founder', password: 'secret-password' })
+        .expect(400);
+      expect(res.body.message).toBeDefined();
+    });
+
+    // Valid-format emails: the DTO validation must pass them through to
+    // the service. We assert this indirectly: with a user already in the
+    // table, the service throws ConflictException (409) — which is only
+    // reachable AFTER ValidationPipe has accepted the body.
+    it.each([
+      ['founder+label@example.com', 'plus addressing'],
+      ['founder.tag@sub.example.co.uk', 'dotted local + multi-label TLD'],
+    ])('accepts valid email %p (%s) past DTO validation', async (email) => {
+      const ds = app.get(DataSource);
+      await ds.query(
+        `INSERT INTO "user" (id, email, "emailVerified") VALUES ($1, $2, true)`,
+        ['blocking-admin', 'admin@example.com'],
+      );
+
+      const res = await request(app.getHttpServer())
+        .post('/api/v1/setup/admin')
+        .send({ email, name: 'Founder', password: 'secret-password' });
+
+      // 409 (not 400) proves validation passed and the request reached
+      // SetupService, which rejected due to the existing user.
+      expect(res.status).toBe(409);
+    });
+
     it('rejects when name is missing', async () => {
       const res = await request(app.getHttpServer())
         .post('/api/v1/setup/admin')

--- a/packages/backend/test/tokens.e2e-spec.ts
+++ b/packages/backend/test/tokens.e2e-spec.ts
@@ -54,6 +54,12 @@ describe('GET /api/v1/tokens', () => {
     expect(Array.isArray(res.body.hourly)).toBe(true);
     expect(res.body.hourly.length).toBeGreaterThan(0);
   });
+
+  it('rejects request without auth with 401', async () => {
+    await request(app.getHttpServer())
+      .get('/api/v1/tokens?range=24h')
+      .expect(401);
+  });
 });
 
 describe('GET /api/v1/costs', () => {

--- a/packages/frontend/tests/components/CostByModelTable.test.tsx
+++ b/packages/frontend/tests/components/CostByModelTable.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from '@solidjs/testing-library';
 import CostByModelTable from '../../src/components/CostByModelTable';
 
@@ -74,6 +74,7 @@ describe('CostByModelTable', () => {
   });
 
   it('renders a custom-provider letter badge when no logo is registered', () => {
+    const customProviderName = vi.fn(() => 'My Provider');
     const { container } = render(() => (
       <CostByModelTable
         rows={[
@@ -82,7 +83,7 @@ describe('CostByModelTable', () => {
             auth_type: null,
           }),
         ]}
-        customProviderName={() => 'My Provider'}
+        customProviderName={customProviderName}
       />
     ));
     const letterBadge = container.querySelector('.provider-card__logo-letter');
@@ -90,6 +91,8 @@ describe('CostByModelTable', () => {
     expect(letterBadge?.textContent).toBe('M');
     // Full cell text should include the namespaced custom model name.
     expect(container.textContent).toContain('custom:My Provider/gpt-custom');
+    // The component must call customProviderName with the row's model name.
+    expect(customProviderName).toHaveBeenCalledWith('custom:abc123/gpt-custom');
   });
 
   it('falls back to the stripped custom prefix when the provider name lookup returns nothing', () => {
@@ -140,5 +143,125 @@ describe('CostByModelTable', () => {
     ));
     const providerSpan = container.querySelector('tbody tr td span[title]');
     expect(providerSpan?.getAttribute('title')).toContain('Anthropic');
+  });
+
+  describe('boundary values', () => {
+    function shareCellOf(container: HTMLElement) {
+      return container.querySelector('tbody tr td:nth-child(3)');
+    }
+
+    function costCellOf(container: HTMLElement) {
+      return container.querySelector('tbody tr td:nth-child(4)');
+    }
+
+    function barWidthStyle(container: HTMLElement): string {
+      // Cell structure: <td><div flex><div bar-bg><div bar-fill/></div><span/></div></td>
+      // The bar fill is the deepest div, three levels below the cell.
+      const inner = container.querySelector(
+        'tbody tr td:nth-child(3) > div > div > div',
+      );
+      return inner?.getAttribute('style') ?? '';
+    }
+
+    it('handles share_pct = 0', () => {
+      const { container } = render(() => (
+        <CostByModelTable
+          rows={[row({ share_pct: 0 })]}
+          customProviderName={() => undefined}
+        />
+      ));
+      expect(barWidthStyle(container)).toContain('width: 0%');
+      expect(shareCellOf(container)?.textContent).toContain('0%');
+    });
+
+    it('handles share_pct = -1 without crashing', () => {
+      const { container } = render(() => (
+        <CostByModelTable
+          rows={[row({ share_pct: -1 })]}
+          customProviderName={() => undefined}
+        />
+      ));
+      // The text label uses Math.round, so "-1%" is shown verbatim.
+      expect(shareCellOf(container)?.textContent).toContain('-1%');
+      // jsdom filters invalid CSS values (width cannot be negative), so the
+      // width declaration is dropped from the parsed style. We only assert
+      // the component rendered without throwing.
+      expect(container.querySelector('tbody tr')).not.toBeNull();
+    });
+
+    it('handles share_pct > 100 without crashing', () => {
+      const { container } = render(() => (
+        <CostByModelTable
+          rows={[row({ share_pct: 150 })]}
+          customProviderName={() => undefined}
+        />
+      ));
+      expect(shareCellOf(container)?.textContent).toContain('150%');
+      // Width over 100% is allowed by the browser (will overflow the parent),
+      // but we just verify the value made it into the style untouched.
+      expect(barWidthStyle(container)).toContain('width: 150%');
+    });
+
+    it('handles share_pct = NaN without crashing', () => {
+      const { container } = render(() => (
+        <CostByModelTable
+          rows={[row({ share_pct: NaN })]}
+          customProviderName={() => undefined}
+        />
+      ));
+      // Math.round(NaN) is NaN — rendered as "NaN%". The component must
+      // remain renderable; we only care that no exception was thrown.
+      expect(shareCellOf(container)?.textContent).toContain('NaN%');
+      // The width style contains "NaN%" which is invalid CSS, but Solid
+      // still attaches the attribute. Ensure the row exists.
+      expect(container.querySelector('tbody tr')).not.toBeNull();
+    });
+
+    it('handles estimated_cost = -0.50 (returns null → em-dash)', () => {
+      const { container } = render(() => (
+        <CostByModelTable
+          rows={[row({ estimated_cost: -0.5 })]}
+          customProviderName={() => undefined}
+        />
+      ));
+      const cell = costCellOf(container);
+      expect(cell?.textContent?.trim()).toBe('—');
+      // No tooltip should be attached for invalid / negative costs.
+      expect(cell?.getAttribute('title')).toBeNull();
+    });
+
+    it('handles estimated_cost = NaN without crashing', () => {
+      const { container } = render(() => (
+        <CostByModelTable
+          rows={[row({ estimated_cost: NaN })]}
+          customProviderName={() => undefined}
+        />
+      ));
+      const cell = costCellOf(container);
+      // formatCost(NaN) currently falls through the comparisons and prints
+      // "$NaN". The contract under test is that the component does not
+      // throw and renders SOMETHING (em-dash OR the NaN-safe fallback).
+      const text = cell?.textContent?.trim() ?? '';
+      expect(text === '—' || text === '$NaN').toBe(true);
+      // The sub-penny tooltip path requires cost > 0 — NaN > 0 is false,
+      // so no tooltip should be set.
+      expect(cell?.getAttribute('title')).toBeNull();
+    });
+
+    it('handles estimated_cost = Infinity without crashing', () => {
+      const { container } = render(() => (
+        <CostByModelTable
+          rows={[row({ estimated_cost: Infinity })]}
+          customProviderName={() => undefined}
+        />
+      ));
+      const cell = costCellOf(container);
+      const text = cell?.textContent?.trim() ?? '';
+      // formatCost(Infinity) → "$Infinity". Em-dash is also acceptable if
+      // the helper is hardened later. Either way, no crash.
+      expect(text === '—' || text === '$Infinity').toBe(true);
+      // Infinity > 0 && Infinity < 0.01 is false, so no sub-penny tooltip.
+      expect(cell?.getAttribute('title')).toBeNull();
+    });
   });
 });

--- a/packages/frontend/tests/components/HeaderTierCard.test.tsx
+++ b/packages/frontend/tests/components/HeaderTierCard.test.tsx
@@ -1550,4 +1550,56 @@ describe('HeaderTierCard', () => {
       );
     });
   });
+
+  it('handles empty model in override_route gracefully', () => {
+    const tierEmptyModel = {
+      ...baseTier,
+      override_route: {
+        provider: 'openai',
+        authType: 'api_key' as const,
+        model: '',
+      },
+    };
+    const { container } = render(() => (
+      <HeaderTierCard
+        agentName="demo"
+        tier={tierEmptyModel}
+        models={models}
+        customProviders={customProviders}
+        connectedProviders={connectedProviders}
+        onOverride={vi.fn()}
+        onFallbacksUpdate={vi.fn()}
+      />
+    ));
+    // Empty model is falsy under <Show when={currentModel()}>, so the chip is
+    // suppressed and the "+ Add model" affordance takes the fallback slot.
+    expect(container.querySelector('.routing-card__model-chip')).toBeNull();
+    expect(container.textContent).toContain('+ Add model');
+  });
+
+  it('handles null provider with valid model by inferring from model name', () => {
+    const tierNullProvider = {
+      ...baseTier,
+      override_route: {
+        provider: null as unknown as string,
+        authType: 'api_key' as const,
+        model: 'gpt-4o',
+      },
+    };
+    const { container } = render(() => (
+      <HeaderTierCard
+        agentName="demo"
+        tier={tierNullProvider}
+        models={models}
+        customProviders={customProviders}
+        connectedProviders={connectedProviders}
+        onOverride={vi.fn()}
+        onFallbacksUpdate={vi.fn()}
+      />
+    ));
+    // A null provider is falsy, so providerId() falls to providerIdForModel,
+    // which resolves the openai prefix and renders the matching icon.
+    expect(container.querySelector('.routing-card__main')?.textContent).toBe('GPT-4o');
+    expect(container.querySelector('[data-testid="provider-icon-openai"]')).not.toBeNull();
+  });
 });

--- a/packages/frontend/tests/components/Help.test.tsx
+++ b/packages/frontend/tests/components/Help.test.tsx
@@ -44,4 +44,68 @@ describe("Help", () => {
     const contactLink = links.find((l) => l.textContent?.includes("Contact"));
     expect(contactLink).toBeDefined();
   });
+
+  it("Calendly link has correct href", () => {
+    render(() => <Help />);
+    const links = screen.getAllByRole("link");
+    const bookLink = links.find((l) => l.textContent?.includes("Book"));
+    expect(bookLink?.getAttribute("href")).toBe(
+      "https://calendly.com/sebastien-manifest/30min?month=2026-02",
+    );
+  });
+
+  it("Calendly link opens in new tab with noopener noreferrer", () => {
+    render(() => <Help />);
+    const links = screen.getAllByRole("link");
+    const bookLink = links.find((l) => l.textContent?.includes("Book"));
+    expect(bookLink?.getAttribute("target")).toBe("_blank");
+    expect(bookLink?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("Email link is mailto", () => {
+    render(() => <Help />);
+    const links = screen.getAllByRole("link");
+    const contactLink = links.find((l) => l.textContent?.includes("Contact"));
+    expect(contactLink?.getAttribute("href")).toBe(
+      "mailto:sebastien@manifest.build",
+    );
+  });
+
+  it("renders Title metadata", () => {
+    const { container } = render(() => <Help />);
+    const title = container.querySelector("title");
+    expect(title?.textContent).toContain("Help & Support - Manifest");
+  });
+
+  it("renders breadcrumb prompt text", () => {
+    render(() => <Help />);
+    expect(
+      screen.getByText(
+        /Questions or issues\? Reach out and we'll get back to you quickly/,
+      ),
+    ).toBeDefined();
+  });
+
+  it("describes the call duration in the Schedule a Call section", () => {
+    render(() => <Help />);
+    expect(
+      screen.getByText(/Book a 30-min call with us to get help setting things up\./),
+    ).toBeDefined();
+  });
+
+  it("shows the support email address with the response window", () => {
+    render(() => <Help />);
+    expect(
+      screen.getByText(/sebastien@manifest.build/),
+    ).toBeDefined();
+    expect(
+      screen.getByText(/we typically respond within 24 hours/),
+    ).toBeDefined();
+  });
+
+  it("renders exactly two action links (Book and Contact)", () => {
+    render(() => <Help />);
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBe(2);
+  });
 });

--- a/packages/frontend/tests/components/Pagination.test.tsx
+++ b/packages/frontend/tests/components/Pagination.test.tsx
@@ -93,7 +93,7 @@ describe("Pagination", () => {
       />
     ));
     fireEvent.click(screen.getByText("Previous"));
-    expect(onPrevious).toHaveBeenCalled();
+    expect(onPrevious).toHaveBeenCalledTimes(1);
   });
 
   it("calls onNext when Next clicked", () => {
@@ -109,7 +109,7 @@ describe("Pagination", () => {
       />
     ));
     fireEvent.click(screen.getByText("Next"));
-    expect(onNext).toHaveBeenCalled();
+    expect(onNext).toHaveBeenCalledTimes(1);
   });
 
   it("hidden when items fit on one page", () => {
@@ -174,5 +174,75 @@ describe("Pagination", () => {
     const next = screen.getByText("Next");
     expect(prev.getAttribute("aria-label")).toBe("Go to previous page");
     expect(next.getAttribute("aria-label")).toBe("Go to next page");
+  });
+
+  it("handles currentPage 0 gracefully", () => {
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 0}
+        totalItems={() => 100}
+        pageSize={25}
+        hasNextPage={() => true}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    // Exposes off-by-one: (0-1)*25+1 = -24, min(0*25, 100) = 0
+    expect(container.textContent).toContain("Showing -24");
+    expect(container.textContent).toContain("0");
+    expect(container.textContent).toContain("100");
+    // Previous button must remain disabled (currentPage <= 1)
+    expect(screen.getByText("Previous").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("handles pageSize of 0", () => {
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 1}
+        totalItems={() => 100}
+        pageSize={0}
+        hasNextPage={() => true}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    // Exposes nonsensical range: (1-1)*0+1 = 1, min(1*0, 100) = 0
+    expect(container.textContent).toContain("Showing 1");
+    expect(container.textContent).toContain("0");
+    expect(container.textContent).toContain("100");
+  });
+
+  it("hides pagination when pageSize exceeds totalItems", () => {
+    // Boundary: when pageSize > totalItems, Show condition is false
+    // so the nav is not rendered at all.
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 1}
+        totalItems={() => 20}
+        pageSize={50}
+        hasNextPage={() => false}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    expect(container.querySelector(".pagination")).toBeNull();
+    expect(container.textContent).not.toContain("Showing");
+  });
+
+  it("clamps end via Math.min when on last partial page", () => {
+    // Explicitly tests Math.min clamping at line 15: end = min(page*size, total)
+    // Page 2 of 15-per-page with 20 total → range 16-20 (clamped from 30 to 20).
+    const { container } = render(() => (
+      <Pagination
+        currentPage={() => 2}
+        totalItems={() => 20}
+        pageSize={15}
+        hasNextPage={() => false}
+        onPrevious={() => {}}
+        onNext={() => {}}
+      />
+    ));
+    expect(container.textContent).toContain("16");
+    expect(container.textContent).toContain("20");
   });
 });

--- a/packages/frontend/tests/components/ProviderSubscriptionTab.test.tsx
+++ b/packages/frontend/tests/components/ProviderSubscriptionTab.test.tsx
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+
+import ProviderSubscriptionTab from '../../src/components/ProviderSubscriptionTab';
+import type { ProviderDef } from '../../src/services/providers';
+
+const provider = (overrides: Partial<ProviderDef> & { id: string; name: string }): ProviderDef =>
+  ({
+    color: '#333',
+    initial: overrides.name.charAt(0),
+    supportsSubscription: true,
+    subtitle: '',
+    keyPrefix: '',
+    minKeyLength: 0,
+    keyPlaceholder: '',
+    models: [],
+    ...overrides,
+  }) as ProviderDef;
+
+const baseProps = {
+  busy: () => false,
+  isSubscriptionConnected: () => false,
+  isSubscriptionWithToken: () => false,
+  onOpenDetail: vi.fn(),
+  onAddKey: vi.fn(),
+  onToggle: vi.fn(),
+};
+
+const renderTab = (
+  subs: ProviderDef[],
+  overrides: Partial<typeof baseProps> = {},
+) =>
+  render(() => (
+    <ProviderSubscriptionTab
+      {...baseProps}
+      {...overrides}
+      subscriptionProviders={subs}
+    />
+  ));
+
+describe('ProviderSubscriptionTab', () => {
+  it('renders the hint, link, and falls back to default "Subscription" label', () => {
+    const { container } = renderTab([provider({ id: 'p1', name: 'Provider One' })]);
+    expect(container.querySelector('.provider-modal__tab-hint')?.textContent).toContain(
+      'subscription',
+    );
+    const link = container.querySelector('.provider-modal__add-custom-chip') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('https://github.com/mnfst/manifest/discussions/973');
+    expect(link.getAttribute('rel')).toContain('noopener');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(container.querySelector('.provider-toggle__name')?.textContent).toBe('Provider One');
+    expect(container.querySelector('.provider-toggle__local-only')?.textContent).toBe(
+      'Subscription',
+    );
+  });
+
+  it('uses subscriptionLabel when provided', () => {
+    const { container } = renderTab([
+      provider({ id: 'sub', name: 'SubProvider', subscriptionLabel: 'Pro Plan' }),
+    ]);
+    expect(container.querySelector('.provider-toggle__local-only')?.textContent).toBe('Pro Plan');
+  });
+
+  it('renders a letter badge when providerIcon returns null', () => {
+    const { container } = renderTab([
+      provider({ id: 'unknown-prov', name: 'Unknown', initial: 'U', color: '#abcdef' }),
+    ]);
+    expect(container.querySelector('.provider-card__logo-letter')?.textContent).toBe('U');
+  });
+
+  // ── hasDetailView() branch coverage ─────────────────────────────────
+
+  it.each([
+    ['subscriptionKeyPlaceholder', { subscriptionKeyPlaceholder: 'sk-...' }],
+    ['subscriptionCommand', { subscriptionCommand: 'manifest auth login cmd' }],
+    ['subscriptionAuthMode=popup_oauth', { subscriptionAuthMode: 'popup_oauth' as const }],
+    ['subscriptionAuthMode=device_code', { subscriptionAuthMode: 'device_code' as const }],
+    ['subscriptionAuthMode=popup_paste', { subscriptionAuthMode: 'popup_paste' as const }],
+    ['subscriptionAuthMode=token', { subscriptionAuthMode: 'token' as const }],
+  ])('opens detail view when provider has %s', (_, extra) => {
+    const onOpenDetail = vi.fn();
+    const onToggle = vi.fn();
+    const { container } = renderTab(
+      [provider({ id: 'dv', name: 'DV', ...extra })],
+      { onOpenDetail, onToggle },
+    );
+    fireEvent.click(container.querySelector('button.provider-toggle') as HTMLButtonElement);
+    expect(onOpenDetail).toHaveBeenCalledWith('dv', 'subscription');
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('calls onToggle (not onOpenDetail) when provider has no detail-view fields', () => {
+    const onOpenDetail = vi.fn();
+    const onToggle = vi.fn();
+    const { container } = renderTab(
+      // No subscriptionKeyPlaceholder, no subscriptionCommand, no subscriptionAuthMode.
+      [provider({ id: 'plain', name: 'Plain' })],
+      { onOpenDetail, onToggle },
+    );
+    fireEvent.click(container.querySelector('button.provider-toggle') as HTMLButtonElement);
+    expect(onToggle).toHaveBeenCalledWith('plain');
+    expect(onOpenDetail).not.toHaveBeenCalled();
+  });
+
+  // ── connected() / requiresStoredToken() branches ────────────────────
+
+  it('uses isSubscriptionWithToken for explicit token-mode providers', () => {
+    const isSubscriptionWithToken = vi.fn(() => true);
+    const isSubscriptionConnected = vi.fn(() => false);
+    const { container } = renderTab(
+      [
+        provider({
+          id: 'tk',
+          name: 'TokenMode',
+          subscriptionAuthMode: 'token',
+          subscriptionKeyPlaceholder: 'sk-...',
+        }),
+      ],
+      { isSubscriptionWithToken, isSubscriptionConnected },
+    );
+    expect(isSubscriptionWithToken).toHaveBeenCalledWith('tk');
+    expect(isSubscriptionConnected).not.toHaveBeenCalled();
+    expect(container.querySelector('.provider-toggle__switch--on')).not.toBeNull();
+  });
+
+  it('uses isSubscriptionWithToken when token mode is inferred via subscriptionKeyPlaceholder', () => {
+    // No explicit subscriptionAuthMode but has subscriptionKeyPlaceholder
+    // → getSubscriptionAuthMode falls back to 'token'.
+    const isSubscriptionWithToken = vi.fn(() => true);
+    const isSubscriptionConnected = vi.fn(() => false);
+    renderTab(
+      [provider({ id: 'inf', name: 'Inferred', subscriptionKeyPlaceholder: 'paste-token' })],
+      { isSubscriptionWithToken, isSubscriptionConnected },
+    );
+    expect(isSubscriptionWithToken).toHaveBeenCalledWith('inf');
+    expect(isSubscriptionConnected).not.toHaveBeenCalled();
+  });
+
+  it('uses isSubscriptionConnected for non-token (oauth/device_code) providers', () => {
+    const isSubscriptionWithToken = vi.fn(() => false);
+    const isSubscriptionConnected = vi.fn(() => true);
+    const { container } = renderTab(
+      [provider({ id: 'oa2', name: 'OAuthOther', subscriptionAuthMode: 'popup_oauth' })],
+      { isSubscriptionWithToken, isSubscriptionConnected },
+    );
+    expect(isSubscriptionConnected).toHaveBeenCalledWith('oa2');
+    expect(isSubscriptionWithToken).not.toHaveBeenCalled();
+    expect(container.querySelector('.provider-toggle__switch--on')).not.toBeNull();
+  });
+
+  it('uses isSubscriptionConnected for providers with no auth mode (undefined)', () => {
+    const isSubscriptionWithToken = vi.fn(() => false);
+    const isSubscriptionConnected = vi.fn(() => false);
+    renderTab(
+      [provider({ id: 'plain2', name: 'Plain2' })],
+      { isSubscriptionWithToken, isSubscriptionConnected },
+    );
+    expect(isSubscriptionConnected).toHaveBeenCalledWith('plain2');
+    expect(isSubscriptionWithToken).not.toHaveBeenCalled();
+  });
+
+  it('omits the provider-toggle__switch--on class when disconnected', () => {
+    const { container } = renderTab(
+      [provider({ id: 'p', name: 'P', subscriptionAuthMode: 'popup_oauth' })],
+      { isSubscriptionConnected: () => false },
+    );
+    expect(container.querySelector('.provider-toggle__switch--on')).toBeNull();
+  });
+
+  // ── Add connection button ───────────────────────────────────────────
+
+  it('shows add-connection button only when connected (token mode)', () => {
+    const tokenProv = provider({
+      id: 'tok',
+      name: 'TokenProv',
+      subscriptionAuthMode: 'token',
+      subscriptionKeyPlaceholder: 'sk-...',
+    });
+    const { container: connectedC } = renderTab([tokenProv], {
+      isSubscriptionWithToken: () => true,
+    });
+    expect(connectedC.querySelector('.provider-toggle__add-btn')).not.toBeNull();
+
+    const { container: disconnectedC } = renderTab([tokenProv], {
+      isSubscriptionWithToken: () => false,
+    });
+    expect(disconnectedC.querySelector('.provider-toggle__add-btn')).toBeNull();
+  });
+
+  it('shows add-connection button for non-token providers iff isSubscriptionConnected is true', () => {
+    const oauthProv = provider({
+      id: 'oa3',
+      name: 'OAuthProv',
+      subscriptionAuthMode: 'popup_oauth',
+    });
+    const { container: c1 } = renderTab([oauthProv], {
+      isSubscriptionConnected: () => false,
+    });
+    expect(c1.querySelector('.provider-toggle__add-btn')).toBeNull();
+
+    const { container: c2 } = renderTab([oauthProv], {
+      isSubscriptionConnected: () => true,
+    });
+    expect(c2.querySelector('.provider-toggle__add-btn')).not.toBeNull();
+  });
+
+  it('calls onAddKey when add-connection button is clicked and stops propagation', () => {
+    const onAddKey = vi.fn();
+    const onOpenDetail = vi.fn();
+    const onToggle = vi.fn();
+    const { container } = renderTab(
+      [
+        provider({
+          id: 'tok',
+          name: 'TokenProv',
+          subscriptionAuthMode: 'token',
+          subscriptionKeyPlaceholder: 'sk-...',
+        }),
+      ],
+      {
+        isSubscriptionWithToken: () => true,
+        onAddKey,
+        onOpenDetail,
+        onToggle,
+      },
+    );
+    fireEvent.click(container.querySelector('.provider-toggle__add-btn') as HTMLButtonElement);
+    expect(onAddKey).toHaveBeenCalledWith('tok', 'subscription');
+    // stopPropagation: parent button should NOT have been invoked.
+    expect(onOpenDetail).not.toHaveBeenCalled();
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('exposes an accessible label on the add-connection button', () => {
+    const { container } = renderTab(
+      [
+        provider({
+          id: 'tok',
+          name: 'NamedProv',
+          subscriptionAuthMode: 'token',
+          subscriptionKeyPlaceholder: 'sk-...',
+        }),
+      ],
+      { isSubscriptionWithToken: () => true },
+    );
+    const addBtn = container.querySelector('.provider-toggle__add-btn') as HTMLButtonElement;
+    expect(addBtn.getAttribute('aria-label')).toBe('Add connection for NamedProv');
+  });
+
+  // ── busy / multi-provider rendering ─────────────────────────────────
+
+  it('disables the provider tile button when busy() is true', () => {
+    const { container } = renderTab(
+      [provider({ id: 'p', name: 'P', subscriptionAuthMode: 'popup_oauth' })],
+      { busy: () => true },
+    );
+    const btn = container.querySelector('button.provider-toggle') as HTMLButtonElement;
+    expect(btn.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('renders multiple subscription providers in a single list', () => {
+    const { container } = renderTab([
+      provider({ id: 'a', name: 'Alpha', subscriptionAuthMode: 'token' }),
+      provider({ id: 'b', name: 'Beta', subscriptionAuthMode: 'popup_oauth' }),
+      provider({ id: 'c', name: 'Gamma' }),
+    ]);
+    expect(container.querySelectorAll('button.provider-toggle').length).toBe(3);
+    const names = Array.from(container.querySelectorAll('.provider-toggle__name')).map(
+      (n) => n.textContent?.trim() ?? '',
+    );
+    expect(names).toEqual(['Alpha', 'Beta', 'Gamma']);
+  });
+});

--- a/packages/frontend/tests/components/RecordedOutline.test.tsx
+++ b/packages/frontend/tests/components/RecordedOutline.test.tsx
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+import RecordedOutline, {
+  type OutlineRow,
+} from "../../src/components/RecordedOutline";
+import { MAX_COUNTED_MATCHES, type Role } from "../../src/components/recorded-message-helpers";
+
+const ALL_ROLES: ReadonlySet<Role> = new Set<Role>(["user", "assistant", "system", "tool"]);
+
+function buildRows(): OutlineRow[] {
+  return [
+    { index: 0, role: "system", roleLabel: "system", preview: "sys hello", tokens: 12 },
+    { index: 1, role: "user", roleLabel: "user", preview: "first user", tokens: 50 },
+    { index: 2, role: "assistant", roleLabel: "assistant", preview: "asst reply 1", tokens: 1500 },
+    { index: 3, role: "tool", roleLabel: "tool", preview: "tool out", tokens: 8 },
+    { index: 4, role: "user", roleLabel: "user", preview: "last user", tokens: 30 },
+    { index: 5, role: "assistant", roleLabel: "assistant", preview: "asst reply 2", tokens: 2200 },
+  ];
+}
+
+function defaultProps(overrides: Partial<Parameters<typeof RecordedOutline>[0]> = {}) {
+  return {
+    rows: buildRows(),
+    activeIndex: null as number | null,
+    visibleRoles: ALL_ROLES,
+    searchQuery: "",
+    onSearch: vi.fn(),
+    onJump: vi.fn(),
+    onToggleRole: vi.fn(),
+    onJumpLastUser: vi.fn(),
+    onJumpLastAssistant: vi.fn(),
+    onJumpFirstUser: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("RecordedOutline — search input", () => {
+  it("renders the input with the provided searchQuery value", () => {
+    const props = defaultProps({ searchQuery: "hello" });
+    render(() => <RecordedOutline {...props} />);
+    const input = screen.getByLabelText("Search conversation") as HTMLInputElement;
+    expect(input).toBeDefined();
+    expect(input.value).toBe("hello");
+  });
+
+  it("calls onSearch with the typed value when input changes", () => {
+    const onSearch = vi.fn();
+    render(() => <RecordedOutline {...defaultProps({ onSearch })} />);
+    const input = screen.getByLabelText("Search conversation") as HTMLInputElement;
+    fireEvent.input(input, { target: { value: "needle" } });
+    expect(onSearch).toHaveBeenCalledWith("needle");
+  });
+
+  it("renders the '/' keyboard hint", () => {
+    render(() => <RecordedOutline {...defaultProps()} />);
+    const kbd = document.querySelector(".recorded-modal__rail-kbd");
+    expect(kbd).not.toBeNull();
+    expect(kbd!.textContent).toBe("/");
+  });
+});
+
+describe("RecordedOutline — role chips", () => {
+  it("renders one chip per role with the correct data-role and label", () => {
+    render(() => <RecordedOutline {...defaultProps()} />);
+    for (const role of ["user", "assistant", "system", "tool"] as Role[]) {
+      const chip = document.querySelector(`button[data-role="${role}"]`);
+      expect(chip).not.toBeNull();
+      const label = role.charAt(0).toUpperCase() + role.slice(1);
+      expect(chip!.textContent).toContain(label);
+    }
+  });
+
+  it("reflects active state via aria-pressed and active class", () => {
+    const visibleRoles = new Set<Role>(["user", "assistant"]);
+    render(() => <RecordedOutline {...defaultProps({ visibleRoles })} />);
+
+    const userChip = document.querySelector('button[data-role="user"]')!;
+    expect(userChip.getAttribute("aria-pressed")).toBe("true");
+    expect(userChip.classList.contains("recorded-modal__rail-filter--active")).toBe(true);
+
+    const systemChip = document.querySelector('button[data-role="system"]')!;
+    expect(systemChip.getAttribute("aria-pressed")).toBe("false");
+    expect(systemChip.classList.contains("recorded-modal__rail-filter--active")).toBe(false);
+  });
+
+  it("hides the check icon when inactive via opacity style", () => {
+    const visibleRoles = new Set<Role>(["user"]);
+    render(() => <RecordedOutline {...defaultProps({ visibleRoles })} />);
+
+    const userChip = document.querySelector('button[data-role="user"]')!;
+    const userCheck = userChip.querySelector(".recorded-modal__rail-filter-check") as HTMLElement;
+    expect(userCheck.getAttribute("style")).toBeNull();
+
+    const systemChip = document.querySelector('button[data-role="system"]')!;
+    const systemCheck = systemChip.querySelector(".recorded-modal__rail-filter-check") as HTMLElement;
+    expect(systemCheck.getAttribute("style")).toContain("opacity: 0");
+  });
+
+  it("calls onToggleRole with the clicked role", async () => {
+    const onToggleRole = vi.fn();
+    render(() => <RecordedOutline {...defaultProps({ onToggleRole })} />);
+    await fireEvent.click(document.querySelector('button[data-role="system"]')!);
+    expect(onToggleRole).toHaveBeenCalledWith("system");
+  });
+
+  it("renders the CheckIcon SVG inside each chip", () => {
+    render(() => <RecordedOutline {...defaultProps()} />);
+    const chips = document.querySelectorAll(".recorded-modal__rail-filter");
+    expect(chips.length).toBe(4);
+    chips.forEach((chip) => {
+      expect(chip.querySelector("svg")).not.toBeNull();
+    });
+  });
+});
+
+describe("RecordedOutline — jump buttons", () => {
+  it("calls onJumpFirstUser when 'First user' is clicked", async () => {
+    const onJumpFirstUser = vi.fn();
+    render(() => <RecordedOutline {...defaultProps({ onJumpFirstUser })} />);
+    await fireEvent.click(screen.getByTitle("First user message"));
+    expect(onJumpFirstUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onJumpLastUser when 'Last user' is clicked", async () => {
+    const onJumpLastUser = vi.fn();
+    render(() => <RecordedOutline {...defaultProps({ onJumpLastUser })} />);
+    await fireEvent.click(screen.getByTitle("Last user message"));
+    expect(onJumpLastUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onJumpLastAssistant when 'Last assistant' is clicked", async () => {
+    const onJumpLastAssistant = vi.fn();
+    render(() => <RecordedOutline {...defaultProps({ onJumpLastAssistant })} />);
+    await fireEvent.click(screen.getByTitle("Last assistant reply"));
+    expect(onJumpLastAssistant).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("RecordedOutline — outline rows", () => {
+  it("renders one outline row per filtered row", () => {
+    render(() => <RecordedOutline {...defaultProps()} />);
+    const rowButtons = document.querySelectorAll(".recorded-modal__outline-row");
+    expect(rowButtons.length).toBe(6);
+  });
+
+  it("filters rows by visibleRoles", () => {
+    const visibleRoles = new Set<Role>(["user"]);
+    render(() => <RecordedOutline {...defaultProps({ visibleRoles })} />);
+    const rowButtons = document.querySelectorAll(".recorded-modal__outline-row");
+    expect(rowButtons.length).toBe(2);
+    rowButtons.forEach((btn) => {
+      expect(btn.getAttribute("data-role")).toBe("user");
+    });
+  });
+
+  it("calls onJump with the row index on click", async () => {
+    const onJump = vi.fn();
+    render(() => <RecordedOutline {...defaultProps({ onJump })} />);
+    const rowButtons = document.querySelectorAll(".recorded-modal__outline-row");
+    await fireEvent.click(rowButtons[2]!);
+    // 3rd row in the rows array has index === 2
+    expect(onJump).toHaveBeenCalledWith(2);
+  });
+
+  it("marks the active row with aria-current and active class", () => {
+    render(() => <RecordedOutline {...defaultProps({ activeIndex: 4 })} />);
+    const rowButtons = Array.from(
+      document.querySelectorAll(".recorded-modal__outline-row"),
+    ) as HTMLElement[];
+    const active = rowButtons.find((b) => b.classList.contains("recorded-modal__outline-row--active"));
+    expect(active).toBeDefined();
+    expect(active!.getAttribute("aria-current")).toBe("true");
+    expect(active!.textContent).toContain("last user");
+    // Non-active rows have no aria-current attribute
+    const inactive = rowButtons.filter(
+      (b) => !b.classList.contains("recorded-modal__outline-row--active"),
+    );
+    inactive.forEach((b) => expect(b.getAttribute("aria-current")).toBeNull());
+  });
+
+  it("renders index as 1-based and preview text", () => {
+    render(() => <RecordedOutline {...defaultProps()} />);
+    expect(screen.getByText("#1")).toBeDefined();
+    expect(screen.getByText("#6")).toBeDefined();
+    expect(screen.getByText("first user")).toBeDefined();
+    expect(screen.getByText("asst reply 2")).toBeDefined();
+  });
+
+  it("formats tokens >= 1000 with a 'k' suffix and one decimal", () => {
+    render(() => <RecordedOutline {...defaultProps()} />);
+    // tokens 1500 → "1.5k"
+    expect(screen.getByText("1.5k")).toBeDefined();
+    // tokens 2200 → "2.2k"
+    expect(screen.getByText("2.2k")).toBeDefined();
+    // tokens 12 → "12"
+    expect(screen.getByText("12")).toBeDefined();
+  });
+});
+
+describe("RecordedOutline — match badge", () => {
+  it("does not render the badge when matchCount is missing or zero", () => {
+    const rows: OutlineRow[] = [
+      { index: 0, role: "user", roleLabel: "user", preview: "a", tokens: 1 },
+      { index: 1, role: "user", roleLabel: "user", preview: "b", tokens: 1, matchCount: 0 },
+    ];
+    render(() => <RecordedOutline {...defaultProps({ rows })} />);
+    expect(document.querySelectorAll(".recorded-modal__outline-match").length).toBe(0);
+  });
+
+  it("renders matchCount when present and below the cap", () => {
+    const rows: OutlineRow[] = [
+      { index: 0, role: "user", roleLabel: "user", preview: "x", tokens: 1, matchCount: 3 },
+    ];
+    render(() => <RecordedOutline {...defaultProps({ rows })} />);
+    const badge = document.querySelector(".recorded-modal__outline-match");
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toBe("3");
+    expect(badge!.getAttribute("aria-label")).toBe("3 matches");
+  });
+
+  it("renders '<MAX>+' badge text and aria-label when at or above the cap", () => {
+    const rows: OutlineRow[] = [
+      {
+        index: 0,
+        role: "user",
+        roleLabel: "user",
+        preview: "x",
+        tokens: 1,
+        matchCount: MAX_COUNTED_MATCHES,
+      },
+    ];
+    render(() => <RecordedOutline {...defaultProps({ rows })} />);
+    const badge = document.querySelector(".recorded-modal__outline-match")!;
+    expect(badge.textContent).toBe(`${MAX_COUNTED_MATCHES}+`);
+    expect(badge.getAttribute("aria-label")).toBe(`More than ${MAX_COUNTED_MATCHES} matches`);
+  });
+});
+
+describe("RecordedOutline — empty state", () => {
+  it("renders 'No turns match the current filter.' when filtered list is empty", () => {
+    const visibleRoles = new Set<Role>([]);
+    render(() => <RecordedOutline {...defaultProps({ visibleRoles })} />);
+    expect(screen.getByText("No turns match the current filter.")).toBeDefined();
+  });
+
+  it("renders the empty state when rows are empty", () => {
+    render(() => <RecordedOutline {...defaultProps({ rows: [] })} />);
+    expect(screen.getByText("No turns match the current filter.")).toBeDefined();
+    expect(document.querySelectorAll(".recorded-modal__outline-row").length).toBe(0);
+  });
+
+  it("does not render the empty state when at least one row is visible", () => {
+    render(() => <RecordedOutline {...defaultProps()} />);
+    expect(document.querySelector(".recorded-modal__outline-empty")).toBeNull();
+  });
+});

--- a/packages/frontend/tests/components/RouteKeyChip.test.tsx
+++ b/packages/frontend/tests/components/RouteKeyChip.test.tsx
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
+import type { RoutingProvider } from '../../src/services/api/routing.js';
+import RouteKeyChip from '../../src/components/RouteKeyChip';
+
+function makeKey(label: string, overrides: Partial<RoutingProvider> = {}): RoutingProvider {
+  return {
+    id: `id-${label}`,
+    provider: 'openai',
+    auth_type: 'api_key',
+    is_active: true,
+    has_api_key: true,
+    label,
+    priority: 0,
+    connected_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const twoKeys: RoutingProvider[] = [makeKey('key-1'), makeKey('key-2', { id: 'id-key-2', priority: 1 })];
+
+function renderChip(propsOverride: Partial<Parameters<typeof RouteKeyChip>[0]> = {}) {
+  const onPick = propsOverride.onPick ?? vi.fn();
+  const result = render(() => (
+    <RouteKeyChip
+      keys={propsOverride.keys ?? twoKeys}
+      currentLabel={propsOverride.currentLabel ?? null}
+      modelLabel={propsOverride.modelLabel ?? 'GPT-4o'}
+      usedLabels={propsOverride.usedLabels}
+      onPick={onPick}
+      buttonClass={propsOverride.buttonClass ?? 'chip-class'}
+      disabled={propsOverride.disabled}
+      allowClear={propsOverride.allowClear}
+      leadingMargin={propsOverride.leadingMargin}
+      menuMinWidth={propsOverride.menuMinWidth}
+      stopPropagation={propsOverride.stopPropagation}
+    />
+  ));
+  return { ...result, onPick };
+}
+
+function getTriggerButton(container: HTMLElement): HTMLButtonElement {
+  return container.querySelector('button[aria-haspopup="listbox"]') as HTMLButtonElement;
+}
+
+function getListbox(container: HTMLElement): HTMLElement | null {
+  return container.querySelector('ul[role="listbox"]');
+}
+
+function getOptionButtons(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll('button[role="option"]'));
+}
+
+describe('RouteKeyChip', () => {
+  it('renders button with currentLabel and aria-label referencing modelLabel', () => {
+    const { container } = renderChip({ currentLabel: 'my-key', modelLabel: 'Claude Opus' });
+    const button = getTriggerButton(container);
+    expect(button).toBeDefined();
+    expect(button.textContent).toContain('my-key');
+    expect(button.getAttribute('aria-label')).toContain('Claude Opus');
+    expect(button.getAttribute('aria-label')).toContain('my-key');
+  });
+
+  it('opens dropdown on button click and toggles aria-expanded to true', () => {
+    const { container } = renderChip();
+    const button = getTriggerButton(container);
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(getListbox(container)).toBeNull();
+
+    fireEvent.click(button);
+
+    expect(getListbox(container)).not.toBeNull();
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('closes dropdown on button click when already open', () => {
+    const { container } = renderChip();
+    const button = getTriggerButton(container);
+    fireEvent.click(button);
+    expect(getListbox(container)).not.toBeNull();
+
+    fireEvent.click(button);
+
+    expect(getListbox(container)).toBeNull();
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('closes dropdown when clicking outside via mousedown', () => {
+    const { container } = renderChip();
+    fireEvent.click(getTriggerButton(container));
+    expect(getListbox(container)).not.toBeNull();
+
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+    fireEvent.mouseDown(outside);
+
+    expect(getListbox(container)).toBeNull();
+    outside.remove();
+  });
+
+  it('does not close dropdown when clicking inside the listbox', () => {
+    const { container } = renderChip();
+    fireEvent.click(getTriggerButton(container));
+    const listbox = getListbox(container);
+    expect(listbox).not.toBeNull();
+
+    // mousedown on the listbox itself — it is contained by containerRef
+    fireEvent.mouseDown(listbox!);
+
+    expect(getListbox(container)).not.toBeNull();
+  });
+
+  it('disables option buttons whose lowercase label is in usedLabels', () => {
+    const { container } = renderChip({
+      usedLabels: () => new Set(['key-1']),
+    });
+    fireEvent.click(getTriggerButton(container));
+
+    const options = getOptionButtons(container);
+    const optKey1 = options.find((o) => o.textContent?.includes('key-1'));
+    const optKey2 = options.find((o) => o.textContent?.includes('key-2'));
+    expect(optKey1).toBeDefined();
+    expect(optKey2).toBeDefined();
+    expect(optKey1!.hasAttribute('disabled')).toBe(true);
+    expect(optKey2!.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('calls onPick with null when Clear pin is clicked and closes dropdown', () => {
+    const onPick = vi.fn();
+    const { container } = renderChip({ allowClear: true, currentLabel: 'key-1', onPick });
+    fireEvent.click(getTriggerButton(container));
+
+    const clearBtn = getOptionButtons(container).find((b) => b.textContent?.includes('Clear pin'));
+    expect(clearBtn).toBeDefined();
+    fireEvent.click(clearBtn!);
+
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick).toHaveBeenCalledWith(null);
+    expect(getListbox(container)).toBeNull();
+  });
+
+  it('calls onPick with selected label when a non-selected option is clicked', () => {
+    const onPick = vi.fn();
+    const { container } = renderChip({ currentLabel: 'key-1', onPick });
+    fireEvent.click(getTriggerButton(container));
+
+    const optKey2 = getOptionButtons(container).find((o) => o.textContent?.includes('key-2'));
+    expect(optKey2).toBeDefined();
+    fireEvent.click(optKey2!);
+
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick).toHaveBeenCalledWith('key-2');
+    expect(getListbox(container)).toBeNull();
+  });
+
+  it('does not call onPick when clicking the already-selected option', () => {
+    const onPick = vi.fn();
+    const { container } = renderChip({ currentLabel: 'key-1', onPick });
+    fireEvent.click(getTriggerButton(container));
+
+    const optKey1 = getOptionButtons(container).find((o) => o.textContent?.includes('key-1'));
+    expect(optKey1).toBeDefined();
+    fireEvent.click(optKey1!);
+
+    expect(onPick).not.toHaveBeenCalled();
+    // Clicking an option still closes the dropdown (setOpen(false) runs unconditionally)
+    expect(getListbox(container)).toBeNull();
+  });
+
+  it('sets aria-selected correctly on options based on currentLabel', () => {
+    const { container } = renderChip({ currentLabel: 'key-1' });
+    fireEvent.click(getTriggerButton(container));
+
+    const optKey1 = getOptionButtons(container).find((o) => o.textContent?.includes('key-1'));
+    const optKey2 = getOptionButtons(container).find((o) => o.textContent?.includes('key-2'));
+    expect(optKey1!.getAttribute('aria-selected')).toBe('true');
+    expect(optKey2!.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('falls back to first key label when currentLabel is null', () => {
+    const { container } = renderChip({
+      currentLabel: null,
+      keys: [makeKey('default-key'), makeKey('other-key', { id: 'id-other', priority: 1 })],
+    });
+    const button = getTriggerButton(container);
+    expect(button.textContent).toContain('default-key');
+    expect(button.textContent).not.toContain('other-key');
+  });
+
+  it('calls event.stopPropagation when stopPropagation prop is true', () => {
+    const { container } = renderChip({ stopPropagation: true });
+    const button = getTriggerButton(container);
+
+    // Spy on stopPropagation by synthesizing the event explicitly.
+    const evt = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const stopSpy = vi.spyOn(evt, 'stopPropagation');
+    button.dispatchEvent(evt);
+
+    expect(stopSpy).toHaveBeenCalled();
+  });
+
+  it('does not call stopPropagation when stopPropagation prop is false/undefined', () => {
+    const { container } = renderChip();
+    const button = getTriggerButton(container);
+
+    const evt = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const stopSpy = vi.spyOn(evt, 'stopPropagation');
+    button.dispatchEvent(evt);
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  it('hides Clear pin button when allowClear is false even if currentLabel is set', () => {
+    const { container } = renderChip({ allowClear: false, currentLabel: 'key-1' });
+    fireEvent.click(getTriggerButton(container));
+
+    const clearBtn = getOptionButtons(container).find((b) => b.textContent?.includes('Clear pin'));
+    expect(clearBtn).toBeUndefined();
+  });
+
+  it('disables the trigger button when disabled prop is true', () => {
+    const { container } = renderChip({ disabled: true });
+    const button = getTriggerButton(container);
+    expect(button.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('does not open the dropdown when disabled prop is true', () => {
+    const { container } = renderChip({ disabled: true });
+    fireEvent.click(getTriggerButton(container));
+
+    // A disabled <button> swallows click events, so the dropdown never renders.
+    const options = getOptionButtons(container);
+    expect(options.length).toBe(0);
+  });
+
+  it('applies margin-left: 4px inline style when leadingMargin is true', () => {
+    const { container } = renderChip({ leadingMargin: true });
+    const style = getTriggerButton(container).getAttribute('style') ?? '';
+    expect(style).toContain('margin-left: 4px');
+  });
+
+  it('omits the margin-left rule when leadingMargin is false/undefined', () => {
+    const { container } = renderChip();
+    const style = getTriggerButton(container).getAttribute('style') ?? '';
+    expect(style).not.toContain('margin-left: 4px');
+  });
+
+  it('uses the menuMinWidth prop for the dropdown min-width', () => {
+    const { container } = renderChip({ menuMinWidth: 200 });
+    fireEvent.click(getTriggerButton(container));
+    const ul = getListbox(container);
+    expect(ul).not.toBeNull();
+    const style = ul!.getAttribute('style') ?? '';
+    expect(style).toContain('min-width: 200px');
+  });
+
+  it('falls back to a 160px min-width when menuMinWidth is not provided', () => {
+    const { container } = renderChip();
+    fireEvent.click(getTriggerButton(container));
+    const ul = getListbox(container);
+    const style = ul!.getAttribute('style') ?? '';
+    expect(style).toContain('min-width: 160px');
+  });
+
+  it('renders an empty string when keys is empty and currentLabel is null', () => {
+    const { container } = renderChip({ keys: [], currentLabel: null });
+    const button = getTriggerButton(container);
+    // The displayed label span is the first child span — its text should be empty.
+    const labelSpan = button.querySelector('span:first-child');
+    expect(labelSpan?.textContent).toBe('');
+  });
+
+  it('treats usedLabels as case-insensitive (lowercase set lookup)', () => {
+    // The component lowercases the key.label before checking usedLabels —
+    // a Set containing the lowercase form must mark it as used.
+    const { container } = renderChip({
+      keys: [makeKey('Key-MixedCase')],
+      usedLabels: () => new Set(['key-mixedcase']),
+    });
+    fireEvent.click(getTriggerButton(container));
+    const option = getOptionButtons(container)[0];
+    expect(option.hasAttribute('disabled')).toBe(true);
+  });
+});

--- a/packages/frontend/tests/components/Select.test.tsx
+++ b/packages/frontend/tests/components/Select.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { render, screen, fireEvent, waitFor } from "@solidjs/testing-library";
 import Select from "../../src/components/Select";
 
 describe("Select", () => {
@@ -41,8 +41,53 @@ describe("Select", () => {
     const trigger = screen.getByRole("button", { name: /Option A/i });
     await fireEvent.click(trigger);
     expect(screen.getByRole("listbox")).toBeDefined();
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
     await fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    });
     expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("does not close on non-Escape keys", async () => {
+    render(() => <Select options={options} value="a" onChange={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Option A/i });
+    await fireEvent.click(trigger);
+    expect(screen.getByRole("listbox")).toBeDefined();
+    await fireEvent.keyDown(document, { key: "Enter" });
+    await fireEvent.keyDown(document, { key: "ArrowDown" });
+    await fireEvent.keyDown(document, { key: "a" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.queryByRole("listbox")).not.toBeNull();
+  });
+
+  it("closes dropdown when clicking outside", async () => {
+    render(() => <Select options={options} value="a" onChange={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Option A/i });
+    await fireEvent.click(trigger);
+    expect(screen.getByRole("listbox")).toBeDefined();
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    const outsideElement = document.createElement("div");
+    document.body.appendChild(outsideElement);
+    await fireEvent.click(outsideElement);
+    await waitFor(() => {
+      expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    });
+    expect(screen.queryByRole("listbox")).toBeNull();
+    document.body.removeChild(outsideElement);
+  });
+
+  it("does not close when clicking inside the dropdown options", async () => {
+    render(() => <Select options={options} value="a" onChange={() => {}} />);
+    const trigger = screen.getByRole("button", { name: /Option A/i });
+    await fireEvent.click(trigger);
+    const listbox = screen.getByRole("listbox");
+    expect(listbox).toBeDefined();
+    // Click on the listbox container itself (not an option) — should remain open
+    // because the ref contains it.
+    await fireEvent.click(listbox);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.queryByRole("listbox")).not.toBeNull();
   });
 
   it("has correct aria attributes", () => {

--- a/packages/frontend/tests/components/Sparkline.test.tsx
+++ b/packages/frontend/tests/components/Sparkline.test.tsx
@@ -13,7 +13,13 @@ describe('Sparkline', () => {
   it('renders path data for non-empty data', () => {
     const { container } = render(() => <Sparkline data={[10, 20, 30]} />);
     const paths = container.querySelectorAll('path');
-    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.length).toBe(2);
+    // Verify area path (first path with fill gradient)
+    expect(paths[0]!.getAttribute('fill')).toBeTruthy();
+    expect(paths[0]!.getAttribute('fill')).toContain('url(#');
+    // Verify line path (second path with stroke)
+    expect(paths[1]!.getAttribute('stroke')).toBeTruthy();
+    expect(paths[1]!.getAttribute('fill')).toBe('none');
   });
 
   it('renders empty SVG for no data', () => {
@@ -21,6 +27,8 @@ describe('Sparkline', () => {
     const svg = container.querySelector('svg');
     expect(svg).not.toBeNull();
     expect(container.querySelectorAll('path').length).toBe(0);
+    // No gradient defs should be rendered either
+    expect(container.querySelectorAll('linearGradient').length).toBe(0);
   });
 
   it('applies custom dimensions', () => {
@@ -28,5 +36,86 @@ describe('Sparkline', () => {
     const svg = container.querySelector('svg');
     expect(svg!.getAttribute('width')).toBe('100');
     expect(svg!.getAttribute('height')).toBe('25');
+  });
+
+  it('handles single data point', () => {
+    // Single point hits stepX = w() / Math.max(0, 1) = w() / 1 fallback.
+    // Should not throw or produce NaN coordinates.
+    const { container } = render(() => <Sparkline data={[5]} />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBe(2);
+    // Path data must not contain NaN
+    expect(paths[0]!.getAttribute('d')).not.toContain('NaN');
+    expect(paths[1]!.getAttribute('d')).not.toContain('NaN');
+  });
+
+  it('handles all-zero data', () => {
+    // All zeros hits Math.max(...points, 1) = 1 fallback to avoid divide-by-zero.
+    const { container } = render(() => <Sparkline data={[0, 0, 0]} />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBe(2);
+    // Path data must not contain NaN or Infinity
+    expect(paths[0]!.getAttribute('d')).not.toContain('NaN');
+    expect(paths[0]!.getAttribute('d')).not.toContain('Infinity');
+    expect(paths[1]!.getAttribute('d')).not.toContain('NaN');
+    expect(paths[1]!.getAttribute('d')).not.toContain('Infinity');
+  });
+
+  it('applies custom color to stroke and gradient stops', () => {
+    const { container } = render(() => (
+      <Sparkline data={[1, 2, 3]} color="rgb(255, 0, 0)" />
+    ));
+    const linePath = container.querySelectorAll('path')[1];
+    expect(linePath!.getAttribute('stroke')).toBe('rgb(255, 0, 0)');
+    const stops = container.querySelectorAll('stop');
+    expect(stops.length).toBe(2);
+    expect(stops[0]!.getAttribute('stop-color')).toBe('rgb(255, 0, 0)');
+    expect(stops[1]!.getAttribute('stop-color')).toBe('rgb(255, 0, 0)');
+  });
+
+  it('generates unique gradient ids across instances rendered together', () => {
+    // Guards against gradient-id collisions when multiple sparklines are
+    // mounted in the same container. If the id scheme regresses (e.g. a
+    // constant id), the gradient fills bleed across instances.
+    const { container } = render(() => (
+      <>
+        <Sparkline data={[1, 2, 3]} />
+        <Sparkline data={[4, 5, 6]} />
+        <Sparkline data={[7, 8, 9]} />
+      </>
+    ));
+    const gradients = container.querySelectorAll('linearGradient');
+    expect(gradients.length).toBe(3);
+    const ids = Array.from(gradients).map((g) => g.getAttribute('id'));
+    // Every id must be a non-empty string
+    for (const id of ids) {
+      expect(id).toBeTruthy();
+    }
+    // Every id must be unique
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+    // Each area path's fill must reference its sibling gradient's id
+    const areaPaths = Array.from(container.querySelectorAll('path')).filter(
+      (p) => p.getAttribute('fill') !== 'none',
+    );
+    expect(areaPaths.length).toBe(3);
+    for (const path of areaPaths) {
+      const fill = path.getAttribute('fill') ?? '';
+      const match = fill.match(/^url\(#(.+)\)$/);
+      expect(match).not.toBeNull();
+      expect(ids).toContain(match![1]);
+    }
+  });
+
+  it('uses default width and height when not provided', () => {
+    const { container } = render(() => <Sparkline data={[1, 2, 3]} />);
+    const svg = container.querySelector('svg');
+    expect(svg!.getAttribute('width')).toBe('200');
+    expect(svg!.getAttribute('height')).toBe('50');
+    expect(svg!.getAttribute('viewBox')).toBe('0 0 200 50');
   });
 });

--- a/packages/frontend/tests/components/playground/PlaygroundPrompt.test.tsx
+++ b/packages/frontend/tests/components/playground/PlaygroundPrompt.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render } from '@solidjs/testing-library';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@solidjs/testing-library';
 
 /* ── Mock ResizeObserver ─────────────────────────────────────── */
 
@@ -22,7 +22,43 @@ vi.stubGlobal('ResizeObserver', MockResizeObserver);
 
 import PlaygroundPrompt from '../../../src/components/playground/PlaygroundPrompt';
 
-/* ── Tests ───────────────────────────────────────────────────── */
+/* ── Helper ──────────────────────────────────────────────────── */
+
+interface PropsOverride {
+  value?: string;
+  disabled?: boolean;
+  running?: boolean;
+  onSubmit?: () => void;
+  onChange?: (v: string) => void;
+  onRecallPrevious?: () => void;
+  onHeightChange?: (h: number) => void;
+  historyOpen?: boolean;
+}
+
+function setup(o: PropsOverride = {}) {
+  const onSubmit = o.onSubmit ?? vi.fn();
+  const onChange = o.onChange ?? vi.fn();
+  const onRecallPrevious = o.onRecallPrevious ?? vi.fn();
+  const utils = render(() => (
+    <PlaygroundPrompt
+      value={o.value ?? 'hello'}
+      disabled={o.disabled ?? false}
+      running={o.running ?? false}
+      onChange={onChange}
+      onSubmit={onSubmit}
+      onRecallPrevious={onRecallPrevious}
+      onHeightChange={o.onHeightChange}
+      historyOpen={o.historyOpen}
+    />
+  ));
+  const textarea = utils.container.querySelector('textarea') as HTMLTextAreaElement;
+  const button = utils.container.querySelector(
+    '.playground-prompt__send'
+  ) as HTMLButtonElement;
+  return { ...utils, textarea, button, onSubmit, onChange, onRecallPrevious };
+}
+
+/* ── Existing tests ──────────────────────────────────────────── */
 
 describe('PlaygroundPrompt', () => {
   beforeEach(() => {
@@ -31,50 +67,20 @@ describe('PlaygroundPrompt', () => {
   });
 
   it('adds the --history-open class when historyOpen is true', () => {
-    const { container } = render(() => (
-      <PlaygroundPrompt
-        value=""
-        onChange={vi.fn()}
-        onSubmit={vi.fn()}
-        onRecallPrevious={vi.fn()}
-        disabled={false}
-        running={false}
-        historyOpen={true}
-      />
-    ));
+    const { container } = setup({ historyOpen: true });
     const wrapper = container.querySelector('.playground-prompt-wrapper');
     expect(wrapper!.classList.contains('playground-prompt-wrapper--history-open')).toBe(true);
   });
 
   it('does NOT add the --history-open class when historyOpen is false', () => {
-    const { container } = render(() => (
-      <PlaygroundPrompt
-        value=""
-        onChange={vi.fn()}
-        onSubmit={vi.fn()}
-        onRecallPrevious={vi.fn()}
-        disabled={false}
-        running={false}
-        historyOpen={false}
-      />
-    ));
+    const { container } = setup({ historyOpen: false });
     const wrapper = container.querySelector('.playground-prompt-wrapper');
     expect(wrapper!.classList.contains('playground-prompt-wrapper--history-open')).toBe(false);
   });
 
   it('calls onHeightChange when the ResizeObserver fires and disconnects on cleanup', () => {
     const onHeightChange = vi.fn();
-    const { unmount } = render(() => (
-      <PlaygroundPrompt
-        value=""
-        onChange={vi.fn()}
-        onSubmit={vi.fn()}
-        onRecallPrevious={vi.fn()}
-        disabled={false}
-        running={false}
-        onHeightChange={onHeightChange}
-      />
-    ));
+    const { unmount } = setup({ onHeightChange });
 
     // Simulate a resize observation
     expect(roCallback).not.toBeNull();
@@ -88,17 +94,161 @@ describe('PlaygroundPrompt', () => {
 
   it('mounts without error when onHeightChange is not provided (ResizeObserver not created)', () => {
     roCallback = null;
-    render(() => (
-      <PlaygroundPrompt
-        value=""
-        onChange={vi.fn()}
-        onSubmit={vi.fn()}
-        onRecallPrevious={vi.fn()}
-        disabled={false}
-        running={false}
-      />
-    ));
+    setup({ value: '' });
     // No ResizeObserver created because onHeightChange is undefined
     expect(roCallback).toBeNull();
+  });
+});
+
+/* ── Button disabled state ───────────────────────────────────── */
+
+describe('PlaygroundPrompt button disabled state', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('disables send button when disabled=true (non-empty value)', () => {
+    const { button } = setup({ value: 'test prompt', disabled: true, running: false });
+    expect(button.hasAttribute('disabled')).toBe(true);
+    // aria-label depends on `running` only, not `disabled`
+    expect(button.getAttribute('aria-label')).toBe('Send prompt');
+  });
+
+  it('disables send button when value is empty (disabled=false)', () => {
+    const { button } = setup({ value: '', disabled: false, running: false });
+    expect(button.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('disables send button when value is whitespace-only', () => {
+    const { button } = setup({ value: '   \n  ', disabled: false, running: false });
+    expect(button.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('changes aria-label to "Running" when running=true (button stays enabled)', () => {
+    // Source line 117 only flips `disabled` on `props.disabled || empty value` —
+    // `running` alone does NOT disable the button, it only changes the aria-label.
+    const { button } = setup({ value: 'test prompt', disabled: false, running: true });
+    expect(button.hasAttribute('disabled')).toBe(false);
+    expect(button.getAttribute('aria-label')).toBe('Running');
+  });
+
+  it('enables send button when disabled=false, value non-empty, running=false', () => {
+    const { button } = setup({ value: 'test prompt', disabled: false, running: false });
+    expect(button.hasAttribute('disabled')).toBe(false);
+    expect(button.getAttribute('aria-label')).toBe('Send prompt');
+  });
+});
+
+/* ── Keyboard submission ─────────────────────────────────────── */
+
+describe('PlaygroundPrompt keyboard submission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits on plain Enter key', () => {
+    const onSubmit = vi.fn();
+    const { textarea } = setup({ value: 'test prompt', onSubmit });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits on Cmd+Enter (metaKey) — Mac shortcut', () => {
+    const onSubmit = vi.fn();
+    const { textarea } = setup({ value: 'test prompt', onSubmit });
+    fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits on Ctrl+Enter (ctrlKey) — Windows/Linux shortcut', () => {
+    const onSubmit = vi.fn();
+    const { textarea } = setup({ value: 'test prompt', onSubmit });
+    fireEvent.keyDown(textarea, { key: 'Enter', ctrlKey: true });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT submit on Shift+Enter (multiline / line break)', () => {
+    const onSubmit = vi.fn();
+    const { textarea } = setup({ value: 'test prompt', onSubmit });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does NOT submit when value is empty', () => {
+    const onSubmit = vi.fn();
+    const { textarea } = setup({ value: '', onSubmit });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does NOT submit when disabled=true', () => {
+    const onSubmit = vi.fn();
+    const { textarea } = setup({ value: 'test prompt', disabled: true, onSubmit });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does NOT submit when running=true', () => {
+    const onSubmit = vi.fn();
+    const { textarea } = setup({ value: 'test prompt', running: true, onSubmit });
+    fireEvent.keyDown(textarea, { key: 'Enter' });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('recalls previous prompt on ArrowUp when value is empty', () => {
+    const onRecallPrevious = vi.fn();
+    const { textarea } = setup({ value: '', onRecallPrevious });
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+    expect(onRecallPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT recall on ArrowUp when value is non-empty (cursor nav wins)', () => {
+    const onRecallPrevious = vi.fn();
+    const { textarea } = setup({ value: 'some text', onRecallPrevious });
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' });
+    expect(onRecallPrevious).not.toHaveBeenCalled();
+  });
+});
+
+/* ── onChange rapid typing ───────────────────────────────────── */
+
+describe('PlaygroundPrompt onChange', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards each onInput to onChange with correct value during rapid typing', () => {
+    const onChange = vi.fn();
+    const { textarea } = setup({ value: '', onChange });
+    fireEvent.input(textarea, { target: { value: 'a' } });
+    fireEvent.input(textarea, { target: { value: 'ab' } });
+    fireEvent.input(textarea, { target: { value: 'abc' } });
+    expect(onChange).toHaveBeenCalledTimes(3);
+    expect(onChange).toHaveBeenNthCalledWith(1, 'a');
+    expect(onChange).toHaveBeenNthCalledWith(2, 'ab');
+    expect(onChange).toHaveBeenNthCalledWith(3, 'abc');
+  });
+});
+
+/* ── autoGrow / MAX_PROMPT_LINES cap ─────────────────────────── */
+
+describe('PlaygroundPrompt autoGrow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('caps height at MAX_PROMPT_LINES * PROMPT_LINE_HEIGHT_PX (15 * 22 = 330px) when scrollHeight exceeds it', () => {
+    const { textarea } = setup({ value: '' });
+    // jsdom has no layout; define scrollHeight manually to simulate overflow
+    Object.defineProperty(textarea, 'scrollHeight', { configurable: true, value: 1000 });
+    fireEvent.input(textarea, { target: { value: 'lots\nof\nlines' } });
+    expect(textarea.style.height).toBe('330px');
+  });
+
+  it('grows textarea to scrollHeight when below the cap', () => {
+    const { textarea } = setup({ value: '' });
+    Object.defineProperty(textarea, 'scrollHeight', { configurable: true, value: 88 });
+    fireEvent.input(textarea, { target: { value: 'line1\nline2' } });
+    expect(textarea.style.height).toBe('88px');
   });
 });

--- a/packages/frontend/tests/pages/ConnectProvider.test.tsx
+++ b/packages/frontend/tests/pages/ConnectProvider.test.tsx
@@ -201,3 +201,86 @@ describe('ConnectProvider with provider deep-link', () => {
     expect(url).not.toContain('provider=custom');
   });
 });
+
+describe('ConnectProvider agent name URL encoding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('URL-encodes unsafe characters in agent name for single-agent redirect', async () => {
+    const unsafeName = 'test/agent?id=1&x=2#frag';
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: unsafeName }] });
+
+    render(() => <ConnectProvider />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled();
+    });
+
+    const url = mockNavigate.mock.calls[0][0] as string;
+    // Verify each unsafe character is percent-encoded in the path segment
+    expect(url).toContain('/agents/test%2Fagent%3Fid%3D1%26x%3D2%23frag/routing?');
+    // Raw unsafe characters must NOT appear in the path segment
+    expect(url).not.toContain('/agents/test/agent');
+    expect(url).not.toMatch(/\/agents\/[^/?]*\?id=1/);
+    expect(url).not.toMatch(/\/agents\/[^/?]*#frag/);
+  });
+
+  it('URL-encodes unsafe characters in agent name when clicking picker button', async () => {
+    const unsafeName = 'test/agent?id=1';
+    mockGetAgents.mockResolvedValue({
+      agents: [
+        { agent_name: 'agent-1', display_name: 'Agent One' },
+        { agent_name: unsafeName, display_name: 'Tricky' },
+      ],
+    });
+
+    render(() => <ConnectProvider />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tricky')).toBeDefined();
+    });
+
+    fireEvent.click(screen.getByText('Tricky'));
+
+    const url = mockNavigate.mock.calls[0][0] as string;
+    expect(url).toContain('/agents/test%2Fagent%3Fid%3D1/routing?');
+    expect(url).not.toContain('/agents/test/agent');
+  });
+
+  it('URL-encodes unicode (emoji + non-Latin) agent names', async () => {
+    const unicodeName = 'test-🤖-агент';
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: unicodeName }] });
+
+    render(() => <ConnectProvider />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled();
+    });
+
+    const url = mockNavigate.mock.calls[0][0] as string;
+    // encodeURIComponent of '🤖' is '%F0%9F%A4%96', cyrillic 'а' is '%D0%B0'
+    expect(url).toContain('/agents/test-%F0%9F%A4%96-%D0%B0%D0%B3%D0%B5%D0%BD%D1%82/routing?');
+    // Raw unicode should not appear in the encoded URL
+    expect(url).not.toContain('🤖');
+    expect(url).not.toContain('агент');
+  });
+
+  it('produces a parseable URL pathname when agent name has unsafe characters', async () => {
+    const unsafeName = 'a/b?c=d&e=f#g';
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: unsafeName }] });
+
+    render(() => <ConnectProvider />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled();
+    });
+
+    const url = mockNavigate.mock.calls[0][0] as string;
+    // Parsing must recover the original agent name from the path segment
+    const parsed = new URL(url, 'http://example.com');
+    const match = parsed.pathname.match(/^\/agents\/([^/]+)\/routing$/);
+    expect(match).not.toBeNull();
+    expect(decodeURIComponent(match![1])).toBe(unsafeName);
+  });
+});

--- a/packages/frontend/tests/pages/Login-validation.test.tsx
+++ b/packages/frontend/tests/pages/Login-validation.test.tsx
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent } from "@solidjs/testing-library";
+
+const mockSignInEmail = vi.fn().mockResolvedValue({});
+const mockSendVerificationEmail = vi.fn().mockResolvedValue({});
+
+let mockSearchParams: Record<string, string> = {};
+vi.mock("@solidjs/router", () => ({
+  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [mockSearchParams],
+}));
+
+vi.mock("@solidjs/meta", () => ({
+  Title: (props: any) => <title>{props.children}</title>,
+  Meta: () => null,
+}));
+
+vi.mock("../../src/services/auth-client.js", () => ({
+  authClient: {
+    signIn: { email: (...args: unknown[]) => mockSignInEmail(...args), social: vi.fn() },
+    sendVerificationEmail: (...args: unknown[]) => mockSendVerificationEmail(...args),
+  },
+}));
+
+vi.mock("../../src/services/toast-store.js", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+const mockCheckSocialProviders = vi.fn().mockResolvedValue([]);
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkSocialProviders: (...args: unknown[]) => mockCheckSocialProviders(...args),
+}));
+
+import Login from "../../src/pages/Login";
+
+const setupForm = () => {
+  const { container, unmount } = render(() => <Login />);
+  const form = container.querySelector("form") as HTMLFormElement;
+  const emailInput = container.querySelector('input[type="email"]') as HTMLInputElement;
+  const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement;
+  return { container, form, emailInput, passwordInput, unmount };
+};
+
+describe("Login validation - empty/invalid inputs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = {};
+    mockSignInEmail.mockResolvedValue({});
+    mockSendVerificationEmail.mockResolvedValue({});
+    mockCheckSocialProviders.mockResolvedValue([]);
+    localStorage.clear();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+  });
+
+  it("marks the form invalid when both email and password are empty", () => {
+    const { form, emailInput, passwordInput } = setupForm();
+    expect(emailInput.value).toBe("");
+    expect(passwordInput.value).toBe("");
+    expect(emailInput.hasAttribute("required")).toBe(true);
+    expect(passwordInput.hasAttribute("required")).toBe(true);
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  it("marks the form invalid when email is empty but password is set", () => {
+    const { form, passwordInput } = setupForm();
+    fireEvent.input(passwordInput, { target: { value: "validpassword" } });
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  it("marks the form invalid when password is empty but email is set", () => {
+    const { form, emailInput } = setupForm();
+    fireEvent.input(emailInput, { target: { value: "user@example.com" } });
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  it("marks the form invalid when the email format is not a valid address", () => {
+    const { form, emailInput, passwordInput } = setupForm();
+    fireEvent.input(emailInput, { target: { value: "not-an-email" } });
+    fireEvent.input(passwordInput, { target: { value: "validpassword" } });
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  it("marks the form valid when both fields are populated correctly", () => {
+    const { form, emailInput, passwordInput } = setupForm();
+    fireEvent.input(emailInput, { target: { value: "user@example.com" } });
+    fireEvent.input(passwordInput, { target: { value: "validpassword" } });
+    expect(form.checkValidity()).toBe(true);
+  });
+
+  it("uses the email input type so browsers enforce address format", () => {
+    const { emailInput } = setupForm();
+    expect(emailInput.type).toBe("email");
+  });
+
+  it("accepts emails containing SQL meta-characters but the browser still requires a valid shape", () => {
+    const { form, emailInput, passwordInput } = setupForm();
+    // SQL-meta characters embedded in a syntactically valid email
+    fireEvent.input(emailInput, { target: { value: "drop'table--@example.com" } });
+    fireEvent.input(passwordInput, { target: { value: "validpassword" } });
+    // type=email allows quotes; what matters is the @domain shape stays valid
+    expect(form.checkValidity()).toBe(true);
+  });
+
+  it("rejects a SQL-meta string that is not a valid email shape", () => {
+    const { form, emailInput, passwordInput } = setupForm();
+    fireEvent.input(emailInput, { target: { value: "' OR 1=1 --" } });
+    fireEvent.input(passwordInput, { target: { value: "validpassword" } });
+    expect(form.checkValidity()).toBe(false);
+  });
+
+  it("does not trim password whitespace before forwarding to authClient", async () => {
+    const { container, emailInput, passwordInput } = setupForm();
+    mockSignInEmail.mockResolvedValue({ error: null });
+    fireEvent.input(emailInput, { target: { value: "user@example.com" } });
+    // The password input is type=password, so the raw value (including whitespace) is preserved.
+    fireEvent.input(passwordInput, { target: { value: "  pass  " } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(mockSignInEmail).toHaveBeenCalledTimes(1);
+    });
+    // The email input has type=email so its value is browser/jsdom-normalized
+    // (leading/trailing whitespace stripped). The component itself does not trim
+    // either signal, but the platform-level email type may.
+    const call = mockSignInEmail.mock.calls[0][0];
+    expect(call.password).toBe("  pass  ");
+    expect(call.email).toBe("user@example.com");
+  });
+
+  it("accepts unicode characters in the email local part", () => {
+    const { form, emailInput, passwordInput } = setupForm();
+    fireEvent.input(emailInput, { target: { value: "用户@example.com" } });
+    fireEvent.input(passwordInput, { target: { value: "validpassword" } });
+    // jsdom + type=email permits unicode local-parts; assert it does not throw
+    expect(() => form.checkValidity()).not.toThrow();
+  });
+
+  it("handles very large password inputs without throwing", async () => {
+    const { container, emailInput, passwordInput } = setupForm();
+    mockSignInEmail.mockResolvedValue({ error: null });
+    const huge = "a".repeat(10 * 1024 + 1); // 10KB + 1 char
+    fireEvent.input(emailInput, { target: { value: "user@example.com" } });
+    fireEvent.input(passwordInput, { target: { value: huge } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(mockSignInEmail).toHaveBeenCalledTimes(1);
+    });
+    const call = mockSignInEmail.mock.calls[0][0] as { password: string };
+    expect(call.password.length).toBe(huge.length);
+  });
+});
+
+describe("Login resend cooldown - timer edge cases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams = {};
+    mockSignInEmail.mockResolvedValue({});
+    mockSendVerificationEmail.mockResolvedValue({});
+    mockCheckSocialProviders.mockResolvedValue([]);
+    localStorage.clear();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const triggerVerificationState = async (container: HTMLElement) => {
+    mockSignInEmail.mockResolvedValue({
+      error: { message: "Email is not verified", code: "EMAIL_NOT_VERIFIED" },
+    });
+    fireEvent.input(container.querySelector('input[type="email"]')!, {
+      target: { value: "user@example.com" },
+    });
+    fireEvent.input(container.querySelector('input[type="password"]')!, {
+      target: { value: "pass" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend verification email");
+    });
+    return Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Resend verification email"),
+    ) as HTMLButtonElement;
+  };
+
+  it("does not start a second cooldown when the resend button is clicked while disabled", async () => {
+    mockSendVerificationEmail.mockResolvedValue({ error: null });
+    const { container } = render(() => <Login />);
+    const resendBtn = await triggerVerificationState(container);
+    fireEvent.click(resendBtn);
+    // First call resolves and cooldown starts
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend in");
+    });
+    expect(mockSendVerificationEmail).toHaveBeenCalledTimes(1);
+    // Now the button is disabled — fireEvent.click on a disabled button is a no-op
+    const disabledBtn = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("Resend in"),
+    ) as HTMLButtonElement;
+    expect(disabledBtn.disabled).toBe(true);
+    fireEvent.click(disabledBtn);
+    fireEvent.click(disabledBtn);
+    // Allow any micro-tasks to flush before asserting
+    await Promise.resolve();
+    expect(mockSendVerificationEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it("never decrements the cooldown below zero", async () => {
+    vi.useFakeTimers();
+    mockSendVerificationEmail.mockResolvedValue({ error: null });
+    const { container } = render(() => <Login />);
+    const resendBtn = await triggerVerificationState(container);
+    fireEvent.click(resendBtn);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend in 60s");
+    });
+    // Drain the entire 60-second window plus a generous overshoot
+    vi.advanceTimersByTime(120_000);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend verification email");
+    });
+    // No negative seconds should ever render
+    expect(container.textContent).not.toMatch(/Resend in -\d+s/);
+  });
+
+  it("stops the interval once the cooldown reaches zero", async () => {
+    vi.useFakeTimers();
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    mockSendVerificationEmail.mockResolvedValue({ error: null });
+    const { container } = render(() => <Login />);
+    const resendBtn = await triggerVerificationState(container);
+    fireEvent.click(resendBtn);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend in 60s");
+    });
+    vi.advanceTimersByTime(60_000);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend verification email");
+    });
+    // clearInterval is called both inside the tick that hits zero and (potentially)
+    // on unmount; at minimum it must have fired once before unmount.
+    const callsBeforeUnmount = clearIntervalSpy.mock.calls.length;
+    expect(callsBeforeUnmount).toBeGreaterThanOrEqual(1);
+    clearIntervalSpy.mockRestore();
+  });
+
+  it("does not leak the interval when unmounted mid-cooldown", async () => {
+    vi.useFakeTimers();
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockSendVerificationEmail.mockResolvedValue({ error: null });
+    const { container, unmount } = render(() => <Login />);
+    const resendBtn = await triggerVerificationState(container);
+    fireEvent.click(resendBtn);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Resend in 60s");
+    });
+    // Unmount while ~58 seconds still remain
+    vi.advanceTimersByTime(2000);
+    unmount();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    // Advancing the clock further should not trigger any state updates,
+    // and therefore no "unmounted state update" warnings.
+    vi.advanceTimersByTime(120_000);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/packages/frontend/tests/pages/ResetPassword.test.tsx
+++ b/packages/frontend/tests/pages/ResetPassword.test.tsx
@@ -203,4 +203,90 @@ describe("ResetPassword - Set new password form (with token)", () => {
     render(() => <ResetPassword />);
     expect(screen.getByText("Back to sign in")).toBeDefined();
   });
+
+  it("renders RequestResetForm when token is empty string", () => {
+    mockSearchParamsValue = { token: "" };
+    render(() => <ResetPassword />);
+    expect(screen.getByPlaceholderText("you@example.com")).toBeDefined();
+    expect(screen.getByText("Reset your password")).toBeDefined();
+    expect(screen.queryByText("Set new password")).toBeNull();
+  });
+
+  it("renders RequestResetForm when token is undefined", () => {
+    mockSearchParamsValue = {};
+    render(() => <ResetPassword />);
+    expect(screen.getByPlaceholderText("you@example.com")).toBeDefined();
+    expect(screen.getByText("Reset your password")).toBeDefined();
+    expect(screen.queryByText("Set new password")).toBeNull();
+  });
+
+  it("form remains interactive after API error", async () => {
+    mockResetPassword.mockResolvedValue({ error: { message: "Token invalid" } });
+    const { container } = render(() => <ResetPassword />);
+    const inputs = container.querySelectorAll('input[type="password"]');
+    fireEvent.input(inputs[0], { target: { value: "newpass123" } });
+    fireEvent.input(inputs[1], { target: { value: "newpass123" } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Token invalid");
+    });
+    const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.querySelector(".spinner")).toBeNull();
+    // Form is still rendered and can be re-submitted
+    expect(container.querySelector("form")).not.toBeNull();
+    mockResetPassword.mockResolvedValue({ error: null });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(mockResetPassword).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("ResetPassword - Invalid/malformed token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParamsValue = { token: "not-a-valid-uuid" };
+  });
+
+  it("shows error when token is malformed", async () => {
+    mockResetPassword.mockResolvedValue({
+      error: { message: "Token is invalid or expired" },
+    });
+    const { container } = render(() => <ResetPassword />);
+    const inputs = container.querySelectorAll('input[type="password"]');
+    fireEvent.input(inputs[0], { target: { value: "newpass123" } });
+    fireEvent.input(inputs[1], { target: { value: "newpass123" } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Token is invalid or expired");
+    });
+    expect(mockResetPassword).toHaveBeenCalledWith({
+      newPassword: "newpass123",
+      token: "not-a-valid-uuid",
+    });
+  });
+
+  it("form recovers after token expiry mid-request (race condition)", async () => {
+    // Race: user submits, token expires server-side, API rejects mid-request
+    mockResetPassword.mockResolvedValue({
+      error: { message: "Token expired" },
+    });
+    const { container } = render(() => <ResetPassword />);
+    const inputs = container.querySelectorAll('input[type="password"]');
+    fireEvent.input(inputs[0], { target: { value: "newpass123" } });
+    fireEvent.input(inputs[1], { target: { value: "newpass123" } });
+    fireEvent.submit(container.querySelector("form")!);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain("Token expired");
+    });
+    // Button is re-enabled and spinner is gone so the user can retry
+    const btn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    expect(btn.querySelector(".spinner")).toBeNull();
+    // Form fields are still mounted and editable
+    const inputsAfter = container.querySelectorAll('input[type="password"]');
+    expect(inputsAfter.length).toBe(2);
+    expect((inputsAfter[0] as HTMLInputElement).value).toBe("newpass123");
+  });
 });

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -558,6 +558,11 @@ vi.mock('../../src/pages/RoutingPanels.js', () => ({
 }));
 
 const mockActionGetTier = vi.fn();
+const mockActionHandleOverride = vi.fn();
+const mockActionHandleResetAll = vi.fn();
+const mockActionHandleReset = vi.fn();
+const mockActionHandleAddFallback = vi.fn();
+const mockActionHandleFallbackUpdate = vi.fn();
 vi.mock('../../src/pages/RoutingActions.js', () => ({
   createRoutingActions: () => ({
     changingTier: () => null,
@@ -566,11 +571,11 @@ vi.mock('../../src/pages/RoutingActions.js', () => ({
     addingFallback: () => null,
     getTier: (...args: unknown[]) => mockActionGetTier(...args),
     getFallbacksFor: () => [],
-    handleOverride: vi.fn(),
-    handleResetAll: vi.fn(),
-    handleReset: vi.fn(),
-    handleAddFallback: vi.fn(),
-    handleFallbackUpdate: vi.fn(),
+    handleOverride: (...args: unknown[]) => mockActionHandleOverride(...args),
+    handleResetAll: (...args: unknown[]) => mockActionHandleResetAll(...args),
+    handleReset: (...args: unknown[]) => mockActionHandleReset(...args),
+    handleAddFallback: (...args: unknown[]) => mockActionHandleAddFallback(...args),
+    handleFallbackUpdate: (...args: unknown[]) => mockActionHandleFallbackUpdate(...args),
   }),
 }));
 
@@ -1175,27 +1180,50 @@ describe('Routing page', () => {
       expect(screen.getByText('Connect providers')).toBeDefined();
     });
     fireEvent.click(screen.getByText('Connect providers'));
+    // After opening, showProviderModal accessor reports true.
+    await waitFor(() => {
+      expect((lastModalsProps?.showProviderModal as () => boolean)()).toBe(true);
+    });
     fireEvent.click(screen.getByTestId('modal-trigger-provider-close'));
-    // No throw / hang is sufficient — internal state flips and reads cleanly.
-    expect(true).toBe(true);
+    // After close, the signal flips back to false.
+    await waitFor(() => {
+      expect((lastModalsProps?.showProviderModal as () => boolean)()).toBe(false);
+    });
   });
 
   it('closes the instruction modal via onInstructionClose', async () => {
     render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByTestId('modal-trigger-instruction-close')).toBeDefined();
+      expect(screen.getByTestId('show-instructions')).toBeDefined();
     });
+    // Open the instruction modal first via the footer.
+    fireEvent.click(screen.getByTestId('show-instructions'));
+    await waitFor(() => {
+      expect((lastModalsProps?.instructionModal as () => string | null)()).toBe('enable');
+    });
+    // Close it — both instructionModal and instructionProvider reset to null.
     fireEvent.click(screen.getByTestId('modal-trigger-instruction-close'));
-    expect(true).toBe(true);
+    await waitFor(() => {
+      expect((lastModalsProps?.instructionModal as () => string | null)()).toBeNull();
+      expect((lastModalsProps?.instructionProvider as () => string | null)()).toBeNull();
+    });
   });
 
   it('closes the fallback picker via onFallbackPickerClose', async () => {
     render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByTestId('modal-trigger-fallback-close')).toBeDefined();
+      expect(screen.getByTestId('spec-add-fallback')).toBeDefined();
     });
+    // Open the fallback picker first by clicking the spec section button.
+    fireEvent.click(screen.getByTestId('spec-add-fallback'));
+    await waitFor(() => {
+      expect((lastModalsProps?.fallbackPickerTier as () => string | null)()).toBe('coding');
+    });
+    // Close it — fallbackPickerTier resets to null.
     fireEvent.click(screen.getByTestId('modal-trigger-fallback-close'));
-    expect(true).toBe(true);
+    await waitFor(() => {
+      expect((lastModalsProps?.fallbackPickerTier as () => string | null)()).toBeNull();
+    });
   });
 
   it('triggers ResetAll via the footer', async () => {
@@ -1204,8 +1232,10 @@ describe('Routing page', () => {
       expect(screen.getByTestId('reset-all')).toBeDefined();
     });
     fireEvent.click(screen.getByTestId('reset-all'));
-    // No assertion — handler is mocked via createRoutingActions.
-    expect(true).toBe(true);
+    // Footer's onResetAll is wired to actions.handleResetAll.
+    await waitFor(() => {
+      expect(mockActionHandleResetAll).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('opens the instructions modal via the footer', async () => {
@@ -1214,7 +1244,10 @@ describe('Routing page', () => {
       expect(screen.getByTestId('show-instructions')).toBeDefined();
     });
     fireEvent.click(screen.getByTestId('show-instructions'));
-    expect(true).toBe(true);
+    // Footer's onShowInstructions sets instructionModal to 'enable'.
+    await waitFor(() => {
+      expect((lastModalsProps?.instructionModal as () => string | null)()).toBe('enable');
+    });
   });
 
   it('opens the dropdown picker from the default tier section', async () => {
@@ -1223,7 +1256,10 @@ describe('Routing page', () => {
       expect(screen.getByTestId('open-dropdown')).toBeDefined();
     });
     fireEvent.click(screen.getByTestId('open-dropdown'));
-    expect(true).toBe(true);
+    // The default-section's onDropdownOpen('simple') flows through to setDropdownTier.
+    await waitFor(() => {
+      expect((lastModalsProps?.dropdownTier as () => string | null)()).toBe('simple');
+    });
   });
 
   it('opens the specificity dropdown picker from the spec section', async () => {
@@ -1232,7 +1268,10 @@ describe('Routing page', () => {
       expect(screen.getByTestId('spec-open')).toBeDefined();
     });
     fireEvent.click(screen.getByTestId('spec-open'));
-    expect(true).toBe(true);
+    // spec-open triggers onDropdownOpen('coding') which sets specificityDropdown.
+    await waitFor(() => {
+      expect((lastModalsProps?.specificityDropdown as () => string | null)()).toBe('coding');
+    });
   });
 
   it('opens the spec fallback picker from the spec section', async () => {
@@ -1241,7 +1280,10 @@ describe('Routing page', () => {
       expect(screen.getByTestId('spec-add-fallback')).toBeDefined();
     });
     fireEvent.click(screen.getByTestId('spec-add-fallback'));
-    expect(true).toBe(true);
+    // spec-add-fallback triggers onAddFallback('coding') → setFallbackPickerTier.
+    await waitFor(() => {
+      expect((lastModalsProps?.fallbackPickerTier as () => string | null)()).toBe('coding');
+    });
   });
 
   it('auto-opens the provider modal when location.state.openProviders is set', async () => {
@@ -1260,10 +1302,23 @@ describe('Routing page', () => {
     });
     // Open dropdown first via the default-section open button.
     fireEvent.click(screen.getByTestId('open-dropdown'));
+    await waitFor(() => {
+      expect((lastModalsProps?.dropdownTier as () => string | null)()).toBe('simple');
+    });
     // Then trigger an override — Routing.tsx wraps actions.handleOverride and
     // resets the dropdown tier in the same call.
     fireEvent.click(screen.getByTestId('modal-trigger-override'));
-    expect(true).toBe(true);
+    await waitFor(() => {
+      // dropdownTier signal cleared back to null.
+      expect((lastModalsProps?.dropdownTier as () => string | null)()).toBeNull();
+      // actions.handleOverride was invoked with the args from the modal trigger.
+      expect(mockActionHandleOverride).toHaveBeenCalledWith(
+        'simple',
+        'gpt-4o',
+        'openai',
+        'api_key',
+      );
+    });
   });
 
   it('calls actions.handleAddFallback for non-specificity tiers when modals add a fallback', async () => {
@@ -1272,8 +1327,18 @@ describe('Routing page', () => {
       expect(screen.getByTestId('modal-trigger-add-fallback')).toBeDefined();
     });
     fireEvent.click(screen.getByTestId('modal-trigger-add-fallback'));
-    // The default-tier path delegates to actions.handleAddFallback (mocked).
-    expect(true).toBe(true);
+    // The default-tier path delegates to actions.handleAddFallback.
+    await waitFor(() => {
+      expect(mockActionHandleAddFallback).toHaveBeenCalledWith(
+        'simple',
+        'fb-new',
+        'openai',
+        'api_key',
+        undefined,
+      );
+    });
+    // No specificity persist should occur for a non-spec tier.
+    expect(mockSetSpecificityFallbacks).not.toHaveBeenCalled();
   });
 
   it('ignores duplicate fallback adds for an already-listed model on a specificity tier', async () => {
@@ -1369,17 +1434,30 @@ describe('Routing page', () => {
       expect(mockGetProviders).toHaveBeenCalledTimes(2);
     });
     fireEvent.click(screen.getByTestId('modal-trigger-provider-close'));
-    // The instruction modal flows through internal state — assertion is implicit.
-    expect(true).toBe(true);
+    // closeProviderModal sets instructionModal to 'enable' because
+    // wasEnabledBeforeModal()=false, isEnabled()=true now, hadProvidersBeforeModal()=true.
+    await waitFor(() => {
+      expect((lastModalsProps?.instructionModal as () => string | null)()).toBe('enable');
+      // And the provider modal flipped back to closed.
+      expect((lastModalsProps?.showProviderModal as () => boolean)()).toBe(false);
+    });
   });
 
   it('getTier returns the generalist assignment when one exists', async () => {
+    // Make actions.getTier resolve to a real generalist row so the outer
+    // getTier short-circuits before falling back to specificity.
+    const generalist = { tier: 'simple', response_mode: 'buffered' as const };
+    mockActionGetTier.mockReturnValue(generalist);
     render(() => <Routing />);
     await waitFor(() => {
       expect(screen.getByTestId('modal-trigger-get-tier')).toBeDefined();
     });
+    mockActionGetTier.mockClear();
     fireEvent.click(screen.getByTestId('modal-trigger-get-tier'));
-    expect(true).toBe(true);
+    // The modal-side getTier delegates to actions.getTier('simple').
+    expect(mockActionGetTier).toHaveBeenCalledWith('simple');
+    // Outer getTier returns the generalist value verbatim.
+    expect((lastModalsProps?.getTier as (id: string) => unknown)('simple')).toBe(generalist);
   });
 
   it('getTier falls back to the specificity assignment when no generalist tier matches', async () => {
@@ -1395,12 +1473,29 @@ describe('Routing page', () => {
         updated_at: '2025-01-01',
       },
     ]);
+    // No generalist tier matches 'coding'.
+    mockActionGetTier.mockReturnValue(undefined);
     render(() => <Routing />);
     await waitFor(() => {
       expect(screen.getByTestId('modal-trigger-get-tier-spec')).toBeDefined();
     });
+    // Wait until the specificity resource resolves so the outer getTier can
+    // find the 'coding' assignment in the array.
+    await waitFor(() => {
+      expect(mockGetSpecificityAssignments).toHaveBeenCalled();
+      const specs = (lastModalsProps?.specificityAssignments as () => unknown[])();
+      expect(specs?.length).toBeGreaterThan(0);
+    });
     fireEvent.click(screen.getByTestId('modal-trigger-get-tier-spec'));
-    expect(true).toBe(true);
+    // actions.getTier was consulted first with the category id.
+    expect(mockActionGetTier).toHaveBeenCalledWith('coding');
+    // Outer getTier maps the specificity row's category to tier and returns it.
+    const result = (lastModalsProps?.getTier as (id: string) => Record<string, unknown> | undefined)(
+      'coding',
+    );
+    expect(result).toBeDefined();
+    expect(result?.tier).toBe('coding');
+    expect(result?.category).toBe('coding');
   });
 
   // Verify the per-model params wiring. Each Section's mock invokes the
@@ -1504,12 +1599,34 @@ describe('Routing page', () => {
   });
 
   it('getModelParams threads through to the Specificity Section without a fetch per surface', async () => {
+    // Seed the in-memory model-params cache so getModelParamsFor has a row to
+    // surface for the (scope, provider, authType, model) key used by spec-saved-params.
+    const saved = { thinking: { type: 'disabled' as const } };
+    mockListModelParams.mockResolvedValue([
+      {
+        scope: 'specificity:coding',
+        provider: 'deepseek',
+        authType: 'api_key' as const,
+        model: 'deepseek-v4',
+        params: saved,
+      },
+    ]);
     render(() => <Routing />);
     await waitFor(() => {
       expect(screen.getByTestId('spec-saved-params')).toBeDefined();
     });
+    // listModelParams should be called exactly once on mount — not per surface —
+    // since the cache is shared across the default tier, specificity, and custom sections.
+    expect(mockListModelParams).toHaveBeenCalledTimes(1);
+    expect(mockListModelParams).toHaveBeenCalledWith('demo');
+    // The spec section's getModelParams accessor reads from that same cache.
     fireEvent.click(screen.getByTestId('spec-saved-params'));
-    expect(true).toBe(true);
+    // No extra network calls for a UI lookup — listModelParams stays at one call.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(mockListModelParams).toHaveBeenCalledTimes(1);
+    // setModelParams was NOT triggered by a read-only lookup.
+    expect(mockSetModelParams).not.toHaveBeenCalled();
+    expect(mockDeleteModelParams).not.toHaveBeenCalled();
   });
 
   it('renders the response mode button in headerRight (lines 538-556)', async () => {

--- a/packages/frontend/tests/pages/RoutingTierCard.test.tsx
+++ b/packages/frontend/tests/pages/RoutingTierCard.test.tsx
@@ -546,12 +546,30 @@ describe('RoutingTierCard', () => {
     expect(mockSetFallbacks).not.toHaveBeenCalled();
   });
 
-  it('clears the fallbackDragging state on drag end', () => {
-    const { getByTestId } = render(() => <RoutingTierCard {...makeProps()} />);
+  it('clears the fallbackDragging state on drag end so subsequent drops are no-ops', async () => {
+    // After a fallback drag ends, the internal `fallbackDragging` signal must
+    // reset to null. Verify the state change via observable behavior:
+    // - With fallbackDragging set, a drop on the primary chip would call
+    //   swapPrimaryWithFallback → onOverride.
+    // - With fallbackDragging cleared (after drag-end), the drop handler
+    //   short-circuits at `if (fbIndex === null) return;` and onOverride is
+    //   never invoked.
+    const onOverride = vi.fn();
+    const { container, getByTestId } = render(() => (
+      <RoutingTierCard {...makeProps({ onOverride })} />
+    ));
     fireEvent.click(getByTestId('trigger-fb-drag-start-1'));
     fireEvent.click(getByTestId('trigger-fb-drag-end'));
-    // No assertion on internal state — coverage of the end handler is sufficient.
-    expect(true).toBe(true);
+    // Now that drag-end has fired, a drop on the primary chip should be a no-op.
+    const chip = container.querySelector('.routing-card__model-chip') as HTMLElement;
+    fireEvent.drop(chip, {
+      dataTransfer: { dropEffect: '' },
+      preventDefault: vi.fn(),
+    });
+    // Wait a tick to let any potential async swap kick off.
+    await Promise.resolve();
+    expect(onOverride).not.toHaveBeenCalled();
+    expect(mockSetFallbacks).not.toHaveBeenCalled();
   });
 
   it('renders the FallbackList only when there is an effective model', () => {
@@ -720,21 +738,45 @@ describe('RoutingTierCard', () => {
     expect(container.querySelector('.routing-card__main')?.textContent).toBe('OpenAI / GPT-4o');
   });
 
-  it('invokes onPrimaryDragStart wiring without throwing', () => {
+  it('sets dataTransfer payload on dragStart and toggles the dragging class', () => {
+    // handlePrimaryDragStart should: (1) write the primary drag payload to
+    // dataTransfer (`text/plain` = "primary", `application/x-primary` = "true",
+    // effectAllowed = "move"), and (2) set the primaryDragging signal so the
+    // chip gets the `--dragging` class. handlePrimaryDragEnd should clear it.
+    const setData = vi.fn();
+    const dataTransfer: { effectAllowed: string; setData: typeof setData } = {
+      effectAllowed: '',
+      setData,
+    };
     const { container } = render(() => <RoutingTierCard {...makeProps()} />);
     const chip = container.querySelector('.routing-card__model-chip') as HTMLElement;
-    fireEvent.dragStart(chip, { dataTransfer: { effectAllowed: '', setData: vi.fn() } });
+    fireEvent.dragStart(chip, { dataTransfer });
+    // dataTransfer payload + effectAllowed set
+    expect(dataTransfer.effectAllowed).toBe('move');
+    expect(setData).toHaveBeenCalledWith('text/plain', 'primary');
+    expect(setData).toHaveBeenCalledWith('application/x-primary', 'true');
+    // dragging class is reflected on the chip
+    expect(chip.classList.contains('routing-card__model-chip--dragging')).toBe(true);
+    // After drag-end, both dragging and drop-target classes clear.
     fireEvent.dragEnd(chip);
-    // Coverage of the drag-start/drag-end handlers is sufficient.
-    expect(true).toBe(true);
+    expect(chip.classList.contains('routing-card__model-chip--dragging')).toBe(false);
+    expect(chip.classList.contains('routing-card__model-chip--drop-target')).toBe(false);
   });
 
-  it('clears primaryDropTarget on dragLeave', () => {
-    const { container } = render(() => <RoutingTierCard {...makeProps()} />);
+  it('toggles the drop-target class on dragOver and clears it on dragLeave', () => {
+    // dragOver is gated by `fallbackDragging() !== null`, so first signal a
+    // fallback drag-start from FallbackList. Then dragOver should set the
+    // `--drop-target` class, and dragLeave should clear it.
+    const { container, getByTestId } = render(() => <RoutingTierCard {...makeProps()} />);
     const chip = container.querySelector('.routing-card__model-chip') as HTMLElement;
+    fireEvent.click(getByTestId('trigger-fb-drag-start-1'));
+    fireEvent.dragOver(chip, {
+      dataTransfer: { dropEffect: '' },
+      preventDefault: vi.fn(),
+    });
+    expect(chip.classList.contains('routing-card__model-chip--drop-target')).toBe(true);
     fireEvent.dragLeave(chip);
-    // Coverage of dragLeave handler.
-    expect(true).toBe(true);
+    expect(chip.classList.contains('routing-card__model-chip--drop-target')).toBe(false);
   });
 
   it('falls back to legacy persist (no routes) when fallback_routes length is mismatched', async () => {

--- a/packages/frontend/tests/pages/Setup.test.tsx
+++ b/packages/frontend/tests/pages/Setup.test.tsx
@@ -52,6 +52,19 @@ describe('Setup page', () => {
     return result;
   }
 
+  function fillValidForm(password = 'secretpassword', confirm = password) {
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: password },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: confirm },
+    });
+  }
+
   it('redirects to /login when setup is already complete', async () => {
     mockCheckNeedsSetup.mockResolvedValue(false);
     render(() => <Setup />);
@@ -71,16 +84,7 @@ describe('Setup page', () => {
 
   it('shows an error when passwords do not match', async () => {
     const { container } = await renderSetup();
-    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
-    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'founder@example.com' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
-      target: { value: 'secretpassword' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
-      target: { value: 'different' },
-    });
+    fillValidForm('secretpassword', 'different');
     fireEvent.submit(container.querySelector('form')!);
 
     await waitFor(() => {
@@ -91,16 +95,7 @@ describe('Setup page', () => {
 
   it('calls createFirstAdmin with form values on valid submit', async () => {
     const { container } = await renderSetup();
-    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
-    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'founder@example.com' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
-      target: { value: 'secretpassword' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
-      target: { value: 'secretpassword' },
-    });
+    fillValidForm();
     fireEvent.submit(container.querySelector('form')!);
 
     await waitFor(() => {
@@ -114,16 +109,7 @@ describe('Setup page', () => {
 
   it('auto-signs-in after successful setup', async () => {
     const { container } = await renderSetup();
-    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
-    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'founder@example.com' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
-      target: { value: 'secretpassword' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
-      target: { value: 'secretpassword' },
-    });
+    fillValidForm();
     fireEvent.submit(container.querySelector('form')!);
 
     await waitFor(() => {
@@ -137,16 +123,7 @@ describe('Setup page', () => {
   it('surfaces server errors from createFirstAdmin', async () => {
     mockCreateFirstAdmin.mockRejectedValue(new Error('already exists'));
     const { container } = await renderSetup();
-    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
-    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'founder@example.com' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
-      target: { value: 'secretpassword' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
-      target: { value: 'secretpassword' },
-    });
+    fillValidForm();
     fireEvent.submit(container.querySelector('form')!);
 
     await waitFor(() => {
@@ -157,16 +134,7 @@ describe('Setup page', () => {
   it('falls back to /login if auto-sign-in fails after setup', async () => {
     mockSignInEmail.mockResolvedValue({ error: { message: 'session failed' } });
     const { container } = await renderSetup();
-    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
-    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
-      target: { value: 'founder@example.com' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
-      target: { value: 'secretpassword' },
-    });
-    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
-      target: { value: 'secretpassword' },
-    });
+    fillValidForm();
     fireEvent.submit(container.querySelector('form')!);
 
     await waitFor(() => {
@@ -193,5 +161,114 @@ describe('Setup page', () => {
       expect(screen.queryByText('Password must be at least 8 characters')).toBeDefined();
     });
     expect(mockCreateFirstAdmin).not.toHaveBeenCalled();
+  });
+
+  it('rejects zero-length password with the length error', async () => {
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    const passwordInput = screen.getByPlaceholderText('At least 8 characters') as HTMLInputElement;
+    const confirmInput = screen.getByPlaceholderText('Re-enter password') as HTMLInputElement;
+    // Bypass native required + minLength so handleSubmit's length check is exercised
+    passwordInput.removeAttribute('required');
+    passwordInput.removeAttribute('minLength');
+    confirmInput.removeAttribute('required');
+    confirmInput.removeAttribute('minLength');
+    fireEvent.input(passwordInput, { target: { value: '' } });
+    fireEvent.input(confirmInput, { target: { value: '' } });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Password must be at least 8 characters')).toBeDefined();
+    });
+    expect(mockCreateFirstAdmin).not.toHaveBeenCalled();
+  });
+
+  it('accepts password at the 8-character boundary', async () => {
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    // Exactly 8 chars — must satisfy length >= 8 branch
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: '12345678' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: '12345678' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockCreateFirstAdmin).toHaveBeenCalledWith({
+        email: 'founder@example.com',
+        name: 'Founder',
+        password: '12345678',
+      });
+    });
+    // No length error should have been displayed
+    expect(screen.queryByText('Password must be at least 8 characters')).toBeNull();
+  });
+
+  it('passes password containing control characters through to createFirstAdmin verbatim', async () => {
+    const { container } = await renderSetup();
+    fireEvent.input(screen.getByPlaceholderText('Your name'), { target: { value: 'Founder' } });
+    fireEvent.input(screen.getByPlaceholderText('you@example.com'), {
+      target: { value: 'founder@example.com' },
+    });
+    // 8 visible chars + a NUL byte and a control char. The client doesn't sanitize —
+    // it forwards verbatim so the server can apply its own policy.
+    const weird = 'abcdefgh ';
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: weird },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: weird },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockCreateFirstAdmin).toHaveBeenCalledWith({
+        email: 'founder@example.com',
+        name: 'Founder',
+        password: weird,
+      });
+    });
+  });
+
+  it('forwards empty email + name to createFirstAdmin when native required is bypassed', async () => {
+    // Simulate the server-side validation path: required attributes can be stripped
+    // (e.g. via DevTools) so the client must still call createFirstAdmin and let the
+    // backend reject empty email/name. The component itself only validates passwords.
+    mockCreateFirstAdmin.mockRejectedValue(new Error('Email is required'));
+    const { container } = await renderSetup();
+    const nameInput = screen.getByPlaceholderText('Your name') as HTMLInputElement;
+    const emailInput = screen.getByPlaceholderText('you@example.com') as HTMLInputElement;
+    nameInput.removeAttribute('required');
+    emailInput.removeAttribute('required');
+    // Leave name + email empty; only password is filled.
+    fireEvent.input(screen.getByPlaceholderText('At least 8 characters'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.input(screen.getByPlaceholderText('Re-enter password'), {
+      target: { value: 'secretpassword' },
+    });
+    fireEvent.submit(container.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(mockCreateFirstAdmin).toHaveBeenCalledWith({
+        email: '',
+        name: '',
+        password: 'secretpassword',
+      });
+    });
+    // The server error must surface to the user
+    await waitFor(() => {
+      expect(screen.queryByText('Email is required')).toBeDefined();
+    });
+    // And auto-signin must not be attempted when creation failed
+    expect(mockSignInEmail).not.toHaveBeenCalled();
   });
 });

--- a/packages/frontend/tests/pages/Workspace-validation.test.tsx
+++ b/packages/frontend/tests/pages/Workspace-validation.test.tsx
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+// Reuses the mock surface from Workspace.test.tsx. Tests here focus on
+// AddAgentModal validation edges and the exact shape of the createAgent
+// payload, which the happy-path tests don't strictly assert.
+
+const mockNavigate = vi.fn();
+vi.mock("@solidjs/router", () => ({
+  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@solidjs/meta", () => ({
+  Title: (props: any) => <title>{props.children}</title>,
+  Meta: () => null,
+}));
+
+const mockGetAgents = vi.fn();
+const mockCreateAgent = vi.fn();
+const mockDeleteAgent = vi.fn();
+vi.mock("../../src/services/api.js", () => ({
+  getAgents: (...args: unknown[]) => mockGetAgents(...args),
+  createAgent: (...args: unknown[]) => mockCreateAgent(...args),
+  deleteAgent: (...args: unknown[]) => mockDeleteAgent(...args),
+}));
+
+vi.mock("../../src/components/DuplicateAgentModal.jsx", () => ({ default: () => null }));
+
+vi.mock("../../src/services/toast-store.js", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock("../../src/services/formatters.js", () => ({
+  formatNumber: (v: number) => String(v),
+  formatCost: (v: number) => `$${v.toFixed(2)}`,
+}));
+
+vi.mock("../../src/components/Sparkline.jsx", () => ({
+  default: () => <div data-testid="sparkline" />,
+}));
+
+vi.mock("../../src/services/sse.js", () => ({
+  pingCount: () => 0,
+  messagePing: () => 0,
+  agentPing: () => 0,
+  routingPing: () => 0,
+}));
+
+vi.mock("../../src/components/AgentTypeSelect.jsx", () => ({
+  default: (props: any) => (
+    <div
+      data-testid="agent-type-picker"
+      data-category={props.category ?? ""}
+      data-platform={props.platform ?? ""}
+      data-disabled={String(!!props.disabled)}
+    >
+      <button data-testid="pick-app" onClick={() => props.onCategoryChange("app")}>App</button>
+      <button data-testid="pick-langchain" onClick={() => props.onPlatformChange("langchain")}>LC</button>
+    </div>
+  ),
+}));
+
+const mockMarkAgentCreated = vi.fn();
+vi.mock("../../src/services/recent-agents.js", () => ({
+  markAgentCreated: (...args: unknown[]) => mockMarkAgentCreated(...args),
+}));
+
+vi.mock("manifest-shared", () => ({
+  AGENT_CATEGORIES: ["personal", "app", "coding"],
+  PLATFORM_ICONS: {},
+  PLATFORMS_BY_CATEGORY: {
+    personal: ["openclaw", "hermes", "other"],
+    app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
+    coding: ["claude-code", "other"],
+  },
+  platformIcon: () => undefined,
+}));
+
+import Workspace from "../../src/pages/Workspace";
+
+const openModal = () => {
+  const result = render(() => <Workspace />);
+  fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+  const input = result.container.querySelector(".modal-card__input") as HTMLInputElement;
+  const createBtn = Array.from(
+    result.container.querySelectorAll<HTMLButtonElement>(".modal-card button.btn--primary"),
+  ).pop() as HTMLButtonElement;
+  return { ...result, input, createBtn };
+};
+
+describe("Workspace AddAgentModal - name validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAgents.mockResolvedValue({ agents: [] });
+    mockCreateAgent.mockResolvedValue({ agent: { name: "stub" }, apiKey: "k" });
+  });
+
+  it("keeps Create disabled while the name is the empty string", () => {
+    const { input, createBtn } = openModal();
+    expect(input.value).toBe("");
+    expect(createBtn.disabled).toBe(true);
+  });
+
+  it("keeps Create disabled when the name is only spaces", () => {
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "     " } });
+    expect(createBtn.disabled).toBe(true);
+  });
+
+  it("keeps Create disabled when the name is only tabs and newlines", () => {
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "\t\n\t  " } });
+    expect(createBtn.disabled).toBe(true);
+  });
+
+  it("does not call createAgent when the user clicks Create with whitespace only", () => {
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "   " } });
+    fireEvent.click(createBtn);
+    expect(mockCreateAgent).not.toHaveBeenCalled();
+  });
+
+  it("does not call createAgent when Enter is pressed with whitespace only", () => {
+    const { input } = openModal();
+    fireEvent.input(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(mockCreateAgent).not.toHaveBeenCalled();
+  });
+
+  it("enables Create as soon as a single non-space character is typed", () => {
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "a" } });
+    expect(createBtn.disabled).toBe(false);
+  });
+
+  it("accepts a name with a URL-reserved slash and routes through encodeURIComponent", async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: "weird/name" }, apiKey: "k" });
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "weird/name" } });
+    expect(createBtn.disabled).toBe(false);
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/agents/weird%2Fname", expect.anything());
+    });
+  });
+
+  it("accepts a name with a percent sign without double-encoding", async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: "100%cool" }, apiKey: "k" });
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "100%cool" } });
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/agents/100%25cool", expect.anything());
+    });
+  });
+
+  it("accepts a unicode emoji name and url-encodes the navigation target", async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: "bot-🚀" }, apiKey: "k" });
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "bot-🚀" } });
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/agents/${encodeURIComponent("bot-🚀")}`,
+        expect.anything(),
+      );
+    });
+  });
+
+  it("trims surrounding whitespace before submitting the name", async () => {
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "  spaced-out  " } });
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockCreateAgent).toHaveBeenCalledWith({
+        name: "spaced-out",
+        agent_category: "personal",
+        agent_platform: "openclaw",
+      });
+    });
+  });
+
+  it("accepts a very long name (256 chars) without truncating client-side", async () => {
+    const longName = "a".repeat(256);
+    mockCreateAgent.mockResolvedValue({ agent: { name: longName }, apiKey: "k" });
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: longName } });
+    expect(createBtn.disabled).toBe(false);
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockCreateAgent).toHaveBeenCalledWith({
+        name: longName,
+        agent_category: "personal",
+        agent_platform: "openclaw",
+      });
+    });
+  });
+});
+
+describe("Workspace AddAgentModal - exact createAgent payload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAgents.mockResolvedValue({ agents: [] });
+    mockCreateAgent.mockResolvedValue({ agent: { name: "demo" }, apiKey: "k" });
+  });
+
+  it("submits the default category and platform when the user only types a name", async () => {
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "Demo Agent" } });
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockCreateAgent).toHaveBeenCalledWith({
+        name: "Demo Agent",
+        agent_category: "personal",
+        agent_platform: "openclaw",
+      });
+    });
+    // Strict: nothing else was sneaked in (e.g. recordMessages, displayName).
+    const call = mockCreateAgent.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(call).sort()).toEqual(["agent_category", "agent_platform", "name"]);
+  });
+
+  it("includes the user-selected category and platform in the payload", async () => {
+    const { container, input, createBtn } = openModal();
+    fireEvent.click(container.querySelector('[data-testid="pick-app"]')!);
+    fireEvent.click(container.querySelector('[data-testid="pick-langchain"]')!);
+    fireEvent.input(input, { target: { value: "my-langchain-agent" } });
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockCreateAgent).toHaveBeenCalledWith({
+        name: "my-langchain-agent",
+        agent_category: "app",
+        agent_platform: "langchain",
+      });
+    });
+  });
+
+  it("navigates to the slug returned by the server, not the typed name", async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: "demo-agent-1" }, apiKey: "key-xyz" });
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "Demo Agent" } });
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/agents/demo-agent-1", {
+        state: { newApiKey: "key-xyz" },
+      });
+    });
+    expect(mockMarkAgentCreated).toHaveBeenCalledWith("demo-agent-1");
+  });
+
+  it("falls back to the typed name when the server omits the slug", async () => {
+    mockCreateAgent.mockResolvedValue({ apiKey: "k" });
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "Fallback Agent" } });
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/agents/${encodeURIComponent("Fallback Agent")}`,
+        { state: { newApiKey: "k" } },
+      );
+    });
+    expect(mockMarkAgentCreated).toHaveBeenCalledWith("Fallback Agent");
+  });
+
+  it("does not call markAgentCreated or navigate when createAgent rejects", async () => {
+    mockCreateAgent.mockRejectedValue(new Error("boom"));
+    const { input, createBtn } = openModal();
+    fireEvent.input(input, { target: { value: "Demo Agent" } });
+    fireEvent.click(createBtn);
+    await vi.waitFor(() => {
+      expect(mockCreateAgent).toHaveBeenCalled();
+    });
+    expect(mockMarkAgentCreated).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/tests/services/api/core.test.ts
+++ b/packages/frontend/tests/services/api/core.test.ts
@@ -137,6 +137,21 @@ describe('core api helpers', () => {
 
       await expect(fetchJson('/anything')).rejects.toThrow(/API error: 503/);
     });
+
+    it('re-throws when fetch() throws a network error', async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error('Network error'));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(fetchJson('/anything')).rejects.toThrow('Network error');
+    });
+
+    it('re-throws when fetch() throws DOMException (AbortError)', async () => {
+      const abortError = new DOMException('The operation was aborted', 'AbortError');
+      const fetchMock = vi.fn().mockRejectedValue(abortError);
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(fetchJson('/anything')).rejects.toThrow('The operation was aborted');
+    });
   });
 
   describe('parseErrorMessage', () => {
@@ -191,6 +206,25 @@ describe('core api helpers', () => {
 
       await expect(fetchMutate('/something', { method: 'POST' })).rejects.toThrow('bad');
       expect(mockToastError).toHaveBeenCalledWith('bad');
+    });
+
+    it('re-throws when fetch() throws a network error', async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error('Network error'));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(fetchMutate('/something', { method: 'POST' })).rejects.toThrow('Network error');
+      expect(mockToastError).not.toHaveBeenCalled();
+    });
+
+    it('re-throws when fetch() throws DOMException (AbortError)', async () => {
+      const abortError = new DOMException('The operation was aborted', 'AbortError');
+      const fetchMock = vi.fn().mockRejectedValue(abortError);
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(fetchMutate('/something', { method: 'POST' })).rejects.toThrow(
+        'The operation was aborted',
+      );
+      expect(mockToastError).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/frontend/tests/services/auth-client.test.ts
+++ b/packages/frontend/tests/services/auth-client.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Spy that `createAuthClient` from `better-auth/solid` resolves to. The
+// module under test (`auth-client.ts`) imports this symbol and invokes it
+// once at module-load time, so we mock it before any dynamic import below.
+// Use `vi.hoisted` so the spy is available to the hoisted `vi.mock` factory.
+const { createAuthClientMock } = vi.hoisted(() => ({
+  createAuthClientMock: vi.fn((config: unknown) => ({
+    __mockClient: true,
+    config,
+  })),
+}));
+
+vi.mock("better-auth/solid", () => ({
+  createAuthClient: createAuthClientMock,
+}));
+
+describe("authClient", () => {
+  beforeEach(() => {
+    // Each test re-imports the module to re-trigger the top-level
+    // `createAuthClient({...})` call against a fresh mock state.
+    vi.resetModules();
+    createAuthClientMock.mockClear();
+
+    // Pin `window.location.origin` to a deterministic value. jsdom would
+    // otherwise return "http://localhost:3000", which is fine but we want
+    // tests to be insensitive to harness defaults.
+    vi.stubGlobal("window", {
+      ...window,
+      location: {
+        ...window.location,
+        origin: "https://dashboard.manifest.build",
+      },
+    } as Window & typeof globalThis);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("creates client with correct baseURL from window.location.origin", async () => {
+    await import("../../src/services/auth-client.js");
+
+    expect(createAuthClientMock).toHaveBeenCalledTimes(1);
+    const config = createAuthClientMock.mock.calls[0][0] as {
+      baseURL: string;
+      basePath: string;
+    };
+    expect(config.baseURL).toBe("https://dashboard.manifest.build");
+  });
+
+  it("creates client with basePath /api/auth", async () => {
+    await import("../../src/services/auth-client.js");
+
+    expect(createAuthClientMock).toHaveBeenCalledTimes(1);
+    const config = createAuthClientMock.mock.calls[0][0] as {
+      baseURL: string;
+      basePath: string;
+    };
+    expect(config.basePath).toBe("/api/auth");
+  });
+
+  it("exports authClient as createAuthClient return type", async () => {
+    const mod = await import("../../src/services/auth-client.js");
+
+    // The exported `authClient` must be the exact value returned by
+    // `createAuthClient`. We return a tagged object from the mock so we
+    // can assert identity, not just shape.
+    expect(mod.authClient).toBeDefined();
+    expect((mod.authClient as unknown as { __mockClient: boolean }).__mockClient).toBe(true);
+    expect(mod.authClient).toBe(createAuthClientMock.mock.results[0].value);
+  });
+
+  it("initialization does not throw errors", async () => {
+    // The module evaluates its top-level `createAuthClient({...})` call
+    // synchronously on import. A throw inside `createAuthClient` would
+    // surface here as a rejected promise from the dynamic import.
+    await expect(import("../../src/services/auth-client.js")).resolves.toBeDefined();
+  });
+
+  it("re-reads window.location.origin on each module load", async () => {
+    // First load uses the stubbed origin from beforeEach.
+    await import("../../src/services/auth-client.js");
+    expect(createAuthClientMock.mock.calls[0][0]).toMatchObject({
+      baseURL: "https://dashboard.manifest.build",
+    });
+
+    // Swap the origin and reload. We expect a fresh `createAuthClient`
+    // call with the new origin, proving the module is not cached against
+    // a stale value baked at first import.
+    vi.resetModules();
+    createAuthClientMock.mockClear();
+    vi.stubGlobal("window", {
+      ...window,
+      location: {
+        ...window.location,
+        origin: "http://localhost:3001",
+      },
+    } as Window & typeof globalThis);
+
+    await import("../../src/services/auth-client.js");
+    expect(createAuthClientMock).toHaveBeenCalledTimes(1);
+    expect(createAuthClientMock.mock.calls[0][0]).toMatchObject({
+      baseURL: "http://localhost:3001",
+      basePath: "/api/auth",
+    });
+  });
+});

--- a/packages/frontend/tests/services/oauth-popup.test.ts
+++ b/packages/frontend/tests/services/oauth-popup.test.ts
@@ -114,6 +114,30 @@ describe("monitorOAuthPopup", () => {
 
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onFailure).not.toHaveBeenCalled();
+
+    // null data — !!null short-circuits isOAuthMessage to false
+    window.dispatchEvent(new MessageEvent("message", { data: null }));
+
+    vi.advanceTimersByTime(300);
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+
+    // Empty object — typeof === 'object' but 'type' not in data
+    window.dispatchEvent(new MessageEvent("message", { data: {} }));
+
+    vi.advanceTimersByTime(300);
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
+
+    // undefined data — !!undefined short-circuits isOAuthMessage to false
+    window.dispatchEvent(new MessageEvent("message", { data: undefined }));
+
+    vi.advanceTimersByTime(300);
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onFailure).not.toHaveBeenCalled();
   });
 
   it("recognizes custom provider done paths during URL polling", () => {

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -88,7 +88,6 @@ export default defineConfig(({ command }) => ({
         'src/components/SingleTokenChart.tsx',
         'src/components/SavingsChart.tsx',
         'src/components/Sparkline.tsx',
-        'src/services/auth-client.ts',
       ],
     },
   },


### PR DESCRIPTION
### 💭 Why
A repo-wide audit surfaced 182 actionable test gaps. The highest-risk holes were around OAuth state validation, SSRF protection, and cross-tenant boundaries — places where a regression would leak data or auth.

### ✨ What changed
- OAuth security: state cross-user, code reuse, refresh expiry, callback host pinning
- provider-client split: SSRF revalidation, header-shape pinning per auth path, real timeout abort
- Cross-tenant isolation: messages list/filter/feedback e2e, OTLP onboarding, OpenAI OAuth controller
- Concurrency: anthropic adapter transformer state isolation, session-guard cache races
- Edge cases: cost calc numeric edges, pricing zero-handling, model-discovery boundaries, scoring sigmoid stability
- Coverage: ~30 previously untested files (resolve.controller, RouteKeyChip, RecordedOutline, ProviderSubscriptionTab, etc.)
- Replaced 14 `expect(true).toBe(true)` placeholders in Routing.test.tsx with real signal/handler assertions
- Tightened bare `.toHaveBeenCalled()` to argument-shape checks across the suite

### 🔧 For operators
One non-test source touch: `EmailProviderConfigService.setNotificationEmail` now rejects empty/whitespace input at the service level. The DTO `@IsEmail` already blocks this at the HTTP boundary, so it is defense-in-depth for internal callers and not a behavior change for HTTP clients.

### 📝 Notes
- Backend unit: 320 suites, 5921 tests pass
- Backend e2e: 25 suites, 206 tests pass
- Frontend: 181 files, 3717 tests pass
- Shared: 14 suites, 251 tests pass
- 43 modified test files, 44 new test files
- `vite.config.ts` drops `auth-client.ts` from the coverage exclusion list now that it has a test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds high‑risk security and isolation tests for OAuth (state, code reuse, host pinning), SSRF revalidation and provider timeouts, and cross‑tenant boundaries in messages and routing. Tightens assertions across backend/frontend, replaces placeholders, and drops the `auth-client` coverage exclusion now that it’s tested.

- **Bug Fixes**
  - `EmailProviderConfigService.setNotificationEmail` now rejects empty/whitespace input (matches DTO validation; no change for HTTP clients).

<sup>Written for commit 60ae299c53bdabd9a98875849383c51006a3ef24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

