### PR TITLE
fix: forward image inputs to Anthropic

### DIFF
--- a/.changeset/anthropic-image-input.md
+++ b/.changeset/anthropic-image-input.md
@@ -1,0 +1,5 @@
+---
+"manifest": patch
+---
+
+Forward OpenAI-compatible image inputs as Anthropic image content blocks when routing Chat Completions or Responses requests to Claude.

--- a/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/anthropic-adapter.spec.ts
@@ -291,6 +291,65 @@ describe('Anthropic Adapter', () => {
       expect(content[1]).toEqual({ type: 'text', text: 'Second' });
     });
 
+    it('converts OpenAI image_url content blocks to Anthropic image blocks', () => {
+      const body = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Look at these.' },
+              {
+                type: 'image_url',
+                image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' },
+              },
+              {
+                type: 'image_url',
+                image_url: { url: 'https://example.com/image.webp' },
+              },
+            ],
+          },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+
+      const messages = result.messages as Array<{ content: Array<Record<string, unknown>> }>;
+      expect(messages[0].content).toEqual([
+        { type: 'text', text: 'Look at these.' },
+        {
+          type: 'image',
+          source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' },
+        },
+        {
+          type: 'image',
+          source: { type: 'url', url: 'https://example.com/image.webp' },
+        },
+      ]);
+    });
+
+    it('converts Responses input_image content blocks to Anthropic image blocks', () => {
+      const body = {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'What is in this image?' },
+              { type: 'input_image', image_url: 'data:image/jpeg;base64,/9j/4AAQSkZJRg==' },
+            ],
+          },
+        ],
+      };
+      const result = toAnthropicRequest(body, 'claude-sonnet-4-20250514');
+
+      const messages = result.messages as Array<{ content: Array<Record<string, unknown>> }>;
+      expect(messages[0].content).toEqual([
+        { type: 'text', text: 'What is in this image?' },
+        {
+          type: 'image',
+          source: { type: 'base64', media_type: 'image/jpeg', data: '/9j/4AAQSkZJRg==' },
+        },
+      ]);
+    });
+
     it('handles system message with array content', () => {
       const body = {
         messages: [

--- a/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
+++ b/packages/backend/src/routing/proxy/__tests__/provider-client.spec.ts
@@ -428,6 +428,52 @@ describe('ProviderClient', () => {
       expect(sent.tools[0]).toMatchObject({ name: 'lookup', input_schema: { type: 'object' } });
     });
 
+    it('forwards Responses image inputs to Anthropic image content blocks', async () => {
+      mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
+
+      await client.forward({
+        provider: 'anthropic',
+        apiKey: 'sk-ant-test',
+        model: 'claude-sonnet-4-5-20250929',
+        body: {
+          input: [
+            {
+              role: 'user',
+              content: [
+                { type: 'input_text', text: 'What is in this image?' },
+                { type: 'input_image', image_url: 'data:image/png;base64,iVBORw0KGgo=' },
+              ],
+            },
+          ],
+          stream: false,
+        },
+        chatBody: {
+          messages: [
+            {
+              role: 'user',
+              content: [
+                { type: 'text', text: 'What is in this image?' },
+                { type: 'image_url', image_url: { url: 'data:image/png;base64,iVBORw0KGgo=' } },
+              ],
+            },
+          ],
+          stream: false,
+        },
+        stream: false,
+        apiMode: 'responses',
+      });
+
+      const sent = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(sent.input).toBeUndefined();
+      expect(sent.messages[0].content).toEqual([
+        { type: 'text', text: 'What is in this image?' },
+        {
+          type: 'image',
+          source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' },
+        },
+      ]);
+    });
+
     it('strips Codex-unsupported params on the subscription Responses path', async () => {
       mockFetch.mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/packages/backend/src/routing/proxy/anthropic-adapter.ts
+++ b/packages/backend/src/routing/proxy/anthropic-adapter.ts
@@ -11,6 +11,7 @@ import type { ThinkingBlock } from './thinking-block-cache';
 interface ContentBlock {
   type: string;
   text?: string;
+  source?: { type: string; media_type?: string; data?: string; url?: string };
   id?: string;
   name?: string;
   input?: unknown;
@@ -33,6 +34,7 @@ interface AnthropicTool {
 
 const CACHE = { type: 'ephemeral' } as const;
 const ANTHROPIC_PREFIX = 'anthropic/';
+const DATA_IMAGE_URL_RE = /^data:([^;,]+)(?:;[^,]*)?;base64,(.*)$/is;
 
 function bareAnthropicModel(model: string): string {
   return model.startsWith(ANTHROPIC_PREFIX) ? model.slice(ANTHROPIC_PREFIX.length) : model;
@@ -75,7 +77,20 @@ function safeParseArgs(args: string | undefined): unknown {
   }
 }
 
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 /* ── Request helpers ── */
+
+function isTextContentPart(part: Record<string, unknown>): part is Record<string, unknown> & {
+  text: string;
+} {
+  return (
+    typeof part.text === 'string' &&
+    (part.type === 'text' || part.type === 'input_text' || part.type === 'output_text')
+  );
+}
 
 function extractSystemBlocks(messages: OpenAIMessage[]): ContentBlock[] {
   const blocks: ContentBlock[] = [];
@@ -85,7 +100,7 @@ function extractSystemBlocks(messages: OpenAIMessage[]): ContentBlock[] {
       blocks.push({ type: 'text', text: msg.content });
     } else if (Array.isArray(msg.content)) {
       for (const part of msg.content as Array<Record<string, unknown>>) {
-        if (part.type === 'text' && typeof part.text === 'string') {
+        if (isObjectRecord(part) && isTextContentPart(part)) {
           blocks.push({ type: 'text', text: part.text });
         }
       }
@@ -94,12 +109,61 @@ function extractSystemBlocks(messages: OpenAIMessage[]): ContentBlock[] {
   return blocks;
 }
 
-function toContentBlocks(content: unknown): ContentBlock[] {
+function extractOpenAiImageUrl(imageUrl: unknown): string | null {
+  if (typeof imageUrl === 'string') return imageUrl;
+  if (!isObjectRecord(imageUrl) || typeof imageUrl.url !== 'string') return null;
+  return imageUrl.url;
+}
+
+function imageUrlToAnthropicBlock(imageUrl: unknown): ContentBlock | null {
+  const url = extractOpenAiImageUrl(imageUrl);
+  if (!url) return null;
+
+  const dataUrl = DATA_IMAGE_URL_RE.exec(url);
+  if (dataUrl) {
+    const mediaType = dataUrl[1] || 'image/png';
+    if (!mediaType.toLowerCase().startsWith('image/')) return null;
+    return {
+      type: 'image',
+      source: { type: 'base64', media_type: mediaType, data: dataUrl[2] },
+    };
+  }
+
+  return { type: 'image', source: { type: 'url', url } };
+}
+
+function normalizeAnthropicImageBlock(part: Record<string, unknown>): ContentBlock | null {
+  if (part.type !== 'image' || !isObjectRecord(part.source)) return null;
+  const source = part.source;
+  if (source.type === 'base64' && typeof source.data === 'string') {
+    const mediaType = typeof source.media_type === 'string' ? source.media_type : 'image/png';
+    return { type: 'image', source: { type: 'base64', media_type: mediaType, data: source.data } };
+  }
+  if (source.type === 'url' && typeof source.url === 'string') {
+    return { type: 'image', source: { type: 'url', url: source.url } };
+  }
+  return null;
+}
+
+function toContentBlocks(content: unknown, includeImages = false): ContentBlock[] {
   if (typeof content === 'string') return content ? [{ type: 'text', text: content }] : [];
   if (Array.isArray(content)) {
-    return (content as Array<Record<string, unknown>>)
-      .filter((b) => b.type === 'text' && typeof b.text === 'string')
-      .map((b) => ({ type: 'text', text: b.text as string }));
+    const blocks: ContentBlock[] = [];
+    for (const part of content) {
+      if (!isObjectRecord(part)) continue;
+      if (isTextContentPart(part)) {
+        blocks.push({ type: 'text', text: part.text });
+      } else if (includeImages) {
+        const imageBlock =
+          part.type === 'image_url'
+            ? imageUrlToAnthropicBlock(part.image_url)
+            : part.type === 'input_image'
+              ? imageUrlToAnthropicBlock(part.image_url)
+              : normalizeAnthropicImageBlock(part);
+        if (imageBlock) blocks.push(imageBlock);
+      }
+    }
+    return blocks;
   }
   return [];
 }
@@ -155,7 +219,7 @@ function convertMessage(
     return blocks.length > 0 ? { role: 'assistant', content: blocks } : null;
   }
 
-  const blocks = toContentBlocks(msg.content);
+  const blocks = toContentBlocks(msg.content, true);
   return blocks.length > 0 ? { role: 'user', content: blocks } : null;
 }
 


### PR DESCRIPTION
## Summary
- convert OpenAI-compatible image inputs into Anthropic image content blocks when routing through Claude
- support Chat Completions `image_url` parts, Responses `input_image` parts, data URLs, hosted image URLs, and valid Anthropic image blocks
- keep assistant/system conversion text-only and add backend regressions plus a changeset

## Validation
- `./node_modules/.bin/jest --config packages/backend/package.json anthropic-adapter.spec.ts provider-client.spec.ts --runInBand`
- `npm --workspace packages/backend run build`
- `git diff --check`
- `./node_modules/.bin/changeset status`
- live Anthropic smoke with `claude-sonnet-4-6`: Responses base64 80x80 PNG and hosted URL both returned `RED` with image input tokens counted; text-only control returned `NOT_RED`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward OpenAI-style image inputs to Anthropic so multimodal prompts work when routing to Claude for both Chat Completions and Responses. Converts data URLs and hosted URLs into Anthropic `image` content blocks.

- **Bug Fixes**
  - Map Chat Completions `image_url` and Responses `input_image` to Anthropic `image` blocks (data URLs -> `base64`, HTTP(S) -> `url`).
  - Normalize valid Anthropic `image` blocks and keep system/assistant conversion text-only.
  - Add coverage in `anthropic-adapter.spec.ts` and `provider-client.spec.ts`, plus a patch changeset in `manifest`.

<sup>Written for commit 6eb902d1a112aee980a06246852d00788b4946d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mnfst/manifest/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

