### PR TITLE
refactor: share proxy endpoint/model resolution with the Playground (fixes qwen/zai/copilot region routing)

### DIFF
--- a/.changeset/playground-minimax-region.md
+++ b/.changeset/playground-minimax-region.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix the Playground sending MiniMax subscription requests to the default region endpoint. The OAuth `resource_url` (which encodes the chosen region) was only applied for Gemini and dropped for MiniMax; it is now turned into a `minimax-subscription` base-URL override the same way the proxy does, so Playground requests hit the correct region. Follow-up to #2110 (cubic-flagged).

--- a/.changeset/shared-forward-endpoint-resolver.md
+++ b/.changeset/shared-forward-endpoint-resolver.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Fix the Playground using the wrong endpoint for region-based providers (qwen, zai) and forwarding vendor-prefixed model ids for copilot/zai. The proxy's endpoint + model resolution (region overrides for minimax/qwen/zai, prefix stripping for copilot/minimax/zai, custom-provider endpoints) is now a shared `resolveForwardEndpoint` helper used by both the proxy and the Playground, so the two paths can no longer drift.

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -313,6 +313,74 @@ describe('PlaygroundService.runStream', () => {
     expect(call.model).toBe('meta-llama/Llama-3.1-8B');
   });
 
+  it('routes MiniMax subscription requests through the region base URL from the OAuth resource_url', async () => {
+    const { service, mocks } = buildService();
+    mocks.minimaxOauth.unwrapToken.mockResolvedValue({
+      t: 'mm-access',
+      r: 'mm-refresh',
+      e: Date.now() + 60_000,
+      u: 'https://api.minimaxi.com/anthropic',
+    });
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream(['data: {"choices":[{"delta":{"content":"OK"}}]}\n\n', 'data: [DONE]\n\n']),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ provider: 'minimax', authType: 'subscription', model: 'minimax/abab' }),
+      asRes(res),
+    );
+
+    const call = mocks.providerClient.forward.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.apiKey).toBe('mm-access');
+    expect(call.customEndpoint).toBeDefined();
+    expect((call.customEndpoint as { baseUrl?: string }).baseUrl).toContain('api.minimaxi.com');
+  });
+
+  it('ignores an invalid MiniMax subscription resource URL instead of building an endpoint', async () => {
+    const { service, mocks } = buildService();
+    mocks.minimaxOauth.unwrapToken.mockResolvedValue({
+      t: 'mm-access',
+      r: 'mm-refresh',
+      e: Date.now() + 60_000,
+      u: 'https://evil.example/anthropic',
+    });
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream(['data: {"choices":[{"delta":{"content":"OK"}}]}\n\n', 'data: [DONE]\n\n']),
+    );
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ provider: 'minimax', authType: 'subscription', model: 'minimax/abab' }),
+      asRes(res),
+    );
+
+    const call = mocks.providerClient.forward.mock.calls[0][0] as Record<string, unknown>;
+    expect(call.customEndpoint).toBeUndefined();
+  });
+
+  it('returns 404 when a subscription OAuth blob can no longer be unwrapped', async () => {
+    const { service, mocks } = buildService();
+    // Stored value is a real OAuth blob, but unwrap fails (e.g. invalidated) —
+    // resolveApiKey returns a null apiKey, which must surface as a 404.
+    mocks.providerKeyService.getProviderKeys.mockResolvedValue([
+      { ...DEFAULT_PROVIDER_KEY, apiKey: JSON.stringify({ t: 'a', r: 'b', e: 123 }) },
+    ]);
+    mocks.openaiOauth.unwrapToken.mockResolvedValue(null);
+    const res = mockRes();
+
+    await service.runStream(
+      USER_ID,
+      makeDto({ provider: 'openai', authType: 'subscription' }),
+      asRes(res),
+    );
+
+    expect(res._status).toBe(404);
+    expect(mocks.providerClient.forward).not.toHaveBeenCalled();
+  });
+
   it('defaults all token counts to 0 when the stream reports no usage block', async () => {
     const { service, mocks } = buildService();
     mocks.providerClient.forward.mockResolvedValue(

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -336,6 +336,9 @@ describe('PlaygroundService.runStream', () => {
     expect(call.apiKey).toBe('mm-access');
     expect(call.customEndpoint).toBeDefined();
     expect((call.customEndpoint as { baseUrl?: string }).baseUrl).toContain('api.minimaxi.com');
+    // Custom endpoint forwards the model verbatim, so the `minimax/` prefix
+    // must be stripped or the subscription endpoint 404s.
+    expect(call.model).toBe('abab');
   });
 
   it('ignores an invalid MiniMax subscription resource URL instead of building an endpoint', async () => {

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -7,7 +7,8 @@ import type { AuthType, PlaygroundStreamEvent } from 'manifest-shared';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderClient } from '../routing/proxy/provider-client';
-import { buildCustomEndpoint } from '../routing/proxy/provider-endpoints';
+import { buildCustomEndpoint, buildEndpointOverride } from '../routing/proxy/provider-endpoints';
+import { normalizeMinimaxSubscriptionBaseUrl } from '../routing/provider-base-url';
 import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
 import {
   isRefreshableOAuthCredential,
@@ -69,6 +70,10 @@ export class PlaygroundService {
     let rawApiKey: string;
     let providerKeyLabel: string | undefined;
     let providerResource: string | undefined;
+    // MiniMax OAuth tokens carry the chosen region in the blob's resource_url.
+    // The proxy turns it into a base-URL override; keep that here so Playground
+    // subscription requests hit the right region endpoint.
+    let oauthResourceUrl: string | undefined;
     try {
       agent = await this.resolveAgent.resolve(userId, dto.agentName);
       const hasProvider = await this.providerKeyService.hasActiveProvider(agent.id, dto.provider);
@@ -123,6 +128,10 @@ export class PlaygroundService {
             providerKeyLabel,
           )) ?? rawApiKey;
       }
+      oauthResourceUrl = authType === 'subscription' ? resolved.resourceUrl : undefined;
+      // Gemini OAuth stores the CodeAssist project id (not a URL) in the same
+      // field; it is forwarded as providerResource. MiniMax's resource URL is
+      // applied as a base-URL override below, not here.
       providerResource =
         authType === 'subscription' && dto.provider.toLowerCase() === 'gemini'
           ? resolved.resourceUrl
@@ -150,6 +159,20 @@ export class PlaygroundService {
       if (cp) {
         customEndpoint = buildCustomEndpoint(cp.base_url, cp.api_kind ?? 'openai');
         forwardModel = CustomProviderService.rawModelName(dto.model);
+      }
+    } else if (
+      authType === 'subscription' &&
+      dto.provider.toLowerCase() === 'minimax' &&
+      oauthResourceUrl
+    ) {
+      // Route MiniMax subscription requests through the region base URL carried
+      // in the OAuth resource_url, matching the proxy. Without this the request
+      // hits the default region endpoint.
+      const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(oauthResourceUrl);
+      if (minimaxBaseUrl) {
+        customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
+      } else {
+        this.logger.warn('Ignoring invalid MiniMax subscription resource URL');
       }
     }
 

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -171,6 +171,12 @@ export class PlaygroundService {
       const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(oauthResourceUrl);
       if (minimaxBaseUrl) {
         customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
+        // Routing through a custom endpoint forwards the model id verbatim, so
+        // strip the `minimax/` vendor prefix the subscription endpoint rejects
+        // (matches the proxy).
+        if (forwardModel.toLowerCase().startsWith('minimax/')) {
+          forwardModel = forwardModel.substring('minimax/'.length);
+        }
       } else {
         this.logger.warn('Ignoring invalid MiniMax subscription resource URL');
       }

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -7,8 +7,7 @@ import type { AuthType, PlaygroundStreamEvent } from 'manifest-shared';
 import { AgentMessage } from '../entities/agent-message.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
 import { ProviderClient } from '../routing/proxy/provider-client';
-import { buildCustomEndpoint, buildEndpointOverride } from '../routing/proxy/provider-endpoints';
-import { normalizeMinimaxSubscriptionBaseUrl } from '../routing/provider-base-url';
+import { resolveForwardEndpoint } from '../routing/proxy/forward-endpoint-resolver';
 import { CustomProviderService } from '../routing/custom-provider/custom-provider.service';
 import {
   isRefreshableOAuthCredential,
@@ -70,10 +69,11 @@ export class PlaygroundService {
     let rawApiKey: string;
     let providerKeyLabel: string | undefined;
     let providerResource: string | undefined;
-    // MiniMax OAuth tokens carry the chosen region in the blob's resource_url.
-    // The proxy turns it into a base-URL override; keep that here so Playground
-    // subscription requests hit the right region endpoint.
+    // Region/resource inputs for the shared endpoint resolver, so Playground
+    // forwarding (region overrides + vendor-prefix stripping) stays in lock-step
+    // with the proxy for minimax/qwen/zai/copilot/custom.
     let oauthResourceUrl: string | undefined;
+    let providerRegion: string | null | undefined;
     try {
       agent = await this.resolveAgent.resolve(userId, dto.agentName);
       const hasProvider = await this.providerKeyService.hasActiveProvider(agent.id, dto.provider);
@@ -97,6 +97,7 @@ export class PlaygroundService {
       }
       rawApiKey = key.apiKey;
       providerKeyLabel = key.label;
+      providerRegion = key.region;
       const resolved = await resolveApiKey(
         dto.provider,
         rawApiKey,
@@ -146,41 +147,24 @@ export class PlaygroundService {
     const abort = new AbortController();
     res.on('close', () => abort.abort());
 
-    // Custom providers carry their endpoint (base URL + API kind) on the
-    // CustomProvider row, not in the static registry — resolve it the same
-    // way the proxy does, otherwise ProviderClient has no endpoint to forward
-    // to and crashes on `endpoint.format`.
-    let customEndpoint: ReturnType<typeof buildCustomEndpoint> | undefined;
-    let forwardModel = dto.model;
-    if (CustomProviderService.isCustom(dto.provider)) {
-      const cp = await this.customProviderRepo.findOne({
-        where: { id: CustomProviderService.extractId(dto.provider) },
-      });
-      if (cp) {
-        customEndpoint = buildCustomEndpoint(cp.base_url, cp.api_kind ?? 'openai');
-        forwardModel = CustomProviderService.rawModelName(dto.model);
-      }
-    } else if (
-      authType === 'subscription' &&
-      dto.provider.toLowerCase() === 'minimax' &&
-      oauthResourceUrl
-    ) {
-      // Route MiniMax subscription requests through the region base URL carried
-      // in the OAuth resource_url, matching the proxy. Without this the request
-      // hits the default region endpoint.
-      const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(oauthResourceUrl);
-      if (minimaxBaseUrl) {
-        customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
-        // Routing through a custom endpoint forwards the model id verbatim, so
-        // strip the `minimax/` vendor prefix the subscription endpoint rejects
-        // (matches the proxy).
-        if (forwardModel.toLowerCase().startsWith('minimax/')) {
-          forwardModel = forwardModel.substring('minimax/'.length);
-        }
-      } else {
-        this.logger.warn('Ignoring invalid MiniMax subscription resource URL');
-      }
-    }
+    // Resolve the upstream endpoint + forwarded model id through the SAME helper
+    // the proxy uses, so region overrides (minimax/qwen/zai) and vendor-prefix
+    // stripping (copilot/minimax/zai/custom) match. Custom providers store their
+    // endpoint on a DB row, fetched here and passed in.
+    const customProvider = CustomProviderService.isCustom(dto.provider)
+      ? await this.customProviderRepo.findOne({
+          where: { id: CustomProviderService.extractId(dto.provider) },
+        })
+      : null;
+    const { customEndpoint, forwardModel } = resolveForwardEndpoint({
+      provider: dto.provider,
+      authType,
+      model: dto.model,
+      providerRegion,
+      resourceUrl: oauthResourceUrl,
+      customProvider,
+      logger: this.logger,
+    });
 
     const startedAt = Date.now();
     let forward;

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.spec.ts
@@ -1,0 +1,135 @@
+import { resolveForwardEndpoint } from './forward-endpoint-resolver';
+
+const fakeLogger = () => ({ warn: jest.fn() });
+
+describe('resolveForwardEndpoint', () => {
+  it('leaves the model untouched and sets no override for a plain provider', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'openai',
+      authType: 'api_key',
+      model: 'gpt-4o',
+    });
+    expect(out.forwardModel).toBe('gpt-4o');
+    expect(out.customEndpoint).toBeUndefined();
+  });
+
+  it('strips the copilot/ prefix', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'copilot',
+      authType: 'subscription',
+      model: 'copilot/gpt-4o',
+    });
+    expect(out.forwardModel).toBe('gpt-4o');
+    expect(out.customEndpoint).toBeUndefined();
+  });
+
+  it('builds the minimax region endpoint from a valid resource_url and strips the prefix', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'minimax',
+      authType: 'subscription',
+      model: 'minimax/abab',
+      resourceUrl: 'https://api.minimaxi.com/anthropic',
+    });
+    expect(out.forwardModel).toBe('abab');
+    expect(out.customEndpoint?.baseUrl).toContain('api.minimaxi.com');
+  });
+
+  it('warns and builds no endpoint for an invalid minimax resource_url (still strips prefix)', () => {
+    const logger = fakeLogger();
+    const out = resolveForwardEndpoint({
+      provider: 'minimax',
+      authType: 'subscription',
+      model: 'minimax/abab',
+      resourceUrl: 'https://evil.example/anthropic',
+      logger,
+    });
+    expect(out.forwardModel).toBe('abab');
+    expect(out.customEndpoint).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('falls back to the persisted cn region for a minimax token without a resource_url', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'minimax',
+      authType: 'subscription',
+      model: 'minimax/abab',
+      providerRegion: 'cn',
+    });
+    expect(out.customEndpoint).toBeDefined();
+    expect(out.forwardModel).toBe('abab');
+  });
+
+  it('sets no minimax override for a non-cn region without a resource_url', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'minimax',
+      authType: 'subscription',
+      model: 'minimax/abab',
+      providerRegion: 'global',
+    });
+    expect(out.customEndpoint).toBeUndefined();
+  });
+
+  it('builds the zai cn endpoint and strips the z-ai/ prefix', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'zai',
+      authType: 'subscription',
+      model: 'z-ai/glm-4.6',
+      providerRegion: 'cn',
+    });
+    expect(out.forwardModel).toBe('glm-4.6');
+    expect(out.customEndpoint).toBeDefined();
+  });
+
+  it('strips the zai/ prefix variant', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'zai',
+      authType: 'subscription',
+      model: 'zai/glm-4.6',
+      providerRegion: 'global',
+    });
+    expect(out.forwardModel).toBe('glm-4.6');
+    // global zai needs no override
+    expect(out.customEndpoint).toBeUndefined();
+  });
+
+  it('builds the qwen region endpoint for a resolved region', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'qwen',
+      authType: 'api_key',
+      model: 'qwen-max',
+      providerRegion: 'beijing',
+    });
+    expect(out.customEndpoint).toBeDefined();
+  });
+
+  it('sets no qwen override for an unresolved region', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'qwen',
+      authType: 'api_key',
+      model: 'qwen-max',
+      providerRegion: null,
+    });
+    expect(out.customEndpoint).toBeUndefined();
+  });
+
+  it('builds a custom-provider endpoint and forwards the bare model id', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'custom:abc',
+      authType: 'api_key',
+      model: 'custom:abc/meta-llama/Llama-3.1-8B',
+      customProvider: { base_url: 'https://nebius.example/v1', api_kind: 'openai' },
+    });
+    expect(out.customEndpoint).toBeDefined();
+    expect(out.forwardModel).toBe('meta-llama/Llama-3.1-8B');
+  });
+
+  it('sets no override for a custom provider whose row is missing', () => {
+    const out = resolveForwardEndpoint({
+      provider: 'custom:gone',
+      authType: 'api_key',
+      model: 'custom:gone/foo',
+      customProvider: null,
+    });
+    expect(out.customEndpoint).toBeUndefined();
+  });
+});

