### PR TITLE
fix: refresh OAuth subscription tokens before fallback

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -1,9 +1,6 @@
 import { Repository } from 'typeorm';
-import {
-  ProxyFallbackService,
-  normalizeProviderModel,
-  resolveApiKey,
-} from '../proxy-fallback.service';
+import { ProxyFallbackService, normalizeProviderModel } from '../proxy-fallback.service';
+import { resolveApiKey } from '../oauth-credentials';
 import { ProviderKeyService } from '../../routing-core/provider-key.service';
 import { CustomProvider } from '../../../entities/custom-provider.entity';
 import { OpenaiOauthService } from '../../oauth/openai-oauth.service';
@@ -1113,6 +1110,81 @@ describe('ProxyFallbackService', () => {
       expect(providerClient.forward).toHaveBeenCalledWith(
         expect.objectContaining({ model: 'gemini-2.5-flash' }),
       );
+    });
+
+    it('uses the latest stored OAuth blob for fallback retries after preflight refresh', async () => {
+      const staleBlob = JSON.stringify({
+        t: 'stale-access',
+        r: 'stale-refresh',
+        e: Date.now() - 10 * 60 * 1000,
+      });
+      const refreshedBlob = JSON.stringify({
+        t: 'fresh-access',
+        r: 'rotated-refresh',
+        e: Date.now() + 10 * 60 * 1000,
+      });
+      providerKeyService.getProviderApiKey
+        .mockResolvedValueOnce(staleBlob)
+        .mockResolvedValueOnce(refreshedBlob);
+      openaiOauth.unwrapToken
+        .mockResolvedValueOnce('fresh-access')
+        .mockResolvedValueOnce('recovered-access');
+      providerClient.forward
+        .mockResolvedValueOnce({
+          response: new Response('unauthorized', { status: 401 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: true,
+        })
+        .mockResolvedValueOnce({
+          response: new Response('{}', { status: 200 }),
+          isGoogle: false,
+          isAnthropic: false,
+          isChatGpt: true,
+        });
+
+      const result = await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['gpt-5.3-codex'],
+        body,
+        false,
+        'sess-1',
+        'claude-sonnet-4',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [
+          {
+            provider: 'openai',
+            authType: 'subscription',
+            model: 'gpt-5.3-codex',
+            keyLabel: 'Work',
+          },
+        ],
+      );
+
+      expect(result.success).not.toBeNull();
+      expect(providerKeyService.getProviderApiKey).toHaveBeenCalledTimes(2);
+      expect(providerClient.forward).toHaveBeenCalledTimes(2);
+      expect(providerClient.forward.mock.calls[0][0].apiKey).toBe('fresh-access');
+      expect(providerClient.forward.mock.calls[1][0].apiKey).toBe('recovered-access');
+
+      const forcedRefreshBlob = JSON.parse(openaiOauth.unwrapToken.mock.calls[1][0] as string) as {
+        e: number;
+        r: string;
+        t: string;
+      };
+      expect(forcedRefreshBlob).toMatchObject({
+        e: 0,
+        r: 'rotated-refresh',
+        t: 'fresh-access',
+      });
+      expect(openaiOauth.unwrapToken.mock.calls[1][3]).toBe('Work');
     });
 
     it('does not exclude auth types for different provider', async () => {

--- a/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts
@@ -349,6 +349,50 @@ describe('ProxyService — orchestration', () => {
       );
     });
 
+    it('passes the latest stored OAuth blob after preflight refresh rotates tokens', async () => {
+      const staleBlob = JSON.stringify({
+        t: 'stale-access',
+        r: 'stale-refresh',
+        e: Date.now() - 10 * 60 * 1000,
+      });
+      const refreshedBlob = JSON.stringify({
+        t: 'fresh-access',
+        r: 'rotated-refresh',
+        e: Date.now() + 10 * 60 * 1000,
+      });
+      resolveService.resolve.mockResolvedValue({
+        tier: 'standard',
+        route: { ...route('openai', 'subscription', 'gpt-5.3-codex'), keyLabel: 'Work' },
+        fallback_routes: null,
+        confidence: 0.9,
+        score: 5,
+        reason: 'scored',
+      });
+      providerKeyService.getProviderApiKey
+        .mockResolvedValueOnce(staleBlob)
+        .mockResolvedValueOnce(refreshedBlob);
+      openaiOauth.unwrapToken.mockResolvedValue('fresh-access');
+      fallbackService.tryForwardToProvider.mockResolvedValue({
+        response: okResponse(200),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      });
+
+      await svc.proxyRequest(baseOpts());
+
+      expect(providerKeyService.getProviderApiKey).toHaveBeenCalledTimes(2);
+      expect(fallbackService.tryForwardToProvider).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: 'openai',
+          authType: 'subscription',
+          apiKey: 'fresh-access',
+          rawApiKey: refreshedBlob,
+          providerKeyLabel: 'Work',
+        }),
+      );
+    });
+
     it('records the specificity category when the route originates from specificity', async () => {
       resolveService.resolve.mockResolvedValue({
         tier: 'standard',

--- a/packages/backend/src/routing/proxy/oauth-credentials.ts
+++ b/packages/backend/src/routing/proxy/oauth-credentials.ts
@@ -1,0 +1,164 @@
+import { OpenaiOauthService } from '../oauth/openai-oauth.service';
+import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
+import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.service';
+import { GeminiOauthService } from '../oauth/gemini-oauth.service';
+import { parseOAuthTokenBlob } from '../oauth/core';
+import { KiroOauthService } from '../oauth/kiro-oauth.service';
+import { XaiOauthService } from '../oauth/xai/xai-oauth.service';
+
+export interface OAuthServiceSet {
+  openaiOauth: OpenaiOauthService;
+  minimaxOauth: MinimaxOauthService;
+  anthropicOauth: AnthropicOauthService;
+  geminiOauth: GeminiOauthService;
+  kiroOauth: KiroOauthService;
+  xaiOauth: XaiOauthService;
+}
+
+export interface ResolvedCredentials {
+  apiKey: string | null;
+  resourceUrl?: string;
+}
+
+function expireRefreshableOAuthBlob(rawValue: string): string | null {
+  try {
+    const parsed = JSON.parse(rawValue) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    const blob = parsed as Record<string, unknown>;
+    if (typeof blob.t !== 'string' || typeof blob.r !== 'string' || typeof blob.e !== 'number') {
+      return null;
+    }
+    if (!blob.r) return null;
+    return JSON.stringify({ ...blob, e: 0 });
+  } catch {
+    return null;
+  }
+}
+
+export function isRefreshableOAuthCredential(rawValue: string): boolean {
+  return expireRefreshableOAuthBlob(rawValue) !== null;
+}
+
+export async function refreshRejectedOAuthCredential(
+  provider: string,
+  rawValue: string,
+  agentId: string,
+  userId: string,
+  keyLabel: string | undefined,
+  services: OAuthServiceSet,
+): Promise<ResolvedCredentials | null> {
+  const expiredRawValue = expireRefreshableOAuthBlob(rawValue);
+  if (!expiredRawValue) return null;
+
+  const lower = provider.toLowerCase();
+  if (lower === 'openai') {
+    const unwrapped = await services.openaiOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
+    return unwrapped ? { apiKey: unwrapped } : null;
+  }
+  if (lower === 'minimax') {
+    const unwrapped = await services.minimaxOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
+    return unwrapped ? { apiKey: unwrapped.t, resourceUrl: unwrapped.u } : null;
+  }
+  if (lower === 'anthropic') {
+    const unwrapped = await services.anthropicOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
+    return unwrapped ? { apiKey: unwrapped } : null;
+  }
+  if (lower === 'gemini') {
+    const unwrapped = await services.geminiOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
+    return unwrapped ? { apiKey: unwrapped, resourceUrl: parseOAuthTokenBlob(rawValue)?.u } : null;
+  }
+  if (lower === 'kiro') {
+    const unwrapped = await services.kiroOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
+    return unwrapped ? { apiKey: unwrapped } : null;
+  }
+  if (lower === 'xai') {
+    const unwrapped = await services.xaiOauth.unwrapToken(
+      expiredRawValue,
+      agentId,
+      userId,
+      keyLabel,
+    );
+    return unwrapped ? { apiKey: unwrapped } : null;
+  }
+  return null;
+}
+
+export async function resolveApiKey(
+  provider: string,
+  apiKey: string,
+  authType: string | undefined,
+  agentId: string,
+  userId: string,
+  openaiOauth: OpenaiOauthService,
+  minimaxOauth: MinimaxOauthService,
+  anthropicOauth: AnthropicOauthService,
+  geminiOauth: GeminiOauthService,
+  kiroOauth: KiroOauthService,
+  xaiOauth: XaiOauthService,
+  keyLabel?: string,
+): Promise<ResolvedCredentials> {
+  if (authType === 'subscription') {
+    const lower = provider.toLowerCase();
+    if (lower === 'openai') {
+      const unwrapped = await openaiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
+      if (unwrapped) return { apiKey: unwrapped };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
+    }
+    if (lower === 'minimax') {
+      const unwrapped = await minimaxOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
+      if (unwrapped) return { apiKey: unwrapped.t, resourceUrl: unwrapped.u };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
+    }
+    if (lower === 'anthropic') {
+      const unwrapped = await anthropicOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
+      if (unwrapped) return { apiKey: unwrapped };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
+    }
+    if (lower === 'gemini') {
+      const unwrapped = await geminiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
+      if (unwrapped) {
+        // The CodeAssist project id was stored in `blob.u` by enrichBlob.
+        // Read it from the input blob (refreshes preserve the field).
+        const projectId = parseOAuthTokenBlob(apiKey)?.u;
+        return { apiKey: unwrapped, resourceUrl: projectId };
+      }
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
+    }
+    if (lower === 'kiro') {
+      const unwrapped = await kiroOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
+      if (unwrapped) return { apiKey: unwrapped };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
+    }
+    if (lower === 'xai') {
+      const unwrapped = await xaiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
+      if (unwrapped) return { apiKey: unwrapped };
+      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
+    }
+  }
+  return { apiKey };
+}

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -51,7 +51,6 @@ import { OpenaiOauthService } from '../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
 import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.service';
 import { GeminiOauthService } from '../oauth/gemini-oauth.service';
-import { parseOAuthTokenBlob } from '../oauth/core';
 import { KiroOauthService } from '../oauth/kiro-oauth.service';
 import { XaiOauthService } from '../oauth/xai/xai-oauth.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
@@ -79,6 +78,11 @@ import {
 } from './proxy-transport';
 import type { SignatureLookup, ThinkingBlockLookup, ReasoningContentLookup } from './proxy-types';
 import type { ProxyApiMode } from './proxy-types';
+import {
+  isRefreshableOAuthCredential,
+  refreshRejectedOAuthCredential,
+  resolveApiKey,
+} from './oauth-credentials';
 
 export interface FailedFallback {
   model: string;
@@ -261,6 +265,16 @@ export class ProxyFallbackService {
         );
         continue;
       }
+      let rawApiKey = apiKey;
+      if (authType === 'subscription' && isRefreshableOAuthCredential(apiKey)) {
+        rawApiKey =
+          (await this.providerKeyService.getProviderApiKey(
+            agentId,
+            provider,
+            authType,
+            providerKeyLabel,
+          )) ?? apiKey;
+      }
       const providerRegion = await this.providerKeyService.getProviderRegion(
         agentId,
         provider,
@@ -283,7 +297,7 @@ export class ProxyFallbackService {
         signal,
         agentId,
         userId,
-        rawApiKey: apiKey,
+        rawApiKey,
         providerKeyLabel,
         authType,
         apiMode,
@@ -545,163 +559,6 @@ export class ProxyFallbackService {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Shared helpers (used by both ProxyService and ProxyFallbackService)
-// ---------------------------------------------------------------------------
-
 export function normalizeProviderModel(provider: string, model: string): string {
   return provider.toLowerCase() === 'anthropic' ? normalizeAnthropicShortModelId(model) : model;
-}
-
-interface OAuthServiceSet {
-  openaiOauth: OpenaiOauthService;
-  minimaxOauth: MinimaxOauthService;
-  anthropicOauth: AnthropicOauthService;
-  geminiOauth: GeminiOauthService;
-  kiroOauth: KiroOauthService;
-  xaiOauth: XaiOauthService;
-}
-
-interface ResolvedCredentials {
-  apiKey: string | null;
-  resourceUrl?: string;
-}
-
-function expireRefreshableOAuthBlob(rawValue: string): string | null {
-  try {
-    const parsed = JSON.parse(rawValue) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
-    const blob = parsed as Record<string, unknown>;
-    if (typeof blob.t !== 'string' || typeof blob.r !== 'string' || typeof blob.e !== 'number') {
-      return null;
-    }
-    if (!blob.r) return null;
-    return JSON.stringify({ ...blob, e: 0 });
-  } catch {
-    return null;
-  }
-}
-
-async function refreshRejectedOAuthCredential(
-  provider: string,
-  rawValue: string,
-  agentId: string,
-  userId: string,
-  keyLabel: string | undefined,
-  services: OAuthServiceSet,
-): Promise<ResolvedCredentials | null> {
-  const expiredRawValue = expireRefreshableOAuthBlob(rawValue);
-  if (!expiredRawValue) return null;
-
-  const lower = provider.toLowerCase();
-  if (lower === 'openai') {
-    const unwrapped = await services.openaiOauth.unwrapToken(
-      expiredRawValue,
-      agentId,
-      userId,
-      keyLabel,
-    );
-    return unwrapped ? { apiKey: unwrapped } : null;
-  }
-  if (lower === 'minimax') {
-    const unwrapped = await services.minimaxOauth.unwrapToken(
-      expiredRawValue,
-      agentId,
-      userId,
-      keyLabel,
-    );
-    return unwrapped ? { apiKey: unwrapped.t, resourceUrl: unwrapped.u } : null;
-  }
-  if (lower === 'anthropic') {
-    const unwrapped = await services.anthropicOauth.unwrapToken(
-      expiredRawValue,
-      agentId,
-      userId,
-      keyLabel,
-    );
-    return unwrapped ? { apiKey: unwrapped } : null;
-  }
-  if (lower === 'gemini') {
-    const unwrapped = await services.geminiOauth.unwrapToken(
-      expiredRawValue,
-      agentId,
-      userId,
-      keyLabel,
-    );
-    return unwrapped ? { apiKey: unwrapped, resourceUrl: parseOAuthTokenBlob(rawValue)?.u } : null;
-  }
-  if (lower === 'kiro') {
-    const unwrapped = await services.kiroOauth.unwrapToken(
-      expiredRawValue,
-      agentId,
-      userId,
-      keyLabel,
-    );
-    return unwrapped ? { apiKey: unwrapped } : null;
-  }
-  if (lower === 'xai') {
-    const unwrapped = await services.xaiOauth.unwrapToken(
-      expiredRawValue,
-      agentId,
-      userId,
-      keyLabel,
-    );
-    return unwrapped ? { apiKey: unwrapped } : null;
-  }
-  return null;
-}
-
-export async function resolveApiKey(
-  provider: string,
-  apiKey: string,
-  authType: string | undefined,
-  agentId: string,
-  userId: string,
-  openaiOauth: OpenaiOauthService,
-  minimaxOauth: MinimaxOauthService,
-  anthropicOauth: AnthropicOauthService,
-  geminiOauth: GeminiOauthService,
-  kiroOauth: KiroOauthService,
-  xaiOauth: XaiOauthService,
-  keyLabel?: string,
-): Promise<ResolvedCredentials> {
-  if (authType === 'subscription') {
-    const lower = provider.toLowerCase();
-    if (lower === 'openai') {
-      const unwrapped = await openaiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
-      if (unwrapped) return { apiKey: unwrapped };
-      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
-    }
-    if (lower === 'minimax') {
-      const unwrapped = await minimaxOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
-      if (unwrapped) return { apiKey: unwrapped.t, resourceUrl: unwrapped.u };
-      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
-    }
-    if (lower === 'anthropic') {
-      const unwrapped = await anthropicOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
-      if (unwrapped) return { apiKey: unwrapped };
-      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
-    }
-    if (lower === 'gemini') {
-      const unwrapped = await geminiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
-      if (unwrapped) {
-        // The CodeAssist project id was stored in `blob.u` by enrichBlob.
-        // Read it from the input blob (refreshes preserve the field).
-        const projectId = parseOAuthTokenBlob(apiKey)?.u;
-        return { apiKey: unwrapped, resourceUrl: projectId };
-      }
-      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
-    }
-    if (lower === 'kiro') {
-      const unwrapped = await kiroOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
-      if (unwrapped) return { apiKey: unwrapped };
-      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
-    }
-    if (lower === 'xai') {
-      const unwrapped = await xaiOauth.unwrapToken(apiKey, agentId, userId, keyLabel);
-      if (unwrapped) return { apiKey: unwrapped };
-      if (parseOAuthTokenBlob(apiKey)) return { apiKey: null };
-    }
-  }
-  return { apiKey };
 }

--- a/packages/backend/src/routing/proxy/proxy.service.ts
+++ b/packages/backend/src/routing/proxy/proxy.service.ts
@@ -34,8 +34,8 @@ import {
   ProxyFallbackService,
   FailedFallback,
   normalizeProviderModel,
-  resolveApiKey,
 } from './proxy-fallback.service';
+import { isRefreshableOAuthCredential, resolveApiKey } from './oauth-credentials';
 import {
   ProxyApiMode,
   ProxyRequestOptions,
@@ -456,6 +456,16 @@ export class ProxyService {
     );
     const unwrappedApiKey = unwrapped.apiKey;
     if (unwrappedApiKey === null) return null;
+    let rawApiKey = apiKey;
+    if (resolved.auth_type === 'subscription' && isRefreshableOAuthCredential(apiKey)) {
+      rawApiKey =
+        (await this.providerKeyService.getProviderApiKey(
+          agentId,
+          resolved.provider,
+          resolved.auth_type,
+          resolved.provider_key_label,
+        )) ?? apiKey;
+    }
     const providerRegion = await this.providerKeyService.getProviderRegion(
       agentId,
       resolved.provider,
@@ -464,7 +474,7 @@ export class ProxyService {
     );
     return {
       apiKey: unwrappedApiKey,
-      rawApiKey: apiKey,
+      rawApiKey,
       resourceUrl: unwrapped.resourceUrl,
       providerRegion,
     };


### PR DESCRIPTION
## Summary

- extract shared OAuth credential helpers into `oauth-credentials.ts`
- keep primary and fallback routing on the shared preflight unwrap + forced 401 refresh path
- after preflight unwrap refreshes and persists a rotated token blob, re-read the stored blob before passing `rawApiKey` into retry handling
- add regressions for primary routing and fallback routing so an OpenAI subscription token refresh happens before fallback instead of falling through with stale raw credentials

## Root Cause

Normal routing already attempts a forced OAuth refresh inside `tryForwardToProvider` before `ProxyService` considers fallback. The broken case is when preflight unwrap refreshes and persists a rotated OAuth blob, but the later forced 401 retry still receives the original raw blob captured before unwrap. That can make the retry refresh against stale raw credentials, fail, and return the original 401 to the fallback decision.

## Scope

This is the urgent normal-routing refresh fix. Playground should reuse this shared credential module in the separate Playground PR. The fallback key-label edge case remains a separate, lower-priority draft.

## Validation

- npm ci
- npm --workspace manifest-shared run build
- npm --workspace manifest-backend test -- proxy.service.spec.ts proxy-fallback.service.spec.ts --runInBand
- npm --workspace manifest-backend run build
- npx prettier --check packages/backend/src/routing/proxy/oauth-credentials.ts packages/backend/src/routing/proxy/proxy.service.ts packages/backend/src/routing/proxy/proxy-fallback.service.ts packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
- npx eslint packages/backend/src/routing/proxy/oauth-credentials.ts packages/backend/src/routing/proxy/proxy.service.ts packages/backend/src/routing/proxy/proxy-fallback.service.ts packages/backend/src/routing/proxy/__tests__/proxy.service.spec.ts packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
- git diff --check
- npx changeset status --since=upstream/main

Note: npm ci reports existing audit findings: 15 vulnerabilities (13 moderate, 2 critical).