### PR TITLE
feat: use providerless modelparams lookup

### DIFF
--- a/.changeset/providerless-modelparams-lookup.md
+++ b/.changeset/providerless-modelparams-lookup.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Resolve model parameter specs through the providerless modelparams.dev by-model endpoint so gateway routes such as GitHub Copilot can expose the underlying model's thinking and reasoning controls.

--- a/docs/model-parameters-schema.md
+++ b/docs/model-parameters-schema.md
@@ -7,9 +7,12 @@ catalog. The catalog is metadata: it describes which request parameters Manifest
 can configure for a provider/auth/model tuple. User-selected values still live in
 `agent_model_params`.
 
-The runtime source is `https://modelparams.dev/api/v1/models.json`.
-Manifest caches the latest valid remote catalog in memory and keeps that cache
-through transient refresh failures.
+The primary on-demand runtime source is
+`https://modelparams.dev/api/v1/params/{model}.json`, where subscription
+variants use the `-subscription` model suffix. Manifest still refreshes
+`https://modelparams.dev/api/v1/models.json` as the offline/index fallback, and
+keeps the latest valid remote catalog in memory through transient refresh
+failures.
 
 The executable validator is `isParamApplicability` in
 `packages/shared/src/provider-params-spec.ts`. Any schema change must update:

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1038,6 +1038,26 @@ describe('ProviderClient', () => {
       },
     );
 
+    it('preserves reasoning and text params when converting Copilot Codex requests', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'gpt-5.2-codex',
+        body: {
+          messages: [{ role: 'user', content: 'Hello' }],
+          reasoning: { effort: 'high', summary: 'concise' },
+          text: { verbosity: 'low' },
+        },
+        stream: false,
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.reasoning).toEqual({ effort: 'high', summary: 'concise' });
+      expect(sentBody.text).toEqual({ verbosity: 'low' });
+    });
+
     it('leaves non-Codex Copilot models on /chat/completions', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/chatgpt-adapter.ts
+++ b/packages/backend/src/routing/proxy/chatgpt-adapter.ts
@@ -85,6 +85,14 @@ export function toResponsesRequest(
     }
   }
 
+  if (isObjectRecord(body.reasoning)) {
+    request.reasoning = body.reasoning;
+  }
+
+  if (isObjectRecord(body.text)) {
+    request.text = body.text;
+  }
+
   if (Array.isArray(body.tools)) {
     request.tools = convertTools(body.tools as Record<string, unknown>[]);
   }

--- a/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts
@@ -71,6 +71,45 @@ describe('ProviderParamSpecService', () => {
     } as unknown as Response);
   }
 