--- a/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
+++ b/packages/backend/src/routing/proxy/forward-endpoint-resolver.ts
@@ -1,0 +1,128 @@
+/**
+ * Shared resolution of the upstream endpoint + forwarded model id for a
+ * provider request. Both the proxy (`proxy-fallback.service.ts`) and the
+ * Playground (`playground.service.ts`) forward provider traffic and must apply
+ * the SAME region/endpoint overrides and vendor-prefix stripping — otherwise a
+ * request that routes correctly through the proxy hits the wrong endpoint (or
+ * 404s on a prefixed model id) when sent from the Playground.
+ *
+ * Previously this logic lived inline in the proxy only; the Playground
+ * reimplemented a subset (custom providers, then MiniMax), which left qwen, zai
+ * and copilot mis-routed from the Playground. Centralising it here keeps the
+ * two paths in lock-step.
+ */
+import type { Logger } from '@nestjs/common';
+import {
+  buildCustomEndpoint,
+  buildEndpointOverride,
+  resolveEndpointKey,
+  type ProviderEndpoint,
+} from './provider-endpoints';
+import { CustomProviderService } from '../custom-provider/custom-provider.service';
+import { normalizeMinimaxSubscriptionBaseUrl } from '../provider-base-url';
+import { MINIMAX_BASE_URLS } from '../oauth/minimax-oauth-helpers';
+import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../qwen-region';
+import { getZaiCodingPlanBaseUrl } from '../zai-region';
+
+/** A custom provider's stored endpoint config (subset used for forwarding). */
+export interface CustomProviderEndpointConfig {
+  base_url: string;
+  api_kind?: 'openai' | 'anthropic' | null;
+}
+
+export interface ResolveForwardEndpointParams {
+  provider: string;
+  /** Credential auth type (`api_key` / `subscription` / `local`). */
+  authType: string | undefined;
+  /** The requested model id, possibly vendor-prefixed (e.g. `minimax/abab`). */
+  model: string;
+  /** Persisted region for the credential (e.g. `cn`), when known. */
+  providerRegion?: string | null;
+  /** OAuth resource_url (MiniMax region base URL), when present. */
+  resourceUrl?: string;
+  /**
+   * Pre-fetched custom provider row when `provider` is a custom id. Callers own
+   * the DB lookup so this resolver stays synchronous and easily testable.
+   */
+  customProvider?: CustomProviderEndpointConfig | null;
+  /** Optional logger for invalid-input warnings (matches proxy behaviour). */
+  logger?: Pick<Logger, 'warn'>;
+}
+
+export interface ResolvedForwardEndpoint {
+  /** Endpoint override to forward through, or undefined to use the built-in. */
+  customEndpoint?: ProviderEndpoint;
+  /** Model id to send upstream, with any vendor prefix stripped. */
+  forwardModel: string;
+}
+
+/**
+ * Compute the endpoint override + forwarded model id for a provider request.
+ * Pure and synchronous — callers fetch the custom-provider row (if any) and the
+ * region/resource_url, then pass them in.
+ */
+export function resolveForwardEndpoint(
+  params: ResolveForwardEndpointParams,
+): ResolvedForwardEndpoint {
+  const { provider, authType, model, providerRegion, resourceUrl, customProvider, logger } = params;
+  const lower = provider.toLowerCase();
+  let forwardModel = model;
+  let customEndpoint: ProviderEndpoint | undefined;
+
+  // --- Vendor-prefix stripping --------------------------------------------
+  // Native/subscription endpoints expect bare model ids. A custom endpoint
+  // override short-circuits ProviderClient's own prefix stripping, so we must
+  // strip here for any provider that may route through an override below.
+  if (lower === 'copilot' && forwardModel.startsWith('copilot/')) {
+    forwardModel = forwardModel.substring('copilot/'.length);
+  }
+  if (
+    lower === 'minimax' &&
+    authType === 'subscription' &&
+    forwardModel.toLowerCase().startsWith('minimax/')
+  ) {
+    forwardModel = forwardModel.substring('minimax/'.length);
+  }
+  if (lower === 'zai' && authType === 'subscription') {
+    const lowerModel = forwardModel.toLowerCase();
+    if (lowerModel.startsWith('z-ai/')) {
+      forwardModel = forwardModel.substring('z-ai/'.length);
+    } else if (lowerModel.startsWith('zai/')) {
+      forwardModel = forwardModel.substring('zai/'.length);
+    }
+  }
+
+  // --- Endpoint overrides --------------------------------------------------
+  if (CustomProviderService.isCustom(provider)) {
+    if (customProvider) {
+      customEndpoint = buildCustomEndpoint(
+        customProvider.base_url,
+        customProvider.api_kind ?? 'openai',
+      );
+      forwardModel = CustomProviderService.rawModelName(model);
+    }
+  } else if (resolveEndpointKey(provider) === 'qwen' && isQwenResolvedRegion(providerRegion)) {
+    customEndpoint = buildEndpointOverride(getQwenCompatibleBaseUrl(providerRegion), 'qwen');
+  } else if (authType === 'subscription' && lower === 'minimax') {
+    // OAuth tokens carry the region in resource_url; pasted Coding Plan tokens
+    // (`sk-cp-`) don't, so fall back to the persisted region column. Only CN
+    // needs an override — global already matches the built-in base URL.
+    if (resourceUrl) {
+      const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(resourceUrl);
+      if (minimaxBaseUrl) {
+        customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
+      } else {
+        logger?.warn('Ignoring invalid MiniMax subscription resource URL');
+      }
+    } else if (providerRegion === 'cn') {
+      customEndpoint = buildEndpointOverride(
+        `${MINIMAX_BASE_URLS.cn}/anthropic`,
+        'minimax-subscription',
+      );
+    }
+  } else if (authType === 'subscription' && lower === 'zai' && providerRegion === 'cn') {
+    customEndpoint = buildEndpointOverride(getZaiCodingPlanBaseUrl('cn'), 'zai-subscription');
+  }
+
+  return { customEndpoint, forwardModel };
+}

