### PR TITLE
feat: add Qwen Token Plan subscription

### DIFF
--- a/.changeset/qwen-token-plan-subscription.md
+++ b/.changeset/qwen-token-plan-subscription.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add Qwen Token Plan as a subscription option for the Alibaba Cloud provider.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1603,6 +1603,27 @@ describe('ModelDiscoveryService', () => {
       expect(fetcher.fetch).not.toHaveBeenCalled();
     });
 
+    it('should not hardcode Qwen Token Plan fallback models when subscription fetch returns no models', async () => {
+      mockDecrypt.mockReturnValue('sk-sp-token-plan-key');
+      fetcher.fetch.mockResolvedValue([]);
+
+      const result = await service.discoverModels(
+        makeProvider({
+          provider: 'qwen',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted-token-plan-key',
+        }),
+      );
+
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'qwen',
+        'sk-sp-token-plan-key',
+        'subscription',
+        undefined,
+      );
+      expect(result).toEqual([]);
+    });
+
     it('should exchange Copilot GitHub token before fetching models', async () => {
       mockDecrypt.mockReturnValue('ghu_github_oauth_token');
       mockCopilotTokenService.getCopilotToken.mockResolvedValue('tid=copilot-api-token');
@@ -2163,6 +2184,43 @@ describe('ModelDiscoveryService', () => {
         'MiniMax-M2.1-highspeed',
         'MiniMax-M2',
       ]);
+    });
+
+    it('should not build hardcoded Qwen Token Plan fallback models', () => {
+      const orMap = new Map([
+        [
+          'qwen/qwen3.6-plus',
+          {
+            input: 0.0000005,
+            output: 0.000003,
+            contextWindow: 1000000,
+            displayName: 'Qwen 3.6 Plus',
+          },
+        ],
+        [
+          'qwen/qwen3.6-plus-20260402',
+          {
+            input: 0.0000005,
+            output: 0.000003,
+            contextWindow: 1000000,
+            displayName: 'Qwen 3.6 Plus snapshot',
+          },
+        ],
+        [
+          'qwen/qwen-image-2.0',
+          {
+            input: 0,
+            output: 0,
+            contextWindow: 0,
+            displayName: 'Qwen Image 2.0',
+          },
+        ],
+      ]);
+      mockPricingSync.getAll.mockReturnValue(orMap);
+
+      const result = buildSubscriptionFallbackModels(mockPricingSync as never, 'qwen');
+
+      expect(result).toEqual([]);
     });
 
     it('should use exact match mode for gemini — excludes suffixed cache entries', () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -634,6 +634,58 @@ describe('ProviderModelFetcherService', () => {
     );
   });
 
