### PR TITLE
feat: report provider usage by API key vs subscription

### DIFF
--- a/.changeset/provider-tokens-auth-type-breakdown.md
+++ b/.changeset/provider-tokens-auth-type-breakdown.md
@@ -1,0 +1,5 @@
+---
+'manifest': minor
+---
+
+Add a per-auth-type breakdown to the public `provider-tokens` endpoint. Each provider now carries an `auth_types` array (`{ auth_type, total_tokens, model_count }`) alongside the existing `models` list, so a provider that is used both with an API key and a subscription (e.g. OpenAI API key vs ChatGPT subscription) can be listed once per auth method. Usage with no recorded auth type is counted as `api_key`. The existing `provider`/`total_tokens`/`models` fields are unchanged, so the addition is backwards compatible.

--- a/packages/backend/src/public-stats/public-stats.controller.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.controller.spec.ts
@@ -202,6 +202,7 @@ describe('PublicStatsController', () => {
             ],
           },
         ],
+        auth_types: [{ auth_type: 'api_key', total_tokens: 1100000, model_count: 1 }],
       },
     ];
 
@@ -212,6 +213,9 @@ describe('PublicStatsController', () => {
 
       expect(result.providers).toHaveLength(1);
       expect(result.providers[0].provider).toBe('OpenAI');
+      expect(result.providers[0].auth_types).toEqual([
+        { auth_type: 'api_key', total_tokens: 1100000, model_count: 1 },
+      ]);
       expect(result.cached_at).toBeDefined();
       expect(mockService.getProviderDailyTokens).toHaveBeenCalledTimes(1);
     });

