### PR TITLE
feat: add global dashboard (Overview, Messages, Agents nav)

### DIFF
--- a/.changeset/global-dashboard-overview.md
+++ b/.changeset/global-dashboard-overview.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Add global dashboard with Overview, Messages, and Agents navigation for tenant-wide usage analytics.

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -36,7 +36,11 @@ const AppInner: ParentComponent = (props) => {
   const location = useLocation();
   const [mobileNavOpen, setMobileNavOpen] = createSignal(false);
   const isAgentMode = () => location.pathname.startsWith('/agents/');
-  const showSidebar = () => isAgentMode();
+  const isGlobalRoute = () =>
+    location.pathname === '/overview' ||
+    location.pathname === '/messages' ||
+    location.pathname === '/agents';
+  const showSidebar = () => isAgentMode() || isGlobalRoute();
   const { content: rightSidebar } = useRightSidebar();
 
   createEffect<string | undefined>((previousPath) => {

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -134,7 +134,7 @@ const Header: Component<HeaderProps> = (props) => {
         )}
         <Show when={getAgentName()}>
           <span class="header__separator">/</span>
-          <A href="/" class="header__breadcrumb-link">
+          <A href="/agents" class="header__breadcrumb-link">
             Workspace
           </A>
           <span class="header__separator">/</span>

--- a/packages/frontend/src/components/MessageTable.tsx
+++ b/packages/frontend/src/components/MessageTable.tsx
@@ -6,7 +6,7 @@ import { columnHeader, renderCell } from './message-table-cells.jsx';
 export interface MessageTableProps {
   items: MessageRow[];
   columns: MessageColumnKey[];
-  agentName: string;
+  agentName?: string;
   customProviderName: (model: string) => string | undefined;
   onFallbackErrorClick?: (model: string) => void;
   onFeedbackLike?: (id: string) => void;

--- a/packages/frontend/src/components/RootRedirect.tsx
+++ b/packages/frontend/src/components/RootRedirect.tsx
@@ -1,0 +1,6 @@
+import { Navigate } from '@solidjs/router';
+import type { Component } from 'solid-js';
+
+const RootRedirect: Component = () => <Navigate href="/overview" />;
+
+export default RootRedirect;

--- a/packages/frontend/src/components/Sidebar.tsx
+++ b/packages/frontend/src/components/Sidebar.tsx
@@ -34,10 +34,26 @@ const Sidebar: Component<SidebarProps> = (props) => {
     >
       <Show when={!getAgentName()}>
         <A
-          href="/"
+          href="/overview"
           class="sidebar__link"
-          classList={{ active: location.pathname === '/' }}
-          aria-current={location.pathname === '/' ? 'page' : undefined}
+          classList={{ active: location.pathname === '/overview' }}
+          aria-current={location.pathname === '/overview' ? 'page' : undefined}
+        >
+          Overview
+        </A>
+        <A
+          href="/messages"
+          class="sidebar__link"
+          classList={{ active: location.pathname === '/messages' }}
+          aria-current={location.pathname === '/messages' ? 'page' : undefined}
+        >
+          Messages
+        </A>
+        <A
+          href="/agents"
+          class="sidebar__link"
+          classList={{ active: location.pathname === '/agents' }}
+          aria-current={location.pathname === '/agents' ? 'page' : undefined}
         >
           Agents
         </A>

--- a/packages/frontend/src/components/message-table-cells.tsx
+++ b/packages/frontend/src/components/message-table-cells.tsx
@@ -132,6 +132,7 @@ const HEADER_LABELS: Record<MessageColumnKey, string> = {
   duration: 'Latency',
   status: 'Status',
   feedback: '',
+  agent: 'Agent',
 };
 
 const TOOLTIP_TEXT: Partial<Record<MessageColumnKey, string>> = {
@@ -345,9 +346,13 @@ export function DurationCell(item: MessageRow): JSX.Element {
   );
 }
 
+export function AgentCell(item: MessageRow): JSX.Element {
+  return <td>{item.agent_name ?? '—'}</td>;
+}
+
 export function StatusCell(
   item: MessageRow,
-  agentName: string,
+  agentName: string | undefined,
   onFallbackErrorClick?: (model: string) => void,
 ): JSX.Element {
   return (
@@ -358,9 +363,13 @@ export function StatusCell(
           <span class={`status-badge status-badge--${item.status}`}>
             {item.status === 'fallback_error' && <FallbackIcon />}
             {item.status === 'rate_limited' ? (
-              <A href={`/agents/${encodeURIComponent(agentName)}/limits`}>
-                {formatStatus(item.status)}
-              </A>
+              agentName ? (
+                <A href={`/agents/${encodeURIComponent(agentName)}/limits`}>
+                  {formatStatus(item.status)}
+                </A>
+              ) : (
+                formatStatus(item.status)
+              )
             ) : (
               formatStatus(item.status)
             )}
@@ -443,7 +452,7 @@ export function FeedbackCell(
 }
 
 export interface CellRenderContext {
-  agentName: string;
+  agentName?: string;
   customProviderName: (model: string) => string | undefined;
   onFallbackErrorClick?: (model: string) => void;
   onFeedbackLike?: (id: string) => void;
@@ -485,5 +494,7 @@ export function renderCell(
         ctx.onFeedbackDislike ?? (() => {}),
         ctx.onFeedbackClear ?? (() => {}),
       );
+    case 'agent':
+      return AgentCell(item);
   }
 }

--- a/packages/frontend/src/components/message-table-types.ts
+++ b/packages/frontend/src/components/message-table-types.ts
@@ -38,7 +38,8 @@ export type MessageColumnKey =
   | 'cache'
   | 'duration'
   | 'status'
-  | 'feedback';
+  | 'feedback'
+  | 'agent';
 
 export const COMPACT_COLUMNS: MessageColumnKey[] = [
   'feedback',

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import { MetaProvider, Title } from '@solidjs/meta';
 import App from './App.jsx';
 import AuthLayout from './layouts/AuthLayout.jsx';
 import Workspace from './pages/Workspace.jsx';
+import RootRedirect from './components/RootRedirect.jsx';
 import AgentGuard from './components/AgentGuard.jsx';
 import GuestGuard from './components/GuestGuard.jsx';
 import NotFound from './pages/NotFound.jsx';
@@ -15,6 +16,7 @@ import './styles/theme.css';
 
 clearReloadFlag();
 
+const GlobalOverview = lazyReload(() => import('./pages/GlobalOverview.jsx'));
 const Overview = lazyReload(() => import('./pages/Overview.jsx'));
 const MessageLog = lazyReload(() => import('./pages/MessageLog.jsx'));
 const Settings = lazyReload(() => import('./pages/Settings.jsx'));
@@ -57,7 +59,10 @@ render(
       <ToastContainer />
       <Router>
         <Route path="/" component={App}>
-          <Route path="/" component={Workspace} />
+          <Route path="/" component={RootRedirect} />
+          <Route path="/overview" component={GlobalOverview} />
+          <Route path="/messages" component={MessageLog} />
+          <Route path="/agents" component={Workspace} />
           <Route path="/agents/:agentName" component={AgentGuard}>
             <Route path="/" component={Overview} />
             <Route path="/messages" component={MessageLog} />

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -1,0 +1,194 @@
+import { Meta, Title } from '@solidjs/meta';
+import { A } from '@solidjs/router';
+import { createMemo, createResource, createSignal, onMount, Show, type Component } from 'solid-js';
+import ChartCard from '../components/ChartCard.jsx';
+import CostByModelTable from '../components/CostByModelTable.jsx';
+import ErrorState from '../components/ErrorState.jsx';
+import MessageTable from '../components/MessageTable.jsx';
+import OverviewSkeleton from '../components/OverviewSkeleton.jsx';
+import Select from '../components/Select.jsx';
+import { COMPACT_COLUMNS, type MessageRow } from '../components/message-table-types.js';
+import { getOverview } from '../services/api.js';
+import { preloadModelDisplayNames } from '../services/model-display.js';
+import { checkIsSelfHosted } from '../services/setup-status.js';
+import { messagePing } from '../services/sse.js';
+import '../styles/overview.css';
+
+interface GlobalOverviewData {
+  summary: {
+    tokens_today: {
+      value: number;
+      trend_pct: number;
+      sub_values?: { input: number; output: number };
+    };
+    cost_today: { value: number; trend_pct: number };
+    messages: { value: number; trend_pct: number };
+    services_hit: { total: number; healthy: number; issues: number };
+  };
+  token_usage: Array<{
+    hour?: string;
+    date?: string;
+    input_tokens: number;
+    output_tokens: number;
+  }>;
+  cost_usage: Array<{ hour?: string; date?: string; cost: number }>;
+  message_usage: Array<{ hour?: string; date?: string; count: number }>;
+  cost_by_model: Array<{
+    model: string;
+    display_name?: string;
+    tokens: number;
+    share_pct: number;
+    estimated_cost: number;
+    auth_type: string | null;
+    provider?: string | null;
+  }>;
+  recent_activity: MessageRow[];
+  has_data?: boolean;
+  has_providers?: boolean;
+}
+
+const GlobalOverview: Component = () => {
+  preloadModelDisplayNames();
+  const [isSelfHosted, setIsSelfHosted] = createSignal(false);
+  onMount(() => {
+    checkIsSelfHosted().then(setIsSelfHosted);
+  });
+  const columns = () =>
+    isSelfHosted() ? COMPACT_COLUMNS.filter((c) => c !== 'feedback') : COMPACT_COLUMNS;
+
+  const RANGE_STORAGE_KEY = 'manifest_chart_range';
+  const VALID_RANGES = new Set(['24h', '7d', '30d']);
+  const savedRange = localStorage.getItem(RANGE_STORAGE_KEY);
+  const [range, setRange] = createSignal(
+    savedRange && VALID_RANGES.has(savedRange) ? savedRange : '30d',
+  );
+
+  const handleRangeChange = (value: string) => {
+    setRange(value);
+    localStorage.setItem(RANGE_STORAGE_KEY, value);
+  };
+
+  const [activeView, setActiveView] = createSignal<'cost' | 'tokens' | 'messages' | 'savings'>(
+    'messages',
+  );
+
+  // Global overview: no agentName → tenant-wide aggregation
+  const [data, { refetch }] = createResource(
+    () => ({ range: range(), _ping: messagePing() }),
+    (p) => getOverview(p.range) as Promise<GlobalOverviewData>,
+  );
+
+  // Empty state is keyed off has_data, NOT has_providers.
+  // has_providers is always false in global mode (overview.controller.ts:63-64).
+  const showEmptyState = () => {
+    const d = data();
+    return !!d && d.has_data === false;
+  };
+
+  const showDashboard = () => {
+    const d = data();
+    return !!d && d.has_data !== false;
+  };
+
+  const messageChartData = createMemo(() => {
+    const src = data()?.message_usage;
+    return src?.map((d) => ({ time: d.hour ?? d.date ?? '', value: d.count })) ?? [];
+  });
+
+  return (
+    <div class="container--lg">
+      <Title>Overview - Manifest</Title>
+      <Meta name="description" content="Tenant-wide overview — costs, tokens, and activity." />
+      <div class="page-header">
+        <div>
+          <h1>Overview</h1>
+          <span class="breadcrumb">Real-time summary of spending, tokens, and messages</span>
+        </div>
+        <div class="header-controls">
+          <Show when={showDashboard()}>
+            <Select
+              value={range()}
+              onChange={handleRangeChange}
+              options={[
+                { label: 'Last 24 hours', value: '24h' },
+                { label: 'Last 7 days', value: '7d' },
+                { label: 'Last 30 days', value: '30d' },
+              ]}
+            />
+          </Show>
+        </div>
+      </div>
+
+      <Show when={data() !== undefined || !data.loading} fallback={<OverviewSkeleton />}>
+        <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
+          <Show when={showEmptyState()}>
+            <div class="empty-state">
+              <div class="empty-state__title">No activity yet</div>
+              <p>Create an agent and send a message. Usage data shows up here.</p>
+              <A href="/agents" class="btn btn--primary btn--sm" style="margin-top: var(--gap-md);">
+                Go to Agents
+              </A>
+              <div class="empty-state__img-wrapper">
+                <img
+                  src="/example-overview.svg"
+                  alt="Example dashboard overview showing cost and token charts"
+                  class="empty-state__img"
+                  loading="lazy"
+                />
+              </div>
+            </div>
+          </Show>
+          <Show when={showDashboard()}>
+            {(_) => {
+              const d = () => data() as GlobalOverviewData;
+              return (
+                <>
+                  <ChartCard
+                    activeView={activeView()}
+                    onViewChange={setActiveView}
+                    costValue={d().summary?.cost_today?.value ?? 0}
+                    costTrendPct={d().summary?.cost_today?.trend_pct ?? 0}
+                    tokensValue={d().summary?.tokens_today?.value ?? 0}
+                    tokensTrendPct={d().summary?.tokens_today?.trend_pct ?? 0}
+                    messagesValue={d().summary?.messages?.value ?? 0}
+                    messagesTrendPct={d().summary?.messages?.trend_pct ?? 0}
+                    costUsage={d().cost_usage}
+                    tokenUsage={d().token_usage}
+                    messageChartData={messageChartData()}
+                    range={range()}
+                  />
+
+                  {/* Recent Messages */}
+                  <div class="panel">
+                    <div
+                      class="panel__title"
+                      style="display: flex; justify-content: space-between; align-items: center;"
+                    >
+                      Recent Messages
+                      <A href="/messages" class="view-more-link">
+                        View more
+                      </A>
+                    </div>
+                    <MessageTable
+                      items={d().recent_activity?.slice(0, 5) ?? []}
+                      columns={columns()}
+                      agentName=""
+                      customProviderName={() => undefined}
+                    />
+                  </div>
+
+                  <CostByModelTable
+                    rows={d().cost_by_model ?? []}
+                    customProviderName={() => undefined}
+                  />
+                </>
+              );
+            }}
+          </Show>
+        </Show>
+      </Show>
+    </div>
+  );
+};
+
+export default GlobalOverview;

--- a/packages/frontend/src/pages/GlobalOverview.tsx
+++ b/packages/frontend/src/pages/GlobalOverview.tsx
@@ -1,17 +1,17 @@
 import { Meta, Title } from '@solidjs/meta';
 import { A } from '@solidjs/router';
-import { createMemo, createResource, createSignal, onMount, Show, type Component } from 'solid-js';
+import { createMemo, createResource, createSignal, Show, type Component } from 'solid-js';
 import ChartCard from '../components/ChartCard.jsx';
 import CostByModelTable from '../components/CostByModelTable.jsx';
 import ErrorState from '../components/ErrorState.jsx';
 import MessageTable from '../components/MessageTable.jsx';
 import OverviewSkeleton from '../components/OverviewSkeleton.jsx';
 import Select from '../components/Select.jsx';
-import { COMPACT_COLUMNS, type MessageRow } from '../components/message-table-types.js';
+import { type MessageRow } from '../components/message-table-types.js';
 import { getOverview } from '../services/api.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
-import { checkIsSelfHosted } from '../services/setup-status.js';
 import { messagePing } from '../services/sse.js';
+import { useOverviewColumns, useOverviewRange } from '../services/use-overview-range.js';
 import '../styles/overview.css';
 
 interface GlobalOverviewData {
@@ -49,24 +49,8 @@ interface GlobalOverviewData {
 
 const GlobalOverview: Component = () => {
   preloadModelDisplayNames();
-  const [isSelfHosted, setIsSelfHosted] = createSignal(false);
-  onMount(() => {
-    checkIsSelfHosted().then(setIsSelfHosted);
-  });
-  const columns = () =>
-    isSelfHosted() ? COMPACT_COLUMNS.filter((c) => c !== 'feedback') : COMPACT_COLUMNS;
-
-  const RANGE_STORAGE_KEY = 'manifest_chart_range';
-  const VALID_RANGES = new Set(['24h', '7d', '30d']);
-  const savedRange = localStorage.getItem(RANGE_STORAGE_KEY);
-  const [range, setRange] = createSignal(
-    savedRange && VALID_RANGES.has(savedRange) ? savedRange : '30d',
-  );
-
-  const handleRangeChange = (value: string) => {
-    setRange(value);
-    localStorage.setItem(RANGE_STORAGE_KEY, value);
-  };
+  const { columns } = useOverviewColumns();
+  const { range, handleRangeChange } = useOverviewRange();
 
   const [activeView, setActiveView] = createSignal<'cost' | 'tokens' | 'messages' | 'savings'>(
     'messages',

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -23,6 +23,7 @@ import { DETAILED_COLUMNS, type MessageRow } from '../components/message-table-t
 import { agentDisplayName } from '../services/agent-display-name.js';
 import { agentPlatform, agentCategory } from '../services/agent-platform-store.js';
 import {
+  getAgents,
   getCustomProviders,
   getSpecificityAssignments,
   getMessages,
@@ -67,6 +68,28 @@ const MessageLog: Component = () => {
   });
   const columns = () =>
     isSelfHosted() ? DETAILED_COLUMNS.filter((c) => c !== 'feedback') : DETAILED_COLUMNS;
+  const [agentFilter, setAgentFilter] = createSignal('');
+  const [agentList] = createResource(
+    () => !params.agentName,
+    async (isGlobal) => {
+      if (!isGlobal) return [] as string[];
+      try {
+        const data = (await getAgents()) as
+          | { agents?: Array<{ agent_name: string }> }
+          | Array<{ agent_name: string }>;
+        const list = (Array.isArray(data) ? data : (data?.agents ?? [])) as Array<{
+          agent_name: string;
+        }>;
+        return list.map((a) => a.agent_name).sort();
+      } catch {
+        return [] as string[];
+      }
+    },
+  );
+  const agentFilterOptions = createMemo(() => [
+    { label: 'All agents', value: '' },
+    ...(agentList() ?? []).map((a) => ({ label: a, value: a })),
+  ]);
   const [providerFilter, setProviderFilter] = createSignal('');
   const [tierFilter, setTierFilter] = createSignal('');
   const [costMin, setCostMin] = createSignal('');
@@ -175,7 +198,7 @@ const MessageLog: Component = () => {
   };
 
   createEffect(
-    on([providerFilter, tierFilter, costMin, costMax], () => pager.resetPage(), {
+    on([agentFilter, providerFilter, tierFilter, costMin, costMax], () => pager.resetPage(), {
       defer: true,
     }),
   );
@@ -186,7 +209,7 @@ const MessageLog: Component = () => {
       tier: tierFilter(),
       costMin: costMin(),
       costMax: costMax(),
-      agentName: params.agentName,
+      agentName: agentFilter() || params.agentName,
       _ping: messagePing(),
       cursor: pager.currentCursor(),
       limit: pager.pageSize,
@@ -231,7 +254,11 @@ const MessageLog: Component = () => {
   );
 
   const hasActiveFilters = () =>
-    providerFilter() !== '' || tierFilter() !== '' || costMin() !== '' || costMax() !== '';
+    agentFilter() !== '' ||
+    providerFilter() !== '' ||
+    tierFilter() !== '' ||
+    costMin() !== '' ||
+    costMax() !== '';
 
   const hasNoData = () => {
     const d = data();
@@ -243,6 +270,7 @@ const MessageLog: Component = () => {
   const showMessages = () => !hasNoData() || (hasProviders() && !hasActiveFilters());
 
   const clearFilters = () => {
+    setAgentFilter('');
     setProviderFilter('');
     setTierFilter('');
     setCostMin('');
@@ -315,6 +343,13 @@ const MessageLog: Component = () => {
         </div>
         <div class="header-controls">
           <Show when={!showEmptyState()}>
+            <Show when={!params.agentName}>
+              <Select
+                value={agentFilter()}
+                onChange={setAgentFilter}
+                options={agentFilterOptions()}
+              />
+            </Show>
             <Select
               value={providerFilter()}
               onChange={setProviderFilter}

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -66,24 +66,27 @@ const MessageLog: Component = () => {
   onMount(() => {
     checkIsSelfHosted().then(setIsSelfHosted);
   });
-  const columns = () =>
-    isSelfHosted() ? DETAILED_COLUMNS.filter((c) => c !== 'feedback') : DETAILED_COLUMNS;
+  const columns = () => {
+    const base = isSelfHosted()
+      ? DETAILED_COLUMNS.filter((c) => c !== 'feedback')
+      : DETAILED_COLUMNS;
+    if (params.agentName) return base;
+    // Global Messages spans every agent, so show which agent each row belongs to.
+    const at = base.indexOf('model');
+    return [...base.slice(0, at), 'agent' as const, ...base.slice(at)];
+  };
   const [agentFilter, setAgentFilter] = createSignal('');
   const [agentList] = createResource(
     () => !params.agentName,
     async (isGlobal) => {
       if (!isGlobal) return [] as string[];
-      try {
-        const data = (await getAgents()) as
-          | { agents?: Array<{ agent_name: string }> }
-          | Array<{ agent_name: string }>;
-        const list = (Array.isArray(data) ? data : (data?.agents ?? [])) as Array<{
-          agent_name: string;
-        }>;
-        return list.map((a) => a.agent_name).sort();
-      } catch {
-        return [] as string[];
-      }
+      const data = (await getAgents()) as
+        | { agents?: Array<{ agent_name: string }> }
+        | Array<{ agent_name: string }>;
+      const list = (Array.isArray(data) ? data : (data?.agents ?? [])) as Array<{
+        agent_name: string;
+      }>;
+      return list.map((a) => a.agent_name).sort();
     },
   );
   const agentFilterOptions = createMemo(() => [

--- a/packages/frontend/src/pages/MessageLog.tsx
+++ b/packages/frontend/src/pages/MessageLog.tsx
@@ -1,5 +1,5 @@
 import { Meta, Title } from '@solidjs/meta';
-import { useNavigate, useParams } from '@solidjs/router';
+import { A, useNavigate, useParams } from '@solidjs/router';
 import {
   createEffect,
   createMemo,
@@ -333,11 +333,17 @@ const MessageLog: Component = () => {
   return (
     <div class="container--full">
       <Title>
-        {agentDisplayName() ?? decodeURIComponent(params.agentName)} Messages - Manifest
+        {params.agentName
+          ? `${agentDisplayName() ?? decodeURIComponent(params.agentName)} Messages - Manifest`
+          : 'Messages - Manifest'}
       </Title>
       <Meta
         name="description"
-        content={`Browse all messages sent and received by ${agentDisplayName() ?? decodeURIComponent(params.agentName)}. Filter by provider or cost.`}
+        content={
+          params.agentName
+            ? `Browse all messages sent and received by ${agentDisplayName() ?? decodeURIComponent(params.agentName)}. Filter by provider or cost.`
+            : 'Browse all messages across all agents. Filter by provider or cost.'
+        }
       />
       <div class="page-header">
         <div>
@@ -383,7 +389,7 @@ const MessageLog: Component = () => {
               />
             </div>
           </Show>
-          <Show when={showEmptyState() && !setupCompleted()}>
+          <Show when={showEmptyState() && !!params.agentName && !setupCompleted()}>
             <button class="btn btn--primary btn--sm" onClick={() => setSetupOpen(true)}>
               Set up agent
             </button>
@@ -461,18 +467,34 @@ const MessageLog: Component = () => {
         <Show when={!data.error} fallback={<ErrorState error={data.error} onRetry={refetch} />}>
           <Show when={showEmptyState()}>
             <Show
-              when={setupCompleted()}
+              when={params.agentName && setupCompleted()}
               fallback={
                 <div class="empty-state">
                   <div class="empty-state__title">No messages yet</div>
-                  <p>Set up your agent and send a message. Every LLM call shows up here.</p>
-                  <button
-                    class="btn btn--primary btn--sm"
-                    style="margin-top: var(--gap-md);"
-                    onClick={() => setSetupOpen(true)}
+                  <Show
+                    when={params.agentName}
+                    fallback={
+                      <>
+                        <p>Create an agent and send a message. Every LLM call shows up here.</p>
+                        <A
+                          href="/agents"
+                          class="btn btn--primary btn--sm"
+                          style="margin-top: var(--gap-md);"
+                        >
+                          Go to Agents
+                        </A>
+                      </>
+                    }
                   >
-                    Set up agent
-                  </button>
+                    <p>Set up your agent and send a message. Every LLM call shows up here.</p>
+                    <button
+                      class="btn btn--primary btn--sm"
+                      style="margin-top: var(--gap-md);"
+                      onClick={() => setSetupOpen(true)}
+                    >
+                      Set up agent
+                    </button>
+                  </Show>
                   <div class="empty-state__img-wrapper">
                     <img
                       src="/example-messages.svg"
@@ -576,13 +598,15 @@ const MessageLog: Component = () => {
         </Show>
       </Show>
 
-      <SetupModal
-        open={setupOpen()}
-        agentName={decodeURIComponent(params.agentName)}
-        agentPlatform={agentPlatform()}
-        agentCategory={agentCategory()}
-        onClose={() => setSetupOpen(false)}
-      />
+      <Show when={!!params.agentName}>
+        <SetupModal
+          open={setupOpen()}
+          agentName={decodeURIComponent(params.agentName)}
+          agentPlatform={agentPlatform()}
+          agentCategory={agentCategory()}
+          onClose={() => setSetupOpen(false)}
+        />
+      </Show>
 
       <Show when={!isSelfHosted()}>
         <FeedbackModal

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -6,7 +6,6 @@ import {
   createResource,
   createSignal,
   on,
-  onMount,
   Show,
   type Component,
 } from 'solid-js';
@@ -18,7 +17,7 @@ import MessageTable from '../components/MessageTable.jsx';
 import OverviewSkeleton from '../components/OverviewSkeleton.jsx';
 import Select from '../components/Select.jsx';
 import SetupModal from '../components/SetupModal.jsx';
-import { COMPACT_COLUMNS, type MessageRow } from '../components/message-table-types.js';
+import { type MessageRow } from '../components/message-table-types.js';
 import { agentDisplayName } from '../services/agent-display-name.js';
 import {
   agentPlatform,
@@ -34,8 +33,12 @@ import {
 } from '../services/api.js';
 import { preloadModelDisplayNames } from '../services/model-display.js';
 import { isRecentlyCreated } from '../services/recent-agents.js';
-import { checkIsSelfHosted } from '../services/setup-status.js';
 import { messagePing } from '../services/sse.js';
+import {
+  RANGE_STORAGE_KEY,
+  useOverviewColumns,
+  useOverviewRange,
+} from '../services/use-overview-range.js';
 import SavingsCard from '../components/SavingsCard.jsx';
 import SavingsExplainer from '../components/SavingsExplainer.jsx';
 import '../styles/overview.css';
@@ -86,25 +89,13 @@ const Overview: Component = () => {
   const location = useLocation<{ newApiKey?: string }>();
   const navigate = useNavigate();
   preloadModelDisplayNames();
-  const [isSelfHosted, setIsSelfHosted] = createSignal(false);
-  onMount(() => {
-    checkIsSelfHosted().then(setIsSelfHosted);
-  });
-  const columns = () =>
-    isSelfHosted() ? COMPACT_COLUMNS.filter((c) => c !== 'feedback') : COMPACT_COLUMNS;
-  const RANGE_STORAGE_KEY = 'manifest_chart_range';
-  const VALID_RANGES = new Set(['24h', '7d', '30d']);
-  const savedRange = localStorage.getItem(RANGE_STORAGE_KEY);
-  const [range, setRange] = createSignal(
-    savedRange && VALID_RANGES.has(savedRange) ? savedRange : '30d',
+  const { isSelfHosted, columns } = useOverviewColumns();
+  const [userSelectedRange, setUserSelectedRange] = createSignal(
+    !!localStorage.getItem(RANGE_STORAGE_KEY),
   );
-  const [userSelectedRange, setUserSelectedRange] = createSignal(!!savedRange);
-
-  const handleRangeChange = (value: string) => {
-    setRange(value);
-    setUserSelectedRange(true);
-    localStorage.setItem(RANGE_STORAGE_KEY, value);
-  };
+  const { range, setRange, handleRangeChange } = useOverviewRange({
+    markUserSelected: () => setUserSelectedRange(true),
+  });
   const [activeView, setActiveView] = createSignal<'cost' | 'tokens' | 'messages' | 'savings'>(
     'messages',
   );

--- a/packages/frontend/src/pages/Overview.tsx
+++ b/packages/frontend/src/pages/Overview.tsx
@@ -36,6 +36,7 @@ import { isRecentlyCreated } from '../services/recent-agents.js';
 import { messagePing } from '../services/sse.js';
 import {
   RANGE_STORAGE_KEY,
+  VALID_RANGES,
   useOverviewColumns,
   useOverviewRange,
 } from '../services/use-overview-range.js';
@@ -90,8 +91,10 @@ const Overview: Component = () => {
   const navigate = useNavigate();
   preloadModelDisplayNames();
   const { isSelfHosted, columns } = useOverviewColumns();
+  // Only treat the stored value as a user selection when it is actually valid.
+  // An invalid stored range falls through to the smart-range cascade.
   const [userSelectedRange, setUserSelectedRange] = createSignal(
-    !!localStorage.getItem(RANGE_STORAGE_KEY),
+    VALID_RANGES.has(localStorage.getItem(RANGE_STORAGE_KEY) ?? ''),
   );
   const { range, setRange, handleRangeChange } = useOverviewRange({
     markUserSelected: () => setUserSelectedRange(true),

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -137,7 +137,7 @@ const Settings: Component = () => {
     try {
       await deleteAgent(agentName());
       toast.success(`Agent "${agentName()}" deleted`);
-      navigate('/', { replace: true });
+      navigate('/agents', { replace: true });
     } catch {
       setDeleting(false);
     }

--- a/packages/frontend/src/services/use-overview-range.ts
+++ b/packages/frontend/src/services/use-overview-range.ts
@@ -1,0 +1,41 @@
+import { createSignal, onMount } from 'solid-js';
+import { COMPACT_COLUMNS } from '../components/message-table-types.js';
+import { checkIsSelfHosted } from './setup-status.js';
+
+export const RANGE_STORAGE_KEY = 'manifest_chart_range';
+export const VALID_RANGES = new Set(['24h', '7d', '30d']);
+
+/**
+ * Shared range signal + localStorage persistence for Overview pages.
+ * Returns `range`, `setRange`, and `handleRangeChange`.
+ * `handleRangeChange` persists the new value and, when `markUserSelected` is
+ * provided, calls it so the smart-range cascade in the per-agent Overview knows
+ * the user made an explicit choice.
+ */
+export function useOverviewRange(options?: { markUserSelected?: () => void }) {
+  const saved = localStorage.getItem(RANGE_STORAGE_KEY);
+  const [range, setRange] = createSignal(saved && VALID_RANGES.has(saved) ? saved : '30d');
+
+  const handleRangeChange = (value: string) => {
+    setRange(value);
+    options?.markUserSelected?.();
+    localStorage.setItem(RANGE_STORAGE_KEY, value);
+  };
+
+  return { range, setRange, handleRangeChange };
+}
+
+/**
+ * Shared self-hosted check + column filter used by all Overview pages.
+ * Returns reactive `isSelfHosted` signal and derived `columns` accessor.
+ */
+export function useOverviewColumns() {
+  const [isSelfHosted, setIsSelfHosted] = createSignal(false);
+  onMount(() => {
+    checkIsSelfHosted().then(setIsSelfHosted);
+  });
+  const columns = () =>
+    isSelfHosted() ? COMPACT_COLUMNS.filter((c) => c !== 'feedback') : COMPACT_COLUMNS;
+
+  return { isSelfHosted, columns };
+}

--- a/packages/frontend/tests/components/App.test.tsx
+++ b/packages/frontend/tests/components/App.test.tsx
@@ -91,6 +91,27 @@ describe("App with agent path", () => {
     expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();
   });
 
+  it("shows sidebar on /overview path", () => {
+    routerState.pathname = "/overview";
+    const { container } = render(() => <App />);
+    expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
+    expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();
+  });
+
+  it("shows sidebar on /messages path", () => {
+    routerState.pathname = "/messages";
+    const { container } = render(() => <App />);
+    expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
+    expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();
+  });
+
+  it("shows sidebar on /agents path (workspace list)", () => {
+    routerState.pathname = "/agents";
+    const { container } = render(() => <App />);
+    expect(container.querySelector('[data-testid="sidebar"]')).not.toBeNull();
+    expect(container.querySelector(".app-body--with-sidebar")).not.toBeNull();
+  });
+
   it("opens and closes the mobile sidebar drawer", () => {
     routerState.pathname = "/agents/demo";
 

--- a/packages/frontend/tests/components/MessageTable.test.tsx
+++ b/packages/frontend/tests/components/MessageTable.test.tsx
@@ -983,4 +983,52 @@ describe('MessageTable', () => {
       expect(container.querySelector('.msg-detail__chevron-btn')).not.toBeNull();
     });
   });
+
+  describe('agent column (global mode)', () => {
+    it('renders Agent column header when agent column is in columns list', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ agent_name: 'my-agent' })]}
+          columns={['agent', 'date']}
+          customProviderName={noopProvider}
+        />
+      ));
+      const headers = container.querySelectorAll('th');
+      expect(headers[0]!.textContent).toContain('Agent');
+      expect(headers[1]!.textContent).toContain('Date');
+    });
+
+    it('renders agent_name value in agent cell', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ agent_name: 'my-agent' })]}
+          columns={['agent']}
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('my-agent');
+    });
+
+    it('renders em dash when agent_name is null', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow({ agent_name: null })]}
+          columns={['agent']}
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.textContent).toContain('—');
+    });
+
+    it('works without agentName prop (global mode)', () => {
+      const { container } = render(() => (
+        <MessageTable
+          items={[makeRow()]}
+          columns={['date', 'status']}
+          customProviderName={noopProvider}
+        />
+      ));
+      expect(container.querySelector('.data-table')).not.toBeNull();
+    });
+  });
 });

--- a/packages/frontend/tests/components/RootRedirect.test.tsx
+++ b/packages/frontend/tests/components/RootRedirect.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@solidjs/testing-library";
+
+vi.mock("@solidjs/router", () => ({
+  Navigate: (props: Record<string, unknown>) => (
+    <div data-testid="navigate" data-href={props.href as string} />
+  ),
+}));
+
+import RootRedirect from "../../src/components/RootRedirect";
+
+describe("RootRedirect", () => {
+  it("redirects the root path to the global Overview", () => {
+    const { container } = render(() => <RootRedirect />);
+    const navigate = container.querySelector('[data-testid="navigate"]');
+    expect(navigate).not.toBeNull();
+    expect(navigate?.getAttribute("data-href")).toBe("/overview");
+  });
+});

--- a/packages/frontend/tests/components/Sidebar.test.tsx
+++ b/packages/frontend/tests/components/Sidebar.test.tsx
@@ -142,15 +142,27 @@ describe("Sidebar with agent", () => {
   });
 });
 
-describe("Sidebar without agent", () => {
+describe("Sidebar without agent (global mode)", () => {
   beforeAll(() => {
     mockAgentName = null;
-    mockPathname = "/";
+    mockPathname = "/overview";
   });
 
-  it("renders Agents link when no agent selected", () => {
+  it("renders Overview link in global mode", () => {
     render(() => <Sidebar />);
-    expect(screen.getByText("Agents")).toBeDefined();
+    expect(screen.getByText("Overview")).toBeDefined();
+  });
+
+  it("renders Messages link in global mode", () => {
+    render(() => <Sidebar />);
+    expect(screen.getByText("Messages")).toBeDefined();
+  });
+
+  it("renders Agents link pointing to /agents in global mode", () => {
+    const { container } = render(() => <Sidebar />);
+    const agentsLink = container.querySelector('a[href="/agents"]');
+    expect(agentsLink).not.toBeNull();
+    expect(agentsLink?.textContent).toContain("Agents");
   });
 
   it("does not render MONITORING section when no agent", () => {
@@ -158,10 +170,26 @@ describe("Sidebar without agent", () => {
     expect(container.textContent).not.toContain("MONITORING");
   });
 
-  it("does not render agent navigation links when no agent", () => {
+  it("marks Overview link active on /overview path", () => {
     const { container } = render(() => <Sidebar />);
-    expect(container.textContent).not.toContain("Overview");
-    expect(container.textContent).not.toContain("Messages");
+    const overviewLink = container.querySelector('a[href="/overview"]');
+    expect(overviewLink?.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("marks Messages link active on /messages path", () => {
+    mockPathname = "/messages";
+    const { container } = render(() => <Sidebar />);
+    const messagesLink = container.querySelector('a[href="/messages"]');
+    expect(messagesLink?.getAttribute("aria-current")).toBe("page");
+    mockPathname = "/overview";
+  });
+
+  it("marks Agents link active on /agents path", () => {
+    mockPathname = "/agents";
+    const { container } = render(() => <Sidebar />);
+    const agentsLink = container.querySelector('a[href="/agents"]');
+    expect(agentsLink?.getAttribute("aria-current")).toBe("page");
+    mockPathname = "/overview";
   });
 });
 
@@ -216,11 +244,12 @@ describe("Sidebar active states for sub-paths", () => {
 describe("Sidebar with no agent selected", () => {
   beforeAll(() => {
     mockAgentName = null;
-    mockPathname = "/";
+    mockPathname = "/overview";
   });
 
-  it("shows Agents link when no agent is selected", () => {
-    render(() => <Sidebar />);
-    expect(screen.getByText("Agents")).toBeDefined();
+  it("shows Agents link pointing to /agents when no agent is selected", () => {
+    const { container } = render(() => <Sidebar />);
+    const agentsLink = container.querySelector('a[href="/agents"]');
+    expect(agentsLink).not.toBeNull();
   });
 });

--- a/packages/frontend/tests/components/message-table-cells.test.tsx
+++ b/packages/frontend/tests/components/message-table-cells.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@solidjs/testing-library';
-import { FallbackIcon, HeartbeatIcon, ModelCell, RecordedIcon } from '../../src/components/message-table-cells';
+import { FallbackIcon, HeartbeatIcon, ModelCell, RecordedIcon, AgentCell, StatusCell } from '../../src/components/message-table-cells';
 import type { MessageRow } from '../../src/components/message-table-types';
 
 vi.mock('@solidjs/router', () => ({
@@ -82,6 +82,38 @@ describe('RecordedIcon', () => {
     expect(svg!.getAttribute('aria-hidden')).toBe('true');
     const circles = container.querySelectorAll('circle');
     expect(circles.length).toBe(2);
+  });
+});
+
+describe('AgentCell', () => {
+  it('renders agent_name when present', () => {
+    const row = baseRow({ agent_name: 'my-agent' });
+    const { container } = render(() => <table><tbody><tr>{AgentCell(row)}</tr></tbody></table>);
+    expect(container.textContent).toContain('my-agent');
+  });
+
+  it('renders em dash when agent_name is null', () => {
+    const row = baseRow({ agent_name: null });
+    const { container } = render(() => <table><tbody><tr>{AgentCell(row)}</tr></tbody></table>);
+    expect(container.textContent).toContain('—');
+  });
+});
+
+describe('StatusCell without agentName (global mode)', () => {
+  it('renders plain text for rate_limited when no agentName provided', () => {
+    const row = baseRow({ status: 'rate_limited' });
+    const { container } = render(() => <table><tbody><tr>{StatusCell(row, undefined)}</tr></tbody></table>);
+    // No link, just text
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('rate_limited');
+  });
+
+  it('renders link for rate_limited when agentName is provided', () => {
+    const row = baseRow({ status: 'rate_limited' });
+    const { container } = render(() => <table><tbody><tr>{StatusCell(row, 'my-agent')}</tr></tbody></table>);
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute('href')).toContain('/agents/my-agent/limits');
   });
 });
 

--- a/packages/frontend/tests/pages/GlobalOverview.test.tsx
+++ b/packages/frontend/tests/pages/GlobalOverview.test.tsx
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@solidjs/testing-library";
+
+vi.mock("@solidjs/router", () => ({
+  A: (props: any) => <a href={props.href} class={props.class}>{props.children}</a>,
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@solidjs/meta", () => ({
+  Title: (props: any) => <title>{props.children}</title>,
+  Meta: (props: any) => <meta name={props.name ?? ""} content={props.content ?? ""} />,
+}));
+
+const mockGetOverview = vi.fn();
+vi.mock("../../src/services/api.js", () => ({
+  getOverview: (...args: unknown[]) => mockGetOverview(...args),
+}));
+
+vi.mock("../../src/services/sse.js", () => ({
+  messagePing: () => 0,
+}));
+
+vi.mock("../../src/services/model-display.js", () => ({
+  preloadModelDisplayNames: () => {},
+  getModelDisplayName: (slug: string) => slug,
+}));
+
+vi.mock("../../src/services/formatters.js", () => ({
+  formatCost: (v: number) => `$${v.toFixed(2)}`,
+  formatNumber: (v: number) => String(v),
+  formatStatus: (s: string) => s,
+  formatTime: (t: string) => t,
+  formatErrorMessage: (s: string) => s,
+  customProviderColor: vi.fn(() => "#6366f1"),
+}));
+
+const mockCheckIsSelfHosted = vi.fn(() => Promise.resolve(false));
+vi.mock("../../src/services/setup-status.js", () => ({
+  checkIsSelfHosted: () => mockCheckIsSelfHosted(),
+}));
+
+vi.mock("../../src/components/ChartCard.jsx", () => ({
+  default: (props: any) => (
+    <div
+      data-testid="chart-card"
+      data-active-view={props.activeView}
+      data-cost={props.costValue}
+      data-cost-trend={props.costTrendPct}
+      data-tokens={props.tokensValue}
+      data-tokens-trend={props.tokensTrendPct}
+      data-messages={props.messagesValue}
+      data-messages-trend={props.messagesTrendPct}
+      data-cost-usage={JSON.stringify(props.costUsage)}
+      data-token-usage={JSON.stringify(props.tokenUsage)}
+      data-range={props.range}
+      data-chart={JSON.stringify(props.messageChartData)}
+      onClick={() => props.onViewChange?.('cost')}
+    />
+  ),
+}));
+
+vi.mock("../../src/components/CostByModelTable.jsx", () => ({
+  default: (props: any) => (
+    <div data-testid="cost-by-model-table" data-rows={props.rows.length} />
+  ),
+}));
+
+vi.mock("../../src/components/MessageTable.jsx", () => ({
+  default: (props: any) => (
+    <div
+      data-testid="message-table"
+      data-items={props.items.length}
+      data-columns={props.columns?.join(',')}
+      data-agent={props.agentName}
+    />
+  ),
+}));
+
+vi.mock("../../src/components/OverviewSkeleton.jsx", () => ({
+  default: () => <div data-testid="overview-skeleton" />,
+}));
+
+vi.mock("../../src/components/Select.jsx", () => ({
+  default: (props: any) => (
+    <select data-testid="select" value={props.value} onChange={(e: any) => props.onChange(e.target.value)}>
+      {props.options?.map((o: any) => <option value={o.value}>{o.label}</option>)}
+    </select>
+  ),
+}));
+
+vi.mock("../../src/components/ErrorState.jsx", () => ({
+  default: (props: any) => <div data-testid="error-state">{props.title}</div>,
+}));
+
+vi.mock("../../src/components/InfoTooltip.jsx", () => ({
+  default: () => <span data-testid="info-tooltip" />,
+}));
+
+import GlobalOverview from "../../src/pages/GlobalOverview";
+
+const overviewData = {
+  summary: {
+    tokens_today: { value: 50000, trend_pct: 12, sub_values: { input: 30000, output: 20000 } },
+    cost_today: { value: 3.5, trend_pct: -5 },
+    messages: { value: 42, trend_pct: 8 },
+    services_hit: { total: 3, healthy: 3, issues: 0 },
+  },
+  token_usage: [{ hour: "2026-02-18 10:00:00", input_tokens: 1000, output_tokens: 500 }],
+  cost_usage: [{ hour: "2026-02-18 10:00:00", cost: 0.5 }],
+  message_usage: [{ hour: "2026-02-18 10:00:00", count: 5 }],
+  cost_by_model: [
+    { model: "gpt-4o", tokens: 30000, share_pct: 60, estimated_cost: 2.1, auth_type: "api_key" },
+  ],
+  recent_activity: [
+    { id: "msg-12345678", timestamp: "2026-02-18T10:00:00Z", agent_name: "agent-a", model: "gpt-4o", input_tokens: 100, output_tokens: 50, total_tokens: 150, cost: 0.01, status: "ok" },
+  ],
+  has_data: true,
+};
+
+const emptyOverviewData = {
+  summary: {
+    tokens_today: { value: 0, trend_pct: 0 },
+    cost_today: { value: 0, trend_pct: 0 },
+    messages: { value: 0, trend_pct: 0 },
+    services_hit: { total: 0, healthy: 0, issues: 0 },
+  },
+  token_usage: [],
+  cost_usage: [],
+  message_usage: [],
+  cost_by_model: [],
+  recent_activity: [],
+  has_data: false,
+  has_providers: false,
+};
+
+describe("GlobalOverview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it("renders Overview heading", () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    render(() => <GlobalOverview />);
+    expect(screen.getByText("Overview")).toBeDefined();
+  });
+
+  it("renders the page title", () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    expect(container.querySelector("title")?.textContent).toContain("Overview");
+  });
+
+  it("calls getOverview without agentName (global mode)", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      expect(mockGetOverview).toHaveBeenCalled();
+      const [range, agentName] = mockGetOverview.mock.calls[0];
+      expect(agentName).toBeUndefined();
+    });
+  });
+
+  it("shows loading skeleton while fetching", () => {
+    mockGetOverview.mockReturnValue(new Promise(() => {}));
+    const { container } = render(() => <GlobalOverview />);
+    expect(container.querySelector("[data-testid='overview-skeleton']")).not.toBeNull();
+  });
+
+  it("shows ChartCard after data loads", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      expect(container.querySelector("[data-testid='chart-card']")).not.toBeNull();
+    });
+  });
+
+  it("shows CostByModelTable after data loads", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      expect(container.querySelector("[data-testid='cost-by-model-table']")).not.toBeNull();
+    });
+  });
+
+  it("shows MessageTable with recent activity", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      expect(container.querySelector("[data-testid='message-table']")).not.toBeNull();
+    });
+  });
+
+  it("shows 'View more' link pointing to /messages", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      const link = container.querySelector('a[href="/messages"]');
+      expect(link).not.toBeNull();
+      expect(link?.textContent).toContain("View more");
+    });
+  });
+
+  it("updates range when select changes", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      expect(container.querySelector("[data-testid='select']")).not.toBeNull();
+    });
+    const select = container.querySelector("[data-testid='select']") as HTMLSelectElement;
+    const { fireEvent } = await import("@solidjs/testing-library");
+    fireEvent.change(select, { target: { value: "7d" } });
+    expect(localStorage.getItem("manifest_chart_range")).toBe("7d");
+  });
+
+  it("does not show agent-specific chrome (no setup modal, no agent title)", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      expect(container.querySelector("[data-testid='setup-modal']")).toBeNull();
+      expect(container.textContent).not.toContain("Set up agent");
+    });
+  });
+
+  it("shows range selector when data is present", async () => {
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      expect(container.querySelector("[data-testid='select']")).not.toBeNull();
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows empty state when has_data is false", async () => {
+      mockGetOverview.mockResolvedValue(emptyOverviewData);
+      const { container } = render(() => <GlobalOverview />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("No activity yet");
+      });
+    });
+
+    it("shows CTA link to /agents in empty state", async () => {
+      mockGetOverview.mockResolvedValue(emptyOverviewData);
+      const { container } = render(() => <GlobalOverview />);
+      await vi.waitFor(() => {
+        const agentsLink = container.querySelector('a[href="/agents"]');
+        expect(agentsLink).not.toBeNull();
+      });
+    });
+
+    it("does NOT key off has_providers for empty state (landmine guard)", async () => {
+      // has_providers is always false for global queries - must not cause perpetual empty state
+      const dataWithFalseProviders = { ...overviewData, has_providers: false };
+      mockGetOverview.mockResolvedValue(dataWithFalseProviders);
+      const { container } = render(() => <GlobalOverview />);
+      await vi.waitFor(() => {
+        // Dashboard should show (has_data: true), not empty state
+        expect(container.querySelector("[data-testid='chart-card']")).not.toBeNull();
+        expect(container.textContent).not.toContain("No activity yet");
+      });
+    });
+
+    it("does not show range selector in empty state", async () => {
+      mockGetOverview.mockResolvedValue(emptyOverviewData);
+      const { container } = render(() => <GlobalOverview />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("No activity yet");
+        expect(container.querySelector("[data-testid='select']")).toBeNull();
+      });
+    });
+  });
+
+
+  it("hides feedback column in self-hosted mode", async () => {
+    mockCheckIsSelfHosted.mockResolvedValue(true);
+    mockGetOverview.mockResolvedValue(overviewData);
+    const { container } = render(() => <GlobalOverview />);
+    await vi.waitFor(() => {
+      const table = container.querySelector("[data-testid='message-table']");
+      expect(table).not.toBeNull();
+    });
+    mockCheckIsSelfHosted.mockResolvedValue(false);
+  });
+});

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@solidjs/meta", () => ({
 }));
 
 const mockGetMessages = vi.fn();
