### PR TITLE
Route Copilot models by endpoint metadata

### DIFF
--- a/.changeset/copilot-supported-endpoints.md
+++ b/.changeset/copilot-supported-endpoints.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Route Copilot subscription models using their advertised supported endpoints so responses-only models use `/responses` directly instead of failing on `/chat/completions`.

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -326,10 +326,7 @@ describe('ModelDiscoveryService', () => {
 
       await service.discoverModels(makeProvider());
 
-      expect(mockModelRegistry.registerModels).toHaveBeenCalledWith('openai', [
-        'gpt-4o',
-        'gpt-4-turbo',
-      ]);
+      expect(mockModelRegistry.registerModels).toHaveBeenCalledWith('openai', models);
     });
 
     it('should not register models when native fetch returns empty', async () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -160,10 +160,7 @@ export class ModelDiscoveryService {
 
       // Register confirmed model IDs from native API for future fallback filtering
       if (raw.length > 0 && this.modelRegistry) {
-        this.modelRegistry.registerModels(
-          provider.provider,
-          raw.map((m) => m.id),
-        );
+        this.modelRegistry.registerModels(provider.provider, raw);
       }
 
       // Subscription providers whose `/models` endpoint either does not

--- a/packages/backend/src/model-discovery/model-fetcher.ts
+++ b/packages/backend/src/model-discovery/model-fetcher.ts
@@ -26,6 +26,7 @@ export interface DiscoveredModel {
   capabilities?: readonly ModelCapability[];
   inputModalities?: readonly ModelModality[];
   outputModalities?: readonly ModelModality[];
+  supportedEndpoints?: readonly string[];
   qualityScore: number;
   authType?: AuthType;
 }

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts
@@ -1873,7 +1873,11 @@ describe('ProviderModelFetcherService', () => {
         ok: true,
         json: async () => ({
           data: [
-            { id: 'claude-opus-4.6', object: 'model' },
+            {
+              id: 'claude-opus-4.6',
+              object: 'model',
+              supported_endpoints: ['/chat/completions', '/v1/messages'],
+            },
             { id: 'gpt-4o', object: 'model' },
           ],
         }),
@@ -1890,6 +1894,7 @@ describe('ProviderModelFetcherService', () => {
           inputPricePerToken: 0,
           outputPricePerToken: 0,
           qualityScore: 3,
+          supportedEndpoints: ['/chat/completions', '/v1/messages'],
         }),
       );
       expect(result[1].id).toBe('copilot/gpt-4o');

--- a/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-fetcher.service.ts
@@ -45,6 +45,7 @@ interface ModelParserConfig<T> {
   inputPricePerToken?: number | null;
   outputPricePerToken?: number | null;
   capabilityCode?: boolean | ((entry: T) => boolean);
+  supportedEndpoints?: (entry: T) => readonly string[] | undefined;
   qualityScore?: number;
 }
 
@@ -60,6 +61,7 @@ function createModelParser<T>(
         const entry = m as T;
         const id = config.getId(entry);
         const ctxVal = config.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+        const supportedEndpoints = config.supportedEndpoints?.(entry);
         return {
           id,
           displayName: config.getDisplayName(entry, id),
@@ -72,10 +74,17 @@ function createModelParser<T>(
             typeof config.capabilityCode === 'function'
               ? config.capabilityCode(entry)
               : (config.capabilityCode ?? false),
+          ...(supportedEndpoints && supportedEndpoints.length > 0 ? { supportedEndpoints } : {}),
           qualityScore: config.qualityScore ?? 3,
         };
       });
   };
+}
+
+function getStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter((entry): entry is string => typeof entry === 'string');
+  return strings.length > 0 ? strings : undefined;
 }
 
 /* ── Shared OpenAI-compatible parser ── */