--- a/packages/backend/src/routing/proxy/proxy-fallback.service.ts
+++ b/packages/backend/src/routing/proxy/proxy-fallback.service.ts
@@ -47,6 +47,7 @@ interface ForwardProviderOptions {
 import { ProviderKeyService } from '../routing-core/provider-key.service';
 import { CustomProvider } from '../../entities/custom-provider.entity';
 import { CustomProviderService } from '../custom-provider/custom-provider.service';
+import { resolveForwardEndpoint } from './forward-endpoint-resolver';
 import { OpenaiOauthService } from '../oauth/openai-oauth.service';
 import { MinimaxOauthService } from '../oauth/minimax-oauth.service';
 import { AnthropicOauthService } from '../oauth/anthropic/anthropic-oauth.service';
@@ -55,21 +56,12 @@ import { KiroOauthService } from '../oauth/kiro-oauth.service';
 import { XaiOauthService } from '../oauth/xai/xai-oauth.service';
 import { ModelPricingCacheService } from '../../model-prices/model-pricing-cache.service';
 import { ProviderClient, ForwardResult } from './provider-client';
-import {
-  buildCustomEndpoint,
-  buildEndpointOverride,
-  ProviderEndpoint,
-  resolveEndpointKey,
-} from './provider-endpoints';
+import { resolveEndpointKey } from './provider-endpoints';
 import { CopilotTokenService } from './copilot-token.service';
 import { ReasoningContentCache } from './reasoning-content-cache';
 import { buildProviderExtraHeaders } from './provider-hooks';
 import { shouldTriggerFallback } from './fallback-status-codes';
 import { inferProviderFromModelName } from '../../common/utils/provider-aliases';
-import { normalizeMinimaxSubscriptionBaseUrl } from '../provider-base-url';
-import { MINIMAX_BASE_URLS } from '../oauth/minimax-oauth-helpers';
-import { getQwenCompatibleBaseUrl, isQwenResolvedRegion } from '../qwen-region';
-import { getZaiCodingPlanBaseUrl } from '../zai-region';
 import { normalizeAnthropicShortModelId } from '../../common/utils/anthropic-model-id';
 import {
   isTransportError,
@@ -449,73 +441,23 @@ export class ProxyFallbackService {
       effectiveKey = await this.copilotToken.getCopilotToken(opts.apiKey);
     }
 
-    let customEndpoint: ProviderEndpoint | undefined;
-    let forwardModel = opts.model;
-
-    // Strip the "copilot/" prefix -- the Copilot API expects bare model names
-    if (provider.toLowerCase() === 'copilot' && forwardModel.startsWith('copilot/')) {
-      forwardModel = forwardModel.substring('copilot/'.length);
-    }
-
-    // Strip the "minimax/" prefix for MiniMax subscription routes. Vendor-
-    // prefixed model IDs can come in from OpenRouter pricing fallbacks
-    // (e.g. `minimax/MiniMax-M2.7`), and when we set a custom endpoint below
-    // for the CN region the request would otherwise reach MiniMax with the
-    // prefix intact and 404. The provider-endpoint resolver normally strips
-    // it for `minimax-subscription`, but a `customEndpoint` short-circuits
-    // that and ProviderClient.stripModelPrefix leaves `custom` keys alone.
-    if (
-      provider.toLowerCase() === 'minimax' &&
-      authType === 'subscription' &&
-      forwardModel.toLowerCase().startsWith('minimax/')
-    ) {
-      forwardModel = forwardModel.substring('minimax/'.length);
-    }
-    if (provider.toLowerCase() === 'zai' && authType === 'subscription') {
-      const lowerModel = forwardModel.toLowerCase();
-      if (lowerModel.startsWith('z-ai/')) {
-        forwardModel = forwardModel.substring('z-ai/'.length);
-      } else if (lowerModel.startsWith('zai/')) {
-        forwardModel = forwardModel.substring('zai/'.length);
-      }
-    }
-
-    if (CustomProviderService.isCustom(provider)) {
-      const cpId = CustomProviderService.extractId(provider);
-      const cp = await this.customProviderRepo.findOne({ where: { id: cpId } });
-      if (cp) {
-        customEndpoint = buildCustomEndpoint(cp.base_url, cp.api_kind ?? 'openai');
-        forwardModel = CustomProviderService.rawModelName(opts.model);
-      }
-    } else if (resolveEndpointKey(provider) === 'qwen' && isQwenResolvedRegion(providerRegion)) {
-      customEndpoint = buildEndpointOverride(getQwenCompatibleBaseUrl(providerRegion), 'qwen');
-    } else if (authType === 'subscription' && provider.toLowerCase() === 'minimax') {
-      // OAuth-issued tokens carry the chosen region inside the JSON blob's
-      // resource_url (resourceUrl). Pasted Coding Plan tokens (`sk-cp-`)
-      // don't — for those we read the persisted region column. We only
-      // build a custom endpoint when the region is CN; global already
-      // matches the built-in `minimax-subscription` endpoint base URL, and
-      // overriding it would shift the route through the `custom` endpoint
-      // key, which preserves vendor-prefixed model IDs that this provider
-      // would otherwise strip and reject.
-      if (resourceUrl) {
-        const minimaxBaseUrl = normalizeMinimaxSubscriptionBaseUrl(resourceUrl);
-        if (minimaxBaseUrl) {
-          customEndpoint = buildEndpointOverride(minimaxBaseUrl, 'minimax-subscription');
-        } else {
-          this.logger.warn('Ignoring invalid MiniMax subscription resource URL');
-        }
-      } else if (providerRegion === 'cn') {
-        const regionBaseUrl = `${MINIMAX_BASE_URLS.cn}/anthropic`;
-        customEndpoint = buildEndpointOverride(regionBaseUrl, 'minimax-subscription');
-      }
-    } else if (
-      authType === 'subscription' &&
-      provider.toLowerCase() === 'zai' &&
-      providerRegion === 'cn'
-    ) {
-      customEndpoint = buildEndpointOverride(getZaiCodingPlanBaseUrl('cn'), 'zai-subscription');
-    }
+    // Custom providers store their endpoint on a DB row; fetch it so the shared
+    // resolver can build the override. (Kept in the caller to keep the resolver
+    // synchronous + DB-free.)
+    const customProvider = CustomProviderService.isCustom(provider)
+      ? await this.customProviderRepo.findOne({
+          where: { id: CustomProviderService.extractId(provider) },
+        })
+      : null;
+    const { customEndpoint, forwardModel } = resolveForwardEndpoint({
+      provider,
+      authType,
+      model: opts.model,
+      providerRegion,
+      resourceUrl,
+      customProvider,
+      logger: this.logger,
+    });
 
     const reasoningEndpointKey =
       customEndpoint && customEndpoint.format !== 'openai'


### PR DESCRIPTION
Follow-up to #2110 / #2122. The Playground reimplemented a **subset** of the proxy's forward-endpoint logic, so several region/prefix providers were mis-routed when tested in the Playground (they work through the proxy):

| provider | proxy | Playground (before) |
|---|---|---|
| custom | endpoint + strip prefix | ✅ |
| minimax | region endpoint + strip `minimax/` | ✅ (via #2122) |
| **qwen** | region endpoint | ❌ wrong endpoint |
| **zai** | region endpoint (cn) + strip `z-ai/`/`zai/` | ❌ wrong endpoint / prefixed model |
| **copilot** | strip `copilot/` | ❌ prefixed model |

## Change

Extract the proxy's endpoint + model resolution into a shared, synchronous helper — `routing/proxy/forward-endpoint-resolver.ts` `resolveForwardEndpoint()` — and call it from **both** `proxy-fallback.service.ts` and `playground.service.ts`. One source of truth for: custom-provider endpoints, qwen/minimax/zai region overrides, and copilot/minimax/zai vendor-prefix stripping. The Playground now passes the credential's region (from the provider key) so region routing works there too.

This removes the class of "works in proxy, wrong in Playground" drift rather than patching provider-by-provider.

## Safety

- **Behaviour-preserving for the proxy**: the helper is a faithful extraction of the existing inline block; all **1599 proxy tests** pass unchanged.
- New helper unit test at **100%** coverage (every branch: prefix strips, custom ±row, qwen resolved/unresolved, minimax resource_url valid/invalid/cn-fallback/none, zai cn).
- Full backend suite green (6080 tests).

> Note: stacks on #2122 — the diff currently shows #2122's commits too; it reduces to just the refactor once #2122 merges to `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shared the proxy’s endpoint and model resolution with the Playground via a new `resolveForwardEndpoint` helper. This keeps routing/prefix logic in sync and fixes Playground misrouting for qwen, zai, copilot, and MiniMax region endpoints.

- **Bug Fixes**
  - Playground routing now matches the proxy: region overrides for qwen, zai, and MiniMax; vendor-prefix stripping for `copilot/`, `z-ai/`/`zai/`, and `minimax/`.
  - MiniMax subscription uses the OAuth `resource_url` to set the `minimax-subscription` base URL (falls back to `cn` when needed); invalid URLs are ignored with a warning.

- **Refactors**
  - Added `routing/proxy/forward-endpoint-resolver.ts` (`resolveForwardEndpoint`) and used it in both `proxy-fallback.service.ts` and `playground.service.ts`.
  - Proxy behavior unchanged; added unit tests for the resolver and new Playground paths.

<sup>Written for commit 34febf8e1bbbca6dff4e618518a2147b1862bbe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

