### PR TITLE
Normalize Copilot reasoning streams

### DIFF
--- a/.changeset/reasoning-stream-normalization.md
+++ b/.changeset/reasoning-stream-normalization.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Normalize provider reasoning stream aliases such as Copilot's `reasoning_text` to OpenAI-compatible `reasoning_content` for chat-completions clients while preserving provider-specific replay safeguards.

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -942,6 +942,54 @@ describe('provider-client-converters', () => {
   });
 
   describe('createReasoningContentStreamTransformer', () => {
+    it('normalizes Copilot reasoning_text to reasoning_content for clients', () => {
+      const transform = createReasoningContentStreamTransformer(undefined, {
+        outputStreamDeltaPaths: ['reasoning_content', 'reasoning_text'],
+        clientStreamDeltaPath: 'reasoning_content',
+      });
+
+      const out = transform(
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                role: 'assistant',
+                content: '',
+                reasoning_text: 'Let me think.',
+              },
+              finish_reason: null,
+            },
+          ],
+          model: 'claude-sonnet-4.6',
+        }),
+      );
+      const data = JSON.parse(out!.replace('data: ', '').trim());
+
+      expect(data.choices[0].delta.reasoning_text).toBe('Let me think.');
+      expect(data.choices[0].delta.reasoning_content).toBe('Let me think.');
+    });
+
+    it('keeps existing reasoning_content when a provider sends multiple reasoning aliases', () => {
+      const transform = createReasoningContentStreamTransformer(undefined, {
+        outputStreamDeltaPaths: ['reasoning_content', 'reasoning_text'],
+        clientStreamDeltaPath: 'reasoning_content',
+      });
+
+      const input = JSON.stringify({
+        choices: [
+          {
+            delta: {
+              reasoning_content: 'standard',
+              reasoning_text: 'provider alias',
+            },
+            finish_reason: null,
+          },
+        ],
+      });
+
+      expect(transform(input)).toBe(`data: ${input}\n\n`);
+    });
+
     it('accumulates reasoning_content and fires callback on tool-call finish', () => {
       const callback = jest.fn();
       const transform = createReasoningContentStreamTransformer(callback);
@@ -1053,6 +1101,39 @@ describe('provider-client-converters', () => {
 
       expect(transform('not json')).toBe('data: not json\n\n');
       expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('accumulates normalized reasoning aliases for tool-call replay cache', () => {
+      const callback = jest.fn();
+      const transform = createReasoningContentStreamTransformer(callback, {
+        outputStreamDeltaPaths: ['reasoning_content', 'reasoning_text'],
+        clientStreamDeltaPath: 'reasoning_content',
+      });
+
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { reasoning_text: 'use ' }, finish_reason: null }],
+        }),
+      );
+      transform(
+        JSON.stringify({
+          choices: [{ delta: { reasoning_text: 'a tool' }, finish_reason: null }],
+        }),
+      );
+      transform(
+        JSON.stringify({
+          choices: [
+            {
+              delta: {
+                tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'lookup' } }],
+              },
+              finish_reason: null,
+            },
+          ],
+        }),
+      );
+
+      expect(callback).toHaveBeenCalledWith('call_1', 'use a tool');
     });
   });
 });

--- a/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts
@@ -990,6 +990,19 @@ describe('provider-client-converters', () => {
       expect(transform(input)).toBe(`data: ${input}\n\n`);
     });
 
