### PR TITLE
fix: stop reverse-proxied requests from bypassing auth

### DIFF
--- a/.changeset/harden-loopback-auth-behind-proxy.md
+++ b/.changeset/harden-loopback-auth-behind-proxy.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Harden loopback auth: the self-hosted dashboard shortcut and the dev-mode ingest shortcut no longer trust requests that arrive through a reverse proxy (any `X-Forwarded-For` / `X-Real-IP` / `Forwarded` header), so a same-host proxy can't expose them to remote callers. The API also rejects unexpected fields in request bodies instead of silently dropping them.

--- a/packages/backend/src/auth/session.guard.spec.ts
+++ b/packages/backend/src/auth/session.guard.spec.ts
@@ -248,6 +248,23 @@ describe('SessionGuard', () => {
       expect(request['user']).toBeUndefined();
       expect(request['authMethod']).toBeUndefined();
     });
+
+    it('does NOT inject synthetic user for a loopback peer behind a reverse proxy', async () => {
+      // A same-host reverse proxy makes the socket peer 127.0.0.1 for every
+      // forwarded request. The presence of a forwarding header proves this is
+      // not a direct local call, so the shortcut must be suppressed.
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(false);
+      (auth.api.getSession as jest.Mock).mockResolvedValue(null);
+      const { context, request } = createMockContext({
+        ip: '127.0.0.1',
+        headers: { 'x-forwarded-for': '8.8.8.8' },
+      });
+
+      await guard.canActivate(context);
+
+      expect(request['user']).toBeUndefined();
+      expect(request['authMethod']).toBeUndefined();
+    });
   });
 
   describe('session cache', () => {

--- a/packages/backend/src/auth/session.guard.ts
+++ b/packages/backend/src/auth/session.guard.ts
@@ -5,7 +5,7 @@ import { fromNodeHeaders } from 'better-auth/node';
 import { createHash } from 'crypto';
 import { auth } from './auth.instance';
 import { IS_PUBLIC_KEY } from '../common/decorators/public.decorator';
-import { isLoopbackPeer } from '../common/utils/local-ip';
+import { isTrustedLoopbackPeer } from '../common/utils/local-ip';
 import { isSelfHosted } from '../common/utils/detect-self-hosted';
 
 interface CachedSession {
@@ -86,11 +86,14 @@ export class SessionGuard implements CanActivate, OnModuleDestroy {
     // In the self-hosted version, fall back to a synthetic user for loopback
     // requests without a session (e.g. curl, programmatic access).
     //
-    // Use the TCP peer address (request.socket.remoteAddress) — request.ip
-    // honors `trust proxy` and X-Forwarded-For, which a remote attacker can
-    // forge when the backend is reachable directly or sits behind a proxy
-    // that fails to strip XFF. The socket address cannot be spoofed.
-    if (isSelfHosted() && isLoopbackPeer(request)) {
+    // `isTrustedLoopbackPeer` checks the TCP peer address
+    // (request.socket.remoteAddress) — request.ip honors `trust proxy` and
+    // X-Forwarded-For, which a remote attacker can forge. It also suppresses
+    // the shortcut whenever a forwarding header is present: a same-host
+    // reverse proxy makes every request's peer 127.0.0.1, so without that
+    // guard a proxied self-hosted instance would hand the trusted Local User
+    // to anyone on the internet.
+    if (isSelfHosted() && isTrustedLoopbackPeer(request)) {
       (request as Request & { user: unknown }).user = {
         id: 'local',
         name: 'Local User',

--- a/packages/backend/src/common/utils/local-ip.spec.ts
+++ b/packages/backend/src/common/utils/local-ip.spec.ts
@@ -1,0 +1,96 @@
+import type { Request } from 'express';
+import {
+  getSocketRemoteAddress,
+  hasForwardedHeaders,
+  isLoopbackIp,
+  isLoopbackPeer,
+  isTrustedLoopbackPeer,
+} from './local-ip';
+
+function makeRequest(
+  peer: string | undefined,
+  headers: Record<string, string | string[] | undefined> = {},
+): Request {
+  return {
+    socket: peer === undefined ? {} : { remoteAddress: peer },
+    headers,
+  } as unknown as Request;
+}
+
+describe('local-ip', () => {
+  describe('isLoopbackIp', () => {
+    it('recognizes IPv4, IPv6 and IPv4-mapped loopback', () => {
+      expect(isLoopbackIp('127.0.0.1')).toBe(true);
+      expect(isLoopbackIp('::1')).toBe(true);
+      expect(isLoopbackIp('::ffff:127.0.0.1')).toBe(true);
+    });
+
+    it('rejects non-loopback addresses', () => {
+      expect(isLoopbackIp('8.8.8.8')).toBe(false);
+      expect(isLoopbackIp('192.168.1.1')).toBe(false);
+      expect(isLoopbackIp('')).toBe(false);
+    });
+  });
+
+  describe('getSocketRemoteAddress', () => {
+    it('returns the socket peer address', () => {
+      expect(getSocketRemoteAddress(makeRequest('203.0.113.5'))).toBe('203.0.113.5');
+    });
+
+    it('returns undefined when the socket has no remote address', () => {
+      expect(getSocketRemoteAddress(makeRequest(undefined))).toBeUndefined();
+    });
+  });
+
+  describe('isLoopbackPeer', () => {
+    it('is true for a loopback TCP peer', () => {
+      expect(isLoopbackPeer(makeRequest('127.0.0.1'))).toBe(true);
+      expect(isLoopbackPeer(makeRequest('::1'))).toBe(true);
+    });
+
+    it('is false for a remote peer or a missing peer', () => {
+      expect(isLoopbackPeer(makeRequest('203.0.113.5'))).toBe(false);
+      expect(isLoopbackPeer(makeRequest(undefined))).toBe(false);
+    });
+  });
+
+  describe('hasForwardedHeaders', () => {
+    it.each(['forwarded', 'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-real-ip'])(
+      'detects the %s header when set to a non-empty string',
+      (header) => {
+        expect(hasForwardedHeaders(makeRequest('127.0.0.1', { [header]: '1.2.3.4' }))).toBe(true);
+      },
+    );
+
+    it('detects a forwarding header set to a non-empty array', () => {
+      expect(
+        hasForwardedHeaders(makeRequest('127.0.0.1', { 'x-forwarded-for': ['1.2.3.4'] })),
+      ).toBe(true);
+    });
+
+    it('ignores empty string and empty array header values', () => {
+      expect(hasForwardedHeaders(makeRequest('127.0.0.1', { 'x-forwarded-for': '' }))).toBe(false);
+      expect(hasForwardedHeaders(makeRequest('127.0.0.1', { 'x-forwarded-for': [] }))).toBe(false);
+    });
+
+    it('is false when no forwarding headers are present', () => {
+      expect(hasForwardedHeaders(makeRequest('127.0.0.1', { cookie: 'a=b' }))).toBe(false);
+    });
+  });
+
+  describe('isTrustedLoopbackPeer', () => {
+    it('trusts a direct loopback call with no forwarding headers', () => {
+      expect(isTrustedLoopbackPeer(makeRequest('127.0.0.1'))).toBe(true);
+    });
+
+    it('does NOT trust a loopback peer that carries a forwarding header (reverse proxy)', () => {
+      expect(
+        isTrustedLoopbackPeer(makeRequest('127.0.0.1', { 'x-forwarded-for': '8.8.8.8' })),
+      ).toBe(false);
+    });
+
+    it('does NOT trust a non-loopback peer', () => {
+      expect(isTrustedLoopbackPeer(makeRequest('203.0.113.5'))).toBe(false);
+    });
+  });
+});

--- a/packages/backend/src/common/utils/local-ip.spec.ts
+++ b/packages/backend/src/common/utils/local-ip.spec.ts
@@ -55,22 +55,28 @@ describe('local-ip', () => {
   });
 
   describe('hasForwardedHeaders', () => {
-    it.each(['forwarded', 'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-real-ip'])(
-      'detects the %s header when set to a non-empty string',
-      (header) => {
-        expect(hasForwardedHeaders(makeRequest('127.0.0.1', { [header]: '1.2.3.4' }))).toBe(true);
-      },
-    );
+    it.each([
+      'forwarded',
+      'x-forwarded-for',
+      'x-forwarded-host',
+      'x-forwarded-proto',
+      'x-forwarded-port',
+      'x-real-ip',
+      'via',
+    ])('detects the %s proxy header', (header) => {
+      expect(hasForwardedHeaders(makeRequest('127.0.0.1', { [header]: '1.2.3.4' }))).toBe(true);
+    });
 
-    it('detects a forwarding header set to a non-empty array', () => {
+    it('detects a forwarding header set to an array', () => {
       expect(
         hasForwardedHeaders(makeRequest('127.0.0.1', { 'x-forwarded-for': ['1.2.3.4'] })),
       ).toBe(true);
     });
 
-    it('ignores empty string and empty array header values', () => {
-      expect(hasForwardedHeaders(makeRequest('127.0.0.1', { 'x-forwarded-for': '' }))).toBe(false);
-      expect(hasForwardedHeaders(makeRequest('127.0.0.1', { 'x-forwarded-for': [] }))).toBe(false);
+    it('detects a forwarding header by presence even when its value is empty', () => {
+      // An empty value is still proof a proxy inserted the header.
+      expect(hasForwardedHeaders(makeRequest('127.0.0.1', { 'x-forwarded-for': '' }))).toBe(true);
+      expect(hasForwardedHeaders(makeRequest('127.0.0.1', { 'x-forwarded-for': [] }))).toBe(true);
     });
 
     it('is false when no forwarding headers are present', () => {

--- a/packages/backend/src/common/utils/local-ip.ts
+++ b/packages/backend/src/common/utils/local-ip.ts
@@ -23,27 +23,26 @@ export function isLoopbackPeer(request: Request): boolean {
 
 // Headers that are only ever set by a reverse proxy / load balancer. A direct
 // local caller (curl on the box, a local SDK, the bundled dashboard) sets none
-// of them.
-const FORWARDED_HEADER_NAMES = [
-  'forwarded',
-  'x-forwarded-for',
-  'x-forwarded-host',
-  'x-forwarded-proto',
-  'x-real-ip',
-] as const;
+// of them. The whole `x-forwarded-*` family is matched by prefix so a variant
+// like `x-forwarded-port` can't slip a proxy hop past the check.
+const PROXY_HEADER_PREFIX = 'x-forwarded-';
+const PROXY_HEADER_NAMES = ['forwarded', 'x-real-ip', 'via'] as const;
 
 /**
  * True when the request carries any header indicating it traversed a proxy hop.
  *
- * We deliberately trust only the *presence* of these headers, never their
- * values (those are attacker-spoofable). Presence alone is enough to prove the
- * request did not arrive as a direct local call.
+ * We deliberately key off the *presence* of these headers, never their values
+ * (those are attacker-spoofable, and an empty value is still proof a proxy
+ * inserted the header). Presence alone is enough to show the request did not
+ * arrive as a direct local call. Node lowercases inbound header names, so the
+ * comparison is case-insensitive.
  */
 export function hasForwardedHeaders(request: Request): boolean {
-  return FORWARDED_HEADER_NAMES.some((name) => {
-    const value = request.headers[name];
-    return Array.isArray(value) ? value.length > 0 : typeof value === 'string' && value.length > 0;
-  });
+  return Object.keys(request.headers).some(
+    (name) =>
+      name.startsWith(PROXY_HEADER_PREFIX) ||
+      (PROXY_HEADER_NAMES as readonly string[]).includes(name),
+  );
 }
 
 /**

--- a/packages/backend/src/common/utils/local-ip.ts
+++ b/packages/backend/src/common/utils/local-ip.ts
@@ -20,3 +20,43 @@ export function isLoopbackPeer(request: Request): boolean {
   const peer = getSocketRemoteAddress(request);
   return !!peer && isLoopbackIp(peer);
 }
+
+// Headers that are only ever set by a reverse proxy / load balancer. A direct
+// local caller (curl on the box, a local SDK, the bundled dashboard) sets none
+// of them.
+const FORWARDED_HEADER_NAMES = [
+  'forwarded',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+  'x-real-ip',
+] as const;
+
+/**
+ * True when the request carries any header indicating it traversed a proxy hop.
+ *
+ * We deliberately trust only the *presence* of these headers, never their
+ * values (those are attacker-spoofable). Presence alone is enough to prove the
+ * request did not arrive as a direct local call.
+ */
+export function hasForwardedHeaders(request: Request): boolean {
+  return FORWARDED_HEADER_NAMES.some((name) => {
+    const value = request.headers[name];
+    return Array.isArray(value) ? value.length > 0 : typeof value === 'string' && value.length > 0;
+  });
+}
+
+/**
+ * The gate for loopback auth shortcuts: a request is treated as a trusted local
+ * caller only when its TCP socket peer is loopback AND it shows no sign of a
+ * proxy hop.
+ *
+ * A same-host reverse proxy (`proxy_pass http://127.0.0.1:PORT`) makes the
+ * socket peer `127.0.0.1` for every forwarded request, so "peer is loopback"
+ * on its own would extend the trusted-local shortcut to the entire internet.
+ * Suppressing it whenever a forwarding header is present closes that gap while
+ * still letting a genuine direct local call through.
+ */
+export function isTrustedLoopbackPeer(request: Request): boolean {
+  return isLoopbackPeer(request) && !hasForwardedHeaders(request);
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -109,6 +109,11 @@ export async function bootstrap() {
     new ValidationPipe({
       transform: true,
       whitelist: true,
+      // Reject (rather than silently strip) unexpected fields so mass-assignment
+      // probes and malformed clients get a clear 400 instead of a quietly
+      // half-honored request. The proxy passthrough routes read the raw body
+      // (no DTO), so upstream LLM payloads are unaffected.
+      forbidNonWhitelisted: true,
     }),
   );
 

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.spec.ts
@@ -337,6 +337,34 @@ describe('AgentKeyAuthGuard', () => {
       await guard.canActivate(ctx2);
       expect(mockFindOne).not.toHaveBeenCalled();
     });
+
+    it('suppresses the loopback bypass when a forwarding header is present (no auth header)', async () => {
+      // A reverse proxy in front of a dev instance makes the peer 127.0.0.1 for
+      // every forwarded request. An active key exists, so the only thing
+      // blocking the bypass is the forwarding-header guard.
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'dev-tenant',
+        agent_id: 'dev-agent',
+        agent: { name: 'demo-agent' },
+        tenant: { name: 'dev-user' },
+      });
+      const { ctx } = makeContext({ 'x-forwarded-for': '8.8.8.8' }, '127.0.0.1');
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Authorization header required');
+    });
+
+    it('suppresses the loopback bypass for a non-mnfst token behind a proxy', async () => {
+      mockFindOne.mockResolvedValue({
+        tenant_id: 'dev-tenant',
+        agent_id: 'dev-agent',
+        agent: { name: 'demo-agent' },
+        tenant: { name: 'dev-user' },
+      });
+      const { ctx } = makeContext(
+        { authorization: 'Bearer dev-no-auth', 'x-forwarded-for': '8.8.8.8' },
+        '127.0.0.1',
+      );
+      await expect(guard.canActivate(ctx)).rejects.toThrow('Invalid API key format');
+    });
   });
 
   it('handles request.ip being undefined without crashing', async () => {

--- a/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
+++ b/packages/backend/src/otlp/guards/agent-key-auth.guard.ts
@@ -16,7 +16,7 @@ import { AgentApiKey } from '../../entities/agent-api-key.entity';
 import { IngestionContext } from '../interfaces/ingestion-context.interface';
 import { verifyKey, keyPrefix as computePrefix } from '../../common/utils/hash.util';
 import { API_KEY_PREFIX } from '../../common/constants/api-key.constants';
-import { isLoopbackPeer } from '../../common/utils/local-ip';
+import { isTrustedLoopbackPeer } from '../../common/utils/local-ip';
 const MIN_TOKEN_LENGTH = 12;
 
 function cacheKey(token: string): string {
@@ -87,10 +87,14 @@ export class AgentKeyAuthGuard implements CanActivate, OnModuleInit, OnModuleDes
     const request = context.switchToHttp().getRequest<Request>();
     const authHeader = request.headers['authorization'];
 
-    // Use socket.remoteAddress (TCP peer) — request.ip honors X-Forwarded-For
-    // and is spoofable when `trust proxy` is enabled.
+    // `isTrustedLoopbackPeer` uses socket.remoteAddress (TCP peer) — request.ip
+    // honors X-Forwarded-For and is spoofable when `trust proxy` is enabled —
+    // and suppresses the shortcut when a forwarding header is present, so a
+    // dev instance fronted by a reverse proxy can't have unauthenticated ingest
+    // opened up to remote callers that appear as loopback.
     const isDevLoopback =
-      this.configService.get<string>('app.nodeEnv') === 'development' && isLoopbackPeer(request);
+      this.configService.get<string>('app.nodeEnv') === 'development' &&
+      isTrustedLoopbackPeer(request);
 
     if (!authHeader) {
       if (await this.handleDevLoopback(request, isDevLoopback)) return true;

--- a/packages/backend/test/helpers.ts
+++ b/packages/backend/test/helpers.ts
@@ -200,10 +200,13 @@ export async function createTestApp(): Promise<INestApplication> {
     }).compile();
 
     const app = moduleFixture.createNestApplication();
+    // Mirror the production pipe in main.ts (incl. forbidNonWhitelisted) so e2e
+    // faithfully exercises the strict-input behavior the app actually ships.
     app.useGlobalPipes(
       new ValidationPipe({
         transform: true,
         whitelist: true,
+        forbidNonWhitelisted: true,
       }),
     );
     await app.init();


### PR DESCRIPTION
### 💭 Why
Loopback auth shortcuts trusted any request whose TCP peer is `127.0.0.1`. A same-host reverse proxy (`proxy_pass http://127.0.0.1:PORT`) makes every forwarded request look like loopback, so a self-hosted dashboard, or a dev-mode ingest endpoint, placed behind one handed full access to remote callers. Found during a local pen test.

### ✨ What changed
- Self-hosted dashboard and dev-mode ingest loopback shortcuts now bail out when a forwarding header is present (`X-Forwarded-For`, `X-Real-IP`, `Forwarded`, `X-Forwarded-*`).
- Trust only the header's presence, never its value (values are spoofable).
- API rejects unexpected request-body fields (`forbidNonWhitelisted`) instead of silently stripping them.

### 👤 For users
Nothing visible. A direct local call still works; a proxied request just has to authenticate normally.

### 🔧 For operators
If you front a self-hosted instance with a same-host reverse proxy, the dashboard now requires a real login instead of trusting loopback. Requests carrying unexpected JSON fields now get a `400` instead of having them dropped.

### 📝 Notes
Two related items intentionally left for their own PRs: connect-time IP pinning for SSRF DNS-rebinding (touches the proxy hot path) and a dedicated `MANIFEST_ENCRYPTION_KEY` in production.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened loopback auth so same-host reverse proxies can’t make remote calls look local. Direct localhost still works; proxied requests must authenticate, and unexpected JSON fields now return 400.

- **Bug Fixes**
  - Suppress loopback shortcuts for the self-hosted dashboard and dev-mode ingest when any proxy header is present (`X-Forwarded-*`, `X-Real-IP`, `Forwarded`, `Via`); detect by presence only (values ignored, empty counts).
  - Enable `forbidNonWhitelisted` in the global validation pipe to reject extra request-body fields with a 400.

<sup>Written for commit ea90599cf3f329c8a8bfd4220b6274de918984e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

