### PR TITLE
fix: prevent OAuth subscription tokens from being invalidated on refresh (#2012)

### DIFF
--- a/.changeset/oauth-refresh-coordinator.md
+++ b/.changeset/oauth-refresh-coordinator.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix OAuth subscription tokens getting permanently invalidated (#2012). Providers like OpenAI now rotate refresh tokens on every refresh, so the previous "refresh then persist" path could brick an account when parallel proxy requests refreshed the same credential at once, or when the DB write failed after the provider had already rotated. Lazy refreshes are now coordinated per credential: concurrent refreshes coalesce into a single round-trip, the freshest token is re-read from the database before refreshing, and the rotated token is persisted with retries. Applies to all subscription OAuth providers (OpenAI, Gemini, Anthropic, MiniMax, xAI, Kiro).

--- a/packages/backend/src/routing/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/minimax-oauth.service.spec.ts
@@ -20,6 +20,7 @@ describe('MinimaxOauthService', () => {
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
       nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
+      getFreshSubscriptionCredential: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<ProviderService>;
 
     configService = {

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.security.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.security.spec.ts
@@ -22,11 +22,18 @@ function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
+  const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
   return {
-    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    svc: {
+      upsertProvider,
+      recalculateTiers,
+      nextOAuthLabel,
+      getFreshSubscriptionCredential,
+    } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
+    getFreshSubscriptionCredential,
   };
 }
 

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.spec.ts
@@ -27,11 +27,18 @@ function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
+  const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
   return {
-    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    svc: {
+      upsertProvider,
+      recalculateTiers,
+      nextOAuthLabel,
+      getFreshSubscriptionCredential,
+    } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
+    getFreshSubscriptionCredential,
   };
 }
 

--- a/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/anthropic/anthropic-oauth.service.ts
@@ -3,7 +3,9 @@ import { ProviderService } from '../../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../../common/utils/secret-scrub';
 import {
+  coordinateOAuthRefresh,
   generatePkce,
+  oauthRefreshKey,
   OAuthPendingFlowStore,
   parseOAuthTokenBlob,
   serializeOAuthTokenBlob,
@@ -214,18 +216,28 @@ export class AnthropicOauthService {
       return blob.t;
     }
     try {
-      const refreshed = await this.refreshAccessToken(blob.r);
-      await this.providerService.upsertProvider(
-        agentId,
-        userId,
-        'anthropic',
-        serializeOAuthTokenBlob(refreshed),
-        'subscription',
-        undefined,
-        keyLabel,
-      );
-      this.logger.log(`Anthropic OAuth token refreshed for agent=${agentId}`);
-      return refreshed.t;
+      const resolved = await coordinateOAuthRefresh<OAuthTokenBlob>({
+        key: oauthRefreshKey('anthropic', userId, agentId, keyLabel),
+        logger: this.logger,
+        callerBlob: blob,
+        readFreshRaw: () =>
+          this.providerService.getFreshSubscriptionCredential(agentId, 'anthropic', keyLabel),
+        parse: parseOAuthTokenBlob,
+        refresh: (current) => this.refreshAccessToken(current.r),
+        persist: (refreshed) =>
+          this.providerService
+            .upsertProvider(
+              agentId,
+              userId,
+              'anthropic',
+              serializeOAuthTokenBlob(refreshed),
+              'subscription',
+              undefined,
+              keyLabel,
+            )
+            .then(() => undefined),
+      });
+      return resolved.t;
     } catch (err) {
       this.logger.error(`Failed to refresh Anthropic token for agent=${agentId}: ${err}`);
       return null;

--- a/packages/backend/src/routing/oauth/core/index.ts
+++ b/packages/backend/src/routing/oauth/core/index.ts
@@ -12,3 +12,12 @@ export {
 } from './oauth-pending-flow.store';
 export { PendingStore, type PendingEntry } from './pending-store';
 export { oauthDoneHtml } from './callback-page';
+export {
+  coordinateOAuthRefresh,
+  oauthRefreshKey,
+  __resetOAuthRefreshCoordinator,
+  REFRESH_EXPIRY_SKEW_MS,
+  PERSIST_MAX_ATTEMPTS,
+  type RefreshableBlob,
+  type CoordinatedRefreshParams,
+} from './oauth-refresh-coordinator';

--- a/packages/backend/src/routing/oauth/core/oauth-refresh-coordinator.spec.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-refresh-coordinator.spec.ts
@@ -1,0 +1,187 @@
+import { Logger } from '@nestjs/common';
+import {
+  coordinateOAuthRefresh,
+  oauthRefreshKey,
+  __resetOAuthRefreshCoordinator,
+  PERSIST_MAX_ATTEMPTS,
+  REFRESH_EXPIRY_SKEW_MS,
+  type CoordinatedRefreshParams,
+} from './oauth-refresh-coordinator';
+
+interface TestBlob {
+  t: string;
+  e: number;
+  r: string;
+}
+
+function fakeLogger(): Logger {
+  return { warn: jest.fn(), error: jest.fn(), log: jest.fn() } as unknown as Logger;
+}
+
+const expired = (): TestBlob => ({ t: 'old', e: Date.now() - 1_000, r: 'refresh-old' });
+const valid = (t = 'fresh'): TestBlob => ({ t, e: Date.now() + 5 * 60_000, r: 'refresh-new' });
+
+function makeParams(overrides: Partial<CoordinatedRefreshParams<TestBlob>> = {}): {
+  params: CoordinatedRefreshParams<TestBlob>;
+  refresh: jest.Mock;
+  persist: jest.Mock;
+  readFreshRaw: jest.Mock;
+  logger: Logger;
+} {
+  const logger = overrides.logger ?? fakeLogger();
+  const refresh = (overrides.refresh as jest.Mock) ?? jest.fn().mockResolvedValue(valid());
+  const persist = (overrides.persist as jest.Mock) ?? jest.fn().mockResolvedValue(undefined);
+  const readFreshRaw = (overrides.readFreshRaw as jest.Mock) ?? jest.fn().mockResolvedValue(null);
+  const params: CoordinatedRefreshParams<TestBlob> = {
+    key: overrides.key ?? 'openai:user-1:agent-1:Default',
+    logger,
+    callerBlob: overrides.callerBlob ?? expired(),
+    readFreshRaw,
+    parse: overrides.parse ?? ((raw: string) => JSON.parse(raw) as TestBlob),
+    refresh,
+    persist,
+  };
+  return { params, refresh, persist, readFreshRaw, logger };
+}
+
+describe('oauthRefreshKey', () => {
+  it('namespaces by provider/user/agent and defaults the label', () => {
+    expect(oauthRefreshKey('openai', 'u', 'a')).toBe('openai:u:a:Default');
+  });
+
+  it('uses an explicit label when provided', () => {
+    expect(oauthRefreshKey('openai', 'u', 'a', 'Work')).toBe('openai:u:a:Work');
+  });
+});
+
+describe('coordinateOAuthRefresh', () => {
+  afterEach(() => __resetOAuthRefreshCoordinator());
+
+  it('refreshes and persists when the credential is expired and no fresher copy exists', async () => {
+    const refreshed = valid('brand-new');
+    const { params, refresh, persist, readFreshRaw } = makeParams({
+      refresh: jest.fn().mockResolvedValue(refreshed),
+    });
+
+    const result = await coordinateOAuthRefresh(params);
+
+    expect(result).toBe(refreshed);
+    expect(readFreshRaw).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledWith(params.callerBlob);
+    expect(persist).toHaveBeenCalledWith(refreshed);
+  });
+
+  it('returns the fresher DB copy without refreshing when it is already valid', async () => {
+    const dbBlob = valid('already-refreshed');
+    const { params, refresh, persist } = makeParams({
+      readFreshRaw: jest.fn().mockResolvedValue(JSON.stringify(dbBlob)),
+    });
+
+    const result = await coordinateOAuthRefresh(params);
+
+    expect(result).toEqual(dbBlob);
+    expect(refresh).not.toHaveBeenCalled();
+    expect(persist).not.toHaveBeenCalled();
+  });
+
+  it('refreshes using the fresher DB refresh token when the DB copy is also expired', async () => {
+    const dbBlob: TestBlob = { t: 'db', e: Date.now() - 500, r: 'refresh-from-db' };
+    const refreshed = valid('rotated');
+    const refresh = jest.fn().mockResolvedValue(refreshed);
+    const { params } = makeParams({
+      readFreshRaw: jest.fn().mockResolvedValue(JSON.stringify(dbBlob)),
+      refresh,
+    });
+
+    const result = await coordinateOAuthRefresh(params);
+
+    expect(result).toBe(refreshed);
+    expect(refresh).toHaveBeenCalledWith(dbBlob);
+  });
+
+  it('falls back to the caller blob when the fresh DB value cannot be parsed', async () => {
+    const refresh = jest.fn().mockResolvedValue(valid('rotated'));
+    const { params } = makeParams({
+      readFreshRaw: jest.fn().mockResolvedValue('not-json'),
+      parse: () => null,
+      refresh,
+    });
+
+    await coordinateOAuthRefresh(params);
+
+    expect(refresh).toHaveBeenCalledWith(params.callerBlob);
+  });
+
+  it('coalesces concurrent refreshes for the same key into a single round-trip', async () => {
+    let resolveRefresh!: (b: TestBlob) => void;
+    const refreshed = valid('shared');
+    const refresh = jest.fn().mockReturnValue(
+      new Promise<TestBlob>((res) => {
+        resolveRefresh = res;
+      }),
+    );
+    const { params, persist, readFreshRaw } = makeParams({ refresh });
+
+    const p1 = coordinateOAuthRefresh(params);
+    const p2 = coordinateOAuthRefresh(params);
+    resolveRefresh(refreshed);
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toBe(refreshed);
+    expect(r2).toBe(refreshed);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(readFreshRaw).toHaveBeenCalledTimes(1);
+    expect(persist).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs a new refresh once the previous in-flight one has settled', async () => {
+    const { params, refresh } = makeParams();
+    await coordinateOAuthRefresh(params);
+    await coordinateOAuthRefresh(params);
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries persistence and succeeds after transient failures', async () => {
+    const persist = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('db blip'))
+      .mockRejectedValueOnce(new Error('db blip'))
+      .mockResolvedValueOnce(undefined);
+    const refreshed = valid('rotated');
+    const { params, logger } = makeParams({
+      refresh: jest.fn().mockResolvedValue(refreshed),
+      persist,
+    });
+
+    const result = await coordinateOAuthRefresh(params);
+
+    expect(result).toBe(refreshed);
+    expect(persist).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting persistence retries', async () => {
+    const err = new Error('db down');
+    const persist = jest.fn().mockRejectedValue(err);
+    const { params, logger } = makeParams({ persist });
+
+    await expect(coordinateOAuthRefresh(params)).rejects.toBe(err);
+    expect(persist).toHaveBeenCalledTimes(PERSIST_MAX_ATTEMPTS);
+    expect(logger.warn).toHaveBeenCalledTimes(PERSIST_MAX_ATTEMPTS);
+  });
+
+  it('refreshes a credential whose expiry is inside the early-refresh skew window', async () => {
+    const nearExpiry: TestBlob = {
+      t: 'soon',
+      e: Date.now() + REFRESH_EXPIRY_SKEW_MS - 1_000,
+      r: 'r',
+    };
+    const refresh = jest.fn().mockResolvedValue(valid('rotated'));
+    const { params } = makeParams({ callerBlob: nearExpiry, refresh });
+
+    await coordinateOAuthRefresh(params);
+
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/backend/src/routing/oauth/core/oauth-refresh-coordinator.ts
+++ b/packages/backend/src/routing/oauth/core/oauth-refresh-coordinator.ts
@@ -1,0 +1,167 @@
+/**
+ * Single-flight coordinator for lazy OAuth access-token refreshes.
+ *
+ * Why this exists (issue #2012): providers like OpenAI now issue ROTATING
+ * refresh tokens — every successful refresh invalidates the old refresh token
+ * and returns a new one. The naive "parse blob → refresh(blob.r) → persist"
+ * path each `unwrapToken()` used has two fatal races under that model:
+ *
+ *   1. Concurrent requests. An agent fires many parallel requests against an
+ *      expired token. Each one parsed its own (stale) blob and calls the
+ *      provider with the SAME old refresh token. The first rotates it; every
+ *      other one gets `refresh_token_invalidated` and fails. A request that
+ *      arrives just after a refresh finishes can still hold the pre-refresh
+ *      blob (read from the routing cache) and refresh again with the now-dead
+ *      token.
+ *
+ *   2. Persist-after-rotate failure. If the DB write fails AFTER the provider
+ *      already rotated, the only copy of the new refresh token is lost while
+ *      the stored one is already dead — the account is bricked until the user
+ *      deletes and recreates it (exactly issue #2012).
+ *
+ * This coordinator fixes both for a single backend instance (the current
+ * deployment shape) without a distributed lock:
+ *
+ *   - Concurrent refreshes for the SAME credential coalesce onto one in-flight
+ *     promise, keyed by provider+user+agent+label. Different credentials never
+ *     block each other.
+ *   - Before refreshing, it re-reads the freshest persisted blob straight from
+ *     the DB (bypassing the routing cache). If another request already
+ *     refreshed it, the fresh blob is returned and the redundant rotation is
+ *     skipped. The fresh refresh token — not the caller's stale one — is the
+ *     refresh source.
+ *   - The refreshed blob is persisted with a few retries. The provider has
+ *     already rotated, so we NEVER refresh again on a persist failure (that
+ *     would just reuse the dead token); we retry persisting the same blob.
+ *
+ * Multi-replica correctness (two backend instances refreshing the same
+ * credential at the same instant) is intentionally out of scope here — it
+ * needs an optimistic compare-and-set on persist or a DB lease, tracked as a
+ * follow-up. The pending-OAuth store is already documented as single-instance.
+ */
+import { Logger } from '@nestjs/common';
+
+/** Minimum shape every provider's stored OAuth blob shares. */
+export interface RefreshableBlob {
+  /** Access token. */
+  t: string;
+  /** Access-token expiry (epoch ms). */
+  e: number;
+}
+
+/** Skew applied to expiry so a token about to expire is refreshed early. */
+export const REFRESH_EXPIRY_SKEW_MS = 60_000;
+
+/** How many times to retry persisting an already-rotated blob before giving up. */
+export const PERSIST_MAX_ATTEMPTS = 3;
+
+export interface CoordinatedRefreshParams<T extends RefreshableBlob> {
+  /** Identity key for single-flight: `${provider}:${userId}:${agentId}:${label}`. */
+  readonly key: string;
+  readonly logger: Logger;
+  /**
+   * Blob the caller already parsed from the value it was handed. May be stale
+   * (read before a concurrent refresh) — used only as a fallback when the
+   * fresh DB read returns nothing.
+   */
+  readonly callerBlob: T;
+  /** Fresh, cache-bypassing read of the persisted raw credential value. */
+  readonly readFreshRaw: () => Promise<string | null>;
+  /** Parse a raw stored value into the provider's blob type. */
+  readonly parse: (raw: string) => T | null;
+  /** Perform the provider-specific refresh-token exchange. */
+  readonly refresh: (current: T) => Promise<T>;
+  /** Persist the refreshed blob (serialize + upsert). */
+  readonly persist: (refreshed: T) => Promise<void>;
+}
+
+/**
+ * Build the single-flight key for one credential. Namespaced by provider so two
+ * providers never share an entry, and by label so an agent's multiple keys for
+ * the same provider refresh independently. `undefined`/`'Default'` labels map to
+ * the same key, matching how the row is persisted.
+ */
+export function oauthRefreshKey(
+  providerId: string,
+  userId: string,
+  agentId: string,
+  label?: string,
+): string {
+  return `${providerId}:${userId}:${agentId}:${label ?? 'Default'}`;
+}
+
+// Shared across every OAuth service. Each value is the in-flight refresh for
+// one credential; the key namespaces by provider so collisions are impossible.
+const inFlight = new Map<string, Promise<RefreshableBlob>>();
+
+/**
+ * Refresh (or reuse a concurrently-refreshed) OAuth blob for one credential,
+ * guaranteeing at most one provider round-trip in flight per credential.
+ *
+ * Resolves to the usable blob (freshly refreshed, or the already-valid blob
+ * found in the DB). Rejects if the provider refresh fails or the blob cannot
+ * be persisted after retries — callers keep their provider-specific fallback
+ * behaviour in a `catch`.
+ */
+export async function coordinateOAuthRefresh<T extends RefreshableBlob>(
+  params: CoordinatedRefreshParams<T>,
+): Promise<T> {
+  const pending = inFlight.get(params.key) as Promise<T> | undefined;
+  if (pending) return pending;
+
+  const run = refreshOnce(params);
+  inFlight.set(params.key, run);
+  try {
+    return await run;
+  } finally {
+    inFlight.delete(params.key);
+  }
+}
+
+async function refreshOnce<T extends RefreshableBlob>(
+  params: CoordinatedRefreshParams<T>,
+): Promise<T> {
+  // The DB is the source of truth: a parallel request (or a previous one that
+  // resolved just before this caller read its cached copy) may have already
+  // rotated the token. Re-read it so we never refresh with a stale token.
+  let current = params.callerBlob;
+  const freshRaw = await params.readFreshRaw();
+  if (freshRaw) {
+    const fresh = params.parse(freshRaw);
+    if (fresh) current = fresh;
+  }
+
+  // Already valid — either it never really expired, or someone just refreshed.
+  if (Date.now() < current.e - REFRESH_EXPIRY_SKEW_MS) return current;
+
+  const refreshed = await params.refresh(current);
+  await persistWithRetry(params, refreshed);
+  return refreshed;
+}
+
+async function persistWithRetry<T extends RefreshableBlob>(
+  params: CoordinatedRefreshParams<T>,
+  refreshed: T,
+): Promise<void> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= PERSIST_MAX_ATTEMPTS; attempt++) {
+    try {
+      await params.persist(refreshed);
+      return;
+    } catch (err) {
+      lastErr = err;
+      params.logger.warn(
+        `OAuth token persist attempt ${attempt}/${PERSIST_MAX_ATTEMPTS} failed for ${params.key}: ${err}`,
+      );
+    }
+  }
+  // Surface the failure so the caller's catch runs, but the rotated token is
+  // gone either way — this is the brick window we cannot fully close without a
+  // distributed lease. Retrying the same blob is the best we can do.
+  throw lastErr;
+}
+
+/** Test seam: clear in-flight state between cases. */
+export function __resetOAuthRefreshCoordinator(): void {
+  inFlight.clear();
+}

--- a/packages/backend/src/routing/oauth/gemini-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/gemini-oauth.service.spec.ts
@@ -31,15 +31,23 @@ function createProviderService(): {
   upsertProvider: jest.Mock;
   recalculateTiers: jest.Mock;
   nextOAuthLabel: jest.Mock;
+  getFreshSubscriptionCredential: jest.Mock;
 } {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
+  const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
   return {
-    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    svc: {
+      upsertProvider,
+      recalculateTiers,
+      nextOAuthLabel,
+      getFreshSubscriptionCredential,
+    } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
+    getFreshSubscriptionCredential,
   };
 }
 

--- a/packages/backend/src/routing/oauth/kiro-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.service.spec.ts
@@ -32,11 +32,18 @@ function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue('Kiro 1');
+  const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
   return {
-    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    svc: {
+      upsertProvider,
+      recalculateTiers,
+      nextOAuthLabel,
+      getFreshSubscriptionCredential,
+    } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
+    getFreshSubscriptionCredential,
   };
 }
 

--- a/packages/backend/src/routing/oauth/kiro-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/kiro-oauth.service.ts
@@ -4,6 +4,7 @@ import { randomBytes } from 'node:crypto';
 import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../common/utils/secret-scrub';
+import { coordinateOAuthRefresh, oauthRefreshKey } from './core';
 import {
   KIRO_CLIENT_NAME,
   KIRO_CLIENT_TYPE,
@@ -226,18 +227,28 @@ export class KiroOauthService {
     if (!blob) return null;
     if (Date.now() < blob.e - 60_000) return blob.t;
     try {
-      const refreshed = await this.refreshAccessToken(blob);
-      await this.providerService.upsertProvider(
-        agentId,
-        userId,
-        'kiro',
-        serializeKiroOAuthTokenBlob(refreshed),
-        'subscription',
-        undefined,
-        keyLabel,
-      );
-      this.logger.log(`Kiro OAuth token refreshed for agent=${agentId}`);
-      return refreshed.t;
+      const resolved = await coordinateOAuthRefresh<KiroOAuthTokenBlob>({
+        key: oauthRefreshKey('kiro', userId, agentId, keyLabel),
+        logger: this.logger,
+        callerBlob: blob,
+        readFreshRaw: () =>
+          this.providerService.getFreshSubscriptionCredential(agentId, 'kiro', keyLabel),
+        parse: parseKiroOAuthTokenBlob,
+        refresh: (current) => this.refreshAccessToken(current),
+        persist: (refreshed) =>
+          this.providerService
+            .upsertProvider(
+              agentId,
+              userId,
+              'kiro',
+              serializeKiroOAuthTokenBlob(refreshed),
+              'subscription',
+              undefined,
+              keyLabel,
+            )
+            .then(() => undefined),
+      });
+      return resolved.t;
     } catch (err) {
       this.logger.error(`Failed to refresh Kiro OAuth token for agent=${agentId}: ${err}`);
       return Date.now() < blob.e ? blob.t : null;

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.spec.ts
@@ -31,11 +31,18 @@ function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
+  const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
   return {
-    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    svc: {
+      upsertProvider,
+      recalculateTiers,
+      nextOAuthLabel,
+      getFreshSubscriptionCredential,
+    } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
+    getFreshSubscriptionCredential,
   };
 }
 
@@ -322,6 +329,35 @@ describe('MinimaxOauthService', () => {
       fetchMock.mockRejectedValueOnce(new Error('network'));
       const out = await svc.unwrapToken(JSON.stringify(blob), 'a', 'u');
       expect(out).toEqual(blob);
+    });
+
+    it('returns the fresher persisted blob without refreshing when one already exists', async () => {
+      const stale = { t: 'old', r: 'rf', e: Date.now() - 1_000 };
+      const fresh = { t: 'fresh', r: 'rf2', e: Date.now() + 10 * 60 * 1000 };
+      provider.getFreshSubscriptionCredential.mockResolvedValueOnce(JSON.stringify(fresh));
+      const out = await svc.unwrapToken(JSON.stringify(stale), 'agent-1', 'user-1', 'Work');
+      expect(out).toEqual(fresh);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('ignores an unparseable persisted credential and refreshes from the caller blob', async () => {
+      const stale = { t: 'old', r: 'rf', e: Date.now() - 1_000 };
+      provider.getFreshSubscriptionCredential.mockResolvedValueOnce('not-json{');
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expired_in: 3600 }),
+      );
+      const out = await svc.unwrapToken(JSON.stringify(stale), 'agent-1', 'user-1');
+      expect(out?.t).toBe('new');
+    });
+
+    it('ignores a persisted value that is valid JSON but not a token blob', async () => {
+      const stale = { t: 'old', r: 'rf', e: Date.now() - 1_000 };
+      provider.getFreshSubscriptionCredential.mockResolvedValueOnce(JSON.stringify({ nope: true }));
+      fetchMock.mockResolvedValueOnce(
+        mockResponse(200, { access_token: 'new', refresh_token: 'rf2', expired_in: 3600 }),
+      );
+      const out = await svc.unwrapToken(JSON.stringify(stale), 'agent-1', 'user-1');
+      expect(out?.t).toBe('new');
     });
   });
 });

--- a/packages/backend/src/routing/oauth/minimax-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/minimax-oauth.service.ts
@@ -4,6 +4,7 @@ import { createHash, randomBytes, randomUUID } from 'crypto';
 import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../common/utils/secret-scrub';
+import { coordinateOAuthRefresh, oauthRefreshKey } from './core';
 import { OAuthTokenBlob } from './openai-oauth.types';
 import {
   MinimaxRegion,
@@ -19,6 +20,16 @@ import {
   toPollIntervalMs,
   isOAuthTokenBlob,
 } from './minimax-oauth-helpers';
+
+/** Parse a stored MiniMax credential into a validated OAuth blob, or null. */
+function parseMinimaxBlob(raw: string): OAuthTokenBlob | null {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isOAuthTokenBlob(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
 
 export type { MinimaxRegion };
 
@@ -277,18 +288,27 @@ export class MinimaxOauthService {
     if (!blob.t || !blob.r || !blob.e) return null;
     if (Date.now() < blob.e - 60_000) return blob;
     try {
-      const refreshed = await this.refreshAccessToken(blob.r, blob.u);
-      await this.providerService.upsertProvider(
-        agentId,
-        userId,
-        'minimax',
-        JSON.stringify(refreshed),
-        'subscription',
-        undefined,
-        keyLabel,
-      );
-      this.logger.log(`MiniMax OAuth token refreshed for agent=${agentId}`);
-      return refreshed;
+      return await coordinateOAuthRefresh<OAuthTokenBlob>({
+        key: oauthRefreshKey('minimax', userId, agentId, keyLabel),
+        logger: this.logger,
+        callerBlob: blob,
+        readFreshRaw: () =>
+          this.providerService.getFreshSubscriptionCredential(agentId, 'minimax', keyLabel),
+        parse: parseMinimaxBlob,
+        refresh: (current) => this.refreshAccessToken(current.r, current.u),
+        persist: (refreshed) =>
+          this.providerService
+            .upsertProvider(
+              agentId,
+              userId,
+              'minimax',
+              JSON.stringify(refreshed),
+              'subscription',
+              undefined,
+              keyLabel,
+            )
+            .then(() => undefined),
+      });
     } catch (err) {
       this.logger.error(`Failed to refresh MiniMax token: ${err}`);
       return blob;

--- a/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.service.spec.ts
@@ -29,11 +29,18 @@ function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue(undefined);
+  const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
   return {
-    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    svc: {
+      upsertProvider,
+      recalculateTiers,
+      nextOAuthLabel,
+      getFreshSubscriptionCredential,
+    } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
+    getFreshSubscriptionCredential,
   };
 }
 

--- a/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
@@ -17,6 +17,8 @@ import { ProviderService } from '../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../common/utils/secret-scrub';
 import {
+  coordinateOAuthRefresh,
+  oauthRefreshKey,
   generatePkce,
   generateState,
   oauthDoneHtml,
@@ -263,23 +265,32 @@ export abstract class RedirectPkceOauthBaseService {
     userId: string,
     keyLabel?: string,
   ): Promise<string | null> {
+    const providerId = this.oauthConfig.providerId;
     try {
-      const refreshed = await this.refreshAccessToken(blob.r, blob.u);
-      await this.providerService.upsertProvider(
-        agentId,
-        userId,
-        this.oauthConfig.providerId,
-        serializeOAuthTokenBlob(refreshed),
-        'subscription',
-        undefined,
-        keyLabel,
-      );
-      this.logger.log(`${this.oauthConfig.providerId} OAuth token refreshed for agent=${agentId}`);
-      return refreshed.t;
+      const resolved = await coordinateOAuthRefresh<OAuthTokenBlob>({
+        key: oauthRefreshKey(providerId, userId, agentId, keyLabel),
+        logger: this.logger,
+        callerBlob: blob,
+        readFreshRaw: () =>
+          this.providerService.getFreshSubscriptionCredential(agentId, providerId, keyLabel),
+        parse: parseOAuthTokenBlob,
+        refresh: (current) => this.refreshAccessToken(current.r, current.u),
+        persist: (refreshed) =>
+          this.providerService
+            .upsertProvider(
+              agentId,
+              userId,
+              providerId,
+              serializeOAuthTokenBlob(refreshed),
+              'subscription',
+              undefined,
+              keyLabel,
+            )
+            .then(() => undefined),
+      });
+      return resolved.t;
     } catch (err) {
-      this.logger.error(
-        `Failed to refresh ${this.oauthConfig.providerId} token for agent=${agentId}: ${err}`,
-      );
+      this.logger.error(`Failed to refresh ${providerId} token for agent=${agentId}: ${err}`);
       return null;
     }
   }

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.service.spec.ts
@@ -28,11 +28,18 @@ function createProviderService() {
   const upsertProvider = jest.fn().mockResolvedValue({ provider: { id: 'p1' } });
   const recalculateTiers = jest.fn().mockResolvedValue(undefined);
   const nextOAuthLabel = jest.fn().mockResolvedValue('X Account');
+  const getFreshSubscriptionCredential = jest.fn().mockResolvedValue(null);
   return {
-    svc: { upsertProvider, recalculateTiers, nextOAuthLabel } as unknown as ProviderService,
+    svc: {
+      upsertProvider,
+      recalculateTiers,
+      nextOAuthLabel,
+      getFreshSubscriptionCredential,
+    } as unknown as ProviderService,
     upsertProvider,
     recalculateTiers,
     nextOAuthLabel,
+    getFreshSubscriptionCredential,
   };
 }
 

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.service.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.service.ts
@@ -5,9 +5,11 @@ import { ProviderService } from '../../routing-core/provider.service';
 import { ModelDiscoveryService } from '../../../model-discovery/model-discovery.service';
 import { scrubSecrets } from '../../../common/utils/secret-scrub';
 import {
+  coordinateOAuthRefresh,
   generatePkce,
   generateState,
   oauthDoneHtml,
+  oauthRefreshKey,
   parseOAuthTokenBlob,
   PendingStore,
   serializeOAuthTokenBlob,
@@ -180,18 +182,28 @@ export class XaiOauthService {
     if (!blob) return null;
     if (Date.now() < blob.e - 60_000) return blob.t;
     try {
-      const refreshed = await this.refreshAccessToken(blob.r);
-      await this.providerService.upsertProvider(
-        agentId,
-        userId,
-        'xai',
-        serializeOAuthTokenBlob(refreshed),
-        'subscription',
-        undefined,
-        keyLabel,
-      );
-      this.logger.log(`xAI OAuth token refreshed for agent=${agentId}`);
-      return refreshed.t;
+      const resolved = await coordinateOAuthRefresh<OAuthTokenBlob>({
+        key: oauthRefreshKey('xai', userId, agentId, keyLabel),
+        logger: this.logger,
+        callerBlob: blob,
+        readFreshRaw: () =>
+          this.providerService.getFreshSubscriptionCredential(agentId, 'xai', keyLabel),
+        parse: parseOAuthTokenBlob,
+        refresh: (current) => this.refreshAccessToken(current.r),
+        persist: (refreshed) =>
+          this.providerService
+            .upsertProvider(
+              agentId,
+              userId,
+              'xai',
+              serializeOAuthTokenBlob(refreshed),
+              'subscription',
+              undefined,
+              keyLabel,
+            )
+            .then(() => undefined),
+      });
+      return resolved.t;
     } catch (err) {
       this.logger.error(`Failed to refresh xAI token for agent=${agentId}: ${err}`);
       return null;

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -35,6 +35,7 @@ describe('OpenaiOauthService', () => {
       upsertProvider: jest.fn().mockResolvedValue({ provider: {}, isNew: true }),
       recalculateTiers: jest.fn().mockResolvedValue(undefined),
       nextOAuthLabel: jest.fn().mockResolvedValue(undefined),
+      getFreshSubscriptionCredential: jest.fn().mockResolvedValue(null),
     } as unknown as jest.Mocked<ProviderService>;
 
     configService = {

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -711,49 +711,63 @@ describe('ProviderService — getFreshSubscriptionCredential', () => {
     );
   });
 
-  it('returns the decrypted raw credential and queries the subscription row by label', async () => {
+  it('returns the decrypted raw credential, scanning subscription rows for the agent/provider', async () => {
     const raw = JSON.stringify({ t: 'access', r: 'refresh', e: 123 });
-    providerRepo.findOne.mockResolvedValue({
-      api_key_encrypted: encrypt(raw, getEncryptionSecret()),
-    });
+    providerRepo.find.mockResolvedValue([
+      { label: 'Work', api_key_encrypted: encrypt(raw, getEncryptionSecret()) },
+    ]);
 
     const out = await svc.getFreshSubscriptionCredential('agent-1', 'openai', 'Work');
 
     expect(out).toBe(raw);
-    expect(providerRepo.findOne).toHaveBeenCalledWith({
-      where: { agent_id: 'agent-1', provider: 'openai', auth_type: 'subscription', label: 'Work' },
+    expect(providerRepo.find).toHaveBeenCalledWith({
+      where: { agent_id: 'agent-1', provider: 'openai', auth_type: 'subscription' },
     });
+  });
+
+  it('matches the label case-insensitively', async () => {
+    const raw = JSON.stringify({ t: 'a', r: 'r', e: 1 });
+    providerRepo.find.mockResolvedValue([
+      { label: 'Other', api_key_encrypted: encrypt('nope', getEncryptionSecret()) },
+      { label: 'work', api_key_encrypted: encrypt(raw, getEncryptionSecret()) },
+    ]);
+
+    // Stored row is "work"; the pinned route asks for "WORK".
+    const out = await svc.getFreshSubscriptionCredential('agent-1', 'openai', 'WORK');
+
+    expect(out).toBe(raw);
   });
 
   it('defaults the label to Default when none is provided', async () => {
-    providerRepo.findOne.mockResolvedValue({
-      api_key_encrypted: encrypt('payload', getEncryptionSecret()),
-    });
+    const raw = JSON.stringify({ t: 'a', r: 'r', e: 1 });
+    providerRepo.find.mockResolvedValue([
+      { label: 'Default', api_key_encrypted: encrypt(raw, getEncryptionSecret()) },
+    ]);
 
-    await svc.getFreshSubscriptionCredential('agent-1', 'anthropic');
-
-    expect(providerRepo.findOne).toHaveBeenCalledWith({
-      where: {
-        agent_id: 'agent-1',
-        provider: 'anthropic',
-        auth_type: 'subscription',
-        label: 'Default',
-      },
-    });
+    expect(await svc.getFreshSubscriptionCredential('agent-1', 'anthropic')).toBe(raw);
   });
 
-  it('returns null when there is no matching row', async () => {
-    providerRepo.findOne.mockResolvedValue(null);
+  it('returns null when no row matches the label', async () => {
+    providerRepo.find.mockResolvedValue([
+      { label: 'Something else', api_key_encrypted: encrypt('x', getEncryptionSecret()) },
+    ]);
     expect(await svc.getFreshSubscriptionCredential('agent-1', 'openai')).toBeNull();
   });
 
-  it('returns null when the row has no stored credential', async () => {
-    providerRepo.findOne.mockResolvedValue({ api_key_encrypted: null });
+  it('returns null when there are no subscription rows', async () => {
+    providerRepo.find.mockResolvedValue([]);
+    expect(await svc.getFreshSubscriptionCredential('agent-1', 'openai')).toBeNull();
+  });
+
+  it('returns null when the matched row has no stored credential', async () => {
+    providerRepo.find.mockResolvedValue([{ label: 'Default', api_key_encrypted: null }]);
     expect(await svc.getFreshSubscriptionCredential('agent-1', 'openai')).toBeNull();
   });
 
   it('returns null when the stored credential cannot be decrypted', async () => {
-    providerRepo.findOne.mockResolvedValue({ api_key_encrypted: 'not-a-valid-ciphertext' });
+    providerRepo.find.mockResolvedValue([
+      { label: 'Default', api_key_encrypted: 'not-a-valid-ciphertext' },
+    ]);
     expect(await svc.getFreshSubscriptionCredential('agent-1', 'openai')).toBeNull();
   });
 });

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -7,6 +7,7 @@ import type { Repository } from 'typeorm';
 import type { TierAutoAssignService } from '../tier-auto-assign.service';
 import type { RoutingCacheService } from '../routing-cache.service';
 import type { ModelPricingCacheService } from '../../../model-prices/model-pricing-cache.service';
+import { encrypt, getEncryptionSecret } from '../../../common/utils/crypto.util';
 
 const route = (
   provider: string,
@@ -678,5 +679,81 @@ describe('ProviderService — route-only cleanup paths', () => {
       const label = await svc.nextOAuthLabel('agent-1', 'openai');
       expect(label).toBe('Key 3');
     });
+  });
+});
+
+describe('ProviderService — getFreshSubscriptionCredential', () => {
+  const PREV_KEY = process.env.MANIFEST_ENCRYPTION_KEY;
+  let providerRepo: ReturnType<typeof makeRepo>;
+  let svc: ProviderService;
+
+  beforeAll(() => {
+    process.env.MANIFEST_ENCRYPTION_KEY = 'unit-test-encryption-key-1234567890';
+  });
+  afterAll(() => {
+    if (PREV_KEY === undefined) delete process.env.MANIFEST_ENCRYPTION_KEY;
+    else process.env.MANIFEST_ENCRYPTION_KEY = PREV_KEY;
+  });
+
+  beforeEach(() => {
+    providerRepo = makeRepo();
+    svc = new ProviderService(
+      providerRepo as unknown as Repository<UserProvider>,
+      makeRepo() as unknown as Repository<TierAssignment>,
+      makeRepo() as unknown as Repository<SpecificityAssignment>,
+      { recalculate: jest.fn() } as unknown as TierAutoAssignService,
+      { getByModel: jest.fn() } as unknown as ModelPricingCacheService,
+      {
+        getProviders: jest.fn(),
+        setProviders: jest.fn(),
+        invalidateAgent: jest.fn(),
+      } as unknown as RoutingCacheService,
+    );
+  });
+
+  it('returns the decrypted raw credential and queries the subscription row by label', async () => {
+    const raw = JSON.stringify({ t: 'access', r: 'refresh', e: 123 });
+    providerRepo.findOne.mockResolvedValue({
+      api_key_encrypted: encrypt(raw, getEncryptionSecret()),
+    });
+
+    const out = await svc.getFreshSubscriptionCredential('agent-1', 'openai', 'Work');
+
+    expect(out).toBe(raw);
+    expect(providerRepo.findOne).toHaveBeenCalledWith({
+      where: { agent_id: 'agent-1', provider: 'openai', auth_type: 'subscription', label: 'Work' },
+    });
+  });
+
+  it('defaults the label to Default when none is provided', async () => {
+    providerRepo.findOne.mockResolvedValue({
+      api_key_encrypted: encrypt('payload', getEncryptionSecret()),
+    });
+
+    await svc.getFreshSubscriptionCredential('agent-1', 'anthropic');
+
+    expect(providerRepo.findOne).toHaveBeenCalledWith({
+      where: {
+        agent_id: 'agent-1',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        label: 'Default',
+      },
+    });
+  });
+
+  it('returns null when there is no matching row', async () => {
+    providerRepo.findOne.mockResolvedValue(null);
+    expect(await svc.getFreshSubscriptionCredential('agent-1', 'openai')).toBeNull();
+  });
+
+  it('returns null when the row has no stored credential', async () => {
+    providerRepo.findOne.mockResolvedValue({ api_key_encrypted: null });
+    expect(await svc.getFreshSubscriptionCredential('agent-1', 'openai')).toBeNull();
+  });
+
+  it('returns null when the stored credential cannot be decrypted', async () => {
+    providerRepo.findOne.mockResolvedValue({ api_key_encrypted: 'not-a-valid-ciphertext' });
+    expect(await svc.getFreshSubscriptionCredential('agent-1', 'openai')).toBeNull();
   });
 });

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -69,14 +69,16 @@ export class ProviderService {
     provider: string,
     label?: string,
   ): Promise<string | null> {
-    const row = await this.providerRepo.findOne({
-      where: {
-        agent_id: agentId,
-        provider,
-        auth_type: 'subscription',
-        label: label ?? DEFAULT_LABEL,
-      },
+    // Match the label case-insensitively, consistent with the rest of the
+    // label handling and the unique index on (agent_id, provider, auth_type,
+    // LOWER(label)). A pinned route may carry a different casing than the
+    // stored row; a case-sensitive lookup would miss it and refresh from the
+    // stale caller blob instead of the freshest DB row.
+    const wantedLabel = (label ?? DEFAULT_LABEL).toLowerCase();
+    const rows = await this.providerRepo.find({
+      where: { agent_id: agentId, provider, auth_type: 'subscription' },
     });
+    const row = rows.find((r) => r.label.toLowerCase() === wantedLabel);
     if (!row?.api_key_encrypted) return null;
     try {
       return decrypt(row.api_key_encrypted, getEncryptionSecret());

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -57,6 +57,34 @@ export class ProviderService {
     return providers;
   }
 
+  /**
+   * Read the freshest persisted subscription credential straight from the DB,
+   * decrypted, bypassing the routing cache. The OAuth refresh coordinator uses
+   * this so a lazy token refresh never rotates based on a stale cached blob
+   * (see issue #2012). Returns the decrypted raw stored value, or null when
+   * there is no row / no stored credential / it cannot be decrypted.
+   */
+  async getFreshSubscriptionCredential(
+    agentId: string,
+    provider: string,
+    label?: string,
+  ): Promise<string | null> {
+    const row = await this.providerRepo.findOne({
+      where: {
+        agent_id: agentId,
+        provider,
+        auth_type: 'subscription',
+        label: label ?? DEFAULT_LABEL,
+      },
+    });
+    if (!row?.api_key_encrypted) return null;
+    try {
+      return decrypt(row.api_key_encrypted, getEncryptionSecret());
+    } catch {
+      return null;
+    }
+  }
+
   async upsertProvider(
     agentId: string,
     userId: string,


### PR DESCRIPTION
## Problem (fixes #2012)

OAuth subscription tokens are stored encrypted in `user_providers.api_key_encrypted` as a blob `{ t: access, r: refresh, e: expiry, u?: resource }`, and the proxy lazily refreshes the access token before forwarding. Providers like **OpenAI now issue rotating refresh tokens** — every successful refresh invalidates the old refresh token and returns a new one (verified live: `rt_…` 90-char → `rt.1.AAC…` 343-char; reusing the old one returns `401 refresh_token_invalidated`).

The previous `parse blob → refresh(blob.r) → upsert` path in each `unwrapToken()` had two fatal races under rotation:

1. **Concurrent requests.** An agent fires many parallel requests against an expired token. Each parsed its own (stale) blob and refreshed with the **same** old refresh token — the first rotated it, the rest got `refresh_token_invalidated`. A request arriving just after a refresh finished could still hold the pre-refresh blob (from the routing cache) and refresh again with the now-dead token.
2. **Persist-after-rotate failure.** If the DB write failed *after* the provider already rotated, the only copy of the new refresh token was lost while the stored one was already dead → the account is bricked until the user deletes and recreates it (exactly #2012). The old `catch` just logged and returned `null`, silently bricking it.

This was reproduced against production data: expired accounts returned `refresh_token_invalidated`, while accounts whose stored token hadn't been clobbered refreshed fine from a plain script.

## Fix

A single-flight **OAuth refresh coordinator** (`oauth/core/oauth-refresh-coordinator.ts`), wired into every subscription OAuth provider (OpenAI/Gemini via the shared base, plus Anthropic, MiniMax, xAI, Kiro):

- **Coalesce** concurrent refreshes for the same credential onto one in-flight promise, keyed by `provider:user:agent:label`. Different credentials never block each other.
- **Re-read the freshest blob from the DB** (bypassing the routing cache) before refreshing. If another request already refreshed it, return that and skip the redundant rotation. The fresh refresh token — not the caller's stale one — is the refresh source. New helper: `ProviderService.getFreshSubscriptionCredential()`.
- **Persist with retries**, and never refresh again on a persist failure (the old token is already dead — retrying the same rotated blob is the only safe move).

### Scope / follow-up

This makes refresh correct for a **single backend instance** (today's deployment). Two replicas refreshing the same credential at the same instant is intentionally out of scope — that needs an optimistic compare-and-set on persist or a DB lease, noted as a follow-up in the coordinator's header comment.

Note: this prevents healthy accounts from being bricked going forward; accounts whose refresh token OpenAI has **already** invalidated still require a reconnect.

## Tests

- New `oauth-refresh-coordinator.spec.ts` (100% coverage): coalescing, fresh-DB-copy reuse, unparseable-fresh-value fallback, persist retry/exhaustion, early-refresh skew, key formatting.
- New `ProviderService.getFreshSubscriptionCredential` cases (row found/decrypt, missing row, no credential, decrypt failure, label defaulting).
- Added MiniMax cases covering the new blob-parse helper.
- Full backend suite green (6058 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OAuth subscription tokens from being invalidated during refresh by coordinating refreshes and safely persisting rotated tokens. Fixes #2012 and stops accounts from getting bricked with rotating refresh tokens (e.g., OpenAI).

- **Bug Fixes**
  - Added a single-flight refresh coordinator that coalesces concurrent refreshes per credential (`provider:user:agent:label`) for a single backend instance.
  - Re-reads the freshest credential from the DB before refreshing and skips refresh if it’s already valid; uses the latest refresh token.
  - Persists rotated tokens with retries and never re-rotates on persist failures.
  - Integrated into all subscription OAuth providers (OpenAI/Gemini via the shared base; Anthropic, MiniMax, xAI, Kiro) and added `ProviderService.getFreshSubscriptionCredential()` for cache-bypassing reads.
  - Updated `ProviderService.getFreshSubscriptionCredential()` to match labels case-insensitively so fresh reads work even when label casing differs.

<sup>Written for commit 757c4ef764a06fb258027bad7224caa5a7089d1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

