### PR TITLE
feat: add Z.ai subscription endpoint selector

### DIFF
--- a/.changeset/zai-subscription-endpoint.md
+++ b/.changeset/zai-subscription-endpoint.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Add a Z.ai GLM Coding Plan endpoint selector for outside-China and China Mainland subscription routing.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -1357,6 +1357,43 @@ describe('ModelDiscoveryService', () => {
       );
     });
 
+    it('routes Z.ai CN subscription discovery to the China Coding Plan host', async () => {
+      mockDecrypt.mockReturnValue('zai-sub-key');
+      fetcher.fetch.mockResolvedValue([]);
+
+      await service.discoverModels(
+        makeProvider({
+          provider: 'zai',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted',
+          region: 'cn',
+        }),
+      );
+
+      expect(fetcher.fetch).toHaveBeenCalledWith(
+        'zai',
+        'zai-sub-key',
+        'subscription',
+        'https://open.bigmodel.cn/api/coding/paas/v4',
+      );
+    });
+
+    it('leaves Z.ai global subscription discovery on the default outside-China host', async () => {
+      mockDecrypt.mockReturnValue('zai-sub-key');
+      fetcher.fetch.mockResolvedValue([]);
+
+      await service.discoverModels(
+        makeProvider({
+          provider: 'zai',
+          auth_type: 'subscription',
+          api_key_encrypted: 'encrypted',
+          region: 'global',
+        }),
+      );
+
+      expect(fetcher.fetch).toHaveBeenCalledWith('zai', 'zai-sub-key', 'subscription', undefined);
+    });
+
     it('should fall back to subscription fallback when OpenAI token fetch returns empty', async () => {
       const blob = JSON.stringify({ t: 'expired-token', r: 'refresh', e: Date.now() - 1000 });
       mockDecrypt.mockReturnValue(blob);

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -14,6 +14,7 @@ import { ModelsDevSyncService } from '../database/models-dev-sync.service';
 import { parseOAuthTokenBlob } from '../routing/oauth/openai-oauth.types';
 import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../routing/qwen-region';
 import { MINIMAX_BASE_URLS } from '../routing/oauth/minimax-oauth-helpers';
+import { getZaiCodingPlanBaseUrl } from '../routing/zai-region';
 import { CopilotTokenService } from '../routing/proxy/copilot-token.service';
 import { filterBySubscriptionAccess } from './anthropic-subscription-probe';
 import {
@@ -112,6 +113,13 @@ export class ModelDiscoveryService {
     }
     if (isQwenProvider(provider.provider) && isQwenResolvedRegion(provider.region)) {
       endpointOverride = getQwenCompatibleBaseUrl(provider.region);
+    }
+    if (
+      provider.provider.toLowerCase() === 'zai' &&
+      provider.auth_type === 'subscription' &&
+      provider.region === 'cn'
+    ) {
+      endpointOverride = getZaiCodingPlanBaseUrl('cn');
     }
 
     let raw: DiscoveredModel[];

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -637,12 +637,31 @@ describe('ProviderModelFetcherService', () => {
     const result = await service.fetch('zai', 'zai-sub-key', 'subscription');
 
     expect(fetchSpy).toHaveBeenCalledWith(
-      'https://open.bigmodel.cn/api/coding/paas/v4/models',
+      'https://api.z.ai/api/coding/paas/v4/models',
       expect.objectContaining({
         headers: expect.objectContaining({ Authorization: 'Bearer zai-sub-key' }),
       }),
     );
     expect(result.map((m) => m.id)).toEqual(['glm-5.1', 'glm-4.7']);
+  });
+
+  it('should route zai+subscription endpoint override to selected Coding Plan models endpoint', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ id: 'glm-5.1' }] }),
+    });
+
+    await service.fetch(
+      'zai',
+      'zai-sub-key',
+      'subscription',
+      'https://open.bigmodel.cn/api/coding/paas/v4',
+    );
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://open.bigmodel.cn/api/coding/paas/v4/models',
+      expect.any(Object),
+    );
   });
 
   it('should route zai+api_key to standard models endpoint', async () => {

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -10,6 +10,7 @@ import {
 } from '../common/constants/subscription-clients';
 import { normalizeMinimaxSubscriptionBaseUrl } from '../routing/provider-base-url';
 import { getQwenCompatibleBaseUrl, normalizeQwenCompatibleBaseUrl } from '../routing/qwen-region';
+import { getZaiCodingPlanBaseUrl, normalizeZaiCodingPlanBaseUrl } from '../routing/zai-region';
 import { OpencodeGoCatalogService } from './opencode-go-catalog.service';
 import {
   buildKiroHeaders,
@@ -572,7 +573,7 @@ export const PROVIDER_CONFIGS: Record<string, FetcherConfig> = {
     parse: parseOpenAI,
   },
   'zai-subscription': {
-    endpoint: 'https://open.bigmodel.cn/api/coding/paas/v4/models',
+    endpoint: `${getZaiCodingPlanBaseUrl('global')}/models`,
     buildHeaders: bearerHeaders,
     parse: parseOpenAI,
   },
@@ -697,6 +698,13 @@ export class ProviderModelFetcherService {
         url = `${qwenBaseUrl}/v1/models`;
       } else {
         this.logger.warn('Ignoring invalid Qwen endpoint override');
+      }
+    } else if (endpointOverride && configKey === 'zai-subscription') {
+      const zaiBaseUrl = normalizeZaiCodingPlanBaseUrl(endpointOverride);
+      if (zaiBaseUrl) {
+        url = `${zaiBaseUrl}/models`;
+      } else {
+        this.logger.warn('Ignoring invalid Z.ai subscription endpoint override');
       }
     }
 

--- a/packages/backend/src/routing/provider.controller.spec.ts
+++ b/packages/backend/src/routing/provider.controller.spec.ts
@@ -418,6 +418,79 @@ describe('ProviderController', () => {
       ).rejects.toThrow('MiniMax subscription region must be one of: global, cn');
     });
 
+    it('should accept region=cn for Z.ai subscription', async () => {
+      mockProviderService.upsertProvider.mockResolvedValue({
+        provider: {
+          id: 'p1',
+          provider: 'zai',
+          is_active: true,
+          auth_type: 'subscription',
+          region: 'cn',
+        },
+        isNew: true,
+      });
+
+      const result = await controller.upsertProvider(mockUser, mockAgentName, {
+        provider: 'zai',
+        apiKey: 'zai-sub-key',
+        authType: 'subscription',
+        region: 'cn',
+      });
+
+      expect(mockProviderService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'user-1',
+        'zai',
+        'zai-sub-key',
+        'subscription',
+        'cn',
+        undefined,
+      );
+      expect(result.region).toBe('cn');
+    });
+
+    it('should accept region=cn for dotted Z.ai subscription alias', async () => {
+      mockProviderService.upsertProvider.mockResolvedValue({
+        provider: {
+          id: 'p1',
+          provider: 'z.ai',
+          is_active: true,
+          auth_type: 'subscription',
+          region: 'cn',
+        },
+        isNew: true,
+      });
+
+      const result = await controller.upsertProvider(mockUser, mockAgentName, {
+        provider: 'z.ai',
+        apiKey: 'zai-sub-key',
+        authType: 'subscription',
+        region: 'cn',
+      });
+
+      expect(mockProviderService.upsertProvider).toHaveBeenCalledWith(
+        TEST_AGENT_ID,
+        'user-1',
+        'z.ai',
+        'zai-sub-key',
+        'subscription',
+        'cn',
+        undefined,
+      );
+      expect(result.region).toBe('cn');
+    });
+
+    it('should reject invalid Z.ai subscription region', async () => {
+      await expect(
+        controller.upsertProvider(mockUser, mockAgentName, {
+          provider: 'zai',
+          apiKey: 'zai-sub-key',
+          authType: 'subscription',
+          region: 'eu',
+        }),
+      ).rejects.toThrow('Z.ai subscription region must be one of: global, cn');
+    });
+
     it('should reject region when MiniMax is connected with api_key auth', async () => {
       await expect(
         controller.upsertProvider(mockUser, mockAgentName, {
@@ -427,7 +500,7 @@ describe('ProviderController', () => {
           region: 'cn',
         }),
       ).rejects.toThrow(
-        'region is only supported for Alibaba/Qwen providers and MiniMax subscriptions',
+        'region is only supported for Alibaba/Qwen providers, MiniMax subscriptions, and Z.ai subscriptions',
       );
     });
   });

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -29,6 +29,7 @@ import {
 } from './dto/routing.dto';
 import { isQwenRegion } from './qwen-region';
 import { isMinimaxRegion } from './oauth/minimax-oauth-helpers';
+import { isZaiCodingPlanRegion, isZaiProviderId } from './zai-region';
 
 @Controller('api/v1/routing')
 export class ProviderController {
@@ -97,6 +98,7 @@ export class ProviderController {
     const lowerProvider = body.provider.toLowerCase();
     const isQwenProvider = lowerProvider === 'qwen' || lowerProvider === 'alibaba';
     const isMinimaxSubscription = lowerProvider === 'minimax' && body.authType === 'subscription';
+    const isZaiSubscription = isZaiProviderId(lowerProvider) && body.authType === 'subscription';
 
     if (body.region !== undefined) {
       if (isQwenProvider) {
@@ -107,9 +109,13 @@ export class ProviderController {
         if (!isMinimaxRegion(body.region)) {
           throw new BadRequestException('MiniMax subscription region must be one of: global, cn');
         }
+      } else if (isZaiSubscription) {
+        if (!isZaiCodingPlanRegion(body.region)) {
+          throw new BadRequestException('Z.ai subscription region must be one of: global, cn');
+        }
       } else {
         throw new BadRequestException(
-          'region is only supported for Alibaba/Qwen providers and MiniMax subscriptions',
+          'region is only supported for Alibaba/Qwen providers, MiniMax subscriptions, and Z.ai subscriptions',
         );
       }
     }

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1155,7 +1155,7 @@ describe('ProviderClient', () => {
       });
 
       const url = mockFetch.mock.calls[0][0] as string;
-      expect(url).toBe('https://open.bigmodel.cn/api/coding/paas/v4/chat/completions');
+      expect(url).toBe('https://api.z.ai/api/coding/paas/v4/chat/completions');
 
       const headers = mockFetch.mock.calls[0][1].headers;
       expect(headers['Authorization']).toBe('Bearer zai-sub-key');

--- a/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-endpoints.spec.ts
@@ -450,7 +450,7 @@ describe('PROVIDER_ENDPOINTS', () => {
 
   it('zai-subscription uses Coding Plan base URL', () => {
     const ep = PROVIDER_ENDPOINTS['zai-subscription'];
-    expect(ep.baseUrl).toBe('https://open.bigmodel.cn/api/coding/paas/v4');
+    expect(ep.baseUrl).toBe('https://api.z.ai/api/coding/paas/v4');
   });
 
   it('zai-subscription builds /chat/completions path', () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -835,6 +835,84 @@ describe('ProxyFallbackService', () => {
       const call = providerClient.forward.mock.calls[0][0];
       expect(call.customEndpoint).toBeUndefined();
     });
+
+    it('routes Z.ai subscription region=cn to the China Coding Plan endpoint', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await service.tryForwardToProvider({
+        provider: 'zai',
+        apiKey: 'zai-sub-key',
+        model: 'glm-5.1',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'subscription',
+        providerRegion: 'cn',
+      });
+
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          customEndpoint: expect.objectContaining({
+            baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
+            format: 'openai',
+          }),
+        }),
+      );
+    });
+
+    it('leaves Z.ai subscription region=global on the built-in outside-China endpoint', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await service.tryForwardToProvider({
+        provider: 'zai',
+        apiKey: 'zai-sub-key',
+        model: 'glm-5.1',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'subscription',
+        providerRegion: 'global',
+      });
+
+      const call = providerClient.forward.mock.calls[0][0];
+      expect(call.customEndpoint).toBeUndefined();
+    });
+
+    it('strips Z.ai vendor prefixes on subscription routes before endpoint overrides', async () => {
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: false,
+      });
+
+      await service.tryForwardToProvider({
+        provider: 'zai',
+        apiKey: 'zai-sub-key',
+        model: 'z-ai/glm-5.1',
+        body,
+        stream: false,
+        sessionKey: 'sess-1',
+        authType: 'subscription',
+        providerRegion: 'cn',
+      });
+
+      expect(providerClient.forward).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'glm-5.1',
+        }),
+      );
+    });
   });
 
   describe('tryFallbacks', () => {

--- a/packages/backend/src/routing/proxy/provider-endpoints.ts
+++ b/packages/backend/src/routing/proxy/provider-endpoints.ts
@@ -8,6 +8,7 @@ import {
 } from '../../common/constants/subscription-clients';
 import { normalizeProviderBaseUrl } from '../provider-base-url';
 import { getQwenCompatibleBaseUrl } from '../qwen-region';
+import { getZaiCodingPlanBaseUrl } from '../zai-region';
 import { buildKiroHeaders, KIRO_BASE_URL, KIRO_CHAT_TARGET } from './kiro-adapter';
 
 export interface ProviderEndpoint {
@@ -102,7 +103,7 @@ const COMMAND_CODE_PROVIDER_BASE = 'https://api.commandcode.ai/provider';
 const KIMI_CODING_SUBSCRIPTION_BASE = 'https://api.kimi.com/coding';
 const MINIMAX_SUBSCRIPTION_BASE = 'https://api.minimax.io/anthropic';
 const QWEN_TOKEN_PLAN_BASE = 'https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode';
-const ZAI_SUBSCRIPTION_BASE = 'https://open.bigmodel.cn/api/coding/paas/v4';
+const ZAI_SUBSCRIPTION_BASE = getZaiCodingPlanBaseUrl('global');
 const OPENCODE_GO_BASE = 'https://opencode.ai/zen/go';
 const OPENCODE_ZEN_BASE = 'https://opencode.ai/zen';
 const KILO_GATEWAY_BASE = 'https://api.kilo.ai/api/gateway';

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -70,6 +70,7 @@ import { inferProviderFromModelName } from '../../common/utils/provider-aliases'
 import { normalizeMinimaxSubscriptionBaseUrl } from '../provider-base-url';
 import { MINIMAX_BASE_URLS } from '../oauth/minimax-oauth-helpers';
 import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../qwen-region';
+import { getZaiCodingPlanBaseUrl } from '../zai-region';
 import { normalizeAnthropicShortModelId } from '../../common/utils/anthropic-model-id';
 import {
   isTransportError,
@@ -449,6 +450,14 @@ export class ProxyFallbackService {
     ) {
       forwardModel = forwardModel.substring('minimax/'.length);
     }
+    if (provider.toLowerCase() === 'zai' && authType === 'subscription') {
+      const lowerModel = forwardModel.toLowerCase();
+      if (lowerModel.startsWith('z-ai/')) {
+        forwardModel = forwardModel.substring('z-ai/'.length);
+      } else if (lowerModel.startsWith('zai/')) {
+        forwardModel = forwardModel.substring('zai/'.length);
+      }
+    }
 
     if (CustomProviderService.isCustom(provider)) {
       const cpId = CustomProviderService.extractId(provider);
@@ -479,6 +488,12 @@ export class ProxyFallbackService {
         const regionBaseUrl = `${MINIMAX_BASE_URLS.cn}/anthropic`;
         customEndpoint = buildEndpointOverride(regionBaseUrl, 'minimax-subscription');
       }
+    } else if (
+      authType === 'subscription' &&
+      provider.toLowerCase() === 'zai' &&
+      providerRegion === 'cn'
+    ) {
+      customEndpoint = buildEndpointOverride(getZaiCodingPlanBaseUrl('cn'), 'zai-subscription');
     }
 
     const reasoningEndpointKey =

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -525,6 +525,104 @@ describe('ProviderService — route-only cleanup paths', () => {
     });
   });
 
+  describe('upsertProvider — Z.ai subscription region', () => {
+    let originalSecret: string | undefined;
+    beforeAll(() => {
+      originalSecret = process.env.BETTER_AUTH_SECRET;
+      process.env.BETTER_AUTH_SECRET = 'a'.repeat(48);
+    });
+    afterAll(() => {
+      if (originalSecret === undefined) {
+        delete process.env.BETTER_AUTH_SECRET;
+      } else {
+        process.env.BETTER_AUTH_SECRET = originalSecret;
+      }
+    });
+
+    it('persists region=global on a new Z.ai subscription row', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+
+      await svc.upsertProvider('agent-1', 'user-1', 'zai', 'zai-sub-key', 'subscription', 'global');
+
+      expect(providerRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'zai',
+          auth_type: 'subscription',
+          region: 'global',
+        }),
+      );
+    });
+
+    it('updates region on an existing Z.ai subscription row', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'zai',
+        auth_type: 'subscription',
+        label: 'Default',
+        region: 'cn',
+        is_active: true,
+      });
+
+      await svc.upsertProvider('agent-1', 'user-1', 'zai', 'zai-new-key', 'subscription', 'global');
+
+      expect(providerRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          region: 'global',
+        }),
+      );
+    });
+
+    it('preserves existing Z.ai subscription region when caller omits it', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'zai',
+        auth_type: 'subscription',
+        label: 'Default',
+        region: 'cn',
+        is_active: true,
+      });
+
+      await svc.upsertProvider('agent-1', 'user-1', 'zai', 'zai-rotated', 'subscription');
+
+      expect(providerRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          region: 'cn',
+        }),
+      );
+    });
+
+    it('preserves existing dotted Z.ai alias subscription region when caller omits it', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'z.ai',
+        auth_type: 'subscription',
+        label: 'Default',
+        region: 'cn',
+        is_active: true,
+      });
+
+      await svc.upsertProvider('agent-1', 'user-1', 'z.ai', 'zai-rotated', 'subscription');
+
+      expect(providerRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'z.ai',
+          region: 'cn',
+        }),
+      );
+    });
+
+    it('rejects unsupported Z.ai subscription region', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+
+      await expect(
+        svc.upsertProvider('agent-1', 'user-1', 'zai', 'zai-sub-key', 'subscription', 'eu'),
+      ).rejects.toThrow('Z.ai subscription region must be one of: global, cn');
+    });
+  });
+
   describe('nextOAuthLabel', () => {
     it('returns undefined when no subscription rows exist', async () => {
       providerRepo.find.mockResolvedValue([]);

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -17,6 +17,7 @@ import type { AuthType, ModelRoute } from 'manifest-shared';
 import { TIER_LABELS } from 'manifest-shared';
 import { detectQwenRegion, isQwenRegion, isQwenResolvedRegion } from '../qwen-region';
 import { isMinimaxRegion } from '../oauth/minimax-oauth-helpers';
+import { isZaiCodingPlanRegion, isZaiProviderId } from '../zai-region';
 
 const MAX_KEYS_PER_PROVIDER = 5;
 const MAX_LABEL_LENGTH = 50;
@@ -307,6 +308,16 @@ export class ProviderService {
       }
       if (!isMinimaxRegion(requestedRegion)) {
         throw new BadRequestException('MiniMax subscription region must be one of: global, cn');
+      }
+      return requestedRegion;
+    }
+
+    if (isZaiProviderId(lower) && authType === 'subscription') {
+      if (requestedRegion === undefined) {
+        return isZaiCodingPlanRegion(existing?.region) ? existing.region : null;
+      }
+      if (!isZaiCodingPlanRegion(requestedRegion)) {
+        throw new BadRequestException('Z.ai subscription region must be one of: global, cn');
       }
       return requestedRegion;
     }

--- a/packages/backend/src/routing/zai-region.spec.ts
+++ b/packages/backend/src/routing/zai-region.spec.ts
@@ -1,0 +1,38 @@
+import {
+  getZaiCodingPlanBaseUrl,
+  isZaiCodingPlanRegion,
+  isZaiProviderId,
+  normalizeZaiCodingPlanBaseUrl,
+} from './zai-region';
+
+describe('zai-region', () => {
+  it('recognizes the supported Coding Plan regions', () => {
+    expect(isZaiCodingPlanRegion('global')).toBe(true);
+    expect(isZaiCodingPlanRegion('cn')).toBe(true);
+    expect(isZaiCodingPlanRegion('eu')).toBe(false);
+    expect(isZaiCodingPlanRegion(undefined)).toBe(false);
+  });
+
+  it('recognizes canonical and dotted provider ids', () => {
+    expect(isZaiProviderId('zai')).toBe(true);
+    expect(isZaiProviderId('z.ai')).toBe(true);
+    expect(isZaiProviderId('Z.AI')).toBe(true);
+    expect(isZaiProviderId('openai')).toBe(false);
+  });
+
+  it('maps regions to Coding Plan base URLs', () => {
+    expect(getZaiCodingPlanBaseUrl()).toBe('https://api.z.ai/api/coding/paas/v4');
+    expect(getZaiCodingPlanBaseUrl('global')).toBe('https://api.z.ai/api/coding/paas/v4');
+    expect(getZaiCodingPlanBaseUrl('cn')).toBe('https://open.bigmodel.cn/api/coding/paas/v4');
+  });
+
+  it('normalizes only supported Coding Plan base URLs', () => {
+    expect(normalizeZaiCodingPlanBaseUrl('https://api.z.ai/api/coding/paas/v4/')).toBe(
+      'https://api.z.ai/api/coding/paas/v4',
+    );
+    expect(normalizeZaiCodingPlanBaseUrl('https://open.bigmodel.cn/api/coding/paas/v4')).toBe(
+      'https://open.bigmodel.cn/api/coding/paas/v4',
+    );
+    expect(normalizeZaiCodingPlanBaseUrl('https://example.com/api/coding/paas/v4')).toBeNull();
+  });
+});

--- a/packages/backend/src/routing/zai-region.ts
+++ b/packages/backend/src/routing/zai-region.ts
@@ -1,0 +1,31 @@
+export const ZAI_CODING_PLAN_BASE_URLS = {
+  global: 'https://api.z.ai/api/coding/paas/v4',
+  cn: 'https://open.bigmodel.cn/api/coding/paas/v4',
+} as const;
+
+export type ZaiCodingPlanRegion = keyof typeof ZAI_CODING_PLAN_BASE_URLS;
+
+export const DEFAULT_ZAI_CODING_PLAN_REGION: ZaiCodingPlanRegion = 'global';
+
+export function isZaiCodingPlanRegion(
+  value: string | undefined | null,
+): value is ZaiCodingPlanRegion {
+  return value === 'global' || value === 'cn';
+}
+
+export function isZaiProviderId(value: string | undefined | null): boolean {
+  const lower = value?.toLowerCase();
+  return lower === 'zai' || lower === 'z.ai';
+}
+
+export function getZaiCodingPlanBaseUrl(
+  region: ZaiCodingPlanRegion = DEFAULT_ZAI_CODING_PLAN_REGION,
+): string {
+  return ZAI_CODING_PLAN_BASE_URLS[region];
+}
+
+export function normalizeZaiCodingPlanBaseUrl(baseUrl: string): string | null {
+  const normalized = baseUrl.replace(/\/+$/, '');
+  const allowedBaseUrls: readonly string[] = Object.values(ZAI_CODING_PLAN_BASE_URLS);
+  return allowedBaseUrls.includes(normalized) ? normalized : null;
+}

--- a/packages/frontend/src/components/ProviderKeyForm.tsx
+++ b/packages/frontend/src/components/ProviderKeyForm.tsx
@@ -75,6 +75,12 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
     props.isSubMode()
       ? (props.provDef.subscriptionKeyPlaceholder ?? 'Paste token')
       : props.provDef.keyPlaceholder;
+  const endpointRegions = () =>
+    props.isSubMode() ? (props.provDef.subscriptionEndpointRegions ?? []) : [];
+  const hasEndpointRegions = () => endpointRegions().length > 0;
+  const defaultEndpointRegion = () => endpointRegions()[0]?.value;
+  const endpointRegionLabel = (value: string | null | undefined) =>
+    endpointRegions().find((region) => region.value === value)?.label;
   const whereToGetUrl = () =>
     props.isSubMode()
       ? getSubscriptionProviderKeyUrl(props.provId)
@@ -100,6 +106,56 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
   });
 
   const isListMode = () => supportsMultiKey() && activeKeys().length > 1;
+  const savedEndpointRegion = () => activeKeys()[0]?.region;
+  const [selectedEndpointRegion, setSelectedEndpointRegion] = createSignal<string | undefined>();
+
+  createEffect(() => {
+    if (!hasEndpointRegions()) {
+      setSelectedEndpointRegion(undefined);
+      return;
+    }
+    if (props.connected()) {
+      if (activeKeys().length > 0) {
+        setSelectedEndpointRegion(savedEndpointRegion() ?? defaultEndpointRegion());
+      } else {
+        setSelectedEndpointRegion(undefined);
+      }
+      return;
+    }
+    const selected = selectedEndpointRegion();
+    if (!selected || !endpointRegions().some((region) => region.value === selected)) {
+      setSelectedEndpointRegion(defaultEndpointRegion());
+    }
+  });
+
+  const displayedEndpointRegion = () => selectedEndpointRegion() ?? defaultEndpointRegion();
+  const endpointRegionPayload = () => {
+    if (!hasEndpointRegions()) return undefined;
+    const selected = selectedEndpointRegion();
+    if (selected) return selected;
+    return props.connected() ? undefined : defaultEndpointRegion();
+  };
+
+  const EndpointRegionSelect = (selectProps: { id: string; disabled?: boolean }) => (
+    <Show when={hasEndpointRegions()}>
+      <div class="provider-detail__field">
+        <label class="provider-detail__label" for={selectProps.id}>
+          Region
+        </label>
+        <select
+          id={selectProps.id}
+          class="provider-detail__input"
+          value={displayedEndpointRegion()}
+          disabled={selectProps.disabled}
+          onChange={(e) => setSelectedEndpointRegion(e.currentTarget.value)}
+        >
+          <For each={endpointRegions()}>
+            {(region) => <option value={region.value}>{region.label}</option>}
+          </For>
+        </select>
+      </div>
+    </Show>
+  );
 
   const fieldLabel = () => {
     if (isListMode()) return 'API Keys';
@@ -121,6 +177,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
         provider: props.provId,
         apiKey: props.keyInput().replace(/\s/g, ''),
         authType: props.selectedAuthType(),
+        ...(endpointRegionPayload() && { region: endpointRegionPayload() }),
         ...(label && { label }),
       });
       toast.success(`${props.provDef.name} connected`);
