### PR TITLE
feat: sync manifest subscription model lists (2026-06-06)

### DIFF
--- a/packages/shared/src/subscription/configs.ts
+++ b/packages/shared/src/subscription/configs.ts
@@ -166,10 +166,14 @@ export const SUBSCRIPTION_PROVIDER_CONFIGS: Readonly<
     knownModels: Object.freeze([
       'glm-5.1',
       'glm-5-turbo',
+      'glm-5v-turbo',
       'glm-5',
       'glm-4.7',
+      'glm-4.7-flash',
       'glm-4.6',
+      'glm-4.6v',
       'glm-4.5',
+      'glm-4.5v',
       'glm-4.5-air',
     ]),
     subscriptionCapabilities: Object.freeze({


### PR DESCRIPTION
Auto-generated by the modelparams agent. Codex reconciled subscription `knownModels` against today's provider discovery. Prices (models.dev) and parameters (modelparams.dev) are out of scope.

New subscription models: xai/grok-4.20-0309-non-reasoning, xai/grok-4.20-0309-reasoning, xai/grok-4.3, xai/grok-build-0.1, zai/glm-5v-turbo, zai/glm-4.7-flash, zai/glm-4.6v, zai/glm-4.5v, zai/glm-4.5-air:free
(134 new api_key models auto-discovered, not listed.)

Draft PR — please review the model list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synced subscription `knownModels` with the latest provider discovery to keep manifests accurate. Added `glm-5v-turbo`, `glm-4.7-flash`, `glm-4.6v`, and `glm-4.5v` to the `zai` provider list.

<sup>Written for commit c5ab6ceb369d9e6482021c6b35c933adaec1dedb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

