### PR TITLE
feat: tabbed agent detail with unified global sidebar

### DIFF
--- a/.changeset/agent-tabbed-shell.md
+++ b/.changeset/agent-tabbed-shell.md
@@ -2,4 +2,4 @@
 "manifest": patch
 ---
 
-Restructure agent detail view into a horizontal-tabbed shell (Overview / Routing / Guardrails / Settings) with back-link navigation.
+Restructure agent detail view into a horizontal-tabbed shell (Overview / Routing / Guardrails / Settings) with back-link navigation. Unify sidebar to a single global nav (Overview / Messages / Agents) rendered identically on every authenticated route; remove the agent-scoped MONITORING/MANAGE/RESOURCES sub-nav.

--- a/.changeset/agent-tabbed-shell.md
+++ b/.changeset/agent-tabbed-shell.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Restructure agent detail view into a horizontal-tabbed shell (Overview / Routing / Guardrails / Settings) with back-link navigation.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -35,12 +35,11 @@ const SseConnector: ParentComponent = (props) => {
 const AppInner: ParentComponent = (props) => {
   const location = useLocation();
   const [mobileNavOpen, setMobileNavOpen] = createSignal(false);
-  const isAgentMode = () => location.pathname.startsWith('/agents/');
-  const isGlobalRoute = () =>
-    location.pathname === '/overview' ||
-    location.pathname === '/messages' ||
-    location.pathname === '/agents';
-  const showSidebar = () => isAgentMode() || isGlobalRoute();
+  // The sidebar is global and rendered identically on every authenticated
+  // route. Guest/setup routes never reach this component, so we show the
+  // sidebar everywhere except the root redirect ("/") which navigates away
+  // immediately and needs no nav chrome.
+  const showSidebar = () => location.pathname !== '/';
   const { content: rightSidebar } = useRightSidebar();
 
   createEffect<string | undefined>((previousPath) => {

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -1,23 +1,25 @@
 import { A, useLocation } from '@solidjs/router';
-import { Show, type Component } from 'solid-js';
-import { useAgentName, agentPath } from '../services/routing.js';
+import type { Component } from 'solid-js';
 
 interface SidebarProps {
   mobileOpen?: boolean;
   onNavigate?: () => void;
 }
 
+/**
+ * Returns true when the given route matches the current location either
+ * exactly or as a path prefix (so `/agents` stays active on `/agents/:name/*`).
+ */
+function makeIsGlobalActive(pathname: () => string) {
+  return (route: string): boolean => {
+    const p = pathname();
+    return p === route || p.startsWith(route + '/');
+  };
+}
+
 const Sidebar: Component<SidebarProps> = (props) => {
   const location = useLocation();
-  const getAgentName = useAgentName();
-
-  const path = (sub: string) => agentPath(getAgentName(), sub);
-
-  const isActive = (sub: string) => {
-    const p = path(sub);
-    if (sub === '') return location.pathname === p;
-    return location.pathname.startsWith(p);
-  };
+  const isGlobalActive = makeIsGlobalActive(() => location.pathname);
 
   return (
     <nav
@@ -32,119 +34,30 @@ const Sidebar: Component<SidebarProps> = (props) => {
         }
       }}
     >
-      <Show when={!getAgentName()}>
-        <A
-          href="/overview"
-          class="sidebar__link"
-          classList={{ active: location.pathname === '/overview' }}
-          aria-current={location.pathname === '/overview' ? 'page' : undefined}
-        >
-          Overview
-        </A>
-        <A
-          href="/messages"
-          class="sidebar__link"
-          classList={{ active: location.pathname === '/messages' }}
-          aria-current={location.pathname === '/messages' ? 'page' : undefined}
-        >
-          Messages
-        </A>
-        <A
-          href="/agents"
-          class="sidebar__link"
-          classList={{ active: location.pathname === '/agents' }}
-          aria-current={location.pathname === '/agents' ? 'page' : undefined}
-        >
-          Agents
-        </A>
-      </Show>
-
-      <Show when={getAgentName()}>
-        <div class="sidebar__section-label">MONITORING</div>
-        <A
-          href={path('')}
-          class="sidebar__link"
-          classList={{ active: isActive('') }}
-          aria-current={isActive('') ? 'page' : undefined}
-        >
-          Overview
-        </A>
-        <A
-          href={path('/messages')}
-          class="sidebar__link"
-          classList={{ active: isActive('/messages') }}
-          aria-current={isActive('/messages') ? 'page' : undefined}
-        >
-          Messages
-        </A>
-
-        <div class="sidebar__section-label">MANAGE</div>
-        <A
-          href={path('/routing')}
-          class="sidebar__link"
-          classList={{ active: isActive('/routing') }}
-          aria-current={isActive('/routing') ? 'page' : undefined}
-        >
-          Routing
-        </A>
-        <A
-          href={path('/playground')}
-          class="sidebar__link"
-          classList={{ active: isActive('/playground') }}
-          aria-current={isActive('/playground') ? 'page' : undefined}
-        >
-          Playground
-        </A>
-        <A
-          href={path('/limits')}
-          class="sidebar__link"
-          classList={{ active: isActive('/limits') }}
-          aria-current={isActive('/limits') ? 'page' : undefined}
-        >
-          Limits
-        </A>
-        <A
-          href={path('/settings')}
-          class="sidebar__link"
-          classList={{ active: isActive('/settings') }}
-          aria-current={isActive('/settings') ? 'page' : undefined}
-        >
-          Settings
-        </A>
-      </Show>
-
-      <Show when={getAgentName()}>
-        <div class="sidebar__section-label">RESOURCES</div>
-        <A
-          href={path('/model-prices')}
-          class="sidebar__link"
-          classList={{ active: isActive('/model-prices') }}
-          aria-current={isActive('/model-prices') ? 'page' : undefined}
-        >
-          Model Prices
-        </A>
-        <A
-          href={path('/free-models')}
-          class="sidebar__link"
-          classList={{ active: isActive('/free-models') }}
-          aria-current={isActive('/free-models') ? 'page' : undefined}
-        >
-          <img
-            src="/icons/free.svg"
-            alt="Free Models"
-            style="height: 12px; vertical-align: middle;"
-          />{' '}
-          Models
-        </A>
-        <A
-          href={path('/help')}
-          class="sidebar__link"
-          classList={{ active: isActive('/help') }}
-          aria-current={isActive('/help') ? 'page' : undefined}
-        >
-          Help
-        </A>
-      </Show>
+      <A
+        href="/overview"
+        class="sidebar__link"
+        classList={{ active: isGlobalActive('/overview') }}
+        aria-current={isGlobalActive('/overview') ? 'page' : undefined}
+      >
+        Overview
+      </A>
+      <A
+        href="/messages"
+        class="sidebar__link"
+        classList={{ active: isGlobalActive('/messages') }}
+        aria-current={isGlobalActive('/messages') ? 'page' : undefined}
+      >
+        Messages
+      </A>
+      <A
+        href="/agents"
+        class="sidebar__link"
+        classList={{ active: isGlobalActive('/agents') }}
+        aria-current={isGlobalActive('/agents') ? 'page' : undefined}
+      >
+        Agents
+      </A>
 
       <div class="sidebar__spacer" />
 

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -71,7 +71,7 @@ render(
             <Route path="/limits" component={AgentLimitsRedirect} />
             <Route path="/messages" component={AgentMessagesRedirect} />
 
-            {/* Tabbed shell wraps Overview / Routing / Guardrails / Settings */}
+            {/* Tabbed shell wraps Overview / Routing / Limits / Settings */}
             <Route path="/" component={AgentDetail}>
               <Route path="/" component={AgentOverview} />
               <Route path="/overview" component={AgentOverview} />

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -17,7 +17,10 @@ import './styles/theme.css';
 clearReloadFlag();
 
 const GlobalOverview = lazyReload(() => import('./pages/GlobalOverview.jsx'));
-const Overview = lazyReload(() => import('./pages/Overview.jsx'));
+const AgentDetail = lazyReload(() => import('./pages/AgentDetail.jsx'));
+const AgentOverview = lazyReload(() => import('./pages/AgentOverview.jsx'));
+const AgentLimitsRedirect = lazyReload(() => import('./pages/AgentLimitsRedirect.jsx'));
+const AgentMessagesRedirect = lazyReload(() => import('./pages/AgentMessagesRedirect.jsx'));
 const MessageLog = lazyReload(() => import('./pages/MessageLog.jsx'));
 const Settings = lazyReload(() => import('./pages/Settings.jsx'));
 const Routing = lazyReload(() => import('./pages/Routing.jsx'));
@@ -64,15 +67,23 @@ render(
           <Route path="/messages" component={MessageLog} />
           <Route path="/agents" component={Workspace} />
           <Route path="/agents/:agentName" component={AgentGuard}>
-            <Route path="/" component={Overview} />
-            <Route path="/messages" component={MessageLog} />
-            <Route path="/settings/*" component={Settings} />
-            <Route path="/routing" component={Routing} />
+            {/* Redirects: /limits → /guardrails, /messages → global /messages */}
+            <Route path="/limits" component={AgentLimitsRedirect} />
+            <Route path="/messages" component={AgentMessagesRedirect} />
+
+            {/* Tabbed shell wraps Overview / Routing / Guardrails / Settings */}
+            <Route path="/" component={AgentDetail}>
+              <Route path="/" component={AgentOverview} />
+              <Route path="/overview" component={AgentOverview} />
+              <Route path="/routing" component={Routing} />
+              <Route path="/guardrails" component={Limits} />
+              <Route path="/settings/*" component={Settings} />
+            </Route>
+
+            {/* Non-tab agent routes: kept reachable but not primary tabs */}
             <Route path="/playground" component={Playground} />
-            <Route path="/limits" component={Limits} />
             <Route path="/model-prices" component={ModelPrices} />
             <Route path="/free-models" component={FreeModels} />
-
             <Route path="/help" component={Help} />
           </Route>
           <Route path="/connect-provider" component={ConnectProvider} />

--- a/packages/frontend/src/pages/AgentDetail.tsx
+++ b/packages/frontend/src/pages/AgentDetail.tsx
@@ -9,7 +9,7 @@ import { agentDisplayName } from '../services/agent-display-name.js';
  * AgentDetail — horizontal-tabbed shell for the agent detail view.
  *
  * Renders a header (back-link to /agents + agent display name) and a
- * horizontal tab bar (Overview / Routing / Guardrails / Settings). Child
+ * horizontal tab bar (Overview / Routing / Limits / Settings). Child
  * routes render in the body via props.children (SolidJS nested <Route>).
  */
 const AgentDetail: ParentComponent = (props) => {
@@ -78,7 +78,7 @@ const AgentDetail: ParentComponent = (props) => {
           class="panel__tab"
           classList={{ 'panel__tab--active': isActive('/guardrails') }}
         >
-          Guardrails
+          Limits
         </A>
         <A
           href={path('/settings')}

--- a/packages/frontend/src/pages/AgentDetail.tsx
+++ b/packages/frontend/src/pages/AgentDetail.tsx
@@ -3,6 +3,7 @@ import { Show, type ParentComponent } from 'solid-js';
 import { Title } from '@solidjs/meta';
 import { agentPath } from '../services/routing.js';
 import { agentPlatformIcon } from '../services/agent-platform-store.js';
+import { agentDisplayName } from '../services/agent-display-name.js';
 
 /**
  * AgentDetail — horizontal-tabbed shell for the agent detail view.
@@ -31,7 +32,7 @@ const AgentDetail: ParentComponent = (props) => {
 
   return (
     <div class="container--lg">
-      <Title>{agentName()} | Manifest</Title>
+      <Title>{agentDisplayName() ?? agentName()} | Manifest</Title>
 
       <div style="margin-bottom: 8px;">
         <A
@@ -46,7 +47,7 @@ const AgentDetail: ParentComponent = (props) => {
           <img src={agentPlatformIcon()!} alt="" width="28" height="28" style="flex-shrink: 0;" />
         </Show>
         <h1 class="page-header__title" style="margin: 0;">
-          {agentName()}
+          {agentDisplayName() ?? agentName()}
         </h1>
       </div>
 

--- a/packages/frontend/src/pages/AgentDetail.tsx
+++ b/packages/frontend/src/pages/AgentDetail.tsx
@@ -1,14 +1,15 @@
 import { A, useLocation, useParams } from '@solidjs/router';
-import { type ParentComponent } from 'solid-js';
+import { type ParentComponent, Show } from 'solid-js';
 import { Title } from '@solidjs/meta';
 import { agentPath } from '../services/routing.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
+import { agentPlatformIcon } from '../services/agent-platform-store.js';
 
 /**
  * AgentDetail — horizontal-tabbed shell for the agent detail view.
  *
- * Renders a header (back-link to /agents + agent display name) and a
- * horizontal tab bar (Overview / Routing / Limits / Settings). Child
+ * Renders a header (back-link to /agents + platform icon + agent display name)
+ * and a horizontal tab bar (Overview / Routing / Limits / Settings). Child
  * routes render in the body via props.children (SolidJS nested <Route>).
  */
 const AgentDetail: ParentComponent = (props) => {
@@ -40,6 +41,15 @@ const AgentDetail: ParentComponent = (props) => {
         >
           ← Agents
         </A>
+      </div>
+
+      <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 0;">
+        <Show when={agentPlatformIcon()}>
+          <img src={agentPlatformIcon()!} alt="" width="28" height="28" style="flex-shrink: 0;" />
+        </Show>
+        <h1 class="page-header__title" style="margin: 0;">
+          {agentDisplayName() ?? agentName()}
+        </h1>
       </div>
 
       {/* Horizontal tabs */}

--- a/packages/frontend/src/pages/AgentDetail.tsx
+++ b/packages/frontend/src/pages/AgentDetail.tsx
@@ -1,0 +1,100 @@
+import { A, useLocation, useParams } from '@solidjs/router';
+import { Show, type ParentComponent } from 'solid-js';
+import { Title } from '@solidjs/meta';
+import { agentPath } from '../services/routing.js';
+import { agentPlatformIcon } from '../services/agent-platform-store.js';
+
+/**
+ * AgentDetail — horizontal-tabbed shell for the agent detail view.
+ *
+ * Renders a header (back-link to /agents + agent display name) and a
+ * horizontal tab bar (Overview / Routing / Guardrails / Settings). Child
+ * routes render in the body via props.children (SolidJS nested <Route>).
+ */
+const AgentDetail: ParentComponent = (props) => {
+  const params = useParams<{ agentName: string }>();
+  const location = useLocation();
+
+  const agentName = () => decodeURIComponent(params.agentName);
+  const path = (sub: string) => agentPath(params.agentName, sub);
+
+  const isActive = (sub: string) => {
+    const p = path(sub);
+    if (sub === '' || sub === '/overview') {
+      return location.pathname === path('') || location.pathname === path('/overview');
+    }
+    if (sub === '/routing') {
+      return location.pathname === path('/routing');
+    }
+    return location.pathname.startsWith(p);
+  };
+
+  return (
+    <div class="container--lg">
+      <Title>{agentName()} | Manifest</Title>
+
+      <div style="margin-bottom: 8px;">
+        <A
+          href="/agents"
+          style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); text-decoration: none;"
+        >
+          ← Agents
+        </A>
+      </div>
+      <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 0;">
+        <Show when={agentPlatformIcon()}>
+          <img src={agentPlatformIcon()!} alt="" width="28" height="28" style="flex-shrink: 0;" />
+        </Show>
+        <h1 class="page-header__title" style="margin: 0;">
+          {agentName()}
+        </h1>
+      </div>
+
+      {/* Horizontal tabs */}
+      <div class="panel__tabs" role="tablist" style="margin-top: 12px; margin-bottom: 0;">
+        <A
+          href={path('')}
+          role="tab"
+          aria-selected={isActive('/overview')}
+          class="panel__tab"
+          classList={{ 'panel__tab--active': isActive('/overview') }}
+        >
+          Overview
+        </A>
+        <A
+          href={path('/routing')}
+          role="tab"
+          aria-selected={isActive('/routing')}
+          class="panel__tab"
+          classList={{ 'panel__tab--active': isActive('/routing') }}
+        >
+          Routing
+        </A>
+        <A
+          href={path('/guardrails')}
+          role="tab"
+          aria-selected={isActive('/guardrails')}
+          class="panel__tab"
+          classList={{ 'panel__tab--active': isActive('/guardrails') }}
+        >
+          Guardrails
+        </A>
+        <A
+          href={path('/settings')}
+          role="tab"
+          aria-selected={isActive('/settings')}
+          class="panel__tab"
+          classList={{ 'panel__tab--active': isActive('/settings') }}
+        >
+          Settings
+        </A>
+      </div>
+      <hr style="border: none; border-top: 1px solid hsl(var(--border)); margin: 8px 0 24px;" />
+
+      {/* Tab content from child routes */}
+      {props.children}
+    </div>
+  );
+};
+
+export default AgentDetail;

--- a/packages/frontend/src/pages/AgentDetail.tsx
+++ b/packages/frontend/src/pages/AgentDetail.tsx
@@ -1,8 +1,7 @@
 import { A, useLocation, useParams } from '@solidjs/router';
-import { Show, type ParentComponent } from 'solid-js';
+import { type ParentComponent } from 'solid-js';
 import { Title } from '@solidjs/meta';
 import { agentPath } from '../services/routing.js';
-import { agentPlatformIcon } from '../services/agent-platform-store.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 
 /**
@@ -41,14 +40,6 @@ const AgentDetail: ParentComponent = (props) => {
         >
           ← Agents
         </A>
-      </div>
-      <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 0;">
-        <Show when={agentPlatformIcon()}>
-          <img src={agentPlatformIcon()!} alt="" width="28" height="28" style="flex-shrink: 0;" />
-        </Show>
-        <h1 class="page-header__title" style="margin: 0;">
-          {agentDisplayName() ?? agentName()}
-        </h1>
       </div>
 
       {/* Horizontal tabs */}

--- a/packages/frontend/src/pages/AgentLimitsRedirect.tsx
+++ b/packages/frontend/src/pages/AgentLimitsRedirect.tsx
@@ -1,0 +1,14 @@
+import { Navigate, useParams } from '@solidjs/router';
+import type { Component } from 'solid-js';
+import { agentPath } from '../services/routing.js';
+
+/**
+ * Redirects /agents/:agentName/limits → /agents/:agentName/guardrails.
+ * Keeps backward-compat for any bookmarks or links using the old path.
+ */
+const AgentLimitsRedirect: Component = () => {
+  const params = useParams<{ agentName: string }>();
+  return <Navigate href={agentPath(params.agentName, '/guardrails')} />;
+};
+
+export default AgentLimitsRedirect;

--- a/packages/frontend/src/pages/AgentMessagesRedirect.tsx
+++ b/packages/frontend/src/pages/AgentMessagesRedirect.tsx
@@ -1,0 +1,10 @@
+import { Navigate } from '@solidjs/router';
+import type { Component } from 'solid-js';
+
+/**
+ * Redirects /agents/:agentName/messages → /messages (global message log).
+ * Keeps backward-compat now that messages has a global home from PR1.
+ */
+const AgentMessagesRedirect: Component = () => <Navigate href="/messages" />;
+
+export default AgentMessagesRedirect;

--- a/packages/frontend/src/pages/AgentOverview.tsx
+++ b/packages/frontend/src/pages/AgentOverview.tsx
@@ -1,0 +1,9 @@
+/**
+ * AgentOverview — the agent-scoped overview page.
+ *
+ * This is the canonical name for the agent dashboard (renamed from Overview
+ * for symmetry with GlobalOverview from PR1). All logic lives in Overview.tsx;
+ * this file re-exports it so both import paths work during the transition and
+ * the route table can reference the semantically-correct name.
+ */
+export { default } from './Overview.js';

--- a/packages/frontend/src/pages/Limits.tsx
+++ b/packages/frontend/src/pages/Limits.tsx
@@ -130,13 +130,9 @@ const Limits: Component = () => {
       />
 
       <div class="page-header">
-        <div>
-          <h1>Limits</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Get notified or block requests when token
-            or cost thresholds are exceeded
-          </span>
-        </div>
+        <span class="breadcrumb">
+          Get notified or block requests when token or cost thresholds are exceeded
+        </span>
         <button
           class="btn btn--primary btn--sm"
           onClick={() => {

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -19,11 +19,7 @@ import Select from '../components/Select.jsx';
 import SetupModal from '../components/SetupModal.jsx';
 import { type MessageRow } from '../components/message-table-types.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
-import {
-  agentPlatform,
-  agentCategory,
-  agentPlatformIcon,
-} from '../services/agent-platform-store.js';
+import { agentPlatform, agentCategory } from '../services/agent-platform-store.js';
 import {
   getCustomProviders,
   getOverview,
@@ -249,22 +245,6 @@ const Overview: Component = () => {
           content={`Monitor ${agentDisplayName() ?? decodeURIComponent(params.agentName)} performance — costs, tokens, and activity.`}
         />
         <div class="page-header">
-          <div>
-            <h1 style="display: flex; align-items: center; gap: 10px;">
-              <Show when={agentPlatformIcon()}>
-                <img
-                  src={agentPlatformIcon()}
-                  alt=""
-                  width="28"
-                  height="28"
-                  class="overview__platform-icon"
-                  style="border-radius: 4px;"
-                />
-              </Show>
-              {agentDisplayName() ?? decodeURIComponent(params.agentName)} Overview
-            </h1>
-            <span class="breadcrumb">Real-time summary of spending, tokens, and messages</span>
-          </div>
           <div class="header-controls">
             <Show when={showDashboard()}>
               <Select

--- a/packages/frontend/src/pages/Routing.tsx
+++ b/packages/frontend/src/pages/Routing.tsx
@@ -435,13 +435,7 @@ const Routing: Component = () => {
       />
 
       <div class="page-header routing-page-header">
-        <div>
-          <h1>Routing</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Pick which model handles each type of
-            request
-          </span>
-        </div>
+        <span class="breadcrumb">Pick which model handles each type of request</span>
         <Show when={!connectedProviders.loading}>
           <div style="display: flex; gap: 8px;">
             <Show when={isEnabled()}>

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -182,15 +182,9 @@ const Settings: Component = () => {
         name="description"
         content={`Configure settings for ${agentDisplayName() ?? agentName()}.`}
       />
-      <div class="page-header">
-        <div>
-          <h1>Settings</h1>
-          <span class="breadcrumb">
-            {agentDisplayName() ?? agentName()} &rsaquo; Rename your agent, manage API keys, and
-            view setup instructions
-          </span>
-        </div>
-      </div>
+      <p style="color: hsl(var(--muted-foreground)); font-size: var(--font-size-sm); margin: 0 0 var(--gap-lg);">
+        Rename your agent, manage API keys, and view setup instructions
+      </p>
 
       {/* -- Agent Name ------------------------------ */}
       <div class="settings-card">

--- a/packages/frontend/src/styles/cards.css
+++ b/packages/frontend/src/styles/cards.css
@@ -214,6 +214,7 @@
   border: none;
   border-radius: calc(var(--radius) - 2px);
   cursor: pointer;
+  text-decoration: none;
   transition: all var(--transition-fast);
 }
 

--- a/packages/frontend/tests/components/App.test.tsx
+++ b/packages/frontend/tests/components/App.test.tsx
@@ -70,18 +70,21 @@ describe("App", () => {
     expect(container.querySelector(".main-content")).not.toBeNull();
   });
 
-  it("does not show sidebar on non-agent paths", () => {
+  it("does not show sidebar on root redirect path /", () => {
+    // The root "/" is a transient redirect — sidebar is intentionally hidden
+    routerState.pathname = "/";
     const { container } = render(() => <App />);
     expect(container.querySelector('[data-testid="sidebar"]')).toBeNull();
   });
 
-  it("does not show mobile navigation toggle on non-agent paths", () => {
+  it("does not show mobile navigation toggle on root redirect path", () => {
+    routerState.pathname = "/";
     const { container } = render(() => <App />);
     expect(container.querySelector('[data-testid="mobile-nav-toggle"]')).toBeNull();
   });
 });
 
-describe("App with agent path", () => {
+describe("App with authenticated paths", () => {
   it("shows sidebar on /agents/ paths", () => {
     routerState.pathname = "/agents/demo";
 
@@ -107,6 +110,20 @@ describe("App with agent path", () => {
 
   it("shows sidebar on /agents path (workspace list)", () => {
     routerState.pathname = "/agents";
+    const { container } = render(() => <App />);
+    expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
+    expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();
+  });
+
+  it("shows sidebar on /account path", () => {
+    routerState.pathname = "/account";
+    const { container } = render(() => <App />);
+    expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
+    expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();
+  });
+
+  it("shows sidebar on /agents/:name/routing (deep agent sub-path)", () => {
+    routerState.pathname = "/agents/demo/routing";
     const { container } = render(() => <App />);
     expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
     expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fireEvent, render, screen } from "@solidjs/testing-library";
 
-let mockAgentName: string | null = "test-agent";
-let mockPathname = "/agents/test-agent";
+let mockPathname = "/overview";
+
 vi.mock("@solidjs/router", () => ({
   A: (props: any) => {
     // Access classList to trigger coverage of classList expressions
@@ -13,27 +13,24 @@ vi.mock("@solidjs/router", () => ({
         if (val) classes.push(key);
       }
     }
-    return <a href={props.href} class={classes.join(" ").trim()} aria-current={props["aria-current"]}>{props.children}</a>;
+    return (
+      <a href={props.href} class={classes.join(" ").trim()} aria-current={props["aria-current"]}>
+        {props.children}
+      </a>
+    );
   },
-  useLocation: () => ({ pathname: mockPathname }),
-}));
-
-vi.mock("../../src/services/routing.js", () => ({
-  useAgentName: () => () => mockAgentName,
-  agentPath: (name: string, sub: string) => name ? `/agents/${name}${sub}` : "/",
+  useLocation: () => ({ get pathname() { return mockPathname; } }),
 }));
 
 import Sidebar from "../../src/components/Sidebar";
 
-describe("Sidebar with agent", () => {
-  beforeAll(() => {
-    mockAgentName = "test-agent";
-    mockPathname = "/agents/test-agent";
-  });
+beforeEach(() => {
+  mockPathname = "/overview";
+});
 
-  it("renders MONITORING section", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("MONITORING")).toBeDefined();
+describe("Sidebar — global nav (agent route)", () => {
+  beforeEach(() => {
+    mockPathname = "/agents/test-agent";
   });
 
   it("renders Overview link", () => {
@@ -46,62 +43,118 @@ describe("Sidebar with agent", () => {
     expect(screen.getByText("Messages")).toBeDefined();
   });
 
-  it("renders MANAGE section", () => {
+  it("renders Agents link", () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("MANAGE")).toBeDefined();
+    expect(screen.getByText("Agents")).toBeDefined();
   });
 
-  it("renders Settings link", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Settings")).toBeDefined();
-  });
-
-  it("renders Limits link", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Limits")).toBeDefined();
-  });
-
-  it("renders RESOURCES section", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("RESOURCES")).toBeDefined();
-  });
-
-  it("renders Help link", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Help")).toBeDefined();
-  });
-
-  it("renders Model Prices link", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Model Prices")).toBeDefined();
-  });
-
-  it("renders Feedback section", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Feedback")).toBeDefined();
-  });
-
-  it("renders Routing link", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Routing")).toBeDefined();
-  });
-
-  it("has correct link hrefs for agent routes", () => {
+  it("does not render MONITORING section on agent route", () => {
     const { container } = render(() => <Sidebar />);
-    expect(container.querySelector('a[href="/agents/test-agent"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/agents/test-agent/messages"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/agents/test-agent/settings"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/agents/test-agent/limits"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/agents/test-agent/model-prices"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/agents/test-agent/help"]')).not.toBeNull();
+    expect(container.textContent).not.toContain("MONITORING");
   });
 
-  it("marks current page link as active", () => {
+  it("does not render MANAGE section on agent route", () => {
     const { container } = render(() => <Sidebar />);
-    const overviewLink = container.querySelector('a[href="/agents/test-agent"]');
+    expect(container.textContent).not.toContain("MANAGE");
+  });
+
+  it("does not render RESOURCES section on agent route", () => {
+    const { container } = render(() => <Sidebar />);
+    expect(container.textContent).not.toContain("RESOURCES");
+  });
+
+  it("links point to global routes, not agent-scoped routes", () => {
+    const { container } = render(() => <Sidebar />);
+    expect(container.querySelector('a[href="/overview"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/messages"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/agents"]')).not.toBeNull();
+  });
+
+  it("marks Agents link active on /agents/:name path", () => {
+    const { container } = render(() => <Sidebar />);
+    const agentsLink = container.querySelector('a[href="/agents"]');
+    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks Agents link active on /agents/:name/routing sub-path", () => {
+    mockPathname = "/agents/test-agent/routing";
+    const { container } = render(() => <Sidebar />);
+    const agentsLink = container.querySelector('a[href="/agents"]');
+    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
+  });
+});
+
+describe("Sidebar — global nav (global route)", () => {
+  it("renders Overview link in global mode", () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText("Overview")).toBeDefined();
+  });
+
+  it("renders Messages link in global mode", () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText("Messages")).toBeDefined();
+  });
+
+  it("renders Agents link pointing to /agents", () => {
+    const { container } = render(() => <Sidebar />);
+    const agentsLink = container.querySelector('a[href="/agents"]');
+    expect(agentsLink).not.toBeNull();
+    expect(agentsLink?.textContent).toContain("Agents");
+  });
+
+  it("does not render MONITORING section in global mode", () => {
+    const { container } = render(() => <Sidebar />);
+    expect(container.textContent).not.toContain("MONITORING");
+  });
+
+  it("marks Overview link active on /overview path", () => {
+    const { container } = render(() => <Sidebar />);
+    const overviewLink = container.querySelector('a[href="/overview"]');
     expect(overviewLink?.getAttribute("aria-current")).toBe("page");
   });
 
+  it("marks Messages link active on /messages path", () => {
+    mockPathname = "/messages";
+    const { container } = render(() => <Sidebar />);
+    const messagesLink = container.querySelector('a[href="/messages"]');
+    expect(messagesLink?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks Agents link active on /agents path", () => {
+    mockPathname = "/agents";
+    const { container } = render(() => <Sidebar />);
+    const agentsLink = container.querySelector('a[href="/agents"]');
+    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("does not mark Overview active when on /messages", () => {
+    mockPathname = "/messages";
+    const { container } = render(() => <Sidebar />);
+    const overviewLink = container.querySelector('a[href="/overview"]');
+    expect(overviewLink?.getAttribute("aria-current")).not.toBe("page");
+  });
+});
+
+describe("Sidebar — identical in agent and global mode", () => {
+  it("renders the same 3 links on /overview and /agents/:name", () => {
+    mockPathname = "/overview";
+    const { container: globalContainer } = render(() => <Sidebar />);
+    const globalLinks = Array.from(globalContainer.querySelectorAll("a.sidebar__link")).map(
+      (a) => a.getAttribute("href"),
+    );
+
+    mockPathname = "/agents/test-agent";
+    const { container: agentContainer } = render(() => <Sidebar />);
+    const agentLinks = Array.from(agentContainer.querySelectorAll("a.sidebar__link")).map(
+      (a) => a.getAttribute("href"),
+    );
+
+    expect(agentLinks).toEqual(globalLinks);
+    expect(globalLinks).toEqual(["/overview", "/messages", "/agents"]);
+  });
+});
+
+describe("Sidebar — structure and interaction", () => {
   it("has nav element with aria-label", () => {
     const { container } = render(() => <Sidebar />);
     const nav = container.querySelector("nav.sidebar");
@@ -128,6 +181,11 @@ describe("Sidebar with agent", () => {
     expect(onNavigate).toHaveBeenCalledTimes(1);
   });
 
+  it("renders Feedback section", () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText("Feedback")).toBeDefined();
+  });
+
   it("shows feedback hint text", () => {
     const { container } = render(() => <Sidebar />);
     expect(container.textContent).toContain("Share ideas or report bugs");
@@ -142,114 +200,32 @@ describe("Sidebar with agent", () => {
   });
 });
 
-describe("Sidebar without agent (global mode)", () => {
-  beforeAll(() => {
-    mockAgentName = null;
-    mockPathname = "/overview";
-  });
-
-  it("renders Overview link in global mode", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Overview")).toBeDefined();
-  });
-
-  it("renders Messages link in global mode", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Messages")).toBeDefined();
-  });
-
-  it("renders Agents link pointing to /agents in global mode", () => {
-    const { container } = render(() => <Sidebar />);
-    const agentsLink = container.querySelector('a[href="/agents"]');
-    expect(agentsLink).not.toBeNull();
-    expect(agentsLink?.textContent).toContain("Agents");
-  });
-
-  it("does not render MONITORING section when no agent", () => {
-    const { container } = render(() => <Sidebar />);
-    expect(container.textContent).not.toContain("MONITORING");
-  });
-
-  it("marks Overview link active on /overview path", () => {
-    const { container } = render(() => <Sidebar />);
-    const overviewLink = container.querySelector('a[href="/overview"]');
-    expect(overviewLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks Messages link active on /messages path", () => {
-    mockPathname = "/messages";
-    const { container } = render(() => <Sidebar />);
-    const messagesLink = container.querySelector('a[href="/messages"]');
-    expect(messagesLink?.getAttribute("aria-current")).toBe("page");
-    mockPathname = "/overview";
-  });
-
-  it("marks Agents link active on /agents path", () => {
-    mockPathname = "/agents";
+describe("Sidebar — active state via isGlobalActive prefix matching", () => {
+  it("marks /agents active on /agents sub-path /agents/foo/routing", () => {
+    mockPathname = "/agents/foo/routing";
     const { container } = render(() => <Sidebar />);
     const agentsLink = container.querySelector('a[href="/agents"]');
     expect(agentsLink?.getAttribute("aria-current")).toBe("page");
-    mockPathname = "/overview";
-  });
-});
-
-describe("Sidebar active states for sub-paths", () => {
-  beforeAll(() => {
-    mockAgentName = "test-agent";
   });
 
-  it("marks routing link as active on routing path", () => {
-    mockPathname = "/agents/test-agent/routing";
-    const { container } = render(() => <Sidebar />);
-    const routingLink = container.querySelector('a[href="/agents/test-agent/routing"]');
-    expect(routingLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks limits link as active on limits path", () => {
-    mockPathname = "/agents/test-agent/limits";
-    const { container } = render(() => <Sidebar />);
-    const limitsLink = container.querySelector('a[href="/agents/test-agent/limits"]');
-    expect(limitsLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks settings link as active on settings path", () => {
-    mockPathname = "/agents/test-agent/settings";
-    const { container } = render(() => <Sidebar />);
-    const settingsLink = container.querySelector('a[href="/agents/test-agent/settings"]');
-    expect(settingsLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks model-prices link as active on model-prices path", () => {
-    mockPathname = "/agents/test-agent/model-prices";
-    const { container } = render(() => <Sidebar />);
-    const pricesLink = container.querySelector('a[href="/agents/test-agent/model-prices"]');
-    expect(pricesLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks help link as active on help path", () => {
-    mockPathname = "/agents/test-agent/help";
-    const { container } = render(() => <Sidebar />);
-    const helpLink = container.querySelector('a[href="/agents/test-agent/help"]');
-    expect(helpLink?.getAttribute("aria-current")).toBe("page");
-  });
-
-  it("marks messages link as active on messages path", () => {
-    mockPathname = "/agents/test-agent/messages";
-    const { container } = render(() => <Sidebar />);
-    const messagesLink = container.querySelector('a[href="/agents/test-agent/messages"]');
-    expect(messagesLink?.getAttribute("aria-current")).toBe("page");
-  });
-});
-
-describe("Sidebar with no agent selected", () => {
-  beforeAll(() => {
-    mockAgentName = null;
-    mockPathname = "/overview";
-  });
-
-  it("shows Agents link pointing to /agents when no agent is selected", () => {
+  it("marks /agents active on /agents/foo (no trailing slash)", () => {
+    mockPathname = "/agents/foo";
     const { container } = render(() => <Sidebar />);
     const agentsLink = container.querySelector('a[href="/agents"]');
-    expect(agentsLink).not.toBeNull();
+    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("does not mark /overview active when on /agents", () => {
+    mockPathname = "/agents";
+    const { container } = render(() => <Sidebar />);
+    const overviewLink = container.querySelector('a[href="/overview"]');
+    expect(overviewLink?.getAttribute("aria-current")).not.toBe("page");
+  });
+
+  it("marks /overview active only on exact /overview path", () => {
+    mockPathname = "/overview";
+    const { container } = render(() => <Sidebar />);
+    const overviewLink = container.querySelector('a[href="/overview"]');
+    expect(overviewLink?.getAttribute("aria-current")).toBe("page");
   });
 });

--- a/packages/frontend/tests/pages/AgentDetail.test.tsx
+++ b/packages/frontend/tests/pages/AgentDetail.test.tsx
@@ -57,9 +57,9 @@ describe("AgentDetail", () => {
     expect(backLink.textContent).toContain("Agents");
   });
 
-  it("does not render an h1 heading in the agent detail body", () => {
+  it("renders an h1 with the agent name in the agent detail body", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
-    expect(container.querySelector("h1")).toBeNull();
+    expect(container.querySelector("h1")?.textContent?.trim()).toBe("my-agent");
   });
 
   it("renders a tablist with exactly 4 tabs", () => {
@@ -154,10 +154,10 @@ describe("AgentDetail", () => {
     mockPathname = "/agents/my%20agent";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     expect(container.querySelector("title")?.textContent).toBe("my agent | Manifest");
-    expect(container.querySelector("h1")).toBeNull();
+    expect(container.querySelector("h1")?.textContent?.trim()).toBe("my agent");
   });
 
-  it("does not render a platform icon", () => {
+  it("does not render a platform icon when agentPlatformIcon returns undefined", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     expect(container.querySelector("img")).toBeNull();
   });
@@ -176,10 +176,10 @@ describe("AgentDetail", () => {
     expect(container.querySelector("title")?.textContent).toBe("My Cool Agent | Manifest");
   });
 
-  it("does not render an h1 when agentDisplayName is set", () => {
+  it("renders the h1 with the display name when agentDisplayName is set", () => {
     mockAgentDisplayName = "My Cool Agent";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
-    expect(container.querySelector("h1")).toBeNull();
+    expect(container.querySelector("h1")?.textContent?.trim()).toBe("My Cool Agent");
   });
 
   it("falls back to decoded slug in title when agentDisplayName is null", () => {
@@ -188,19 +188,19 @@ describe("AgentDetail", () => {
     expect(container.querySelector("title")?.textContent).toBe("my-agent | Manifest");
   });
 
-  it("does not render an h1 when agentDisplayName is null", () => {
+  it("renders the h1 with the decoded slug when agentDisplayName is null", () => {
     mockAgentDisplayName = null;
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
-    expect(container.querySelector("h1")).toBeNull();
+    expect(container.querySelector("h1")?.textContent?.trim()).toBe("my-agent");
   });
 });
 
-describe("AgentDetail platform icon removal", () => {
+describe("AgentDetail with platform icon", () => {
   beforeEach(() => {
     vi.resetModules();
   });
 
-  it("never renders a platform icon even when agentPlatformIcon returns a URL", async () => {
+  it("renders the platform icon and h1 when agentPlatformIcon is set", async () => {
     vi.doMock("../../src/services/agent-platform-store.js", () => ({
       agentPlatformIcon: () => "/icons/robot.svg",
     }));
@@ -216,9 +216,11 @@ describe("AgentDetail platform icon removal", () => {
       Title: (props: any) => <title>{props.children}</title>,
     }));
 
-    const { default: AgentDetailNoIcon } = await import("../../src/pages/AgentDetail");
-    const { container } = render(() => <AgentDetailNoIcon>{null}</AgentDetailNoIcon>);
-    expect(container.querySelector("img")).toBeNull();
-    expect(container.querySelector("h1")).toBeNull();
+    const { default: AgentDetailWithIcon } = await import("../../src/pages/AgentDetail");
+    const { container } = render(() => <AgentDetailWithIcon>{null}</AgentDetailWithIcon>);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("/icons/robot.svg");
+    expect(container.querySelector("h1")?.textContent?.trim()).toBe("my-agent");
   });
 });

--- a/packages/frontend/tests/pages/AgentDetail.test.tsx
+++ b/packages/frontend/tests/pages/AgentDetail.test.tsx
@@ -57,10 +57,9 @@ describe("AgentDetail", () => {
     expect(backLink.textContent).toContain("Agents");
   });
 
-  it("renders the decoded agent name as a heading", () => {
+  it("does not render an h1 heading in the agent detail body", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
-    const h1 = container.querySelector("h1");
-    expect(h1?.textContent).toContain("my-agent");
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("renders a tablist with exactly 4 tabs", () => {
@@ -71,11 +70,11 @@ describe("AgentDetail", () => {
     expect(tabs.length).toBe(4);
   });
 
-  it("renders tabs labeled Overview, Routing, Guardrails, Settings in order", () => {
+  it("renders tabs labeled Overview, Routing, Limits, Settings in order", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     const tabs = container.querySelectorAll('[role="tab"]');
     const labels = Array.from(tabs).map((t) => t.textContent);
-    expect(labels).toEqual(["Overview", "Routing", "Guardrails", "Settings"]);
+    expect(labels).toEqual(["Overview", "Routing", "Limits", "Settings"]);
   });
 
   it("Overview tab links to the agent root path", () => {
@@ -150,15 +149,15 @@ describe("AgentDetail", () => {
     expect(container.querySelector('[data-testid="child-content"]')).not.toBeNull();
   });
 
-  it("decodes URL-encoded agent names in title and heading", () => {
+  it("decodes URL-encoded agent names in title", () => {
     mockParams.agentName = "my%20agent";
     mockPathname = "/agents/my%20agent";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     expect(container.querySelector("title")?.textContent).toBe("my agent | Manifest");
-    expect(container.querySelector("h1")?.textContent).toContain("my agent");
+    expect(container.querySelector("h1")).toBeNull();
   });
 
-  it("does not show platform icon when agentPlatformIcon returns undefined", () => {
+  it("does not render a platform icon", () => {
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
     expect(container.querySelector("img")).toBeNull();
   });
@@ -177,10 +176,10 @@ describe("AgentDetail", () => {
     expect(container.querySelector("title")?.textContent).toBe("My Cool Agent | Manifest");
   });
 
-  it("uses resolved display name in heading when agentDisplayName is set", () => {
+  it("does not render an h1 when agentDisplayName is set", () => {
     mockAgentDisplayName = "My Cool Agent";
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
-    expect(container.querySelector("h1")?.textContent).toContain("My Cool Agent");
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("falls back to decoded slug in title when agentDisplayName is null", () => {
@@ -189,19 +188,19 @@ describe("AgentDetail", () => {
     expect(container.querySelector("title")?.textContent).toBe("my-agent | Manifest");
   });
 
-  it("falls back to decoded slug in heading when agentDisplayName is null", () => {
+  it("does not render an h1 when agentDisplayName is null", () => {
     mockAgentDisplayName = null;
     const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
-    expect(container.querySelector("h1")?.textContent).toContain("my-agent");
+    expect(container.querySelector("h1")).toBeNull();
   });
 });
 
-describe("AgentDetail with platform icon", () => {
+describe("AgentDetail platform icon removal", () => {
   beforeEach(() => {
     vi.resetModules();
   });
 
-  it("shows platform icon when agentPlatformIcon returns a URL", async () => {
+  it("never renders a platform icon even when agentPlatformIcon returns a URL", async () => {
     vi.doMock("../../src/services/agent-platform-store.js", () => ({
       agentPlatformIcon: () => "/icons/robot.svg",
     }));
@@ -217,10 +216,9 @@ describe("AgentDetail with platform icon", () => {
       Title: (props: any) => <title>{props.children}</title>,
     }));
 
-    const { default: AgentDetailWithIcon } = await import("../../src/pages/AgentDetail");
-    const { container } = render(() => <AgentDetailWithIcon>{null}</AgentDetailWithIcon>);
-    const img = container.querySelector("img");
-    expect(img).not.toBeNull();
-    expect(img?.getAttribute("src")).toBe("/icons/robot.svg");
+    const { default: AgentDetailNoIcon } = await import("../../src/pages/AgentDetail");
+    const { container } = render(() => <AgentDetailNoIcon>{null}</AgentDetailNoIcon>);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("h1")).toBeNull();
   });
 });

--- a/packages/frontend/tests/pages/AgentDetail.test.tsx
+++ b/packages/frontend/tests/pages/AgentDetail.test.tsx
@@ -30,12 +30,19 @@ vi.mock("../../src/services/agent-platform-store.js", () => ({
   agentPlatformIcon: () => undefined,
 }));
 
+// Default: no resolved display name (falls back to decoded slug)
+let mockAgentDisplayName: string | null = null;
+vi.mock("../../src/services/agent-display-name.js", () => ({
+  agentDisplayName: () => mockAgentDisplayName,
+}));
+
 import AgentDetail from "../../src/pages/AgentDetail";
 
 describe("AgentDetail", () => {
   beforeEach(() => {
     mockPathname = "/agents/my-agent";
     mockParams.agentName = "my-agent";
+    mockAgentDisplayName = null;
   });
 
   it("renders the page title with the agent name", () => {
@@ -163,6 +170,30 @@ describe("AgentDetail", () => {
     expect(tabs[1].className).toContain("panel__tab--active");
     expect(tabs[0].className).not.toContain("panel__tab--active");
   });
+
+  it("uses resolved display name in title when agentDisplayName is set", () => {
+    mockAgentDisplayName = "My Cool Agent";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    expect(container.querySelector("title")?.textContent).toBe("My Cool Agent | Manifest");
+  });
+
+  it("uses resolved display name in heading when agentDisplayName is set", () => {
+    mockAgentDisplayName = "My Cool Agent";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    expect(container.querySelector("h1")?.textContent).toContain("My Cool Agent");
+  });
+
+  it("falls back to decoded slug in title when agentDisplayName is null", () => {
+    mockAgentDisplayName = null;
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    expect(container.querySelector("title")?.textContent).toBe("my-agent | Manifest");
+  });
+
+  it("falls back to decoded slug in heading when agentDisplayName is null", () => {
+    mockAgentDisplayName = null;
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    expect(container.querySelector("h1")?.textContent).toContain("my-agent");
+  });
 });
 
 describe("AgentDetail with platform icon", () => {
@@ -173,6 +204,9 @@ describe("AgentDetail with platform icon", () => {
   it("shows platform icon when agentPlatformIcon returns a URL", async () => {
     vi.doMock("../../src/services/agent-platform-store.js", () => ({
       agentPlatformIcon: () => "/icons/robot.svg",
+    }));
+    vi.doMock("../../src/services/agent-display-name.js", () => ({
+      agentDisplayName: () => null,
     }));
     vi.doMock("@solidjs/router", () => ({
       useParams: () => ({ agentName: "my-agent" }),

--- a/packages/frontend/tests/pages/AgentDetail.test.tsx
+++ b/packages/frontend/tests/pages/AgentDetail.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@solidjs/testing-library";
+
+// Hoisted mutable state so individual tests can override pathname
+let mockPathname = "/agents/my-agent";
+const mockParams = { agentName: "my-agent" };
+
+vi.mock("@solidjs/router", () => ({
+  useParams: () => mockParams,
+  useLocation: () => ({ pathname: mockPathname }),
+  A: (props: any) => (
+    <a
+      href={props.href}
+      role={props.role}
+      aria-selected={props["aria-selected"]}
+      class={[props.class, props.classList?.["panel__tab--active"] ? "panel__tab--active" : ""]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {props.children}
+    </a>
+  ),
+}));
+
+vi.mock("@solidjs/meta", () => ({
+  Title: (props: any) => <title>{props.children}</title>,
+}));
+
+vi.mock("../../src/services/agent-platform-store.js", () => ({
+  agentPlatformIcon: () => undefined,
+}));
+
+import AgentDetail from "../../src/pages/AgentDetail";
+
+describe("AgentDetail", () => {
+  beforeEach(() => {
+    mockPathname = "/agents/my-agent";
+    mockParams.agentName = "my-agent";
+  });
+
+  it("renders the page title with the agent name", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    expect(container.querySelector("title")?.textContent).toBe("my-agent | Manifest");
+  });
+
+  it("renders a back-link to /agents", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const backLink = container.querySelector('a[href="/agents"]') as HTMLAnchorElement;
+    expect(backLink).not.toBeNull();
+    expect(backLink.textContent).toContain("Agents");
+  });
+
+  it("renders the decoded agent name as a heading", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const h1 = container.querySelector("h1");
+    expect(h1?.textContent).toContain("my-agent");
+  });
+
+  it("renders a tablist with exactly 4 tabs", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tablist = container.querySelector('[role="tablist"]');
+    expect(tablist).not.toBeNull();
+    const tabs = tablist!.querySelectorAll('[role="tab"]');
+    expect(tabs.length).toBe(4);
+  });
+
+  it("renders tabs labeled Overview, Routing, Guardrails, Settings in order", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    const labels = Array.from(tabs).map((t) => t.textContent);
+    expect(labels).toEqual(["Overview", "Routing", "Guardrails", "Settings"]);
+  });
+
+  it("Overview tab links to the agent root path", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
+    expect(tabs[0].getAttribute("href")).toBe("/agents/my-agent");
+  });
+
+  it("Routing tab links to /agents/:name/routing", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
+    expect(tabs[1].getAttribute("href")).toBe("/agents/my-agent/routing");
+  });
+
+  it("Guardrails tab links to /agents/:name/guardrails", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
+    expect(tabs[2].getAttribute("href")).toBe("/agents/my-agent/guardrails");
+  });
+
+  it("Settings tab links to /agents/:name/settings", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
+    expect(tabs[3].getAttribute("href")).toBe("/agents/my-agent/settings");
+  });
+
+  it("marks Overview tab active when pathname is the agent root", () => {
+    mockPathname = "/agents/my-agent";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]') as NodeListOf<HTMLAnchorElement>;
+    expect(tabs[0].getAttribute("aria-selected")).toBe("true");
+    expect(tabs[1].getAttribute("aria-selected")).toBe("false");
+    expect(tabs[2].getAttribute("aria-selected")).toBe("false");
+    expect(tabs[3].getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("marks Overview tab active when pathname is /overview", () => {
+    mockPathname = "/agents/my-agent/overview";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs[0].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("marks Routing tab active when pathname is /routing", () => {
+    mockPathname = "/agents/my-agent/routing";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs[0].getAttribute("aria-selected")).toBe("false");
+    expect(tabs[1].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("marks Guardrails tab active when pathname is /guardrails", () => {
+    mockPathname = "/agents/my-agent/guardrails";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs[2].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("marks Settings tab active when pathname starts with /settings", () => {
+    mockPathname = "/agents/my-agent/settings/advanced";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs[3].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("renders children inside the shell", () => {
+    const { container } = render(() => (
+      <AgentDetail>
+        <div data-testid="child-content">Tab content</div>
+      </AgentDetail>
+    ));
+    expect(container.querySelector('[data-testid="child-content"]')).not.toBeNull();
+  });
+
+  it("decodes URL-encoded agent names in title and heading", () => {
+    mockParams.agentName = "my%20agent";
+    mockPathname = "/agents/my%20agent";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    expect(container.querySelector("title")?.textContent).toBe("my agent | Manifest");
+    expect(container.querySelector("h1")?.textContent).toContain("my agent");
+  });
+
+  it("does not show platform icon when agentPlatformIcon returns undefined", () => {
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("applies panel__tab--active class to the active tab", () => {
+    mockPathname = "/agents/my-agent/routing";
+    const { container } = render(() => <AgentDetail>{null}</AgentDetail>);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs[1].className).toContain("panel__tab--active");
+    expect(tabs[0].className).not.toContain("panel__tab--active");
+  });
+});
+
+describe("AgentDetail with platform icon", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("shows platform icon when agentPlatformIcon returns a URL", async () => {
+    vi.doMock("../../src/services/agent-platform-store.js", () => ({
+      agentPlatformIcon: () => "/icons/robot.svg",
+    }));
+    vi.doMock("@solidjs/router", () => ({
+      useParams: () => ({ agentName: "my-agent" }),
+      useLocation: () => ({ pathname: "/agents/my-agent" }),
+      A: (props: any) => <a href={props.href} role={props.role}>{props.children}</a>,
+    }));
+    vi.doMock("@solidjs/meta", () => ({
+      Title: (props: any) => <title>{props.children}</title>,
+    }));
+
+    const { default: AgentDetailWithIcon } = await import("../../src/pages/AgentDetail");
+    const { container } = render(() => <AgentDetailWithIcon>{null}</AgentDetailWithIcon>);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("/icons/robot.svg");
+  });
+});

--- a/packages/frontend/tests/pages/AgentOverview.test.tsx
+++ b/packages/frontend/tests/pages/AgentOverview.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@solidjs/testing-library";
+
+// AgentOverview is the canonical name for the agent-scoped overview page.
+// It re-exports Overview, so we verify the rename doesn't break rendering.
+// Overview itself is mocked here to avoid the full dependency tree; the
+// comprehensive behavioral tests live in Overview.test.tsx.
+
+vi.mock("@solidjs/router", () => ({
+  useParams: () => ({ agentName: "test-agent" }),
+  useLocation: () => ({ pathname: "/agents/test-agent", state: null }),
+  useNavigate: () => vi.fn(),
+  A: (props: any) => <a href={props.href}>{props.children}</a>,
+}));
+
+vi.mock("@solidjs/meta", () => ({
+  Title: (props: any) => <title>{props.children}</title>,
+  Meta: () => null,
+}));
+
+// Mock the Overview module that AgentOverview re-exports.
+// This prevents the deep dependency chain (which requires manifest-shared to be
+// built) from being triggered in tests. Behavioral coverage is in Overview.test.tsx.
+vi.mock("../../src/pages/Overview.js", () => ({
+  default: () => <div data-testid="overview-stub">AgentOverview content</div>,
+}));
+
+import AgentOverview from "../../src/pages/AgentOverview";
+
+describe("AgentOverview", () => {
+  it("renders the component provided by the re-export", () => {
+    const { container } = render(() => <AgentOverview />);
+    expect(container.querySelector('[data-testid="overview-stub"]')).not.toBeNull();
+  });
+
+  it("has the same default export as Overview", async () => {
+    const { default: AgentOverviewExport } = await import("../../src/pages/AgentOverview");
+    const { default: OverviewExport } = await import("../../src/pages/Overview");
+    // Both modules export the same component (the re-export works correctly).
+    expect(AgentOverviewExport).toBe(OverviewExport);
+  });
+});

--- a/packages/frontend/tests/pages/AgentRedirects.test.tsx
+++ b/packages/frontend/tests/pages/AgentRedirects.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@solidjs/testing-library";
+
+// Mock params with mutable state so individual tests can override agentName
+const mockParams = { agentName: "demo-agent" };
+
+vi.mock("@solidjs/router", () => ({
+  Navigate: (props: any) => <div data-testid="navigate" data-href={props.href} />,
+  useParams: () => mockParams,
+}));
+
+import AgentLimitsRedirect from "../../src/pages/AgentLimitsRedirect";
+import AgentMessagesRedirect from "../../src/pages/AgentMessagesRedirect";
+
+describe("AgentLimitsRedirect", () => {
+  beforeEach(() => {
+    mockParams.agentName = "demo-agent";
+  });
+
+  it("redirects /limits to /guardrails for the current agent", () => {
+    const { container } = render(() => <AgentLimitsRedirect />);
+    const navigate = container.querySelector('[data-testid="navigate"]');
+    expect(navigate).not.toBeNull();
+    expect(navigate?.getAttribute("data-href")).toBe("/agents/demo-agent/guardrails");
+  });
+
+  it("encodes agent names with special characters correctly", () => {
+    mockParams.agentName = "my agent";
+    const { container } = render(() => <AgentLimitsRedirect />);
+    const navigate = container.querySelector('[data-testid="navigate"]');
+    expect(navigate?.getAttribute("data-href")).toBe("/agents/my%20agent/guardrails");
+  });
+});
+
+describe("AgentMessagesRedirect", () => {
+  it("redirects /agents/:name/messages to global /messages", () => {
+    const { container } = render(() => <AgentMessagesRedirect />);
+    const navigate = container.querySelector('[data-testid="navigate"]');
+    expect(navigate).not.toBeNull();
+    expect(navigate?.getAttribute("data-href")).toBe("/messages");
+  });
+});

--- a/packages/frontend/tests/pages/Limits.test.tsx
+++ b/packages/frontend/tests/pages/Limits.test.tsx
@@ -61,14 +61,13 @@ describe("Limits page", () => {
     mockRoutingStatus = { enabled: false };
   });
 
-  it("renders page title", () => {
-    render(() => <Limits />);
-    expect(screen.getByText("Limits")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Limits />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
-  it("renders breadcrumb with agent name", () => {
+  it("renders page description without duplicating the agent heading", () => {
     const { container } = render(() => <Limits />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Get notified or block requests when token or cost thresholds are exceeded");
   });
 

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -168,10 +168,14 @@ describe("Overview", () => {
     expect(container.textContent).toContain("Overview");
   });
 
-  it("renders breadcrumb subtitle", () => {
+  it("does not render duplicate agent-name H1 or breadcrumb subtitle (AgentDetail owns the H1)", () => {
     mockGetOverview.mockResolvedValue(overviewData);
-    render(() => <Overview />);
-    expect(screen.getByText(/Real-time summary of spending/)).toBeDefined();
+    const { container } = render(() => <Overview />);
+    // The breadcrumb "Real-time summary…" must no longer be rendered inside Overview,
+    // because AgentDetail already shows the agent name as an H1 above the tabs.
+    expect(container.querySelector('.breadcrumb')).toBeNull();
+    // No H1 element should be rendered by Overview itself.
+    expect(container.querySelector('h1')).toBeNull();
   });
 
   it("shows loading skeleton while fetching", () => {

--- a/packages/frontend/tests/pages/Routing.test.tsx
+++ b/packages/frontend/tests/pages/Routing.test.tsx
@@ -617,12 +617,12 @@ beforeEach(() => {
 });
 
 describe('Routing page', () => {
-  it('renders the page header with the agent display name', async () => {
-    render(() => <Routing />);
+  it('renders routing description without a duplicate page heading', async () => {
+    const { container } = render(() => <Routing />);
     await waitFor(() => {
-      expect(screen.getByText('Routing')).toBeDefined();
+      expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
     });
-    expect(screen.getByText(/Pick which model handles each type of request/)).toBeDefined();
+    expect(container.querySelector('h1')).toBeNull();
   });
 
   it('renders the empty providers state when no providers are connected', async () => {

--- a/packages/frontend/tests/pages/Settings.test.tsx
+++ b/packages/frontend/tests/pages/Settings.test.tsx
@@ -138,9 +138,9 @@ describe("Settings", () => {
     mockUpdateAgent.mockResolvedValue({});
   });
 
-  it("renders Settings heading", () => {
-    render(() => <Settings />);
-    expect(screen.getByText("Settings")).toBeDefined();
+  it("does not render a duplicate page heading", () => {
+    const { container } = render(() => <Settings />);
+    expect(container.querySelector("h1")).toBeNull();
   });
 
   it("renders agent name input with value", () => {
@@ -330,9 +330,8 @@ describe("Settings", () => {
     });
   });
 
-  it("shows breadcrumb with agent name", () => {
+  it("shows settings description without duplicating the agent heading", () => {
     const { container } = render(() => <Settings />);
-    expect(container.textContent).toContain("test-agent");
     expect(container.textContent).toContain("Rename your agent");
   });
 


### PR DESCRIPTION
### ✨ What changed
- Agent detail is now a horizontal-tabbed shell: Overview / Routing / Guardrails / Settings.
- Sidebar unified to one global nav (Overview / Messages / Agents), rendered identically everywhere. Removed the per-agent MONITORING/MANAGE/RESOURCES section.
- Renamed the agent Overview page to `AgentOverview` (mirrors `GlobalOverview`).
- Redirects: `/agents/:name/limits` → Guardrails, `/agents/:name/messages` → global Messages.

### 💭 Why
Second slice of the #2061 navigation rebuild. Collapses the agent view into one consistent surface (tabs) and drops the duplicate sidebar nav.

### 👤 For users
Each agent's pages live behind tabs now, under a single global sidebar. Guardrails replaces Limits (same functionality).

### 📝 Notes
- Frontend only. No backend, no migration.
- Targets `next` (integration branch); stacked on #2149 which is already merged into `next`.
- 3810 tests green, 100% coverage on changed files. tsc, lint, vite build clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches agent details to a horizontal tabbed view and unifies navigation into one global sidebar across all authenticated routes. Restores a concise agent header with platform icon, display name, and tabs. Part of #2061 to make navigation consistent across the app.

- New Features
  - Added `AgentDetail` tabbed shell with Overview / Routing / Limits / Settings and a back-link; agent Overview renamed to `AgentOverview`.
  - One global sidebar (Overview / Messages / Agents) rendered identically everywhere; removed agent-scoped MONITORING/MANAGE/RESOURCES; active state persists on `/agents/:name/*`; sidebar is hidden only on the root redirect `/`.
  - Backward-compatible redirects: `/agents/:name/limits` → `/agents/:name/guardrails` and `/agents/:name/messages` → `/messages`.

- Bug Fixes
  - Restored agent header (platform icon + display name H1); browser tab title uses the resolved display name, falling back to the decoded slug.
  - Removed duplicate H1s and subtitles from `Overview`, `Routing`, `Limits`, and `Settings` so the tabbed shell owns the heading.
  - Renamed the tab label to “Limits” (path remains `/guardrails`) and removed the default underline on tabs.

<sup>Written for commit 6185d873d26bca01b3f2eeb699ff65b4bbbee313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

