### PR TITLE
fix: clear stale account pins on custom (header) tiers when disconnecting a provider key

### DIFF
--- a/.changeset/header-tier-disconnect-cleanup.md
+++ b/.changeset/header-tier-disconnect-cleanup.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix custom (header) routing tiers keeping stale account pins after disconnecting one of several accounts on the same provider. Provider-reference cleanup only updated complexity and specificity tiers, so disconnecting an account, renaming a key, or deactivating all providers left header-tier routes pointing at a removed account (the account chip then rendered blank). `relabelOverrides`, `cleanupProviderReferences`, and `deactivateAllProviders` now clean `header_tiers` routes the same way.

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -3,6 +3,7 @@ import { ProviderService } from '../provider.service';
 import { UserProvider } from '../../../entities/user-provider.entity';
 import { TierAssignment } from '../../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../../entities/specificity-assignment.entity';
+import { HeaderTier } from '../../../entities/header-tier.entity';
 import type { Repository } from 'typeorm';
 import type { TierAutoAssignService } from '../tier-auto-assign.service';
 import type { RoutingCacheService } from '../routing-cache.service';
@@ -25,6 +26,7 @@ const makeRepo = () => ({
   insert: jest.fn().mockResolvedValue(undefined),
   save: jest.fn().mockImplementation(async (rows) => rows),
   delete: jest.fn().mockResolvedValue(undefined),
+  remove: jest.fn().mockResolvedValue(undefined),
   update: jest.fn().mockResolvedValue(undefined),
   manager: { transaction: jest.fn() },
 });