@@ -148,6 +205,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
         provider: props.provId,
         apiKey: props.keyInput().replace(/\s/g, ''),
         authType: props.selectedAuthType(),
+        ...(endpointRegionPayload() && { region: endpointRegionPayload() }),
         ...(label && { label }),
       });
       const noun = props.isSubMode() && !isApiKeyCredential() ? 'token' : 'key';
@@ -203,6 +261,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
     <>
       {/* Not yet connected — first key */}
       <Show when={!props.connected()}>
+        <EndpointRegionSelect id={`${props.provId}-subscription-endpoint`} />
         <div class="provider-detail__field">
           <label class="provider-detail__label">{fieldLabel()}</label>
           <input
@@ -302,7 +361,7 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
             </div>
             <Show when={supportsMultiKey() && activeKeys().length < MAX_KEYS_PER_PROVIDER}>
               <AddAnotherKeyAction
-                onAdd={(label, apiKey) => handleAddKey(props, label, apiKey)}
+                onAdd={(label, apiKey, region) => handleAddKey(props, label, apiKey, region)}
                 busy={props.busy}
                 setBusy={props.setBusy}
                 provDef={props.provDef}
@@ -314,10 +373,13 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
                 open={props.addKeyOpen}
                 setOpen={props.setAddKeyOpen}
                 isSubscription={props.isSubMode()}
