### PR TITLE
feat(backend): make HTTP body parser limit configurable via BODY_PARSER_LIMIT

### DIFF
--- a/.changeset/configurable-body-parser-limit.md
+++ b/.changeset/configurable-body-parser-limit.md
@@ -1,0 +1,14 @@
+---
+'manifest': patch
+---
+
+feat: make HTTP body parser limit configurable via `BODY_PARSER_LIMIT`
+
+Self-hosted operators routing to long-context models (1M-token windows on
+Claude / Gemini, etc.) hit the hardcoded 1MB request cap before they can
+fill the model's actual context. Add a `BODY_PARSER_LIMIT` env var that
+overrides the limit on both `express.json` and `express.urlencoded`.
+
+The default stays `1mb`, so cloud and existing self-hosted deployments are
+unaffected. Accepts any value the `bytes` module understands (`5mb`,
+`20mb`, `100kb`, …).

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -357,7 +357,7 @@ sets this automatically).
 | `OLLAMA_HOST`        | No       | `http://host.docker.internal:11434` | Ollama endpoint for the built-in tile. Override to point at a LAN-hosted Ollama. |
 | `MANIFEST_MODE`      | No       | auto (Docker → selfhosted) | `selfhosted` or `cloud`. `local` is a legacy alias. Self-hosted mode allows private/http URLs for custom providers. |
 | `MANIFEST_TELEMETRY_DISABLED` | No | `0`               | Set `1` to disable anonymous usage telemetry  |
-| `BODY_PARSER_LIMIT`  | No       | `1mb`                   | Max request body size for `/v1` routes. Lift when routing to long-context models (e.g. `5mb`, `20mb`). |
+| `BODY_PARSER_LIMIT`  | No       | `1mb`                   | Max request body size. Applied globally (except auth routes). Lift when routing to long-context models (e.g. `5mb`, `20mb`). |
 
 Full env var reference: [github.com/mnfst/manifest](https://github.com/mnfst/manifest)
 

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -357,6 +357,7 @@ sets this automatically).
 | `OLLAMA_HOST`        | No       | `http://host.docker.internal:11434` | Ollama endpoint for the built-in tile. Override to point at a LAN-hosted Ollama. |
 | `MANIFEST_MODE`      | No       | auto (Docker → selfhosted) | `selfhosted` or `cloud`. `local` is a legacy alias. Self-hosted mode allows private/http URLs for custom providers. |
 | `MANIFEST_TELEMETRY_DISABLED` | No | `0`               | Set `1` to disable anonymous usage telemetry  |