@@ -84,6 +93,7 @@ interface OpenAIModelEntry {
   id: string;
   object?: string;
   owned_by?: string;
+  supported_endpoints?: unknown;
 }
 
 interface CommandCodeModelEntry extends OpenAIModelEntry {
@@ -459,6 +469,7 @@ const parseCopilot = createModelParser<OpenAIModelEntry>({
   getDisplayName: (entry) => entry.id,
   inputPricePerToken: 0,
   outputPricePerToken: 0,
+  supportedEndpoints: (entry) => getStringArray(entry.supported_endpoints),
 });
 
 /* ── OpenCode Zen (aggregator, OpenAI-compatible /models) ── */

--- a/packages/backend/src/model-discovery/provider-model-registry.service.spec.ts
+++ b/packages/backend/src/model-discovery/provider-model-registry.service.spec.ts
@@ -40,6 +40,36 @@ describe('ProviderModelRegistryService', () => {
       expect(confirmed).not.toBeNull();
       expect(confirmed!.has('gpt-4o')).toBe(true);
     });
+
+    it('should store supported endpoint metadata for confirmed models', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('copilot', [
+        {
+          id: 'copilot/gpt-5.5',
+          supportedEndpoints: ['/responses', 'ws:/responses'],
+        },
+      ]);
+
+      expect(service.getModelMetadata('copilot', 'copilot/gpt-5.5')).toEqual({
+        id: 'copilot/gpt-5.5',
+        supportedEndpoints: ['/responses', 'ws:/responses'],
+      });
+    });
+
+    it('should preserve existing metadata when later registering IDs only', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('copilot', [
+        {
+          id: 'copilot/gpt-5.5',
+          supportedEndpoints: ['/responses'],
+        },
+      ]);
+      service.registerModels('copilot', ['copilot/gpt-5.5']);
+
+      expect(service.getModelMetadata('copilot', 'copilot/gpt-5.5')?.supportedEndpoints).toEqual([
+        '/responses',
+      ]);
+    });
   });
 
   describe('getConfirmedModels', () => {
@@ -84,6 +114,14 @@ describe('ProviderModelRegistryService', () => {
 
       expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
     });
+
+    it('should return null metadata for unknown providers or models', () => {
+      const service = new ProviderModelRegistryService(makeMockRepo() as never);
+      service.registerModels('openai', ['gpt-4o']);
+
+      expect(service.getModelMetadata('openai', 'unknown')).toBeNull();
+      expect(service.getModelMetadata('unknown', 'gpt-4o')).toBeNull();
+    });
   });
 
   describe('onApplicationBootstrap', () => {
@@ -108,6 +146,29 @@ describe('ProviderModelRegistryService', () => {
       expect(service.isModelConfirmed('openai', 'gpt-4o')).toBe(true);
       expect(service.isModelConfirmed('openai', 'gpt-4-turbo')).toBe(true);
       expect(service.isModelConfirmed('anthropic', 'claude-opus-4-6')).toBe(true);
+    });
+
+    it('should load supported endpoint metadata from cached user_providers data', async () => {
+      const providers = [
+        {
+          provider: 'copilot',
+          cached_models: [
+            {
+              id: 'copilot/gpt-5.5',
+              displayName: 'gpt-5.5',
+              supportedEndpoints: ['/responses', 'ws:/responses'],
+            },
+          ],
+        },
+      ];
+      const service = new ProviderModelRegistryService(makeMockRepo(providers) as never);
+
+      await service.onApplicationBootstrap();
+
+      expect(service.getModelMetadata('copilot', 'copilot/gpt-5.5')).toEqual({
+        id: 'copilot/gpt-5.5',
+        supportedEndpoints: ['/responses', 'ws:/responses'],
+      });
     });
 
     it('should skip providers with non-array cached_models', async () => {

--- a/packages/backend/src/model-discovery/provider-model-registry.service.ts
+++ b/packages/backend/src/model-discovery/provider-model-registry.service.ts
@@ -2,6 +2,15 @@ import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { UserProvider } from '../entities/user-provider.entity';
+import type { DiscoveredModel } from './model-fetcher';
+
+export interface ProviderModelRegistryEntry {
+  id: string;
+  supportedEndpoints?: readonly string[];
+}
+
+type ProviderModelRegistration = string | Pick<DiscoveredModel, 'id' | 'supportedEndpoints'>;
+type CachedProviderModelRegistration = Pick<DiscoveredModel, 'id' | 'supportedEndpoints'>;
 
 /**
  * Maintains an in-memory registry of model IDs confirmed to exist
@@ -13,7 +22,7 @@ import { UserProvider } from '../entities/user-provider.entity';
 @Injectable()
 export class ProviderModelRegistryService implements OnApplicationBootstrap {
   private readonly logger = new Logger(ProviderModelRegistryService.name);
-  private readonly registry = new Map<string, Set<string>>();
+  private readonly registry = new Map<string, Map<string, ProviderModelRegistryEntry>>();
 
   constructor(
     @InjectRepository(UserProvider)
@@ -28,14 +37,21 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
    * Register model IDs confirmed via a provider's native API.
    * Merges with any existing confirmed models for that provider.
    */
-  registerModels(providerId: string, modelIds: string[]): void {
+  registerModels(providerId: string, models: ProviderModelRegistration[]): void {
     const key = providerId.toLowerCase();
-    const existing = this.registry.get(key);
-    if (existing) {
-      for (const id of modelIds) existing.add(id.toLowerCase());
-    } else {
-      this.registry.set(key, new Set(modelIds.map((id) => id.toLowerCase())));
+    const existing = this.registry.get(key) ?? new Map<string, ProviderModelRegistryEntry>();
+    for (const model of models) {
+      const entry = this.toRegistryEntry(model);
+      if (!entry) continue;
+
+      const previous = existing.get(entry.id);
+      existing.set(entry.id, {
+        ...previous,
+        ...entry,
+        supportedEndpoints: entry.supportedEndpoints ?? previous?.supportedEndpoints,
+      });
     }
+    if (existing.size > 0) this.registry.set(key, existing);
   }
 
   /**
@@ -43,7 +59,8 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
    * Returns null if no native data has ever been recorded for this provider.
    */
   getConfirmedModels(providerId: string): ReadonlySet<string> | null {
-    return this.registry.get(providerId.toLowerCase()) ?? null;
+    const models = this.registry.get(providerId.toLowerCase());
+    return models ? new Set(models.keys()) : null;
   }
 
   /**
@@ -54,6 +71,10 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
     const confirmed = this.registry.get(providerId.toLowerCase());
     if (!confirmed) return null;
     return confirmed.has(modelId.toLowerCase());
+  }
+
+  getModelMetadata(providerId: string, modelId: string): ProviderModelRegistryEntry | null {
+    return this.registry.get(providerId.toLowerCase())?.get(modelId.toLowerCase()) ?? null;
   }
 
   /**
@@ -71,10 +92,18 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
       let totalModels = 0;
       for (const p of providers) {
         if (!Array.isArray(p.cached_models)) continue;
-        const ids = p.cached_models.map((m) => m.id).filter(Boolean);
-        if (ids.length > 0) {
-          this.registerModels(p.provider, ids);
-          totalModels += ids.length;
+        const cachedModels = p.cached_models as unknown[];
+        const models = cachedModels.filter(
+          (m): m is CachedProviderModelRegistration =>
+            typeof m === 'object' &&
+            m !== null &&
+            'id' in m &&
+            typeof (m as { id?: unknown }).id === 'string' &&
+            (m as { id?: string }).id!.length > 0,
+        );
+        if (models.length > 0) {
+          this.registerModels(p.provider, models);
+          totalModels += models.length;
         }
       }
 
@@ -87,5 +116,28 @@ export class ProviderModelRegistryService implements OnApplicationBootstrap {
     } catch (err) {
       this.logger.warn(`Failed to load provider model registry from cache: ${err}`);
     }
+  }
+
+  private toRegistryEntry(model: ProviderModelRegistration): ProviderModelRegistryEntry | null {
+    const id = typeof model === 'string' ? model : model.id;
+    if (typeof id !== 'string' || id.length === 0) return null;
+
+    const supportedEndpoints = typeof model === 'string' ? undefined : model.supportedEndpoints;
+    const endpoints =
+      Array.isArray(supportedEndpoints) && supportedEndpoints.length > 0
+        ? Array.from(
+            new Set(
+              supportedEndpoints.filter(
+                (endpoint): endpoint is string =>
+                  typeof endpoint === 'string' && endpoint.length > 0,
+              ),
+            ),
+          )
+        : undefined;
+
+    return {
+      id: id.toLowerCase(),
+      ...(endpoints && endpoints.length > 0 ? { supportedEndpoints: endpoints } : {}),
+    };
   }
 }

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -1,5 +1,6 @@
 import { ProviderClient } from '../provider-client';
 import { buildCustomEndpoint } from '../provider-endpoints';
+import type { ProviderModelRegistryService } from '../../../model-discovery/provider-model-registry.service';
 
 const mockFetch = jest.fn();
 (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch;
@@ -1004,6 +1005,16 @@ describe('ProviderClient', () => {
       'gpt-5.3-codex',
       'gpt-5.1-codex-mini',
     ];
+    const createClientWithCopilotMetadata = (models: Record<string, readonly string[]>) => {
+      const registry: Pick<ProviderModelRegistryService, 'getModelMetadata'> = {
+        getModelMetadata: jest.fn((provider: string, model: string) => {
+          if (provider !== 'copilot') return null;
+          const endpoints = models[model.toLowerCase()];
+          return endpoints ? { id: model.toLowerCase(), supportedEndpoints: endpoints } : null;
+        }),
+      };
+      return new ProviderClient(undefined, registry as unknown as ProviderModelRegistryService);
+    };
 
     it.each(copilotResponsesOnlyModels)(
       'routes Copilot + Codex model %s to /responses with chatgpt format',
@@ -1037,6 +1048,99 @@ describe('ProviderClient', () => {
         expect(sentBody.model).toBe(model);
       },
     );
+
+    it('routes Copilot chat input to /responses when supported_endpoints excludes chat', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const metadataClient = createClientWithCopilotMetadata({
+        'copilot/gpt-5.5': ['/responses', 'ws:/responses'],
+      });
+
+      const result = await metadataClient.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'gpt-5.5',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.githubcopilot.com/responses');
+      expect(result.isChatGpt).toBe(true);
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(Array.isArray(sentBody.input)).toBe(true);
+      expect(sentBody.messages).toBeUndefined();
+      expect(sentBody.model).toBe('gpt-5.5');
+    });
+
+    it('keeps Copilot chat input on /chat/completions when chat is supported', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const metadataClient = createClientWithCopilotMetadata({
+        'copilot/gpt-5.4': ['/responses', '/chat/completions', 'ws:/responses'],
+      });
+
+      const result = await metadataClient.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'gpt-5.4',
+        body,
+        stream: false,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.githubcopilot.com/chat/completions');
+      expect(result.isChatGpt).toBe(false);
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toBeDefined();
+      expect(sentBody.input).toBeUndefined();
+    });
+
+    it('routes Copilot Responses input to /responses when supported', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const metadataClient = createClientWithCopilotMetadata({
+        'copilot/gpt-5.4': ['/responses', '/chat/completions'],
+      });
+
+      const result = await metadataClient.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'gpt-5.4',
+        body: { input: 'Hello', stream: false },
+        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.githubcopilot.com/responses');
+      expect(result.isResponses).toBe(true);
+    });
+
+    it('routes Copilot Responses input to /chat/completions when only chat is supported', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+      const metadataClient = createClientWithCopilotMetadata({
+        'copilot/claude-sonnet-4.6': ['/chat/completions', '/v1/messages'],
+      });
+
+      const result = await metadataClient.forward({
+        provider: 'copilot',
+        apiKey: 'tid=abc',
+        model: 'claude-sonnet-4.6',
+        body: { input: 'Hello', stream: false },
+        chatBody: { messages: [{ role: 'user', content: 'Hello' }], stream: false },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('https://api.githubcopilot.com/chat/completions');
+      expect(result.isChatGpt).toBe(false);
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sentBody.messages).toBeDefined();
+      expect(sentBody.input).toBeUndefined();
+    });
 
     it('preserves reasoning and text params when converting Copilot Codex requests', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));

--- a/packages/backend/src/routing/proxy/provider-client.ts
+++ b/packages/backend/src/routing/proxy/provider-client.ts
@@ -26,6 +26,7 @@ import { ForwardOptions } from './proxy-types';
 import { toNativeResponsesRequest } from './responses-adapter';
 import { forwardKiroChat } from './kiro-adapter';
 import { OpencodeGoCatalogService } from '../../model-discovery/opencode-go-catalog.service';
+import { ProviderModelRegistryService } from '../../model-discovery/provider-model-registry.service';
 
 export interface ForwardResult {
   response: Response;
@@ -51,6 +52,8 @@ const PROVIDER_TIMEOUT_MS =
     ? parsedProviderTimeout
     : 180_000;
 const QWEN_TOKEN_PLAN_RESPONSES_RE = /^qwen3\.7-max$/i;
+const COPILOT_CHAT_COMPLETIONS_ENDPOINT = '/chat/completions';
+const COPILOT_RESPONSES_ENDPOINTS = new Set(['/responses', 'ws:/responses']);
 
 /**
  * Strip vendor prefix from model name (e.g. "anthropic/claude-sonnet-4" → "claude-sonnet-4").
@@ -84,6 +87,8 @@ export class ProviderClient {
   constructor(
     @Optional()
     private readonly opencodeGoCatalog?: OpencodeGoCatalogService,
+    @Optional()
+    private readonly modelRegistry?: ProviderModelRegistryService,
   ) {}
 
   async forward(opts: ForwardOptions): Promise<ForwardResult> {
@@ -214,10 +219,15 @@ export class ProviderClient {
     if (resolved === 'xai' && XAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
       resolved = 'xai-responses';
     }
-    // Copilot serves Codex variants only at /responses; /chat/completions returns
-    // "Unsupported API for model" (gh issue mnfst/manifest#1849).
-    if (resolved === 'copilot' && OPENAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
-      resolved = 'copilot-responses';
+    if (resolved === 'copilot') {
+      const metadataEndpoint = this.resolveCopilotEndpointFromMetadata(model, apiMode);
+      if (metadataEndpoint) {
+        resolved = metadataEndpoint;
+      } else if (OPENAI_RESPONSES_ONLY_RE.test(stripVendorPrefix(model))) {
+        // Copilot served the original Codex variants only at /responses before
+        // its /models endpoint exposed supported_endpoints.
+        resolved = 'copilot-responses';
+      }
     }
     if (resolved === 'opencode-go') {
       const bareOpenCodeModel = stripVendorPrefix(model).toLowerCase();
@@ -266,6 +276,44 @@ export class ProviderClient {
 
   private isKnownOpencodeGoAnthropicFamily(bareModel: string): boolean {
     return bareModel.startsWith('minimax-') || bareModel.startsWith('qwen3.7');
+  }
+
+  private resolveCopilotEndpointFromMetadata(
+    model: string,
+    apiMode: ForwardOptions['apiMode'],
+  ): 'copilot' | 'copilot-responses' | null {
+    const endpoints = this.getCopilotSupportedEndpoints(model);
+    if (!endpoints) return null;
+
+    const hasChat = endpoints.has(COPILOT_CHAT_COMPLETIONS_ENDPOINT);
+    const hasResponses = Array.from(COPILOT_RESPONSES_ENDPOINTS).some((endpoint) =>
+      endpoints.has(endpoint),
+    );
+
+    if (apiMode === 'responses') {
+      if (hasResponses) return 'copilot-responses';
+      if (hasChat) return 'copilot';
+      return null;
+    }
+
+    if (hasChat) return 'copilot';
+    if (hasResponses) return 'copilot-responses';
+    return null;
+  }
+
+  private getCopilotSupportedEndpoints(model: string): Set<string> | null {
+    const bareModel = stripVendorPrefix(model);
+    const candidates = Array.from(new Set([model, `copilot/${bareModel}`, bareModel]));
+
+    for (const candidate of candidates) {
+      const endpoints = this.modelRegistry?.getModelMetadata(
+        'copilot',
+        candidate,
+      )?.supportedEndpoints;
+      if (endpoints && endpoints.length > 0) return new Set(endpoints);
+    }
+
+    return null;
   }
 
   private buildRequest(ctx: {


### PR DESCRIPTION
## What changed

- Preserve Copilot `supported_endpoints` from the `/models` response in discovered and cached model records.
- Extend the confirmed-model registry so routing can look up per-model endpoint metadata without probing upstream.
- Route Copilot requests from metadata: chat-shaped input stays on `/chat/completions` when chat is supported, otherwise uses `/responses`; Responses-shaped input prefers `/responses` and falls back to chat when only chat is advertised.
- Keep the existing Codex regex as a legacy fallback for cached models without endpoint metadata.

## Why

Copilot `gpt-5.5` is advertised with `/responses` support but no `/chat/completions` support. The previous hardcoded Codex-only check missed it, so Manifest sent chat requests to the wrong Copilot endpoint and received `unsupported_api_for_model`.

Fixes #2119.

## Validation

- `npm --workspace manifest-shared run build`
- `npm --workspace manifest-backend test -- provider-model-fetcher.service.spec.ts provider-model-registry.service.spec.ts model-discovery.service.spec.ts provider-client.spec.ts --runInBand` (466 tests passed; Jest reported its existing open-handle warning after completion)
- `npx prettier --check .changeset/copilot-supported-endpoints.md packages/backend/src/model-discovery/model-fetcher.ts packages/backend/src/model-discovery/provider-model-fetcher.service.ts packages/backend/src/model-discovery/provider-model-registry.service.ts packages/backend/src/model-discovery/model-discovery.service.ts packages/backend/src/routing/proxy/provider-client.ts packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts packages/backend/src/model-discovery/provider-model-registry.service.spec.ts packages/backend/src/model-discovery/model-discovery.service.spec.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts`
- `npx eslint packages/backend/src/model-discovery/model-fetcher.ts packages/backend/src/model-discovery/provider-model-fetcher.service.ts packages/backend/src/model-discovery/provider-model-registry.service.ts packages/backend/src/model-discovery/model-discovery.service.ts packages/backend/src/routing/proxy/provider-client.ts packages/backend/src/model-discovery/provider-model-fetcher.service.spec.ts packages/backend/src/model-discovery/provider-model-registry.service.spec.ts packages/backend/src/model-discovery/model-discovery.service.spec.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts` (0 errors; existing spec `no-explicit-any` warnings only)
- `npm --workspace manifest-backend run build`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route GitHub Copilot models by their advertised supported endpoints so requests hit the right API (`/responses` vs `/chat/completions`). This fixes “unsupported_api_for_model” errors on responses‑only models like `gpt-5.5` and avoids probing upstream on each request.

- **New Features**
  - Preserve `supported_endpoints` from `/models` as `supportedEndpoints` on discovered/cached models.
  - Extend the model registry to store per‑model endpoint metadata and expose lookups for routing.
  - Route Copilot requests from metadata:
    - Chat-shaped input uses `/chat/completions` when supported, otherwise `/responses`.
    - Responses-shaped input prefers `/responses`, falling back to chat when only chat is advertised.

- **Bug Fixes**
  - Correctly route responses‑only Copilot models (e.g., `gpt-5.5`) to `/responses`; keep the Codex regex as a legacy fallback for cached models without endpoint metadata.

<sup>Written for commit 3f59cc4c806d285b5390f88e5d9eaf2b24eab10f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

