### PR TITLE
fix: strip exclusive bounds from Gemini tool schemas

### DIFF
--- a/.changeset/google-exclusive-schema-bounds.md
+++ b/.changeset/google-exclusive-schema-bounds.md
@@ -1,0 +1,5 @@
+---
+'manifest': patch
+---
+
+Strip unsupported `exclusiveMinimum` and `exclusiveMaximum` JSON Schema fields from Google/Gemini tool declarations so function-calling requests do not fail validation.

--- a/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts
@@ -161,6 +161,7 @@ describe('Google Adapter', () => {
                 type: 'object',
                 properties: {
                   name: { type: 'string', title: 'Name', default: 'foo' },
+                  count: { type: 'integer', minimum: 0, exclusiveMinimum: true },
                   config: {
                     type: 'object',
                     additionalProperties: true,
@@ -190,14 +191,61 @@ describe('Google Adapter', () => {
       const props = params.properties as Record<string, Record<string, unknown>>;
       expect(props.name).not.toHaveProperty('title');
       expect(props.name).not.toHaveProperty('default');
+      expect(props.count).not.toHaveProperty('exclusiveMinimum');
       expect(props.config).not.toHaveProperty('additionalProperties');
       expect(props.config).not.toHaveProperty('patternProperties');
 
       // Supported fields preserved
       expect(params.type).toBe('object');
       expect(props.name.type).toBe('string');
+      expect(props.count).toEqual({ type: 'integer', minimum: 0 });
       expect(props.config.type).toBe('object');
       expect(props.config.properties).toEqual({ key: { type: 'string' } });
+    });
+
+    it('strips exclusive numeric bounds without removing same-named properties', () => {
+      const body = {
+        messages: [{ role: 'user', content: 'Set limits' }],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'set_limits',
+              parameters: {
+                type: 'object',
+                properties: {
+                  threshold: {
+                    type: 'number',
+                    minimum: 0,
+                    maximum: 1,
+                    exclusiveMinimum: true,
+                    exclusiveMaximum: false,
+                  },
+                  exclusiveMinimum: {
+                    type: 'string',
+                    description: 'A user-defined property name',
+                  },
+                },
+              },
+            },
+          },
+        ],
+      };
+      const result = toGoogleRequest(body, 'gemini-2.5-flash');
+
+      const tools = result.tools as Array<{
+        functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+      }>;
+      const props = tools[0].functionDeclarations[0].parameters.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+
+      expect(props.threshold).toEqual({ type: 'number', minimum: 0, maximum: 1 });
+      expect(props.exclusiveMinimum).toEqual({
+        type: 'string',
+        description: 'A user-defined property name',
+      });
     });
 
     it('strips both $ref and the non-standard dollar-less ref variant', () => {

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -3439,6 +3439,51 @@ describe('ProviderClient', () => {
       expect(result.isCodeAssist).toBe(true);
     });
 
+    it('sanitizes tool schemas inside the CodeAssist envelope for gemini subscription', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'gemini',
+        apiKey: 'access-token',
+        model: 'gemini-2.5-pro',
+        body: {
+          messages: [{ role: 'user', content: 'Set a threshold' }],
+          tools: [
+            {
+              type: 'function',
+              function: {
+                name: 'set_threshold',
+                parameters: {
+                  type: 'object',
+                  properties: {
+                    threshold: {
+                      type: 'number',
+                      minimum: 0,
+                      exclusiveMinimum: true,
+                      exclusiveMaximum: false,
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        stream: false,
+        authType: 'subscription',
+        providerResource: 'proj-code-assist-999',
+      });
+
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      const tools = sentBody.request.tools as Array<{
+        functionDeclarations: Array<{ parameters: Record<string, unknown> }>;
+      }>;
+      const props = tools[0].functionDeclarations[0].parameters.properties as Record<
+        string,
+        Record<string, unknown>
+      >;
+      expect(props.threshold).toEqual({ type: 'number', minimum: 0 });
+    });
+
     it('uses the non-stream generateContent path for non-streaming requests', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/google-adapter.ts
+++ b/packages/backend/src/routing/proxy/google-adapter.ts
@@ -73,6 +73,8 @@ const UNSUPPORTED_SCHEMA_FIELDS = new Set([
   'default',
   'const',
   'title',
+  'exclusiveMinimum',
+  'exclusiveMaximum',
 ]);
 
 function sanitizeSchema(schema: unknown, isPropertiesMap = false): unknown {


### PR DESCRIPTION
## Summary

Closes #2137.

Google/Gemini tool schema sanitization already removed several JSON Schema keywords that Gemini rejects, but it still let `exclusiveMinimum` and `exclusiveMaximum` through. Gemini validates function declarations before generation, so schemas produced by common tooling can fail with errors like `Unknown name "exclusiveMinimum"` before any model call succeeds.

This adds those two fields to the unsupported schema keyword strip list, while preserving user-defined property names that happen to collide with schema keywords.

## Testing

Red/green repro:
- Reproduced on upstream `main` with a throwaway regression spec: the generated Google schema still included `exclusiveMinimum` / `exclusiveMaximum`.
- Verified this branch removes those fields and keeps same-named user properties intact.

Validation:
- `npm run lint` (passes; repo has existing warnings)
- `npm run build`
- `npm --workspace packages/backend test -- google-adapter.spec.ts`
- `npm --workspace packages/backend test -- provider-client.spec.ts`
- `npx prettier --check packages/backend/src/routing/proxy/google-adapter.ts packages/backend/src/routing/proxy/__tests__/google-adapter.spec.ts packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts .changeset/google-exclusive-schema-bounds.md`
- `npx changeset status`
- `git diff --check`

Note: I did not need a live Gemini subscription to validate the root failure mode; the subscription CodeAssist envelope path is covered with a mocked provider-client regression that inspects the forwarded request body.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip unsupported JSON Schema fields `exclusiveMinimum` and `exclusiveMaximum` from Gemini tool/function schemas to prevent validation failures before generation. Preserves same-named user properties and fulfills #2137.

- **Bug Fixes**
  - Added these fields to the `google-adapter` schema sanitizer.
  - Covered both direct tool declarations and the CodeAssist subscription envelope.
  - Tests ensure numeric bounds are kept while keyword collisions remain intact.

<sup>Written for commit 09a73799a7f4f30f7da408c6e7f84328325a7ae9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