@@ -33,6 +35,7 @@ describe('ProviderService — route-only cleanup paths', () => {
   let providerRepo: ReturnType<typeof makeRepo>;
   let tierRepo: ReturnType<typeof makeRepo>;
   let specRepo: ReturnType<typeof makeRepo>;
+  let headerTierRepo: ReturnType<typeof makeRepo>;
   let autoAssign: jest.Mocked<Pick<TierAutoAssignService, 'recalculate'>>;
   let pricingCache: jest.Mocked<Pick<ModelPricingCacheService, 'getByModel'>>;
   let routingCache: {
@@ -46,6 +49,7 @@ describe('ProviderService — route-only cleanup paths', () => {
     providerRepo = makeRepo();
     tierRepo = makeRepo();
     specRepo = makeRepo();
+    headerTierRepo = makeRepo();
     autoAssign = { recalculate: jest.fn().mockResolvedValue(undefined) };
     pricingCache = { getByModel: jest.fn().mockReturnValue(undefined) };
     routingCache = {
@@ -58,6 +62,7 @@ describe('ProviderService — route-only cleanup paths', () => {
       providerRepo as unknown as Repository<UserProvider>,
       tierRepo as unknown as Repository<TierAssignment>,
       specRepo as unknown as Repository<SpecificityAssignment>,
+      headerTierRepo as unknown as Repository<HeaderTier>,
       autoAssign as unknown as TierAutoAssignService,
       pricingCache as unknown as ModelPricingCacheService,
       routingCache as unknown as RoutingCacheService,
@@ -390,8 +395,129 @@ describe('ProviderService — route-only cleanup paths', () => {
           fallback_routes: null,
         }),
       );
+      expect(headerTierRepo.update).toHaveBeenCalledWith(
+        { agent_id: 'agent-1' },
+        expect.objectContaining({ override_route: null, fallback_routes: null }),
+      );
       expect(autoAssign.recalculate).toHaveBeenCalledWith('agent-1');
       expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
+  });
+
+  describe('header-tier cleanup on disconnect / rename', () => {
+    const headerPin = (keyLabel: string | null) => ({
+      provider: 'openai',
+      authType: 'subscription' as const,
+      model: 'openai/gpt-5',
+      keyLabel,
+    });
+
+    it('relabels header-tier key pins to null when one of several keys is disconnected', async () => {
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'target',
+          agent_id: 'agent-1',
+          provider: 'openai',
+          auth_type: 'subscription',
+          label: 'Key 2',
+          is_active: true,
+        },
+        {
+          id: 'other',
+          agent_id: 'agent-1',
+          provider: 'openai',
+          auth_type: 'subscription',
+          label: 'Default',
+          is_active: true,
+        },
+      ]);
+      tierRepo.find.mockResolvedValue([]);
+      specRepo.find.mockResolvedValue([]);
+      headerTierRepo.find.mockResolvedValue([
+        {
+          id: 'h1',
+          override_route: headerPin('Key 2'),
+          fallback_routes: [headerPin('Key 2'), headerPin('Default')],
+        } as unknown as HeaderTier,
+        // Non-matching tier (different pinned label) must be left untouched.
+        {
+          id: 'h2',
+          override_route: headerPin('Default'),
+          fallback_routes: null,
+        } as unknown as HeaderTier,
+      ]);
+
+      await svc.removeProvider('agent-1', 'openai', 'subscription', 'Key 2');
+
+      expect(headerTierRepo.save).toHaveBeenCalledTimes(1);
+      const saved = headerTierRepo.save.mock.calls[0][0] as HeaderTier[];
+      expect(saved).toHaveLength(1);
+      expect(saved[0].id).toBe('h1');
+      expect(saved[0].override_route?.keyLabel).toBeNull();
+      expect(saved[0].fallback_routes?.[0].keyLabel).toBeNull();
+      expect(saved[0].fallback_routes?.[1].keyLabel).toBe('Default');
+    });
+
+    it('rewrites header-tier key pins to the new label on rename', async () => {
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'target',
+          agent_id: 'agent-1',
+          provider: 'openai',
+          auth_type: 'subscription',
+          label: 'Key 2',
+          is_active: true,
+        },
+      ]);
+      tierRepo.find.mockResolvedValue([]);
+      specRepo.find.mockResolvedValue([]);
+      headerTierRepo.find.mockResolvedValue([
+        {
+          id: 'h1',
+          override_route: headerPin('Key 2'),
+          fallback_routes: null,
+        } as unknown as HeaderTier,
+      ]);
+
+      await svc.renameKey('agent-1', 'openai', 'subscription', 'Key 2', 'Renamed');
+
+      const saved = headerTierRepo.save.mock.calls[0][0] as HeaderTier[];
+      expect(saved[0].override_route?.keyLabel).toBe('Renamed');
+    });
+
+    it('clears header-tier routes belonging to a fully disconnected provider', async () => {
+      providerRepo.findOne.mockResolvedValue({
+        id: 'p1',
+        agent_id: 'agent-1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        is_active: true,
+      });
+      providerRepo.find.mockResolvedValue([]);
+      tierRepo.find.mockResolvedValue([]);
+      specRepo.find.mockResolvedValue([]);
+      headerTierRepo.find.mockResolvedValue([
+        {
+          id: 'h1',
+          override_route: route('OpenAI', 'gpt-4o'),
+          fallback_routes: [route('openai', 'gpt-4o-mini'), route('anthropic', 'claude')],
+        } as unknown as HeaderTier,
+        // Belongs to another provider — must survive.
+        {
+          id: 'h2',
+          override_route: route('anthropic', 'claude'),
+          fallback_routes: null,
+        } as unknown as HeaderTier,
+      ]);
+
+      await svc.removeProvider('agent-1', 'openai');
+
+      expect(headerTierRepo.save).toHaveBeenCalledTimes(1);
+      const saved = headerTierRepo.save.mock.calls[0][0] as HeaderTier[];
+      expect(saved).toHaveLength(1);
+      expect(saved[0].id).toBe('h1');
+      expect(saved[0].override_route).toBeNull();
+      expect(saved[0].fallback_routes).toEqual([route('anthropic', 'claude')]);
     });
   });
 