--- a/packages/backend/src/public-stats/public-stats.service.spec.ts
+++ b/packages/backend/src/public-stats/public-stats.service.spec.ts
@@ -578,6 +578,63 @@ describe('PublicStatsService', () => {
       expect(subModel).toBeDefined();
       expect(subModel!.total_tokens).toBe(2000);
       expect(subModel!.total_cost).toBe(0);
+
+      // The provider is also broken down by auth type so the public site can
+      // list it once per auth method.
+      expect(result[0].auth_types).toContainEqual({
+        auth_type: 'api_key',
+        total_tokens: 3000,
+        model_count: 1,
+      });
+      expect(result[0].auth_types).toContainEqual({
+        auth_type: 'subscription',
+        total_tokens: 2000,
+        model_count: 1,
+      });
+    });
+
+    it('breaks a provider down by auth type, counting null usage as api_key', async () => {
+      setupProviderQuery([
+        { model: 'gpt-4o', date: '2026-04-07', tokens: '500', auth_type: null, cost: null },
+        {
+          model: 'gpt-4o-mini',
+          date: '2026-04-07',
+          tokens: '300',
+          auth_type: 'api_key',
+          cost: null,
+        },
+        {
+          model: 'gpt-4o',
+          date: '2026-04-07',
+          tokens: '2000',
+          auth_type: 'subscription',
+          cost: null,
+        },
+      ]);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
+
+      const result = await service.getProviderDailyTokens();
+
+      const apiKey = result[0].auth_types.find((a) => a.auth_type === 'api_key');
+      const sub = result[0].auth_types.find((a) => a.auth_type === 'subscription');
+      // gpt-4o (null → api_key) + gpt-4o-mini (api_key) collapse into one bucket.
+      expect(apiKey).toEqual({ auth_type: 'api_key', total_tokens: 800, model_count: 2 });
+      expect(sub).toEqual({ auth_type: 'subscription', total_tokens: 2000, model_count: 1 });
+      // Breakdown is sorted by token usage descending.
+      expect(result[0].auth_types[0].auth_type).toBe('subscription');
+    });
+
+    it('excludes zero-token models from auth_types model_count', async () => {
+      setupProviderQuery([
+        { model: 'gpt-4o', date: '2026-04-07', tokens: null, auth_type: 'api_key', cost: null },
+      ]);
+      mockPricingCache.getByModel.mockReturnValue(makePricingEntry({ provider: 'OpenAI' }));
+
+      const result = await service.getProviderDailyTokens();
+
+      expect(result[0].auth_types).toEqual([
+        { auth_type: 'api_key', total_tokens: 0, model_count: 0 },
+      ]);
     });
 
     it('returns null total_cost when all costs are null', async () => {

--- a/packages/backend/src/public-stats/public-stats.service.ts
+++ b/packages/backend/src/public-stats/public-stats.service.ts
@@ -62,10 +62,17 @@ export interface ModelBreakdown {
   daily: DailyModelTokens[];
 }
 
+export interface ProviderAuthBreakdown {
+  auth_type: string;
+  total_tokens: number;
+  model_count: number;
+}
+
 export interface ProviderDailyTokens {
   provider: string;
   total_tokens: number;
   models: ModelBreakdown[];
+  auth_types: ProviderAuthBreakdown[];
 }
 
 export interface AgentDailyTokens {
@@ -251,12 +258,19 @@ export class PublicStatsService {
       entry.daily.set(r.date, (entry.daily.get(r.date) ?? 0) + tokens);
     }
 
-    const providerMap = new Map<string, { total: number; models: ModelBreakdown[] }>();
+    const providerMap = new Map<
+      string,
+      {
+        total: number;
+        models: ModelBreakdown[];
+        authTotals: Map<string, { total: number; modelCount: number }>;
+      }
+    >();
 
     for (const [, entry] of modelMap) {
       let prov = providerMap.get(entry.provider);
       if (!prov) {
-        prov = { total: 0, models: [] };
+        prov = { total: 0, models: [], authTotals: new Map() };
         providerMap.set(entry.provider, prov);
       }
       prov.total += entry.total;
@@ -269,6 +283,20 @@ export class PublicStatsService {
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([date, tokens]) => ({ date, tokens })),
       });
+
+      // Break each provider's usage down by auth type so the public site can
+      // list a provider once per auth method (e.g. an OpenAI API-key card and a
+      // separate ChatGPT subscription card). Rows with no recorded auth type
+      // (older messages) are counted as API key, matching how the model table
+      // renders a null auth_type.
+      const authKey = entry.authType ?? 'api_key';
+      let auth = prov.authTotals.get(authKey);
+      if (!auth) {
+        auth = { total: 0, modelCount: 0 };
+        prov.authTotals.set(authKey, auth);
+      }
+      auth.total += entry.total;
+      if (entry.total > 0) auth.modelCount += 1;
     }
 
     return Array.from(providerMap.entries())
@@ -277,6 +305,13 @@ export class PublicStatsService {
         provider,
         total_tokens: data.total,
         models: data.models.sort((a, b) => b.total_tokens - a.total_tokens),
+        auth_types: Array.from(data.authTotals.entries())
+          .map(([auth_type, totals]) => ({
+            auth_type,
+            total_tokens: totals.total,
+            model_count: totals.modelCount,
+          }))
+          .sort((a, b) => b.total_tokens - a.total_tokens),
       }));
   }
 


### PR DESCRIPTION
### 💭 Why
The public providers page lists each provider once and can't tell API-key usage from subscription usage. OpenAI on Manifest is both: GPT via API key and ChatGPT via subscription. The data already records auth type per message, but the endpoint collapsed it at the provider level.

### ✨ What changed
- Each provider in /api/v1/public/provider-tokens gains an `auth_types` array: `{ auth_type, total_tokens, model_count }`.
- Usage with no recorded auth type counts as `api_key`.
- Breakdown is sorted by token usage, descending.
- Existing `provider`, `total_tokens`, and `models` fields are untouched, so the change is backwards compatible.

### 🔧 For operators
No migration. Additive field on an existing public endpoint.

### 📝 Notes
Lets the public site group providers by API key vs subscription. Paired with mnfst/website#162.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an auth-type breakdown to public provider usage so you can see API-key vs subscription tokens per provider. Existing `provider`, `total_tokens`, and `models` fields are unchanged; this is backward compatible.

- New Features
  - Providers in `GET /api/v1/public/provider-tokens` now include `auth_types`: `{ auth_type, total_tokens, model_count }`.
  - Null or missing auth type counts as `api_key`.
  - `auth_types` is sorted by `total_tokens` (desc); zero-token models do not increment `model_count`.

<sup>Written for commit a29a7057552be32c1e7bbef007fbc2bf589d63f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

