### PR TITLE
feat: add global provider playground

### DIFF
--- a/.changeset/global-provider-connections.md
+++ b/.changeset/global-provider-connections.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add tenant-level global provider connections while keeping existing agent provider connections.

--- a/.changeset/global-provider-playground.md
+++ b/.changeset/global-provider-playground.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add a tenant-level playground for global providers and let new agents copy selected global provider connections.

--- a/packages/backend/src/analytics/controllers/agents.controller.spec.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.spec.ts
@@ -12,11 +12,13 @@ import { ApiKeyGeneratorService } from '../../otlp/services/api-key.service';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { IngestEventBusService } from '../../common/services/ingest-event-bus.service';
 import { AgentRecordingCacheService } from '../../common/services/agent-recording-cache.service';
+import { ProviderService } from '../../routing/routing-core/provider.service';
 
 describe('AgentsController', () => {
   let controller: AgentsController;
   let cacheManager: Cache;
   let mockGetAgentList: jest.Mock;
+  let mockOnboardAgent: jest.Mock;
   let mockGetKeyForAgent: jest.Mock;
   let mockRotateKey: jest.Mock;
   let mockConfigGet: jest.Mock;
@@ -26,12 +28,18 @@ describe('AgentsController', () => {
   let mockDuplicate: jest.Mock;
   let mockGetCopySummary: jest.Mock;
   let mockSuggestName: jest.Mock;
+  let mockCopyGlobalProvidersToAgent: jest.Mock;
 
   beforeEach(async () => {
     mockGetAgentList = jest.fn().mockResolvedValue([
       { agent_name: 'bot-1', agent_id: 'id-1', message_count: 100 },
       { agent_name: 'bot-2', agent_id: 'id-2', message_count: 50 },
     ]);
+    mockOnboardAgent = jest.fn().mockResolvedValue({
+      tenantId: 't1',
+      agentId: 'a1',
+      apiKey: 'mnfst_key',
+    });
     mockGetKeyForAgent = jest.fn().mockResolvedValue({ keyPrefix: 'mnfst_test1234' });
     mockRotateKey = jest.fn().mockResolvedValue({ apiKey: 'mnfst_new_key_123' });
     mockConfigGet = jest.fn().mockReturnValue('');
@@ -59,6 +67,7 @@ describe('AgentsController', () => {
       modelParams: 0,
     });
     mockSuggestName = jest.fn().mockResolvedValue('bot-copy');
+    mockCopyGlobalProvidersToAgent = jest.fn().mockResolvedValue(0);
 
     const module: TestingModule = await Test.createTestingModule({
       imports: [CacheModule.register()],
@@ -95,7 +104,7 @@ describe('AgentsController', () => {
         {
           provide: ApiKeyGeneratorService,
           useValue: {
-            onboardAgent: jest.fn(),
+            onboardAgent: mockOnboardAgent,
             getKeyForAgent: mockGetKeyForAgent,
             rotateKey: mockRotateKey,
           },
@@ -119,6 +128,10 @@ describe('AgentsController', () => {
         {
           provide: IngestEventBusService,
           useValue: { emit: jest.fn() },
+        },
+        {
+          provide: ProviderService,
+          useValue: { copyGlobalProvidersToAgent: mockCopyGlobalProvidersToAgent },
         },
       ],
     }).compile();
@@ -248,6 +261,46 @@ describe('AgentsController', () => {
     expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
   });
 
+  it('copies selected global providers after creating an agent', async () => {
+    mockCopyGlobalProvidersToAgent.mockResolvedValueOnce(2);
+    const providerIds = [
+      '550e8400-e29b-41d4-a716-446655440000',
+      '550e8400-e29b-41d4-a716-446655440001',
+    ];
+    const user = { id: 'u1', email: 'test@example.com' };
+
+    const result = await controller.createAgent(
+      user as never,
+      {
+        name: 'My Agent',
+        global_provider_ids: providerIds,
+      } as never,
+    );
+
+    expect(mockOnboardAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantName: 'u1', agentName: 'my-agent' }),
+    );
+    expect(mockCopyGlobalProvidersToAgent).toHaveBeenCalledWith('u1', 'a1', providerIds);
+    expect(result.copied).toEqual({ globalProviders: 2 });
+  });
+
+  it('keeps agent creation successful when global provider copy fails', async () => {
+    mockCopyGlobalProvidersToAgent.mockRejectedValueOnce(new Error('copy failed'));
+    const user = { id: 'u1', email: 'test@example.com' };
+
+    const result = await controller.createAgent(
+      user as never,
+      {
+        name: 'My Agent',
+        global_provider_ids: ['550e8400-e29b-41d4-a716-446655440000'],
+      } as never,
+    );
+
+    expect(result.agent.name).toBe('my-agent');
+    expect(result.copied).toEqual({ globalProviders: 0 });
+    expect(cacheManager.del).toHaveBeenCalledWith('u1:/api/v1/agents');
+  });
+
   it('passes agent_category and agent_platform to onboardAgent', async () => {
     const mockOnboard = jest.fn().mockResolvedValue({
       tenantId: 't1',
@@ -283,6 +336,10 @@ describe('AgentsController', () => {
         {
           provide: AgentRecordingCacheService,
           useValue: { isRecording: jest.fn(), invalidate: jest.fn() },
+        },
+        {
+          provide: ProviderService,
+          useValue: { copyGlobalProvidersToAgent: jest.fn().mockResolvedValue(0) },
         },
       ],
     }).compile();
@@ -346,6 +403,10 @@ describe('AgentsController', () => {
           provide: AgentRecordingCacheService,
           useValue: { isRecording: jest.fn(), invalidate: jest.fn() },
         },
+        {
+          provide: ProviderService,
+          useValue: { copyGlobalProvidersToAgent: jest.fn().mockResolvedValue(0) },
+        },
       ],
     }).compile();
 
@@ -360,7 +421,6 @@ describe('AgentsController', () => {
   });
 
   it('passes category/platform to updateAgentType on PATCH', async () => {
-    const mockUpdateType = jest.fn().mockResolvedValue(undefined);
     const user = { id: 'u1' };
     const result = await controller.updateAgent(user as never, 'bot-1', {
       agent_category: 'app',
@@ -405,6 +465,10 @@ describe('AgentsController', () => {
         {
           provide: AgentRecordingCacheService,
           useValue: { isRecording: jest.fn(), invalidate: mockInvalidate },
+        },
+        {
+          provide: ProviderService,
+          useValue: { copyGlobalProvidersToAgent: jest.fn().mockResolvedValue(0) },
         },
       ],
     }).compile();
@@ -456,6 +520,10 @@ describe('AgentsController', () => {
           provide: AgentRecordingCacheService,
           useValue: { isRecording: jest.fn(), invalidate: jest.fn() },
         },
+        {
+          provide: ProviderService,
+          useValue: { copyGlobalProvidersToAgent: jest.fn().mockResolvedValue(0) },
+        },
       ],
     }).compile();
 
@@ -501,6 +569,10 @@ describe('AgentsController', () => {
           provide: AgentRecordingCacheService,
           useValue: { isRecording: jest.fn(), invalidate: jest.fn() },
         },
+        {
+          provide: ProviderService,
+          useValue: { copyGlobalProvidersToAgent: jest.fn().mockResolvedValue(0) },
+        },
       ],
     }).compile();
 
@@ -544,6 +616,10 @@ describe('AgentsController', () => {
         {
           provide: AgentRecordingCacheService,
           useValue: { isRecording: jest.fn(), invalidate: jest.fn() },
+        },
+        {
+          provide: ProviderService,
+          useValue: { copyGlobalProvidersToAgent: jest.fn().mockResolvedValue(0) },
         },
       ],
     }).compile();
@@ -646,6 +722,10 @@ describe('AgentsController', () => {
         {
           provide: AgentRecordingCacheService,
           useValue: { isRecording: jest.fn(), invalidate: jest.fn() },
+        },
+        {
+          provide: ProviderService,
+          useValue: { copyGlobalProvidersToAgent: jest.fn().mockResolvedValue(0) },
         },
       ],
     }).compile();

--- a/packages/backend/src/analytics/controllers/agents.controller.ts
+++ b/packages/backend/src/analytics/controllers/agents.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Get,
   Inject,
+  Logger,
   Param,
   Patch,
   Post,
@@ -29,9 +30,12 @@ import { AGENT_LIST_CACHE_TTL_MS } from '../../common/constants/cache.constants'
 import { slugify } from '../../common/utils/slugify';
 import { TenantCacheService } from '../../common/services/tenant-cache.service';
 import { AgentRecordingCacheService } from '../../common/services/agent-recording-cache.service';
+import { ProviderService } from '../../routing/routing-core/provider.service';
 
 @Controller('api/v1')
 export class AgentsController {
+  private readonly logger = new Logger(AgentsController.name);
+
   constructor(
     private readonly timeseries: TimeseriesQueriesService,
     private readonly lifecycle: AgentLifecycleService,
@@ -40,6 +44,7 @@ export class AgentsController {
     private readonly tenantCache: TenantCacheService,
     private readonly eventBus: IngestEventBusService,
     private readonly recordingCache: AgentRecordingCacheService,
+    private readonly providerService: ProviderService,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
@@ -79,6 +84,22 @@ export class AgentsController {
       }
       throw error;
     }
+    let copiedGlobalProviders = 0;
+    if (body.global_provider_ids?.length) {
+      try {
+        copiedGlobalProviders = await this.providerService.copyGlobalProvidersToAgent(
+          user.id,
+          result.agentId,
+          body.global_provider_ids,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Failed to copy global providers into new agent ${result.agentId}: ${
+            error instanceof Error ? error.message : error
+          }`,
+        );
+      }
+    }
     await this.cacheManager.del(this.agentListCacheKey(user.id));
     this.eventBus.emit(user.id, 'agent');
     return {
@@ -90,6 +111,7 @@ export class AgentsController {
         agent_platform: body.agent_platform ?? null,
       },
       apiKey: result.apiKey,
+      copied: { globalProviders: copiedGlobalProviders },
     };
   }
 

--- a/packages/backend/src/common/dto/create-agent.dto.spec.ts
+++ b/packages/backend/src/common/dto/create-agent.dto.spec.ts
@@ -95,4 +95,22 @@ describe('CreateAgentDto', () => {
     const errors = await validate(dto);
     expect(errors).toHaveLength(0);
   });
+
+  it('accepts selected global provider IDs', async () => {
+    const dto = plainToInstance(CreateAgentDto, {
+      name: 'my-agent',
+      global_provider_ids: ['550e8400-e29b-41d4-a716-446655440000'],
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects non-UUID global provider IDs', async () => {
+    const dto = plainToInstance(CreateAgentDto, {
+      name: 'my-agent',
+      global_provider_ids: ['not-a-provider-id'],
+    });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/backend/src/common/dto/create-agent.dto.ts
+++ b/packages/backend/src/common/dto/create-agent.dto.ts
@@ -6,6 +6,9 @@ import {
   Matches,
   IsOptional,
   IsIn,
+  IsArray,
+  ArrayMaxSize,
+  IsUUID,
 } from 'class-validator';
 import { AGENT_CATEGORIES, AGENT_PLATFORMS } from 'manifest-shared';
 
@@ -28,4 +31,10 @@ export class CreateAgentDto {
   @IsString()
   @IsIn([...AGENT_PLATFORMS])
   agent_platform?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(25)
+  @IsUUID('4', { each: true })
+  global_provider_ids?: string[];
 }

--- a/packages/backend/src/database/migrations/1790500000000-AddGlobalProviderScope.spec.ts
+++ b/packages/backend/src/database/migrations/1790500000000-AddGlobalProviderScope.spec.ts
@@ -1,0 +1,38 @@
+import { AddGlobalProviderScope1790500000000 } from './1790500000000-AddGlobalProviderScope';
+
+describe('AddGlobalProviderScope1790500000000', () => {
+  const makeRunner = () => {
+    const queries: string[] = [];
+    return {
+      queries,
+      runner: {
+        query: jest.fn((sql: string) => {
+          queries.push(sql);
+          return Promise.resolve();
+        }),
+      },
+    };
+  };
+
+  it('makes agent_id nullable and creates scoped unique indexes', async () => {
+    const migration = new AddGlobalProviderScope1790500000000();
+    const { queries, runner } = makeRunner();
+
+    await migration.up(runner as any);
+
+    expect(queries.join('\n')).toContain('ALTER COLUMN "agent_id" DROP NOT NULL');
+    expect(queries.join('\n')).toContain('WHERE "agent_id" IS NOT NULL');
+    expect(queries.join('\n')).toContain('IDX_user_providers_global_provider_auth_label');
+    expect(queries.join('\n')).toContain('WHERE "agent_id" IS NULL');
+  });
+
+  it('drops global rows before restoring the not-null agent scope', async () => {
+    const migration = new AddGlobalProviderScope1790500000000();
+    const { queries, runner } = makeRunner();
+
+    await migration.down(runner as any);
+
+    expect(queries[0]).toContain('DELETE FROM "user_providers" WHERE "agent_id" IS NULL');
+    expect(queries.join('\n')).toContain('ALTER COLUMN "agent_id" SET NOT NULL');
+  });
+});

--- a/packages/backend/src/database/migrations/1790500000000-AddGlobalProviderScope.ts
+++ b/packages/backend/src/database/migrations/1790500000000-AddGlobalProviderScope.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddGlobalProviderScope1790500000000 implements MigrationInterface {
+  name = 'AddGlobalProviderScope1790500000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user_providers" ALTER COLUMN "agent_id" DROP NOT NULL`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_user_providers_agent_provider_auth_label"`);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_user_providers_agent_provider_auth_label"
+      ON "user_providers" ("agent_id", "provider", "auth_type", LOWER("label"))
+      WHERE "agent_id" IS NOT NULL
+    `);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_user_providers_global_provider_auth_label"
+      ON "user_providers" ("user_id", "provider", "auth_type", LOWER("label"))
+      WHERE "agent_id" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DELETE FROM "user_providers" WHERE "agent_id" IS NULL`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_user_providers_global_provider_auth_label"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_user_providers_agent_provider_auth_label"`);
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_user_providers_agent_provider_auth_label"
+      ON "user_providers" ("agent_id", "provider", "auth_type", LOWER("label"))
+    `);
+    await queryRunner.query(`ALTER TABLE "user_providers" ALTER COLUMN "agent_id" SET NOT NULL`);
+  }
+}

--- a/packages/backend/src/entities/user-provider.entity.ts
+++ b/packages/backend/src/entities/user-provider.entity.ts
@@ -11,8 +11,8 @@ export class UserProvider {
   @Column('varchar')
   user_id!: string;
 
-  @Column('varchar')
-  agent_id!: string;
+  @Column('varchar', { nullable: true, default: null })
+  agent_id!: string | null;
 
   @Column('varchar')
   provider!: string;

--- a/packages/backend/src/model-discovery/model-discovery.service.spec.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.spec.ts
@@ -728,6 +728,32 @@ describe('ModelDiscoveryService', () => {
     });
   });
 
+  describe('getModelsForGlobalProviders', () => {
+    it('returns cached models from active global provider rows', async () => {
+      providerRepo.find.mockResolvedValue([
+        makeProvider({
+          agent_id: null,
+          user_id: 'user-1',
+          provider: 'openai',
+          cached_models: [makeModel({ id: 'gpt-4o-mini', provider: 'openai' })],
+        }),
+      ]);
+
+      const result = await service.getModelsForGlobalProviders('user-1');
+
+      expect(providerRepo.find).toHaveBeenCalledWith({
+        where: expect.objectContaining({ user_id: 'user-1', agent_id: expect.any(Object) }),
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: 'gpt-4o-mini',
+        provider: 'openai',
+        authType: 'api_key',
+      });
+      expect(customProviderRepo.find).not.toHaveBeenCalled();
+    });
+  });
+
   /* ── getModelsForAgent caching ── */
 
   describe('getModelsForAgent (cache)', () => {

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -437,28 +437,13 @@ export class ModelDiscoveryService {
       where: { agent_id: agentId, is_active: true },
     });
 
-    const models: DiscoveredModel[] = [];
-    const seen = new Map<string, number>();
-
-    for (const p of providers) {
-      if (p.provider.startsWith('custom:')) continue;
-      const rawCached = p.cached_models;
-      if (!Array.isArray(rawCached)) continue;
-      const cached = filterNonChatModels(rawCached, p.provider.toLowerCase());
-      const providerAuthType: AuthType = p.auth_type;
-      const providerId = p.provider.toLowerCase();
-      for (const m of cached) {
-        const effectiveAuthType = m.authType ?? providerAuthType;
-        // Deduplicate by the routable tuple, not just model ID. Multiple
-        // providers can expose the same native model name, and the picker must
-        // keep each provider-specific route selectable.
-        const dedupeKey = `${providerId}::${effectiveAuthType}::${m.id}`;
-        if (!seen.has(dedupeKey)) {
-          seen.set(dedupeKey, models.length);
-          models.push({ ...m, provider: p.provider, authType: effectiveAuthType });
-        }
-      }
-    }
+    const models = this.collectCachedProviderModels(providers);
+    const seen = new Map(
+      models.map((model, index) => [
+        `${model.provider}::${model.authType ?? 'api_key'}::${model.id}`,
+        index,
+      ]),
+    );
 
     // Build auth_type lookup for custom providers from their user_providers rows
     const customAuthTypes = new Map<string, AuthType>();
@@ -499,6 +484,40 @@ export class ModelDiscoveryService {
           capabilityCode: false,
           qualityScore: 2,
         });
+      }
+    }
+
+    return models;
+  }
+
+  async getModelsForGlobalProviders(userId: string): Promise<DiscoveredModel[]> {
+    const providers = await this.providerRepo.find({
+      where: { user_id: userId, agent_id: IsNull(), is_active: true },
+    });
+    return this.collectCachedProviderModels(providers);
+  }
+
+  private collectCachedProviderModels(providers: UserProvider[]): DiscoveredModel[] {
+    const models: DiscoveredModel[] = [];
+    const seen = new Map<string, number>();
+
+    for (const p of providers) {
+      if (p.provider.startsWith('custom:')) continue;
+      const rawCached = p.cached_models;
+      if (!Array.isArray(rawCached)) continue;
+      const cached = filterNonChatModels(rawCached, p.provider.toLowerCase());
+      const providerAuthType: AuthType = p.auth_type;
+      const providerId = p.provider.toLowerCase();
+      for (const m of cached) {
+        const effectiveAuthType = m.authType ?? providerAuthType;
+        // Deduplicate by the routable tuple, not just model ID. Multiple
+        // providers can expose the same native model name, and the picker must
+        // keep each provider-specific route selectable.
+        const dedupeKey = `${providerId}::${effectiveAuthType}::${m.id}`;
+        if (!seen.has(dedupeKey)) {
+          seen.set(dedupeKey, models.length);
+          models.push({ ...m, provider: p.provider, authType: effectiveAuthType });
+        }
       }
     }
 

--- a/packages/backend/src/model-discovery/model-discovery.service.ts
+++ b/packages/backend/src/model-discovery/model-discovery.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, Inject, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import type { AuthType } from 'manifest-shared';
 import { UserProvider } from '../entities/user-provider.entity';
 import { CustomProvider } from '../entities/custom-provider.entity';
@@ -259,7 +259,7 @@ export class ModelDiscoveryService {
     await this.providerRepo.save(provider);
     // The agent's effective model list just changed on disk — drop the cache
     // so getModelsForAgent() reassembles it on the next read.
-    this.invalidate(provider.agent_id);
+    if (provider.agent_id) this.invalidate(provider.agent_id);
 
     this.logger.log(
       `Discovered ${filtered.length} models for provider ${provider.provider} (agent ${provider.agent_id})`,
@@ -329,6 +329,68 @@ export class ModelDiscoveryService {
       const message = err instanceof Error ? err.message : String(err);
       this.logger.warn(
         `Per-provider refresh failed for ${provider.provider} (agent ${agentId}): ${message}`,
+      );
+      return {
+        ok: false,
+        model_count: previousCount,
+        last_fetched_at: previousFetchedAt,
+        error: message,
+      };
+    }
+  }
+
+  async refreshGlobalProvider(
+    userId: string,
+    providerId: string,
+    authType?: AuthType,
+  ): Promise<{
+    ok: boolean;
+    model_count: number;
+    last_fetched_at: string | null;
+    error: string | null;
+  }> {
+    const where: {
+      user_id: string;
+      agent_id: ReturnType<typeof IsNull>;
+      provider: string;
+      is_active: true;
+      auth_type?: AuthType;
+    } = {
+      user_id: userId,
+      agent_id: IsNull(),
+      provider: providerId,
+      is_active: true,
+    };
+    if (authType) where.auth_type = authType;
+    const provider = await this.providerRepo.findOne({ where });
+    if (!provider) {
+      return { ok: false, model_count: 0, last_fetched_at: null, error: 'Provider not found' };
+    }
+
+    const previousCount = Array.isArray(provider.cached_models) ? provider.cached_models.length : 0;
+    const previousFetchedAt = provider.models_fetched_at;
+
+    if (provider.provider.startsWith('custom:')) {
+      return {
+        ok: false,
+        model_count: previousCount,
+        last_fetched_at: previousFetchedAt,
+        error: 'Custom providers are managed manually — edit the provider to update its model list',
+      };
+    }
+
+    try {
+      const models = await this.discoverModels(provider);
+      return {
+        ok: models.length > 0,
+        model_count: models.length,
+        last_fetched_at: provider.models_fetched_at,
+        error: models.length === 0 ? 'Provider returned no models' : null,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn(
+        `Per-provider refresh failed for global ${provider.provider} (user ${userId}): ${message}`,
       );
       return {
         ok: false,

--- a/packages/backend/src/playground/dto/run-playground.dto.spec.ts
+++ b/packages/backend/src/playground/dto/run-playground.dto.spec.ts
@@ -136,6 +136,26 @@ describe('RunPlaygroundDto', () => {
       const errors = await validate(dto);
       expect(errors.length).toBeGreaterThan(0);
     });
+
+    it('accepts the global playground scope', async () => {
+      const dto = toDto({
+        ...VALID_BASE,
+        scope: 'global',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects unknown playground scopes', async () => {
+      const dto = toDto({
+        ...VALID_BASE,
+        scope: 'tenant',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+      const errors = await validate(dto);
+      expect(errors.some((e) => e.property === 'scope')).toBe(true);
+    });
   });
 });
 

--- a/packages/backend/src/playground/dto/run-playground.dto.ts
+++ b/packages/backend/src/playground/dto/run-playground.dto.ts
@@ -71,6 +71,10 @@ export class RunPlaygroundDto {
   @Validate(PlaygroundPayloadShapeConstraint)
   agentName!: string;
 
+  @IsOptional()
+  @IsIn(['agent', 'global'])
+  scope?: 'agent' | 'global';
+
   @IsString()
   @IsNotEmpty()
   model!: string;

--- a/packages/backend/src/playground/playground.service.spec.ts
+++ b/packages/backend/src/playground/playground.service.spec.ts
@@ -160,8 +160,11 @@ interface Mocks {
   resolveAgent: { resolve: jest.Mock };
   providerKeyService: {
     hasActiveProvider: jest.Mock;
+    hasActiveGlobalProvider: jest.Mock;
     getAuthType: jest.Mock;
+    getGlobalAuthType: jest.Mock;
     getProviderKeys: jest.Mock;
+    getGlobalProviderKeys: jest.Mock;
     getProviderApiKey: jest.Mock;
   };
   providerClient: {
@@ -183,15 +186,22 @@ interface Mocks {
   customProviderRepo: { findOne: jest.Mock };
 }
 
-function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService; mocks: Mocks } {
-  const full: Mocks = {
+type MockOverrides = Omit<Partial<Mocks>, 'providerKeyService'> & {
+  providerKeyService?: Partial<Mocks['providerKeyService']>;
+};
+
+function buildService(mocks: MockOverrides = {}): { service: PlaygroundService; mocks: Mocks } {
+  const defaults: Mocks = {
     resolveAgent: {
       resolve: jest.fn().mockResolvedValue(AGENT),
     },
     providerKeyService: {
       hasActiveProvider: jest.fn().mockResolvedValue(true),
+      hasActiveGlobalProvider: jest.fn().mockResolvedValue(true),
       getAuthType: jest.fn().mockResolvedValue('api_key'),
+      getGlobalAuthType: jest.fn().mockResolvedValue('api_key'),
       getProviderKeys: jest.fn().mockResolvedValue([DEFAULT_PROVIDER_KEY]),
+      getGlobalProviderKeys: jest.fn().mockResolvedValue([DEFAULT_PROVIDER_KEY]),
       getProviderApiKey: jest.fn().mockResolvedValue(DEFAULT_PROVIDER_KEY.apiKey),
     },
     providerClient: {
@@ -216,7 +226,14 @@ function buildService(mocks: Partial<Mocks> = {}): { service: PlaygroundService;
     history: { saveColumn: jest.fn().mockResolvedValue('col-1') },
     messageRepo: { insert: jest.fn().mockResolvedValue(undefined) },
     customProviderRepo: { findOne: jest.fn().mockResolvedValue(null) },
+  };
+  const full: Mocks = {
+    ...defaults,
     ...mocks,
+    providerKeyService: {
+      ...defaults.providerKeyService,
+      ...mocks.providerKeyService,
+    },
   };
   const service = new PlaygroundService(
     full.resolveAgent as unknown as ResolveAgentService,
@@ -286,6 +303,43 @@ describe('PlaygroundService.runStream', () => {
       status: 'success',
       content: 'hello',
     });
+  });
+
+  it('streams global provider runs without resolving an agent or writing history', async () => {
+    const { service, mocks } = buildService();
+    mocks.providerKeyService.getGlobalProviderKeys.mockResolvedValue([
+      { ...DEFAULT_PROVIDER_KEY, apiKey: 'sk-global' },
+    ]);
+    mocks.providerClient.forward.mockResolvedValue(
+      okStream([
+        'data: {"choices":[{"delta":{"content":"global"}}]}\n\n',
+        'data: {"usage":{"prompt_tokens":3,"completion_tokens":2}}\n\n',
+        'data: [DONE]\n\n',
+      ]),
+    );
+    const res = mockRes();
+
+    await service.runStream(USER_ID, makeDto({ agentName: 'global', scope: 'global' }), asRes(res));
+
+    expect(mocks.resolveAgent.resolve).not.toHaveBeenCalled();
+    expect(mocks.providerKeyService.hasActiveGlobalProvider).toHaveBeenCalledWith(
+      USER_ID,
+      'openai',
+    );
+    expect(mocks.providerKeyService.getGlobalProviderKeys).toHaveBeenCalledWith(
+      USER_ID,
+      'openai',
+      'api_key',
+    );
+    expect(mocks.providerClient.forward).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'sk-global', provider: 'openai' }),
+    );
+    const done = parseSse(res).find((e) => e.type === 'done') as Record<string, unknown>;
+    expect(done.columnId).toBeNull();
+    expect(done.content).toBe('global');
+    expect(mocks.messageRepo.insert).not.toHaveBeenCalled();
+    expect(mocks.history.saveColumn).not.toHaveBeenCalled();
+    expect(mocks.eventBus.emit).not.toHaveBeenCalled();
   });
 
   it('resolves a custom provider endpoint and forwards the raw (unprefixed) model name', async () => {

--- a/packages/backend/src/playground/playground.service.ts
+++ b/packages/backend/src/playground/playground.service.ts
@@ -33,6 +33,9 @@ import { buildForwardBody, derivePromptForHistory } from './playground-payload';
 import { consumeProviderStream } from './playground-stream';
 import type { RunPlaygroundDto } from './dto/run-playground.dto';
 
+type PlaygroundAgent = { id: string; tenant_id: string; name: string };
+type PlaygroundScope = { type: 'agent'; agent: PlaygroundAgent } | { type: 'global' };
+
 @Injectable()
 export class PlaygroundService {
   private readonly logger = new Logger(PlaygroundService.name);
@@ -63,7 +66,7 @@ export class PlaygroundService {
    * *after* the stream opens are delivered as a terminal `error` event.
    */
   async runStream(userId: string, dto: RunPlaygroundDto, res: ExpressResponse): Promise<void> {
-    let agent: { id: string; tenant_id: string; name: string };
+    let scope: PlaygroundScope;
     let authType: AuthType;
     let apiKey: string;
     let rawApiKey: string;
@@ -75,68 +78,109 @@ export class PlaygroundService {
     let oauthResourceUrl: string | undefined;
     let providerRegion: string | null | undefined;
     try {
-      agent = await this.resolveAgent.resolve(userId, dto.agentName);
-      const hasProvider = await this.providerKeyService.hasActiveProvider(agent.id, dto.provider);
-      if (!hasProvider) {
-        return this.sendPreStreamError(
-          res,
-          404,
-          `Provider "${dto.provider}" is not connected for this agent`,
+      if (dto.scope === 'global') {
+        scope = { type: 'global' };
+        const hasProvider = await this.providerKeyService.hasActiveGlobalProvider(
+          userId,
+          dto.provider,
         );
-      }
-      authType =
-        dto.authType ?? (await this.providerKeyService.getAuthType(agent.id, dto.provider));
-      const keys = await this.providerKeyService.getProviderKeys(agent.id, dto.provider, authType);
-      const key = keys[0];
-      if (!key || key.apiKey === null) {
-        return this.sendPreStreamError(
-          res,
-          404,
-          `No usable API key found for provider "${dto.provider}"`,
+        if (!hasProvider) {
+          return this.sendPreStreamError(
+            res,
+            404,
+            `Provider "${dto.provider}" is not connected globally`,
+          );
+        }
+        authType =
+          dto.authType ?? (await this.providerKeyService.getGlobalAuthType(userId, dto.provider));
+        const keys = await this.providerKeyService.getGlobalProviderKeys(
+          userId,
+          dto.provider,
+          authType,
         );
-      }
-      rawApiKey = key.apiKey;
-      providerKeyLabel = key.label;
-      providerRegion = key.region;
-      const resolved = await resolveApiKey(
-        dto.provider,
-        rawApiKey,
-        authType,
-        agent.id,
-        userId,
-        this.openaiOauth,
-        this.minimaxOauth,
-        this.anthropicOauth,
-        this.geminiOauth,
-        this.kiroOauth,
-        this.xaiOauth,
-        providerKeyLabel,
-      );
-      if (resolved.apiKey === null) {
-        return this.sendPreStreamError(
-          res,
-          404,
-          `No usable API key found for provider "${dto.provider}"`,
+        const key = keys[0];
+        if (!key || key.apiKey === null) {
+          return this.sendPreStreamError(
+            res,
+            404,
+            `No usable API key found for provider "${dto.provider}"`,
+          );
+        }
+        rawApiKey = key.apiKey;
+        apiKey = rawApiKey;
+        providerKeyLabel = key.label;
+        providerRegion = key.region;
+        oauthResourceUrl = undefined;
+        providerResource = undefined;
+      } else {
+        const agent = await this.resolveAgent.resolve(userId, dto.agentName);
+        scope = { type: 'agent', agent };
+        const hasProvider = await this.providerKeyService.hasActiveProvider(agent.id, dto.provider);
+        if (!hasProvider) {
+          return this.sendPreStreamError(
+            res,
+            404,
+            `Provider "${dto.provider}" is not connected for this agent`,
+          );
+        }
+        authType =
+          dto.authType ?? (await this.providerKeyService.getAuthType(agent.id, dto.provider));
+        const keys = await this.providerKeyService.getProviderKeys(
+          agent.id,
+          dto.provider,
+          authType,
         );
+        const key = keys[0];
+        if (!key || key.apiKey === null) {
+          return this.sendPreStreamError(
+            res,
+            404,
+            `No usable API key found for provider "${dto.provider}"`,
+          );
+        }
+        rawApiKey = key.apiKey;
+        providerKeyLabel = key.label;
+        providerRegion = key.region;
+        const resolved = await resolveApiKey(
+          dto.provider,
+          rawApiKey,
+          authType,
+          agent.id,
+          userId,
+          this.openaiOauth,
+          this.minimaxOauth,
+          this.anthropicOauth,
+          this.geminiOauth,
+          this.kiroOauth,
+          this.xaiOauth,
+          providerKeyLabel,
+        );
+        if (resolved.apiKey === null) {
+          return this.sendPreStreamError(
+            res,
+            404,
+            `No usable API key found for provider "${dto.provider}"`,
+          );
+        }
+        apiKey = resolved.apiKey;
+        if (authType === 'subscription' && isRefreshableOAuthCredential(rawApiKey)) {
+          rawApiKey =
+            (await this.providerKeyService.getProviderApiKey(
+              agent.id,
+              dto.provider,
+              authType,
+              providerKeyLabel,
+            )) ?? rawApiKey;
+        }
+        oauthResourceUrl = authType === 'subscription' ? resolved.resourceUrl : undefined;
+        // Gemini OAuth stores the CodeAssist project id (not a URL) in the same
+        // field; it is forwarded as providerResource. MiniMax's resource URL is
+        // applied as a base-URL override below, not here.
+        providerResource =
+          authType === 'subscription' && dto.provider.toLowerCase() === 'gemini'
+            ? resolved.resourceUrl
+            : undefined;
       }
-      apiKey = resolved.apiKey;
-      if (authType === 'subscription' && isRefreshableOAuthCredential(rawApiKey)) {
-        rawApiKey =
-          (await this.providerKeyService.getProviderApiKey(
-            agent.id,
-            dto.provider,
-            authType,
-            providerKeyLabel,
-          )) ?? rawApiKey;
-      }
-      oauthResourceUrl = authType === 'subscription' ? resolved.resourceUrl : undefined;
-      // Gemini OAuth stores the CodeAssist project id (not a URL) in the same
-      // field; it is forwarded as providerResource. MiniMax's resource URL is
-      // applied as a base-URL override below, not here.
-      providerResource =
-        authType === 'subscription' && dto.provider.toLowerCase() === 'gemini'
-          ? resolved.resourceUrl
-          : undefined;
     } catch (err) {
       const status = err instanceof HttpException ? err.getStatus() : 500;
       const message = err instanceof Error ? err.message : String(err);
@@ -182,11 +226,15 @@ export class PlaygroundService {
         providerResource,
       };
       forward = await this.providerClient.forward(forwardOptions);
-      if (forward.response.status === 401 && authType === 'subscription') {
+      if (
+        forward.response.status === 401 &&
+        authType === 'subscription' &&
+        scope.type === 'agent'
+      ) {
         const refreshed = await refreshRejectedOAuthCredential(
           dto.provider,
           rawApiKey,
-          agent.id,
+          scope.agent.id,
           userId,
           providerKeyLabel,
           {
@@ -200,7 +248,7 @@ export class PlaygroundService {
         );
         if (refreshed?.apiKey && refreshed.apiKey !== apiKey) {
           this.logger.log(
-            `OAuth token rejected upstream in Playground; refreshed provider=${dto.provider} agent=${agent.id}`,
+            `OAuth token rejected upstream in Playground; refreshed provider=${dto.provider} agent=${scope.agent.id}`,
           );
           apiKey = refreshed.apiKey;
           providerResource =
@@ -231,18 +279,20 @@ export class PlaygroundService {
       }
       const durationMs = Date.now() - startedAt;
       const errorSummary = this.truncateError(bodyText, forward.response.status);
-      await this.recordError(
-        userId,
-        agent,
-        dto,
-        authType,
-        forward.response.status,
-        bodyText,
-        durationMs,
-      );
-      await this.history.saveColumn(
-        this.errorColumn(userId, agent, dto, authType, headers, errorSummary),
-      );
+      if (scope.type === 'agent') {
+        await this.recordError(
+          userId,
+          scope.agent,
+          dto,
+          authType,
+          forward.response.status,
+          bodyText,
+          durationMs,
+        );
+        await this.history.saveColumn(
+          this.errorColumn(userId, scope.agent, dto, authType, headers, errorSummary),
+        );
+      }
       return this.sendPreStreamError(res, 502, errorSummary);
     }
 
@@ -255,10 +305,20 @@ export class PlaygroundService {
 
     if (!forward.response.body) {
       const message = 'Provider returned an empty stream';
-      await this.recordError(userId, agent, dto, authType, 502, message, Date.now() - startedAt);
-      await this.history.saveColumn(
-        this.errorColumn(userId, agent, dto, authType, headers, message),
-      );
+      if (scope.type === 'agent') {
+        await this.recordError(
+          userId,
+          scope.agent,
+          dto,
+          authType,
+          502,
+          message,
+          Date.now() - startedAt,
+        );
+        await this.history.saveColumn(
+          this.errorColumn(userId, scope.agent, dto, authType, headers, message),
+        );
+      }
       send({ type: 'error', message });
       res.end();
       return;
@@ -289,31 +349,34 @@ export class PlaygroundService {
       });
       const tokensPerSec = outputTokens > 0 ? outputTokens / (Math.max(totalMs, 1) / 1000) : null;
 
-      await this.recordSuccess(userId, agent, dto, authType, {
-        inputTokens,
-        outputTokens,
-        cacheReadTokens,
-        cacheCreationTokens,
-        cost,
-        durationMs: totalMs,
-      });
+      let columnId: string | null = null;
+      if (scope.type === 'agent') {
+        await this.recordSuccess(userId, scope.agent, dto, authType, {
+          inputTokens,
+          outputTokens,
+          cacheReadTokens,
+          cacheCreationTokens,
+          cost,
+          durationMs: totalMs,
+        });
 
-      const columnId = await this.history.saveColumn({
-        userId,
-        agent,
-        runId: dto.runId,
-        prompt: derivePromptForHistory(dto),
-        model: dto.model,
-        provider: dto.provider,
-        authType,
-        displayName: null,
-        position: dto.position ?? 0,
-        status: 'success',
-        content,
-        headers,
-        errorMessage: null,
-        metrics: { inputTokens, outputTokens, cost, durationMs: totalMs },
-      });
+        columnId = await this.history.saveColumn({
+          userId,
+          agent: scope.agent,
+          runId: dto.runId,
+          prompt: derivePromptForHistory(dto),
+          model: dto.model,
+          provider: dto.provider,
+          authType,
+          displayName: null,
+          position: dto.position ?? 0,
+          status: 'success',
+          content,
+          headers,
+          errorMessage: null,
+          metrics: { inputTokens, outputTokens, cost, durationMs: totalMs },
+        });
+      }
 
       send({
         type: 'done',
@@ -332,10 +395,12 @@ export class PlaygroundService {
       }
       const message = err instanceof Error ? err.message : String(err);
       const durationMs = Date.now() - startedAt;
-      await this.recordError(userId, agent, dto, authType, 502, message, durationMs);
-      await this.history.saveColumn(
-        this.errorColumn(userId, agent, dto, authType, headers, message),
-      );
+      if (scope.type === 'agent') {
+        await this.recordError(userId, scope.agent, dto, authType, 502, message, durationMs);
+        await this.history.saveColumn(
+          this.errorColumn(userId, scope.agent, dto, authType, headers, message),
+        );
+      }
       send({ type: 'error', message });
       if (!res.writableEnded) res.end();
     }

--- a/packages/backend/src/routing/dto/routing.dto.spec.ts
+++ b/packages/backend/src/routing/dto/routing.dto.spec.ts
@@ -5,6 +5,7 @@ import {
   AgentNameParamDto,
   ConnectProviderDto,
   CopilotPollDto,
+  ProviderKeyParamDto,
   SetResponseModeDto,
   SetFallbacksDto,
   responseModeFromDto,
@@ -130,6 +131,26 @@ describe('ConnectProviderDto', () => {
     expect(dto.provider).toBe(42 as unknown as string);
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ProviderKeyParamDto', () => {
+  function toProviderKeyParamDto(data: Record<string, unknown>): ProviderKeyParamDto {
+    return plainToInstance(ProviderKeyParamDto, data);
+  }
+
+  it('accepts provider and labeled key params', async () => {
+    const dto = toProviderKeyParamDto({ provider: 'openai', label: 'Default' });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects empty and overlong labels', async () => {
+    const empty = toProviderKeyParamDto({ provider: 'openai', label: '' });
+    const overlong = toProviderKeyParamDto({ provider: 'openai', label: 'x'.repeat(51) });
+
+    await expect(validate(empty)).resolves.not.toHaveLength(0);
+    await expect(validate(overlong)).resolves.not.toHaveLength(0);
   });
 });
 

--- a/packages/backend/src/routing/dto/routing.dto.ts
+++ b/packages/backend/src/routing/dto/routing.dto.ts
@@ -113,6 +113,17 @@ export class AgentProviderKeyParamDto {
   label!: string;
 }
 
+export class ProviderKeyParamDto {
+  @IsString()
+  @IsNotEmpty()
+  provider!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(MAX_PROVIDER_KEY_LABEL_LENGTH)
+  label!: string;
+}
+
 export class RemoveProviderQueryDto {
   @IsOptional()
   @IsIn(AUTH_TYPES)

--- a/packages/backend/src/routing/global-providers.controller.spec.ts
+++ b/packages/backend/src/routing/global-providers.controller.spec.ts
@@ -111,7 +111,11 @@ describe('GlobalProvidersController', () => {
     });
     providerService.reorderGlobalKeys.mockResolvedValue([{ id: 'p1', label: 'Work', priority: 0 }]);
 
-    await controller.renameKey(user, 'openai', 'Default', { newLabel: 'Work' });
+    await controller.renameKey(
+      user,
+      { provider: 'openai', label: 'Default' },
+      { newLabel: 'Work' },
+    );
     await controller.reorderKeys(user, 'openai', { labels: ['Work'] });
     await controller.refreshProviderModels(user, 'openai', { authType: 'api_key' });
     const removed = await controller.remove(user, 'openai', { authType: 'api_key', label: 'Work' });

--- a/packages/backend/src/routing/global-providers.controller.spec.ts
+++ b/packages/backend/src/routing/global-providers.controller.spec.ts
@@ -1,0 +1,142 @@
+import { GlobalProvidersController } from './global-providers.controller';
+import { ProviderService } from './routing-core/provider.service';
+import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
+import { OllamaSyncService } from '../database/ollama-sync.service';
+
+const user = { id: 'user-1' } as never;
+
+describe('GlobalProvidersController', () => {
+  let providerService: {
+    getGlobalProviders: jest.Mock;
+    upsertGlobalProvider: jest.Mock;
+    renameGlobalKey: jest.Mock;
+    reorderGlobalKeys: jest.Mock;
+    removeGlobalProvider: jest.Mock;
+  };
+  let discoveryService: {
+    discoverModels: jest.Mock;
+    refreshGlobalProvider: jest.Mock;
+  };
+  let ollamaSync: { sync: jest.Mock };
+  let controller: GlobalProvidersController;
+
+  beforeEach(() => {
+    providerService = {
+      getGlobalProviders: jest.fn().mockResolvedValue([]),
+      upsertGlobalProvider: jest.fn(),
+      renameGlobalKey: jest.fn(),
+      reorderGlobalKeys: jest.fn(),
+      removeGlobalProvider: jest.fn().mockResolvedValue({ notifications: [] }),
+    };
+    discoveryService = {
+      discoverModels: jest.fn().mockResolvedValue([]),
+      refreshGlobalProvider: jest.fn().mockResolvedValue({ ok: true }),
+    };
+    ollamaSync = { sync: jest.fn().mockResolvedValue({ count: 0 }) };
+
+    controller = new GlobalProvidersController(
+      providerService as unknown as ProviderService,
+      discoveryService as unknown as ModelDiscoveryService,
+      ollamaSync as unknown as OllamaSyncService,
+    );
+  });
+
+  it('lists global providers without leaking encrypted keys', async () => {
+    providerService.getGlobalProviders.mockResolvedValue([
+      {
+        id: 'p1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        is_active: true,
+        api_key_encrypted: 'secret',
+        key_prefix: 'sk-test',
+        label: 'Default',
+        priority: 0,
+        region: null,
+        connected_at: '2026-01-01T00:00:00.000Z',
+        models_fetched_at: null,
+        cached_models: [{ id: 'gpt-4o' }],
+      },
+    ]);
+
+    const result = await controller.list(user);
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'p1',
+        has_api_key: true,
+        cached_model_count: 1,
+      }),
+    ]);
+    expect(result[0]).not.toHaveProperty('api_key_encrypted');
+  });
+
+  it('connects a global provider and triggers model discovery', async () => {
+    const provider = {
+      id: 'p1',
+      provider: 'openai',
+      auth_type: 'api_key',
+      is_active: true,
+      label: 'Default',
+      priority: 0,
+      connected_at: '2026-01-01T00:00:00.000Z',
+    };
+    providerService.upsertGlobalProvider.mockResolvedValue({ provider, isNew: true });
+
+    const result = await controller.upsert(user, {
+      provider: 'openai',
+      apiKey: 'sk-test',
+      authType: 'api_key',
+    });
+
+    expect(providerService.upsertGlobalProvider).toHaveBeenCalledWith(
+      'user-1',
+      'openai',
+      'sk-test',
+      'api_key',
+      undefined,
+      undefined,
+    );
+    expect(discoveryService.discoverModels).toHaveBeenCalledWith(provider);
+    expect(result.id).toBe('p1');
+  });
+
+  it('renames, reorders, refreshes, and removes global provider rows', async () => {
+    providerService.renameGlobalKey.mockResolvedValue({
+      id: 'p1',
+      provider: 'openai',
+      auth_type: 'api_key',
+      label: 'Work',
+      priority: 0,
+    });
+    providerService.reorderGlobalKeys.mockResolvedValue([{ id: 'p1', label: 'Work', priority: 0 }]);
+
+    await controller.renameKey(user, 'openai', 'Default', { newLabel: 'Work' });
+    await controller.reorderKeys(user, 'openai', { labels: ['Work'] });
+    await controller.refreshProviderModels(user, 'openai', { authType: 'api_key' });
+    const removed = await controller.remove(user, 'openai', { authType: 'api_key', label: 'Work' });
+
+    expect(providerService.renameGlobalKey).toHaveBeenCalledWith(
+      'user-1',
+      'openai',
+      'api_key',
+      'Default',
+      'Work',
+    );
+    expect(providerService.reorderGlobalKeys).toHaveBeenCalledWith('user-1', 'openai', 'api_key', [
+      'Work',
+    ]);
+    expect(discoveryService.refreshGlobalProvider).toHaveBeenCalledWith(
+      'user-1',
+      'openai',
+      'api_key',
+    );
+    expect(providerService.removeGlobalProvider).toHaveBeenCalledWith(
+      'user-1',
+      'openai',
+      'api_key',
+      'Work',
+    );
+    expect(removed).toEqual({ ok: true, notifications: [] });
+  });
+});

--- a/packages/backend/src/routing/global-providers.controller.ts
+++ b/packages/backend/src/routing/global-providers.controller.ts
@@ -6,28 +6,13 @@ import { OllamaSyncService } from '../database/ollama-sync.service';
 import { ProviderService } from './routing-core/provider.service';
 import {
   ConnectProviderDto,
+  ProviderKeyParamDto,
   RemoveProviderQueryDto,
   RenameProviderKeyDto,
   ReorderProviderKeysDto,
 } from './dto/routing.dto';
 import { assertProviderRegionSupported } from './provider-region-validation';
-
-function serializeProvider(p: Awaited<ReturnType<ProviderService['getGlobalProviders']>>[number]) {
-  return {
-    id: p.id,
-    provider: p.provider,
-    auth_type: p.auth_type ?? 'api_key',
-    is_active: p.is_active,
-    has_api_key: !!p.api_key_encrypted,
-    key_prefix: p.key_prefix ?? null,
-    label: p.label,
-    priority: p.priority,
-    region: p.region ?? null,
-    connected_at: p.connected_at,
-    models_fetched_at: p.models_fetched_at ?? null,
-    cached_model_count: Array.isArray(p.cached_models) ? p.cached_models.length : 0,
-  };
-}
+import { serializeProviderConnection } from './provider-response';
 
 @Controller('api/v1/providers')
 export class GlobalProvidersController {
@@ -40,7 +25,7 @@ export class GlobalProvidersController {
   @Get()
   async list(@CurrentUser() user: AuthUser) {
     const providers = await this.providerService.getGlobalProviders(user.id);
-    return providers.map(serializeProvider);
+    return providers.map(serializeProviderConnection);
   }
 
   @Post()
@@ -66,21 +51,20 @@ export class GlobalProvidersController {
       // Global provider connection should survive a transient model fetch failure.
     }
 
-    return serializeProvider(provider);
+    return serializeProviderConnection(provider);
   }
 
   @Patch(':provider/keys/:label')
   async renameKey(
     @CurrentUser() user: AuthUser,
-    @Param('provider') provider: string,
-    @Param('label') label: string,
+    @Param() params: ProviderKeyParamDto,
     @Body() body: RenameProviderKeyDto,
   ) {
     const updated = await this.providerService.renameGlobalKey(
       user.id,
-      provider,
+      params.provider,
       body.authType ?? 'api_key',
-      label,
+      params.label,
       body.newLabel,
     );
     return {

--- a/packages/backend/src/routing/global-providers.controller.ts
+++ b/packages/backend/src/routing/global-providers.controller.ts
@@ -1,0 +1,135 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from '@nestjs/common';
+import { CurrentUser } from '../auth/current-user.decorator';
+import type { AuthUser } from '../auth/auth.instance';
+import { ModelDiscoveryService } from '../model-discovery/model-discovery.service';
+import { OllamaSyncService } from '../database/ollama-sync.service';
+import { ProviderService } from './routing-core/provider.service';
+import {
+  ConnectProviderDto,
+  RemoveProviderQueryDto,
+  RenameProviderKeyDto,
+  ReorderProviderKeysDto,
+} from './dto/routing.dto';
+import { assertProviderRegionSupported } from './provider-region-validation';
+
+function serializeProvider(p: Awaited<ReturnType<ProviderService['getGlobalProviders']>>[number]) {
+  return {
+    id: p.id,
+    provider: p.provider,
+    auth_type: p.auth_type ?? 'api_key',
+    is_active: p.is_active,
+    has_api_key: !!p.api_key_encrypted,
+    key_prefix: p.key_prefix ?? null,
+    label: p.label,
+    priority: p.priority,
+    region: p.region ?? null,
+    connected_at: p.connected_at,
+    models_fetched_at: p.models_fetched_at ?? null,
+    cached_model_count: Array.isArray(p.cached_models) ? p.cached_models.length : 0,
+  };
+}
+
+@Controller('api/v1/providers')
+export class GlobalProvidersController {
+  constructor(
+    private readonly providerService: ProviderService,
+    private readonly discoveryService: ModelDiscoveryService,
+    private readonly ollamaSync: OllamaSyncService,
+  ) {}
+
+  @Get()
+  async list(@CurrentUser() user: AuthUser) {
+    const providers = await this.providerService.getGlobalProviders(user.id);
+    return providers.map(serializeProvider);
+  }
+
+  @Post()
+  async upsert(@CurrentUser() user: AuthUser, @Body() body: ConnectProviderDto) {
+    assertProviderRegionSupported(body.provider, body.authType, body.region);
+
+    if (body.provider.toLowerCase() === 'ollama') {
+      await this.ollamaSync.sync();
+    }
+
+    const { provider } = await this.providerService.upsertGlobalProvider(
+      user.id,
+      body.provider,
+      body.apiKey,
+      body.authType,
+      body.region,
+      body.label,
+    );
+
+    try {
+      await this.discoveryService.discoverModels(provider);
+    } catch {
+      // Global provider connection should survive a transient model fetch failure.
+    }
+
+    return serializeProvider(provider);
+  }
+
+  @Patch(':provider/keys/:label')
+  async renameKey(
+    @CurrentUser() user: AuthUser,
+    @Param('provider') provider: string,
+    @Param('label') label: string,
+    @Body() body: RenameProviderKeyDto,
+  ) {
+    const updated = await this.providerService.renameGlobalKey(
+      user.id,
+      provider,
+      body.authType ?? 'api_key',
+      label,
+      body.newLabel,
+    );
+    return {
+      id: updated.id,
+      provider: updated.provider,
+      auth_type: updated.auth_type,
+      label: updated.label,
+      priority: updated.priority,
+    };
+  }
+
+  @Put(':provider/keys/order')
+  async reorderKeys(
+    @CurrentUser() user: AuthUser,
+    @Param('provider') provider: string,
+    @Body() body: ReorderProviderKeysDto,
+  ) {
+    const updated = await this.providerService.reorderGlobalKeys(
+      user.id,
+      provider,
+      body.authType ?? 'api_key',
+      body.labels,
+    );
+    return updated
+      .sort((a, b) => a.priority - b.priority)
+      .map((row) => ({ id: row.id, label: row.label, priority: row.priority }));
+  }
+
+  @Post(':provider/refresh-models')
+  async refreshProviderModels(
+    @CurrentUser() user: AuthUser,
+    @Param('provider') provider: string,
+    @Query() query: RemoveProviderQueryDto,
+  ) {
+    return this.discoveryService.refreshGlobalProvider(user.id, provider, query.authType);
+  }
+
+  @Delete(':provider')
+  async remove(
+    @CurrentUser() user: AuthUser,
+    @Param('provider') provider: string,
+    @Query() query: RemoveProviderQueryDto,
+  ) {
+    const { notifications } = await this.providerService.removeGlobalProvider(
+      user.id,
+      provider,
+      query.authType,
+      query.label,
+    );
+    return { ok: true, notifications };
+  }
+}

--- a/packages/backend/src/routing/model.controller.spec.ts
+++ b/packages/backend/src/routing/model.controller.spec.ts
@@ -49,6 +49,7 @@ describe('ModelController', () => {
     };
     mockDiscoveryService = {
       getModelsForAgent: jest.fn().mockResolvedValue([]),
+      getModelsForGlobalProviders: jest.fn().mockResolvedValue([]),
       discoverAllForAgent: jest.fn().mockResolvedValue(undefined),
       refreshProvider: jest.fn().mockResolvedValue({
         ok: true,
@@ -230,6 +231,23 @@ describe('ModelController', () => {
   /* ── getAvailableModels ── */
 
   describe('getAvailableModels', () => {
+    it('should return global provider models without resolving an agent', async () => {
+      mockDiscoveryService.getModelsForGlobalProviders.mockResolvedValue([
+        makeDiscovered({ id: 'gpt-4o-mini', provider: 'openai', displayName: 'GPT-4o mini' }),
+      ]);
+
+      const result = await controller.getGlobalAvailableModels(mockUser);
+
+      expect(mockDiscoveryService.getModelsForGlobalProviders).toHaveBeenCalledWith('user-1');
+      expect(mockResolveAgent.resolve).not.toHaveBeenCalled();
+      expect(result[0]).toMatchObject({
+        model_name: 'gpt-4o-mini',
+        provider: 'openai',
+        auth_type: 'api_key',
+        display_name: 'GPT-4o mini',
+      });
+    });
+
     it('should return models from discovery service', async () => {
       mockDiscoveryService.getModelsForAgent.mockResolvedValue([
         makeDiscovered({ id: 'gpt-4o', provider: 'openai', displayName: 'GPT-4o' }),

--- a/packages/backend/src/routing/model.controller.ts
+++ b/packages/backend/src/routing/model.controller.ts
@@ -10,6 +10,7 @@ import { OpencodeGoCatalogService } from '../model-discovery/opencode-go-catalog
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { PricingSyncService } from '../database/pricing-sync.service';
 import { ModelsDevSyncService } from '../database/models-dev-sync.service';
+import type { DiscoveredModel } from '../model-discovery/model-fetcher';
 import { resolveUnderlyingModelIdentity } from 'manifest-shared';
 import {
   inputModalitiesFromCapabilities,
@@ -85,6 +86,12 @@ export class ModelController {
     return this.ollamaSync.sync();
   }
 
+  @Get('available-models')
+  async getGlobalAvailableModels(@CurrentUser() user: AuthUser) {
+    const models = await this.discoveryService.getModelsForGlobalProviders(user.id);
+    return this.serializeAvailableModels(models);
+  }
+
   @Get(':agentName/available-models')
   async getAvailableModels(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
@@ -97,6 +104,13 @@ export class ModelController {
       cpNameMap.set(CustomProviderService.providerKey(cp.id), cp.name);
     }
 
+    return this.serializeAvailableModels(models, cpNameMap);
+  }
+
+  private serializeAvailableModels(
+    models: DiscoveredModel[],
+    customProviderNames = new Map<string, string>(),
+  ) {
     return Promise.all(
       models.map(async (m) => {
         const isCustom = CustomProviderService.isCustom(m.provider);
@@ -147,7 +161,7 @@ export class ModelController {
           quality_score: m.qualityScore,
           display_name: isCustom ? CustomProviderService.rawModelName(m.id) : m.displayName || null,
           ...(isCustom && {
-            provider_display_name: cpNameMap.get(m.provider) ?? m.provider,
+            provider_display_name: customProviderNames.get(m.provider) ?? m.provider,
           }),
         };
       }),

--- a/packages/backend/src/routing/provider-region-validation.spec.ts
+++ b/packages/backend/src/routing/provider-region-validation.spec.ts
@@ -1,0 +1,22 @@
+import { BadRequestException } from '@nestjs/common';
+import { assertProviderRegionSupported } from './provider-region-validation';
+
+describe('assertProviderRegionSupported', () => {
+  it('allows omitted region', () => {
+    expect(() => assertProviderRegionSupported('openai', 'api_key', undefined)).not.toThrow();
+  });
+
+  it('allows Qwen regions', () => {
+    expect(() => assertProviderRegionSupported('qwen', 'api_key', 'auto')).not.toThrow();
+  });
+
+  it('allows subscription endpoint regions from shared config', () => {
+    expect(() => assertProviderRegionSupported('minimax', 'subscription', 'global')).not.toThrow();
+  });
+
+  it('rejects region for unsupported providers', () => {
+    expect(() => assertProviderRegionSupported('openai', 'api_key', 'global')).toThrow(
+      BadRequestException,
+    );
+  });
+});

--- a/packages/backend/src/routing/provider-region-validation.spec.ts
+++ b/packages/backend/src/routing/provider-region-validation.spec.ts
@@ -10,6 +10,12 @@ describe('assertProviderRegionSupported', () => {
     expect(() => assertProviderRegionSupported('qwen', 'api_key', 'auto')).not.toThrow();
   });
 
+  it('rejects Qwen regions for non-API-key auth types', () => {
+    expect(() => assertProviderRegionSupported('qwen', 'subscription', 'auto')).toThrow(
+      BadRequestException,
+    );
+  });
+
   it('allows subscription endpoint regions from shared config', () => {
     expect(() => assertProviderRegionSupported('minimax', 'subscription', 'global')).not.toThrow();
   });

--- a/packages/backend/src/routing/provider-region-validation.ts
+++ b/packages/backend/src/routing/provider-region-validation.ts
@@ -1,0 +1,34 @@
+import { BadRequestException } from '@nestjs/common';
+import type { AuthType } from 'manifest-shared';
+import { isQwenRegion } from './qwen-region';
+import { getSubscriptionEndpointRegionConfig } from './subscription-region';
+
+export function assertProviderRegionSupported(
+  provider: string,
+  authType: AuthType | undefined,
+  region: string | undefined,
+): void {
+  if (region === undefined) return;
+
+  const lowerProvider = provider.toLowerCase();
+  const isQwenProvider = lowerProvider === 'qwen' || lowerProvider === 'alibaba';
+  const subscriptionRegionConfig = getSubscriptionEndpointRegionConfig(lowerProvider, authType);
+
+  if (isQwenProvider) {
+    if (!isQwenRegion(region)) {
+      throw new BadRequestException('region must be one of: auto, singapore, us, beijing');
+    }
+    return;
+  }
+
+  if (subscriptionRegionConfig) {
+    if (!subscriptionRegionConfig.isRegion(region)) {
+      throw new BadRequestException(subscriptionRegionConfig.validationMessage);
+    }
+    return;
+  }
+
+  throw new BadRequestException(
+    'region is only supported for Alibaba/Qwen providers, MiniMax subscriptions, Xiaomi MiMo Token Plan, and Z.ai subscriptions',
+  );
+}

--- a/packages/backend/src/routing/provider-region-validation.ts
+++ b/packages/backend/src/routing/provider-region-validation.ts
@@ -14,7 +14,7 @@ export function assertProviderRegionSupported(
   const isQwenProvider = lowerProvider === 'qwen' || lowerProvider === 'alibaba';
   const subscriptionRegionConfig = getSubscriptionEndpointRegionConfig(lowerProvider, authType);
 
-  if (isQwenProvider) {
+  if (isQwenProvider && (authType === undefined || authType === 'api_key')) {
     if (!isQwenRegion(region)) {
       throw new BadRequestException('region must be one of: auto, singapore, us, beijing');
     }

--- a/packages/backend/src/routing/provider-response.ts
+++ b/packages/backend/src/routing/provider-response.ts
@@ -1,0 +1,18 @@
+import type { UserProvider } from '../entities/user-provider.entity';
+
+export function serializeProviderConnection(p: UserProvider) {
+  return {
+    id: p.id,
+    provider: p.provider,
+    auth_type: p.auth_type ?? 'api_key',
+    is_active: p.is_active,
+    has_api_key: !!p.api_key_encrypted,
+    key_prefix: p.key_prefix ?? null,
+    label: p.label,
+    priority: p.priority,
+    region: p.region ?? null,
+    connected_at: p.connected_at,
+    models_fetched_at: p.models_fetched_at ?? null,
+    cached_model_count: Array.isArray(p.cached_models) ? p.cached_models.length : 0,
+  };
+}

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -17,6 +17,7 @@ import {
   ReorderProviderKeysDto,
 } from './dto/routing.dto';
 import { assertProviderRegionSupported } from './provider-region-validation';
+import { serializeProviderConnection } from './provider-response';
 
 @Controller('api/v1/routing')
 export class ProviderController {
@@ -59,20 +60,7 @@ export class ProviderController {
   async getProviders(@CurrentUser() user: AuthUser, @Param() params: AgentNameParamDto) {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
     const providers = await this.providerService.getProviders(agent.id);
-    return providers.map((p) => ({
-      id: p.id,
-      provider: p.provider,
-      auth_type: p.auth_type ?? 'api_key',
-      is_active: p.is_active,
-      has_api_key: !!p.api_key_encrypted,
-      key_prefix: p.key_prefix ?? null,
-      label: p.label,
-      priority: p.priority,
-      region: p.region ?? null,
-      connected_at: p.connected_at,
-      models_fetched_at: p.models_fetched_at ?? null,
-      cached_model_count: Array.isArray(p.cached_models) ? p.cached_models.length : 0,
-    }));
+    return providers.map(serializeProviderConnection);
   }
 
   @Post(':agentName/providers')

--- a/packages/backend/src/routing/provider.controller.ts
+++ b/packages/backend/src/routing/provider.controller.ts
@@ -1,15 +1,4 @@
-import {
-  BadRequestException,
-  Body,
-  Controller,
-  Delete,
-  Get,
-  Param,
-  Patch,
-  Post,
-  Put,
-  Query,
-} from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Put, Query } from '@nestjs/common';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { AuthUser } from '../auth/auth.instance';
 import { ProviderService } from './routing-core/provider.service';
@@ -27,8 +16,7 @@ import {
   RenameProviderKeyDto,
   ReorderProviderKeysDto,
 } from './dto/routing.dto';
-import { isQwenRegion } from './qwen-region';
-import { getSubscriptionEndpointRegionConfig } from './subscription-region';
+import { assertProviderRegionSupported } from './provider-region-validation';
 
 @Controller('api/v1/routing')
 export class ProviderController {
@@ -94,28 +82,7 @@ export class ProviderController {
     @Body() body: ConnectProviderDto,
   ) {
     const agent = await this.resolveAgentService.resolve(user.id, params.agentName);
-    const lowerProvider = body.provider.toLowerCase();
-    const isQwenProvider = lowerProvider === 'qwen' || lowerProvider === 'alibaba';
-    const subscriptionRegionConfig = getSubscriptionEndpointRegionConfig(
-      lowerProvider,
-      body.authType,
-    );
-
-    if (body.region !== undefined) {
-      if (isQwenProvider) {
-        if (!isQwenRegion(body.region)) {
-          throw new BadRequestException('region must be one of: auto, singapore, us, beijing');
-        }
-      } else if (subscriptionRegionConfig) {
-        if (!subscriptionRegionConfig.isRegion(body.region)) {
-          throw new BadRequestException(subscriptionRegionConfig.validationMessage);
-        }
-      } else {
-        throw new BadRequestException(
-          'region is only supported for Alibaba/Qwen providers, MiniMax subscriptions, Xiaomi MiMo Token Plan, and Z.ai subscriptions',
-        );
-      }
-    }
+    assertProviderRegionSupported(body.provider, body.authType, body.region);
 
     // Sync Ollama models before connecting so tier assignment has data
     if (body.provider.toLowerCase() === 'ollama') {

--- a/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider-key.service.spec.ts
@@ -37,7 +37,7 @@ describe('ProviderKeyService', () => {
     getProviderKeys: jest.Mock;
     setProviderKeys: jest.Mock;
   };
-  let providerService: jest.Mocked<Pick<ProviderService, 'getProviders'>>;
+  let providerService: jest.Mocked<Pick<ProviderService, 'getProviders' | 'getGlobalProviders'>>;
   let svc: ProviderKeyService;
 
   beforeEach(() => {
@@ -54,7 +54,10 @@ describe('ProviderKeyService', () => {
       getProviderKeys: jest.fn().mockReturnValue(undefined),
       setProviderKeys: jest.fn(),
     };
-    providerService = { getProviders: jest.fn().mockResolvedValue([]) };
+    providerService = {
+      getProviders: jest.fn().mockResolvedValue([]),
+      getGlobalProviders: jest.fn().mockResolvedValue([]),
+    };
 
     svc = new ProviderKeyService(
       providerRepo as unknown as Repository<UserProvider>,
@@ -248,6 +251,56 @@ describe('ProviderKeyService', () => {
 
       const result = await svc.getProviderApiKey('agent-1', 'openai');
       expect(result).toBe('real-key');
+    });
+  });
+
+  describe('global provider keys', () => {
+    it('resolves decrypted global provider keys by user scope', async () => {
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'global-1',
+          user_id: 'user-1',
+          agent_id: null,
+          provider: 'openai',
+          auth_type: 'api_key',
+          api_key_encrypted: 'enc',
+          is_active: true,
+          label: 'Work',
+          priority: 0,
+          region: null,
+        },
+      ]);
+      mockedDecrypt.mockReturnValue('plaintext-global-key');
+
+      const result = await svc.getGlobalProviderApiKey('user-1', 'openai', 'api_key', 'Work');
+
+      expect(result).toBe('plaintext-global-key');
+      expect(providerRepo.find).toHaveBeenCalledWith({
+        where: expect.objectContaining({ user_id: 'user-1', agent_id: expect.any(Object) }),
+        order: { priority: 'ASC' },
+      });
+      expect(routingCache.setProviderKeys).not.toHaveBeenCalled();
+    });
+
+    it('chooses subscription auth for active global providers with a token', async () => {
+      providerService.getGlobalProviders.mockResolvedValue([
+        {
+          provider: 'openai',
+          auth_type: 'api_key',
+          api_key_encrypted: 'enc-key',
+          is_active: true,
+        },
+        {
+          provider: 'openai',
+          auth_type: 'subscription',
+          api_key_encrypted: 'enc-sub',
+          is_active: true,
+        },
+      ] as UserProvider[]);
+
+      const result = await svc.getGlobalAuthType('user-1', 'openai');
+
+      expect(result).toBe('subscription');
     });
   });
 

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -158,6 +158,58 @@ describe('ProviderService — route-only cleanup paths', () => {
       ).rejects.toThrow('authType is required');
       expect(providerRepo.find).not.toHaveBeenCalled();
     });
+
+    it('copies selected global providers into an agent and recalculates once', async () => {
+      const txRepo = {
+        find: jest
+          .fn()
+          .mockResolvedValueOnce([
+            {
+              id: 'global-1',
+              user_id: 'user-1',
+              agent_id: null,
+              provider: 'openai',
+              auth_type: 'api_key',
+              label: 'Work',
+              priority: 0,
+              api_key_encrypted: 'enc',
+              key_prefix: 'sk-test',
+              region: null,
+              is_active: true,
+              cached_models: [{ id: 'gpt-4o-mini' }],
+              models_fetched_at: '2026-01-01T00:00:00.000Z',
+            },
+          ])
+          .mockResolvedValueOnce([]),
+        insert: jest.fn().mockResolvedValue(undefined),
+      };
+      providerRepo.manager.transaction.mockImplementation(async (callback) =>
+        callback({ getRepository: () => txRepo } as never),
+      );
+
+      const copied = await svc.copyGlobalProvidersToAgent('user-1', 'agent-1', ['global-1']);
+
+      expect(copied).toBe(1);
+      expect(txRepo.find).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          where: expect.objectContaining({ id: expect.any(Object), user_id: 'user-1' }),
+        }),
+      );
+      expect(txRepo.insert).toHaveBeenCalledWith([
+        expect.objectContaining({
+          user_id: 'user-1',
+          agent_id: 'agent-1',
+          provider: 'openai',
+          auth_type: 'api_key',
+          label: 'Work',
+          key_prefix: 'sk-test',
+          cached_models: [{ id: 'gpt-4o-mini' }],
+        }),
+      ]);
+      expect(autoAssign.recalculate).toHaveBeenCalledWith('agent-1');
+      expect(routingCache.invalidateAgent).toHaveBeenCalledWith('agent-1');
+    });
   });
 
   describe('removeProvider — cleanupProviderReferences', () => {

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -151,6 +151,13 @@ describe('ProviderService — route-only cleanup paths', () => {
       expect(autoAssign.recalculate).not.toHaveBeenCalled();
       expect(tierRepo.find).not.toHaveBeenCalled();
     });
+
+    it('requires authType when deleting a labeled global provider key', async () => {
+      await expect(
+        svc.removeGlobalProvider('user-1', 'openai', undefined, 'Default'),
+      ).rejects.toThrow('authType is required');
+      expect(providerRepo.find).not.toHaveBeenCalled();
+    });
   });
 
   describe('removeProvider — cleanupProviderReferences', () => {

--- a/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
+++ b/packages/backend/src/routing/routing-core/__tests__/provider.service.spec.ts
@@ -46,6 +46,7 @@ describe('ProviderService — route-only cleanup paths', () => {
   let svc: ProviderService;
 
   beforeEach(() => {
+    process.env.MANIFEST_ENCRYPTION_KEY = 'test-encryption-key-32-bytes-long';
     providerRepo = makeRepo();
     tierRepo = makeRepo();
     specRepo = makeRepo();
@@ -67,6 +68,89 @@ describe('ProviderService — route-only cleanup paths', () => {
       pricingCache as unknown as ModelPricingCacheService,
       routingCache as unknown as RoutingCacheService,
     );
+  });
+
+  describe('global provider scope', () => {
+    it('creates global providers with null agent_id and no tier recalculation', async () => {
+      providerRepo.findOne.mockResolvedValue(null);
+
+      const result = await svc.upsertGlobalProvider('user-1', 'openai', 'sk-test', 'api_key');
+
+      expect(result.isNew).toBe(true);
+      expect(providerRepo.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: 'user-1',
+          agent_id: null,
+          provider: 'openai',
+          auth_type: 'api_key',
+          key_prefix: 'sk-test',
+        }),
+      );
+      expect(autoAssign.recalculate).not.toHaveBeenCalled();
+      expect(routingCache.invalidateAgent).not.toHaveBeenCalled();
+    });
+
+    it('lists only usable global provider rows for the current user', async () => {
+      providerRepo.find.mockResolvedValue([
+        { id: 'p1', user_id: 'user-1', agent_id: null, provider: 'openai', auth_type: 'api_key' },
+        {
+          id: 'p2',
+          user_id: 'user-1',
+          agent_id: null,
+          provider: 'unknown-sub',
+          auth_type: 'subscription',
+        },
+      ]);
+
+      const result = await svc.getGlobalProviders('user-1');
+
+      expect(providerRepo.find).toHaveBeenCalledWith({
+        where: expect.objectContaining({ user_id: 'user-1' }),
+      });
+      expect(result.map((row) => row.id)).toEqual(['p1']);
+    });
+
+    it('renames a global key without relabeling agent route overrides', async () => {
+      providerRepo.find.mockResolvedValue([
+        {
+          id: 'p1',
+          user_id: 'user-1',
+          agent_id: null,
+          provider: 'openai',
+          auth_type: 'api_key',
+          label: 'Default',
+        },
+      ]);
+
+      const result = await svc.renameGlobalKey('user-1', 'openai', 'api_key', 'Default', 'Work');
+
+      expect(result.label).toBe('Work');
+      expect(providerRepo.save).toHaveBeenCalledWith(expect.objectContaining({ label: 'Work' }));
+      expect(tierRepo.find).not.toHaveBeenCalled();
+      expect(specRepo.find).not.toHaveBeenCalled();
+      expect(routingCache.invalidateAgent).not.toHaveBeenCalled();
+    });
+
+    it('disconnects global providers without touching agent routing state', async () => {
+      const row = {
+        id: 'p1',
+        user_id: 'user-1',
+        agent_id: null,
+        provider: 'openai',
+        auth_type: 'api_key',
+        is_active: true,
+      };
+      providerRepo.find.mockResolvedValue([row]);
+
+      await svc.removeGlobalProvider('user-1', 'openai', 'api_key');
+
+      expect(row.is_active).toBe(false);
+      expect(providerRepo.save).toHaveBeenCalledWith([
+        expect.objectContaining({ is_active: false }),
+      ]);
+      expect(autoAssign.recalculate).not.toHaveBeenCalled();
+      expect(tierRepo.find).not.toHaveBeenCalled();
+    });
   });
 
   describe('removeProvider — cleanupProviderReferences', () => {

--- a/packages/backend/src/routing/routing-core/provider-key.service.ts
+++ b/packages/backend/src/routing/routing-core/provider-key.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { IsNull, Repository } from 'typeorm';
 import type { AuthType } from 'manifest-shared';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
@@ -51,6 +51,17 @@ export class ProviderKeyService {
     return result;
   }
 
+  async getGlobalProviderKeys(
+    userId: string,
+    provider: string,
+    authType?: AuthType,
+  ): Promise<CachedProviderKey[]> {
+    if (provider.toLowerCase() === 'ollama') {
+      return [{ id: 'ollama', label: 'Default', priority: 0, apiKey: '', region: null }];
+    }
+    return this.resolveGlobalProviderKeys(userId, provider, authType);
+  }
+
   /** Returns the label of the first (default) key for the given provider+authType. */
   async getDefaultKeyLabel(
     agentId: string,
@@ -68,6 +79,21 @@ export class ProviderKeyService {
     label?: string,
   ): Promise<string | null> {
     const keys = await this.getProviderKeys(agentId, provider, authType);
+    if (keys.length === 0) return null;
+    if (label) {
+      const match = keys.find((k) => k.label.toLowerCase() === label.toLowerCase());
+      if (match) return match.apiKey;
+    }
+    return keys[0].apiKey;
+  }
+
+  async getGlobalProviderApiKey(
+    userId: string,
+    provider: string,
+    authType?: AuthType,
+    label?: string,
+  ): Promise<string | null> {
+    const keys = await this.getGlobalProviderKeys(userId, provider, authType);
     if (keys.length === 0) return null;
     if (label) {
       const match = keys.find((k) => k.label.toLowerCase() === label.toLowerCase());
@@ -104,9 +130,35 @@ export class ProviderKeyService {
     return withKey?.auth_type ?? matches[0]?.auth_type ?? 'api_key';
   }
 
+  async getGlobalAuthType(
+    userId: string,
+    provider: string,
+    excludeAuthTypes?: Set<string>,
+  ): Promise<AuthType> {
+    const names = expandProviderNames([provider]);
+    const records = await this.providerService.getGlobalProviders(userId);
+    let matches = records.filter((r) => r.is_active && names.has(r.provider.toLowerCase()));
+    if (excludeAuthTypes && excludeAuthTypes.size > 0) {
+      const filtered = matches.filter((r) => !excludeAuthTypes.has(r.auth_type));
+      if (filtered.length > 0) matches = filtered;
+    }
+    const localMatch = matches.find((r) => r.auth_type === 'local');
+    if (localMatch) return 'local';
+    const subMatch = matches.find((r) => r.auth_type === 'subscription' && r.api_key_encrypted);
+    if (subMatch) return 'subscription';
+    const withKey = matches.find((r) => r.api_key_encrypted);
+    return withKey?.auth_type ?? matches[0]?.auth_type ?? 'api_key';
+  }
+
   async hasActiveProvider(agentId: string, provider: string): Promise<boolean> {
     const names = expandProviderNames([provider]);
     const records = await this.providerService.getProviders(agentId);
+    return records.some((r) => r.is_active && names.has(r.provider.toLowerCase()));
+  }
+
+  async hasActiveGlobalProvider(userId: string, provider: string): Promise<boolean> {
+    const names = expandProviderNames([provider]);
+    const records = await this.providerService.getGlobalProviders(userId);
     return records.some((r) => r.is_active && names.has(r.provider.toLowerCase()));
   }
 
@@ -117,6 +169,21 @@ export class ProviderKeyService {
     label?: string,
   ): Promise<string | null> {
     const keys = await this.getProviderKeys(agentId, provider, authType);
+    if (keys.length === 0) return null;
+    if (label) {
+      const match = keys.find((k) => k.label.toLowerCase() === label.toLowerCase());
+      if (match) return match.region;
+    }
+    return keys[0].region;
+  }
+
+  async getGlobalProviderRegion(
+    userId: string,
+    provider: string,
+    authType?: AuthType,
+    label?: string,
+  ): Promise<string | null> {
+    const keys = await this.getGlobalProviderKeys(userId, provider, authType);
     if (keys.length === 0) return null;
     if (label) {
       const match = keys.find((k) => k.label.toLowerCase() === label.toLowerCase());
@@ -182,6 +249,34 @@ export class ProviderKeyService {
 
     // When a caller explicitly requests an auth type, do not fall through
     // to a different auth type record.
+    const candidates = preferredAuthType
+      ? matches.filter((m) => m.auth_type === preferredAuthType)
+      : [...matches].sort((a, b) => {
+          const aPref = a.auth_type === 'api_key' ? 0 : 1;
+          const bPref = b.auth_type === 'api_key' ? 0 : 1;
+          if (aPref !== bPref) return aPref - bPref;
+          return a.priority - b.priority;
+        });
+
+    return candidates.flatMap((record) => this.decryptOne(record));
+  }
+
+  private async resolveGlobalProviderKeys(
+    userId: string,
+    provider: string,
+    preferredAuthType?: AuthType,
+  ): Promise<CachedProviderKey[]> {
+    const names = expandProviderNames([provider]);
+    const records = await this.providerRepo.find({
+      where: { user_id: userId, agent_id: IsNull(), is_active: true },
+      order: { priority: 'ASC' },
+    });
+
+    const matches = records.filter(
+      (r) => isManifestUsableProvider(r) && names.has(r.provider.toLowerCase()),
+    );
+    if (matches.length === 0) return [];
+
     const candidates = preferredAuthType
       ? matches.filter((m) => m.auth_type === preferredAuthType)
       : [...matches].sort((a, b) => {

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -71,6 +71,73 @@ export class ProviderService {
     return providers.filter(isManifestUsableProvider);
   }
 
+  async copyGlobalProvidersToAgent(
+    userId: string,
+    agentId: string,
+    providerIds: string[],
+  ): Promise<number> {
+    const ids = Array.from(new Set(providerIds.map((id) => id.trim()).filter(Boolean)));
+    if (ids.length === 0) return 0;
+
+    const copied = await this.providerRepo.manager.transaction(async (manager) => {
+      const txRepo = manager.getRepository(UserProvider);
+      const globals = (
+        await txRepo.find({
+          where: {
+            id: In(ids),
+            user_id: userId,
+            agent_id: IsNull(),
+            is_active: true,
+          },
+          order: { priority: 'ASC' },
+        })
+      ).filter(isManifestUsableProvider);
+
+      if (globals.length === 0) return 0;
+
+      const existingRows = await txRepo.find({ where: { agent_id: agentId } });
+      const existingKeys = new Set(
+        existingRows.map(
+          (row) => `${row.provider.toLowerCase()}::${row.auth_type}::${row.label.toLowerCase()}`,
+        ),
+      );
+      const now = new Date().toISOString();
+      const records = globals
+        .filter((row) => {
+          const key = `${row.provider.toLowerCase()}::${row.auth_type}::${row.label.toLowerCase()}`;
+          if (existingKeys.has(key)) return false;
+          existingKeys.add(key);
+          return true;
+        })
+        .map((row) =>
+          Object.assign(new UserProvider(), {
+            id: randomUUID(),
+            user_id: userId,
+            agent_id: agentId,
+            provider: row.provider,
+            auth_type: row.auth_type,
+            label: row.label,
+            priority: row.priority,
+            api_key_encrypted: row.api_key_encrypted,
+            key_prefix: row.key_prefix,
+            region: row.region,
+            is_active: true,
+            connected_at: now,
+            updated_at: now,
+            cached_models: row.cached_models,
+            models_fetched_at: row.models_fetched_at,
+          }),
+        );
+
+      if (records.length === 0) return 0;
+      await txRepo.insert(records);
+      return records.length;
+    });
+
+    if (copied > 0) await this.afterScopedProviderChange({ type: 'agent', agentId });
+    return copied;
+  }
+
   private scopeWhere(
     scope: ProviderScope,
     extra?: FindOptionsWhere<UserProvider>,

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -692,6 +692,9 @@ export class ProviderService {
     label?: string,
   ): Promise<{ notifications: string[] }> {
     if (label) {
+      if (!authType) {
+        throw new BadRequestException('authType is required when deleting a labeled provider key');
+      }
       return this.removeGlobalKeyByLabel(userId, provider, authType, label);
     }
 

--- a/packages/backend/src/routing/routing-core/provider.service.ts
+++ b/packages/backend/src/routing/routing-core/provider.service.ts
@@ -1,6 +1,6 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In, FindOptionsWhere } from 'typeorm';
+import { Repository, In, FindOptionsWhere, IsNull } from 'typeorm';
 import { UserProvider } from '../../entities/user-provider.entity';
 import { TierAssignment } from '../../entities/tier-assignment.entity';
 import { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
@@ -25,6 +25,8 @@ import {
 const MAX_KEYS_PER_PROVIDER = 5;
 const MAX_LABEL_LENGTH = 50;
 const DEFAULT_LABEL = 'Default';
+
+type ProviderScope = { type: 'agent'; agentId: string } | { type: 'global'; userId: string };
 
 @Injectable()
 export class ProviderService {
@@ -60,6 +62,37 @@ export class ProviderService {
     );
     this.routingCache.setProviders(agentId, providers);
     return providers;
+  }
+
+  async getGlobalProviders(userId: string): Promise<UserProvider[]> {
+    const providers = await this.providerRepo.find({
+      where: this.scopeWhere({ type: 'global', userId }),
+    });
+    return providers.filter(isManifestUsableProvider);
+  }
+
+  private scopeWhere(
+    scope: ProviderScope,
+    extra?: FindOptionsWhere<UserProvider>,
+  ): FindOptionsWhere<UserProvider> {
+    const where: FindOptionsWhere<UserProvider> = { ...(extra ?? {}) };
+    if (scope.type === 'agent') {
+      where.agent_id = scope.agentId;
+    } else {
+      where.agent_id = IsNull();
+      where.user_id = scope.userId;
+    }
+    return where;
+  }
+
+  private scopeAgentId(scope: ProviderScope): string | null {
+    return scope.type === 'agent' ? scope.agentId : null;
+  }
+
+  private async afterScopedProviderChange(scope: ProviderScope): Promise<void> {
+    if (scope.type !== 'agent') return;
+    await this.autoAssign.recalculate(scope.agentId);
+    this.routingCache.invalidateAgent(scope.agentId);
   }
 
   /**
@@ -101,12 +134,51 @@ export class ProviderService {
     region?: string,
     label?: string,
   ): Promise<{ provider: UserProvider; isNew: boolean }> {
+    return this.upsertProviderInScope(
+      { type: 'agent', agentId },
+      userId,
+      provider,
+      apiKey,
+      authType,
+      region,
+      label,
+    );
+  }
+
+  async upsertGlobalProvider(
+    userId: string,
+    provider: string,
+    apiKey?: string,
+    authType?: AuthType,
+    region?: string,
+    label?: string,
+  ): Promise<{ provider: UserProvider; isNew: boolean }> {
+    return this.upsertProviderInScope(
+      { type: 'global', userId },
+      userId,
+      provider,
+      apiKey,
+      authType,
+      region,
+      label,
+    );
+  }
+
+  private async upsertProviderInScope(
+    scope: ProviderScope,
+    userId: string,
+    provider: string,
+    apiKey?: string,
+    authType?: AuthType,
+    region?: string,
+    label?: string,
+  ): Promise<{ provider: UserProvider; isNew: boolean }> {
     const effectiveAuthType = authType ?? 'api_key';
     const trimmedLabel = this.normalizeLabel(label, effectiveAuthType);
 
     if (trimmedLabel) {
       return this.upsertProviderWithLabel(
-        agentId,
+        scope,
         userId,
         provider,
         apiKey,
@@ -123,7 +195,11 @@ export class ProviderService {
     // this lookup is unambiguous (the unique index guarantees at most one
     // 'Default' row per tuple).
     const existing = await this.providerRepo.findOne({
-      where: { agent_id: agentId, provider, auth_type: effectiveAuthType, label: DEFAULT_LABEL },
+      where: this.scopeWhere(scope, {
+        provider,
+        auth_type: effectiveAuthType,
+        label: DEFAULT_LABEL,
+      }),
     });
     const resolvedRegion = await this.resolveProviderRegion(
       provider,
@@ -144,14 +220,14 @@ export class ProviderService {
       existing.is_active = true;
       existing.updated_at = new Date().toISOString();
       await this.providerRepo.save(existing);
-      await this.afterProviderInsert(agentId);
+      await this.afterScopedProviderChange(scope);
       return { provider: existing, isNew: false };
     }
 
     const record: UserProvider = Object.assign(new UserProvider(), {
       id: randomUUID(),
       user_id: userId,
-      agent_id: agentId,
+      agent_id: this.scopeAgentId(scope),
       provider,
       auth_type: effectiveAuthType,
       label: DEFAULT_LABEL,
@@ -165,12 +241,12 @@ export class ProviderService {
     });
 
     await this.providerRepo.insert(record);
-    await this.afterProviderInsert(agentId);
+    await this.afterScopedProviderChange(scope);
     return { provider: record, isNew: true };
   }
 
   private async upsertProviderWithLabel(
-    agentId: string,
+    scope: ProviderScope,
     userId: string,
     provider: string,
     apiKey: string | undefined,
@@ -179,7 +255,7 @@ export class ProviderService {
     label: string,
   ): Promise<{ provider: UserProvider; isNew: boolean }> {
     const existingRows = await this.providerRepo.find({
-      where: { agent_id: agentId, provider, auth_type: authType },
+      where: this.scopeWhere(scope, { provider, auth_type: authType }),
     });
     const existing =
       existingRows.find((r) => r.label.toLowerCase() === label.toLowerCase()) ?? null;
@@ -202,7 +278,7 @@ export class ProviderService {
       existing.is_active = true;
       existing.updated_at = new Date().toISOString();
       await this.providerRepo.save(existing);
-      await this.afterProviderInsert(agentId);
+      await this.afterScopedProviderChange(scope);
       return { provider: existing, isNew: false };
     }
 
@@ -234,7 +310,7 @@ export class ProviderService {
     const record: UserProvider = Object.assign(new UserProvider(), {
       id: randomUUID(),
       user_id: userId,
-      agent_id: agentId,
+      agent_id: this.scopeAgentId(scope),
       provider,
       auth_type: authType,
       label,
@@ -248,7 +324,7 @@ export class ProviderService {
     });
 
     await this.providerRepo.insert(record);
-    await this.afterProviderInsert(agentId);
+    await this.afterScopedProviderChange(scope);
     return { provider: record, isNew: true };
   }
 
@@ -259,11 +335,43 @@ export class ProviderService {
     currentLabel: string,
     newLabel: string,
   ): Promise<UserProvider> {
+    return this.renameKeyInScope(
+      { type: 'agent', agentId },
+      provider,
+      authType,
+      currentLabel,
+      newLabel,
+    );
+  }
+
+  async renameGlobalKey(
+    userId: string,
+    provider: string,
+    authType: AuthType,
+    currentLabel: string,
+    newLabel: string,
+  ): Promise<UserProvider> {
+    return this.renameKeyInScope(
+      { type: 'global', userId },
+      provider,
+      authType,
+      currentLabel,
+      newLabel,
+    );
+  }
+
+  private async renameKeyInScope(
+    scope: ProviderScope,
+    provider: string,
+    authType: AuthType,
+    currentLabel: string,
+    newLabel: string,
+  ): Promise<UserProvider> {
     const trimmed = newLabel.trim();
     this.assertLabelLooksValid(trimmed);
 
     const rows = await this.providerRepo.find({
-      where: { agent_id: agentId, provider, auth_type: authType },
+      where: this.scopeWhere(scope, { provider, auth_type: authType }),
     });
     const target = rows.find((r) => r.label.toLowerCase() === currentLabel.toLowerCase());
     if (!target) throw new NotFoundException('Provider key not found');
@@ -275,8 +383,10 @@ export class ProviderService {
     target.label = trimmed;
     target.updated_at = new Date().toISOString();
     await this.providerRepo.save(target);
-    await this.relabelOverrides(agentId, provider, authType, previousLabel, trimmed);
-    this.routingCache.invalidateAgent(agentId);
+    if (scope.type === 'agent') {
+      await this.relabelOverrides(scope.agentId, provider, authType, previousLabel, trimmed);
+      this.routingCache.invalidateAgent(scope.agentId);
+    }
     return target;
   }
 
@@ -286,8 +396,26 @@ export class ProviderService {
     authType: AuthType,
     orderedLabels: string[],
   ): Promise<UserProvider[]> {
+    return this.reorderKeysInScope({ type: 'agent', agentId }, provider, authType, orderedLabels);
+  }
+
+  async reorderGlobalKeys(
+    userId: string,
+    provider: string,
+    authType: AuthType,
+    orderedLabels: string[],
+  ): Promise<UserProvider[]> {
+    return this.reorderKeysInScope({ type: 'global', userId }, provider, authType, orderedLabels);
+  }
+
+  private async reorderKeysInScope(
+    scope: ProviderScope,
+    provider: string,
+    authType: AuthType,
+    orderedLabels: string[],
+  ): Promise<UserProvider[]> {
     const allRows = await this.providerRepo.find({
-      where: { agent_id: agentId, provider, auth_type: authType },
+      where: this.scopeWhere(scope, { provider, auth_type: authType }),
     });
     const rows = allRows.filter((r) => r.is_active);
     if (rows.length === 0) throw new NotFoundException('Provider not found');
@@ -319,7 +447,7 @@ export class ProviderService {
       updated.push(row);
     }
     await this.providerRepo.save(updated);
-    this.routingCache.invalidateAgent(agentId);
+    if (scope.type === 'agent') this.routingCache.invalidateAgent(scope.agentId);
     return updated;
   }
 
@@ -557,6 +685,38 @@ export class ProviderService {
     return { notifications };
   }
 
+  async removeGlobalProvider(
+    userId: string,
+    provider: string,
+    authType?: AuthType,
+    label?: string,
+  ): Promise<{ notifications: string[] }> {
+    if (label) {
+      return this.removeGlobalKeyByLabel(userId, provider, authType, label);
+    }
+
+    const scope: ProviderScope = { type: 'global', userId };
+    const where = this.scopeWhere(scope, { provider, is_active: true });
+    if (authType) where.auth_type = authType;
+    const activeRows = await this.providerRepo.find({ where });
+
+    if (activeRows.length === 0) {
+      const fallbackWhere = this.scopeWhere(scope, { provider });
+      if (authType) fallbackWhere.auth_type = authType;
+      const any = await this.providerRepo.findOne({ where: fallbackWhere });
+      if (!any) throw new NotFoundException('Provider not found');
+    } else {
+      const now = new Date().toISOString();
+      for (const row of activeRows) {
+        row.is_active = false;
+        row.updated_at = now;
+      }
+      await this.providerRepo.save(activeRows);
+    }
+
+    return { notifications: [] };
+  }
+
   /**
    * Delete a single labeled key from a provider's chain. If it was the last
    * key for the (agent, provider, auth_type) tuple, falls through to the
@@ -591,6 +751,33 @@ export class ProviderService {
     await this.relabelOverrides(agentId, provider, target.auth_type, target.label, null);
     await this.renumberPriorities(agentId, provider, target.auth_type);
     this.routingCache.invalidateAgent(agentId);
+    return { notifications: [] };
+  }
+
+  private async removeGlobalKeyByLabel(
+    userId: string,
+    provider: string,
+    authType: AuthType | undefined,
+    label: string,
+  ): Promise<{ notifications: string[] }> {
+    const scope: ProviderScope = { type: 'global', userId };
+    const where = this.scopeWhere(scope, { provider });
+    if (authType) where.auth_type = authType;
+    const matching = await this.providerRepo.find({ where });
+    if (matching.length === 0) throw new NotFoundException('Provider not found');
+
+    const target = matching.find((r) => r.label.toLowerCase() === label.toLowerCase());
+    if (!target) throw new NotFoundException('Provider key not found');
+
+    const stillHasOtherKeys = matching.some(
+      (r) => r.id !== target.id && r.is_active && isManifestUsableProvider(r),
+    );
+    if (!stillHasOtherKeys) {
+      return this.removeGlobalProvider(userId, provider, target.auth_type);
+    }
+
+    await this.providerRepo.remove(target);
+    await this.renumberPrioritiesInScope(scope, provider, target.auth_type);
     return { notifications: [] };
   }
 
@@ -890,8 +1077,16 @@ export class ProviderService {
     provider: string,
     authType: AuthType,
   ): Promise<void> {
+    await this.renumberPrioritiesInScope({ type: 'agent', agentId }, provider, authType);
+  }
+
+  private async renumberPrioritiesInScope(
+    scope: ProviderScope,
+    provider: string,
+    authType: AuthType,
+  ): Promise<void> {
     const allRows = await this.providerRepo.find({
-      where: { agent_id: agentId, provider, auth_type: authType },
+      where: this.scopeWhere(scope, { provider, auth_type: authType }),
       order: { priority: 'ASC' },
     });
     // Only contiguous-renumber active rows. Inactive rows are deactivated

--- a/packages/backend/src/routing/routing.module.ts
+++ b/packages/backend/src/routing/routing.module.ts
@@ -14,6 +14,7 @@ import { ModelController } from './model.controller';
 import { CopilotController } from './copilot.controller';
 import { SpecificityController } from './specificity.controller';
 import { ModelParamsController } from './model-params.controller';
+import { GlobalProvidersController } from './global-providers.controller';
 import { OllamaSyncService } from '../database/ollama-sync.service';
 import { NotificationsModule } from '../notifications/notifications.module';
 
@@ -37,6 +38,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
     CopilotController,
     SpecificityController,
     ModelParamsController,
+    GlobalProvidersController,
   ],
   providers: [OllamaSyncService],
   exports: [RoutingCoreModule, CustomProviderModule, OAuthModule],

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -36,7 +36,8 @@ const AppInner: ParentComponent = (props) => {
   const location = useLocation();
   const [mobileNavOpen, setMobileNavOpen] = createSignal(false);
   const isAgentMode = () => location.pathname.startsWith('/agents/');
-  const isTenantMode = () => location.pathname === '/providers';
+  const isTenantMode = () =>
+    location.pathname === '/providers' || location.pathname === '/playground';
   const showSidebar = () => isAgentMode() || isTenantMode();
   const { content: rightSidebar } = useRightSidebar();
 

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -36,7 +36,8 @@ const AppInner: ParentComponent = (props) => {
   const location = useLocation();
   const [mobileNavOpen, setMobileNavOpen] = createSignal(false);
   const isAgentMode = () => location.pathname.startsWith('/agents/');
-  const showSidebar = () => isAgentMode();
+  const isTenantMode = () => location.pathname === '/providers';
+  const showSidebar = () => isAgentMode() || isTenantMode();
   const { content: rightSidebar } = useRightSidebar();
 
   createEffect<string | undefined>((previousPath) => {

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -41,6 +41,15 @@ const Sidebar: Component<SidebarProps> = (props) => {
         >
           Agents
         </A>
+        <div class="sidebar__section-label">TENANT</div>
+        <A
+          href="/providers"
+          class="sidebar__link"
+          classList={{ active: location.pathname === '/providers' }}
+          aria-current={location.pathname === '/providers' ? 'page' : undefined}
+        >
+          Providers
+        </A>
       </Show>
 
       <Show when={getAgentName()}>
@@ -78,6 +87,16 @@ const Sidebar: Component<SidebarProps> = (props) => {
           aria-current={isActive('/playground') ? 'page' : undefined}
         >
           Playground
+        </A>
+
+        <div class="sidebar__section-label">TENANT</div>
+        <A
+          href="/providers"
+          class="sidebar__link"
+          classList={{ active: location.pathname === '/providers' }}
+          aria-current={location.pathname === '/providers' ? 'page' : undefined}
+        >
+          Providers
         </A>
         <A
           href={path('/limits')}

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -50,6 +50,14 @@ const Sidebar: Component<SidebarProps> = (props) => {
         >
           Providers
         </A>
+        <A
+          href="/playground"
+          class="sidebar__link"
+          classList={{ active: location.pathname === '/playground' }}
+          aria-current={location.pathname === '/playground' ? 'page' : undefined}
+        >
+          Playground
+        </A>
       </Show>
 
       <Show when={getAgentName()}>
@@ -97,6 +105,14 @@ const Sidebar: Component<SidebarProps> = (props) => {
           aria-current={location.pathname === '/providers' ? 'page' : undefined}
         >
           Providers
+        </A>
+        <A
+          href="/playground"
+          class="sidebar__link"
+          classList={{ active: location.pathname === '/playground' }}
+          aria-current={location.pathname === '/playground' ? 'page' : undefined}
+        >
+          Playground
         </A>
         <A
           href={path('/limits')}

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -30,6 +30,7 @@ const ModelPrices = lazyReload(() => import('./pages/ModelPrices.jsx'));
 const Help = lazyReload(() => import('./pages/Help.jsx'));
 const FreeModels = lazyReload(() => import('./pages/FreeModels.jsx'));
 const ConnectProvider = lazyReload(() => import('./pages/ConnectProvider.jsx'));
+const GlobalProviders = lazyReload(() => import('./pages/GlobalProviders.jsx'));
 
 const GuestLayout: ParentComponent = (props) => (
   <GuestGuard>
@@ -70,6 +71,7 @@ render(
 
             <Route path="/help" component={Help} />
           </Route>
+          <Route path="/providers" component={GlobalProviders} />
           <Route path="/connect-provider" component={ConnectProvider} />
           <Route path="/account" component={Account} />
         </Route>

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -72,6 +72,7 @@ render(
             <Route path="/help" component={Help} />
           </Route>
           <Route path="/providers" component={GlobalProviders} />
+          <Route path="/playground" component={Playground} />
           <Route path="/connect-provider" component={ConnectProvider} />
           <Route path="/account" component={Account} />
         </Route>

--- a/packages/frontend/src/pages/GlobalProviders.tsx
+++ b/packages/frontend/src/pages/GlobalProviders.tsx
@@ -1,0 +1,327 @@
+import { createMemo, createResource, createSignal, For, Show, type Component } from 'solid-js';
+import { Meta, Title } from '@solidjs/meta';
+import {
+  connectGlobalProvider,
+  disconnectGlobalProvider,
+  getGlobalProviders,
+  refreshGlobalProviderModels,
+  type AuthType,
+  type RoutingProvider,
+} from '../services/api.js';
+import { PROVIDERS, type ProviderDef } from '../services/providers.js';
+import { providerIcon } from '../components/ProviderIcon.js';
+import { validateApiKey, validateSubscriptionKey } from '../services/provider-utils.js';
+import { formatTimeAgo } from '../services/formatters.js';
+import { toast } from '../services/toast-store.js';
+import '../styles/global-providers.css';
+
+const providerName = (id: string): string => PROVIDERS.find((p) => p.id === id)?.name ?? id;
+
+const supportsGlobalSubscription = (provider: ProviderDef): boolean => {
+  if (!provider.supportsSubscription) return false;
+  if (provider.deviceLogin) return false;
+  return (
+    provider.subscriptionAuthMode !== 'popup_oauth' &&
+    provider.subscriptionAuthMode !== 'popup_paste'
+  );
+};
+
+const authTypeLabel = (authType: AuthType): string => {
+  if (authType === 'subscription') return 'Subscription';
+  if (authType === 'local') return 'Local';
+  return 'API key';
+};
+
+const GlobalProviders: Component = () => {
+  const [providers, { refetch }] = createResource(getGlobalProviders);
+  const selectableProviders = () =>
+    PROVIDERS.filter(
+      (provider) => !provider.subscriptionOnly || supportsGlobalSubscription(provider),
+    );
+  const [providerId, setProviderId] = createSignal(selectableProviders()[0]?.id ?? 'openai');
+  const [authType, setAuthType] = createSignal<AuthType>('api_key');
+  const [apiKey, setApiKey] = createSignal('');
+  const [label, setLabel] = createSignal('');
+  const [region, setRegion] = createSignal<string | undefined>(undefined);
+  const [saving, setSaving] = createSignal(false);
+  const [busyId, setBusyId] = createSignal<string | null>(null);
+  const selectedProvider = createMemo(
+    () => PROVIDERS.find((p) => p.id === providerId()) ?? selectableProviders()[0],
+  );
+  const authOptions = createMemo<AuthType[]>(() => {
+    const provider = selectedProvider();
+    if (!provider) return ['api_key'];
+    const options: AuthType[] = [];
+    if (!provider.subscriptionOnly) options.push(provider.localOnly ? 'local' : 'api_key');
+    if (supportsGlobalSubscription(provider)) options.push('subscription');
+    return options.length > 0 ? options : ['api_key'];
+  });
+  const endpointRegions = () =>
+    authType() === 'subscription' ? (selectedProvider()?.subscriptionEndpointRegions ?? []) : [];
+
+  const providerRows = createMemo(() =>
+    (providers() ?? []).slice().sort((a, b) => {
+      const name = providerName(a.provider).localeCompare(providerName(b.provider));
+      if (name !== 0) return name;
+      if (a.auth_type !== b.auth_type) return a.auth_type.localeCompare(b.auth_type);
+      return a.priority - b.priority;
+    }),
+  );
+
+  const resetForm = () => {
+    setApiKey('');
+    setLabel('');
+    setRegion(undefined);
+  };
+
+  const handleProviderChange = (id: string) => {
+    setProviderId(id);
+    const nextProvider = PROVIDERS.find((p) => p.id === id);
+    if (nextProvider?.subscriptionOnly && supportsGlobalSubscription(nextProvider)) {
+      setAuthType('subscription');
+    } else if (nextProvider?.localOnly) {
+      setAuthType('local');
+    } else {
+      setAuthType('api_key');
+    }
+    resetForm();
+  };
+
+  const handleConnect = async () => {
+    const provider = selectedProvider();
+    if (!provider) return;
+    const key = apiKey().replace(/\s/g, '');
+    if (authType() === 'api_key' && !provider.noKeyRequired) {
+      const result = validateApiKey(provider, key);
+      if (!result.valid) {
+        toast.error(result.error ?? 'Invalid API key');
+        return;
+      }
+    }
+    if (authType() === 'subscription' && provider.subscriptionKeyPlaceholder) {
+      const result = validateSubscriptionKey(provider, key);
+      if (!result.valid) {
+        toast.error(result.error ?? 'Invalid subscription credential');
+        return;
+      }
+    }
+
+    setSaving(true);
+    try {
+      await connectGlobalProvider({
+        provider: provider.id,
+        authType: authType(),
+        ...(key ? { apiKey: key } : {}),
+        ...(label().trim() ? { label: label().trim() } : {}),
+        ...(region() ? { region: region() } : {}),
+      });
+      toast.success(`${provider.name} connected`);
+      resetForm();
+      await refetch();
+    } catch {
+      // fetchMutate already shows the server error.
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRefresh = async (row: RoutingProvider) => {
+    setBusyId(row.id);
+    try {
+      const result = await refreshGlobalProviderModels(row.provider, row.auth_type);
+      if (result.ok) {
+        toast.success(
+          `Refreshed ${result.model_count} model${result.model_count === 1 ? '' : 's'}`,
+        );
+      } else {
+        toast.error(result.error ?? 'Refresh failed');
+      }
+      await refetch();
+    } catch {
+      // fetchMutate already shows the server error.
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDisconnect = async (row: RoutingProvider) => {
+    setBusyId(row.id);
+    try {
+      await disconnectGlobalProvider(row.provider, row.auth_type, row.label);
+      toast.success(`${providerName(row.provider)} disconnected`);
+      await refetch();
+    } catch {
+      // fetchMutate already shows the server error.
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <>
+      <Title>Providers - Manifest</Title>
+      <Meta name="description" content="Manage global Manifest provider connections." />
+      <div class="global-providers-page">
+        <header class="page-header">
+          <div>
+            <span class="breadcrumb">Tenant</span>
+            <h1>Providers</h1>
+          </div>
+        </header>
+
+        <section class="global-provider-panel" aria-labelledby="add-global-provider-title">
+          <div class="global-provider-panel__header">
+            <h2 id="add-global-provider-title">Add provider</h2>
+          </div>
+          <div class="global-provider-form">
+            <label>
+              Provider
+              <select
+                value={providerId()}
+                onChange={(e) => handleProviderChange(e.currentTarget.value)}
+                disabled={saving()}
+              >
+                <For each={selectableProviders()}>
+                  {(provider) => <option value={provider.id}>{provider.name}</option>}
+                </For>
+              </select>
+            </label>
+            <label>
+              Type
+              <select
+                value={authType()}
+                onChange={(e) => {
+                  setAuthType(e.currentTarget.value as AuthType);
+                  setRegion(undefined);
+                }}
+                disabled={saving()}
+              >
+                <For each={authOptions()}>
+                  {(option) => <option value={option}>{authTypeLabel(option)}</option>}
+                </For>
+              </select>
+            </label>
+            <Show when={endpointRegions().length > 0}>
+              <label>
+                Region
+                <select
+                  value={region() ?? endpointRegions()[0]?.value}
+                  onChange={(e) => setRegion(e.currentTarget.value)}
+                  disabled={saving()}
+                >
+                  <For each={endpointRegions()}>
+                    {(option) => <option value={option.value}>{option.label}</option>}
+                  </For>
+                </select>
+              </label>
+            </Show>
+            <label>
+              Label
+              <input
+                value={label()}
+                placeholder="Default"
+                onInput={(e) => setLabel(e.currentTarget.value)}
+                disabled={saving()}
+              />
+            </label>
+            <Show when={authType() !== 'local' && !selectedProvider()?.noKeyRequired}>
+              <label class="global-provider-form__key">
+                Key
+                <input
+                  value={apiKey()}
+                  placeholder={
+                    authType() === 'subscription'
+                      ? (selectedProvider()?.subscriptionKeyPlaceholder ?? 'Paste credential')
+                      : (selectedProvider()?.keyPlaceholder ?? 'Paste API key')
+                  }
+                  onInput={(e) => setApiKey(e.currentTarget.value)}
+                  disabled={saving()}
+                />
+              </label>
+            </Show>
+            <button class="btn btn--primary btn--sm" onClick={handleConnect} disabled={saving()}>
+              {saving() ? <span class="spinner" /> : 'Connect'}
+            </button>
+          </div>
+        </section>
+
+        <section class="global-provider-panel" aria-labelledby="global-provider-list-title">
+          <div class="global-provider-panel__header">
+            <h2 id="global-provider-list-title">Connections</h2>
+            <span>{providerRows().filter((row) => row.is_active).length} active</span>
+          </div>
+
+          <Show
+            when={providerRows().length > 0}
+            fallback={
+              <div class="empty-state">
+                <div class="empty-state__title">No global providers yet</div>
+              </div>
+            }
+          >
+            <div class="global-provider-list">
+              <For each={providerRows()}>
+                {(row) => {
+                  const definition = () => PROVIDERS.find((p) => p.id === row.provider);
+                  return (
+                    <div class="global-provider-row" classList={{ 'is-inactive': !row.is_active }}>
+                      <div class="global-provider-row__icon">
+                        {providerIcon(row.provider, 24) ?? (
+                          <span
+                            class="provider-card__logo-letter"
+                            style={{ background: definition()?.color ?? 'hsl(var(--muted))' }}
+                          >
+                            {(definition()?.initial ?? row.provider[0] ?? '?').toUpperCase()}
+                          </span>
+                        )}
+                      </div>
+                      <div class="global-provider-row__main">
+                        <div class="global-provider-row__title">
+                          <span>{providerName(row.provider)}</span>
+                          <span class="global-provider-row__pill">
+                            {authTypeLabel(row.auth_type)}
+                          </span>
+                          <Show when={!row.is_active}>
+                            <span class="global-provider-row__pill">Inactive</span>
+                          </Show>
+                        </div>
+                        <div class="global-provider-row__meta">
+                          <span>{row.label}</span>
+                          <Show when={row.key_prefix}>
+                            <span>{row.key_prefix}********</span>
+                          </Show>
+                          <span>{row.cached_model_count ?? 0} models</span>
+                          <Show when={row.models_fetched_at}>
+                            <span>refreshed {formatTimeAgo(row.models_fetched_at ?? null)}</span>
+                          </Show>
+                        </div>
+                      </div>
+                      <div class="global-provider-row__actions">
+                        <button
+                          class="btn btn--outline btn--sm"
+                          disabled={busyId() === row.id || !row.is_active}
+                          onClick={() => void handleRefresh(row)}
+                        >
+                          Refresh
+                        </button>
+                        <button
+                          class="btn btn--ghost btn--sm"
+                          disabled={busyId() === row.id || !row.is_active}
+                          onClick={() => void handleDisconnect(row)}
+                        >
+                          Disconnect
+                        </button>
+                      </div>
+                    </div>
+                  );
+                }}
+              </For>
+            </div>
+          </Show>
+        </section>
+      </div>
+    </>
+  );
+};
+
+export default GlobalProviders;

--- a/packages/frontend/src/pages/GlobalProviders.tsx
+++ b/packages/frontend/src/pages/GlobalProviders.tsx
@@ -91,6 +91,8 @@ const GlobalProviders: Component = () => {
     const provider = selectedProvider();
     if (!provider) return;
     const key = apiKey().replace(/\s/g, '');
+    const selectedRegion =
+      endpointRegions().length > 0 ? (region() ?? endpointRegions()[0]?.value) : undefined;
     if (authType() === 'api_key' && !provider.noKeyRequired) {
       const result = validateApiKey(provider, key);
       if (!result.valid) {
@@ -113,7 +115,7 @@ const GlobalProviders: Component = () => {
         authType: authType(),
         ...(key ? { apiKey: key } : {}),
         ...(label().trim() ? { label: label().trim() } : {}),
-        ...(region() ? { region: region() } : {}),
+        ...(selectedRegion ? { region: selectedRegion } : {}),
       });
       toast.success(`${provider.name} connected`);
       resetForm();

--- a/packages/frontend/src/pages/Playground.tsx
+++ b/packages/frontend/src/pages/Playground.tsx
@@ -10,11 +10,13 @@ import {
   Suspense,
   type Component,
 } from 'solid-js';
-import { useParams, useSearchParams } from '@solidjs/router';
+import { useNavigate, useParams, useSearchParams } from '@solidjs/router';
 import { Meta, Title } from '@solidjs/meta';
 import type { AuthType, PlaygroundHistoryRunSummary } from '../services/api.js';
 import {
   getAvailableModels,
+  getGlobalAvailableModels,
+  getGlobalProviders,
   getPlaygroundRun,
   getCustomProviders,
   getProviders,
@@ -127,26 +129,37 @@ function findWinners(columns: readonly ColumnData[]): {
 }
 
 const Playground: Component = () => {
-  const params = useParams<{ agentName: string }>();
+  const params = useParams<{ agentName?: string }>();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams<{ run?: string }>();
-  const agentName = () => decodeURIComponent(params.agentName);
+  const isGlobalPlayground = () => !params.agentName;
+  const playgroundScope = () => (isGlobalPlayground() ? 'global' : 'agent');
+  const agentName = () =>
+    isGlobalPlayground() ? 'global' : decodeURIComponent(params.agentName ?? '');
+  const resourceScope = () => ({ scope: playgroundScope(), agentName: agentName() });
 
-  const [available, { refetch: refetchAvailable }] = createResource(agentName, getAvailableModels);
-  const [providers, { refetch: refetchProviders }] = createResource(agentName, getProviders);
+  const [available, { refetch: refetchAvailable }] = createResource(resourceScope, (source) =>
+    source.scope === 'global' ? getGlobalAvailableModels() : getAvailableModels(source.agentName),
+  );
+  const [providers, { refetch: refetchProviders }] = createResource(resourceScope, (source) =>
+    source.scope === 'global' ? getGlobalProviders() : getProviders(source.agentName),
+  );
   const [customProviders, { refetch: refetchCustomProviders }] = createResource(
-    agentName,
-    getCustomProviders,
+    resourceScope,
+    (source) =>
+      source.scope === 'global' ? Promise.resolve([]) : getCustomProviders(source.agentName),
   );
 
-  const store = getOrCreatePlaygroundStore(agentName());
+  const store = getOrCreatePlaygroundStore(agentName(), playgroundScope());
   const [pickerForColumn, setPickerForColumn] = createSignal<string | null>(null);
   const [showAddPicker, setShowAddPicker] = createSignal(false);
   const [announcement, setAnnouncement] = createSignal('');
   const [promptHeight, setPromptHeight] = createSignal(0);
   const [historyOpen, setHistoryOpen] = createSignal(
-    localStorage.getItem('manifest.playground.recentOpen') !== 'false',
+    !isGlobalPlayground() && localStorage.getItem('manifest.playground.recentOpen') !== 'false',
   );
   const toggleRecent = () => {
+    if (isGlobalPlayground()) return;
     const next = !historyOpen();
     setHistoryOpen(next);
     localStorage.setItem('manifest.playground.recentOpen', String(next));
@@ -226,10 +239,11 @@ const Playground: Component = () => {
     if (store.columns.length > 0 && !store.isAnyRunning() && !completedResults()) {
       setCompletedResults([...store.columns]);
     }
+    if (isGlobalPlayground()) return;
     if (store.columns.length > 0) return;
     const runId = searchParams.run || sessionStorage.getItem('manifest.playground.lastRun');
     if (runId && !activeRunId()) {
-      getPlaygroundRun(runId, params.agentName)
+      getPlaygroundRun(runId, agentName())
         .then((detail) => {
           store.loadHistoryRun(detail);
           setCompletedResults([...store.columns]);
@@ -260,6 +274,13 @@ const Playground: Component = () => {
     const runId = store.runAll({ requestHeaders: toHeaderRecord(headerEntries()) });
     if (!runId) return;
 
+    if (isGlobalPlayground()) {
+      setActiveRunId(null);
+      setLiveRunId(runId);
+      setViewingHistory(null);
+      return;
+    }
+
     // Add to history immediately so user sees the running playground
     setHistoryRuns((prev) => [
       {
@@ -285,6 +306,7 @@ const Playground: Component = () => {
   };
 
   const refreshHistory = async () => {
+    if (isGlobalPlayground()) return;
     setHistoryLoading(true);
     try {
       setHistoryRuns(await listPlaygroundRuns(agentName()));
@@ -310,6 +332,7 @@ const Playground: Component = () => {
           setLiveRunId(null);
           // Snapshot completed results so the summary table survives column removals
           setCompletedResults([...store.columns]);
+          if (isGlobalPlayground()) return;
           void refreshHistory().then(() => {
             // If user isn't viewing a past run, auto-select the latest
             if (!viewingHistory()) {
@@ -366,6 +389,7 @@ const Playground: Component = () => {
   };
 
   const handlePickHistory = async (runId: string) => {
+    if (isGlobalPlayground()) return;
     // If clicking on the live (currently running) run, just show live columns
     if (runId === liveRunId()) {
       setViewingHistory(null);
@@ -375,7 +399,7 @@ const Playground: Component = () => {
       return;
     }
     try {
-      const detail = await getPlaygroundRun(runId, params.agentName);
+      const detail = await getPlaygroundRun(runId, agentName());
       const toReadOnlyCols = (): import('../services/playground-store.js').PlaygroundColumn[] =>
         detail.columns.map((c, i) => ({
           id: `hist-${i}`,
@@ -415,6 +439,10 @@ const Playground: Component = () => {
   };
 
   createEffect(() => {
+    if (isGlobalPlayground()) {
+      setRightSidebar(null);
+      return;
+    }
     setRightSidebar(
       <PlaygroundRecentSidebar
         open={historyOpen()}
@@ -431,13 +459,20 @@ const Playground: Component = () => {
   onCleanup(() => setRightSidebar(null));
 
   const hasConnectedProviders = () => (providers() ?? []).some((p) => p.is_active);
+  const openProviders = () => {
+    if (isGlobalPlayground()) {
+      navigate('/providers');
+      return;
+    }
+    setShowProviderModal(true);
+  };
   // Compute winners from whatever set is actually rendered — when a history
   // run is open its columns drive the badges, not the live store.
   const winners = () => findWinners(viewingHistory() ?? store.columns);
 
   return (
     <div class="playground" style={{ 'padding-bottom': `${promptHeight() + 48}px` }}>
-      <Title>Playground · Manifest</Title>
+      <Title>{isGlobalPlayground() ? 'Global Playground' : 'Playground'} · Manifest</Title>
       <Meta
         name="description"
         content="Compare models side by side for cost, speed, and quality."
@@ -445,17 +480,15 @@ const Playground: Component = () => {
 
       <header class="page-header">
         <div>
-          <h1>Playground</h1>
+          <h1>{isGlobalPlayground() ? 'Global Playground' : 'Playground'}</h1>
           <p class="page-header__sub">
-            Send one prompt to multiple models and compare cost, speed, and quality.
+            {isGlobalPlayground()
+              ? 'Test models from tenant provider connections before copying them into agents.'
+              : 'Send one prompt to multiple models and compare cost, speed, and quality.'}
           </p>
         </div>
-        <button
-          type="button"
-          class="btn btn--primary btn--sm"
-          onClick={() => setShowProviderModal(true)}
-        >
-          Connect providers
+        <button type="button" class="btn btn--primary btn--sm" onClick={openProviders}>
+          {isGlobalPlayground() ? 'Manage providers' : 'Connect providers'}
         </button>
       </header>
 
@@ -463,7 +496,7 @@ const Playground: Component = () => {
         when={(available() && providers() && hasConnectedProviders()) || viewingHistory()}
         fallback={
           <Show when={available() && providers()}>
-            <PlaygroundEmptyState onConnect={() => setShowProviderModal(true)} />
+            <PlaygroundEmptyState onConnect={openProviders} />
           </Show>
         }
       >
@@ -519,12 +552,8 @@ const Playground: Component = () => {
             <div class="playground-prompt-wrapper">
               <div class="playground-prompt playground-prompt--info">
                 <span class="playground-prompt__info-text">Connect a provider to get started</span>
-                <button
-                  type="button"
-                  class="btn btn--primary btn--sm"
-                  onClick={() => setShowProviderModal(true)}
-                >
-                  Connect provider
+                <button type="button" class="btn btn--primary btn--sm" onClick={openProviders}>
+                  {isGlobalPlayground() ? 'Manage providers' : 'Connect provider'}
                 </button>
               </div>
             </div>
@@ -596,7 +625,7 @@ const Playground: Component = () => {
         />
       </Show>
 
-      <Show when={showProviderModal()}>
+      <Show when={showProviderModal() && !isGlobalPlayground()}>
         <Suspense fallback={null}>
           <ProviderSelectModal
             agentName={agentName()}

--- a/packages/frontend/src/pages/Workspace.tsx
+++ b/packages/frontend/src/pages/Workspace.tsx
@@ -1,5 +1,6 @@
 import {
   createEffect,
+  createMemo,
   createResource,
   createSignal,
   Show,
@@ -12,7 +13,8 @@ import { Title, Meta } from '@solidjs/meta';
 import ErrorState from '../components/ErrorState.jsx';
 import AgentTypeSelect from '../components/AgentTypeSelect.jsx';
 import DuplicateAgentModal from '../components/DuplicateAgentModal.jsx';
-import { getAgents, createAgent, deleteAgent } from '../services/api.js';
+import { getAgents, createAgent, deleteAgent, getGlobalProviders } from '../services/api.js';
+import type { RoutingProvider } from '../services/api.js';
 import { toast } from '../services/toast-store.js';
 import { markAgentCreated } from '../services/recent-agents.js';
 import { formatNumber } from '../services/formatters.js';
@@ -49,6 +51,28 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
     PLATFORMS_BY_CATEGORY['personal'][0] ?? null,
   );
   const [creating, setCreating] = createSignal(false);
+  const [selectedGlobalProviders, setSelectedGlobalProviders] = createSignal<Set<string>>(
+    new Set(),
+  );
+  const [globalProviders] = createResource(
+    () => props.open,
+    (open) => (open ? getGlobalProviders() : Promise.resolve([] as RoutingProvider[])),
+  );
+  const copyableGlobalProviders = createMemo(() =>
+    (globalProviders() ?? [])
+      .filter((provider) => provider.is_active)
+      .sort((a, b) => {
+        const providerName = a.provider.localeCompare(b.provider);
+        if (providerName !== 0) return providerName;
+        return a.label.localeCompare(b.label);
+      }),
+  );
+
+  createEffect(() => {
+    if (!props.open) return;
+    const ids = copyableGlobalProviders().map((provider) => provider.id);
+    setSelectedGlobalProviders(new Set(ids));
+  });
 
   const handleCategoryChange = (c: AgentCategory) => {
     setCategory(c);
@@ -60,10 +84,12 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
     if (!agentName) return;
     setCreating(true);
     try {
+      const providerIds = Array.from(selectedGlobalProviders());
       const result = await createAgent({
         name: agentName,
         ...(category() ? { agent_category: category()! } : {}),
         ...(platform() ? { agent_platform: platform()! } : {}),
+        ...(providerIds.length > 0 ? { global_provider_ids: providerIds } : {}),
       });
       toast.success(`Agent "${agentName}" connected`);
       props.onClose();
@@ -84,6 +110,16 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
     setName('');
     setCategory('personal');
     setPlatform(PLATFORMS_BY_CATEGORY['personal'][0] ?? null);
+    setSelectedGlobalProviders(new Set(copyableGlobalProviders().map((provider) => provider.id)));
+  };
+
+  const toggleGlobalProvider = (id: string) => {
+    setSelectedGlobalProviders((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -146,6 +182,35 @@ const AddAgentModal: Component<{ open: boolean; onClose: () => void }> = (props)
               />
             </div>
           </div>
+
+          <Show when={copyableGlobalProviders().length > 0}>
+            <div class="agent-global-providers">
+              <div class="agent-global-providers__header">
+                <span class="modal-card__field-label">Global providers</span>
+                <span>{selectedGlobalProviders().size} selected</span>
+              </div>
+              <div class="agent-global-providers__list">
+                <For each={copyableGlobalProviders()}>
+                  {(provider) => (
+                    <label class="agent-global-provider-row">
+                      <input
+                        type="checkbox"
+                        checked={selectedGlobalProviders().has(provider.id)}
+                        disabled={creating()}
+                        onChange={() => toggleGlobalProvider(provider.id)}
+                      />
+                      <span class="agent-global-provider-row__main">
+                        <span class="agent-global-provider-row__name">{provider.provider}</span>
+                        <span class="agent-global-provider-row__meta">
+                          {provider.label} - {provider.auth_type}
+                        </span>
+                      </span>
+                    </label>
+                  )}
+                </For>
+              </div>
+            </div>
+          </Show>
 
           <div class="modal-card__footer">
             <button

--- a/packages/frontend/src/services/api/agents.ts
+++ b/packages/frontend/src/services/api/agents.ts
@@ -61,6 +61,7 @@ export interface CreateAgentParams {
   name: string;
   agent_category?: string;
   agent_platform?: string;
+  global_provider_ids?: string[];
 }
 
 export interface DuplicateAgentPreview {
@@ -104,6 +105,7 @@ export function createAgent(params: CreateAgentParams) {
       agent_platform: string | null;
     };
     apiKey: string;
+    copied?: { globalProviders: number };
   }>('/agents', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/packages/frontend/src/services/api/playground.ts
+++ b/packages/frontend/src/services/api/playground.ts
@@ -25,6 +25,7 @@ export interface PlaygroundStreamResult {
 
 export interface RunPlaygroundRequest {
   agentName: string;
+  scope?: 'agent' | 'global';
   model: string;
   provider: string;
   authType?: AuthType;

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -53,6 +53,10 @@ export function getProviders(agentName: string) {
   return fetchJson<RoutingProvider[]>(routingPath(agentName, 'providers'));
 }
 
+export function getGlobalProviders() {
+  return fetchJson<RoutingProvider[]>('/providers');
+}
+
 export function connectProvider(
   agentName: string,
   data: {
@@ -78,6 +82,20 @@ export function connectProvider(
   });
 }
 
+export function connectGlobalProvider(data: {
+  provider: string;
+  apiKey?: string;
+  authType?: AuthType;
+  label?: string;
+  region?: string;
+}) {
+  return fetchMutate<RoutingProvider>('/providers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+}
+
 export function disconnectProvider(
   agentName: string,
   provider: string,
@@ -85,6 +103,16 @@ export function disconnectProvider(
   label?: string,
 ) {
   const base = routingPath(agentName, `providers/${encodeURIComponent(provider)}`);
+  const params = new URLSearchParams();
+  if (authType) params.set('authType', authType);
+  if (label) params.set('label', label);
+  const qs = params.toString();
+  const path = qs ? `${base}?${qs}` : base;
+  return fetchMutate<{ ok: boolean; notifications: string[] }>(path, { method: 'DELETE' });
+}
+
+export function disconnectGlobalProvider(provider: string, authType?: AuthType, label?: string) {
+  const base = `/providers/${encodeURIComponent(provider)}`;
   const params = new URLSearchParams();
   if (authType) params.set('authType', authType);
   if (label) params.set('label', label);
@@ -113,6 +141,22 @@ export function renameProviderKey(
   );
 }
 
+export function renameGlobalProviderKey(
+  provider: string,
+  currentLabel: string,
+  newLabel: string,
+  authType?: AuthType,
+) {
+  return fetchMutate<{ id: string; label: string; priority: number }>(
+    `/providers/${encodeURIComponent(provider)}/keys/${encodeURIComponent(currentLabel)}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ newLabel, ...(authType && { authType }) }),
+    },
+  );
+}
+
 export function reorderProviderKeys(
   agentName: string,
   provider: string,
@@ -121,6 +165,17 @@ export function reorderProviderKeys(
 ) {
   return fetchMutate<Array<{ id: string; label: string; priority: number }>>(
     routingPath(agentName, `providers/${encodeURIComponent(provider)}/keys/order`),
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ labels, ...(authType && { authType }) }),
+    },
+  );
+}
+
+export function reorderGlobalProviderKeys(provider: string, labels: string[], authType?: AuthType) {
+  return fetchMutate<Array<{ id: string; label: string; priority: number }>>(
+    `/providers/${encodeURIComponent(provider)}/keys/order`,
     {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -324,6 +379,12 @@ export interface ProviderRefreshResult {
 
 export function refreshProviderModels(agentName: string, provider: string, authType?: AuthType) {
   const base = routingPath(agentName, `providers/${encodeURIComponent(provider)}/refresh-models`);
+  const path = authType ? `${base}?authType=${authType}` : base;
+  return fetchMutate<ProviderRefreshResult>(path, { method: 'POST' });
+}
+
+export function refreshGlobalProviderModels(provider: string, authType?: AuthType) {
+  const base = `/providers/${encodeURIComponent(provider)}/refresh-models`;
   const path = authType ? `${base}?authType=${authType}` : base;
   return fetchMutate<ProviderRefreshResult>(path, { method: 'POST' });
 }

--- a/packages/frontend/src/services/api/routing.ts
+++ b/packages/frontend/src/services/api/routing.ts
@@ -364,6 +364,10 @@ export function getAvailableModels(agentName: string) {
   return fetchJson<AvailableModel[]>(routingPath(agentName, 'available-models'));
 }
 
+export function getGlobalAvailableModels() {
+  return fetchJson<AvailableModel[]>('/routing/available-models');
+}
+
 export function refreshModels(agentName: string) {
   return fetchMutate<{ ok: boolean }>(routingPath(agentName, 'refresh-models'), {
     method: 'POST',

--- a/packages/frontend/src/services/playground-store.ts
+++ b/packages/frontend/src/services/playground-store.ts
@@ -63,6 +63,8 @@ export interface RunOptions {
   requestHeaders?: Record<string, string>;
 }
 
+export type PlaygroundScope = 'agent' | 'global';
+
 let columnCounter = 0;
 const nextColumnId = (): string => `col-${++columnCounter}-${Date.now().toString(36)}`;
 
@@ -125,7 +127,10 @@ function modelBrandId(modelName: string): string | undefined {
   return inferProviderFromModel(modelName);
 }
 
-export function createPlaygroundStore(agentName: string): PlaygroundStore {
+export function createPlaygroundStore(
+  agentName: string,
+  scope: PlaygroundScope = 'agent',
+): PlaygroundStore {
   const [columns, setColumns] = createStore<PlaygroundColumn[]>([]);
   const [prompt, setPrompt] = createSignal('');
   const [history, setHistory] = createSignal<string[]>([]);
@@ -216,6 +221,7 @@ export function createPlaygroundStore(agentName: string): PlaygroundStore {
       const result = await streamPlayground(
         {
           agentName,
+          scope,
           model: col.model,
           provider: col.provider,
           authType: col.authType,
@@ -483,12 +489,16 @@ export function createPlaygroundStore(agentName: string): PlaygroundStore {
  */
 const storeCache = new Map<string, PlaygroundStore>();
 
-export function getOrCreatePlaygroundStore(agentName: string): PlaygroundStore {
-  let store = storeCache.get(agentName);
+export function getOrCreatePlaygroundStore(
+  agentName: string,
+  scope: PlaygroundScope = 'agent',
+): PlaygroundStore {
+  const cacheKey = `${scope}:${agentName}`;
+  let store = storeCache.get(cacheKey);
   if (!store) {
     createRoot(() => {
-      store = createPlaygroundStore(agentName);
-      storeCache.set(agentName, store!);
+      store = createPlaygroundStore(agentName, scope);
+      storeCache.set(cacheKey, store!);
     });
   }
   return store!;

--- a/packages/frontend/src/styles/agents.css
+++ b/packages/frontend/src/styles/agents.css
@@ -172,6 +172,70 @@
   margin-top: var(--gap-sm);
 }
 
+/* ── Add Agent Global Providers ───────────────────── */
+.agent-global-providers {
+  margin-top: var(--gap-lg);
+  padding: var(--gap-sm);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--muted) / 0.35);
+}
+
+.agent-global-providers__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gap-sm);
+  margin-bottom: var(--gap-xs);
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+}
+
+.agent-global-providers__list {
+  display: grid;
+  gap: 4px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.agent-global-provider-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  border-radius: calc(var(--radius) - 2px);
+  cursor: pointer;
+}
+
+.agent-global-provider-row:hover {
+  background: hsl(var(--accent));
+}
+
+.agent-global-provider-row input {
+  width: 16px;
+  height: 16px;
+}
+
+.agent-global-provider-row__main {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.agent-global-provider-row__name {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: hsl(var(--foreground));
+  overflow-wrap: anywhere;
+}
+
+.agent-global-provider-row__meta {
+  font-size: var(--font-size-xs);
+  color: hsl(var(--muted-foreground));
+  overflow-wrap: anywhere;
+}
+
 .agent-card__top {
   display: flex;
   align-items: center;

--- a/packages/frontend/src/styles/global-providers.css
+++ b/packages/frontend/src/styles/global-providers.css
@@ -1,0 +1,167 @@
+.global-providers-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.global-provider-panel {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-lg);
+  background: hsl(var(--card));
+}
+
+.global-provider-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px;
+  border-bottom: 1px solid hsl(var(--border));
+}
+
+.global-provider-panel__header h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+
+.global-provider-panel__header span {
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-sm);
+}
+
+.global-provider-form {
+  display: grid;
+  grid-template-columns:
+    minmax(160px, 1.1fr) minmax(130px, 0.7fr) minmax(140px, 0.8fr) minmax(180px, 1fr)
+    auto;
+  gap: 14px;
+  align-items: end;
+  padding: 20px;
+}
+
+.global-provider-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
+.global-provider-form select,
+.global-provider-form input {
+  min-width: 0;
+  height: 36px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-sm);
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  padding: 0 10px;
+  font: inherit;
+}
+
+.global-provider-form__key {
+  grid-column: span 2;
+}
+
+.global-provider-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.global-provider-row {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: center;
+  padding: 16px 20px;
+  border-top: 1px solid hsl(var(--border));
+}
+
+.global-provider-row:first-child {
+  border-top: 0;
+}
+
+.global-provider-row.is-inactive {
+  opacity: 0.62;
+}
+
+.global-provider-row__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.global-provider-row__main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.global-provider-row__title,
+.global-provider-row__meta,
+.global-provider-row__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.global-provider-row__title {
+  font-weight: 600;
+}
+
+.global-provider-row__meta {
+  flex-wrap: wrap;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-sm);
+}
+
+.global-provider-row__pill {
+  border: 1px solid hsl(var(--border));
+  border-radius: 999px;
+  color: hsl(var(--muted-foreground));
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  padding: 2px 8px;
+}
+
+@media (max-width: 900px) {
+  .global-provider-form {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .global-provider-form__key {
+    grid-column: span 2;
+  }
+
+  .global-provider-row {
+    grid-template-columns: 40px minmax(0, 1fr);
+  }
+
+  .global-provider-row__actions {
+    grid-column: 2;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 640px) {
+  .global-provider-form {
+    grid-template-columns: 1fr;
+  }
+
+  .global-provider-form__key,
+  .global-provider-row__actions {
+    grid-column: auto;
+  }
+
+  .global-provider-row {
+    grid-template-columns: 1fr;
+  }
+
+  .global-provider-row__icon {
+    justify-content: flex-start;
+  }
+}

--- a/packages/frontend/tests/components/App.test.tsx
+++ b/packages/frontend/tests/components/App.test.tsx
@@ -125,6 +125,15 @@ describe('App with tenant provider path', () => {
     expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
     expect(container.querySelector('.app-body--with-sidebar')).not.toBeNull();
   });
+
+  it('shows sidebar on /playground', () => {
+    routerState.pathname = '/playground';
+
+    const { container } = render(() => <App />);
+
+    expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
+    expect(container.querySelector('.app-body--with-sidebar')).not.toBeNull();
+  });
 });
 
 describe('App structure', () => {

--- a/packages/frontend/tests/components/App.test.tsx
+++ b/packages/frontend/tests/components/App.test.tsx
@@ -1,15 +1,15 @@
-import { describe, it, expect, vi } from "vitest";
-import { fireEvent, render } from "@solidjs/testing-library";
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render } from '@solidjs/testing-library';
 
 const routerState = vi.hoisted(() => ({
-  pathname: "/",
+  pathname: '/',
 }));
 
-vi.mock("@solidjs/router", () => ({
+vi.mock('@solidjs/router', () => ({
   useLocation: () => routerState,
 }));
 
-vi.mock("../../src/components/Header.jsx", () => ({
+vi.mock('../../src/components/Header.jsx', () => ({
   default: (props: any) => (
     <div data-testid="header">
       Header
@@ -26,118 +26,129 @@ vi.mock("../../src/components/Header.jsx", () => ({
   ),
 }));
 
-vi.mock("../../src/components/Sidebar.jsx", () => ({
+vi.mock('../../src/components/Sidebar.jsx', () => ({
   default: (props: any) => (
-    <div data-testid="sidebar" data-mobile-open={props.mobileOpen ? "true" : "false"}>
+    <div data-testid="sidebar" data-mobile-open={props.mobileOpen ? 'true' : 'false'}>
       Sidebar
     </div>
   ),
 }));
 
-vi.mock("../../src/components/AuthGuard.jsx", () => ({
+vi.mock('../../src/components/AuthGuard.jsx', () => ({
   default: (props: any) => <div data-testid="auth-guard">{props.children}</div>,
 }));
 
-vi.mock("../../src/services/sse.js", () => ({
+vi.mock('../../src/services/sse.js', () => ({
   connectSse: () => () => {},
 }));
 
-import App from "../../src/App";
+import App from '../../src/App';
 
 beforeEach(() => {
   sessionStorage.clear();
-  routerState.pathname = "/";
+  routerState.pathname = '/';
 });
 
-describe("App", () => {
-  it("renders the app shell", () => {
+describe('App', () => {
+  it('renders the app shell', () => {
     const { container } = render(() => <App />);
-    expect(container.querySelector(".app-shell")).not.toBeNull();
+    expect(container.querySelector('.app-shell')).not.toBeNull();
   });
 
-  it("renders AuthGuard wrapper", () => {
+  it('renders AuthGuard wrapper', () => {
     const { container } = render(() => <App />);
     expect(container.querySelector('[data-testid="auth-guard"]')).not.toBeNull();
   });
 
-  it("renders Header", () => {
+  it('renders Header', () => {
     const { container } = render(() => <App />);
     expect(container.querySelector('[data-testid="header"]')).not.toBeNull();
   });
 
-  it("renders main content area", () => {
+  it('renders main content area', () => {
     const { container } = render(() => <App />);
-    expect(container.querySelector(".main-content")).not.toBeNull();
+    expect(container.querySelector('.main-content')).not.toBeNull();
   });
 
-  it("does not show sidebar on non-agent paths", () => {
+  it('does not show sidebar on non-agent paths', () => {
     const { container } = render(() => <App />);
     expect(container.querySelector('[data-testid="sidebar"]')).toBeNull();
   });
 
-  it("does not show mobile navigation toggle on non-agent paths", () => {
+  it('does not show mobile navigation toggle on non-agent paths', () => {
     const { container } = render(() => <App />);
     expect(container.querySelector('[data-testid="mobile-nav-toggle"]')).toBeNull();
   });
 });
 
-describe("App with agent path", () => {
-  it("shows sidebar on /agents/ paths", () => {
-    routerState.pathname = "/agents/demo";
+describe('App with agent path', () => {
+  it('shows sidebar on /agents/ paths', () => {
+    routerState.pathname = '/agents/demo';
 
     const { container } = render(() => <App />);
 
     expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
-    expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();
+    expect(container.querySelector('.app-body--with-sidebar')).not.toBeNull();
   });
 
-  it("opens and closes the mobile sidebar drawer", () => {
-    routerState.pathname = "/agents/demo";
+  it('opens and closes the mobile sidebar drawer', () => {
+    routerState.pathname = '/agents/demo';
 
     const { container } = render(() => <App />);
     const toggle = container.querySelector('[data-testid="mobile-nav-toggle"]');
     const sidebar = container.querySelector('[data-testid="sidebar"]');
 
     expect(toggle).not.toBeNull();
-    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
-    expect(sidebar?.getAttribute("data-mobile-open")).toBe("false");
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(sidebar?.getAttribute('data-mobile-open')).toBe('false');
 
     fireEvent.click(toggle!);
 
-    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
-    expect(sidebar?.getAttribute("data-mobile-open")).toBe("true");
-    expect(container.querySelector(".mobile-nav-backdrop")).not.toBeNull();
+    expect(toggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(sidebar?.getAttribute('data-mobile-open')).toBe('true');
+    expect(container.querySelector('.mobile-nav-backdrop')).not.toBeNull();
 
-    fireEvent.click(container.querySelector(".mobile-nav-backdrop")!);
+    fireEvent.click(container.querySelector('.mobile-nav-backdrop')!);
 
-    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
-    expect(sidebar?.getAttribute("data-mobile-open")).toBe("false");
-    expect(container.querySelector(".mobile-nav-backdrop")).toBeNull();
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+    expect(sidebar?.getAttribute('data-mobile-open')).toBe('false');
+    expect(container.querySelector('.mobile-nav-backdrop')).toBeNull();
   });
 });
 
-describe("App structure", () => {
-  it("renders app-body container", () => {
+describe('App with tenant provider path', () => {
+  it('shows sidebar on /providers', () => {
+    routerState.pathname = '/providers';
+
     const { container } = render(() => <App />);
-    expect(container.querySelector(".app-body")).not.toBeNull();
+
+    expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
+    expect(container.querySelector('.app-body--with-sidebar')).not.toBeNull();
+  });
+});
+
+describe('App structure', () => {
+  it('renders app-body container', () => {
+    const { container } = render(() => <App />);
+    expect(container.querySelector('.app-body')).not.toBeNull();
   });
 
-  it("has aria-label on main content", () => {
+  it('has aria-label on main content', () => {
     const { container } = render(() => <App />);
     const main = container.querySelector('main[aria-label="Dashboard content"]');
     expect(main).not.toBeNull();
   });
 
-  it("renders skip-to-content link", () => {
+  it('renders skip-to-content link', () => {
     const { container } = render(() => <App />);
     const skipLink = container.querySelector('a.skip-link[href="#main-content"]');
     expect(skipLink).not.toBeNull();
-    expect(skipLink?.textContent).toBe("Skip to main content");
+    expect(skipLink?.textContent).toBe('Skip to main content');
   });
 
-  it("main content has matching id for skip link", () => {
+  it('main content has matching id for skip link', () => {
     const { container } = render(() => <App />);
-    const main = container.querySelector("main#main-content");
+    const main = container.querySelector('main#main-content');
     expect(main).not.toBeNull();
   });
 });

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -1,92 +1,102 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
-import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@solidjs/testing-library';
 
-let mockAgentName: string | null = "test-agent";
-let mockPathname = "/agents/test-agent";
-vi.mock("@solidjs/router", () => ({
+let mockAgentName: string | null = 'test-agent';
+let mockPathname = '/agents/test-agent';
+vi.mock('@solidjs/router', () => ({
   A: (props: any) => {
     // Access classList to trigger coverage of classList expressions
     const cl = props.classList;
-    const classes = [props.class || ""];
+    const classes = [props.class || ''];
     if (cl) {
       for (const [key, val] of Object.entries(cl)) {
         if (val) classes.push(key);
       }
     }
-    return <a href={props.href} class={classes.join(" ").trim()} aria-current={props["aria-current"]}>{props.children}</a>;
+    return (
+      <a href={props.href} class={classes.join(' ').trim()} aria-current={props['aria-current']}>
+        {props.children}
+      </a>
+    );
   },
   useLocation: () => ({ pathname: mockPathname }),
 }));
 
-vi.mock("../../src/services/routing.js", () => ({
+vi.mock('../../src/services/routing.js', () => ({
   useAgentName: () => () => mockAgentName,
-  agentPath: (name: string, sub: string) => name ? `/agents/${name}${sub}` : "/",
+  agentPath: (name: string, sub: string) => (name ? `/agents/${name}${sub}` : '/'),
 }));
 
-import Sidebar from "../../src/components/Sidebar";
+import Sidebar from '../../src/components/Sidebar';
 
-describe("Sidebar with agent", () => {
+describe('Sidebar with agent', () => {
   beforeAll(() => {
-    mockAgentName = "test-agent";
-    mockPathname = "/agents/test-agent";
+    mockAgentName = 'test-agent';
+    mockPathname = '/agents/test-agent';
   });
 
-  it("renders MONITORING section", () => {
+  it('renders MONITORING section', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("MONITORING")).toBeDefined();
+    expect(screen.getByText('MONITORING')).toBeDefined();
   });
 
-  it("renders Overview link", () => {
+  it('renders Overview link', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Overview")).toBeDefined();
+    expect(screen.getByText('Overview')).toBeDefined();
   });
 
-  it("renders Messages link", () => {
+  it('renders Messages link', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Messages")).toBeDefined();
+    expect(screen.getByText('Messages')).toBeDefined();
   });
 
-  it("renders MANAGE section", () => {
+  it('renders MANAGE section', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("MANAGE")).toBeDefined();
+    expect(screen.getByText('MANAGE')).toBeDefined();
   });
 
-  it("renders Settings link", () => {
+  it('renders Settings link', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Settings")).toBeDefined();
+    expect(screen.getByText('Settings')).toBeDefined();
   });
 
-  it("renders Limits link", () => {
+  it('renders Limits link', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Limits")).toBeDefined();
+    expect(screen.getByText('Limits')).toBeDefined();
   });
 
-  it("renders RESOURCES section", () => {
+  it('renders RESOURCES section', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("RESOURCES")).toBeDefined();
+    expect(screen.getByText('RESOURCES')).toBeDefined();
   });
 
-  it("renders Help link", () => {
+  it('renders Help link', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Help")).toBeDefined();
+    expect(screen.getByText('Help')).toBeDefined();
   });
 
-  it("renders Model Prices link", () => {
+  it('renders Model Prices link', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Model Prices")).toBeDefined();
+    expect(screen.getByText('Model Prices')).toBeDefined();
   });
 
-  it("renders Feedback section", () => {
+  it('renders Feedback section', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Feedback")).toBeDefined();
+    expect(screen.getByText('Feedback')).toBeDefined();
   });
 
-  it("renders Routing link", () => {
+  it('renders Routing link', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Routing")).toBeDefined();
+    expect(screen.getByText('Routing')).toBeDefined();
   });
 
-  it("has correct link hrefs for agent routes", () => {
+  it('renders tenant Providers link', () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText('TENANT')).toBeDefined();
+    expect(screen.getByText('Providers')).toBeDefined();
+  });
+
+  it('has correct link hrefs for agent routes', () => {
     const { container } = render(() => <Sidebar />);
     expect(container.querySelector('a[href="/agents/test-agent"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/messages"]')).not.toBeNull();
@@ -94,133 +104,147 @@ describe("Sidebar with agent", () => {
     expect(container.querySelector('a[href="/agents/test-agent/limits"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/model-prices"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/help"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/providers"]')).not.toBeNull();
   });
 
-  it("marks current page link as active", () => {
+  it('marks current page link as active', () => {
     const { container } = render(() => <Sidebar />);
     const overviewLink = container.querySelector('a[href="/agents/test-agent"]');
-    expect(overviewLink?.getAttribute("aria-current")).toBe("page");
+    expect(overviewLink?.getAttribute('aria-current')).toBe('page');
   });
 
-  it("has nav element with aria-label", () => {
+  it('has nav element with aria-label', () => {
     const { container } = render(() => <Sidebar />);
-    const nav = container.querySelector("nav.sidebar");
+    const nav = container.querySelector('nav.sidebar');
     expect(nav).not.toBeNull();
-    expect(nav?.getAttribute("aria-label")).toBe("Agent navigation");
+    expect(nav?.getAttribute('aria-label')).toBe('Agent navigation');
   });
 
-  it("applies the mobile open class", () => {
+  it('applies the mobile open class', () => {
     const { container } = render(() => <Sidebar mobileOpen />);
-    const nav = container.querySelector("nav.sidebar");
-    expect(nav?.classList.contains("sidebar--mobile-open")).toBe(true);
+    const nav = container.querySelector('nav.sidebar');
+    expect(nav?.classList.contains('sidebar--mobile-open')).toBe(true);
   });
 
-  it("calls onNavigate when a sidebar link is clicked", async () => {
+  it('calls onNavigate when a sidebar link is clicked', async () => {
     const onNavigate = vi.fn();
     const { container } = render(() => <Sidebar onNavigate={onNavigate} />);
-    const link = container.querySelector("a.sidebar__link");
+    const link = container.querySelector('a.sidebar__link');
 
     expect(link).not.toBeNull();
-    link!.addEventListener("click", (event) => event.preventDefault(), { once: true });
+    link!.addEventListener('click', (event) => event.preventDefault(), { once: true });
 
     await fireEvent.click(link!);
 
     expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 
-  it("shows feedback hint text", () => {
+  it('shows feedback hint text', () => {
     const { container } = render(() => <Sidebar />);
-    expect(container.textContent).toContain("Share ideas or report bugs");
+    expect(container.textContent).toContain('Share ideas or report bugs');
   });
 
-  it("feedback link is external with correct attributes", () => {
+  it('feedback link is external with correct attributes', () => {
     const { container } = render(() => <Sidebar />);
-    const feedbackLink = container.querySelector("a.sidebar__feedback") as HTMLAnchorElement;
+    const feedbackLink = container.querySelector('a.sidebar__feedback') as HTMLAnchorElement;
     expect(feedbackLink).not.toBeNull();
-    expect(feedbackLink.target).toBe("_blank");
-    expect(feedbackLink.rel).toContain("noopener");
+    expect(feedbackLink.target).toBe('_blank');
+    expect(feedbackLink.rel).toContain('noopener');
   });
 });
 
-describe("Sidebar without agent", () => {
+describe('Sidebar without agent', () => {
   beforeAll(() => {
     mockAgentName = null;
-    mockPathname = "/";
+    mockPathname = '/';
   });
 
-  it("renders Agents link when no agent selected", () => {
+  it('renders Agents link when no agent selected', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Agents")).toBeDefined();
+    expect(screen.getByText('Agents')).toBeDefined();
   });
 
-  it("does not render MONITORING section when no agent", () => {
-    const { container } = render(() => <Sidebar />);
-    expect(container.textContent).not.toContain("MONITORING");
+  it('renders Providers link when no agent selected', () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText('Providers')).toBeDefined();
   });
 
-  it("does not render agent navigation links when no agent", () => {
+  it('does not render MONITORING section when no agent', () => {
     const { container } = render(() => <Sidebar />);
-    expect(container.textContent).not.toContain("Overview");
-    expect(container.textContent).not.toContain("Messages");
+    expect(container.textContent).not.toContain('MONITORING');
+  });
+
+  it('does not render agent navigation links when no agent', () => {
+    const { container } = render(() => <Sidebar />);
+    expect(container.textContent).not.toContain('Overview');
+    expect(container.textContent).not.toContain('Messages');
   });
 });
 
-describe("Sidebar active states for sub-paths", () => {
+describe('Sidebar active states for sub-paths', () => {
   beforeAll(() => {
-    mockAgentName = "test-agent";
+    mockAgentName = 'test-agent';
   });
 
-  it("marks routing link as active on routing path", () => {
-    mockPathname = "/agents/test-agent/routing";
+  it('marks routing link as active on routing path', () => {
+    mockPathname = '/agents/test-agent/routing';
     const { container } = render(() => <Sidebar />);
     const routingLink = container.querySelector('a[href="/agents/test-agent/routing"]');
-    expect(routingLink?.getAttribute("aria-current")).toBe("page");
+    expect(routingLink?.getAttribute('aria-current')).toBe('page');
   });
 
-  it("marks limits link as active on limits path", () => {
-    mockPathname = "/agents/test-agent/limits";
+  it('marks limits link as active on limits path', () => {
+    mockPathname = '/agents/test-agent/limits';
     const { container } = render(() => <Sidebar />);
     const limitsLink = container.querySelector('a[href="/agents/test-agent/limits"]');
-    expect(limitsLink?.getAttribute("aria-current")).toBe("page");
+    expect(limitsLink?.getAttribute('aria-current')).toBe('page');
   });
 
-  it("marks settings link as active on settings path", () => {
-    mockPathname = "/agents/test-agent/settings";
+  it('marks settings link as active on settings path', () => {
+    mockPathname = '/agents/test-agent/settings';
     const { container } = render(() => <Sidebar />);
     const settingsLink = container.querySelector('a[href="/agents/test-agent/settings"]');
-    expect(settingsLink?.getAttribute("aria-current")).toBe("page");
+    expect(settingsLink?.getAttribute('aria-current')).toBe('page');
   });
 
-  it("marks model-prices link as active on model-prices path", () => {
-    mockPathname = "/agents/test-agent/model-prices";
+  it('marks model-prices link as active on model-prices path', () => {
+    mockPathname = '/agents/test-agent/model-prices';
     const { container } = render(() => <Sidebar />);
     const pricesLink = container.querySelector('a[href="/agents/test-agent/model-prices"]');
-    expect(pricesLink?.getAttribute("aria-current")).toBe("page");
+    expect(pricesLink?.getAttribute('aria-current')).toBe('page');
   });
 
-  it("marks help link as active on help path", () => {
-    mockPathname = "/agents/test-agent/help";
+  it('marks help link as active on help path', () => {
+    mockPathname = '/agents/test-agent/help';
     const { container } = render(() => <Sidebar />);
     const helpLink = container.querySelector('a[href="/agents/test-agent/help"]');
-    expect(helpLink?.getAttribute("aria-current")).toBe("page");
+    expect(helpLink?.getAttribute('aria-current')).toBe('page');
   });
 
-  it("marks messages link as active on messages path", () => {
-    mockPathname = "/agents/test-agent/messages";
+  it('marks messages link as active on messages path', () => {
+    mockPathname = '/agents/test-agent/messages';
     const { container } = render(() => <Sidebar />);
     const messagesLink = container.querySelector('a[href="/agents/test-agent/messages"]');
-    expect(messagesLink?.getAttribute("aria-current")).toBe("page");
+    expect(messagesLink?.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('marks providers link as active on tenant provider path', () => {
+    mockAgentName = null;
+    mockPathname = '/providers';
+    const { container } = render(() => <Sidebar />);
+    const providersLink = container.querySelector('a[href="/providers"]');
+    expect(providersLink?.getAttribute('aria-current')).toBe('page');
   });
 });
 
-describe("Sidebar with no agent selected", () => {
+describe('Sidebar with no agent selected', () => {
   beforeAll(() => {
     mockAgentName = null;
-    mockPathname = "/";
+    mockPathname = '/';
   });
 
-  it("shows Agents link when no agent is selected", () => {
+  it('shows Agents link when no agent is selected', () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Agents")).toBeDefined();
+    expect(screen.getByText('Agents')).toBeDefined();
   });
 });

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -96,6 +96,11 @@ describe('Sidebar with agent', () => {
     expect(screen.getByText('Providers')).toBeDefined();
   });
 
+  it('renders tenant Playground link alongside the agent playground', () => {
+    render(() => <Sidebar />);
+    expect(screen.getAllByText('Playground')).toHaveLength(2);
+  });
+
   it('has correct link hrefs for agent routes', () => {
     const { container } = render(() => <Sidebar />);
     expect(container.querySelector('a[href="/agents/test-agent"]')).not.toBeNull();
@@ -105,6 +110,7 @@ describe('Sidebar with agent', () => {
     expect(container.querySelector('a[href="/agents/test-agent/model-prices"]')).not.toBeNull();
     expect(container.querySelector('a[href="/agents/test-agent/help"]')).not.toBeNull();
     expect(container.querySelector('a[href="/providers"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/playground"]')).not.toBeNull();
   });
 
   it('marks current page link as active', () => {
@@ -167,6 +173,11 @@ describe('Sidebar without agent', () => {
   it('renders Providers link when no agent selected', () => {
     render(() => <Sidebar />);
     expect(screen.getByText('Providers')).toBeDefined();
+  });
+
+  it('renders Playground link when no agent selected', () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText('Playground')).toBeDefined();
   });
 
   it('does not render MONITORING section when no agent', () => {
@@ -234,6 +245,14 @@ describe('Sidebar active states for sub-paths', () => {
     const { container } = render(() => <Sidebar />);
     const providersLink = container.querySelector('a[href="/providers"]');
     expect(providersLink?.getAttribute('aria-current')).toBe('page');
+  });
+
+  it('marks playground link as active on tenant playground path', () => {
+    mockAgentName = null;
+    mockPathname = '/playground';
+    const { container } = render(() => <Sidebar />);
+    const playgroundLink = container.querySelector('a[href="/playground"]');
+    expect(playgroundLink?.getAttribute('aria-current')).toBe('page');
   });
 });
 

--- a/packages/frontend/tests/pages/GlobalProviders.test.tsx
+++ b/packages/frontend/tests/pages/GlobalProviders.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library';
+
+const mockGetGlobalProviders = vi.fn();
+const mockConnectGlobalProvider = vi.fn();
+const mockDisconnectGlobalProvider = vi.fn();
+const mockRefreshGlobalProviderModels = vi.fn();
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('../../src/services/api.js', () => ({
+  getGlobalProviders: (...args: unknown[]) => mockGetGlobalProviders(...args),
+  connectGlobalProvider: (...args: unknown[]) => mockConnectGlobalProvider(...args),
+  disconnectGlobalProvider: (...args: unknown[]) => mockDisconnectGlobalProvider(...args),
+  refreshGlobalProviderModels: (...args: unknown[]) => mockRefreshGlobalProviderModels(...args),
+}));
+
+vi.mock('../../src/services/providers.js', () => ({
+  PROVIDERS: [
+    {
+      id: 'openai',
+      name: 'OpenAI',
+      color: '#111',
+      initial: 'O',
+      subtitle: '',
+      models: [],
+      keyPrefix: 'sk-',
+      minKeyLength: 3,
+      keyPlaceholder: 'sk-test',
+    },
+    {
+      id: 'minimax',
+      name: 'MiniMax',
+      color: '#222',
+      initial: 'M',
+      subtitle: '',
+      models: [],
+      keyPrefix: 'sk-',
+      minKeyLength: 3,
+      keyPlaceholder: 'sk-test',
+      supportsSubscription: true,
+      subscriptionAuthMode: 'token',
+      subscriptionKeyPlaceholder: 'sk-cp-test',
+      subscriptionEndpointRegions: [{ value: 'global', label: 'Global' }],
+    },
+  ],
+}));
+
+vi.mock('../../src/components/ProviderIcon.js', () => ({
+  providerIcon: () => null,
+}));
+
+vi.mock('../../src/services/provider-utils.js', () => ({
+  validateApiKey: () => ({ valid: true }),
+  validateSubscriptionKey: () => ({ valid: true }),
+}));
+
+vi.mock('../../src/services/formatters.js', () => ({
+  formatTimeAgo: () => 'just now',
+}));
+
+vi.mock('../../src/services/toast-store.js', () => ({ toast }));
+
+vi.mock('@solidjs/meta', () => ({
+  Title: (props: any) => <title>{props.children}</title>,
+  Meta: () => null,
+}));
+
+import GlobalProviders from '../../src/pages/GlobalProviders';
+
+describe('GlobalProviders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGlobalProviders.mockResolvedValue([
+      {
+        id: 'p1',
+        provider: 'openai',
+        auth_type: 'api_key',
+        is_active: true,
+        has_api_key: true,
+        key_prefix: 'sk-test',
+        label: 'Default',
+        priority: 0,
+        connected_at: '2026-01-01T00:00:00.000Z',
+        models_fetched_at: '2026-01-01T00:00:00.000Z',
+        cached_model_count: 2,
+      },
+    ]);
+    mockConnectGlobalProvider.mockResolvedValue({ id: 'p2' });
+    mockRefreshGlobalProviderModels.mockResolvedValue({
+      ok: true,
+      model_count: 3,
+      last_fetched_at: '2026-01-01T00:00:00.000Z',
+      error: null,
+    });
+    mockDisconnectGlobalProvider.mockResolvedValue({ ok: true, notifications: [] });
+  });
+
+  it('renders global provider rows', async () => {
+    render(() => <GlobalProviders />);
+
+    await screen.findByText('OpenAI');
+
+    expect(screen.getByText('Connections')).toBeDefined();
+    expect(screen.getByText('1 active')).toBeDefined();
+    expect(screen.getByText('2 models')).toBeDefined();
+  });
+
+  it('connects a global API-key provider', async () => {
+    render(() => <GlobalProviders />);
+    await screen.findByText('OpenAI');
+
+    await fireEvent.input(screen.getByLabelText('Key'), { target: { value: 'sk-new' } });
+    await fireEvent.input(screen.getByLabelText('Label'), { target: { value: 'Work' } });
+    await fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() =>
+      expect(mockConnectGlobalProvider).toHaveBeenCalledWith({
+        provider: 'openai',
+        authType: 'api_key',
+        apiKey: 'sk-new',
+        label: 'Work',
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith('OpenAI connected');
+  });
+
+  it('refreshes and disconnects a global provider row', async () => {
+    render(() => <GlobalProviders />);
+    await screen.findByText('OpenAI');
+
+    await fireEvent.click(screen.getByText('Refresh'));
+    await waitFor(() =>
+      expect(mockRefreshGlobalProviderModels).toHaveBeenCalledWith('openai', 'api_key'),
+    );
+    await waitFor(() =>
+      expect((screen.getByText('Disconnect') as HTMLButtonElement).disabled).toBe(false),
+    );
+
+    await fireEvent.click(screen.getByText('Disconnect'));
+    await waitFor(() =>
+      expect(mockDisconnectGlobalProvider).toHaveBeenCalledWith('openai', 'api_key', 'Default'),
+    );
+  });
+});

--- a/packages/frontend/tests/pages/GlobalProviders.test.tsx
+++ b/packages/frontend/tests/pages/GlobalProviders.test.tsx
@@ -6,6 +6,8 @@ const mockConnectGlobalProvider = vi.fn();
 const mockDisconnectGlobalProvider = vi.fn();
 const mockRefreshGlobalProviderModels = vi.fn();
 const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+const validateApiKeyMock = vi.hoisted(() => vi.fn());
+const validateSubscriptionKeyMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../../src/services/api.js', () => ({
   getGlobalProviders: (...args: unknown[]) => mockGetGlobalProviders(...args),
@@ -50,8 +52,8 @@ vi.mock('../../src/components/ProviderIcon.js', () => ({
 }));
 
 vi.mock('../../src/services/provider-utils.js', () => ({
-  validateApiKey: () => ({ valid: true }),
-  validateSubscriptionKey: () => ({ valid: true }),
+  validateApiKey: (...args: unknown[]) => validateApiKeyMock(...args),
+  validateSubscriptionKey: (...args: unknown[]) => validateSubscriptionKeyMock(...args),
 }));
 
 vi.mock('../../src/services/formatters.js', () => ({
@@ -93,6 +95,8 @@ describe('GlobalProviders', () => {
       error: null,
     });
     mockDisconnectGlobalProvider.mockResolvedValue({ ok: true, notifications: [] });
+    validateApiKeyMock.mockReturnValue({ valid: true });
+    validateSubscriptionKeyMock.mockReturnValue({ valid: true });
   });
 
   it('renders global provider rows', async () => {
@@ -103,6 +107,15 @@ describe('GlobalProviders', () => {
     expect(screen.getByText('Connections')).toBeDefined();
     expect(screen.getByText('1 active')).toBeDefined();
     expect(screen.getByText('2 models')).toBeDefined();
+  });
+
+  it('renders an empty state when no global providers exist', async () => {
+    mockGetGlobalProviders.mockResolvedValueOnce([]);
+    render(() => <GlobalProviders />);
+
+    await screen.findByText('No global providers yet');
+
+    expect(screen.getByText('0 active')).toBeDefined();
   });
 
   it('connects a global API-key provider', async () => {
@@ -124,6 +137,64 @@ describe('GlobalProviders', () => {
     expect(toast.success).toHaveBeenCalledWith('OpenAI connected');
   });
 
+  it('stops before connect when API-key validation fails', async () => {
+    validateApiKeyMock.mockReturnValueOnce({ valid: false, error: 'Bad key' });
+    render(() => <GlobalProviders />);
+    await screen.findByText('OpenAI');
+
+    await fireEvent.input(screen.getByLabelText('Key'), { target: { value: 'bad' } });
+    await fireEvent.click(screen.getByText('Connect'));
+
+    expect(toast.error).toHaveBeenCalledWith('Bad key');
+    expect(mockConnectGlobalProvider).not.toHaveBeenCalled();
+  });
+
+  it('connects a subscription provider with the default region', async () => {
+    render(() => <GlobalProviders />);
+    await screen.findByText('OpenAI');
+
+    await fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'minimax' } });
+    await fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'subscription' } });
+    await fireEvent.input(screen.getByLabelText('Key'), { target: { value: 'sk-cp-new' } });
+    await fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() =>
+      expect(mockConnectGlobalProvider).toHaveBeenCalledWith({
+        provider: 'minimax',
+        authType: 'subscription',
+        apiKey: 'sk-cp-new',
+        region: 'global',
+      }),
+    );
+  });
+
+  it('stops before connect when subscription credential validation fails', async () => {
+    validateSubscriptionKeyMock.mockReturnValueOnce({ valid: false });
+    render(() => <GlobalProviders />);
+    await screen.findByText('OpenAI');
+
+    await fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'minimax' } });
+    await fireEvent.change(screen.getByLabelText('Type'), { target: { value: 'subscription' } });
+    await fireEvent.input(screen.getByLabelText('Key'), { target: { value: 'bad' } });
+    await fireEvent.click(screen.getByText('Connect'));
+
+    expect(toast.error).toHaveBeenCalledWith('Invalid subscription credential');
+    expect(mockConnectGlobalProvider).not.toHaveBeenCalled();
+  });
+
+  it('clears saving state when connect rejects', async () => {
+    mockConnectGlobalProvider.mockRejectedValueOnce(new Error('network'));
+    render(() => <GlobalProviders />);
+    await screen.findByText('OpenAI');
+
+    await fireEvent.input(screen.getByLabelText('Key'), { target: { value: 'sk-new' } });
+    await fireEvent.click(screen.getByText('Connect'));
+
+    await waitFor(() =>
+      expect((screen.getByText('Connect') as HTMLButtonElement).disabled).toBe(false),
+    );
+  });
+
   it('refreshes and disconnects a global provider row', async () => {
     render(() => <GlobalProviders />);
     await screen.findByText('OpenAI');
@@ -139,6 +210,41 @@ describe('GlobalProviders', () => {
     await fireEvent.click(screen.getByText('Disconnect'));
     await waitFor(() =>
       expect(mockDisconnectGlobalProvider).toHaveBeenCalledWith('openai', 'api_key', 'Default'),
+    );
+  });
+
+  it('shows a refresh error and clears the busy state', async () => {
+    mockRefreshGlobalProviderModels.mockResolvedValueOnce({
+      ok: false,
+      model_count: 0,
+      last_fetched_at: null,
+      error: 'Provider timed out',
+    });
+    render(() => <GlobalProviders />);
+    await screen.findByText('OpenAI');
+
+    await fireEvent.click(screen.getByText('Refresh'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Provider timed out'));
+    await waitFor(() =>
+      expect((screen.getByText('Refresh') as HTMLButtonElement).disabled).toBe(false),
+    );
+  });
+
+  it('clears row busy state when refresh or disconnect rejects', async () => {
+    mockRefreshGlobalProviderModels.mockRejectedValueOnce(new Error('network'));
+    mockDisconnectGlobalProvider.mockRejectedValueOnce(new Error('network'));
+    render(() => <GlobalProviders />);
+    await screen.findByText('OpenAI');
+
+    await fireEvent.click(screen.getByText('Refresh'));
+    await waitFor(() =>
+      expect((screen.getByText('Refresh') as HTMLButtonElement).disabled).toBe(false),
+    );
+
+    await fireEvent.click(screen.getByText('Disconnect'));
+    await waitFor(() =>
+      expect((screen.getByText('Disconnect') as HTMLButtonElement).disabled).toBe(false),
     );
   });
 });

--- a/packages/frontend/tests/pages/Playground.test.tsx
+++ b/packages/frontend/tests/pages/Playground.test.tsx
@@ -4,7 +4,9 @@ import type { JSX } from 'solid-js';
 
 // ─── API mocks (incl. the streaming primitive the real store calls) ─────────
 const mockGetAvailableModels = vi.fn();
+const mockGetGlobalAvailableModels = vi.fn();
 const mockGetProviders = vi.fn();
+const mockGetGlobalProviders = vi.fn();
 const mockGetCustomProviders = vi.fn();
 const mockGetPlaygroundRun = vi.fn();
 const mockListPlaygroundRuns = vi.fn();
@@ -13,7 +15,9 @@ const mockSetPlaygroundRunBest = vi.fn();
 
 vi.mock('../../src/services/api.js', () => ({
   getAvailableModels: (...a: unknown[]) => mockGetAvailableModels(...a),
+  getGlobalAvailableModels: (...a: unknown[]) => mockGetGlobalAvailableModels(...a),
   getProviders: (...a: unknown[]) => mockGetProviders(...a),
+  getGlobalProviders: (...a: unknown[]) => mockGetGlobalProviders(...a),
   getCustomProviders: (...a: unknown[]) => mockGetCustomProviders(...a),
   getPlaygroundRun: (...a: unknown[]) => mockGetPlaygroundRun(...a),
   listPlaygroundRuns: (...a: unknown[]) => mockListPlaygroundRuns(...a),
@@ -33,10 +37,12 @@ const setSearchParamsFn = vi.fn((p: { run?: string }) => {
 const searchParamsState: { run?: string } = {};
 // Each test gets a unique agent name so getOrCreatePlaygroundStore() hands
 // out a fresh store (the cache is module-level and survives between tests).
-let currentAgent = 'demo-0';
+let currentAgent: string | undefined = 'demo-0';
+const mockNavigate = vi.fn();
 vi.mock('@solidjs/router', () => ({
   useParams: () => ({ agentName: currentAgent }),
   useSearchParams: () => [searchParamsState, setSearchParamsFn],
+  useNavigate: () => mockNavigate,
 }));
 
 vi.mock('@solidjs/meta', () => ({
@@ -68,7 +74,10 @@ vi.mock('../../src/components/playground/PlaygroundColumn.jsx', () => ({
         <span data-testid={`fastest-${c.id}`}>{String(props.isFastest)}</span>
         <span data-testid={`readonly-${c.id}`}>{String(props.readOnly)}</span>
         <span data-testid={`hasmarkbest-${c.id}`}>{String(!!props.onMarkBest)}</span>
-        <button data-testid={`markbest-${c.id}`} onClick={() => (props.onMarkBest as () => void)?.()}>
+        <button
+          data-testid={`markbest-${c.id}`}
+          onClick={() => (props.onMarkBest as () => void)?.()}
+        >
           mb
         </button>
         <button
@@ -83,7 +92,10 @@ vi.mock('../../src/components/playground/PlaygroundColumn.jsx', () => ({
         >
           ch
         </button>
-        <button data-testid={`retry-${c.id}`} onClick={() => (props.onRetry as (id: string) => void)(c.id)}>
+        <button
+          data-testid={`retry-${c.id}`}
+          onClick={() => (props.onRetry as (id: string) => void)(c.id)}
+        >
           rt
         </button>
       </div>
@@ -108,10 +120,7 @@ vi.mock('../../src/components/playground/PlaygroundPrompt.jsx', () => ({
       >
         set
       </button>
-      <button
-        data-testid="prompt-recall"
-        onClick={() => (props.onRecallPrevious as () => void)()}
-      >
+      <button data-testid="prompt-recall" onClick={() => (props.onRecallPrevious as () => void)()}>
         recall
       </button>
     </div>
@@ -227,9 +236,7 @@ vi.mock('../../src/components/playground/RequestHeadersPopover.jsx', async (impo
         <span data-testid="headers-entrycount">{props.entries.length}</span>
         <button
           data-testid="headers-change"
-          onClick={() =>
-            props.onChange([{ id: 'h1', key: 'X-Custom', value: 'v1' }])
-          }
+          onClick={() => props.onChange([{ id: 'h1', key: 'X-Custom', value: 'v1' }])}
         >
           change
         </button>
@@ -272,7 +279,10 @@ vi.mock('../../src/components/ProviderSelectModal.jsx', () => ({
         <button data-testid="provider-modal-close" onClick={() => (props.onClose as () => void)()}>
           close
         </button>
-        <button data-testid="provider-modal-update" onClick={() => (props.onUpdate as () => void)()}>
+        <button
+          data-testid="provider-modal-update"
+          onClick={() => (props.onUpdate as () => void)()}
+        >
           update
         </button>
       </div>
@@ -366,17 +376,26 @@ describe('Playground page', () => {
     for (const k of Object.keys(ssStore)) delete ssStore[k];
 
     mockGetAvailableModels.mockReset().mockResolvedValue([MODEL_A, MODEL_B]);
+    mockGetGlobalAvailableModels.mockReset().mockResolvedValue([MODEL_A, MODEL_B]);
     mockGetProviders.mockReset().mockResolvedValue([ACTIVE_PROVIDER, ACTIVE_PROVIDER_B]);
+    mockGetGlobalProviders.mockReset().mockResolvedValue([ACTIVE_PROVIDER, ACTIVE_PROVIDER_B]);
     mockGetCustomProviders.mockReset().mockResolvedValue([]);
     mockGetPlaygroundRun.mockReset().mockResolvedValue(makeRunDetail());
-    mockListPlaygroundRuns
-      .mockReset()
-      .mockResolvedValue([
-        { id: 'r-42', prompt: 'p', createdAt: '2026-01-01', modelCount: 1, models: ['M'], starred: false, bestColumnId: null },
-      ]);
+    mockListPlaygroundRuns.mockReset().mockResolvedValue([
+      {
+        id: 'r-42',
+        prompt: 'p',
+        createdAt: '2026-01-01',
+        modelCount: 1,
+        models: ['M'],
+        starred: false,
+        bestColumnId: null,
+      },
+    ]);
     mockStreamPlayground.mockReset().mockResolvedValue(streamResult());
     mockSetPlaygroundRunBest.mockReset().mockResolvedValue('dbcol-1');
     setSearchParamsFn.mockClear();
+    mockNavigate.mockReset();
     mockToastError.mockReset();
 
     vi.stubGlobal('localStorage', {
@@ -420,6 +439,32 @@ describe('Playground page', () => {
     });
   });
 
+  it('uses global provider APIs on the tenant playground route', async () => {
+    currentAgent = undefined;
+    const { getByText } = render(() => <Playground />);
+    expect(getByText('Global Playground')).toBeDefined();
+
+    await waitFor(() => expect(mockGetGlobalAvailableModels).toHaveBeenCalled());
+    await waitFor(() => expect(mockGetGlobalProviders).toHaveBeenCalled());
+    expect(mockGetAvailableModels).not.toHaveBeenCalled();
+    expect(mockGetProviders).not.toHaveBeenCalled();
+    expect(mockGetCustomProviders).not.toHaveBeenCalled();
+
+    fireEvent.click(await find('prompt-set'));
+    fireEvent.click(await find('prompt-submit'));
+
+    await waitFor(() => expect(mockStreamPlayground).toHaveBeenCalled());
+    expect(mockStreamPlayground.mock.calls[0][0]).toMatchObject({
+      agentName: 'global',
+      scope: 'global',
+    });
+    expect(mockListPlaygroundRuns).not.toHaveBeenCalled();
+    expect(ssStore['manifest.playground.lastRun']).toBeUndefined();
+
+    fireEvent.click(getByText('Manage providers'));
+    expect(mockNavigate).toHaveBeenCalledWith('/providers');
+  });
+
   it('shows the empty state when providers exist but none are active', async () => {
     mockGetProviders.mockResolvedValue([{ ...ACTIVE_PROVIDER, is_active: false }]);
     render(() => <Playground />);
@@ -438,9 +483,7 @@ describe('Playground page', () => {
 
       await waitFor(() => expect(mockStreamPlayground).toHaveBeenCalled());
       // Run id was set in the URL + sessionStorage.
-      await waitFor(() =>
-        expect(ssStore['manifest.playground.lastRun']).toBeDefined(),
-      );
+      await waitFor(() => expect(ssStore['manifest.playground.lastRun']).toBeDefined());
       // The running→idle effect refreshes history and auto-selects the latest.
       await waitFor(() => expect(mockListPlaygroundRuns).toHaveBeenCalled());
       // After streaming completes the summary table receives the columns.
@@ -457,9 +500,9 @@ describe('Playground page', () => {
       fireEvent.click(await find('prompt-submit'));
       // No prompt set → runAll() returns undefined → no run param written.
       await new Promise((r) => setTimeout(r, 20));
-      expect(
-        setSearchParamsFn.mock.calls.some((c) => c[0] && 'run' in c[0] && c[0].run),
-      ).toBe(false);
+      expect(setSearchParamsFn.mock.calls.some((c) => c[0] && 'run' in c[0] && c[0].run)).toBe(
+        false,
+      );
     });
 
     it('toasts when the streamed run fails for a column', async () => {
@@ -475,17 +518,16 @@ describe('Playground page', () => {
 
   describe('winner badges (real findWinners)', () => {
     it('marks the cheapest + fastest columns once two columns succeed', async () => {
-      mockStreamPlayground.mockImplementation(
-        async (req: { model: string }) =>
-          req.model === 'openai/gpt-4o-mini'
-            ? streamResult({
-                columnId: 'db-openai',
-                metrics: { cost: 0.001, inputTokens: 1, outputTokens: 2, durationMs: 50 },
-              })
-            : streamResult({
-                columnId: 'db-anthropic',
-                metrics: { cost: 0.005, inputTokens: 1, outputTokens: 2, durationMs: 300 },
-              }),
+      mockStreamPlayground.mockImplementation(async (req: { model: string }) =>
+        req.model === 'openai/gpt-4o-mini'
+          ? streamResult({
+              columnId: 'db-openai',
+              metrics: { cost: 0.001, inputTokens: 1, outputTokens: 2, durationMs: 50 },
+            })
+          : streamResult({
+              columnId: 'db-anthropic',
+              metrics: { cost: 0.005, inputTokens: 1, outputTokens: 2, durationMs: 300 },
+            }),
       );
       render(() => <Playground />);
       await find('prompt-set');
@@ -505,9 +547,7 @@ describe('Playground page', () => {
       expect(fastFlags).toContain('true');
       // Summary table receives the completed columns.
       await waitFor(() =>
-        expect(Number(document.querySelector('[data-testid="summary-cols"]')?.textContent)).toBe(
-          2,
-        ),
+        expect(Number(document.querySelector('[data-testid="summary-cols"]')?.textContent)).toBe(2),
       );
     });
   });
@@ -530,9 +570,7 @@ describe('Playground page', () => {
       fireEvent.click(await find(`markbest-${colId}`));
       await waitFor(() => expect(mockSetPlaygroundRunBest).toHaveBeenCalled());
       await waitFor(() =>
-        expect(document.querySelector('[data-testid="summary-best"]')?.textContent).toBe(
-          'dbcol-1',
-        ),
+        expect(document.querySelector('[data-testid="summary-best"]')?.textContent).toBe('dbcol-1'),
       );
     });
 
@@ -681,7 +719,9 @@ describe('Playground page', () => {
       expect(document.querySelector('[data-testid="prompt"]')).not.toBeNull();
 
       fireEvent.click(await find(`remove-${colId}`));
-      await waitFor(() => expect(document.querySelector(`[data-testid="col-${colId}"]`)).toBeNull());
+      await waitFor(() =>
+        expect(document.querySelector(`[data-testid="col-${colId}"]`)).toBeNull(),
+      );
     });
 
     it('opens the add-model picker via the Add button and adds a column', async () => {
@@ -723,9 +763,7 @@ describe('Playground page', () => {
       // Close via the popover and via the toggle.
       fireEvent.click(await find('headers-close'));
       await waitFor(() =>
-        expect(document.querySelector('[data-testid="headers-open"]')?.textContent).toBe(
-          'closed',
-        ),
+        expect(document.querySelector('[data-testid="headers-open"]')?.textContent).toBe('closed'),
       );
       fireEvent.click(trigger);
       fireEvent.click(trigger);
@@ -778,7 +816,9 @@ describe('Playground page', () => {
         },
       });
       // onChange triggers updateHeaders → persistHeaders → swallowed throw.
-      expect(() => fireEvent.click(document.querySelector('[data-testid="headers-change"]') as HTMLElement)).not.toThrow();
+      expect(() =>
+        fireEvent.click(document.querySelector('[data-testid="headers-change"]') as HTMLElement),
+      ).not.toThrow();
     });
   });
 
@@ -895,7 +935,9 @@ describe('Playground page', () => {
     await find('provider-modal');
     fireEvent.click(await find('provider-modal-update'));
     fireEvent.click(await find('provider-modal-close'));
-    await waitFor(() => expect(document.querySelector('[data-testid="provider-modal"]')).toBeNull());
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="provider-modal"]')).toBeNull(),
+    );
     // Closing triggers refetchAllProviders → providers fetched again.
     await waitFor(() => expect(mockGetProviders.mock.calls.length).toBeGreaterThan(1));
   });

--- a/packages/frontend/tests/pages/Workspace-validation.test.tsx
+++ b/packages/frontend/tests/pages/Workspace-validation.test.tsx
@@ -1,17 +1,21 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
 
 // Reuses the mock surface from Workspace.test.tsx. Tests here focus on
 // AddAgentModal validation edges and the exact shape of the createAgent
 // payload, which the happy-path tests don't strictly assert.
 
 const mockNavigate = vi.fn();
-vi.mock("@solidjs/router", () => ({
-  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+vi.mock('@solidjs/router', () => ({
+  A: (props: any) => (
+    <a href={props.href} class={props.class}>
+      {props.children}
+    </a>
+  ),
   useNavigate: () => mockNavigate,
 }));
 
-vi.mock("@solidjs/meta", () => ({
+vi.mock('@solidjs/meta', () => ({
   Title: (props: any) => <title>{props.children}</title>,
   Meta: () => null,
 }));
@@ -19,171 +23,178 @@ vi.mock("@solidjs/meta", () => ({
 const mockGetAgents = vi.fn();
 const mockCreateAgent = vi.fn();
 const mockDeleteAgent = vi.fn();
-vi.mock("../../src/services/api.js", () => ({
+const mockGetGlobalProviders = vi.fn();
+vi.mock('../../src/services/api.js', () => ({
   getAgents: (...args: unknown[]) => mockGetAgents(...args),
   createAgent: (...args: unknown[]) => mockCreateAgent(...args),
   deleteAgent: (...args: unknown[]) => mockDeleteAgent(...args),
+  getGlobalProviders: (...args: unknown[]) => mockGetGlobalProviders(...args),
 }));
 
-vi.mock("../../src/components/DuplicateAgentModal.jsx", () => ({ default: () => null }));
+vi.mock('../../src/components/DuplicateAgentModal.jsx', () => ({ default: () => null }));
 
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
-vi.mock("../../src/services/formatters.js", () => ({
+vi.mock('../../src/services/formatters.js', () => ({
   formatNumber: (v: number) => String(v),
   formatCost: (v: number) => `$${v.toFixed(2)}`,
 }));
 
-vi.mock("../../src/components/Sparkline.jsx", () => ({
+vi.mock('../../src/components/Sparkline.jsx', () => ({
   default: () => <div data-testid="sparkline" />,
 }));
 
-vi.mock("../../src/services/sse.js", () => ({
+vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
 }));
 
-vi.mock("../../src/components/AgentTypeSelect.jsx", () => ({
+vi.mock('../../src/components/AgentTypeSelect.jsx', () => ({
   default: (props: any) => (
     <div
       data-testid="agent-type-picker"
-      data-category={props.category ?? ""}
-      data-platform={props.platform ?? ""}
+      data-category={props.category ?? ''}
+      data-platform={props.platform ?? ''}
       data-disabled={String(!!props.disabled)}
     >
-      <button data-testid="pick-app" onClick={() => props.onCategoryChange("app")}>App</button>
-      <button data-testid="pick-langchain" onClick={() => props.onPlatformChange("langchain")}>LC</button>
+      <button data-testid="pick-app" onClick={() => props.onCategoryChange('app')}>
+        App
+      </button>
+      <button data-testid="pick-langchain" onClick={() => props.onPlatformChange('langchain')}>
+        LC
+      </button>
     </div>
   ),
 }));
 
 const mockMarkAgentCreated = vi.fn();
-vi.mock("../../src/services/recent-agents.js", () => ({
+vi.mock('../../src/services/recent-agents.js', () => ({
   markAgentCreated: (...args: unknown[]) => mockMarkAgentCreated(...args),
 }));
 
-vi.mock("manifest-shared", () => ({
-  AGENT_CATEGORIES: ["personal", "app", "coding"],
+vi.mock('manifest-shared', () => ({
+  AGENT_CATEGORIES: ['personal', 'app', 'coding'],
   PLATFORM_ICONS: {},
   PLATFORMS_BY_CATEGORY: {
-    personal: ["openclaw", "hermes", "other"],
-    app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
-    coding: ["claude-code", "other"],
+    personal: ['openclaw', 'hermes', 'other'],
+    app: ['openai-sdk', 'vercel-ai-sdk', 'langchain', 'other'],
+    coding: ['claude-code', 'other'],
   },
   platformIcon: () => undefined,
 }));
 
-import Workspace from "../../src/pages/Workspace";
+import Workspace from '../../src/pages/Workspace';
 
 const openModal = () => {
   const result = render(() => <Workspace />);
-  fireEvent.click(screen.getAllByText("Connect Agent")[0]);
-  const input = result.container.querySelector(".modal-card__input") as HTMLInputElement;
+  fireEvent.click(screen.getAllByText('Connect Agent')[0]);
+  const input = result.container.querySelector('.modal-card__input') as HTMLInputElement;
   const createBtn = Array.from(
-    result.container.querySelectorAll<HTMLButtonElement>(".modal-card button.btn--primary"),
+    result.container.querySelectorAll<HTMLButtonElement>('.modal-card button.btn--primary'),
   ).pop() as HTMLButtonElement;
   return { ...result, input, createBtn };
 };
 
-describe("Workspace AddAgentModal - name validation", () => {
+describe('Workspace AddAgentModal - name validation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAgents.mockResolvedValue({ agents: [] });
-    mockCreateAgent.mockResolvedValue({ agent: { name: "stub" }, apiKey: "k" });
+    mockCreateAgent.mockResolvedValue({ agent: { name: 'stub' }, apiKey: 'k' });
+    mockGetGlobalProviders.mockResolvedValue([]);
   });
 
-  it("keeps Create disabled while the name is the empty string", () => {
+  it('keeps Create disabled while the name is the empty string', () => {
     const { input, createBtn } = openModal();
-    expect(input.value).toBe("");
+    expect(input.value).toBe('');
     expect(createBtn.disabled).toBe(true);
   });
 
-  it("keeps Create disabled when the name is only spaces", () => {
+  it('keeps Create disabled when the name is only spaces', () => {
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "     " } });
+    fireEvent.input(input, { target: { value: '     ' } });
     expect(createBtn.disabled).toBe(true);
   });
 
-  it("keeps Create disabled when the name is only tabs and newlines", () => {
+  it('keeps Create disabled when the name is only tabs and newlines', () => {
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "\t\n\t  " } });
+    fireEvent.input(input, { target: { value: '\t\n\t  ' } });
     expect(createBtn.disabled).toBe(true);
   });
 
-  it("does not call createAgent when the user clicks Create with whitespace only", () => {
+  it('does not call createAgent when the user clicks Create with whitespace only', () => {
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "   " } });
+    fireEvent.input(input, { target: { value: '   ' } });
     fireEvent.click(createBtn);
     expect(mockCreateAgent).not.toHaveBeenCalled();
   });
 
-  it("does not call createAgent when Enter is pressed with whitespace only", () => {
+  it('does not call createAgent when Enter is pressed with whitespace only', () => {
     const { input } = openModal();
-    fireEvent.input(input, { target: { value: "   " } });
-    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.input(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
     expect(mockCreateAgent).not.toHaveBeenCalled();
   });
 
-  it("enables Create as soon as a single non-space character is typed", () => {
+  it('enables Create as soon as a single non-space character is typed', () => {
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "a" } });
+    fireEvent.input(input, { target: { value: 'a' } });
     expect(createBtn.disabled).toBe(false);
   });
 
-  it("accepts a name with a URL-reserved slash and routes through encodeURIComponent", async () => {
-    mockCreateAgent.mockResolvedValue({ agent: { name: "weird/name" }, apiKey: "k" });
+  it('accepts a name with a URL-reserved slash and routes through encodeURIComponent', async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: 'weird/name' }, apiKey: 'k' });
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "weird/name" } });
+    fireEvent.input(input, { target: { value: 'weird/name' } });
     expect(createBtn.disabled).toBe(false);
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/weird%2Fname", expect.anything());
+      expect(mockNavigate).toHaveBeenCalledWith('/agents/weird%2Fname', expect.anything());
     });
   });
 
-  it("accepts a name with a percent sign without double-encoding", async () => {
-    mockCreateAgent.mockResolvedValue({ agent: { name: "100%cool" }, apiKey: "k" });
+  it('accepts a name with a percent sign without double-encoding', async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: '100%cool' }, apiKey: 'k' });
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "100%cool" } });
+    fireEvent.input(input, { target: { value: '100%cool' } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/100%25cool", expect.anything());
+      expect(mockNavigate).toHaveBeenCalledWith('/agents/100%25cool', expect.anything());
     });
   });
 
-  it("accepts a unicode emoji name and url-encodes the navigation target", async () => {
-    mockCreateAgent.mockResolvedValue({ agent: { name: "bot-🚀" }, apiKey: "k" });
+  it('accepts a unicode emoji name and url-encodes the navigation target', async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: 'bot-🚀' }, apiKey: 'k' });
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "bot-🚀" } });
+    fireEvent.input(input, { target: { value: 'bot-🚀' } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
-        `/agents/${encodeURIComponent("bot-🚀")}`,
+        `/agents/${encodeURIComponent('bot-🚀')}`,
         expect.anything(),
       );
     });
   });
 
-  it("trims surrounding whitespace before submitting the name", async () => {
+  it('trims surrounding whitespace before submitting the name', async () => {
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "  spaced-out  " } });
+    fireEvent.input(input, { target: { value: '  spaced-out  ' } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockCreateAgent).toHaveBeenCalledWith({
-        name: "spaced-out",
-        agent_category: "personal",
-        agent_platform: "openclaw",
+        name: 'spaced-out',
+        agent_category: 'personal',
+        agent_platform: 'openclaw',
       });
     });
   });
 
-  it("accepts a very long name (256 chars) without truncating client-side", async () => {
-    const longName = "a".repeat(256);
-    mockCreateAgent.mockResolvedValue({ agent: { name: longName }, apiKey: "k" });
+  it('accepts a very long name (256 chars) without truncating client-side', async () => {
+    const longName = 'a'.repeat(256);
+    mockCreateAgent.mockResolvedValue({ agent: { name: longName }, apiKey: 'k' });
     const { input, createBtn } = openModal();
     fireEvent.input(input, { target: { value: longName } });
     expect(createBtn.disabled).toBe(false);
@@ -191,82 +202,82 @@ describe("Workspace AddAgentModal - name validation", () => {
     await vi.waitFor(() => {
       expect(mockCreateAgent).toHaveBeenCalledWith({
         name: longName,
-        agent_category: "personal",
-        agent_platform: "openclaw",
+        agent_category: 'personal',
+        agent_platform: 'openclaw',
       });
     });
   });
 });
 
-describe("Workspace AddAgentModal - exact createAgent payload", () => {
+describe('Workspace AddAgentModal - exact createAgent payload', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAgents.mockResolvedValue({ agents: [] });
-    mockCreateAgent.mockResolvedValue({ agent: { name: "demo" }, apiKey: "k" });
+    mockCreateAgent.mockResolvedValue({ agent: { name: 'demo' }, apiKey: 'k' });
+    mockGetGlobalProviders.mockResolvedValue([]);
   });
 
-  it("submits the default category and platform when the user only types a name", async () => {
+  it('submits the default category and platform when the user only types a name', async () => {
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "Demo Agent" } });
+    fireEvent.input(input, { target: { value: 'Demo Agent' } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockCreateAgent).toHaveBeenCalledWith({
-        name: "Demo Agent",
-        agent_category: "personal",
-        agent_platform: "openclaw",
+        name: 'Demo Agent',
+        agent_category: 'personal',
+        agent_platform: 'openclaw',
       });
     });
     // Strict: nothing else was sneaked in (e.g. recordMessages, displayName).
     const call = mockCreateAgent.mock.calls[0][0] as Record<string, unknown>;
-    expect(Object.keys(call).sort()).toEqual(["agent_category", "agent_platform", "name"]);
+    expect(Object.keys(call).sort()).toEqual(['agent_category', 'agent_platform', 'name']);
   });
 
-  it("includes the user-selected category and platform in the payload", async () => {
+  it('includes the user-selected category and platform in the payload', async () => {
     const { container, input, createBtn } = openModal();
     fireEvent.click(container.querySelector('[data-testid="pick-app"]')!);
     fireEvent.click(container.querySelector('[data-testid="pick-langchain"]')!);
-    fireEvent.input(input, { target: { value: "my-langchain-agent" } });
+    fireEvent.input(input, { target: { value: 'my-langchain-agent' } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockCreateAgent).toHaveBeenCalledWith({
-        name: "my-langchain-agent",
-        agent_category: "app",
-        agent_platform: "langchain",
+        name: 'my-langchain-agent',
+        agent_category: 'app',
+        agent_platform: 'langchain',
       });
     });
   });
 
-  it("navigates to the slug returned by the server, not the typed name", async () => {
-    mockCreateAgent.mockResolvedValue({ agent: { name: "demo-agent-1" }, apiKey: "key-xyz" });
+  it('navigates to the slug returned by the server, not the typed name', async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: 'demo-agent-1' }, apiKey: 'key-xyz' });
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "Demo Agent" } });
+    fireEvent.input(input, { target: { value: 'Demo Agent' } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/agents/demo-agent-1", {
-        state: { newApiKey: "key-xyz" },
+      expect(mockNavigate).toHaveBeenCalledWith('/agents/demo-agent-1', {
+        state: { newApiKey: 'key-xyz' },
       });
     });
-    expect(mockMarkAgentCreated).toHaveBeenCalledWith("demo-agent-1");
+    expect(mockMarkAgentCreated).toHaveBeenCalledWith('demo-agent-1');
   });
 
-  it("falls back to the typed name when the server omits the slug", async () => {
-    mockCreateAgent.mockResolvedValue({ apiKey: "k" });
+  it('falls back to the typed name when the server omits the slug', async () => {
+    mockCreateAgent.mockResolvedValue({ apiKey: 'k' });
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "Fallback Agent" } });
+    fireEvent.input(input, { target: { value: 'Fallback Agent' } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(
-        `/agents/${encodeURIComponent("Fallback Agent")}`,
-        { state: { newApiKey: "k" } },
-      );
+      expect(mockNavigate).toHaveBeenCalledWith(`/agents/${encodeURIComponent('Fallback Agent')}`, {
+        state: { newApiKey: 'k' },
+      });
     });
-    expect(mockMarkAgentCreated).toHaveBeenCalledWith("Fallback Agent");
+    expect(mockMarkAgentCreated).toHaveBeenCalledWith('Fallback Agent');
   });
 
-  it("does not call markAgentCreated or navigate when createAgent rejects", async () => {
-    mockCreateAgent.mockRejectedValue(new Error("boom"));
+  it('does not call markAgentCreated or navigate when createAgent rejects', async () => {
+    mockCreateAgent.mockRejectedValue(new Error('boom'));
     const { input, createBtn } = openModal();
-    fireEvent.input(input, { target: { value: "Demo Agent" } });
+    fireEvent.input(input, { target: { value: 'Demo Agent' } });
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
       expect(mockCreateAgent).toHaveBeenCalled();

--- a/packages/frontend/tests/pages/Workspace.test.tsx
+++ b/packages/frontend/tests/pages/Workspace.test.tsx
@@ -1,13 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@solidjs/testing-library';
 
 const mockNavigate = vi.fn();
-vi.mock("@solidjs/router", () => ({
-  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+vi.mock('@solidjs/router', () => ({
+  A: (props: any) => (
+    <a href={props.href} class={props.class}>
+      {props.children}
+    </a>
+  ),
   useNavigate: () => mockNavigate,
 }));
 
-vi.mock("@solidjs/meta", () => ({
+vi.mock('@solidjs/meta', () => ({
   Title: (props: any) => <title>{props.children}</title>,
   Meta: () => null,
 }));
@@ -15,14 +19,16 @@ vi.mock("@solidjs/meta", () => ({
 const mockGetAgents = vi.fn();
 const mockCreateAgent = vi.fn();
 const mockDeleteAgent = vi.fn();
-vi.mock("../../src/services/api.js", () => ({
+const mockGetGlobalProviders = vi.fn();
+vi.mock('../../src/services/api.js', () => ({
   getAgents: (...args: unknown[]) => mockGetAgents(...args),
   createAgent: (...args: unknown[]) => mockCreateAgent(...args),
   deleteAgent: (...args: unknown[]) => mockDeleteAgent(...args),
+  getGlobalProviders: (...args: unknown[]) => mockGetGlobalProviders(...args),
 }));
 
-vi.mock("../../src/components/DuplicateAgentModal.jsx", async () => {
-  const { Show } = await import("solid-js");
+vi.mock('../../src/components/DuplicateAgentModal.jsx', async () => {
+  const { Show } = await import('solid-js');
   return {
     default: (props: {
       open: boolean;
@@ -50,137 +56,153 @@ vi.mock("../../src/components/DuplicateAgentModal.jsx", async () => {
   };
 });
 
-vi.mock("../../src/services/toast-store.js", () => ({
+vi.mock('../../src/services/toast-store.js', () => ({
   toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
-vi.mock("../../src/services/formatters.js", () => ({
+vi.mock('../../src/services/formatters.js', () => ({
   formatNumber: (v: number) => String(v),
   formatCost: (v: number) => `$${v.toFixed(2)}`,
 }));
 
-vi.mock("../../src/components/Sparkline.jsx", () => ({
+vi.mock('../../src/components/Sparkline.jsx', () => ({
   default: () => <div data-testid="sparkline" />,
 }));
 
-vi.mock("../../src/services/sse.js", () => ({
+vi.mock('../../src/services/sse.js', () => ({
   pingCount: () => 0,
   messagePing: () => 0,
   agentPing: () => 0,
   routingPing: () => 0,
 }));
 
-vi.mock("../../src/components/AgentTypeSelect.jsx", () => ({
+vi.mock('../../src/components/AgentTypeSelect.jsx', () => ({
   default: (props: any) => (
     <div
       data-testid="agent-type-picker"
-      data-category={props.category ?? ""}
-      data-platform={props.platform ?? ""}
+      data-category={props.category ?? ''}
+      data-platform={props.platform ?? ''}
       data-disabled={String(!!props.disabled)}
     >
-      <button data-testid="pick-category" onClick={() => props.onCategoryChange("personal")}>Pick Category</button>
-      <button data-testid="pick-platform" onClick={() => props.onPlatformChange("openclaw")}>Pick Platform</button>
+      <button data-testid="pick-category" onClick={() => props.onCategoryChange('personal')}>
+        Pick Category
+      </button>
+      <button data-testid="pick-platform" onClick={() => props.onPlatformChange('openclaw')}>
+        Pick Platform
+      </button>
     </div>
   ),
 }));
 
 const mockMarkAgentCreated = vi.fn();
-vi.mock("../../src/services/recent-agents.js", () => ({
+vi.mock('../../src/services/recent-agents.js', () => ({
   markAgentCreated: (...args: unknown[]) => mockMarkAgentCreated(...args),
 }));
 
-vi.mock("manifest-shared", () => ({
-  AGENT_CATEGORIES: ["personal", "app", "coding"],
+vi.mock('manifest-shared', () => ({
+  AGENT_CATEGORIES: ['personal', 'app', 'coding'],
   PLATFORM_ICONS: {
-    openclaw: "/icons/openclaw.png",
-    hermes: "/icons/hermes.png",
-    "openai-sdk": "/icons/providers/openai.svg",
-    "vercel-ai-sdk": "/icons/vercel.svg",
-    langchain: "/icons/langchain.svg",
-    "claude-code": "/icons/providers/claude-code.svg",
-    other: "/icons/other.svg",
+    openclaw: '/icons/openclaw.png',
+    hermes: '/icons/hermes.png',
+    'openai-sdk': '/icons/providers/openai.svg',
+    'vercel-ai-sdk': '/icons/vercel.svg',
+    langchain: '/icons/langchain.svg',
+    'claude-code': '/icons/providers/claude-code.svg',
+    other: '/icons/other.svg',
   },
   PLATFORMS_BY_CATEGORY: {
-    personal: ["openclaw", "hermes", "other"],
-    app: ["openai-sdk", "vercel-ai-sdk", "langchain", "other"],
-    coding: ["claude-code", "other"],
+    personal: ['openclaw', 'hermes', 'other'],
+    app: ['openai-sdk', 'vercel-ai-sdk', 'langchain', 'other'],
+    coding: ['claude-code', 'other'],
   },
   platformIcon: (plat: string | null, cat: string | null) => {
     if (!plat) return undefined;
-    if (plat === "other") return cat === "personal" ? "/icons/other-agent.svg" : "/icons/other.svg";
+    if (plat === 'other') return cat === 'personal' ? '/icons/other-agent.svg' : '/icons/other.svg';
     const icons: Record<string, string> = {
-      openclaw: "/icons/openclaw.png",
-      hermes: "/icons/hermes.png",
-      "openai-sdk": "/icons/providers/openai.svg",
-      "vercel-ai-sdk": "/icons/vercel.svg",
-      langchain: "/icons/langchain.svg",
-      "claude-code": "/icons/providers/claude-code.svg",
+      openclaw: '/icons/openclaw.png',
+      hermes: '/icons/hermes.png',
+      'openai-sdk': '/icons/providers/openai.svg',
+      'vercel-ai-sdk': '/icons/vercel.svg',
+      langchain: '/icons/langchain.svg',
+      'claude-code': '/icons/providers/claude-code.svg',
     };
     return icons[plat];
   },
 }));
 
-import Workspace from "../../src/pages/Workspace";
+import Workspace from '../../src/pages/Workspace';
 
-describe("Workspace", () => {
+describe('Workspace', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAgents.mockResolvedValue({
       agents: [
-        { agent_name: "demo-agent", display_name: "Demo Agent", message_count: 42, last_active: "2024-01-01", total_cost: 5.5, total_tokens: 15000, sparkline: [1, 2, 3] },
+        {
+          agent_name: 'demo-agent',
+          display_name: 'Demo Agent',
+          message_count: 42,
+          last_active: '2024-01-01',
+          total_cost: 5.5,
+          total_tokens: 15000,
+          sparkline: [1, 2, 3],
+        },
       ],
     });
-    mockCreateAgent.mockResolvedValue({ agent: { name: "new-agent", display_name: "new-agent" }, apiKey: "test-key" });
+    mockCreateAgent.mockResolvedValue({
+      agent: { name: 'new-agent', display_name: 'new-agent' },
+      apiKey: 'test-key',
+    });
+    mockGetGlobalProviders.mockResolvedValue([]);
   });
 
-  it("renders My Agents heading", async () => {
+  it('renders My Agents heading', async () => {
     render(() => <Workspace />);
-    expect(screen.getByText("My Agents")).toBeDefined();
+    expect(screen.getByText('My Agents')).toBeDefined();
   });
 
-  it("renders Connect Agent button", () => {
+  it('renders Connect Agent button', () => {
     render(() => <Workspace />);
-    const buttons = screen.getAllByText("Connect Agent");
+    const buttons = screen.getAllByText('Connect Agent');
     expect(buttons.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("renders agent cards with display name when data loads", async () => {
+  it('renders agent cards with display name when data loads', async () => {
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Demo Agent");
+      expect(container.textContent).toContain('Demo Agent');
     });
   });
 
-  it("shows agent stats", async () => {
+  it('shows agent stats', async () => {
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("15000");
-      expect(container.textContent).toContain("42");
+      expect(container.textContent).toContain('15000');
+      expect(container.textContent).toContain('42');
     });
   });
 
-  it("shows empty state when no agents", async () => {
+  it('shows empty state when no agents', async () => {
     mockGetAgents.mockResolvedValue({ agents: [] });
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("No agents yet");
+      expect(container.textContent).toContain('No agents yet');
     });
   });
 
-  it("shows loading skeleton", () => {
+  it('shows loading skeleton', () => {
     mockGetAgents.mockReturnValue(new Promise(() => {}));
     const { container } = render(() => <Workspace />);
-    expect(container.querySelectorAll(".skeleton").length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
   });
 
-  it("opens create agent modal on Connect Agent click", () => {
+  it('opens create agent modal on Connect Agent click', () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    expect(container.querySelector(".modal-card__input")).not.toBeNull();
+    expect(container.querySelector('.modal-card__input')).not.toBeNull();
   });
 
-  it("agents link to agent detail page", async () => {
+  it('agents link to agent detail page', async () => {
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
       const link = container.querySelector('a[href="/agents/demo-agent"]');
@@ -188,146 +210,214 @@ describe("Workspace", () => {
     });
   });
 
-  it("shows agent card stat labels", async () => {
+  it('shows agent card stat labels', async () => {
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Tokens");
-      expect(container.textContent).toContain("Messages");
+      expect(container.textContent).toContain('Tokens');
+      expect(container.textContent).toContain('Messages');
     });
   });
 
-  it("shows message count in agent card", async () => {
+  it('shows message count in agent card', async () => {
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("42");
+      expect(container.textContent).toContain('42');
     });
   });
 
-  it("creates agent when form submitted", async () => {
-    mockCreateAgent.mockResolvedValue({ agent: { name: "new-agent" }, apiKey: "test-key" });
+  it('creates agent when form submitted', async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: 'new-agent' }, apiKey: 'test-key' });
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "new-agent" } });
-    const createBtn = screen.getByText("Create");
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'new-agent' } });
+    const createBtn = screen.getByText('Create');
     fireEvent.click(createBtn);
     await vi.waitFor(() => {
-      expect(mockCreateAgent).toHaveBeenCalledWith(expect.objectContaining({ name: "new-agent" }));
+      expect(mockCreateAgent).toHaveBeenCalledWith(expect.objectContaining({ name: 'new-agent' }));
     });
     await vi.waitFor(() => {
-      expect(mockMarkAgentCreated).toHaveBeenCalledWith("new-agent");
+      expect(mockMarkAgentCreated).toHaveBeenCalledWith('new-agent');
     });
   });
 
-  it("create button is disabled when name is empty", () => {
+  it('copies selected global providers into a new agent', async () => {
+    mockGetGlobalProviders.mockResolvedValue([
+      {
+        id: 'gp-openai',
+        provider: 'openai',
+        auth_type: 'api_key',
+        label: 'Work',
+        is_active: true,
+        has_api_key: true,
+        connected_at: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 'gp-anthropic',
+        provider: 'anthropic',
+        auth_type: 'subscription',
+        label: 'Team',
+        is_active: true,
+        has_api_key: true,
+        connected_at: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        id: 'gp-disabled',
+        provider: 'google',
+        auth_type: 'api_key',
+        label: 'Disabled',
+        is_active: false,
+        has_api_key: true,
+        connected_at: '2024-01-01T00:00:00.000Z',
+      },
+    ]);
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    fireEvent.click(screen.getAllByText('Connect Agent')[0]);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Global providers');
+      expect(container.textContent).toContain('anthropic');
+      expect(container.textContent).toContain('openai');
+      expect(container.textContent).not.toContain('google');
+    });
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLLabelElement>('.agent-global-provider-row'),
+    );
+    const openAiRow = rows.find((row) => row.textContent?.includes('openai'))!;
+    fireEvent.click(openAiRow.querySelector('input')!);
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'global-copy-agent' } });
+    fireEvent.click(screen.getByText('Create'));
+
+    await vi.waitFor(() => {
+      expect(mockCreateAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'global-copy-agent',
+          global_provider_ids: ['gp-anthropic'],
+        }),
+      );
+    });
+  });
+
+  it('create button is disabled when name is empty', () => {
+    const { container } = render(() => <Workspace />);
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    const createBtn = screen.getByText("Create") as HTMLButtonElement;
+    const createBtn = screen.getByText('Create') as HTMLButtonElement;
     expect(createBtn.disabled).toBe(true);
   });
 
-  it("shows modal dialog title", () => {
+  it('shows modal dialog title', () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    expect(container.textContent).toContain("Name your agent to start tracking");
+    expect(container.textContent).toContain('Name your agent to start tracking');
   });
 
-  it("shows breadcrumb text", () => {
+  it('shows breadcrumb text', () => {
     const { container } = render(() => <Workspace />);
-    expect(container.textContent).toContain("View and manage all your connected AI agents");
+    expect(container.textContent).toContain('View and manage all your connected AI agents');
   });
 
-  it("shows connect button in empty state", async () => {
+  it('shows connect button in empty state', async () => {
     mockGetAgents.mockResolvedValue({ agents: [] });
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Connect your first agent");
+      expect(container.textContent).toContain('Connect your first agent');
     });
   });
 
-  it("shows Creating... text and disables button during submission", async () => {
+  it('shows Creating... text and disables button during submission', async () => {
     let resolveCreate: (v: any) => void;
-    mockCreateAgent.mockReturnValue(new Promise((r) => { resolveCreate = r; }));
+    mockCreateAgent.mockReturnValue(
+      new Promise((r) => {
+        resolveCreate = r;
+      }),
+    );
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "new-agent" } });
-    fireEvent.click(screen.getByText("Create"));
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'new-agent' } });
+    fireEvent.click(screen.getByText('Create'));
     await vi.waitFor(() => {
-      const btns = container.querySelectorAll(".modal-card button.btn--primary");
+      const btns = container.querySelectorAll('.modal-card button.btn--primary');
       const createBtn = btns[btns.length - 1] as HTMLButtonElement;
-      expect(createBtn.querySelector(".spinner")).not.toBeNull();
+      expect(createBtn.querySelector('.spinner')).not.toBeNull();
       expect(createBtn.disabled).toBe(true);
     });
-    resolveCreate!({ agent: { name: "new-agent" }, apiKey: "k" });
+    resolveCreate!({ agent: { name: 'new-agent' }, apiKey: 'k' });
   });
 
-  it("disables input during creation", async () => {
+  it('disables input during creation', async () => {
     let resolveCreate: (v: any) => void;
-    mockCreateAgent.mockReturnValue(new Promise((r) => { resolveCreate = r; }));
+    mockCreateAgent.mockReturnValue(
+      new Promise((r) => {
+        resolveCreate = r;
+      }),
+    );
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "new-agent" } });
-    fireEvent.click(screen.getByText("Create"));
+    fireEvent.click(screen.getAllByText('Connect Agent')[0]);
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'new-agent' } });
+    fireEvent.click(screen.getByText('Create'));
     await vi.waitFor(() => {
       expect(input.disabled).toBe(true);
     });
-    resolveCreate!({ agent: { name: "new-agent" }, apiKey: "k" });
+    resolveCreate!({ agent: { name: 'new-agent' }, apiKey: 'k' });
   });
 
-  it("handles createAgent error gracefully", async () => {
-    mockCreateAgent.mockRejectedValue(new Error("Failed to create"));
+  it('handles createAgent error gracefully', async () => {
+    mockCreateAgent.mockRejectedValue(new Error('Failed to create'));
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "new-agent" } });
-    fireEvent.click(screen.getByText("Create"));
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'new-agent' } });
+    fireEvent.click(screen.getByText('Create'));
     await vi.waitFor(() => {
       expect(mockCreateAgent).toHaveBeenCalled();
     });
   });
 
-  it("creates agent on Enter key press", async () => {
+  it('creates agent on Enter key press', async () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "enter-agent" } });
-    fireEvent.keyDown(input, { key: "Enter" });
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'enter-agent' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
     await vi.waitFor(() => {
-      expect(mockCreateAgent).toHaveBeenCalledWith(expect.objectContaining({ name: "enter-agent" }));
+      expect(mockCreateAgent).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'enter-agent' }),
+      );
     });
   });
 
-  it("closes modal and clears input on Escape key", () => {
+  it('closes modal and clears input on Escape key', () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "test" } });
-    fireEvent.keyDown(input, { key: "Escape" });
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'test' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
     // Modal should be closed (no modal input visible)
-    expect(container.querySelector(".modal-card__input")).toBeNull();
+    expect(container.querySelector('.modal-card__input')).toBeNull();
   });
 
-  it("closes modal on overlay click", () => {
+  it('closes modal on overlay click', () => {
     const { container } = render(() => <Workspace />);
-    const btn = screen.getAllByText("Connect Agent")[0];
+    const btn = screen.getAllByText('Connect Agent')[0];
     fireEvent.click(btn);
-    expect(container.querySelector(".modal-overlay")).not.toBeNull();
-    const overlay = container.querySelector(".modal-overlay")!;
+    expect(container.querySelector('.modal-overlay')).not.toBeNull();
+    const overlay = container.querySelector('.modal-overlay')!;
     fireEvent.click(overlay);
     // Modal should be closed after overlay click
-    expect(container.querySelector(".modal-card__input")).toBeNull();
+    expect(container.querySelector('.modal-card__input')).toBeNull();
   });
 
-  it("does not redirect in any mode", async () => {
+  it('does not redirect in any mode', async () => {
     render(() => <Workspace />);
     await vi.waitFor(() => {
       expect(mockGetAgents).toHaveBeenCalled();
@@ -335,281 +425,305 @@ describe("Workspace", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("shows AgentTypePicker in create modal", () => {
+  it('shows AgentTypePicker in create modal', () => {
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+    fireEvent.click(screen.getAllByText('Connect Agent')[0]);
     expect(container.querySelector('[data-testid="agent-type-picker"]')).not.toBeNull();
   });
 
-  it("sets first platform when category changes in create modal", () => {
+  it('sets first platform when category changes in create modal', () => {
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
+    fireEvent.click(screen.getAllByText('Connect Agent')[0]);
     // First pick a platform
     fireEvent.click(container.querySelector('[data-testid="pick-platform"]')!);
     // Then change category which should set platform to first of new category
     fireEvent.click(container.querySelector('[data-testid="pick-category"]')!);
     const picker = container.querySelector('[data-testid="agent-type-picker"]');
-    expect(picker!.getAttribute("data-platform")).toBe("openclaw");
+    expect(picker!.getAttribute('data-platform')).toBe('openclaw');
   });
 
-  it("sends category and platform with createAgent", async () => {
-    mockCreateAgent.mockResolvedValue({ agent: { name: "typed-agent" }, apiKey: "k" });
+  it('sends category and platform with createAgent', async () => {
+    mockCreateAgent.mockResolvedValue({ agent: { name: 'typed-agent' }, apiKey: 'k' });
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "typed-agent" } });
+    fireEvent.click(screen.getAllByText('Connect Agent')[0]);
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'typed-agent' } });
     fireEvent.click(container.querySelector('[data-testid="pick-category"]')!);
     fireEvent.click(container.querySelector('[data-testid="pick-platform"]')!);
-    fireEvent.click(screen.getByText("Create"));
+    fireEvent.click(screen.getByText('Create'));
     await vi.waitFor(() => {
-      expect(mockCreateAgent).toHaveBeenCalledWith(expect.objectContaining({
-        name: "typed-agent",
-        agent_category: "personal",
-        agent_platform: "openclaw",
-      }));
+      expect(mockCreateAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'typed-agent',
+          agent_category: 'personal',
+          agent_platform: 'openclaw',
+        }),
+      );
     });
   });
 
-  it("does not submit when name is empty", async () => {
+  it('does not submit when name is empty', async () => {
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "   " } });
-    fireEvent.click(screen.getByText("Create"));
+    fireEvent.click(screen.getAllByText('Connect Agent')[0]);
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: '   ' } });
+    fireEvent.click(screen.getByText('Create'));
     expect(mockCreateAgent).not.toHaveBeenCalled();
   });
 
-  it("shows agent_name when display_name is missing", async () => {
+  it('shows agent_name when display_name is missing', async () => {
     mockGetAgents.mockResolvedValue({
       agents: [
-        { agent_name: "raw-agent", message_count: 1, last_active: "2024-01-01", total_cost: 0, total_tokens: 0, sparkline: [] },
+        {
+          agent_name: 'raw-agent',
+          message_count: 1,
+          last_active: '2024-01-01',
+          total_cost: 0,
+          total_tokens: 0,
+          sparkline: [],
+        },
       ],
     });
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("raw-agent");
+      expect(container.textContent).toContain('raw-agent');
     });
   });
 
-  it("shows error state when getAgents fails", async () => {
-    mockGetAgents.mockRejectedValue(new Error("Network error"));
+  it('shows error state when getAgents fails', async () => {
+    mockGetAgents.mockRejectedValue(new Error('Network error'));
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
       // ErrorState component should render
-      expect(container.querySelector(".error-state") || container.textContent?.includes("error")).toBeDefined();
+      expect(
+        container.querySelector('.error-state') || container.textContent?.includes('error'),
+      ).toBeDefined();
     });
   });
 
-  it("opens modal from empty state connect button", async () => {
+  it('opens modal from empty state connect button', async () => {
     mockGetAgents.mockResolvedValue({ agents: [] });
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      expect(container.textContent).toContain("Connect your first agent");
+      expect(container.textContent).toContain('Connect your first agent');
     });
-    const btn = Array.from(container.querySelectorAll("button")).find(
-      (b) => b.textContent?.includes("Connect your first agent"),
+    const btn = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Connect your first agent'),
     )!;
     fireEvent.click(btn);
-    expect(container.querySelector(".modal-card__input")).not.toBeNull();
+    expect(container.querySelector('.modal-card__input')).not.toBeNull();
   });
 
-  it("shows platform icon when agent has a platform", async () => {
+  it('shows platform icon when agent has a platform', async () => {
     mockGetAgents.mockResolvedValue({
       agents: [
-        { agent_name: "my-agent", display_name: "My Agent", agent_platform: "openclaw", message_count: 1, last_active: "2024-01-01", total_cost: 0, total_tokens: 0, sparkline: [] },
+        {
+          agent_name: 'my-agent',
+          display_name: 'My Agent',
+          agent_platform: 'openclaw',
+          message_count: 1,
+          last_active: '2024-01-01',
+          total_cost: 0,
+          total_tokens: 0,
+          sparkline: [],
+        },
       ],
     });
     const { container } = render(() => <Workspace />);
     await vi.waitFor(() => {
-      const icon = container.querySelector(".agent-card__platform-icon");
+      const icon = container.querySelector('.agent-card__platform-icon');
       expect(icon).not.toBeNull();
-      expect(icon!.getAttribute("src")).toBe("/icons/openclaw.png");
+      expect(icon!.getAttribute('src')).toBe('/icons/openclaw.png');
     });
   });
 
-  it("disables picker during creation", async () => {
+  it('disables picker during creation', async () => {
     let resolveCreate: (v: any) => void;
-    mockCreateAgent.mockReturnValue(new Promise((r) => { resolveCreate = r; }));
+    mockCreateAgent.mockReturnValue(
+      new Promise((r) => {
+        resolveCreate = r;
+      }),
+    );
     const { container } = render(() => <Workspace />);
-    fireEvent.click(screen.getAllByText("Connect Agent")[0]);
-    const input = container.querySelector(".modal-card__input") as HTMLInputElement;
-    fireEvent.input(input, { target: { value: "test" } });
-    fireEvent.click(screen.getByText("Create"));
+    fireEvent.click(screen.getAllByText('Connect Agent')[0]);
+    const input = container.querySelector('.modal-card__input') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'test' } });
+    fireEvent.click(screen.getByText('Create'));
     await vi.waitFor(() => {
       const picker = container.querySelector('[data-testid="agent-type-picker"]');
-      expect(picker!.getAttribute("data-disabled")).toBe("true");
+      expect(picker!.getAttribute('data-disabled')).toBe('true');
     });
-    resolveCreate!({ agent: { name: "test" }, apiKey: "k" });
+    resolveCreate!({ agent: { name: 'test' }, apiKey: 'k' });
   });
 
-  describe("agent card menu", () => {
+  describe('agent card menu', () => {
     const clickKebab = async (container: HTMLElement) => {
       await vi.waitFor(() => {
-        const trigger = container.querySelector(".agent-card__menu-trigger");
+        const trigger = container.querySelector('.agent-card__menu-trigger');
         expect(trigger).not.toBeNull();
       });
-      const trigger = container.querySelector(".agent-card__menu-trigger") as HTMLButtonElement;
+      const trigger = container.querySelector('.agent-card__menu-trigger') as HTMLButtonElement;
       fireEvent.click(trigger);
     };
 
-    it("opens kebab popover with Duplicate and Delete", async () => {
+    it('opens kebab popover with Duplicate and Delete', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      expect(container.querySelector(".agent-card__menu-popover")).not.toBeNull();
-      expect(container.textContent).toContain("Duplicate");
-      expect(container.textContent).toContain("Delete");
+      expect(container.querySelector('.agent-card__menu-popover')).not.toBeNull();
+      expect(container.textContent).toContain('Duplicate');
+      expect(container.textContent).toContain('Delete');
     });
 
-    it("toggles the popover closed on a second trigger click", async () => {
+    it('toggles the popover closed on a second trigger click', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
       await clickKebab(container);
-      expect(container.querySelector(".agent-card__menu-popover")).toBeNull();
+      expect(container.querySelector('.agent-card__menu-popover')).toBeNull();
     });
 
-    it("closes the popover when clicking outside", async () => {
+    it('closes the popover when clicking outside', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      expect(container.querySelector(".agent-card__menu-popover")).not.toBeNull();
+      expect(container.querySelector('.agent-card__menu-popover')).not.toBeNull();
       fireEvent.click(document.body);
-      expect(container.querySelector(".agent-card__menu-popover")).toBeNull();
+      expect(container.querySelector('.agent-card__menu-popover')).toBeNull();
     });
 
-    it("closes the popover on Escape", async () => {
+    it('closes the popover on Escape', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.keyDown(document, { key: "Escape" });
-      expect(container.querySelector(".agent-card__menu-popover")).toBeNull();
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(container.querySelector('.agent-card__menu-popover')).toBeNull();
     });
 
-    it("ignores Escape when popover is already closed", async () => {
+    it('ignores Escape when popover is already closed', async () => {
       const { container } = render(() => <Workspace />);
       await vi.waitFor(() => {
-        expect(container.querySelector(".agent-card__menu-trigger")).not.toBeNull();
+        expect(container.querySelector('.agent-card__menu-trigger')).not.toBeNull();
       });
-      fireEvent.keyDown(document, { key: "Escape" });
-      expect(container.querySelector(".agent-card__menu-popover")).toBeNull();
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(container.querySelector('.agent-card__menu-popover')).toBeNull();
     });
 
-    it("opens the DuplicateAgentModal when Duplicate is clicked", async () => {
+    it('opens the DuplicateAgentModal when Duplicate is clicked', async () => {
       const { container, getByTestId } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Duplicate"));
-      const modal = getByTestId("duplicate-modal");
-      expect(modal.getAttribute("data-source")).toBe("demo-agent");
+      fireEvent.click(screen.getByText('Duplicate'));
+      const modal = getByTestId('duplicate-modal');
+      expect(modal.getAttribute('data-source')).toBe('demo-agent');
     });
 
-    it("closes the DuplicateAgentModal when the user cancels", async () => {
+    it('closes the DuplicateAgentModal when the user cancels', async () => {
       const { container, getByTestId, queryByTestId } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Duplicate"));
-      expect(getByTestId("duplicate-modal")).toBeDefined();
-      fireEvent.click(getByTestId("duplicate-modal-close"));
-      expect(queryByTestId("duplicate-modal")).toBeNull();
+      fireEvent.click(screen.getByText('Duplicate'));
+      expect(getByTestId('duplicate-modal')).toBeDefined();
+      fireEvent.click(getByTestId('duplicate-modal-close'));
+      expect(queryByTestId('duplicate-modal')).toBeNull();
     });
 
-    it("refetches agents after a successful duplicate", async () => {
+    it('refetches agents after a successful duplicate', async () => {
       const { container, getByTestId } = render(() => <Workspace />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("Demo Agent");
+        expect(container.textContent).toContain('Demo Agent');
       });
       expect(mockGetAgents).toHaveBeenCalledTimes(1);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Duplicate"));
-      fireEvent.click(getByTestId("duplicate-modal-done"));
+      fireEvent.click(screen.getByText('Duplicate'));
+      fireEvent.click(getByTestId('duplicate-modal-done'));
       await vi.waitFor(() => {
         expect(mockGetAgents).toHaveBeenCalledTimes(2);
       });
     });
 
-    it("opens the delete confirmation modal when Delete is clicked", async () => {
+    it('opens the delete confirmation modal when Delete is clicked', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Delete"));
-      expect(container.textContent).toContain("Delete demo-agent");
+      fireEvent.click(screen.getByText('Delete'));
+      expect(container.textContent).toContain('Delete demo-agent');
       expect(container.querySelector('input[placeholder="demo-agent"]')).not.toBeNull();
     });
 
-    it("requires exact name match before enabling delete button", async () => {
+    it('requires exact name match before enabling delete button', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Delete"));
-      const deleteBtn = Array.from(container.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === "Delete agent",
+      fireEvent.click(screen.getByText('Delete'));
+      const deleteBtn = Array.from(container.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Delete agent',
       ) as HTMLButtonElement;
-      expect(deleteBtn.hasAttribute("disabled")).toBe(true);
+      expect(deleteBtn.hasAttribute('disabled')).toBe(true);
       const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
-      fireEvent.input(input, { target: { value: "wrong-name" } });
-      expect(deleteBtn.hasAttribute("disabled")).toBe(true);
-      fireEvent.input(input, { target: { value: "demo-agent" } });
-      expect(deleteBtn.hasAttribute("disabled")).toBe(false);
+      fireEvent.input(input, { target: { value: 'wrong-name' } });
+      expect(deleteBtn.hasAttribute('disabled')).toBe(true);
+      fireEvent.input(input, { target: { value: 'demo-agent' } });
+      expect(deleteBtn.hasAttribute('disabled')).toBe(false);
     });
 
-    it("deletes the agent and refetches after confirmation", async () => {
+    it('deletes the agent and refetches after confirmation', async () => {
       mockDeleteAgent.mockResolvedValue({ deleted: true });
       const { container } = render(() => <Workspace />);
       await vi.waitFor(() => {
-        expect(container.textContent).toContain("Demo Agent");
+        expect(container.textContent).toContain('Demo Agent');
       });
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Delete"));
+      fireEvent.click(screen.getByText('Delete'));
       const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
-      fireEvent.input(input, { target: { value: "demo-agent" } });
-      const deleteBtn = Array.from(container.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === "Delete agent",
+      fireEvent.input(input, { target: { value: 'demo-agent' } });
+      const deleteBtn = Array.from(container.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Delete agent',
       ) as HTMLButtonElement;
       fireEvent.click(deleteBtn);
       await vi.waitFor(() => {
-        expect(mockDeleteAgent).toHaveBeenCalledWith("demo-agent");
+        expect(mockDeleteAgent).toHaveBeenCalledWith('demo-agent');
         expect(mockGetAgents).toHaveBeenCalledTimes(2);
       });
     });
 
-    it("keeps the modal open when deletion fails so the user can retry", async () => {
-      mockDeleteAgent.mockRejectedValue(new Error("boom"));
+    it('keeps the modal open when deletion fails so the user can retry', async () => {
+      mockDeleteAgent.mockRejectedValue(new Error('boom'));
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Delete"));
+      fireEvent.click(screen.getByText('Delete'));
       const input = container.querySelector('input[placeholder="demo-agent"]') as HTMLInputElement;
-      fireEvent.input(input, { target: { value: "demo-agent" } });
-      const deleteBtn = Array.from(container.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === "Delete agent",
+      fireEvent.input(input, { target: { value: 'demo-agent' } });
+      const deleteBtn = Array.from(container.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Delete agent',
       ) as HTMLButtonElement;
       fireEvent.click(deleteBtn);
       await vi.waitFor(() => {
         expect(mockDeleteAgent).toHaveBeenCalled();
       });
-      expect(container.textContent).toContain("Delete demo-agent");
+      expect(container.textContent).toContain('Delete demo-agent');
     });
 
-    it("cancels the delete modal without deleting", async () => {
+    it('cancels the delete modal without deleting', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Delete"));
-      const cancelBtn = Array.from(container.querySelectorAll("button")).find(
-        (b) => b.textContent?.trim() === "Cancel",
+      fireEvent.click(screen.getByText('Delete'));
+      const cancelBtn = Array.from(container.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Cancel',
       ) as HTMLButtonElement;
       fireEvent.click(cancelBtn);
-      expect(container.textContent).not.toContain("Delete demo-agent");
+      expect(container.textContent).not.toContain('Delete demo-agent');
       expect(mockDeleteAgent).not.toHaveBeenCalled();
     });
 
-    it("closes the delete modal when the backdrop is clicked", async () => {
+    it('closes the delete modal when the backdrop is clicked', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Delete"));
-      const overlay = container.querySelector(".modal-overlay") as HTMLDivElement;
+      fireEvent.click(screen.getByText('Delete'));
+      const overlay = container.querySelector('.modal-overlay') as HTMLDivElement;
       fireEvent.click(overlay);
-      expect(container.textContent).not.toContain("Delete demo-agent");
+      expect(container.textContent).not.toContain('Delete demo-agent');
     });
 
-    it("closes the delete modal on Escape from the overlay", async () => {
+    it('closes the delete modal on Escape from the overlay', async () => {
       const { container } = render(() => <Workspace />);
       await clickKebab(container);
-      fireEvent.click(screen.getByText("Delete"));
-      const overlay = container.querySelector(".modal-overlay") as HTMLDivElement;
-      fireEvent.keyDown(overlay, { key: "Escape" });
-      expect(container.textContent).not.toContain("Delete demo-agent");
+      fireEvent.click(screen.getByText('Delete'));
+      const overlay = container.querySelector('.modal-overlay') as HTMLDivElement;
+      fireEvent.keyDown(overlay, { key: 'Escape' });
+      expect(container.textContent).not.toContain('Delete demo-agent');
     });
   });
 });

--- a/packages/frontend/tests/services/api/agents.test.ts
+++ b/packages/frontend/tests/services/api/agents.test.ts
@@ -34,9 +34,16 @@ describe('agents API client', () => {
   });
 
   it('getAgentInfo unwraps the { agent } envelope', async () => {
-    const fetchMock = setupFetch({ agent: { agent_name: 'a', display_name: 'A', agent_category: null, agent_platform: null } });
+    const fetchMock = setupFetch({
+      agent: { agent_name: 'a', display_name: 'A', agent_category: null, agent_platform: null },
+    });
     const out = await agents.getAgentInfo('a');
-    expect(out).toEqual({ agent_name: 'a', display_name: 'A', agent_category: null, agent_platform: null });
+    expect(out).toEqual({
+      agent_name: 'a',
+      display_name: 'A',
+      agent_category: null,
+      agent_platform: null,
+    });
     const url = fetchMock.mock.calls[0][0] as string;
     expect(url).toContain('/api/v1/agents/a');
   });
@@ -121,7 +128,13 @@ describe('agents API client', () => {
     const fetchMock = setupFetch({
       agent: { id: '1', name: 'demo-copy', display_name: 'Demo Copy' },
       apiKey: 'mnfst_new',
-      copied: { providers: 0, customProviders: 0, tierAssignments: 0, specificityAssignments: 0, modelParams: 0 },
+      copied: {
+        providers: 0,
+        customProviders: 0,
+        tierAssignments: 0,
+        specificityAssignments: 0,
+        modelParams: 0,
+      },
     });
     const out = await agents.duplicateAgent('demo', 'demo-copy');
     expect(out.agent.name).toBe('demo-copy');
@@ -141,13 +154,16 @@ describe('agents API client', () => {
         agent_platform: 'openclaw',
       },
       apiKey: 'mnfst_xxx',
+      copied: { globalProviders: 1 },
     });
     const out = await agents.createAgent({
       name: 'new-agent',
       agent_category: 'coding',
       agent_platform: 'openclaw',
+      global_provider_ids: ['provider-1'],
     });
     expect(out.agent.name).toBe('new-agent');
+    expect(out.copied?.globalProviders).toBe(1);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toContain('/api/v1/agents');
     expect((init as RequestInit).method).toBe('POST');
@@ -155,6 +171,7 @@ describe('agents API client', () => {
       name: 'new-agent',
       agent_category: 'coding',
       agent_platform: 'openclaw',
+      global_provider_ids: ['provider-1'],
     });
   });
 });

--- a/packages/frontend/tests/services/api/routing-extra.test.ts
+++ b/packages/frontend/tests/services/api/routing-extra.test.ts
@@ -42,6 +42,13 @@ describe('routing API client (additional coverage)', () => {
     expect(url).toContain('/api/v1/routing/demo/providers');
   });
 
+  it('getGlobalProviders GETs the tenant providers list', async () => {
+    const fetchMock = setupFetch([{ id: 'p1' }]);
+    await routing.getGlobalProviders();
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/providers');
+  });
+
   it('connectProvider POSTs the new provider record', async () => {
     const fetchMock = setupFetch({
       id: 'p1',
@@ -79,6 +86,59 @@ describe('routing API client (additional coverage)', () => {
     await routing.disconnectProvider('demo', 'openai', 'subscription');
     const url = fetchMock.mock.calls[0][0] as string;
     expect(url).toContain('authType=subscription');
+  });
+
+  it('connectGlobalProvider POSTs to the tenant providers endpoint', async () => {
+    const fetchMock = setupFetch({ id: 'p1', provider: 'openai' });
+    await routing.connectGlobalProvider({
+      provider: 'openai',
+      authType: 'api_key',
+      apiKey: 'sk-1',
+      label: 'Work',
+    });
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/providers');
+    expect((init as RequestInit).method).toBe('POST');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      provider: 'openai',
+      authType: 'api_key',
+      apiKey: 'sk-1',
+      label: 'Work',
+    });
+  });
+
+  it('disconnectGlobalProvider DELETEs with authType and label query params', async () => {
+    const fetchMock = setupFetch({ ok: true, notifications: [] });
+    await routing.disconnectGlobalProvider('openai', 'api_key', 'Work');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/providers/openai');
+    expect(url).toContain('authType=api_key');
+    expect(url).toContain('label=Work');
+    expect((init as RequestInit).method).toBe('DELETE');
+  });
+
+  it('renameGlobalProviderKey PATCHes the global key route', async () => {
+    const fetchMock = setupFetch({ id: 'p1', label: 'Work', priority: 0 });
+    await routing.renameGlobalProviderKey('openai', 'Default', 'Work', 'api_key');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/providers/openai/keys/Default');
+    expect((init as RequestInit).method).toBe('PATCH');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      newLabel: 'Work',
+      authType: 'api_key',
+    });
+  });
+
+  it('reorderGlobalProviderKeys PUTs ordered labels', async () => {
+    const fetchMock = setupFetch([{ id: 'p1', label: 'Work', priority: 0 }]);
+    await routing.reorderGlobalProviderKeys('openai', ['Work'], 'api_key');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/providers/openai/keys/order');
+    expect((init as RequestInit).method).toBe('PUT');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      labels: ['Work'],
+      authType: 'api_key',
+    });
   });
 
   it('copilotDeviceCode POSTs to the device-code endpoint', async () => {
@@ -183,6 +243,15 @@ describe('routing API client (additional coverage)', () => {
     await routing.refreshPricing();
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toContain('/api/v1/routing/pricing/refresh');
+    expect((init as RequestInit).method).toBe('POST');
+  });
+
+  it('refreshGlobalProviderModels POSTs the tenant provider refresh endpoint', async () => {
+    const fetchMock = setupFetch({ ok: true, model_count: 1, last_fetched_at: null, error: null });
+    await routing.refreshGlobalProviderModels('openai', 'api_key');
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain('/api/v1/providers/openai/refresh-models');
+    expect(url).toContain('authType=api_key');
     expect((init as RequestInit).method).toBe('POST');
   });
 

--- a/packages/frontend/tests/services/api/routing-extra.test.ts
+++ b/packages/frontend/tests/services/api/routing-extra.test.ts
@@ -231,6 +231,13 @@ describe('routing API client (additional coverage)', () => {
     expect(url).toContain('/api/v1/routing/demo/available-models');
   });
 
+  it('getGlobalAvailableModels GETs tenant available models', async () => {
+    const fetchMock = setupFetch([]);
+    await routing.getGlobalAvailableModels();
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain('/api/v1/routing/available-models');
+  });
+
   it('getPricingHealth GETs the pricing-health endpoint', async () => {
     const fetchMock = setupFetch({ model_count: 100, last_fetched_at: '2025-01-01' });
     await routing.getPricingHealth();

--- a/packages/frontend/tests/services/playground-store.test.ts
+++ b/packages/frontend/tests/services/playground-store.test.ts
@@ -341,6 +341,20 @@ describe('createPlaygroundStore', () => {
       expect(new Set(calls.map((c) => c.position))).toEqual(new Set([0, 1]));
     });
 
+    it('passes global scope for tenant playground stores', async () => {
+      const store = createPlaygroundStore('global', 'global');
+      store.addColumn('openai/gpt-4o-mini', 'openai', 'api_key', 'A');
+      streamPlaygroundMock.mockResolvedValue(okResult());
+      store.setPrompt('hi');
+
+      await store.runAll();
+
+      expect(streamPlaygroundMock.mock.calls[0][0]).toMatchObject({
+        agentName: 'global',
+        scope: 'global',
+      });
+    });
+
     it('does not append a late delta after the column was replaced', async () => {
       const store = createPlaygroundStore('demo');
       store.addColumn('openai/gpt-4o-mini', 'openai', 'api_key', 'A');
@@ -609,9 +623,7 @@ describe('createPlaygroundStore', () => {
       store.setPrompt('hi');
 
       let resolveFirst: ((v: unknown) => void) | null = null;
-      streamPlaygroundMock.mockImplementationOnce(
-        () => new Promise((res) => (resolveFirst = res)),
-      );
+      streamPlaygroundMock.mockImplementationOnce(() => new Promise((res) => (resolveFirst = res)));
       streamPlaygroundMock.mockImplementationOnce(async () => okResult({ content: 'second' }));
 
       const colId = store.columns[0]!.id;
@@ -955,9 +967,7 @@ describe('createPlaygroundStore', () => {
       store.addColumn('openai/gpt-4o-mini', 'openai', 'api_key', 'A');
       store.setPrompt('hi');
       let resolveStream: ((v: unknown) => void) | null = null;
-      streamPlaygroundMock.mockImplementation(
-        () => new Promise((res) => (resolveStream = res)),
-      );
+      streamPlaygroundMock.mockImplementation(() => new Promise((res) => (resolveStream = res)));
       const p = store.runAll();
       await Promise.resolve();
       expect(store.isAnyRunning()).toBe(true);


### PR DESCRIPTION
### ✨ What changed
- Added tenant `/playground` using global provider models and credentials.
- Added `/api/v1/routing/available-models` for global provider model lists.
- Let new agents copy selected global provider connections on create.
- Added tenant sidebar links for Providers and Playground.

### 💭 Why
Global providers need a place to test models before agents use them. Agent creation can now start with the same provider keys without manual reconnects.

### 👤 For users
Tenant users can manage global providers, test them, then prefill new agents with selected keys.

### 🔧 For operators
No new env vars. This stacks on #2131 and should be reviewed as commit `3ad98ab82` after #2131 lands.

### 📝 Notes
- Changeset: minor `manifest`.
- Validation: focused backend/frontend tests, backend/frontend builds, frontend typecheck, lint, prettier, diff check.
- Known baseline: `npm run check:api-prefix` still fails extracting the shared `API_KEY_PREFIX`.