+  const reasoningEffortParam = {
+    path: 'reasoning.effort',
+    type: 'enum',
+    label: 'Reasoning effort',
+    description: 'Controls reasoning effort.',
+    group: 'reasoning',
+    default: 'medium',
+    values: ['low', 'medium', 'high'],
+  };
+
+  const temperatureParam = {
+    path: 'temperature',
+    type: 'number',
+    label: 'Temperature',
+    description: 'Controls randomness.',
+    group: 'sampling',
+    default: 1,
+    range: { min: 0, max: 2, step: 0.1 },
+  };
+
+  function mockProviderlessParams(
+    responses: Record<string, readonly Record<string, unknown>[]>,
+  ): void {
+    fetchSpy.mockImplementation(async (url: string | URL) => {
+      const text = String(url);
+      for (const [slug, params] of Object.entries(responses)) {
+        if (text === `https://modelparams.dev/api/v1/params/${slug}.json`) {
+          return {
+            ok: true,
+            status: 200,
+            headers: { get: () => null },
+            json: async () => ({ model: slug, params }),
+          } as unknown as Response;
+        }
+      }
+      return { ok: false, status: 404, headers: { get: () => null } } as unknown as Response;
+    });
+  }
+
   it('seeds from the bundled snapshot before the remote catalog loads', async () => {
     const service = new ProviderParamSpecService();
 
@@ -111,6 +150,32 @@ describe('ProviderParamSpecService', () => {
     expect(service.getLastFetchedAt()).toBeInstanceOf(Date);
   });
 
+  it('uses the providerless model endpoint before provider/auth catalog matches', async () => {
+    mockRemoteCatalog();
+    const service = new ProviderParamSpecService();
+    await service.refreshCache();
+    fetchSpy.mockClear();
+    mockProviderlessParams({
+      'gpt-test': [reasoningEffortParam],
+    });
+
+    const specs = await service.getSpecs('openai', 'api_key', 'gpt-test');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://modelparams.dev/api/v1/params/gpt-test.json',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(specs).toEqual([
+      expect.objectContaining({
+        provider: 'openai',
+        authType: 'api_key',
+        model: 'gpt-test',
+        path: 'reasoning.effort',
+      }),
+    ]);
+    expect(specs.map((spec) => spec.path)).not.toContain('temperature');
+  });
+
   it('lists model identities without param details', async () => {
     mockRemoteCatalog();
     const service = new ProviderParamSpecService();
@@ -120,6 +185,144 @@ describe('ProviderParamSpecService', () => {
       { provider: 'anthropic', authType: 'api_key', model: 'claude-sonnet-4-6' },
       { provider: 'openai', authType: 'api_key', model: 'gpt-test' },
     ]);
+  });
+
+  it('loads providerless subscription specs for prefixed Copilot models', async () => {
+    mockProviderlessParams({
+      'gpt-5.5-subscription': [reasoningEffortParam],
+    });
+    const service = new ProviderParamSpecService();
+
+    const specs = await service.getSpecs('copilot', 'subscription', 'copilot/gpt-5.5');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://modelparams.dev/api/v1/params/gpt-5.5-subscription.json',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(specs).toEqual([
+      expect.objectContaining({
+        provider: 'copilot',
+        authType: 'subscription',
+        model: 'copilot/gpt-5.5',
+        path: 'reasoning.effort',
+      }),
+    ]);
+  });
+
+  it('normalizes Copilot Claude dotted minor versions before providerless lookup', async () => {
+    mockProviderlessParams({
+      'claude-sonnet-4-6-subscription': [reasoningEffortParam],
+    });
+    const service = new ProviderParamSpecService();
+
+    const specs = await service.getSpecs('copilot', 'subscription', 'copilot/claude-sonnet-4.6');
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://modelparams.dev/api/v1/params/claude-sonnet-4-6-subscription.json',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      'https://modelparams.dev/api/v1/params/claude-sonnet-4.6-subscription.json',
+      expect.anything(),
+    );
+    expect(specs.map((spec) => spec.path)).toEqual(['reasoning.effort']);
+  });
+
+  it('falls back to the providerless API-key slug for subscription routes', async () => {
+    mockProviderlessParams({
+      'gpt-4o-mini': [temperatureParam],
+    });
+    const service = new ProviderParamSpecService();
+
+    const specs = await service.getSpecs('copilot', 'subscription', 'copilot/gpt-4o-mini');
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      'https://modelparams.dev/api/v1/params/gpt-4o-mini-subscription.json',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      'https://modelparams.dev/api/v1/params/gpt-4o-mini.json',
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(specs).toEqual([
+      expect.objectContaining({
+        provider: 'copilot',
+        authType: 'subscription',
+        model: 'copilot/gpt-4o-mini',
+        path: 'temperature',
+      }),
+    ]);
+  });
+
+  it('caches providerless hits by slug', async () => {
+    mockProviderlessParams({
+      'gpt-5.5-subscription': [reasoningEffortParam],
+    });
+    const service = new ProviderParamSpecService();
+
+    await service.getSpecs('copilot', 'subscription', 'copilot/gpt-5.5');
+    await service.getSpecs('copilot', 'subscription', 'copilot/gpt-5.5');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches providerless misses briefly without refetching immediately', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      json: async () => ({ model: 'missing-model', params: [] }),
+    } as unknown as Response);
+    const service = new ProviderParamSpecService();
+
+    await service.getSpecs('openai', 'api_key', 'missing-model');
+    await service.getSpecs('openai', 'api_key', 'missing-model');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache transient providerless failures', async () => {
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        headers: { get: () => null },
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => ({ model: 'gpt-retry', params: [reasoningEffortParam] }),
+      } as unknown as Response);
+    const service = new ProviderParamSpecService();
+
+    await expect(service.getSpecs('openai', 'api_key', 'gpt-retry')).resolves.toEqual([]);
+    await expect(service.getSpecs('openai', 'api_key', 'gpt-retry')).resolves.toEqual([
+      expect.objectContaining({ path: 'reasoning.effort' }),
+    ]);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds providerless cache entries', async () => {
+    fetchSpy.mockImplementation(async (url: string | URL) => {
+      const slug = String(url).match(/\/params\/(.+)\.json$/)?.[1] ?? 'unknown';
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+        json: async () => ({ model: decodeURIComponent(slug), params: [temperatureParam] }),
+      } as unknown as Response;
+    });
+    const service = new ProviderParamSpecService();
+
+    for (let i = 0; i < 257; i += 1) {
+      await service.getSpecs('openai', 'api_key', `gpt-cache-${i}`);
+    }
+    await service.getSpecs('openai', 'api_key', 'gpt-cache-0');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(258);
   });
 
   it('canonicalizes provider aliases when listing model identities', async () => {

--- a/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-param-spec.service.ts
@@ -10,6 +10,7 @@ import {
   isProviderParamPath,
   normalizeProviderParamProviderId,
   providerParamValueIsValid,
+  underlyingGatewayModel,
   type AuthType,
   type JsonValue,
   type ModelCapability,
@@ -24,7 +25,14 @@ import {
 import { MPS_CATALOG_SNAPSHOT } from './mps-catalog-snapshot';
 
 const MODEL_PARAMETERS_API = 'https://modelparams.dev/api/v1/models.json';
+const MODEL_PARAMETERS_BY_MODEL_API = 'https://modelparams.dev/api/v1/params';
 const FETCH_TIMEOUT_MS = 10000;
+const BY_MODEL_FETCH_TIMEOUT_MS = 1500;
+const BY_MODEL_CACHE_MAX_ENTRIES = 256;
+const BY_MODEL_MISS_CACHE_TTL_MS = 5 * 60 * 1000;
+const SUBSCRIPTION_MODEL_SUFFIX = '-subscription';
+const SHORT_CLAUDE_MODEL_RE = /^claude-(opus|sonnet|haiku)-/i;
+const DOTTED_CLAUDE_MINOR_RE = /-(\d+)\.(\d{1,2})(?=$|-\d{8}$)/g;
 const MODEL_PARAM_TYPES: readonly ModelParamType[] = [
   'boolean',
   'enum',
@@ -47,6 +55,16 @@ interface ModelParametersApiResponse {
   models?: unknown;
 }
 
+interface ModelParametersByModelApiResponse {
+  model?: unknown;
+  params?: unknown;
+}
+
+interface ProviderlessModelParamsCacheEntry {
+  params: readonly ModelParamDefinition[] | null;
+  expiresAt: number | null;
+}
+
 @Injectable()
 export class ProviderParamSpecService implements OnModuleInit {
   private readonly logger = new Logger(ProviderParamSpecService.name);
@@ -56,6 +74,7 @@ export class ProviderParamSpecService implements OnModuleInit {
   private specs: ProviderParamSpecCatalog = freezeCatalog(
     parseModelParametersCatalog(MPS_CATALOG_SNAPSHOT) ?? [],
   );
+  private readonly byModelParams = new Map<string, ProviderlessModelParamsCacheEntry>();
   private lastFetchedAt: Date | null = null;
   private etag: string | null = null;
 
@@ -86,6 +105,7 @@ export class ProviderParamSpecService implements OnModuleInit {
     }
 
     this.specs = freezeCatalog(catalog);
+    this.byModelParams.clear();
     // Adopt the ETag only now that the body parsed cleanly, so a malformed-but-new
     // 200 can't suppress a future re-fetch under the same ETag.
     if (etag) this.etag = etag;
@@ -119,6 +139,8 @@ export class ProviderParamSpecService implements OnModuleInit {
     authType: AuthType | undefined,
     model: string | undefined,
   ): Promise<readonly ProviderParamSpec[]> {
+    const providerlessSpecs = await this.getProviderlessSpecs(providerId, authType, model);
+    if (providerlessSpecs.length > 0) return providerlessSpecs;
     return getProviderParamSpecs(this.specs, providerId, authType, model);
   }
 
@@ -168,6 +190,131 @@ export class ProviderParamSpecService implements OnModuleInit {
       clearTimeout(timeout);
     }
   }
+
+  private async getProviderlessSpecs(
+    providerId: string | undefined,
+    authType: AuthType | undefined,
+    model: string | undefined,
+  ): Promise<readonly ProviderParamSpec[]> {
+    if (!providerId || !authType || !model || authType === 'local') return [];
+
+    const provider = normalizeProviderParamProviderId(providerId);
+    const slugs = providerlessModelParamSlugs(provider, authType, model);
+    for (const slug of slugs) {
+      const params = await this.fetchProviderlessModelParams(slug);
+      if (!params || params.length === 0) continue;
+      return params
+        .map((param) => ({ provider, authType, model, ...param }))
+        .sort(compareProviderParamSpecs);
+    }
+    return [];
+  }
+
+  private async fetchProviderlessModelParams(
+    slug: string,
+  ): Promise<readonly ModelParamDefinition[] | null> {
+    const cached = this.byModelParams.get(slug);
+    if (cached) {
+      if (cached.expiresAt === null || cached.expiresAt > Date.now()) return cached.params;
+      this.byModelParams.delete(slug);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), BY_MODEL_FETCH_TIMEOUT_MS);
+    try {
+      const url = `${MODEL_PARAMETERS_BY_MODEL_API}/${encodeURIComponent(slug)}.json`;
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) {
+        return null;
+      }
+
+      const contentType = res.headers.get('content-type') ?? '';
+      if (contentType && !contentType.toLowerCase().includes('application/json')) {
+        this.cacheProviderlessModelParams(slug, null, true);
+        return null;
+      }
+      const params = parseProviderlessModelParams((await res.json()) as unknown);
+      this.cacheProviderlessModelParams(slug, params, params === null);
+      return params;
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private cacheProviderlessModelParams(
+    slug: string,
+    params: readonly ModelParamDefinition[] | null,
+    expires: boolean,
+  ): void {
+    this.byModelParams.delete(slug);
+    this.byModelParams.set(slug, {
+      params,
+      expiresAt: expires ? Date.now() + BY_MODEL_MISS_CACHE_TTL_MS : null,
+    });
+
+    while (this.byModelParams.size > BY_MODEL_CACHE_MAX_ENTRIES) {
+      const oldest = this.byModelParams.keys().next().value;
+      if (oldest === undefined) break;
+      this.byModelParams.delete(oldest);
+    }
+  }
+}
+
+function providerlessModelParamSlugs(
+  providerId: string,
+  authType: AuthType,
+  model: string,
+): readonly string[] {
+  const out: string[] = [];
+  for (const base of providerlessModelBaseCandidates(providerId, model)) {
+    for (const variant of providerlessModelSlugVariants(base)) {
+      if (authType === 'subscription' && !variant.endsWith(SUBSCRIPTION_MODEL_SUFFIX)) {
+        pushUnique(out, `${variant}${SUBSCRIPTION_MODEL_SUFFIX}`);
+      }
+      pushUnique(out, variant);
+    }
+  }
+  return out;
+}
+
+function providerlessModelBaseCandidates(providerId: string, model: string): readonly string[] {
+  const out: string[] = [];
+  const add = (candidate: string | null | undefined): void => {
+    if (!candidate) return;
+    if (candidate.includes('/')) {
+      const last = candidate.slice(candidate.lastIndexOf('/') + 1);
+      pushUnique(out, last);
+      return;
+    }
+    pushUnique(out, candidate);
+  };
+
+  add(underlyingGatewayModel(model));
+  const normalizedProvider = providerId.toLowerCase();
+  if (model.toLowerCase().startsWith(`${normalizedProvider}/`)) {
+    add(model.slice(normalizedProvider.length + 1));
+  }
+  add(model);
+  return out;
+}
+
+function providerlessModelSlugVariants(model: string): readonly string[] {
+  const out: string[] = [];
+  const normalizedClaude = normalizeClaudeProviderlessSlug(model);
+  pushUnique(out, normalizedClaude);
+  pushUnique(out, model);
+  return out;
+}
+
+function normalizeClaudeProviderlessSlug(model: string): string {
+  if (!SHORT_CLAUDE_MODEL_RE.test(model)) return model;
+  return model.replace(DOTTED_CLAUDE_MINOR_RE, '-$1-$2');
+}
+
+function pushUnique(values: string[], value: string): void {
+  if (value && !values.includes(value)) values.push(value);
 }
 
 function freezeCatalog(catalog: ProviderParamSpecCatalog): ProviderParamSpecCatalog {
@@ -196,6 +343,18 @@ function parseModelParametersCatalog(raw: unknown): ProviderParamSpecCatalog | n
     if (entry) catalog.push(entry);
   }
   return catalog.length > 0 ? catalog : null;
+}
+
+function parseProviderlessModelParams(raw: unknown): readonly ModelParamDefinition[] | null {
+  if (!isRecord(raw)) return null;
+  const response = raw as ModelParametersByModelApiResponse;
+  if (!isNonEmptyString(response.model)) return null;
+  if (!Array.isArray(response.params)) return null;
+
+  const params = response.params
+    .map(parseModelParamDefinition)
+    .filter((param): param is ModelParamDefinition => param !== null);
+  return params.length > 0 ? Object.freeze(params.sort(compareProviderParamSpecs)) : null;
 }
 
 function parseProviderModelParamSpec(raw: unknown): ProviderModelParamSpec | null {

--- a/packages/frontend/tests/services/api/model-params.test.ts
+++ b/packages/frontend/tests/services/api/model-params.test.ts
@@ -44,6 +44,44 @@ describe('model-params API client', () => {
     expect(String(url)).toContain('model=anthropic%2Fclaude-opus-4-7');
   });
 
+  it('does not cache model specs in the frontend client', async () => {
+    const specs = [{ path: 'reasoning.effort', type: 'enum' }];
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(specs),
+    } as unknown as Response);
+
+    const first = await getModelParamSpecs('demo', 'copilot', 'subscription', 'copilot/gpt-5.5');
+    const second = await getModelParamSpecs('demo', 'Copilot', 'subscription', 'copilot/gpt-5.5');
+
+    expect(first).toBe(second);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache failed model spec lookups', async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text: () => Promise.resolve('temporary outage'),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+      } as unknown as Response);
+
+    await expect(
+      getModelParamSpecs('demo', 'copilot', 'subscription', 'copilot/gpt-5.5'),
+    ).rejects.toThrow('temporary outage');
+    await expect(
+      getModelParamSpecs('demo', 'copilot', 'subscription', 'copilot/gpt-5.5'),
+    ).resolves.toEqual([]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
   it('listModelParamSpecIndex GETs the spec identity index', async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,


### PR DESCRIPTION
## Summary
- resolve missing MPS catalog entries through the providerless `modelparams.dev/api/v1/params/{model}.json` endpoint
- derive lookup slugs by stripping gateway/provider prefixes, normalizing short Claude dotted minors, and trying `-subscription` before the API-key slug for subscription routes
- preserve `reasoning` and `text` params when Copilot Codex chat requests are converted to `/responses`

Closes #2103

## Validation
- `npm ci`
- `npm --workspace manifest-shared run build`
- `npm --workspace manifest-backend test -- provider-param-spec.service.spec.ts provider-client.spec.ts --runInBand`
- `npm --workspace manifest-backend run build`
- `npx prettier --check docs/model-parameters-schema.md packages/backend/src/routing/routing-core/provider-param-spec.service.ts packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts packages/backend/src/routing/proxy/chatgpt-adapter.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts .changeset/providerless-modelparams-lookup.md`
- `npx eslint packages/backend/src/routing/routing-core/provider-param-spec.service.ts packages/backend/src/routing/routing-core/__tests__/provider-param-spec.service.spec.ts packages/backend/src/routing/proxy/chatgpt-adapter.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts`
- `npx changeset status --since=upstream/main`
- `git diff --check`
- `npm run build`
- `npm run lint` (passes with existing warnings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch param resolution to the providerless by-model API so gateway models (e.g., GitHub Copilot) expose reasoning/thinking controls. Adds smarter slug derivation and bounds backend caching; the frontend no longer caches model specs.

- **New Features**
  - Fetch params from `https://modelparams.dev/api/v1/params/{model}.json` with a 1.5s timeout. Cache hits by slug (256-entry cap); cache misses for 5 minutes; don’t cache transient failures or non-JSON responses.
  - Derive slugs using the underlying gateway model, strip provider prefixes, normalize short Claude dotted minors (e.g., `4.6` → `4-6`), and try `-subscription` before the non-suffixed slug for subscription routes.
  - Keep `https://modelparams.dev/api/v1/models.json` as the offline/index fallback.
  - Frontend no longer caches model specs; each request fetches fresh data and does not cache failures.

- **Bug Fixes**
  - Preserve `reasoning` and `text` fields when converting Copilot Codex chat requests to `/responses`.

<sup>Written for commit 2d7541b46fa1a054d6b7f0847999f26bbbf3b65b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

