### PR TITLE
fix: use shared OAuth credentials in Playground

### DIFF
--- a/packages/backend/src/playground/playground.module.ts
+++ b/packages/backend/src/playground/playground.module.ts
@@ -8,6 +8,7 @@ import { CommonModule } from '../common/common.module';
 import { ModelPricesModule } from '../model-prices/model-prices.module';
 import { RoutingCoreModule } from '../routing/routing-core/routing-core.module';
 import { ProxyModule } from '../routing/proxy/proxy.module';
+import { OAuthModule } from '../routing/oauth/oauth.module';
 import { PlaygroundController } from './playground.controller';
 import { PlaygroundService } from './playground.service';
 import { PlaygroundHistoryService } from './playground-history.service';
@@ -19,6 +20,7 @@ import { PlaygroundHistoryService } from './playground-history.service';
     ModelPricesModule,
     RoutingCoreModule,
     ProxyModule,
+    OAuthModule,
   ],
   controllers: [PlaygroundController],
   providers: [PlaygroundService, PlaygroundHistoryService],

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -4,6 +4,12 @@ import { PlaygroundService } from './playground.service';
 import type { ProviderClient } from '../routing/proxy/provider-client';
 import type { ProviderKeyService } from '../routing/routing-core/provider-key.service';
 import type { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import type { OpenaiOauthService } from '../routing/oauth/openai-oauth.service';
+import type { MinimaxOauthService } from '../routing/oauth/minimax-oauth.service';
+import type { AnthropicOauthService } from '../routing/oauth/anthropic/anthropic-oauth.service';
+import type { GeminiOauthService } from '../routing/oauth/gemini-oauth.service';
+import type { KiroOauthService } from '../routing/oauth/kiro-oauth.service';
+import type { XaiOauthService } from '../routing/oauth/xai/xai-oauth.service';
 import type { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import type { IngestEventBusService } from '../common/services/ingest-event-bus.service';
 import type { PlaygroundHistoryService } from './playground-history.service';
@@ -14,6 +20,13 @@ import type { RunPlaygroundDto } from './dto/run-playground.dto';
 
 const USER_ID = 'user-1';
 const AGENT = { id: 'agent-1', tenant_id: 'tenant-1', name: 'demo' };
+const DEFAULT_PROVIDER_KEY = {
+  id: 'key-1',
+  label: 'Default',
+  priority: 0,
+  apiKey: 'sk-test',
+  region: null,
+};
 
 function makeDto(overrides: Partial<RunPlaygroundDto> = {}): RunPlaygroundDto {
   return {
@@ -128,11 +141,27 @@ function okStream(
   };
 }
 
+function errorForward(status: number, bodyText: string) {
+  return {
+    response: {
+      ok: false,
+      status,
+      headers: new Headers(),
+      text: jest.fn().mockResolvedValue(bodyText),
+      body: null,
+    },
+    isGoogle: false,
+    isAnthropic: false,
+    isChatGpt: false,
+  };
+}
+
 interface Mocks {
   resolveAgent: { resolve: jest.Mock };
   providerKeyService: {
     hasActiveProvider: jest.Mock;
     getAuthType: jest.Mock;
+    getProviderKeys: jest.Mock;
     getProviderApiKey: jest.Mock;
   };
   providerClient: {
@@ -141,6 +170,12 @@ interface Mocks {
     createAnthropicStreamTransformer: jest.Mock;
     convertChatGptStreamChunk: jest.Mock;
   };
+  openaiOauth: { unwrapToken: jest.Mock };
+  minimaxOauth: { unwrapToken: jest.Mock };
+  anthropicOauth: { unwrapToken: jest.Mock };
+  geminiOauth: { unwrapToken: jest.Mock };
+  kiroOauth: { unwrapToken: jest.Mock };
+  xaiOauth: { unwrapToken: jest.Mock };
   pricingCache: { getByModel: jest.Mock };
   eventBus: { emit: jest.Mock };
   history: { saveColumn: jest.Mock };
@@ -156,7 +191,8 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     providerKeyService: {
       hasActiveProvider: jest.fn().mockResolvedValue(true),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
-      getProviderApiKey: jest.fn().mockResolvedValue('sk-test'),
+      getProviderKeys: jest.fn().mockResolvedValue([DEFAULT_PROVIDER_KEY]),
+      getProviderApiKey: jest.fn().mockResolvedValue(DEFAULT_PROVIDER_KEY.apiKey),
     },
     providerClient: {
       forward: jest.fn(),
@@ -164,6 +200,12 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
       createAnthropicStreamTransformer: jest.fn(),
       convertChatGptStreamChunk: jest.fn(),
     },
+    openaiOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    minimaxOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    anthropicOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    geminiOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    kiroOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    xaiOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
     pricingCache: {
       getByModel: jest.fn().mockReturnValue({
         input_price_per_token: 0.000001,
@@ -180,6 +222,12 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     full.resolveAgent as unknown as ResolveAgentService,
     full.providerKeyService as unknown as ProviderKeyService,
     full.providerClient as unknown as ProviderClient,
+    full.openaiOauth as unknown as OpenaiOauthService,
+    full.minimaxOauth as unknown as MinimaxOauthService,
+    full.anthropicOauth as unknown as AnthropicOauthService,
+    full.geminiOauth as unknown as GeminiOauthService,
+    full.kiroOauth as unknown as KiroOauthService,
+    full.xaiOauth as unknown as XaiOauthService,
     full.pricingCache as unknown as ModelPricingCacheService,
     full.eventBus as unknown as IngestEventBusService,
     full.history as unknown as PlaygroundHistoryService,
@@ -291,7 +339,7 @@ describe('PlaygroundService.runStream', () => {
     const res = mockRes();
     res.headersSent = true;
     // Provider connected but key missing → sendPreStreamError path.
-    mocks.providerKeyService.getProviderApiKey.mockResolvedValue(null);
+    mocks.providerKeyService.getProviderKeys.mockResolvedValue([]);
 
     await service.runStream(USER_ID, makeDto(), asRes(res));
 
@@ -344,6 +392,7 @@ describe('PlaygroundService.runStream', () => {
       providerKeyService: {
         hasActiveProvider: jest.fn().mockResolvedValue(false),
         getAuthType: jest.fn(),
+        getProviderKeys: jest.fn(),
         getProviderApiKey: jest.fn(),
       },
     });
@@ -362,7 +411,8 @@ describe('PlaygroundService.runStream', () => {
       providerKeyService: {
         hasActiveProvider: jest.fn().mockResolvedValue(true),
         getAuthType: jest.fn().mockResolvedValue('api_key'),
-        getProviderApiKey: jest.fn().mockResolvedValue(null),
+        getProviderKeys: jest.fn().mockResolvedValue([]),
+        getProviderApiKey: jest.fn(),
       },
     });
     const res = mockRes();
@@ -391,6 +441,121 @@ describe('PlaygroundService.runStream', () => {
     const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
     expect((done.metrics as Record<string, unknown>).cost).toBe(0);
     expect(mocks.messageRepo.insert.mock.calls[0][0].auth_type).toBe('subscription');
+  });
+
+  it('unwraps OpenAI OAuth blobs before forwarding subscription Playground requests', async () => {
+    const oauthBlob = JSON.stringify({
+      t: 'stored-access-token',
+      r: 'refresh-token',
+      e: Date.now() + 10 * 60 * 1000,
+    });
+    const { service, mocks } = buildService();
+    mocks.providerKeyService.getProviderKeys.mockResolvedValue([
+      { ...DEFAULT_PROVIDER_KEY, label: 'Work', apiKey: oauthBlob },
+    ]);
+    mocks.providerKeyService.getProviderApiKey.mockResolvedValue(oauthBlob);
+    mocks.openaiOauth.unwrapToken.mockResolvedValue('fresh-access-token');
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":4,"completion_tokens":1}}\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ model: 'gpt-5.5', authType: 'subscription' }),
+      asRes(res),
+    );
+
+    expect(mocks.providerKeyService.getProviderKeys).toHaveBeenCalledWith(
+      AGENT.id,
+      'openai',
+      'subscription',
+    );
+    expect(mocks.openaiOauth.unwrapToken).toHaveBeenCalledWith(
+      oauthBlob,
+      AGENT.id,
+      USER_ID,
+      'Work',
+    );
+    expect(mocks.providerClient.forward).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'openai',
+        model: 'gpt-5.5',
+        authType: 'subscription',
+        apiKey: 'fresh-access-token',
+      }),
+    );
+    expect(res._status).toBeNull();
+  });
+
+  it('forces an OpenAI OAuth refresh and retries when Playground receives a 401', async () => {
+    const oauthBlob = JSON.stringify({
+      t: 'stored-access-token',
+      r: 'refresh-token',
+      e: Date.now() - 10 * 60 * 1000,
+    });
+    const refreshedBlob = JSON.stringify({
+      t: 'fresh-access-token',
+      r: 'rotated-refresh-token',
+      e: Date.now() + 10 * 60 * 1000,
+    });
+    const { service, mocks } = buildService();
+    mocks.providerKeyService.getProviderKeys.mockResolvedValue([
+      { ...DEFAULT_PROVIDER_KEY, label: 'Work', apiKey: oauthBlob },
+    ]);
+    mocks.providerKeyService.getProviderApiKey.mockResolvedValue(refreshedBlob);
+    mocks.openaiOauth.unwrapToken
+      .mockResolvedValueOnce('fresh-access-token')
+      .mockResolvedValueOnce('refreshed-access-token');
+    mocks.providerClient.forward
+      .mockResolvedValueOnce(errorForward(401, 'expired token'))
+      .mockResolvedValueOnce(
+        okStream([
+          'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n',
+          'data: {"usage":{"prompt_tokens":4,"completion_tokens":1}}\n\n',
+        ]),
+      );
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ model: 'gpt-5.5', authType: 'subscription' }),
+      asRes(res),
+    );
+
+    expect(mocks.providerClient.forward).toHaveBeenCalledTimes(2);
+    expect(mocks.providerClient.forward.mock.calls[0][0]).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-5.5',
+      authType: 'subscription',
+      apiKey: 'fresh-access-token',
+    });
+    expect(mocks.providerClient.forward.mock.calls[1][0]).toMatchObject({
+      provider: 'openai',
+      model: 'gpt-5.5',
+      authType: 'subscription',
+      apiKey: 'refreshed-access-token',
+    });
+    const forcedRefreshBlob = JSON.parse(mocks.openaiOauth.unwrapToken.mock.calls[1][0]) as Record<
+      string,
+      unknown
+    >;
+    expect(forcedRefreshBlob).toMatchObject({
+      t: 'fresh-access-token',
+      r: 'rotated-refresh-token',
+      e: 0,
+    });
+    expect(mocks.openaiOauth.unwrapToken).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      AGENT.id,
+      USER_ID,
+      'Work',
+    );
+    expect(res._status).toBeNull();
   });
 
   it('maps an HttpException thrown during preflight to its status', async () => {

--- a/packages/backend/src/playground/playground.service.truncation.spec.ts
+++ b/packages/backend/src/playground/playground.service.truncation.spec.ts
@@ -6,6 +6,12 @@ import type { ResolveAgentService } from '../routing/routing-core/resolve-agent.
 import type { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import type { IngestEventBusService } from '../common/services/ingest-event-bus.service';
 import type { PlaygroundHistoryService } from './playground-history.service';
+import type { OpenaiOauthService } from '../routing/oauth/openai-oauth.service';
+import type { MinimaxOauthService } from '../routing/oauth/minimax-oauth.service';
+import type { AnthropicOauthService } from '../routing/oauth/anthropic/anthropic-oauth.service';
+import type { GeminiOauthService } from '../routing/oauth/gemini-oauth.service';
+import type { KiroOauthService } from '../routing/oauth/kiro-oauth.service';
+import type { XaiOauthService } from '../routing/oauth/xai/xai-oauth.service';
 import type { Repository } from 'typeorm';
 import type { AgentMessage } from '../entities/agent-message.entity';
 import type { CustomProvider } from '../entities/custom-provider.entity';
@@ -82,6 +88,7 @@ interface Mocks {
   providerKeyService: {
     hasActiveProvider: jest.Mock;
     getAuthType: jest.Mock;
+    getProviderKeys: jest.Mock;
     getProviderApiKey: jest.Mock;
   };
   providerClient: {
@@ -90,6 +97,12 @@ interface Mocks {
     createAnthropicStreamTransformer: jest.Mock;
     convertChatGptStreamChunk: jest.Mock;
   };
+  openaiOauth: { unwrapToken: jest.Mock };
+  minimaxOauth: { unwrapToken: jest.Mock };
+  anthropicOauth: { unwrapToken: jest.Mock };
+  geminiOauth: { unwrapToken: jest.Mock };
+  kiroOauth: { unwrapToken: jest.Mock };
+  xaiOauth: { unwrapToken: jest.Mock };
   pricingCache: { getByModel: jest.Mock };
   eventBus: { emit: jest.Mock };
   history: { saveColumn: jest.Mock };
@@ -105,6 +118,7 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     providerKeyService: {
       hasActiveProvider: jest.fn().mockResolvedValue(true),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
+      getProviderKeys: jest.fn().mockResolvedValue([{ apiKey: 'sk-test', label: 'Default' }]),
       getProviderApiKey: jest.fn().mockResolvedValue('sk-test'),
     },
     providerClient: {
@@ -113,6 +127,12 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
       createAnthropicStreamTransformer: jest.fn(),
       convertChatGptStreamChunk: jest.fn(),
     },
+    openaiOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    minimaxOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    anthropicOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    geminiOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    kiroOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
+    xaiOauth: { unwrapToken: jest.fn().mockResolvedValue(null) },
     pricingCache: {
       getByModel: jest.fn().mockReturnValue({
         input_price_per_token: 0.000001,
@@ -129,6 +149,12 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     full.resolveAgent as unknown as ResolveAgentService,
     full.providerKeyService as unknown as ProviderKeyService,
     full.providerClient as unknown as ProviderClient,
+    full.openaiOauth as unknown as OpenaiOauthService,
+    full.minimaxOauth as unknown as MinimaxOauthService,
+    full.anthropicOauth as unknown as AnthropicOauthService,
+    full.geminiOauth as unknown as GeminiOauthService,
+    full.kiroOauth as unknown as KiroOauthService,
+    full.xaiOauth as unknown as XaiOauthService,
     full.pricingCache as unknown as ModelPricingCacheService,
     full.eventBus as unknown as IngestEventBusService,
     full.history as unknown as PlaygroundHistoryService,

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -9,8 +9,19 @@ import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderClient } from '../routing/proxy/provider-client';
 import { buildCustomEndpoint } from '../routing/proxy/provider-endpoints';
 import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
+import {
+  isRefreshableOAuthCredential,
+  refreshRejectedOAuthCredential,
+  resolveApiKey,
+} from '../routing/proxy/oauth-credentials';
 import { ProviderKeyService } from '../routing/routing-core/provider-key.service';
 import { ResolveAgentService } from '../routing/routing-core/resolve-agent.service';
+import { OpenaiOauthService } from '../routing/oauth/openai-oauth.service';
+import { MinimaxOauthService } from '../routing/oauth/minimax-oauth.service';
+import { AnthropicOauthService } from '../routing/oauth/anthropic/anthropic-oauth.service';
+import { GeminiOauthService } from '../routing/oauth/gemini-oauth.service';
+import { KiroOauthService } from '../routing/oauth/kiro-oauth.service';
+import { XaiOauthService } from '../routing/oauth/xai/xai-oauth.service';
 import { ModelPricingCacheService } from '../model-prices/model-pricing-cache.service';
 import { computeTokenCost } from '../common/utils/cost-calculator';
 import { IngestEventBusService } from '../common/services/ingest-event-bus.service';
@@ -30,6 +41,12 @@ export class PlaygroundService {
     private readonly resolveAgent: ResolveAgentService,
     private readonly providerKeyService: ProviderKeyService,
     private readonly providerClient: ProviderClient,
+    private readonly openaiOauth: OpenaiOauthService,
+    private readonly minimaxOauth: MinimaxOauthService,
+    private readonly anthropicOauth: AnthropicOauthService,
+    private readonly geminiOauth: GeminiOauthService,
+    private readonly kiroOauth: KiroOauthService,
+    private readonly xaiOauth: XaiOauthService,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly eventBus: IngestEventBusService,
     private readonly history: PlaygroundHistoryService,
@@ -49,6 +66,9 @@ export class PlaygroundService {
     let agent: { id: string; tenant_id: string; name: string };
     let authType: AuthType;
     let apiKey: string;
+    let rawApiKey: string;
+    let providerKeyLabel: string | undefined;
+    let providerResource: string | undefined;
     try {
       agent = await this.resolveAgent.resolve(userId, dto.agentName);
       const hasProvider = await this.providerKeyService.hasActiveProvider(agent.id, dto.provider);
@@ -61,15 +81,52 @@ export class PlaygroundService {
       }
       authType =
         dto.authType ?? (await this.providerKeyService.getAuthType(agent.id, dto.provider));
-      const key = await this.providerKeyService.getProviderApiKey(agent.id, dto.provider, authType);
-      if (key === null) {
+      const keys = await this.providerKeyService.getProviderKeys(agent.id, dto.provider, authType);
+      const key = keys[0];
+      if (!key || key.apiKey === null) {
         return this.sendPreStreamError(
           res,
           404,
           `No usable API key found for provider "${dto.provider}"`,
         );
       }
-      apiKey = key;
+      rawApiKey = key.apiKey;
+      providerKeyLabel = key.label;
+      const resolved = await resolveApiKey(
+        dto.provider,
+        rawApiKey,
+        authType,
+        agent.id,
+        userId,
+        this.openaiOauth,
+        this.minimaxOauth,
+        this.anthropicOauth,
+        this.geminiOauth,
+        this.kiroOauth,
+        this.xaiOauth,
+        providerKeyLabel,
+      );
+      if (resolved.apiKey === null) {
+        return this.sendPreStreamError(
+          res,
+          404,
+          `No usable API key found for provider "${dto.provider}"`,
+        );
+      }
+      apiKey = resolved.apiKey;
+      if (authType === 'subscription' && isRefreshableOAuthCredential(rawApiKey)) {
+        rawApiKey =
+          (await this.providerKeyService.getProviderApiKey(
+            agent.id,
+            dto.provider,
+            authType,
+            providerKeyLabel,
+          )) ?? rawApiKey;
+      }
+      providerResource =
+        authType === 'subscription' && dto.provider.toLowerCase() === 'gemini'
+          ? resolved.resourceUrl
+          : undefined;
     } catch (err) {
       const status = err instanceof HttpException ? err.getStatus() : 500;
       const message = err instanceof Error ? err.message : String(err);
@@ -99,7 +156,7 @@ export class PlaygroundService {
     const startedAt = Date.now();
     let forward;
     try {
-      forward = await this.providerClient.forward({
+      const forwardOptions = {
         provider: dto.provider,
         apiKey,
         model: forwardModel,
@@ -109,7 +166,41 @@ export class PlaygroundService {
         extraHeaders,
         customEndpoint,
         signal: abort.signal,
-      });
+        providerResource,
+      };
+      forward = await this.providerClient.forward(forwardOptions);
+      if (forward.response.status === 401 && authType === 'subscription') {
+        const refreshed = await refreshRejectedOAuthCredential(
+          dto.provider,
+          rawApiKey,
+          agent.id,
+          userId,
+          providerKeyLabel,
+          {
+            openaiOauth: this.openaiOauth,
+            minimaxOauth: this.minimaxOauth,
+            anthropicOauth: this.anthropicOauth,
+            geminiOauth: this.geminiOauth,
+            kiroOauth: this.kiroOauth,
+            xaiOauth: this.xaiOauth,
+          },
+        );
+        if (refreshed?.apiKey && refreshed.apiKey !== apiKey) {
+          this.logger.log(
+            `OAuth token rejected upstream in Playground; refreshed provider=${dto.provider} agent=${agent.id}`,
+          );
+          apiKey = refreshed.apiKey;
+          providerResource =
+            authType === 'subscription' && dto.provider.toLowerCase() === 'gemini'
+              ? (refreshed.resourceUrl ?? providerResource)
+              : providerResource;
+          forward = await this.providerClient.forward({
+            ...forwardOptions,
+            apiKey,
+            providerResource,
+          });
+        }
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return this.sendPreStreamError(res, 502, `Provider request failed: ${message}`);


### PR DESCRIPTION
## Summary

- use the shared routing OAuth credential helpers from `oauth-credentials.ts` in Playground
- unwrap subscription OAuth credential blobs before Playground forwards provider calls
- re-read the latest persisted OAuth blob after preflight refresh so a later forced 401 retry does not use stale raw credentials
- add Playground parity with proxy routing by forcing one OAuth refresh/retry after an upstream 401
- wire OAuth services into the Playground module and cover the OAuth forwarding/retry paths

## Root Cause

Playground was reading the stored subscription credential directly and forwarding the persisted OAuth JSON blob as the bearer token. Normal proxy routing now has shared OAuth credential handling; Playground should use that same component instead of owning fallback-specific helper exports.

## Validation

- npm --workspace manifest-shared run build
- npm --workspace manifest-backend test -- playground.service.spec.ts --runInBand
- npm --workspace manifest-backend run build
- npx prettier --check packages/backend/src/playground/playground.service.ts packages/backend/src/playground/playground.module.ts packages/backend/src/playground/playground.service.spec.ts
- npx eslint packages/backend/src/playground/playground.service.ts packages/backend/src/playground/playground.module.ts packages/backend/src/playground/playground.service.spec.ts
- git diff --check
- npx changeset status --since=upstream/main

Related to mnfst/modelparams.dev#40.