### PR TITLE
fix: apply MiniMax subscription region base URL in Playground

### DIFF
--- a/.changeset/playground-minimax-region.md
+++ b/.changeset/playground-minimax-region.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix the Playground sending MiniMax subscription requests to the default region endpoint. The OAuth `resource_url` (which encodes the chosen region) was only applied for Gemini and dropped for MiniMax; it is now turned into a `minimax-subscription` base-URL override the same way the proxy does, so Playground requests hit the correct region. Follow-up to #2110 (cubic-flagged).

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -313,6 +313,74 @@ describe('PlaygroundService.runStream', () => {
     expect(call.model).toBe('meta-llama/Llama-3.1-8B');
   });
 
+  it('routes MiniMax subscription requests through the region base URL from the OAuth resource_url', async () => {
+    const { service, mocks } = buildService();
+    mocks.minimaxOauth.unwrapToken.mockResolvedValue({
+      t: 'mm-access',
+      r: 'mm-refresh',
+      e: Date.now() + 60_000,
+      u: 'https://api.minimaxi.com/anthropic',
+    });
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream(['data: {"choices":[{"delta":{"content":"OK"}}]}\n\n', 'data: [DONE]\n\n']),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ provider: 'minimax', authType: 'subscription', model: 'minimax/abab' }),
+      asRes(res),
+    );
+
+    const call = mocks.providerClient.forward.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.apiKey).toBe('mm-access');
+    expect(call.customEndpoint).toBeDefined();
+    expect((call.customEndpoint as { baseUrl?: string }).baseUrl).toContain('api.minimaxi.com');
+  });
+
+  it('ignores an invalid MiniMax subscription resource URL instead of building an endpoint', async () => {
+    const { service, mocks } = buildService();
+    mocks.minimaxOauth.unwrapToken.mockResolvedValue({
+      t: 'mm-access',
+      r: 'mm-refresh',
+      e: Date.now() + 60_000,
+      u: 'https://evil.example/anthropic',
+    });
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream(['data: {"choices":[{"delta":{"content":"OK"}}]}\n\n', 'data: [DONE]\n\n']),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ provider: 'minimax', authType: 'subscription', model: 'minimax/abab' }),
+      asRes(res),
+    );
+
+    const call = mocks.providerClient.forward.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.customEndpoint).toBeUndefined();
+  });
+
+  it('returns 404 when a subscription OAuth blob can no longer be unwrapped', async () => {
+    const { service, mocks } = buildService();
+    // Stored value is a real OAuth blob, but unwrap fails (e.g. invalidated) —
+    // resolveApiKey returns a null apiKey, which must surface as a 404.
+    mocks.providerKeyService.getProviderKeys.mockResolvedValue([
+      { ...DEFAULT_PROVIDER_KEY, apiKey: JSON.stringify({ t: 'a', r: 'b', e: 123 }) },
+    ]);
+    mocks.openaiOauth.unwrapToken.mockResolvedValue(null);
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ provider: 'openai', authType: 'subscription' }),
+      asRes(res),
+    );
+
+    expect(res._status).toBe(404);
+    expect(mocks.providerClient.forward).not.toHaveBeenCalled();
+  });
+
   it('defaults all token counts to 0 when the stream reports no usage block', async () => {
     const { service, mocks } = buildService();
     mocks.providerClient.forward.mockResolvedValue(

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -336,6 +336,9 @@ describe('PlaygroundService.runStream', () => {
     expect(call.apiKey).toBe('mm-access');
     expect(call.customEndpoint).toBeDefined();
     expect((call.customEndpoint as { baseUrl?: string }).baseUrl).toContain('api.minimaxi.com');
+    // Custom endpoint forwards the model verbatim, so the `minimax/` prefix
+    // must be stripped or the subscription endpoint 404s.
+    expect(call.model).toBe('abab');
   });
 
   it('ignores an invalid MiniMax subscription resource URL instead of building an endpoint', async () => {

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -7,7 +7,8 @@ import type { AuthType, PlaygroundStreamEvent } from 'manifest-shared';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderClient } from '../routing/proxy/provider-client';
-import { buildCustomEndpoint } from '../routing/proxy/provider-endpoints';
+import { buildCustomEndpoint, buildEndpointOverride } from '../routing/proxy/provider-endpoints';
+import { normalizeMinimaxSubscriptionBaseUrl } from '../routing/provider-base-url';
 import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
 import {
   isRefreshableOAuthCredential,
@@ -69,6 +70,10 @@ export class PlaygroundService {
     let rawApiKey: string;
     let providerKeyLabel: string | undefined;
     let providerResource: string | undefined;
+    // MiniMax OAuth tokens carry the chosen region in the blob's resource_url.
+    // The proxy turns it into a base-URL override; keep that here so Playground
+    // subscription requests hit the right region endpoint.
+    let oauthResourceUrl: string | undefined;
     try {
       agent = await this.resolveAgent.resolve(userId, dto.agentName);
       const hasProvider = await this.providerKeyService.hasActiveProvider(agent.id, dto.provider);
@@ -123,6 +128,10 @@ export class PlaygroundService {
             providerKeyLabel,
           )) ?? rawApiKey;
       }
+      oauthResourceUrl = authType === 'subscription' ? resolved.resourceUrl : undefined;
+      // Gemini OAuth stores the CodeAssist project id (not a URL) in the same
+      // field; it is forwarded as providerResource. MiniMax's resource URL is
+      // applied as a base-URL override below, not here.
       providerResource =
         authType === 'subscription' && dto.provider.toLowerCase() === 'gemini'
           ? resolved.resourceUrl
@@ -150,6 +159,20 @@ export class PlaygroundService {
       if (cp) {
         customEndpoint = buildCustomEndpoint(cp.base_url, cp.api_kind ?? 'openai');
         forwardModel = CustomProviderService.rawModelName(dto.model);
+      }
+    } else if (
+      authType === 'subscription' &&
+      dto.provider.toLowerCase() === 'minimax' &&
+      oauthResourceUrl
+    ) {
+      // Route MiniMax subscription requests through the region base URL carried
+      // in the OAuth resource_url, matching the proxy. Without this the request
+      // hits the default region endpoint.
+      const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(oauthResourceUrl);
+      if (minimaxBaseUrl) {
+        customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
+      } else {
+        this.logger.warn('Ignoring invalid MiniMax subscription resource URL');
       }
     }
 

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -171,6 +171,12 @@ export class PlaygroundService {
       const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(oauthResourceUrl);
       if (minimaxBaseUrl) {
         customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
+        // Routing through a custom endpoint forwards the model id verbatim, so
+        // strip the `minimax/` vendor prefix the subscription endpoint rejects
+        // (matches the proxy).
+        if (forwardModel.toLowerCase().startsWith('minimax/')) {
+          forwardModel = forwardModel.substring('minimax/'.length);
+        }
       } else {
         this.logger.warn('Ignoring invalid MiniMax subscription resource URL');
       }


### PR DESCRIPTION
Follow-up to #2110. cubic flagged a P2 on that PR — *"Playground drops MiniMax OAuth `resourceUrl`, so subscription requests can target the wrong region endpoint"* — but #2110 merged before the fix landed, so the issue is still present on `main`. This PR lands it.

## Problem

Playground only forwarded the OAuth `resource_url` for Gemini (CodeAssist project id) and dropped it for MiniMax. MiniMax encodes the chosen **region** in that field, which the proxy turns into a base-URL override — so Playground subscription requests went to the default region endpoint instead of the user's.

## Fix

Mirror the proxy (`proxy-fallback.service.ts`): when a MiniMax subscription credential carries a `resource_url`, normalize it via `normalizeMinimaxSubscriptionBaseUrl` and build a `minimax-subscription` endpoint override. Invalid URLs are ignored with a warning (no override).

## Tests

- routes MiniMax subscription requests through the region base URL from the OAuth `resource_url`
- ignores an invalid MiniMax `resource_url` instead of building an endpoint
- (plus the unwrap-failure 404 path) — `playground.service.ts` stays at 100% line coverage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MiniMax subscription routing in Playground by applying the OAuth `resource_url` as the region base URL and stripping the `minimax/` model prefix when using the region endpoint. Requests now hit the user’s region endpoint and avoid 404s.

- **Bug Fixes**
  - Normalize the MiniMax `resource_url` and build a `minimax-subscription` endpoint override; ignore invalid values with a warning.
  - Strip the `minimax/` model prefix before forwarding through the region endpoint to prevent 404s.
  - Add tests for region routing, invalid-URL fallback, prefix handling, and the unwrap-failure 404 path.

<sup>Written for commit cd30668d7ef24293b8e8dc84224848e989d02a44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