+const mockGetAgents = vi.fn();
 const mockGetCustomProviders = vi.fn();
 const mockGetSpecificityAssignments = vi.fn();
 const mockGetMessageDetails = vi.fn();
@@ -25,6 +26,7 @@ const mockClearMessageFeedback = vi.fn();
 const mockDeleteMessageRecording = vi.fn();
 vi.mock("../../src/services/api.js", () => ({
   getMessages: (...args: unknown[]) => mockGetMessages(...args),
+  getAgents: (...args: unknown[]) => mockGetAgents(...args),
   getCustomProviders: (...args: unknown[]) => mockGetCustomProviders(...args),
   getSpecificityAssignments: (...args: unknown[]) => mockGetSpecificityAssignments(...args),
   getMessageDetails: (...args: unknown[]) => mockGetMessageDetails(...args),
@@ -132,6 +134,7 @@ describe("MessageLog", () => {
     vi.clearAllMocks();
     localStorage.clear();
     mockAgentName = "test-agent";
+    mockGetAgents.mockResolvedValue({ agents: [{ agent_name: "agent-alpha" }, { agent_name: "agent-beta" }] });
     mockGetCustomProviders.mockResolvedValue([]);
     mockGetSpecificityAssignments.mockResolvedValue([]);
     mockGetRoutingStatus.mockResolvedValue({ enabled: false });
@@ -1275,6 +1278,170 @@ describe("MessageLog", () => {
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
         expect(lastQ.header_tier_id).toBe("ht-premium");
         expect(lastQ.routing_tier).toBeUndefined();
+      });
+    });
+  });
+
+  describe("Agent filter (global mode)", () => {
+    it("renders agent filter dropdown in global mode (no agentName)", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const selects = container.querySelectorAll('[data-testid="select"]');
+        // agent filter is the first select in global mode
+        expect(selects.length).toBeGreaterThanOrEqual(1);
+        expect(selects[0].textContent).toContain("All agents");
+      });
+    });
+
+    it("populates agent filter with sorted agent names from getAgents()", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const selects = container.querySelectorAll('[data-testid="select"]');
+        expect(selects[0].textContent).toContain("agent-alpha");
+        expect(selects[0].textContent).toContain("agent-beta");
+      });
+    });
+
+    it("does NOT render agent filter dropdown in agent-scoped mode", async () => {
+      // mockAgentName is "test-agent" from beforeEach
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const selects = container.querySelectorAll('[data-testid="select"]');
+        // In agent mode, first select is provider filter (no "All agents" option)
+        expect(selects[0].textContent).not.toContain("All agents");
+        expect(selects[0].textContent).toContain("All providers");
+      });
+    });
+
+    it("passes agent_name query param when an agent is selected", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      // Wait for agentList to resolve so the options are populated
+      await vi.waitFor(() => {
+        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain("agent-alpha");
+      });
+      mockGetMessages.mockClear();
+      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      await vi.waitFor(() => {
+        const calls = mockGetMessages.mock.calls;
+        const lastQ = calls[calls.length - 1]?.[0] ?? {};
+        expect(lastQ.agent_name).toBe("agent-alpha");
+      });
+    });
+
+    it("omits agent_name query param when 'All agents' is selected", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      // Wait for agentList to resolve so the options are populated
+      await vi.waitFor(() => {
+        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain("agent-alpha");
+      });
+      // Select an agent first
+      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      await vi.waitFor(() => {
+        const calls = mockGetMessages.mock.calls;
+        expect(calls.some((c: any[]) => c[0]?.agent_name === "agent-alpha")).toBe(true);
+      });
+      mockGetMessages.mockClear();
+      // Then go back to "All agents"
+      fireEvent.change(agentSelect, { target: { value: "" } });
+      await vi.waitFor(() => {
+        const calls = mockGetMessages.mock.calls;
+        const lastQ = calls[calls.length - 1]?.[0] ?? {};
+        expect(lastQ.agent_name).toBeUndefined();
+      });
+    });
+
+    it("includes agentFilter in hasActiveFilters so filtered-empty state appears", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      // Wait for agentList to resolve before interacting with the filter
+      await vi.waitFor(() => {
+        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain("agent-alpha");
+      });
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
+      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("No messages match your filters");
+      });
+    });
+
+    it("clears agentFilter when Clear filters is clicked", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      // Wait for agentList to resolve before interacting with the filter
+      await vi.waitFor(() => {
+        const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+        expect(agentSelect.textContent).toContain("agent-alpha");
+      });
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: ["openai"] });
+      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("No messages match your filters");
+      });
+      // Clear filters — restores data
+      mockGetMessages.mockResolvedValue(messagesData);
+      const clearBtn = container.querySelector(".btn--outline") as HTMLButtonElement;
+      fireEvent.click(clearBtn);
+      await vi.waitFor(() => {
+        const calls = mockGetMessages.mock.calls;
+        expect(calls.some((c: any[]) => !c[0]?.agent_name)).toBe(true);
+      });
+    });
+
+    it("handles getAgents() error gracefully (empty agent list)", async () => {
+      mockAgentName = "";
+      mockGetAgents.mockRejectedValue(new Error("network error"));
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        const selects = container.querySelectorAll('[data-testid="select"]');
+        // Agent filter still renders with just "All agents"
+        expect(selects[0].textContent).toContain("All agents");
+        expect(selects[0].textContent).not.toContain("agent-alpha");
+      });
+    });
+
+    it("resets page when agentFilter changes", async () => {
+      mockAgentName = "";
+      const bigData = { ...messagesData, total_count: 120, next_cursor: "cursor-2" };
+      mockGetMessages.mockResolvedValue(bigData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.querySelector('[data-testid="pagination-next"]')).not.toBeNull();
+      });
+      // Navigate to next page
+      const nextBtn = container.querySelector('[data-testid="pagination-next"]') as HTMLButtonElement;
+      mockGetMessages.mockResolvedValue({ ...bigData, next_cursor: null });
+      nextBtn.click();
+      await vi.waitFor(() => {
+        expect(mockGetMessages).toHaveBeenCalledWith(expect.objectContaining({ cursor: "cursor-2" }));
+      });
+      // Changing agent filter should reset page (no cursor)
+      mockGetMessages.mockClear();
+      mockGetMessages.mockResolvedValue(messagesData);
+      const agentSelect = container.querySelectorAll('[data-testid="select"]')[0] as HTMLSelectElement;
+      fireEvent.change(agentSelect, { target: { value: "agent-alpha" } });
+      await vi.waitFor(() => {
+        const calls = mockGetMessages.mock.calls;
+        const lastQ = calls[calls.length - 1]?.[0] ?? {};
+        expect(lastQ.cursor).toBeUndefined();
       });
     });
   });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -1405,17 +1405,28 @@ describe("MessageLog", () => {
       });
     });
 