+  /* ── Qwen Token Plan subscription routing ── */
+
+  it('should fetch Qwen Token Plan models and filter image-only models', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          { id: 'qwen3.6-plus', object: 'model' },
+          { id: 'qwen-image-2.0', object: 'model' },
+          { id: 'wan2.7-image-pro', object: 'model' },
+          { id: 'deepseek-v4-pro', object: 'model' },
+        ],
+      }),
+    });
+
+    const result = await service.fetch('qwen', 'sk-sp-token-plan-key', 'subscription');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer sk-sp-token-plan-key' },
+      }),
+    );
+    expect(result.map((m) => m.id)).toEqual(['qwen3.6-plus', 'deepseek-v4-pro']);
+    expect(result[0]).toMatchObject({
+      contextWindow: 991000,
+      inputPricePerToken: 0,
+      outputPricePerToken: 0,
+    });
+  });
+
+  it('should apply endpoint override for Qwen Token Plan subscription discovery', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+
+    await service.fetch(
+      'qwen',
+      'sk-sp-token-plan-key',
+      'subscription',
+      'https://dashscope-intl.aliyuncs.com/compatible-mode',
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer sk-sp-token-plan-key' },
+      }),
+    );
+  });
+
   /* ── Kimi Coding Plan subscription routing ── */
 
   it('should skip live model fetching for moonshot subscription auth', async () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -24,6 +24,9 @@ const ANTHROPIC_DEFAULT_CONTEXT = 200000;
 const GEMINI_DEFAULT_CONTEXT = 1000000;
 const MINIMAX_SUBSCRIPTION_MODELS_URL = 'https://api.minimax.io/anthropic/v1/models?limit=100';
 const COMMAND_CODE_MODELS_URL = 'https://api.commandcode.ai/provider/v1/models';
+const QWEN_TOKEN_PLAN_MODELS_URL =
+  'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models';
+const QWEN_TOKEN_PLAN_CONTEXT_WINDOW = 991000;
 const KILO_GATEWAY_BASE = 'https://api.kilo.ai/api/gateway';
 const FIREWORKS_MODELS_URL = 'https://api.fireworks.ai/v1/accounts/fireworks/models';
 const FIREWORKS_MODELS_PAGE_SIZE = 200;
@@ -102,6 +105,16 @@ const parseCommandCode = createModelParser<CommandCodeModelEntry>({
   capabilityCode: true,
 });
 
+const parseQwenTokenPlan = createModelParser<OpenAIModelEntry>({
+  arrayKey: 'data',
+  filter: (entry) => typeof entry.id === 'string' && entry.id.length > 0,
+  getId: (entry) => entry.id,
+  getDisplayName: (_entry, id) => id,
+  contextWindow: QWEN_TOKEN_PLAN_CONTEXT_WINDOW,
+  inputPricePerToken: 0,
+  outputPricePerToken: 0,
+});
+
 /* ── OpenAI-specific structural filters (not non-chat) ── */
 
 /** Date-suffixed snapshots returned by OpenAI (e.g. gpt-4o-mini-2024-07-18). */
@@ -171,6 +184,7 @@ export const PROVIDER_NON_CHAT: Record<string, RegExp> = {
     /(?:flux|stable-diffusion|image|embedding|rerank|speech|audio|whisper|tts|upscaler|controlnet)/i,
   nvidia:
     /(?:flux|cosmos|detector|gliner|calibration|embed|retriever|parse|tts|translate|safety|guard|reward|nvclip|vila|neva)/i,
+  'qwen-subscription': /(?:^qwen-image-|^wan.*image)/i,
   xai: /imagine/i,
   copilot: /accounts\/[^/]+\/routers\//i,
 };
@@ -535,6 +549,11 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     buildHeaders: bearerHeaders,
     parse: parseOpenAI,
   },
