### PR TITLE
fix: require full AES-GCM authentication tags

### DIFF
--- a/packages/backend/src/common/utils/crypto.util.spec.ts
+++ b/packages/backend/src/common/utils/crypto.util.spec.ts
@@ -90,6 +90,15 @@ describe('encrypt / decrypt', () => {
     expect(() => decrypt(parts.join(':'), secret)).toThrow();
   });
 
+  it('decrypt throws on truncated authentication tags', () => {
+    const ciphertext = encrypt('secret data', secret);
+    const parts = ciphertext.split(':');
+    const tag = Buffer.from(parts[2], 'base64');
+    parts[2] = tag.subarray(0, 8).toString('base64');
+
+    expect(() => decrypt(parts.join(':'), secret)).toThrow('Invalid authentication tag length');
+  });
+
   it('decrypt throws when the wrong secret is used', () => {
     const ciphertext = encrypt('payload', secret);
     const wrongSecret = 'different-secret-also-long-enough-for-scrypt';

--- a/packages/backend/src/common/utils/crypto.util.ts
+++ b/packages/backend/src/common/utils/crypto.util.ts
@@ -7,6 +7,7 @@ const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const SALT_LENGTH = 16;
 const KEY_LENGTH = 32;
+const AUTH_TAG_LENGTH = 16;
 // Cheap scrypt fingerprint for cache indexing only — N=2 keeps it ~10µs while
 // remaining the same approved KDF family as the actual derivation below.
 const FINGERPRINT_LENGTH = 16;
@@ -76,7 +77,7 @@ export function encrypt(plaintext: string, secret: string): string {
   const salt = randomBytes(SALT_LENGTH);
   const key = deriveKey(secret, salt);
   const iv = randomBytes(IV_LENGTH);
-  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
   const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
   const tag = cipher.getAuthTag();
   return [
@@ -97,8 +98,11 @@ export function decrypt(ciphertext: string, secret: string): string {
   const iv = Buffer.from(ivB64, 'base64');
   const tag = Buffer.from(tagB64, 'base64');
   const encrypted = Buffer.from(encryptedB64, 'base64');
+  if (tag.length !== AUTH_TAG_LENGTH) {
+    throw new Error('Invalid authentication tag length');
+  }
   const key = deriveKey(secret, salt);
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: AUTH_TAG_LENGTH });
   decipher.setAuthTag(tag);
   const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
   return decrypted.toString('utf8');


### PR DESCRIPTION
## Summary
- define and pass the expected 16-byte AES-GCM authentication tag length
- reject malformed ciphertext envelopes with truncated tags before decryption
- add truncated-tag regression coverage

## Validation
- npm test -- crypto.util.spec.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce 16-byte AES‑GCM authentication tags in `packages/backend/src/common/utils/crypto.util.ts` and reject truncated tags before decryption. This hardens ciphertext validation and prevents malformed envelopes from being processed.

- **Bug Fixes**
  - Set `authTagLength: 16` in `createCipheriv` and `createDecipheriv`.
  - Validate tag length and throw "Invalid authentication tag length".
  - Add regression test for truncated tags in `crypto.util.spec.ts`.

<sup>Written for commit e3a6ad572598d5348133dc1b8a11a105f6244077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