@@ -701,6 +827,7 @@ describe('ProviderService — getFreshSubscriptionCredential', () => {
       providerRepo as unknown as Repository<UserProvider>,
       makeRepo() as unknown as Repository<TierAssignment>,
       makeRepo() as unknown as Repository<SpecificityAssignment>,
+      makeRepo() as unknown as Repository<HeaderTier>,
       { recalculate: jest.fn() } as unknown as TierAutoAssignService,
       { getByModel: jest.fn() } as unknown as ModelPricingCacheService,
       {

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -4,6 +4,7 @@ import { Repository, In, FindOptionsWhere } from 'typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
+import { HeaderTier } from '../../entities/header-tier.entity';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { TierAutoAssignService } from './tier-auto-assign.service';
 import { RoutingCacheService } from './routing-cache.service';
@@ -34,6 +35,8 @@ export class ProviderService {
     private readonly tierRepo: Repository<TierAssignment>,
     @InjectRepository(SpecificityAssignment)
     private readonly specificityRepo: Repository<SpecificityAssignment>,
+    @InjectRepository(HeaderTier)
+    private readonly headerTierRepo: Repository<HeaderTier>,
     private readonly autoAssign: TierAutoAssignService,
     private readonly pricingCache: ModelPricingCacheService,
     private readonly routingCache: RoutingCacheService,
@@ -602,6 +605,16 @@ export class ProviderService {
         updated_at: new Date().toISOString(),
       },
     );
+    // Custom (header) tiers are user-configured only — clear their routes too
+    // so deactivating every provider doesn't leave stale pins behind.
+    await this.headerTierRepo.update(
+      { agent_id: agentId },
+      {
+        override_route: null,
+        fallback_routes: null,
+        updated_at: new Date().toISOString(),
+      },
+    );
     await this.autoAssign.recalculate(agentId);
     this.routingCache.invalidateAgent(agentId);
   }
@@ -734,6 +747,33 @@ export class ProviderService {
     }
     if (specToSave.length > 0) await this.specificityRepo.save(specToSave);
 
+    // Custom (header) tiers reference the same providers. Drop routes that
+    // belong to the removed provider so they don't linger after a full
+    // disconnect. Header tiers have no auto-assigned slot, so a cleared
+    // override just leaves the tier empty (resolve treats that as fallthrough)
+    // — no notification path, unlike standard tiers above.
+    const headerTiers = await this.headerTierRepo.find({ where: { agent_id: agentId } });
+    const headerTiersToSave: HeaderTier[] = [];
+    for (const h of headerTiers) {
+      let changed = false;
+      if (h.override_route && routeBelongs(h.override_route)) {
+        h.override_route = null;
+        changed = true;
+      }
+      if (h.fallback_routes && h.fallback_routes.length > 0) {
+        const filteredRoutes = h.fallback_routes.filter((route) => !routeBelongs(route));
+        if (filteredRoutes.length !== h.fallback_routes.length) {
+          h.fallback_routes = filteredRoutes.length > 0 ? filteredRoutes : null;
+          changed = true;
+        }
+      }
+      if (changed) {
+        h.updated_at = new Date().toISOString();
+        headerTiersToSave.push(h);
+      }
+    }
+    if (headerTiersToSave.length > 0) await this.headerTierRepo.save(headerTiersToSave);
+
     return { invalidated, hadTierAssignments };
   }
 
@@ -815,6 +855,31 @@ export class ProviderService {
       }
     }
     if (specsToSave.length > 0) await this.specificityRepo.save(specsToSave);