+  'qwen-subscription': {
+    endpoint: QWEN_TOKEN_PLAN_MODELS_URL,
+    buildHeaders: bearerHeaders,
+    parse: parseQwenTokenPlan,
+  },
   zai: {
     endpoint: 'https://open.bigmodel.cn/api/paas/v4/models',
     buildHeaders: bearerHeaders,
@@ -628,6 +647,8 @@ export class ProviderModelFetcherService {
       // Kimi Code documents a fixed subscription model id (`kimi-for-coding`)
       // rather than a subscription-scoped /models endpoint.
       return [];
+    } else if (configKey === 'qwen' && authType === 'subscription') {
+      configKey = 'qwen-subscription';
     } else if (configKey === 'zai' && authType === 'subscription') {
       configKey = 'zai-subscription';
     } else if (configKey === 'opencode-go') {
@@ -658,7 +679,7 @@ export class ProviderModelFetcherService {
       } else {
         this.logger.warn('Ignoring invalid MiniMax subscription endpoint override');
       }
-    } else if (endpointOverride && configKey === 'qwen') {
+    } else if (endpointOverride && (configKey === 'qwen' || configKey === 'qwen-subscription')) {
       const qwenBaseUrl = normalizeQwenCompatibleBaseUrl(endpointOverride);
       if (qwenBaseUrl) {
         url = `${qwenBaseUrl}/v1/models`;

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1226,6 +1226,86 @@ describe('ProviderClient', () => {
     });
   });
 
+  describe('Qwen Token Plan subscription provider', () => {
+    it('routes Qwen subscription auth to the Token Plan chat endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'qwen',
+        apiKey: 'sk-sp-token-plan-key',
+        model: 'qwen3.6-plus',
+        body,
+        stream: false,
+        authType: 'subscription',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer sk-sp-token-plan-key',
+            'Content-Type': 'application/json',
+          },
+        }),
+      );
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('qwen3.6-plus');
+    });
+
+    it('routes qwen3.7-max through the Token Plan Responses endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'qwen',
+        apiKey: 'sk-sp-token-plan-key',
+        model: 'qwen3.7-max',
+        body,
+        stream: false,
+        authType: 'subscription',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/responses',
+        expect.any(Object),
+      );
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('qwen3.7-max');
+      expect(sentBody.input).toBeDefined();
+      expect(sentBody.messages).toBeUndefined();
+      expect(result.isChatGpt).toBe(true);
+    });
+
+    it('routes inbound Responses API requests through the Token Plan Responses endpoint', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      const result = await client.forward({
+        provider: 'qwen',
+        apiKey: 'sk-sp-token-plan-key',
+        model: 'qwen3.7-max',
+        body: {
+          input: [{ role: 'user', content: 'Hello' }],
+          stream: false,
+        },
+        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        stream: false,
+        authType: 'subscription',
+        apiMode: 'responses',
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/responses',
+        expect.any(Object),
+      );
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.model).toBe('qwen3.7-max');
+      expect(sentBody.input).toEqual([
+        { role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+      ]);
+      expect(result.isResponses).toBe(true);
+    });
+  });
+
   describe('Kilo API-key provider', () => {
     it('routes to the Kilo Gateway and preserves provider-prefixed model IDs', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
@@ -2806,6 +2886,21 @@ describe('ProviderClient', () => {
         provider: 'zai',
         apiKey: 'sk-zai-sub',
         model: 'glm-4.6',
+        body: { messages: [{ role: 'user', content: 'Hello' }] },
+        stream: true,
+        authType: 'subscription',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.stream_options).toEqual({ include_usage: true });
+    });
+
+    it('injects stream_options.include_usage for Qwen Token Plan streaming requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      await client.forward({
+        provider: 'qwen',
+        apiKey: 'sk-sp-token-plan-key',
+        model: 'qwen3.6-plus',
         body: { messages: [{ role: 'user', content: 'Hello' }] },
         stream: true,
         authType: 'subscription',

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -130,6 +130,8 @@ describe('resolveEndpointKey', () => {
     expect(known).toContain('nvidia');
     expect(known).toContain('ollama');
     expect(known).toContain('ollama-cloud');
+    expect(known).toContain('qwen-subscription');
+    expect(known).toContain('qwen-subscription-responses');
     expect(known).toContain('kiro');
     expect(known).toContain('opencode-go');
     expect(known).toContain('opencode-go-anthropic');
@@ -505,6 +507,17 @@ describe('PROVIDER_ENDPOINTS', () => {
     });
   });
 
+  it('qwen-subscription uses the Token Plan OpenAI-compatible chat endpoint', () => {
+    const ep = PROVIDER_ENDPOINTS['qwen-subscription'];
+    expect(ep.baseUrl).toBe('https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode');
+    expect(ep.format).toBe('openai');
+    expect(ep.buildPath('qwen3.6-plus')).toBe('/v1/chat/completions');
+    expect(ep.buildHeaders('sk-sp-test')).toEqual({
+      Authorization: 'Bearer sk-sp-test',
+      'Content-Type': 'application/json',
+    });
+  });
+
   it('commandcode-anthropic uses the Command Code Provider API messages endpoint', () => {
     const ep = PROVIDER_ENDPOINTS['commandcode-anthropic'];
     expect(ep.baseUrl).toBe('https://api.commandcode.ai/provider');
@@ -516,6 +529,13 @@ describe('PROVIDER_ENDPOINTS', () => {
       'Content-Type': 'application/json',
       'anthropic-version': '2023-06-01',
     });
+  });
+
+  it('qwen-subscription-responses uses the Token Plan Responses endpoint', () => {
+    const ep = PROVIDER_ENDPOINTS['qwen-subscription-responses'];
+    expect(ep.baseUrl).toBe('https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode');
+    expect(ep.format).toBe('chatgpt');
+    expect(ep.buildPath('qwen3.7-max')).toBe('/v1/responses');
   });
 
   it('marks OpenAI-compatible streaming endpoints that support usage chunks', () => {
@@ -530,6 +550,7 @@ describe('PROVIDER_ENDPOINTS', () => {
       'moonshot',
       'nvidia',
       'qwen',
+      'qwen-subscription',
       'zai',
       'zai-subscription',
       'copilot',
@@ -558,6 +579,7 @@ describe('PROVIDER_ENDPOINTS', () => {
       'copilot-responses',
       'commandcode-anthropic',
       'minimax-subscription',
+      'qwen-subscription-responses',
       'opencode-go-anthropic',
       'opencode-zen-google',
     ];

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -50,6 +50,7 @@ const PROVIDER_TIMEOUT_MS =
   Number.isFinite(parsedProviderTimeout) && parsedProviderTimeout > 0
     ? parsedProviderTimeout
     : 180_000;
+const QWEN_TOKEN_PLAN_RESPONSES_RE = /^qwen3\.7-max$/i;
 
 /**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").
@@ -191,6 +192,12 @@ export class ProviderClient {
     if (authType === 'subscription') {
       const override = resolveSubscriptionEndpointKey(resolved);
       if (override) resolved = override;
+    }
+    if (resolved === 'qwen-subscription') {
+      const bareQwenModel = stripVendorPrefix(model);
+      if (apiMode === 'responses' || QWEN_TOKEN_PLAN_RESPONSES_RE.test(bareQwenModel)) {
+        resolved = 'qwen-subscription-responses';
+      }
     }
     if (apiMode === 'responses' && resolved === 'openai') {
       resolved = 'openai-responses';

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -100,6 +100,7 @@ const CHATGPT_SUBSCRIPTION_BASE = 'https://chatgpt.com/backend-api';
 const COMMAND_CODE_PROVIDER_BASE = 'https://api.commandcode.ai/provider';
 const KIMI_CODING_SUBSCRIPTION_BASE = 'https://api.kimi.com/coding';
 const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
+const QWEN_TOKEN_PLAN_BASE = 'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode';
 const ZAI_SUBSCRIPTION_BASE = 'https://open.bigmodel.cn/api/coding/paas/v4';
 const OPENCODE_GO_BASE = 'https://opencode.ai/zen/go';
 const OPENCODE_ZEN_BASE = 'https://opencode.ai/zen';
@@ -242,6 +243,19 @@ export const PROVIDER_ENDPOINTS: Record<string, ProviderEndpoint> = {
     buildPath: openaiPath,
     format: 'openai',
     ...openaiStreamUsage,
+  },
+  'qwen-subscription': {
+    baseUrl: QWEN_TOKEN_PLAN_BASE,
+    buildHeaders: openaiHeaders,
+    buildPath: openaiPath,
+    format: 'openai',
+    ...openaiStreamUsage,
+  },
+  'qwen-subscription-responses': {
+    baseUrl: QWEN_TOKEN_PLAN_BASE,
+    buildHeaders: openaiHeaders,
+    buildPath: () => '/v1/responses',
+    format: 'chatgpt',
   },
   zai: {
     baseUrl: 'https://api.z.ai',

--- a/packages/backend/src/routing/proxy/provider-hooks.ts
+++ b/packages/backend/src/routing/proxy/provider-hooks.ts
@@ -16,6 +16,7 @@ const SUBSCRIPTION_ENDPOINT_OVERRIDES: Record<string, string> = {
   openai: 'openai-subscription',
   minimax: 'minimax-subscription',
   moonshot: 'moonshot-subscription',
+  qwen: 'qwen-subscription',
   zai: 'zai-subscription',
   // Gemini's per-API-key endpoint is registered under the legacy key
   // `'google'`, so the override is keyed there too. The OAuth flow shifts

--- a/packages/frontend/src/services/provider-api-key-urls.ts
+++ b/packages/frontend/src/services/provider-api-key-urls.ts
@@ -31,6 +31,7 @@ export const getRoutingProviderApiKeyUrl = (providerId: string): string | undefi
  */
 export const SUBSCRIPTION_PROVIDER_KEY_URLS: Record<string, string> = {
   commandcode: 'https://commandcode.ai/studio',
+  qwen: 'https://home.qwencloud.com/api-keys',
   moonshot: 'https://www.kimi.com/code/console',
   'ollama-cloud': 'https://ollama.com/settings/keys',
   kiro: 'https://app.kiro.dev',

--- a/packages/frontend/src/services/provider-utils.ts
+++ b/packages/frontend/src/services/provider-utils.ts
@@ -33,6 +33,11 @@ export function validateApiKey(
 const SUBSCRIPTION_PREFIXES: Record<string, string> = {
   anthropic: 'sk-ant-oat',
   minimax: 'sk-cp-',
+  qwen: 'sk-sp-',
+};
+
+const SUBSCRIPTION_MIN_LENGTHS: Record<string, number> = {
+  qwen: 30,
 };
 
 /** Prefixes that identify API keys — reject these in subscription mode. */
@@ -67,9 +72,10 @@ export function validateSubscriptionKey(
   // providers (Anthropic setup-token, OpenAI ChatGPT JWT) stay on the generic
   // 10-char floor since their tokens can be legitimately shorter.
   const minLength =
-    provider.subscriptionTokenAlternative && provider.minKeyLength > 10
+    SUBSCRIPTION_MIN_LENGTHS[provider.id] ??
+    (provider.subscriptionTokenAlternative && provider.minKeyLength > 10
       ? provider.minKeyLength
-      : 10;
+      : 10);
   if (trimmed.length < minLength) {
     return {
       valid: false,

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -99,7 +99,13 @@ interface ProviderUIOverlay {
 const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
   qwen: {
     initial: 'Al',
-    subtitle: 'Qwen3, Qwen2.5, QwQ',
+    subtitle: 'Qwen, DeepSeek, Kimi, GLM via Alibaba Cloud',
+    supportsSubscription: true,
+    subscriptionLabel: 'Qwen Token Plan',
+    subscriptionAuthMode: 'token',
+    subscriptionCredentialKind: 'api-key',
+    subscriptionCredentialName: 'Qwen Token Plan',
+    subscriptionKeyPlaceholder: 'Paste your Qwen Token Plan API key',
     models: [],
   },
   anthropic: {

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -229,6 +229,29 @@ describe('validateSubscriptionKey', () => {
     });
   });
 
+  it('rejects a regular Qwen API key in Token Plan subscription mode', () => {
+    const qwen = getProvider('qwen')!;
+    expect(validateSubscriptionKey(qwen, 'sk-' + 'a'.repeat(40))).toEqual({
+      valid: false,
+      error: 'Alibaba Cloud subscription tokens start with "sk-sp-"',
+    });
+  });
+
+  it('accepts a valid Qwen Token Plan sk-sp API key', () => {
+    const qwen = getProvider('qwen')!;
+    expect(validateSubscriptionKey(qwen, 'sk-sp-' + 'a'.repeat(40))).toEqual({
+      valid: true,
+    });
+  });
+
+  it('rejects a too-short Qwen Token Plan key', () => {
+    const qwen = getProvider('qwen')!;
+    expect(validateSubscriptionKey(qwen, 'sk-sp-1234')).toEqual({
+      valid: false,
+      error: 'Token is too short (minimum 30 characters)',
+    });
+  });
+
   it("rejects a MiniMax Coding Plan token shorter than the provider's minKeyLength", () => {
     const minimax = getProvider('minimax')!;
     // sk-cp- prefix (6) + 4 chars = 10 total: passes the generic 10-char floor
@@ -401,6 +424,17 @@ describe('PROVIDERS', () => {
     expect(minimax.subscriptionAuthMode).toBe('device_code');
   });
 
+  it('Qwen supports Token Plan subscription with token flow', () => {
+    const qwen = PROVIDERS.find((p) => p.id === 'qwen')!;
+    expect(qwen.supportsSubscription).toBe(true);
+    expect(qwen.subscriptionLabel).toBe('Qwen Token Plan');
+    expect(qwen.subscriptionAuthMode).toBe('token');
+    expect(qwen.subscriptionKeyPlaceholder).toBe('Paste your Qwen Token Plan API key');
+    expect(qwen.subscriptionCredentialKind).toBe('api-key');
+    expect(qwen.subscriptionCredentialName).toBe('Qwen Token Plan');
+    expect(qwen.subscriptionOnly).toBeUndefined();
+  });
+
   it('Moonshot supports Kimi Coding Plan subscription with token flow', () => {
     const moonshot = PROVIDERS.find((p) => p.id === 'moonshot')!;
     expect(moonshot.supportsSubscription).toBe(true);
@@ -449,6 +483,10 @@ describe('PROVIDERS', () => {
   it('provides only the subscription-key URL for Command Code', () => {
     expect(getRoutingProviderApiKeyUrl('commandcode')).toBeUndefined();
     expect(getSubscriptionProviderKeyUrl('commandcode')).toBe('https://commandcode.ai/studio');
+  });
+
+  it('provides a subscription-key URL for Qwen Token Plan', () => {
+    expect(getSubscriptionProviderKeyUrl('qwen')).toBe('https://home.qwencloud.com/api-keys');
   });
 
   it('provides an API-key URL for Kilo', () => {

--- a/packages/shared/__tests__/subscription.spec.ts
+++ b/packages/shared/__tests__/subscription.spec.ts
@@ -15,6 +15,7 @@ describe('SUBSCRIPTION_PROVIDER_CONFIGS', () => {
         'anthropic',
         'openai',
         'minimax',
+        'qwen',
         'moonshot',
         'copilot',
         'commandcode',
@@ -70,6 +71,19 @@ describe('getSubscriptionProviderConfig', () => {
     expect(config).toMatchObject({
       subscriptionAuthMode: 'device_code',
     });
+  });
+
+  it('returns config for Qwen Token Plan', () => {
+    const config = getSubscriptionProviderConfig('qwen');
+    expect(config).toMatchObject({
+      supportsSubscription: true,
+      subscriptionLabel: 'Qwen Token Plan',
+      subscriptionAuthMode: 'token',
+      subscriptionKeyPlaceholder: 'Paste your Qwen Token Plan API key',
+      subscriptionTokenPrefix: 'sk-sp-',
+    });
+    expect(config?.knownModels).toBeUndefined();
+    expect(config?.knownModelsMatch).toBeUndefined();
   });
 
   it('returns config for moonshot Kimi Coding Plan', () => {
@@ -202,6 +216,7 @@ describe('supportsSubscriptionProvider', () => {
     expect(supportsSubscriptionProvider('anthropic')).toBe(true);
     expect(supportsSubscriptionProvider('openai')).toBe(true);
     expect(supportsSubscriptionProvider('minimax')).toBe(true);
+    expect(supportsSubscriptionProvider('qwen')).toBe(true);
     expect(supportsSubscriptionProvider('moonshot')).toBe(true);
     expect(supportsSubscriptionProvider('copilot')).toBe(true);
     expect(supportsSubscriptionProvider('commandcode')).toBe(true);
@@ -241,6 +256,10 @@ describe('getSubscriptionKnownModels', () => {
     expect(models).toContain('MiniMax-M2.7');
     expect(models).toContain('MiniMax-M2.7-highspeed');
     expect(models).toContain('MiniMax-M2.5');
+  });
+
+  it('returns null known models for Qwen Token Plan (relies on live /v1/models discovery)', () => {
+    expect(getSubscriptionKnownModels('qwen')).toBeNull();
   });
 
   it('returns the fixed model id for moonshot Kimi Coding Plan', () => {
@@ -303,6 +322,10 @@ describe('getSubscriptionKnownModelsMatch', () => {
     expect(getSubscriptionKnownModelsMatch('moonshot')).toBe('exact');
   });
 
+  it('returns prefix for Qwen Token Plan (no hardcoded known-model matching)', () => {
+    expect(getSubscriptionKnownModelsMatch('qwen')).toBe('prefix');
+  });
+
   it('returns prefix for unsupported providers (graceful fallback)', () => {
     expect(getSubscriptionKnownModelsMatch('unknown')).toBe('prefix');
   });
@@ -355,6 +378,15 @@ describe('getSubscriptionCapabilities', () => {
     const caps = getSubscriptionCapabilities('moonshot');
     expect(caps).toMatchObject({
       maxContextWindow: 262144,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    });
+  });
+
+  it('returns capabilities for Qwen Token Plan', () => {
+    const caps = getSubscriptionCapabilities('qwen');
+    expect(caps).toMatchObject({
+      maxContextWindow: 991000,
       supportsPromptCaching: false,
       supportsBatching: false,
     });

--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -57,6 +57,18 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
       supportsBatching: false,
     }),
   }),
+  qwen: Object.freeze({
+    supportsSubscription: true as const,
+    subscriptionLabel: 'Qwen Token Plan',
+    subscriptionAuthMode: 'token' as const,
+    subscriptionKeyPlaceholder: 'Paste your Qwen Token Plan API key',
+    subscriptionTokenPrefix: 'sk-sp-',
+    subscriptionCapabilities: Object.freeze({
+      maxContextWindow: 991000,
+      supportsPromptCaching: false,
+      supportsBatching: false,
+    }),
+  }),
   moonshot: Object.freeze({
     supportsSubscription: true as const,
     subscriptionLabel: 'Kimi Coding Plan',


### PR DESCRIPTION
## What changed

- Adds Qwen Token Plan as a subscription option for the Alibaba Cloud/Qwen provider.
- Wires `sk-sp-` Token Plan API-key validation and the Qwen Cloud API Keys URL in the frontend.
- Routes Token Plan chat traffic to `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions`.
- Routes `qwen3.7-max` and inbound Responses API requests to `/v1/responses`.
- Fetches Token Plan models dynamically from `/v1/models` and filters image-only models out of Manifest chat routing.
- Keeps a curated text-model fallback when discovery is unavailable.

## Why

Qwen Token Plan exposes a plan-specific OpenAI-compatible endpoint and API key for AI coding tools. Manifest should let users connect that subscription without using regular pay-as-you-go Qwen keys or DashScope base URLs.

## Validation

- `npm --workspace packages/shared run build`
- `npm --workspace packages/shared test -- --runInBand subscription.spec.ts`
- `npm --workspace packages/backend test -- --runInBand model-discovery/model-discovery.service.spec.ts model-discovery/provider-model-fetcher.service.spec.ts routing/proxy/__tests__/provider-endpoints.spec.ts routing/proxy/__tests__/provider-client.spec.ts`
- `npm --workspace packages/backend run build`
- `npm --workspace packages/frontend test -- tests/services/providers.test.ts`
- `npm --workspace packages/frontend run build`
- `npx prettier --check ...` on touched files
- `git diff --check`

## Notes

- Verified that Qwen Token Plan `/v1/models` returns HTTP 200 and the current model list without a subscribed key.
- Did not run a paid completion smoke because no subscribed Qwen Token Plan `sk-sp-...` key was available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Qwen Token Plan as a subscription for the Qwen provider with `sk-sp-` key validation, live model discovery, and routing to Token Plan’s OpenAI-compatible Chat and Responses endpoints. Filters image-only models and skips hardcoded fallbacks.

- **New Features**
  - Frontend (`packages/frontend`)
    - Qwen Token Plan subscription: label, token auth, placeholder, key URL `https://home.qwencloud.com/api-keys`.
    - Validates `sk-sp-` API keys (min length 30); rejects regular `sk-` keys in subscription mode.
  - Backend (`packages/backend`)
    - Adds `qwen-subscription` and `qwen-subscription-responses` endpoints.
    - Routes chat to `https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/chat/completions`.
    - Routes `qwen3.7-max` and inbound Responses API to `/v1/responses`.
    - Injects `stream_options.include_usage` for streaming requests.
    - Discovers models from `/v1/models`, filters image-only models, supports endpoint override, and returns no fallback when discovery is empty.
  - Shared (`packages/shared`)
    - Qwen Token Plan config: token prefix `sk-sp-`, max context window 991k, no prompt caching/batching, no hardcoded known models (prefix match only).

- **Migration**
  - In Providers, select Qwen → Subscription, then paste your `sk-sp-` API key from `https://home.qwencloud.com/api-keys`.

<sup>Written for commit 4884967ff75dac98f4944f986259d0c369cd126a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

