### PR TITLE
fix: try tier fallbacks before auto route

### DIFF
--- a/.changeset/tier-fallback-before-auto.md
+++ b/.changeset/tier-fallback-before-auto.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Try configured tier fallback routes before the auto-assigned route when a manual override model is unavailable.

--- a/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
+++ b/packages/backend/src/routing/resolve/__tests__/resolve.service.spec.ts
@@ -706,7 +706,7 @@ describe('ResolveService', () => {
       expect(result.reason).toBe('default');
     });
 
-    it('returns null route when the override is orphaned and auto is null', async () => {
+    it('uses the first fallback when the override is orphaned and auto is null', async () => {
       mockedScore.mockReturnValue({
         tier: 'standard',
         confidence: 0.7,
@@ -725,11 +725,11 @@ describe('ResolveService', () => {
 
       const result = await svc.resolve('agent-1', messages);
       expect(result.tier).toBe('standard');
-      expect(result.route).toBeNull();
-      expect(result.fallback_routes).toEqual([route('anthropic', 'api_key', 'fallback-1')]);
+      expect(result.route).toEqual(route('anthropic', 'api_key', 'fallback-1'));
+      expect(result.fallback_routes).toBeNull();
     });
 
-    it('falls through to auto when override is orphaned but auto is set', async () => {
+    it('tries fallbacks before auto when the override is orphaned but auto is set', async () => {
       mockedScore.mockReturnValue({
         tier: 'standard',
         confidence: 0.7,
@@ -741,13 +741,20 @@ describe('ResolveService', () => {
           tier: 'standard',
           override_route: route('openai', 'api_key', 'orphaned'),
           auto_assigned_route: route('openai', 'api_key', 'auto'),
-          fallback_routes: null,
+          fallback_routes: [
+            route('anthropic', 'api_key', 'fallback-1'),
+            route('google', 'api_key', 'fallback-2'),
+          ],
         } as unknown as TierAssignment,
       ]);
       providerKeyService.isModelAvailable.mockResolvedValue(false);
 
       const result = await svc.resolve('agent-1', messages);
-      expect(result.route).toEqual(route('openai', 'api_key', 'auto'));
+      expect(result.route).toEqual(route('anthropic', 'api_key', 'fallback-1'));
+      expect(result.fallback_routes).toEqual([
+        route('google', 'api_key', 'fallback-2'),
+        route('openai', 'api_key', 'auto'),
+      ]);
     });
 
     it('passes momentum input when recentTiers is non-empty', async () => {

--- a/packages/backend/src/routing/resolve/resolve.service.ts
+++ b/packages/backend/src/routing/resolve/resolve.service.ts
@@ -29,6 +29,11 @@ import type { HeaderTier } from '../../entities/header-tier.entity';
 import type { TierAssignment } from '../../entities/tier-assignment.entity';
 import type { SpecificityAssignment } from '../../entities/specificity-assignment.entity';
 
+interface ResolvedRouteChain {
+  primaryRoute: ModelRoute | null;
+  fallbackRoutes: ModelRoute[] | null;
+}
+
 /**
  * When specificity detection is below this confidence, skip specificity
  * routing and fall through to the complexity tier. Low-confidence detections
@@ -118,8 +123,12 @@ export class ResolveService {
     const outputModality = outputModalityFor(assignment);
     const responseMode = responseModeFor(assignment);
     const fallbackRoutes = readFallbackRoutes(assignment);
-    const route = await this.buildResolvedRoute(agentId, assignment);
-    const effectiveRoutes = effectiveRoutesForResponseMode(responseMode, route, fallbackRoutes);
+    const routeChain = await this.buildResolvedRouteChain(agentId, assignment, fallbackRoutes);
+    const effectiveRoutes = effectiveRoutesForResponseMode(
+      responseMode,
+      routeChain.primaryRoute,
+      routeChain.fallbackRoutes,
+    );
     if (!effectiveRoutes.primaryRoute) {
       this.logger.warn(
         `No route resolved for agent=${agentId} tier=${result.tier} ` +
@@ -174,8 +183,12 @@ export class ResolveService {
     const outputModality = outputModalityFor(assignment);
     const responseMode = responseModeFor(assignment);
     const fallbackRoutes = readFallbackRoutes(assignment);
-    const route = await this.buildResolvedRoute(agentId, assignment);
-    const effectiveRoutes = effectiveRoutesForResponseMode(responseMode, route, fallbackRoutes);
+    const routeChain = await this.buildResolvedRouteChain(agentId, assignment, fallbackRoutes);
+    const effectiveRoutes = effectiveRoutesForResponseMode(
+      responseMode,
+      routeChain.primaryRoute,
+      routeChain.fallbackRoutes,
+    );
     return {
       tier,
       route: effectiveRoutes.primaryRoute,
@@ -329,27 +342,44 @@ export class ResolveService {
   }
 
   /**
-   * Build the resolved route for a tier assignment. Validates the override
-   * still points to an available model; falls through to auto-assigned when
-   * the override is orphaned. Enriches with the default key label when no
-   * explicit pin is present.
+   * Build the resolved route chain for a tier assignment. Validates the
+   * override still points to an available model; when an override is orphaned,
+   * walk configured fallbacks before trying the auto-assigned route. Enriches
+   * routes with the default key label when no explicit pin is present.
    */
-  private async buildResolvedRoute(
+  private async buildResolvedRouteChain(
     agentId: string,
     assignment: TierAssignment | SpecificityAssignment,
-  ): Promise<ModelRoute | null> {
+    fallbackRoutes: ModelRoute[] | null,
+  ): Promise<ResolvedRouteChain> {
     const override = readOverrideRoute(assignment);
     if (override) {
       if (await this.providerKeyService.isModelAvailable(agentId, override.model)) {
-        return this.enrichRouteKeyLabel(agentId, override);
+        return {
+          primaryRoute: await this.enrichRouteKeyLabel(agentId, override),
+          fallbackRoutes,
+        };
       }
       this.logger.warn(
-        `Override ${override.model} unavailable for agent=${agentId} — falling back to auto`,
+        `Override ${override.model} unavailable for agent=${agentId} — ` +
+          `falling back to configured routes`,
       );
+      const candidates = [
+        ...(fallbackRoutes ?? []),
+        ...(assignment.auto_assigned_route ? [assignment.auto_assigned_route] : []),
+      ];
+      const [primaryRoute, ...remainingFallbacks] = candidates;
+      return {
+        primaryRoute: primaryRoute ? await this.enrichRouteKeyLabel(agentId, primaryRoute) : null,
+        fallbackRoutes: remainingFallbacks.length > 0 ? remainingFallbacks : null,
+      };
     }
-    return assignment.auto_assigned_route
-      ? this.enrichRouteKeyLabel(agentId, assignment.auto_assigned_route)
-      : null;
+    return {
+      primaryRoute: assignment.auto_assigned_route
+        ? await this.enrichRouteKeyLabel(agentId, assignment.auto_assigned_route)
+        : null,
+      fallbackRoutes,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

- make orphaned manual tier overrides try configured fallback routes before the auto-assigned route
- preserve the remaining fallback chain and append the auto-assigned route as the final attempt
- add resolver regressions for orphaned overrides with and without an auto route

Closes #2117.

## Root Cause

When a manual tier override pointed to a model that was no longer available, `ResolveService` immediately resolved the tier to `auto_assigned_route`. That skipped the tier's configured `fallback_routes` at resolve time, so fallbacks were only considered later if the auto route failed mid-flight.

## Reproduction

A throwaway upstream-main repro at `7caad4c0b` with only the new expected-behavior resolver assertions failed in both issue cases:

- orphaned override + configured fallback + no auto route returned `route=null`
- orphaned override + configured fallback + auto route returned `route=auto`

## Notes

The issue's secondary auto-assignment observation is related but separate: `TierAutoAssignService` intentionally recalculates `auto_assigned_route`, but it does not overwrite manual `override_route` or `fallback_routes`. This PR makes that auto route a last resort when the manual override is unavailable.

## Validation

- `npm ci`
- `npm --workspace packages/shared run build`
- `npm --workspace packages/backend run test -- resolve.service.spec.ts resolve.service.edge.spec.ts`
- `npm --workspace packages/backend run test -- tier-auto-assign.service.spec.ts`
- `npm --workspace packages/backend run build`
- `npx changeset status`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route resolver now tries configured tier fallbacks before the auto-assigned route when a manual override is unavailable; auto is used last. Fixes #2117.

- **Bug Fixes**
  - Added `buildResolvedRouteChain` to return `primaryRoute` + `fallbackRoutes`; when an `override_route` is orphaned, walk `fallback_routes` first and append `auto_assigned_route` as the final attempt.
  - Updated resolver tests to cover orphaned overrides with/without auto and assert the new ordering.

<sup>Written for commit 6154127b28cd23cbb0deb816a9b79308d8b031db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

