### PR TITLE
fix: bind OAuth callbacks to the current user

### DIFF
--- a/packages/backend/src/routing/gemini-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/gemini-oauth.controller.spec.ts
@@ -246,7 +246,7 @@ describe('GeminiOauthController', () => {
     it('exchanges code and returns ok', async () => {
       const result = await controller.callback('auth-code', 'state-123', { id: 'user-1' } as never);
 
-      expect(oauthService.exchangeCode).toHaveBeenCalledWith('state-123', 'auth-code');
+      expect(oauthService.exchangeCode).toHaveBeenCalledWith('state-123', 'auth-code', 'user-1');
       expect(result).toEqual({ ok: true });
     });
 

--- a/packages/backend/src/routing/oauth/gemini-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/gemini-oauth.controller.ts
@@ -15,7 +15,6 @@ import { randomBytes } from 'crypto';
 import { Request, Response } from 'express';
 import { Public } from '../../common/decorators/public.decorator';
 import { CurrentUser } from '../../auth/current-user.decorator';
-import { AuthUser } from '../../auth/auth.instance';
 import { OAuthTokenBlob, oauthDoneHtml } from './openai-oauth.types';
 import { GeminiOauthService } from './gemini-oauth.service';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
@@ -44,7 +43,7 @@ export class GeminiOauthController {
   @Get('authorize')
   async authorize(
     @Query('agentName') agentName: string,
-    @CurrentUser() user: AuthUser,
+    @CurrentUser() user: { id: string },
     @Req() req: Request,
   ) {
     if (!agentName) {
@@ -72,7 +71,7 @@ export class GeminiOauthController {
   async revoke(
     @Query('agentName') agentName: string,
     @Query('label') label: string | string[] | undefined,
-    @CurrentUser() user: AuthUser,
+    @CurrentUser() user: { id: string },
   ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
@@ -114,14 +113,14 @@ export class GeminiOauthController {
   async callback(
     @Body('code') code: string,
     @Body('state') state: string,
-    @CurrentUser() _user: AuthUser,
+    @CurrentUser() user: { id: string },
   ) {
     if (!code || !state) {
       throw new HttpException('code and state are required', HttpStatus.BAD_REQUEST);
     }
 
     try {
-      await this.oauthService.exchangeCode(state, code);
+      await this.oauthService.exchangeCode(state, code, user.id);
       return { ok: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Token exchange failed';

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.spec.ts
@@ -243,7 +243,7 @@ describe('OpenaiOauthController', () => {
       const { ctrl, oauth } = build();
       (oauth.exchangeCode as jest.Mock).mockResolvedValue(undefined);
       await expect(ctrl.callback('auth-code', 'state-1', user)).resolves.toEqual({ ok: true });
-      expect(oauth.exchangeCode).toHaveBeenCalledWith('state-1', 'auth-code');
+      expect(oauth.exchangeCode).toHaveBeenCalledWith('state-1', 'auth-code', 'user-1');
     });
 
     it('wraps service errors in a 400 carrying the original message', async () => {

--- a/packages/backend/src/routing/oauth/openai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/openai-oauth.controller.ts
@@ -15,7 +15,6 @@ import { randomBytes } from 'crypto';
 import { Request, Response } from 'express';
 import { Public } from '../../common/decorators/public.decorator';
 import { CurrentUser } from '../../auth/current-user.decorator';
-import { AuthUser } from '../../auth/auth.instance';
 import { OpenaiOauthService, OAuthTokenBlob, oauthDoneHtml } from './openai-oauth.service';
 import { ResolveAgentService } from '../routing-core/resolve-agent.service';
 import { ProviderService } from '../routing-core/provider.service';
@@ -42,7 +41,7 @@ export class OpenaiOauthController {
   @Get('authorize')
   async authorize(
     @Query('agentName') agentName: string,
-    @CurrentUser() user: AuthUser,
+    @CurrentUser() user: { id: string },
     @Req() req: Request,
   ) {
     if (!agentName) {
@@ -70,7 +69,7 @@ export class OpenaiOauthController {
   async revoke(
     @Query('agentName') agentName: string,
     @Query('label') label: string | string[] | undefined,
-    @CurrentUser() user: AuthUser,
+    @CurrentUser() user: { id: string },
   ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);
@@ -112,14 +111,14 @@ export class OpenaiOauthController {
   async callback(
     @Body('code') code: string,
     @Body('state') state: string,
-    @CurrentUser() _user: AuthUser,
+    @CurrentUser() user: { id: string },
   ) {
     if (!code || !state) {
       throw new HttpException('code and state are required', HttpStatus.BAD_REQUEST);
     }
 
     try {
-      await this.oauthService.exchangeCode(state, code);
+      await this.oauthService.exchangeCode(state, code, user.id);
       return { ok: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Token exchange failed';

--- a/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
+++ b/packages/backend/src/routing/oauth/redirect-pkce-oauth.base.ts
@@ -147,12 +147,15 @@ export abstract class RedirectPkceOauthBaseService {
     return `${this.oauthConfig.authorizeUrl}?${params.toString()}`;
   }
 
-  async exchangeCode(state: string, code: string): Promise<void> {
+  async exchangeCode(state: string, code: string, expectedUserId?: string): Promise<void> {
     const pending = this.pending.peek(state);
     if (!pending) throw new Error('Invalid or expired OAuth state');
     if (pending.expiresAt < Date.now()) {
       this.pending.delete(state);
       throw new Error('OAuth state expired');
+    }
+    if (expectedUserId && pending.userId !== expectedUserId) {
+      throw new Error('Invalid or expired OAuth state');
     }
     this.pending.delete(state);
     const body = new URLSearchParams({

--- a/packages/backend/src/routing/oauth/xai/xai-oauth.controller.ts
+++ b/packages/backend/src/routing/oauth/xai/xai-oauth.controller.ts
@@ -13,7 +13,6 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { randomBytes } from 'crypto';
 import { Request, Response } from 'express';
-import { AuthUser } from '../../../auth/auth.instance';
 import { CurrentUser } from '../../../auth/current-user.decorator';
 import { Public } from '../../../common/decorators/public.decorator';
 import { ResolveAgentService } from '../../routing-core/resolve-agent.service';
@@ -38,7 +37,7 @@ export class XaiOauthController {
   @Get('authorize')
   async authorize(
     @Query('agentName') agentName: string,
-    @CurrentUser() user: AuthUser,
+    @CurrentUser() user: { id: string },
     @Req() req: Request,
   ) {
     if (!agentName) {
@@ -60,14 +59,14 @@ export class XaiOauthController {
   async callback(
     @Body('code') code: string,
     @Body('state') state: string,
-    @CurrentUser() _user: AuthUser,
+    @CurrentUser() user: { id: string },
   ) {
     if (!code || !state) {
       throw new HttpException('code and state are required', HttpStatus.BAD_REQUEST);
     }
 
     try {
-      await this.oauthService.exchangeCode(state, code);
+      await this.oauthService.exchangeCode(state, code, user.id);
       return { ok: true };
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Token exchange failed';
@@ -80,7 +79,7 @@ export class XaiOauthController {
   async revoke(
     @Query('agentName') agentName: string,
     @Query('label') label: string | string[] | undefined,
-    @CurrentUser() user: AuthUser,
+    @CurrentUser() user: { id: string },
   ) {
     if (!agentName) {
       throw new HttpException('agentName query parameter is required', HttpStatus.BAD_REQUEST);

--- a/packages/backend/src/routing/openai-oauth.controller.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.controller.spec.ts
@@ -280,7 +280,7 @@ describe('OpenaiOauthController', () => {
     it('exchanges code and returns ok', async () => {
       const result = await controller.callback('auth-code', 'state-123', { id: 'user-1' } as never);
 
-      expect(oauthService.exchangeCode).toHaveBeenCalledWith('state-123', 'auth-code');
+      expect(oauthService.exchangeCode).toHaveBeenCalledWith('state-123', 'auth-code', 'user-1');
       expect(result).toEqual({ ok: true });
     });
 

--- a/packages/backend/src/routing/openai-oauth.service.spec.ts
+++ b/packages/backend/src/routing/openai-oauth.service.spec.ts
@@ -137,6 +137,18 @@ describe('OpenaiOauthService', () => {
       );
     });
 
+    it('rejects a manual callback when the state belongs to another user', async () => {
+      const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
+      const state = new URL(url).searchParams.get('state')!;
+
+      await expect(service.exchangeCode(state, 'code', 'user-2')).rejects.toThrow(
+        'Invalid or expired OAuth state',
+      );
+      expect(service.getPendingCount()).toBe(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(providerService.upsertProvider).not.toHaveBeenCalled();
+    });
+
     it('throws for expired state', async () => {
       const url = await service.generateAuthorizationUrl('agent-1', 'user-1');
       const state = new URL(url).searchParams.get('state')!;


### PR DESCRIPTION
## Summary
- pass the authenticated user id into OpenAI/Gemini/xAI manual OAuth callback exchanges
- reject pending OAuth states that belong to a different user without consuming the pending state
- use runtime-safe CurrentUser parameter annotations in these OAuth controllers
- add regression coverage for cross-user state rejection

## Validation
- npm test -- openai-oauth.controller.spec.ts gemini-oauth.controller.spec.ts openai-oauth.service.spec.ts xai-oauth.service.spec.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind manual OAuth callbacks to the authenticated user to prevent cross‑user token exchanges. Enforces state ownership during code exchange for OpenAI, Gemini, and xAI.

- **Bug Fixes**
  - Pass `user.id` to `exchangeCode` in OpenAI/Gemini/xAI OAuth controllers.
  - Add `expectedUserId` to `exchangeCode` in the base PKCE service and verify it matches the pending state’s `userId`; do not consume the state on mismatch.
  - Use runtime-safe `@CurrentUser() user: { id: string }` in controllers.
  - Add regression tests for cross-user state rejection and update existing specs.

<sup>Written for commit 03f92d625bc023e987c69ca095d9a9271a53aa11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

