### PR TITLE
fix: persist refreshed OAuth tokens to selected account

### DIFF
--- a/.changeset/oauth-refresh-key-label.md
+++ b/.changeset/oauth-refresh-key-label.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Persist refreshed OAuth subscription tokens to the same provider account label that supplied the token.

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -390,7 +390,7 @@ describe('AnthropicOauthService', () => {
       fetchMock.mockResolvedValue(
         mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
       );
-      const token = await svc.unwrapToken(blob, 'agent-1', 'user-1');
+      const token = await svc.unwrapToken(blob, 'agent-1', 'user-1', 'Work');
       expect(token).toBe('new');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
         'agent-1',
@@ -398,6 +398,8 @@ describe('AnthropicOauthService', () => {
         'anthropic',
         expect.stringContaining('"t":"new"'),
         'subscription',
+        undefined,
+        'Work',
       );
     });
 

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -196,7 +196,12 @@ export class AnthropicOauthService {
    *   - Plain string (from the legacy `claude setup-token` paste flow) —
    *     returned as-is, since those tokens have no refresh counterpart.
    */
-  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
+  async unwrapToken(
+    rawValue: string,
+    agentId: string,
+    userId: string,
+    keyLabel?: string,
+  ): Promise<string | null> {
     const blob = parseOAuthTokenBlob(rawValue);
     if (!blob) {
       // Legacy setup-token paste — keep working until the user reconnects.
@@ -216,6 +221,8 @@ export class AnthropicOauthService {
         'anthropic',
         serializeOAuthTokenBlob(refreshed),
         'subscription',
+        undefined,
+        keyLabel,
       );
       this.logger.log(`Anthropic OAuth token refreshed for agent=${agentId}`);
       return refreshed.t;

--- a/packages/backend/src/routing/oauth/gemini-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/gemini-oauth.service.spec.ts
@@ -333,6 +333,8 @@ describe('GeminiOauthService', () => {
         'gemini',
         expect.stringContaining('"u":"proj-abc"'),
         'subscription',
+        undefined,
+        undefined,
       );
     });
 
@@ -341,7 +343,7 @@ describe('GeminiOauthService', () => {
       fetchMock.mockResolvedValue(
         mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
       );
-      const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+      const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1', 'Work');
       expect(token).toBe('new');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
         'agent-1',
@@ -349,6 +351,8 @@ describe('GeminiOauthService', () => {
         'gemini',
         expect.stringContaining('"t":"new"'),
         'subscription',
+        undefined,
+        'Work',
       );
     });
 

--- a/packages/backend/src/routing/oauth/kiro-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.service.spec.ts
@@ -354,9 +354,10 @@ describe('KiroOauthService', () => {
           expiresIn: 3600,
         }),
       );
-      expect(await service.unwrapToken(raw, 'agent-1', 'user-1')).toBe('fresh-access');
+      expect(await service.unwrapToken(raw, 'agent-1', 'user-1', 'Work')).toBe('fresh-access');
       const saved = parseKiroOAuthTokenBlob(provider.upsertProvider.mock.calls[0][3] as string);
       expect(saved).toMatchObject({ t: 'fresh-access', r: 'fresh-refresh' });
+      expect(provider.upsertProvider.mock.calls[0][6]).toBe('Work');
     });
 
     it('keeps the old refresh token when the refresh response omits one', async () => {

--- a/packages/backend/src/routing/oauth/kiro-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.service.ts
@@ -216,7 +216,12 @@ export class KiroOauthService {
     return { status: 'success' };
   }
 
-  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
+  async unwrapToken(
+    rawValue: string,
+    agentId: string,
+    userId: string,
+    keyLabel?: string,
+  ): Promise<string | null> {
     const blob = parseKiroOAuthTokenBlob(rawValue);
     if (!blob) return null;
     if (Date.now() < blob.e - 60_000) return blob.t;
@@ -228,6 +233,8 @@ export class KiroOauthService {
         'kiro',
         serializeKiroOAuthTokenBlob(refreshed),
         'subscription',
+        undefined,
+        keyLabel,
       );
       this.logger.log(`Kiro OAuth token refreshed for agent=${agentId}`);
       return refreshed.t;

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
@@ -311,9 +311,10 @@ describe('MinimaxOauthService', () => {
       fetchMock.mockResolvedValueOnce(
         mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expired_in: 3600 }),
       );
-      const out = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+      const out = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1', 'Work');
       expect(out?.t).toBe('new');
       expect(provider.upsertProvider).toHaveBeenCalled();
+      expect(provider.upsertProvider.mock.calls[0][6]).toBe('Work');
     });
 
     it('returns the original blob (not null) when refresh fails', async () => {

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.ts
@@ -264,6 +264,7 @@ export class MinimaxOauthService {
     rawValue: string,
     agentId: string,
     userId: string,
+    keyLabel?: string,
   ): Promise<OAuthTokenBlob | null> {
     let blob: OAuthTokenBlob;
     try {
@@ -283,6 +284,8 @@ export class MinimaxOauthService {
         'minimax',
         JSON.stringify(refreshed),
         'subscription',
+        undefined,
+        keyLabel,
       );
       this.logger.log(`MiniMax OAuth token refreshed for agent=${agentId}`);
       return refreshed;

--- a/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
@@ -248,7 +248,7 @@ describe('OpenaiOauthService', () => {
       fetchMock.mockResolvedValue(
         mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expires_in: 3600 }),
       );
-      const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+      const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1', 'Work');
       expect(token).toBe('new');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
         'agent-1',
@@ -256,6 +256,8 @@ describe('OpenaiOauthService', () => {
         'openai',
         expect.stringContaining('"t":"new"'),
         'subscription',
+        undefined,
+        'Work',
       );
     });
 

--- a/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
@@ -240,7 +240,12 @@ export abstract class RedirectPkceOauthBaseService {
   }
 
   /** Parse an OAuth blob and return a valid access token, refreshing if expired. */
-  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
+  async unwrapToken(
+    rawValue: string,
+    agentId: string,
+    userId: string,
+    keyLabel?: string,
+  ): Promise<string | null> {
     const blob = parseOAuthTokenBlob(rawValue);
     if (!blob) return null;
     // Access token + expiry are required to use the token at all. Refresh
@@ -249,13 +254,14 @@ export abstract class RedirectPkceOauthBaseService {
     // still produce a usable short-lived access token.
     if (Date.now() < blob.e - 60_000) return blob.t;
     if (!blob.r) return null;
-    return this.refreshAndPersistToken(blob, agentId, userId);
+    return this.refreshAndPersistToken(blob, agentId, userId, keyLabel);
   }
 
   private async refreshAndPersistToken(
     blob: OAuthTokenBlob,
     agentId: string,
     userId: string,
+    keyLabel?: string,
   ): Promise<string | null> {
     try {
       const refreshed = await this.refreshAccessToken(blob.r, blob.u);
@@ -265,6 +271,8 @@ export abstract class RedirectPkceOauthBaseService {
         this.oauthConfig.providerId,
         serializeOAuthTokenBlob(refreshed),
         'subscription',
+        undefined,
+        keyLabel,
       );
       this.logger.log(`${this.oauthConfig.providerId} OAuth token refreshed for agent=${agentId}`);
       return refreshed.t;

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
@@ -168,7 +168,7 @@ describe('XaiOauthService', () => {
       }),
     );
 
-    const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+    const token = await svc.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1', 'Work');
 
     expect(token).toBe('new-access');
     expect(fetchMock).toHaveBeenCalledWith(
@@ -181,6 +181,8 @@ describe('XaiOauthService', () => {
       'xai',
       expect.stringContaining('"t":"new-access"'),
       'subscription',
+      undefined,
+      'Work',
     );
   });
 

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.service.ts
@@ -170,7 +170,12 @@ export class XaiOauthService {
     };
   }
 
-  async unwrapToken(rawValue: string, agentId: string, userId: string): Promise<string | null> {
+  async unwrapToken(
+    rawValue: string,
+    agentId: string,
+    userId: string,
+    keyLabel?: string,
+  ): Promise<string | null> {
     const blob = parseOAuthTokenBlob(rawValue);
     if (!blob) return null;
     if (Date.now() < blob.e - 60_000) return blob.t;
@@ -182,6 +187,8 @@ export class XaiOauthService {
         'xai',
         serializeOAuthTokenBlob(refreshed),
         'subscription',
+        undefined,
+        keyLabel,
       );
       this.logger.log(`xAI OAuth token refreshed for agent=${agentId}`);
       return refreshed.t;

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -280,7 +280,7 @@ describe('OpenaiOauthService', () => {
         }),
       });
 
-      const result = await service.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1');
+      const result = await service.unwrapToken(JSON.stringify(blob), 'agent-1', 'user-1', 'Work');
 
       expect(result).toBe('new-access');
       expect(providerService.upsertProvider).toHaveBeenCalledWith(
@@ -289,6 +289,8 @@ describe('OpenaiOauthService', () => {
         'openai',
         expect.any(String),
         'subscription',
+        undefined,
+        'Work',
       );
     });
 

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -271,6 +271,7 @@ describe('ProxyFallbackService', () => {
           provider,
           apiKey: 'old-access-token',
           rawApiKey: rawBlob,
+          providerKeyLabel: 'Work',
           agentId: 'agent-1',
           userId: 'user-1',
           model: `${provider}-model`,
@@ -294,6 +295,7 @@ describe('ProxyFallbackService', () => {
         };
         expect(expiredBlob.e).toBe(0);
         if (provider === 'kiro') expect(expiredBlob.source).toBe('kiro-oidc');
+        expect(unwrap().mock.calls[0][3]).toBe('Work');
       },
     );
 
@@ -1204,10 +1206,11 @@ describe('ProxyFallbackService', () => {
         geminiOauth,
         kiroOauth,
         xaiOauth,
+        'Work',
       );
 
       expect(result.apiKey).toBe('access-token');
-      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1');
+      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1', 'Work');
     });
 
     it('unwraps MiniMax subscription token with resource URL', async () => {
@@ -1294,7 +1297,12 @@ describe('ProxyFallbackService', () => {
       );
 
       expect(result.apiKey).toBe('access-claude');
-      expect(anthropicOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1');
+      expect(anthropicOauth.unwrapToken).toHaveBeenCalledWith(
+        'blob',
+        'agent-1',
+        'user-1',
+        undefined,
+      );
     });
 
     it('returns the original key when Anthropic unwrap returns null', async () => {
@@ -1336,7 +1344,7 @@ describe('ProxyFallbackService', () => {
       );
 
       expect(result.apiKey).toBe('kiro-access');
-      expect(kiroOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1');
+      expect(kiroOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1', undefined);
     });
 
     it('does not unwrap for non-OAuth subscription providers (e.g. Qwen)', async () => {
@@ -1380,7 +1388,7 @@ describe('ProxyFallbackService', () => {
       );
 
       expect(result.apiKey).toBe('xai-access');
-      expect(xaiOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1');
+      expect(xaiOauth.unwrapToken).toHaveBeenCalledWith('blob', 'agent-1', 'user-1', undefined);
     });
 
     it('returns original key when MiniMax unwrap returns null', async () => {
@@ -1452,7 +1460,7 @@ describe('ProxyFallbackService', () => {
 
       expect(result.apiKey).toBe('fresh-access-token');
       expect(result.resourceUrl).toBe('proj-789');
-      expect(geminiOauth.unwrapToken).toHaveBeenCalledWith(blob, 'agent-1', 'user-1');
+      expect(geminiOauth.unwrapToken).toHaveBeenCalledWith(blob, 'agent-1', 'user-1', undefined);
     });
 
     it('returns null when Gemini unwrapToken cannot recover a stored OAuth blob', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -319,7 +319,7 @@ describe('ProxyService — orchestration', () => {
       });
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',
-        route: route('openai', 'subscription', 'gpt-5.3-codex'),
+        route: { ...route('openai', 'subscription', 'gpt-5.3-codex'), keyLabel: 'Work' },
         fallback_routes: null,
         confidence: 0.9,
         score: 5,
@@ -342,6 +342,7 @@ describe('ProxyService — orchestration', () => {
           authType: 'subscription',
           apiKey: 'cached-access',
           rawApiKey: rawBlob,
+          providerKeyLabel: 'Work',
           agentId: 'agent-1',
           userId: 'user-1',
         }),

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -32,6 +32,7 @@ interface ForwardProviderOptions {
   signal?: AbortSignal;
   authType?: string;
   rawApiKey?: string;
+  providerKeyLabel?: string;
   agentId?: string;
   userId?: string;
   resourceUrl?: string;
@@ -251,6 +252,7 @@ export class ProxyFallbackService {
         this.geminiOauth,
         this.kiroOauth,
         this.xaiOauth,
+        providerKeyLabel,
       );
       if (resolvedCredentials.apiKey === null) {
         this.logger.debug(
@@ -281,6 +283,7 @@ export class ProxyFallbackService {
         agentId,
         userId,
         rawApiKey: apiKey,
+        providerKeyLabel,
         authType,
         apiMode,
         resourceUrl: resolvedCredentials.resourceUrl,
@@ -360,6 +363,7 @@ export class ProxyFallbackService {
       opts.rawApiKey,
       opts.agentId,
       opts.userId,
+      opts.providerKeyLabel,
       {
         openaiOauth: this.openaiOauth,
         minimaxOauth: this.minimaxOauth,
@@ -568,6 +572,7 @@ async function refreshRejectedOAuthCredential(
   rawValue: string,
   agentId: string,
   userId: string,
+  keyLabel: string | undefined,
   services: OAuthServiceSet,
 ): Promise<ResolvedCredentials | null> {
   const expiredRawValue = expireRefreshableOAuthBlob(rawValue);
@@ -575,27 +580,57 @@ async function refreshRejectedOAuthCredential(
 
   const lower = provider.toLowerCase();
   if (lower === 'openai') {
-    const unwrapped = await services.openaiOauth.unwrapToken(expiredRawValue, agentId, userId);
+    const unwrapped = await services.openaiOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
     return unwrapped ? { apiKey: unwrapped } : null;
   }
   if (lower === 'minimax') {
-    const unwrapped = await services.minimaxOauth.unwrapToken(expiredRawValue, agentId, userId);
+    const unwrapped = await services.minimaxOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
     return unwrapped ? { apiKey: unwrapped.t, resourceUrl: unwrapped.u } : null;
   }
   if (lower === 'anthropic') {
-    const unwrapped = await services.anthropicOauth.unwrapToken(expiredRawValue, agentId, userId);
+    const unwrapped = await services.anthropicOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
     return unwrapped ? { apiKey: unwrapped } : null;
   }
   if (lower === 'gemini') {
-    const unwrapped = await services.geminiOauth.unwrapToken(expiredRawValue, agentId, userId);
+    const unwrapped = await services.geminiOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
     return unwrapped ? { apiKey: unwrapped, resourceUrl: parseOAuthTokenBlob(rawValue)?.u } : null;
   }
   if (lower === 'kiro') {
-    const unwrapped = await services.kiroOauth.unwrapToken(expiredRawValue, agentId, userId);
+    const unwrapped = await services.kiroOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
     return unwrapped ? { apiKey: unwrapped } : null;
   }
   if (lower === 'xai') {
-    const unwrapped = await services.xaiOauth.unwrapToken(expiredRawValue, agentId, userId);
+    const unwrapped = await services.xaiOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
     return unwrapped ? { apiKey: unwrapped } : null;
   }
   return null;
@@ -613,26 +648,27 @@ export async function resolveApiKey(
   geminiOauth: GeminiOauthService,
   kiroOauth: KiroOauthService,
   xaiOauth: XaiOauthService,
+  keyLabel?: string,
 ): Promise<ResolvedCredentials> {
   if (authType === 'subscription') {
     const lower = provider.toLowerCase();
     if (lower === 'openai') {
-      const unwrapped = await openaiOauth.unwrapToken(apiKey, agentId, userId);
+      const unwrapped = await openaiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
       if (unwrapped) return { apiKey: unwrapped };
       if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'minimax') {
-      const unwrapped = await minimaxOauth.unwrapToken(apiKey, agentId, userId);
+      const unwrapped = await minimaxOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
       if (unwrapped) return { apiKey: unwrapped.t, resourceUrl: unwrapped.u };
       if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'anthropic') {
-      const unwrapped = await anthropicOauth.unwrapToken(apiKey, agentId, userId);
+      const unwrapped = await anthropicOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
       if (unwrapped) return { apiKey: unwrapped };
       if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'gemini') {
-      const unwrapped = await geminiOauth.unwrapToken(apiKey, agentId, userId);
+      const unwrapped = await geminiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
       if (unwrapped) {
         // The CodeAssist project id was stored in `blob.u` by enrichBlob.
         // Read it from the input blob (refreshes preserve the field).
@@ -642,12 +678,12 @@ export async function resolveApiKey(
       if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'kiro') {
-      const unwrapped = await kiroOauth.unwrapToken(apiKey, agentId, userId);
+      const unwrapped = await kiroOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
       if (unwrapped) return { apiKey: unwrapped };
       if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }
     if (lower === 'xai') {
-      const unwrapped = await xaiOauth.unwrapToken(apiKey, agentId, userId);
+      const unwrapped = await xaiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
       if (unwrapped) return { apiKey: unwrapped };
       if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
     }

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -260,6 +260,7 @@ export class ProxyService {
       agentId,
       userId,
       rawApiKey: credentials.rawApiKey,
+      providerKeyLabel: route.keyLabel ?? undefined,
       authType: route.authType,
       apiMode,
       resourceUrl: credentials.resourceUrl,
@@ -451,6 +452,7 @@ export class ProxyService {
       this.geminiOauth,
       this.kiroOauth,
       this.xaiOauth,
+      resolved.provider_key_label,
     );
     const unwrappedApiKey = unwrapped.apiKey;
     if (unwrappedApiKey === null) return null;


### PR DESCRIPTION
## Summary
- pass provider key labels through OAuth unwrap/refresh for primary and fallback routing
- persist refreshed OAuth blobs back to the same labeled subscription account
- cover OpenAI, Gemini, Anthropic, MiniMax, Kiro, and xAI refresh persistence

## Validation
- npm test --workspace=packages/backend -- --runInBand src/routing/proxy/__tests__/proxy-fallback.service.spec.ts src/routing/proxy/__tests__/proxy.service.spec.ts src/routing/oauth/openai-oauth.service.spec.ts src/routing/openai-oauth.service.spec.ts src/routing/oauth/gemini-oauth.service.spec.ts src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts src/routing/oauth/minimax-oauth.service.spec.ts src/routing/oauth/kiro-oauth.service.spec.ts src/routing/oauth/xai/xai-oauth.service.spec.ts
- npm run build --workspace=packages/backend
- npx prettier --check $(git diff --name-only)
- npx changeset status
- npm run lint (existing warnings only)
- npm run build
- npm test --workspace=packages/backend -- --runInBand

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist refreshed OAuth tokens to the same labeled subscription account that supplied them, across primary and fallback routing. This prevents tokens from being saved to the wrong account when auto-refreshing.

- **Bug Fixes**
  - Propagated `keyLabel`/`providerKeyLabel` from routing into all OAuth `unwrapToken(...)` calls.
  - Saved refreshed blobs with `upsertProvider(..., 'subscription', undefined, keyLabel)` for OpenAI, Gemini, Anthropic, MiniMax, Kiro, and xAI.
  - Applied label-aware refresh in fallback paths and `resolveApiKey`.
  - Updated tests to verify label propagation and persistence.

<sup>Written for commit c78f6fb20e23c742a5a1388fa890e35d44afed62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

