### PR TITLE
Fix per-agent cost discrepancy and dedupe backend code

### DIFF
--- a/packages/backend/src/analytics/dto/messages-query.dto.ts
+++ b/packages/backend/src/analytics/dto/messages-query.dto.ts
@@ -37,6 +37,7 @@ export class MessagesQueryDto {
 
   @IsOptional()
   @IsNumber()
+  @Min(0)
   @Max(999999)
   @Type(() => Number)
   cost_max?: number;

--- a/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.spec.ts
@@ -7,16 +7,20 @@ describe('AgentAnalyticsService', () => {
   let service: AgentAnalyticsService;
   let mockGetRawOne: jest.Mock;
   let mockGetRawMany: jest.Mock;
+  let mockSelect: jest.Mock;
+  let mockAddSelect: jest.Mock;
 
   const scope = { tenantId: 't1', agentId: 'a1' };
 
   beforeEach(async () => {
     mockGetRawOne = jest.fn();
     mockGetRawMany = jest.fn();
+    mockSelect = jest.fn().mockReturnThis();
+    mockAddSelect = jest.fn().mockReturnThis();
 
     const mockQb = {
-      select: jest.fn().mockReturnThis(),
-      addSelect: jest.fn().mockReturnThis(),
+      select: mockSelect,
+      addSelect: mockAddSelect,
       where: jest.fn().mockReturnThis(),
       andWhere: jest.fn().mockReturnThis(),
       groupBy: jest.fn().mockReturnThis(),
@@ -103,6 +107,24 @@ describe('AgentAnalyticsService', () => {
 
       expect(result.total_cost_usd).toBe(0);
       expect(result.by_model).toEqual([]);
+    });
+
+    it('sanitizes negative costs (failed pricing lookups) in every cost sum', async () => {
+      mockGetRawOne.mockResolvedValueOnce({ total: 0 }).mockResolvedValueOnce({ total: 0 });
+      mockGetRawMany.mockResolvedValueOnce([]);
+
+      await service.getCosts('24h', scope);
+
+      const sanitized = 'CASE WHEN at.cost_usd >= 0 THEN at.cost_usd ELSE NULL END';
+      const costExprs = [
+        ...mockSelect.mock.calls.map((c) => String(c[0])),
+        ...mockAddSelect.mock.calls.map((c) => String(c[0])),
+      ].filter((expr) => expr.includes('cost_usd'));
+      // current total + previous total + per-model breakdown = 3 cost sums.
+      expect(costExprs).toHaveLength(3);
+      for (const expr of costExprs) {
+        expect(expr).toContain(sanitized);
+      }
     });
   });
 });

--- a/packages/backend/src/analytics/services/agent-analytics.service.ts
+++ b/packages/backend/src/analytics/services/agent-analytics.service.ts
@@ -4,7 +4,7 @@ import { Repository } from 'typeorm';
 import { AgentMessage } from '../../entities/agent-message.entity';
 import { rangeToInterval, rangeToPreviousInterval } from '../../common/utils/range.util';
 import { computeTrend } from './query-helpers';
-import { computeCutoff } from '../../common/utils/postgres-sql';
+import { computeCutoff, sqlSanitizeCost } from '../../common/utils/postgres-sql';
 
 interface AgentScope {
   tenantId: string;
@@ -88,18 +88,21 @@ export class AgentAnalyticsService {
     const prevInterval = rangeToPreviousInterval(range);
     const cutoff = computeCutoff(interval);
     const prevCutoff = computeCutoff(prevInterval);
+    // Treat negative costs (failed pricing lookups) as NULL so this agent-key
+    // endpoint stays consistent with the dashboard's session-auth cost path.
+    const safeCost = sqlSanitizeCost('at.cost_usd');
 
     const [currentRows, prevRows, modelRows] = await Promise.all([
       this.turnRepo
         .createQueryBuilder('at')
-        .select('COALESCE(SUM(at.cost_usd), 0)', 'total')
+        .select(`COALESCE(SUM(${safeCost}), 0)`, 'total')
         .where('at.timestamp >= :cutoff', { cutoff })
         .andWhere('at.tenant_id = :tenantId', { tenantId: scope.tenantId })
         .andWhere('at.agent_id = :agentId', { agentId: scope.agentId })
         .getRawOne(),
       this.turnRepo
         .createQueryBuilder('at')
-        .select('COALESCE(SUM(at.cost_usd), 0)', 'total')
+        .select(`COALESCE(SUM(${safeCost}), 0)`, 'total')
         .where('at.timestamp >= :prevCutoff', { prevCutoff })
         .andWhere('at.timestamp < :cutoff', { cutoff })
         .andWhere('at.tenant_id = :tenantId', { tenantId: scope.tenantId })
@@ -108,7 +111,7 @@ export class AgentAnalyticsService {
       this.turnRepo
         .createQueryBuilder('at')
         .select('at.model', 'model')
-        .addSelect('COALESCE(SUM(at.cost_usd), 0)', 'cost_usd')
+        .addSelect(`COALESCE(SUM(${safeCost}), 0)`, 'cost_usd')
         .addSelect('COALESCE(SUM(at.input_tokens), 0)', 'input_tokens')
         .addSelect('COALESCE(SUM(at.output_tokens), 0)', 'output_tokens')
         .where('at.timestamp >= :cutoff', { cutoff })

--- a/packages/backend/src/common/dto/range-query.dto.ts
+++ b/packages/backend/src/common/dto/range-query.dto.ts
@@ -1,8 +1,9 @@
 import { IsOptional, IsString, IsIn } from 'class-validator';
+import { RANGE_VALUES } from '../utils/range.util';
 
 export class RangeQueryDto {
   @IsOptional()
-  @IsIn(['1h', '6h', '24h', '7d', '30d'])
+  @IsIn(RANGE_VALUES)
   range?: string;
 
   @IsOptional()

--- a/packages/backend/src/common/dto/savings-query.dto.ts
+++ b/packages/backend/src/common/dto/savings-query.dto.ts
@@ -1,7 +1,8 @@
 import { IsNotEmpty, IsOptional, IsString, IsIn, MaxLength } from 'class-validator';
+import { RANGE_VALUES } from '../utils/range.util';
 
 export class SavingsQueryDto {
-  @IsIn(['1h', '6h', '24h', '7d', '30d'])
+  @IsIn(RANGE_VALUES)
   range!: string;
 
   @IsNotEmpty()
@@ -15,7 +16,7 @@ export class SavingsQueryDto {
 }
 
 export class SavingsTimeseriesQueryDto {
-  @IsIn(['1h', '6h', '24h', '7d', '30d'])
+  @IsIn(RANGE_VALUES)
   range!: string;
 
   @IsNotEmpty()

--- a/packages/backend/src/common/utils/period.util.ts
+++ b/packages/backend/src/common/utils/period.util.ts
@@ -1,9 +1,9 @@
+import { toSqlTimestamp } from './postgres-sql';
+
 export interface PeriodBoundaries {
   periodStart: string;
   periodEnd: string;
 }
-
-const fmt = (d: Date) => d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
 
 export function computePeriodBoundaries(period: string): PeriodBoundaries {
   const now = new Date();
@@ -34,7 +34,7 @@ export function computePeriodBoundaries(period: string): PeriodBoundaries {
   }
 
   const end = new Date(now.getTime());
-  return { periodStart: fmt(start), periodEnd: fmt(end) };
+  return { periodStart: toSqlTimestamp(start), periodEnd: toSqlTimestamp(end) };
 }
 
 export function computePeriodResetDate(period: string): string {
@@ -67,5 +67,5 @@ export function computePeriodResetDate(period: string): string {
       );
   }
 
-  return fmt(reset);
+  return toSqlTimestamp(reset);
 }

--- a/packages/backend/src/common/utils/postgres-sql.spec.ts
+++ b/packages/backend/src/common/utils/postgres-sql.spec.ts
@@ -8,6 +8,7 @@ import {
   sqlSanitizeCost,
   timestampDefault,
   timestampType,
+  toSqlTimestamp,
 } from './postgres-sql';
 
 describe('postgres-sql', () => {
@@ -93,6 +94,23 @@ describe('postgres-sql', () => {
 
     it('sqlCastInterval wraps a named parameter in CAST(... AS interval)', () => {
       expect(sqlCastInterval('since')).toBe('CAST(:since AS interval)');
+    });
+  });
+
+  describe('toSqlTimestamp', () => {
+    it('formats a Date as a space-separated string without T or Z (19 chars)', () => {
+      const out = toSqlTimestamp(new Date('2026-04-20T12:34:56.789Z'));
+      expect(out).toBe('2026-04-20 12:34:56');
+      expect(out).not.toContain('T');
+      expect(out).not.toContain('Z');
+      expect(out).toHaveLength(19);
+    });
+
+    it('defaults to the current time when no Date is given', () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2026-01-02T03:04:05.000Z').getTime());
+      expect(toSqlTimestamp()).toBe('2026-01-02 03:04:05');
+      jest.useRealTimers();
     });
   });
 });

--- a/packages/backend/src/common/utils/postgres-sql.ts
+++ b/packages/backend/src/common/utils/postgres-sql.ts
@@ -76,6 +76,19 @@ export function sqlCastInterval(paramName: string): string {
 }
 
 /**
+ * Format a Date as a Postgres-friendly timestamp string
+ * (`YYYY-MM-DD HH:MM:SS` — space-separated, no timezone suffix).
+ *
+ * Used for notification-log / notification-rule writes and alert-period
+ * boundaries. This emits UTC and is space-separated, intentionally distinct
+ * from {@link sqlNow} / {@link computeCutoff}, which emit local-time,
+ * `T`-separated strings for the analytics range cutoffs.
+ */
+export function toSqlTimestamp(d: Date = new Date()): string {
+  return d.toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+}
+
+/**
  * Format a Date as a local-time ISO-8601 string without timezone suffix.
  * Matches the format PostgreSQL stores for `timestamp without time zone`
  * when the pg driver serialises JS Dates in the Node process's local TZ.

--- a/packages/backend/src/common/utils/range.util.ts
+++ b/packages/backend/src/common/utils/range.util.ts
@@ -1,22 +1,41 @@
+/**
+ * The set of analytics range tokens accepted by range-query DTOs. Single
+ * source of truth so DTO validation and {@link rangeToInterval} cannot drift.
+ */
+export const RANGE_VALUES = ['1h', '6h', '24h', '7d', '30d'] as const;
+export type RangeValue = (typeof RANGE_VALUES)[number];
+
 export function rangeToInterval(range: string): string {
   switch (range) {
-    case '1h': return '1 hour';
-    case '6h': return '6 hours';
-    case '24h': return '24 hours';
-    case '7d': return '7 days';
-    case '30d': return '30 days';
-    default: return '24 hours';
+    case '1h':
+      return '1 hour';
+    case '6h':
+      return '6 hours';
+    case '24h':
+      return '24 hours';
+    case '7d':
+      return '7 days';
+    case '30d':
+      return '30 days';
+    default:
+      return '24 hours';
   }
 }
 
 export function rangeToPreviousInterval(range: string): string {
   switch (range) {
-    case '1h': return '2 hours';
-    case '6h': return '12 hours';
-    case '24h': return '48 hours';
-    case '7d': return '14 days';
-    case '30d': return '60 days';
-    default: return '48 hours';
+    case '1h':
+      return '2 hours';
+    case '6h':
+      return '12 hours';
+    case '24h':
+      return '48 hours';
+    case '7d':
+      return '14 days';
+    case '30d':
+      return '60 days';
+    default:
+      return '48 hours';
   }
 }
 

--- a/packages/backend/src/database/models-dev-sync.service.ts
+++ b/packages/backend/src/database/models-dev-sync.service.ts
@@ -6,6 +6,7 @@ import {
   capabilitiesFromModelsDev,
   modelModalitiesFromModelsDev,
 } from '../model-discovery/model-capabilities';
+import { GOOGLE_VARIANT_RE } from '../model-prices/model-name-normalizer';
 
 /**
  * Mapping from our internal provider IDs to models.dev provider directory names.
@@ -86,8 +87,6 @@ const DATE_SUFFIX_RE = /-\d{4}-?\d{2}-?\d{2}$/;
 const SHORT_DATE_SUFFIX_RE = /-\d{4}$/;
 /** Common suffix aliases: try appending -latest when the base name is not found. */
 const LATEST_SUFFIX = '-latest';
-/** Google variant suffixes: -preview-MM-DD, -preview-YYYY-MM-DD, -exp-MMDD, -latest. */
-const GOOGLE_VARIANT_RE = /-(?:preview(?:-\d{2,4}){1,3}|exp-\d{4}|latest)$/;
 /** xAI reasoning/non-reasoning mode suffixes. */
 const REASONING_SUFFIX_RE = /-(reasoning|non-reasoning)$/;
 /**

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -6,7 +6,7 @@ import { UserProvider } from '../entities/user-provider.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderModelFetcherService, filterNonChatModels } from './provider-model-fetcher.service';
 import { ProviderModelRegistryService } from './provider-model-registry.service';
-import { DiscoveredModel } from './model-fetcher';
+import { DiscoveredModel, DEFAULT_CONTEXT_WINDOW } from './model-fetcher';
 import { decrypt, getEncryptionSecret } from '../common/utils/crypto.util';
 import { computeQualityScore } from '../database/quality-score.util';
 import { PricingSyncService } from '../database/pricing-sync.service';
@@ -361,7 +361,7 @@ export class ModelDiscoveryService {
           displayName: m.model_name,
           provider: cpKey,
           authType: customAuthTypes.get(cpKey) ?? 'api_key',
-          contextWindow: m.context_window ?? 128000,
+          contextWindow: m.context_window ?? DEFAULT_CONTEXT_WINDOW,
           inputPricePerToken: inputPerToken,
           outputPricePerToken: outputPerToken,
           capabilityReasoning: false,

--- a/packages/backend/src/model-discovery/model-fallback.ts
+++ b/packages/backend/src/model-discovery/model-fallback.ts
@@ -1,4 +1,4 @@
-import { DiscoveredModel } from './model-fetcher';
+import { DiscoveredModel, DEFAULT_CONTEXT_WINDOW } from './model-fetcher';
 import {
   OPENROUTER_PREFIX_TO_PROVIDER,
   PROVIDER_BY_ID_OR_ALIAS,
@@ -160,7 +160,7 @@ export function buildModelsDevFallback(
     id: e.id,
     displayName: e.name || e.id,
     provider: providerId,
-    contextWindow: e.contextWindow ?? 128000,
+    contextWindow: e.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
     inputPricePerToken: e.inputPricePerToken,
     outputPricePerToken: e.outputPricePerToken,
     capabilityReasoning: e.reasoning ?? false,
@@ -206,7 +206,7 @@ export function buildFallbackModels(
       id: modelId,
       displayName: entry.displayName || modelId,
       provider: providerId,
-      contextWindow: entry.contextWindow ?? 128000,
+      contextWindow: entry.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
       inputPricePerToken: entry.input,
       outputPricePerToken: entry.output,
       capabilityReasoning: false,
@@ -252,7 +252,7 @@ export function buildSubscriptionFallbackModels(
       if (seen.has(modelId)) continue;
       seen.add(modelId);
 
-      let contextWindow = entry.contextWindow ?? 128000;
+      let contextWindow = entry.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
       if (capabilities?.maxContextWindow && contextWindow > capabilities.maxContextWindow) {
         contextWindow = capabilities.maxContextWindow;
       }

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -8,6 +8,12 @@
 
 import type { AuthType, ModelCapability, ModelModality } from 'manifest-shared';
 
+/**
+ * Default context-window size assumed when a provider's API or the pricing
+ * cache does not report one. Single source of truth for model discovery.
+ */
+export const DEFAULT_CONTEXT_WINDOW = 128000;
+
 export interface DiscoveredModel {
   id: string;
   displayName: string;

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
-import { DiscoveredModel, FetcherConfig } from './model-fetcher';
+import { DiscoveredModel, FetcherConfig, DEFAULT_CONTEXT_WINDOW } from './model-fetcher';
 import { OLLAMA_CLOUD_HOST, OLLAMA_HOST } from '../common/constants/ollama';
 import {
   CODEX_CLI_ORIGINATOR,
@@ -19,7 +19,6 @@ import {
 } from '../routing/proxy/kiro-adapter';
 
 const FETCH_TIMEOUT_MS = 5000;
-const DEFAULT_CONTEXT_WINDOW = 128000;
 const ANTHROPIC_DEFAULT_CONTEXT = 200000;
 const GEMINI_DEFAULT_CONTEXT = 1000000;
 const MINIMAX_SUBSCRIPTION_MODELS_URL = 'https://api.minimax.io/anthropic/v1/models?limit=100';
@@ -335,7 +334,7 @@ function parseOpenRouter(body: unknown, provider: string): DiscoveredModel[] {
         id: entry.id,
         displayName: entry.name || entry.id,
         provider,
-        contextWindow: entry.context_length ?? 128000,
+        contextWindow: entry.context_length ?? DEFAULT_CONTEXT_WINDOW,
         inputPricePerToken:
           prompt !== null && Number.isFinite(prompt) && prompt >= 0 ? prompt : null,
         outputPricePerToken:

--- a/packages/backend/src/notifications/services/email-provider-validation.ts
+++ b/packages/backend/src/notifications/services/email-provider-validation.ts
@@ -1,4 +1,5 @@
-const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+/** Hostname validation for email-provider domains (e.g. Mailgun sending domain). */
+export const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
 
 export interface ValidationResult {
   valid: boolean;

--- a/packages/backend/src/notifications/services/email-providers/mailgun.provider.ts
+++ b/packages/backend/src/notifications/services/email-providers/mailgun.provider.ts
@@ -1,7 +1,7 @@
 import { EmailProvider, EmailProviderConfig, SendEmailOptions } from './email-provider.interface';
+import { DOMAIN_RE } from '../email-provider-validation';
 
 const MAILGUN_BASE = 'https://api.mailgun.net';
-const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
 
 const logger = {
   warn: (msg: string) => console.warn(`[Mailgun] ${msg}`),

--- a/packages/backend/src/notifications/services/notification-log.service.ts
+++ b/packages/backend/src/notifications/services/notification-log.service.ts
@@ -1,22 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { v4 as uuid } from 'uuid';
+import { toSqlTimestamp } from '../../common/utils/postgres-sql';
 
 export function formatNotificationTimestamp(): string {
-  return new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
+  return toSqlTimestamp();
 }
 
 @Injectable()
 export class NotificationLogService {
   constructor(private readonly ds: DataSource) {}
 
-  private sql(query: string): string {
-    return query;
-  }
-
   async hasAlreadySent(ruleId: string, periodStart: string): Promise<boolean> {
     const rows = await this.ds.query(
-      this.sql(`SELECT 1 FROM notification_logs WHERE rule_id = $1 AND period_start = $2`),
+      `SELECT 1 FROM notification_logs WHERE rule_id = $1 AND period_start = $2`,
       [ruleId, periodStart],
     );
     return rows.length > 0;
@@ -33,11 +30,9 @@ export class NotificationLogService {
     sentAt: string;
   }): Promise<void> {
     await this.ds.query(
-      this.sql(
-        `INSERT INTO notification_logs
+      `INSERT INTO notification_logs
          (id, rule_id, period_start, period_end, actual_value, threshold_value, metric_type, agent_name, sent_at)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-      ),
       [
         uuid(),
         params.ruleId,
@@ -54,15 +49,13 @@ export class NotificationLogService {
 
   async getLogsForAgent(userId: string, agentName: string) {
     return this.ds.query(
-      this.sql(
-        `SELECT nl.id, nl.sent_at, nl.actual_value, nl.threshold_value,
+      `SELECT nl.id, nl.sent_at, nl.actual_value, nl.threshold_value,
                 nl.metric_type, nl.period_start, nl.period_end, nl.agent_name
          FROM notification_logs nl
          JOIN notification_rules nr ON nr.id = nl.rule_id
          WHERE nr.user_id = $1 AND nl.agent_name = $2
          ORDER BY nl.sent_at DESC
          LIMIT 50`,
-      ),
       [userId, agentName],
     );
   }
@@ -73,7 +66,7 @@ export class NotificationLogService {
   ): Promise<string | null> {
     if (notificationEmail) return notificationEmail;
 
-    const rows = await this.ds.query(this.sql(`SELECT email FROM "user" WHERE id = $1`), [userId]);
+    const rows = await this.ds.query(`SELECT email FROM "user" WHERE id = $1`, [userId]);
     return rows[0]?.email ?? null;
   }
 }

--- a/packages/backend/src/notifications/services/notification-rules.service.ts
+++ b/packages/backend/src/notifications/services/notification-rules.service.ts
@@ -8,6 +8,7 @@ import { AgentMessage } from '../../entities/agent-message.entity';
 import { Agent } from '../../entities/agent.entity';
 import { Tenant } from '../../entities/tenant.entity';
 import { CreateNotificationRuleDto, UpdateNotificationRuleDto } from '../dto/notification-rule.dto';
+import { toSqlTimestamp } from '../../common/utils/postgres-sql';
 
 export interface NotificationRuleWithTriggerCount extends NotificationRule {
   trigger_count: number;
@@ -56,7 +57,7 @@ export class NotificationRulesService {
   async createRule(userId: string, dto: CreateNotificationRuleDto): Promise<NotificationRule> {
     const agent = await this.resolveAgent(userId, dto.agent_name);
     const id = uuid();
-    const now = nowSqlTimestamp();
+    const now = toSqlTimestamp();
 
     const rule: Partial<NotificationRule> = {
       id,
@@ -95,7 +96,7 @@ export class NotificationRulesService {
       return this.getRule(ruleId);
     }
 
-    patch.updated_at = nowSqlTimestamp();
+    patch.updated_at = toSqlTimestamp();
     await this.ruleRepo.update({ id: ruleId }, patch);
     return this.getRule(ruleId);
   }
@@ -189,8 +190,4 @@ export class NotificationRulesService {
     const count = await this.ruleRepo.count({ where: { id: ruleId, user_id: userId } });
     if (count === 0) throw new NotFoundException('Notification rule not found');
   }
-}
-
-function nowSqlTimestamp(): string {
-  return new Date().toISOString().replace('T', ' ').replace('Z', '').slice(0, 19);
 }

--- a/packages/backend/src/otlp/otlp-deprecated.controller.ts
+++ b/packages/backend/src/otlp/otlp-deprecated.controller.ts
@@ -22,21 +22,6 @@ const GONE_RESPONSE = {
 };
 
 /**
- * Some old clients prepend /api/v1 to the OTLP path or strip the /otlp prefix,
- * producing paths like /api/v1/otlp/v1/metrics or /v1/metrics. Catch those too.
- */
-const GONE_RESPONSE_MISROUTED = {
-  error: {
-    message:
-      'OTLP telemetry endpoints have been removed. ' +
-      'Use the routing proxy at /v1/chat/completions instead. ' +
-      'See https://manifest.build/docs/migration for details.',
-    type: 'gone',
-    status: 410,
-  },
-};
-
-/**
  * Structured 404 response for /chat/completions (missing /v1 prefix).
  * The OpenAI SDK appends /chat/completions to the base URL, so users who
  * set baseURL without the /v1 suffix hit this path.
@@ -85,41 +70,44 @@ export class OtlpDeprecatedController {
   }
 
   // --- Misrouted OTLP variants (wrong prefix) ---
+  // Some old clients prepend /api/v1 to the OTLP path or strip the /otlp
+  // prefix, producing paths like /api/v1/otlp/v1/metrics or /v1/metrics.
+  // Catch those too and return the same 410 Gone payload.
 
   @All('api/v1/otlp/v1/traces')
   @HttpCode(HttpStatus.GONE)
   misroutedTraces() {
-    return GONE_RESPONSE_MISROUTED;
+    return GONE_RESPONSE;
   }
 
   @All('api/v1/otlp/v1/metrics')
   @HttpCode(HttpStatus.GONE)
   misroutedMetrics() {
-    return GONE_RESPONSE_MISROUTED;
+    return GONE_RESPONSE;
   }
 
   @All('api/v1/otlp/v1/logs')
   @HttpCode(HttpStatus.GONE)
   misroutedLogs() {
-    return GONE_RESPONSE_MISROUTED;
+    return GONE_RESPONSE;
   }
 
   @All('v1/metrics')
   @HttpCode(HttpStatus.GONE)
   strippedMetrics() {
-    return GONE_RESPONSE_MISROUTED;
+    return GONE_RESPONSE;
   }
 
   @All('v1/traces')
   @HttpCode(HttpStatus.GONE)
   strippedTraces() {
-    return GONE_RESPONSE_MISROUTED;
+    return GONE_RESPONSE;
   }
 
   @All('v1/logs')
   @HttpCode(HttpStatus.GONE)
   strippedLogs() {
-    return GONE_RESPONSE_MISROUTED;
+    return GONE_RESPONSE;
   }
 
   // --- Wrong path for chat completions (missing /v1 prefix) ---

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -348,6 +348,31 @@ describe('ProviderService — route-only cleanup paths', () => {
     });
   });
 
+  describe('removeProvider — removeKeyByLabel', () => {
+    it('throws NotFoundException when no keys match the (provider, auth_type)', async () => {
+      providerRepo.find.mockResolvedValue([]);
+      await expect(svc.removeProvider('agent-1', 'openai', 'api_key', 'default')).rejects.toThrow(
+        'Provider not found',
+      );
+    });
+
+    it('throws NotFoundException when no key carries the requested label', async () => {
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'p1',
+          agent_id: 'agent-1',
+          provider: 'openai',
+          auth_type: 'api_key',
+          label: 'primary',
+          is_active: true,
+        } as unknown as UserProvider,
+      ]);
+      await expect(svc.removeProvider('agent-1', 'openai', 'api_key', 'secondary')).rejects.toThrow(
+        'Provider key not found',
+      );
+    });
+  });
+
   describe('deactivateAllProviders', () => {
     it('updates providers and tiers, then recalculates and invalidates cache', async () => {
       await svc.deactivateAllProviders('agent-1');

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In } from 'typeorm';
+import { Repository, In, FindOptionsWhere } from 'typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
@@ -454,12 +454,12 @@ export class ProviderService {
     // Legacy disconnect: deactivate every active key for the (provider,
     // [auth_type]) tuple. Falls back to findOne for compatibility with the
     // already-disconnected case so tier-cleanup still runs.
-    const where: Record<string, unknown> = { agent_id: agentId, provider, is_active: true };
+    const where: FindOptionsWhere<UserProvider> = { agent_id: agentId, provider, is_active: true };
     if (authType) where.auth_type = authType;
     const activeRows = await this.providerRepo.find({ where });
 
     if (activeRows.length === 0) {
-      const fallbackWhere: Record<string, unknown> = { agent_id: agentId, provider };
+      const fallbackWhere: FindOptionsWhere<UserProvider> = { agent_id: agentId, provider };
       if (authType) fallbackWhere.auth_type = authType;
       const any = await this.providerRepo.findOne({ where: fallbackWhere });
       if (!any) throw new NotFoundException('Provider not found');
@@ -521,7 +521,7 @@ export class ProviderService {
     authType: AuthType | undefined,
     label: string,
   ): Promise<{ notifications: string[] }> {
-    const where: Record<string, unknown> = { agent_id: agentId, provider };
+    const where: FindOptionsWhere<UserProvider> = { agent_id: agentId, provider };
     if (authType) where.auth_type = authType;
     const matching = await this.providerRepo.find({ where });
     if (matching.length === 0) throw new NotFoundException('Provider not found');

--- a/packages/backend/src/scoring/__tests__/extract-tool-name.spec.ts
+++ b/packages/backend/src/scoring/__tests__/extract-tool-name.spec.ts
@@ -1,0 +1,16 @@
+import { extractToolName } from '../types';
+
+describe('extractToolName', () => {
+  it('returns the top-level name (Anthropic-style tool)', () => {
+    expect(extractToolName({ name: 'str_replace' })).toBe('str_replace');
+  });
+
+  it('falls back to function.name (OpenAI-style tool)', () => {
+    expect(extractToolName({ function: { name: 'apply_patch' } })).toBe('apply_patch');
+  });
+
+  it('returns null when no tool name is present', () => {
+    expect(extractToolName({})).toBeNull();
+    expect(extractToolName({ function: {} })).toBeNull();
+  });
+});

--- a/packages/backend/src/scoring/specificity-detector.ts
+++ b/packages/backend/src/scoring/specificity-detector.ts
@@ -1,5 +1,5 @@
 import { TrieMatch } from './keyword-trie';
-import { ScorerTool } from './types';
+import { ScorerTool, extractToolName } from './types';
 import { SpecificityCategory, SPECIFICITY_CATEGORIES } from 'manifest-shared';
 import { ACTIVATION_THRESHOLDS, weightFor } from './specificity-weights';
 import { computeSignalBoosts } from './specificity-signals';
@@ -196,13 +196,6 @@ function applyToolHeuristics(tools: ScorerTool[], scores: Map<SpecificityCategor
       }
     }
   }
-}
-
-function extractToolName(tool: ScorerTool): string | null {
-  if (typeof tool.name === 'string') return tool.name;
-  const fn = tool.function as { name?: string } | undefined;
-  if (fn && typeof fn.name === 'string') return fn.name;
-  return null;
 }
 
 function isValidCategory(value: string): value is SpecificityCategory {

--- a/packages/backend/src/scoring/specificity-signals.ts
+++ b/packages/backend/src/scoring/specificity-signals.ts
@@ -1,5 +1,5 @@
 import type { SpecificityCategory } from 'manifest-shared';
-import { ScorerTool } from './types';
+import { ScorerTool, extractToolName } from './types';
 
 /**
  * Heuristic signals that sit alongside keyword matches. These fire off
@@ -96,11 +96,4 @@ export function computeSignalBoosts(text: string, tools?: ScorerTool[]): SignalB
   }
 
   return { boosts };
-}
-
-function extractToolName(tool: ScorerTool): string | null {
-  if (typeof tool.name === 'string') return tool.name;
-  const fn = tool.function as { name?: string } | undefined;
-  if (fn && typeof fn.name === 'string') return fn.name;
-  return null;
 }

--- a/packages/backend/src/scoring/types.ts
+++ b/packages/backend/src/scoring/types.ts
@@ -10,6 +10,18 @@ export interface ScorerTool {
   [key: string]: unknown;
 }
 
+/**
+ * Extract a tool's name across the two shapes agents send: a top-level `name`
+ * (Anthropic-style) or a nested `function.name` (OpenAI-style). Returns null
+ * when neither is present.
+ */
+export function extractToolName(tool: ScorerTool): string | null {
+  if (typeof tool.name === 'string') return tool.name;
+  const fn = tool.function as { name?: string } | undefined;
+  if (fn && typeof fn.name === 'string') return fn.name;
+  return null;
+}
+
 export interface ScorerInput {
   messages: ScorerMessage[];
   tools?: ScorerTool[];


### PR DESCRIPTION
## What & why

A file-by-file code-quality audit of the backend surfaced one real correctness
bug, several duplicated helpers/constants, some dead code, and a few
type-safety gaps. This PR fixes the highest-value, lowest-risk items. Every
change is behavior-preserving **except** the two correctness fixes below, and
all are covered by tests.

## Correctness

- **Per-agent cost totals were inconsistent with the dashboard.**
  `AgentAnalyticsService.getCosts()` summed `cost_usd` raw, while every other
  analytics path wraps it in `sqlSanitizeCost()` (a negative cost means a failed
  pricing lookup and is treated as `NULL`). `/api/v1/agent/:name/costs` could
  therefore report a different total than the dashboard `/costs` for identical
  data. Both now use the same sanitization.
- **`cost_max` accepted negatives.** The messages query DTO had `@Max(999999)`
  but no lower bound, so a negative `cost_max` silently produced an
  always-empty result. Added `@Min(0)`.

## DRY / single source of truth

- `toSqlTimestamp()` in `postgres-sql.ts` replaces three identical timestamp
  formatters (`notification-log`, `notification-rules`, `period.util`).
- `extractToolName()` hoisted into `scoring/types.ts` — was duplicated verbatim
  in `specificity-detector` and `specificity-signals`.
- `RANGE_VALUES` in `range.util.ts`, reused across the range query DTOs so DTO
  validation and `rangeToInterval` can't drift.
- `models-dev-sync` imports the canonical `GOOGLE_VARIANT_RE` instead of a
  hand-copied (already-divergent) duplicate.
- `DOMAIN_RE` shared between the email validator and the Mailgun provider.
- `DEFAULT_CONTEXT_WINDOW` promoted to `model-fetcher.ts`; the `128000` magic
  numbers across model discovery/fallback now reference it.

## Dead code / type safety

- Removed the no-op `NotificationLogService.sql()` pass-through.
- Merged the byte-identical `GONE_RESPONSE_MISROUTED` into `GONE_RESPONSE`.
- Typed `provider.service` lookup `WHERE` clauses as
  `FindOptionsWhere<UserProvider>` instead of `Record<string, unknown>`,
  restoring column type-checking.

## Tests

- Strengthened the agent-analytics spec to assert every cost sum is sanitized.
- Added unit tests for `toSqlTimestamp`, `extractToolName`, and the previously
  untested `removeKeyByLabel` guard paths.

## Verification (local)

- `tsc --noEmit`: clean
- Backend unit: **5943 passing**; e2e: **206 passing**
- ESLint: no new warnings on changed files
- Coverage: all changed lines covered (tests added where gaps existed)

## Deferred (found in the audit, intentionally out of scope here)

Larger or higher-risk items, left for focused follow-ups so this PR stays safe
and reviewable:

- Split the 867-line `provider.service.ts` god service (region detection, key
  chain, assignment cleanup) — SRP.
- Proxy adapters: consolidate `isRecord`/`safeParse`/SSE-framing and the
  OpenAI-envelope builders duplicated across the anthropic/google/responses/
  chatgpt adapters.
- Frontend: decompose the large page/components (`RoutingTierCard`, `Routing`,
  `ProviderIcon`) and extract shared modal/dismiss/key-chain primitives.
- Shared: reconcile subscription metadata duplicated between
  `shared/subscription/configs.ts` and the frontend `PROVIDER_UI` (already
  drifted on `anthropic` auth mode).
- `shared` path helpers (`getPath`/`hasPath`) diverge in validation/throw
  semantics between `request-params.ts` and `provider-params-spec.ts` —
  converging them is a behavior decision, not a mechanical dedup.
- OAuth: `XaiOauthService` re-implements the redirect-PKCE base; Kiro/MiniMax
  hand-roll a pending-flow map that `PendingStore` already provides.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inconsistent per‑agent cost totals by sanitizing negative costs and consolidates duplicated backend helpers into single sources of truth. Also rejects negative `cost_max` and tightens types.

- **Bug Fixes**
  - Agent cost sums now use `sqlSanitizeCost()` in `AgentAnalyticsService.getCosts()` to match the dashboard totals.
  - Messages query DTO adds `@Min(0)` to `cost_max` to prevent silent empty results.

- **Refactors**
  - Added `toSqlTimestamp()` and replaced duplicate timestamp formatters.
  - Centralized `extractToolName()` in `scoring/types.ts`; removed duplicates.
  - Introduced `RANGE_VALUES` for shared range validation across DTOs.
  - Promoted `DEFAULT_CONTEXT_WINDOW` and removed `128000` literals across discovery/fallback.
  - Shared `DOMAIN_RE`; removed dead code; typed TypeORM `where` as `FindOptionsWhere<UserProvider>`; merged misrouted OTLP response into `GONE_RESPONSE`.

<sup>Written for commit effddd1f780a8382166ed2153fda9809953e9119. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