+                endpointRegions={endpointRegions()}
+                initialEndpointRegion={displayedEndpointRegion()}
               />
             </Show>
           </Show>
           <Show when={props.editing()}>
+            <EndpointRegionSelect id={`${props.provId}-subscription-endpoint-edit`} />
             <input
               class="provider-detail__input provider-detail__input--masked"
               classList={{ 'provider-detail__input--error': !!props.validationError() }}
@@ -377,6 +439,8 @@ const ProviderKeyForm: Component<ProviderKeyFormProps> = (props) => {
           whereToGetUrl={whereToGetUrl}
           addKeyOpen={props.addKeyOpen}
           setAddKeyOpen={props.setAddKeyOpen}
+          endpointRegions={endpointRegions()}
+          endpointRegionLabel={endpointRegionLabel}
           onUpdate={props.onUpdate}
           onDelete={(label) => handleDisconnect(label)}
         />
@@ -389,6 +453,7 @@ async function handleAddKey(
   props: ProviderKeyFormProps,
   label: string,
   apiKey: string,
+  region?: string,
 ): Promise<boolean> {
   // Subscription-mode providers (Anthropic Pro, ChatGPT Plus, etc.) often
   // validate paste tokens with a different prefix/format than their api_key
@@ -408,6 +473,7 @@ async function handleAddKey(
       apiKey: apiKey.replace(/\s/g, ''),
       authType: props.selectedAuthType(),
       label,
+      ...(region && { region }),
     });
     toast.success(`${props.provDef.name} key "${label}" added`);
     props.onUpdate();
@@ -421,7 +487,7 @@ async function handleAddKey(
 
 /** @internal Exported for testing only. */
 export interface AddAnotherKeyActionProps {
-  onAdd: (label: string, apiKey: string) => Promise<boolean>;
+  onAdd: (label: string, apiKey: string, region?: string) => Promise<boolean>;
   busy: Accessor<boolean>;
   setBusy: Setter<boolean>;
   provDef: ProviderDef;
@@ -433,6 +499,8 @@ export interface AddAnotherKeyActionProps {
   open?: Accessor<boolean>;
   setOpen?: Setter<boolean>;
   isSubscription?: boolean;
+  endpointRegions?: { value: string; label: string }[];
+  initialEndpointRegion?: string;
 }
 
 /** @internal Exported for testing only. */
@@ -444,6 +512,9 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
   };
   const [label, setLabel] = createSignal('');
   const [apiKey, setApiKey] = createSignal('');
+  const [endpointRegion, setEndpointRegion] = createSignal<string | undefined>(
+    props.initialEndpointRegion ?? props.endpointRegions?.[0]?.value,
+  );
   let apiKeyInputRef: HTMLInputElement | undefined;
 
   const defaultLabel = () => suggestNextProviderKeyLabel(props.existingLabels());
@@ -453,6 +524,10 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
     if (isOpen() && !label().trim()) {
       setLabel(defaultLabel());
     }
+    const defaultEndpointRegion = props.endpointRegions?.[0]?.value;
+    if (isOpen() && defaultEndpointRegion && !endpointRegion()) {
+      setEndpointRegion(props.initialEndpointRegion ?? defaultEndpointRegion);
+    }
     if (isOpen()) {
       requestAnimationFrame(() => apiKeyInputRef?.focus());
     }
@@ -460,7 +535,7 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
 
   const submit = async () => {
     const labelToUse = (label().trim() || defaultLabel()).slice(0, MAX_LABEL_LENGTH);
-    const ok = await props.onAdd(labelToUse, apiKey().trim());
+    const ok = await props.onAdd(labelToUse, apiKey().trim(), endpointRegion());
     if (ok) {
       setIsOpen(false);
       setLabel('');
@@ -515,6 +590,22 @@ export const AddAnotherKeyAction: Component<AddAnotherKeyActionProps> = (props) 
           placeholder={defaultLabel()}
           onInput={(e) => setLabel(e.currentTarget.value)}
         />
+        <Show when={props.endpointRegions?.length}>
+          <label class="provider-detail__label" for="add-key-endpoint" style="margin-top: 8px;">
+            Region
+          </label>
+          <select
+            id="add-key-endpoint"
+            class="provider-detail__input"
+            value={endpointRegion()}
+            disabled={props.busy()}
+            onChange={(e) => setEndpointRegion(e.currentTarget.value)}
+          >
+            <For each={props.endpointRegions ?? []}>
+              {(region) => <option value={region.value}>{region.label}</option>}
+            </For>
+          </select>
+        </Show>
         <label class="provider-detail__label" for="add-key-value" style="margin-top: 8px;">
           {props.credentialOwnerName()} {props.credentialNoun()}
         </label>
@@ -581,6 +672,8 @@ interface KeyChainViewProps {
   whereToGetUrl: () => string | undefined;
   addKeyOpen?: Accessor<boolean>;
   setAddKeyOpen?: Setter<boolean>;
+  endpointRegions: { value: string; label: string }[];
+  endpointRegionLabel: (value: string | null | undefined) => string | undefined;
   onUpdate: () => void;
   onDelete: (label: string) => void;
 }
@@ -633,7 +726,12 @@ const KeyChainView: Component<KeyChainViewProps> = (props) => {
                         {k.label}
                       </div>
                       <div style="font-size: var(--font-size-xs); color: hsl(var(--muted-foreground));">
-                        {k.key_prefix ? `${k.key_prefix}${'•'.repeat(12)}` : '••••••••••••'}
+                        {[
+                          k.key_prefix ? `${k.key_prefix}${'•'.repeat(12)}` : '••••••••••••',
+                          props.endpointRegionLabel(k.region),
+                        ]
+                          .filter(Boolean)
+                          .join(' · ')}
                       </div>
                     </div>
                     <button
@@ -703,7 +801,7 @@ const KeyChainView: Component<KeyChainViewProps> = (props) => {
       </ul>
       <Show when={props.activeKeys().length < MAX_KEYS_PER_PROVIDER}>
         <AddAnotherKeyAction
-          onAdd={async (label, apiKey) => {
+          onAdd={async (label, apiKey, region) => {
             // Subscription chains paste setup tokens, which validate
             // differently from api keys. Pick the right validator based on
             // the chain's auth_type.
@@ -722,6 +820,7 @@ const KeyChainView: Component<KeyChainViewProps> = (props) => {
                 apiKey: apiKey.replace(/\s/g, ''),
                 authType: props.authType(),
                 label,
+                ...(region && { region }),
               });
               toast.success(`${props.provDef.name} key "${label}" added`);
               props.onUpdate();
@@ -743,6 +842,8 @@ const KeyChainView: Component<KeyChainViewProps> = (props) => {
           open={props.addKeyOpen}
           setOpen={props.setAddKeyOpen}
           isSubscription={props.authType() === 'subscription'}
+          endpointRegions={props.endpointRegions}
+          initialEndpointRegion={props.activeKeys()[0]?.region ?? props.endpointRegions[0]?.value}
         />
       </Show>
     </div>

--- a/packages/frontend/src/services/providers.ts
+++ b/packages/frontend/src/services/providers.ts
@@ -2,6 +2,11 @@
 
 import { SHARED_PROVIDER_BY_ID, type SharedProviderEntry } from 'manifest-shared';
 
+export interface SubscriptionEndpointRegion {
+  value: string;
+  label: string;
+}
+
 export interface ProviderDef {
   id: string;
   name: string;
@@ -36,6 +41,8 @@ export interface ProviderDef {
   deviceLogin?: boolean;
   /** UI auth mode for subscription flows. */
   subscriptionAuthMode?: 'popup_oauth' | 'popup_paste' | 'device_code' | 'token';
+  /** Optional endpoint selector for token-mode subscription providers. */
+  subscriptionEndpointRegions?: SubscriptionEndpointRegion[];
   /**
    * Optional secondary subscription path. Lets a provider expose a pasted-token
    * shortcut alongside its primary OAuth/device-code flow — currently used so
@@ -82,6 +89,7 @@ interface ProviderUIOverlay {
   subscriptionCommand?: string;
   deviceLogin?: boolean;
   subscriptionAuthMode?: 'popup_oauth' | 'popup_paste' | 'device_code' | 'token';
+  subscriptionEndpointRegions?: SubscriptionEndpointRegion[];
   subscriptionTokenAlternative?: {
     prefix: string;
     placeholder: string;
@@ -329,6 +337,10 @@ const PROVIDER_UI: Record<string, ProviderUIOverlay> = {
     subscriptionAuthMode: 'token',
     subscriptionKeyPlaceholder: 'Paste your Z.ai API key',
     subscriptionCredentialKind: 'api-key',
+    subscriptionEndpointRegions: [
+      { value: 'global', label: 'Outside China (api.z.ai)' },
+      { value: 'cn', label: 'China Mainland (open.bigmodel.cn)' },
+    ],
     models: [],
   },
 };

--- a/packages/frontend/tests/components/ProviderKeyForm.test.tsx
+++ b/packages/frontend/tests/components/ProviderKeyForm.test.tsx
@@ -296,6 +296,45 @@ describe('ProviderKeyForm', () => {
       expect(onBack).toHaveBeenCalled();
       expect(onUpdate).toHaveBeenCalled();
     });
+
+    it('sends the selected Z.ai subscription endpoint region on connect', async () => {
+      const def = makeProviderDef({
+        id: 'zai',
+        name: 'Z.ai',
+        supportsSubscription: true,
+        subscriptionAuthMode: 'token',
+        subscriptionCredentialKind: 'api-key',
+        subscriptionKeyPlaceholder: 'Paste your Z.ai API key',
+        subscriptionEndpointRegions: [
+          { value: 'global', label: 'Outside China (api.z.ai)' },
+          { value: 'cn', label: 'China Mainland (open.bigmodel.cn)' },
+        ],
+      });
+      const { container } = mount({
+        provDef: def,
+        provId: 'zai',
+        isSubMode: true,
+        selectedAuthType: 'subscription',
+        keyInput: 'zai-sub-key',
+      });
+
+      const endpoint = container.querySelector('#zai-subscription-endpoint') as HTMLSelectElement;
+      expect(endpoint.value).toBe('global');
+      expect(screen.getByLabelText('Region')).toBe(endpoint);
+      fireEvent.change(endpoint, { target: { value: 'cn' } });
+
+      const connectBtn = container.querySelector('.provider-detail__action') as HTMLButtonElement;
+      fireEvent.click(connectBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'zai',
+        apiKey: 'zai-sub-key',
+        authType: 'subscription',
+        region: 'cn',
+      });
+    });
   });
 
   describe('handleUpdateKey toast labels', () => {
@@ -365,6 +404,94 @@ describe('ProviderKeyForm', () => {
       // Even though isSubMode() is true, isApiKeyCredential() short-circuits
       // the "token" label and we use "key".
       expect(toastSuccess).toHaveBeenCalledWith('Ollama Cloud key updated');
+    });
+
+    it('preserves the saved Z.ai endpoint region when updating a subscription key', async () => {
+      const def = makeProviderDef({
+        id: 'zai',
+        name: 'Z.ai',
+        supportsSubscription: true,
+        subscriptionCredentialKind: 'api-key',
+        subscriptionEndpointRegions: [
+          { value: 'global', label: 'Outside China (api.z.ai)' },
+          { value: 'cn', label: 'China Mainland (open.bigmodel.cn)' },
+        ],
+      });
+      const { container } = mount({
+        provDef: def,
+        provId: 'zai',
+        connected: true,
+        editing: true,
+        isSubMode: true,
+        selectedAuthType: 'subscription',
+        keyInput: 'zai-new-key',
+        providers: [
+          makeProvider({
+            provider: 'zai',
+            auth_type: 'subscription',
+            region: 'cn',
+          }),
+        ],
+      });
+
+      const endpoint = container.querySelector(
+        '#zai-subscription-endpoint-edit',
+      ) as HTMLSelectElement;
+      expect(endpoint.value).toBe('cn');
+
+      const saveBtn = Array.from(container.querySelectorAll('.provider-detail__action')).find((b) =>
+        b.textContent?.includes('Save'),
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'zai',
+        apiKey: 'zai-new-key',
+        authType: 'subscription',
+        region: 'cn',
+      });
+    });
+
+    it('omits Z.ai endpoint region on update when provider chain data is unavailable', async () => {
+      const def = makeProviderDef({
+        id: 'zai',
+        name: 'Z.ai',
+        supportsSubscription: true,
+        subscriptionCredentialKind: 'api-key',
+        subscriptionEndpointRegions: [
+          { value: 'global', label: 'Outside China (api.z.ai)' },
+          { value: 'cn', label: 'China Mainland (open.bigmodel.cn)' },
+        ],
+      });
+      const { container } = mount({
+        provDef: def,
+        provId: 'zai',
+        connected: true,
+        editing: true,
+        isSubMode: true,
+        selectedAuthType: 'subscription',
+        keyInput: 'zai-new-key',
+      });
+
+      const endpoint = container.querySelector(
+        '#zai-subscription-endpoint-edit',
+      ) as HTMLSelectElement;
+      expect(endpoint.value).toBe('global');
+
+      const saveBtn = Array.from(container.querySelectorAll('.provider-detail__action')).find((b) =>
+        b.textContent?.includes('Save'),
+      ) as HTMLButtonElement;
+      fireEvent.click(saveBtn);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'zai',
+        apiKey: 'zai-new-key',
+        authType: 'subscription',
+      });
     });
   });
 
@@ -834,6 +961,62 @@ describe('ProviderKeyForm', () => {
         apiKey: 'sub-third-token',
         authType: 'subscription',
         label: 'Key 3',
+      });
+    });
+
+    it('list-mode AddAnotherKey includes the selected Z.ai subscription endpoint region', async () => {
+      const def = makeProviderDef({
+        id: 'zai',
+        name: 'Z.ai',
+        supportsSubscription: true,
+        subscriptionCredentialKind: 'api-key',
+        subscriptionEndpointRegions: [
+          { value: 'global', label: 'Outside China (api.z.ai)' },
+          { value: 'cn', label: 'China Mainland (open.bigmodel.cn)' },
+        ],
+      });
+      const { container, getByText } = mount({
+        provDef: def,
+        provId: 'zai',
+        connected: true,
+        isSubMode: true,
+        selectedAuthType: 'subscription',
+        addKeyOpen: true,
+        providers: [
+          makeProvider({
+            id: 'z1',
+            provider: 'zai',
+            auth_type: 'subscription',
+            label: 'Personal',
+            priority: 0,
+            region: 'global',
+          }),
+          makeProvider({
+            id: 'z2',
+            provider: 'zai',
+            auth_type: 'subscription',
+            label: 'Work',
+            priority: 1,
+            region: 'cn',
+          }),
+        ],
+      });
+
+      const endpoint = container.querySelector('#add-key-endpoint') as HTMLSelectElement;
+      expect(screen.getByLabelText('Region')).toBe(endpoint);
+      fireEvent.change(endpoint, { target: { value: 'cn' } });
+      const tokenInput = container.querySelector('#add-key-value') as HTMLInputElement;
+      fireEvent.input(tokenInput, { target: { value: 'zai-third-key' } });
+      fireEvent.click(getByText('Add key'));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(connectProviderMock).toHaveBeenCalledWith('test-agent', {
+        provider: 'zai',
+        apiKey: 'zai-third-key',
+        authType: 'subscription',
+        label: 'Key 3',
+        region: 'cn',
       });
     });
 

--- a/packages/frontend/tests/services/providers.test.ts
+++ b/packages/frontend/tests/services/providers.test.ts
@@ -532,6 +532,10 @@ describe('PROVIDERS', () => {
     expect(zai.subscriptionLabel).toBe('GLM Coding Plan');
     expect(zai.subscriptionAuthMode).toBe('token');
     expect(zai.subscriptionKeyPlaceholder).toBe('Paste your Z.ai API key');
+    expect(zai.subscriptionEndpointRegions).toEqual([
+      { value: 'global', label: 'Outside China (api.z.ai)' },
+      { value: 'cn', label: 'China Mainland (open.bigmodel.cn)' },
+    ]);
     expect(zai.subscriptionOnly).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

- Add a Z.ai GLM Coding Plan region selector for subscription keys, matching the MiniMax-style region choice.
- Default Outside China traffic to `https://api.z.ai/api/coding/paas/v4` and route China Mainland selections to `https://open.bigmodel.cn/api/coding/paas/v4`.
- Persist the selected region on Z.ai subscription provider rows and use it for chat routing and model discovery.
- Expose the frontend selector as `Region` with endpoint-specific option labels.

## Validation

- `npm --workspace manifest-shared run build`
- `npm --workspace manifest-backend test -- --runInBand src/routing/zai-region.spec.ts src/routing/proxy/__tests__/provider-endpoints.spec.ts src/routing/proxy/__tests__/provider-client.spec.ts src/routing/proxy/__tests__/proxy-fallback.service.spec.ts src/routing/provider.controller.spec.ts src/routing/routing-core/__tests__/provider.service.spec.ts src/model-discovery/provider-model-fetcher.service.spec.ts src/model-discovery/model-discovery.service.spec.ts`
- `npm --workspace manifest-frontend test -- tests/components/ProviderKeyForm.test.tsx tests/services/providers.test.ts`
- `npm --workspace manifest-backend run build`
- `npm --workspace manifest-frontend run build`
- `npx prettier --check .changeset/zai-subscription-endpoint.md packages/backend/src/routing/zai-region.ts packages/backend/src/routing/zai-region.spec.ts packages/backend/src/routing/proxy/provider-endpoints.ts packages/backend/src/routing/proxy/proxy-fallback.service.ts packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts packages/backend/src/routing/routing-core/provider.service.ts packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts packages/backend/src/model-discovery/model-discovery.service.ts packages/backend/src/model-discovery/model-discovery.service.spec.ts packages/backend/src/model-discovery/provider-model-fetcher.service.ts packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts packages/backend/src/routing/provider.controller.ts packages/backend/src/routing/provider.controller.spec.ts packages/frontend/src/services/providers.ts packages/frontend/tests/services/providers.test.ts packages/frontend/src/components/ProviderKeyForm.tsx packages/frontend/tests/components/ProviderKeyForm.test.tsx`
- `npx changeset status`
- `git diff --check`

## Notes

No live Z.ai key smoke was run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a region selector for Z.ai GLM Coding Plan subscriptions to route traffic to the correct endpoint. Defaults to Outside China at https://api.z.ai/api/coding/paas/v4 and routes China Mainland to https://open.bigmodel.cn/api/coding/paas/v4; the choice is saved and used for chat and model discovery.

- **New Features**
  - Frontend
    - Adds a Region dropdown for Z.ai subscription keys with endpoint-specific labels.
    - Sends the selected region on connect/update and when adding additional keys.
    - Shows the saved region label in the key list.
  - Backend
    - Validates and persists Z.ai subscription regions (`global` or `cn`) for `zai` and `z.ai`.
    - Routes chat via the Coding Plan base URL; defaults to `https://api.z.ai/api/coding/paas/v4`, overrides to CN when `region=cn`.
    - Uses the selected base URL for model discovery, with endpoint override normalization.
    - Strips `z-ai/` or `zai/` prefixes from model names on subscription routes.

<sup>Written for commit 6cdd23d25ad6738d6da8b0953a271faa579bc277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

