### PR TITLE
fix: add opencode-zen, xiaomi, nvidia to STREAMING_ENDPOINT_PROVIDERS

### DIFF
--- a/packages/backend/src/model-discovery/model-capabilities.ts
+++ b/packages/backend/src/model-discovery/model-capabilities.ts
@@ -24,13 +24,16 @@ const STREAMING_ENDPOINT_PROVIDERS = new Set([
   'minimax',
   'mistral',
   'moonshot',
+  'nvidia',
   'ollama',
   'ollama-cloud',
   'openai',
   'opencode-go',
+  'opencode-zen',
   'openrouter',
   'qwen',
   'xai',
+  'xiaomi',
   'zai',
 ]);
 


### PR DESCRIPTION
## Problem

The `response-mode-guard` silently drops routes from providers not in `STREAMING_ENDPOINT_PROVIDERS` when a tier uses `response_mode: stream`. For users routing through opencode-zen or xiaomi, this means their primary and fallback models are filtered out at runtime with no warning, and the first stream-capable fallback gets silently promoted — which is confusing and defeats the purpose of having fallback chains.

Specifically:

- **opencode-zen** (MiniMax M3, Qwen 3.6 Plus, etc.) — filtered out
- **xiaomi** (MiMo-V2.5, MiMo-V2.5-Pro) — filtered out
- **nvidia** (Nemotron 3 Ultra, Nemotron 3 Super, etc.) — filtered out

All three providers support SSE streaming. Their entries in `PROVIDER_ENDPOINTS` (`provider-endpoints.ts`) already include `...openaiStreamUsage`, which configures the proxy to request `stream_options.include_usage` for streaming responses.

## Fix

Add `'opencode-zen'`, `'xiaomi'`, and `'nvidia'` to the `STREAMING_ENDPOINT_PROVIDERS` set in `model-capabilities.ts`.

## Related

- A PR to add the nvidia provider to modelparams.dev: [mnfst/modelparams.dev#48](https://github.com/mnfst/modelparams.dev/pull/48)
- `PROVIDER_ENDPOINTS` entries for xiaomi-subscription (L246-250), opencode-zen (L419-424), and nvidia (L267-272) in `provider-endpoints.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `opencode-zen`, `xiaomi`, and `nvidia` to `STREAMING_ENDPOINT_PROVIDERS` so streaming tiers route correctly instead of being dropped by `response-mode-guard`. All three support SSE via OpenAI‑compatible chat completions; no other changes.

<sup>Written for commit 14eb3809b4f5566d35bccee3f6eed70a7223ef59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


