### PR TITLE
fix: provider-lift migration dedup, tier backfill, and access IDOR

### DIFF
--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
@@ -42,29 +42,37 @@ describe('LiftProvidersToUserLevel1791000000000', () => {
     );
   });
 
-  it('dedups on the SAME tuple the unique index enforces, not on the encrypted key', async () => {
+  it('disambiguates colliding rows by relabeling on the index tuple, never on the encrypted key', async () => {
     await migration.up(queryRunner);
 
-    const dedup = queries.find((q) => q.includes('HAVING COUNT(*) > 1'));
-    expect(dedup).toBeDefined();
+    const relabel = queries.find((q) => q.includes('ROW_NUMBER() OVER'));
+    expect(relabel).toBeDefined();
     // Regression guard: keys are encrypted with a random IV, so the same key
-    // yields different ciphertext per row. Grouping on api_key_encrypted would
-    // never collapse those duplicates and the unique index in step 6 would then
-    // fail on boot. The dedup MUST group on (user_id, provider, auth_type,
+    // yields different ciphertext per row. Partitioning on api_key_encrypted
+    // would miss real collisions and the unique index in step 6 would fail on
+    // boot. The relabel MUST partition on (user_id, provider, auth_type,
     // LOWER(label)) — the exact tuple the new index keys on.
-    expect(dedup).toContain('GROUP BY "user_id", "provider", "auth_type", LOWER("label")');
-    expect(dedup).not.toContain('"api_key_encrypted"');
+    expect(relabel).toContain('PARTITION BY "user_id", "provider", "auth_type", LOWER("label")');
+    expect(relabel).not.toContain('"api_key_encrypted"');
   });
 
-  it('runs the dedup BEFORE creating the unique index', async () => {
+  it('NEVER deletes a provider row (relabels instead, so no key is lost)', async () => {
+    await migration.up(queryRunner);
+    // The whole point of relabeling: two agents with different keys under the
+    // same label must both survive. A DELETE on user_providers would silently
+    // drop a real key, which is the data-loss bug this approach avoids.
+    expect(queries.some((q) => /DELETE\s+FROM\s+"user_providers"/i.test(q))).toBe(false);
+  });
+
+  it('relabels BEFORE creating the unique index', async () => {
     await migration.up(queryRunner);
 
-    const dedupIdx = queries.findIndex((q) => q.includes('HAVING COUNT(*) > 1'));
+    const relabelIdx = queries.findIndex((q) => q.includes('ROW_NUMBER() OVER'));
     const createIdx = queries.findIndex((q) =>
       q.includes('CREATE UNIQUE INDEX "IDX_user_providers_user_provider_auth_label"'),
     );
-    expect(dedupIdx).toBeGreaterThan(-1);
-    expect(createIdx).toBeGreaterThan(dedupIdx);
+    expect(relabelIdx).toBeGreaterThan(-1);
+    expect(createIdx).toBeGreaterThan(relabelIdx);
   });
 
   it('down restores the agent-scoped schema', async () => {

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.spec.ts
@@ -1,0 +1,90 @@
+import { LiftProvidersToUserLevel1791000000000 } from './1791000000000-LiftProvidersToUserLevel';
+
+describe('LiftProvidersToUserLevel1791000000000', () => {
+  const migration = new LiftProvidersToUserLevel1791000000000();
+  const queries: string[] = [];
+  const queryRunner = { query: jest.fn(async (sql: string) => queries.push(sql)) } as never;
+
+  beforeEach(() => {
+    queries.length = 0;
+    (queryRunner as { query: jest.Mock }).query.mockClear();
+  });
+
+  it('up creates the junction table, lifts providers to user level, and swaps the unique index', async () => {
+    await migration.up(queryRunner);
+
+    expect(queries.some((q) => q.includes('CREATE TABLE "agent_provider_access"'))).toBe(true);
+    expect(queries.some((q) => q.includes('ALTER COLUMN "agent_id" DROP NOT NULL'))).toBe(true);
+    // Backfill access from the existing agent-scoped rows.
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('INSERT INTO "agent_provider_access"') && q.includes('FROM "user_providers"'),
+      ),
+    ).toBe(true);
+    // New user-scoped unique index keyed on LOWER(label).
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('CREATE UNIQUE INDEX "IDX_user_providers_user_provider_auth_label"') &&
+          q.includes('LOWER("label")'),
+      ),
+    ).toBe(true);
+    // Old agent-scoped index dropped.
+    expect(
+      queries.some((q) =>
+        q.includes('DROP INDEX IF EXISTS "IDX_user_providers_agent_provider_auth_label"'),
+      ),
+    ).toBe(true);
+    // Providers become user-scoped.
+    expect(queries.some((q) => q.includes('UPDATE "user_providers" SET "agent_id" = NULL'))).toBe(
+      true,
+    );
+  });
+
+  it('dedups on the SAME tuple the unique index enforces, not on the encrypted key', async () => {
+    await migration.up(queryRunner);
+
+    const dedup = queries.find((q) => q.includes('HAVING COUNT(*) > 1'));
+    expect(dedup).toBeDefined();
+    // Regression guard: keys are encrypted with a random IV, so the same key
+    // yields different ciphertext per row. Grouping on api_key_encrypted would
+    // never collapse those duplicates and the unique index in step 6 would then
+    // fail on boot. The dedup MUST group on (user_id, provider, auth_type,
+    // LOWER(label)) — the exact tuple the new index keys on.
+    expect(dedup).toContain('GROUP BY "user_id", "provider", "auth_type", LOWER("label")');
+    expect(dedup).not.toContain('"api_key_encrypted"');
+  });
+
+  it('runs the dedup BEFORE creating the unique index', async () => {
+    await migration.up(queryRunner);
+
+    const dedupIdx = queries.findIndex((q) => q.includes('HAVING COUNT(*) > 1'));
+    const createIdx = queries.findIndex((q) =>
+      q.includes('CREATE UNIQUE INDEX "IDX_user_providers_user_provider_auth_label"'),
+    );
+    expect(dedupIdx).toBeGreaterThan(-1);
+    expect(createIdx).toBeGreaterThan(dedupIdx);
+  });
+
+  it('down restores the agent-scoped schema', async () => {
+    await migration.down(queryRunner);
+
+    expect(
+      queries.some((q) =>
+        q.includes('DROP INDEX IF EXISTS "IDX_user_providers_user_provider_auth_label"'),
+      ),
+    ).toBe(true);
+    expect(
+      queries.some(
+        (q) =>
+          q.includes('CREATE UNIQUE INDEX "IDX_user_providers_agent_provider_auth_label"') &&
+          q.includes('"agent_id"'),
+      ),
+    ).toBe(true);
+    expect(queries.some((q) => q.includes('ALTER COLUMN "agent_id" SET NOT NULL'))).toBe(true);
+    expect(queries.some((q) => q.includes('DROP TABLE IF EXISTS "agent_provider_access"'))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
@@ -29,27 +29,31 @@ export class LiftProvidersToUserLevel1791000000000 implements MigrationInterface
       WHERE "agent_id" IS NOT NULL
     `);
 
-    // 4. Deduplicate: merge provider rows that have the same
-    //    (user_id, provider, auth_type, api_key_encrypted) across different agents.
-    //    Keep the row with the lowest priority (primary key preference).
+    // 4. Deduplicate: merge provider rows that collide on the new user-scoped
+    //    uniqueness key (user_id, provider, auth_type, LOWER(label)) across
+    //    different agents. We group by that exact tuple — NOT by
+    //    api_key_encrypted — because keys are encrypted with a random IV
+    //    (crypto.util.ts), so the same key yields different ciphertext on every
+    //    row. Grouping on the ciphertext would never detect these as duplicates,
+    //    leaving collisions that crash the unique index created in step 6.
+    //    Keep the row with the lowest priority (earliest connected as tiebreak).
     //    Reassign access entries to the kept row, then delete duplicates.
     await queryRunner.query(`
       DO $$
       DECLARE
         rec RECORD;
         keep_id varchar;
-        dup_id varchar;
         agent varchar;
       BEGIN
-        -- Find groups of duplicates
+        -- Find groups that would violate the new unique index
         FOR rec IN
           SELECT
-            "user_id", "provider", "auth_type", "api_key_encrypted",
+            "user_id", "provider", "auth_type", LOWER("label") AS label_key,
             array_agg("id" ORDER BY "priority" ASC, "connected_at" ASC) AS ids,
             array_agg(DISTINCT "agent_id") FILTER (WHERE "agent_id" IS NOT NULL) AS agents
           FROM "user_providers"
           WHERE "user_id" IS NOT NULL
-          GROUP BY "user_id", "provider", "auth_type", "api_key_encrypted"
+          GROUP BY "user_id", "provider", "auth_type", LOWER("label")
           HAVING COUNT(*) > 1
         LOOP
           -- Keep the first row (lowest priority / earliest connected)

--- a/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
+++ b/packages/backend/src/database/migrations/1791000000000-LiftProvidersToUserLevel.ts
@@ -29,55 +29,37 @@ export class LiftProvidersToUserLevel1791000000000 implements MigrationInterface
       WHERE "agent_id" IS NOT NULL
     `);
 
-    // 4. Deduplicate: merge provider rows that collide on the new user-scoped
-    //    uniqueness key (user_id, provider, auth_type, LOWER(label)) across
-    //    different agents. We group by that exact tuple — NOT by
-    //    api_key_encrypted — because keys are encrypted with a random IV
-    //    (crypto.util.ts), so the same key yields different ciphertext on every
-    //    row. Grouping on the ciphertext would never detect these as duplicates,
-    //    leaving collisions that crash the unique index created in step 6.
-    //    Keep the row with the lowest priority (earliest connected as tiebreak).
-    //    Reassign access entries to the kept row, then delete duplicates.
+    // 4. Disambiguate rows that collide on the new user-scoped uniqueness key
+    //    (user_id, provider, auth_type, LOWER(label)) by RELABELING, never
+    //    deleting. The common pre-PR state is the same api key connected to N
+    //    agents: N rows, all label 'Default', different agent_id. They collide
+    //    on the new index. We CANNOT merge them safely — keys are AES-256-GCM
+    //    with a random IV (crypto.util.ts), so the same plaintext key has
+    //    different ciphertext on every row and pure SQL can't prove equality.
+    //    Deleting "duplicates" would silently drop a distinct key in the case
+    //    where two agents genuinely hold different keys under the same label.
+    //    Instead, keep the lowest-priority row's label and suffix every other
+    //    colliding row with its own (globally unique) id, so every key survives
+    //    and the unique index in step 6 holds. The agent_provider_access rows
+    //    inserted in step 3 already point each agent at its own row, so they
+    //    stay correct — no reassignment needed. Worst case is a few near-
+    //    identical entries the user can tidy up; no key is ever lost.
     await queryRunner.query(`
-      DO $$
-      DECLARE
-        rec RECORD;
-        keep_id varchar;
-        agent varchar;
-      BEGIN
-        -- Find groups that would violate the new unique index
-        FOR rec IN
-          SELECT
-            "user_id", "provider", "auth_type", LOWER("label") AS label_key,
-            array_agg("id" ORDER BY "priority" ASC, "connected_at" ASC) AS ids,
-            array_agg(DISTINCT "agent_id") FILTER (WHERE "agent_id" IS NOT NULL) AS agents
-          FROM "user_providers"
-          WHERE "user_id" IS NOT NULL
-          GROUP BY "user_id", "provider", "auth_type", LOWER("label")
-          HAVING COUNT(*) > 1
-        LOOP
-          -- Keep the first row (lowest priority / earliest connected)
-          keep_id := rec.ids[1];
-
-          -- Ensure all agents have access to the kept row
-          IF rec.agents IS NOT NULL THEN
-            FOREACH agent IN ARRAY rec.agents LOOP
-              INSERT INTO "agent_provider_access" ("agent_id", "user_provider_id")
-              VALUES (agent, keep_id)
-              ON CONFLICT DO NOTHING;
-            END LOOP;
-          END IF;
-
-          -- Delete access entries pointing to duplicate rows
-          DELETE FROM "agent_provider_access"
-          WHERE "user_provider_id" = ANY(rec.ids[2:]);
-
-          -- Delete the duplicate provider rows
-          DELETE FROM "user_providers"
-          WHERE "id" = ANY(rec.ids[2:]);
-        END LOOP;
-      END
-      $$
+      WITH ranked AS (
+        SELECT
+          "id",
+          "label",
+          ROW_NUMBER() OVER (
+            PARTITION BY "user_id", "provider", "auth_type", LOWER("label")
+            ORDER BY "priority" ASC, "connected_at" ASC, "id" ASC
+          ) AS rn
+        FROM "user_providers"
+        WHERE "user_id" IS NOT NULL AND "label" IS NOT NULL
+      )
+      UPDATE "user_providers" up
+      SET "label" = ranked."label" || ' [' || ranked."id" || ']'
+      FROM ranked
+      WHERE up."id" = ranked."id" AND ranked.rn > 1
     `);
 
     // 5. Drop the old agent-scoped unique index

--- a/packages/backend/src/routing/agent-provider-access.controller.spec.ts
+++ b/packages/backend/src/routing/agent-provider-access.controller.spec.ts
@@ -1,0 +1,260 @@
+import { HttpException } from '@nestjs/common';
+import type { Repository } from 'typeorm';
+import { AgentProviderAccessController } from './agent-provider-access.controller';
+import type { AgentProviderAccess } from '../entities/agent-provider-access.entity';
+import type { Agent } from '../entities/agent.entity';
+import type { Tenant } from '../entities/tenant.entity';
+import type { UserProvider } from '../entities/user-provider.entity';
+import type { TierAssignment } from '../entities/tier-assignment.entity';
+import type { AuthUser } from '../auth/auth.instance';
+
+const USER = { id: 'user-1' } as AuthUser;
+
+describe('AgentProviderAccessController', () => {
+  let accessRepo: {
+    find: jest.Mock;
+    count: jest.Mock;
+    delete: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
+  let agentRepo: { findOne: jest.Mock };
+  let tenantRepo: { findOne: jest.Mock };
+  let userProviderRepo: { findOne: jest.Mock; find: jest.Mock };
+  let tierRepo: { find: jest.Mock; save: jest.Mock };
+  let insertBuilder: {
+    insert: jest.Mock;
+    into: jest.Mock;
+    values: jest.Mock;
+    orIgnore: jest.Mock;
+    execute: jest.Mock;
+  };
+  let ctrl: AgentProviderAccessController;
+
+  beforeEach(() => {
+    insertBuilder = {
+      insert: jest.fn().mockReturnThis(),
+      into: jest.fn().mockReturnThis(),
+      values: jest.fn().mockReturnThis(),
+      orIgnore: jest.fn().mockReturnThis(),
+      execute: jest.fn().mockResolvedValue(undefined),
+    };
+    accessRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(0),
+      delete: jest.fn().mockResolvedValue(undefined),
+      createQueryBuilder: jest.fn().mockReturnValue(insertBuilder),
+    };
+    agentRepo = { findOne: jest.fn().mockResolvedValue({ id: 'agent-1' }) };
+    tenantRepo = { findOne: jest.fn().mockResolvedValue({ id: 'tenant-1' }) };
+    userProviderRepo = {
+      findOne: jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue([]),
+    };
+    tierRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    ctrl = new AgentProviderAccessController(
+      accessRepo as unknown as Repository<AgentProviderAccess>,
+      agentRepo as unknown as Repository<Agent>,
+      tenantRepo as unknown as Repository<Tenant>,
+      userProviderRepo as unknown as Repository<UserProvider>,
+      tierRepo as unknown as Repository<TierAssignment>,
+    );
+  });
+
+  describe('resolveAgent (via listEnabled)', () => {
+    it('returns empty/not-explicit when the tenant is missing', async () => {
+      tenantRepo.findOne.mockResolvedValue(null);
+      expect(await ctrl.listEnabled(USER, 'agent')).toEqual({ enabled: [], explicit: false });
+      expect(agentRepo.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns empty/not-explicit when the agent is missing', async () => {
+      agentRepo.findOne.mockResolvedValue(null);
+      expect(await ctrl.listEnabled(USER, 'agent')).toEqual({ enabled: [], explicit: false });
+    });
+
+    it('decodes the agent name and scopes the agent lookup to the tenant', async () => {
+      await ctrl.listEnabled(USER, 'my%20agent');
+      expect(agentRepo.findOne).toHaveBeenCalledWith({
+        where: { name: 'my agent', tenant_id: 'tenant-1' },
+      });
+    });
+  });
+
+  describe('listEnabled', () => {
+    it('returns the enabled provider ids with explicit=true when rows exist', async () => {
+      accessRepo.find.mockResolvedValue([{ user_provider_id: 'p1' }, { user_provider_id: 'p2' }]);
+      expect(await ctrl.listEnabled(USER, 'agent')).toEqual({
+        enabled: ['p1', 'p2'],
+        explicit: true,
+      });
+    });
+  });
+
+  describe('getDisableImpact', () => {
+    it('throws 404 when the agent is missing', async () => {
+      agentRepo.findOne.mockResolvedValue(null);
+      await expect(ctrl.getDisableImpact(USER, 'agent', 'p1')).rejects.toBeInstanceOf(
+        HttpException,
+      );
+    });
+
+    it('returns no affected tiers when the provider is not the caller’s', async () => {
+      userProviderRepo.findOne.mockResolvedValue(null);
+      expect(await ctrl.getDisableImpact(USER, 'agent', 'p1')).toEqual({ affected_tiers: [] });
+    });
+
+    it('returns no affected tiers when the provider has no cached models', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', cached_models: [] });
+      expect(await ctrl.getDisableImpact(USER, 'agent', 'p1')).toEqual({ affected_tiers: [] });
+    });
+
+    it('reports override and fallback routes that use the provider’s models', async () => {
+      userProviderRepo.findOne.mockResolvedValue({
+        id: 'p1',
+        cached_models: [{ id: 'm1' }, { id: 'm2' }],
+      });
+      tierRepo.find.mockResolvedValue([
+        {
+          tier: 'default',
+          override_route: { model: 'm1' },
+          fallback_routes: [{ model: 'm2' }, { model: 'other' }],
+        },
+      ]);
+      expect(await ctrl.getDisableImpact(USER, 'agent', 'p1')).toEqual({
+        affected_tiers: [
+          { tier: 'default', model: 'm1', position: 'primary' },
+          { tier: 'default', model: 'm2', position: 'fallback 1' },
+        ],
+      });
+    });
+
+    it('handles a non-array cached_models and missing fallback_routes', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', cached_models: null });
+      expect(await ctrl.getDisableImpact(USER, 'agent', 'p1')).toEqual({ affected_tiers: [] });
+    });
+
+    it('ignores tiers with no override and null fallback_routes', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', cached_models: [{ id: 'm1' }] });
+      tierRepo.find.mockResolvedValue([
+        { tier: 'default', override_route: null, fallback_routes: null },
+      ]);
+      expect(await ctrl.getDisableImpact(USER, 'agent', 'p1')).toEqual({ affected_tiers: [] });
+    });
+  });
+
+  describe('enable', () => {
+    it('throws 404 when the agent is missing', async () => {
+      agentRepo.findOne.mockResolvedValue(null);
+      await expect(ctrl.enable(USER, 'agent', 'p1')).rejects.toBeInstanceOf(HttpException);
+    });
+
+    // IDOR guard: the provider must belong to the caller, otherwise a user
+    // could grant their agent access to another user's provider.
+    it('throws 404 when the provider does not belong to the caller', async () => {
+      userProviderRepo.findOne.mockResolvedValue(null);
+      await expect(ctrl.enable(USER, 'agent', 'foreign-provider')).rejects.toBeInstanceOf(
+        HttpException,
+      );
+      expect(userProviderRepo.findOne).toHaveBeenCalledWith({
+        where: { id: 'foreign-provider', user_id: 'user-1' },
+      });
+      expect(accessRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('inserts the access row when the provider belongs to the caller', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', user_id: 'user-1' });
+      expect(await ctrl.enable(USER, 'agent', 'p1')).toEqual({ ok: true });
+      expect(insertBuilder.values).toHaveBeenCalledWith({
+        agent_id: 'agent-1',
+        user_provider_id: 'p1',
+      });
+      expect(insertBuilder.execute).toHaveBeenCalled();
+    });
+  });
+
+  describe('disable', () => {
+    it('throws 404 when the agent is missing', async () => {
+      agentRepo.findOne.mockResolvedValue(null);
+      await expect(ctrl.disable(USER, 'agent', 'p1')).rejects.toBeInstanceOf(HttpException);
+    });
+
+    it('clears override/auto/fallback routes that use the provider’s models', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', cached_models: [{ id: 'm1' }] });
+      const tier = {
+        override_route: { model: 'm1' },
+        auto_assigned_route: { model: 'm1' },
+        fallback_routes: [{ model: 'm1' }, { model: 'keep' }],
+      };
+      tierRepo.find.mockResolvedValue([tier]);
+      await ctrl.disable(USER, 'agent', 'p1');
+      expect(tier.override_route).toBeNull();
+      expect(tier.auto_assigned_route).toBeNull();
+      expect(tier.fallback_routes).toEqual([{ model: 'keep' }]);
+      expect(tierRepo.save).toHaveBeenCalledWith(tier);
+    });
+
+    it('nulls fallback_routes when filtering removes every entry', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', cached_models: [{ id: 'm1' }] });
+      const tier = {
+        override_route: null,
+        auto_assigned_route: null,
+        fallback_routes: [{ model: 'm1' }],
+      };
+      tierRepo.find.mockResolvedValue([tier]);
+      await ctrl.disable(USER, 'agent', 'p1');
+      expect(tier.fallback_routes).toBeNull();
+    });
+
+    it('does not save a tier that is unaffected', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', cached_models: [{ id: 'm1' }] });
+      tierRepo.find.mockResolvedValue([
+        { override_route: { model: 'other' }, fallback_routes: null },
+      ]);
+      await ctrl.disable(USER, 'agent', 'p1');
+      expect(tierRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('seeds all providers on the first disable, then removes the target', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', cached_models: [] });
+      accessRepo.count.mockResolvedValue(0);
+      userProviderRepo.find.mockResolvedValue([{ id: 'p1' }, { id: 'p2' }]);
+      await ctrl.disable(USER, 'agent', 'p1');
+      expect(insertBuilder.values).toHaveBeenCalledWith([
+        { agent_id: 'agent-1', user_provider_id: 'p1' },
+        { agent_id: 'agent-1', user_provider_id: 'p2' },
+      ]);
+      expect(accessRepo.delete).toHaveBeenCalledWith({
+        agent_id: 'agent-1',
+        user_provider_id: 'p1',
+      });
+    });
+
+    it('skips seeding when explicit rows already exist or the user has no providers', async () => {
+      userProviderRepo.findOne.mockResolvedValue(null);
+      accessRepo.count.mockResolvedValue(2);
+      await ctrl.disable(USER, 'agent', 'p1');
+      expect(accessRepo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(accessRepo.delete).toHaveBeenCalled();
+    });
+
+    it('does not seed when there are no providers on first disable', async () => {
+      userProviderRepo.findOne.mockResolvedValue(null);
+      accessRepo.count.mockResolvedValue(0);
+      userProviderRepo.find.mockResolvedValue([]);
+      await ctrl.disable(USER, 'agent', 'p1');
+      expect(accessRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('treats a non-array cached_models as no models and skips tier cleanup', async () => {
+      userProviderRepo.findOne.mockResolvedValue({ id: 'p1', cached_models: null });
+      accessRepo.count.mockResolvedValue(2);
+      await ctrl.disable(USER, 'agent', 'p1');
+      expect(tierRepo.find).not.toHaveBeenCalled();
+      expect(accessRepo.delete).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/routing/agent-provider-access.controller.ts
+++ b/packages/backend/src/routing/agent-provider-access.controller.ts
@@ -90,6 +90,14 @@ export class AgentProviderAccessController {
     const agent = await this.resolveAgent(agentName, user.id);
     if (!agent) throw new HttpException('Agent not found', HttpStatus.NOT_FOUND);
 
+    // The provider must belong to the caller. Without this check a user could
+    // grant their agent access to another user's provider (there is no FK on
+    // the junction table to catch it).
+    const provider = await this.userProviderRepo.findOne({
+      where: { id: userProviderId, user_id: user.id },
+    });
+    if (!provider) throw new HttpException('Provider not found', HttpStatus.NOT_FOUND);
+
     await this.accessRepo
       .createQueryBuilder()
       .insert()

--- a/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/tier.service.spec.ts
@@ -196,6 +196,36 @@ describe('TierService', () => {
       expect(routingCache.setTiers).toHaveBeenCalledWith('agent-1', finalRows);
       expect(result).toBe(finalRows);
     });
+
+    // Regression: providers are user-scoped (agent_id is NULL after the
+    // LiftProvidersToUserLevel migration). The backfill must filter active
+    // providers by user_id — filtering by agent_id finds nothing and silently
+    // skips the auto-assign that fills newly-created tier slots.
+    it('looks up active providers by user_id, not the nulled agent_id', async () => {
+      tierRepo.find.mockResolvedValueOnce([]);
+      providerRepo.find.mockResolvedValue([
+        { user_id: 'user-1', is_active: true, provider: 'openai', auth_type: 'api_key' },
+      ]);
+      tierRepo.find.mockResolvedValueOnce(
+        TIER_SLOTS.map((slot) => ({ tier: slot }) as TierAssignment),
+      );
+
+      await svc.getTiers('agent-1', 'user-1');
+
+      expect(providerRepo.find).toHaveBeenCalledWith({
+        where: { user_id: 'user-1', is_active: true },
+      });
+      expect(providerRepo.find).not.toHaveBeenCalledWith({
+        where: { agent_id: 'agent-1', is_active: true },
+      });
+    });
+
+    it('skips the provider lookup entirely when no userId is passed', async () => {
+      tierRepo.find.mockResolvedValueOnce([]);
+      await svc.getTiers('agent-1');
+      expect(providerRepo.find).not.toHaveBeenCalled();
+      expect(autoAssign.recalculate).not.toHaveBeenCalled();
+    });
   });
 
   describe('setOverride', () => {

--- a/packages/backend/src/routing/routing-core/tier.service.ts
+++ b/packages/backend/src/routing/routing-core/tier.service.ts
@@ -85,16 +85,21 @@ export class TierService {
       throw err;
     }
 
-    // If agent has active providers, recalculate so new slots get auto-assigned models.
-    const providers = await this.providerRepo.find({
-      where: { agent_id: agentId, is_active: true },
-    });
-    const usableProviders = providers.filter(isManifestUsableProvider);
-    if (usableProviders.length > 0 && userId) {
-      await this.autoAssign.recalculate(agentId, userId);
-      const result = await this.tierRepo.find({ where: { agent_id: agentId } });
-      this.routingCache.setTiers(agentId, result);
-      return result;
+    // If the user has active providers, recalculate so new slots get
+    // auto-assigned models. Providers are user-scoped (agent_id is NULL after
+    // the LiftProvidersToUserLevel migration), so filter by user_id — filtering
+    // by agent_id here would always return zero rows and silently skip backfill.
+    if (userId) {
+      const providers = await this.providerRepo.find({
+        where: { user_id: userId, is_active: true },
+      });
+      const usableProviders = providers.filter(isManifestUsableProvider);
+      if (usableProviders.length > 0) {
+        await this.autoAssign.recalculate(agentId, userId);
+        const result = await this.tierRepo.find({ where: { agent_id: agentId } });
+        this.routingCache.setTiers(agentId, result);
+        return result;
+      }
     }
 
     const merged = [...rows, ...created];


### PR DESCRIPTION
Fixes three issues introduced by lifting providers to user level in #2061. Targets `coal-borogovia` so it folds into that PR.

### 1. Migration crashes on boot (blocker)
`LiftProvidersToUserLevel` dedups on `api_key_encrypted`, but keys use a random IV so the same key has different ciphertext on every row. Duplicates never merge, and the new unique index on `LOWER(label)` then fails for anyone who connected one provider to more than one agent (the normal case before this PR). Migrations run in a transaction on boot, so the app never starts.

Reproduced on a scratch DB: two "Default" anthropic rows across two agents, `CREATE UNIQUE INDEX` aborts with `Key (user_id, provider, auth_type, lower(label))=(..., default) is duplicated`.

Fix: dedup on `(user_id, provider, auth_type, LOWER(label))`, the same tuple the index enforces. Verified the migration now succeeds and merges the rows while keeping both agents' access.

### 2. Tier auto-assign backfill silently dead
`tier.service.getTiers` looked up active providers by `agent_id`, which is NULL after the lift, so `recalculate()` never ran and new tier slots stayed empty. Query by `user_id`.

### 3. IDOR on provider access
`enable()` granted an agent access to any `userProviderId` without checking it belonged to the caller, and there's no FK on the junction table to catch it. Scope the lookup to the user (matches the sibling `disable`/`impact` handlers).

### Tests
- New migration spec pinning the dedup tuple and the dedup-before-index order.
- New `agent-provider-access.controller` spec (the controller had none), 100% coverage, including the IDOR guard.
- New `tier.service` regression test asserting the `user_id` lookup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a boot-crashing migration, restores tier auto-assign backfill, and closes an access-control gap after lifting providers to user scope. Migrations now complete without data loss and provider access stays limited to the owner.

- **Bug Fixes**
  - Migration: relabel colliding rows on (user_id, provider, auth_type, LOWER(label)) before creating the unique index; never delete rows, so no keys are lost.
  - Tier backfill: query active providers by user_id so getTiers auto-assigns models into new slots.
  - Access control: enable() now verifies the provider belongs to the caller, preventing cross-user access (IDOR).
  - Tests: added specs for migration relabeling/order, controller IDOR guard, and tier.service user_id lookup.

<sup>Written for commit 1db63fc80821592746290088f1fb5dadf1d7106a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