+| `BODY_PARSER_LIMIT`  | No       | `1mb`                   | Max request body size for `/v1` routes. Lift when routing to long-context models (e.g. `5mb`, `20mb`). |
 
 Full env var reference: [github.com/mnfst/manifest](https://github.com/mnfst/manifest)
 

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -34,6 +34,12 @@ BETTER_AUTH_URL=http://localhost:3001
 # Set strictly below your client's timeout so the fallback chain has room to run.
 # PROVIDER_TIMEOUT_MS=180000
 
+# Maximum HTTP request body size for /v1 routes (json + urlencoded). The 1mb
+# default fits typical chat completions; lift it when routing to long-context
+# models (large message histories, big tool definitions) exceed the cap.
+# Accepts any value the bytes module understands ('5mb', '20mb', '100kb', etc.).
+# BODY_PARSER_LIMIT=1mb
+
 # ── Email provider (optional, unified) ──────────────
 # Used for BOTH Better Auth transactional emails (login verification,
 # password reset) and threshold alert notifications when no per-user

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -34,9 +34,11 @@ BETTER_AUTH_URL=http://localhost:3001
 # Set strictly below your client's timeout so the fallback chain has room to run.
 # PROVIDER_TIMEOUT_MS=180000
 
-# Maximum HTTP request body size for /v1 routes (json + urlencoded). The 1mb
-# default fits typical chat completions; lift it when routing to long-context
-# models (large message histories, big tool definitions) exceed the cap.
+# Maximum HTTP request body size (applied globally to express.json and
+# express.urlencoded; auth routes mount a raw handler first and are unaffected).
+# The 1mb default fits typical chat completions; lift it when routing to
+# long-context models (large message histories, big tool definitions) exceed
+# the cap.
 # Accepts any value the bytes module understands ('5mb', '20mb', '100kb', etc.).
 # BODY_PARSER_LIMIT=1mb
 

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -186,9 +186,14 @@ export async function bootstrap() {
   const { toNodeHandler } = await import('better-auth/node');
   expressApp.all('/api/auth/*splat', toNodeHandler(auth));
 
-  // Re-add body parsing for NestJS routes
-  expressApp.use(express.json({ limit: '1mb' }));
-  expressApp.use(express.urlencoded({ extended: true, limit: '1mb' }));
+  // Re-add body parsing for NestJS routes. The 1mb default matches the
+  // body-parser default and is enough for normal chat completions. Self-hosted
+  // operators routing to long-context models (e.g. 1M-token windows) can lift
+  // this cap with BODY_PARSER_LIMIT (any value accepted by the bytes module:
+  // '5mb', '20mb', '100kb', etc.).
+  const bodyLimit = process.env['BODY_PARSER_LIMIT'] ?? '1mb';
+  expressApp.use(express.json({ limit: bodyLimit }));
+  expressApp.use(express.urlencoded({ extended: true, limit: bodyLimit }));
 
   const port = Number(process.env['PORT'] ?? 3001);
   const host = process.env['BIND_ADDRESS'] ?? '127.0.0.1';


### PR DESCRIPTION
## Summary

Make the Express body parser limit configurable via a new `BODY_PARSER_LIMIT` env var. Default stays `'1mb'` — no behavior change for cloud or existing self-hosted deployments. Operators routing to long-context models can opt in to a larger cap.

## Motivation

The current `'1mb'` hardcode in `packages/backend/src/main.ts` matches the [body-parser default](https://github.com/expressjs/body-parser#limit) and is plenty for typical chat completions. It becomes a hard ceiling when self-hosted users route to long-context models (Claude 4 1M, Gemini 1.5 Pro 1M/2M, etc.):

| Context window | Realistic 1MB body capacity | Effective ceiling |
| --- | --- | --- |
| 128K | well below limit | ✅ no issue |
| 200K | well below limit | ✅ no issue |
| 512K | ~50–60% of window | ⚠️ occasional 413s |
| 1M+ | ~25–30% of window | 🔴 blocks the use case |

A 1MB JSON body lands somewhere between **~210K tokens** (English prose) and **~340K tokens** (Chinese / mixed) in real-world agent traffic (messages + tool definitions + JSON tool-call args). With Claude Opus 4 1M, that ceiling is hit well before the model's actual capacity, even in single-turn requests with a large `messages` array.

## Why not just raise the default?

Cloud-hosted operators have legitimate reasons to keep a tight cap (DoS surface, OOM exposure on JSON.parse, cost amplification, DB write pressure on `llm_calls` / `message_recordings`). Bumping the default would silently weaken that floor for every deployment.

An env-driven override solves the self-hosted use case without changing cloud defaults — exactly the same pattern as the existing `PROVIDER_TIMEOUT_MS`, `THROTTLE_LIMIT` / `THROTTLE_TTL`, and `DB_POOL_MAX` knobs.

## Changes

- **`packages/backend/src/main.ts`** — read `BODY_PARSER_LIMIT` env var with `'1mb'` fallback, apply to both `express.json` and `express.urlencoded` (kept in sync — current behavior). Inline comment explains the knob.
- **`packages/backend/.env.example`** — document the new var in the `LLM Proxy` section, next to `PROVIDER_TIMEOUT_MS`.
- **`docker/DOCKER_README.md`** — add row to the env var table.
- **`.changeset/configurable-body-parser-limit.md`** — patch-level changeset.

Diff: **+29 / -3 lines**, no new dependencies, no test additions needed (no existing `main.spec.ts` covers `bootstrap()`; behavior is exercised by the existing e2e suite which boots the app and continues to pass with the unchanged default).

## Testing

Verified locally on a self-hosted deployment running this branch built from the same `docker/Dockerfile`:

| Body size | Default (`1mb`) | With `BODY_PARSER_LIMIT=20mb` |
| --- | --- | --- |
| 0.47 MB | ✅ 200 OK | ✅ 200 OK |
| 1.42 MB | ❌ rejected | ✅ 200 OK, `prompt_tokens=675020` |
| 1.70 MB | ❌ rejected | ✅ 200 OK, `prompt_tokens=810020` |

Body parser accepts any value the [`bytes` module](https://github.com/visionmedia/bytes.js#bytesparsestringnumber-value) understands (`'5mb'`, `'20mb'`, `'100kb'`, …) since that's what `body-parser` delegates to.

## Out of scope

- Returning a proper `413 Payload Too Large` JSON instead of the current Express HTML / proxy 404. Happy to send as a follow-up if maintainers want it; keeping this PR single-purpose.
- Differentiating limits per route (e.g. higher for `/v1/chat/completions`, lower elsewhere). The single env var matches the current single-limit setup; can be revisited if needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the HTTP body size limit configurable via `BODY_PARSER_LIMIT`, applied globally to all Express routes (auth routes are unaffected). Default stays `1mb`; raise it when needed for long-context models (e.g., `5mb`, `20mb`).

- **New Features**
  - Read `BODY_PARSER_LIMIT` in `packages/backend/src/main.ts` and apply to `express.json` and `express.urlencoded` globally; auth routes bypass this.
  - Documented in `packages/backend/.env.example` and `docker/DOCKER_README.md`.
  - Accepts any `bytes`-style value.

- **Migration**
  - Self-hosted: set `BODY_PARSER_LIMIT=<size>` to lift the cap; otherwise no action.

<sup>Written for commit f3d5aad6612f2999b6d07ce56fa17f32ec519609. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