-    it("handles getAgents() error gracefully (empty agent list)", async () => {
+    it("surfaces getAgents() errors to the resource error state (not silently empty)", async () => {
       mockAgentName = "";
-      mockGetAgents.mockRejectedValue(new Error("network error"));
+      // The loader no longer swallows errors: when getAgents() rejects the
+      // rejection propagates out of the loader so SolidJS resource transitions
+      // into error state instead of silently returning [].
+      // We verify: (1) getAgents was actually called; (2) the UI still renders
+      // the agent filter gracefully via `agentList() ?? []`.
+      mockGetAgents.mockImplementation(async () => {
+        throw new Error("network error");
+      });
       mockGetMessages.mockResolvedValue(messagesData);
-      const { container } = render(() => <MessageLog />);
+      const { container, unmount } = render(() => <MessageLog />);
       await vi.waitFor(() => {
+        expect(mockGetAgents).toHaveBeenCalled();
         const selects = container.querySelectorAll('[data-testid="select"]');
-        // Agent filter still renders with just "All agents"
+        // Agent filter still renders gracefully (agentList() ?? [] = [])
         expect(selects[0].textContent).toContain("All agents");
         expect(selects[0].textContent).not.toContain("agent-alpha");
       });
+      // Unmount and reset before the rejection can leak into the next test.
+      unmount();
+      mockGetAgents.mockResolvedValue({ agents: [] });
     });
 
     it("resets page when agentFilter changes", async () => {
@@ -1442,6 +1453,53 @@ describe("MessageLog", () => {
         const calls = mockGetMessages.mock.calls;
         const lastQ = calls[calls.length - 1]?.[0] ?? {};
         expect(lastQ.cursor).toBeUndefined();
+      });
+    });
+
+    it("renders 'Agent' column header in the message table when in global mode", async () => {
+      // Fix: columns() now inserts 'agent' before 'model' when !params.agentName.
+      // This test asserts the Agent column header actually appears in the DOM,
+      // not just that the component receives the columns array.
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("gpt-4o");
+      });
+      const headers = Array.from(container.querySelectorAll("thead th"));
+      const headerTexts = headers.map((th) => th.textContent?.trim());
+      expect(headerTexts).toContain("Agent");
+    });
+
+    it("does NOT render 'Agent' column header in agent-scoped mode", async () => {
+      // mockAgentName is "test-agent" from beforeEach — agent-scoped mode.
+      // columns() returns DETAILED_COLUMNS unchanged (no 'agent' key).
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("gpt-4o");
+      });
+      const headers = Array.from(container.querySelectorAll("thead th"));
+      const headerTexts = headers.map((th) => th.textContent?.trim());
+      expect(headerTexts).not.toContain("Agent");
+    });
+
+    it("renders agent_name values in the Agent column cells in global mode", async () => {
+      // Each message row must show its agent_name in the Agent cell when
+      // the 'agent' column is included (global mode).
+      mockAgentName = "";
+      const globalMessagesData = {
+        ...messagesData,
+        items: [
+          { ...messagesData.items[0], agent_name: "alpha-bot" },
+          { ...messagesData.items[1], agent_name: "beta-bot" },
+        ],
+      };
+      mockGetMessages.mockResolvedValue(globalMessagesData);
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("alpha-bot");
+        expect(container.textContent).toContain("beta-bot");
       });
     });
   });

