### PR TITLE
fix: preserve non-message Responses input items

### DIFF
--- a/.changeset/responses-non-message-input.md
+++ b/.changeset/responses-non-message-input.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Fix native `/v1/responses` forwarding so typed non-message input items such as `reasoning` and `item_reference` are preserved without a `role`, preventing ChatGPT subscription Codex backend 400 errors on multi-turn Codex requests.

--- a/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts
@@ -220,6 +220,49 @@ describe('Responses adapter', () => {
     ]);
   });
 
+  it('passes typed non-message Responses items through when normalizing native input', () => {
+    const reasoning = { type: 'reasoning', id: 'rs_1', summary: [] };
+    const itemReference = { type: 'item_reference', id: 'fc_1' };
+    const result = toNativeResponsesRequest(
+      {
+        input: [{ type: 'message', role: 'user', content: 'hello' }, reasoning, itemReference],
+      },
+      'gpt-5.4',
+    ).input as unknown[];
+
+    expect(result).toEqual([
+      { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
+      reasoning,
+      itemReference,
+    ]);
+    expect(result[1]).toBe(reasoning);
+    expect(result[2]).toBe(itemReference);
+  });
+
+  it('does not add roles to typed non-message Responses items in native input lists', () => {
+    const reasoning = { type: 'reasoning', id: 'rs_1', summary: [] };
+    const itemReference = { type: 'item_reference', id: 'fc_1' };
+    const result = toNativeResponsesRequest(
+      {
+        input: [
+          { type: 'message', role: 'assistant', content: [{ type: 'text', text: 'done' }] },
+          reasoning,
+          itemReference,
+        ],
+      },
+      'gpt-5.4',
+      { inputList: true },
+    ).input as unknown[];
+
+    expect(result).toEqual([
+      { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'done' }] },
+      reasoning,
+      itemReference,
+    ]);
+    expect(result[1]).toBe(reasoning);
+    expect(result[2]).toBe(itemReference);
+  });
+
   it('normalizes legacy image_url content parts in native Responses input lists', () => {
     expect(
       toNativeResponsesRequest(

--- a/packages/backend/src/routing/proxy/responses-adapter.ts
+++ b/packages/backend/src/routing/proxy/responses-adapter.ts
@@ -199,7 +199,7 @@ function normalizeNativeResponsesInput(input: unknown): unknown {
 
   return input.map((item) => {
     if (!isRecord(item)) return item;
-    if (item.type === 'function_call' || item.type === 'function_call_output') return item;
+    if (!isNativeResponsesMessageItem(item)) return item;
 
     const role = typeof item.role === 'string' ? item.role : 'user';
     return { ...item, content: toNativeResponsesContent(item.content, role) };
@@ -216,13 +216,16 @@ function toNativeResponsesInput(input: unknown): unknown {
     if (typeof item === 'string') {
       return [{ role: 'user', content: [{ type: 'input_text', text: item }] }];
     }
-    if (!isRecord(item) || item.type === 'function_call' || item.type === 'function_call_output') {
-      return isRecord(item) ? [item] : [];
-    }
+    if (!isRecord(item)) return [];
+    if (!isNativeResponsesMessageItem(item)) return [item];
 
     const role = typeof item.role === 'string' ? item.role : 'user';
     return [{ ...item, role, content: toNativeResponsesContent(item.content, role) }];
   });
+}
+
+function isNativeResponsesMessageItem(item: JsonRecord): boolean {
+  return item.type === undefined || item.type === 'message';
 }
 
 function toNativeResponsesContent(content: unknown, role: string): unknown {


### PR DESCRIPTION
Fixes #2105.

## Summary
- Preserve typed non-message native Responses input items without adding `role`.
- Keep role/content normalization for message items only.
- Add regressions for both native Responses normalization paths.
- Add a patch changeset.

## Why
The ChatGPT subscription Codex backend rejects `role` on non-message Responses input items such as `reasoning` and `item_reference`. PR #2050 handles a related Chat Completions fallback sanitizer path, but native `/v1/responses` forwarding still normalized every typed item except function calls.

## Validation
- `npm ci` (Node v23.7.0 engine warning plus existing audit findings)
- `npm --workspace=packages/shared run build`
- `npm test --workspace=packages/backend -- --runTestsByPath src/routing/proxy/__tests__/responses-adapter.spec.ts`
- `npm --workspace=packages/backend run build`
- `npx prettier --check .changeset/responses-non-message-input.md packages/backend/src/routing/proxy/responses-adapter.ts packages/backend/src/routing/proxy/__tests__/responses-adapter.spec.ts`
- `npx changeset status`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix native `/v1/responses` forwarding to stop adding `role` to typed non-message input items (e.g., `reasoning`, `item_reference`). Only message items are normalized, preventing Codex 400 errors on multi-turn requests.

- **Bug Fixes**
  - Preserve typed non-message items as-is; no `role` added.
  - Normalize role/content for message items only via `isNativeResponsesMessageItem`.
  - Add regression tests for native normalization paths and a patch changeset.

<sup>Written for commit aad30330b724db2b93caccb58a29f808aebfd15b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

