### PR TITLE
fix: scope message detail logs by tenant and agent

### DIFF
--- a/packages/backend/src/analytics/services/message-details.service.spec.ts
+++ b/packages/backend/src/analytics/services/message-details.service.spec.ts
@@ -52,6 +52,7 @@ describe('MessageDetailsService', () => {
     routing_tier: 'standard',
     routing_reason: null,
     auth_type: 'api_key',
+    provider_key_label: null,
     skill_name: null,
     fallback_from_model: null,
     fallback_index: null,
@@ -63,6 +64,9 @@ describe('MessageDetailsService', () => {
     request_headers: null,
     request_params: null,
     caller_attribution: null,
+    header_tier_id: null,
+    header_tier_name: null,
+    header_tier_color: null,
     recorded: false,
     specificity_category: null,
     specificity_miscategorized: false,
@@ -210,9 +214,31 @@ describe('MessageDetailsService', () => {
     expect(result.agent_logs[0].severity).toBe('info');
   });
 
+  it('scopes related agent logs by tenant and agent from the owned message', async () => {
+    await service.getDetails('msg-1', 'u1');
+
+    expect(logQb.where).toHaveBeenCalledWith('al.trace_id = :traceId', { traceId: 'trace-abc' });
+    expect(logQb.andWhere).toHaveBeenCalledWith('al.tenant_id = :logTenantId', {
+      logTenantId: 't1',
+    });
+    expect(logQb.andWhere).toHaveBeenCalledWith('al.agent_id = :logAgentId', {
+      logAgentId: 'a1',
+    });
+  });
+
   it('does not query agent logs when trace_id is null', async () => {
     const msgNoTrace = { ...baseMessage, trace_id: null };
     msgQb.getOne.mockResolvedValue(msgNoTrace);
+
+    const result = await service.getDetails('msg-1', 'u1');
+
+    expect(result.agent_logs).toEqual([]);
+    expect(logQb.where).not.toHaveBeenCalled();
+  });
+
+  it('does not query agent logs without a tenant or agent scope', async () => {
+    const msgWithoutLogScope = { ...baseMessage, tenant_id: null, agent_id: null };
+    msgQb.getOne.mockResolvedValue(msgWithoutLogScope);
 
     const result = await service.getDetails('msg-1', 'u1');
 
@@ -243,6 +269,7 @@ describe('MessageDetailsService', () => {
       routing_tier: 'standard',
       routing_reason: null,
       auth_type: 'api_key',
+      provider_key_label: null,
       skill_name: null,
       fallback_from_model: null,
       fallback_index: null,
@@ -253,6 +280,9 @@ describe('MessageDetailsService', () => {
       request_headers: null,
       request_params: null,
       caller_attribution: null,
+      header_tier_id: null,
+      header_tier_name: null,
+      header_tier_color: null,
       recorded: false,
       specificity_category: null,
       specificity_miscategorized: false,

--- a/packages/backend/src/analytics/services/message-details.service.ts
+++ b/packages/backend/src/analytics/services/message-details.service.ts
@@ -125,12 +125,23 @@ export class MessageDetailsService {
       .orderBy('lc.call_index', 'ASC')
       .addOrderBy('lc.timestamp', 'ASC');
 
-    const logsQb = message.trace_id
-      ? this.logRepo
-          .createQueryBuilder('al')
-          .where('al.trace_id = :traceId', { traceId: message.trace_id })
-          .orderBy('al.timestamp', 'ASC')
-      : null;
+    const logsQb = (() => {
+      if (!message.trace_id || (!message.tenant_id && !message.agent_id)) {
+        return null;
+      }
+
+      // trace_id can be supplied by callers via traceparent, so it is not an isolation boundary.
+      const qb = this.logRepo
+        .createQueryBuilder('al')
+        .where('al.trace_id = :traceId', { traceId: message.trace_id });
+      if (message.tenant_id) {
+        qb.andWhere('al.tenant_id = :logTenantId', { logTenantId: message.tenant_id });
+      }
+      if (message.agent_id) {
+        qb.andWhere('al.agent_id = :logAgentId', { logAgentId: message.agent_id });
+      }
+      return qb.orderBy('al.timestamp', 'ASC');
+    })();
 
     const recordingPromise = message.recorded
       ? this.recordingRepo.findOne({ where: { message_id: message.id } })


### PR DESCRIPTION
## Summary
- scope message-detail agent log lookup by the already-owned message tenant/agent
- avoid returning trace-only logs because trace IDs can be caller supplied through traceparent
- add regression coverage for tenant/agent filters and unsafe unscoped fallback

## Validation
- npm test -- message-details.service.spec.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope agent log lookups in message details by the message’s tenant and agent to prevent cross-tenant access via caller-supplied `trace_id`. Also skip querying logs when there’s no trace or scope, and add regression tests.

- **Bug Fixes**
  - Filter agent logs by `tenant_id` and `agent_id` in addition to `trace_id`.
  - Skip log queries when `trace_id` is null or both `tenant_id` and `agent_id` are missing.
  - Add tests for scoping and no-scope cases; timestamp ordering unchanged.

<sup>Written for commit 52089e7b91a99a0f95a443049286d1d39cc3f7ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