--- a/packages/frontend/tests/pages/MessageLog.test.tsx
+++ b/packages/frontend/tests/pages/MessageLog.test.tsx
@@ -1503,4 +1503,71 @@ describe("MessageLog", () => {
       });
     });
   });
+
+  describe("global mode title and CTA (Bug 2 + Bug 3)", () => {
+    it("renders 'Messages - Manifest' title without agent prefix in global mode", () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      const title = container.querySelector("title");
+      expect(title?.textContent).toBe("Messages - Manifest");
+    });
+
+    it("renders agent-scoped title in agent mode", () => {
+      // mockAgentName is "test-agent" from beforeEach
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      const title = container.querySelector("title");
+      expect(title?.textContent).toContain("test-agent");
+      expect(title?.textContent).toContain("Messages - Manifest");
+    });
+
+    it("does not render 'undefined' in the title in global mode", () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue(messagesData);
+      const { container } = render(() => <MessageLog />);
+      const title = container.querySelector("title");
+      expect(title?.textContent).not.toContain("undefined");
+    });
+
+    it("does not render SetupModal in global mode (no agentName)", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        // Setup modal must not be rendered when there is no agentName
+        expect(container.querySelector('[data-testid="setup-modal"]')).toBeNull();
+      });
+    });
+
+    it("shows 'Go to Agents' link (not SetupModal CTA) in the empty state in global mode", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("No messages yet");
+        // Global empty state guides to /agents, not set-up-agent modal
+        const link = container.querySelector('a[href="/agents"]') as HTMLAnchorElement;
+        expect(link).not.toBeNull();
+        expect(link.textContent).toContain("Go to Agents");
+        // No "Set up agent" button in global mode
+        expect(container.textContent).not.toContain("Set up agent");
+      });
+    });
+
+    it("does not navigate to /agents/undefined/routing in global mode", async () => {
+      mockAgentName = "";
+      mockGetMessages.mockResolvedValue({ items: [], next_cursor: null, total_count: 0, providers: [] });
+      const { container } = render(() => <MessageLog />);
+      await vi.waitFor(() => {
+        expect(container.textContent).toContain("No messages yet");
+      });
+      // Clicking the "Go to Agents" link should use the href attribute, not navigate()
+      // Verify no button triggers mockNavigate with "/agents/undefined/routing"
+      expect(mockNavigate).not.toHaveBeenCalledWith(
+        expect.stringContaining("undefined"),
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/packages/frontend/tests/pages/Overview.test.tsx
+++ b/packages/frontend/tests/pages/Overview.test.tsx
@@ -697,6 +697,26 @@ describe("Overview", () => {
         expect(select.value).toBe("30d");
       });
     });
+
+    it("cascades when localStorage contains an invalid range (not treated as user selection)", async () => {
+      // An invalid stored range must NOT lock userSelectedRange=true;
+      // the smart-range cascade must still kick in.
+      localStorage.setItem("manifest_chart_range", "invalid");
+      const emptyUsageData = {
+        ...overviewData,
+        has_data: true,
+        token_usage: [],
+        cost_usage: [],
+        message_usage: [],
+      };
+      mockGetOverview.mockResolvedValue(emptyUsageData);
+      const { container } = render(() => <Overview />);
+      await vi.waitFor(() => {
+        // Cascade should run: all-empty data + invalid stored range → lands at 24h
+        const select = container.querySelector('[data-testid="select"]') as HTMLSelectElement;
+        expect(select.value).toBe("24h");
+      });
+    });
   });
 
   it("renders provider icon and auth badge in cost_by_model for known providers", async () => {

--- a/packages/frontend/tests/services/use-overview-range.test.ts
+++ b/packages/frontend/tests/services/use-overview-range.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'solid-js';
+import {
+  RANGE_STORAGE_KEY,
+  VALID_RANGES,
+  useOverviewRange,
+  useOverviewColumns,
+} from '../../src/services/use-overview-range';
+
+const mockCheckIsSelfHosted = vi.fn(() => Promise.resolve(false));
+vi.mock('../../src/services/setup-status.js', () => ({
+  checkIsSelfHosted: () => mockCheckIsSelfHosted(),
+}));
+
+vi.mock('../../src/components/message-table-types.js', () => ({
+  COMPACT_COLUMNS: ['timestamp', 'model', 'cost', 'feedback'],
+}));
+
+describe('use-overview-range', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockCheckIsSelfHosted.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('RANGE_STORAGE_KEY', () => {
+    it('is the expected localStorage key string', () => {
+      expect(RANGE_STORAGE_KEY).toBe('manifest_chart_range');
+    });
+  });
+
+  describe('VALID_RANGES', () => {
+    it('contains 24h, 7d, and 30d', () => {
+      expect(VALID_RANGES.has('24h')).toBe(true);
+      expect(VALID_RANGES.has('7d')).toBe(true);
+      expect(VALID_RANGES.has('30d')).toBe(true);
+    });
+
+    it('does not contain invalid values', () => {
+      expect(VALID_RANGES.has('1y')).toBe(false);
+      expect(VALID_RANGES.has('')).toBe(false);
+    });
+  });
+
+  describe('useOverviewRange', () => {
+    it('defaults to 30d when localStorage is empty', () => {
+      let rangeValue: string | undefined;
+      const dispose = createRoot((d) => {
+        const { range } = useOverviewRange();
+        rangeValue = range();
+        return d;
+      });
+      expect(rangeValue).toBe('30d');
+      dispose();
+    });
+
+    it('reads saved range from localStorage when valid', () => {
+      localStorage.setItem(RANGE_STORAGE_KEY, '7d');
+      let rangeValue: string | undefined;
+      const dispose = createRoot((d) => {
+        const { range } = useOverviewRange();
+        rangeValue = range();
+        return d;
+      });
+      expect(rangeValue).toBe('7d');
+      dispose();
+    });
+
+    it('falls back to 30d when localStorage contains an invalid value', () => {
+      localStorage.setItem(RANGE_STORAGE_KEY, 'invalid-range');
+      let rangeValue: string | undefined;
+      const dispose = createRoot((d) => {
+        const { range } = useOverviewRange();
+        rangeValue = range();
+        return d;
+      });
+      expect(rangeValue).toBe('30d');
+      dispose();
+    });
+
+    it('handleRangeChange updates the signal and persists to localStorage', () => {
+      let rangeValue: (() => string) | undefined;
+      let handleChange: ((v: string) => void) | undefined;
+      const dispose = createRoot((d) => {
+        const { range, handleRangeChange } = useOverviewRange();
+        rangeValue = range;
+        handleChange = handleRangeChange;
+        return d;
+      });
+
+      handleChange!('24h');
+
+      expect(rangeValue!()).toBe('24h');
+      expect(localStorage.getItem(RANGE_STORAGE_KEY)).toBe('24h');
+      dispose();
+    });
+
+    it('handleRangeChange calls markUserSelected when provided', () => {
+      const markUserSelected = vi.fn();
+      let handleChange: ((v: string) => void) | undefined;
+      const dispose = createRoot((d) => {
+        const { handleRangeChange } = useOverviewRange({ markUserSelected });
+        handleChange = handleRangeChange;
+        return d;
+      });
+
+      handleChange!('7d');
+
+      expect(markUserSelected).toHaveBeenCalledTimes(1);
+      dispose();
+    });
+
+    it('handleRangeChange does not throw when markUserSelected is not provided', () => {
+      let handleChange: ((v: string) => void) | undefined;
+      const dispose = createRoot((d) => {
+        const { handleRangeChange } = useOverviewRange();
+        handleChange = handleRangeChange;
+        return d;
+      });
+
+      expect(() => handleChange!('24h')).not.toThrow();
+      dispose();
+    });
+
+    it('exposes setRange for direct signal mutation', () => {
+      let rangeValue: (() => string) | undefined;
+      let setRangeFunc: ((v: string) => void) | undefined;
+      const dispose = createRoot((d) => {
+        const { range, setRange } = useOverviewRange();
+        rangeValue = range;
+        setRangeFunc = setRange;
+        return d;
+      });
+
+      setRangeFunc!('7d');
+      expect(rangeValue!()).toBe('7d');
+      dispose();
+    });
+  });
+
+  describe('useOverviewColumns', () => {
+    it('initially returns all COMPACT_COLUMNS (isSelfHosted defaults false)', () => {
+      let cols: (() => string[]) | undefined;
+      const dispose = createRoot((d) => {
+        const { columns } = useOverviewColumns();
+        cols = columns;
+        return d;
+      });
+      // Before the async check resolves, isSelfHosted is false → full columns
+      expect(cols!()).toEqual(['timestamp', 'model', 'cost', 'feedback']);
+      dispose();
+    });
+
+    it('filters out feedback column when isSelfHosted resolves to true', async () => {
+      mockCheckIsSelfHosted.mockResolvedValue(true);
+      let cols: (() => string[]) | undefined;
+      const dispose = createRoot((d) => {
+        const { columns } = useOverviewColumns();
+        cols = columns;
+        return d;
+      });
+
+      await vi.waitFor(() => {
+        expect(cols!()).not.toContain('feedback');
+      });
+      dispose();
+    });
+
+    it('keeps feedback column when isSelfHosted resolves to false', async () => {
+      mockCheckIsSelfHosted.mockResolvedValue(false);
+      let cols: (() => string[]) | undefined;
+      const dispose = createRoot((d) => {
+        const { columns } = useOverviewColumns();
+        cols = columns;
+        return d;
+      });
+
+      await vi.waitFor(() => {
+        expect(cols!()).toContain('feedback');
+      });
+      dispose();
+    });
+
+    it('exposes the isSelfHosted signal', async () => {
+      mockCheckIsSelfHosted.mockResolvedValue(true);
+      let selfHosted: (() => boolean) | undefined;
+      const dispose = createRoot((d) => {
+        const { isSelfHosted } = useOverviewColumns();
+        selfHosted = isSelfHosted;
+        return d;
+      });
+
+      await vi.waitFor(() => {
+        expect(selfHosted!()).toBe(true);
+      });
+      dispose();
+    });
+  });
+});


### PR DESCRIPTION
### ✨ What changed
- Add tenant-global `/overview` and `/messages` routes. `/` redirects to `/overview`.
- Move the agents grid to `/agents`. Sidebar gains a global section (Overview / Messages / Agents).
- Global Messages: Agent column + "All agents" filter; correct page title and empty-state CTA in global mode.
- New lean `GlobalOverview` page.

### 💭 Why
First slice of the larger provider-management UI (#2061), split so the navigation shell ships on its own.

### 👤 For users
The landing page is a dashboard across all agents; Messages can be filtered by agent. Per-agent views are unchanged.

### 📝 Notes
- Frontend only. No backend or schema change (reuses existing tenant-scoped endpoints).
- 100% line coverage on changed files; full frontend suite green.
- Base of the stacked series; PR2 (#2150) targets this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tenant-wide dashboard with new `/overview` and `/messages` pages, a global sidebar (Overview / Messages / Agents), and redirects `/` to `/overview`. The agents list now lives at `/agents`; per‑agent pages remain unchanged.

- New Features
  - Added `/overview` (global summary with charts, recent messages, and cost-by-model) and `/messages`; `/` now redirects to `/overview`.
  - Sidebar shows a global section and is visible on `/overview`, `/messages`, and `/agents`.
  - Moved agents grid to `/agents`; breadcrumb and post-delete navigation now point to `/agents`.
  - Global Messages: added an “All agents” filter and an Agent column; correct page title and a global empty-state CTA to Agents.

- Bug Fixes and Refactors
  - Fixed global Messages to avoid agent-scoped UI: no “undefined” titles, no agent setup modal, and proper empty-state CTA.
  - In global mode, “rate_limited” status renders as text (no agent limits link).
  - Surface agent list load errors instead of silently hiding them.
  - Extracted shared hooks `useOverviewRange` and `useOverviewColumns` for chart range persistence and self-hosted column logic across Overview pages.
  - Overview: only valid saved ranges are treated as user selections; invalid values no longer disable the smart-range cascade.

<sup>Written for commit c2b2992389d4f4ac4468a47d8c6ffc0515d55f16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