+    it('does not assign unsafe reasoning client paths', () => {
+      const transform = createReasoningContentStreamTransformer(undefined, {
+        outputStreamDeltaPaths: ['reasoning_text'],
+        clientStreamDeltaPath: '__proto__.polluted' as 'reasoning_content',
+      });
+      const input = JSON.stringify({
+        choices: [{ delta: { reasoning_text: 'unsafe' }, finish_reason: null }],
+      });
+
+      expect(transform(input)).toBe(`data: ${input}\n\n`);
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
     it('accumulates reasoning_content and fires callback on tool-call finish', () => {
       const callback = jest.fn();
       const transform = createReasoningContentStreamTransformer(callback);

--- a/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts
@@ -732,6 +732,29 @@ describe('proxy-response-handler', () => {
       );
     });
 
+    it('normalizes Copilot OpenAI-compatible reasoning streams through the reasoning transformer', async () => {
+      const { res } = mockResponse();
+      const forward = mockForward();
+      const client = mockProviderClient();
+      const meta = makeMeta({ provider: 'copilot', model: 'copilot/claude-sonnet-4.6' });
+      const transformer = jest.fn((chunk: string) => `data: ${chunk}\n\n`);
+      client.createReasoningContentStreamTransformer.mockReturnValue(transformer);
+
+      await handleStreamResponse(res as any, forward as any, meta, {}, client as any);
+
+      expect(client.createReasoningContentStreamTransformer).toHaveBeenCalledWith(undefined, {
+        outputStreamDeltaPaths: ['reasoning_content', 'reasoning_text'],
+        clientStreamDeltaPath: 'reasoning_content',
+      });
+      expect(pipeStreamSpy).toHaveBeenCalledWith(
+        forward.response.body,
+        res,
+        expect.any(Function),
+        undefined,
+        undefined,
+      );
+    });
+
     it('passes a finalize callback to pipeStream when apiMode=messages (default OpenAI provider)', async () => {
       const { res } = mockResponse();
       const forward = mockForward();

--- a/packages/backend/src/routing/proxy/provider-client-converters.ts
+++ b/packages/backend/src/routing/proxy/provider-client-converters.ts
@@ -19,6 +19,11 @@ import {
   transformResponsesStreamChunk,
   collectChatGptSseResponse,
 } from './chatgpt-adapter';
+import {
+  normalizeOpenAiReasoningDelta,
+  type OpenAiReasoningStreamFormat,
+  supportsReasoningContent,
+} from './reasoning-format';
 
 /** Convert a ChatGPT Responses API response to OpenAI format. */
 export function convertChatGptResponse(
@@ -126,52 +131,6 @@ function usesOpenAiMaxCompletionTokens(endpointKey: string, bareModel: string): 
   );
 }
 
-/**
- * Endpoints that tolerate `reasoning_content` for at least one model family.
- * Restricting model-family matching to this set prevents false positives on
- * strict OpenAI-compatible hosts that happen to serve a reasoning-derived
- * community slug and would reject the unknown message field.
- */
-const REASONING_CONTENT_AWARE_ENDPOINTS = new Set(['openrouter', 'opencode-go', 'custom']);
-
-const OPENCODE_GO_REASONING_MODEL_FAMILY_RE =
-  /^(?:deepseek|kimi|glm|qwen|minimax|mimo)(?:[-_.\d]|$)/i;
-
-/**
- * Some reasoning APIs reject follow-up turns that don't echo back the previous
- * assistant's `reasoning_content`. Preserve it for:
- *  - the native `deepseek` and `moonshot` endpoints (always)
- *  - OpenCode Go's known reasoning model families
- *  - aggregator/proxy endpoints whose `deepseek-*` slugs forward to a DeepSeek
- *    engine, or whose `moonshotai/*` slugs forward to Kimi
- *    (OpenRouter `deepseek/*` / `moonshotai/*` and DeepSeek custom providers).
- * Strict OpenAI-compatible endpoints (Mistral, native OpenAI, etc.) keep
- * stripping the field even if a community fine-tune slug contains "deepseek".
- */
-export function supportsReasoningContent(endpointKey: string, model: string): boolean {
-  const normalizedEndpoint = endpointKey.toLowerCase();
-  const key = normalizedEndpoint.startsWith('custom:') ? 'custom' : normalizedEndpoint;
-  if (key === 'deepseek') return true;
-  if (key === 'moonshot') return true;
-  if (!REASONING_CONTENT_AWARE_ENDPOINTS.has(key)) return false;
-  // Bare model id after stripping any vendor/aggregator prefix:
-  //   "deepseek/r1"             → "r1"            — OpenRouter, not deepseek-family
-  //   "openrouter" + "deepseek/deepseek-r1" → "deepseek-r1" ✓
-  //   "opencode-go/kimi-k2.6" → "kimi-k2.6" ✓
-  //   "custom:<uuid>/deepseek-reasoner" → "deepseek-reasoner" ✓
-  // (proxy-fallback.service strips "custom:<uuid>/" before forward, so in
-  // practice the custom path passes the already-bare model — both shapes
-  // are handled.)
-  const bare = model.toLowerCase().split('/').pop() ?? '';
-  if (key === 'opencode-go') {
-    return OPENCODE_GO_REASONING_MODEL_FAMILY_RE.test(bare);
-  }
-  if (key === 'openrouter' && model.toLowerCase().startsWith('moonshotai/')) {
-    return true;
-  }
-  return bare.includes('deepseek');
-}
-
 export type ReasoningContentCallback = (firstToolCallId: string, content: string) => void;
 
 /**
@@ -180,6 +139,10 @@ export type ReasoningContentCallback = (firstToolCallId: string, content: string
  */
 export function createReasoningContentStreamTransformer(
   onReasoningContent?: ReasoningContentCallback,
+  format: OpenAiReasoningStreamFormat = {
+    outputStreamDeltaPaths: ['reasoning_content'],
+    clientStreamDeltaPath: 'reasoning_content',
+  },
 ): (chunk: string) => string | null {
   let accumulatedReasoning = '';
   let firstToolCallId: string | null = null;
@@ -198,14 +161,17 @@ export function createReasoningContentStreamTransformer(
   };
 
   return (chunk: string): string | null => {
+    let outChunk = chunk;
     try {
       const parsed = JSON.parse(chunk) as Record<string, unknown>;
       const choice = (parsed.choices as Array<Record<string, unknown>> | undefined)?.[0];
       const delta = choice?.delta as Record<string, unknown> | undefined;
 
       if (delta) {
-        if (typeof delta.reasoning_content === 'string') {
-          accumulatedReasoning += delta.reasoning_content;
+        const reasoning = normalizeOpenAiReasoningDelta(delta, format);
+        if (reasoning) {
+          accumulatedReasoning += reasoning.text;
+          if (reasoning.normalized) outChunk = JSON.stringify(parsed);
           storeIfReady();
         }
         const toolCalls = delta.tool_calls as Array<Record<string, unknown>> | undefined;
@@ -225,7 +191,7 @@ export function createReasoningContentStreamTransformer(
       // Pass malformed/non-JSON chunks through unchanged.
     }
 
-    return `data: ${chunk}\n\n`;
+    return `data: ${outChunk}\n\n`;
   };
 }
 

--- a/packages/backend/src/routing/proxy/proxy-response-handler.ts
+++ b/packages/backend/src/routing/proxy/proxy-response-handler.ts
@@ -32,7 +32,7 @@ import {
   extractThinkingBlocksFromMessagesResponse,
   type ExtractedThinkingBlocks,
 } from './anthropic-adapter';
-import { supportsReasoningContent } from './provider-client-converters';
+import { getOpenAiReasoningStreamFormat, supportsReasoningContent } from './reasoning-format';
 import type { CallerAttribution } from './caller-classifier';
 import type { CaptureSink } from './recording-capture';
 import { sanitizeResponseHeaders } from './recording-capture';
@@ -379,14 +379,18 @@ export async function handleStreamResponse(
       onClient,
     );
   }
-  if (supportsReasoningContent(meta.provider, meta.model)) {
+  const reasoningStreamFormat = getOpenAiReasoningStreamFormat(meta.provider, meta.model);
+  if (reasoningStreamFormat) {
     const onReasoningContent =
       reasoningCache && sessionKey
         ? (firstToolCallId: string, content: string) => {
             reasoningCache.store(sessionKey, firstToolCallId, content);
           }
         : undefined;
-    const transformer = providerClient.createReasoningContentStreamTransformer(onReasoningContent);
+    const transformer = providerClient.createReasoningContentStreamTransformer(
+      onReasoningContent,
+      reasoningStreamFormat,
+    );
     return pipeStream(
       forward.response.body!,
       res,

--- a/packages/backend/src/routing/proxy/reasoning-content-cache.ts
+++ b/packages/backend/src/routing/proxy/reasoning-content-cache.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, Repository } from 'typeorm';
 import { ReasoningContentCacheEntry } from '../../entities/reasoning-content-cache-entry.entity';
-import { supportsReasoningContent } from './provider-client-converters';
+import { supportsReasoningContent } from './reasoning-format';
 
 interface CachedReasoningContent {
   content: string;

--- a/packages/backend/src/routing/proxy/reasoning-format.ts
+++ b/packages/backend/src/routing/proxy/reasoning-format.ts
@@ -92,12 +92,12 @@ export function normalizeOpenAiReasoningDelta(
   const reasoning = firstStringAtPaths(delta, format.outputStreamDeltaPaths);
   if (!reasoning) return null;
 
-  const existingClientValue = getPath(delta, format.clientStreamDeltaPath);
+  const existingClientValue = getClientStreamDelta(delta, format.clientStreamDeltaPath);
   if (typeof existingClientValue === 'string' && existingClientValue.length > 0) {
     return { text: reasoning, normalized: false };
   }
 
-  const normalized = setPath(delta, format.clientStreamDeltaPath, reasoning);
+  const normalized = setClientStreamDelta(delta, format.clientStreamDeltaPath, reasoning);
   return { text: reasoning, normalized };
 }
 
@@ -121,28 +121,19 @@ function getPath(obj: Record<string, unknown>, path: string): unknown {
   return current;
 }
 
-function setPath(obj: Record<string, unknown>, path: string, value: string): boolean {
-  const segments = safePathSegments(path);
-  if (!segments) return false;
-
-  let current = obj;
-  for (let i = 0; i < segments.length - 1; i++) {
-    const segment = segments[i];
-    const next = current[segment];
-    if (!next || typeof next !== 'object' || Array.isArray(next)) {
-      const replacement: Record<string, unknown> = {};
-      current[segment] = replacement;
-      current = replacement;
-    } else {
-      current = next as Record<string, unknown>;
-    }
-  }
-  current[segments[segments.length - 1]] = value;
-  return true;
-}
-
 function safePathSegments(path: string): string[] | null {
   const segments = path.split('.');
   if (segments.some((segment) => !segment || UNSAFE_PATH_SEGMENTS.has(segment))) return null;
   return segments;
+}
+
+function getClientStreamDelta(obj: Record<string, unknown>, path: string): unknown {
+  if (path !== 'reasoning_content') return undefined;
+  return obj.reasoning_content;
+}
+
+function setClientStreamDelta(obj: Record<string, unknown>, path: string, value: string): boolean {
+  if (path !== 'reasoning_content') return false;
+  obj.reasoning_content = value;
+  return true;
 }

--- a/packages/backend/src/routing/proxy/reasoning-format.ts
+++ b/packages/backend/src/routing/proxy/reasoning-format.ts
@@ -37,6 +37,8 @@ const REASONING_CONTENT_AWARE_ENDPOINTS = new Set(['openrouter', 'opencode-go', 
 const OPENCODE_GO_REASONING_MODEL_FAMILY_RE =
   /^(?:deepseek|kimi|glm|qwen|minimax|mimo)(?:[-_.\d]|$)/i;
 
+const UNSAFE_PATH_SEGMENTS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * Some reasoning APIs reject follow-up turns that don't echo back the previous
  * assistant's `reasoning_content`. Preserve it for:
@@ -95,8 +97,8 @@ export function normalizeOpenAiReasoningDelta(
     return { text: reasoning, normalized: false };
   }
 
-  setPath(delta, format.clientStreamDeltaPath, reasoning);
-  return { text: reasoning, normalized: true };
+  const normalized = setPath(delta, format.clientStreamDeltaPath, reasoning);
+  return { text: reasoning, normalized };
 }
 
 function firstStringAtPaths(obj: Record<string, unknown>, paths: readonly string[]): string | null {
@@ -108,16 +110,21 @@ function firstStringAtPaths(obj: Record<string, unknown>, paths: readonly string
 }
 
 function getPath(obj: Record<string, unknown>, path: string): unknown {
+  const segments = safePathSegments(path);
+  if (!segments) return undefined;
+
   let current: unknown = obj;
-  for (const segment of path.split('.')) {
+  for (const segment of segments) {
     if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined;
     current = (current as Record<string, unknown>)[segment];
   }
   return current;
 }
 
-function setPath(obj: Record<string, unknown>, path: string, value: string): void {
-  const segments = path.split('.');
+function setPath(obj: Record<string, unknown>, path: string, value: string): boolean {
+  const segments = safePathSegments(path);
+  if (!segments) return false;
+
   let current = obj;
   for (let i = 0; i < segments.length - 1; i++) {
     const segment = segments[i];
@@ -131,4 +138,11 @@ function setPath(obj: Record<string, unknown>, path: string, value: string): voi
     }
   }
   current[segments[segments.length - 1]] = value;
+  return true;
+}
+
+function safePathSegments(path: string): string[] | null {
+  const segments = path.split('.');
+  if (segments.some((segment) => !segment || UNSAFE_PATH_SEGMENTS.has(segment))) return null;
+  return segments;
 }

--- a/packages/backend/src/routing/proxy/reasoning-format.ts
+++ b/packages/backend/src/routing/proxy/reasoning-format.ts
@@ -1,0 +1,134 @@
+/**
+ * Client-facing reasoning stream metadata for OpenAI-compatible chunks.
+ *
+ * This is intentionally separate from request-parameter MPS metadata:
+ * providers may use one field to enable reasoning and another field to stream
+ * the resulting trace.
+ */
+
+export interface OpenAiReasoningStreamFormat {
+  outputStreamDeltaPaths: readonly string[];
+  clientStreamDeltaPath: 'reasoning_content';
+}
+
+export interface NormalizedReasoningDelta {
+  text: string;
+  normalized: boolean;
+}
+
+const STANDARD_OPENAI_REASONING_STREAM_FORMAT: OpenAiReasoningStreamFormat = Object.freeze({
+  outputStreamDeltaPaths: Object.freeze(['reasoning_content']),
+  clientStreamDeltaPath: 'reasoning_content',
+});
+
+const COPILOT_REASONING_STREAM_FORMAT: OpenAiReasoningStreamFormat = Object.freeze({
+  outputStreamDeltaPaths: Object.freeze(['reasoning_content', 'reasoning_text']),
+  clientStreamDeltaPath: 'reasoning_content',
+});
+
+/**
+ * Endpoints that tolerate `reasoning_content` for at least one model family.
+ * Restricting model-family matching to this set prevents false positives on
+ * strict OpenAI-compatible hosts that happen to serve a reasoning-derived
+ * community slug and would reject the unknown message field.
+ */
+const REASONING_CONTENT_AWARE_ENDPOINTS = new Set(['openrouter', 'opencode-go', 'custom']);
+
+const OPENCODE_GO_REASONING_MODEL_FAMILY_RE =
+  /^(?:deepseek|kimi|glm|qwen|minimax|mimo)(?:[-_.\d]|$)/i;
+
+/**
+ * Some reasoning APIs reject follow-up turns that don't echo back the previous
+ * assistant's `reasoning_content`. Preserve it for:
+ *  - the native `deepseek` and `moonshot` endpoints (always)
+ *  - OpenCode Go's known reasoning model families
+ *  - aggregator/proxy endpoints whose `deepseek-*` slugs forward to a DeepSeek
+ *    engine, or whose `moonshotai/*` slugs forward to Kimi
+ *    (OpenRouter `deepseek/*` / `moonshotai/*` and DeepSeek custom providers).
+ * Strict OpenAI-compatible endpoints (Mistral, native OpenAI, etc.) keep
+ * stripping the field even if a community fine-tune slug contains "deepseek".
+ */
+export function supportsReasoningContent(endpointKey: string, model: string): boolean {
+  const normalizedEndpoint = endpointKey.toLowerCase();
+  const key = normalizedEndpoint.startsWith('custom:') ? 'custom' : normalizedEndpoint;
+  if (key === 'deepseek') return true;
+  if (key === 'moonshot') return true;
+  if (!REASONING_CONTENT_AWARE_ENDPOINTS.has(key)) return false;
+  // Bare model id after stripping any vendor/aggregator prefix:
+  //   "deepseek/r1"             -> "r1"            -- OpenRouter, not deepseek-family
+  //   "openrouter" + "deepseek/deepseek-r1" -> "deepseek-r1"
+  //   "opencode-go/kimi-k2.6" -> "kimi-k2.6"
+  //   "custom:<uuid>/deepseek-reasoner" -> "deepseek-reasoner"
+  // (proxy-fallback.service strips "custom:<uuid>/" before forward, so in
+  // practice the custom path passes the already-bare model -- both shapes
+  // are handled.)
+  const bare = model.toLowerCase().split('/').pop() ?? '';
+  if (key === 'opencode-go') {
+    return OPENCODE_GO_REASONING_MODEL_FAMILY_RE.test(bare);
+  }
+  if (key === 'openrouter' && model.toLowerCase().startsWith('moonshotai/')) {
+    return true;
+  }
+  return bare.includes('deepseek');
+}
+
+export function getOpenAiReasoningStreamFormat(
+  endpointKey: string,
+  model: string,
+): OpenAiReasoningStreamFormat | null {
+  const normalizedEndpoint = endpointKey.toLowerCase();
+  const key = normalizedEndpoint.startsWith('custom:') ? 'custom' : normalizedEndpoint;
+  if (key === 'copilot') return COPILOT_REASONING_STREAM_FORMAT;
+  if (supportsReasoningContent(endpointKey, model)) return STANDARD_OPENAI_REASONING_STREAM_FORMAT;
+  return null;
+}
+
+export function normalizeOpenAiReasoningDelta(
+  delta: Record<string, unknown>,
+  format: OpenAiReasoningStreamFormat,
+): NormalizedReasoningDelta | null {
+  const reasoning = firstStringAtPaths(delta, format.outputStreamDeltaPaths);
+  if (!reasoning) return null;
+
+  const existingClientValue = getPath(delta, format.clientStreamDeltaPath);
+  if (typeof existingClientValue === 'string' && existingClientValue.length > 0) {
+    return { text: reasoning, normalized: false };
+  }
+
+  setPath(delta, format.clientStreamDeltaPath, reasoning);
+  return { text: reasoning, normalized: true };
+}
+
+function firstStringAtPaths(obj: Record<string, unknown>, paths: readonly string[]): string | null {
+  for (const path of paths) {
+    const value = getPath(obj, path);
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return null;
+}
+
+function getPath(obj: Record<string, unknown>, path: string): unknown {
+  let current: unknown = obj;
+  for (const segment of path.split('.')) {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function setPath(obj: Record<string, unknown>, path: string, value: string): void {
+  const segments = path.split('.');
+  let current = obj;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const segment = segments[i];
+    const next = current[segment];
+    if (!next || typeof next !== 'object' || Array.isArray(next)) {
+      const replacement: Record<string, unknown> = {};
+      current[segment] = replacement;
+      current = replacement;
+    } else {
+      current = next as Record<string, unknown>;
+    }
+  }
+  current[segments[segments.length - 1]] = value;
+}


### PR DESCRIPTION
## Summary

- add a small reasoning stream format helper for OpenAI-compatible stream aliases
- normalize Copilot `delta.reasoning_text` into client-facing `delta.reasoning_content`
- preserve existing `reasoning_content` behavior and replay-cache safeguards for compatible providers
- add focused proxy tests plus a patch changeset

Fixes #2121.

## Validation

- `npm test --workspace=packages/backend -- --runInBand routing/proxy/__tests__/provider-client-converters.spec.ts routing/proxy/__tests__/proxy-response-handler.spec.ts`
- `npm run build --workspace=packages/shared`
- `npm run build --workspace=packages/backend`
- `npx prettier --check .changeset/reasoning-stream-normalization.md packages/backend/src/routing/proxy/reasoning-format.ts packages/backend/src/routing/proxy/provider-client-converters.ts packages/backend/src/routing/proxy/proxy-response-handler.ts packages/backend/src/routing/proxy/reasoning-content-cache.ts packages/backend/src/routing/proxy/__tests__/provider-client-converters.spec.ts packages/backend/src/routing/proxy/__tests__/proxy-response-handler.spec.ts`
- `git diff --check`

## Local Copilot smoke

Ran a local stack at `http://127.0.0.1:38290` with a real Copilot device-login subscription.

- Copilot device auth completed
- Copilot token exchange succeeded
- model discovery found 31 Copilot models
- `copilot/gpt-4o` returned 200
- `copilot/gpt-5-mini` streamed successfully with `reasoning_effort=high`
- `copilot/claude-haiku-4.5` streamed successfully with `thinking.type=enabled`

The accepted live Copilot chat-completions models did not emit `reasoning_text` deltas during smoke, so the live smoke verified auth/routing/MPS params/streaming but not a provider-produced reasoning alias. The alias normalization itself is covered by focused tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Copilot reasoning streams so clients always get OpenAI-compatible `reasoning_content`, mapping `reasoning_text` when present, preserving replay-cache behavior, and preventing unsafe/dynamic writes. Addresses #2121.

- **Bug Fixes**
  - Map Copilot `delta.reasoning_text` to client `delta.reasoning_content` without removing the alias.
  - Add `reasoning-format` helper and select provider-specific formats from the proxy (normalize for `copilot`; keep `reasoning_content` for DeepSeek/Moonshot and compatible aggregators).
  - Update transformer to accept a format, normalize and accumulate reasoning text, and trigger the tool-call replay-cache callback.
  - Prevent dynamic/unsafe client path writes; only set `reasoning_content`.
  - Add tests for normalization, replay cache accumulation (including alias accumulation), and path safety.

<sup>Written for commit 489f04e18aefe7a76b2f3f5652837311e6b85b7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

