### PR TITLE
fix: preserve subscription fallback key labels

### DIFF
--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.routes.spec.ts
@@ -47,6 +47,7 @@ describe('ProxyFallbackService.tryFallbacks — route-aware path', () => {
   beforeEach(() => {
     providerKeyService = {
       getProviderApiKey: jest.fn().mockResolvedValue('sk-test'),
+      getDefaultKeyLabel: jest.fn().mockResolvedValue(undefined),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       findProviderForModel: jest.fn().mockResolvedValue(undefined),
       getProviderRegion: jest.fn().mockResolvedValue(null),

--- a/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
@@ -56,6 +56,7 @@ describe('ProxyFallbackService', () => {
   beforeEach(() => {
     providerKeyService = {
       getProviderApiKey: jest.fn(),
+      getDefaultKeyLabel: jest.fn().mockResolvedValue(undefined),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
       findProviderForModel: jest.fn().mockResolvedValue(undefined),
       getProviderRegion: jest.fn().mockResolvedValue(null),
@@ -1112,6 +1113,62 @@ describe('ProxyFallbackService', () => {
       );
     });
 
+    it('uses the selected default key label for unpinned structured subscription fallbacks', async () => {
+      const rawBlob = JSON.stringify({
+        t: 'cached-access',
+        r: 'refresh-token',
+        e: Date.now() + 10 * 60 * 1000,
+      });
+      providerKeyService.getDefaultKeyLabel.mockResolvedValue('Work');
+      providerKeyService.getProviderApiKey.mockResolvedValue(rawBlob);
+      openaiOauth.unwrapToken.mockResolvedValue('fresh-access');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      });
+
+      const result = await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['gpt-5.3-codex'],
+        body,
+        false,
+        'sess-1',
+        'claude-sonnet-4',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [{ provider: 'openai', authType: 'subscription', model: 'gpt-5.3-codex' }],
+      );
+
+      expect(result.success).not.toBeNull();
+      expect(providerKeyService.getAuthType).not.toHaveBeenCalled();
+      expect(providerKeyService.getDefaultKeyLabel).toHaveBeenCalledWith(
+        'agent-1',
+        'openai',
+        'subscription',
+      );
+      expect(providerKeyService.getProviderApiKey).toHaveBeenCalledWith(
+        'agent-1',
+        'openai',
+        'subscription',
+        'Work',
+      );
+      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith(rawBlob, 'agent-1', 'user-1', 'Work');
+      expect(providerKeyService.getProviderRegion).toHaveBeenCalledWith(
+        'agent-1',
+        'openai',
+        'subscription',
+        'Work',
+      );
+    });
+
     it('uses the latest stored OAuth blob for fallback retries after preflight refresh', async () => {
       const staleBlob = JSON.stringify({
         t: 'stale-access',
@@ -1142,7 +1199,6 @@ describe('ProxyFallbackService', () => {
           isAnthropic: false,
           isChatGpt: true,
         });
-
       const result = await service.tryFallbacks(
         'agent-1',
         'user-1',
@@ -1185,6 +1241,55 @@ describe('ProxyFallbackService', () => {
         t: 'fresh-access',
       });
       expect(openaiOauth.unwrapToken.mock.calls[1][3]).toBe('Work');
+    });
+
+    it('uses the selected default subscription key label when refreshing legacy fallbacks', async () => {
+      const rawBlob = JSON.stringify({
+        t: 'cached-access',
+        r: 'refresh-token',
+        e: Date.now() + 10 * 60 * 1000,
+      });
+      providerKeyService.getAuthType.mockResolvedValue('subscription');
+      providerKeyService.getDefaultKeyLabel.mockResolvedValue('Work');
+      providerKeyService.getProviderApiKey.mockResolvedValue(rawBlob);
+      pricingCache.getByModel.mockReturnValue({ provider: 'OpenAI' } as never);
+      openaiOauth.unwrapToken.mockResolvedValue('fresh-access');
+      providerClient.forward.mockResolvedValue({
+        response: new Response('{}', { status: 200 }),
+        isGoogle: false,
+        isAnthropic: false,
+        isChatGpt: true,
+      });
+
+      const result = await service.tryFallbacks(
+        'agent-1',
+        'user-1',
+        ['gpt-5.3-codex'],
+        body,
+        false,
+        'sess-1',
+        'claude-sonnet-4',
+      );
+
+      expect(result.success).not.toBeNull();
+      expect(providerKeyService.getDefaultKeyLabel).toHaveBeenCalledWith(
+        'agent-1',
+        'OpenAI',
+        'subscription',
+      );
+      expect(providerKeyService.getProviderApiKey).toHaveBeenCalledWith(
+        'agent-1',
+        'OpenAI',
+        'subscription',
+        'Work',
+      );
+      expect(openaiOauth.unwrapToken).toHaveBeenCalledWith(rawBlob, 'agent-1', 'user-1', 'Work');
+      expect(providerKeyService.getProviderRegion).toHaveBeenCalledWith(
+        'agent-1',
+        'OpenAI',
+        'subscription',
+        'Work',
+      );
     });
 
     it('does not exclude auth types for different provider', async () => {

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -197,10 +197,10 @@ export class ProxyFallbackService {
       let authType: AuthType;
       // Pinned key label: prefer the structured route's keyLabel. Each
       // fallback can be pinned to a specific provider key (e.g. "Work" vs
-      // "Personal" Anthropic Console). When no route is supplied (legacy
-      // string-only inputs), the pin is undefined and we fall back to the
-      // priority-0 default key inside getProviderApiKey().
-      const providerKeyLabel = route?.keyLabel ?? undefined;
+      // "Personal" Anthropic Console). When no label is supplied for a
+      // subscription fallback, resolve the priority-0 key's label so OAuth
+      // refresh persistence updates the same key getProviderApiKey selected.
+      let providerKeyLabel = route?.keyLabel ?? undefined;
 
       if (route) {
         provider = route.provider;
@@ -229,6 +229,13 @@ export class ProxyFallbackService {
           provider,
           excludeAuth,
         )) as AuthType;
+      }
+      if (!providerKeyLabel && authType === 'subscription') {
+        providerKeyLabel = await this.providerKeyService.getDefaultKeyLabel(
+          agentId,
+          provider,
+          authType,
+        );
       }
 
       const model = normalizeProviderModel(provider, requestedModel);


### PR DESCRIPTION
## Summary
- resolve the selected default provider-key label for unpinned subscription fallback routes
- ensure OAuth refresh persistence updates the same key that fallback routing selected
- cover both structured fallback routes, like header-tier fallbacks, and legacy fallback model entries

## Validation
- npm --workspace manifest-backend test -- proxy-fallback.service.spec.ts --runInBand
- npm --workspace manifest-backend run build
- npx prettier --check packages/backend/src/routing/proxy/proxy-fallback.service.ts packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
- npx eslint packages/backend/src/routing/proxy/proxy-fallback.service.ts packages/backend/src/routing/proxy/__tests__/proxy-fallback.service.spec.ts
- npx changeset status --since=upstream/main
- git diff --check