+
+    // Custom (header) tiers carry the same ModelRoute shape. They were
+    // omitted here originally, so disconnecting one account out of several
+    // (or renaming a key) left header-tier routes pinned to a label that no
+    // longer exists — the account chip then renders blank. Relabel them too.
+    const headerTiers = await this.headerTierRepo.find({ where: { agent_id: agentId } });
+    const headerTiersToSave: HeaderTier[] = [];
+    for (const h of headerTiers) {
+      let mutated = false;
+      if (routeMatchesKey(h.override_route)) {
+        h.override_route = replaceKeyLabel(h.override_route!);
+        mutated = true;
+      }
+      if (h.fallback_routes && h.fallback_routes.some(routeMatchesKey)) {
+        h.fallback_routes = h.fallback_routes.map((r) =>
+          routeMatchesKey(r) ? replaceKeyLabel(r) : r,
+        );
+        mutated = true;
+      }
+      if (mutated) {
+        h.updated_at = now;
+        headerTiersToSave.push(h);
+      }
+    }
+    if (headerTiersToSave.length > 0) await this.headerTierRepo.save(headerTiersToSave);
   }
 
   private async renumberPriorities(

--- a/packages/backend/src/routing/routing-core/routing-core.module.ts
+++ b/packages/backend/src/routing/routing-core/routing-core.module.ts
@@ -7,6 +7,7 @@ import { AgentModelParams } from '../../entities/agent-model-params.entity';
 import { Agent } from '../../entities/agent.entity';
 import { Tenant } from '../../entities/tenant.entity';
 import { AgentMessage } from '../../entities/agent-message.entity';
+import { HeaderTier } from '../../entities/header-tier.entity';
 import { ModelPricesModule } from '../../model-prices/model-prices.module';
 import { ModelDiscoveryModule } from '../../model-discovery/model-discovery.module';
 import { ProviderService } from './provider.service';
@@ -31,6 +32,7 @@ import { ProviderParamSpecService } from './provider-param-spec.service';
       Agent,
       Tenant,
       AgentMessage,
+      HeaderTier,
     ]),
     ModelPricesModule,
     ModelDiscoveryModule,


### PR DESCRIPTION
## Problem

Disconnecting one account out of several on the same provider leaves the **custom (header) routing tiers** showing the models but with **no account chip** — the account pin (`ModelRoute.keyLabel`) is left dangling at the removed account. Same happens on key rename and on deactivate-all.

Root cause: provider-reference cleanup in `ProviderService` only iterated `tier_assignments` (complexity tiers) and `specificity_assignments`. The `header_tiers` table — which stores the same `override_route` / `fallback_routes: ModelRoute` shape — was never touched. The models stay because another account still backs them, but the chip can't resolve the dead `keyLabel`, so it renders blank.

This sits in the seam between #2068/#2069 (custom-tier account chips, on the **connect** path) and #1965 (disconnect cleanup, **standard routes only**).

## Fix

Inject the `HeaderTier` repo into `ProviderService` and clean header-tier routes everywhere tier/specificity routes are already cleaned:

- **`relabelOverrides`** — re-point/clear `keyLabel` on `override_route` + `fallback_routes` (covers disconnect-one-key and rename)
- **`cleanupProviderReferences`** — null/filter routes belonging to a removed provider (whole-provider teardown)
- **`deactivateAllProviders`** — clear header-tier routes alongside tier routes

Header tiers have no auto-assigned slot, so a cleared override just leaves the tier empty (resolve already treats that as fallthrough) — no notification path, unlike standard tiers. Cache invalidation already clears the header-tier cache via `invalidateAgent`.

Codex reviewed the approach (flagged `deactivateAllProviders` as the same bug class and warned against wedging header tiers into the standard-tier notification array — both addressed).

## Tests

New `header-tier cleanup on disconnect / rename` cases: disconnect-one-of-several relabels pins to null (and leaves non-matching tiers untouched), rename rewrites the pin, whole-provider disconnect clears matching routes while preserving others, and `deactivateAllProviders` clears header-tier routes. Full backend suite green (6063 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale account pins in custom (header) routing tiers when a provider key is disconnected, renamed, or all providers are deactivated. Header-tier routes are now cleaned so account chips don’t go blank and tiers fall through as expected.

- **Bug Fixes**
  - Clean header-tier `override_route`/`fallback_routes` in `relabelOverrides`, `cleanupProviderReferences`, and `deactivateAllProviders`.
  - Inject `HeaderTier` repo so `ProviderService` updates header tiers alongside complexity/specificity tiers.
  - Add tests for disconnect-one-of-several, rename, full provider removal, and deactivate-all; existing routing cache invalidation applies.

<sup>Written for commit d018cb43d5ee73976901360f0857366ff1862511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

